### PR TITLE
release-25.4: goexectrace: fix file descriptor leak and stale file on WriteTo error

### DIFF
--- a/pkg/util/tracing/goexectrace/simple_flight_recorder.go
+++ b/pkg/util/tracing/goexectrace/simple_flight_recorder.go
@@ -178,13 +178,14 @@ func (sfr *SimpleFlightRecorder) Start(ctx context.Context, stopper *stop.Stoppe
 					continue
 				}
 				_, err = sfr.fr.WriteTo(destFile)
-				if err != nil {
+				if err = errors.CombineErrors(err, destFile.Close()); err != nil {
 					log.Dev.Warningf(ctx, "error while writing flight record to %s, will try again: %v", filename, err)
+					_ = os.Remove(filename)
 					t.Reset(max(interval-timeutil.Since(startTime), 0))
 					continue
 				}
 
-				// Can run GC since we successfully wrote a new file.
+				// Can run GC since we successfully wrote and closed a new file.
 				sfr.dumpStore.GC(ctx, timeutil.Now(), sfr)
 				t.Reset(max(interval-timeutil.Since(startTime), 0))
 			case <-stopper.ShouldQuiesce():


### PR DESCRIPTION
Backport 1/1 commits from #165538 on behalf of @jasonlmfong.

----

Previously, if `FlightRecorder.WriteTo` failed, the destination file was never closed (leaking a file descriptor) and the partially-written file was left on disk. Fix this by always closing the file after `WriteTo` and removing it on error, using `errors.CombineErrors` to surface both the write and close errors.

Epic: None
Release Note: None

----

Release justification: fixes a leaked file descriptor when running flightrecorder