### PR TITLE
sql/distsql: skip ST_AsMVT in TestAggregatorAgainstProcessor

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -189,6 +189,10 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 				execinfrapb.MergeAggregatedStmtMetadata:
 				// We skip merge statistics functions because they
 				// require custom JSON objects.
+			case execinfrapb.StAsMVT:
+				// We skip ST_AsMVT because it requires a tuple as
+				// its first argument and specific types for its
+				// optional arguments.
 			default:
 				found = true
 			}


### PR DESCRIPTION
ST_AsMVT requires a tuple as its first argument and specific scalar types (DString, DInt) for its optional arguments. The randomized test generates arbitrary types for aggregate inputs, which can produce types that cause panics in MustBeDInt/MustBeDString when they don't match the expected types. Skip ST_AsMVT alongside other aggregate functions that have special input requirements.

Resolves: #165533

Release note: None