### PR TITLE
changefeedccl: backport highwater backoff reset + gating to 25.2

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -208,6 +208,7 @@ go_test(
         "nemeses_test.go",
         "parquet_test.go",
         "protected_timestamps_test.go",
+        "retry_test.go",
         "scheduled_changefeed_test.go",
         "schema_registry_test.go",
         "show_changefeed_jobs_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1726,10 +1726,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 ) (bool, error) {
 	defer cf.sliMetrics.Timers.CheckpointJobProgress.Start()()
 
-	if cf.knobs.RaiseRetryableError != nil {
-		if err := cf.knobs.RaiseRetryableError(); err != nil {
-			return false, changefeedbase.MarkRetryableError(
-				errors.New("cf.knobs.RaiseRetryableError"))
+	if cf.knobs.BeforeCheckpoint != nil {
+		if err := cf.knobs.BeforeCheckpoint(); err != nil {
+			return false, changefeedbase.MarkRetryableError(err)
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1423,6 +1423,14 @@ func (b *changefeedResumer) resumeWithRetries(
 	maxBackoff := changefeedbase.MaxRetryBackoff.Get(&execCfg.Settings.SV)
 	backoffReset := changefeedbase.RetryBackoffReset.Get(&execCfg.Settings.SV)
 	for r := getRetry(ctx, maxBackoff, backoffReset); r.Next(); {
+		// Capture the current highwater before running the flow so we can
+		// detect if the changefeed made forward progress. If it did, the
+		// retry backoff is reset regardless of how long the flow ran.
+		var preFlowHighWater hlc.Timestamp
+		if hw := localState.progress.GetHighWater(); hw != nil {
+			preFlowHighWater = *hw
+		}
+
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 
 		if flowErr == nil {
@@ -1508,6 +1516,18 @@ func (b *changefeedResumer) resumeWithRetries(
 			// claim information, and will restart this job somewhere else (though,
 			// it's possible that the job gets restarted on this node).
 			return jobs.MarkAsRetryJobError(err)
+		}
+
+		// Reset retry backoff if the highwater advanced, indicating the
+		// changefeed made meaningful forward progress before the error.
+		if hw := localState.progress.GetHighWater(); hw != nil && preFlowHighWater.Less(*hw) {
+			log.Infof(ctx,
+				"changefeed %d highwater advanced (%s -> %s); resetting retry backoff",
+				jobID, preFlowHighWater, *hw)
+			r.Reset()
+			if knobs != nil && knobs.OnRetryBackoffReset != nil {
+				knobs.OnRetryBackoffReset()
+			}
 		}
 
 		if errors.Is(flowErr, changefeedbase.ErrNodeDraining) {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1520,7 +1520,8 @@ func (b *changefeedResumer) resumeWithRetries(
 
 		// Reset retry backoff if the highwater advanced, indicating the
 		// changefeed made meaningful forward progress before the error.
-		if hw := localState.progress.GetHighWater(); hw != nil && preFlowHighWater.Less(*hw) {
+		resetOnProgress := changefeedbase.ResetBackoffOnHighwaterAdvance.Get(&execCfg.Settings.SV)
+		if hw := localState.progress.GetHighWater(); resetOnProgress && hw != nil && preFlowHighWater.Less(*hw) {
 			log.Infof(ctx,
 				"changefeed %d highwater advanced (%s -> %s); resetting retry backoff",
 				jobID, preFlowHighWater, *hw)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11381,6 +11381,58 @@ func TestChangefeedHeadersJSONVals(t *testing.T) {
 	}
 }
 
+// TestChangefeedRetryBackoffResetOnHighwaterAdvance verifies that the retry
+// backoff is reset when a changefeed advances its highwater mark before
+// encountering a retryable error. This ensures that transient errors after
+// meaningful forward progress don't leave the backoff unnecessarily elevated.
+func TestChangefeedRetryBackoffResetOnHighwaterAdvance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+
+		// Let the first few checkpoints succeed so the highwater gets
+		// persisted to the job record, then fire a retryable error. The
+		// retry loop should detect that the highwater advanced past its
+		// initial value and reset the backoff.
+		var checkpointCount atomic.Int32
+		knobs.BeforeCheckpoint = func() error {
+			if checkpointCount.Add(1) == 3 {
+				return errors.New("test transient error")
+			}
+			return nil
+		}
+
+		backoffResetCh := make(chan struct{}, 1)
+		knobs.OnRetryBackoffReset = func() {
+			select {
+			case backoffResetCh <- struct{}{}:
+			default:
+			}
+		}
+
+		feed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH initial_scan='no'`)
+		defer closeFeed(t, feed)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		assertPayloads(t, feed, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+		})
+
+		select {
+		case <-backoffResetCh:
+		case <-time.After(testutils.DefaultSucceedsSoonDuration):
+			t.Fatal("timed out waiting for retry backoff reset after highwater advance")
+		}
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
 // TestPubsubAttributes tests that the "attributes" field in the
 // `pubsub_sink_config` behaves as expected.
 func TestPubsubAttributes(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11393,6 +11393,9 @@ func TestChangefeedRetryBackoffResetOnHighwaterAdvance(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 
+		changefeedbase.ResetBackoffOnHighwaterAdvance.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
 		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
 
 		// Let the first few checkpoints succeed so the highwater gets

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -8871,7 +8871,7 @@ func TestCoreChangefeedBackfillScanCheckpoint(t *testing.T) {
 			context.Background(), &s.Server.ClusterSettings().SV, 100<<20)
 
 		emittedCount := 0
-		knobs.RaiseRetryableError = func() error {
+		knobs.BeforeCheckpoint = func() error {
 			emittedCount++
 			if emittedCount%200 == 0 {
 				return errors.New("test transient error")
@@ -10922,7 +10922,7 @@ func TestHighwaterDoesNotRegressOnRetry(t *testing.T) {
 
 		// A flag we toggle on to put the changefeed in a retrying state.
 		var changefeedIsRetrying atomic.Bool
-		knobs.RaiseRetryableError = func() error {
+		knobs.BeforeCheckpoint = func() error {
 			if changefeedIsRetrying.Load() {
 				return errors.New("test retryable error")
 			}
@@ -11005,7 +11005,7 @@ func TestHighwaterDoesNotRegressOnRetry(t *testing.T) {
 		// Check that the following happens soon.
 		//
 		// Step 2: Since `changefeedIsRetrying` is true, the changefeed will now attempt retries in
-		//         via `knobs.RaiseRetryableError`.
+		//         via `knobs.BeforeCheckpoint`.
 		// Step 3: `knobs.LoadJobErr` will result an in error when reading the job record a couple of times, causing
 		//          more retries.
 		// Step 4: Eventually, a dist changefeed is started at a certain highwater timestamp.

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -367,6 +367,16 @@ var MaxRetryBackoff = settings.RegisterDurationSettingWithExplicitUnit(
 	settings.DurationInRange(1*time.Second, 1*time.Hour),
 )
 
+// ResetBackoffOnHighwaterAdvance controls whether the changefeed retry
+// backoff resets when the highwater mark advances between retries.
+var ResetBackoffOnHighwaterAdvance = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.reset_backoff_on_highwater_advance.enabled",
+	"if true, the changefeed retry backoff resets when the resolved "+
+		"timestamp advances between retries",
+	false,
+)
+
 // RetryBackoffReset is the time between changefeed retries before the
 // backoff timer resets.
 var RetryBackoffReset = settings.RegisterDurationSettingWithExplicitUnit(

--- a/pkg/ccl/changefeedccl/retry_test.go
+++ b/pkg/ccl/changefeedccl/retry_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryResetOnProgress verifies that calling Reset()
+// on the changefeed Retry wrapper resets the backoff to
+// its initial value.
+func TestRetryResetOnProgress(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	r := getRetry(ctx, 10*time.Minute, 10*time.Minute)
+
+	require.True(t, r.Next())
+	require.Equal(t, 0, r.CurrentAttempt())
+	initialBackoff := r.NextBackoff()
+
+	for i := 0; i < 5; i++ {
+		require.True(t, r.Next())
+	}
+	require.Equal(t, 5, r.CurrentAttempt())
+	elevatedBackoff := r.NextBackoff()
+	require.Greater(t, elevatedBackoff, initialBackoff,
+		"backoff should increase after multiple attempts")
+
+	r.Reset()
+	require.Equal(t, 0, r.CurrentAttempt(),
+		"attempt counter should be zero after reset")
+	require.Equal(t, initialBackoff, r.NextBackoff(),
+		"backoff should return to initial value after reset")
+}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -54,6 +54,9 @@ type TestingKnobs struct {
 	// checkpointJobProgress. Returning a non-nil error causes a retryable
 	// failure before the checkpoint is persisted.
 	BeforeCheckpoint func() error
+	// OnRetryBackoffReset, if set, is called when the changefeed retry loop
+	// resets its backoff due to changefeed progress.
+	OnRetryBackoffReset func()
 	// StartDistChangefeedInitialHighwater is called when starting the dist changefeed with the initial highwater
 	// of the changefeed. Note that this will be called when the changefeed starts and subsequently when the changefeed
 	// is retried.

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -50,8 +50,10 @@ type TestingKnobs struct {
 	NullSinkIsExternalIOAccounted bool
 	// OnDistflowSpec is called when specs for distflow planning have been created
 	OnDistflowSpec func(aggregatorSpecs []*execinfrapb.ChangeAggregatorSpec, frontierSpec *execinfrapb.ChangeFrontierSpec)
-	// RaiseRetryableError is a knob used to possibly return an error.
-	RaiseRetryableError func() error
+	// BeforeCheckpoint, if set, is called at the start of
+	// checkpointJobProgress. Returning a non-nil error causes a retryable
+	// failure before the checkpoint is persisted.
+	BeforeCheckpoint func() error
 	// StartDistChangefeedInitialHighwater is called when starting the dist changefeed with the initial highwater
 	// of the changefeed. Note that this will be called when the changefeed starts and subsequently when the changefeed
 	// is retried.

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -158,6 +158,16 @@ func (r *Retry) NextCh() <-chan time.Time {
 	return time.After(r.retryIn())
 }
 
+// NextBackoff returns the average duration to wait before the next retry attempt
+// without any randomization factor. Use this for logging and testing purposes only.
+func (r *Retry) NextBackoff() time.Duration {
+	backoff := float64(r.opts.InitialBackoff) * math.Pow(r.opts.Multiplier, float64(r.currentAttempt))
+	if maxBackoff := float64(r.opts.MaxBackoff); backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	return time.Duration(backoff)
+}
+
 // CurrentAttempt returns the current attempt
 func (r *Retry) CurrentAttempt() int {
 	return r.currentAttempt


### PR DESCRIPTION
Backport of #164933 and #165494 to release-25.2.

Resets changefeed retry backoff when the highwater mark advances between
retries, gated behind `changefeed.reset_backoff_on_highwater_advance.enabled`
(default **false** on this release branch).

This prevents transient errors during rolling restarts from causing
changefeeds to fall behind due to excessive backoff, while keeping the
new behavior opt-in on the release branch.

Adapted for release-25.2: uses `localState.progress.GetHighWater()` instead
of `reloadJobProgress` (which doesn't exist on this branch).

Informs: #164695
Release note: None

----

Release justification: fixes a serious changefeed issue (falling behind because of backoff), it's behing a FF that's off by default, should be safe to not backoff if the feed is healthy enough to advance the highwater. 