### PR TITLE
concurrency: collapse toResolve after AddDiscovered

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -592,12 +592,6 @@ func (m *managerImpl) HandleLockConflictError(
 	//
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
-
-	// Condense point resolve entries into range entries before they are cleared
-	// by the next ScanAndEnqueue. This prevents livelock when the lock table
-	// evicts entries under memory pressure.
-	g.PrepareForLockConflictRetry(ctx)
-
 	consultTxnStatusCache :=
 		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
 	var numAdded int
@@ -617,6 +611,11 @@ func (m *managerImpl) HandleLockConflictError(
 	if numAdded > 0 {
 		log.VEventf(ctx, 2, "added %d discovered lock(s) to lock table: %v", numAdded, t)
 	}
+
+	// Condense point resolve entries into range entries before they are cleared
+	// by the next ScanAndEnqueue. This prevents livelock when the lock table
+	// evicts entries under memory pressure.
+	g.PrepareForLockConflictRetry(ctx)
 
 	// Release the Guard's latches but continue to remain in lock wait-queues by
 	// not releasing lockWaitQueueGuards. We expect the caller of this method to

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -2406,6 +2407,11 @@ func TestVirtualIntentResolutionReentryAfterEvaluationLiveLock(t *testing.T) {
 	concurrency.VirtualIntentResolution.Override(ctx, &st.SV, true)
 	concurrency.DefaultLockTableSize.Override(ctx, &st.SV, 4)
 	storage.MaxConflictsPerLockConflictError.Override(ctx, &st.SV, 3)
+	rng, _ := randutil.NewTestRand()
+	if rng.Float32() > 0.5 {
+		t.Logf("setting DiscoveredLocksThresholdToConsultTxnStatusCache = 1")
+		concurrency.DiscoveredLocksThresholdToConsultTxnStatusCache.Override(ctx, &st.SV, 1)
+	}
 
 	store, err := tc.Server(0).GetStores().(*Stores).GetStore(tc.Server(0).GetFirstStoreID())
 	require.NoError(t, err)


### PR DESCRIPTION
When we cross the consultTxnCache threshold, we may not add transactions to the transaction status cache. For the non-VIR path, this is fine since we will be actually resolving them. The VIR path was previously not handling this because toResolve is reset on re-entry to ScanAndEnqueue.  Here, we collapse toResolve after calling AddDiscovered so that we include any newly encountered intents.

One consequence of this is that we'll use ranged intent resolution more often since we'll collapse intents encountered even on the first scan. Since this feature is still under analysis, we are OK with this trade-off for now.

Epic: none
Release note: None