### PR TITLE
ui: migrate health check polling from Redux to SWR

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -202,6 +202,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.Indexes = util.CombineUnique(s.Indexes, other.Indexes)
 	s.ExecStats.Add(other.ExecStats)
 	s.LatencyInfo.MergeMaxMin(other.LatencyInfo)
+	s.CanaryStatsInfo.Add(other.CanaryStatsInfo)
 
 	if s.SensitiveInfo.MostRecentPlanTimestamp.Before(other.SensitiveInfo.MostRecentPlanTimestamp) {
 		s.SensitiveInfo = other.SensitiveInfo
@@ -294,4 +295,14 @@ func (s *LatencyInfo) MergeMaxMin(other LatencyInfo) {
 	if other.Max > s.Max {
 		s.Max = other.Max
 	}
+}
+
+// Add combines other into this CanaryStatsInfo
+func (c *CanaryStatsInfo) Add(other CanaryStatsInfo) {
+	currentCount := c.Count
+	c.Count += other.Count
+	c.PlanLat.Add(other.PlanLat, currentCount, other.Count)
+	c.ParseLat.Add(other.ParseLat, currentCount, other.Count)
+	c.RunLat.Add(other.RunLat, currentCount, other.Count)
+	c.ServiceLat.Add(other.ServiceLat, currentCount, other.Count)
 }

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -147,6 +147,11 @@ message StatementStatistics {
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 38 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 
+  // canary_stats_info contains stats for statements executed with canary
+  // stats. Non-canary stats can be derived from the overall stats minus the
+  // canary stats.
+  optional CanaryStatsInfo canary_stats_info = 39 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;
@@ -200,6 +205,23 @@ message TransactionStatistics {
   optional NumericStat kv_cpu_time_nanos = 12 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 }
 
+// CanaryStatsInfo contains the subset of statistics that are used to differentiate
+// between statements executed with and without canary stats.
+message CanaryStatsInfo {
+  optional int64 count = 1 [(gogoproto.nullable) = false];
+
+  // ParseLat is the time in seconds to transform the SQL string into an AST.
+  optional NumericStat parse_lat = 2 [(gogoproto.nullable) = false];
+
+  // PlanLat is the time spent in seconds to transform the AST into a logical query plan.
+  optional NumericStat plan_lat = 3 [(gogoproto.nullable) = false];
+
+  // RunLat is the time in seconds to run the query and fetch/compute the result rows.
+  optional NumericStat run_lat = 4 [(gogoproto.nullable) = false];
+
+  // ServiceLat is the time in seconds to service the query, from start of parse to end of execute.
+  optional NumericStat service_lat = 5 [(gogoproto.nullable) = false];
+}
 
 message SensitiveInfo {
   option (gogoproto.equal) = true;

--- a/pkg/sql/appstatspb/app_stats_test.go
+++ b/pkg/sql/appstatspb/app_stats_test.go
@@ -79,6 +79,49 @@ func TestAddNumericStats(t *testing.T) {
 	}
 }
 
+func TestAddCanaryStatsInfo(t *testing.T) {
+	numericStatA := NumericStat{Mean: 0.5, SquaredDiffs: 0.1}
+	numericStatB := NumericStat{Mean: 1.5, SquaredDiffs: 0.3}
+
+	a := CanaryStatsInfo{
+		Count:      3,
+		PlanLat:    numericStatA,
+		ParseLat:   numericStatA,
+		RunLat:     numericStatA,
+		ServiceLat: numericStatA,
+	}
+	b := CanaryStatsInfo{
+		Count:      2,
+		PlanLat:    numericStatB,
+		ParseLat:   numericStatB,
+		RunLat:     numericStatB,
+		ServiceLat: numericStatB,
+	}
+
+	expectedPlanLat := AddNumericStats(a.PlanLat, b.PlanLat, a.Count, b.Count)
+	expectedParseLat := AddNumericStats(a.ParseLat, b.ParseLat, a.Count, b.Count)
+	expectedRunLat := AddNumericStats(a.RunLat, b.RunLat, a.Count, b.Count)
+	expectedServiceLat := AddNumericStats(a.ServiceLat, b.ServiceLat, a.Count, b.Count)
+
+	a.Add(b)
+
+	require.Equal(t, int64(5), a.Count)
+	epsilon := 0.00000001
+	require.True(t, expectedPlanLat.AlmostEqual(a.PlanLat, epsilon),
+		"expected PlanLat %+v, but found %+v", expectedPlanLat, a.PlanLat)
+	require.True(t, expectedParseLat.AlmostEqual(a.ParseLat, epsilon),
+		"expected ParseLat %+v, but found %+v", expectedParseLat, a.ParseLat)
+	require.True(t, expectedRunLat.AlmostEqual(a.RunLat, epsilon),
+		"expected RunLat %+v, but found %+v", expectedRunLat, a.RunLat)
+	require.True(t, expectedServiceLat.AlmostEqual(a.ServiceLat, epsilon),
+		"expected ServiceLat %+v, but found %+v", expectedServiceLat, a.ServiceLat)
+
+	// Verify adding zero-count CanaryStatsInfo is a no-op on counts.
+	before := a
+	a.Add(CanaryStatsInfo{})
+	require.Equal(t, before.Count, a.Count)
+}
+
 func TestAddExecStats(t *testing.T) {
 	numericStatA := NumericStat{Mean: 354.123, SquaredDiffs: 34.34123}
 	numericStatB := NumericStat{Mean: 9.34354, SquaredDiffs: 75.321}

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -233,6 +233,10 @@ func (ex *connExecutor) recordStatementSummary(
 			b.AppliedStatementHints()
 		}
 
+		if ex.planner.EvalContext().UseCanaryStats {
+			b.UsedCanaryStats()
+		}
+
 		ex.statsCollector.RecordStatement(ctx, b.Build())
 	}
 

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -386,6 +386,9 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 						log.Dev.Error(ctx, "No stats collector exists on the planner, cannot record statement stats")
 						return
 					}
+					if g.p.ExtendedEvalContext().UseCanaryStats {
+						statsBuilder.UsedCanaryStats()
+					}
 					stmtStats := statsBuilder.
 						SessionID(g.p.ExtendedEvalContext().SessionID).
 						QueryID(g.p.execCfg.GenerateID()).

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -112,7 +112,26 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "max": {{.Float}}
          },
          "lastErrorCode": "{{.String}}",
-				 "sqlType": "{{.String}}" 
+				 "sqlType": "{{.String}}",
+         "canaryStatsInfo": {
+           "count": {{.Int64}},
+           "parseLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           },
+           "planLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           },
+           "runLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           },
+           "svcLat": {
+             "mean": {{.Float}},
+             "sqDiff": {{.Float}}
+           }
+         }
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -47,6 +47,7 @@ var (
 	_ jsonMarshaler = (*int64Array)(nil)
 	_ jsonMarshaler = (*int32Array)(nil)
 	_ jsonMarshaler = &latencyInfo{}
+	_ jsonMarshaler = &canaryStatsInfo{}
 )
 
 type txnStats appstatspb.TransactionStatistics
@@ -349,6 +350,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"genericCount", (*jsonInt)(&s.GenericCount)},
 		{"stmtHintsCount", (*jsonInt)(&s.StmtHintsCount)},
 		{"sqlType", (*jsonString)(&s.SQLType)},
+		{"canaryStatsInfo", (*canaryStatsInfo)(&s.CanaryStatsInfo)},
 	}
 }
 
