### PR TITLE
roachtest: remove enable_super_regions feature gate from super-region-failover

### DIFF
--- a/pkg/cmd/roachtest/tests/super_region_failover.go
+++ b/pkg/cmd/roachtest/tests/super_region_failover.go
@@ -141,8 +141,6 @@ func setupDatabase(ctx context.Context, t test.Test, conn *gosql.DB) {
 	stmts := []string{
 		`SET CLUSTER SETTING sql.defaults.primary_region = ''`,
 		`SET CLUSTER SETTING server.time_until_store_dead = '30s'`,
-		`SET enable_super_regions = 'on'`,
-		`ALTER ROLE ALL SET enable_super_regions = 'on'`,
 		`CREATE DATABASE test_sr PRIMARY REGION "europe-west2"
 			REGIONS "us-east1", "us-central1", "us-west1"`,
 		`ALTER DATABASE test_sr ADD SUPER REGION "americas"


### PR DESCRIPTION
The `enable_super_regions` session variable was converted to a no-op since super regions are now always enabled. Removing their usage from the test.

Closes #165544

Release note: None
Epic: None