### PR TITLE
sql: add database and enabled columns to SHOW STATEMENT HINTS

### DIFF
--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -198,6 +198,8 @@ var ShowStatementHintsColumns = ResultColumns{
 	{Name: "row_id", Typ: types.Int},
 	{Name: "fingerprint", Typ: types.String},
 	{Name: "hint_type", Typ: types.String},
+	{Name: "database", Typ: types.String},
+	{Name: "enabled", Typ: types.Bool},
 	{Name: "created_at", Typ: types.TimestampTZ},
 }
 
@@ -207,6 +209,8 @@ var ShowStatementHintsDetailsColumns = ResultColumns{
 	{Name: "row_id", Typ: types.Int},
 	{Name: "fingerprint", Typ: types.String},
 	{Name: "hint_type", Typ: types.String},
+	{Name: "database", Typ: types.String},
+	{Name: "enabled", Typ: types.Bool},
 	{Name: "created_at", Typ: types.TimestampTZ},
 	{Name: "details", Typ: types.Jsonb},
 }

--- a/pkg/sql/logictest/testdata/logic_test/show_statement_hints
+++ b/pkg/sql/logictest/testdata/logic_test/show_statement_hints
@@ -28,28 +28,28 @@ GRANT SYSTEM VIEWCLUSTERMETADATA TO testuser2
 # Now testuser2 can query statement hints.
 user testuser2
 
-query ITTT colnames
+query ITTTBT colnames
 SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10';
 ----
-row_id  fingerprint  hint_type  created_at
+row_id  fingerprint  hint_type  database  enabled  created_at
 
-query ITTTT colnames
+query ITTTBTT colnames
 SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10' WITH DETAILS;
 ----
-row_id  fingerprint  hint_type  created_at  details
+row_id  fingerprint  hint_type  database  enabled  created_at  details
 
 user root
 
 # Test with no hints.
-query ITTT colnames
+query ITTTBT colnames
 SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10';
 ----
-row_id  fingerprint  hint_type  created_at
+row_id  fingerprint  hint_type  database  enabled  created_at
 
-query ITTTT colnames
+query ITTTBTT colnames
 SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10' WITH DETAILS;
 ----
-row_id  fingerprint  hint_type  created_at  details
+row_id  fingerprint  hint_type  database  enabled  created_at  details
 
 statement ok
 SELECT crdb_internal.inject_hint(
@@ -59,20 +59,20 @@ SELECT crdb_internal.inject_hint(
 
 # Test SHOW STATEMENT HINTS without DETAILS. Note that hints are shown for the
 # fingerprint with constants removed.
-query TT colnames
-SELECT fingerprint, hint_type
+query TTBT colnames
+SELECT fingerprint, hint_type, enabled, database
 FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10'];
 ----
-fingerprint                   hint_type
-SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS
+fingerprint                   hint_type             enabled  database
+SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS  true     NULL
 
 # Test SHOW STATEMENT HINTS with DETAILS.
-query TTT colnames
-SELECT fingerprint, hint_type, details
+query TTTBT colnames
+SELECT fingerprint, hint_type, details, enabled, database
 FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10' WITH DETAILS];
 ----
-fingerprint                   hint_type             details
-SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM xy@xy_y_idx WHERE y = _"}
+fingerprint                   hint_type             details                                                  enabled  database
+SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM xy@xy_y_idx WHERE y = _"}  true     NULL
 
 # Case with a placeholder in the requested statement.
 query TTT
@@ -96,8 +96,24 @@ ORDER BY created_at DESC, row_id DESC;
 fingerprint                                                   hint_type             details
 WITH cte AS (SELECT * FROM xy WHERE y = _) SELECT * FROM cte  REWRITE INLINE HINTS  {"donorSql": "WITH cte AS (SELECT * FROM xy@xy_y_idx WHERE y = _) SELECT * FROM cte"}
 
+# Test with a hint scoped to a specific database using the 3-arg overload.
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT * FROM ab WHERE b = _',
+  'SELECT * FROM ab@ab_b_idx WHERE b = _',
+  'test'
+);
+
+skipif config local-mixed-25.4 local-mixed-26.1
+query TTBT colnames
+SELECT fingerprint, hint_type, enabled, database
+FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM ab WHERE b = 10'];
+----
+fingerprint                   hint_type             enabled  database
+SELECT * FROM ab WHERE b = _  REWRITE INLINE HINTS  true     test
+
 # Test with non-existent fingerprint.
-query ITTT
+query ITTTBT
 SHOW STATEMENT HINTS FOR 'SELECT * FROM nonexistent WHERE x = 1';
 ----
 

--- a/pkg/sql/show_statement_hints.go
+++ b/pkg/sql/show_statement_hints.go
@@ -131,13 +131,13 @@ func (p *planner) ShowStatementHints(
 			var query string
 			if versionHasHintTypeCol {
 				query = `
-SELECT row_id, fingerprint, hint, created_at, hint_type
+SELECT row_id, fingerprint, hint, created_at, hint_type, database, enabled
 FROM system.statement_hints
 WHERE fingerprint = $1
 ORDER BY created_at DESC, row_id DESC`
 			} else {
 				query = `
-SELECT row_id, fingerprint, hint, created_at, NULL::STRING AS hint_type
+SELECT row_id, fingerprint, hint, created_at, NULL::STRING AS hint_type, NULL::STRING AS database, true::BOOL AS enabled
 FROM system.statement_hints
 WHERE fingerprint = $1
 ORDER BY created_at DESC, row_id DESC`
@@ -163,6 +163,8 @@ ORDER BY created_at DESC, row_id DESC`
 				hintBytes := row[2] // BYTES
 				createdAt := row[3] // TIMESTAMPTZ
 				hintType := row[4]  // STRING (hint_type column)
+				database := row[5]  // STRING (database column, nullable)
+				enabled := row[6]   // BOOL (enabled column)
 
 				var details = tree.DNull
 				if (!versionHasHintTypeCol || n.Options.Details) && hintBytes != tree.DNull {
@@ -186,9 +188,9 @@ ORDER BY created_at DESC, row_id DESC`
 
 				var outputRow tree.Datums
 				if n.Options.Details {
-					outputRow = tree.Datums{rowID, fp, hintType, createdAt, details}
+					outputRow = tree.Datums{rowID, fp, hintType, database, enabled, createdAt, details}
 				} else {
-					outputRow = tree.Datums{rowID, fp, hintType, createdAt}
+					outputRow = tree.Datums{rowID, fp, hintType, database, enabled, createdAt}
 				}
 
 				if _, err := v.rows.AddRow(ctx, outputRow); err != nil {


### PR DESCRIPTION
#### sql: add database and enabled columns to SHOW STATEMENT HINTS

Add the `database` and `enabled` columns to the output of
SHOW STATEMENT HINTS, matching the columns added to the
system.statement_hints table by the
V26_2_StatementHintsTypeNameEnabledColumnsAdded migration.

New column order:
  row_id, fingerprint, hint_type, database, enabled, created_at [, details]

For clusters that haven't completed the migration, `database`
defaults to NULL and `enabled` defaults to true.

Informs: #163522
Release note (sql change): SHOW STATEMENT HINTS now includes
`database` and `enabled` columns in its output.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>