### PR TITLE
sql/catalog: resolve temp schemas from other sessions by ID

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -429,6 +429,11 @@ func (q *byIDLookupContext) lookupTemporary(
 ) (catalog.Descriptor, catalog.ValidationLevel, error) {
 	td := q.tc.getTemporarySchemaByID(id)
 	if td == nil {
+		// Check if this ID corresponds to a temp schema from another session
+		// that we've seen in the namespace cache.
+		td = q.tc.getOtherSessionTemporarySchemaByID(id)
+	}
+	if td == nil {
 		return nil, catalog.NoValidation, nil
 	}
 	if q.flags.isMutable {

--- a/pkg/sql/catalog/descs/temporary_descriptors.go
+++ b/pkg/sql/catalog/descs/temporary_descriptors.go
@@ -6,6 +6,8 @@
 package descs
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
@@ -54,4 +56,24 @@ func (tc *Collection) getTemporarySchemaByID(schemaID descpb.ID) catalog.SchemaD
 		schemaID,
 		dbID,
 	)
+}
+
+// getOtherSessionTemporarySchemaByID checks the catalog reader's cached
+// namespace entries for a temporary schema from another session with the
+// given ID. This is a fallback for when getTemporarySchemaByID returns nil
+// because the schema doesn't belong to the current session.
+func (tc *Collection) getOtherSessionTemporarySchemaByID(id descpb.ID) catalog.SchemaDescriptor {
+	e := tc.cr.Cache().LookupNamespaceEntryByID(id)
+	if e == nil {
+		return nil
+	}
+	// Verify this is actually a schema namespace entry: it must have a valid
+	// parent database ID and no parent schema ID.
+	if e.GetParentID() == descpb.InvalidID || e.GetParentSchemaID() != descpb.InvalidID {
+		return nil
+	}
+	if !strings.HasPrefix(e.GetName(), catconstants.PgTempSchemaName) {
+		return nil
+	}
+	return schemadesc.NewTemporarySchema(e.GetName(), id, e.GetParentID())
 }

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
@@ -133,6 +133,10 @@ func (c *cachedCatalogReader) IsDescIDKnownToNotExist(id, maybeParentID descpb.I
 		return false
 	}
 	if c.hasScanAll {
+		// Temp schemas have namespace entries but no descriptors.
+		if c.cache.LookupNamespaceEntryByID(id) != nil {
+			return false
+		}
 		return true
 	}
 	if c.byIDState[maybeParentID].hasScanNamespaceForDatabaseEntries {

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -24,6 +24,11 @@ type Catalog struct {
 	byID     byIDMap
 	byName   byNameMap
 	byteSize int64
+	// nsEntryByID is a secondary index for looking up namespace entries by
+	// their ID. Unlike byName (a btree keyed by name), this is a plain map
+	// because only O(1) point lookups are needed, not ordered iteration.
+	// It is maintained by MutableCatalog mutation methods.
+	nsEntryByID map[descpb.ID]*byNameEntry
 }
 
 // CommentCatalog is a limited interface wrapper, which is used for partial
@@ -181,6 +186,20 @@ func (c Catalog) LookupNamespaceEntry(key descpb.NameInfo) NamespaceEntry {
 	return e.(NamespaceEntry)
 }
 
+// LookupNamespaceEntryByID looks up a namespace entry by its ID using
+// a secondary index. This is used as a fallback for resolving temporary
+// schemas from other sessions, which have namespace entries but no
+// descriptors.
+func (c Catalog) LookupNamespaceEntryByID(id descpb.ID) NamespaceEntry {
+	if !c.IsInitialized() {
+		return nil
+	}
+	if e := c.nsEntryByID[id]; e != nil {
+		return e
+	}
+	return nil
+}
+
 // OrderedDescriptors returns the descriptors in an ordered fashion.
 func (c Catalog) OrderedDescriptors() []catalog.Descriptor {
 	if !c.IsInitialized() {
@@ -328,6 +347,7 @@ func (c Catalog) FilterByIDs(ids []descpb.ID) Catalog {
 		}
 		e := ret.ensureForName(found)
 		*e = *found.(*byNameEntry)
+		ret.nsEntryByID[e.GetID()] = e
 		return nil
 	})
 	return ret.Catalog
@@ -368,6 +388,7 @@ func (c Catalog) FilterByNames(nameInfos []descpb.NameInfo) Catalog {
 		}
 		e := ret.ensureForName(ni)
 		*e = *found.(*byNameEntry)
+		ret.nsEntryByID[e.GetID()] = e
 		if foundByID := c.byID.get(e.id); foundByID != nil {
 			e := ret.ensureForID(e.id)
 			*e = *foundByID.(*byIDEntry)

--- a/pkg/sql/catalog/nstree/catalog_mutable.go
+++ b/pkg/sql/catalog/nstree/catalog_mutable.go
@@ -28,6 +28,7 @@ func (mc *MutableCatalog) maybeInitialize() {
 	}
 	mc.byID = makeByIDMap()
 	mc.byName = makeByNameMap()
+	mc.nsEntryByID = make(map[descpb.ID]*byNameEntry)
 }
 
 // Clear empties the MutableCatalog.
@@ -104,6 +105,7 @@ func (mc *MutableCatalog) DeleteByName(key catalog.NameKey) {
 	}
 	if removed := mc.byName.delete(key); removed != nil {
 		mc.byteSize -= removed.(catalogEntry).ByteSize()
+		delete(mc.nsEntryByID, removed.GetID())
 	}
 }
 
