### PR TITLE
build: fix cloud-only docker publish for cross-platform pulls, add s390x

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
@@ -28,8 +28,9 @@ tc_end_block "Variable Setup"
 
 
 docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
-docker pull "${gcr_staged_repository}:amd64-${version}"
-docker pull "${gcr_staged_repository}:arm64-${version}"
+docker pull --platform linux/amd64 "${gcr_staged_repository}:amd64-${version}"
+docker pull --platform linux/arm64 "${gcr_staged_repository}:arm64-${version}"
+docker pull --platform linux/s390x "${gcr_staged_repository}:s390x-${version}"
 
 cloud_release=
 for i in $(seq 1 10); do
@@ -59,13 +60,18 @@ docker tag \
 docker tag \
   "${gcr_staged_repository}:arm64-${version}" \
   "${gcr_repository}:arm64-${version_cloudonly}"
+docker tag \
+  "${gcr_staged_repository}:s390x-${version}" \
+  "${gcr_repository}:s390x-${version_cloudonly}"
 
 docker push "${gcr_repository}:amd64-${version_cloudonly}"
 docker push "${gcr_repository}:arm64-${version_cloudonly}"
+docker push "${gcr_repository}:s390x-${version_cloudonly}"
 
 create_and_push_multi_arch_manifest "$manifest" \
   "${gcr_repository}:amd64-${version_cloudonly}" \
-  "${gcr_repository}:arm64-${version_cloudonly}"
+  "${gcr_repository}:arm64-${version_cloudonly}" \
+  "${gcr_repository}:s390x-${version_cloudonly}"
 echo "==========="
 echo "published to"
 echo "$manifest"
@@ -73,7 +79,7 @@ echo "==========="
 
 tc_start_block "Verify docker images"
 error=0
-for arch in amd64 arm64; do
+for arch in amd64 arm64 s390x; do
     tc_start_block "Verify $manifest on $arch"
     if ! verify_docker_image "$manifest" "linux/$arch" "$BUILD_VCS_NUMBER" "$version" false false; then
       error=1


### PR DESCRIPTION
The cloud-only publish script was failing because `docker pull` without `--platform` refuses to pull images whose manifest doesn't match the host architecture. Add explicit `--platform` flags to all pulls.

Also add s390x support to the cloud-only publish pipeline: pull, tag, push, multi-arch manifest creation, and image verification.

Release note: None
Epic: None