### PR TITLE
sql,stats,server: backend for canary vs stable charts in statement details

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4725,6 +4725,8 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 | aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 | plan_hash | [uint64](#cockroach.server.serverpb.StatementDetailsResponse-uint64) |  |  | [reserved](#support-status) |
 | plan_gist | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  |  | [reserved](#support-status) |
+| canary_execution_count | [int64](#cockroach.server.serverpb.StatementDetailsResponse-int64) |  | canary_execution_count is the number of executions that used canary (newest) table statistics during the canary experiment. | [reserved](#support-status) |
+| stable_execution_count | [int64](#cockroach.server.serverpb.StatementDetailsResponse-int64) |  | stable_execution_count is the number of executions that used stable (second-newest) table statistics while the canary experiment was active. This is tracked explicitly rather than derived from execution_count - canary_execution_count, because executions where the canary experiment is off should not count as stable. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1880,6 +1880,15 @@ message StatementDetailsResponse {
     google.protobuf.Timestamp aggregated_ts = 2 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
     uint64 plan_hash = 3;
     string plan_gist = 4;
+    // canary_execution_count is the number of executions that used canary
+    // (newest) table statistics during the canary experiment.
+    int64 canary_execution_count = 5;
+    // stable_execution_count is the number of executions that used stable
+    // (second-newest) table statistics while the canary experiment was
+    // active. This is tracked explicitly rather than derived from
+    // execution_count - canary_execution_count, because executions where
+    // the canary experiment is off should not count as stable.
+    int64 stable_execution_count = 6;
   }
 
   // statement returns the total statistics for the statement.

--- a/pkg/server/statement_details.go
+++ b/pkg/server/statement_details.go
@@ -665,13 +665,15 @@ LIMIT $%d`, rb.mergeAggStmtMetadataColExpr, rb.whereClause, len(args)), args...)
 func (rb *statementDetailsRespBuilder) getStatementDetailsPerAggregatedTsAndPlanHash(
 	ctx context.Context,
 ) ([]serverpb.StatementDetailsResponse_StatementPlanDistribution, error) {
-	const expectedNumDatums = 4
+	const expectedNumDatums = 6
 	const queryFormat = `
 SELECT
     COALESCE(sum((statistics -> 'statistics' ->> 'cnt')::INT8), 0)::INT8 AS execution_count,
     aggregated_ts,
     plan_hash,
-    (statistics -> 'statistics' -> 'planGists' ->> 0) AS plan_gist
+    (statistics -> 'statistics' -> 'planGists' ->> 0) AS plan_gist,
+    COALESCE(sum((statistics -> 'statistics' -> 'canaryStats' ->> 'count')::INT8), 0)::INT8 AS canary_execution_count,
+    COALESCE(sum((statistics -> 'statistics' -> 'stableStats' ->> 'count')::INT8), 0)::INT8 AS stable_execution_count
 FROM %s %s
 GROUP BY
     aggregated_ts,
@@ -752,11 +754,16 @@ LIMIT $%d`
 			planGist = string(tree.MustBeDString(row[3]))
 		}
 
+		canaryExecutionCount := int64(tree.MustBeDInt(row[4]))
+		stableExecutionCount := int64(tree.MustBeDInt(row[5]))
+
 		stmt := serverpb.StatementDetailsResponse_StatementPlanDistribution{
-			ExecutionCount: executionCount,
-			AggregatedTs:   aggregatedTs,
-			PlanHash:       planHash,
-			PlanGist:       planGist,
+			ExecutionCount:       executionCount,
+			AggregatedTs:         aggregatedTs,
+			PlanHash:             planHash,
+			PlanGist:             planGist,
+			CanaryExecutionCount: canaryExecutionCount,
+			StableExecutionCount: stableExecutionCount,
 		}
 
 		statements = append(statements, stmt)

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -228,6 +228,9 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.FailureCount += other.FailureCount
 	s.GenericCount += other.GenericCount
 	s.StmtHintsCount += other.StmtHintsCount
+
+	s.CanaryStats.Add(other.CanaryStats)
+	s.StableStats.Add(other.StableStats)
 }
 
 // AlmostEqual compares two StatementStatistics and their contained NumericStats
@@ -246,10 +249,30 @@ func (s *StatementStatistics) AlmostEqual(other *StatementStatistics, eps float6
 		s.SensitiveInfo.Equal(other.SensitiveInfo) &&
 		s.BytesRead.AlmostEqual(other.BytesRead, eps) &&
 		s.RowsRead.AlmostEqual(other.RowsRead, eps) &&
-		s.RowsWritten.AlmostEqual(other.RowsWritten, eps)
+		s.RowsWritten.AlmostEqual(other.RowsWritten, eps) &&
+		s.CanaryStats.AlmostEqual(other.CanaryStats, eps) &&
+		s.StableStats.AlmostEqual(other.StableStats, eps)
 	// s.ExecStats are deliberately ignored since they are subject to sampling
 	// probability and are not fully deterministic (e.g. the number of network
 	// messages depends on the range cache state).
+}
+
+// Add combines other into this ExperimentStatsInfo.
+func (e *ExperimentStatsInfo) Add(other ExperimentStatsInfo) {
+	statsCount := e.Count
+	if statsCount == 0 && other.Count == 0 {
+		statsCount = 1
+	}
+	e.RunLat.Add(other.RunLat, statsCount, other.Count)
+	e.PlanLat.Add(other.PlanLat, statsCount, other.Count)
+	e.Count += other.Count
+}
+
+// AlmostEqual compares two ExperimentStatsInfo within a window of size eps.
+func (e *ExperimentStatsInfo) AlmostEqual(other ExperimentStatsInfo, eps float64) bool {
+	return e.Count == other.Count &&
+		e.RunLat.AlmostEqual(other.RunLat, eps) &&
+		e.PlanLat.AlmostEqual(other.PlanLat, eps)
 }
 
 // Add combines other into this ExecStats.

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -147,6 +147,19 @@ message StatementStatistics {
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 38 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 
+  // canary_stats tracks execution statistics for the subset of executions
+  // that used canary (newest) table statistics for planning. This is used
+  // to compare performance between canary and stable statistics rollout
+  // paths.
+  optional ExperimentStatsInfo canary_stats = 39 [(gogoproto.nullable) = false];
+
+  // stable_stats tracks execution statistics for the subset of executions
+  // that used stable (second-newest) table statistics while the canary
+  // experiment was active (i.e. sql.stats.canary_fraction > 0). Executions
+  // where the canary experiment is off are neither canary nor stable — they
+  // are unclassified and not counted here.
+  optional ExperimentStatsInfo stable_stats = 40 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;
@@ -200,6 +213,15 @@ message TransactionStatistics {
   optional NumericStat kv_cpu_time_nanos = 12 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 }
 
+
+// ExperimentStatsInfo groups the count and latency statistics for a single
+// bucket of the canary-vs-stable table statistics experiment. Two instances
+// are embedded in StatementStatistics: one for canary and one for stable.
+message ExperimentStatsInfo {
+  optional int64 count = 1 [(gogoproto.nullable) = false];
+  optional NumericStat run_lat = 2 [(gogoproto.nullable) = false];
+  optional NumericStat plan_lat = 3 [(gogoproto.nullable) = false];
+}
 
 message SensitiveInfo {
   option (gogoproto.equal) = true;

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -156,35 +156,31 @@ var detailedLatencyMetrics = settings.RegisterBoolSetting(
 	settings.WithPublic,
 )
 
-// canaryRollDice performs the probabilistic check to determine if a query
-// should use the "canary path" for statistics.
-// This selection is atomic per query, meaning that if a query is chosen to use
-// canary stats, all the tables involved in this query will use canary stats for
-// planning, if applicable.
-// This canary stats decision is made only for non-internal queries.
-func canaryRollDice(evalCtx *eval.Context, rng *rand.Rand) bool {
-	switch m := evalCtx.SessionData().CanaryStatsMode; m {
-	case sessiondatapb.CanaryStatsModeAuto:
-		threshold := stats.CanaryFraction.Get(&evalCtx.Settings.SV)
-		// If the fraction is 0, never use canary stats.
-		if threshold == 0 {
-			return false
-		}
-		// If the fraction is 1, always use canary stats.
-		if threshold == 1 {
-			return true
-		}
-
-		actual := rng.Float64()
-		return actual < threshold
-	case sessiondatapb.CanaryStatsModeOff:
-		return false
-	case sessiondatapb.CanaryStatsModeOn:
-		return true
+// canaryRollDice determines the stats rollout selection for a query.
+// The result is one of:
+//   - StatsRolloutDefault: experiment not active, use default stats.
+//   - StatsRolloutCanary:  experiment active, dice selected canary (newest) stats.
+//   - StatsRolloutStable:  experiment active, dice selected stable (second-newest) stats.
+//
+// The selection is atomic per query — all tables in the query use the same
+// rollout path. Only called for non-internal queries.
+func canaryRollDice(evalCtx *eval.Context, rng *rand.Rand) eval.StatsRolloutSelection {
+	threshold := stats.CanaryFraction.Get(&evalCtx.Settings.SV)
+	if threshold == 0 {
+		return eval.StatsRolloutDefault
 	}
-	// This should not happen but just in case of an unknown mode, we
-	// default to not using canary stats.
-	return false
+	switch m := evalCtx.SessionData().CanaryStatsMode; m {
+	case sessiondatapb.CanaryStatsModeOff:
+		return eval.StatsRolloutStable
+	case sessiondatapb.CanaryStatsModeOn:
+		return eval.StatsRolloutCanary
+	case sessiondatapb.CanaryStatsModeAuto:
+		if rng.Float64() < threshold {
+			return eval.StatsRolloutCanary
+		}
+		return eval.StatsRolloutStable
+	}
+	return eval.StatsRolloutDefault
 }
 
 // The metric label name we'll use to facet latency metrics by statement fingerprint.
@@ -4026,7 +4022,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.SkipNormalize = false
 	evalCtx.SchemaChangerState = ex.extraTxnState.schemaChangerState
 	evalCtx.DescIDGenerator = ex.getDescIDGenerator()
-	evalCtx.UseCanaryStats = false
+	evalCtx.StatsRollout = eval.StatsRolloutDefault
 
 	// See resetPlanner for more context on setting the maximum timestamp for
 	// AOST read retries.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3494,10 +3494,14 @@ func (ex *connExecutor) makeExecPlan(
 		return ctx, err
 	}
 
-	// For each non-internal query, we roll the dice to decide to use
-	// canary stats or stable stats for planning.
+	// For each non-internal query, roll the dice to determine the canary
+	// stats rollout path. The result is one of three states:
+	//   - StatsRolloutDefault: experiment off, use default stats
+	//   - StatsRolloutCanary:  experiment on, use canary (newest) stats
+	//   - StatsRolloutStable:  experiment on, use stable (second-newest) stats
 	if !planner.SessionData().Internal {
-		planner.EvalContext().UseCanaryStats = canaryRollDice(planner.EvalContext(), ex.rng.internal)
+		planner.EvalContext().StatsRollout =
+			canaryRollDice(planner.EvalContext(), ex.rng.internal)
 	}
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -233,6 +233,10 @@ func (ex *connExecutor) recordStatementSummary(
 			b.AppliedStatementHints()
 		}
 
+		if flags.IsSet(planFlagCanaryAndStableStatsDiffer) {
+			b.CanaryStatsRollout(planner.EvalContext().StatsRollout)
+		}
+
 		ex.statsCollector.RecordStatement(ctx, b.Build())
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
@@ -987,5 +987,236 @@ true
 
 subtest end
 
+subtest stats_differ_metrics
+
+# This subtest verifies that canary/stable execution counts are recorded in
+# statement statistics when planFlagCanaryAndStableStatsDiffer is set (i.e.
+# canary and stable stats genuinely diverge within the canary window).
+
+# crdb_internal.cluster_statement_statistics reads from the in-memory
+# stats store. We need to prevent stats from being flushed and cleared
+# from the in-memory store.
+statement ok
+SET CLUSTER SETTING sql.stats.flush.enabled = false
+
+statement ok
+SET optimizer_use_forecasts = off
+
+statement ok
+DROP TABLE IF EXISTS t_metrics;
+
+statement ok
+CREATE TABLE t_metrics (k INT PRIMARY KEY) WITH (sql_stats_canary_window = '3600s');
+
+# Inject two generations of stats so canary != stable within the canary window.
+statement ok
+ALTER TABLE t_metrics INJECT STATISTICS '[
+  {
+    "avg_size": 1,
+    "columns": ["k"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10,
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "avg_size": 1,
+    "columns": ["k"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20,
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 20
+  }
+]'
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = '0.1'
+
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
+# ── Test 1: canary path records canary count ──
+
+# Truncate system.statement_statistics.
+statement ok
+SELECT crdb_internal.reset_sql_stats()
+
+statement ok
+SET canary_stats_mode = on
+
+statement ok
+SELECT * FROM t_metrics
+
+query III retry
+SELECT
+  (statistics->'statistics'->>'cnt')::INT,
+  COALESCE((statistics->'statistics'->'canaryStats'->>'count')::INT, 0),
+  COALESCE((statistics->'statistics'->'stableStats'->>'count')::INT, 0)
+FROM crdb_internal.cluster_statement_statistics
+WHERE metadata->>'query' LIKE 'SELECT * FROM %t_metrics'
+----
+1  1  0
+
+# ── Test 2: stable path records stable count ──
+
+# Truncate system.statement_statistics.
+statement ok
+SELECT crdb_internal.reset_sql_stats()
+
+statement ok
+SET canary_stats_mode = off
+
+statement ok
+SELECT * FROM t_metrics
+
+# "retry" is needed for queries against crdb_internal.cluster_statement_statistics,
+# which is ingested asynchronously via SQLStatsIngester with a 500ms timer.
+query III retry
+SELECT
+  (statistics->'statistics'->>'cnt')::INT,
+  COALESCE((statistics->'statistics'->'canaryStats'->>'count')::INT, 0),
+  COALESCE((statistics->'statistics'->'stableStats'->>'count')::INT, 0)
+FROM crdb_internal.cluster_statement_statistics
+WHERE metadata->>'query' LIKE 'SELECT * FROM %t_metrics'
+----
+1  0  1
+
+# ── Test 3: stats don't differ -> no canary/stable counts ──
+
+# Move stats_as_of past the canary window (latest stats at 00:01:00 + 3600s
+# canary window = 01:01:00) so that the stats have "ripened" and
+# canaryAndStableStatsDiffer returns false.
+statement ok
+SET stats_as_of = '2000-01-01 02:00:00.000000'
+
+# Truncate system.statement_statistics.
+statement ok
+SELECT crdb_internal.reset_sql_stats()
+
+statement ok
+SET canary_stats_mode = on
+
+statement ok
+SELECT * FROM t_metrics
+
+# Both canary and stable counts should be zero since stats_as_of is past
+# the canary window, so canaryAndStableStatsDiffer returns false.
+query III retry
+SELECT
+  (statistics->'statistics'->>'cnt')::INT,
+  COALESCE((statistics->'statistics'->'canaryStats'->>'count')::INT, 0),
+  COALESCE((statistics->'statistics'->'stableStats'->>'count')::INT, 0)
+FROM crdb_internal.cluster_statement_statistics
+WHERE metadata->>'query' LIKE 'SELECT * FROM %t_metrics'
+----
+1  0  0
+
+# ── Test 4: cached memo (prepared statement) preserves the flag ──
+
+# Move stats_as_of back within the canary window.
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
+statement ok
+DEALLOCATE ALL
+
+# Truncate system.statement_statistics.
+statement ok
+SELECT crdb_internal.reset_sql_stats()
+
+# Use stable path so the memo gets cached inside the prepared statement.
+# We only need to test with stable path since the canary path doesn't
+# reuse memo.
+statement ok
+SET canary_stats_mode = off
+
+statement ok
+PREPARE p_metrics AS SELECT * FROM t_metrics
+
+statement ok
+EXECUTE p_metrics
+
+query III retry
+SELECT
+  (statistics->'statistics'->>'cnt')::INT,
+  COALESCE((statistics->'statistics'->'canaryStats'->>'count')::INT, 0),
+  COALESCE((statistics->'statistics'->'stableStats'->>'count')::INT, 0)
+FROM crdb_internal.cluster_statement_statistics
+WHERE metadata->>'query' LIKE 'SELECT * FROM %t_metrics'
+----
+1  0  1
+
+# Truncate system.statement_statistics and execute again — the cached
+# memo should still be marked with statsDiff = true.
+statement ok
+SELECT crdb_internal.reset_sql_stats()
+
+statement ok
+SET TRACING = "on", cluster
+
+statement ok
+EXECUTE p_metrics
+
+statement ok
+SET TRACING = "off"
+
+# Confirm the cached memo was reused.
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%cached memo%'
+----
+reusing cached memo
+
+query III retry
+SELECT
+  (statistics->'statistics'->>'cnt')::INT,
+  COALESCE((statistics->'statistics'->'canaryStats'->>'count')::INT, 0),
+  COALESCE((statistics->'statistics'->'stableStats'->>'count')::INT, 0)
+FROM crdb_internal.cluster_statement_statistics
+WHERE metadata->>'query' LIKE 'SELECT * FROM %t_metrics'
+----
+1  0  1
+
+# Turn off the experiment.
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = '0'
+
+statement ok
+SELECT crdb_internal.reset_sql_stats()
+
+statement ok
+EXECUTE p_metrics
+
+statement ok
+SET TRACING = "off"
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%cached memo%'
+----
+reusing cached memo
+
+# Though the experiment is off _now_, we are executing a prepared statement
+# whose plan was built while the experiment was on, so it's execution
+# statistics still serves as useful datapoint for stable table stats
+# evaluation.
+query III retry
+SELECT
+  (statistics->'statistics'->>'cnt')::INT,
+  COALESCE((statistics->'statistics'->'canaryStats'->>'count')::INT, 0),
+  COALESCE((statistics->'statistics'->'stableStats'->>'count')::INT, 0)
+FROM crdb_internal.cluster_statement_statistics
+WHERE metadata->>'query' LIKE 'SELECT * FROM %t_metrics'
+----
+1  0  0
+
+statement ok
+SET CLUSTER SETTING sql.stats.flush.enabled = true
+
+statement ok
+DEALLOCATE ALL
+
+subtest end
+
 statement ok
 SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecast;

--- a/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
@@ -315,6 +315,10 @@ subtest end
 
 subtest simple_auto_stats_collection
 
+# Set sql.stats.canary_fraction to be non-zero so that we're in "experiment on" mode.
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='0.1';
+
 statement ok
 SET optimizer_use_forecasts = off
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -699,7 +699,8 @@ func (oc *optCatalog) dataSourceForTable(
 		var statsCanaryWindow time.Duration
 		var statsAsOf hlc.Timestamp
 		if desc.TableDesc() != nil && oc.planner != nil && oc.planner.EvalContext() != nil {
-			stable = desc.TableDesc().StatsCanaryWindow > 0 && !oc.planner.EvalContext().UseCanaryStats
+			stable = desc.TableDesc().StatsCanaryWindow > 0 &&
+				oc.planner.EvalContext().StatsRollout == eval.StatsRolloutStable
 			statsCanaryWindow = desc.TableDesc().StatsCanaryWindow
 			statsAsOf = oc.planner.EvalContext().SessionData().StatsAsOf
 		}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -507,7 +507,8 @@ func (opc *optPlanningCtx) reset(ctx context.Context) {
 		// potential reuse of versions. To avoid these issues, we prevent saving a
 		// memo (for prepare) or reusing a saved memo (for execute).
 		// We only allow reusing memo if this plan is not going to use canary stats.
-		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables() && !p.EvalContext().UseCanaryStats
+		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables() &&
+			p.EvalContext().StatsRollout != eval.StatsRolloutCanary
 		opc.useCache = opc.allowMemoReuse && queryCacheEnabled.Get(&p.execCfg.Settings.SV)
 
 		if _, isCanned := p.stmt.AST.(*tree.CannedOptPlan); isCanned {

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -52,6 +52,22 @@ import (
 
 var ErrNilTxnInClusterContext = errors.New("nil txn in cluster context")
 
+// StatsRolloutSelection describes the role of a query execution in the
+// canary stats rollout experiment.
+type StatsRolloutSelection int
+
+const (
+	// StatsRolloutDefault means the canary experiment is not active for
+	// this execution. The optimizer uses default stats.
+	StatsRolloutDefault StatsRolloutSelection = iota
+	// StatsRolloutCanary means this execution uses canary (newest) table
+	// statistics as part of the canary experiment.
+	StatsRolloutCanary
+	// StatsRolloutStable means this execution uses stable (second-newest)
+	// table statistics while the canary experiment is active.
+	StatsRolloutStable
+)
+
 // Context defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
 //
@@ -327,40 +343,36 @@ type Context struct {
 	// ExecutedStatementCounters contains metrics for successfully executed
 	// statements defined within the body of a UDF/SP.
 	ExecutedRoutineStatementCounters RoutineStatementCounters
-	// UseCanaryStats indicates whether this query participates in the canary
-	// statistics rollout feature. When set to true, the optimizer attempts to use
-	// "canary statistics" for all tables referenced by the query.
+	// StatsRollout records the outcome of the canary stats rollout dice
+	// roll for this query execution. It has three possible values:
 	//
-	// This flag is determined probabilistically during query planning based on the
-	// sql.stats.canary_fraction cluster setting. The selection is atomic per query:
-	// either all tables use canary stats (when available) or all use stable stats.
+	//   - StatsRolloutDefault: the canary experiment is not active
+	//     (sql.stats.canary_fraction = 0 or mode is off). The optimizer
+	//     uses whatever stats are available (default behavior). The
+	//     execution is not classified as canary or stable.
 	//
-	// Canary statistics are newly collected table statistics that are still within
-	// their configured "canary window" (sql_stats_canary_window storage parameter).
-	// These stats provide a controlled way to gradually roll out new statistics
-	// before promoting them to stable, allowing for manual intervention if
-	// performance regressions are detected.
+	//   - StatsRolloutCanary: the canary experiment is active and this
+	//     execution was selected to use canary (newest) table statistics.
+	//     The optimizer attempts to use canary stats for all tables
+	//     referenced by the query. If a table lacks distinct canary stats
+	//     (e.g., only one version exists or canary stats have expired),
+	//     the optimizer falls back to stable stats for that table.
 	//
-	// Stable statistics are the previously established statistics that have either
-	// been promoted from canary status or were collected before canary mode was
-	// enabled for the table.
+	//   - StatsRolloutStable: the canary experiment is active but this
+	//     execution was not selected for canary — it uses stable
+	//     (second-newest) table statistics.
 	//
-	// Fallback behavior: If a table lacks distinct canary statistics (e.g., only
-	// one statistics version exists, or canary stats have expired), the optimizer
-	// will use the available stable statistics even when this flag is true.
+	// The selection is determined probabilistically during query planning
+	// based on the sql.stats.canary_fraction cluster setting. It is
+	// atomic per query: all tables use the same rollout path.
 	//
-	// UseCanaryStats should only be set True for non-internal and when creating
-	// a not-prepared stmt. In other words, internal queries and prepared statements
-	// will always use stable statistics.
+	// Only set for non-internal, non-prepared queries. Internal queries
+	// and prepared statements always use StatsRolloutDefault.
 	//
-	// When UseCanaryStats is true, the optimizer will bypass query cache or
-	// the cached memo within a prepared stmt, but rather build a one-off memo
-	// only for this query execution. This is because we roll the dice for
-	// query execution to decide whether to use canary stats or not, and
-	// we'd like to avoid frequently invalidating cached plans. The rule of
-	// thumb is: the cached memo, either in query cache or prepared stmt,
-	// are always for stable stats.
-	UseCanaryStats bool
+	// When StatsRolloutCanary, the optimizer bypasses the query cache and
+	// the cached memo within a prepared stmt, building a one-off memo for
+	// this execution. Cached memos are always built with stable stats.
+	StatsRollout StatsRolloutSelection
 
 	// WorkloadID for ASH sampling.
 	WorkloadID uint64

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/clusterunique",
         "//pkg/sql/execstats",
         "//pkg/sql/memsize",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlcommenter",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -37,6 +37,8 @@ func GetRandomizedCollectedStatementStatisticsForTest(
 	data := sqlstatsutil.GenRandomData()
 	sqlstatsutil.FillObject(t, reflect.ValueOf(&result), &data)
 	result.Stats.Count = 1
+	result.Stats.CanaryStats.Count = 1
+	result.Stats.StableStats.Count = 1
 
 	return result
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -112,7 +112,29 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "max": {{.Float}}
          },
          "lastErrorCode": "{{.String}}",
-				 "sqlType": "{{.String}}" 
+				 "sqlType": "{{.String}}",
+				 "canaryStats": {
+				   "count": {{.Int64}},
+				   "runLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   },
+				   "planLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   }
+				 },
+				 "stableStats": {
+				   "count": {{.Int64}},
+				   "runLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   },
+				   "planLat": {
+				     "mean": {{.Float}},
+				     "sqDiff": {{.Float}}
+				   }
+				 }
        },
        "execution_statistics": {
          "cnt": {{.Int64}},
@@ -231,6 +253,78 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 		err = DecodeStmtStatsStatisticsJSON(actualStatisticsJSON, &actualJSONUnmarshalled.Stats)
 		require.NoError(t, err)
 		require.Equal(t, input, actualJSONUnmarshalled)
+	})
+
+	// Verify that when CanaryCount and StableCount are zero, the canary/stable
+	// fields are omitted from the JSON encoding to save storage, and that
+	// decoding such JSON back produces the correct zero-valued fields.
+	t.Run("statement_statistics zero canary and stable roundtrip", func(t *testing.T) {
+		input := appstatspb.StatementStatistics{
+			Count:             5,
+			FirstAttemptCount: 3,
+			// CanaryCount and StableCount are zero — fields should be omitted.
+		}
+
+		statsJSON, err := BuildStmtStatisticsJSON(&input)
+		require.NoError(t, err)
+
+		// Verify canary and stable fields are absent from the encoded JSON.
+		statsField, err := statsJSON.FetchValKey("statistics")
+		require.NoError(t, err)
+		canaryStats, err := statsField.FetchValKey("canaryStats")
+		require.NoError(t, err)
+		require.Nil(t, canaryStats, "canaryStats should be omitted when zero")
+		stableStats, err := statsField.FetchValKey("stableStats")
+		require.NoError(t, err)
+		require.Nil(t, stableStats, "stableStats should be omitted when zero")
+
+		// Decode and verify roundtrip produces zero values.
+		var decoded appstatspb.StatementStatistics
+		err = DecodeStmtStatsStatisticsJSON(statsJSON, &decoded)
+		require.NoError(t, err)
+		require.Equal(t, appstatspb.ExperimentStatsInfo{}, decoded.CanaryStats)
+		require.Equal(t, appstatspb.ExperimentStatsInfo{}, decoded.StableStats)
+	})
+
+	// Verify that when CanaryStats and StableStats have non-zero counts, the
+	// fields are present in the encoded JSON and survive a roundtrip.
+	t.Run("statement_statistics non-zero canary and stable roundtrip", func(t *testing.T) {
+		input := appstatspb.StatementStatistics{
+			Count:             10,
+			FirstAttemptCount: 8,
+			CanaryStats: appstatspb.ExperimentStatsInfo{
+				Count:   3,
+				RunLat:  appstatspb.NumericStat{Mean: 0.05, SquaredDiffs: 0.001},
+				PlanLat: appstatspb.NumericStat{Mean: 0.02, SquaredDiffs: 0.0005},
+			},
+			StableStats: appstatspb.ExperimentStatsInfo{
+				Count:   7,
+				RunLat:  appstatspb.NumericStat{Mean: 0.08, SquaredDiffs: 0.003},
+				PlanLat: appstatspb.NumericStat{Mean: 0.03, SquaredDiffs: 0.001},
+			},
+		}
+
+		statsJSON, err := BuildStmtStatisticsJSON(&input)
+		require.NoError(t, err)
+
+		// Verify canary and stable fields are present in the encoded JSON.
+		statsField, err := statsJSON.FetchValKey("statistics")
+		require.NoError(t, err)
+		canaryStats, err := statsField.FetchValKey("canaryStats")
+		require.NoError(t, err)
+		require.NotNil(t, canaryStats, "canaryStats should be present when non-zero")
+		stableStats, err := statsField.FetchValKey("stableStats")
+		require.NoError(t, err)
+		require.NotNil(t, stableStats, "stableStats should be present when non-zero")
+
+		// Decode and verify roundtrip.
+		var decoded appstatspb.StatementStatistics
+		err = DecodeStmtStatsStatisticsJSON(statsJSON, &decoded)
+		require.NoError(t, err)
+		require.Equal(t, input.CanaryStats.Count, decoded.CanaryStats.Count)
+		require.Equal(t, input.StableStats.Count, decoded.StableStats.Count)
+		require.InEpsilon(t, input.CanaryStats.RunLat.Mean, decoded.CanaryStats.RunLat.Mean, 0.0000001)
+		require.InEpsilon(t, input.StableStats.RunLat.Mean, decoded.StableStats.RunLat.Mean, 0.0000001)
 	})
 
 	// When a new statistic is added to a statement payload, older versions won't have the

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -47,6 +47,7 @@ var (
 	_ jsonMarshaler = (*int64Array)(nil)
 	_ jsonMarshaler = (*int32Array)(nil)
 	_ jsonMarshaler = &latencyInfo{}
+	_ jsonMarshaler = &experimentStatsInfo{}
 )
 
 type txnStats appstatspb.TransactionStatistics
@@ -352,12 +353,51 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 	}
 }
 
+// canaryJsonFields returns the JSON fields for canary stats tracking.
+// These are separated from jsonFields() so they can be conditionally
+// encoded only when canary/stable data is present, avoiding storage
+// overhead per row in system.statement_statistics for the common case
+// where the canary experiment is not active.
+func (s *innerStmtStats) canaryJsonFields() jsonFields {
+	return jsonFields{
+		{"canaryStats", (*experimentStatsInfo)(&s.CanaryStats)},
+	}
+}
+
+// stableJsonFields returns the JSON fields for stable stats tracking.
+// Like canaryJsonFields, these are conditionally encoded.
+func (s *innerStmtStats) stableJsonFields() jsonFields {
+	return jsonFields{
+		{"stableStats", (*experimentStatsInfo)(&s.StableStats)},
+	}
+}
+
 func (s *innerStmtStats) decodeJSON(js json.JSON) error {
-	return s.jsonFields().decodeJSON(js)
+	if err := s.jsonFields().decodeJSON(js); err != nil {
+		return err
+	}
+	// Canary and stable fields are optional in the JSON — they are only
+	// present when the canary experiment was active. Decode them if present;
+	// missing fields are left at their zero values by decodeJSON.
+	if err := s.canaryJsonFields().decodeJSON(js); err != nil {
+		return err
+	}
+	return s.stableJsonFields().decodeJSON(js)
 }
 
 func (s *innerStmtStats) encodeJSON() (json.JSON, error) {
-	return s.jsonFields().encodeJSON()
+	fields := s.jsonFields()
+	// Only include canary/stable fields when the respective stats were
+	// actually collected. This avoids adding zero-valued JSON to every
+	// row in system.statement_statistics when the canary experiment is
+	// not in use.
+	if s.CanaryStats.Count > 0 {
+		fields = append(fields, s.canaryJsonFields()...)
+	}
+	if s.StableStats.Count > 0 {
+		fields = append(fields, s.stableJsonFields()...)
+	}
+	return fields.encodeJSON()
 }
 
 type execStats appstatspb.ExecStats
@@ -444,6 +484,24 @@ func (l *latencyInfo) decodeJSON(js json.JSON) error {
 
 func (l *latencyInfo) encodeJSON() (json.JSON, error) {
 	return l.jsonFields().encodeJSON()
+}
+
+type experimentStatsInfo appstatspb.ExperimentStatsInfo
+
+func (e *experimentStatsInfo) jsonFields() jsonFields {
+	return jsonFields{
+		{"count", (*jsonInt)(&e.Count)},
+		{"runLat", (*numericStats)(&e.RunLat)},
+		{"planLat", (*numericStats)(&e.PlanLat)},
+	}
+}
+
+func (e *experimentStatsInfo) decodeJSON(js json.JSON) error {
+	return e.jsonFields().decodeJSON(js)
+}
+
+func (e *experimentStatsInfo) encodeJSON() (json.JSON, error) {
+	return e.jsonFields().encodeJSON()
 }
 
 type jsonFields []jsonField

--- a/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/appstatspb",
         "//pkg/sql/execstats",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sqlstats",
         "//pkg/util",
         "//pkg/util/log",

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
@@ -82,6 +83,21 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 	}
 	if value.AppliedStmtHints {
 		stats.mu.data.StmtHintsCount++
+	}
+	// Track canary and stable stats separately: these latencies use their own
+	// counts (not the overall Count) for Welford's running average, since they
+	// represent only the subsets of executions that participated in the canary
+	// experiment. Executions where the experiment is off (canary_fraction = 0)
+	// are counted in neither bucket.
+	switch value.StatsRollout {
+	case eval.StatsRolloutCanary:
+		stats.mu.data.CanaryStats.Count++
+		stats.mu.data.CanaryStats.RunLat.Record(stats.mu.data.CanaryStats.Count, value.RunLatencySec)
+		stats.mu.data.CanaryStats.PlanLat.Record(stats.mu.data.CanaryStats.Count, value.PlanLatencySec)
+	case eval.StatsRolloutStable:
+		stats.mu.data.StableStats.Count++
+		stats.mu.data.StableStats.RunLat.Record(stats.mu.data.StableStats.Count, value.RunLatencySec)
+		stats.mu.data.StableStats.PlanLat.Record(stats.mu.data.StableStats.Count, value.PlanLatencySec)
 	}
 	if value.AutoRetryCount == 0 {
 		stats.mu.data.FirstAttemptCount++

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlcommenter"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -101,6 +102,7 @@ type RecordedStmtStats struct {
 	Indexes                  []string
 	QueryTags                []sqlcommenter.QueryTag
 	UnderOuterTxn            bool
+	StatsRollout             eval.StatsRolloutSelection
 }
 
 var recordedStmtStatsSize = int64(unsafe.Sizeof(RecordedStmtStats{}))
@@ -410,6 +412,16 @@ func (b *RecordedStatementStatsBuilder) AppliedStatementHints() *RecordedStateme
 		return b
 	}
 	b.stmtStats.AppliedStmtHints = true
+	return b
+}
+
+func (b *RecordedStatementStatsBuilder) CanaryStatsRollout(
+	sel eval.StatsRolloutSelection,
+) *RecordedStatementStatsBuilder {
+	if b == nil {
+		return b
+	}
+	b.stmtStats.StatsRollout = sel
 	return b
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -270,6 +270,31 @@ export function addStatementStats(
     indexes: indexes,
     latency_info: aggregateLatencyInfo(a, b),
     last_error_code: "",
+    canary_stats: addExperimentStats(a.canary_stats, b.canary_stats),
+    stable_stats: addExperimentStats(a.stable_stats, b.stable_stats),
+  };
+}
+
+function addExperimentStats(
+  a: cockroach.sql.IExperimentStatsInfo | null | undefined,
+  b: cockroach.sql.IExperimentStatsInfo | null | undefined,
+): cockroach.sql.IExperimentStatsInfo {
+  const countA = FixLong(a?.count).toInt();
+  const countB = FixLong(b?.count).toInt();
+  return {
+    count: Long.fromInt(countA + countB),
+    run_lat: aggregateNumericStats(
+      a?.run_lat ?? { mean: 0, squared_diffs: 0 },
+      b?.run_lat ?? { mean: 0, squared_diffs: 0 },
+      countA,
+      countB,
+    ),
+    plan_lat: aggregateNumericStats(
+      a?.plan_lat ?? { mean: 0, squared_diffs: 0 },
+      b?.plan_lat ?? { mean: 0, squared_diffs: 0 },
+      countA,
+      countB,
+    ),
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -299,6 +299,8 @@ function makeStats(): Required<StatementStatistics> {
     generic_count: Long.fromNumber(0),
     stmt_hints_count: Long.fromNumber(0),
     kv_cpu_time_nanos: makeStat(),
+    canary_stats: null,
+    stable_stats: null,
   };
 }
 


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/156817

Backend support for two upcoming DB Console charts on the Statement Details page (frontend in a follow-up PR):

- `Canary vs stable statement times`: Track canary and stable execution/plan latencies separately in statement statistics via a new `ExperimentStatsInfo` proto. A three-way `StatsRolloutSelection` enum (`Default/Canary/Stable`) replaces the former boolean so that executions are only recorded as canary or stable when the experiment is actually active (`canary_fraction > 0`). `Canary/stable` JSON fields are conditionally encoded to avoid storage overhead when the experiment is off.
- `Canary vs stable plan distribution`: Add `canary_execution_count` and `stable_execution_count` to the
`StatementPlanDistribution` API response.

Release note: None
