### PR TITLE
roachtest: disable runtime assertions for ruby-pg test

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -266,11 +266,14 @@ func registerRubyPG(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "ruby-pg",
-		Timeout:          1 * time.Hour,
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
-		Leases:           registry.MetamorphicLeases,
+		Name:    "ruby-pg",
+		Timeout: 1 * time.Hour,
+		Owner:   registry.OwnerSQLFoundations,
+		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
+		// Never run with runtime assertions as the overhead can delay
+		// sqlliveness heartbeats enough to cause session expiration errors.
+		CockroachBinary:  registry.StandardCockroach,
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.Driver),


### PR DESCRIPTION
The ruby-pg roachtest fails intermittently with "liveness session expired before transaction" errors exclusively when runtime assertions are enabled. The assertions overhead delays sqlliveness heartbeats enough that the session expiration drifts close to the current time (19-29ms margin), causing descriptor lease deadline checks to fail.

Resolves: #163431

Release note: None