### PR TITLE
jobs: store DistSQL diagram URLs as .url files

### DIFF
--- a/pkg/jobs/execution_detail_utils.go
+++ b/pkg/jobs/execution_detail_utils.go
@@ -115,6 +115,24 @@ func ReadExecutionDetailFile(
 		return stringifyProtobinFile(trimmedFilename, fileBytes)
 	}
 
+	// If the file requested ends in `.url.html`, strip the `.html` suffix to
+	// find the underlying `.url` file and wrap its contents in an HTML redirect.
+	if strings.HasSuffix(filename, ".url.html") {
+		urlFilename := strings.TrimSuffix(filename, ".html")
+		urlBytes, err := ReadChunkedFileToJobInfo(
+			ctx,
+			profilerconstants.MakeProfilerExecutionDetailsChunkKeyPrefix(urlFilename),
+			txn,
+			jobID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(fmt.Sprintf(
+			`<meta http-equiv="Refresh" content="0; url=%s">`, string(urlBytes),
+		)), nil
+	}
+
 	return ReadChunkedFileToJobInfo(
 		ctx,
 		profilerconstants.MakeProfilerExecutionDetailsChunkKeyPrefix(filename),
@@ -144,6 +162,11 @@ func ListExecutionDetailFiles(
 					// the file available for consumption.
 					if strings.HasSuffix(filename, ".binpb") {
 						files = append(files, filename+".txt")
+					}
+					// If we see a `.url` file, also list a `.url.html`
+					// virtual entry that serves the URL wrapped in HTML.
+					if strings.HasSuffix(filename, ".url") {
+						files = append(files, filename+".html")
 					}
 					files = append(files, filename)
 				}

--- a/pkg/server/job_profiler.go
+++ b/pkg/server/job_profiler.go
@@ -135,7 +135,9 @@ func (e *executionDetailsBuilder) addLabelledGoroutines(ctx context.Context) {
 	}
 }
 
-// addDistSQLDiagram generates and persists a `distsql.<timestamp>.html` file.
+// addDistSQLDiagram generates and persists a `distsql-plan.url` file containing
+// the raw DistSQL diagram URL. The UI layer converts this to a `.html` virtual
+// file on the fly via ReadExecutionDetailFile.
 func (e *executionDetailsBuilder) addDistSQLDiagram(ctx context.Context) {
 	query := `SELECT plan_diagram FROM [SHOW JOB $1 WITH EXECUTION DETAILS]`
 	row, err := e.db.Executor().QueryRowEx(ctx, "profiler-bundler-add-diagram", nil, /* txn */
@@ -146,10 +148,10 @@ func (e *executionDetailsBuilder) addDistSQLDiagram(ctx context.Context) {
 	}
 	if row != nil && row[0] != tree.DNull {
 		dspDiagramURL := string(tree.MustBeDString(row[0]))
-		filename := fmt.Sprintf("%s/distsql-plan.html", timeutil.Now().Format("20060102_150405.00"))
+		filename := fmt.Sprintf("%s/distsql-plan.url", timeutil.Now().Format("20060102_150405.00"))
 		if err := e.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			return jobs.WriteExecutionDetailFile(ctx, filename,
-				[]byte(fmt.Sprintf(`<meta http-equiv="Refresh" content="0; url=%s">`, dspDiagramURL)),
+				[]byte(dspDiagramURL),
 				txn, e.jobID)
 		}); err != nil {
 			log.Dev.Errorf(ctx, "failed to write DistSQL diagram for job %d: %v", e.jobID, err.Error())

--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -195,7 +195,7 @@ func TestReadWriteProfilerExecutionDetails(t *testing.T) {
 		runner.Exec(t, `SELECT crdb_internal.request_job_execution_details($1)`, importJobID)
 		distSQLDiagram, err := checkExecutionDetails(t, s, jobspb.JobID(importJobID), "distsql")
 		require.NoError(t, err)
-		require.Regexp(t, "<meta http-equiv=\"Refresh\" content=\"0\\; url=https://cockroachdb\\.github\\.io/distsqlplan/decode.html.*>", string(distSQLDiagram))
+		require.Regexp(t, "https://cockroachdb\\.github\\.io/distsqlplan/decode.html.*", string(distSQLDiagram))
 		close(continueRunning)
 		jobutils.WaitForJobToSucceed(t, runner, jobspb.JobID(importJobID))
 	})
@@ -378,7 +378,8 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 		files := listExecutionDetails(t, s, jobspb.JobID(importJobID))
 
 		patterns := []string{
-			".*/distsql-plan.html",
+			".*/distsql-plan.url",
+			".*/distsql-plan.url.html",
 		}
 		if !s.DeploymentMode().IsExternal() {
 			patterns = append(patterns, ".*/job-goroutines.txt")
@@ -395,7 +396,7 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 
 		testutils.SucceedsSoon(t, func() error {
 			files = listExecutionDetails(t, s, jobspb.JobID(importJobID))
-			expectedCount := 5
+			expectedCount := 6
 			if s.DeploymentMode().IsExternal() {
 				expectedCount--
 			}
@@ -416,9 +417,9 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 		jobutils.WaitForJobToSucceed(t, runner, jobspb.JobID(importJobID))
 		testutils.SucceedsSoon(t, func() error {
 			files = listExecutionDetails(t, s, jobspb.JobID(importJobID))
-			expectedCount := 10
+			expectedCount := 12
 			if s.DeploymentMode().IsExternal() {
-				expectedCount = 8
+				expectedCount = 10
 			}
 			if len(files) != expectedCount {
 				return errors.Newf("expected %d files, got %d: %v", expectedCount, len(files), files)
@@ -426,8 +427,10 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 			return nil
 		})
 		patterns = []string{
-			".*/distsql-plan.html",
-			".*/distsql-plan.html",
+			".*/distsql-plan.url",
+			".*/distsql-plan.url",
+			".*/distsql-plan.url.html",
+			".*/distsql-plan.url.html",
 		}
 		if !s.DeploymentMode().IsExternal() {
 			patterns = append(patterns, ".*/job-goroutines.txt", ".*/job-goroutines.txt")


### PR DESCRIPTION
## Summary

Stacked on #165447.

- Change `addDistSQLDiagram` to write the raw DistSQL diagram URL as a
  `.url` file instead of wrapping it in HTML at write time.
- `ReadExecutionDetailFile` now generates the HTML redirect wrapper on
  the fly when a `.html` file is requested and a corresponding `.url`
  backing file exists, following the same virtual-file pattern used for
  `.binpb` → `.binpb.txt`. Legacy `.html` files continue to be served
  as-is.
- `ListExecutionDetailFiles` maps `.url` files to `.html` virtual
  entries so the UI sees `.html` filenames without changes.

This separation enables future inline viewing of the URL content
without the HTML redirect wrapping.

Epic: None
Release note: None