### PR TITLE
ui: remove unused queryPlan, nonTableStats, and schemaInsights reducers

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -138,13 +138,6 @@ export const invalidateIndexStats =
   indexStatsReducerObj.cachedDataReducer.invalidateData;
 export const refreshIndexStats = indexStatsReducerObj.refresh;
 
-const nonTableStatsReducerObj = new CachedDataReducer(
-  api.getNonTableStats,
-  "nonTableStats",
-  moment.duration(1, "m"),
-);
-export const refreshNonTableStats = nonTableStatsReducerObj.refresh;
-
 const logsReducerObj = new CachedDataReducer(
   api.getLogs,
   "logs",
@@ -158,15 +151,6 @@ export const livenessReducerObj = new CachedDataReducer(
   moment.duration(10, "s"),
 );
 export const refreshLiveness = livenessReducerObj.refresh;
-
-export const queryToID = (req: api.QueryPlanRequestMessage): string =>
-  req.query;
-
-const queryPlanReducerObj = new CachedDataReducer(
-  api.getQueryPlan,
-  "queryPlan",
-);
-export const refreshQueryPlan = queryPlanReducerObj.refresh;
 
 export const problemRangesRequestKey = (
   req: api.ProblemRangesRequestMessage,
@@ -406,14 +390,6 @@ const statementFingerprintInsightsReducerObj = new KeyedCachedDataReducer(
 export const refreshStatementFingerprintInsights =
   statementFingerprintInsightsReducerObj.refresh;
 
-const schemaInsightsReducerObj = new CachedDataReducer(
-  clusterUiApi.getSchemaInsights,
-  "schemaInsights",
-  null,
-  moment.duration(5, "m"),
-);
-export const refreshSchemaInsights = schemaInsightsReducerObj.refresh;
-
 const snapshotsReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.listTracingSnapshots,
   "snapshots",
@@ -465,10 +441,8 @@ export interface APIReducersState {
   locations: CachedDataReducerState<api.LocationsResponseMessage>;
   databases: CachedDataReducerState<clusterUiApi.DatabasesListResponse>;
   indexStats: KeyedCachedDataReducerState<api.IndexStatsResponseMessage>;
-  nonTableStats: CachedDataReducerState<api.NonTableStatsResponseMessage>;
   logs: CachedDataReducerState<api.LogEntriesResponseMessage>;
   liveness: CachedDataReducerState<api.LivenessResponseMessage>;
-  queryPlan: CachedDataReducerState<api.QueryPlanResponseMessage>;
   problemRanges: KeyedCachedDataReducerState<api.ProblemRangesResponseMessage>;
   certificates: KeyedCachedDataReducerState<api.CertificatesResponseMessage>;
   range: KeyedCachedDataReducerState<api.RangeResponseMessage>;
@@ -497,9 +471,6 @@ export interface APIReducersState {
   txnInsights: CachedDataReducerState<
     clusterUiApi.SqlApiResponse<TxnInsightEvent[]>
   >;
-  schemaInsights: CachedDataReducerState<
-    clusterUiApi.SqlApiResponse<clusterUiApi.InsightRecommendation[]>
-  >;
   statementFingerprintInsights: KeyedCachedDataReducerState<
     clusterUiApi.SqlApiResponse<StmtInsightEvent[]>
   >;
@@ -518,10 +489,8 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [locationsReducerObj.actionNamespace]: locationsReducerObj.reducer,
   [databasesReducerObj.actionNamespace]: databasesReducerObj.reducer,
   [indexStatsReducerObj.actionNamespace]: indexStatsReducerObj.reducer,
-  [nonTableStatsReducerObj.actionNamespace]: nonTableStatsReducerObj.reducer,
   [logsReducerObj.actionNamespace]: logsReducerObj.reducer,
   [livenessReducerObj.actionNamespace]: livenessReducerObj.reducer,
-  [queryPlanReducerObj.actionNamespace]: queryPlanReducerObj.reducer,
   [problemRangesReducerObj.actionNamespace]: problemRangesReducerObj.reducer,
   [certificatesReducerObj.actionNamespace]: certificatesReducerObj.reducer,
   [rangeReducerObj.actionNamespace]: rangeReducerObj.reducer,
@@ -547,7 +516,6 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [txnInsightDetailsReducerObj.actionNamespace]:
     txnInsightDetailsReducerObj.reducer,
   [stmtInsightsReducerObj.actionNamespace]: stmtInsightsReducerObj.reducer,
-  [schemaInsightsReducerObj.actionNamespace]: schemaInsightsReducerObj.reducer,
   [snapshotsReducerObj.actionNamespace]: snapshotsReducerObj.reducer,
   [snapshotReducerObj.actionNamespace]: snapshotReducerObj.reducer,
   [rawTraceReducerObj.actionNamespace]: rawTraceReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -63,11 +63,6 @@ export type IndexStatsRequestMessage =
 export type IndexStatsResponseMessage =
   protos.cockroach.server.serverpb.TableIndexStatsResponse;
 
-export type NonTableStatsRequestMessage =
-  protos.cockroach.server.serverpb.NonTableStatsRequest;
-export type NonTableStatsResponseMessage =
-  protos.cockroach.server.serverpb.NonTableStatsResponse;
-
 export type LogsRequestMessage = protos.cockroach.server.serverpb.LogsRequest;
 export type LogEntriesResponseMessage =
   protos.cockroach.server.serverpb.LogEntriesResponse;
@@ -87,11 +82,6 @@ export type ListJobProfilerExecutionDetailsRequestMessage =
   protos.cockroach.server.serverpb.ListJobProfilerExecutionDetailsRequest;
 export type ListJobProfilerExecutionDetailsResponseMessage =
   protos.cockroach.server.serverpb.ListJobProfilerExecutionDetailsResponse;
-
-export type QueryPlanRequestMessage =
-  protos.cockroach.server.serverpb.QueryPlanRequest;
-export type QueryPlanResponseMessage =
-  protos.cockroach.server.serverpb.QueryPlanResponse;
 
 export type ProblemRangesRequestMessage =
   protos.cockroach.server.serverpb.ProblemRangesRequest;
@@ -512,20 +502,6 @@ export function getIndexStats(
   );
 }
 
-// getNonTableStats gets detailed stats about non-table data ranges on the
-// cluster.
-export function getNonTableStats(
-  _req: NonTableStatsRequestMessage,
-  timeout?: moment.Duration,
-): Promise<NonTableStatsResponseMessage> {
-  return timeoutFetch(
-    serverpb.NonTableStatsResponse,
-    `${API_PREFIX}/nontablestats`,
-    null,
-    timeout,
-  );
-}
-
 // TODO (maxlang): add filtering
 // getLogs gets the logs for a specific node
 export function getLogs(
@@ -548,19 +524,6 @@ export function getLiveness(
   return timeoutFetch(
     serverpb.LivenessResponse,
     `${API_PREFIX}/liveness`,
-    null,
-    timeout,
-  );
-}
-
-// getQueryPlan gets physical query plan JSON for the provided query.
-export function getQueryPlan(
-  req: QueryPlanRequestMessage,
-  timeout?: moment.Duration,
-): Promise<QueryPlanResponseMessage> {
-  return timeoutFetch(
-    serverpb.QueryPlanResponse,
-    `${API_PREFIX}/queryplan?query=${encodeURIComponent(req.query)}`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -6,8 +6,6 @@
 import {
   defaultFilters,
   WorkloadInsightEventFilters,
-  insightType,
-  SchemaInsightEventFilters,
   SortSetting,
   selectID,
   selectTransactionFingerprintID,
@@ -153,60 +151,4 @@ export const selectStatementInsightDetails = createSelector(
   selectStmtInsights,
   selectID,
   selectStatementInsightDetailsCombiner,
-);
-
-export const schemaInsightsFiltersLocalSetting = new LocalSetting<
-  AdminUIState,
-  SchemaInsightEventFilters
->("filters/SchemaInsightsPage", (state: AdminUIState) => state.localSettings, {
-  database: defaultFilters.database,
-  schemaInsightType: defaultFilters.schemaInsightType,
-});
-
-export const schemaInsightsSortLocalSetting = new LocalSetting<
-  AdminUIState,
-  SortSetting
->(
-  "sortSetting/SchemaInsightsPage",
-  (state: AdminUIState) => state.localSettings,
-  {
-    ascending: false,
-    columnTitle: "insights",
-  },
-);
-
-export const selectSchemaInsights = createSelector(
-  (state: AdminUIState) => state.cachedData,
-  adminUiState => {
-    if (!adminUiState?.schemaInsights) return [];
-    return adminUiState?.schemaInsights.data?.results;
-  },
-);
-
-export const selectSchemaInsightsMaxApiReached = (
-  state: AdminUIState,
-): boolean => {
-  return !!state.cachedData.schemaInsights?.data?.maxSizeReached;
-};
-
-export const selectSchemaInsightsDatabases = createSelector(
-  selectSchemaInsights,
-  schemaInsights => {
-    if (!schemaInsights) return [];
-    return Array.from(
-      new Set(schemaInsights.map(schemaInsight => schemaInsight.database)),
-    ).sort();
-  },
-);
-
-export const selectSchemaInsightsTypes = createSelector(
-  selectSchemaInsights,
-  schemaInsights => {
-    if (!schemaInsights) return [];
-    return Array.from(
-      new Set(
-        schemaInsights.map(schemaInsight => insightType(schemaInsight.type)),
-      ),
-    ).sort();
-  },
 );


### PR DESCRIPTION
## Summary

- Remove the `queryPlan` and `nonTableStats` CachedDataReducers, their
  API functions (`getQueryPlan`, `getNonTableStats`), and type aliases.
  Neither `refreshQueryPlan` nor `refreshNonTableStats` is imported
  anywhere.
- Remove the `schemaInsights` CachedDataReducer. The db-console schema
  insights page renders cluster-ui's `SchemaInsightsView` directly,
  which fetches data via its own `useSchemaInsights()` SWR hook. Also
  remove the dead `selectSchemaInsights*` selectors and local settings
  from `insightsSelectors.ts`.

Epic: CRDB-58145
Release note: None