### PR TITLE
drt: implemented disk fill: OOD operation

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "cancel_job.go",
         "cluster_settings.go",
         "debug_zip.go",
+        "disk_fill.go",
         "disk_stall.go",
         "grant_revoke_all.go",
         "grant_role.go",

--- a/pkg/cmd/roachtest/operations/disk_fill.go
+++ b/pkg/cmd/roachtest/operations/disk_fill.go
@@ -1,0 +1,364 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations/helpers"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+const (
+	// reserveBytes is the free space to leave per store after
+	// filling. 1 GiB per store creates real pressure; with 4
+	// stores that's 4 GiB total headroom on the node.
+	reserveBytes int64 = 1 << 30 // 1 GiB
+	// minFreeRequired is the minimum free space per store
+	// required to proceed with filling. Skip stores that are
+	// already tight.
+	minFreeRequired int64 = 2 << 30 // 2 GiB
+
+	monitorDuration = 15 * time.Minute
+	checkInterval   = 2 * time.Minute
+	// dangerThresholdBytes is the minimum free space (512 MiB)
+	// below which we abort the pressure period early. This
+	// aligns with Pebble's emergency ballast size.
+	dangerThresholdBytes int64 = 512 << 20 // 512 MiB
+)
+
+// ballastPath returns the path to the disk-fill ballast file for the
+// given store index (1-based).
+func ballastPath(storeIdx int) string {
+	return fmt.Sprintf("{store-dir:%d}/disk-fill-ballast", storeIdx)
+}
+
+// removeFillFiles removes ballast files from all stores on the target
+// node. rm -f is idempotent, so this is safe to call multiple times or
+// when files do not exist.
+func removeFillFiles(
+	ctx context.Context,
+	o operation.Operation,
+	c cluster.Cluster,
+	node option.NodeListOption,
+	storeCount int,
+) {
+	for i := 1; i <= storeCount; i++ {
+		if err := c.RunE(
+			ctx, option.WithNodes(node),
+			fmt.Sprintf("rm -f %s", ballastPath(i)),
+		); err != nil {
+			o.Errorf("failed to remove ballast on store %d: %v", i, err)
+		}
+	}
+}
+
+type cleanupDiskFill struct {
+	node       option.NodeListOption
+	storeCount int
+}
+
+func (cl *cleanupDiskFill) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	o.Status(fmt.Sprintf(
+		"removing fill files on node %s (%d stores)",
+		cl.node.NodeIDsString(), cl.storeCount,
+	))
+	removeFillFiles(ctx, o, c, cl.node, cl.storeCount)
+
+	// Retry the SQL connection a few times before concluding the node
+	// is down. Disk pressure may cause temporary unresponsiveness that
+	// resolves on its own once the fill files are removed.
+	if helpers.CheckNodeHealth(ctx, o, c, cl.node[0], 5 /* maxAttempts */, 5*time.Second) {
+		o.Status(fmt.Sprintf("node %s healthy after cleanup", cl.node.NodeIDsString()))
+		return
+	}
+
+	// Node is unresponsive — restart it via cockroach.sh (matches
+	// disk_stall cleanup pattern).
+	o.Status(fmt.Sprintf(
+		"node %d unresponsive after cleanup, restarting via cockroach.sh",
+		cl.node[0],
+	))
+	if err := c.RunE(ctx, option.WithNodes(cl.node), "./cockroach.sh"); err != nil {
+		o.Errorf("failed to restart node %d: %v", cl.node[0], err)
+		return
+	}
+
+	// Verify health after restart.
+	if !helpers.CheckNodeHealth(ctx, o, c, cl.node[0], 5 /* maxAttempts */, 10*time.Second) {
+		o.Errorf("node %d still unresponsive after restart", cl.node[0])
+		return
+	}
+	o.Status(fmt.Sprintf("node %d healthy after restart", cl.node[0]))
+}
+
+// fillStores creates ballast files on each store of the target node,
+// leaving reserveBytes free per store. Returns true if at least one
+// store was filled.
+func fillStores(
+	ctx context.Context,
+	o operation.Operation,
+	c cluster.Cluster,
+	targetNode option.NodeListOption,
+	storeCount int,
+) bool {
+	filledAny := false
+	for i := 1; i <= storeCount; i++ {
+		availBytes, err := roachtestutil.GetDiskAvailInBytes(
+			ctx, c, o.L(), targetNode[0], i,
+		)
+		if err != nil {
+			o.Errorf("unable to determine disk space on store %d: %v", i, err)
+			continue
+		}
+
+		if availBytes < minFreeRequired {
+			o.Status(fmt.Sprintf(
+				"store %d: only %d MiB free, need at least %d MiB — skipping",
+				i, availBytes>>20, minFreeRequired>>20,
+			))
+			continue
+		}
+
+		fillBytes := availBytes - reserveBytes
+		o.Status(fmt.Sprintf(
+			"store %d: filling %d MiB (leaving %d MiB reserve)",
+			i, fillBytes>>20, reserveBytes>>20,
+		))
+
+		// fallocate is O(1) on ext4/xfs (standard on GCE and AWS).
+		if err := c.RunE(
+			ctx, option.WithNodes(targetNode),
+			fmt.Sprintf("fallocate -l %d %s", fillBytes, ballastPath(i)),
+		); err != nil {
+			o.Errorf("fallocate failed on store %d: %v", i, err)
+			continue
+		}
+		filledAny = true
+	}
+	return filledAny
+}
+
+// runMonitorCheck performs a single iteration of the disk pressure
+// monitoring loop. It checks target and peer node health, per-store
+// free space, and range availability. Returns true if monitoring
+// should stop (target node down, danger threshold hit, etc.).
+func runMonitorCheck(
+	ctx context.Context,
+	o operation.Operation,
+	c cluster.Cluster,
+	tick int,
+	targetNode option.NodeListOption,
+	peerNodeID int,
+	storeCount int,
+	deadline time.Time,
+) bool {
+	// Check target node health. If it's down, that's an expected
+	// outcome of disk pressure — log and stop monitoring.
+	if !helpers.CheckNodeHealth(ctx, o, c, targetNode[0], 3 /* maxAttempts */, 5*time.Second) {
+		o.Status(fmt.Sprintf(
+			"check %d: target node %d went down under disk pressure (expected behavior)",
+			tick, targetNode[0],
+		))
+		return true
+	}
+
+	// Check peer node health — if a non-target node is
+	// unresponsive, something is wrong beyond our test.
+	if !helpers.CheckNodeHealth(ctx, o, c, peerNodeID, 3 /* maxAttempts */, 5*time.Second) {
+		o.Fatalf("check %d: peer node %d unresponsive", tick, peerNodeID)
+	}
+
+	// Log per-store disk usage and check danger threshold.
+	belowDanger := false
+	for i := 1; i <= storeCount; i++ {
+		curAvailBytes, err := roachtestutil.GetDiskAvailInBytes(
+			ctx, c, o.L(), targetNode[0], i,
+		)
+		if err != nil {
+			o.Errorf("check %d: unable to read store %d disk space: %v", tick, i, err)
+			continue
+		}
+		remaining := time.Until(deadline).Truncate(time.Second)
+		o.Status(fmt.Sprintf(
+			"check %d: store %d: %d MiB free, %s remaining",
+			tick, i, curAvailBytes>>20, remaining,
+		))
+		if curAvailBytes < dangerThresholdBytes {
+			o.Status(fmt.Sprintf(
+				"check %d: store %d dropped to %d MiB (below %d MiB danger threshold)",
+				tick, i, curAvailBytes>>20, dangerThresholdBytes>>20,
+			))
+			belowDanger = true
+		}
+	}
+	if belowDanger {
+		o.Status("ending pressure period early — store below danger threshold")
+		return true
+	}
+
+	// Check range availability from the peer node. Uses the same
+	// query as checkZeroUnavailableRanges in dependency.go, but
+	// connects to a specific peer (the target may be under pressure)
+	// and logs the count rather than returning a bool.
+	db, err := c.ConnE(ctx, o.L(), peerNodeID)
+	if err != nil {
+		o.Errorf("check %d: failed to connect to node %d for range check: %v",
+			tick, peerNodeID, err)
+		return false
+	}
+	defer db.Close()
+	var unavail int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COALESCE(sum(unavailable_ranges), 0) FROM system.replication_stats",
+	).Scan(&unavail); err != nil {
+		o.Errorf("check %d: failed to query unavailable ranges: %v", tick, err)
+	} else if unavail > 0 {
+		o.Status(fmt.Sprintf(
+			"check %d: %d unavailable ranges detected during pressure",
+			tick, unavail,
+		))
+	} else {
+		o.Status(fmt.Sprintf("check %d: 0 unavailable ranges", tick))
+	}
+
+	return false
+}
+
+// monitorDiskPressure watches the cluster while a node is under disk
+// pressure. It checks node health, store free space, and range
+// availability at regular intervals for monitorDuration.
+func monitorDiskPressure(
+	ctx context.Context,
+	o operation.Operation,
+	c cluster.Cluster,
+	targetNode option.NodeListOption,
+	storeCount int,
+	peerNodeID int,
+) time.Duration {
+	start := timeutil.Now()
+	deadline := start.Add(monitorDuration)
+	monitorCtx, monitorCancel := context.WithDeadline(ctx, deadline)
+	defer monitorCancel()
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	elapsed := func() time.Duration { return timeutil.Since(start) }
+
+	// Run the first check immediately so we catch fast failures
+	// right after filling (the ticker only fires after the first
+	// interval).
+	tick := 1
+	if runMonitorCheck(monitorCtx, o, c, tick, targetNode,
+		peerNodeID, storeCount, deadline) {
+		return elapsed()
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			if timeutil.Now().After(deadline) {
+				return elapsed()
+			}
+			tick++
+			if runMonitorCheck(monitorCtx, o, c, tick, targetNode,
+				peerNodeID, storeCount, deadline) {
+				return elapsed()
+			}
+		case <-monitorCtx.Done():
+			o.Status("monitor period ended, proceeding to cleanup")
+			return elapsed()
+		}
+	}
+}
+
+func runDiskFill(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) (cleanup registry.OperationCleanup) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Log the panic but do NOT nil out cleanup — if it was
+			// assigned before the panic, the framework should still
+			// run it to remove ballast files and restart the node.
+			o.Errorf("panic during disk fill: %v", r)
+		}
+	}()
+
+	nodes := c.All()
+	if len(nodes) < 2 {
+		o.Status("skipping disk-fill: need at least 2 nodes")
+		return nil
+	}
+
+	liveNodes := helpers.GetLiveNodes(ctx, o, c)
+	if len(liveNodes) < 2 {
+		o.Status(fmt.Sprintf(
+			"skipping disk-fill: need at least 2 live nodes, found %d",
+			len(liveNodes),
+		))
+		return nil
+	}
+
+	rng, _ := randutil.NewPseudoRand()
+	targetNode := liveNodes.SeededRandNode(rng)
+
+	// Determine store count on the target node.
+	db, err := c.ConnE(ctx, o.L(), targetNode[0])
+	if err != nil {
+		o.Fatalf("failed to connect to target node %d: %v", targetNode[0], err)
+	}
+	storeCount := helpers.GetStoreCount(ctx, o, db, targetNode[0])
+	db.Close()
+
+	// Assign cleanup before any destructive action so the ballast
+	// files are always removed — even if a later step panics.
+	cleanup = &cleanupDiskFill{node: targetNode, storeCount: storeCount}
+
+	if !fillStores(ctx, o, c, targetNode, storeCount) {
+		o.Status("no stores filled — cleaning up and returning")
+		removeFillFiles(ctx, o, c, targetNode, storeCount)
+		return nil
+	}
+
+	// Pick a peer node for cluster-level health and range checks.
+	var peerNodeID int
+	for _, n := range liveNodes {
+		if n != targetNode[0] {
+			peerNodeID = n
+			break
+		}
+	}
+
+	elapsed := monitorDiskPressure(ctx, o, c, targetNode, storeCount, peerNodeID)
+
+	o.Status(fmt.Sprintf(
+		"disk pressure period complete on node %d after %s",
+		targetNode[0], elapsed.Truncate(time.Second),
+	))
+
+	return cleanup
+}
+
+func registerDiskFill(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:               "disk-fill/ood",
+		Owner:              registry.OwnerStorage,
+		Timeout:            45 * time.Minute,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCannotRunConcurrently,
+		Dependencies:       []registry.OperationDependency{},
+		Run:                runDiskFill,
+	})
+}

