### PR TITLE
changefeedccl: add external sink to rolling restart roachtest

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1007,6 +1008,95 @@ func (v *CountValidator) NoteResolved(partition string, resolved hlc.Timestamp) 
 
 // Failures implements the Validator interface.
 func (v *CountValidator) Failures() []string {
+	return v.v.Failures()
+}
+
+// DuplicateCountingValidator wraps a Validator and counts duplicate rows.
+// All rows (including duplicates) are forwarded to the wrapped validator;
+// this validator only observes and counts. The inner validator is responsible
+// for its own duplicate handling.
+//
+// NoteRow and NoteResolved must be called from a single goroutine (they
+// access unsynchronized map state). NumTotal and NumDuplicates are safe
+// to read from other goroutines concurrently.
+type DuplicateCountingValidator struct {
+	v Validator
+	// resolved tracks the highest resolved timestamp seen per partition.
+	resolved map[string]hlc.Timestamp
+	// seen tracks the latest timestamp observed for each key per partition,
+	// for detecting duplicates that arrive before or between resolved
+	// timestamps. Changefeed ordering guarantees that once a key has been
+	// emitted at timestamp T, no previously unseen version of that key
+	// will arrive at a timestamp <= T. This means we only need to store
+	// one timestamp per key: any row at or below that timestamp is a
+	// duplicate.
+	//
+	// On each resolved timestamp, entries whose timestamp is at or below
+	// the resolved are pruned (the resolved check in NoteRow handles
+	// those going forward). This keeps the map bounded by the number of
+	// keys updated since the last resolved timestamp rather than growing
+	// with every row over the life of the test.
+	seen map[string]map[string]hlc.Timestamp
+
+	// NumTotal and NumDuplicates use atomic operations so they can be read
+	// safely from a monitoring goroutine while a consumer goroutine calls
+	// NoteRow.
+
+	// NumTotal is the total number of rows seen (duplicates + unique).
+	NumTotal atomic.Int64
+	// NumDuplicates is the number of rows that were identified as duplicates.
+	NumDuplicates atomic.Int64
+}
+
+// NewDuplicateCountingValidator returns a DuplicateCountingValidator wrapping
+// the given Validator.
+func NewDuplicateCountingValidator(v Validator) *DuplicateCountingValidator {
+	return &DuplicateCountingValidator{
+		v:        v,
+		resolved: make(map[string]hlc.Timestamp),
+		seen:     make(map[string]map[string]hlc.Timestamp),
+	}
+}
+
+// NoteRow implements the Validator interface.
+func (v *DuplicateCountingValidator) NoteRow(
+	partition, key, value string, updated hlc.Timestamp, topic string,
+) error {
+	v.NumTotal.Add(1)
+	if r, ok := v.resolved[partition]; ok && updated.LessEq(r) {
+		// Changefeed guarantees mean we must have seen this update before.
+		v.NumDuplicates.Add(1)
+	} else if lastSeen, ok := v.seen[partition][key]; ok && updated.LessEq(lastSeen) {
+		// We've seen a more recent update of this key. Changefeed guarantees
+		// mean this must be a duplicate.
+		v.NumDuplicates.Add(1)
+	} else {
+		// This row is not a duplicate.
+		if v.seen[partition] == nil {
+			v.seen[partition] = make(map[string]hlc.Timestamp)
+		}
+		v.seen[partition][key] = updated
+	}
+	return v.v.NoteRow(partition, key, value, updated, topic)
+}
+
+// NoteResolved implements the Validator interface.
+func (v *DuplicateCountingValidator) NoteResolved(partition string, resolved hlc.Timestamp) error {
+	if cur, ok := v.resolved[partition]; !ok || cur.Less(resolved) {
+		v.resolved[partition] = resolved
+		// Prune seen keys before this timestamp. This keeps the memory usage
+		// of `seen` in check.
+		for key, ts := range v.seen[partition] {
+			if ts.LessEq(resolved) {
+				delete(v.seen[partition], key)
+			}
+		}
+	}
+	return v.v.NoteResolved(partition, resolved)
+}
+
+// Failures implements the Validator interface.
+func (v *DuplicateCountingValidator) Failures() []string {
 	return v.v.Failures()
 }
 

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -549,6 +549,119 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 }
 
