### PR TITLE
catalog/lease: emit transaction updates asynchronously

### DIFF
--- a/pkg/sql/catalog/descpb/descriptor.go
+++ b/pkg/sql/catalog/descpb/descriptor.go
@@ -52,6 +52,24 @@ func GetDescriptorMetadata(
 	return id, version, name, state, err
 }
 
+// GetDescriptorModificationTime returns the modification time of a descriptor.
+func GetDescriptorModificationTime(desc *Descriptor) (hlc.Timestamp, error) {
+	switch t := desc.Union.(type) {
+	case *Descriptor_Table:
+		return t.Table.ModificationTime, nil
+	case *Descriptor_Database:
+		return t.Database.ModificationTime, nil
+	case *Descriptor_Type:
+		return t.Type.ModificationTime, nil
+	case *Descriptor_Schema:
+		return t.Schema.ModificationTime, nil
+	case *Descriptor_Function:
+		return t.Function.ModificationTime, nil
+	default:
+		return hlc.Timestamp{}, errors.AssertionFailedf("Unknown descpb.Descriptor type %T", t)
+	}
+}
+
 // GetDescriptors is a replacement for Get* methods on descpb.Descriptor.
 //
 // A linter check ensures that GetTable() et al. are not called elsewhere unless

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1207,10 +1207,24 @@ func (m *Manager) generateDescriptorTxnInfo(
 				timestamp: timestamp,
 			}
 			update.mu.DescriptorUpdates = updateEntry
-			select {
-			case <-m.stopper.ShouldQuiesce():
-			case <-ctx.Done():
-			case m.descMetaDataUpdateCh <- update:
+			// Process the update directly inside here. If the timestamp
+			// has already moved ahead it can be skipped.
+			allApplied, remaining := m.hasDescUpdateBeenApplied(update.mu.DescriptorUpdates)
+			update.mu.DescriptorUpdates = remaining
+			advanceTimestamp := func() bool {
+				m.mu.Lock()
+				defer m.mu.Unlock()
+				m.mu.hasUpdatesToDelete = true
+				minUpdate, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
+				if allApplied && (!hasMin ||
+					!minUpdate.timestamp.Less(update.timestamp)) {
+					return true
+				}
+				m.mu.descriptorTxnUpdatesToProcess.ReplaceOrInsert(update)
+				return false
+			}()
+			if advanceTimestamp {
+				m.advanceCloseTimestamp(ctx, update.timestamp)
 			}
 			return nil, nil
 		})
