### PR TITLE
sql/stats: only record canary/stable experiment metrics when stats actually differ

### DIFF
--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -479,7 +479,7 @@ func (c *cdcOptCatalog) newCDCDataSource(
 	if err != nil {
 		return nil, err
 	}
-	return newOptTable(ctx, d, c.codec(), nil /* stats */, emptyZoneConfig)
+	return newOptTable(ctx, d, c.codec(), nil /* stats */, emptyZoneConfig, false /* canaryAndStableStatsDiffer */)
 }
 
 // familyTableDescriptor wraps underlying catalog.TableDescriptor,

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -123,6 +123,9 @@ func constructPlan(
 	if flags.IsSet(exec.PlanFlagUsesRLS) {
 		res.flags.Set(planFlagUsesRLS)
 	}
+	if flags.IsSet(exec.PlanFlagCanaryAndStableStatsDiffer) {
+		res.flags.Set(planFlagCanaryAndStableStatsDiffer)
+	}
 
 	return res, nil
 }

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -208,6 +208,12 @@ type Table interface {
 
 	// Policies returns all the policies defined for this table.
 	Policies() *Policies
+
+	// CanaryAndStableStatsDiffer returns true when the canary (newest) and
+	// stable (second-newest) statistics for this table genuinely differ
+	// within the canary window. This is used solely to gate canary/stable
+	// experiment metric recording.
+	CanaryAndStableStatsDiffer() bool
 }
 
 // CheckConstraint represents a check constraint on a table. Check constraints

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -316,6 +316,16 @@ func (b *Builder) Build() (_ exec.Plan, err error) {
 		}
 	}
 
+	// If any table in the plan has divergent canary vs. stable statistics,
+	// mark the execution so that it is counted in canary/stable experiment
+	// metrics.
+	for _, tabMeta := range b.mem.Metadata().AllTables() {
+		if tabMeta.Table.CanaryAndStableStatsDiffer() {
+			b.flags.Set(exec.PlanFlagCanaryAndStableStatsDiffer)
+			break
+		}
+	}
+
 	rootRowCount := int64(b.e.(memo.RelExpr).Relational().Statistics().RowCountIfAvailable())
 	return b.factory.ConstructPlan(
 		plan.root, b.subqueries, b.cascades, b.triggers, b.checks, rootRowCount, b.flags,

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -671,6 +671,9 @@ func (u *unknownTable) IsRowLevelSecurityForced() bool { return false }
 // Policies is part of the cat.Table interface.
 func (u *unknownTable) Policies() *cat.Policies { return nil }
 
+// CanaryAndStableStatsDiffer is part of the cat.Table interface.
+func (u *unknownTable) CanaryAndStableStatsDiffer() bool { return false }
+
 var _ cat.Table = &unknownTable{}
 
 // unknownTable implements the cat.Index interface and is used to represent

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -93,6 +93,12 @@ const (
 
 	// PlanFlagUsesRLS is set if the plan applies row-level security policies.
 	PlanFlagUsesRLS
+
+	// PlanFlagCanaryAndStableStatsDiffer is set if at least one table
+	// referenced by the query has genuinely different canary (newest) vs.
+	// stable (second-newest) statistics within its canary window. This
+	// gates canary/stable experiment metric recording.
+	PlanFlagCanaryAndStableStatsDiffer
 )
 
 // IsSet returns true if the receiver has all of the given flags set.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1247,6 +1247,9 @@ func (tt *Table) Policies() *cat.Policies {
 	return &tt.policies
 }
 
+// CanaryAndStableStatsDiffer is part of the cat.Table interface.
+func (tt *Table) CanaryAndStableStatsDiffer() bool { return false }
+
 // findPolicyByName will lookup the policy by its name. It returns it's policy
 // type and index within that policy type slice so that callers can do removal
 // if needed.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -686,6 +686,7 @@ func (oc *optCatalog) dataSourceForTable(
 	// Even if we have a cached data source, we still have to cross-check that
 	// statistics and the zone config haven't changed.
 	var tableStats []*stats.TableStatistic
