### PR TITLE
backup: enable fast restore metamorphic for tests using knob

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1314,9 +1314,6 @@ func TestRestoreCheckpointing(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer jobs.TestingSetProgressThresholds()()
 
-	// TODO(at): OR does not use RunAfterProcessingRestoreSpanEntry; adapt test for OR.
-	backuptestutils.DisableFastRestoreForTest(t)
-
 	// totalEntries represents the number of entries to appear in the persisted frontier.
 	const totalEntries = 7
 	const entriesBeforePause = 4
@@ -7529,11 +7526,6 @@ func TestClientDisconnect(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.jobType, func(t *testing.T) {
-			if testCase.jobType == "RESTORE" {
-				// TODO(at): OR does not use RunAfterProcessingRestoreSpanEntry; adapt test for OR.
-				backuptestutils.DisableFastRestoreForTest(t)
-			}
-
 			// When completing an export request, signal the a request has been sent and
 			// then wait to be signaled.
 			allowResponse := make(chan struct{})

--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -541,6 +541,14 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 					}
 				}
 
+				if restoreKnobs, ok := rd.FlowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+					if restoreKnobs.RunAfterProcessingRestoreSpanEntry != nil {
+						if err := restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx, &entry); err != nil {
+							return done, err
+						}
+					}
+				}
+
 				select {
 				case rd.progCh <- makeProgressUpdate(summary, entry, rd.spec.PKIDs, rd.spec.RestoreTime):
 				case <-ctx.Done():
@@ -840,14 +848,6 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	// Flush out the last batch.
 	if err := batcher.Flush(ctx); err != nil {
 		return summary, err
-	}
-
-	if restoreKnobs, ok := rd.FlowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
-		if restoreKnobs.RunAfterProcessingRestoreSpanEntry != nil {
-			if err := restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx, &entry); err != nil {
-				return summary, err
-			}
-		}
 	}
 
 	return batcher.GetSummary(), nil


### PR DESCRIPTION
This patch enables the fast restore metamorphic for two tests which use the `RunAfterProcessingRestoreSpanEntry` knob. Previously this knob was checked only in the ingest path, but not the link path. This patch moves the knob check to a shared code path for both restore flavors.

Informs: #163236

Release note: None