--- a/pkg/cmd/roachtest/operations/helpers/utils.go
+++ b/pkg/cmd/roachtest/operations/helpers/utils.go
@@ -248,3 +248,108 @@ func EnvOrDefaultInt(name string, value int) (int, error) {
 	}
 	return value, nil
 }
+
+// GetLiveNodes queries gossip to discover all live nodes in the
+// cluster. It tries each cluster node until it finds one it can
+// connect to, then reads crdb_internal.gossip_nodes. Returns the list
+// of live node IDs, or nil if none can be determined.
+func GetLiveNodes(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) option.NodeListOption {
+	for _, n := range c.All() {
+		db, err := c.ConnE(ctx, o.L(), n)
+		if err != nil {
+			o.Status(fmt.Sprintf("GetLiveNodes: connect to node %d failed: %v", n, err))
+			continue
+		}
+		rows, err := db.QueryContext(ctx,
+			"SELECT node_id FROM crdb_internal.gossip_nodes WHERE is_live = true")
+		if err != nil {
+			o.Status(fmt.Sprintf("GetLiveNodes: gossip query on node %d failed: %v", n, err))
+			db.Close()
+			continue
+		}
+		var liveNodes option.NodeListOption
+		for rows.Next() {
+			var nid int
+			if err := rows.Scan(&nid); err != nil {
+				break
+			}
+			liveNodes = append(liveNodes, nid)
+		}
+		rows.Close()
+		db.Close()
+		return liveNodes
+	}
+	return nil
+}
+
+// GetStoreCount returns the number of stores on the given node by
+// querying crdb_internal.kv_store_status.
+func GetStoreCount(ctx context.Context, o operation.Operation, conn *gosql.DB, nodeID int) int {
+	var count int
+	err := conn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT count(*) FROM crdb_internal.kv_store_status WHERE node_id = %d", nodeID),
+	).Scan(&count)
+	if err != nil {
+		o.Fatalf("failed to get store count for node %d: %v", nodeID, err)
+	}
+	if count == 0 {
+		o.Fatalf("unexpected zero stores found on node %d", nodeID)
+	}
+	return count
+}
+
+// CheckNodeHealth verifies that a node is responsive by opening a SQL
+// connection and executing SELECT 1. It retries up to maxAttempts
+// times with retryDelay between attempts. Returns true on the first
+// successful response, or false if all attempts fail or the context
+// is cancelled.
+//
+// This is intentionally different from roachtestutil.WaitForSQLReady:
+// WaitForSQLReady requires an already-established *gosql.DB and waits
+// for full SQL subsystem initialization. CheckNodeHealth needs to
+// detect nodes that are completely unreachable (e.g. crashed under
+// disk pressure), where even opening a connection will fail.
+func CheckNodeHealth(
+	ctx context.Context,
+	o operation.Operation,
+	c cluster.Cluster,
+	nodeID int,
+	maxAttempts int,
+	retryDelay time.Duration,
+) bool {
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		db, err := c.ConnE(ctx, o.L(), nodeID)
+		if err != nil {
+			o.Status(fmt.Sprintf(
+				"node %d connection attempt %d/%d failed: %v", nodeID, attempt, maxAttempts, err,
+			))
+			if attempt < maxAttempts {
+				select {
+				case <-time.After(retryDelay):
+				case <-ctx.Done():
+					return false
+				}
+			}
+			continue
+		}
+		_, err = db.ExecContext(ctx, "SELECT 1")
+		db.Close()
+		if err != nil {
+			o.Status(fmt.Sprintf(
+				"node %d health check %d/%d failed: %v", nodeID, attempt, maxAttempts, err,
+			))
+			if attempt < maxAttempts {
+				select {
+				case <-time.After(retryDelay):
+				case <-ctx.Done():
+					return false
+				}
+			}
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -33,6 +33,7 @@ func RegisterOperations(r registry.Registry) {
 	registerLicenseThrottle(r)
 	registerSessionVariables(r)
 	registerDebugZip(r)
+	registerDiskFill(r)
 	changefeeds.RegisterChangefeeds(r)
 	registerInspect(r)
 }

--- a/pkg/cmd/roachtest/roachtestutil/disk_usage.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_usage.go
@@ -128,6 +128,29 @@ func NewDiskUsageTracker(
 	return &DiskUsageTracker{c: c, l: diskLogger}, nil
 }
 
+// GetDiskAvailInBytes returns the available (free) disk space in bytes
+// for the given store on the specified node. nodeIdx and storeIdx are
+// both 1-based.
+func GetDiskAvailInBytes(
+	ctx context.Context, c cluster.Cluster, logger *logger.Logger, nodeIdx int, storeIdx int,
+) (int64, error) {
+	result, err := c.RunWithDetailsSingleNode(
+		ctx, logger, option.WithNodes(c.Node(nodeIdx)),
+		fmt.Sprintf(
+			"df --output=avail {store-dir:%d} | tail -1 | tr -d ' '",
+			storeIdx,
+		),
+	)
+	if err != nil {
+		return 0, err
+	}
+	kb, err := strconv.ParseInt(strings.TrimSpace(result.Stdout), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return kb * 1024, nil
+}
+
 // GetDiskUsageInBytes executes the command `du {store-dir}` on node `nodeIdx` and
 // parses the result to bytes. nodeIdx starts at one.
 func GetDiskUsageInBytes(

--- a/pkg/cmd/roachtest/roachtestutil/operations/dependency.go
+++ b/pkg/cmd/roachtest/roachtestutil/operations/dependency.go
@@ -97,7 +97,7 @@ func checkZeroUnavailableRanges(
 	conn := c.Conn(ctx, l, 1, option.VirtualClusterName("system"))
 	defer conn.Close()
 
-	rangesCur, err := conn.QueryContext(ctx, "SELECT sum(unavailable_ranges) FROM system.replication_stats")
+	rangesCur, err := conn.QueryContext(ctx, "SELECT COALESCE(sum(unavailable_ranges), 0) FROM system.replication_stats")
 	if err != nil {
 		return false, err
 	}
@@ -117,7 +117,7 @@ func checkZeroUnderreplicatedRanges(
 	conn := c.Conn(ctx, l, 1, option.VirtualClusterName("system"))
 	defer conn.Close()
 
-	rangesCur, err := conn.QueryContext(ctx, "SELECT sum(under_replicated_ranges) FROM system.replication_stats")
+	rangesCur, err := conn.QueryContext(ctx, "SELECT COALESCE(sum(under_replicated_ranges), 0) FROM system.replication_stats")
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Adds a new disk-fill/ood roachtest operation that simulates out-of-disk conditions on a live cluster node:                                                                                                 

  - Picks a random live node via gossip and fills its disk using fallocate, leaving 3 GiB free as a safety reserve.
  - Monitors the node under disk pressure for 15 minutes, checking both the target and a peer node for health every 2 minutes.
  - Exits early if free space drops below a 2 GiB danger threshold to avoid unintended node crashes.
  - Cleanup removes the ballast file and verifies node health, restarting if necessary.
  
 


Epic: None
Release Note: None
Fixes: None