### PR TITLE
changefeedccl: gate highwater backoff reset behind cluster setting

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1975,7 +1975,8 @@ func (b *changefeedResumer) resumeWithRetries(
 
 		// Reset retry backoff if the highwater advanced, indicating the
 		// changefeed made meaningful forward progress before the error.
-		if hw := progress.GetHighWater(); hw != nil && preFlowHighWater.Less(*hw) {
+		resetOnProgress := changefeedbase.ResetBackoffOnHighwaterAdvance.Get(&execCfg.Settings.SV)
+		if hw := progress.GetHighWater(); resetOnProgress && hw != nil && preFlowHighWater.Less(*hw) {
 			log.Changefeed.Infof(ctx,
 				"changefeed %d highwater advanced (%s -> %s); resetting retry backoff",
 				jobID, preFlowHighWater, *hw)

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -373,6 +373,16 @@ var MaxRetryBackoff = settings.RegisterDurationSettingWithExplicitUnit(
 	settings.DurationInRange(1*time.Second, 1*time.Hour),
 )
 
+// ResetBackoffOnHighwaterAdvance controls whether the changefeed retry
+// backoff resets when the highwater mark advances between retries.
+var ResetBackoffOnHighwaterAdvance = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.reset_backoff_on_highwater_advance.enabled",
+	"if true, the changefeed retry backoff resets when the resolved "+
+		"timestamp advances between retries",
+	true,
+)
+
 // RetryBackoffReset is the time between changefeed retries before the
 // backoff timer resets.
 var RetryBackoffReset = settings.RegisterDurationSettingWithExplicitUnit(


### PR DESCRIPTION
Put the retry backoff reset on highwater advance (from PR #164933) behind a new cluster setting:
changefeed.reset_backoff_on_highwater_advance.enabled

The setting is enabled by default on master, preserving the current behavior. This gating allows the change to be safely backported to release branches where the setting can be disabled by default.

Informs: #164695
Release note: None