### PR TITLE
storage: expose WAL failover secondary disk utilization

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -11394,6 +11394,26 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric reports the number of a node's LSM compactions. If the number of compactions remains elevated while the LSM health does not improve, compactions are not keeping up with the workload. If the condition persists for an extended period, the cluster will initially exhibit performance issues that will eventually escalate into stability issues.
       visibility: ESSENTIAL
+    - name: storage.wal.failover.secondary.disk.available
+      exported_name: storage_wal_failover_secondary_disk_available
+      description: Available disk space on the secondary WAL failover volume.
+      y_axis_label: Storage
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: Only populated when WAL failover is configured.
+      visibility: ESSENTIAL
+    - name: storage.wal.failover.secondary.disk.capacity
+      exported_name: storage_wal_failover_secondary_disk_capacity
+      description: Total disk capacity of the secondary WAL failover volume.
+      y_axis_label: Storage
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: Only populated when WAL failover is configured.
+      visibility: ESSENTIAL
     - name: storage.wal.failover.write_and_sync.latency
       exported_name: storage_wal_failover_write_and_sync_latency
       description: The observed latency for writing and syncing to the logical Write-Ahead Log.

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -3205,6 +3205,24 @@ var (
 			relevant metric is storage.wal.fsync.latency.
 		`),
 	}
+	metaStorageWALFailoverSecondaryDiskCapacity = metric.Metadata{
+		Name:        "storage.wal.failover.secondary.disk.capacity",
+		Help:        "Total disk capacity of the secondary WAL failover volume.",
+		Measurement: "Storage",
+		Unit:        metric.Unit_BYTES,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_STORAGE,
+		HowToUse:    "Only populated when WAL failover is configured.",
+	}
+	metaStorageWALFailoverSecondaryDiskAvailable = metric.Metadata{
+		Name:        "storage.wal.failover.secondary.disk.available",
+		Help:        "Available disk space on the secondary WAL failover volume.",
+		Measurement: "Storage",
+		Unit:        metric.Unit_BYTES,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_STORAGE,
+		HowToUse:    "Only populated when WAL failover is configured.",
+	}
 	metaReplicaReadBatchDroppedLatchesBeforeEval = metric.Metadata{
 		Name:        "kv.replica_read_batch_evaluate.dropped_latches_before_eval",
 		Help:        `Number of times read-only batches dropped latches before evaluation.`,
@@ -3526,6 +3544,8 @@ type StoreMetrics struct {
 	WALFailoverPrimaryDuration         *metric.Counter
 	WALFailoverSecondaryDuration       *metric.Counter
 	WALFailoverWriteAndSyncLatency     *metric.ManualWindowHistogram
+	WALFailoverSecondaryDiskCapacity   *metric.Gauge
+	WALFailoverSecondaryDiskAvailable  *metric.Gauge
 
 	RdbCheckpoints *metric.Gauge
 
@@ -4309,6 +4329,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			pebble.FsyncLatencyBuckets,
 			false, /* withRotate */
 		),
+		WALFailoverSecondaryDiskCapacity:  metric.NewGauge(metaStorageWALFailoverSecondaryDiskCapacity),
+		WALFailoverSecondaryDiskAvailable: metric.NewGauge(metaStorageWALFailoverSecondaryDiskAvailable),
 
 		// Ingestion metrics
 		IngestCount: metric.NewGauge(metaIngestCount),

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//metrics",
         "@com_github_cockroachdb_pebble//rangekey",
+        "@com_github_cockroachdb_pebble//vfs",
     ],
 )
 

--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/metrics"
+	"github.com/cockroachdb/pebble/vfs"
 )
 
 // EnableAssertions is a convenient entry point to enable/disable spanset
@@ -174,6 +175,11 @@ func (s *spanSetEngine) Attrs() roachpb.Attributes {
 // Capacity implements the storage.EngineWithoutRW interface.
 func (s *spanSetEngine) Capacity() (roachpb.StoreCapacity, error) {
 	return s.e.Capacity()
+}
+
+// WALFailoverDiskUsage implements the storage.Engine interface.
+func (s *spanSetEngine) WALFailoverDiskUsage() (vfs.DiskUsage, error) {
+	return s.e.WALFailoverDiskUsage()
 }
 
 // Properties implements the storage.EngineWithoutRW interface.

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -1183,5 +1183,10 @@ func (s *Store) updateCapacityGauges(ctx context.Context) error {
 	s.metrics.Available.Update(desc.Capacity.Available)
 	s.metrics.Used.Update(desc.Capacity.Used)
 
+	if du, err := s.TODOBothEngines().WALFailoverDiskUsage(); err == nil {
+		s.metrics.WALFailoverSecondaryDiskCapacity.Update(int64(du.TotalBytes))
+		s.metrics.WALFailoverSecondaryDiskAvailable.Update(int64(du.AvailBytes))
+	}
+
 	return nil
 }

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2903,6 +2903,8 @@ storage_value_separation_value_retrieval_count: storage.value_separation.value_r
 storage_wal_bytes_in: storage.wal.bytes_in
 storage_wal_bytes_written: storage.wal.bytes_written
 storage_wal_failover_primary_duration: storage.wal.failover.primary.duration
+storage_wal_failover_secondary_disk_available: storage.wal.failover.secondary.disk.available
+storage_wal_failover_secondary_disk_capacity: storage.wal.failover.secondary.disk.capacity
 storage_wal_failover_secondary_duration: storage.wal.failover.secondary.duration
 storage_wal_failover_switch_count: storage.wal.failover.switch.count
 storage_wal_failover_write_and_sync_latency: storage.wal.failover.write_and_sync.latency

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -923,6 +923,9 @@ type Engine interface {
 	Attrs() roachpb.Attributes
 	// Capacity returns capacity details for the engine's available storage.
 	Capacity() (roachpb.StoreCapacity, error)
+	// WALFailoverDiskUsage returns disk usage for the WAL failover secondary
+	// volume. Returns vfs.ErrUnsupported if WAL failover is not configured.
+	WALFailoverDiskUsage() (vfs.DiskUsage, error)
 	// Properties returns the low-level properties for the engine's underlying storage.
 	Properties() roachpb.StoreProperties
 	// ProfileSeparatedValueRetrievals collects a profile of the engine's

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2067,6 +2067,16 @@ func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
 	}, nil
 }
 
+// WALFailoverDiskUsage implements the Engine interface.
+func (p *Pebble) WALFailoverDiskUsage() (vfs.DiskUsage, error) {
+	if p.cfg.opts.WALFailover == nil {
+		return vfs.DiskUsage{}, vfs.ErrUnsupported
+	}
+	return p.cfg.opts.WALFailover.Secondary.FS.GetDiskUsage(
+		p.cfg.opts.WALFailover.Secondary.Dirname,
+	)
+}
+
 // auxiliaryDirSize computes the size of the auxiliary directory. There are
 // multiple Cockroach subsystems that write into the auxiliary directory, and
 // they don't incrementally account for their disk space usage. This function


### PR DESCRIPTION
Previously, when WAL failover was configured, there was no visibility into the disk space utilization of the secondary WAL volume. If the secondary disk ran out of space, the node would crash with no prior warning in metrics.

This commit adds two new timeseries metrics:
- storage.wal.failover.secondary.disk.capacity
- storage.wal.failover.secondary.disk.available

These are exposed via a new `WALFailoverDiskUsage()` method on the Engine interface, implemented on Pebble by calling `GetDiskUsage` on the WAL failover secondary filesystem. The metrics are updated periodically (~60s) alongside existing primary store capacity gauges in `updateCapacityGauges`. When WAL failover is not configured, the method returns `vfs.ErrUnsupported` and the gauges remain at zero.

Fixes: #160924

Release note (ops change): Two new metrics
`storage.wal.failover.secondary.disk.capacity` and `storage.wal.failover.secondary.disk.available` are now exposed when WAL failover is configured, providing visibility into disk space utilization of the secondary WAL volume.