### PR TITLE
release-26.1: roachtest: restrict inspect scale test to GCE

### DIFF
--- a/pkg/cmd/roachtest/tests/inspect_throughput.go
+++ b/pkg/cmd/roachtest/tests/inspect_throughput.go
@@ -85,7 +85,7 @@ func makeInspectThroughputTest(
 		Owner:               registry.OwnerSQLFoundations,
 		Benchmark:           true,
 		Cluster:             r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.CPU(numCPUs)),
-		CompatibleClouds:    registry.AllExceptAWS,
+		CompatibleClouds:    registry.OnlyGCE,
 		Suites:              registry.Suites(registry.Nightly),
 		Leases:              registry.LeaderLeases,
 		Timeout:             length,


### PR DESCRIPTION
Backport 1/1 commits from #165368.

/cc @cockroachdb/release

---

Azure tends to experience more infrastructure flakes and appears more susceptible to tests that drive high machine utilization. The inspect scale test is resource intensive. We are restricting that tests so it only runs on GCE.

Epic: None
Release note: none

Closes #165005

Release justification: test only fix