@@ -117,6 +119,7 @@ func (mc *MutableCatalog) UpsertNamespaceEntry(
 	e := mc.ensureForName(key)
 	e.id = id
 	e.timestamp = mvccTimestamp
+	mc.nsEntryByID[id] = e
 }
 
 // DeleteByID removes all by-ID mappings from the MutableCatalog.
@@ -220,6 +223,7 @@ func (mc *MutableCatalog) AddAll(c Catalog) {
 			mc.byteSize -= e.ByteSize()
 			mc.byteSize += ne.ByteSize()
 		}
+		mc.nsEntryByID[ne.GetID()] = ne
 		return nil
 	})
 	_ = c.byID.ascend(func(entry catalog.NameEntry) error {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -5750,26 +5750,9 @@ func populateVirtualIndexForTable(
 	}
 	h := makeOidHasher()
 	scResolver := oneAtATimeSchemaResolver{p: p, ctx: ctx}
-	var sc catalog.SchemaDescriptor
-	if tableDesc.IsTemporary() {
-		// Temp tables from other sessions should still be visible here.
-		// Ideally, the catalog API would be able to return the temporary
-		// schemas from other sessions, but it cannot right now. See
-		// https://github.com/cockroachdb/cockroach/issues/97822.
-		if err := forEachSchema(ctx, p, dbContext, false /* requiresPrivileges */, false /* includeMetadata */, func(ctx context.Context, schema catalog.SchemaDescriptor) error {
-			if schema.GetID() == tableDesc.GetParentSchemaID() {
-				sc = schema
-			}
-			return nil
-		}); err != nil {
-			return false, err
-		}
-	}
-	if sc == nil {
-		sc, err = descs.GetCatalogDescriptorGetter(ctx, p.Descriptors(), p.txn, p.EvalContext().Settings).WithoutNonPublic().Get().Schema(ctx, tableDesc.GetParentSchemaID())
-		if err != nil {
-			return false, err
-		}
+	sc, err := descs.GetCatalogDescriptorGetter(ctx, p.Descriptors(), p.txn, p.EvalContext().Settings).WithoutNonPublic().Get().Schema(ctx, tableDesc.GetParentSchemaID())
+	if err != nil {
+		return false, err
 	}
 	db := dbContext
 	if db == nil {


### PR DESCRIPTION
Temporary schemas have no descriptor in system.descriptor — only namespace entries in system.namespace. The by-ID resolution path (lookupTemporary) only checked the current session's data via TemporarySchemaProvider, so temp schemas from other sessions couldn't be resolved by ID even though they could be found by name.

This caused failures when resolving a table from another session's temp schema, then trying to resolve its parent schema by ID. A workaround existed in pg_catalog.go that iterated all schemas to find the match.

Fix this by enhancing the by-ID resolution path to check the catalog reader's cached namespace entries as a fallback when the session-local check returns nil. Also fix IsDescIDKnownToNotExist to not incorrectly report temp schema IDs as non-existent after ScanAll (since they have namespace entries but no descriptors). With these fixes, the pg_catalog.go workaround is no longer needed and is removed.

Resolves: #97822

Release note (bug fix): Fixed a bug where temporary tables created in one session could fail to appear in pg_catalog queries from another session because the parent temporary schema could not be resolved by ID.