### PR TITLE
roachtest: add disk bandwidth AC testing to index-backfill test

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "roachtestutil",
     srcs = [
         "commandbuilder.go",
+        "disk_snapshot.go",
         "disk_stall.go",
         "disk_usage.go",
         "failure_injection.go",
@@ -34,6 +35,7 @@ go_library(
         "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/vm",
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/testutils",

--- a/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+)
+
+// CopySnapshotDataToNodes copies CockroachDB data from GCE disk snapshots to
+// each CRDB node's primary disk, replacing any existing data in
+// /mnt/data1/cockroach. This avoids using cluster.ApplySnapshots directly
+// because GCE snapshot-backed disks have a hydration problem: reads are very
+// slow (~50 MB/s with 250ms latency) until the disk is fully hydrated in the
+// background.
+//
+// For each CRDB node, the function:
+//  1. Finds the matching snapshot by node number suffix
+//  2. Creates a temporary pd-ssd disk from the snapshot
+//  3. Attaches and mounts it read-only
+//  4. Removes existing data at /mnt/data1/cockroach and copies snapshot
+//     data in its place via rsync
+//  5. Cleans up (unmount, detach, delete the temporary disk)
+//
+// All nodes are processed in parallel.
+func CopySnapshotDataToNodes(
+	ctx context.Context, t test.Test, c cluster.Cluster, snapshots []vm.VolumeSnapshot,
+) {
+	t.Status("copying snapshot data to CRDB nodes (avoiding GCE hydration problem)")
+
+	g := t.NewGroup(task.WithContext(ctx))
+	for _, nodeID := range c.CRDBNodes() {
+		nodeID := nodeID
+		g.Go(func(ctx context.Context, l *logger.Logger) error {
+			return copySnapshotDataToNode(ctx, l, c, snapshots, nodeID)
+		}, task.Name(fmt.Sprintf("copy-snapshot-n%d", nodeID)))
+	}
+	g.Wait()
+
+	t.L().Printf("snapshot data successfully copied to all %d CRDB nodes",
+		len(c.CRDBNodes()))
+}
+
+func copySnapshotDataToNode(
+	ctx context.Context,
+	l *logger.Logger,
+	c cluster.Cluster,
+	snapshots []vm.VolumeSnapshot,
+	nodeID int,
+) error {
+	node := option.NodeListOption{nodeID}
+
+	// Find the snapshot for this node. Snapshot names end with a zero-padded
+	// node number, e.g. "index-backfill-tpce-100k-v24.3.0-n10-0003".
+	suffix := fmt.Sprintf("-%04d", nodeID)
+	var snap vm.VolumeSnapshot
+	for _, s := range snapshots {
+		if strings.HasSuffix(s.Name, suffix) {
+			snap = s
+			break
+		}
+	}
+	if snap.ID == "" {
+		return fmt.Errorf("no snapshot found for node %d (suffix %s)", nodeID, suffix)
+	}
+	l.Printf("n%d: using snapshot %s (ID: %s)", nodeID, snap.Name, snap.ID)
+
+	// Query the GCE zone from instance metadata rather than hardcoding it.
+	getZoneCmd := `curl -sf -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/zone`
+	zoneOutput, err := c.RunWithDetailsSingleNode(
+		ctx, l, option.WithNodes(node), getZoneCmd,
+	)
+	if err != nil {
+		return fmt.Errorf("n%d: failed to get zone from GCE metadata: %w", nodeID, err)
+	}
+	// Zone format: projects/PROJECT_NUMBER/zones/ZONE_NAME
+	zoneParts := strings.Split(strings.TrimSpace(zoneOutput.Stdout), "/")
+	if len(zoneParts) < 4 || zoneParts[len(zoneParts)-2] != "zones" {
+		return fmt.Errorf(
+			"n%d: unexpected zone format from metadata: %q", nodeID, zoneOutput.Stdout,
+		)
+	}
+	zone := zoneParts[len(zoneParts)-1]
+
+	// Use a per-node temp disk name to avoid collisions when running in
+	// parallel across nodes.
+	tempDiskName := fmt.Sprintf("%s-temp-snapshot-%04d", c.Name(), nodeID)
+	deviceName := fmt.Sprintf("snapshot-disk-%04d", nodeID)
+
+	// Create a temporary disk from the snapshot.
+	l.Printf("n%d: creating temp disk %s from snapshot in zone %s",
+		nodeID, tempDiskName, zone)
+	createDiskCmd := fmt.Sprintf(
+		`gcloud compute disks create %s --source-snapshot=%s --zone=%s --type=pd-ssd --quiet`,
+		tempDiskName, snap.ID, zone,
+	)
+	if err := c.RunE(ctx, option.WithNodes(node), createDiskCmd); err != nil {
+		return fmt.Errorf("n%d: failed to create disk from snapshot: %w", nodeID, err)
+	}
+
+	// Clean up the temp disk when we're done, regardless of success or
+	// failure. Use a fresh context since the original may be cancelled
+	// on test timeout, and we don't want to leave orphaned GCE disks.
+	unmountCmd := `sudo umount /mnt/snapshot && sudo rmdir /mnt/snapshot`
+	mounted := false
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		if mounted {
+			if err := c.RunE(cleanupCtx, option.WithNodes(node), unmountCmd); err != nil {
+				l.Printf("n%d: warning: failed to unmount snapshot disk: %v", nodeID, err)
+			}
+		}
+
+		l.Printf("n%d: cleaning up temp disk %s", nodeID, tempDiskName)
+		detachCmd := fmt.Sprintf(
+			`gcloud compute instances detach-disk $(hostname) --disk=%s --zone=%s --quiet`,
+			tempDiskName, zone,
+		)
+		_ = c.RunE(cleanupCtx, option.WithNodes(node), detachCmd)
+		deleteCmd := fmt.Sprintf(
+			`gcloud compute disks delete %s --zone=%s --quiet`,
+			tempDiskName, zone,
+		)
+		_ = c.RunE(cleanupCtx, option.WithNodes(node), deleteCmd)
+	}()
+
+	// Attach the temporary disk.
+	l.Printf("n%d: attaching temp disk", nodeID)
+	attachCmd := fmt.Sprintf(
+		`gcloud compute instances attach-disk $(hostname) --disk=%s --zone=%s --device-name=%s --quiet`,
+		tempDiskName, zone, deviceName,
+	)
+	if err := c.RunE(ctx, option.WithNodes(node), attachCmd); err != nil {
+		return fmt.Errorf("n%d: failed to attach snapshot disk: %w", nodeID, err)
+	}
+
+	// Mount the temporary disk read-only.
+	l.Printf("n%d: mounting snapshot disk", nodeID)
+	mountCmd := fmt.Sprintf(
+		`sudo mkdir -p /mnt/snapshot && sudo mount -o ro /dev/disk/by-id/google-%s /mnt/snapshot`,
+		deviceName,
+	)
+	if err := c.RunE(ctx, option.WithNodes(node), mountCmd); err != nil {
+		return fmt.Errorf("n%d: failed to mount snapshot disk: %w", nodeID, err)
+	}
+	mounted = true
+
+	// Remove existing data and copy snapshot data to the primary disk.
+	l.Printf("n%d: wiping /mnt/data1/cockroach and copying snapshot data", nodeID)
+	copyCmd := `sudo rm -rf /mnt/data1/cockroach && ` +
+		`sudo rsync -ah --info=progress2 /mnt/snapshot/cockroach /mnt/data1/`
+	if err := c.RunE(ctx, option.WithNodes(node), copyCmd); err != nil {
+		return fmt.Errorf("n%d: failed to copy data from snapshot: %w", nodeID, err)
+	}
+	l.Printf("n%d: data copy complete", nodeID)
+
+	return nil
+}

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -37,29 +37,42 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
+		spec.ReuseNone(),
 	)
 
