### PR TITLE
release-26.1: kvnemesis: temporarily allow mid-test stats mismatches

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -86,7 +86,12 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 				// will likely be caught by the consistency checker at the end of the
 				// test as well, but it may not be if there is a stats recomputation for
 				// some reason.
-				t.Errorf("SysBytes mismatch detected during Raft command application: %v", mismatchErr)
+				//
+				// TODO(#160144): Until we get some of these failures under control, we
+				// have reverted this to a log line so that the nightlies can discover
+				// other issues. Now, we'll only report failures if they persist until
+				// the consistency check at the end fo the test.
+				t.Logf("SysBytes mismatch detected during Raft command application: %v", mismatchErr)
 			}
 		},
 	}


### PR DESCRIPTION
Backport 1/1 commits from #160905 on behalf of @stevendanna.

----

This increased the failure rate of some KVNemesis suites more than expected. We have plenty examples of such failures and are investigating them. Moving this to a log line will hopefully ensure our nightly stress runs isn't just finding these stats mismatch problems.

Epic: none

Release note: None

----

Release justification: Testing only.