### PR TITLE
vscode: add example settings for dev

### DIFF
--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,0 +1,59 @@
+{
+    "[go]": {
+        "editor.rulers": [
+            80,
+            100
+        ]
+    },
+    "[git-commit]": {
+        "editor.rulers": [
+            72,
+            100
+        ],
+        "editor.wordWrap": "off"
+    },
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--fast"
+    ],
+    "files.exclude": {
+        "**/_bazel": true,
+        "**/bin/": true,
+        "**/c-deps/": true,
+        "**/pkg/ui/": true
+    },
+    "search.exclude": {
+        "**/_bazel": true,
+        "**/bin/": true,
+        "**/c-deps/": true,
+        "**/pkg/ui/": true
+    },
+    "files.watcherExclude": {
+        "**/_bazel": true,
+        "**/bin/": true,
+        "**/c-deps/": true,
+        "**/pkg/ui/": true
+    },
+    "gopls": {
+        "directoryFilters": [
+            "-_bazel",
+            "-bin",
+            "-c-deps",
+            "-pkg/ui"
+        ]
+    },
+    "filewatcher.commands": [
+        {
+            "match": ".*\\.go$",
+            "isAsync": true,
+            "cmd": "${workspaceRoot}/bin/crlfmt -w -tab=2 ${file}",
+            "event": "onFileChange"
+        }
+    ],
+    // To share gopls instances between Claude Code and VS Code, follow the
+    // instructions on Claude Code's settings.
+    // https://github.com/anthropics/claude-plugins-official/issues/261#issuecomment-3774463000
+    "go.languageServerFlags": [
+        "-remote=auto"
+    ]
+}


### PR DESCRIPTION
These settings configure VS Code and Cursor for typical dev use.

Epic: none

Release note: None
