### PR TITLE
flowinfra: use large EngFlow VM for heavy configs

### DIFF
--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -78,6 +78,10 @@ go_test(
         "utils_test.go",
     ],
     embed = [":flowinfra"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/kv",


### PR DESCRIPTION
We recently saw two OOMs on the default EngFlow worker on `TestDistSQLReadsFillGatewayID` under race, so let's use `large` VM on heavy configs in the package.

Fixes: #165534.
Release note: None