### PR TITLE
changefeedccl: deflake TestChangefeedUnwatchedFamilyMemoryMonitoring

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_memory_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_memory_test.go
@@ -55,8 +55,10 @@ func TestChangefeedUnwatchedFamilyMemoryMonitoring(t *testing.T) {
 
 		// Start changefeed watching only f1 with diff enabled.
 		// Events from f2 should return DecodeSkipUnwatchedFamily status.
+		// Override min_checkpoint_frequency so the sink flushes more often,
+		// making testing with cloudstorage sink more reliable.
 		feed := feed(t, f,
-			`CREATE CHANGEFEED FOR foo FAMILY f1 WITH diff, initial_scan='no', resolved`, args...)
+			`CREATE CHANGEFEED FOR foo FAMILY f1 WITH diff, initial_scan='no', resolved='100ms', min_checkpoint_frequency='100ms'`, args...)
 		defer closeFeed(t, feed)
 
 		// Update a watched column to generate an event.


### PR DESCRIPTION
TestChangefeedUnwatchedFamilyMemoryMonitoring failed intermittently 
with the cloudstorage sink when we fail to see a changefeed message 
within the timeout period. This change increases the frequency of flushes 
which reduces flakiness.

This test has been stressed over 100k times without flaking, while
before this change it flaked once every 10k times.

Fixes: #164281
Release note: None