### PR TITLE
kvserver: sep engines in loosely coupled truncs

### DIFF
--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -226,7 +226,7 @@ type storeForTruncator interface {
 	// releaseReplicaForTruncator releases the replica.
 	releaseReplicaForTruncator(r replicaForTruncator)
 	// Engine accessor.
-	getEngine() storage.Engine
+	getEngines() kvstorage.Engines
 }
 
 // replicaForTruncator abstracts the interface of Replica needed by the
@@ -441,7 +441,8 @@ func (t *raftLogTruncator) durabilityAdvanced(ctx context.Context) {
 	// Sort it for deterministic testing output.
 	sort.Sort(rangesByRangeID(ranges))
 	// Create an engine Reader to provide a safe lower bound on what is durable.
-	reader := t.store.getEngine().NewReader(storage.GuaranteedDurability)
+	eng := t.store.getEngines()
+	reader := eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer reader.Close()
 	shouldQuiesce := t.stopper.ShouldQuiesce()
 	quiesced := false
@@ -545,7 +546,8 @@ func (t *raftLogTruncator) tryEnactTruncations(
 	}
 	// Do the truncation of persistent raft entries, specified by enactIndex
 	// (this subsumes all the preceding queued truncations).
-	batch := t.store.getEngine().NewWriteBatch()
+	eng := t.store.getEngines()
+	batch := eng.LogEngine().NewWriteBatch()
 	defer batch.Close()
 	if err := handleTruncatedStateBelowRaftPreApply(ctx, truncState,
 		pendingTruncs.mu.truncs[enactIndex].RaftTruncatedState,

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -236,14 +236,14 @@ func (r *replicaTruncatorTest) printReplicaState() {
 }
 
 type storeTruncatorTest struct {
-	eng      storage.Engine
+	eng      kvstorage.Engines
 	buf      *strings.Builder
 	replicas map[roachpb.RangeID]*replicaTruncatorTest
 }
 
 var _ storeForTruncator = &storeTruncatorTest{}
 
-func makeStoreTT(eng storage.Engine, buf *strings.Builder) *storeTruncatorTest {
+func makeStoreTT(eng kvstorage.Engines, buf *strings.Builder) *storeTruncatorTest {
 	return &storeTruncatorTest{
 		eng:      eng,
 		buf:      buf,
@@ -251,7 +251,7 @@ func makeStoreTT(eng storage.Engine, buf *strings.Builder) *storeTruncatorTest {
 	}
 }
 
-func (s *storeTruncatorTest) getEngine() storage.Engine {
+func (s *storeTruncatorTest) getEngines() kvstorage.Engines {
 	return s.eng
 }
 
@@ -281,7 +281,7 @@ func TestRaftLogTruncator(t *testing.T) {
 		buf.Reset()
 		return str
 	}
-	eng := storage.NewDefaultInMemForTesting()
+	eng := kvstorage.MakeEngines(storage.NewDefaultInMemForTesting())
 	defer eng.Close()
 	store := makeStoreTT(eng, &buf)
 	stopper := stop.NewStopper()
@@ -299,13 +299,13 @@ func TestRaftLogTruncator(t *testing.T) {
 
 				r := makeReplicaTT(rangeID, &buf)
 				r.truncState.Index = truncIndex
-				r.writeRaftStateToEngine(t, eng, truncIndex, lastLogEntry)
+				r.writeRaftStateToEngine(t, eng.LogEngine(), truncIndex, lastLogEntry)
 				store.replicas[rangeID] = r
 				return flushAndReset()
 
 			case "print-engine-state":
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "id")
-				store.replicas[rangeID].printEngine(t, eng)
+				store.replicas[rangeID].printEngine(t, eng.TODOEngine())
 				return flushAndReset()
 
 			case "add-pending-truncation":
@@ -342,7 +342,8 @@ func TestRaftLogTruncator(t *testing.T) {
 				// encounter an unexpected flush.
 				noFlush := dd.ScanArgOr(t, d, "no-flush", false)
 
-				store.replicas[rangeID].writeRaftAppliedIndex(t, eng, raftAppliedIndex, !noFlush)
+				store.replicas[rangeID].writeRaftAppliedIndex(
+					t, eng.StateEngine(), raftAppliedIndex, !noFlush)
 				return flushAndReset()
 
 			case "add-replica-to-truncator":

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -24,8 +24,8 @@ func (r *raftTruncatorReplica) getRangeID() roachpb.RangeID {
 }
 
 func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState {
-	r.mu.Lock() // TODO(pav-kv): not needed if raftMu is held.
-	defer r.mu.Unlock()
+	r.mu.RLock() // TODO(pav-kv): not needed if raftMu is held.
+	defer r.mu.RUnlock()
 	return (*Replica)(r).asLogStorage().shMu.trunc
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -4265,10 +4265,8 @@ func (s *storeForTruncatorImpl) releaseReplicaForTruncator(r replicaForTruncator
 	replica.raftMu.Unlock()
 }
 
-func (s *storeForTruncatorImpl) getEngine() storage.Engine {
-	// TODO(sep-raft-log): we'll need the log engine here but need
-	// to read code to see if more needs to be done.
-	return (*Store)(s).TODOEngine()
+func (s *storeForTruncatorImpl) getEngines() kvstorage.Engines {
+	return (*Store)(s).internalEngines
 }
 
 func init() {


### PR DESCRIPTION
This PR ensures that loosely coupled truncations stack uses `LogEngine` for updating the raft log, and `StateEngine` for watching durable applied state.

Part of #97627