### PR TITLE
logical: fix integration with admission control

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -192,6 +192,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/admission",
         "//pkg/util/allstacks",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -170,6 +170,7 @@ go_test(
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/resolver",
+        "//pkg/sql/distsql",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1959,6 +1960,67 @@ func TestFlushErrorHandling(t *testing.T) {
 	require.NoError(t, lrw.handleStreamBuffer(ctx, []streampb.StreamEvent_KV{skv("d")}))
 	require.Equal(t, 1, int(dlq))
 	require.Equal(t, int64(3), lrw.metrics.RetryQueueEvents.Value())
+}
+
+// cpuHandleAssertingSession wraps an isql.Session and asserts that the context
+// carries a SQL CPU handle with AtGateway=false and that the calling goroutine
+// has its handle registered before any SQL execution begins.
+type cpuHandleAssertingSession struct {
+	isql.Session
+	t *testing.T
+}
+
+func (s *cpuHandleAssertingSession) assertHandle(ctx context.Context) {
+	h := admission.SQLCPUHandleFromContext(ctx)
+	if h != nil {
+		require.False(s.t, h.WorkInfo().AtGateway,
+			"LDR CPU handle should have AtGateway=false")
+		require.True(s.t, h.IsGoroutineRegistered(),
+			"goroutine handle should be registered before internal SQL execution")
+	}
+}
+
+func (s *cpuHandleAssertingSession) Txn(ctx context.Context, do func(context.Context) error) error {
+	s.assertHandle(ctx)
+	return s.Session.Txn(ctx, do)
+}
+
+func TestLDRCPUHandle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlock(t)
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	clusterArgs := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(134857),
+			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					SessionWrapper: func(session isql.Session) isql.Session {
+						return &cpuHandleAssertingSession{
+							Session: session,
+							t:       t,
+						}
+					},
+				},
+			},
+		},
+	}
+
+	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, clusterArgs, 1)
+	defer server.Stopper().Stop(ctx)
+
+	dbB.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
+
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
+	var jobAID jobspb.JobID
+	dbA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab",
+		dbBURL.String()).Scan(&jobAID)
+
+	now := s.Clock().Now()
+	WaitUntilReplicatedTime(t, now, dbA, jobAID)
 }
 
 func TestLogicalStreamIngestionJobWithFallbackUDF(t *testing.T) {

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -36,12 +36,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
@@ -1905,12 +1907,26 @@ func (m *mockDLQ) Log(
 func TestFlushErrorHandling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderDeadlock(t)
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
+
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
+
 	dlq := mockDLQ(0)
 	lrw := &logicalReplicationWriterProcessor{
 		metrics:   MakeMetrics(0).(*Metrics),
 		dlqClient: &dlq,
+	}
+	writerWorkers.Override(ctx, &serverCfg.Settings.SV, 1)
+	lrw.FlowCtx = &execinfra.FlowCtx{
+		Cfg: &serverCfg,
+		EvalCtx: &eval.Context{
+			Codec: s.Codec(),
+		},
 	}
 	lrw.purgatory.flush = lrw.flushBuffer
 	lrw.purgatory.bytesGauge = lrw.metrics.RetryQueueBytes

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -848,11 +849,28 @@ func (lrw *logicalReplicationWriterProcessor) flushBuffer(
 	// rather than starting new ones for each flush.
 	chunks := make(chan []streampb.StreamEvent_KV)
 
+	// The LDR processor is running inside of a distsql flow and this
+	// goroutine will be executing SQL inside that flow. By default, the flow
+	// has a CPU handle that has `AtGateway: false`. This is an issue because
+	// the multi metric allocator assumes non-gateway sql cpu usage will
+	// follow the leaseholder when the leaseholder moves. LDR work is
+	// not collocated with leaseholders in the destination cluster.
+	handle := lrw.FlowCtx.Cfg.SQLCPUProvider.GetHandle(admission.SQLWorkInfo{
+		AtGateway:  false,
+		TenantID:   lrw.FlowCtx.Codec().TenantID,
+		Priority:   admissionpb.LowPri,
+		CreateTime: timeutil.Now().UnixNano(),
+	})
+	defer handle.Close()
+
+	ctx = admission.ContextWithSQLCPUHandle(ctx, handle)
 	g := ctxgroup.WithContext(ctx)
 	for worker := range lrw.bh[:requiredWorkers] {
 		w := worker
 		lrw.bhStats[w] = flushStats{}
 		g.GoCtx(func(ctx context.Context) error {
+			defer handle.RegisterGoroutine().Close(ctx)
+
 			for chunk := range chunks {
 				s, err := lrw.flushChunk(ctx, lrw.bh[w], chunk, canRetry)
 				if err != nil {

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -641,6 +641,11 @@ func (lrw *logicalReplicationWriterProcessor) handleStreamBuffer(
 	ctx context.Context, kvs []streampb.StreamEvent_KV,
 ) error {
 	const notRetry = false
+
+	if err := lrw.setupBatchHandlers(ctx); err != nil {
+		return err
+	}
+
 	unapplied, unappliedBytes, err := lrw.flushBuffer(ctx, kvs, notRetry, lrw.purgatory.Enabled())
 	if err != nil {
 		return err
@@ -670,10 +675,6 @@ func filterRemaining(kvs []streampb.StreamEvent_KV) []streampb.StreamEvent_KV {
 }
 
 func (lrw *logicalReplicationWriterProcessor) setupBatchHandlers(ctx context.Context) error {
-	if lrw.FlowCtx == nil {
-		return nil
-	}
-
 	poolSize := writerWorkers.Get(&lrw.FlowCtx.Cfg.Settings.SV)
 
 	if len(lrw.bh) >= int(poolSize) {
@@ -770,10 +771,6 @@ func (lrw *logicalReplicationWriterProcessor) flushBuffer(
 		return nil, 0, nil
 	}
 
-	if err := lrw.setupBatchHandlers(ctx); err != nil {
-		return kvs, int64(len(kvs)), err
-	}
-
 	preFlushTime := timeutil.Now()
 
 	// Inform the debugging helper that a flush is starting and configure failure
@@ -836,10 +833,7 @@ func (lrw *logicalReplicationWriterProcessor) flushBuffer(
 	// if it takes longer to process some keys in a chunk, the other 3/4 can be
 	// stolen by other workers. That said, we don't want tiny chunks that are more
 	// channel overhead than work, nor giant chunks, so bound it by the settings.
-	minChunk, maxChunk := minChunkSize.Default(), maxChunkSize.Default()
-	if lrw.FlowCtx != nil {
-		minChunk, maxChunk = minChunkSize.Get(&lrw.FlowCtx.Cfg.Settings.SV), maxChunkSize.Get(&lrw.FlowCtx.Cfg.Settings.SV)
-	}
+	minChunk, maxChunk := minChunkSize.Get(&lrw.FlowCtx.Cfg.Settings.SV), maxChunkSize.Get(&lrw.FlowCtx.Cfg.Settings.SV)
 	chunkSize := min(max(len(kvs)/(len(lrw.bh)*4), int(minChunk)), int(maxChunk))
 
 	// Figure out how many workers we can utilize from the pool for the number of
@@ -994,18 +988,16 @@ func (lrw *logicalReplicationWriterProcessor) flushChunk(
 		chunk = chunk[len(batch):]
 
 		// Make sure we're not ingesting events with origin TS in the future.
-		if lrw.FlowCtx != nil { // Some unit tests don't set this and that's fine.
-			hlcNow := lrw.FlowCtx.Cfg.DB.KV().Clock().Now()
-			logClock := true
-			for _, kv := range batch {
-				if ts := kv.KeyValue.Value.Timestamp; ts.After(hlcNow) {
-					if logClock || log.V(1) {
-						log.Dev.Warningf(ctx, "event timestamp %s is ahead of local clock %s; delaying batch...", ts, hlcNow)
-						logClock = false
-					}
-					if err := lrw.FlowCtx.Cfg.DB.KV().Clock().SleepUntil(ctx, ts); err != nil {
-						return flushStats{}, err
-					}
+		hlcNow := lrw.FlowCtx.Cfg.DB.KV().Clock().Now()
+		logClock := true
+		for _, kv := range batch {
+			if ts := kv.KeyValue.Value.Timestamp; ts.After(hlcNow) {
+				if logClock || log.V(1) {
+					log.Dev.Warningf(ctx, "event timestamp %s is ahead of local clock %s; delaying batch...", ts, hlcNow)
+					logClock = false
+				}
+				if err := lrw.FlowCtx.Cfg.DB.KV().Clock().SleepUntil(ctx, ts); err != nil {
+					return flushStats{}, err
 				}
 			}
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2163,6 +2163,11 @@ type ExecutorTestingKnobs struct {
 	// BeforeIndexSplitAndScatter is invoked with the split and scatter of an index
 	// occurs.
 	BeforeIndexSplitAndScatter func(splitPoints [][]byte)
+
+	// SessionWrapper, if set, wraps every isql.Session created by the
+	// internal executor. This can be used in tests to intercept session
+	// method calls like ExecutePrepared.
+	SessionWrapper func(isql.Session) isql.Session
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/internal_session.go
+++ b/pkg/sql/internal_session.go
@@ -150,5 +150,12 @@ func (s *Server) NewInternalSession(
 	csm.config.sd = sd
 	csm.config.appStats = s.localSqlStats.GetApplicationStats(sessionName)
 
-	return ISessionFactoryHook(ctx, csm)
+	session, err := ISessionFactoryHook(ctx, csm)
+	if err != nil {
+		return nil, err
+	}
+	if w := s.cfg.TestingKnobs.SessionWrapper; w != nil {
+		session = w(session)
+	}
+	return session, nil
 }

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -114,6 +114,26 @@ func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
 // https://github.com/cockroachdb/cockroach/pull/161952#pullrequestreview-3741525716
 // on additional integrations that may need to call RegisterGoroutine.
 
+// WorkInfo returns the SQLWorkInfo that was used to create this handle.
+func (h *SQLCPUHandle) WorkInfo() SQLWorkInfo {
+	return h.workInfo
+}
+
+// IsGoroutineRegistered returns true if the calling goroutine already has a
+// registered handle. Unlike RegisterGoroutine, this does not create a new
+// handle as a side effect.
+func (h *SQLCPUHandle) IsGoroutineRegistered() bool {
+	gid := goid.Get()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, gh := range h.mu.gHandles {
+		if gh.gid == gid {
+			return true
+		}
+	}
+	return false
+}
+
 // RegisterGoroutine returns a GoroutineCPUHandle to use for reporting and
 // admission. If the goroutine was already registered, the existing handle
 // will be returned. CPU time is accounted for at this goroutine from the


### PR DESCRIPTION
## logical: fix integration with admission control
PR https://github.com/cockroachdb/cockroach/pull/161952 added sql cpu accounting. This doesn't play well with LDR
because we are executing a lot of SQL statements inside of a distsql
flow. This breaks two of the invariants expected by https://github.com/cockroachdb/cockroach/pull/161952:

1. SQL execution is inside of a distsql flow context, but the
   workload doesn't actually follow the leaseholder. It should be
   treated as "gateway" cpu load.
2. The isession is a connExecutor instance that is not tied to any
   particular goroutine. As a result, the CancelChecker is leaking the
   goroutine handle it requests.

Fix this by creating a dedicated CPU handle per flush worker goroutine
with AtGateway=false and LowPri, and registering the goroutine before
executing SQL. Add a SessionWrapper testing knob and TestLDRCPUHandle
to validate the handle properties.

Release note: none
Fixes: https://github.com/cockroachdb/cockroach/issues/164737
Fixes: https://github.com/cockroachdb/cockroach/issues/163603

### logical: update TestFlushErrorHandling to use a real FlowCtx

TestFlushErrorHandling previously ran with a nil FlowCtx, which required
defensive nil checks scattered throughout the writer processor. Update
the test to start a test server and wire up a real FlowCtx/ServerConfig
so those nil guards can be removed.

Release note: none
Epic: none