-	r.Add(registry.TestSpec{
-		Name:             "admission-control/index-backfill",
-		Timeout:          12 * time.Hour,
-		Owner:            registry.OwnerAdmissionControl,
-		Benchmark:        true,
-		CompatibleClouds: registry.OnlyGCE,
-		Suites:           registry.Suites(registry.Nightly),
-		// TODO(aaditya): Revisit this as part of #111614.
-		//Tags:             registry.Tags(`weekly`),
-		Cluster:        clusterSpec,
-		SnapshotPrefix: "index-backfill-tpce-100k",
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runIndexBackfill(ctx, t, c, clusterSpec)
-		},
-	})
+	for _, withProvisionedBandwidth := range []bool{false, true} {
+		snapshotPrefix := "index-backfill-tpce-100k-nobw"
+		if withProvisionedBandwidth {
+			snapshotPrefix = "index-backfill-tpce-100k-bw"
+		}
+
+		r.Add(registry.TestSpec{
+			Name: fmt.Sprintf(
+				"admission-control/index-backfill/provisioned-bandwidth=%t",
+				withProvisionedBandwidth,
+			),
+			Timeout:          12 * time.Hour,
+			Owner:            registry.OwnerAdmissionControl,
+			Benchmark:        true,
+			CompatibleClouds: registry.OnlyGCE,
+			Suites:           registry.Suites(registry.Nightly),
+			Cluster:          clusterSpec,
+			SnapshotPrefix:   snapshotPrefix,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runIndexBackfill(ctx, t, c, clusterSpec, withProvisionedBandwidth)
+			},
+		})
+	}
 }
 
 const indexBackfillDiskBandwidth = 128 << 20 // 128 MiB/s
 
 func runIndexBackfill(
-	ctx context.Context, t test.Test, c cluster.Cluster, clusterSpec spec.ClusterSpec,
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	clusterSpec spec.ClusterSpec,
+	withProvisionedBandwidth bool,
 ) {
 	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 		// TODO(irfansharif): Search by taking in the other parts of the
@@ -171,6 +184,23 @@ func runIndexBackfill(
 				"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false",
 			); err != nil {
 				t.Fatal(err)
+			}
+
+			// Optionally tell admission control the disk's provisioned
+			// bandwidth so it can manage elastic vs. foreground work.
+			if withProvisionedBandwidth {
+				if _, err := db.ExecContext(ctx,
+					"SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
+				); err != nil {
+					t.Fatal(err)
+				}
+				// Allow elastic work to fully utilize the provisioned
+				// bandwidth.
+				if _, err := db.ExecContext(ctx,
+					"SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
+				); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			// Limit disk bandwidth to 128 MiB/s via cgroups so that

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -28,6 +28,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type indexBackfillVariant struct {
+	nameSuffix               string
+	snapshotPrefix           string
+	withCgroupLimiting       bool
+	withProvisionedBandwidth bool
+}
+
+var indexBackfillVariants = []indexBackfillVariant{
+	{
+		nameSuffix:     "/no-disk-limit",
+		snapshotPrefix: "index-backfill-tpce-100k-nodisklimit",
+	},
+	{
+		nameSuffix:         "/provisioned-bandwidth=false",
+		snapshotPrefix:     "index-backfill-tpce-100k-nobw",
+		withCgroupLimiting: true,
+	},
+	{
+		nameSuffix:               "/provisioned-bandwidth=true",
+		snapshotPrefix:           "index-backfill-tpce-100k-bw",
+		withCgroupLimiting:       true,
+		withProvisionedBandwidth: true,
+	},
+}
+
 func registerIndexBackfill(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
@@ -44,26 +69,18 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.ReuseNone(),
 	)
 
-	for _, withProvisionedBandwidth := range []bool{false, true} {
-		snapshotPrefix := "index-backfill-tpce-100k-nobw"
-		if withProvisionedBandwidth {
-			snapshotPrefix = "index-backfill-tpce-100k-bw"
-		}
-
+	for _, v := range indexBackfillVariants {
 		r.Add(registry.TestSpec{
-			Name: fmt.Sprintf(
-				"admission-control/index-backfill/provisioned-bandwidth=%t",
-				withProvisionedBandwidth,
-			),
+			Name:             "admission-control/index-backfill" + v.nameSuffix,
 			Timeout:          12 * time.Hour,
 			Owner:            registry.OwnerAdmissionControl,
 			Benchmark:        true,
 			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),
 			Cluster:          clusterSpec,
-			SnapshotPrefix:   snapshotPrefix,
+			SnapshotPrefix:   v.snapshotPrefix,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runIndexBackfill(ctx, t, c, clusterSpec, withProvisionedBandwidth)
+				runIndexBackfill(ctx, t, c, clusterSpec, v.withCgroupLimiting, v.withProvisionedBandwidth)
 			},
 		})
 	}
@@ -76,6 +93,7 @@ func runIndexBackfill(
 	t test.Test,
 	c cluster.Cluster,
 	clusterSpec spec.ClusterSpec,
+	withCgroupLimiting bool,
 	withProvisionedBandwidth bool,
 ) {
 	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
@@ -197,34 +215,36 @@ func runIndexBackfill(
 		t.Fatal(err)
 	}
 
-	// Optionally tell admission control the disk's provisioned
-	// bandwidth so it can manage elastic vs. foreground work.
-	if withProvisionedBandwidth {
-		if _, err := db.ExecContext(ctx,
-			"SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
-		); err != nil {
-			t.Fatal(err)
+	if withCgroupLimiting {
+		// Optionally tell admission control the disk's provisioned
+		// bandwidth so it can manage elastic vs. foreground work.
+		if withProvisionedBandwidth {
+			if _, err := db.ExecContext(ctx,
+				"SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
+			); err != nil {
+				t.Fatal(err)
+			}
+			// Allow elastic work to fully utilize the provisioned
+			// bandwidth.
+			if _, err := db.ExecContext(ctx,
+				"SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
+			); err != nil {
+				t.Fatal(err)
+			}
 		}
-		// Allow elastic work to fully utilize the provisioned
-		// bandwidth.
-		if _, err := db.ExecContext(ctx,
-			"SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
-		); err != nil {
-			t.Fatal(err)
-		}
-	}
 
-	// Limit disk bandwidth to 128 MiB/s via cgroups so that disk I/O
-	// becomes the bottleneck. Without this, pd-ssd disks are fast enough
-	// that admission control has nothing meaningful to manage. This must
-	// run after c.StartE, since the cgroup path for the cockroach systemd
-	// service only exists after the service has been created.
-	t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups",
-		indexBackfillDiskBandwidth))
-	staller := roachtestutil.MakeCgroupDiskStaller(t, c,
-		true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
-	staller.Setup(ctx)
-	staller.Slow(ctx, c.CRDBNodes(), indexBackfillDiskBandwidth)
+		// Limit disk bandwidth to 128 MiB/s via cgroups so that disk I/O
+		// becomes the bottleneck. Without this, pd-ssd disks are fast enough
+		// that admission control has nothing meaningful to manage. This must
+		// run after c.StartE, since the cgroup path for the cockroach systemd
+		// service only exists after the service has been created.
+		t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups",
+			indexBackfillDiskBandwidth))
+		staller := roachtestutil.MakeCgroupDiskStaller(t, c,
+			true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
+		staller.Setup(ctx)
+		staller.Slow(ctx, c.CRDBNodes(), indexBackfillDiskBandwidth)
+	}
 
 	// Initialize TPC-E spec for running workload commands.
 	tpceSpec, err := initTPCESpec(ctx, t.L(), c)

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -45,9 +45,8 @@ func registerIndexBackfill(r registry.Registry) {
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		CompatibleClouds: registry.OnlyGCE,
-		Suites:           registry.ManualOnly,
+		Suites:           registry.Suites(registry.Nightly),
 		// TODO(aaditya): Revisit this as part of #111614.
-		//Suites:           registry.Suites(registry.Weekly),
 		//Tags:             registry.Tags(`weekly`),
 		Cluster:        clusterSpec,
 		SnapshotPrefix: "index-backfill-tpce-100k",
@@ -120,12 +119,7 @@ func registerIndexBackfill(r registry.Registry) {
 					len(snapshots), t.SnapshotPrefix())
 
 				if !t.SkipInit() {
-					// Creating and attaching volumes takes some time. This test
-					// is written to be re-entrant. Assume the user passing in
-					// --skip-init knows this particular test behavior.
-					if err := c.ApplySnapshots(ctx, snapshots); err != nil {
-						t.Fatal(err)
-					}
+					roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
 				}
 			}
 

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -41,7 +41,7 @@ func registerIndexBackfill(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/index-backfill",
-		Timeout:          6 * time.Hour,
+		Timeout:          12 * time.Hour,
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		CompatibleClouds: registry.OnlyGCE,
@@ -51,165 +51,191 @@ func registerIndexBackfill(r registry.Registry) {
 		Cluster:        clusterSpec,
 		SnapshotPrefix: "index-backfill-tpce-100k",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
-				// TODO(irfansharif): Search by taking in the other parts of the
-				// snapshot fingerprint, i.e. the node count, the version, etc.
-				NamePrefix: t.SnapshotPrefix(),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(snapshots) == 0 {
-				t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
-					t.Name(), t.SnapshotPrefix())
+			runIndexBackfill(ctx, t, c, clusterSpec)
+		},
+	})
+}
 
