### PR TITLE
opt: fix incorrect reuse of existing column in findExistingColInList

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -732,3 +732,47 @@ CPut /Table/117/4/4/0 -> /BYTES/0x89
 
 statement ok
 RESET use_cputs_on_non_unique_indexes;
+
+# Regression test for incorrectly reusing existing column that has a different
+# type (#163911).
+statement ok
+CREATE TABLE t163911 (a INT PRIMARY KEY);
+
+statement ok
+ALTER TABLE t163911 ADD COLUMN new1 STRING DEFAULT (true);
+
+statement ok
+ALTER TABLE t163911 ADD COLUMN new2 STRING CHECK (true);
+
+query T
+EXPLAIN (OPT, TYPES) INSERT INTO t163911 VALUES (1);
+----
+insert t163911
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => a:1
+ │    ├── new1_cast:11 => new1:2
+ │    └── new2_default:10 => new2:3
+ ├── check columns: check1:12(bool)
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── cost: 0.03
+ ├── distribution: test
+ └── values
+      ├── columns: column1:8(int!null) new2_default:10(string) new1_cast:11(string!null) check1:12(bool!null)
+      ├── cardinality: [1 - 1]
+      ├── stats: [rows=1]
+      ├── cost: 0.02
+      ├── key: ()
+      ├── fd: ()-->(8,10-12)
+      ├── distribution: test
+      └── tuple [type=tuple{int, string, string, bool}]
+           ├── const: 1 [type=int]
+           ├── null [type=string]
+           ├── const: 'true' [type=string]
+           └── true [type=bool]
+
+# Also run the statement to ensure it doesn't hit an internal error.
+statement ok
+INSERT INTO t163911 VALUES (1);

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -622,7 +622,7 @@ func findExistingColInList(
 		if expr == col {
 			return col
 		}
-		if exprStr == col.getExprStr() {
+		if col.typ.Identical(expr.ResolvedType()) && exprStr == col.getExprStr() {
 			if allowSideEffects || col.scalar == nil {
 				return col
 			}
@@ -638,7 +638,9 @@ func findExistingColInList(
 
 // findExistingCol finds the given expression among the bound variables in this
 // scope. Returns nil if the expression is not found (or an expression is found
-// but it has side-effects and allowSideEffects is false).
+// but it has side-effects and allowSideEffects is false). The types of the
+// given expression and the bound variable need to be identical.
+//
 // If a column is found and we are tracking view dependencies, we add the column
 // to the view dependencies since it means this column is being referenced.
 func (s *scope) findExistingCol(expr tree.TypedExpr, allowSideEffects bool) *scopeColumn {

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -3875,71 +3875,81 @@ upsert assn_cast
  │    └── d_comp_cast:19 => d_comp:7
  ├── update-mapping:
  │    ├── d_cast:12 => d:6
- │    └── d_comp_cast:19 => d_comp:7
+ │    └── upsert_d_comp:36 => d_comp:7
  └── project
-      ├── columns: upsert_k:29 upsert_c:30 upsert_qc:31 upsert_i:32 upsert_s:33 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      ├── left-join (hash)
-      │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19
-      │    │    ├── grouping columns: column1:10!null
-      │    │    ├── project
-      │    │    │    ├── columns: d_comp_cast:19 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: d_comp_comp:18 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      ├── columns: upsert_k:31 upsert_c:32 upsert_qc:33 upsert_i:34 upsert_s:35 upsert_d_comp:36 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28 d_comp_cast:30
+      ├── project
+      │    ├── columns: d_comp_cast:30 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    ├── project
+      │    │    ├── columns: d_comp_comp:29 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19
+      │    │    │    │    ├── grouping columns: column1:10!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16
+      │    │    │    │    │    ├── columns: d_comp_cast:19 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12
+      │    │    │    │    │    │    ├── columns: d_comp_comp:18 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: d_cast:12 column1:10!null
-      │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11
-      │    │    │    │    │    │    │    │    └── (1, 1.45::DECIMAL(10,2))
+      │    │    │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16
+      │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12
+      │    │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    │    │    ├── columns: d_cast:12 column1:10!null
+      │    │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11
+      │    │    │    │    │    │    │    │    │    │    └── (1, 1.45::DECIMAL(10,2))
+      │    │    │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
+      │    │    │    │    │    │    │    │    │              └── column2:11
+      │    │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
+      │    │    │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
+      │    │    │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
+      │    │    │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
-      │    │    │    │    │    │    │              └── column2:11
+      │    │    │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
+      │    │    │    │    │    │    │              └── i_default:15
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
-      │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
-      │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
-      │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
+      │    │    │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
-      │    │    │    │    │              └── i_default:15
-      │    │    │    │    └── projections
-      │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
-      │    │    │    └── projections
-      │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
-      │    │    │              └── d_comp_comp:18
-      │    │    └── aggregations
-      │    │         ├── first-agg [as=d_cast:12]
-      │    │         │    └── d_cast:12
-      │    │         ├── first-agg [as=c_default:13]
-      │    │         │    └── c_default:13
-      │    │         ├── first-agg [as=qc_default:14]
-      │    │         │    └── qc_default:14
-      │    │         ├── first-agg [as=i_cast:17]
-      │    │         │    └── i_cast:17
-      │    │         ├── first-agg [as=s_default:16]
-      │    │         │    └── s_default:16
-      │    │         └── first-agg [as=d_comp_cast:19]
-      │    │              └── d_comp_cast:19
-      │    ├── scan assn_cast
-      │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    ├── computed column expressions
-      │    │    │    └── d_comp:26
-      │    │    │         └── assignment-cast: DECIMAL(10)
-      │    │    │              └── d:25 + 10.0
-      │    │    └── flags: avoid-full-scan disabled not visible index feature
-      │    └── filters
-      │         └── column1:10 = k:20
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
+      │    │    │    │    │              └── d_comp_comp:18
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=d_cast:12]
+      │    │    │    │         │    └── d_cast:12
+      │    │    │    │         ├── first-agg [as=c_default:13]
+      │    │    │    │         │    └── c_default:13
+      │    │    │    │         ├── first-agg [as=qc_default:14]
+      │    │    │    │         │    └── qc_default:14
+      │    │    │    │         ├── first-agg [as=i_cast:17]
+      │    │    │    │         │    └── i_cast:17
+      │    │    │    │         ├── first-agg [as=s_default:16]
+      │    │    │    │         │    └── s_default:16
+      │    │    │    │         └── first-agg [as=d_comp_cast:19]
+      │    │    │    │              └── d_comp_cast:19
+      │    │    │    ├── scan assn_cast
+      │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d_comp:26
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │    │              └── d:25 + 10.0
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:10 = k:20
+      │    │    └── projections
+      │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:29]
+      │    └── projections
+      │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:30]
+      │              └── d_comp_comp:29
       └── projections
-           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:29]
-           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:30]
-           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:31]
-           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:32]
-           └── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:33]
+           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:31]
+           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:32]
+           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:33]
+           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:34]
+           ├── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:35]
+           └── CASE WHEN k:20 IS NULL THEN d_comp_cast:19 ELSE d_comp_cast:30 END [as=upsert_d_comp:36]
 
 # Test prepared upsert to a column that requires an assignment cast and a
 # computed column that depends on the new value.
