### PR TITLE
upgradecluster: clarify UseDRPC usecase in TestHelperEveryNode

### DIFF
--- a/pkg/upgrade/upgradecluster/helper_test.go
+++ b/pkg/upgrade/upgradecluster/helper_test.go
@@ -52,7 +52,9 @@ func TestHelperEveryNode(t *testing.T) {
 		h := New(ClusterConfig{
 			NodeLiveness: tc,
 			Dialer:       NoopDialer{},
-			UseDRPC:      false, // TODO(server): enable DRPC
+			// UseDRPC is irrelevant here since NoopDialer returns nil for both
+			// Dial and DRPCDial; the dialer is never actually used in these tests.
+			UseDRPC: false,
 		})
 		opCount := 0
 		err := h.UntilClusterStable(ctx, retry.Options{
@@ -92,7 +94,9 @@ func TestHelperEveryNode(t *testing.T) {
 		h := New(ClusterConfig{
 			NodeLiveness: tc,
 			Dialer:       NoopDialer{},
-			UseDRPC:      false, // TODO(server): enable DRPC
+			// UseDRPC is irrelevant here since NoopDialer returns nil for both
+			// Dial and DRPCDial; the dialer is never actually used in these tests.
+			UseDRPC: false,
 		})
 		opCount := 0
 		err := h.UntilClusterStable(ctx, retry.Options{
@@ -133,7 +137,9 @@ func TestHelperEveryNode(t *testing.T) {
 		h := New(ClusterConfig{
 			NodeLiveness: tc,
 			Dialer:       NoopDialer{},
-			UseDRPC:      false, // TODO(server): enable DRPC
+			// UseDRPC is irrelevant here since NoopDialer returns nil for both
+			// Dial and DRPCDial; the dialer is never actually used in these tests.
+			UseDRPC: false,
 		})
 		expRe := "cluster not stable, nodes: n\\{1,2,3\\}, unavailable: n\\{2\\}"
 		opCount := 0


### PR DESCRIPTION
The test uses NoopDialer{} which returns nil for both Dial and DRPCDial,
so the UseDRPC flag has no observable effect. Remove the unnecessary
ShouldEnableDRPC call and document why UseDRPC doesn't matter here.
Tested with --count 20 and all tenant modes.

Epic: CRDB-55382
Fixes: #165523
Release note: None