### PR TITLE
sqlproxyccl: add new way of parsing cluster name / tenant ID from SNI

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -776,12 +776,8 @@ func clusterNameAndTenantFromParams(
 	var tenID roachpb.TenantID
 	// No cluster identifiers were specified.
 	if clusterIdentifierDB == "" && clusterIdentifierOpt == "" {
-		var clusterIdentifierSNI string
-		if i := strings.Index(fe.SniServerName, "."); i >= 0 {
-			clusterIdentifierSNI = fe.SniServerName[:i]
-		}
-		if clusterIdentifierSNI != "" {
-			clusterName, tenID, err = parseClusterIdentifier(ctx, clusterIdentifierSNI)
+		if fe.SniServerName != "" {
+			clusterName, tenID, err = parseClusterIdentifierFromSNI(ctx, fe.SniServerName)
 			if err == nil {
 				// Identifier provider via SNI is a bit different from the identifiers
 				// provided via DB (with dot) or options. With SNI it is possible that
@@ -814,9 +810,9 @@ func clusterNameAndTenantFromParams(
 	}
 
 	if clusterIdentifierDB != "" {
-		clusterName, tenID, err = parseClusterIdentifier(ctx, clusterIdentifierDB)
+		clusterName, tenID, err = parseClusterIdentifierFromOldSNI(ctx, clusterIdentifierDB)
 	} else {
-		clusterName, tenID, err = parseClusterIdentifier(ctx, clusterIdentifierOpt)
+		clusterName, tenID, err = parseClusterIdentifierFromOldSNI(ctx, clusterIdentifierOpt)
 	}
 	if err != nil {
 		return fe.Msg, "", roachpb.MaxTenantID, err
@@ -853,9 +849,43 @@ func clusterNameAndTenantFromParams(
 	return outMsg, clusterName, tenID, nil
 }
 
-// parseClusterIdentifier will parse an identifier received via DB, opts or SNI
+// parseClusterIdentifierFromSNI parses the cluster name and tenant ID from an
+// SNI server name. It supports two formats:
+//
+//   - New format: <cluster-name>.<tenant-id>.<host>.<region>.<root>
+//     e.g. "happy-seal.10.abc.gcp-us-central1.cockroachlabs.cloud"
+//     The cluster name is the first DNS label, and the tenant ID is the second.
+//
+//   - Old format: <cluster-name>-<tenant-id>.<host>.<region>.<root>
+//     e.g. "happy-seal-10.abc.gcp-us-central1.cockroachlabs.cloud"
+//     The cluster name and tenant ID are both in the first DNS label, separated
+//     by a hyphen.
+//
+// The new format is tried first. If the second DNS label is a valid tenant ID
+// and the first label is a valid cluster name, the new format is used.
+// Otherwise, the old format is used as a fallback.
+func parseClusterIdentifierFromSNI(
+	ctx context.Context, sniServerName string,
+) (string, roachpb.TenantID, error) {
+	parts := strings.SplitN(sniServerName, ".", 3)
+	if len(parts) < 2 {
+		return "", roachpb.MaxTenantID, errors.New("invalid SNI server name")
+	}
+
+	// Try new format: first label = cluster name, second label = tenant ID.
+	if tenID, err := strconv.ParseUint(parts[1], 10, 64); err == nil &&
+		tenID >= roachpb.MinTenantID.ToUint64() &&
+		clusterNameRegex.MatchString(parts[0]) {
+		return parts[0], roachpb.MustMakeTenantID(tenID), nil
+	}
+
+	// Fall back to old format: first label = name-tenantID.
+	return parseClusterIdentifierFromOldSNI(ctx, parts[0])
+}
+
+// parseClusterIdentifierFromOldSNI will parse an identifier received via DB, opts or SNI
 // and extract the tenant cluster name and tenant ID.
-func parseClusterIdentifier(
+func parseClusterIdentifierFromOldSNI(
 	ctx context.Context, clusterIdentifier string,
 ) (string, roachpb.TenantID, error) {
 	sepIdx := strings.LastIndex(clusterIdentifier, clusterTenantSep)

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -396,7 +396,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 	}
 
 	t.Run("private connection allowed", func(t *testing.T) {
-		url := fmt.Sprintf("postgres://bob:builder@%s/my-tenant-10.defaultdb?sslmode=require", addrs.listenAddr)
+		url := fmt.Sprintf("postgres://bob:builder@%s/my-tenant-10.defaultdb?sslmode=require&sslrootcert=%s", addrs.listenAddr, datapathutils.TestDataPath(t, "testserver.crt"))
 		te.TestConnectWithPGConfig(
 			ctx, t, url,
 			func(c *pgx.ConnConfig) {
@@ -2798,6 +2798,51 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 				require.Equal(t, int64(1), m.RoutingMethodCount.Count())
 				require.Equal(t, int64(1), m.DatabaseRoutingMethodCount.Value())
 			},
+		},
+		{
+			name:                "new sni format with dot separator",
+			sniServerName:       "happy-seal.10.abc.gcp-us-central1.cockroachlabs.cloud",
+			params:              map[string]string{},
+			expectedClusterName: "happy-seal",
+			expectedTenantID:    10,
+			expectedParams:      map[string]string{},
+			expectedMetrics: func(t *testing.T, m *metrics) {
+				require.Equal(t, int64(1), m.RoutingMethodCount.Count())
+				require.Equal(t, int64(1), m.SNIRoutingMethodCount.Value())
+			},
+		},
+		{
+			name:                "new sni format with longer cluster name",
+			sniServerName:       "palm-chamois.5829.jxf.gcp-us-east1.cockroachlabs.cloud",
+			params:              map[string]string{},
+			expectedClusterName: "palm-chamois",
+			expectedTenantID:    5829,
+			expectedParams:      map[string]string{},
+			expectedMetrics: func(t *testing.T, m *metrics) {
+				require.Equal(t, int64(1), m.RoutingMethodCount.Count())
+				require.Equal(t, int64(1), m.SNIRoutingMethodCount.Value())
+			},
+		},
+		{
+			name:          "new sni format with non-numeric second label falls back",
+			sniServerName: "happy-seal.abc.gcp-us-central1.cockroachlabs.cloud",
+			params:        map[string]string{},
+			expectedError: "missing cluster identifier",
+			expectedHint:  clusterIdentifierHint,
+		},
+		{
+			name:          "new sni format with zero tenant ID",
+			sniServerName: "happy-seal.0.abc.gcp-us-central1.cockroachlabs.cloud",
+			params:        map[string]string{},
+			expectedError: "missing cluster identifier",
+			expectedHint:  clusterIdentifierHint,
+		},
+		{
+			name:          "new sni format with short cluster name falls back to old parsing",
+			sniServerName: "short.10.abc.gcp-us-central1.cockroachlabs.cloud",
+			params:        map[string]string{},
+			expectedError: "missing cluster identifier",
+			expectedHint:  clusterIdentifierHint,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR makes it so that an SNI starting with either the old form ("cluster-name-123.") or a new form ("cluster-name.123.") can have the cluster name and tenant ID successfully parsed out of it. This makes it so that eventually, we can issue wildcard certs like those starting with "*.123." which are specific to a tenant ID but not a cluster name.

Release note: None
Fixes: https://cockroachlabs.atlassian.net/browse/CC-35371