+	var statsDiffer bool
 	if !flags.NoTableStats {
 		var typeResolver *descs.DistSQLTypeResolver
 		if p := oc.planner; p != nil {
@@ -701,7 +702,7 @@ func (oc *optCatalog) dataSourceForTable(
 			statsCanaryWindow = desc.TableDesc().StatsCanaryWindow
 			statsAsOf = oc.planner.EvalContext().SessionData().StatsAsOf
 		}
-		tableStats, err = oc.planner.execCfg.TableStatsCache.GetTableStatsMaybeStable(ctx, desc, typeResolver, stable, statsCanaryWindow, statsAsOf)
+		tableStats, statsDiffer, err = oc.planner.execCfg.TableStatsCache.GetTableStatsMaybeStable(ctx, desc, typeResolver, stable, statsCanaryWindow, statsAsOf)
 		if err != nil {
 			// Ignore any error. We still want to be able to run queries even if we lose
 			// access to the statistics table.
@@ -721,7 +722,7 @@ func (oc *optCatalog) dataSourceForTable(
 		return ds, nil
 	}
 
-	ds, err := newOptTable(ctx, desc, oc.codec(), tableStats, zoneConfig)
+	ds, err := newOptTable(ctx, desc, oc.codec(), tableStats, zoneConfig, statsDiffer)
 	if err != nil {
 		return nil, err
 	}
@@ -962,6 +963,11 @@ type optTable struct {
 
 	triggers []optTrigger
 
+	// canaryAndStableStatsDiffer is true when the canary (newest) and stable
+	// (second-newest) statistics for this table genuinely differ within the
+	// canary window.
+	canaryAndStableStatsDiffer bool
+
 	// Row-level security (RLS) fields
 	rlsEnabled bool
 	rlsForced  bool
@@ -980,12 +986,14 @@ func newOptTable(
 	codec keys.SQLCodec,
 	stats []*stats.TableStatistic,
 	tblZone cat.Zone,
+	canaryAndStableStatsDiffer bool,
 ) (*optTable, error) {
 	ot := &optTable{
-		desc:     desc,
-		codec:    codec,
-		rawStats: stats,
-		zone:     tblZone,
+		desc:                       desc,
+		codec:                      codec,
+		rawStats:                   stats,
+		zone:                       tblZone,
+		canaryAndStableStatsDiffer: canaryAndStableStatsDiffer,
 	}
 
 	// Determine the primary key columns.
@@ -1697,6 +1705,11 @@ func (ot *optTable) Policies() *cat.Policies {
 		return nil
 	}
 	return &ot.policies
+}
+
+// CanaryAndStableStatsDiffer is part of the cat.Table interface.
+func (ot *optTable) CanaryAndStableStatsDiffer() bool {
+	return ot.canaryAndStableStatsDiffer
 }
 
 // LookupColumnOrdinal returns the ordinal of the column with the given ID. A
@@ -2844,6 +2857,9 @@ func (ot *optVirtualTable) IsRowLevelSecurityForced() bool { return false }
 
 // Policies is part of the cat.Table interface.
 func (ot *optVirtualTable) Policies() *cat.Policies { return nil }
+
+// CanaryAndStableStatsDiffer is part of the cat.Table interface.
+func (ot *optVirtualTable) CanaryAndStableStatsDiffer() bool { return false }
 
 // optVirtualIndex is a dummy implementation of cat.Index for the indexes
 // reported by a virtual table. The index assumes that table column 0 is a dummy

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -694,6 +694,14 @@ const (
 
 	// planFlagUsesRLS is set if the plan applies row-level security policies.
 	planFlagUsesRLS
+
+	// planFlagCanaryAndStableStatsDiffer is set if at least one table
+	// referenced by the query has genuinely different canary (newest) vs.
+	// stable (second-newest) statistics within its canary window. This
+	// gates experiment metric recording: when false, the execution is not
+	// recorded in canary/stable experiment buckets even if StatsRollout is
+	// Canary or Stable.
+	planFlagCanaryAndStableStatsDiffer
 )
 
 // IsSet returns true if the receiver has all of the given flags set.

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -910,7 +910,7 @@ func (r *Refresher) EstimateStaleness(
 	// NB: we pass nil boolean as 'forecast' argument in order to not invalidate
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
-	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, _, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		return 0, err
 	}
@@ -964,7 +964,7 @@ func (r *Refresher) maybeRefreshStats(
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
 	var forecast *bool
-	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, _, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		log.Dev.Errorf(ctx, "failed to get table statistics: %v", err)
 		return

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -261,7 +261,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+			tableStats, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 			if err != nil {
 				return err
 			}
@@ -269,7 +269,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+					stats, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 					if err != nil {
 						return err
 					}
@@ -555,7 +555,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+			tableStats, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 			if err != nil {
 				return err
 			}
@@ -563,7 +563,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+					stats, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -288,13 +288,21 @@ func (sc *TableStatisticsCache) GetFreshTableStats(
 		return nil, nil
 	}
 	forecast := forecastAllowed(table, sc.settings)
-	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	stats, _, err = sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	return stats, err
 }
 
-// GetTableStatsMaybeStable is similar to GetFreshTableStats, but maybe return
-// the stable stats cache opposed to the freshest "canary" table statistics.
-// It only differs with GetFreshTableStats if the table has the canary window size
-// set.
+// GetTableStatsMaybeStable is similar to GetFreshTableStats, but may return
+// the stable stats cache instead of the freshest "canary" table statistics.
+// It only differs from GetFreshTableStats when the table has a non-zero canary
+// window size.
+//
+// The returned statsDiffer flag indicates whether the canary (newest)
+// and stable (second-newest) statistics for this table are genuinely
+// different. The flag is not affected by which stats the optimizer
+// uses; it only determines whether this execution is worth recording
+// for canary vs. stable experiment metrics (when false, both paths use
+// identical stats, so recording would add noise).
 func (sc *TableStatisticsCache) GetTableStatsMaybeStable(
 	ctx context.Context,
 	table catalog.TableDescriptor,
@@ -302,9 +310,9 @@ func (sc *TableStatisticsCache) GetTableStatsMaybeStable(
 	stable bool,
 	canaryWindowSize time.Duration,
 	statsAsOf hlc.Timestamp,
-) (stats []*TableStatistic, err error) {
+) (stats []*TableStatistic, statsDiffer bool, err error) {
 	if !sc.statsUsageAllowed(table) {
-		return nil, nil
+		return nil, false, nil
 	}
 	forecast := forecastAllowed(table, sc.settings)
 	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, stable, canaryWindowSize, statsAsOf)
@@ -423,7 +431,7 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 	stable bool,
 	canaryWindowSize time.Duration,
 	statsAsOf hlc.Timestamp,
-) ([]*TableStatistic, error) {
+) ([]*TableStatistic, bool, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
@@ -437,10 +445,11 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 			// Evict the cache entry and build it again.
 			sc.mu.cache.Del(tableID)
 		} else {
+			statsDiffer := e.canaryAndStableStatsDiffer(canaryWindowSize, asOfTs)
 			if stable {
-				return e.getStableStatsLocked(ctx, canaryWindowSize, asOfTs), e.err
+				return e.getStableStatsLocked(ctx, canaryWindowSize, asOfTs), statsDiffer, e.err
 			}
-			return e.stats, e.err
+			return e.stats, statsDiffer, e.err
 		}
 	}
 
@@ -506,6 +515,32 @@ func (e *cacheEntry) getStableStatsLocked(
 	return e.stats
 }
 
+// canaryAndStableStatsDiffer reports whether this table's canary (newest)
+// and stable (second-newest) statistics are genuinely different under the
+// given canary window. It returns true when both conditions hold:
+//
+//  1. The table has a non-zero canary window (canaryWindowSize > 0).
+//  2. We are still within the canary window (the freshest stats have not
+//     yet "ripened" past it).
+//
+// This is used to gate "canary vs stable" metric recording: when canary
+// and stable stats are identical (this returns false), tagging the
+// execution as "canary" or "stable" would only add noise.
+//
+// Note: this does NOT affect which stats the optimizer uses — that is
+// controlled by canaryRollDice (the dice roll) and getStableStatsLocked.
+func (e *cacheEntry) canaryAndStableStatsDiffer(
+	canaryWindowSize time.Duration, asOf hlc.Timestamp,
+) bool {
+	if canaryWindowSize == 0 || e.latestFullStatsTimestamp.IsEmpty() {
+		return false
+	}
+	// Within the canary window, canary and stable stats always differ: either
+	// there is a distinct older generation of stats, or the stable path uses
+	// the empty set while the canary path has actual stats.
+	return e.latestFullStatsTimestamp.AddDuration(canaryWindowSize).After(asOf)
+}
+
 // lookupStatsLocked retrieves any existing stats for the given table.
 //
 // If another goroutine is in the process of retrieving the same stats, this
@@ -550,7 +585,7 @@ func (sc *TableStatisticsCache) lookupStatsLocked(
 // addCacheEntryLocked creates a new cache entry and retrieves table statistics
 // from the database. It does this in a way so that the other goroutines that
 // need the same stats can wait on us:
-//   - an cache entry with wait=true is created;
+//   - a cache entry with wait=true is created;
 //   - mutex is unlocked;
 //   - stats are retrieved from database:
 //   - mutex is locked again and the entry is updated.
@@ -567,7 +602,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 	stable bool,
 	canaryWindowSize time.Duration,
 	asOf hlc.Timestamp,
-) (stats []*TableStatistic, err error) {
+) (stats []*TableStatistic, statsDiffer bool, err error) {
 	defer sc.generation.Add(1)
 	// Add a cache entry that other queries can find and wait on until we have the
 	// stats.
@@ -608,11 +643,13 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 		sc.mu.cache.Del(tableID)
 	}
 
+	statsDiffer = e.canaryAndStableStatsDiffer(canaryWindowSize, asOf)
+
 	if err == nil && stable {
-		return e.getStableStatsLocked(ctx, canaryWindowSize, asOf), nil
+		return e.getStableStatsLocked(ctx, canaryWindowSize, asOf), statsDiffer, nil
 	}
 
-	return stats, err
+	return stats, statsDiffer, err
 }
 
 // refreshCacheEntry retrieves table statistics from the database and updates

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -114,7 +115,7 @@ func checkStatsForTable(
 
 	// Perform the lookup and refresh, and confirm the
 	// returned stats match the expected values.
-	statsList, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	statsList, _, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		t.Fatalf("error retrieving stats: %s", err)
 	}
@@ -412,7 +413,7 @@ func TestCacheWait(t *testing.T) {
 		for n := 0; n < 10; n++ {
 			wg.Add(1)
 			go func() {
-				stats, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+				stats, _, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 				if err != nil {
 					t.Error(err)
 				} else if !checkStats(stats, expectedStats[id]) {
@@ -840,13 +841,186 @@ func TestDecodeHistogramBucketsEnum(t *testing.T) {
 	}
 }
 
-// TestCanaryDualCache tests the dual cache mechanism that maintains
-// separate fresh and stable statistics caches. The stable cache
-// preserves older stats during canary windows to ensure query plan
-// stability. Uses data-driven testing to validate complex scenarios
-// including stats retention policies, delayed deletion, and partial
-// stats merging.
-func TestCanaryDualCache(t *testing.T) {
+// TestCanaryAndStableStatsDiffer exercises the cacheEntry.canaryAndStableStatsDiffer
+// method with a table-driven test covering all edge cases.
+func TestCanaryAndStableStatsDiffer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	now := hlc.Timestamp{WallTime: 1000 * time.Second.Nanoseconds()}
+	latestTS := hlc.Timestamp{WallTime: 999 * time.Second.Nanoseconds()}
+	stableTS := hlc.Timestamp{WallTime: 990 * time.Second.Nanoseconds()}
+	window := 10 * time.Second
+
+	tests := []struct {
+		name                           string
+		canaryWindowSize               time.Duration
+		asOf                           hlc.Timestamp
+		latestFullStatsTimestamp       hlc.Timestamp
+		latestStableFullStatsTimestamp hlc.Timestamp
+		expected                       bool
+	}{
+		{
+			name:             "no canary window",
+			canaryWindowSize: 0,
+			asOf:             now,
+			expected:         false,
+		},
+		{
+			name:                           "within window, two distinct generations",
+			canaryWindowSize:               window,
+			asOf:                           now,
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       true,
+		},
+		{
+			name:                           "past canary window",
+			canaryWindowSize:               window,
+			asOf:                           hlc.Timestamp{WallTime: 1100 * time.Second.Nanoseconds()},
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       false,
+		},
+		{
+			name:                     "within window, only one generation (stable is empty set)",
+			canaryWindowSize:         window,
+			asOf:                     now,
+			latestFullStatsTimestamp: latestTS,
+			expected:                 true,
+		},
+		{
+			name:             "empty latestFullStatsTimestamp",
+			canaryWindowSize: window,
+			asOf:             now,
+			expected:         false,
+		},
+		{
+			name:                           "exactly at window boundary (window just expired)",
+			canaryWindowSize:               window,
+			asOf:                           hlc.Timestamp{WallTime: (999*time.Second + window).Nanoseconds()},
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       false,
+		},
+		{
+			name:                           "one nanosecond before window expires",
+			canaryWindowSize:               window,
+			asOf:                           hlc.Timestamp{WallTime: (999*time.Second + window).Nanoseconds() - 1},
+			latestFullStatsTimestamp:       latestTS,
+			latestStableFullStatsTimestamp: stableTS,
+			expected:                       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &cacheEntry{
+				latestFullStatsTimestamp:       tc.latestFullStatsTimestamp,
+				latestStableFullStatsTimestamp: tc.latestStableFullStatsTimestamp,
+			}
+			got := e.canaryAndStableStatsDiffer(tc.canaryWindowSize, tc.asOf)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// runStatsCacheDataDriven is the shared datadriven command handler for
+// stats cache tests. It supports the following commands:
+//
+//   - exec: execute SQL statements
+//   - stats-cache: query the stats cache (args: table, forecast)
+//   - stats-differ: check whether canary and stable stats differ
+//     (args: table, canary-window, asof, no-invalidate)
+func runStatsCacheDataDriven(
+	t *testing.T,
+	d *datadriven.TestData,
+	ctx context.Context,
+	sqlRunner *sqlutils.SQLRunner,
+	kvDB *kv.DB,
+	s serverutils.ApplicationLayerInterface,
+	sc *TableStatisticsCache,
+) string {
+	switch d.Cmd {
+	case "exec":
+		sqlRunner.Exec(t, d.Input)
+		return ""
+	case "stats-cache":
+		tableName := "test"
+		forecast := false
+		if d.HasArg("table") {
+			d.ScanArgs(t, "table", &tableName)
+		}
+		if d.HasArg("forecast") {
+			forecast = true
+		}
+
+		tbl := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
+		stats, stableStats, _, _, _, err := sc.getTableStatsFromDB(ctx, tbl.GetID(), forecast, s.ClusterSettings(), nil)
+		if err != nil {
+			return fmt.Sprintf("error: %v", err)
+		}
+		var result strings.Builder
+
+		formatStats := func(label string, statsCache []*TableStatistic) {
+			result.WriteString(fmt.Sprintf("%s stats (count=%d):\n", label, len(statsCache)))
+			for _, stat := range statsCache {
+				result.WriteString(fmt.Sprintf("created_at=%s, name=%q, row_count=%d, distinct_count=%d, null_count=%d, delayed_delete=%t\n",
+					stat.CreatedAt.Format("2006-01-02 15:04:05"), stat.Name, stat.RowCount, stat.DistinctCount, stat.NullCount, stat.DelayDelete))
+			}
+		}
+
+		formatStats("fresh", stats)
+		formatStats("stable", stableStats)
+		return result.String()
+
+	case "stats-differ":
+		tableName := "test"
+		if d.HasArg("table") {
+			d.ScanArgs(t, "table", &tableName)
+		}
+		var canaryWindow time.Duration
+		if d.HasArg("canary-window") {
+			var windowStr string
+			d.ScanArgs(t, "canary-window", &windowStr)
+			var err error
+			canaryWindow, err = time.ParseDuration(windowStr)
+			if err != nil {
+				return fmt.Sprintf("error parsing canary-window: %v", err)
+			}
+		}
+		var statsAsOf hlc.Timestamp
+		if d.HasArg("asof") {
+			var asofStr string
+			d.ScanArgs(t, "asof", &asofStr)
+			parsed, _, err := tree.ParseDTimestamp(nil, asofStr, time.Microsecond)
+			if err != nil {
+				return fmt.Sprintf("error parsing asof: %v", err)
+			}
+			statsAsOf = hlc.Timestamp{WallTime: parsed.Time.UnixNano()}
+		}
+
+		tbl := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
+		if !d.HasArg("no-invalidate") {
+			sc.InvalidateTableStats(ctx, tbl.GetID())
+		}
+		_, statsDiffer, err := sc.GetTableStatsMaybeStable(
+			ctx, tbl, nil /* typeResolver */, false /* stable */, canaryWindow, statsAsOf,
+		)
+		if err != nil {
+			return fmt.Sprintf("error: %v", err)
+		}
+		return fmt.Sprintf("stats_differ: %t\n", statsDiffer)
+
+	default:
+		return fmt.Sprintf("unknown command: %s", d.Cmd)
+	}
+}
+
+// TestCanaryStatsDataDriven uses data-driven tests under testdata/ to exercise
+// canary-related statistics behaviour. See the header of each file for the testing
+// topic.
+func TestCanaryStatsDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -860,41 +1034,9 @@ func TestCanaryDualCache(t *testing.T) {
 	sc := NewTableStatisticsCache(10 /* cacheSize */, s.ClusterSettings(), db, s.AppStopper())
 	require.NoError(t, sc.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory), s.SystemTableIDResolver().(catalog.SystemTableIDResolver)))
 
-	datadriven.RunTest(t, "testdata/dual_cache", func(t *testing.T, d *datadriven.TestData) string {
-		switch d.Cmd {
-		case "exec":
-			sqlRunner.Exec(t, d.Input)
-			return ""
-		case "stats-cache":
-			tableName := "test"
-			forecast := false
-			if d.HasArg("table") {
-				d.ScanArgs(t, "table", &tableName)
-			}
-			if d.HasArg("forecast") {
-				forecast = true
-			}
-
-			tbl := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
-			stats, stableStats, _, _, _, err := sc.getTableStatsFromDB(ctx, tbl.GetID(), forecast, s.ClusterSettings(), nil)
-			if err != nil {
-				return fmt.Sprintf("error: %v", err)
-			}
-			var result strings.Builder
-
-			formatStats := func(label string, statsCache []*TableStatistic) {
-				result.WriteString(fmt.Sprintf("%s stats (count=%d):\n", label, len(statsCache)))
-				for _, stat := range statsCache {
-					result.WriteString(fmt.Sprintf("created_at=%s, name=%q, row_count=%d, distinct_count=%d, null_count=%d, delayed_delete=%t\n",
-						stat.CreatedAt.Format("2006-01-02 15:04:05"), stat.Name, stat.RowCount, stat.DistinctCount, stat.NullCount, stat.DelayDelete))
-				}
-			}
-
-			formatStats("fresh", stats)
-			formatStats("stable", stableStats)
-			return result.String()
-		default:
-			return fmt.Sprintf("unknown command: %s", d.Cmd)
-		}
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			return runStatsCacheDataDriven(t, d, ctx, sqlRunner, kvDB, s, sc)
+		})
 	})
 }

--- a/pkg/sql/stats/testdata/dual_cache
+++ b/pkg/sql/stats/testdata/dual_cache
@@ -1,3 +1,17 @@
+# dual_cache — Tests the dual (fresh + stable) statistics cache.
+#
+# When a canary window is configured, the stats cache maintains two views of
+# table statistics: "fresh" (the latest stats) and "stable" (older stats that
+# were current before the most recent collection). This lets the optimizer
+# compare plans under old vs new stats during the canary window. The tests
+# below verify:
+#   - Stats retention: stale stats get delayed-delete markers instead of
+#     immediate removal while the canary window is open.
+#   - Stable cache contents: the stable cache picks the correct generation
+#     boundary.
+#   - Partial-stats merging: partial statistics (using_extreme, __merged__)
+#     are handled correctly in both caches.
+
 # Setup a test table with positive canary window, so that the delete of
 # stale stats are delayed.
 exec

--- a/pkg/sql/stats/testdata/stats_differ
+++ b/pkg/sql/stats/testdata/stats_differ
@@ -1,0 +1,85 @@
+# stats_differ — Tests the statsDiffer flag from GetTableStatsMaybeStable.
+#
+# When a canary window is active, GetTableStatsMaybeStable returns a
+# statsDiffer bool that indicates whether the fresh and stable stats are
+# different at the given asof timestamp. This flag is later used to indicate
+# that the current execution should be included in the "canary vs stable" metric.
+
+exec
+CREATE TABLE differ_test (id INT PRIMARY KEY) WITH (sql_stats_canary_window = '1h')
+----
+
+# No stats yet — stats should not differ (latestFullStatsTimestamp is empty).
+stats-differ table=differ_test canary-window=1h asof=2025-01-01T10:30:00
+----
+stats_differ: false
+
+exec
+ALTER TABLE differ_test INJECT STATISTICS '[
+  {
+    "columns": ["id"],
+    "created_at": "2025-01-01 10:00:00.000000",
+    "row_count": 100,
+    "distinct_count": 100,
+    "null_count": 0,
+    "avg_size": 8,
+    "name": "__auto__"
+  }
+]'
+----
+
+# One generation within canary window: stable is empty but canary has stats,
+# so they differ. asof=10:30 is within 1h of created_at=10:00.
+stats-differ table=differ_test canary-window=1h asof=2025-01-01T10:30:00
+----
+stats_differ: true
+
+# One generation but asof is past the canary window
+# (asof=12:00 > 10:00 + 1h), so stats no longer differ.
+stats-differ table=differ_test canary-window=1h asof=2025-01-01T12:00:00
+----
+stats_differ: false
+
+exec
+ALTER TABLE differ_test INJECT STATISTICS '[
+  {
+    "columns": ["id"],
+    "created_at": "2025-01-01 10:00:00.000000",
+    "row_count": 100,
+    "distinct_count": 100,
+    "null_count": 0,
+    "avg_size": 8,
+    "name": "__auto__"
+  },
+  {
+    "columns": ["id"],
+    "created_at": "2025-01-01 11:00:00.000000",
+    "row_count": 200,
+    "distinct_count": 200,
+    "null_count": 0,
+    "avg_size": 8,
+    "name": "__auto__"
+  }
+]'
+----
+
+# 11:30 < 11:00 + 1h. Two distinct generations → stats differ.
+stats-differ table=differ_test canary-window=1h asof=2025-01-01T11:30:00
+----
+stats_differ: true
+
+# No canary window — stats should not differ even with two generations.
+stats-differ table=differ_test canary-window=0s asof=2025-01-01T11:30:00
+----
+stats_differ: false
+
+# Test warm-cache path: call stats-differ without invalidating the cache
+# first (no-invalidate). The cache-hit branch in getTableStatsFromCache
+# should return the same statsDiffer value.
+stats-differ table=differ_test canary-window=1h no-invalidate asof=2025-01-01T11:30:00
+----
+stats_differ: true
+
+stats-differ table=differ_test canary-window=0s no-invalidate asof=2025-01-01T11:30:00
+----
+stats_differ: false


### PR DESCRIPTION
Informs: #156817

The canary stats system has two distinct concepts:

 1. The dice roll (`canaryRollDice`): picks a rollout *path* — canary (newest stats) or stable (second-newest). Decided once per query before planning; unconditional when `canary_fraction` > 0.

 2. Actual stats divergence: whether the canary and stable statistics for a table are genuinely different. Depends on per-table canary window size, timing, and the existence of two distinct stat generations.

Previously, the dice roll alone determined whether an execution was tagged as canary or stable for experiment metrics. This tagged every execution when `canary_fraction > 0`, even for queries whose tables all use identical stats regardless of path — which will potentially dilute the "canary vs stable" metrics with noise.

---- 

Consider a workload with two query patterns and canary_fraction = 10%:                                   
                                                                                                       
- `SELECT * FROM t1`                    (90% of executions)
- `SELECT * FROM t1 JOIN t2 ...`  (10% of executions)

- t1 has no canary window (canaryWindowSize = 0).
- t2 has a canary window, and its canary and stable stats genuinely
  differ (fresh stats were recently collected).

Out of 1000 executions, the dice roll tags ~100 as "canary" and ~90 as "stable" — regardless of which tables they touch. That means ~90 of those tagged executions are the single-table query on t1, where canary and stable stats are identical. These 90 executions add pure noise to the A/B comparison metric.

Only the ~10 executions that touch t2 (the JOIN query) actually use different stats on the canary vs. stable path and produce a meaningful signal. With canaryAndStableStatsDiffer, the t1-only executions are excluded from experiment metrics, keeping the comparison clean.

----

This commit adds divergence detection during planning: for each table, we check whether its canary and stable stat sets actually differ (`canaryAndStableStatsDiffer`). The result is OR'd across all tables into `eval.Context.CanaryAndStableStatsDiffer`. A follow-up PR (#165257) will use this flag to gate experiment metric recording.

The dice roll still controls which stats the optimizer uses; this change only provides the signal for whether recording the experiment is meaningful.

Release note: None