### PR TITLE
serverutils: resolve ShouldEnableDRPC to bool

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -100,7 +100,6 @@ type TestServerArgs struct {
 
 	// Fields copied to the server.Config.
 	Insecure                    bool
-	UseDRPC                     bool
 	RetryOptions                retry.Options // TODO(tbg): make testing knob.
 	SocketFile                  string
 	ScanInterval                time.Duration
@@ -171,6 +170,11 @@ type TestServerArgs struct {
 	// server. This controls whether inter-node connectivity uses DRPC, just
 	// gRPC, or is chosen randomly.
 	DefaultDRPCOption DefaultTestDRPCOption
+
+	// UseDRPC is the resolved DRPC enablement decision, set by the test
+	// framework after evaluating DefaultDRPCOption. It's a framework-internal
+	// arg and tests should not set this directly; use DefaultDRPCOption instead.
+	UseDRPC bool
 
 	// DefaultTenantName is the name of the tenant created implicitly according
 	// to DefaultTestTenant. It is typically `test-tenant` for unit tests and

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -55,6 +55,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 		joinAddr          string
 		sqlPoolMemorySize int64
 		cacheSize         int64
+		useDRPC           bool
 
 		expected base.TestServerArgs
 	}{
@@ -114,6 +115,36 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				ExternalIODir: "nodelocal/n3",
 			},
 		},
+		{
+			serverIdx:         0,
+			joinAddr:          "127.0.0.1",
+			sqlPoolMemorySize: 2 << 10,
+			cacheSize:         1 << 10,
+			useDRPC:           true,
+			expected: base.TestServerArgs{
+				DefaultTenantName:             "demoapp",
+				DefaultTestTenant:             base.TestControlsTenantsExplicitly,
+				PartOfCluster:                 true,
+				JoinAddr:                      "127.0.0.1",
+				DisableTLSForHTTP:             true,
+				Addr:                          "127.0.0.1:1334",
+				SQLAddr:                       "127.0.0.1:1234",
+				HTTPAddr:                      "127.0.0.1:4567",
+				ApplicationInternalRPCPortMin: 1332,
+				ApplicationInternalRPCPortMax: 2356,
+				SQLMemoryPoolSize:             2 << 10,
+				CacheSize:                     1 << 10,
+				NoAutoInitializeCluster:       true,
+				EnableDemoLoginEndpoint:       true,
+				UseDRPC:                       true,
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						StickyVFSRegistry: stickyVFSRegistry,
+					},
+				},
+				ExternalIODir: "nodelocal/n1",
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -123,6 +154,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			demoCtx.CacheSize = tc.cacheSize
 			demoCtx.SQLPort = 1234
 			demoCtx.HTTPPort = 4567
+			demoCtx.UseDRPC = tc.useDRPC
 			actual := demoCtx.testServerArgsForTransientCluster(unixSocketDetails{}, tc.serverIdx, tc.joinAddr, "", stickyVFSRegistry)
 			stopper := actual.Stopper
 			defer stopper.Stop(context.Background())

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -188,7 +188,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.ClusterName = params.ClusterName
 	cfg.ExternalIODirConfig = params.ExternalIODirConfig
 	cfg.Insecure = params.Insecure
-	cfg.UseDRPC = params.UseDRPC
 	cfg.AutoInitializeCluster = !params.NoAutoInitializeCluster
 	cfg.SocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions
@@ -335,9 +334,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.TestingKnobs.AdmissionControlOptions = &admission.Options{}
 	}
 
