### PR TITLE
importer: disable elastic CPU control in a few tests

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -254,7 +254,7 @@ func TestImportData(t *testing.T) {
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
-
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.elastic_control.enabled = false`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 
 	tests := []struct {
@@ -1617,6 +1617,7 @@ func setupTestImportCSVStmt(
 	conn := tc.ServerConn(0)
 
 	sqlDB = sqlutils.MakeSQLRunner(conn)
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.elastic_control.enabled = false`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 
 	testFiles = makeCSVData(t, numFiles, rowsPerFile, nodes, rowsPerRaceFile)
@@ -2487,6 +2488,7 @@ func setupImportIntoCSVTest(t *testing.T) *importIntoCSVTestFixture {
 	}})
 	conn := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.elastic_control.enabled = false`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 	// 'import-into-no-glob-wildcard' hits an error that the file doesn't exist
 	// in external storage. When run with test tenants, that error also happens


### PR DESCRIPTION
We've seen a few tests take really long time, and we recently enabled elastic CPU control in the IMPORT jobs which might be contributing to the slowness. This commit disables the throttling on tests that we've seen slowness on. (Note that I was unable to reproduce the slowness, so it's just a guess.)

Fixes: #163968.
Release note: None