### PR TITLE
*: enable DRPC for tests in ttljob package

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -142,7 +142,6 @@ go_test(
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
-        "//pkg/rpc/rpcpb",
         "//pkg/security",
         "//pkg/security/certnames",
         "//pkg/security/securityassets",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2118,8 +2118,6 @@ func (rpcCtx *Context) grpcDialRaw(
 }
 
 // drpcDialRaw is similar to grpcDialRaw but for drpc connections.
-//
-//lint:ignore U1000 used in the future commits.
 func (rpcCtx *Context) drpcDialRaw(
 	ctx context.Context,
 	target string,
@@ -2332,13 +2330,15 @@ func (rpcCtx *Context) NewHeartbeatService() *HeartbeatService {
 	}
 }
 
-type Dialbacker interface {
-	GRPCUnvalidatedDial(string, roachpb.Locality) *GRPCConnection
-	GRPCDialNode(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *GRPCConnection
-	grpcDialRaw(
-		context.Context, string, rpcbase.ConnectionClass, onDialFunc, ...grpc.DialOption,
-	) (*grpc.ClientConn, error)
-	wrapCtx(
+// Dialbacker is a generic interface for verifying dialback connectivity.
+// Protocol-specific adapters (GRPCDialbackAdapter, DRPCDialbackAdapter)
+// implement this interface, and the caller dispatches based on the active
+// protocol.
+type Dialbacker[Conn rpcConn] interface {
+	UnvalidatedDial(string, roachpb.Locality) *Connection[Conn]
+	DialNode(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *Connection[Conn]
+	DialRaw(ctx context.Context, target string, class rpcbase.ConnectionClass) error
+	WrapCtx(
 		ctx context.Context, target string, remoteNodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 	) context.Context
 }
@@ -2354,9 +2354,9 @@ type Dialbacker interface {
 //     attempt succeeded.
 //   - for a non-blocking ping, returns the health state of the system-class
 //     connection, with the exception of ErrNotHeartbeated, which maps to `nil`.
-func VerifyDialback(
+func VerifyDialback[Conn rpcConn](
 	ctx context.Context,
-	rpcCtx Dialbacker,
+	d Dialbacker[Conn],
 	request *PingRequest,
 	_ *PingResponse,
 	locality roachpb.Locality,
@@ -2381,12 +2381,14 @@ func VerifyDialback(
 	// check will return an error until the connection is re-established.
 	var connHealthErr error
 	if request.OriginNodeID == 0 {
-		// The incoming connection was initiated using rpcCtx.GRPCUnvalidatedDial,
-		// so we don't know the origin's NodeID and use gRPCUnvalidatedDial to
-		// inform the fast path as well.
-		connHealthErr = rpcCtx.GRPCUnvalidatedDial(target, roachpb.Locality{}).Health() // NB: dials SystemClass
+		// The incoming connection was initiated using UnvalidatedDial, so we
+		// don't know the origin's NodeID and use UnvalidatedDial to inform
+		// the fast path as well.
+		connHealthErr = d.UnvalidatedDial(target, roachpb.Locality{}).Health() // NB: dials SystemClass
 	} else {
-		connHealthErr = rpcCtx.GRPCDialNode(target, request.OriginNodeID, roachpb.Locality{}, rpcbase.SystemClass).Health()
+		connHealthErr = d.DialNode(
+			target, request.OriginNodeID, roachpb.Locality{}, rpcbase.SystemClass,
+		).Health()
 	}
 
 	// We have a successful connection so report success. Any ongoing attempts no
@@ -2400,28 +2402,26 @@ func VerifyDialback(
 			return nil
 		}
 		return connHealthErr
-	} else {
-		log.VEventf(ctx, 2, "unable to verify health on existing conn, trying dialback conn to %s, n%d mode %v, %v",
-			target, request.OriginNodeID, request.NeedsDialback, connHealthErr)
-
-		// Since we don't have a successful reverse connection, try and dial back
-		// manually. We don't use the regular dialer pool to avoid a circular dependency:
-		// Dialing through the pool starts with a BLOCKING connection, which the remote
-		// side would try to dial back, which would call into VerifyDialback for this
-		// connection again, etc, for an infinite loop of blocking connections.
-		// A throwaway connection keeps it simple.
-		ctx := rpcCtx.wrapCtx(ctx, target, request.OriginNodeID, rpcbase.SystemClass)
-		ctx = logtags.AddTag(ctx, "dialback", nil)
-		onNetworkDial := func(conn net.Conn) {}
-		conn, err := rpcCtx.grpcDialRaw(ctx, target, rpcbase.SystemClass, onNetworkDial, grpc.WithBlock())
-		if conn != nil { // NB: the nil check simplifies mocking in TestVerifyDialback
-			_ = conn.Close() // nolint:grpcconnclose
-		}
-		if err != nil {
-			log.Dev.Infof(ctx, "blocking dialback connection failed to %s, n%d, %v", target, request.OriginNodeID, err)
-			return err
-		}
-		log.VEventf(ctx, 2, "blocking dialback connection to n%d succeeded", request.OriginNodeID)
-		return nil
 	}
+
+	log.VEventf(ctx, 2,
+		"unable to verify health on existing conn, trying dialback conn to %s, n%d mode %v, %v",
+		target, request.OriginNodeID, request.NeedsDialback, connHealthErr)
+
+	// Since we don't have a successful reverse connection, try and dial back
+	// manually. We don't use the regular dialer pool to avoid a circular
+	// dependency: dialing through the pool starts with a BLOCKING connection,
+	// which the remote side would try to dial back, which would call into
+	// VerifyDialback for this connection again, etc, for an infinite loop of
+	// blocking connections. A throwaway connection keeps it simple.
+	ctx = d.WrapCtx(ctx, target, request.OriginNodeID, rpcbase.SystemClass)
+	ctx = logtags.AddTag(ctx, "dialback", nil)
+	if err := d.DialRaw(ctx, target, rpcbase.SystemClass); err != nil {
+		log.Dev.Infof(ctx,
+			"blocking dialback connection failed to %s, n%d, %v",
+			target, request.OriginNodeID, err)
+		return err
+	}
+	log.VEventf(ctx, 2, "blocking dialback connection to n%d succeeded", request.OriginNodeID)
+	return nil
 }

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -51,6 +51,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"storj.io/drpc"
 	"storj.io/drpc/drpcmux"
 	"storj.io/drpc/drpcserver"
 )
@@ -1923,9 +1924,19 @@ func newRegisteredServer(
 	opts.RPCHeartbeatTimeout = 1000 * time.Millisecond
 
 	rpcCtx := NewContext(context.Background(), opts)
-	// This is normally set up inside the server, we want to hold onto all PingRequests that come through.
+
+	verifyDialbackFn := func() func(context.Context, *PingRequest, *PingResponse) error {
+		if !rpcCtx.UseDRPC {
+			return func(ctx context.Context, req *PingRequest, resp *PingResponse) error {
+				return VerifyDialback(ctx, NewGRPCDialbackAdapter(rpcCtx), req, resp, roachpb.Locality{}, &rpcCtx.Settings.SV)
+			}
+		}
+		return func(ctx context.Context, req *PingRequest, resp *PingResponse) error {
+			return VerifyDialback(ctx, NewDRPCDialbackAdapter(rpcCtx), req, resp, roachpb.Locality{}, &rpcCtx.Settings.SV)
+		}
+	}()
 	rpcCtx.OnIncomingPing = func(ctx context.Context, req *PingRequest, resp *PingResponse) error {
-		err := VerifyDialback(ctx, rpcCtx, req, resp, roachpb.Locality{}, &rpcCtx.Settings.SV)
+		err := verifyDialbackFn(ctx, req, resp)
 		if err != nil {
 			t.Logf("dialback error n%d->n%d @ %s: %s", nodeID, req.OriginNodeID, req.OriginAddr, err)
 			return err
@@ -2044,18 +2055,26 @@ func TestHeartbeatDialback(t *testing.T) {
 
 func TestVerifyDialback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Run("grpc", testVerifyDialbackImpl[*grpc.ClientConn])
+	t.Run("drpc", testVerifyDialbackImpl[drpc.Conn])
+}
 
-	run := func(t *testing.T, name string, f func(t *testing.T, mockRPCCtx *MockDialbacker, sv *settings.Values)) {
+func testVerifyDialbackImpl[Conn rpcConn](t *testing.T) {
+	run := func(
+		t *testing.T,
+		name string,
+		f func(t *testing.T, mockRPCCtx *MockDialbacker[Conn], sv *settings.Values),
+	) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			f(t, NewMockDialbacker(ctrl), &cluster.MakeTestingClusterSettings().SV)
+			f(t, NewMockDialbacker[Conn](ctrl), &cluster.MakeTestingClusterSettings().SV)
 		})
 	}
 
-	mkConn := func() *GRPCConnection {
-		c := &GRPCConnection{
+	mkConn := func() *Connection[Conn] {
+		c := &Connection[Conn]{
 			breakerSignalFn: func() circuit.Signal {
 				return &neverTripSignal{}
 			},
@@ -2072,7 +2091,7 @@ func TestVerifyDialback(t *testing.T) {
 		}
 	}
 
-	run(t, "no-ops", func(t *testing.T, mockRPCCtx *MockDialbacker, sv *settings.Values) {
+	run(t, "no-ops", func(t *testing.T, mockRPCCtx *MockDialbacker[Conn], sv *settings.Values) {
 		// NONE always no-ops, the other modes do if setting is disabled.
 		require.NoError(t, VerifyDialback(context.Background(), mockRPCCtx, ping(PingRequest_NONE),
 			&PingResponse{}, roachpb.Locality{}, sv))
@@ -2087,10 +2106,9 @@ func TestVerifyDialback(t *testing.T) {
 	// hits the fast-path, returning success.
 	for _, typ := range []PingRequest_DialbackType{PingRequest_BLOCKING, PingRequest_NON_BLOCKING} {
 		run(t, fmt.Sprintf("fast-path/healthy/%s", typ),
-			func(t *testing.T, mockRPCCtx *MockDialbacker, sv *settings.Values) {
-
-				mockRPCCtx.EXPECT().GRPCDialNode("1.1.1.1", roachpb.NodeID(2), roachpb.Locality{}, rpcbase.SystemClass).
-					DoAndReturn(func(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *GRPCConnection {
+			func(t *testing.T, mockRPCCtx *MockDialbacker[Conn], sv *settings.Values) {
+				mockRPCCtx.EXPECT().DialNode("1.1.1.1", roachpb.NodeID(2), roachpb.Locality{}, rpcbase.SystemClass).
+					DoAndReturn(func(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *Connection[Conn] {
 						healthyConn := mkConn()
 						close(healthyConn.connFuture.ready)
 						return healthyConn
@@ -2105,79 +2123,86 @@ func TestVerifyDialback(t *testing.T) {
 			})
 	}
 
-	run(t, "fast-path/pending/NON_BLOCKING", func(t *testing.T, mockRPCCtx *MockDialbacker, sv *settings.Values) {
-		// If reverse system class connection is not healthy, non-blocking dial attempt
-		// interprets this as success.
-		mockRPCCtx.EXPECT().GRPCDialNode("1.1.1.1", roachpb.NodeID(2), roachpb.Locality{}, rpcbase.SystemClass).
-			DoAndReturn(func(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *GRPCConnection {
-				tmpConn := mkConn()
-				assert.Equal(t, ErrNotHeartbeated, tmpConn.Health())
-				return tmpConn
-			})
-		require.NoError(t, VerifyDialback(context.Background(), mockRPCCtx, &PingRequest{
-			OriginAddr:    "1.1.1.1",
-			TargetNodeID:  1,
-			OriginNodeID:  2,
-			NeedsDialback: PingRequest_NON_BLOCKING,
-		}, &PingResponse{}, roachpb.Locality{}, sv))
-	})
-
-	for _, dialbackOK := range []bool{true, false} {
-		run(t, fmt.Sprintf("fast-path/pending/BLOCKING/success=%t", dialbackOK), func(t *testing.T, mockRPCCtx *MockDialbacker, sv *settings.Values) {
-			// If reverse system class connection is not healthy, blocking dial attempt
-			// will do a one-off dialback.
-			mockRPCCtx.EXPECT().GRPCDialNode("1.1.1.1", roachpb.NodeID(2), roachpb.Locality{}, rpcbase.SystemClass).
-				DoAndReturn(func(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *GRPCConnection {
+	run(t, "fast-path/pending/NON_BLOCKING",
+		func(t *testing.T, mockRPCCtx *MockDialbacker[Conn], sv *settings.Values) {
+			// If reverse system class connection is not healthy, non-blocking dial attempt
+			// interprets this as success.
+			mockRPCCtx.EXPECT().DialNode("1.1.1.1", roachpb.NodeID(2), roachpb.Locality{}, rpcbase.SystemClass).
+				DoAndReturn(func(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *Connection[Conn] {
 					tmpConn := mkConn()
 					assert.Equal(t, ErrNotHeartbeated, tmpConn.Health())
 					return tmpConn
 				})
-			mockRPCCtx.EXPECT().wrapCtx(gomock.Any(), "1.1.1.1", roachpb.NodeID(2), rpcbase.SystemClass).DoAndReturn(func(
-				ctx context.Context, _ string, _ roachpb.NodeID, _ rpcbase.ConnectionClass) context.Context {
-				return ctx
-			})
-			mockRPCCtx.EXPECT().grpcDialRaw(gomock.Any() /* ctx */, "1.1.1.1", rpcbase.SystemClass, gomock.Any() /* onDialFunc */, gomock.Any()).
-				DoAndReturn(func(context.Context, string, rpcbase.ConnectionClass, onDialFunc, ...grpc.DialOption) (*grpc.ClientConn, error) {
-					if dialbackOK {
-						return nil, nil
-					}
-					return nil, errors.New("boom")
-				})
-			err := VerifyDialback(context.Background(), mockRPCCtx, &PingRequest{
+			require.NoError(t, VerifyDialback(context.Background(), mockRPCCtx, &PingRequest{
 				OriginAddr:    "1.1.1.1",
 				TargetNodeID:  1,
 				OriginNodeID:  2,
-				NeedsDialback: PingRequest_BLOCKING,
-			}, &PingResponse{}, roachpb.Locality{}, sv)
-			if dialbackOK {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-			}
+				NeedsDialback: PingRequest_NON_BLOCKING,
+			}, &PingResponse{}, roachpb.Locality{}, sv))
 		})
+
+	for _, dialbackOK := range []bool{true, false} {
+		run(t, fmt.Sprintf("fast-path/pending/BLOCKING/success=%t", dialbackOK),
+			func(t *testing.T, mockRPCCtx *MockDialbacker[Conn], sv *settings.Values) {
+				// If reverse system class connection is not healthy, blocking dial attempt
+				// will do a one-off dialback.
+				mockRPCCtx.EXPECT().DialNode("1.1.1.1", roachpb.NodeID(2), roachpb.Locality{}, rpcbase.SystemClass).
+					DoAndReturn(func(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *Connection[Conn] {
+						tmpConn := mkConn()
+						assert.Equal(t, ErrNotHeartbeated, tmpConn.Health())
+						return tmpConn
+					})
+				mockRPCCtx.EXPECT().WrapCtx(gomock.Any(), "1.1.1.1", roachpb.NodeID(2), rpcbase.SystemClass).
+					DoAndReturn(func(
+						ctx context.Context, _ string, _ roachpb.NodeID, _ rpcbase.ConnectionClass,
+					) context.Context {
+						return ctx
+					})
+				mockRPCCtx.EXPECT().DialRaw(gomock.Any(), "1.1.1.1", rpcbase.SystemClass).
+					DoAndReturn(func(context.Context, string, rpcbase.ConnectionClass) error {
+						if dialbackOK {
+							return nil
+						}
+						return errors.New("boom")
+					})
+				err := VerifyDialback(context.Background(), mockRPCCtx, &PingRequest{
+					OriginAddr:    "1.1.1.1",
+					TargetNodeID:  1,
+					OriginNodeID:  2,
+					NeedsDialback: PingRequest_BLOCKING,
+				}, &PingResponse{}, roachpb.Locality{}, sv)
+				if dialbackOK {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+				}
+			})
 	}
 
-	run(t, "without-nodeid", func(t *testing.T, mockRPCCtx *MockDialbacker, sv *settings.Values) {
-		// If PingRequest has no OriginNodeID, we'll check the system-level connection using GRPCUnvalidatedDial
-		// and still do the one-off dialback (in BLOCKING mode)
-		req := ping(PingRequest_BLOCKING)
-		req.OriginNodeID = 0
-		mockRPCCtx.EXPECT().GRPCUnvalidatedDial("1.1.1.1", roachpb.Locality{}).
-			DoAndReturn(func(string, roachpb.Locality) *GRPCConnection {
-				tmpConn := mkConn()
-				assert.Equal(t, ErrNotHeartbeated, tmpConn.Health())
-				return tmpConn
-			})
-		mockRPCCtx.EXPECT().wrapCtx(gomock.Any(), "1.1.1.1", roachpb.NodeID(0), rpcbase.SystemClass).DoAndReturn(func(
-			ctx context.Context, _ string, _ roachpb.NodeID, _ rpcbase.ConnectionClass) context.Context {
-			return ctx
+	run(t, "without-nodeid",
+		func(t *testing.T, mockRPCCtx *MockDialbacker[Conn], sv *settings.Values) {
+			// If PingRequest has no OriginNodeID, we'll check the system-level connection
+			// using UnvalidatedDial and still do the one-off dialback (in BLOCKING mode).
+			req := ping(PingRequest_BLOCKING)
+			req.OriginNodeID = 0
+			mockRPCCtx.EXPECT().UnvalidatedDial("1.1.1.1", roachpb.Locality{}).
+				DoAndReturn(func(string, roachpb.Locality) *Connection[Conn] {
+					tmpConn := mkConn()
+					assert.Equal(t, ErrNotHeartbeated, tmpConn.Health())
+					return tmpConn
+				})
+			mockRPCCtx.EXPECT().WrapCtx(gomock.Any(), "1.1.1.1", roachpb.NodeID(0), rpcbase.SystemClass).
+				DoAndReturn(func(
+					ctx context.Context, _ string, _ roachpb.NodeID, _ rpcbase.ConnectionClass,
+				) context.Context {
+					return ctx
+				})
+			mockRPCCtx.EXPECT().DialRaw(gomock.Any(), "1.1.1.1", rpcbase.SystemClass).
+				DoAndReturn(func(context.Context, string, rpcbase.ConnectionClass) error {
+					return nil
+				})
+			require.NoError(t, VerifyDialback(context.Background(), mockRPCCtx, req, &PingResponse{}, roachpb.Locality{}, sv))
 		})
-		mockRPCCtx.EXPECT().grpcDialRaw(gomock.Any() /* ctx */, "1.1.1.1", rpcbase.SystemClass, gomock.Any() /* onDialFunc */, gomock.Any()).
-			DoAndReturn(func(context.Context, string, rpcbase.ConnectionClass, onDialFunc, ...grpc.DialOption) (*grpc.ClientConn, error) {
-				return nil, nil
-			})
-		require.NoError(t, VerifyDialback(context.Background(), mockRPCCtx, req, &PingResponse{}, roachpb.Locality{}, sv))
-	})
 }
 
 // TODO(baptist): Add a test using TestCluster to verify this works in a full

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -218,6 +218,45 @@ func (c *closeEntirePoolConn) Close() (err error) {
 
 type DRPCConnection = Connection[drpc.Conn]
 
+// DRPCDialbackAdapter implements Dialbacker[drpc.Conn] by delegating
+// to the corresponding methods on *Context.
+type DRPCDialbackAdapter struct {
+	rpcCtx *Context
+}
+
+// NewDRPCDialbackAdapter creates a new DRPCDialbackAdapter.
+func NewDRPCDialbackAdapter(rpcCtx *Context) *DRPCDialbackAdapter {
+	return &DRPCDialbackAdapter{rpcCtx: rpcCtx}
+}
+
+func (a *DRPCDialbackAdapter) UnvalidatedDial(
+	target string, locality roachpb.Locality,
+) *DRPCConnection {
+	return a.rpcCtx.DRPCUnvalidatedDial(target, locality)
+}
+
+func (a *DRPCDialbackAdapter) DialNode(
+	target string, nodeID roachpb.NodeID, locality roachpb.Locality, class rpcbase.ConnectionClass,
+) *DRPCConnection {
+	return a.rpcCtx.DRPCDialNode(target, nodeID, locality, class)
+}
+
+func (a *DRPCDialbackAdapter) DialRaw(
+	ctx context.Context, target string, class rpcbase.ConnectionClass,
+) error {
+	conn, err := a.rpcCtx.drpcDialRaw(ctx, target, class)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	return err
+}
+
+func (a *DRPCDialbackAdapter) WrapCtx(
+	ctx context.Context, target string, remoteNodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) context.Context {
+	return a.rpcCtx.wrapCtx(ctx, target, remoteNodeID, class)
+}
+
 // ErrDRPCDisabled is returned from hosts that in principle could but do not
 // have the DRPC server enabled.
 var ErrDRPCDisabled = errors.New("DRPC is not enabled")

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -53,6 +53,46 @@ func (g *grpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
 
 type GRPCConnection = Connection[*grpc.ClientConn]
 
+// GRPCDialbackAdapter implements Dialbacker[*grpc.ClientConn] by
+// delegating to the corresponding methods on *Context.
+type GRPCDialbackAdapter struct {
+	rpcCtx *Context
+}
+
+// NewGRPCDialbackAdapter creates a new GRPCDialbackAdapter.
+func NewGRPCDialbackAdapter(rpcCtx *Context) *GRPCDialbackAdapter {
+	return &GRPCDialbackAdapter{rpcCtx: rpcCtx}
+}
+
+func (a *GRPCDialbackAdapter) UnvalidatedDial(
+	target string, locality roachpb.Locality,
+) *GRPCConnection {
+	return a.rpcCtx.GRPCUnvalidatedDial(target, locality)
+}
+
+func (a *GRPCDialbackAdapter) DialNode(
+	target string, nodeID roachpb.NodeID, locality roachpb.Locality, class rpcbase.ConnectionClass,
+) *GRPCConnection {
+	return a.rpcCtx.GRPCDialNode(target, nodeID, locality, class)
+}
+
+func (a *GRPCDialbackAdapter) DialRaw(
+	ctx context.Context, target string, class rpcbase.ConnectionClass,
+) error {
+	onNetworkDial := func(conn net.Conn) {}
+	conn, err := a.rpcCtx.grpcDialRaw(ctx, target, class, onNetworkDial, grpc.WithBlock())
+	if conn != nil {
+		_ = conn.Close() // nolint:grpcconnclose
+	}
+	return err
+}
+
+func (a *GRPCDialbackAdapter) WrapCtx(
+	ctx context.Context, target string, remoteNodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) context.Context {
+	return a.rpcCtx.wrapCtx(ctx, target, remoteNodeID, class)
+}
+
 // newGRPCPeerOptions creates peerOptions for gRPC peers.
 func newGRPCPeerOptions(
 	rpcCtx *Context, k peerKey, locality roachpb.Locality,

--- a/pkg/rpc/rpc_mock_test.go
+++ b/pkg/rpc/rpc_mock_test.go
@@ -13,9 +13,8 @@ import (
 
 	kvpb "github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
-	rpcpb "github.com/cockroachdb/cockroach/pkg/rpc/rpcpb"
+	rpcbase "github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	gomock "github.com/golang/mock/gomock"
-	"google.golang.org/grpc"
 )
 
 // MockBatchStreamClient is a mock of BatchStreamClient interface.
@@ -70,103 +69,93 @@ func (mr *MockBatchStreamClientMockRecorder) Send(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockBatchStreamClient)(nil).Send), arg0)
 }
 
-// MockDialbacker is a mock of Dialbacker interface.
-type MockDialbacker struct {
+// MockDialbacker is a mock of the generic Dialbacker[Conn] interface.
+type MockDialbacker[Conn rpcConn] struct {
 	ctrl     *gomock.Controller
-	recorder *MockDialbackerMockRecorder
+	recorder *MockDialbackerMockRecorder[Conn]
 }
 
 // MockDialbackerMockRecorder is the mock recorder for MockDialbacker.
-type MockDialbackerMockRecorder struct {
-	mock *MockDialbacker
+type MockDialbackerMockRecorder[Conn rpcConn] struct {
+	mock *MockDialbacker[Conn]
 }
 
 // NewMockDialbacker creates a new mock instance.
-func NewMockDialbacker(ctrl *gomock.Controller) *MockDialbacker {
-	mock := &MockDialbacker{ctrl: ctrl}
-	mock.recorder = &MockDialbackerMockRecorder{mock}
+func NewMockDialbacker[Conn rpcConn](ctrl *gomock.Controller) *MockDialbacker[Conn] {
+	mock := &MockDialbacker[Conn]{ctrl: ctrl}
+	mock.recorder = &MockDialbackerMockRecorder[Conn]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockDialbacker) EXPECT() *MockDialbackerMockRecorder {
+func (m *MockDialbacker[Conn]) EXPECT() *MockDialbackerMockRecorder[Conn] {
 	return m.recorder
 }
 
-// GRPCDialNode mocks base method.
-func (m *MockDialbacker) GRPCDialNode(
-	arg0 string, arg1 roachpb.NodeID, arg2 roachpb.Locality, arg3 rpcpb.ConnectionClass,
-) *Connection[*grpc.ClientConn] {
+// UnvalidatedDial mocks base method.
+func (m *MockDialbacker[Conn]) UnvalidatedDial(
+	arg0 string, arg1 roachpb.Locality,
+) *Connection[Conn] {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GRPCDialNode", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*Connection[*grpc.ClientConn])
+	ret := m.ctrl.Call(m, "UnvalidatedDial", arg0, arg1)
+	ret0, _ := ret[0].(*Connection[Conn])
 	return ret0
 }
 
-// GRPCDialNode indicates an expected call of GRPCDialNode.
-func (mr *MockDialbackerMockRecorder) GRPCDialNode(
+// UnvalidatedDial indicates an expected call of UnvalidatedDial.
+func (mr *MockDialbackerMockRecorder[Conn]) UnvalidatedDial(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCall(mr.mock, "UnvalidatedDial", arg0, arg1)
+}
+
+// DialNode mocks base method.
+func (m *MockDialbacker[Conn]) DialNode(
+	arg0 string, arg1 roachpb.NodeID, arg2 roachpb.Locality, arg3 rpcbase.ConnectionClass,
+) *Connection[Conn] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialNode", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*Connection[Conn])
+	return ret0
+}
+
+// DialNode indicates an expected call of DialNode.
+func (mr *MockDialbackerMockRecorder[Conn]) DialNode(
 	arg0, arg1, arg2, arg3 interface{},
 ) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GRPCDialNode", reflect.TypeOf((*MockDialbacker)(nil).GRPCDialNode), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCall(mr.mock, "DialNode", arg0, arg1, arg2, arg3)
 }
 
-// GRPCUnvalidatedDial mocks base method.
-func (m *MockDialbacker) GRPCUnvalidatedDial(
-	arg0 string, arg1 roachpb.Locality,
-) *Connection[*grpc.ClientConn] {
+// DialRaw mocks base method.
+func (m *MockDialbacker[Conn]) DialRaw(
+	arg0 context.Context, arg1 string, arg2 rpcbase.ConnectionClass,
+) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GRPCUnvalidatedDial", arg0, arg1)
-	ret0, _ := ret[0].(*Connection[*grpc.ClientConn])
+	ret := m.ctrl.Call(m, "DialRaw", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GRPCUnvalidatedDial indicates an expected call of GRPCUnvalidatedDial.
-func (mr *MockDialbackerMockRecorder) GRPCUnvalidatedDial(arg0, arg1 interface{}) *gomock.Call {
+// DialRaw indicates an expected call of DialRaw.
+func (mr *MockDialbackerMockRecorder[Conn]) DialRaw(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GRPCUnvalidatedDial", reflect.TypeOf((*MockDialbacker)(nil).GRPCUnvalidatedDial), arg0, arg1)
+	return mr.mock.ctrl.RecordCall(mr.mock, "DialRaw", arg0, arg1, arg2)
 }
 
-// grpcDialRaw mocks base method.
-func (m *MockDialbacker) grpcDialRaw(
-	arg0 context.Context,
-	arg1 string,
-	arg2 rpcpb.ConnectionClass,
-	arg3 onDialFunc,
-	arg4 ...grpc.DialOption,
-) (*grpc.ClientConn, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2, arg3}
-	for _, a := range arg4 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "grpcDialRaw", varargs...)
-	ret0, _ := ret[0].(*grpc.ClientConn)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// grpcDialRaw indicates an expected call of grpcDialRaw.
-func (mr *MockDialbackerMockRecorder) grpcDialRaw(
-	arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{},
-) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "grpcDialRaw", reflect.TypeOf((*MockDialbacker)(nil).grpcDialRaw), varargs...)
-}
-
-// wrapCtx mocks base method.
-func (m *MockDialbacker) wrapCtx(
-	arg0 context.Context, arg1 string, arg2 roachpb.NodeID, arg3 rpcpb.ConnectionClass,
+// WrapCtx mocks base method.
+func (m *MockDialbacker[Conn]) WrapCtx(
+	arg0 context.Context, arg1 string, arg2 roachpb.NodeID, arg3 rpcbase.ConnectionClass,
 ) context.Context {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "wrapCtx", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "WrapCtx", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
 	return ret0
 }
 
-// wrapCtx indicates an expected call of wrapCtx.
-func (mr *MockDialbackerMockRecorder) wrapCtx(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// WrapCtx indicates an expected call of WrapCtx.
+func (mr *MockDialbackerMockRecorder[Conn]) WrapCtx(
+	arg0, arg1, arg2, arg3 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "wrapCtx", reflect.TypeOf((*MockDialbacker)(nil).wrapCtx), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCall(mr.mock, "WrapCtx", arg0, arg1, arg2, arg3)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -370,6 +370,16 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	}
 	rpcContext := rpc.NewContext(ctx, rpcCtxOpts)
 
+	verifyDialbackFn := func() func(context.Context, *rpc.PingRequest, *rpc.PingResponse) error {
+		if !rpcContext.UseDRPC {
+			return func(ctx context.Context, req *rpc.PingRequest, resp *rpc.PingResponse) error {
+				return rpc.VerifyDialback(ctx, rpc.NewGRPCDialbackAdapter(rpcContext), req, resp, cfg.Locality, &rpcContext.Settings.SV)
+			}
+		}
+		return func(ctx context.Context, req *rpc.PingRequest, resp *rpc.PingResponse) error {
+			return rpc.VerifyDialback(ctx, rpc.NewDRPCDialbackAdapter(rpcContext), req, resp, cfg.Locality, &rpcContext.Settings.SV)
+		}
+	}()
 	rpcContext.OnIncomingPing = func(ctx context.Context, req *rpc.PingRequest, resp *rpc.PingResponse) error {
 		// Decommission state is only tracked for the system tenant.
 		if tenantID, isTenant := roachpb.ClientTenantFromContext(ctx); !isTenant ||
@@ -381,9 +391,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 				return err
 			}
 		}
-		// VerifyDialback verifies if a reverse connection to the sending node can
-		// be established.
-		return rpc.VerifyDialback(ctx, rpcContext, req, resp, cfg.Locality, &rpcContext.Settings.SV)
+		return verifyDialbackFn(ctx, req, resp)
 	}
 
 	appRegistry.AddMetricStruct(rpcContext.Metrics())

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -130,8 +130,6 @@ func newRowLevelTTLTestJobTestHelper(
 			Settings:          makeSettings(),
 			Knobs:             baseTestingKnobs,
 			InsecureWebAccess: true,
-			// TODO(server): re-enable DRPC once flakiness is addressed, see #158387.
-			DefaultDRPCOption: base.TestDRPCDisabled,
 		},
 	})
 	th.testCluster = testCluster


### PR DESCRIPTION
Refactor the `Dialbacker` interface to be generic (`Dialbacker[Conn rpcConn]`) and introduce protocol-specific adapters (`GRPCDialbackAdapter`, `DRPCDialbackAdapter`) that implement it. This allows `VerifyDialback` to work with both gRPC and DRPC connections without coupling to a specific rpc framework.

The `VerifyDialback` function now accepts a `Dialbacker[Conn]` instead of directly calling gRPC-specific methods on `*Context`. Each adapter delegates to the appropriate dial methods on `*Context` for its protocol. The mock in `rpc_mock_test.go` is updated to be generic as well.

With this in place, re-enable DRPC in the row-level TTL job test helper (`newRowLevelTTLTestJobTestHelper`) by removing the `DefaultDRPCOption: base.TestDRPCDisabled` override that was added as a workaround.

Epic: CRDB-55382
Fixes: #158387
Release note: None