@@ -1994,9 +2008,8 @@ type Manager struct {
 	descUpdateCh chan catalog.Descriptor
 	// descDelCh receives deleted descriptors from the range feed.
 	descDelCh chan descpb.ID
-	// descMetaDataUpdateCh receives updated transaction metadata from the
-	// range feed.
-	descMetaDataUpdateCh chan *descriptorTxnUpdate
+	// rangeFeedCheckpointCh receives rangefeed checkpoints from the rangefeed.
+	rangeFeedCheckpointCh chan *kvpb.RangeFeedCheckpoint
 	// rangefeedErrCh receives any terminal errors from the rangefeed.
 	rangefeedErrCh chan error
 	// leaseGeneration increments any time a new or existing descriptor is
@@ -2152,7 +2165,7 @@ func NewLeaseManager(
 	lm.draining.Store(false)
 	lm.descUpdateCh = make(chan catalog.Descriptor)
 	lm.descDelCh = make(chan descpb.ID)
-	lm.descMetaDataUpdateCh = make(chan *descriptorTxnUpdate)
+	lm.rangeFeedCheckpointCh = make(chan *kvpb.RangeFeedCheckpoint)
 	lm.rangefeedErrCh = make(chan error)
 	// Allow the bytes monitor to have allocation buffering
 	// by default. When we specify the minimum memory acquired
@@ -2932,27 +2945,23 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 				if evFunc := m.testingKnobs.TestingDescriptorRefreshedEvent; evFunc != nil {
 					evFunc(desc.DescriptorProto())
 				}
-			case descUpdate := <-m.descMetaDataUpdateCh:
-				// Check if the update has been applied.
-				allApplied, remaining := m.hasDescUpdateBeenApplied(descUpdate.mu.DescriptorUpdates)
-				descUpdate.mu.DescriptorUpdates = remaining
-				advanceTimestamp := func() bool {
+			case checkpoint := <-m.rangeFeedCheckpointCh:
+				func() {
+					// Track checkpoints that occur from the rangefeed to make sure progress
+					// is always made.
+					m.advanceCloseTimestamp(ctx, checkpoint.ResolvedTS)
 					m.mu.Lock()
 					defer m.mu.Unlock()
-					m.mu.hasUpdatesToDelete = true
-					// If there are no other earlier pending updates, advance the timestamp.
-					minUpdate, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
-					if allApplied && (!hasMin ||
-						!minUpdate.timestamp.Less(descUpdate.timestamp)) {
-						return true
+					m.mu.rangeFeedCheckpoints += 1
+					// Clean up all entries before the resolve timestamp.
+					for {
+						minTS, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
+						if !hasMin || !minTS.timestamp.Less(checkpoint.ResolvedTS) {
+							break
+						}
+						m.mu.descriptorTxnUpdatesToProcess.Delete(minTS)
 					}
-					// Otherwise, insert this into the queue of pending updates
-					m.mu.descriptorTxnUpdatesToProcess.ReplaceOrInsert(descUpdate)
-					return false
 				}()
-				if advanceTimestamp {
-					m.advanceCloseTimestamp(ctx, descUpdate.timestamp)
-				}
 			case <-s.ShouldQuiesce():
 				return
 			}
@@ -3070,19 +3079,10 @@ func (m *Manager) watchForUpdates(ctx context.Context) {
 		if m.TestingDisableRangeFeedCheckpoint.Load() {
 			return
 		}
-		// Track checkpoints that occur from the rangefeed to make sure progress
-		// is always made.
-		m.advanceCloseTimestamp(ctx, checkpoint.ResolvedTS)
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		m.mu.rangeFeedCheckpoints += 1
-		// Clean up all entries before the resolve timestamp.
-		for {
-			minTS, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
-			if !hasMin || !minTS.timestamp.Less(checkpoint.ResolvedTS) {
-				break
-			}
-			m.mu.descriptorTxnUpdatesToProcess.Delete(minTS)
+		select {
+		case <-m.stopper.ShouldQuiesce():
+		case <-ctx.Done():
+		case m.rangeFeedCheckpointCh <- checkpoint:
 		}
 	}
 

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1750,7 +1750,7 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	var blockUpdates atomic.Bool
-	updateCh := make(chan struct{})
+	updateCh := make(chan hlc.Timestamp)
 
 	st := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
@@ -1762,6 +1762,7 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 	// historical queries at timestamps before the lease manager is fully caught
 	// up.
 	WaitForInitialVersion.Override(ctx, &st.SV, false)
+	var tableID atomic.Int64
 	srv, db, _ := serverutils.StartServer(
 		t, base.TestServerArgs{
 			// Avoid using tenants since async tenant migration steps can acquire
@@ -1769,11 +1770,22 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 			DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
 			Knobs: base.TestingKnobs{
 				SQLLeaseManager: &ManagerTestingKnobs{
-					TestingDescriptorRefreshedEvent: func(descriptor *descpb.Descriptor) {
-						if !blockUpdates.Load() {
-							return
+					// TestingDescriptorUpdateEvent will fire before the new descriptor version
+					// is leased.
+					TestingDescriptorUpdateEvent: func(descriptor *descpb.Descriptor) error {
+						if !blockUpdates.Load() || descriptor == nil {
+							return nil
 						}
-						<-updateCh
+						id, _, _, _, _ := descpb.GetDescriptorMetadata(descriptor)
+						if id != descpb.ID(tableID.Load()) {
+							return nil
+						}
+						ts, err := descpb.GetDescriptorModificationTime(descriptor)
+						if err != nil {
+							return err
+						}
+						updateCh <- ts
+						return nil
 					},
 				},
 			},
@@ -1792,36 +1804,48 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 	r.Exec(t, "SELECT * FROM t1")
 	r.Exec(t, "INSERT INTO t1 VALUES (1)")
 
-	grp := ctxgroup.WithContext(context.Background())
+	var id int
+	r.QueryRow(t, "SELECT 't1'::REGCLASS::OID;").Scan(&id)
+	tableID.Store(int64(id))
 	blockUpdates.Store(true)
+
+	grp := ctxgroup.WithContext(context.Background())
 	grp.GoCtx(func(ctx context.Context) error {
 		_, err := db.Exec("ALTER TABLE t1 ADD COLUMN n2 int")
 		return err
 	})
-	go func() {
-	}()
-	var id int
-	r.QueryRow(t, "SELECT 't1'::REGCLASS::OID;").Scan(&id)
-	lm := s.LeaseManager().(*Manager)
 
+	lm := s.LeaseManager().(*Manager)
 	getDescriptorVersion := func(ts ReadTimestamp) descpb.DescriptorVersion {
 		state := lm.findDescriptorState(descpb.ID(id), false)
 		require.NotNilf(t, state, "the descriptor was not leased yet")
-		ld, _, err := state.findForTimestamp(ctx, ts)
-		require.NoError(t, err)
-		defer ld.Release(ctx)
-		return ld.GetVersion()
+		var version descpb.DescriptorVersion
+		testutils.SucceedsSoon(t, func() error {
+			ld, _, err := state.findForTimestamp(ctx, ts)
+			// Lease renewal error can be observed as we are processing
+			// the new descriptor version. This happens because we are
+			// aware of the new version but the lease is not yet been
+			// acquired.
+			if errors.Is(err, errRenewLease) {
+				return err
+			}
+			require.NoError(t, err)
+			defer ld.Release(ctx)
+			version = ld.GetVersion()
+			return nil
+		})
+		return version
 	}
 
 	waitForTimestampChange := func(ts ReadTimestamp) {
 		testutils.SucceedsSoon(t, func() error {
-			if lm.GetSafeReplicationTS() == ts.GetTimestamp() {
-				return errors.New("timestamp did not change")
+			if lm.GetSafeReplicationTS().Less(ts.GetTimestamp()) {
+				return errors.Newf("timestamp did not change: %s < %s", lm.GetSafeReplicationTS().String(), ts.GetTimestamp().String())
 			}
 			return nil
 		})
 	}
-	// Allow one descriptor version to be published.
+	// Acquire a read timestamp and wait for it to change.
 	ts := lm.GetReadTimestamp(ctx, srv.Clock().Now())
 	var releaseTS = func() {
 		if ts == nil {
@@ -1831,22 +1855,20 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 		ts = nil
 	}
 	defer releaseTS()
-	updateCh <- struct{}{}
-	waitForTimestampChange(ts)
-	releaseTS()
-	ts = lm.GetReadTimestamp(ctx, srv.Clock().Now())
 	initialVersion := getDescriptorVersion(ts)
 	// The old version will still be cached as long as this timestamp is in use.
 	// Even if we released the leases already.
-	updateCh <- struct{}{}
+	afterTS := <-updateCh
+	// Select a timestamp after which the new version will be visible.
 	nextVersion := getDescriptorVersion(ts)
 	require.Equalf(t, initialVersion, nextVersion, "new version should not be leased yet")
-	waitForTimestampChange(ts)
+	waitForTimestampChange(TimestampToReadTimestamp(afterTS))
 	// If we release the old timestamp, then the old version will be released.
 	releaseTS()
 	ts = lm.GetReadTimestamp(ctx, srv.Clock().Now())
 	nextVersion = getDescriptorVersion(ts)
 	require.Equalf(t, initialVersion+1, nextVersion, "new version should be visible now")
+	blockUpdates.Store(false)
 	close(updateCh)
 	releaseTS()
 	require.NoError(t, grp.Wait())


### PR DESCRIPTION
Previously, we re-used the existing channel logic for generating transaction update events. While this was logically correct, it could lead to test flakes inside our leasing tests, since they intentionally block the go routine processing events for the range feed . To address this, patch directly handles the processing the descriptors updates inside: generateDescriptorTxnInfo

Fixes: #165162
Fixes: #165163
Fixes: #164822

Release note: None