-				// Set up TPC-E with 100k customers. Do so using a published
-				// CRDB release, since we'll use this state to generate disk
-				// snapshots.
-				runTPCE(ctx, t, c, tpceOptions{
-					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						pred, err := release.LatestPredecessor(t.BuildVersion())
-						if err != nil {
-							t.Fatal(err)
-						}
+const indexBackfillDiskBandwidth = 128 << 20 // 128 MiB/s
 
-						path, err := clusterupgrade.UploadCockroach(
-							ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
-						)
-						if err != nil {
-							t.Fatal(err)
-						}
+func runIndexBackfill(
+	ctx context.Context, t test.Test, c cluster.Cluster, clusterSpec spec.ClusterSpec,
+) {
+	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
+		// TODO(irfansharif): Search by taking in the other parts of the
+		// snapshot fingerprint, i.e. the node count, the version, etc.
+		NamePrefix: t.SnapshotPrefix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) == 0 {
+		t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
+			t.Name(), t.SnapshotPrefix())
 
-						// Copy over the binary to ./cockroach and run it from
-						// there. This test captures disk snapshots, which are
-						// fingerprinted using the binary version found in this
-						// path. The reason it can't just poke at the running
-						// CRDB process is because when grabbing snapshots, CRDB
-						// is not running.
-						c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
-						settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
-						startOpts := option.NewStartOpts(option.NoBackupSchedule)
-						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-						if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
-							t.Fatal(err)
-						}
-					},
-					customers:          100_000,
-					disablePrometheus:  true,
-					setupType:          usingTPCEInit,
-					estimatedSetupTime: 4 * time.Hour,
-					nodes:              len(c.CRDBNodes()),
-					cpus:               clusterSpec.CPUs,
-					ssds:               1,
-					onlySetup:          true,
-				})
-
-				// Stop all nodes before capturing cluster snapshots.
-				c.Stop(ctx, t.L(), option.DefaultStopOpts())
-
-				// Create the aforementioned snapshots.
-				snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
+		// Set up TPC-E with 100k customers. Do so using a published
+		// CRDB release, since we'll use this state to generate disk
+		// snapshots.
+		runTPCE(ctx, t, c, tpceOptions{
+			start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				pred, err := release.LatestPredecessor(t.BuildVersion())
 				if err != nil {
 					t.Fatal(err)
 				}
-				t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
-					len(snapshots), t.SnapshotPrefix())
-			} else {
-				t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
-					len(snapshots), t.SnapshotPrefix())
 