@@ -3961,71 +3971,81 @@ upsert assn_cast
  │    └── d_comp_cast:19 => d_comp:7
  ├── update-mapping:
  │    ├── d_cast:12 => d:6
- │    └── d_comp_cast:19 => d_comp:7
+ │    └── upsert_d_comp:36 => d_comp:7
  └── project
-      ├── columns: upsert_k:29 upsert_c:30 upsert_qc:31 upsert_i:32 upsert_s:33 column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      ├── left-join (hash)
-      │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null
-      │    │    ├── grouping columns: column1:10!null
-      │    │    ├── project
-      │    │    │    ├── columns: d_comp_cast:19!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: d_comp_comp:18!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      ├── columns: upsert_k:31 upsert_c:32 upsert_qc:33 upsert_i:34 upsert_s:35 upsert_d_comp:36!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28 d_comp_cast:30!null
+      ├── project
+      │    ├── columns: d_comp_cast:30!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    ├── project
+      │    │    ├── columns: d_comp_comp:29!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null
+      │    │    │    │    ├── grouping columns: column1:10!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16
+      │    │    │    │    │    ├── columns: d_comp_cast:19!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12!null
+      │    │    │    │    │    │    ├── columns: d_comp_comp:18!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: d_cast:12!null column1:10!null
-      │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11!null
-      │    │    │    │    │    │    │    │    └── (1, 1.45)
+      │    │    │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16
+      │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12!null
+      │    │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    │    │    ├── columns: d_cast:12!null column1:10!null
+      │    │    │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11!null
+      │    │    │    │    │    │    │    │    │    │    └── (1, 1.45)
+      │    │    │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
+      │    │    │    │    │    │    │    │    │              └── column2:11
+      │    │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
+      │    │    │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
+      │    │    │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
+      │    │    │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
-      │    │    │    │    │    │    │              └── column2:11
+      │    │    │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
+      │    │    │    │    │    │    │              └── i_default:15
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
-      │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
-      │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
-      │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
+      │    │    │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
-      │    │    │    │    │              └── i_default:15
-      │    │    │    │    └── projections
-      │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
-      │    │    │    └── projections
-      │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
-      │    │    │              └── d_comp_comp:18
-      │    │    └── aggregations
-      │    │         ├── first-agg [as=d_cast:12]
-      │    │         │    └── d_cast:12
-      │    │         ├── first-agg [as=c_default:13]
-      │    │         │    └── c_default:13
-      │    │         ├── first-agg [as=qc_default:14]
-      │    │         │    └── qc_default:14
-      │    │         ├── first-agg [as=i_cast:17]
-      │    │         │    └── i_cast:17
-      │    │         ├── first-agg [as=s_default:16]
-      │    │         │    └── s_default:16
-      │    │         └── first-agg [as=d_comp_cast:19]
-      │    │              └── d_comp_cast:19
-      │    ├── scan assn_cast
-      │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    ├── computed column expressions
-      │    │    │    └── d_comp:26
-      │    │    │         └── assignment-cast: DECIMAL(10)
-      │    │    │              └── d:25 + 10.0
-      │    │    └── flags: avoid-full-scan disabled not visible index feature
-      │    └── filters
-      │         └── column1:10 = k:20
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
+      │    │    │    │    │              └── d_comp_comp:18
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=d_cast:12]
+      │    │    │    │         │    └── d_cast:12
+      │    │    │    │         ├── first-agg [as=c_default:13]
+      │    │    │    │         │    └── c_default:13
+      │    │    │    │         ├── first-agg [as=qc_default:14]
+      │    │    │    │         │    └── qc_default:14
+      │    │    │    │         ├── first-agg [as=i_cast:17]
+      │    │    │    │         │    └── i_cast:17
+      │    │    │    │         ├── first-agg [as=s_default:16]
+      │    │    │    │         │    └── s_default:16
+      │    │    │    │         └── first-agg [as=d_comp_cast:19]
+      │    │    │    │              └── d_comp_cast:19
+      │    │    │    ├── scan assn_cast
+      │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d_comp:26
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │    │              └── d:25 + 10.0
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:10 = k:20
+      │    │    └── projections
+      │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:29]
+      │    └── projections
+      │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:30]
+      │              └── d_comp_comp:29
       └── projections
