### PR TITLE
ui: migrate health check polling from Redux to SWR

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/healthApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/healthApi.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { fetchData } from "src/api";
+
+import { useSwrWithClusterId } from "../util";
+
+const HEALTH_PATH = "_admin/v1/health";
+const HEALTH_SWR_KEY = "health";
+
+const getHealth = (): Promise<cockroach.server.serverpb.HealthResponse> => {
+  return fetchData(cockroach.server.serverpb.HealthResponse, HEALTH_PATH);
+};
+
+export const useHealth = () => {
+  const { data, error, isLoading } = useSwrWithClusterId(
+    HEALTH_SWR_KEY,
+    getHealth,
+    {
+      refreshInterval: 10_000,
+      revalidateOnFocus: false,
+      dedupingInterval: 10_000,
+    },
+  );
+  return { data, error, isLoading };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -24,4 +24,5 @@ export * from "./eventsApi";
 export * from "./types";
 export * from "./jobProfilerApi";
 export * from "./txnInsightDetailsApi";
+export * from "./healthApi";
 export * from "./connectivityApi";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -44,6 +44,7 @@ export * from "./tracez";
 export { util, api };
 export { useNodes } from "./api/nodesApi";
 export { useNodesSummary } from "./api/nodesSummaryApi";
+export { useHealth } from "./api/healthApi";
 export type { NodesSummary } from "./api/nodesSummaryApi";
 export { useConnectivity } from "./api/connectivityApi";
 export * from "./sessions";

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
@@ -33,9 +33,9 @@ import {
   versionReducerObj,
   nodesReducerObj,
   clusterReducerObj,
-  healthReducerObj,
   settingsReducerObj,
 } from "./apiReducers";
+import { setHealthError } from "./health";
 import { loginSuccess } from "./login";
 import { AdminUIState, AppDispatch, createAdminUIStore } from "./state";
 import {
@@ -401,23 +401,20 @@ describe("alerts", function () {
     });
 
     describe("disconnected alert", function () {
-      it("requires health to be available before displaying", function () {
+      it("does not display when no health error is set", function () {
         const alert = disconnectedAlertSelector(state());
         expect(alert).toBeUndefined();
       });
 
-      it("does not display when cluster is healthy", function () {
-        dispatch(
-          healthReducerObj.receiveData(
-            new protos.cockroach.server.serverpb.ClusterResponse({}),
-          ),
-        );
+      it("does not display when health error is cleared", function () {
+        dispatch(setHealthError(new Error("error")));
+        dispatch(setHealthError(null));
         const alert = disconnectedAlertSelector(state());
         expect(alert).toBeUndefined();
       });
 
-      it("displays when cluster health endpoint returns an error", function () {
-        dispatch(healthReducerObj.errorData(new Error("error")));
+      it("displays when health error is set", function () {
+        dispatch(setHealthError(new Error("error")));
         const alert = disconnectedAlertSelector(state());
         expect(typeof alert).toBe("object");
         expect(alert.level).toEqual(AlertLevel.CRITICAL);
@@ -427,14 +424,14 @@ describe("alerts", function () {
       });
 
       it("does not display if dismissed locally", function () {
-        dispatch(healthReducerObj.errorData(new Error("error")));
+        dispatch(setHealthError(new Error("error")));
         dispatch(disconnectedDismissedLocalSetting.set(moment()));
         const alert = disconnectedAlertSelector(state());
         expect(alert).toBeUndefined();
       });
 
       it("dismisses by setting local dismissal", function (done) {
-        dispatch(healthReducerObj.errorData(new Error("error")));
+        dispatch(setHealthError(new Error("error")));
         const alert = disconnectedAlertSelector(state());
         const beforeDismiss = moment();
 
@@ -543,7 +540,6 @@ describe("alerts", function () {
       expect(state().cachedData.cluster.inFlight).toBe(true);
       expect(state().cachedData.nodes.inFlight).toBe(true);
       expect(state().cachedData.version.inFlight).toBe(false);
-      expect(state().cachedData.health.inFlight).toBe(true);
     });
 
     it("dispatches request for version data when cluster ID and nodes are available", function () {
@@ -595,17 +591,6 @@ describe("alerts", function () {
       expect(state().cachedData.version.inFlight).toBe(false);
     });
 
-    it("refreshes health function whenever the last health response is no longer valid.", function () {
-      dispatch(
-        healthReducerObj.receiveData(
-          new protos.cockroach.server.serverpb.ClusterResponse({}),
-        ),
-      );
-      dispatch(healthReducerObj.invalidateData());
-      sync();
-      expect(state().cachedData.health.inFlight).toBe(true);
-    });
-
     it("does not do anything when all data is available.", function () {
       dispatch(
         nodesReducerObj.receiveData([
@@ -629,11 +614,6 @@ describe("alerts", function () {
         versionReducerObj.receiveData({
           details: [],
         }),
-      );
-      dispatch(
-        healthReducerObj.receiveData(
-          new protos.cockroach.server.serverpb.ClusterResponse({}),
-        ),
       );
       dispatch(
         settingsReducerObj.receiveData(

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -32,7 +32,6 @@ import {
   refreshCluster,
   refreshNodes,
   refreshVersion,
-  refreshHealth,
   refreshSettings,
 } from "./apiReducers";
 import {
@@ -280,7 +279,7 @@ export const disconnectedDismissedLocalSetting = new LocalSetting(
  * Notification when the Admin UI is disconnected from the cluster.
  */
 export const disconnectedAlertSelector = createSelector(
-  (state: AdminUIState) => state.cachedData.health,
+  (state: AdminUIState) => state.health,
   disconnectedDismissedLocalSetting.selector,
   (health, disconnectedDismissed): Alert => {
     if (!health || !health.lastError) {
@@ -763,9 +762,6 @@ export function alertDataSync(store: Store<AdminUIState>) {
 
   return () => {
     const state: AdminUIState = store.getState();
-
-    // Always refresh health.
-    dispatch(refreshHealth());
 
     const { Insecure } = getDataFromServer();
     // We should not send out requests to the endpoints below if

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -59,14 +59,6 @@ const eventsReducerObj = new CachedDataReducer(
 );
 export const refreshEvents = eventsReducerObj.refresh;
 
-export type HealthState = CachedDataReducerState<api.HealthResponseMessage>;
-export const healthReducerObj = new CachedDataReducer(
-  api.getHealth,
-  "health",
-  moment.duration(2, "s"),
-);
-export const refreshHealth = healthReducerObj.refresh;
-
 function rollupStoreMetrics(
   res: api.NodesResponseExternalMessage,
 ): INodeStatus[] {
@@ -513,7 +505,6 @@ export interface APIReducersState {
   events: CachedDataReducerState<
     clusterUiApi.SqlApiResponse<clusterUiApi.EventsResponse>
   >;
-  health: HealthState;
   nodes: CachedDataReducerState<INodeStatus[]>;
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;
   version: CachedDataReducerState<VersionList>;
@@ -570,7 +561,6 @@ export interface APIReducersState {
 export const apiReducersReducer = combineReducers<APIReducersState>({
   [clusterReducerObj.actionNamespace]: clusterReducerObj.reducer,
   [eventsReducerObj.actionNamespace]: eventsReducerObj.reducer,
-  [healthReducerObj.actionNamespace]: healthReducerObj.reducer,
   [nodesReducerObj.actionNamespace]: nodesReducerObj.reducer,
   [raftReducerObj.actionNamespace]: raftReducerObj.reducer,
   [versionReducerObj.actionNamespace]: versionReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/redux/health.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/health.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Action } from "redux";
+
+import { AdminUIState } from "./state";
+
+const SET_HEALTH_ERROR = "cockroachui/health/SET_ERROR";
+
+export interface HealthState {
+  lastError: Error | null;
+}
+
+interface SetHealthErrorAction extends Action {
+  type: typeof SET_HEALTH_ERROR;
+  error: Error | null;
+}
+
+export function setHealthError(error: Error | null): SetHealthErrorAction {
+  return { type: SET_HEALTH_ERROR, error };
+}
+
+const initialState: HealthState = { lastError: null };
+
+export function healthReducer(
+  state: HealthState = initialState,
+  action: Action,
+): HealthState {
+  switch (action.type) {
+    case SET_HEALTH_ERROR: {
+      const a = action as SetHealthErrorAction;
+      if (state.lastError === a.error) {
+        return state;
+      }
+      return { lastError: a.error };
+    }
+    default:
+      return state;
+  }
+}
+
+export const selectHealthLastError = (state: AdminUIState) =>
+  state.health.lastError;

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -27,6 +27,7 @@ import { DataFromServer } from "src/util/dataFromServer";
 
 import { initializeAnalytics } from "./analytics";
 import { apiReducersReducer, APIReducersState } from "./apiReducers";
+import { healthReducer, HealthState } from "./health";
 import { hoverReducer, HoverState } from "./hover";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
 import { loginReducer, LoginAPIState } from "./login";
@@ -39,6 +40,7 @@ import FeatureFlags = cockroach.server.serverpb.FeatureFlags;
 
 export interface AdminUIState {
   cachedData: APIReducersState;
+  health: HealthState;
   hover: HoverState;
   localSettings: LocalSettingsState;
   queryManager: QueryManagerState;
@@ -86,6 +88,7 @@ export function createAdminUIStore(
   const s: Store<AdminUIState> = createStore(
     combineReducers<AdminUIState>({
       cachedData: apiReducersReducer,
+      health: healthReducer,
       hover: hoverReducer,
       localSettings: localSettingsReducer,
       queryManager: queryManagerReducer,

--- a/pkg/ui/workspaces/db-console/src/test-utils/renderWithProviders.tsx
+++ b/pkg/ui/workspaces/db-console/src/test-utils/renderWithProviders.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { Provider } from "react-redux";
 
 import { apiReducersReducer } from "src/redux/apiReducers";
+import { healthReducer } from "src/redux/health";
 import { hoverReducer } from "src/redux/hover";
 import { localSettingsReducer } from "src/redux/localsettings";
 import { loginReducer } from "src/redux/login";
@@ -31,6 +32,7 @@ export function renderWithProviders(
   const store = configureStore<AdminUIState>({
     reducer: {
       cachedData: apiReducersReducer,
+      health: healthReducer,
       hover: hoverReducer,
       localSettings: localSettingsReducer,
       // TODO (koorosh): cannot properly cast Query Manager Action types to AnyAction.

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/healthMonitor/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/healthMonitor/index.tsx
@@ -1,0 +1,26 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { useHealth } from "@cockroachlabs/cluster-ui";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import { setHealthError } from "src/redux/health";
+
+/**
+ * HealthMonitor bridges the SWR-based health polling into Redux.
+ * It renders nothing; its only job is to dispatch health error
+ * state so that disconnectedAlertSelector can pick it up.
+ */
+export function HealthMonitor(): null {
+  const { error } = useHealth();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setHealthError(error ?? null));
+  }, [error, dispatch]);
+
+  return null;
+}

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -29,6 +29,7 @@ import ErrorBoundary from "src/views/app/components/errorMessage/errorBoundary";
 import NavigationBar from "src/views/app/components/layoutSidebar";
 import LoginIndicator from "src/views/app/components/loginIndicator";
 import AlertBanner from "src/views/app/containers/alertBanner";
+import { HealthMonitor } from "src/views/app/containers/healthMonitor";
 import TimeWindowManager from "src/views/app/containers/metricsTimeManager";
 import RequireLogin from "src/views/login/requireLogin";
 import { ThrottleNotificationBar } from "src/views/shared/components/alertBar/alertBar";
@@ -82,6 +83,7 @@ function Layout({ children }: LayoutProps): React.ReactElement {
         defaultTitle="Cockroach Console"
       />
       <TimeWindowManager />
+      <HealthMonitor />
       <AlertBanner />
       <div className="layout-panel">
         <div className="layout-panel__header">


### PR DESCRIPTION
Previously, the health endpoint was polled via a CachedDataReducer in
alertDataSync, which ran on every Redux state change and manually
managed request deduplication and staleness. This was part of the
broader Redux/Saga polling infrastructure that is being replaced with
SWR.

Replace the health CachedDataReducer with an SWR-based useHealth hook
in cluster-ui that polls _admin/v1/health every 10 seconds with
built-in deduplication. A HealthMonitor component mounted in the layout
bridges the SWR error state into a minimal Redux slice so that the
existing disconnectedAlertSelector continues to work without changes
to the alert infrastructure.

Epic: CRDB-58145
Release note: None