### PR TITLE
release-25.4: sql/importer: split TestImportIntoCSV to avoid shard timeout

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2169,25 +2169,26 @@ func TestExportImportRoundTrip(t *testing.T) {
 	}
 }
 
-// TODO(adityamaru): Tests still need to be added incrementally as
-// relevant IMPORT INTO logic is added. Some of them include:
-// -> FK and constraint violation
-// -> CSV containing keys which will shadow existing data
-// -> Rollback of a failed IMPORT INTO
-func TestImportIntoCSV(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
+// importIntoCSVTestFixture holds the shared state for TestImportIntoCSV,
+// TestImportIntoCSVExtended, and TestImportIntoCSVCollisions.
+type importIntoCSVTestFixture struct {
+	tc          serverutils.TestClusterInterface
+	sqlDB       *sqlutils.SQLRunner
+	conn        *gosql.DB
+	testFiles   csvTestFiles
+	numFiles    int
+	rowsPerFile int
+}
 
+func setupImportIntoCSVTest(t *testing.T) *importIntoCSVTestFixture {
 	skip.UnderShort(t)
 	skip.UnderRace(t, "takes >1min under race")
 
 	const nodes = 3
-
 	numFiles := nodes + 2
 	rowsPerFile := 1000
 	rowsPerRaceFile := 16
 
-	ctx := context.Background()
 	baseDir := datapathutils.TestDataPath(t, "csv")
 	tc := serverutils.StartCluster(t, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
 		Knobs: base.TestingKnobs{
@@ -2196,98 +2197,68 @@ func TestImportIntoCSV(t *testing.T) {
 		// Test fails when run within a test tenant. More investigation
 		// is required. Tracked with #76378.
 		DefaultTestTenant: base.TODOTestTenantDisabled,
-		ExternalIODir:     baseDir}})
-	defer tc.Stopper().Stop(ctx)
+		ExternalIODir:     baseDir,
+	}})
 	conn := tc.ServerConn(0)
-
-	ctx, cancel := tc.Stopper().WithCancelOnQuiesce(context.Background())
-	defer cancel()
-
-	var forceFailure bool
-	var importBodyFinished chan struct{}
-	var delayImportFinish chan struct{}
-
-	for i := 0; i < tc.NumServers(); i++ {
-		tc.Server(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
-			jobspb.TypeImport,
-			func(raw jobs.Resumer) jobs.Resumer {
-				r := raw.(*importResumer)
-				r.testingKnobs.afterImport = func(_ roachpb.RowCount) error {
-					if importBodyFinished != nil {
-						select {
-						case <-ctx.Done():
-							return ctx.Err()
-						case importBodyFinished <- struct{}{}:
-						}
-					}
-					if delayImportFinish != nil {
-						select {
-						case <-ctx.Done():
-							return ctx.Err()
-						case <-delayImportFinish:
-						}
-					}
-
-					if forceFailure {
-						return errors.New("testing injected failure")
-					}
-					return nil
-				}
-				return r
-			})
-	}
-
 	sqlDB := sqlutils.MakeSQLRunner(conn)