-           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:29]
-           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:30]
-           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:31]
-           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:32]
-           └── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:33]
+           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:31]
+           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:32]
+           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:33]
+           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:34]
+           ├── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:35]
+           └── CASE WHEN k:20 IS NULL THEN d_comp_cast:19 ELSE d_comp_cast:30 END [as=upsert_d_comp:36]
 
 # Test insert-do-nothing to a column that requires an assignment cast and a
 # computed column that depends on the new value.

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1303,16 +1303,16 @@ upsert transactiondetails
  ├── update-mapping:
  │    ├── numeric:20 => sellprice:7
  │    ├── numeric:21 => buyprice:8
- │    └── discount_cast:24 => discount:10
+ │    └── upsert_discount:45 => discount:10
  ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39 upsert_cardid:40 "?column?":15!null bool:16!null current_timestamp:17!null int8:18!null int8:19!null numeric:20!null numeric:21!null version_default:22 discount_cast:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
+ │    ├── columns: upsert_dealerid:39 upsert_isbuy:40 upsert_transactiondate:41 upsert_cardid:42 upsert_discount:45!null "?column?":15!null bool:16!null current_timestamp:17!null int8:18!null int8:19!null numeric:20!null numeric:21!null version_default:22 discount_cast:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
  │    ├── cardinality: [1 - 2]
  │    ├── volatile
  │    ├── key: (18,19)
- │    ├── fd: ()-->(15-17,24), (18,19)-->(20-22,25-34), (25-29)-->(30-34), (25)-->(37), (25,26)-->(38), (25,27)-->(39), (18,25,28)-->(40)
+ │    ├── fd: ()-->(15-17,24), (18,19)-->(20-22,25-34,45), (25-29)-->(30-34), (25)-->(39), (25,26)-->(40), (25,27)-->(41), (18,25,28)-->(42)
  │    ├── left-join (lookup transactiondetails)
  │    │    ├── columns: "?column?":15!null bool:16!null current_timestamp:17!null int8:18!null int8:19!null numeric:20!null numeric:21!null version_default:22 discount_cast:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
  │    │    ├── key columns: [15 16 17 18 19] = [25 26 27 28 29]
@@ -1335,7 +1335,7 @@ upsert transactiondetails
  │    │    │    │    ├── volatile
  │    │    │    │    ├── fd: ()-->(15-17,24)
  │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: detail_b:66!null detail_c:67!null detail_q:68!null detail_s:69!null