-	if params.DefaultDRPCOption == base.TestDRPCEnabled {
-		cfg.UseDRPC = true
-	}
+	cfg.UseDRPC = params.UseDRPC
 
 	return cfg
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -284,7 +284,7 @@ func StartServerOnlyE(t TestLogger, params base.TestServerArgs) (TestServerInter
 	// Priority of these Should* functions:
 	// Test explicit value > env vars > factory defaults > metamorphic.
 	params.DefaultTestTenant = ShouldStartDefaultTestTenant(t, params.DefaultTestTenant)
-	params.DefaultDRPCOption = ShouldEnableDRPC(ctx, t, params.DefaultDRPCOption)
+	params.UseDRPC = ShouldEnableDRPC(ctx, t, params.DefaultDRPCOption)
 
 	s, err := NewServer(params)
 	if err != nil {
@@ -595,16 +595,14 @@ func parseDefaultTestDRPCOptionFromEnv() base.DefaultTestDRPCOption {
 	return base.TestDRPCUnset
 }
 
-// ShouldEnableDRPC determines the final DRPC option based on the input
-// option, resolving random choices to a concrete enabled/disabled state.
-func ShouldEnableDRPC(
-	ctx context.Context, t TestLogger, option base.DefaultTestDRPCOption,
-) base.DefaultTestDRPCOption {
+// ShouldEnableDRPC determines the final DRPC enablement decision based on the
+// input option, resolving random choices to a concrete bool.
+func ShouldEnableDRPC(ctx context.Context, t TestLogger, option base.DefaultTestDRPCOption) bool {
 	if skip.UnderBench() {
 		// Microbenchmarks exercise specific parts of the database and we
 		// want to remove any non-deterministic factors that could affect the
 		// numbers, so we disable the dRPC option until it becomes the default.
-		return base.TestDRPCDisabled
+		return false
 	}
 	var logSuffix string
 
@@ -616,7 +614,7 @@ func ShouldEnableDRPC(
 			option = *factoryDefaultDRPC
 			logSuffix = " (via testserver factory defaults)"
 		} else {
-			return base.TestDRPCUnset
+			return false
 		}
 	} else {
 		logSuffix = " (via test explicit setting)"
@@ -630,16 +628,13 @@ func ShouldEnableDRPC(
 		rng, _ := randutil.NewTestRand()
 		enableDRPC = rng.Intn(2) == 0
 	case base.TestDRPCUnset:
-		return base.TestDRPCUnset
+		return false
 	}
 
-	if enableDRPC {
-		if t != nil {
-			t.Log("DRPC is enabled" + logSuffix)
-		}
-		return base.TestDRPCEnabled
+	if enableDRPC && t != nil {
+		t.Log("DRPC is enabled" + logSuffix)
 	}
-	return base.TestDRPCDisabled
+	return enableDRPC
 }
 
 // SetUnsafeOverride sets an unsafe override for eval.TestingKnobs.UnsafeOverride on

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -83,7 +83,7 @@ type TestCluster struct {
 	clusterArgs base.TestClusterArgs
 
 	defaultTestTenantOptions base.DefaultTestTenantOptions
-	defaultDRPCOption        base.DefaultTestDRPCOption
+	drpcEnabled              bool
 
 	t serverutils.TestFataler
 }
@@ -133,7 +133,7 @@ func (tc *TestCluster) StartedDefaultTestTenant() bool {
 // IsDRPCEnabled returns whether DRPC is enabled for inter-node communication
 // in this cluster.
 func (tc *TestCluster) IsDRPCEnabled() bool {
-	return tc.defaultDRPCOption == base.TestDRPCEnabled
+	return tc.drpcEnabled
 }
 
 // ApplicationLayer calls .ApplicationLayer() on the ith server in
@@ -387,7 +387,7 @@ func NewTestCluster(
 	// by the top-level ServerArgs.
 	defaultDRPCOption := tc.clusterArgs.ServerArgs.DefaultDRPCOption
 	tc.validateDefaultDRPCOption(t, nodes, defaultDRPCOption)
-	tc.defaultDRPCOption = serverutils.ShouldEnableDRPC(context.Background(), t, defaultDRPCOption)
+	tc.drpcEnabled = serverutils.ShouldEnableDRPC(context.Background(), t, defaultDRPCOption)
 
 	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {
@@ -720,7 +720,7 @@ func (tc *TestCluster) AddServer(
 	// Inject the decisions that were made about test configuration
 	// into this new server's configuration.
 	serverArgs.DefaultTestTenant = tc.defaultTestTenantOptions
-	serverArgs.DefaultDRPCOption = tc.defaultDRPCOption
+	serverArgs.UseDRPC = tc.drpcEnabled
 
 	s, err := serverutils.NewServer(serverArgs)
 	if err != nil {


### PR DESCRIPTION
ShouldEnableDRPC now returns a resolved bool instead of a
DefaultTestDRPCOption enum, since after resolution DRPC is simply
on or off. Store the resolved decision in UseDRPC on TestServerArgs
and TestCluster, simplifying downstream consumption.

Epic: CRDB-55382
Fixes: #165508
Release note: None