### PR TITLE
testutils: goroutine dump on timeout in withTimeout

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -485,13 +485,21 @@ func withTimeout(
 	if jobFeed, ok := f.(cdctest.EnterpriseTestFeed); ok {
 		jobID = jobFeed.JobID()
 	}
-	return timeutil.RunWithTimeout(context.Background(),
+	err := timeutil.RunWithTimeout(context.Background(),
 		redact.Sprintf("withTimeout-%d", jobID), timeout,
 		func(ctx context.Context) error {
 			defer stopFeedWhenDone(ctx, f)()
 			return fn(ctx)
 		},
 	)
+	if err != nil {
+		var timeoutErr *timeutil.TimeoutError
+		if errors.As(err, &timeoutErr) {
+			dumpFile := testutils.WriteGoroutineDump()
+			return errors.WithDetail(err, fmt.Sprintf("goroutine dump: %s", dumpFile))
+		}
+	}
+	return err
 }
 
 func assertPayloads(t testing.TB, f cdctest.TestFeed, expected []string) {

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "error.go",
         "exectrace.go",
         "files.go",
+        "goroutinedump.go",
         "hook.go",
         "keys.go",
         "net.go",

--- a/pkg/testutils/goroutinedump.go
+++ b/pkg/testutils/goroutinedump.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package testutils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
+)
+
+// WriteGoroutineDump writes a goroutine stack dump to a file in the test
+// output directory and returns the file path. If the file cannot be created
+// or written, it returns a description of the error.
+func WriteGoroutineDump() string {
+	f, err := os.CreateTemp(datapathutils.DebuggableTempDir(), "goroutine_dump_*.txt")
+	if err != nil {
+		return fmt.Sprintf("<failed to create dump file: %v>", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(allstacks.Get()); err != nil {
+		return fmt.Sprintf("<failed to write dump to %s: %v>", f.Name(), err)
+	}
+	return f.Name()
+}

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -7,13 +7,9 @@ package testutils
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -64,25 +60,10 @@ func SucceedsWithin(t TestFataler, fn func() error, duration time.Duration) {
 		if f, l, _, ok := errors.GetOneLineSource(err); ok {
 			err = errors.Wrapf(err, "from %s:%d", f, l)
 		}
-		dumpFile := writeGoroutineDump()
+		dumpFile := WriteGoroutineDump()
 		t.Fatalf("condition failed to evaluate within %s: %s\n\ngoroutine dump: %s",
 			duration, err, dumpFile)
 	}
-}
-
-// writeGoroutineDump writes a goroutine stack dump to a file in the test
-// output directory and returns the file path. If the file cannot be created
-// or written, it returns a description of the error.
-func writeGoroutineDump() string {
-	f, err := os.CreateTemp(datapathutils.DebuggableTempDir(), "goroutine_dump_*.txt")
-	if err != nil {
-		return fmt.Sprintf("<failed to create dump file: %v>", err)
-	}
-	defer f.Close()
-	if _, err := f.Write(allstacks.Get()); err != nil {
-		return fmt.Sprintf("<failed to write dump to %s: %v>", f.Name(), err)
-	}
-	return f.Name()
 }
 
 // SucceedsWithinError returns an error unless the supplied function


### PR DESCRIPTION
We previously dumped the goroutine stack on succeedsSoon/succeedsWithin
timeout. This change also dumps the goroutine stack on timeout in
withTimeout to help with debugging.

Informs: #165453
Release note: None