### PR TITLE
logictest: skip geospatial tests on fakedist-disk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1,4 +1,7 @@
-# LogicTest: !local-prepared
+# LogicTest: !local-prepared !fakedist-disk
+# ST_AsMVT output depends on input row ordering. Distributed execution with
+# disk spilling does not preserve ORDER BY from subqueries, causing flaky
+# failures on fakedist-disk. See #165515.
 statement ok
 CREATE TABLE geo_table(
   id int primary key,

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -895,13 +895,6 @@ func TestLogic_fuzzystrmatch(
 	runLogicTest(t, "fuzzystrmatch")
 }
 
-func TestLogic_geospatial(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "geospatial")
-}
-
 func TestLogic_geospatial_index(
 	t *testing.T,
 ) {


### PR DESCRIPTION
ST_AsMVT is an order-dependent aggregate whose output depends on the order rows arrive. In the fakedist-disk config, low distsql_workmem forces disk spilling during distributed execution, which does not preserve ORDER BY from subqueries feeding into aggregates. This caused flaky failures in the st_asmvt_postgis_tests subtest.

Skip the entire geospatial logic test file on fakedist-disk since it doesn't specifically need disk-spilling coverage.

Fixes: #165515

Release note: None