### PR TITLE
backup: support range keys in backup compaction

### DIFF
--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -391,11 +391,6 @@ func openSSTs(
 	storeFiles := make([]storage.StoreFile, 0, len(entry.Files))
 	for idx := range entry.Files {
 		file := entry.Files[idx]
-		if file.HasRangeKeys {
-			// TODO (kev-cao): Come back and update this to range keys when
-			// SSTSinkKeyWriter has been updated to support range keys.
-			return mergedSST{}, errors.New("backup compactions does not support range keys")
-		}
 		dir, err := execCfg.DistSQLSrv.ExternalStorage(ctx, file.Dir)
 		if err != nil {
 			return mergedSST{}, err
@@ -404,7 +399,7 @@ func openSSTs(
 		storeFiles = append(storeFiles, storage.StoreFile{Store: dir, FilePath: file.Path})
 	}
 	iterOpts := storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsOnly,
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,
 	}

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1435,6 +1436,104 @@ func TestToggleCompactionForRestore(t *testing.T) {
 
 	require.Equal(t, 2, getNumBackupsInRestore(t, db, compRestoreID))
 	require.Equal(t, 3, getNumBackupsInRestore(t, db, classicRestoreID))
+}
+
+// TestCompactionWithRangeKeys creates a table with the following key span over
+// time with revision history backups taken at each timestamp.
+//
+//	                   range tombstone
+//	                          ᵛ
+//	t@3 |             |-------x-------|
+//	    | xxxxxxxxxxxx|xxxxxxxxxxxxxxx|xxxxxxxxxxxxx
+//	t@2 | xxxxxxxxxxxx|xxxxxxxxxxxxxxx|xxxxxxxxxxxxx
+//	t@1 | xxxxxxxxxxxx|xxxxxxxxxxxxxxx|xxxxxxxxxxxxx
+//	    --------------|---------------|-------------
+//	     primary idx  |     idx y     |    idx z
+//
+// This allows us to test a backup compaction that has keys both before and
+// after a range tombstone.
+func TestCompactionWithRangeKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tempDir, tempDirCleanup := testutils.TempDir(t)
+	defer tempDirCleanup()
+	st := cluster.MakeTestingClusterSettings()
+	_, db, cleanup := backupRestoreTestSetupEmpty(
+		t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+				Settings:          st,
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						DisableGCQueue: true,
+					},
+					GCJob: &sql.GCJobTestingKnobs{
+						SkipWaitingForMVCCGC: true,
+					},
+					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+				},
+			},
+		},
+	)
+	defer cleanup()
+
+	// Create two indexes so that we have keys before and after a range tombstone
+	// when we drop the first index.
+	db.Exec(
+		t,
+		`CREATE TABLE foo (
+			x INT PRIMARY KEY, y INT, z INT,
+			INDEX idx_y (y),
+			INDEX idx_z (z)
+		)`,
+	)
+
+	const numRows = 100
+	for i := range numRows {
+		db.Exec(t, "INSERT INTO foo VALUES ($1, $1, $1)", i)
+	}
+
+	collectionURI := []string{"nodelocal://1/backup"}
+	const revHistOpt = "WITH revision_history"
+	fullEnd := getTime()
+	backupStmt := fullBackupQuery(fullCluster, collectionURI, fullEnd, revHistOpt)
+	db.Exec(t, backupStmt)
+
+	db.Exec(t, "UPDATE foo SET y = y + 1, z = z + 1 WHERE 1=1")
+	db.Exec(t, incBackupQuery(fullCluster, collectionURI, noAOST, revHistOpt))
+
+	db.Exec(t, "UPDATE foo SET y = y + 1, z = z + 1 WHERE 1=1")
+	db.Exec(t, "DROP INDEX foo@idx_y")
+	// Wait for GC to lay the range tombstone so that the next incremental can
+	// capture it and surface it for compaction.
+	var gcJobID jobspb.JobID
+	db.QueryRow(t, "SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC'").Scan(&gcJobID)
+	jobutils.WaitForJobToSucceed(t, db, gcJobID)
+
+	chainEnd := getTime()
+	db.Exec(t, incBackupQuery(fullCluster, collectionURI, chainEnd, revHistOpt))
+
+	var backupPath string
+	db.QueryRow(
+		t,
+		fmt.Sprintf("SHOW BACKUPS IN (%s)", stringifyCollectionURI(collectionURI)),
+	).Scan(&backupPath)
+
+	compJob := triggerCompaction(t, db, backupStmt, backupPath, fullEnd, chainEnd)
+	jobutils.WaitForJobToSucceed(t, db, compJob)
+
+	fingerprint := func() [][]string {
+		rows := db.QueryStr(t, "SHOW FINGERPRINTS FROM TABLE foo")
+		return rows
+	}
+
+	fingerprintsBefore := fingerprint()
+	db.Exec(t, "DROP TABLE foo")
+	db.Exec(t, restoreQuery(t, "TABLE foo", collectionURI, noAOST, noOpts))
+	fingerprintsAfter := fingerprint()
+
+	require.Equal(t, fingerprintsBefore, fingerprintsAfter)
 }
 
 func TestCheckCompactionManifestFields(t *testing.T) {

--- a/pkg/backup/testdata/backup-restore/rangekeys
+++ b/pkg/backup/testdata/backup-restore/rangekeys
@@ -114,10 +114,5 @@ compact start=start end=end tag=comp_job
 SELECT crdb_internal.backup_compaction(0, 'BACKUP INTO LATEST IN ''nodelocal://1/test-root/''', '$backup_path', start, end);
 ----
 
-job tag=comp_job wait-for-state=failed
+job tag=comp_job wait-for-state=succeeded
 ----
-
-query-sql regex=(compactions does not support range keys)
-SELECT error FROM [SHOW JOBS] WHERE job_type = 'BACKUP' AND status = 'failed' ORDER BY created DESC LIMIT 1;
-----
-true

--- a/pkg/storage/backup_compaction_iterator.go
+++ b/pkg/storage/backup_compaction_iterator.go
@@ -75,10 +75,15 @@ func (f *BackupCompactionIterator) updateValid() bool {
 }
 
 // advance moves past keys with timestamps later than f.asOf.
+// If a range key is encountered, the entire span of the range key is skipped.
 func (f *BackupCompactionIterator) advance() {
 	for {
 		if ok := f.updateValid(); !ok {
 			return
+		}
+		if _, hasRange := f.iter.HasPointAndRange(); hasRange {
+			f.iter.Next()
+			continue
 		}
 		if key := f.iter.UnsafeKey(); f.asOf.Less(key.Timestamp) {
 			f.iter.Next()
@@ -114,11 +119,7 @@ func (f *BackupCompactionIterator) ValueLen() int {
 }
 
 func (f *BackupCompactionIterator) HasPointAndRange() (bool, bool) {
-	hasPoint, hasRange := f.iter.HasPointAndRange()
-	if hasRange {
-		panic(errors.AssertionFailedf("unexpected range tombstone"))
-	}
-	return hasPoint, hasRange
+	return true, false
 }
 
 func (f *BackupCompactionIterator) RangeBounds() roachpb.Span {
@@ -151,6 +152,9 @@ func (f *BackupCompactionIterator) assertInvariants() error {
 	}
 	if f.asOf.Less(key.Timestamp) {
 		return errors.AssertionFailedf("emitted key %s above asOf timestamp %s", key, f.asOf)
+	}
+	if _, hasRange := f.iter.HasPointAndRange(); hasRange {
+		return errors.AssertionFailedf("emitted key is within the bounds of a range key")
 	}
 
 	return nil

--- a/pkg/storage/backup_compaction_iterator_test.go
+++ b/pkg/storage/backup_compaction_iterator_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -206,6 +207,87 @@ func TestBackupCompactionIteratorSeek(t *testing.T) {
 				output.WriteRune('X')
 			}
 			require.Equal(t, test.expected, output.String())
+		})
+	}
+}
+
+func TestBackupCompactionIteratorRangeKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pebble, err := Open(context.Background(), InMemory(),
+		cluster.MakeTestingClusterSettings(), CacheSize(1<<20 /* 1 MiB */))
+	require.NoError(t, err)
+	defer pebble.Close()
+
+	tests := []struct {
+		input  string
+		asOf   string
+		output string
+	}{
+		// Simple batch with a range key
+		{"a-c2", "", ""},
+		// Range key with a point key before it.
+		{"a1b-c1", "", "a1"},
+		// Range key with a point key below it.
+		{"a1b1b-d2e2", "", "a1e2"},
+
+		// The backup compaction iterator does not respect MVCC rules for range keys
+		// and simply ignores all keys within the span of the range key. Within the
+		// context of backup compaction, this is fine, but the following tests are
+		// left here to explicitly acknowledge this behavior in the event we decide
+		// to change it in the future.
+		// Range key with a point key above it.
+		{"a1b3b-d2e2", "", "a1e2"},
+		// Range key with point keys below it and an AOST read below it.
+		{"a2b1c2b-d3e1", "2", "a2e1"},
+	}
+
+	for i, test := range tests {
+		name := fmt.Sprintf("Test %d: %s, AOST %s", i, test.input, test.asOf)
+		t.Run(name, func(t *testing.T) {
+			batch := pebble.NewBatch()
+			defer batch.Close()
+			populateBatch(t, batch, test.input)
+
+			iter, err := batch.NewMVCCIterator(
+				context.Background(),
+				MVCCKeyAndIntentsIterKind,
+				IterOptions{
+					KeyTypes:   IterKeyTypePointsAndRanges,
+					UpperBound: roachpb.KeyMax,
+				},
+			)
+			require.NoError(t, err)
+			defer iter.Close()
+
+			asOf := hlc.MaxTimestamp
+			if test.asOf != "" {
+				asOf.WallTime = int64(test.asOf[0])
+			}
+
+			it, err := NewBackupCompactionIterator(iter, asOf)
+			require.NoError(t, err)
+			it.SeekGE(MVCCKey{Key: keys.LocalMax})
+
+			var output bytes.Buffer
+			for {
+				ok, err := it.Valid()
+				require.NoError(t, err)
+				if !ok {
+					break
+				}
+				output.Write(it.UnsafeKey().Key)
+				output.WriteByte(byte(it.UnsafeKey().Timestamp.WallTime))
+				v, err := DecodeMVCCValueAndErr(it.UnsafeValue())
+				require.NoError(t, err)
+				if v.IsTombstone() {
+					output.WriteRune('X')
+				}
+				it.Next()
+			}
+
+			require.Equal(t, test.output, output.String())
 		})
 	}
 }

