### PR TITLE
sql/tablemetadatacache: increase test timeout to large

### DIFF
--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
 
 go_test(
     name = "tablemetadatacache_test",
+    size = "large",
     srcs = [
         "main_test.go",
         "table_metadata_updater_test.go",


### PR DESCRIPTION
## Summary
- Increases the `tablemetadatacache_test` Bazel test size from the default
  "medium" (5 min) to "large" (15 min) to fix a recurring test timeout flake.
- `TestDataDrivenTableMetadataCacheUpdater` takes ~3.3 min, leaving
  insufficient time for `TestTableMetadataUpdateJobProgressAndMetrics`
  under CI resource pressure.

Fixes: #165348

Release note: None