+ │    │    │    │    │    ├── columns: detail_b:69!null detail_c:70!null detail_q:71!null detail_s:72!null
  │    │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    │    ├── ('2.29', '49833', '4', '2.89')
  │    │    │    │    │    └── ('17.59', '29483', '2', '18.93')
@@ -1345,10 +1345,10 @@ upsert transactiondetails
  │    │    │    │         ├── 1 [as="?column?":15]
  │    │    │    │         ├── false [as=bool:16]
  │    │    │    │         ├── '2017-05-10 13:00:00+00' [as=current_timestamp:17]
- │    │    │    │         ├── detail_c:67::STRING::INT8 [as=int8:18, outer=(67), immutable]
- │    │    │    │         ├── detail_q:68::STRING::INT8 [as=int8:19, outer=(68), immutable]
- │    │    │    │         ├── detail_s:69::STRING::DECIMAL(10,4) [as=numeric:20, outer=(69), immutable]
- │    │    │    │         └── detail_b:66::STRING::DECIMAL(10,4) [as=numeric:21, outer=(66), immutable]
+ │    │    │    │         ├── detail_c:70::STRING::INT8 [as=int8:18, outer=(70), immutable]
+ │    │    │    │         ├── detail_q:71::STRING::INT8 [as=int8:19, outer=(71), immutable]
+ │    │    │    │         ├── detail_s:72::STRING::DECIMAL(10,4) [as=numeric:20, outer=(72), immutable]
+ │    │    │    │         └── detail_b:69::STRING::DECIMAL(10,4) [as=numeric:21, outer=(69), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=numeric:20, outer=(20)]
  │    │    │         │    └── numeric:20
@@ -1366,35 +1366,36 @@ upsert transactiondetails
  │    │    │              └── current_timestamp:17
  │    │    └── filters (true)
  │    └── projections
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":15 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:37, outer=(15,25)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:16 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:38, outer=(16,25,26)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:17 ELSE transactiondetails.transactiondate:27 END [as=upsert_transactiondate:39, outer=(17,25,27)]
- │         └── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:18 ELSE transactiondetails.cardid:28 END [as=upsert_cardid:40, outer=(18,25,28)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":15 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:39, outer=(15,25)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:16 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:40, outer=(16,25,26)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:17 ELSE transactiondetails.transactiondate:27 END [as=upsert_transactiondate:41, outer=(17,25,27)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:18 ELSE transactiondetails.cardid:28 END [as=upsert_cardid:42, outer=(18,25,28)]
+ │         └── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount_cast:24 ELSE 0.0000 END [as=upsert_discount:45, outer=(24,25)]
  └── f-k-checks
       ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
       │    └── anti-join (lookup transactions)
-      │         ├── columns: dealerid:43 isbuy:44 transactiondate:45
-      │         ├── key columns: [43 44 45] = [46 47 48]
+      │         ├── columns: dealerid:46 isbuy:47 transactiondate:48
+      │         ├── key columns: [46 47 48] = [49 50 51]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 2]
       │         ├── with-scan &2
-      │         │    ├── columns: dealerid:43 isbuy:44 transactiondate:45
+      │         │    ├── columns: dealerid:46 isbuy:47 transactiondate:48
       │         │    ├── mapping:
-      │         │    │    ├──  upsert_dealerid:37 => dealerid:43
-      │         │    │    ├──  upsert_isbuy:38 => isbuy:44
-      │         │    │    └──  upsert_transactiondate:39 => transactiondate:45
+      │         │    │    ├──  upsert_dealerid:39 => dealerid:46
+      │         │    │    ├──  upsert_isbuy:40 => isbuy:47
+      │         │    │    └──  upsert_transactiondate:41 => transactiondate:48
       │         │    └── cardinality: [1 - 2]
       │         └── filters (true)
       └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
            └── anti-join (lookup cards)
-                ├── columns: cardid:57
-                ├── key columns: [57] = [58]
+                ├── columns: cardid:60
+                ├── key columns: [60] = [61]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 2]
                 ├── with-scan &2
-                │    ├── columns: cardid:57
+                │    ├── columns: cardid:60
                 │    ├── mapping:
-                │    │    └──  upsert_cardid:40 => cardid:57
+                │    │    └──  upsert_cardid:42 => cardid:60
                 │    └── cardinality: [1 - 2]
                 └── filters (true)
 


### PR DESCRIPTION
We recently got a failure where the column of STRING type that has `true` value was incorrectly reused as a column of BOOL type for the CHECK constraint - we hit an internal error when evaluating whether the CHECK constraint was satisfied on INSERT. This commit fixes the issue by requiring that we only reuse an existing column if its type is identical to the given expression's.

I decided to omit a release note given that it seems like an edge case that we only saw once in our randomized tests.

Fixes: #163911.
Release note: None