--- a/pkg/storage/read_as_of_iterator_test.go
+++ b/pkg/storage/read_as_of_iterator_test.go
@@ -187,20 +187,38 @@ func TestReadAsOfIteratorSeek(t *testing.T) {
 }
 
 // populateBatch populates a pebble batch with a series of MVCC key values.
-// input is a string containing key, timestamp, value tuples: first a single
-// character key, then a single character timestamp walltime. If the
-// character after the timestamp is an M, this entry is a "metadata" key
-// (timestamp=0, sorts before any non-0 timestamp, and no value). If the
-// character after the timestamp is an X, this entry is a deletion
-// tombstone. Otherwise the value is the same as the timestamp.
+// The input string is a sequence of the following:
+//
+// - a1   : a key with timestamp 1 and value "1"
+// - a2X  : a point tombstone at timestamp 2 (no value)
+// - aM   : an MVCC metadata key (timestamp 0, no value)
+// - a-c1 : a range tombstone from key a to c at timestamp 1 (no value)
 func populateBatch(t *testing.T, batch Batch, input string) {
 	for i := 0; ; {
 		if i == len(input) {
 			break
 		}
+		require.True(t, i+1 < len(input), "invalid input string: %v", input)
 		k := []byte{input[i]}
-		ts := hlc.Timestamp{WallTime: int64(input[i+1])}
 		var v MVCCValue
+
+		if input[i+1] == '-' {
+			require.True(t, i+3 < len(input), "invalid range key in input string: %v", input)
+			ts := hlc.Timestamp{WallTime: int64(input[i+3])}
+			endKey := []byte{input[i+2]}
+			require.NoError(t, batch.PutMVCCRangeKey(
+				MVCCRangeKey{
+					StartKey:  k,
+					EndKey:    endKey,
+					Timestamp: ts,
+				},
+				v,
+			))
+			i += 4
+			continue
+		}
+
+		ts := hlc.Timestamp{WallTime: int64(input[i+1])}
 		if i+1 < len(input) && input[i+1] == 'M' {
 			ts = hlc.Timestamp{}
 		} else if i+2 < len(input) && input[i+2] == 'X' {


### PR DESCRIPTION
This commit teaches backup compaction to handle range keys from table/index level drops in order to properly support compactions in revision history chains. Given that when compacting such incrementals, we do not write above the range keys nor do we need to read below range keys, the compaction SST iterator simply ignores range keys entirely and skips over all keys within its span, regardless of its MVCC timestamp.

This does not enable compactions for backups of tenants.

Fixes: #165490

Release note: None