### PR TITLE
rpc,server: fix endpoint telemetry test for DRPC

### DIFF
--- a/pkg/rpc/metrics.go
+++ b/pkg/rpc/metrics.go
@@ -776,9 +776,14 @@ func drpcGatewayRequestCounterInterceptor(
 	return invoker(ctx, rpc, enc, in, out, cc)
 }
 
+// GatewayEndpointCounterName returns the telemetry counter name for the
+// given gateway type (e.g. "grpc", "drpc") and RPC method.
+func GatewayEndpointCounterName(gateway, method string) string {
+	return fmt.Sprintf("http.%s-gateway.%s", gateway, method)
+}
+
 // getDRPCGatewayEndpointCounter returns a telemetry Counter corresponding to
 // the given DRPC method.
 func getDRPCGatewayEndpointCounter(method string) telemetry.Counter {
-	const counterPrefix = "http.drpc-gateway"
-	return telemetry.GetCounter(fmt.Sprintf("%s.%s", counterPrefix, method))
+	return telemetry.GetCounter(GatewayEndpointCounterName("drpc", method))
 }

--- a/pkg/server/grpc_gateway.go
+++ b/pkg/server/grpc_gateway.go
@@ -7,7 +7,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
@@ -117,6 +116,5 @@ func configureGRPCGateway(
 // getServerEndpointCounter returns a telemetry Counter corresponding to the
 // given grpc method.
 func getServerEndpointCounter(method string) telemetry.Counter {
-	const counterPrefix = "http.grpc-gateway"
-	return telemetry.GetCounter(fmt.Sprintf("%s.%s", counterPrefix, method))
+	return telemetry.GetCounter(rpc.GatewayEndpointCounterName("grpc", method))
 }

--- a/pkg/server/grpc_gateway_test.go
+++ b/pkg/server/grpc_gateway_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -21,31 +22,48 @@ import (
 
 // TestEndpointTelemetryBasic tests that the telemetry collection on the usage of
 // CRDB's endpoints works as expected by recording the call counts of `Admin` &
-// `Status` requests.
+// `Status` requests, for both gRPC and dRPC gateways.
 func TestEndpointTelemetryBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(81590),
-		DefaultDRPCOption: base.TestDRPCDisabled,
-	})
-	defer s.Stopper().Stop(context.Background())
-
-	// Check that calls over HTTP are recorded.
-	var details serverpb.LocationsResponse
-	if err := srvtestutils.GetAdminJSONProto(s, "locations", &details); err != nil {
-		t.Fatal(err)
+	testCases := []struct {
+		name    string
+		drpcOpt base.DefaultTestDRPCOption
+		gateway string
+	}{
+		{"gRPC", base.TestDRPCDisabled, "grpc"},
+		{"dRPC", base.TestDRPCEnabled, "drpc"},
 	}
-	require.GreaterOrEqual(t, telemetry.Read(getServerEndpointCounter(
-		"/cockroach.server.serverpb.Admin/Locations",
-	)), int32(1))
 
-	var resp serverpb.StatementsResponse
-	if err := srvtestutils.GetStatusJSONProto(s, "statements", &resp); err != nil {
-		t.Fatal(err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{
+				DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(81590),
+				DefaultDRPCOption: tc.drpcOpt,
+			})
+			defer s.Stopper().Stop(context.Background())
+
+			counter := func(method string) telemetry.Counter {
+				return telemetry.GetCounter(rpc.GatewayEndpointCounterName(tc.gateway, method))
+			}
+
+			// Check that calls over HTTP are recorded.
+			var details serverpb.LocationsResponse
+			if err := srvtestutils.GetAdminJSONProto(s, "locations", &details); err != nil {
+				t.Fatal(err)
+			}
+			require.GreaterOrEqual(t, telemetry.Read(counter(
+				"/cockroach.server.serverpb.Admin/Locations",
+			)), int32(1))
+
+			var resp serverpb.StatementsResponse
+			if err := srvtestutils.GetStatusJSONProto(s, "statements", &resp); err != nil {
+				t.Fatal(err)
+			}
+			require.Equal(t, int32(1), telemetry.Read(counter(
+				"/cockroach.server.serverpb.Status/Statements",
+			)))
+		})
 	}
-	require.Equal(t, int32(1), telemetry.Read(getServerEndpointCounter(
-		"/cockroach.server.serverpb.Status/Statements",
-	)))
 }


### PR DESCRIPTION
`TestEndpointTelemetryBasic` was failing when DRPC was enabled because the HTTP gateway uses a different telemetry counter path under DRPC `(http.drpc-gateway.*)` than under gRPC `(http.grpc-gateway.*)`. The gRPC gateway increments counters via a `grpc.UnaryInterceptor` on the loopback ClientConn, while the DRPC gateway uses `drpcGatewayRequestCounterInterceptor` which writes to a separate counter namespace.

This change pins the `TestEndpointTelemetryBasic` to gRPC since it specifically validates the gRPC gateway telemetry path. We separately add `TestDRPCEndpointTelemetryBasic` in `drpc_test.go` that validates the equivalent telemetry under DRPC using the `http.drpc-gateway` counters.

Epic: CRDB-55382
Fixes: #161590
Release note: None