### PR TITLE
build: update PGO profile to 20260311044914-327bfa5a9d46937117f45aa48762f9fb2b364598.pb.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -674,6 +674,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "5a23c5b33325d5fc3dfa4e67d872aa8371756f8e4f8f159509e8cc522c298cb2",
-    url = "https://storage.googleapis.com/cockroach-profiles/20251204202750-818ff5108cdb1f16f69b3d915acdb4f669b848eb.pb.gz",
+    sha256 = "1b202e1c594966bf1aa679b50fe467634ad7fdf0d719966873214a1eb7d8d8d8",
+    url = "https://storage.googleapis.com/cockroach-profiles/20260311044914-327bfa5a9d46937117f45aa48762f9fb2b364598.pb.gz",
 )


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │            ops/sec             │   ops/sec    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                         101.95 ± 5%    98.10 ± 5%       ~ (p=0.324 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         1019.2 ± 5%    980.6 ± 5%       ~ (p=0.324 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      101.95 ± 5%    98.05 ± 5%       ~ (p=0.324 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          1019.4 ± 5%    980.7 ± 5%       ~ (p=0.324 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                       101.90 ± 5%    98.05 ± 5%       ~ (p=0.311 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            2.344k ± 5%   2.255k ± 5%       ~ (p=0.327 n=20)
geomean                                                                          370.3         356.3       -3.79%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/avg             │   ms/avg    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          88.30 ± 6%   84.70 ± 6%       ~ (p=0.140 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          143.1 ± 5%   148.6 ± 6%       ~ (p=0.304 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       18.70 ± 6%   18.70 ± 3%       ~ (p=0.713 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           41.50 ± 5%   43.40 ± 5%       ~ (p=0.213 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        25.20 ± 3%   25.75 ± 3%       ~ (p=0.387 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             85.35 ± 5%   88.70 ± 5%       ~ (p=0.324 n=20)
geomean                                                                          52.56        53.46       +1.70%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p50             │   ms/p50    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          83.90 ± 5%   81.80 ± 8%       ~ (p=0.211 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          138.4 ± 3%   142.6 ± 6%       ~ (p=0.297 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       12.10 ± 4%   12.10 ± 5%       ~ (p=0.194 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           36.70 ± 8%   38.75 ± 3%       ~ (p=0.226 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        19.90 ± 6%   21.00 ± 5%       ~ (p=0.455 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             69.20 ± 3%   67.10 ± 6%       ~ (p=0.971 n=20)
geomean                                                                          43.84        44.44       +1.37%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p95             │   ms/p95    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          151.0 ± 6%   142.6 ± 6%       ~ (p=0.344 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          251.7 ± 3%   260.0 ± 6%       ~ (p=0.097 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       56.60 ± 4%   55.55 ± 6%       ~ (p=0.587 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           83.90 ± 5%   86.00 ± 2%       ~ (p=0.150 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        60.80 ± 3%   61.85 ± 5%       ~ (p=0.393 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             209.7 ± 4%   226.5 ± 7%       ~ (p=0.080 n=20)
geomean                                                                          114.9        116.4       +1.26%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p99             │   ms/p99    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          184.5 ± 5%   184.5 ± 5%       ~ (p=0.536 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          318.8 ± 5%   318.8 ± 5%       ~ (p=0.183 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       86.00 ± 2%   88.10 ± 5%       ~ (p=0.285 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           113.2 ± 4%   117.4 ± 4%       ~ (p=0.264 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        92.30 ± 5%   92.30 ± 5%       ~ (p=0.433 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             285.2 ± 6%   285.2 ± 6%       ~ (p=0.232 n=20)
geomean                                                                          157.2        158.8       +1.01%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/max             │   ms/max     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                         335.5 ± 10%   318.8 ±  5%       ~ (p=0.062 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         520.1 ± 16%   520.1 ± 10%       ~ (p=0.730 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      218.1 ±  4%   218.1 ± 12%       ~ (p=0.834 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          268.4 ± 13%   268.4 ±  6%       ~ (p=0.529 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                       230.7 ±  9%   230.7 ±  9%       ~ (p=0.549 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            520.1 ± 16%   520.1 ± 10%       ~ (p=0.730 n=20)
geomean                                                                         327.1         324.4        -0.85%
```

Epic: none
Release note: none