### PR TITLE
importer: fix expected row count after ingestWithRetry retries

### DIFF
--- a/pkg/backup/testdata/backup-restore/in-progress-imports
+++ b/pkg/backup/testdata/backup-restore/in-progress-imports
@@ -95,14 +95,9 @@ job tag=aa wait-for-state=succeeded
 ----
 
 
-# NOTE: currently the backups below re-capture the _2_ versions of each imported key:
-#  1: the original data that was already captured in the previous backup because BACKUP currently
-#     re-backs up the whole span once the table goes back online. This will change.
-#  2. when the import job resumes, the data is re-ingested, hence a second version of the imported
-#     data gets ingested into the backing up cluster, and consequently, the incremental backup.
-#     This occurs because when a restore job resumes after all data was initially ingested, the last
-#     check pointed restore span entry (i.e. in the mu.requestsCompleted object) gets re-ingested.
-#     -- in this case, there's only one span in the restore job, so all data gets re-ingested.
+# distImport flushes the checkpoint before returning, so resume positions are
+# current and no data is re-ingested when the import resumes. The incremental
+# backup below captures 0 new rows.
 
 
 exec-sql
@@ -121,12 +116,9 @@ BACKUP TABLE d.* INTO LATEST IN 'nodelocal://1/table/' WITH revision_history;
 
 
 # In all backup chains, the following rows get captured:
-# - Full backup: the original data + data from in-progress import (1 row in foo, 2 in foofoo)
-# - First incremental backup: nothing, no new data was ingested and the table is still offline
-# - Second incremental backup (2 row in foo, 3 in foofoo):
-#   - a full backup of the importing data because the tables returned online (1 row in foo, 2 in foofoo)
-#   - and duplicates of the importing data (1 row in foo, 1 in foofoo) because of import job
-#     checkpointing behavior. See note above.
+# - Full backup: original data + in-progress import data (1 row in foo, 2 in foofoo).
+# - First incremental: 0 rows, table is still offline.
+# - Second incremental: 0 rows, no data re-ingested on resume (see note above).
 
 query-sql
 SELECT
@@ -142,8 +134,8 @@ d foo table 1 full
 d foofoo table 2 full
 d foo table 0 incremental
 d foofoo table 0 incremental
-d foo table 1 incremental
-d foofoo table 1 incremental
+d foo table 0 incremental
+d foofoo table 0 incremental
 
 query-sql
 SELECT
@@ -159,8 +151,8 @@ d foo table 1 full
 d foofoo table 2 full
 d foo table 0 incremental
 d foofoo table 0 incremental
-d foo table 1 incremental
-d foofoo table 1 incremental
+d foo table 0 incremental
+d foofoo table 0 incremental
 
 
 query-sql
@@ -177,8 +169,8 @@ d foo table 1 full
 d foofoo table 2 full
 d foo table 0 incremental
 d foofoo table 0 incremental
-d foo table 1 incremental
-d foofoo table 1 incremental
+d foo table 0 incremental
+d foofoo table 0 incremental
 
 
 # Ensure all the RESTOREs contain foo (no data) and foofoo (1 row) as of system time t0

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -510,6 +512,107 @@ func TestImportIntoRowCountCheckAfterPause(t *testing.T) {
 				}
 				return nil
 			})
