### PR TITLE
kvserver: mv TODOBothEngines up the stack

### DIFF
--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -725,6 +725,7 @@ func (r *Replica) computeChecksumPostApply(
 		}
 		// NB: the names here will match on all nodes, which is nice for debugging.
 		tag := fmt.Sprintf("r%d_at_%d", r.RangeID, as.RaftAppliedIndex)
+		_ = r.store.TODOBothEngines() // need two sets of spans, one for each engine
 		spans := r.store.checkpointSpans(&desc)
 		log.KvExec.Warningf(ctx, "creating checkpoint %s with spans %+v", tag, spans)
 		if dir, err := r.store.checkpoint(tag, spans); err != nil {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3618,7 +3618,6 @@ func (s *Store) checkpointsDir() string {
 // storage issues, e.g. in situations when a recent reconfiguration like split
 // or merge occurred.
 func (s *Store) checkpointSpans(desc *roachpb.RangeDescriptor) []roachpb.Span {
-	_ = s.TODOBothEngines() // need to return two sets of spans, one for each engine
 	// Find immediate left and right neighbours by range ID.
 	var prevID, nextID roachpb.RangeID
 	s.mu.replicasByRangeID.Range(func(rangeID roachpb.RangeID, _ *Replica) bool {


### PR DESCRIPTION
The engines are not used inside the `checkpointSpans` func. Moving the placeholder call up fixes a test which has a nil engine.

Fixes #165698