-				if !t.SkipInit() {
-					roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
+				path, err := clusterupgrade.UploadCockroach(
+					ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
+				)
+				if err != nil {
+					t.Fatal(err)
 				}
+
+				// Copy over the binary to ./cockroach and run it from
+				// there. This test captures disk snapshots, which are
+				// fingerprinted using the binary version found in this
+				// path. The reason it can't just poke at the running
+				// CRDB process is because when grabbing snapshots, CRDB
+				// is not running.
+				c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
+				settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
+				roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+				if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+					t.Fatal(err)
+				}
+			},
+			customers:          100_000,
+			disablePrometheus:  true,
+			setupType:          usingTPCEInit,
+			estimatedSetupTime: 4 * time.Hour,
+			nodes:              len(c.CRDBNodes()),
+			cpus:               clusterSpec.CPUs,
+			ssds:               1,
+			onlySetup:          true,
+		})
+
+		// Stop all nodes before capturing cluster snapshots.
+		c.Stop(ctx, t.L(), option.DefaultStopOpts())
+
+		// Create the aforementioned snapshots.
+		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
+			len(snapshots), t.SnapshotPrefix())
+	} else {
+		t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
+			len(snapshots), t.SnapshotPrefix())
+
+		if !t.SkipInit() {
+			roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
+		}
+	}
+
+	promCfg := &prometheus.Config{}
+	promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+		WithNodeExporter(c.CRDBNodes().InstallNodes()).
+		WithCluster(c.CRDBNodes().InstallNodes()).
+		WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
+		WithScrapeConfigs(
+			prometheus.MakeWorkloadScrapeConfig("workload", "/",
+				makeWorkloadScrapeNodes(
+					c.WorkloadNode().InstallNodes()[0],
+					[]workloadInstance{{nodes: c.WorkloadNode()}},
+				),
+			),
+		)
+
+	// Run the foreground TPC-E workload for 20k customers for 1hr. Run
+	// large index backfills while it's running.
+	runTPCE(ctx, t, c, tpceOptions{
+		start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			startOpts := option.NewStartOpts(option.NoBackupSchedule)
+			roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+			settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+			if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+				t.Fatal(err)
 			}
 
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
-				WithNodeExporter(c.CRDBNodes().InstallNodes()).
-				WithCluster(c.CRDBNodes().InstallNodes()).
-				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
-				WithScrapeConfigs(
-					prometheus.MakeWorkloadScrapeConfig("workload", "/",
-						makeWorkloadScrapeNodes(
-							c.WorkloadNode().InstallNodes()[0],
-							[]workloadInstance{{nodes: c.WorkloadNode()}},
-						),
+			// Configure cluster settings before workload begins.
+			db := c.Conn(ctx, t.L(), 1)
+			defer db.Close()
+
+			// Work around https://github.com/cockroachdb/cockroach/issues/98311.
+			// TPC-E tables use a 300s GC TTL. When admission control delays
+			// AddSSTable requests beyond this TTL, the GC threshold advances
+			// past the batch timestamp and the request fails.
+			if _, err := db.ExecContext(ctx,
+				"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false",
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			// Limit disk bandwidth to 128 MiB/s via cgroups so that
+			// disk I/O becomes the bottleneck. Without this, pd-ssd
+			// disks are fast enough that admission control has nothing
+			// meaningful to manage.
+			t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups",
+				indexBackfillDiskBandwidth))
+			staller := roachtestutil.MakeCgroupDiskStaller(t, c,
+				true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
+			staller.Setup(ctx)
+			staller.Slow(ctx, c.CRDBNodes(), indexBackfillDiskBandwidth)
+		},
+		customers:        100_000,
+		activeCustomers:  20_000,
+		threads:          400,
+		skipCleanup:      true,
+		ssds:             1,
+		setupType:        usingExistingTPCEData,
+		nodes:            clusterSpec.NodeCount - 1,
+		cpus:             clusterSpec.CPUs,
+		prometheusConfig: promCfg,
+		workloadDuration: time.Hour + 30*time.Minute,
+		during: func(ctx context.Context) error {
+			t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
+			time.Sleep(5 * time.Minute)
+
+			db := c.Conn(ctx, t.L(), 1)
+			defer db.Close()
+
+			// Choose index creations and primary key changes that would
+			// take ~30 minutes each. Offset them by 5 minutes.
+			//
+			// TODO(irfansharif): These now take closer to an hour after
+			// https://github.com/cockroachdb/cockroach/pull/109085. Do
+			// something about it if customers complain.
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+			m.Go(func(ctx context.Context) error {
+				t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
+				_, err := db.ExecContext(ctx,
+					fmt.Sprintf("CREATE INDEX index_%s ON tpce.cash_transaction (ct_dts)",
+						timeutil.Now().Format("20060102_T150405"),
 					),
 				)
-
-			// Run the foreground TPC-E workload for 20k customers for 1hr. Run
-			// large index backfills while it's running.
-			runTPCE(ctx, t, c, tpceOptions{
-				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					startOpts := option.NewStartOpts(option.NoBackupSchedule)
-					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-					settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
-					if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
-						t.Fatal(err)
-					}
-				},
-				customers:        100_000,
-				activeCustomers:  20_000,
-				threads:          400,
-				skipCleanup:      true,
-				ssds:             1,
-				setupType:        usingExistingTPCEData,
-				nodes:            clusterSpec.NodeCount - 1,
-				cpus:             clusterSpec.CPUs,
-				prometheusConfig: promCfg,
-				workloadDuration: time.Hour + 30*time.Minute,
-				during: func(ctx context.Context) error {
-					db := c.Conn(ctx, t.L(), 1)
-					defer db.Close()
-
-					// Defeat https://github.com/cockroachdb/cockroach/issues/98311.
-					if _, err := db.ExecContext(ctx,
-						"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false;",
-					); err != nil {
-						t.Fatal(err)
-					}
-
-					t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
-					time.Sleep(5 * time.Minute)
-
-					// Choose index creations and primary key changes that would
-					// take ~30 minutes each. Offset them by 5 minutes.
-					//
-					// TODO(irfansharif): These now take closer to an hour after
-					// https://github.com/cockroachdb/cockroach/pull/109085. Do
-					// something about it if customers complain.
-					m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-					m.Go(func(ctx context.Context) error {
-						t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
-						_, err := db.ExecContext(ctx,
-							fmt.Sprintf("CREATE INDEX index_%s ON tpce.cash_transaction (ct_dts)",
-								timeutil.Now().Format("20060102_T150405"),
-							),
-						)
-						t.Status("finished index creation")
-						return err
-					})
-					m.Go(func(ctx context.Context) error {
-						// TODO(irfansharif): Is the re-entrant? As in,
-						// effective when re-running the roachtest against the
-						// same cluster that's already run the test once? Useful
-						// to make it so if possible, to run things more
-						// iteratively.
-						time.Sleep(5 * time.Minute)
-						t.Status(fmt.Sprintf("starting primary key change (<%s)", 30*time.Minute))
-						_, err := db.ExecContext(ctx,
-							"ALTER TABLE tpce.holding_history ALTER PRIMARY KEY USING COLUMNS (hh_h_t_id ASC, hh_t_id ASC, hh_before_qty ASC)",
-						)
-						t.Status("finished primary key change")
-						return err
-					})
-					m.Wait()
-
-					t.Status(fmt.Sprintf("waiting for workload to finish (<%s)", 50*time.Minute))
-					return nil
-				},
+				t.Status("finished index creation")
+				return err
 			})
+			m.Go(func(ctx context.Context) error {
+				// TODO(irfansharif): Is the re-entrant? As in,
+				// effective when re-running the roachtest against the
+				// same cluster that's already run the test once? Useful
+				// to make it so if possible, to run things more
+				// iteratively.
+				time.Sleep(5 * time.Minute)
+				t.Status(fmt.Sprintf("starting primary key change (<%s)", 30*time.Minute))
+				_, err := db.ExecContext(ctx,
+					"ALTER TABLE tpce.holding_history ALTER PRIMARY KEY USING COLUMNS (hh_h_t_id ASC, hh_t_id ASC, hh_before_qty ASC)",
+				)
+				t.Status("finished primary key change")
+				return err
+			})
+			m.Wait()
+
+			t.Status(fmt.Sprintf("waiting for workload to finish (<%s)", 50*time.Minute))
+			return nil
 		},
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -11,17 +11,21 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
 func registerIndexBackfill(r registry.Registry) {
@@ -146,6 +150,7 @@ func runIndexBackfill(
 		}
 	}
 
+	// Set up prometheus for metrics collection.
 	promCfg := &prometheus.Config{}
 	promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
 		WithNodeExporter(c.CRDBNodes().InstallNodes()).
@@ -159,113 +164,266 @@ func runIndexBackfill(
 				),
 			),
 		)
