### PR TITLE
sql/inspect: add sort on uniqueness violation regions

### DIFF
--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -150,7 +150,7 @@ func (c *uniquenessCheck) Start(
 WITH all_regions AS (
   %s
 )
-SELECT %s, array_agg(remote_region) as remote_regions
+SELECT %s, array_agg(remote_region ORDER BY remote_region) as remote_regions
 FROM all_regions
 GROUP BY %s
 `,


### PR DESCRIPTION
The unordered region array used in the details of the uniqueness
violation issue causes logic tests to flake. This adds a sort for the
issue view added in #164948.

Epic: CRDB-58692

Part of: #154551

Release note: None
