### PR TITLE
jobs: add DeleteChunkedFile, WriteChunkedProtos, and ReadChunkedProtos helpers

### DIFF
--- a/pkg/jobs/job_info_utils.go
+++ b/pkg/jobs/job_info_utils.go
@@ -43,34 +43,26 @@ func WriteChunkedFileToJobInfo(
 	}
 
 	var chunkCounter int
-	var chunkName string
 	for len(data) > 0 {
 		if chunkCounter > 9999 {
-			return errors.AssertionFailedf("too many chunks for file %s; chunk name will break lexicographic ordering", filename)
+			return errors.AssertionFailedf(
+				"too many chunks for file %s; chunk name will break lexicographic ordering", filename,
+			)
 		}
-		chunkSize := bundleChunkSize
 		chunk := data
-		if len(chunk) > chunkSize {
-			chunkName = fmt.Sprintf("%s#%04d", filename, chunkCounter)
-			chunk = chunk[:chunkSize]
-		} else {
-			// This is the last chunk we will write, assign it a sentinel file name.
-			chunkName = finalChunkName
+		if len(chunk) > bundleChunkSize {
+			chunk = chunk[:bundleChunkSize]
 		}
 		data = data[len(chunk):]
-		var err error
-		chunk, err = compressChunk(chunk)
-		if err != nil {
-			return errors.Wrapf(err, "failed to compress chunk for file %s", filename)
-		}
 
-		// On listing we want the info_key of each chunk to sort after the
-		// previous chunk of the same file so that the chunks can be reassembled
-		// on download. For this reason we use a monotonically increasing
-		// chunk counter as the suffix.
-		err = jobInfo.Write(ctx, chunkName, chunk)
-		if err != nil {
-			return errors.Wrapf(err, "failed to write chunk for file %s", filename)
+		// Determine the chunk index: use -1 for the final chunk so that
+		// writeCompressedChunk assigns the sentinel #_final suffix.
+		chunkIndex := chunkCounter
+		if len(data) == 0 {
+			chunkIndex = -1
+		}
+		if err := writeCompressedChunk(ctx, jobInfo, filename, chunkIndex, chunk); err != nil {
+			return err
 		}
 		chunkCounter++
 	}
@@ -153,4 +145,137 @@ func (i InfoStorage) GetProto(
 		return false, errors.Wrap(err, "failed to unmarshal proto")
 	}
 	return true, nil
+}
+
+// DeleteChunkedFile deletes all chunks associated with the given filename from
+// the job_info table. Chunks are stored with info keys in [filename,
+// filename#_final~), and this function removes all of them.
+func DeleteChunkedFile(
+	ctx context.Context, filename string, txn isql.Txn, jobID jobspb.JobID,
+) error {
+	finalChunkName := filename + finalChunkSuffix
+	return InfoStorageForJob(txn, jobID).DeleteRange(
+		ctx, filename, finalChunkName+"~", 0,
+	)
+}
+
+// WriteChunkedProtos marshals a slice of protobuf messages and writes them as
+// a chunked file to the job_info table. Each entry is stored with a 4-byte
+// big-endian length prefix followed by its marshaled bytes. Chunks are flushed
+// to the job_info table as they fill up, so only one chunk's worth of
+// marshaled data is buffered in memory at a time. Chunk boundaries are always
+// aligned to proto entry boundaries, so each chunk can be independently
+// decompressed and parsed by ReadChunkedProtos.
+func WriteChunkedProtos[T any, PT interface {
+	*T
+	protoutil.Message
+}](ctx context.Context, filename string, msgs []T, txn isql.Txn, jobID jobspb.JobID) error {
+	if err := DeleteChunkedFile(ctx, filename, txn, jobID); err != nil {
+		return err
+	}
+	jobInfo := InfoStorageForJob(txn, jobID)
+	var buf bytes.Buffer
+	var chunkCounter int
+	for i := range msgs {
+		data, err := protoutil.Marshal(PT(&msgs[i]))
+		if err != nil {
+			return errors.Wrap(err, "marshaling proto entry")
+		}
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(data)))
+		buf.Write(lenBuf[:])
+		buf.Write(data)
+		if buf.Len() >= bundleChunkSize {
+			if err := writeCompressedChunk(ctx, jobInfo, filename, chunkCounter, buf.Bytes()); err != nil {
+				return err
+			}
+			buf.Reset()
+			chunkCounter++
+			if chunkCounter > 9999 {
+				return errors.AssertionFailedf(
+					"too many chunks for file %s; chunk name will break lexicographic ordering", filename,
+				)
+			}
+		}
+	}
+	// Write the final chunk (may be empty if all protos fit evenly into
+	// previous chunks, but we always write a final chunk so the reader can
+	// verify completeness).
+	return writeCompressedChunk(ctx, jobInfo, filename, -1 /* final */, buf.Bytes())
+}
+
+// writeCompressedChunk gzip-compresses data and writes it as a single chunk.
+// A chunkIndex of -1 indicates the final chunk.
+func writeCompressedChunk(
+	ctx context.Context, jobInfo InfoStorage, filename string, chunkIndex int, data []byte,
+) error {
+	var chunkName string
+	if chunkIndex < 0 {
+		chunkName = filename + finalChunkSuffix
+	} else {
+		chunkName = fmt.Sprintf("%s#%04d", filename, chunkIndex)
+	}
+	compressed, err := compressChunk(data)
+	if err != nil {
+		return errors.Wrapf(err, "compressing chunk for file %s", filename)
+	}
+	return jobInfo.Write(ctx, chunkName, compressed)
+}
+
+// ReadChunkedProtos reads length-prefixed proto entries from a chunked file in
+// the job_info table into the provided slice. Each chunk is independently
+// decompressed and its entries are parsed one at a time, so only one chunk's
+// worth of serialized data is in memory at a time. Returns true if any entries
+// were found.
+//
+// T is the concrete proto type (e.g. jobspb.BulkSSTManifest) and PT is its
+// pointer type which must implement protoutil.Message.
+func ReadChunkedProtos[T any, PT interface {
+	*T
+	protoutil.Message
+}](ctx context.Context, filename string, txn isql.Txn, jobID jobspb.JobID, out *[]T) (bool, error) {
+	jobInfo := InfoStorageForJob(txn, jobID)
+	var lastInfoKey string
+	var found bool
+	if err := jobInfo.Iterate(ctx, filename,
+		func(infoKey string, value []byte) error {
+			lastInfoKey = infoKey
+			r, err := gzip.NewReader(bytes.NewBuffer(value))
+			if err != nil {
+				return err
+			}
+			data, err := io.ReadAll(r)
+			if err != nil {
+				return err
+			}
+			for len(data) > 0 {
+				if len(data) < 4 {
+					return errors.New("truncated length prefix in chunked protos")
+				}
+				n := binary.BigEndian.Uint32(data[:4])
+				data = data[4:]
+				if uint32(len(data)) < n {
+					return errors.Newf(
+						"truncated proto entry: expected %d bytes, got %d", n, len(data),
+					)
+				}
+				var msg T
+				if err := protoutil.Unmarshal(data[:n], PT(&msg)); err != nil {
+					return errors.Wrap(err, "unmarshaling proto entry")
+				}
+				*out = append(*out, msg)
+				found = true
+				data = data[n:]
+			}
+			return nil
+		}); err != nil {
+		return false, errors.Wrapf(err, "reading chunked protos for file %s", filename)
+	}
+	if found && !strings.Contains(lastInfoKey, finalChunkSuffix) {
+		return false, errors.AssertionFailedf(
+			"failed to read all chunks for file %s, last info key read was %s",
+			filename, lastInfoKey,
+		)
+	}
+	return found, nil
 }

