### PR TITLE
roachtest: enable ext4 IO barriers for tpccbench chaos tests

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -201,13 +201,19 @@ type ClusterSpec struct {
 	WorkloadNodeCPUs     int
 	WorkloadRequiresDisk bool
 	// CPUs is the number of CPUs per node.
-	CPUs                 int
-	Mem                  MemPerCPU
-	DiskCount            int
-	RAID0                bool
-	VolumeSize           int
-	VolumeType           string
-	LocalSSD             LocalSSDSetting
+	CPUs       int
+	Mem        MemPerCPU
+	DiskCount  int
+	RAID0      bool
+	VolumeSize int
+	VolumeType string
+	LocalSSD   LocalSSDSetting
+	// UseExt4IOBarrier, if set, ensures that the local SSD is mounted with
+	// ext4 IO barriers enabled (i.e. without the "nobarrier" mount option).
+	// Only relevant when the filesystem is ext4. This is important for tests
+	// that SIGKILL nodes, as disabling barriers can lead to lost writes that
+	// surface as storage-level corruption on restart.
+	UseExt4IOBarrier     bool
 	Geo                  bool
 	Lifetime             time.Duration
 	ReusePolicy          clusterReusePolicy
@@ -530,7 +536,7 @@ type RoachprodClusterConfig struct {
 func (s *ClusterSpec) RoachprodOpts(
 	params RoachprodClusterConfig,
 ) (vm.CreateOpts, vm.ProviderOpts, vm.ProviderOpts, vm.CPUArch, error) {
-	useIOBarrier := params.UseIOBarrierOnLocalSSD
+	useIOBarrier := params.UseIOBarrierOnLocalSSD || s.UseExt4IOBarrier
 	requestedArch := params.PreferredArch
 
 	createVMOpts := vm.DefaultCreateOpts()
@@ -723,8 +729,8 @@ func (s *ClusterSpec) RoachprodOpts(
 			// This is because local SSDs have very low latency and ext4 barriers
 			// can significantly degrade performance.
 			// This setting is only relevant if the selected filesystem is ext4.
-			if !useIOBarrier && createVMOpts.SSDOpts.FileSystem == vm.Ext4 {
-				createVMOpts.SSDOpts.NoExt4Barrier = true
+			if createVMOpts.SSDOpts.FileSystem == vm.Ext4 {
+				createVMOpts.SSDOpts.NoExt4Barrier = !useIOBarrier
 			}
 		}
 	} else {

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -204,6 +204,15 @@ func DisableLocalSSD() Option {
 	}
 }
 
+// UseExt4IOBarrier ensures the local SSD is mounted with ext4 IO barriers
+// enabled. Use this for tests that SIGKILL nodes to prevent lost writes
+// from surfacing as storage-level corruption on restart.
+func UseExt4IOBarrier() Option {
+	return func(spec *ClusterSpec) {
+		spec.UseExt4IOBarrier = true
+	}
+}
+
 // RandomizeVolumeType is an Option which randomly picks the volume type
 // to be used. Unless SSD is forced, the volume type is picked randomly
 // between the available types for a provider:

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -2052,6 +2052,9 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 	}
 
 	opts := []spec.Option{spec.CPU(b.CPUs)}
+	if b.Chaos {
+		opts = append(opts, spec.UseExt4IOBarrier())
+	}
 	if b.HighMem {
 		opts = append(opts, spec.Mem(spec.High))
 	}


### PR DESCRIPTION
- Add `UseExt4IOBarrier` option to `ClusterSpec` that ensures local SSDs are mounted with ext4 IO barriers enabled (without the `nobarrier` mount option)
- Apply it to tpccbench chaos tests, which SIGKILL nodes every 90 seconds

The tpccbench chaos test ([#165334](https://github.com/cockroachdb/cockroach/issues/165334)) failed because a node hit a Pebble SST checksum mismatch (CRC of 0, indicating a zeroed/lost block) after being SIGKILLed. The root cause is that GCE local NVMe SSDs are mounted with `nobarrier`, so write ordering is not enforced by the filesystem. When a process is abruptly killed, in-flight writes may not be persisted, and on restart Pebble detects the missing data as corruption.

Enabling ext4 IO barriers ensures write ordering is enforced, preventing lost writes across abrupt kills.

Informs #165334