+
+			runner.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT count(*) FROM %s`, tc.name),
+				[][]string{{fmt.Sprintf("%d", tc.totalRows)}})
+		})
+	}
+}
+
+// TestImportIntoRowCountCheckAfterIngestRetry verifies that the INSPECT row
+// count validation passes after ingestWithRetry retries a failed distImport.
+// When a transient error causes a retry, data from the first attempt persists
+// in KV but the distImport result only reflects the last attempt. The fix
+// reads the total imported row count from the job progress summary, which is
+// correctly maintained across all attempts.
+func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "uses short job adoption intervals that don't work well in slow test configurations")
+
+	ctx := context.Background()
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		ExternalIODir: dir,
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				BulkAdderFlushesEveryBatch: true,
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(db)
+
+	// Use sync mode so the import blocks until the inspect job completes. If
+	// the row count is wrong the import statement itself will fail.
+	runner.Exec(t, `SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'sync'`)
+
+	s := srv.ApplicationLayer()
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	for _, tc := range []struct {
+		name      string
+		setupSQL  string
+		totalRows int
+	}{
+		{
+			name:      "retry_empty_table",
+			setupSQL:  "",
+			totalRows: 10,
+		},
+		{
+			name:      "retry_nonempty_table",
+			setupSQL:  `INSERT INTO retry_nonempty_table SELECT i, i*10 FROM generate_series(1, 5) AS g(i)`,
+			totalRows: 15,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use sync.Once so the injected error fires only on the first
+			// successful distImport call inside ingestWithRetry.
+			var once sync.Once
+			registry.TestingWrapResumerConstructor(
+				jobspb.TypeImport,
+				func(resumer jobs.Resumer) jobs.Resumer {
+					r := resumer.(interface {
+						TestingSetAlwaysFlushJobProgress()
+						TestingSetAfterDistImportKnob(func() error)
+					})
+					r.TestingSetAlwaysFlushJobProgress()
+					r.TestingSetAfterDistImportKnob(func() error {
+						var err error
+						once.Do(func() {
+							// The "rpc error" substring makes this retryable
+							// per sqlerrors.IsDistSQLRetryableError.
+							err = errors.New("rpc error: injected test retry")
+						})
+						return err
+					})
+					return resumer
+				})
+
+			runner.Exec(t, fmt.Sprintf(`CREATE TABLE %s (k INT PRIMARY KEY, v INT)`, tc.name))
+
+			if tc.setupSQL != "" {
+				runner.Exec(t, tc.setupSQL)
+			}
+
+			runner.Exec(t, fmt.Sprintf(
+				`EXPORT INTO CSV 'nodelocal://1/export_%s/' FROM SELECT i, i*10 FROM generate_series(6, 15) AS g(i)`,
+				tc.name))
+
+			// Run import. The first distImport succeeds and ingests all rows,
+			// then the afterDistImport knob injects a retryable error. On
+			// retry, all files are at MaxInt64 resume pos so 0 new rows are
+			// ingested. The import should succeed with correct row count
+			// validation.
+			runner.Exec(t, fmt.Sprintf(
+				`IMPORT INTO %s (k, v) CSV DATA ('nodelocal://1/export_%s/export*-n*.0.csv')`,
+				tc.name, tc.name))
 
 			runner.CheckQueryResults(t,
 				fmt.Sprintf(`SELECT count(*) FROM %s`, tc.name),

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -575,6 +576,7 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 			// Use sync.Once so the injected error fires only on the first
 			// successful distImport call inside ingestWithRetry.
 			var once sync.Once
+			var retryTriggered atomic.Bool
 			registry.TestingWrapResumerConstructor(
 				jobspb.TypeImport,
 				func(resumer jobs.Resumer) jobs.Resumer {
@@ -586,6 +588,7 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 					r.TestingSetAfterDistImportKnob(func() error {
 						var err error
 						once.Do(func() {
+							retryTriggered.Store(true)
 							// The "rpc error" substring makes this retryable
 							// per sqlerrors.IsDistSQLRetryableError.
 							err = errors.New("rpc error: injected test retry")
@@ -613,6 +616,8 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 			runner.Exec(t, fmt.Sprintf(
 				`IMPORT INTO %s (k, v) CSV DATA ('nodelocal://1/export_%s/export*-n*.0.csv')`,
 				tc.name, tc.name))
+
+			require.True(t, retryTriggered.Load(), "expected injected error to trigger a retry")
 
 			runner.CheckQueryResults(t,
 				fmt.Sprintf(`SELECT count(*) FROM %s`, tc.name),

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -64,6 +64,10 @@ type importTestingKnobs struct {
 	// expectedRowCountOffset is added to the expected row count passed to the
 	// inspect row count check.
 	expectedRowCountOffset int64
+	// afterDistImport, if set, is called after each successful distImport
+	// call inside ingestWithRetry. If it returns an error, that error
+	// replaces the nil err and triggers a retry.
+	afterDistImport func() error
 }
 
 type importResumer struct {
@@ -92,6 +96,10 @@ func (r *importResumer) TestingSetExpectedRowCountOffset(offset int64) {
 
 func (r *importResumer) TestingSetAlwaysFlushJobProgress() {
 	r.testingKnobs.alwaysFlushJobProgress = true
+}
+
+func (r *importResumer) TestingSetAfterDistImportKnob(fn func() error) {
+	r.testingKnobs.afterDistImport = fn
 }
 
 var _ jobs.TraceableJob = &importResumer{}
@@ -888,6 +896,9 @@ func ingestWithRetry(
 			if err == nil || !errors.Is(err, sql.ErrPlanChanged) {
 				break
 			}
+		}
+		if err == nil && testingKnobs.afterDistImport != nil {
+			err = testingKnobs.afterDistImport()
 		}
 		if err == nil {
 			break

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -332,18 +332,7 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	procsPerNode := int(processorsPerNode.Get(&p.ExecCfg().Settings.SV))
 	initialSplitsPerProc := int(initialSplitsPerProcessor.Get(&p.ExecCfg().Settings.SV))
 
-	// Capture the cumulative imported row count from previous runs before
-	// starting the current ingest. The progress summary is overwritten during
-	// ingest, so we must read it beforehand. This is needed because r.res.Rows
-	// only reflects the current run's ingested rows.
 	pkID := kvpb.BulkOpSummaryID(uint64(table.Desc.ID), uint64(table.Desc.PrimaryIndex.ID))
-	var previouslyImportedRows int64
-	{
-		prog := r.job.Progress()
-		if importProgress := prog.GetImport(); importProgress != nil {
-			previouslyImportedRows = importProgress.Summary.EntryCounts[pkID]
-		}
-	}
 
 	res, err := ingestWithRetry(
 		ctx, p, r.job, importTable, typeDescs, files, format, details.Walltime,
@@ -352,6 +341,14 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	// Reload the job to pick up progress updates that may have been
+	// written to a reloaded job pointer during ingestWithRetry retries.
+	reloadedJob, err := p.ExecCfg().JobRegistry.LoadClaimedJob(ctx, r.job.ID())
+	if err != nil {
+		return err
+	}
+	r.job = reloadedJob
 
 	r.res.DataSize = res.DataSize
 	for id, count := range res.EntryCounts {
@@ -420,7 +417,16 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 
-			expectedRowCount := uint64(r.res.Rows + previouslyImportedRows + int64(table.InitialRowCount) + r.testingKnobs.expectedRowCountOffset)
+			// Read the total imported row count from the job progress
+			// summary. This is the single source of truth that correctly
+			// accounts for rows across all distImport attempts (including
+			// retries within ingestWithRetry) and previous Resume runs.
+			prog := r.job.Progress()
+			var totalImportedRows int64
+			if importProgress := prog.GetImport(); importProgress != nil {
+				totalImportedRows = importProgress.Summary.EntryCounts[pkID]
+			}
+			expectedRowCount := uint64(totalImportedRows + int64(table.InitialRowCount) + r.testingKnobs.expectedRowCountOffset)
 			checks, err = inspect.ChecksForTable(ctx, p.ExecCfg(), tblDesc, &expectedRowCount)
 			return err
 		}); err != nil {

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -377,6 +377,14 @@ func distImport(
 		return kvpb.BulkOpSummary{}, err
 	}
 
+	// Persist the final checkpoint so the job progress summary reflects
+	// all rows ingested in this distImport call. The periodic ticker may
+	// not have fired since the last batch completed, so without this
+	// explicit flush the summary could be stale.
+	if err := checkpoint.Persist(ctx, job); err != nil {
+		return kvpb.BulkOpSummary{}, err
+	}
+
 	return res, nil
 }
 


### PR DESCRIPTION
The row count validation added for IMPORT INTO accounted for retries that re-enter Resume (pause/resume, node restart) but not retries within ingestWithRetry. When a transient error triggers a retry, rows from the successful first attempt persist in KV, but the result only reflects the last attempt. This caused a row count mismatch.

Fix by using the job progress summary as the source of truth for total imported rows, and ensure distImport always flushes the summary before returning.

Fixes: https://github.com/cockroachdb/cockroach/issues/165540
Release note: None
Epic: None