### PR TITLE
ldrdecoder,txnapply: introduce TxnID to identify transactions

### DIFF
--- a/pkg/crosscluster/logical/ldrdecoder/txn_decoder.go
+++ b/pkg/crosscluster/logical/ldrdecoder/txn_decoder.go
@@ -15,9 +15,27 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type Transaction struct {
+// ApplierID identifies which applier owns a transaction. Used to partition
+// transactions across parallel appliers and coordinate cross-applier
+// dependencies.
+type ApplierID int32
+
+// TxnID uniquely identifies a transaction. Comparison methods (Less, LessEq)
+// delegate to the underlying Timestamp, so TxnIDs are ordered by timestamp.
+type TxnID struct {
 	Timestamp hlc.Timestamp
-	WriteSet  []DecodedRow
+	ApplierID ApplierID
+}
+
+func (t TxnID) Less(s TxnID) bool { return t.Timestamp.Less(s.Timestamp) }
+
+func (t TxnID) LessEq(s TxnID) bool { return t.Timestamp.LessEq(s.Timestamp) }
+
+func (t TxnID) IsSet() bool { return t.Timestamp.IsSet() }
+
+type Transaction struct {
+	TxnID    TxnID
+	WriteSet []DecodedRow
 }
 
 type TxnDecoder struct {
@@ -44,7 +62,7 @@ func (t *TxnDecoder) DecodeTxn(
 	}
 
 	var result Transaction
-	result.Timestamp = transaction[0].KeyValue.Value.Timestamp
+	result.TxnID.Timestamp = transaction[0].KeyValue.Value.Timestamp
 	result.WriteSet = make([]DecodedRow, 0, len(transaction))
 
 	for _, event := range transaction {
@@ -52,9 +70,9 @@ func (t *TxnDecoder) DecodeTxn(
 		if err != nil {
 			return Transaction{}, err
 		}
-		if decoded.RowTimestamp != result.Timestamp {
+		if decoded.RowTimestamp != result.TxnID.Timestamp {
 			return Transaction{}, errors.AssertionFailedf("inconsistent timestamps in transaction: got %s, expected %s",
-				decoded.RowTimestamp, result.Timestamp)
+				decoded.RowTimestamp, result.TxnID.Timestamp)
 		}
 		result.WriteSet = append(result.WriteSet, decoded)
 	}

--- a/pkg/crosscluster/logical/ldrdecoder/txn_decoder_test.go
+++ b/pkg/crosscluster/logical/ldrdecoder/txn_decoder_test.go
@@ -58,7 +58,7 @@ func TestTxnDecoder(t *testing.T) {
 
 	txn, err := decoder.DecodeTxn(ctx, events)
 	require.NoError(t, err)
-	require.Equal(t, txnTime, txn.Timestamp)
+	require.Equal(t, txnTime, txn.TxnID.Timestamp)
 	require.Len(t, txn.WriteSet, 4)
 
 	writeSetChecks := []struct {

--- a/pkg/crosscluster/logical/txnapply/txn_applier.go
+++ b/pkg/crosscluster/logical/txnapply/txn_applier.go
@@ -31,7 +31,7 @@ type appliedTransaction struct {
 
 type ScheduledTransaction struct {
 	ldrdecoder.Transaction
-	Dependencies []hlc.Timestamp
+	Dependencies []ldrdecoder.TxnID
 	EventHorizon hlc.Timestamp
 }
 
@@ -49,23 +49,23 @@ type Applier struct {
 		syncutil.Mutex
 		replicatedTime hlc.Timestamp
 
-		// transactions maps a txn's origin timestamp to its state.
-		transactions map[hlc.Timestamp]transactionState
+		// transactions maps a txn's TxnID to its state.
+		transactions map[ldrdecoder.TxnID]transactionState
 
 		// waiting maps a pending transaction to its dependents. I.e. if t5 depends
 		// on t2, then waiting[t2] will contain t5.
-		waiting map[hlc.Timestamp][]hlc.Timestamp
+		waiting map[ldrdecoder.TxnID][]ldrdecoder.TxnID
 
-		// timestamps buffers timestamps of transactions in the order they were
+		// txnIDs buffers TxnIDs of transactions in the order they were
 		// received, to help with replicatedTime tracking.
-		timestamps ring.Buffer[hlc.Timestamp]
+		txnIDs ring.Buffer[ldrdecoder.TxnID]
 
 		// horizonWaiting tracks transactions that have no remaining
 		// dependencies but cannot be applied yet because the applier's
 		// replicatedTime has not advanced past their EventHorizon.
 		//
 		// TODO(msbutler): consider making this a heap.
-		horizonWaiting []hlc.Timestamp
+		horizonWaiting []ldrdecoder.TxnID
 	}
 	txnWriters []txnwriter.TransactionWriter
 
@@ -77,8 +77,8 @@ func NewApplier(writers []txnwriter.TransactionWriter) *Applier {
 		txnWriters: writers,
 		frontier:   MakeLatest[hlc.Timestamp](),
 	}
-	a.mu.transactions = make(map[hlc.Timestamp]transactionState)
-	a.mu.waiting = make(map[hlc.Timestamp][]hlc.Timestamp)
+	a.mu.transactions = make(map[ldrdecoder.TxnID]transactionState)
+	a.mu.waiting = make(map[ldrdecoder.TxnID][]ldrdecoder.TxnID)
 	return a
 }
 
@@ -147,13 +147,13 @@ func (a *Applier) recordTransaction(transaction ScheduledTransaction) (bool, err
 	var err error
 	// Clone the slice to avoid mutating the caller's slice.
 	transaction.Dependencies = slices.Clone(transaction.Dependencies)
-	transaction.Dependencies = slices.DeleteFunc(transaction.Dependencies, func(txn hlc.Timestamp) bool {
-		if txn.LessEq(a.mu.replicatedTime) {
+	transaction.Dependencies = slices.DeleteFunc(transaction.Dependencies, func(txnID ldrdecoder.TxnID) bool {
+		if txnID.Timestamp.LessEq(a.mu.replicatedTime) {
 			return true
 		}
-		dependency, ok := a.mu.transactions[txn]
+		dependency, ok := a.mu.transactions[txnID]
 		if !ok {
-			err = errors.AssertionFailedf("missing dependency %+v", txn)
+			err = errors.AssertionFailedf("missing dependency %+v", txnID)
 		}
 		return dependency.applied
 	})
@@ -161,24 +161,24 @@ func (a *Applier) recordTransaction(transaction ScheduledTransaction) (bool, err
 		return false, err
 	}
 
-	a.mu.transactions[transaction.Timestamp] = transactionState{
+	a.mu.transactions[transaction.TxnID] = transactionState{
 		ScheduledTransaction: transaction,
 		applied:              false,
 	}
-	if a.mu.timestamps.Len() != 0 && transaction.Timestamp.LessEq(a.mu.timestamps.GetLast()) {
-		return false, errors.AssertionFailedf("transactions must be sent in increasing timestamp order: got %s, last was %s", transaction.Timestamp, a.mu.timestamps.GetLast())
+	if a.mu.txnIDs.Len() != 0 && transaction.TxnID.LessEq(a.mu.txnIDs.GetLast()) {
+		return false, errors.AssertionFailedf("transactions must be sent in increasing timestamp order: got %s, last was %s", transaction.TxnID.Timestamp, a.mu.txnIDs.GetLast().Timestamp)
 	}
-	a.mu.timestamps.AddLast(transaction.Timestamp)
+	a.mu.txnIDs.AddLast(transaction.TxnID)
 
 	for _, dependency := range transaction.Dependencies {
-		a.mu.waiting[dependency] = append(a.mu.waiting[dependency], transaction.Transaction.Timestamp)
+		a.mu.waiting[dependency] = append(a.mu.waiting[dependency], transaction.TxnID)
 	}
 
 	if len(transaction.Dependencies) == 0 {
 		if transaction.EventHorizon.LessEq(a.mu.replicatedTime) {
 			return true, nil
 		}
-		a.mu.horizonWaiting = append(a.mu.horizonWaiting, transaction.Timestamp)
+		a.mu.horizonWaiting = append(a.mu.horizonWaiting, transaction.TxnID)
 	}
 	return false, nil
 }
@@ -206,7 +206,7 @@ func (a *Applier) writer(
 			}
 			if txn.applyResult.DlqReason != nil {
 				// TODO(msbutler): actually write to the DLQ.
-				log.Dev.Errorf(ctx, "transaction %s should be sent to DLQ with reason: %v", transaction.Timestamp, txn.applyResult.DlqReason)
+				log.Dev.Errorf(ctx, "transaction %s should be sent to DLQ with reason: %v", transaction.TxnID.Timestamp, txn.applyResult.DlqReason)
 			}
 			select {
 			case <-ctx.Done():
@@ -259,48 +259,49 @@ func (a *Applier) recordCompletion(
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for _, waitingTs := range a.mu.waiting[completedTxn.Timestamp] {
-		waitingTxn, ok := a.mu.transactions[waitingTs]
+	completedID := completedTxn.TxnID
+	for _, waitingID := range a.mu.waiting[completedID] {
+		waitingTxn, ok := a.mu.transactions[waitingID]
 		if !ok {
-			return errors.AssertionFailedf("missing transaction %+v", waitingTs)
+			return errors.AssertionFailedf("missing transaction %+v", waitingID)
 		}
 
-		waitingTxn.Dependencies = slices.DeleteFunc(waitingTxn.Dependencies, func(ts hlc.Timestamp) bool {
-			return ts == completedTxn.Timestamp
+		waitingTxn.Dependencies = slices.DeleteFunc(waitingTxn.Dependencies, func(id ldrdecoder.TxnID) bool {
+			return id == completedID
 		})
-		a.mu.transactions[waitingTs] = waitingTxn
+		a.mu.transactions[waitingID] = waitingTxn
 
 		if len(waitingTxn.Dependencies) == 0 {
 			if waitingTxn.EventHorizon.LessEq(a.mu.replicatedTime) {
 				readyBuffer.AddLast(waitingTxn.Transaction)
 			} else {
-				a.mu.horizonWaiting = append(a.mu.horizonWaiting, waitingTs)
+				a.mu.horizonWaiting = append(a.mu.horizonWaiting, waitingID)
 			}
 		}
 	}
 
-	delete(a.mu.waiting, completedTxn.Timestamp)
-	txnState := a.mu.transactions[completedTxn.Timestamp]
+	delete(a.mu.waiting, completedID)
+	txnState := a.mu.transactions[completedID]
 	txnState.applied = true
-	a.mu.transactions[completedTxn.Timestamp] = txnState
+	a.mu.transactions[completedID] = txnState
 
 	var newReplicatedTime hlc.Timestamp
-	for a.mu.timestamps.Len() != 0 {
-		txn := a.mu.timestamps.GetFirst()
-		if !a.mu.transactions[txn].applied {
+	for a.mu.txnIDs.Len() != 0 {
+		id := a.mu.txnIDs.GetFirst()
+		if !a.mu.transactions[id].applied {
 			break
 		}
-		newReplicatedTime = txn
-		delete(a.mu.transactions, txn)
-		a.mu.timestamps.RemoveFirst()
+		newReplicatedTime = id.Timestamp
+		delete(a.mu.transactions, id)
+		a.mu.txnIDs.RemoveFirst()
 	}
 	if newReplicatedTime.IsSet() {
 		a.mu.replicatedTime = newReplicatedTime
 		a.frontier.Set(newReplicatedTime)
 
 		// Drain transactions whose EventHorizon is now satisfied.
-		a.mu.horizonWaiting = slices.DeleteFunc(a.mu.horizonWaiting, func(ts hlc.Timestamp) bool {
-			txn := a.mu.transactions[ts]
+		a.mu.horizonWaiting = slices.DeleteFunc(a.mu.horizonWaiting, func(id ldrdecoder.TxnID) bool {
+			txn := a.mu.transactions[id]
 			if txn.EventHorizon.LessEq(newReplicatedTime) {
 				readyBuffer.AddLast(txn.Transaction)
 				return true

--- a/pkg/crosscluster/logical/txnapply/txn_applier_test.go
+++ b/pkg/crosscluster/logical/txnapply/txn_applier_test.go
@@ -48,8 +48,8 @@ func (w *testWriter) ApplyBatch(
 
 	results := make([]txnwriter.ApplyResult, len(txns))
 	for i, txn := range txns {
-		w.t.Logf("applied txn at %s", txn.Timestamp)
-		w.mu.log = append(w.mu.log, txn.Timestamp)
+		w.t.Logf("applied txn at %s", txn.TxnID.Timestamp)
+		w.mu.log = append(w.mu.log, txn.TxnID.Timestamp)
 		results[i] = txnwriter.ApplyResult{AppliedRows: len(txn.WriteSet)}
 	}
 	return results, nil
@@ -60,8 +60,8 @@ func (w *testWriter) Close(ctx context.Context) {}
 // txnNode represents a transaction with its dependencies and an optional
 // EventHorizon that must be met before the transaction can be applied.
 type txnNode struct {
-	ts           hlc.Timestamp
-	deps         []hlc.Timestamp
+	id           ldrdecoder.TxnID
+	deps         []ldrdecoder.TxnID
 	eventHorizon hlc.Timestamp
 }
 
@@ -72,7 +72,10 @@ type depsOpt []int64
 
 func (d depsOpt) add(n *txnNode) {
 	for _, w := range d {
-		n.deps = append(n.deps, hlc.Timestamp{WallTime: w})
+		n.deps = append(n.deps, ldrdecoder.TxnID{
+			Timestamp: hlc.Timestamp{WallTime: w},
+			ApplierID: 1,
+		})
 	}
 }
 
@@ -87,7 +90,10 @@ func (h horizonOpt) add(n *txnNode) {
 func horizon(wallTime int64) horizonOpt { return horizonOpt(wallTime) }
 
 func txn(wallTime int64, opts ...txnOpt) txnNode {
-	n := txnNode{ts: hlc.Timestamp{WallTime: wallTime}}
+	n := txnNode{id: ldrdecoder.TxnID{
+		Timestamp: hlc.Timestamp{WallTime: wallTime},
+		ApplierID: 1,
+	}}
 	for _, o := range opts {
 		o.add(&n)
 	}
@@ -106,7 +112,10 @@ func generateRandomDAG(rng *rand.Rand, numTxns int, maxDeps int) []txnNode {
 	nodes := make([]txnNode, numTxns)
 	var maxHorizonWallTime int64
 	for i := range nodes {
-		nodes[i].ts = hlc.Timestamp{WallTime: int64(i + 1)}
+		nodes[i].id = ldrdecoder.TxnID{
+			Timestamp: hlc.Timestamp{WallTime: int64(i + 1)},
+			ApplierID: 1,
+		}
 
 		horizonRange := int64(i) - maxHorizonWallTime + 1
 		horizonWallTime := maxHorizonWallTime + int64(rng.Intn(int(horizonRange)))
@@ -121,7 +130,7 @@ func generateRandomDAG(rng *rand.Rand, numTxns int, maxDeps int) []txnNode {
 			numDeps := min(rng.Intn(maxDeps+1), availableCount)
 			perm := rng.Perm(availableCount)[:numDeps]
 			for _, p := range perm {
-				nodes[i].deps = append(nodes[i].deps, nodes[availableStart+p].ts)
+				nodes[i].deps = append(nodes[i].deps, nodes[availableStart+p].id)
 			}
 		}
 	}
@@ -132,9 +141,9 @@ func logDAG(t *testing.T, dag []txnNode) {
 	t.Log("transaction dependency graph:")
 	for _, node := range dag {
 		if node.eventHorizon.IsSet() {
-			t.Logf("  %s depends on %v horizon=%s", node.ts, node.deps, node.eventHorizon)
+			t.Logf("  %s depends on %v horizon=%s", node.id.Timestamp, node.deps, node.eventHorizon)
 		} else {
-			t.Logf("  %s depends on %v", node.ts, node.deps)
+			t.Logf("  %s depends on %v", node.id.Timestamp, node.deps)
 		}
 	}
 }
@@ -154,7 +163,7 @@ func runApplier(t *testing.T, dag []txnNode, numWriters int, rngSeed int64) []hl
 	input := make(chan ScheduledTransaction, len(dag))
 	for _, node := range dag {
 		input <- ScheduledTransaction{
-			Transaction:  ldrdecoder.Transaction{Timestamp: node.ts},
+			Transaction:  ldrdecoder.Transaction{TxnID: node.id},
 			Dependencies: node.deps,
 			EventHorizon: node.eventHorizon,
 		}
@@ -171,7 +180,7 @@ func runApplier(t *testing.T, dag []txnNode, numWriters int, rngSeed int64) []hl
 		return applier.Run(ctx, input)
 	})
 
-	lastTs := dag[len(dag)-1].ts
+	lastTs := dag[len(dag)-1].id.Timestamp
 	group.GoCtx(func(ctx context.Context) error {
 		var prev hlc.Timestamp
 		for ts := range applier.Frontier() {
@@ -209,7 +218,7 @@ func checkApplierDrained(t *testing.T, applier *Applier) {
 	defer applier.mu.Unlock()
 	require.Empty(t, applier.mu.transactions, "transactions map should be empty")
 	require.Empty(t, applier.mu.waiting, "waiting map should be empty")
-	require.Equal(t, 0, applier.mu.timestamps.Len(), "timestamps buffer should be empty")
+	require.Equal(t, 0, applier.mu.txnIDs.Len(), "txnIDs buffer should be empty")
 	require.Empty(t, applier.mu.horizonWaiting, "horizonWaiting should be empty")
 }
 
@@ -221,20 +230,20 @@ func checkApplyOrder(t *testing.T, dag []txnNode, applied []hlc.Timestamp) {
 		appliedAt[ts] = i
 	}
 
-	deps := make(map[hlc.Timestamp][]hlc.Timestamp)
+	deps := make(map[hlc.Timestamp][]ldrdecoder.TxnID)
 	horizons := make(map[hlc.Timestamp]hlc.Timestamp)
 	for _, node := range dag {
-		deps[node.ts] = node.deps
-		horizons[node.ts] = node.eventHorizon
+		deps[node.id.Timestamp] = node.deps
+		horizons[node.id.Timestamp] = node.eventHorizon
 	}
 
 	for ts, order := range appliedAt {
 		for _, dep := range deps[ts] {
-			depOrder, ok := appliedAt[dep]
-			require.True(t, ok, "dependency %s of %s was never applied", dep, ts)
+			depOrder, ok := appliedAt[dep.Timestamp]
+			require.True(t, ok, "dependency %s of %s was never applied", dep.Timestamp, ts)
 			require.Less(t, depOrder, order,
 				"dependency %s (position %d) applied after %s (position %d)",
-				dep, depOrder, ts, order)
+				dep.Timestamp, depOrder, ts, order)
 		}
 
 		// Verify that the transaction was not applied before its EventHorizon

--- a/pkg/crosscluster/logical/txnwriter/apply_batch.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch.go
@@ -95,7 +95,7 @@ func (tw *transactionWriter) tryApplyTransaction(
 		tableWriter := tw.tableWriters[row.TableID]
 		switch {
 		case row.IsDeleteRow():
-			err := tableWriter.DeleteRow(ctx, transaction.Timestamp, row.PrevRow)
+			err := tableWriter.DeleteRow(ctx, transaction.TxnID.Timestamp, row.PrevRow)
 			if err != nil {
 				return ApplyResult{}, err
 			}
@@ -103,7 +103,7 @@ func (tw *transactionWriter) tryApplyTransaction(
 			// TODO(jeffswenson): handle the tombstone update case. For ordered mode,
 			// this case is only needed for racing updates.
 		case row.IsInsertRow():
-			err := tableWriter.InsertRow(ctx, transaction.Timestamp, row.Row)
+			err := tableWriter.InsertRow(ctx, transaction.TxnID.Timestamp, row.Row)
 			if sqlwriter.IsLwwLoser(err) {
 				lwwLosers++
 				continue
@@ -114,7 +114,7 @@ func (tw *transactionWriter) tryApplyTransaction(
 		case row.IsUpdateRow():
 			err := tableWriter.UpdateRow(
 				ctx,
-				transaction.Timestamp,
+				transaction.TxnID.Timestamp,
 				row.PrevRow,
 				row.Row,
 			)

--- a/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
@@ -96,7 +96,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		setup: func(t *testing.T, baseID int) {},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     parentRow(baseID+1, "inserted"),
 					PrevRow: nil,
@@ -119,7 +119,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     parentRow(baseID+1, "after"),
 					PrevRow: parentRow(baseID+1, "before"),
@@ -142,7 +142,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
 					PrevRow:  parentRow(baseID+1, "doomed"),
@@ -167,7 +167,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:     parentRow(baseID+1, "updated"),
@@ -209,7 +209,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, preSetupTS hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: preSetupTS,
+				TxnID: ldrdecoder.TxnID{Timestamp: preSetupTS},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:     parentRow(baseID+1, "stale-insert"),
@@ -245,7 +245,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, preSetupTS hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: preSetupTS,
+				TxnID: ldrdecoder.TxnID{Timestamp: preSetupTS},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:     parentRow(baseID+1, "loser"),
@@ -281,7 +281,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, preSetupTS hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: preSetupTS,
+				TxnID: ldrdecoder.TxnID{Timestamp: preSetupTS},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
@@ -320,7 +320,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     parentRow(baseID+1, "winner"),
 					PrevRow: parentRow(baseID+1, "stale"),
@@ -343,7 +343,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
 					PrevRow:  parentRow(baseID+1, "stale"),
@@ -365,7 +365,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     parentRow(baseID+1, "recovered"),
 					PrevRow: parentRow(baseID+1, "phantom"),
@@ -386,7 +386,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
 					PrevRow:  parentRow(baseID+1, "phantom"),
@@ -413,7 +413,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     parentRow(baseID+1, "parent-row"),
 					TableID: parentID,
@@ -437,7 +437,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		setup: func(t *testing.T, baseID int) {},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     childRow(baseID+1, baseID+99, "orphan"), // non-existent parent
 					PrevRow: nil,
@@ -459,7 +459,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     childRow(baseID+1, baseID+99, "child"), // non-existent parent
 					PrevRow: childRow(baseID+1, baseID+1, "child"),
@@ -481,7 +481,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
 					PrevRow:  parentRow(baseID+1, "p"),
@@ -508,7 +508,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{
 					// Delete must precede insert so the unique constraint is freed.
 					{
@@ -554,7 +554,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     childRowWithUnique(baseID+2, baseID+2, baseID+1, "duplicate"), // duplicate unique_val
 					PrevRow: nil,
@@ -578,7 +578,7 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 		},
 		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
 			return ldrdecoder.Transaction{
-				Timestamp: s.Clock().Now(),
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
 				WriteSet: []ldrdecoder.DecodedRow{{
 					Row:     childRowWithUnique(baseID+2, baseID+2, baseID+1, "child2"), // duplicate unique_val
 					PrevRow: childRow(baseID+2, baseID+2, "child2"),

--- a/pkg/crosscluster/logical/txnwriter/refresh.go
+++ b/pkg/crosscluster/logical/txnwriter/refresh.go
@@ -74,7 +74,7 @@ func (tw *transactionWriter) refresh(
 			idx := rowIndex{txn: txnIdx, row: rowIdx}
 			pr, rowExists := priorRows[idx]
 
-			if rowExists && !pr.LogicalTimestamp.Less(transaction.Timestamp) {
+			if rowExists && !pr.LogicalTimestamp.Less(transaction.TxnID.Timestamp) {
 				results[txnIdx].LwwLoserRows++
 				continue
 			}
@@ -88,8 +88,8 @@ func (tw *transactionWriter) refresh(
 			writeSet = append(writeSet, refreshedRow)
 		}
 		refreshed[txnIdx] = ldrdecoder.Transaction{
-			Timestamp: transaction.Timestamp,
-			WriteSet:  writeSet,
+			TxnID:    transaction.TxnID,
+			WriteSet: writeSet,
 		}
 	}
 

--- a/pkg/crosscluster/logical/txnwriter/refresh_test.go
+++ b/pkg/crosscluster/logical/txnwriter/refresh_test.go
@@ -67,7 +67,7 @@ func TestTransactionWriter_Refresh(t *testing.T) {
 		insertRows: []string{"1, 'existing'"},
 		buildBatch: func(descID descpb.ID, tsStart, _ hlc.Timestamp) []ldrdecoder.Transaction {
 			return []ldrdecoder.Transaction{{
-				Timestamp: tsStart,
+				TxnID: ldrdecoder.TxnID{Timestamp: tsStart},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:     tree.Datums{tree.NewDInt(1), tree.NewDString("stale")},
@@ -92,7 +92,7 @@ func TestTransactionWriter_Refresh(t *testing.T) {
 		insertRows: []string{"1, 'row1'", "2, 'row2'"},
 		buildBatch: func(descID descpb.ID, tsStart, _ hlc.Timestamp) []ldrdecoder.Transaction {
 			return []ldrdecoder.Transaction{{
-				Timestamp: tsStart,
+				TxnID: ldrdecoder.TxnID{Timestamp: tsStart},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:     tree.Datums{tree.NewDInt(1), tree.NewDString("stale1")},
@@ -117,7 +117,7 @@ func TestTransactionWriter_Refresh(t *testing.T) {
 		insertRows: []string{"1, 'local_val'"},
 		buildBatch: func(descID descpb.ID, _, tsEnd hlc.Timestamp) []ldrdecoder.Transaction {
 			return []ldrdecoder.Transaction{{
-				Timestamp: tsEnd,
+				TxnID: ldrdecoder.TxnID{Timestamp: tsEnd},
 				WriteSet: []ldrdecoder.DecodedRow{
 					{
 						Row:     tree.Datums{tree.NewDInt(1), tree.NewDString("updated")},


### PR DESCRIPTION
Introduce a TxnID struct containing a Timestamp and an ApplierID field, which does not currently get populated. This refactor sets up work for the distributed applier.

Epic: none

Release note: none