### PR TITLE
*: remove TODOEngine

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -823,7 +823,7 @@ func applyRecoveryToLocalStore(
 		store := kvstorage.MakeEngines(eng)
 		stores[i] = store
 
-		batch := store.TODOEngine().NewBatch()
+		batch := store.TODOBothEngines().NewBatch()
 		defer store.Close() //nolint:deferloop
 		defer batch.Close() //nolint:deferloop
 

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -156,6 +156,12 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	}
 }
 
+func getEnginesKeySet(t *testing.T, e kvstorage.Engines) map[string]struct{} {
+	t.Helper()
+	require.False(t, e.Separated(), "not supported in this test")
+	return getEngineKeySet(t, e.Engine())
+}
+
 func getEngineKeySet(t *testing.T, e storage.Engine) map[string]struct{} {
 	t.Helper()
 	// Have to scan local and global keys separately as mentioned in the comment
@@ -198,7 +204,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	require.NoError(t, pErr.GoError())
 
 	// Collect all the keys.
-	preKeys := getEngineKeySet(t, store.TODOEngine())
+	preKeys := getEnginesKeySet(t, store.Engines())
 
 	// Split the range.
 	lhsDesc, rhsDesc, err := createSplitRanges(ctx, scratchKey(""), store)
@@ -216,7 +222,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	require.NoError(t, pErr.GoError())
 
 	// Collect all the keys again.
-	postKeys := getEngineKeySet(t, store.TODOEngine())
+	postKeys := getEnginesKeySet(t, store.Engines())
 
 	// Compute the new keys.
 	for k := range preKeys {

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4250,8 +4250,8 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			}
 
 			// Verify that the sets of keys in store1 and store3 are identical.
-			storeKeys1 := getKeySet(store1.TODOEngine())
-			storeKeys3 := getKeySet(store3.TODOEngine())
+			storeKeys1 := getKeySet(store1.StateEngine())
+			storeKeys3 := getKeySet(store3.StateEngine())
 			for k := range storeKeys1 {
 				if _, ok := storeKeys3[k]; !ok {
 					return fmt.Errorf("store3 missing key %s", roachpb.Key(k))

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -183,10 +183,9 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1,
-		base.TestClusterArgs{
-			ReplicationMode: base.ReplicationManual,
-		})
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
 	defer tc.Stopper().Stop(context.Background())
 	tc.ScratchRange(t)
 	store := tc.GetFirstStoreFromServer(t, 0)
@@ -194,33 +193,27 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	content := scratchKey("testing!")
 
 	// Write some values left of the proposed split key.
-	pArgs := putArgs(scratchKey("aaa"), content)
-	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	_, pErr := kv.SendWrapped(ctx, store.TestSender(),
+		putArgs(scratchKey("aaa"), content))
+	require.NoError(t, pErr.GoError())
 
 	// Collect all the keys.
 	preKeys := getEngineKeySet(t, store.TODOEngine())
 
 	// Split the range.
 	lhsDesc, rhsDesc, err := createSplitRanges(ctx, scratchKey(""), store)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Write some values right of the split key.
-	pArgs = putArgs(scratchKey("ccc"), content)
-	if _, pErr := kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{
+	_, pErr = kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{
 		RangeID: rhsDesc.RangeID,
-	}, pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	}, putArgs(scratchKey("ccc"), content))
+	require.NoError(t, pErr.GoError())
 
 	// Merge the b range back into the a range.
-	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
-		t.Fatal(pErr)
-	}
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(),
+		adminMergeArgs(lhsDesc.StartKey.AsRawKey()))
+	require.NoError(t, pErr.GoError())
 
 	// Collect all the keys again.
 	postKeys := getEngineKeySet(t, store.TODOEngine())

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -93,7 +93,7 @@ func TestStoreRaftReplicaID(t *testing.T) {
 	require.NoError(t, err)
 	repl, err := store.GetReplica(desc.RangeID)
 	require.NoError(t, err)
-	replicaID, err := kvstorage.MakeStateLoader(desc.RangeID).LoadRaftReplicaID(ctx, store.TODOEngine())
+	replicaID, err := kvstorage.MakeStateLoader(desc.RangeID).LoadRaftReplicaID(ctx, store.StateEngine())
 	require.NoError(t, err)
 	require.Equal(t, repl.ReplicaID(), replicaID.ReplicaID)
 

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -325,7 +325,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	onDiskCheckpointPaths := func(nodeIdx int) []string {
 		fs := stickyVFSRegistry.Get(vfsIDs[nodeIdx])
 		store := tc.GetFirstStoreFromServer(t, nodeIdx)
-		checkpointPath := filepath.Join(store.TODOEngine().GetAuxiliaryDir(), "checkpoints")
+		checkpointPath := filepath.Join(store.TODOBothEngines().GetAuxiliaryDir(), "checkpoints")
 		checkpoints, _ := fs.List(checkpointPath)
 		var checkpointPaths []string
 		for _, cpDirName := range checkpoints {
@@ -354,7 +354,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// Write some arbitrary data only to store on n2. Inconsistent key "e"!
 	s2 := tc.GetFirstStoreFromServer(t, 1)
-	s2AuxDir := s2.TODOEngine().GetAuxiliaryDir()
+	s2AuxDir := s2.TODOBothEngines().GetAuxiliaryDir()
 	var val roachpb.Value
 	val.SetInt(42)
 	// Put an inconsistent key "e" to s2, and have s1 and s3 still agree.

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -210,7 +210,7 @@ func (e *Engines) TODOEngine() storage.Engine {
 // TODO(sep-raft-log): the callers must migrate off as part of separated engines
 // productionization.
 func (e *Engines) TODOBothEngines() storage.Engine {
-	return e.stateEngine
+	return disableAccessAssertions(e.stateEngine)
 }
 
 // Separated returns true iff the engines are logically or physically separated.

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -116,11 +116,6 @@ type Engines struct {
 	// stateEngine is the state machine engine, in which the committed raft state
 	// materializes after being "applied".
 	stateEngine storage.Engine
-	// todoEngine is a placeholder used in cases where:
-	// - the code does not yet cleanly separate between state and log engine
-	// - it is still unclear which of the two engines is the better choice for a
-	//   particular write, or there is a candidate, but it needs to be verified.
-	todoEngine storage.Engine
 	// logEngine is the engine holding mainly the raft state, such as HardState
 	// and logs, and the Store-local keys. This engine provides timely
 	// durability, by frequent and on-demand syncing.
@@ -139,12 +134,10 @@ func MakeEngines(eng storage.Engine) Engines {
 		return Engines{
 			stateEngine: spanset.NewEngine(eng, validateIsStateEngineSpan),
 			logEngine:   spanset.NewEngine(eng, validateIsRaftEngineSpan),
-			todoEngine:  eng,
 		}
 	}
 	return Engines{
 		stateEngine: eng,
-		todoEngine:  eng,
 		logEngine:   eng,
 	}
 }
@@ -161,28 +154,24 @@ func MakeSeparatedEnginesForTesting(state, log storage.Engine) Engines {
 		// accesses.
 		return Engines{
 			stateEngine: spanset.NewEngine(state, validateIsStateEngineSpan),
-			todoEngine:  nil,
 			logEngine:   spanset.NewEngine(log, validateIsRaftEngineSpan),
 			separated:   true,
 		}
 	}
 	return Engines{
 		stateEngine: state,
-		todoEngine:  nil,
 		logEngine:   log,
 		separated:   true,
 	}
 }
 
 // Engine returns the single engine. Used when the caller implements backwards
-// compatible code and neither StateEngine nor LogEngine can be used. This is
-// different from TODOEngine in that the caller explicitly acknowledges the fact
-// that they are using a combined engine.
+// compatible code and neither StateEngine nor LogEngine can be used.
 func (e *Engines) Engine() storage.Engine {
 	if buildutil.CrdbTestBuild && e.separated {
 		panic("engines are separated")
 	}
-	return e.todoEngine
+	return disableAccessAssertions(e.stateEngine)
 }
 
 // StateEngine returns the state machine engine.
@@ -193,13 +182,6 @@ func (e *Engines) StateEngine() storage.Engine {
 // LogEngine returns the raft/log engine.
 func (e *Engines) LogEngine() storage.Engine {
 	return e.logEngine
-}
-
-// TODOEngine returns the combined engine, used in the code which currently does
-// not support separated engines. The caller must eventually "resolve" this call
-// to one of StateEngine, LogEngine, or Engine.
-func (e *Engines) TODOEngine() storage.Engine {
-	return e.todoEngine
 }
 
 // TODOBothEngines returns the StateEngine, and indicates that the caller must

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -386,7 +386,7 @@ func MaybeApplyPendingRecoveryPlan(
 			if err != nil {
 				return errors.Wrap(err, "failed to read store ident when trying to apply loss of quorum recovery plan")
 			}
-			b := e.TODOEngine().NewBatch()
+			b := e.TODOBothEngines().NewBatch()
 			defer b.Close() //nolint:deferloop
 			batches[ident.StoreID] = b
 		}

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -676,7 +676,7 @@ func (e *quorumRecoveryEnv) groupStoresByNodeStore(
 				nodeStores = make(map[roachpb.StoreID]storage.Batch)
 				nodes[nodeID] = nodeStores
 			}
-			nodeStores[storeID] = store.TODOEngine().NewBatch()
+			nodeStores[storeID] = store.TODOBothEngines().NewBatch()
 		})
 	return nodes
 }

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -136,10 +136,9 @@ func (s Server) ServeLocalReplicas(
 		g.Go(func() error {
 			// TODO(sep-raft-log): when raft and state machine engines are separate,
 			// we need two snapshots here. This path is online, so we should make sure
-			// these snapshots are consistent (in particular, the LogID must match
-			// across the two), or make sure that LogID mismatch is handled in
-			// visitStoreReplicas.
-			reader := s.TODOEngine().NewSnapshot()
+			// these snapshots are consistent, or visitStoreReplicas handles the
+			// asynchronous snapshots well.
+			reader := s.TODOBothEngines().NewSnapshot()
 			defer reader.Close()
 			return visitStoreReplicas(ctx, reader, reader, s.StoreID(), s.NodeID(),
 				func(info loqrecoverypb.ReplicaInfo) error {

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -305,7 +305,7 @@ func TestRaftLogTruncator(t *testing.T) {
 
 			case "print-engine-state":
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "id")
-				store.replicas[rangeID].printEngine(t, eng.TODOEngine())
+				store.replicas[rangeID].printEngine(t, eng.TODOBothEngines())
 				return flushAndReset()
 
 			case "add-pending-truncation":

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -446,7 +446,7 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 	r.mu.RUnlock()
 
 	descWriteRepr := func(v string) (kvpb.Request, []byte) {
-		b := tc.store.TODOEngine().NewBatch()
+		b := tc.store.StateEngine().NewBatch()
 		defer b.Close()
 		key := keys.LocalMax
 		val := roachpb.MakeValueFromString("hello")

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7049,7 +7049,7 @@ func TestReplicaDestroy(t *testing.T) {
 
 	// TODO(sep-raft-log): iterate the engines separately here. The state engine
 	// should have only the tombstone, and the log engine should have no keys.
-	engSnapshot := tc.repl.store.TODOEngine().NewSnapshot()
+	engSnapshot := tc.repl.store.TODOBothEngines().NewSnapshot()
 	defer engSnapshot.Close()
 
 	// If the range is destroyed, only a tombstone key should be there.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3613,7 +3613,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 }
 
 func (s *Store) checkpointsDir() string {
-	return filepath.Join(s.TODOEngine().GetAuxiliaryDir(), "checkpoints")
+	return filepath.Join(s.TODOBothEngines().GetAuxiliaryDir(), "checkpoints")
 }
 
 // checkpointSpans returns key spans containing the given range. The spans may
@@ -3622,7 +3622,7 @@ func (s *Store) checkpointsDir() string {
 // storage issues, e.g. in situations when a recent reconfiguration like split
 // or merge occurred.
 func (s *Store) checkpointSpans(desc *roachpb.RangeDescriptor) []roachpb.Span {
-	_ = s.TODOEngine() // this method needs to return two sets of spans, one for each engine
+	_ = s.TODOBothEngines() // need to return two sets of spans, one for each engine
 	// Find immediate left and right neighbours by range ID.
 	var prevID, nextID roachpb.RangeID
 	s.mu.replicasByRangeID.Range(func(rangeID roachpb.RangeID, _ *Replica) bool {
@@ -3691,16 +3691,17 @@ func (s *Store) checkpointSpans(desc *roachpb.RangeDescriptor) []roachpb.Span {
 // the provided key spans. If spans is empty, it includes the entire store.
 func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
 	checkpointBase := s.checkpointsDir()
-	_ = s.TODOEngine().Env().MkdirAll(checkpointBase, os.ModePerm)
+	eng := s.TODOBothEngines()
+	_ = eng.Env().MkdirAll(checkpointBase, os.ModePerm)
 	// Create the checkpoint in a "pending" directory first. If we fail midway, it
 	// should be clear that the directory contains an incomplete checkpoint.
 	pendingDir := filepath.Join(checkpointBase, tag+"_pending")
-	if err := s.TODOEngine().CreateCheckpoint(pendingDir, spans); err != nil {
+	if err := eng.CreateCheckpoint(pendingDir, spans); err != nil {
 		return "", err
 	}
 	// Atomically rename the directory when it represents a complete checkpoint.
 	checkpointDir := filepath.Join(checkpointBase, tag)
-	if err := s.TODOEngine().Env().Rename(pendingDir, checkpointDir); err != nil {
+	if err := eng.Env().Rename(pendingDir, checkpointDir); err != nil {
 		return "", err
 	}
 	return checkpointDir, nil

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3072,6 +3072,11 @@ func (s *Store) StoreID() roachpb.StoreID { return s.Ident.StoreID }
 // Clock accessor.
 func (s *Store) Clock() *hlc.Clock { return s.cfg.Clock }
 
+// Engines returns the storage engines wrapper.
+func (s *Store) Engines() kvstorage.Engines {
+	return s.internalEngines
+}
+
 // EnginesSeparated returns true iff the Store uses separated engines.
 func (s *Store) EnginesSeparated() bool {
 	return s.internalEngines.Separated()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3087,12 +3087,6 @@ func (s *Store) StateEngine() storage.Engine {
 	return s.internalEngines.StateEngine()
 }
 
-// TODOEngine is a placeholder for cases in which the caller needs to be updated
-// in order to use only one engine, or a closer check is still pending.
-func (s *Store) TODOEngine() storage.Engine {
-	return s.internalEngines.TODOEngine()
-}
-
 // TODOBothEngines is a placeholder for cases in which the caller needs to be
 // updated because it likely needs to handle both engines.
 func (s *Store) TODOBothEngines() storage.Engine {

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -175,7 +175,9 @@ func (is Server) CompactEngineSpan(
 	resp := &CompactEngineSpanResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			return s.TODOEngine().CompactRange(ctx, req.Span.Key, req.Span.EndKey)
+			// TODO(sep-raft-log): this is likely only needed for StateEngine, but the
+			// API seems to be generic and may need to support both.
+			return s.TODOBothEngines().CompactRange(ctx, req.Span.Key, req.Span.EndKey)
 		})
 	return resp, err
 }

--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -436,11 +436,12 @@ func TestAdminAPIDatabaseDetails(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Flush all stores here so that we can read the ApproximateDiskBytes field without waiting for a flush.
+	// Flush all stores here so that we can read the ApproximateDiskBytes field
+	// without waiting for a flush.
 	for i := 0; i < numServers; i++ {
 		s := tc.Server(i).StorageLayer()
 		err = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			return store.TODOEngine().Flush()
+			return store.StateEngine().Flush()
 		})
 		require.NoError(t, err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1203,7 +1203,7 @@ func TestStorageBlockLoadConcurrencyLimit(t *testing.T) {
 
 			check := func(expected int64) error {
 				return s.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
-					metrics := s.TODOEngine().GetMetrics()
+					metrics := s.TODOBothEngines().GetMetrics()
 					if metrics.BlockLoadConcurrencyLimit != expected {
 						return fmt.Errorf("expected %d, got %d", expected, metrics.BlockLoadConcurrencyLimit)
 					}

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -294,21 +294,14 @@ func TestClusterVersionUpgrade(t *testing.T) {
 	}
 
 	// Set CLUSTER SETTING cluster.preserve_downgrade_option to oldVersion to prevent upgrade.
-	if err := tc.setDowngrade(0, oldVersion.String()); err != nil {
-		t.Fatalf("error setting CLUSTER SETTING cluster.preserve_downgrade_option: %s", err)
-	}
+	require.NoError(t, tc.setDowngrade(0, oldVersion.String()))
 	close(disableUpgradeCh)
 
 	// Check the cluster version is still oldVersion.
-	curVersion := tc.getVersionFromSelect(0)
-	if curVersion != oldVersion.String() {
-		t.Fatalf("cluster version should still be %s, but got %s", oldVersion, curVersion)
-	}
+	require.Equal(t, oldVersion.String(), tc.getVersionFromSelect(0))
 
 	// Reset cluster.preserve_downgrade_option to enable auto upgrade.
-	if err := tc.resetDowngrade(0); err != nil {
-		t.Fatalf("error resetting CLUSTER SETTING cluster.preserve_downgrade_option: %s", err)
-	}
+	require.NoError(t, tc.resetDowngrade(0))
 
 	// Check the cluster version is bumped to newVersion.
 	testutils.SucceedsWithin(t, func() error {
@@ -317,7 +310,7 @@ func TestClusterVersionUpgrade(t *testing.T) {
 		}
 		return nil
 	}, 3*time.Minute)
-	curVersion = tc.getVersionFromSelect(0)
+	curVersion := tc.getVersionFromSelect(0)
 	isNoopUpdate := curVersion == newVersion.String()
 
 	testutils.SucceedsWithin(t, func() error {
@@ -328,7 +321,6 @@ func TestClusterVersionUpgrade(t *testing.T) {
 			if isActive := v.IsActiveVersion(newVersion); isActive != wantActive {
 				return errors.Errorf("%d: v%s active=%t (wanted %t)", i, newVersion, isActive, wantActive)
 			}
-
 			if tableV, curV := tc.getVersionFromSelect(i), v.String(); tableV != curV {
 				return errors.Errorf("%d: read v%s from table, v%s from setting", i, tableV, curV)
 			}
@@ -374,15 +366,11 @@ func TestClusterVersionUpgrade(t *testing.T) {
 
 	// Since the wrapped version setting exposes the new versions, it must
 	// definitely be present on all stores on the first try.
-	if err := tc.Servers[1].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+	require.NoError(t, tc.Servers[1].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
 		cv := s.TODOEngine().MinVersion()
-		if act := cv.String(); act != exp {
-			t.Fatalf("%s: %s persisted, but should be %s", s, act, exp)
-		}
+		require.Equal(t, exp, cv.String())
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 }
 
 // Test that, after cluster bootstrap, the different ways of getting the cluster

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -367,8 +367,8 @@ func TestClusterVersionUpgrade(t *testing.T) {
 	// Since the wrapped version setting exposes the new versions, it must
 	// definitely be present on all stores on the first try.
 	require.NoError(t, tc.Servers[1].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
-		cv := s.TODOEngine().MinVersion()
-		require.Equal(t, exp, cv.String())
+		require.Equal(t, exp, s.StateEngine().MinVersion().String())
+		require.Equal(t, exp, s.LogEngine().MinVersion().String())
 		return nil
 	}))
 }

--- a/pkg/sql/tablemetadatacache/table_metadata_updater_test.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater_test.go
@@ -119,7 +119,7 @@ func TestDataDrivenTableMetadataCacheUpdater(t *testing.T) {
 				// Flush store so that bytes return non-zero from span stats.
 				s := s.StorageLayer()
 				err := s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-					return store.TODOEngine().Flush()
+					return store.StateEngine().Flush()
 				})
 				if err != nil {
 					return err.Error()

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -388,7 +388,7 @@ func (tm *testModelRunner) rollupWithMemoryContext(
 // maintain calls the same operation called by the TS maintenance queue,
 // simulating the effects in the model at the same time.
 func (tm *testModelRunner) maintain(nowNanos int64) {
-	snap := tm.Store.TODOEngine().NewSnapshot()
+	snap := tm.Store.StateEngine().NewSnapshot()
 	defer snap.Close()
 	if err := tm.DB.MaintainTimeSeries(
 		context.Background(),


### PR DESCRIPTION
This PR clarifies the remaining uses of the `TODOEngine` placeholder and removes it.

The remaining work on logical separation of engines is annotated with the `TODOBothEngines` placeholder, which is scoped to cases when a certain operation must be supported for both engines. Examples: metrics, introspection, storage snapshot in the consistency checker, LoQ recovery tooling.

Resolves #97627