+	if err := c.StartGrafana(ctx, t.L(), promCfg); err != nil {
+		t.Fatal(err)
+	}
 
-	// Run the foreground TPC-E workload for 20k customers for 1hr. Run
-	// large index backfills while it's running.
-	runTPCE(ctx, t, c, tpceOptions{
-		start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			startOpts := option.NewStartOpts(option.NoBackupSchedule)
-			roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-			settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
-			if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
-				t.Fatal(err)
+	// Set up prometheus client and stat collector for roachperf export.
+	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+	require.NoError(t, err)
+	statCollector := clusterstats.NewStatsCollector(ctx, promClient)
+
+	// Start the cluster.
+	t.Status("starting cluster for workload")
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
+	roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+	roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+	settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+	if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure cluster settings before workload begins.
+	db := c.Conn(ctx, t.L(), 1)
+	defer db.Close()
+
+	// Work around https://github.com/cockroachdb/cockroach/issues/98311.
+	// TPC-E tables use a 300s GC TTL. When admission control delays
+	// AddSSTable requests beyond this TTL, the GC threshold advances
+	// past the batch timestamp and the request fails.
+	if _, err := db.ExecContext(ctx,
+		"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Optionally tell admission control the disk's provisioned
+	// bandwidth so it can manage elastic vs. foreground work.
+	if withProvisionedBandwidth {
+		if _, err := db.ExecContext(ctx,
+			"SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
+		); err != nil {
+			t.Fatal(err)
+		}
+		// Allow elastic work to fully utilize the provisioned
+		// bandwidth.
+		if _, err := db.ExecContext(ctx,
+			"SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Limit disk bandwidth to 128 MiB/s via cgroups so that disk I/O
+	// becomes the bottleneck. Without this, pd-ssd disks are fast enough
+	// that admission control has nothing meaningful to manage. This must
+	// run after c.StartE, since the cgroup path for the cockroach systemd
+	// service only exists after the service has been created.
+	t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups",
+		indexBackfillDiskBandwidth))
+	staller := roachtestutil.MakeCgroupDiskStaller(t, c,
+		true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
+	staller.Setup(ctx)
+	staller.Slow(ctx, c.CRDBNodes(), indexBackfillDiskBandwidth)
+
+	// Initialize TPC-E spec for running workload commands.
+	tpceSpec, err := initTPCESpec(ctx, t.L(), c)
+	require.NoError(t, err)
+
+	// Run TPC-E workload and schema changes concurrently, collecting
+	// disk bandwidth metrics during the schema changes.
+	const (
+		workloadDuration = 90 * time.Minute
+		baselineWait     = 5 * time.Minute
+	)
+	var backfillDuration time.Duration
+	var pkChangeDuration time.Duration
+	var totalBWSamples []float64
+	var metricsStart, metricsEnd time.Time
+
+	g := t.NewGroup(task.WithContext(ctx))
+
+	// Goroutine 1: Run TPC-E workload.
+	g.Go(func(ctx context.Context, l *logger.Logger) error {
+		t.Status(fmt.Sprintf("starting TPC-E workload with 20000 active customers (<%s)",
+			workloadDuration))
+		runOptions := tpceCmdOptions{
+			customers:       100_000,
+			activeCustomers: 20_000,
+			racks:           len(c.CRDBNodes()),
+			duration:        workloadDuration,
+			threads:         400,
+			skipCleanup:     true,
+			connectionOpts:  defaultTPCEConnectionOpts(),
+		}
+		result, err := tpceSpec.run(ctx, t, c, runOptions)
+		if err != nil {
+			l.Printf("TPC-E workload error: %v", err)
+			return err
+		}
+		l.Printf("TPC-E workload output:\n%s\n", result.Stdout)
+		return nil
+	}, task.Name("tpce-workload"))
+
+	// Goroutine 2: Run index creation after baseline period.
+	g.Go(func(ctx context.Context, l *logger.Logger) error {
+		t.Status(fmt.Sprintf("recording baseline performance (<%s)", baselineWait))
+		time.Sleep(baselineWait)
+
+		t.Status("starting index creation on tpce.cash_transaction")
+		indexName := fmt.Sprintf("index_%s", timeutil.Now().Format("20060102_T150405"))
+
+		backfillStart := timeutil.Now()
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf("CREATE INDEX %s ON tpce.cash_transaction (ct_dts)", indexName),
+		)
+		backfillDuration = timeutil.Since(backfillStart)
+		if err != nil {
+			l.Printf("index creation error: %v", err)
+			return err
+		}
+		l.Printf("index backfill completed in %s", backfillDuration)
+		t.Status("finished index creation")
+		return nil
+	}, task.Name("index-backfill"))
+
+	// Goroutine 3: Run primary key change, starting 10 minutes after
+	// test start (5 minutes after the index backfill starts).
+	g.Go(func(ctx context.Context, l *logger.Logger) error {
+		time.Sleep(baselineWait + 5*time.Minute)
+
+		t.Status("starting primary key change on tpce.holding_history")
+		pkChangeStart := timeutil.Now()
+		_, err := db.ExecContext(ctx,
+			"ALTER TABLE tpce.holding_history ALTER PRIMARY KEY USING COLUMNS (hh_h_t_id ASC, hh_t_id ASC, hh_before_qty ASC)",
+		)
+		pkChangeDuration = timeutil.Since(pkChangeStart)
+		if err != nil {
+			l.Printf("primary key change error: %v", err)
+			return err
+		}
+		l.Printf("primary key change completed in %s", pkChangeDuration)
+		t.Status("finished primary key change")
+		return nil
+	}, task.Name("pk-change"))
+
+	// Collect disk bandwidth metrics in a separate goroutine outside the
+	// group, so g.Wait() only blocks on the workload and schema changes.
+	stopMetrics := make(chan struct{})
+	metricsDone := make(chan struct{})
+	t.Go(func(ctx context.Context, l *logger.Logger) error {
+		defer close(metricsDone)
+
+		// Wait for baseline period before starting collection.
+		time.Sleep(baselineWait)
+
+		metricsStart = timeutil.Now()
+		defer func() { metricsEnd = timeutil.Now() }()
+
+		// Use avg() across nodes to get per-node average bandwidth,
+		// which is comparable to the 128 MiB/s cgroup limit.
+		writeBWQuery := divQuery("avg(rate(sys_host_disk_write_bytes[1m]))", 1<<20)
+		readBWQuery := divQuery("avg(rate(sys_host_disk_read_bytes[1m]))", 1<<20)
+
+		getMetricVal := func(query string) (float64, error) {
+			point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
+			if err != nil {
+				return 0, err
 			}
-
-			// Configure cluster settings before workload begins.
-			db := c.Conn(ctx, t.L(), 1)
-			defer db.Close()
-
-			// Work around https://github.com/cockroachdb/cockroach/issues/98311.
-			// TPC-E tables use a 300s GC TTL. When admission control delays
-			// AddSSTable requests beyond this TTL, the GC threshold advances
-			// past the batch timestamp and the request fails.
-			if _, err := db.ExecContext(ctx,
-				"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false",
-			); err != nil {
-				t.Fatal(err)
+			for _, v := range point[""] {
+				return v.Value, nil
 			}
+			return 0, fmt.Errorf("no data for query %s", query)
+		}
 
-			// Optionally tell admission control the disk's provisioned
-			// bandwidth so it can manage elastic vs. foreground work.
-			if withProvisionedBandwidth {
-				if _, err := db.ExecContext(ctx,
-					"SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
-				); err != nil {
-					t.Fatal(err)
+		l.Printf("=== DISK BANDWIDTH METRICS COLLECTION STARTED (1m interval) ===")
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
+		iteration := 0
+		for {
+			select {
+			case <-ticker.C:
+				iteration++
+				writeBW, writeErr := getMetricVal(writeBWQuery)
+				readBW, readErr := getMetricVal(readBWQuery)
+				if writeErr != nil || readErr != nil {
+					l.Printf("[metrics %d] error collecting: write=%v, read=%v",
+						iteration, writeErr, readErr)
+					continue
 				}
-				// Allow elastic work to fully utilize the provisioned
-				// bandwidth.
-				if _, err := db.ExecContext(ctx,
-					"SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
-				); err != nil {
-					t.Fatal(err)
-				}
+				totalBW := writeBW + readBW
+				totalBWSamples = append(totalBWSamples, totalBW)
+				l.Printf("[metrics %d] disk bandwidth: read=%.2f MiB/s, write=%.2f MiB/s, total=%.2f MiB/s",
+					iteration, readBW, writeBW, totalBW)
+			case <-stopMetrics:
+				l.Printf("=== DISK BANDWIDTH METRICS COLLECTION STOPPED ===")
+				return nil
+			case <-ctx.Done():
+				return nil
 			}
+		}
+	}, task.Name("metrics-collector"))
 
-			// Limit disk bandwidth to 128 MiB/s via cgroups so that
-			// disk I/O becomes the bottleneck. Without this, pd-ssd
-			// disks are fast enough that admission control has nothing
-			// meaningful to manage.
-			t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups",
-				indexBackfillDiskBandwidth))
-			staller := roachtestutil.MakeCgroupDiskStaller(t, c,
-				true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
-			staller.Setup(ctx)
-			staller.Slow(ctx, c.CRDBNodes(), indexBackfillDiskBandwidth)
-		},
-		customers:        100_000,
-		activeCustomers:  20_000,
-		threads:          400,
-		skipCleanup:      true,
-		ssds:             1,
-		setupType:        usingExistingTPCEData,
-		nodes:            clusterSpec.NodeCount - 1,
-		cpus:             clusterSpec.CPUs,
-		prometheusConfig: promCfg,
-		workloadDuration: time.Hour + 30*time.Minute,
-		during: func(ctx context.Context) error {
-			t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
-			time.Sleep(5 * time.Minute)
+	// Wait for workload and schema changes, then stop metrics collection.
+	g.Wait()
+	close(stopMetrics)
+	<-metricsDone
 
-			db := c.Conn(ctx, t.L(), 1)
-			defer db.Close()
+	t.L().Printf("index backfill duration: %s", backfillDuration)
+	t.L().Printf("primary key change duration: %s", pkChangeDuration)
 
-			// Choose index creations and primary key changes that would
-			// take ~30 minutes each. Offset them by 5 minutes.
-			//
-			// TODO(irfansharif): These now take closer to an hour after
-			// https://github.com/cockroachdb/cockroach/pull/109085. Do
-			// something about it if customers complain.
-			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-			m.Go(func(ctx context.Context) error {
-				t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
-				_, err := db.ExecContext(ctx,
-					fmt.Sprintf("CREATE INDEX index_%s ON tpce.cash_transaction (ct_dts)",
-						timeutil.Now().Format("20060102_T150405"),
-					),
-				)
-				t.Status("finished index creation")
-				return err
-			})
-			m.Go(func(ctx context.Context) error {
-				// TODO(irfansharif): Is the re-entrant? As in,
-				// effective when re-running the roachtest against the
-				// same cluster that's already run the test once? Useful
-				// to make it so if possible, to run things more
-				// iteratively.
-				time.Sleep(5 * time.Minute)
-				t.Status(fmt.Sprintf("starting primary key change (<%s)", 30*time.Minute))
-				_, err := db.ExecContext(ctx,
-					"ALTER TABLE tpce.holding_history ALTER PRIMARY KEY USING COLUMNS (hh_h_t_id ASC, hh_t_id ASC, hh_before_qty ASC)",
-				)
-				t.Status("finished primary key change")
-				return err
-			})
-			m.Wait()
+	// Compute mean total bandwidth from the samples collected during
+	// schema changes.
+	var avgTotalBW float64
+	if len(totalBWSamples) > 0 {
+		var sum float64
+		for _, s := range totalBWSamples {
+			sum += s
+		}
+		avgTotalBW = sum / float64(len(totalBWSamples))
+		t.L().Printf("average total disk bandwidth during schema changes: %.2f MiB/s (%d samples)",
+			avgTotalBW, len(totalBWSamples))
+	}
 
-			t.Status(fmt.Sprintf("waiting for workload to finish (<%s)", 50*time.Minute))
-			return nil
-		},
-	})
+	// Export metrics to roachperf.
+	if !metricsStart.IsZero() && !metricsEnd.IsZero() {
+		_, err := statCollector.Exporter().Export(
+			ctx, c, t, false, /* dryRun */
+			metricsStart, metricsEnd,
+			[]clusterstats.AggQuery{},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return &roachtestutil.AggregatedMetric{
+					Name:           "index_backfill_duration",
+					Value:          roachtestutil.MetricPoint(backfillDuration.Seconds()),
+					Unit:           "s",
+					IsHigherBetter: false,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return &roachtestutil.AggregatedMetric{
+					Name:           "primary_key_change_duration",
+					Value:          roachtestutil.MetricPoint(pkChangeDuration.Seconds()),
+					Unit:           "s",
+					IsHigherBetter: false,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				if avgTotalBW == 0 {
+					return nil
+				}
+				return &roachtestutil.AggregatedMetric{
+					Name:           "mean_total_bandwidth",
+					Value:          roachtestutil.MetricPoint(avgTotalBW),
+					Unit:           "MiB/s",
+					IsHigherBetter: true,
+				}
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Status("test completed successfully")
 }

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -8,7 +8,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -537,125 +536,9 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		}
 		t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), t.SnapshotPrefix())
 	} else {
-		// Existing snapshots found - copy data from snapshot to local disk.
-		// We use a different approach than ApplySnapshots to avoid the GCE
-		// snapshot hydration problem where reads from a snapshot-based disk
-		// are very slow (~50 MB/s with 250ms latency) until fully hydrated.
-		//
-		// Instead, we:
-		// 1. Create a temporary disk from the snapshot
-		// 2. Attach it as a secondary disk
-		// 3. Copy files to the primary (non-snapshot) disk
-		// 4. Detach and delete the temporary disk
-		//
-		// This way, reads and writes to the primary disk are fast, and we
-		// only pay the slow snapshot read cost once during the copy.
-		t.L().Printf("=== FOUND %d EXISTING SNAPSHOT(S) with prefix %q ===", len(snapshots), t.SnapshotPrefix())
-		t.L().Printf("=== WILL COPY DATA FROM SNAPSHOT (avoiding hydration problem) ===")
-
-		// Find the snapshot for the CRDB node (node 1).
-		var crdbSnapshot vm.VolumeSnapshot
-		for _, snap := range snapshots {
-			// Snapshot names end with node number, e.g., "...-n2-0001"
-			if strings.HasSuffix(snap.Name, "-0001") {
-				crdbSnapshot = snap
-				break
-			}
-		}
-		if crdbSnapshot.ID == "" {
-			t.Fatal("could not find snapshot for CRDB node (node 1)")
-		}
-		t.L().Printf("Using snapshot %s (ID: %s)", crdbSnapshot.Name, crdbSnapshot.ID)
-
-		// Get the zone once from GCE metadata and validate it.
-		// This is more robust than repeating the metadata call for each gcloud command.
-		t.Status("getting GCE zone from instance metadata")
-		getZoneCmd := `curl -sf -H "Metadata-Flavor: Google" ` +
-			`http://metadata.google.internal/computeMetadata/v1/instance/zone`
-		zoneOutput, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.CRDBNodes()), getZoneCmd)
-		if err != nil {
-			t.Fatalf("failed to get zone from GCE metadata: %v", err)
-		}
-		// Zone format: projects/PROJECT_NUMBER/zones/ZONE_NAME
-		zoneParts := strings.Split(strings.TrimSpace(zoneOutput.Stdout), "/")
-		if len(zoneParts) < 4 || zoneParts[len(zoneParts)-2] != "zones" {
-			t.Fatalf("unexpected zone format from metadata: %q", zoneOutput.Stdout)
-		}
-		zone := zoneParts[len(zoneParts)-1]
-		t.L().Printf("GCE zone: %s", zone)
-
-		// Create a temporary disk from the snapshot.
-		tempDiskName := fmt.Sprintf("%s-temp-snapshot", c.Name())
-		t.Status("creating temporary disk from snapshot")
-		t.L().Printf("=== CREATING TEMP DISK %s FROM SNAPSHOT ===", tempDiskName)
-
-		createDiskCmd := fmt.Sprintf(
-			`gcloud compute disks create %s --source-snapshot=%s --zone=%s --type=pd-ssd --quiet`,
-			tempDiskName, crdbSnapshot.ID, zone)
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), createDiskCmd); err != nil {
-			t.Fatalf("failed to create disk from snapshot: %v", err)
-		}
-
-		// Attach the temporary disk to the CRDB node.
-		t.Status("attaching temporary snapshot disk")
-		t.L().Printf("=== ATTACHING TEMP DISK ===")
-		attachCmd := fmt.Sprintf(
-			`gcloud compute instances attach-disk $(hostname) --disk=%s --zone=%s --device-name=snapshot-disk --quiet`,
-			tempDiskName, zone)
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), attachCmd); err != nil {
-			t.Fatalf("failed to attach snapshot disk: %v", err)
-		}
-
-		// Mount the temporary disk.
-		t.Status("mounting snapshot disk")
-		t.L().Printf("=== MOUNTING SNAPSHOT DISK ===")
-		mountCmd := `sudo mkdir -p /mnt/snapshot && ` +
-			`sudo mount -o ro /dev/disk/by-id/google-snapshot-disk /mnt/snapshot`
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), mountCmd); err != nil {
-			t.Fatalf("failed to mount snapshot disk: %v", err)
-		}
-
-		// Wipe existing data and copy from snapshot with progress indicator.
-		// Using rsync -ah --progress to show progress during copy.
-		t.Status("copying data from snapshot to local disk")
-		t.L().Printf("=== COPYING DATA FROM SNAPSHOT (this may take a few minutes) ===")
-		copyCmd := `echo "Source data size:" && du -sh /mnt/snapshot/cockroach && ` +
-			`echo "Wiping /mnt/data1/cockroach..." && ` +
-			`sudo rm -rf /mnt/data1/cockroach && ` +
-			`echo "Starting copy with rsync..." && ` +
-			`sudo rsync -ah --info=progress2 /mnt/snapshot/cockroach /mnt/data1/ && ` +
-			`echo "Copy complete. Final size:" && ` +
-			`du -sh /mnt/data1/cockroach`
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), copyCmd); err != nil {
-			t.Fatalf("failed to copy data from snapshot: %v", err)
-		}
-		t.L().Printf("=== DATA COPY COMPLETE ===")
-
-		// Unmount and detach the temporary disk.
-		t.Status("cleaning up temporary snapshot disk")
-		t.L().Printf("=== UNMOUNTING AND DETACHING TEMP DISK ===")
-		unmountCmd := `sudo umount /mnt/snapshot && sudo rmdir /mnt/snapshot`
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), unmountCmd); err != nil {
-			t.L().Printf("Warning: failed to unmount snapshot disk: %v", err)
-		}
-
-		detachCmd := fmt.Sprintf(
-			`gcloud compute instances detach-disk $(hostname) --disk=%s --zone=%s --quiet`,
-			tempDiskName, zone)
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), detachCmd); err != nil {
-			t.L().Printf("Warning: failed to detach snapshot disk: %v", err)
-		}
-
-		// Delete the temporary disk.
-		t.L().Printf("=== DELETING TEMP DISK ===")
-		deleteCmd := fmt.Sprintf(
-			`gcloud compute disks delete %s --zone=%s --quiet`,
-			tempDiskName, zone)
-		if err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), deleteCmd); err != nil {
-			t.L().Printf("Warning: failed to delete temporary disk: %v", err)
-		}
-
-		t.L().Printf("=== SNAPSHOT DATA SUCCESSFULLY COPIED TO LOCAL DISK ===")
+		t.L().Printf("found %d existing snapshot(s) with prefix %q",
+			len(snapshots), t.SnapshotPrefix())
+		roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
 	}
 }
 