@@ -444,6 +446,24 @@ func (l *latencyInfo) decodeJSON(js json.JSON) error {
 
 func (l *latencyInfo) encodeJSON() (json.JSON, error) {
 	return l.jsonFields().encodeJSON()
+}
+
+type canaryStatsInfo appstatspb.CanaryStatsInfo
+
+func (c *canaryStatsInfo) jsonFields() jsonFields {
+	return jsonFields{
+		{"count", (*jsonInt)(&c.Count)},
+		{"parseLat", (*numericStats)(&c.ParseLat)},
+		{"planLat", (*numericStats)(&c.PlanLat)},
+		{"runLat", (*numericStats)(&c.RunLat)},
+		{"svcLat", (*numericStats)(&c.ServiceLat)},
+	}
+}
+func (c *canaryStatsInfo) decodeJSON(js json.JSON) error {
+	return c.jsonFields().decodeJSON(js)
+}
+func (c *canaryStatsInfo) encodeJSON() (json.JSON, error) {
+	return c.jsonFields().encodeJSON()
 }
 
 type jsonFields []jsonField

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -119,6 +119,15 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 	}
 	stats.mu.data.LatencyInfo.MergeMaxMin(latencyInfo)
 
+	if value.UsedCanaryStats {
+		canaryStats := &stats.mu.data.CanaryStatsInfo
+		canaryStats.Count++
+		canaryStats.ServiceLat.Record(canaryStats.Count, value.ServiceLatencySec)
+		canaryStats.ParseLat.Record(canaryStats.Count, value.ParseLatencySec)
+		canaryStats.RunLat.Record(canaryStats.Count, value.RunLatencySec)
+		canaryStats.PlanLat.Record(canaryStats.Count, value.PlanLatencySec)
+	}
+
 	// Note that some fields derived from tracing statements (such as
 	// BytesSentOverNetwork) are not updated here because they are collected
 	// on-demand.

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -287,6 +287,71 @@ func verifyTxnStatsReduced(
 	require.InEpsilon(t, float64(txnStats.KVCPUTimeNanos.Nanoseconds())/cnt, destTxnStats.mu.data.KVCPUTimeNanos.Mean, epsilon)
 }
 
+// TestRecordStatementCanaryStats verifies that canary stats are only recorded
+// into CanaryStatsInfo when UsedCanaryStats is true, and that non-canary
+// statements do not affect CanaryStatsInfo.
+func TestRecordStatementCanaryStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	settings := cluster.MakeTestingClusterSettings()
+
+	container := New(settings,
+		nil, /* uniqueServerCount */
+		testMonitor(ctx, "test-mon", settings),
+		"test-app",
+		nil,
+	)
+
+	// Record a non-canary statement — should not affect CanaryStatsInfo.
+	require.NoError(t, container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:     1,
+		Query:             "SELECT 1",
+		ServiceLatencySec: 0.1,
+		ParseLatencySec:   0.01,
+		PlanLatencySec:    0.02,
+		RunLatencySec:     0.03,
+		UsedCanaryStats:   false,
+	}))
+
+	// Record a canary statement with the same fingerprint.
+	require.NoError(t, container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:     1,
+		Query:             "SELECT 1",
+		ServiceLatencySec: 0.5,
+		ParseLatencySec:   0.05,
+		PlanLatencySec:    0.06,
+		RunLatencySec:     0.07,
+		UsedCanaryStats:   true,
+	}))
+
+	// Record another non-canary statement.
+	require.NoError(t, container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:     1,
+		Query:             "SELECT 1",
+		ServiceLatencySec: 0.2,
+		ParseLatencySec:   0.02,
+		PlanLatencySec:    0.03,
+		RunLatencySec:     0.04,
+		UsedCanaryStats:   false,
+	}))
+
+	stats := container.getStatsForStmtWithKey(stmtKey{fingerprintID: 1})
+	require.NotNil(t, stats)
+
+	// CanaryStatsInfo should only contain the single canary recording.
+	require.Equal(t, int64(1), stats.mu.data.CanaryStatsInfo.Count)
+	require.InEpsilon(t, 0.5, stats.mu.data.CanaryStatsInfo.ServiceLat.Mean, epsilon)
+	require.InEpsilon(t, 0.05, stats.mu.data.CanaryStatsInfo.ParseLat.Mean, epsilon)
+	require.InEpsilon(t, 0.06, stats.mu.data.CanaryStatsInfo.PlanLat.Mean, epsilon)
+	require.InEpsilon(t, 0.07, stats.mu.data.CanaryStatsInfo.RunLat.Mean, epsilon)
+
+	// The overall stats should reflect all 3 recordings (both canary and
+	// non-canary). Non-canary latencies can be derived from overall minus
+	// canary when needed.
+	require.Equal(t, int64(3), stats.mu.data.Count)
+}
+
 func testMonitor(
 	ctx context.Context, name redact.SafeString, settings *cluster.Settings,
 ) *mon.BytesMonitor {

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -101,6 +101,7 @@ type RecordedStmtStats struct {
 	Indexes                  []string
 	QueryTags                []sqlcommenter.QueryTag
 	UnderOuterTxn            bool
+	UsedCanaryStats          bool
 }
 
 var recordedStmtStatsSize = int64(unsafe.Sizeof(RecordedStmtStats{}))
@@ -410,6 +411,14 @@ func (b *RecordedStatementStatsBuilder) AppliedStatementHints() *RecordedStateme
 		return b
 	}
 	b.stmtStats.AppliedStmtHints = true
+	return b
+}
+
+func (b *RecordedStatementStatsBuilder) UsedCanaryStats() *RecordedStatementStatsBuilder {
+	if b == nil {
+		return b
+	}
+	b.stmtStats.UsedCanaryStats = true
 	return b
 }
 

--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -33,11 +33,11 @@ overrides:
   '@cockroachlabs/cluster-ui>yargs-parser': 13.1.2
   analytics-node>axios-retry: 3.1.9
 
-packageExtensionsChecksum: sha256-02fFnGGwSjfYK/rXie5PGkAvEEzXSPuaxyYtaA0W/7E=
+packageExtensionsChecksum: f03a6ac29a2e646ae57bda3f9fc03971
 
 patchedDependencies:
   topojson@3.0.2:
-    hash: be4a1a6184740cb5b3e06c729ecbea528e2f1a80d531f66c1e4c07553c3f6ced
+    hash: wpfs36vhb2v7nm6ekzrirgbci4
     path: patches/topojson@3.0.2.patch
 
 importers:
@@ -732,6 +732,10 @@ importers:
       whatwg-fetch:
         specifier: ^2.0.3
         version: 2.0.3
+    optionalDependencies:
+      timers-browserify:
+        specifier: ^2.0.12
+        version: 2.0.12
     devDependencies:
       '@babel/core':
         specifier: ^7.7.7
@@ -1083,7 +1087,7 @@ importers:
         version: 0.0.33
       topojson:
         specifier: ^3.0.2
-        version: 3.0.2(patch_hash=be4a1a6184740cb5b3e06c729ecbea528e2f1a80d531f66c1e4c07553c3f6ced)
+        version: 3.0.2(patch_hash=wpfs36vhb2v7nm6ekzrirgbci4)
       ts-jest:
         specifier: 27.1.3
         version: 27.1.3(@babel/core@7.8.3)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.8.3))(esbuild@0.14.43)(jest@27.5.1(@babel/runtime@7.12.13))(typescript@5.1.6)
@@ -1120,10 +1124,6 @@ importers:
       world-atlas:
         specifier: ^1.1.4
         version: 1.1.4
-    optionalDependencies:
-      timers-browserify:
-        specifier: ^2.0.12
-        version: 2.0.12
 
   workspaces/db-console/ccl/src/js:
     dependencies:
