### PR TITLE
server: fix serve-loopback-drpc using wrong context on shutdown

### DIFF
--- a/pkg/server/start_listen.go
+++ b/pkg/server/start_listen.go
@@ -201,7 +201,7 @@ func startListenRPCAndSQL(
 		_ = stopper.RunAsyncTask(workersCtx, "serve-loopback-grpc", func(context.Context) {
 			netutil.FatalIfUnexpected(grpc.Serve(grpcLoopbackL))
 		})
-		_ = stopper.RunAsyncTask(workersCtx, "serve-loopback-drpc", func(ctx context.Context) {
+		_ = stopper.RunAsyncTask(drpcCtx, "serve-loopback-drpc", func(ctx context.Context) {
 			netutil.FatalIfUnexpected(drpc.Serve(ctx, drpcLoopbackL))
 		})
 


### PR DESCRIPTION
The serve-loopback-drpc task used workersCtx with an unnamed closure parameter, causing drpc.Serve to capture the outer startRPCServer ctx instead of drpcCtx. This meant drpcCancel() on quiesce never cancelled the loopback DRPC server, hanging stopper.Stop() if any in-flight streams existed on the loopback path.

Fix by using drpcCtx and naming the closure parameter, matching the serve-drpc task pattern.

Epic: CRDB-55382
Fixes: #165524
Release note: None