+func TestDuplicateCountingValidator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const ignored = `ignored`
+
+	t.Run(`distinct keys`, func(t *testing.T) {
+		// Rows for distinct keys are not duplicates.
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(1), `foo`)
+		noteRow(t, dupV, `p1`, `k2`, ignored, ts(1), `foo`)
+		noteRow(t, dupV, `p1`, `k3`, ignored, ts(1), `foo`)
+		require.Equal(t, int64(3), dupV.NumTotal.Load())
+		require.Equal(t, int64(0), dupV.NumDuplicates.Load())
+	})
+	t.Run(`distinct timestamps`, func(t *testing.T) {
+		// Rows for distinct timestamps are not duplicates.
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(1), `foo`)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(2), `foo`)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(3), `foo`)
+		require.Equal(t, int64(3), dupV.NumTotal.Load())
+		require.Equal(t, int64(0), dupV.NumDuplicates.Load())
+	})
+	t.Run(`simple duplicate`, func(t *testing.T) {
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(1), `foo`)
+		// We see a second message for the same key but at a later
+		// timestamp, which is NOT a duplicate.
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(2), `foo`)
+		// This message is exactly the same as the first and is a duplicate.
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(1), `foo`)
+		require.Equal(t, int64(3), dupV.NumTotal.Load())
+		require.Equal(t, int64(1), dupV.NumDuplicates.Load())
+	})
+	t.Run(`duplicate after resolved`, func(t *testing.T) {
+		// We consider all messages that come in after a resolved message
+		// to be duplicates. The resolved message means we must have seen
+		// this update before.
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteResolved(t, dupV, `p1`, ts(5))
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(3), `foo`)
+		noteRow(t, dupV, `p1`, `k2`, ignored, ts(5), `foo`)
+		require.Equal(t, int64(2), dupV.NumTotal.Load())
+		require.Equal(t, int64(2), dupV.NumDuplicates.Load())
+	})
+	t.Run(`non-duplicate after resolved`, func(t *testing.T) {
+		// We may see (non-duplicate) messages on a key after a resolved
+		// message. This is expected.
+		inner := NewOrderValidator(`t1`)
+		dupV := NewDuplicateCountingValidator(inner)
+		noteResolved(t, dupV, `p1`, ts(5))
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(6), `foo`)
+		noteRow(t, dupV, `p1`, `k2`, ignored, ts(7), `foo`)
+		require.Equal(t, int64(2), dupV.NumTotal.Load())
+		require.Equal(t, int64(0), dupV.NumDuplicates.Load())
+	})
+	t.Run(`same key on different partition`, func(t *testing.T) {
+		// Duplicates are tracked independently per partition, even if
+		// they have the same key.
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteResolved(t, dupV, `p1`, ts(10))
+		noteResolved(t, dupV, `p2`, ts(5))
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(8), `foo`)
+		noteRow(t, dupV, `p2`, `k1`, ignored, ts(8), `foo`)
+		require.Equal(t, int64(2), dupV.NumTotal.Load())
+		require.Equal(t, int64(1), dupV.NumDuplicates.Load())
+	})
+	t.Run(`resolved backwards ignored`, func(t *testing.T) {
+		// A resolved timestamp that goes backwards should not lower
+		// the stored value.
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteResolved(t, dupV, `p1`, ts(10))
+		noteResolved(t, dupV, `p1`, ts(5))
+		// This update is still considered a duplicate, even though
+		// resolved regressed. The resolved timestamp of 10 means that
+		// we've seen this message before.
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(7), `foo`)
+		require.Equal(t, int64(1), dupV.NumTotal.Load())
+		require.Equal(t, int64(1), dupV.NumDuplicates.Load())
+	})
+	t.Run(`duplicate above resolved still caught`, func(t *testing.T) {
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(12), `foo`)
+		noteResolved(t, dupV, `p1`, ts(10))
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(12), `foo`)
+		require.Equal(t, int64(2), dupV.NumTotal.Load())
+		require.Equal(t, int64(1), dupV.NumDuplicates.Load())
+	})
+	t.Run(`duplicate does not advance seen timestamp`, func(t *testing.T) {
+		// A duplicate at an older timestamp must not overwrite the seen
+		// entry, otherwise a later duplicate at an intermediate timestamp
+		// would be missed.
+		dupV := NewDuplicateCountingValidator(NoOpValidator)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(5), `foo`)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(3), `foo`) // duplicate
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(4), `foo`) // also duplicate
+		require.Equal(t, int64(3), dupV.NumTotal.Load())
+		require.Equal(t, int64(2), dupV.NumDuplicates.Load())
+	})
+	t.Run(`duplicates forwarded to inner validator`, func(t *testing.T) {
+		// Duplicates are counted but still forwarded to the inner
+		// validator. Wrapping a CountValidator lets us verify that
+		// all rows (including duplicates) reach the inner validator.
+		inner := NewCountValidator(NoOpValidator)
+		dupV := NewDuplicateCountingValidator(inner)
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(10), `foo`)
+		noteResolved(t, dupV, `p1`, ts(10))
+		noteRow(t, dupV, `p1`, `k1`, ignored, ts(10), `foo`)
+		require.Equal(t, int64(2), dupV.NumTotal.Load())
+		require.Equal(t, int64(1), dupV.NumDuplicates.Load())
+		require.Equal(t, 2, inner.NumRows)
+	})
+}
+
 func TestValidators(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const ignored = `ignored`

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1281,7 +1281,6 @@ WITH initial_scan='only', min_checkpoint_frequency='1s'`, sinkURL),
 }
 
 type rollingRestartParams struct {
-	maxBackoff string
 	doRestarts bool
 	// testDuration is the total duration of the test, including the kv workload
 	// and changefeed monitoring. It may be longer than restartDuration to allow
@@ -1296,10 +1295,6 @@ type rollingRestartParams struct {
 // It runs a kv workload while periodically draining and restarting nodes to
 // simulate rolling upgrades. The doRestarts parameter controls whether restarts
 // actually occur (a false value runs a control baseline without restarts).
-//
-// During rolling restarts, each node restart triggers changefeed retries with
-// exponential backoff, and if the max backoff is too large the changefeed can't
-// make enough progress between restarts, causing lag to accumulate.
 func runCDCRollingRestart(
 	ctx context.Context, t test.Test, c cluster.Cluster, params rollingRestartParams,
 ) {
@@ -1313,19 +1308,33 @@ func runCDCRollingRestart(
 		t.Fatal("restartDuration must be less than or equal to testDuration")
 	}
 
+	// Node topology:
+	// - Nodes 1 through N-2: CRDB (subject to rolling restarts)
+	// - Node N-1: CRDB + workload runner + SQL queries (not restarted)
+	// - Node N: Kafka
+	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
+	kafkaNode := c.Node(c.Spec().NodeCount)
+
 	startOpts := option.DefaultStartOpts()
-	racks := install.MakeClusterSettings(install.NumRacksOption(c.Spec().NodeCount))
-	// Override the initial retry backoff so it doesn't take many retries to
-	// reach the max backoff behavior.
-	racks.Env = append(racks.Env, `COCKROACH_CHANGEFEED_TESTING_INITIAL_RETRY_BACKOFF=32s`)
-	c.Start(ctx, t.L(), startOpts, racks)
+	// Start the retry backoff at the max (30s) so that every restart
+	// immediately exercises worst-case backoff behavior. Without this, the
+	// default initial backoff is low enough that ~10 restarts over 20 minutes
+	// never reach problematic values, and the test would pass even if the
+	// backoff handling were broken.
+	settings := install.MakeClusterSettings(
+		install.EnvOption{`COCKROACH_CHANGEFEED_TESTING_INITIAL_RETRY_BACKOFF=30s`},
+	)
+	c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
+
+	kafka, kafkaCleanup := setupKafka(ctx, t, c, kafkaNode)
+	defer kafkaCleanup()
 
 	// Set up prometheus on the workload node for roachperf export. The
 	// workload node is never restarted, so prometheus scraping is stable.
-	workloadNode := c.Spec().NodeCount
+	workloadNode := c.Spec().NodeCount - 1
 	promCfg := (&prometheus.Config{}).
 		WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-		WithCluster(c.All().InstallNodes()).
+		WithCluster(crdbNodes.InstallNodes()).
 		WithNodeExporter(c.All().InstallNodes())
 	if err := c.StartGrafana(ctx, t.L(), promCfg); err != nil {
 		t.Fatal(err)
@@ -1341,7 +1350,7 @@ func runCDCRollingRestart(
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(n))
 		opts := startOpts
 		opts.RoachprodOpts.IsRestart = true
-		c.Start(ctx, t.L(), opts, racks, c.Node(n))
+		c.Start(ctx, t.L(), opts, settings, c.Node(n))
 		t.Monitor().ExpectProcessAlive(c.Node(n))
 		t.L().Printf("node %d restarted successfully", n)
 		return nil
@@ -1351,48 +1360,62 @@ func runCDCRollingRestart(
 	// other nodes during the test.
 	db := c.Conn(ctx, t.L(), workloadNode)
 	defer db.Close()
-	t.L().Printf("setting up test with maxBackoff=%s, doRestarts=%t",
-		params.maxBackoff, params.doRestarts)
-	setupStmts := []string{
-		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
-		fmt.Sprintf(`SET CLUSTER SETTING changefeed.max_retry_backoff = '%s'`, params.maxBackoff),
+	t.L().Printf("setting up test with doRestarts=%t", params.doRestarts)
+	if _, err := db.Exec(`SET CLUSTER SETTING kv.rangefeed.enabled = true`); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, s := range setupStmts {
-		t.L().Printf(s)
-		if _, err := db.Exec(s); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	cmd := fmt.Sprintf("./cockroach workload init kv --splits 50 {pgurl:%d}", c.Spec().NodeCount)
-	if err := c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), cmd); err != nil {
+	cmd := fmt.Sprintf("./cockroach workload init kv --splits 50 {pgurl:%d}", workloadNode)
+	if err := c.RunE(ctx, option.WithNodes(c.Node(workloadNode)), cmd); err != nil {
 		t.Fatal(err)
 	}
 
 	// Run the kv workload for the full test duration.
 	t.Go(func(ctx context.Context, l *logger.Logger) error {
 		cmd := fmt.Sprintf("./cockroach workload run kv --zipfian --duration=%s {pgurl:%d} --tolerate-errors",
-			params.testDuration, c.Spec().NodeCount)
-		return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), cmd)
+			params.testDuration, workloadNode)
+		return c.RunE(ctx, option.WithNodes(c.Node(workloadNode)), cmd)
 	})
 
 	var jobID int
-	if err := db.QueryRow(`CREATE CHANGEFEED FOR TABLE kv.kv INTO 'null://' WITH initial_scan='no'`).Scan(&jobID); err != nil {
+	if err := db.QueryRow(fmt.Sprintf(
+		`CREATE CHANGEFEED FOR TABLE kv.kv INTO '%s'`+
+			` WITH updated, resolved, initial_scan='no', min_checkpoint_frequency='2s',`+
+			` kafka_sink_config='{"Flush": {"Messages": 100, "Frequency": "10ms"}}'`,
+		kafka.sinkURL(ctx),
+	)).Scan(&jobID); err != nil {
 		t.Fatal(err)
 	}
 	t.L().Printf("changefeed %d will run for %s", jobID, params.testDuration)
+
+	// Set up Kafka consumer with duplicate counting.
+	dupV := cdctest.NewDuplicateCountingValidator(cdctest.NoOpValidator)
+	consumerStopper := make(chan struct{})
+	tc, err := kafka.newConsumerWithValidator(ctx, "kv", dupV, consumerStopper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tc.close()
+
+	consumerDone := make(chan struct{})
+	t.Go(func(ctx context.Context, l *logger.Logger) error {
+		defer close(consumerDone)
+		for {
+			m, err := tc.next(ctx)
+			if err != nil {
+				return err
+			}
+			if m == nil {
+				return nil
+			}
+		}
+	})
 
 	beginTime := timeutil.Now()
 
 	// Start rolling restarts in a background goroutine if enabled. We
 	// restart all nodes except the workload node.
 	if params.doRestarts {
-		// With restarts every 2 minutes and a 1m max backoff, the changefeed
-		// should get at least 1m of forward progress between each disruption,
-		// which is sufficient to keep up with the workload. With a higher max
-		// backoff (e.g. 10m), the changefeed spends most of each restart
-		// interval waiting to retry and falls behind.
 		const restartInterval = 2 * time.Minute
 		restartNodes := make([]int, 0, workloadNode-1)
 		for i := 1; i < workloadNode; i++ {
@@ -1470,11 +1493,22 @@ func runCDCRollingRestart(
 			t.L().Printf("[%s] error querying changefeed status: %v", timeutil.Since(beginTime), err)
 			continue
 		}
-		t.L().Printf("[%s] changefeed lag: %s, status: %s, running_status: %s",
-			timeutil.Since(beginTime), currentLag, status, runningStatus)
 		if currentLag > maxHighwaterLag {
 			maxHighwaterLag = currentLag
 		}
+		// Read duplicate stats from dupV's atomic counters rather than
+		// tc.validator.NumRows, which isn't safe to read cross-goroutine.
+		numTotal := dupV.NumTotal.Load()
+		numDuplicates := dupV.NumDuplicates.Load()
+		var dupPctStr string
+		if numTotal > 0 {
+			dupPctStr = fmt.Sprintf("%.2f%%", 100.0*float64(numDuplicates)/float64(numTotal))
+		} else {
+			dupPctStr = "n/a"
+		}
+		t.L().Printf("[%s] lag=%s status=%s running_status=%s total_msgs=%d dupes=%d dupe_pct=%s",
+			timeutil.Since(beginTime), currentLag, status, runningStatus,
+			numTotal, numDuplicates, dupPctStr)
 		if status == "failed" {
 			t.Fatalf("changefeed entered failed status: %s", runningStatus)
 		}
@@ -1482,6 +1516,19 @@ func runCDCRollingRestart(
 			t.Fatalf("changefeed lag %s exceeded maximum allowed (%s) during rolling restarts",
 				currentLag, maxAllowedLag)
 		}
+	}
+
+	// Stop Kafka consumer and report duplicate counts.
+	close(consumerStopper)
+	<-consumerDone
+	numTotal := dupV.NumTotal.Load()
+	numDuplicates := dupV.NumDuplicates.Load()
+	if numTotal > 0 {
+		dupPct := 100.0 * float64(numDuplicates) / float64(numTotal)
+		t.L().Printf("duplicate counting: total_messages=%d unique=%d duplicates=%d duplicate_pct=%.2f%%",
+			numTotal, numTotal-numDuplicates, numDuplicates, dupPct)
+	} else {
+		t.L().Printf("duplicate counting: no messages consumed")
 	}
 
 	// After the test, verify lag has recovered below a tighter threshold.
@@ -1545,6 +1592,18 @@ func runCDCRollingRestart(
 				Name:           "Final highwater lag (s)",
 				Value:          roachtestutil.MetricPoint(finalLag.Seconds()),
 				Unit:           "seconds",
+				IsHigherBetter: false,
+			}
+		},
+		func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+			var dupPct float64
+			if numTotal > 0 {
+				dupPct = 100.0 * float64(numDuplicates) / float64(numTotal)
+			}
+			return &roachtestutil.AggregatedMetric{
+				Name:           "Duplicate percentage",
+				Value:          roachtestutil.MetricPoint(dupPct),
+				Unit:           "percent",
 				IsHigherBetter: false,
 			}
 		},
@@ -2451,14 +2510,13 @@ CONFIGURE ZONE USING
 		Name:             "cdc/rolling-restart",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(4),
+		Cluster:          r.MakeClusterSpec(5),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          30 * time.Minute,
 		Monitor:          true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCRollingRestart(ctx, t, c, rollingRestartParams{
-				maxBackoff:      "1m",
 				doRestarts:      true,
 				testDuration:    20 * time.Minute,
 				restartDuration: 15 * time.Minute,
@@ -2472,14 +2530,13 @@ CONFIGURE ZONE USING
 		Name:             "cdc/no-rolling-restart",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(4),
+		Cluster:          r.MakeClusterSpec(5),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          30 * time.Minute,
 		Monitor:          true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCRollingRestart(ctx, t, c, rollingRestartParams{
-				maxBackoff:   "1m",
 				doRestarts:   false,
 				testDuration: 20 * time.Minute,
 			})
@@ -4586,6 +4643,16 @@ func (k kafkaManager) createTopic(ctx context.Context, topic string) error {
 func (k kafkaManager) newConsumer(
 	ctx context.Context, topic string, stopper <-chan struct{},
 ) (*topicConsumer, error) {
+	var validator cdctest.Validator
+	if k.validateOrder {
+		validator = cdctest.NewOrderValidator(topic)
+	}
+	return k.newConsumerWithValidator(ctx, topic, validator, stopper)
+}
+
+func (k kafkaManager) newConsumerWithValidator(
+	ctx context.Context, topic string, validator cdctest.Validator, stopper <-chan struct{},
+) (*topicConsumer, error) {
 	kafkaAddrs := []string{k.consumerURL(ctx)}
 	config := sarama.NewConfig()
 	// I was seeing "error processing FetchRequest: kafka: error decoding
@@ -4598,10 +4665,6 @@ func (k kafkaManager) newConsumer(
 	consumer, err := sarama.NewConsumer(kafkaAddrs, config)
 	if err != nil {
 		return nil, err
-	}
-	var validator cdctest.Validator
-	if k.validateOrder {
-		validator = cdctest.NewOrderValidator(topic)
 	}
 	tc, err := newTopicConsumer(k.t, consumer, topic, validator, stopper)
 	if err != nil {


### PR DESCRIPTION
changefeedccl: add external sink to rolling restart roachtest
This commit updates the CDC rolling restart test to use a Kafka sink
instead of a null sink, and adds a Kafka consumer that counts duplicate
rows delivered during restarts using the DuplicateCountingValidator.
We report the final number of duplicates as a percentage to roachperf.

The NumRacksOption was removed as rack-aware replica placement is not
relevant to this test. The allocator will distribute replicas evenly
regardless.

Closes: https://github.com/cockroachdb/cockroach/issues/164040
Release note: None