-
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.batch_size = '10KB'`)
 
 	testFiles := makeCSVData(t, numFiles, rowsPerFile, nodes, rowsPerRaceFile)
 	if util.RaceEnabled {
-		// This test takes a while with the race detector, so reduce the number of
-		// files and rows per file in an attempt to speed it up.
 		numFiles = nodes
 		rowsPerFile = rowsPerRaceFile
 	}
+
+	return &importIntoCSVTestFixture{
+		tc:          tc,
+		sqlDB:       sqlDB,
+		conn:        conn,
+		testFiles:   testFiles,
+		numFiles:    numFiles,
+		rowsPerFile: rowsPerFile,
+	}
+}
+
+// dropTableAfterJobComplete handles dropping a table after ensuring any
+// in-progress import job has completed or been cancelled.
+func (f *importIntoCSVTestFixture) dropTableAfterJobComplete(t *testing.T, tableName string) {
+	var jobID int
+	row := f.conn.QueryRow("SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT' AND status IN ('paused', 'pause-requested', 'reverting')")
+	err := row.Scan(&jobID)
+	if err != nil && !errors.Is(err, gosql.ErrNoRows) {
+		t.Fatal(err)
+	}
+	if jobID != 0 {
+		testutils.SucceedsSoon(t, func() error {
+			r := f.sqlDB.QueryRow(t, "SELECT status FROM [SHOW JOBS] WHERE job_id = $1", jobID)
+			var status string
+			r.Scan(&status)
+			if status == string(jobs.StatePauseRequested) {
+				return errors.New("still has pause-requested status")
+			}
+			return nil
+		})
+		f.sqlDB.Exec(t, "CANCEL JOB $1", jobID)
+		f.sqlDB.Exec(t, "SHOW JOB WHEN COMPLETE $1", jobID)
+	}
+	f.sqlDB.Exec(t, fmt.Sprintf("DROP TABLE %s", tableName))
+}
+
+func TestImportIntoCSV(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	f := setupImportIntoCSVTest(t)
+	defer f.tc.Stopper().Stop(context.Background())
+
+	sqlDB := f.sqlDB
+	testFiles := f.testFiles
 
 	empty := []string{"'nodelocal://1/empty.csv'"}
 
 	// Support subtests by keeping track of the number of jobs that are executed.
 	testNum := -1
-	insertedRows := numFiles * rowsPerFile
-
-	// Some of the tests result in a failing import. In this case, the table
-	// won't be able to drop until IMPORT's OnFailOrCancel brings the table back
-	// online.
-	//
-	// Depending on which node that the import started on, we may have paused
-	// rather than failed. This is because _all_ errors that "rpc error" are
-	// retriable. If we end up with a cross-node nodelocal request, we get a
-	// pause.
-	dropTableAfterJobComplete := func(t *testing.T, tableName string) {
-		var jobID int
-		row := conn.QueryRow("SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT' AND status IN ('paused', 'pause-requested', 'reverting')")
-		err := row.Scan(&jobID)
-		if err != nil && !errors.Is(err, gosql.ErrNoRows) {
-			t.Fatal(err)
-		}
-		if jobID != 0 {
-			// If the job has the "pause-requested" status, we must block until
-			// it transitions to the "paused" status (because we cannot cancel
-			// the job otherwise).
-			testutils.SucceedsSoon(t, func() error {
-				r := sqlDB.QueryRow(t, "SELECT status FROM [SHOW JOBS] WHERE job_id = $1", jobID)
-				var status string
-				r.Scan(&status)
-				if status == string(jobs.StatePauseRequested) {
-					return errors.New("still has pause-requested status")
-				}
-				return nil
-			})
-			sqlDB.Exec(t, "CANCEL JOB $1", jobID)
-			sqlDB.Exec(t, "SHOW JOB WHEN COMPLETE $1", jobID)
-		}
-		sqlDB.Exec(t, fmt.Sprintf("DROP TABLE %s", tableName))
-	}
+	insertedRows := f.numFiles * f.rowsPerFile
 
 	for _, tc := range []struct {
 		name    string
@@ -2459,7 +2430,7 @@ func TestImportIntoCSV(t *testing.T) {
 				skip.IgnoreLint(t, "bzip2 not available on PATH?")
 			}
 			sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
-			defer dropTableAfterJobComplete(t, "t")
+			defer f.dropTableAfterJobComplete(t, "t")
 
 			var tableID int64
 			sqlDB.QueryRow(t, `SELECT id FROM system.namespace WHERE name = 't'`).Scan(&tableID)
@@ -2528,11 +2499,60 @@ func TestImportIntoCSV(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestImportIntoCSVExtended(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	f := setupImportIntoCSVTest(t)
+	defer f.tc.Stopper().Stop(context.Background())
+
+	sqlDB := f.sqlDB
+	testFiles := f.testFiles
+	ctx, cancel := f.tc.Stopper().WithCancelOnQuiesce(context.Background())
+	defer cancel()
+	numFiles := f.numFiles
+	rowsPerFile := f.rowsPerFile
+
+	var forceFailure bool
+	var importBodyFinished chan struct{}
+	var delayImportFinish chan struct{}
+
+	for i := 0; i < f.tc.NumServers(); i++ {
+		f.tc.ApplicationLayer(i).JobRegistry().(*jobs.Registry).TestingWrapResumerConstructor(
+			jobspb.TypeImport,
+			func(raw jobs.Resumer) jobs.Resumer {
+				r := raw.(*importResumer)
+				r.testingKnobs.afterImport = func(_ roachpb.RowCount) error {
+					if importBodyFinished != nil {
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						case importBodyFinished <- struct{}{}:
+						}
+					}
+					if delayImportFinish != nil {
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						case <-delayImportFinish:
+						}
+					}
+
+					if forceFailure {
+						return errors.New("testing injected failure")
+					}
+					return nil
+				}
+				return r
+			})
+	}
 
 	// Verify unique_rowid is replaced for tables without primary keys.
 	t.Run("import-into-unique_rowid", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -2566,7 +2586,7 @@ func TestImportIntoCSV(t *testing.T) {
 			}
 			t.Run(subtestName, func(t *testing.T) {
 				sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-				defer dropTableAfterJobComplete(t, "t")
+				defer f.dropTableAfterJobComplete(t, "t")
 
 				if emptyTable != false {
 					// Insert the test data
@@ -2598,7 +2618,7 @@ func TestImportIntoCSV(t *testing.T) {
 	t.Run("offline-state", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 89999, num_replicas = 5;`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -2653,7 +2673,7 @@ func TestImportIntoCSV(t *testing.T) {
 		if err := g.Wait(); err != nil {
 			t.Fatal(err)
 		}
-		waitForJobResult(t, tc, jobspb.JobID(jobID), jobs.StateSucceeded)
+		waitForJobResult(t, f.tc, jobspb.JobID(jobID), jobs.StateSucceeded)
 
 		// Expect it to succeed on re-attempt.
 		sqlDB.QueryRow(t, `SELECT 1 FROM t`).Scan(&unused)
@@ -2681,7 +2701,7 @@ func TestImportIntoCSV(t *testing.T) {
 
 		t.Run(data, func(t *testing.T) {
 			sqlDB.Exec(t, createQuery)
-			defer dropTableAfterJobComplete(t, "t")
+			defer f.dropTableAfterJobComplete(t, "t")
 
 			data = "1"
 			sqlDB.Exec(t, `IMPORT INTO t (a) CSV DATA ($1)`, srv.URL)
@@ -2691,7 +2711,7 @@ func TestImportIntoCSV(t *testing.T) {
 		})
 		t.Run(data, func(t *testing.T) {
 			sqlDB.Exec(t, createQuery)
-			defer dropTableAfterJobComplete(t, "t")
+			defer f.dropTableAfterJobComplete(t, "t")
 
 			data = "1,teststr"
 			sqlDB.Exec(t, `IMPORT INTO t (a, f) CSV DATA ($1)`, srv.URL)
@@ -2701,7 +2721,7 @@ func TestImportIntoCSV(t *testing.T) {
 		})
 		t.Run(data, func(t *testing.T) {
 			sqlDB.Exec(t, createQuery)
-			defer dropTableAfterJobComplete(t, "t")
+			defer f.dropTableAfterJobComplete(t, "t")
 
 			data = "7,12,teststr"
 			sqlDB.Exec(t, `IMPORT INTO t (d, e, f) CSV DATA ($1)`, srv.URL)
@@ -2714,7 +2734,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// Tests IMPORT INTO with a target column set, and an explicit PK.
 	t.Run("target-cols-with-explicit-pk", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -2753,7 +2773,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// get an error indicating the error.
 	t.Run("csv-with-more-than-targeted-columns", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Expect an error if attempting to IMPORT INTO with CSV having more columns
 		// than targeted.
@@ -2768,7 +2788,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// until we support DEFAULT expressions.
 	t.Run("target-cols-excluding-explicit-pk", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Expect an error if attempting to IMPORT INTO a target list which does
 		// not include all the PKs of the table.
@@ -2782,7 +2802,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// in its schema then the source CSV file.
 	t.Run("more-table-cols-than-csv", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING, c INT)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -2802,7 +2822,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// defines in what order columns should be imported to align with table definition
 	t.Run("target-cols-reordered", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE TABLE t (a INT PRIMARY KEY, b INT, c STRING NOT NULL, d DECIMAL NOT NULL)")
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		const data = "3.14,c is a string,1\n2.73,another string,2"
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2818,11 +2838,25 @@ func TestImportIntoCSV(t *testing.T) {
 		)
 	})
 
+}
+
+func TestImportIntoCSVCollisions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	f := setupImportIntoCSVTest(t)
+	defer f.tc.Stopper().Stop(context.Background())
+
+	sqlDB := f.sqlDB
+	testFiles := f.testFiles
+	ctx := context.Background()
+	rowsPerFile := f.rowsPerFile
+
 	// Tests that we can import into the table even if the table has columns named with
 	// reserved keywords.
 	t.Run("cols-named-with-reserved-keywords", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t ("select" INT PRIMARY KEY, "from" INT, "Some-c,ol-'Name'" STRING NOT NULL)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		const data = "today,1,2"
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2841,7 +2875,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// in its schema then the source CSV file.
 	t.Run("fewer-table-cols-than-csv", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		sqlDB.ExpectErr(
 			t, "row 1: expected 1 fields, got 2",
@@ -2853,7 +2887,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// import of all columns in the exisiting table.
 	t.Run("no-target-cols-specified", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -2887,7 +2921,7 @@ func TestImportIntoCSV(t *testing.T) {
 			}
 		}))
 		defer srv.Close()
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 		sqlDB.ExpectErr(t, `violated by column "b"`,
 			fmt.Sprintf(`IMPORT INTO t (a) CSV DATA ("%s")`, srv.URL),
 		)
@@ -2898,7 +2932,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// exercises the row_id generation in IMPORT.
 	t.Run("multiple-import-into-without-pk", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		// Insert the test data
 		insert := []string{"''", "'text'", "'a'", "'e'", "'l'", "'t'", "'z'"}
@@ -2927,7 +2961,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// row_id generation logic.
 	t.Run("multiple-file-import-into-without-pk", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		sqlDB.Exec(t,
 			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s, %s)`, testFiles.files[0], testFiles.files[0]),
@@ -2949,7 +2983,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// collision.
 	t.Run("import-into-same-file-diff-imports", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		sqlDB.Exec(t,
 			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[0]),
@@ -2972,7 +3006,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// value, and succeeds in doing so.
 	t.Run("import-into-dups-in-sst", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		sqlDB.Exec(t,
 			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.fileWithDupKeySameValue[0]),
@@ -2990,7 +3024,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// colliding key sandwiched between valid keys.
 	t.Run("import-into-key-collision", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		sqlDB.Exec(t,
 			fmt.Sprintf(`IMPORT INTO t (a, b) CSV DATA (%s)`, testFiles.files[0]),
@@ -3009,7 +3043,7 @@ func TestImportIntoCSV(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE ref (b STRING PRIMARY KEY)`)
 		defer sqlDB.Exec(t, `DROP TABLE ref`)
 		sqlDB.Exec(t, `CREATE TABLE t (a INT CHECK (a >= 0), b STRING, CONSTRAINT fk_ref FOREIGN KEY (b) REFERENCES ref)`)
-		defer dropTableAfterJobComplete(t, "t")
+		defer f.dropTableAfterJobComplete(t, "t")
 
 		var checkValidated, fkValidated bool
 		sqlDB.QueryRow(t, `SELECT validated from [SHOW CONSTRAINT FROM t] WHERE constraint_name = 'check_a'`).Scan(&checkValidated)
@@ -3034,7 +3068,7 @@ func TestImportIntoCSV(t *testing.T) {
 	// Test userfile IMPORT INTO CSV.
 	t.Run("import-into-userfile-simple", func(t *testing.T) {
 		userfileURI := "userfile://defaultdb.public.root/test.csv"
-		userfileStorage, err := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).DistSQLSrv.
+		userfileStorage, err := f.tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).DistSQLSrv.
 			ExternalStorageFromURI(ctx, userfileURI, username.RootUserName())
 		require.NoError(t, err)
 


### PR DESCRIPTION
Backport 1/1 commits from #165108.

/cc @cockroachdb/release

---

## Summary

TestImportIntoCSV was a single large test function containing ~30
subtests that collectively took ~15 minutes on CI. When Bazel sharding
placed it alongside other tests in the same shard, the combined
execution exceeded the 15-minute test timeout, causing flaky failures.

Split the test into three top-level functions so Bazel can distribute
them across shards:

- **TestImportIntoCSV**: table-driven import format/option cases
- **TestImportIntoCSVExtended**: lifecycle tests (checkpoint, offline
  state, target columns) that need import resumer knobs
- **TestImportIntoCSVCollisions**: collision detection, multi-import,
  and constraint validation tests

Extract the shared cluster setup into `importIntoCSVTestFixture` /
`setupImportIntoCSVTest` to avoid duplicating the boilerplate.

Resolves: #164980

Release note: None

Release justification: test-only change.