--- a/pkg/jobs/job_info_utils_test.go
+++ b/pkg/jobs/job_info_utils_test.go
@@ -78,6 +78,171 @@ func TestReadWriteChunkedFileToJobInfo(t *testing.T) {
 	}
 }
 
+func TestDeleteChunkedFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	params.Knobs.JobsTestingKnobs = NewTestingKnobsWithShortIntervals()
+	s := serverutils.StartServerOnly(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	db := s.InternalDB().(isql.DB)
+	jobID := jobspb.JobID(456)
+
+	require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		data := []byte("test data for deletion")
+		if err := WriteChunkedFileToJobInfo(ctx, "delete-test", data, txn, jobID); err != nil {
+			return err
+		}
+		if err := DeleteChunkedFile(ctx, "delete-test", txn, jobID); err != nil {
+			return err
+		}
+		got, err := ReadChunkedFileToJobInfo(ctx, "delete-test", txn, jobID)
+		if err != nil {
+			return err
+		}
+		require.Empty(t, got)
+		return nil
+	}))
+}
+
+func TestReadWriteChunkedProtos(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rng, _ := randutil.NewTestRand()
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	params.Knobs.JobsTestingKnobs = NewTestingKnobsWithShortIntervals()
+	s := serverutils.StartServerOnly(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	db := s.InternalDB().(isql.DB)
+	jobID := jobspb.JobID(789)
+
+	t.Run("write and read multiple protos", func(t *testing.T) {
+		msgs := []jobspb.Payload{
+			{Description: "first"},
+			{Description: "second"},
+			{Description: "third"},
+		}
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return WriteChunkedProtos(ctx, "test-protos", msgs, txn, jobID)
+		}))
+
+		var got []jobspb.Payload
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProtos(ctx, "test-protos", txn, jobID, &got)
+			require.NoError(t, err)
+			require.True(t, found)
+			return nil
+		}))
+		require.Len(t, got, 3)
+		require.Equal(t, "first", got[0].Description)
+		require.Equal(t, "second", got[1].Description)
+		require.Equal(t, "third", got[2].Description)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return WriteChunkedProtos(
+				ctx, "test-empty", []jobspb.Payload{}, txn, jobID,
+			)
+		}))
+
+		var got []jobspb.Payload
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProtos(ctx, "test-empty", txn, jobID, &got)
+			require.NoError(t, err)
+			require.False(t, found)
+			return nil
+		}))
+		require.Empty(t, got)
+	})
+
+	t.Run("read nonexistent", func(t *testing.T) {
+		var got []jobspb.Payload
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProtos(ctx, "nonexistent", txn, jobID, &got)
+			require.NoError(t, err)
+			require.False(t, found)
+			return nil
+		}))
+		require.Empty(t, got)
+	})
+
+	// Test that protos spanning multiple chunks are written and read correctly,
+	// and that overwriting with a different number of chunks cleans up properly.
+	t.Run("multi-chunk round trip and overwrite", func(t *testing.T) {
+		// Each proto is ~100KB when marshaled, so 15 protos is ~1.5 MiB which
+		// spans at least 2 chunks.
+		makeProtos := func(n int) []jobspb.Payload {
+			msgs := make([]jobspb.Payload, n)
+			for i := range msgs {
+				desc := make([]byte, 100*1024)
+				randutil.ReadTestdataBytes(rng, desc)
+				msgs[i] = jobspb.Payload{Description: string(desc)}
+			}
+			return msgs
+		}
+
+		filename := "test-multi-chunk-protos"
+
+		// Write 15 protos (~1.5 MiB) which should span multiple chunks.
+		msgs := makeProtos(15)
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return WriteChunkedProtos(ctx, filename, msgs, txn, jobID)
+		}))
+		var got []jobspb.Payload
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProtos(ctx, filename, txn, jobID, &got)
+			require.NoError(t, err)
+			require.True(t, found)
+			return nil
+		}))
+		require.Len(t, got, 15)
+		for i, g := range got {
+			require.Equal(t, msgs[i].Description, g.Description)
+		}
+
+		// Overwrite with fewer protos (5, ~500KB, single chunk).
+		msgs2 := makeProtos(5)
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return WriteChunkedProtos(ctx, filename, msgs2, txn, jobID)
+		}))
+		got = nil
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProtos(ctx, filename, txn, jobID, &got)
+			require.NoError(t, err)
+			require.True(t, found)
+			return nil
+		}))
+		require.Len(t, got, 5)
+		for i, g := range got {
+			require.Equal(t, msgs2[i].Description, g.Description)
+		}
+
+		// Overwrite with more protos again (30, ~3 MiB, multiple chunks).
+		msgs3 := makeProtos(30)
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return WriteChunkedProtos(ctx, filename, msgs3, txn, jobID)
+		}))
+		got = nil
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			found, err := ReadChunkedProtos(ctx, filename, txn, jobID, &got)
+			require.NoError(t, err)
+			require.True(t, found)
+			return nil
+		}))
+		require.Len(t, got, 30)
+		for i, g := range got {
+			require.Equal(t, msgs3[i].Description, g.Description)
+		}
+	})
+}
+
 func TestOverwriteChunkingWithVariableLengths(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1061,9 +1061,7 @@ func (r *importResumer) cleanupTempStorage(ctx context.Context, execCfg *sql.Exe
 	// Clean up SST manifest job info keys.
 	besteffort.Warning(ctx, "import-manifest-cleanup", func(ctx context.Context) error {
 		return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-			return jobs.InfoStorageForJob(txn, r.job.ID()).DeleteRange(
-				ctx, importSSTManifestsInfoKey, importSSTManifestsInfoKey+"~", 0,
-			)
+			return jobs.DeleteChunkedFile(ctx, importSSTManifestsInfoKey, txn, r.job.ID())
 		})
 	})
 

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -202,18 +202,13 @@ func distImport(
 		if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
-			data, err := jobs.ReadChunkedFileToJobInfo(
-				ctx, importSSTManifestsInfoKey, txn, job.ID(),
+			found, err := jobs.ReadChunkedProtos(
+				ctx, importSSTManifestsInfoKey, txn, job.ID(), &resumeManifests,
 			)
 			if err != nil {
 				return err
 			}
-			if len(data) > 0 {
-				var stored jobspb.BulkSSTManifests
-				if err := protoutil.Unmarshal(data, &stored); err != nil {
-					return errors.Wrap(err, "unmarshaling SST manifests from job info")
-				}
-				resumeManifests = stored.Manifests
+			if found {
 				processorOutput = append(
 					processorOutput, bulksst.ManifestsToSSTFiles(resumeManifests),
 				)

--- a/pkg/sql/importer/import_progress_tracker.go
+++ b/pkg/sql/importer/import_progress_tracker.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
@@ -86,7 +85,7 @@ type checkpointSnapshot struct {
 	rowProgress       []int64
 	fractionProgress  []float32
 	bulkSummary       kvpb.BulkOpSummary
-	manifestData      []byte
+	manifests         []jobspb.BulkSSTManifest
 	hasDirtyManifests bool
 }
 
@@ -104,15 +103,7 @@ func (t *importCheckpointTracker) snapshot() (checkpointSnapshot, error) {
 
 	snap.hasDirtyManifests = t.manifestBuf != nil && t.manifestBuf.Dirty()
 	if snap.hasDirtyManifests {
-		manifests := t.manifestBuf.SnapshotAndMarkClean()
-		var err error
-		snap.manifestData, err = protoutil.Marshal(
-			&jobspb.BulkSSTManifests{Manifests: manifests},
-		)
-		if err != nil {
-			t.manifestBuf.MarkDirty()
-			return checkpointSnapshot{}, errors.Wrap(err, "marshaling SST manifests")
-		}
+		snap.manifests = t.manifestBuf.SnapshotAndMarkClean()
 	}
 	return snap, nil
 }
@@ -154,9 +145,9 @@ func (t *importCheckpointTracker) Persist(ctx context.Context, job *jobs.Job) er
 		}
 		prog.Summary = snap.bulkSummary
 
-		if len(snap.manifestData) > 0 {
-			if err := jobs.WriteChunkedFileToJobInfo(
-				ctx, importSSTManifestsInfoKey, snap.manifestData, txn, job.ID(),
+		if len(snap.manifests) > 0 {
+			if err := jobs.WriteChunkedProtos(
+				ctx, importSSTManifestsInfoKey, snap.manifests, txn, job.ID(),
 			); err != nil {
 				return errors.Wrap(err, "writing SST manifests to job info")
 			}


### PR DESCRIPTION
Add three new helpers to the jobs package for working with chunked data
in the job_info table:

- DeleteChunkedFile: deletes all chunks associated with a filename.
- WriteChunkedProtos: marshals a slice of protobuf messages with
  length-prefixed framing and writes them as a chunked file, flushing
  each chunk as it fills so only one chunk's worth of data is buffered.
- ReadChunkedProtos: reads length-prefixed proto entries from a chunked
  file, decompressing each chunk independently.

Also refactors WriteChunkedFileToJobInfo to share the new
writeCompressedChunk helper, deduplicating the chunk naming and
compression logic.

Epic: none

Release note: none

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>