### PR DESCRIPTION
## Summary

Repurpose the multi-node `admission-control/index-backfill` roachtest to
properly test disk bandwidth admission control by:

1. **Extract snapshot copy helper** (`roachtestutil.CopySnapshotDataToNodes`):
   copies data from GCE snapshots to CRDB nodes via a temporary disk, avoiding
   the GCE snapshot hydration problem where reads from snapshot-backed disks are
   slow (~50 MB/s, 250ms latency) until fully hydrated.

2. **Fix snapshot hydration**: use the new copy helper in the index-backfill
   test and switch from `ManualOnly` to `Nightly`.

3. **Add cgroup disk bandwidth limiting**: limit disk bandwidth to 128 MiB/s
   via cgroups so disk I/O becomes the bottleneck for admission control.

4. **Add provisioned-bandwidth variant**: register two test variants
   (`provisioned-bandwidth=false` and `provisioned-bandwidth=true`) with
   non-overlapping snapshot prefixes. The `true` variant sets
   `kvadmission.store.provisioned_bandwidth` to match the cgroup limit.

5. **Export metrics to roachperf**: replace `runTPCE` with direct workload
   management via `tpceSpec.run()` and `t.NewGroup`. Export index backfill
   duration, primary key change duration, and mean total disk bandwidth.

Epic: CRDB-47073
Fixes: #165330