@@ -2690,42 +2690,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.4':
     resolution: {integrity: sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.4':
     resolution: {integrity: sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.4':
     resolution: {integrity: sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.4':
     resolution: {integrity: sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.4':
     resolution: {integrity: sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.4':
     resolution: {integrity: sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==}
@@ -10524,56 +10518,48 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-arm@1.97.3:
     resolution: {integrity: sha512-2lPQ7HQQg4CKsH18FTsj2hbw5GJa6sBQgDsls+cV7buXlHjqF8iTKhAQViT6nrpLK/e8nFCoaRgSqEC8xMnXuA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.97.3:
     resolution: {integrity: sha512-Lij0SdZCsr+mNRSyDZ7XtJpXEITrYsaGbOTz5e6uFLJ9bmzUbV7M8BXz2/cA7bhfpRPT7/lwRKPdV4+aR9Ozcw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-arm@1.97.3:
     resolution: {integrity: sha512-cBTMU68X2opBpoYsSZnI321gnoaiMBEtc+60CKCclN6PCL3W3uXm8g4TLoil1hDD6mqU9YYNlVG6sJ+ZNef6Lg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.97.3:
     resolution: {integrity: sha512-sBeLFIzMGshR4WmHAD4oIM7WJVkSoCIEwutzptFtGlSlwfNiijULp+J5hA2KteGvI6Gji35apR5aWj66wEn/iA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-x64@1.97.3:
     resolution: {integrity: sha512-/oWJ+OVrDg7ADDQxRLC/4g1+Nsz1g4mkYS2t6XmyMJKFTFK50FVI2t5sOdFH+zmMp+nXHKM036W94y9m4jjEcw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-riscv64@1.97.3:
     resolution: {integrity: sha512-l3IfySApLVYdNx0Kjm7Zehte1CDPZVcldma3dZt+TfzvlAEerM6YDgsk5XEj3L8eHBCgHgF4A0MJspHEo2WNfA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-x64@1.97.3:
     resolution: {integrity: sha512-Kwqwc/jSSlcpRjULAOVbndqEy2GBzo6OBmmuBVINWUaJLJ8Kczz3vIsDUWLfWz/kTEw9FHBSiL0WCtYLVAXSLg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-unknown-all@1.97.3:
     resolution: {integrity: sha512-/GHajyYJmvb0IABUQHbVHf1nuHPtIDo/ClMZ81IDr59wT5CNcMe7/dMNujXwWugtQVGI5UGmqXWZQCeoGnct8Q==}
@@ -12447,7 +12433,7 @@ snapshots:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.20
@@ -12471,7 +12457,7 @@ snapshots:
       '@babel/types': 7.22.5
       '@nicolo-ribaudo/semver-v6': 6.3.3
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
     transitivePeerDependencies:
@@ -12487,7 +12473,7 @@ snapshots:
       '@babel/traverse': 7.22.6
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.20
@@ -12508,7 +12494,7 @@ snapshots:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.20
@@ -12640,7 +12626,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.8
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -12654,7 +12640,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.8
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.1
@@ -12666,7 +12652,7 @@ snapshots:
       '@babel/core': 7.22.8
       '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.22.8)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -12677,7 +12663,7 @@ snapshots:
       '@babel/core': 7.8.3
       '@babel/helper-compilation-targets': 7.22.6(@babel/core@7.8.3)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -14849,7 +14835,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14864,7 +14850,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -15142,7 +15128,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 7.3.1
       globals: 13.20.0
       ignore: 4.0.6
@@ -15156,7 +15142,7 @@ snapshots:
   '@eslint/eslintrc@1.4.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.0
       globals: 13.20.0
       ignore: 5.2.4
@@ -15170,7 +15156,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -15190,7 +15176,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15198,7 +15184,7 @@ snapshots:
   '@humanwhocodes/config-array@0.9.5':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15567,7 +15553,7 @@ snapshots:
       webpack: 4.46.0(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.33
-      sockjs-client: 1.4.0(supports-color@6.1.0)
+      sockjs-client: 1.4.0
       webpack-dev-server: 3.10.1(webpack-cli@5.1.4)(webpack@5.103.0)
       webpack-hot-middleware: 2.25.4
 
@@ -15583,7 +15569,7 @@ snapshots:
       webpack: 4.46.0(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.33
-      sockjs-client: 1.4.0(supports-color@6.1.0)
+      sockjs-client: 1.4.0
       webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.103.0)
       webpack-hot-middleware: 2.25.4
 
@@ -16370,7 +16356,7 @@ snapshots:
 
   '@storybook/react-docgen-typescript-plugin@1.0.2-canary.3c70e01.0(typescript@5.1.6)(webpack@4.46.0(webpack-cli@5.1.4))':
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
@@ -17142,7 +17128,7 @@ snapshots:
       '@typescript-eslint/experimental-utils': 4.29.1(eslint@7.29.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 2.34.0(eslint@7.29.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 4.29.1
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.29.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
@@ -17160,7 +17146,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -17213,7 +17199,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.0.0
       '@typescript-eslint/types': 5.0.0
       '@typescript-eslint/typescript-estree': 5.0.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.16.0
     optionalDependencies:
       typescript: 5.1.6
@@ -17225,7 +17211,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.1.6
@@ -17238,7 +17224,7 @@ snapshots:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.1.6
@@ -17274,7 +17260,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.1.6)
     optionalDependencies:
@@ -17294,7 +17280,7 @@ snapshots:
 
   '@typescript-eslint/typescript-estree@2.34.0(typescript@5.1.6)':
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -17310,7 +17296,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 4.29.1
       '@typescript-eslint/visitor-keys': 4.29.1
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17324,7 +17310,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.0.0
       '@typescript-eslint/visitor-keys': 5.0.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17338,7 +17324,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.26.0
       '@typescript-eslint/visitor-keys': 5.26.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17352,7 +17338,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -17366,7 +17352,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/visitor-keys': 6.7.0
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -17431,7 +17417,7 @@ snapshots:
 
   '@typescript/vfs@1.5.0':
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17690,7 +17676,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19647,6 +19633,7 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 6.1.0
+    optional: true
 
   debug@3.2.7(supports-color@8.1.1):
     dependencies:
@@ -19800,7 +19787,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20418,7 +20405,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@6.1.0)
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -20426,7 +20413,7 @@ snapshots:
 
   eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
-      debug: 3.2.7(supports-color@6.1.0)
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.1.6)
       eslint: 8.57.0
@@ -20440,7 +20427,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@6.1.0)
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -20576,7 +20563,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -20620,7 +20607,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
@@ -20666,7 +20653,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -21060,7 +21047,7 @@ snapshots:
     dependencies:
       babel-runtime: 6.26.0
       core-js: 3.31.1
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
@@ -21896,7 +21883,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21953,7 +21940,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22427,7 +22414,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -26432,6 +26419,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  sockjs-client@1.4.0:
+    dependencies:
+      debug: 3.2.7(supports-color@8.1.1)
+      eventsource: 1.1.2
+      faye-websocket: 0.11.4
+      inherits: 2.0.4
+      json3: 3.3.3
+      url-parse: 1.5.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   sockjs-client@1.4.0(supports-color@6.1.0):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
@@ -26520,7 +26519,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -26543,7 +26542,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@10.2.2)
+      debug: 4.3.4(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -27121,7 +27120,7 @@ snapshots:
       commander: 2.20.3
       topojson-client: 3.0.0
 
-  topojson@3.0.2(patch_hash=be4a1a6184740cb5b3e06c729ecbea528e2f1a80d531f66c1e4c07553c3f6ced):
+  topojson@3.0.2(patch_hash=wpfs36vhb2v7nm6ekzrirgbci4):
     dependencies:
       topojson-client: 3.0.0
       topojson-server: 3.0.0
@@ -27873,7 +27872,7 @@ snapshots:
 
   webpack-virtual-modules@0.2.2:
     dependencies:
-      debug: 3.2.7(supports-color@6.1.0)
+      debug: 3.2.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/healthApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/healthApi.ts
@@ -1,0 +1,30 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { fetchData } from "src/api";
+
+import { useSwrWithClusterId } from "../util";
+
+const HEALTH_PATH = "_admin/v1/health";
+const HEALTH_SWR_KEY = "health";
+
+const getHealth = (): Promise<cockroach.server.serverpb.HealthResponse> => {
+  return fetchData(cockroach.server.serverpb.HealthResponse, HEALTH_PATH);
+};
+
+export const useHealth = () => {
+  const { data, error, isLoading } = useSwrWithClusterId(
+    HEALTH_SWR_KEY,
+    getHealth,
+    {
+      refreshInterval: 2_000,
+      revalidateOnFocus: false,
+      dedupingInterval: 2_000,
+    },
+  );
+  return { data, error, isLoading };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -24,3 +24,4 @@ export * from "./eventsApi";
 export * from "./types";
 export * from "./jobProfilerApi";
 export * from "./txnInsightDetailsApi";
+export * from "./healthApi";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -44,6 +44,7 @@ export * from "./tracez";
 export { util, api };
 export { useNodes } from "./api/nodesApi";
 export { useNodesSummary } from "./api/nodesSummaryApi";
+export { useHealth } from "./api/healthApi";
 export type { NodesSummary } from "./api/nodesSummaryApi";
 export * from "./sessions";
 export * from "./timeScaleDropdown";

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -14,6 +14,7 @@ export type StatementStatistics = cockroach.sql.IStatementStatistics;
 export type ExecStats = cockroach.sql.IExecStats;
 export type CollectedStatementStatistics =
   cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
+export type CanaryStatsInfo = cockroach.sql.ICanaryStatsInfo;
 
 export interface NumericStat {
   mean?: number;
@@ -162,6 +163,32 @@ export function addExecStats(a: ExecStats, b: ExecStats): ExecStats {
   };
 }
 
+export function addCanaryStatsInfo(
+  a: CanaryStatsInfo,
+  b: CanaryStatsInfo,
+): CanaryStatsInfo {
+  let countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  if (countA === 0 && countB === 0) {
+    // If both counts are zero, artificially set the one count to one to avoid
+    // division by zero when calculating the mean in addNumericStats.
+    countA = 1;
+  }
+
+  return {
+    count: a.count.add(b.count),
+    parse_lat: aggregateNumericStats(a.parse_lat, b.parse_lat, countA, countB),
+    plan_lat: aggregateNumericStats(a.plan_lat, b.plan_lat, countA, countB),
+    run_lat: aggregateNumericStats(a.run_lat, b.run_lat, countA, countB),
+    service_lat: aggregateNumericStats(
+      a.service_lat,
+      b.service_lat,
+      countA,
+      countB,
+    ),
+  };
+}
+
 export function addStatementStats(
   a: StatementStatistics,
   b: StatementStatistics,
@@ -270,6 +297,10 @@ export function addStatementStats(
     indexes: indexes,
     latency_info: aggregateLatencyInfo(a, b),
     last_error_code: "",
+    canary_stats_info: addCanaryStatsInfo(
+      a.canary_stats_info,
+      b.canary_stats_info,
+    ),
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
@@ -21,8 +21,6 @@ import {
   staggeredVersionDismissedSetting,
   newVersionNotificationSelector,
   newVersionDismissedLocalSetting,
-  disconnectedAlertSelector,
-  disconnectedDismissedLocalSetting,
   emailSubscriptionAlertLocalSetting,
   emailSubscriptionAlertSelector,
   clusterPreserveDowngradeOptionDismissedSetting,
@@ -33,7 +31,6 @@ import {
   versionReducerObj,
   nodesReducerObj,
   clusterReducerObj,
-  healthReducerObj,
   settingsReducerObj,
 } from "./apiReducers";
 import { loginSuccess } from "./login";
@@ -400,55 +397,6 @@ describe("alerts", function () {
       });
     });
 
-    describe("disconnected alert", function () {
-      it("requires health to be available before displaying", function () {
-        const alert = disconnectedAlertSelector(state());
-        expect(alert).toBeUndefined();
-      });
-
-      it("does not display when cluster is healthy", function () {
-        dispatch(
-          healthReducerObj.receiveData(
-            new protos.cockroach.server.serverpb.ClusterResponse({}),
-          ),
-        );
-        const alert = disconnectedAlertSelector(state());
-        expect(alert).toBeUndefined();
-      });
-
-      it("displays when cluster health endpoint returns an error", function () {
-        dispatch(healthReducerObj.errorData(new Error("error")));
-        const alert = disconnectedAlertSelector(state());
-        expect(typeof alert).toBe("object");
-        expect(alert.level).toEqual(AlertLevel.CRITICAL);
-        expect(alert.title).toEqual(
-          "We're currently having some trouble fetching updated data. If this persists, it might be a good idea to check your network connection to the CockroachDB cluster.",
-        );
-      });
-
-      it("does not display if dismissed locally", function () {
-        dispatch(healthReducerObj.errorData(new Error("error")));
-        dispatch(disconnectedDismissedLocalSetting.set(moment()));
-        const alert = disconnectedAlertSelector(state());
-        expect(alert).toBeUndefined();
-      });
-
-      it("dismisses by setting local dismissal", function (done) {
-        dispatch(healthReducerObj.errorData(new Error("error")));
-        const alert = disconnectedAlertSelector(state());
-        const beforeDismiss = moment();
-
-        alert.dismiss(dispatch, state).then(() => {
-          expect(
-            disconnectedDismissedLocalSetting
-              .selector(state())
-              .isSameOrAfter(beforeDismiss),
-          ).toBe(true);
-          done();
-        });
-      });
-    });
-
     describe("email signup for release notes alert", () => {
       it("initialized with default 'false' (hidden) state", () => {
         const settingState =
@@ -543,7 +491,6 @@ describe("alerts", function () {
       expect(state().cachedData.cluster.inFlight).toBe(true);
       expect(state().cachedData.nodes.inFlight).toBe(true);
       expect(state().cachedData.version.inFlight).toBe(false);
-      expect(state().cachedData.health.inFlight).toBe(true);
     });
 
     it("dispatches request for version data when cluster ID and nodes are available", function () {
@@ -595,17 +542,6 @@ describe("alerts", function () {
       expect(state().cachedData.version.inFlight).toBe(false);
     });
 
-    it("refreshes health function whenever the last health response is no longer valid.", function () {
-      dispatch(
-        healthReducerObj.receiveData(
-          new protos.cockroach.server.serverpb.ClusterResponse({}),
-        ),
-      );
-      dispatch(healthReducerObj.invalidateData());
-      sync();
-      expect(state().cachedData.health.inFlight).toBe(true);
-    });
-
     it("does not do anything when all data is available.", function () {
       dispatch(
         nodesReducerObj.receiveData([
@@ -629,11 +565,6 @@ describe("alerts", function () {
         versionReducerObj.receiveData({
           details: [],
         }),
-      );
-      dispatch(
-        healthReducerObj.receiveData(
-          new protos.cockroach.server.serverpb.ClusterResponse({}),
-        ),
       );
       dispatch(
         settingsReducerObj.receiveData(

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -32,7 +32,6 @@ import {
   refreshCluster,
   refreshNodes,
   refreshVersion,
-  refreshHealth,
   refreshSettings,
 } from "./apiReducers";
 import {
@@ -265,41 +264,6 @@ export const newVersionNotificationSelector = createSelector(
             value: dismissedAt.valueOf(),
           }),
         );
-      },
-    };
-  },
-);
-
-export const disconnectedDismissedLocalSetting = new LocalSetting(
-  "disconnected_dismissed",
-  localSettingsSelector,
-  moment(0),
-);
-
-/**
- * Notification when the Admin UI is disconnected from the cluster.
- */
-export const disconnectedAlertSelector = createSelector(
-  (state: AdminUIState) => state.cachedData.health,
-  disconnectedDismissedLocalSetting.selector,
-  (health, disconnectedDismissed): Alert => {
-    if (!health || !health.lastError) {
-      return undefined;
-    }
-
-    // Allow local dismissal for one minute.
-    const dismissedMaxTime = moment().subtract(1, "m");
-    if (disconnectedDismissed.isAfter(dismissedMaxTime)) {
-      return undefined;
-    }
-
-    return {
-      level: AlertLevel.CRITICAL,
-      title:
-        "We're currently having some trouble fetching updated data. If this persists, it might be a good idea to check your network connection to the CockroachDB cluster.",
-      dismiss: (dispatch: Dispatch<Action>) => {
-        dispatch(disconnectedDismissedLocalSetting.set(moment()));
-        return Promise.resolve();
       },
     };
   },
@@ -736,7 +700,6 @@ export const isManagedClusterSelector = createSelector(
  * all critical-level alerts.
  */
 export const bannerAlertsSelector = createSelector(
-  disconnectedAlertSelector,
   emailSubscriptionAlertSelector,
   createStatementDiagnosticsAlertSelector,
   cancelStatementDiagnosticsAlertSelector,
@@ -763,9 +726,6 @@ export function alertDataSync(store: Store<AdminUIState>) {
 
   return () => {
     const state: AdminUIState = store.getState();
-
-    // Always refresh health.
-    dispatch(refreshHealth());
 
     const { Insecure } = getDataFromServer();
     // We should not send out requests to the endpoints below if

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -59,14 +59,6 @@ const eventsReducerObj = new CachedDataReducer(
 );
 export const refreshEvents = eventsReducerObj.refresh;
 
-export type HealthState = CachedDataReducerState<api.HealthResponseMessage>;
-export const healthReducerObj = new CachedDataReducer(
-  api.getHealth,
-  "health",
-  moment.duration(2, "s"),
-);
-export const refreshHealth = healthReducerObj.refresh;
-
 function rollupStoreMetrics(
   res: api.NodesResponseExternalMessage,
 ): INodeStatus[] {
@@ -532,7 +524,6 @@ export interface APIReducersState {
   events: CachedDataReducerState<
     clusterUiApi.SqlApiResponse<clusterUiApi.EventsResponse>
   >;
-  health: HealthState;
   nodes: CachedDataReducerState<INodeStatus[]>;
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;
   version: CachedDataReducerState<VersionList>;
@@ -591,7 +582,6 @@ export interface APIReducersState {
 export const apiReducersReducer = combineReducers<APIReducersState>({
   [clusterReducerObj.actionNamespace]: clusterReducerObj.reducer,
   [eventsReducerObj.actionNamespace]: eventsReducerObj.reducer,
-  [healthReducerObj.actionNamespace]: healthReducerObj.reducer,
   [nodesReducerObj.actionNamespace]: nodesReducerObj.reducer,
   [raftReducerObj.actionNamespace]: raftReducerObj.reducer,
   [versionReducerObj.actionNamespace]: versionReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -510,15 +510,6 @@ const tenantsListObj = new CachedDataReducer(
 
 export const refreshTenantsList = tenantsListObj.refresh;
 
-const connectivityObj = new CachedDataReducer(
-  api.getNetworkConnectivity,
-  "connectivity",
-  moment.duration(30, "s"),
-  moment.duration(1, "minute"),
-);
-
-export const refreshConnectivity = connectivityObj.refresh;
-
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<
@@ -576,7 +567,6 @@ export interface APIReducersState {
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
   rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
   tenants: CachedDataReducerState<api.ListTenantsResponseMessage>;
-  connectivity: CachedDataReducerState<api.NetworkConnectivityResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -628,7 +618,6 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [statementFingerprintInsightsReducerObj.actionNamespace]:
     statementFingerprintInsightsReducerObj.reducer,
   [tenantsListObj.actionNamespace]: tenantsListObj.reducer,
-  [connectivityObj.actionNamespace]: connectivityObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/redux/connectivity.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/connectivity.ts
@@ -1,9 +1,0 @@
-// Copyright 2023 The Cockroach Authors.
-//
-// Use of this software is governed by the CockroachDB Software License
-// included in the /LICENSE file.
-
-import { AdminUIState } from "src/redux/state";
-
-export const connectivitySelector = (state: AdminUIState) =>
-  state.cachedData.connectivity;

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/alertBanner/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/alertBanner/index.tsx
@@ -3,16 +3,25 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import React from "react";
+import { useHealth } from "@cockroachlabs/cluster-ui";
+import moment from "moment-timezone";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { bindActionCreators } from "redux";
 
-import { bannerAlertsSelector } from "src/redux/alerts";
+import { AlertLevel, AlertInfo, bannerAlertsSelector } from "src/redux/alerts";
 import { AdminUIState } from "src/redux/state";
 import { AlertBox } from "src/views/shared/components/alertBox";
 import { AlertMessage } from "src/views/shared/components/alertMessage";
 
 import "./alertbanner.scss";
+
+interface DisplayAlert extends AlertInfo {
+  dismiss(): void;
+  showAsAlert?: boolean;
+  autoClose?: boolean;
+  closable?: boolean;
+  autoCloseTimeout?: number;
+}
 
 /**
  * AlertBanner is a React element that displays active critical alerts as a
@@ -20,23 +29,52 @@ import "./alertbanner.scss";
  * overlap content.
  */
 function AlertBanner(): React.ReactElement {
-  const alerts = useSelector((state: AdminUIState) =>
+  const { error: healthError } = useHealth();
+  const [dismissedAt, setDismissedAt] = useState(() => moment(0));
+
+  const reduxAlerts = useSelector((state: AdminUIState) =>
     bannerAlertsSelector(state),
   );
   const dispatch = useDispatch();
 
-  if (!alerts || alerts.length === 0) {
+  // Build combined alerts list.
+  const alerts: DisplayAlert[] = [];
+
+  // Health disconnected alert (driven by SWR polling).
+  if (healthError) {
+    const dismissedMaxTime = moment().subtract(1, "m");
+    if (!dismissedAt.isAfter(dismissedMaxTime)) {
+      alerts.push({
+        level: AlertLevel.CRITICAL,
+        title:
+          "We're currently having some trouble fetching updated data. " +
+          "If this persists, it might be a good idea to check your " +
+          "network connection to the CockroachDB cluster.",
+        dismiss: () => setDismissedAt(moment()),
+      });
+    }
+  }
+
+  // Redux-based alerts.
+  for (const alert of reduxAlerts) {
+    const { dismiss, ...rest } = alert;
+    alerts.push({
+      ...rest,
+      dismiss: () => dispatch(dismiss as any),
+    });
+  }
+
+  if (alerts.length === 0) {
     return null;
   }
 
   // Display only the first visible component.
   const { dismiss, ...alertProps } = alerts[0];
-  const boundDismiss = bindActionCreators(() => dismiss, dispatch);
   const AlertComponent = alertProps.showAsAlert ? AlertMessage : AlertBox;
 
   return (
     <div className="alert-banner">
-      <AlertComponent dismiss={boundDismiss} {...alertProps} />
+      <AlertComponent dismiss={dismiss} {...alertProps} />
     </div>
   );
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.spec.tsx
@@ -3,158 +3,140 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { util } from "@cockroachlabs/cluster-ui";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { render, screen } from "@testing-library/react";
-import { Location } from "history";
 import Long from "long";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import { Network } from "./index";
 
-describe("Network", () => {
-  const defaultProps = {
-    nodesSummary: {
-      nodeStatuses: [
-        {
-          desc: {
-            node_id: 1,
-            address: { address_field: "localhost:26257" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "a" },
-              ],
-            },
-          },
-          updated_at: Long.fromNumber(1000),
-        },
-        {
-          desc: {
-            node_id: 2,
-            address: { address_field: "localhost:26258" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "b" },
-              ],
-            },
-          },
-          updated_at: Long.fromNumber(1000),
-        },
-      ] as any[],
-      nodeStatusByID: {
-        "1": {
-          desc: {
-            node_id: 1,
-            address: { address_field: "localhost:26257" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "a" },
-              ],
-            },
-          },
-          updated_at: Long.fromNumber(1000),
-        },
-        "2": {
-          desc: {
-            node_id: 2,
-            address: { address_field: "localhost:26258" },
-            locality: {
-              tiers: [
-                { key: "region", value: "us-east-1" },
-                { key: "zone", value: "b" },
-              ],
-            },
-          },
-          updated_at: Long.fromNumber(1000),
+const twoNodeNodesResp = {
+  nodes: [
+    {
+      desc: {
+        node_id: 1,
+        address: { address_field: "localhost:26257" },
+        locality: {
+          tiers: [
+            { key: "region", value: "us-east-1" },
+            { key: "zone", value: "a" },
+          ],
         },
       },
-      nodeIDs: ["1", "2"],
-      nodeDisplayNameByID: {
-        "1": "node-1",
-        "2": "node-2",
-      },
-      storeIDsByNodeID: {
-        "1": ["1"],
-        "2": ["2"],
-      },
-      nodeLastError: null as Error | null,
-      livenessByNodeID: {
-        "1": {
-          nodeId: 1,
-          epoch: Long.fromNumber(1),
-          expiration: Long.fromNumber(1000),
-          draining: false,
-          membership:
-            protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
-              .ACTIVE,
-        } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
-        "2": {
-          nodeId: 2,
-          epoch: Long.fromNumber(1),
-          expiration: Long.fromNumber(1000),
-          draining: false,
-          membership:
-            protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
-              .ACTIVE,
-        } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
-      },
-      livenessStatusByNodeID: {
-        "1": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
-          .NODE_STATUS_LIVE,
-        "2": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
-          .NODE_STATUS_LIVE,
-      },
+      metrics: {},
+      store_statuses: [] as any[],
+      updated_at: Long.fromNumber(1000),
     },
-    nodeSummaryErrors: [] as Error[],
-    connectivity: {
-      data: {
-        connections: {
-          "1": {
-            peers: {
-              "2": { latency: { nanos: 1000000 } }, // 1ms
-            },
-          },
-          "2": {
-            peers: {
-              "1": { latency: { nanos: 1000000 } }, // 1ms
-            },
-          },
+    {
+      desc: {
+        node_id: 2,
+        address: { address_field: "localhost:26258" },
+        locality: {
+          tiers: [
+            { key: "region", value: "us-east-1" },
+            { key: "zone", value: "b" },
+          ],
         },
-        errors_by_node_id: {},
       },
-      inFlight: false,
-      valid: true,
-      unauthorized: false,
+      metrics: {},
+      store_statuses: [] as any[],
+      updated_at: Long.fromNumber(1000),
     },
-    refreshNodes: jest.fn(),
-    refreshLiveness: jest.fn(),
-    refreshConnectivity: jest.fn(),
-    match: {
-      params: {},
-      isExact: true,
-      path: "/network",
-      url: "/network",
-    },
-    location: {
-      pathname: "/network",
-      search: "",
-      state: null,
-      hash: "",
-    } as Location,
-    history: {} as any,
-  };
+  ],
+};
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+const twoNodeLivenessResp = {
+  livenesses: [
+    {
+      node_id: 1,
+      epoch: Long.fromNumber(1),
+      expiration: Long.fromNumber(1000),
+      draining: false,
+      membership:
+        protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
+          .ACTIVE,
+    },
+    {
+      node_id: 2,
+      epoch: Long.fromNumber(1),
+      expiration: Long.fromNumber(1000),
+      draining: false,
+      membership:
+        protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
+          .ACTIVE,
+    },
+  ],
+  statuses: {
+    "1": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_LIVE,
+    "2": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+      .NODE_STATUS_LIVE,
+  },
+};
+
+const twoNodeConnectivityResp = {
+  connections: {
+    "1": {
+      peers: {
+        "2": { latency: { nanos: 1000000 } }, // 1ms
+      },
+    },
+    "2": {
+      peers: {
+        "1": { latency: { nanos: 1000000 } }, // 1ms
+      },
+    },
+  },
+  errors_by_node_id: {},
+};
+
+const defaultSwrResult = {
+  isLoading: false,
+  error: null as Error,
+  mutate: jest.fn(),
+  isValidating: false,
+};
+
+function mockSwrWithData(
+  nodesData: any,
+  livenessData: any,
+  connectivityData: any,
+) {
+  return jest
+    .spyOn(util, "useSwrWithClusterId")
+    .mockImplementation((key: any) => {
+      if (key === "networkNodes") {
+        return { ...defaultSwrResult, data: nodesData };
+      }
+      if (key === "networkLiveness") {
+        return { ...defaultSwrResult, data: livenessData };
+      }
+      if (key === "networkConnectivity") {
+        return { ...defaultSwrResult, data: connectivityData };
+      }
+      return { ...defaultSwrResult, data: null };
+    });
+}
+
+describe("Network", () => {
+  let spy: jest.SpyInstance;
+
+  afterEach(() => {
+    spy.mockRestore();
   });
 
   it("renders network page with latency table", () => {
+    spy = mockSwrWithData(
+      twoNodeNodesResp,
+      twoNodeLivenessResp,
+      twoNodeConnectivityResp,
+    );
+
     render(
       <MemoryRouter>
-        <Network {...defaultProps} />
+        <Network />
       </MemoryRouter>,
     );
 
@@ -162,64 +144,62 @@ describe("Network", () => {
     expect(screen.getByRole("table")).toBeTruthy();
   });
 
-  it("calls refresh functions on mount", () => {
+  it("fetches nodes, liveness, and connectivity data via SWR", () => {
+    spy = mockSwrWithData(
+      twoNodeNodesResp,
+      twoNodeLivenessResp,
+      twoNodeConnectivityResp,
+    );
+
     render(
       <MemoryRouter>
-        <Network {...defaultProps} />
+        <Network />
       </MemoryRouter>,
     );
 
-    expect(defaultProps.refreshNodes).toHaveBeenCalled();
-    expect(defaultProps.refreshLiveness).toHaveBeenCalled();
-    expect(defaultProps.refreshConnectivity).toHaveBeenCalled();
+    // useSwrWithClusterId is called 3 times: nodes, liveness, connectivity.
+    expect(spy).toHaveBeenCalledWith(
+      "networkNodes",
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "networkLiveness",
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "networkConnectivity",
+      expect.any(Function),
+      expect.any(Object),
+    );
   });
 
   it("displays message for single node cluster", () => {
-    const propsWithSingleNode = {
-      ...defaultProps,
-      nodesSummary: {
-        nodeStatuses: [defaultProps.nodesSummary.nodeStatuses[0]],
-        nodeStatusByID: {
-          "1": defaultProps.nodesSummary.nodeStatusByID["1"],
-        },
-        nodeIDs: ["1"],
-        nodeDisplayNameByID: {
-          "1": "node-1",
-        },
-        storeIDsByNodeID: {
-          "1": ["1"],
-        },
-        nodeLastError: null as Error | null,
-        livenessByNodeID: {
-          "1": {
-            nodeId: 1,
-            epoch: Long.fromNumber(1),
-            expiration: Long.fromNumber(1000),
-            draining: false,
-            membership:
-              protos.cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus
-                .ACTIVE,
-          } as protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness,
-        },
-        livenessStatusByNodeID: {
-          "1": protos.cockroach.kv.kvserver.liveness.livenesspb
-            .NodeLivenessStatus.NODE_STATUS_LIVE,
-        },
-      },
-      connectivity: {
-        data: {
-          connections: {},
-          errors_by_node_id: {},
-        },
-        inFlight: false,
-        valid: true,
-        unauthorized: false,
+    const singleNodeNodesResp = {
+      nodes: [twoNodeNodesResp.nodes[0]],
+    };
+    const singleNodeLivenessResp = {
+      livenesses: [twoNodeLivenessResp.livenesses[0]],
+      statuses: {
+        "1": protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
+          .NODE_STATUS_LIVE,
       },
     };
+    const singleNodeConnectivityResp = {
+      connections: {},
+      errors_by_node_id: {},
+    };
+
+    spy = mockSwrWithData(
+      singleNodeNodesResp,
+      singleNodeLivenessResp,
+      singleNodeConnectivityResp,
+    );
 
     render(
       <MemoryRouter>
-        <Network {...propsWithSingleNode} />
+        <Network />
       </MemoryRouter>,
     );
 
@@ -231,62 +211,59 @@ describe("Network", () => {
   });
 
   it("handles peers with null latency", () => {
-    const propsWithNullLatency = {
-      ...defaultProps,
-      connectivity: {
-        ...defaultProps.connectivity,
-        data: {
-          connections: {
-            "1": {
-              peers: {
-                "2": {
-                  latency: {
-                    nanos: 1000000,
-                  } as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // 1ms
-                "3": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-              },
-            },
+    const connectivityWithNulls = {
+      connections: {
+        "1": {
+          peers: {
             "2": {
-              peers: {
-                "1": {
-                  latency: {
-                    nanos: 1000000,
-                  } as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // 1ms
-                "3": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-              },
+              latency: {
+                nanos: 1000000,
+              } as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
             },
             "3": {
-              peers: {
-                "1": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-                "2": {
-                  latency:
-                    null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
-                }, // null latency
-              },
+              latency:
+                null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
             },
           },
-          errors_by_node_id: {},
         },
-        inFlight: false,
-        valid: true,
-        unauthorized: false,
+        "2": {
+          peers: {
+            "1": {
+              latency: {
+                nanos: 1000000,
+              } as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
+            },
+            "3": {
+              latency:
+                null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
+            },
+          },
+        },
+        "3": {
+          peers: {
+            "1": {
+              latency:
+                null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
+            },
+            "2": {
+              latency:
+                null as protos.cockroach.server.serverpb.NetworkConnectivityResponse.IPeer["latency"],
+            },
+          },
+        },
       },
+      errors_by_node_id: {},
     };
+
+    spy = mockSwrWithData(
+      twoNodeNodesResp,
+      twoNodeLivenessResp,
+      connectivityWithNulls,
+    );
 
     render(
       <MemoryRouter>
-        <Network {...propsWithNullLatency} />
+        <Network />
       </MemoryRouter>,
     );
 

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
@@ -8,11 +8,13 @@ import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { deviation as d3Deviation, mean as d3Mean } from "d3-array";
 import capitalize from "lodash/capitalize";
+import each from "lodash/each";
 import filter from "lodash/filter";
 import flatMap from "lodash/flatMap";
 import flow from "lodash/flow";
 import isEmpty from "lodash/isEmpty";
 import isUndefined from "lodash/isUndefined";
+import keyBy from "lodash/keyBy";
 import map from "lodash/map";
 import max from "lodash/max";
 import sortBy from "lodash/sortBy";
@@ -20,30 +22,15 @@ import union from "lodash/union";
 import values from "lodash/values";
 import moment from "moment-timezone";
 import { common } from "protobufjs";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
-import { connect } from "react-redux";
-import { withRouter, RouteComponentProps } from "react-router-dom";
-import { createSelector } from "reselect";
+import { useLocation, useRouteMatch } from "react-router-dom";
 
 import { InlineAlert } from "src/components";
-import {
-  CachedDataReducerState,
-  refreshConnectivity,
-  refreshLiveness,
-  refreshNodes,
-} from "src/redux/apiReducers";
-import { connectivitySelector } from "src/redux/connectivity";
-import {
-  NodesSummary,
-  nodesSummarySelector,
-  selectLivenessRequestStatus,
-  selectNodeRequestStatus,
-} from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
+import * as api from "src/util/api";
 import { trackFilter, trackCollapseNodes } from "src/util/analytics";
 import { getDataFromServer } from "src/util/dataFromServer";
-import { getMatchParamByName } from "src/util/query";
+import { INodeStatus, RollupStoreMetrics } from "src/util/proto";
 import {
   getFilters,
   localityToString,
@@ -61,14 +48,7 @@ import IConnectivity = cockroach.server.serverpb.NetworkConnectivityResponse.ICo
 import IPeer = cockroach.server.serverpb.NetworkConnectivityResponse.IPeer;
 import IDuration = common.IDuration;
 
-interface NetworkOwnProps {
-  nodesSummary: NodesSummary;
-  nodeSummaryErrors: Error[];
-  connectivity: CachedDataReducerState<cockroach.server.serverpb.NetworkConnectivityResponse>;
-  refreshNodes: typeof refreshNodes;
-  refreshLiveness: typeof refreshLiveness;
-  refreshConnectivity: typeof refreshConnectivity;
-}
+const { useSwrWithClusterId } = util;
 
 export type Identity = {
   nodeID: number;
@@ -84,8 +64,6 @@ export interface NoConnection {
   to: Identity;
 }
 
-type NetworkProps = NetworkOwnProps & RouteComponentProps;
-
 export interface NetworkFilter {
   [key: string]: Array<string>;
 }
@@ -95,13 +73,108 @@ export interface NetworkSort {
   filters: Array<{ name: string; address: string }>;
 }
 
-function contentAvailable(nodesSummary: NodesSummary) {
+// NodesSummaryLite contains the subset of NodesSummary fields used by the
+// Network page.
+interface NodesSummaryLite {
+  nodeStatuses: INodeStatus[];
+  nodeIDs: string[];
+  nodeStatusByID: { [id: string]: INodeStatus };
+  livenessByNodeID: {
+    [id: string]: protos.cockroach.kv.kvserver.liveness.livenesspb.ILiveness;
+  };
+  livenessStatusByNodeID: {
+    [id: string]: protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+  };
+}
+
+function contentAvailable(summary: NodesSummaryLite) {
   return (
-    !isUndefined(nodesSummary) &&
-    !isEmpty(nodesSummary.nodeStatuses) &&
-    !isEmpty(nodesSummary.nodeStatusByID) &&
-    !isEmpty(nodesSummary.nodeIDs)
+    !isUndefined(summary) &&
+    !isEmpty(summary.nodeStatuses) &&
+    !isEmpty(summary.nodeStatusByID) &&
+    !isEmpty(summary.nodeIDs)
   );
+}
+
+const SWR_OPTS = {
+  revalidateOnFocus: false,
+  dedupingInterval: 10_000, // 10 seconds
+};
+
+const CONNECTIVITY_SWR_OPTS = {
+  revalidateOnFocus: false,
+  dedupingInterval: 30_000, // 30 seconds
+};
+
+function useNetworkData() {
+  const {
+    data: nodesResp,
+    error: nodesError,
+  } = useSwrWithClusterId<api.NodesResponseExternalMessage>(
+    "networkNodes",
+    () => api.getNodesUI(undefined),
+    SWR_OPTS,
+  );
+
+  const {
+    data: livenessResp,
+    error: livenessError,
+  } = useSwrWithClusterId<api.LivenessResponseMessage>(
+    "networkLiveness",
+    () => api.getLiveness(undefined),
+    SWR_OPTS,
+  );
+
+  const {
+    data: connectivityResp,
+  } = useSwrWithClusterId<api.NetworkConnectivityResponse>(
+    "networkConnectivity",
+    () => api.getNetworkConnectivity(undefined),
+    CONNECTIVITY_SWR_OPTS,
+  );
+
+  const nodesSummary = useMemo((): NodesSummaryLite | undefined => {
+    if (!nodesResp || !livenessResp) {
+      return undefined;
+    }
+
+    const nodeStatuses: INodeStatus[] = map(nodesResp.nodes, node => {
+      RollupStoreMetrics(node);
+      return node;
+    });
+
+    const nodeIDs = map(nodeStatuses, ns => ns.desc.node_id.toString());
+
+    const nodeStatusByID: { [s: string]: INodeStatus } = {};
+    each(nodeStatuses, ns => {
+      nodeStatusByID[ns.desc.node_id.toString()] = ns;
+    });
+
+    const livenessByNodeID = livenessResp.livenesses
+      ? keyBy(livenessResp.livenesses, l => l.node_id)
+      : {};
+
+    const livenessStatusByNodeID = livenessResp.statuses || {};
+
+    return {
+      nodeStatuses,
+      nodeIDs,
+      nodeStatusByID,
+      livenessByNodeID,
+      livenessStatusByNodeID,
+    };
+  }, [nodesResp, livenessResp]);
+
+  const errors = useMemo(
+    () => [nodesError, livenessError].filter(Boolean),
+    [nodesError, livenessError],
+  );
+
+  return {
+    nodesSummary,
+    errors,
+    connections: connectivityResp?.connections,
+  };
 }
 
 export const isHealthyLivenessStatus = (
@@ -146,26 +219,19 @@ export function getValueFromString(
 /**
  * Renders the Network Report page.
  */
-export function Network({
-  nodesSummary,
-  nodeSummaryErrors,
-  connectivity,
-  refreshNodes: refreshNodesAction,
-  refreshLiveness: refreshLivenessAction,
-  refreshConnectivity: refreshConnectivityAction,
-  match,
-  location,
-}: NetworkProps): React.ReactElement {
+export function Network(): React.ReactElement {
+  const match = useRouteMatch<{ node_id?: string }>();
+  const location = useLocation();
+  const { nodesSummary, errors, connections } = useNetworkData();
+
   const [collapsed, setCollapsed] = useState(false);
   const [networkFilter, setNetworkFilter] = useState<NetworkFilter | null>(
     null,
   );
 
-  useEffect(() => {
-    refreshLivenessAction();
-    refreshNodesAction();
-    refreshConnectivityAction();
-  });
+  const nodeId = match.params.node_id
+    ? decodeURIComponent(match.params.node_id)
+    : null;
 
   const onChangeCollapse = (newCollapsed: boolean) => {
     trackCollapseNodes(newCollapsed);
@@ -295,7 +361,6 @@ export function Network({
   const getDisplayIdentities = (
     identityByID: Map<number, Identity>,
   ): Identity[] => {
-    const nodeId = getMatchParamByName(match, "node_id");
     const identityContent = sortBy(
       Array.from(identityByID.values()),
       identity => identity.nodeID,
@@ -313,7 +378,6 @@ export function Network({
     latencies: number[],
     displayIdentities: Identity[],
   ) => {
-    const nodeId = getMatchParamByName(match, "node_id");
     const mean = d3Mean(latencies);
     const sortParams = getSortParams(displayIdentities);
     let stddev = d3Deviation(latencies);
@@ -372,9 +436,9 @@ export function Network({
   };
 
   const renderContent = (
-    summary: NodesSummary,
+    summary: NodesSummaryLite,
     filters: NodeFilterListProps,
-    connections: protos.cockroach.server.serverpb.NetworkConnectivityResponse["connections"],
+    conns: protos.cockroach.server.serverpb.NetworkConnectivityResponse["connections"],
   ) => {
     if (!contentAvailable(summary)) {
       return null;
@@ -387,37 +451,37 @@ export function Network({
     // Nodes api to make sure we show all known nodes.
     const knownNodeIds = union(
       Object.keys(summary.livenessByNodeID),
-      Object.keys(connections),
+      Object.keys(conns),
     );
 
     // List of node identities.
     const identityByID: Map<number, Identity> = new Map();
 
-    knownNodeIds.forEach(nodeId => {
-      const nodeIdInt = parseInt(nodeId);
-      const status = summary.nodeStatusByID[nodeId];
+    knownNodeIds.forEach(nid => {
+      const nodeIdInt = parseInt(nid);
+      const status = summary.nodeStatusByID[nid];
       identityByID.set(nodeIdInt, {
         nodeID: nodeIdInt,
         address: status?.desc.address.address_field,
         locality: status && localityToString(status.desc.locality),
         updatedAt: status && util.LongToMoment(status.updated_at),
         livenessStatus:
-          summary.livenessStatusByNodeID[nodeId] ||
+          summary.livenessStatusByNodeID[nid] ||
           protos.cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus
             .NODE_STATUS_UNKNOWN,
-        connectivity: connections[nodeId],
+        connectivity: conns[nid],
       });
     });
 
     // apply filters to exclude items that don't satisfy filter conditions.
-    identityByID.forEach((identity, nodeId) => {
+    identityByID.forEach((identity, nid) => {
       if (
-        (filters.nodeIDs?.size > 0 && !filters.nodeIDs?.has(nodeId)) ||
+        (filters.nodeIDs?.size > 0 && !filters.nodeIDs?.has(nid)) ||
         (!!filters.localityRegex &&
           filters.localityRegex?.test(identity.locality)) ||
         !isHealthyLivenessStatus(identity.livenessStatus)
       ) {
-        identityByID.delete(nodeId);
+        identityByID.delete(nid);
       }
     });
 
@@ -429,7 +493,7 @@ export function Network({
       (vals: IPeer[]) => flatMap(vals, v => v.latency),
       (vals: IDuration[]) => filter(vals, v => v && v.nanos),
       (vals: IDuration[]) => map(vals, v => util.NanoToMilli(v.nanos)),
-    ])(connections);
+    ])(conns);
 
     if (isEmpty(identityByID)) {
       return <h2 className="base-heading">No nodes match the filters</h2>;
@@ -462,11 +526,9 @@ export function Network({
       )}
       {canShowPage && (
         <Loading
-          loading={
-            !contentAvailable(nodesSummary) || !connectivity?.data?.connections
-          }
+          loading={!contentAvailable(nodesSummary) || !connections}
           page={"network"}
-          error={nodeSummaryErrors}
+          error={errors}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           render={() => (
             <div>
@@ -474,11 +536,7 @@ export function Network({
                 nodeIDs={filters.nodeIDs}
                 localityRegex={filters.localityRegex}
               />
-              {renderContent(
-                nodesSummary,
-                filters,
-                connectivity?.data?.connections,
-              )}
+              {renderContent(nodesSummary, filters, connections)}
             </div>
           )}
         />
@@ -487,24 +545,4 @@ export function Network({
   );
 }
 
-const nodeSummaryErrors = createSelector(
-  selectNodeRequestStatus,
-  selectLivenessRequestStatus,
-  (nodes, liveness) => [nodes.lastError, liveness.lastError],
-);
-
-const mapStateToProps = (state: AdminUIState) => ({
-  nodesSummary: nodesSummarySelector(state),
-  nodeSummaryErrors: nodeSummaryErrors(state),
-  connectivity: connectivitySelector(state),
-});
-
-const mapDispatchToProps = {
-  refreshNodes,
-  refreshLiveness,
-  refreshConnectivity,
-};
-
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(Network),
-);
+export default Network;


### PR DESCRIPTION
## Summary

Migrate the DB Console health check polling from Redux to SWR and clean up
dead connectivity Redux code.

**Commit 1: ui: migrate health check polling from Redux to SWR**
- Add `useHealth` SWR hook in cluster-ui that polls `_admin/v1/health`
  every 2s (replicating the existing Redux polling interval).
- Update `AlertBanner` to consume `useHealth()` directly and manage
  dismiss state locally via `useState` instead of Redux `LocalSetting`.
- Remove `disconnectedAlertSelector`, `disconnectedDismissedLocalSetting`,
  `refreshHealth` dispatch from `alertDataSync`, and `HealthState`/
  `healthReducerObj`/`refreshHealth` from Redux.
- Remove corresponding tests from `alerts.spec.ts`.

**Commit 2: ui: remove dead connectivity Redux plumbing**
- Delete `connectivity.ts` and remove `connectivityObj`/
  `refreshConnectivity` from `apiReducers.ts`. The Network page already
  uses SWR directly, making this Redux code dead.

Epic: CRDB-58145

Release note: None