### PR TITLE
ci: remove Claude CLI install step from issue-autosolve

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -157,11 +157,6 @@ jobs:
             echo "assessment=SKIP" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install Claude CLI
-        if: steps.assess_result.outputs.assessment == 'PROCEED'
-        run: |
-          npm install -g @anthropic-ai/claude-code
-
       - name: Stage 2 - Implement Fix (with retries)
         id: implement
         if: steps.assess_result.outputs.assessment == 'PROCEED'


### PR DESCRIPTION
The Claude CLI is now installed natively on the self-hosted runners,
so the `npm install -g @anthropic-ai/claude-code` step in the
issue-autosolve workflow is no longer needed.

Release note: None

Epic: None