### PR TITLE
ui: migrate NavigationBar sidebar from Redux to SWR

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterApi.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterApi.spec.ts
@@ -1,0 +1,299 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { renderHook } from "@testing-library/react-hooks";
+
+import {
+  getClusterName,
+  getClusterVersionLabel,
+  useClusterLabel,
+} from "./clusterApi";
+import * as livenessApi from "./livenessApi";
+import * as nodesApi from "./nodesApi";
+
+type INodeStatus = cockroach.server.status.statuspb.INodeStatus;
+type ILiveness = cockroach.kv.kvserver.liveness.livenesspb.ILiveness;
+const LivenessStatus =
+  cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+const MembershipStatus =
+  cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
+
+function makeNodeStatus(
+  nodeId: number,
+  opts: { tag?: string; clusterName?: string } = {},
+): INodeStatus {
+  return {
+    desc: {
+      node_id: nodeId,
+      cluster_name: opts.clusterName,
+    },
+    build_info: opts.tag != null ? { tag: opts.tag } : undefined,
+  } as INodeStatus;
+}
+
+function makeLiveness(
+  nodeId: number,
+  membership?: cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus,
+): ILiveness {
+  return { node_id: nodeId, membership } as ILiveness;
+}
+
+describe("getClusterName", () => {
+  it("returns undefined for empty node statuses", () => {
+    expect(getClusterName([], {})).toBeUndefined();
+  });
+
+  it("returns undefined for null node statuses", () => {
+    expect(getClusterName(null, {})).toBeUndefined();
+  });
+
+  it("returns undefined when liveness statuses are empty", () => {
+    const nodes = [makeNodeStatus(1, { clusterName: "my-cluster" })];
+    expect(getClusterName(nodes, {})).toBeUndefined();
+  });
+
+  it("returns undefined when no nodes are live", () => {
+    const nodes = [makeNodeStatus(1, { clusterName: "my-cluster" })];
+    expect(
+      getClusterName(nodes, { "1": LivenessStatus.NODE_STATUS_DEAD }),
+    ).toBeUndefined();
+  });
+
+  it("returns cluster name from a live node", () => {
+    const nodes = [makeNodeStatus(1, { clusterName: "my-cluster" })];
+    expect(
+      getClusterName(nodes, { "1": LivenessStatus.NODE_STATUS_LIVE }),
+    ).toBe("my-cluster");
+  });
+
+  it("skips live nodes without a cluster name", () => {
+    const nodes = [
+      makeNodeStatus(1),
+      makeNodeStatus(2, { clusterName: "found-it" }),
+    ];
+    expect(
+      getClusterName(nodes, {
+        "1": LivenessStatus.NODE_STATUS_LIVE,
+        "2": LivenessStatus.NODE_STATUS_LIVE,
+      }),
+    ).toBe("found-it");
+  });
+
+  it("returns undefined when no live nodes have a cluster name", () => {
+    const nodes = [makeNodeStatus(1), makeNodeStatus(2)];
+    expect(
+      getClusterName(nodes, {
+        "1": LivenessStatus.NODE_STATUS_LIVE,
+        "2": LivenessStatus.NODE_STATUS_LIVE,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("getClusterVersionLabel", () => {
+  it("returns undefined for null node statuses", () => {
+    expect(getClusterVersionLabel(null, {})).toBeUndefined();
+  });
+
+  it("returns undefined when no nodes have build info", () => {
+    const nodes = [makeNodeStatus(1)]; // no tag => no build_info
+    expect(getClusterVersionLabel(nodes, {})).toBeUndefined();
+  });
+
+  it("returns single version when all nodes run the same version", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.1.0" }),
+    ];
+    expect(getClusterVersionLabel(nodes, {})).toBe("v23.1.0");
+  });
+
+  it("returns lowest version with suffix for mixed versions", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.2.0" }),
+      makeNodeStatus(2, { tag: "v23.1.0" }),
+    ];
+    expect(getClusterVersionLabel(nodes, {})).toBe("v23.1.0 - Mixed Versions");
+  });
+
+  it("includes nodes with ACTIVE membership (value 0)", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.2.0" }),
+    ];
+    const liveness: Record<string, ILiveness> = {
+      "1": makeLiveness(1, MembershipStatus.ACTIVE),
+      "2": makeLiveness(2, MembershipStatus.ACTIVE),
+    };
+    expect(getClusterVersionLabel(nodes, liveness)).toBe(
+      "v23.1.0 - Mixed Versions",
+    );
+  });
+
+  it("excludes decommissioning nodes from version calculation", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.2.0" }),
+    ];
+    const liveness: Record<string, ILiveness> = {
+      "1": makeLiveness(1, MembershipStatus.ACTIVE),
+      "2": makeLiveness(2, MembershipStatus.DECOMMISSIONING),
+    };
+    // Node 2 excluded; only v23.1.0 remains.
+    expect(getClusterVersionLabel(nodes, liveness)).toBe("v23.1.0");
+  });
+
+  it("excludes decommissioned nodes from version calculation", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.2.0" }),
+    ];
+    const liveness: Record<string, ILiveness> = {
+      "1": makeLiveness(1, MembershipStatus.ACTIVE),
+      "2": makeLiveness(2, MembershipStatus.DECOMMISSIONED),
+    };
+    expect(getClusterVersionLabel(nodes, liveness)).toBe("v23.1.0");
+  });
+
+  it("includes nodes with no liveness record", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.1.0" }),
+    ];
+    // No liveness entries at all.
+    expect(getClusterVersionLabel(nodes, {})).toBe("v23.1.0");
+  });
+
+  it("includes nodes with null membership", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.2.0" }),
+    ];
+    const liveness: Record<string, ILiveness> = {
+      "1": makeLiveness(1, null),
+      "2": makeLiveness(2, null),
+    };
+    expect(getClusterVersionLabel(nodes, liveness)).toBe(
+      "v23.1.0 - Mixed Versions",
+    );
+  });
+
+  it("returns undefined when all nodes are decommissioned", () => {
+    const nodes = [
+      makeNodeStatus(1, { tag: "v23.1.0" }),
+      makeNodeStatus(2, { tag: "v23.2.0" }),
+    ];
+    const liveness: Record<string, ILiveness> = {
+      "1": makeLiveness(1, MembershipStatus.DECOMMISSIONED),
+      "2": makeLiveness(2, MembershipStatus.DECOMMISSIONED),
+    };
+    expect(getClusterVersionLabel(nodes, liveness)).toBeUndefined();
+  });
+});
+
+describe("useClusterLabel", () => {
+  let spyUseNodes: jest.SpyInstance;
+  let spyUseLiveness: jest.SpyInstance;
+
+  beforeEach(() => {
+    spyUseNodes = jest.spyOn(nodesApi, "useNodes");
+    spyUseLiveness = jest.spyOn(livenessApi, "useLiveness");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns cluster name and version from live nodes", () => {
+    spyUseNodes.mockReturnValue({
+      nodeStatuses: [
+        makeNodeStatus(1, { tag: "v23.1.0", clusterName: "my-cluster" }),
+        makeNodeStatus(2, { tag: "v23.1.0" }),
+      ],
+      isLoading: false,
+      error: undefined,
+    });
+    spyUseLiveness.mockReturnValue({
+      livenesses: [
+        makeLiveness(1, MembershipStatus.ACTIVE),
+        makeLiveness(2, MembershipStatus.ACTIVE),
+      ],
+      statuses: {
+        "1": LivenessStatus.NODE_STATUS_LIVE,
+        "2": LivenessStatus.NODE_STATUS_LIVE,
+      },
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useClusterLabel());
+    expect(result.current.clusterName).toBe("my-cluster");
+    expect(result.current.clusterVersion).toBe("v23.1.0");
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("excludes decommissioning nodes from version but not cluster name", () => {
+    spyUseNodes.mockReturnValue({
+      nodeStatuses: [
+        makeNodeStatus(1, { tag: "v23.1.0", clusterName: "my-cluster" }),
+        makeNodeStatus(2, { tag: "v23.2.0" }),
+      ],
+      isLoading: false,
+      error: undefined,
+    });
+    spyUseLiveness.mockReturnValue({
+      livenesses: [
+        makeLiveness(1, MembershipStatus.ACTIVE),
+        makeLiveness(2, MembershipStatus.DECOMMISSIONING),
+      ],
+      statuses: {
+        "1": LivenessStatus.NODE_STATUS_LIVE,
+        "2": LivenessStatus.NODE_STATUS_LIVE,
+      },
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useClusterLabel());
+    expect(result.current.clusterVersion).toBe("v23.1.0");
+  });
+
+  it("is loading when either hook is loading", () => {
+    spyUseNodes.mockReturnValue({
+      nodeStatuses: [],
+      isLoading: true,
+      error: undefined,
+    });
+    spyUseLiveness.mockReturnValue({
+      livenesses: [],
+      statuses: {},
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useClusterLabel());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns first available error", () => {
+    const nodesErr = new Error("nodes failed");
+    spyUseNodes.mockReturnValue({
+      nodeStatuses: [],
+      isLoading: false,
+      error: nodesErr,
+    });
+    spyUseLiveness.mockReturnValue({
+      livenesses: [],
+      statuses: {},
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useClusterLabel());
+    expect(result.current.error).toBe(nodesErr);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterApi.ts
@@ -4,11 +4,20 @@
 // included in the /LICENSE file.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { useMemo } from "react";
 
 import { useSwrWithClusterId } from "../util";
 
 import { fetchData } from "./fetchData";
+import { useLiveness } from "./livenessApi";
+import { useNodes } from "./nodesApi";
 
+type INodeStatus = cockroach.server.status.statuspb.INodeStatus;
+const LivenessStatus =
+  cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus;
+const MembershipStatus =
+  cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
+type ILiveness = cockroach.kv.kvserver.liveness.livenesspb.ILiveness;
 type ClusterResponse = cockroach.server.serverpb.ClusterResponse;
 
 const CLUSTER_SWR_KEY = "cluster";
@@ -21,12 +30,12 @@ const getCluster = (): Promise<ClusterResponse> => {
 };
 
 export const useCluster = () => {
-  const { data, isLoading, error } = useSwrWithClusterId(
+  const { data, error, isLoading } = useSwrWithClusterId(
     CLUSTER_SWR_KEY,
     getCluster,
     {
       revalidateOnFocus: false,
-      dedupingInterval: 10_000,
+      dedupingInterval: 30_000, // 30 seconds; cluster info rarely changes.
     },
   );
 
@@ -35,5 +44,103 @@ export const useCluster = () => {
     isLoading,
     error,
     enterpriseEnabled: data?.enterprise_enabled ?? false,
+  };
+};
+
+// getClusterName returns the name of the cluster from live node statuses.
+// It picks the first non-empty cluster_name from live nodes.
+export function getClusterName(
+  nodeStatuses: INodeStatus[],
+  livenessStatusByNodeID: Record<string, number>,
+): string | undefined {
+  if (!nodeStatuses?.length || !Object.keys(livenessStatusByNodeID).length) {
+    return undefined;
+  }
+  const liveNodes = nodeStatuses.filter(
+    ns =>
+      livenessStatusByNodeID[ns.desc?.node_id?.toString()] ===
+      LivenessStatus.NODE_STATUS_LIVE,
+  );
+  const nodeWithName = liveNodes.find(
+    ns => ns.desc?.cluster_name && ns.desc.cluster_name.length > 0,
+  );
+  return nodeWithName?.desc?.cluster_name;
+}
+
+// getClusterVersionLabel returns the build version label. If nodes are
+// running mixed versions, the lowest version is returned with a
+// " - Mixed Versions" suffix.
+export function getClusterVersionLabel(
+  nodeStatuses: INodeStatus[],
+  livenessByNodeID: Record<string, ILiveness>,
+): string | undefined {
+  if (!nodeStatuses) {
+    return undefined;
+  }
+  // Filter to active, non-decommissioning nodes with build info.
+  const validNodes = nodeStatuses
+    .filter(ns => !!ns.build_info)
+    .filter(ns => {
+      const l = livenessByNodeID[ns.desc?.node_id?.toString()];
+      return (
+        !ns.desc ||
+        !l ||
+        l.membership == null ||
+        l.membership === MembershipStatus.ACTIVE
+      );
+    });
+
+  const versions = [...new Set(validNodes.map(ns => ns.build_info.tag))];
+  if (!versions.length) {
+    return undefined;
+  }
+  if (versions.length > 1) {
+    const sorted = [...versions].sort();
+    return `${sorted[0]} - Mixed Versions`;
+  }
+  return versions[0];
+}
+
+export const useClusterLabel = () => {
+  const {
+    nodeStatuses,
+    isLoading: nodesLoading,
+    error: nodesError,
+  } = useNodes();
+
+  const {
+    livenesses,
+    statuses: livenessStatusByNodeID,
+    isLoading: livenessLoading,
+    error: livenessError,
+  } = useLiveness();
+
+  const isLoading = nodesLoading || livenessLoading;
+
+  const livenessByNodeID: Record<string, ILiveness> = useMemo(() => {
+    const result: Record<string, ILiveness> = {};
+    for (const l of livenesses) {
+      if (l.node_id != null) {
+        result[l.node_id.toString()] = l;
+      }
+    }
+    return result;
+  }, [livenesses]);
+
+  const clusterName = useMemo(
+    () => getClusterName(nodeStatuses, livenessStatusByNodeID),
+    [nodeStatuses, livenessStatusByNodeID],
+  );
+
+  const clusterVersion = useMemo(
+    () => getClusterVersionLabel(nodeStatuses, livenessByNodeID),
+    [nodeStatuses, livenessByNodeID],
+  );
+
+  return {
+    clusterName,
+    clusterVersion,
+    isLoading,
+    error: nodesError ?? livenessError,
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -42,7 +42,7 @@ export * from "./transactionDetails";
 export * from "./text";
 export * from "./tracez";
 export { util, api };
-export { useCluster } from "./api/clusterApi";
+export { useCluster, useClusterLabel } from "./api/clusterApi";
 export { useNodes } from "./api/nodesApi";
 export { useNodesSummary } from "./api/nodesSummaryApi";
 export { useHealth } from "./api/healthApi";

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -545,11 +545,6 @@ export const partitionedStatuses = createSelector(
   },
 );
 
-export const isSingleNodeCluster = createSelector(
-  nodeStatusesSelector,
-  nodeStatuses => nodeStatuses && nodeStatuses.length === 1,
-);
-
 export const nodeOptionsSelector = createSelector(
   nodesSummarySelector,
   (summary: NodesSummary): DropdownOption[] => {

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -7,18 +7,12 @@ import { util, sumNodeStats } from "@cockroachlabs/cluster-ui";
 import countBy from "lodash/countBy";
 import each from "lodash/each";
 import filter from "lodash/filter";
-import first from "lodash/first";
-import flow from "lodash/flow";
 import groupBy from "lodash/groupBy";
-import head from "lodash/head";
 import isEmpty from "lodash/isEmpty";
 import isNil from "lodash/isNil";
-import isUndefined from "lodash/isUndefined";
 import keyBy from "lodash/keyBy";
 import map from "lodash/map";
-import sortBy from "lodash/sortBy";
 import uniq from "lodash/uniq";
-import uniqBy from "lodash/uniqBy";
 import { createSelector } from "reselect";
 
 import * as protos from "src/js/protos";
@@ -401,38 +395,6 @@ export function selectNodesSummaryValid(state: AdminUIState) {
   return state.cachedData.nodes.valid && state.cachedData.liveness.valid;
 }
 
-/*
- * clusterNameSelector returns the name of cluster which has to be the same for every node in the cluster.
- * - That is why it is safe to get first non empty cluster name.
- * - Empty cluster name is possible in case `DisableClusterNameVerification` flag is used (see pkg/base/config.go:176).
- */
-export const clusterNameSelector = createSelector(
-  nodeStatusesSelector,
-  livenessStatusByNodeIDSelector,
-  (nodeStatuses, livenessStatusByNodeID): string => {
-    if (isUndefined(nodeStatuses) || isEmpty(livenessStatusByNodeID)) {
-      return undefined;
-    }
-    const liveNodesOnCluster = nodeStatuses.filter(
-      nodeStatus =>
-        livenessStatusByNodeID[nodeStatus.desc.node_id] ===
-        LivenessStatus.NODE_STATUS_LIVE,
-    );
-
-    const nodesWithUniqClusterNames = flow(
-      (statuses: INodeStatus[]) =>
-        filter(statuses, s => !isEmpty(s.desc.cluster_name)),
-      statuses => uniqBy(statuses, s => s.desc.cluster_name),
-    )(liveNodesOnCluster);
-
-    if (isEmpty(nodesWithUniqClusterNames)) {
-      return undefined;
-    } else {
-      return head(nodesWithUniqClusterNames).desc.cluster_name;
-    }
-  },
-);
-
 export const validateNodesSelector = createSelector(
   nodeStatusesSelector,
   livenessByNodeIDSelector,
@@ -502,22 +464,6 @@ export const singleVersionSelector = createSelector(
   builds => {
     if (!builds || builds.length !== 1) {
       return undefined;
-    }
-    return builds[0];
-  },
-);
-
-// clusterVersionSelector returns build version of the cluster, or returns the lowest version
-// if cluster's version is staggered.
-export const clusterVersionLabelSelector = createSelector(
-  versionsSelector,
-  builds => {
-    if (!builds) {
-      return undefined;
-    }
-    if (builds.length > 1) {
-      const lowestVersion = first(sortBy(builds, b => b));
-      return `${lowestVersion} - Mixed Versions`;
     }
     return builds[0];
   },

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
@@ -3,14 +3,12 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { useNodes } from "@cockroachlabs/cluster-ui";
 import React from "react";
-import { useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
 import { SideNavigation } from "src/components";
 import "./navigation-bar.scss";
-import { isSingleNodeCluster as isSingleNodeClusterSelector } from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
 
 interface RouteParam {
   path: string;
@@ -28,9 +26,8 @@ interface RouteParam {
  * the page which is currently active will be highlighted.
  */
 function Sidebar(): React.ReactElement {
-  const singleNode = useSelector((state: AdminUIState) =>
-    isSingleNodeClusterSelector(state),
-  );
+  const { nodeStatuses } = useNodes();
+  const singleNode = nodeStatuses && nodeStatuses.length === 1;
   const location = useLocation();
 
   const routes: RouteParam[] = [

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/layoutSidebar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/layoutSidebar.spec.tsx
@@ -3,23 +3,24 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { useNodes } from "@cockroachlabs/cluster-ui";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import Sidebar from "./index";
 
-const mockUseSelector = jest.fn();
-jest.mock("react-redux", () => ({
-  ...jest.requireActual("react-redux"),
-  useSelector: (...args: any[]) => mockUseSelector(...args),
-}));
+jest.mock("@cockroachlabs/cluster-ui", () => {
+  const actual = jest.requireActual("@cockroachlabs/cluster-ui");
+  return {
+    ...actual,
+    useNodes: jest.fn(),
+  };
+});
+
+const mockUseNodes = useNodes as jest.Mock;
 
 describe("LayoutSidebar", () => {
-  beforeEach(() => {
-    mockUseSelector.mockReset();
-  });
-
   const renderSidebar = () =>
     render(
       <MemoryRouter initialEntries={["/reports/network"]}>
@@ -28,13 +29,27 @@ describe("LayoutSidebar", () => {
     );
 
   it("does not show Network link for single node cluster", () => {
-    mockUseSelector.mockReturnValue(true);
+    mockUseNodes.mockReturnValue({
+      nodeStatuses: [{}],
+      isLoading: false,
+      error: undefined,
+      nodeStatusByID: {},
+      storeIDToNodeID: {},
+      nodeRegionsByID: {},
+    });
     renderSidebar();
     expect(screen.queryByText("Network")).toBeNull();
   });
 
   it("shows Network link for multi node cluster", () => {
-    mockUseSelector.mockReturnValue(false);
+    mockUseNodes.mockReturnValue({
+      nodeStatuses: [{}, {}],
+      isLoading: false,
+      error: undefined,
+      nodeStatusByID: {},
+      storeIDToNodeID: {},
+      nodeRegionsByID: {},
+    });
     renderSidebar();
     expect(screen.getByText("Network")).toBeTruthy();
   });

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -3,10 +3,9 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Badge } from "@cockroachlabs/cluster-ui";
+import { Badge, useCluster, useClusterLabel } from "@cockroachlabs/cluster-ui";
 import React, { useEffect, useRef } from "react";
 import { Helmet } from "react-helmet";
-import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 
 import {
@@ -18,12 +17,6 @@ import {
   Text,
   TextTypes,
 } from "src/components";
-import {
-  clusterIdSelector,
-  clusterNameSelector,
-  clusterVersionLabelSelector,
-} from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
 import { getDataFromServer } from "src/util/dataFromServer";
 import ErrorBoundary from "src/views/app/components/errorMessage/errorBoundary";
 import NavigationBar from "src/views/app/components/layoutSidebar";
@@ -51,15 +44,9 @@ interface LayoutProps {
  * Individual pages provide their content via react-router.
  */
 function Layout({ children }: LayoutProps): React.ReactElement {
-  const clusterName = useSelector((state: AdminUIState) =>
-    clusterNameSelector(state),
-  );
-  const clusterVersion = useSelector((state: AdminUIState) =>
-    clusterVersionLabelSelector(state),
-  );
-  const clusterId = useSelector((state: AdminUIState) =>
-    clusterIdSelector(state),
-  );
+  const { clusterName, clusterVersion } = useClusterLabel();
+  const { data } = useCluster();
+  const clusterId = data?.cluster_id;
   const location = useLocation();
   const contentRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
The Sidebar component used `useSelector` with the
`isSingleNodeCluster` selector to read from
`state.cachedData.nodes.data` and hide the Network link for
single-node clusters. Replace this with the existing `useNodes()`
SWR hook from cluster-ui, which already fetches and caches the
same node status data.

Since `isSingleNodeCluster` in `redux/nodes.ts` has no remaining
consumers after this change, remove it.

Update the test to mock `useNodes` from `@cockroachlabs/cluster-ui`
instead of `useSelector` from `react-redux`, following the same
pattern used by the network page test.

Epic: CRDB-58145
Release note: None