### PR TITLE
mmaprototype: emit shedding stores via Infof

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -567,7 +567,7 @@ func sortTargetCandidateSetAndPick(
 		if !diversityScoresAlmostEqual(bestDiversity, cand.diversityScore) {
 			// Have a set of candidates with the best diversity.
 			if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
-				log.KvDistribution.VEventf(ctx, 2, "discarding candidates due to lower diversity score: %s", s)
+				log.KvDistribution.VEventf(ctx, 3, "discarding candidates due to lower diversity score: %s", s)
 			}
 			break
 		}
@@ -599,7 +599,7 @@ func sortTargetCandidateSetAndPick(
 				// pending changes. We will wait for those to have no pending changes
 				// before we consider later sets.
 				if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
-					log.KvDistribution.VEventf(ctx, 2,
+					log.KvDistribution.VEventf(ctx, 3,
 						"candidate with pending changes was discarded, discarding remaining candidates with higher load: %s", s)
 				}
 				break
@@ -613,7 +613,7 @@ func sortTargetCandidateSetAndPick(
 			} else if ignoreLevel < ignoreHigherThanLoadThreshold || overloadedDim == NumLoadDimensions {
 				// Past the lowestLoad set. We don't care about these.
 				if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
-					log.KvDistribution.VEventf(ctx, 2,
+					log.KvDistribution.VEventf(ctx, 3,
 						"discarding candidates with higher load than lowestLoadSet(%v): %s", lowestLoadSet, s)
 				}
 				break
@@ -624,7 +624,7 @@ func sortTargetCandidateSetAndPick(
 		}
 		if cand.sls > loadThreshold {
 			if s := formatCandidatesLog(cands.candidates[i:]); s != "" {
-				log.KvDistribution.VEventf(ctx, 2,
+				log.KvDistribution.VEventf(ctx, 3,
 					"discarding candidates with higher load than loadThreshold(%v): %s", loadThreshold, s)
 			}
 			break
@@ -639,7 +639,7 @@ func sortTargetCandidateSetAndPick(
 			if cand.maxFractionPendingIncrease > epsilon && discardedCandsHadNoPendingChanges {
 				discardedCandsHadNoPendingChanges = false
 			}
-			log.KvDistribution.VEventf(ctx, 2,
+			log.KvDistribution.VEventf(ctx, 3,
 				"candidate store %v was discarded due to (nls=%t overloadDim=%t pending_thresh=%t): sls=%v", cand.StoreID,
 				candDiscardedByNLS, candDiscardedByOverloadDim, candDiscardedByPendingThreshold, cand.storeLoadSummary)
 			continue
@@ -648,7 +648,7 @@ func sortTargetCandidateSetAndPick(
 		j++
 	}
 	if j == 0 {
-		log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: no candidates due to load")
+		log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: no candidates due to load")
 		failLogger(noCandidateDueToLoad)
 		return 0
 	}
@@ -680,7 +680,7 @@ func sortTargetCandidateSetAndPick(
 	}
 	// INVARIANT: lowestLoad <= loadThreshold.
 	if lowestLoadSet == loadThreshold && ignoreLevel < ignoreHigherThanLoadThreshold {
-		log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: no candidates due to equal to loadThreshold")
+		log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: no candidates due to equal to loadThreshold")
 		failLogger(noCandidateDueToLoad)
 		return 0
 	}
@@ -691,7 +691,7 @@ func sortTargetCandidateSetAndPick(
 	// [loadNoChange, loadThreshold), or loadThreshold && ignoreHigherThanLoadThreshold.
 	if lowestLoadSet >= loadNoChange &&
 		(!discardedCandsHadNoPendingChanges || ignoreLevel == ignoreLoadNoChangeAndHigher) {
-		log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: no candidates due to loadNoChange")
+		log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: no candidates due to loadNoChange")
 		failLogger(noCandidateDueToLoad)
 		return 0
 	}
@@ -747,7 +747,7 @@ func sortTargetCandidateSetAndPick(
 		j++
 	}
 	if j == 0 {
-		log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: no candidates due to lease preference")
+		log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: no candidates due to lease preference")
 		failLogger(noCandidateDueToUnmatchedLeasePreference)
 		return 0
 	}
@@ -761,7 +761,7 @@ func sortTargetCandidateSetAndPick(
 		})
 		lowestOverloadedLoad := cands.candidates[0].dimSummary[overloadedDim]
 		if lowestOverloadedLoad >= loadNoChange {
-			log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: no candidates due to overloadedDim")
+			log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: no candidates due to overloadedDim")
 			failLogger(noCandidateDueToLoad)
 			return 0
 		}
@@ -773,13 +773,13 @@ func sortTargetCandidateSetAndPick(
 			j++
 		}
 		if s := formatCandidatesLog(cands.candidates[j:]); s != "" {
-			log.KvDistribution.VEventf(ctx, 2, "discarding candidates due to overloadedDim: %s", s)
+			log.KvDistribution.VEventf(ctx, 3, "discarding candidates due to overloadedDim: %s", s)
 		}
 		cands.candidates = cands.candidates[:j]
 	}
 	s := formatCandidatesLog(cands.candidates)
 	j = rng.Intn(j)
-	log.KvDistribution.VEventf(ctx, 2, "sortTargetCandidateSetAndPick: candidates:%s, picked s%v", s, cands.candidates[j].StoreID)
+	log.KvDistribution.VEventf(ctx, 3, "sortTargetCandidateSetAndPick: candidates:%s, picked s%v", s, cands.candidates[j].StoreID)
 	if ignoreLevel == ignoreLoadNoChangeAndHigher && cands.candidates[j].sls >= loadNoChange ||
 		ignoreLevel == ignoreLoadThresholdAndHigher && cands.candidates[j].sls >= loadThreshold ||
 		ignoreLevel == ignoreHigherThanLoadThreshold && cands.candidates[j].sls > loadThreshold {
@@ -945,7 +945,7 @@ func (cs *clusterState) computeCandidatesForReplicaTransfer(
 		cs.scratchMeans = computeMeansForStoreSet(
 			cs, filteredStores, cs.meansMemo.scratchNodes, cs.meansMemo.scratchStores)
 		effectiveMeans = &cs.scratchMeans
-		log.KvDistribution.VEventf(ctx, 2,
+		log.KvDistribution.VEventf(ctx, 3,
 			"pre-means filtered %d stores → remaining %v, means: store=%v node=%v",
 			len(means.stores)-len(filteredStores), filteredStores,
 			effectiveMeans.storeLoad, effectiveMeans.nodeLoad)
@@ -1016,7 +1016,7 @@ func retainReadyReplicaTargetStoresOnly(
 		ss := stores[storeID]
 		switch {
 		case ss.status.Disposition.Replica != ReplicaDispositionOK:
-			log.KvDistribution.VEventf(ctx, 2, "skipping s%d for replica transfer: replica disposition %v (health %v)", storeID, ss.status.Disposition.Replica, ss.status.Health)
+			log.KvDistribution.VEventf(ctx, 3, "skipping s%d for replica transfer: replica disposition %v (health %v)", storeID, ss.status.Disposition.Replica, ss.status.Health)
 		default:
 			out = append(out, storeID)
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -2442,13 +2442,13 @@ func (cs *clusterState) canShedAndAddLoad(
 	srcNS.adjustedCPU += delta[CPURate]
 
 	var failureReason redact.StringBuilder
-	populateFailureReason := log.ExpensiveLogEnabled(ctx, 2)
+	populateFailureReason := log.ExpensiveLogEnabled(ctx, 3)
 	defer func() {
 		if canAddLoad {
 			log.KvDistribution.VEventf(ctx, 3, "can add load to n%vs%v: %v targetSLS[%v] srcSLS[%v]",
 				targetNS.NodeID, targetSS.StoreID, canAddLoad, targetSLS, srcSLS)
 		} else if populateFailureReason {
-			log.KvDistribution.VEventf(ctx, 2,
+			log.KvDistribution.VEventf(ctx, 3,
 				"cannot add load from n%vs%v to n%vs%v for r%v due to %v: delta(%v) targetSLS[%v] srcSLS[%v]",
 				srcNS.NodeID, srcSS.StoreID, targetNS.NodeID, targetSS.StoreID, rangeID,
 				&failureReason, delta, targetSLS, srcSLS)
@@ -2536,7 +2536,7 @@ func (cs *clusterState) canShedAndAddLoad(
 			dimFractionIncrease := float64(deltaToAdd[dim]) / float64(targetSS.adjusted.load[dim])
 			// The use of 33% is arbitrary.
 			if dimFractionIncrease > overloadedDimFractionIncrease/3 {
-				log.KvDistribution.VEventf(ctx, 2, "%v: %f > %f/3", dim, dimFractionIncrease, overloadedDimFractionIncrease)
+				log.KvDistribution.VEventf(ctx, 3, "%v: %f > %f/3", dim, dimFractionIncrease, overloadedDimFractionIncrease)
 				otherDimensionsBecameWorseInTarget = true
 				break
 			}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -245,11 +245,13 @@ func (re *rebalanceEnv) rebalanceStores(
 			cmp.Compare(a.StoreID, b.StoreID))
 	})
 
-	if log.V(2) {
-		log.KvDistribution.VEventf(ctx, 2, "sorted shedding stores:")
+	if re.passObs != nil && len(sheddingStores) > 0 {
+		var buf redact.StringBuilder
+		buf.SafeString("sorted shedding stores:")
 		for _, store := range sheddingStores {
-			log.KvDistribution.VEventf(ctx, 2, "  (s%d: %s)", store.StoreID, store.sls)
+			buf.Printf(" (s%d: %s)", store.StoreID, store.sls)
 		}
+		log.KvDistribution.Infof(ctx, "%s", buf.RedactableString())
 	}
 
 	i := 0

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -479,12 +479,12 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		rstate := re.ranges[rangeID]
 		if len(rstate.pendingChanges) > 0 {
 			// If the range has pending changes, don't make more changes.
-			log.KvDistribution.VEventf(ctx, 2, "skipping r%d: has pending changes", rangeID)
+			log.KvDistribution.VEventf(ctx, 3, "skipping r%d: has pending changes", rangeID)
 			re.passObs.replicaShed(rangeTransient)
 			continue
 		}
 		if re.now.Sub(rstate.lastFailedChange) < re.lastFailedChangeDelayDuration {
-			log.KvDistribution.VEventf(ctx, 2, "skipping r%d: too soon after failed change", rangeID)
+			log.KvDistribution.VEventf(ctx, 3, "skipping r%d: too soon after failed change", rangeID)
 			re.passObs.replicaShed(rangeTransient)
 			continue
 		}
@@ -520,7 +520,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 			// This range has some constraints that are violated. Let those be
 			// fixed first.
 			re.passObs.replicaShed(rangeConstraintsViolated)
-			log.KvDistribution.VEventf(ctx, 2, "skipping r%d: constraint violation needs fixing first: %v", rangeID, err)
+			log.KvDistribution.VEventf(ctx, 3, "skipping r%d: constraint violation needs fixing first: %v", rangeID, err)
 			continue
 		}
 		// Build post-means exclusions: stores whose load is included in the mean
@@ -555,7 +555,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		//
 		// TODO(sumeer): eliminate cands allocations by passing a scratch slice.
 		cands, ssSLS := re.computeCandidatesForReplicaTransfer(ctx, conj, existingReplicas, re.scratch.postMeansExclusions, store.StoreID, re.passObs)
-		log.KvDistribution.VEventf(ctx, 2, "considering replica-transfer r%v from s%v: store load %v",
+		log.KvDistribution.VEventf(ctx, 3, "considering replica-transfer r%v from s%v: store load %v",
 			rangeID, store.StoreID, ss.adjusted.load)
 		if log.ExpensiveLogEnabled(ctx, 3) {
 			var buf redact.StringBuilder
@@ -567,7 +567,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		}
 
 		if len(cands.candidates) == 0 {
-			log.KvDistribution.VEventf(ctx, 2, "result(failed): no candidates found for r%d after exclusions", rangeID)
+			log.KvDistribution.VEventf(ctx, 3, "result(failed): no candidates found for r%d after exclusions", rangeID)
 			continue
 		}
 		var rlocalities replicasLocalityTiers
@@ -599,7 +599,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 			ctx, cands, ssSLS.sls, ignoreLevel, loadDim, re.rng,
 			re.fractionPendingIncreaseOrDecreaseThreshold, re.passObs.replicaShed)
 		if targetStoreID == 0 {
-			log.KvDistribution.VEventf(ctx, 2, "result(failed): no suitable target found among candidates for r%d "+
+			log.KvDistribution.VEventf(ctx, 3, "result(failed): no suitable target found among candidates for r%d "+
 				"(threshold %s; %s)", rangeID, ssSLS.sls, ignoreLevel)
 			continue
 		}
@@ -676,7 +676,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		rstate := re.ranges[rangeID]
 		if len(rstate.pendingChanges) > 0 {
 			// If the range has pending changes, don't make more changes.
-			log.KvDistribution.VEventf(ctx, 2, "skipping r%d: has pending changes", rangeID)
+			log.KvDistribution.VEventf(ctx, 3, "skipping r%d: has pending changes", rangeID)
 			re.passObs.leaseShed(rangeTransient)
 			continue
 		}
@@ -706,7 +706,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 				ctx, "internal state inconsistency: local store is not a replica: %+v", rstate)
 		}
 		if re.now.Sub(rstate.lastFailedChange) < re.lastFailedChangeDelayDuration {
-			log.KvDistribution.VEventf(ctx, 2, "skipping r%d: too soon after failed change", rangeID)
+			log.KvDistribution.VEventf(ctx, 3, "skipping r%d: too soon after failed change", rangeID)
 			re.passObs.leaseShed(rangeTransient)
 			continue
 		}
@@ -757,7 +757,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		}
 		// NB: intentionally log before re-adding the current leaseholder so
 		// we don't list it as a candidate.
-		log.KvDistribution.VEventf(ctx, 2, "considering lease-transfer r%v from s%v: candidates are %v", rangeID, store.StoreID, candsPL)
+		log.KvDistribution.VEventf(ctx, 3, "considering lease-transfer r%v from s%v: candidates are %v", rangeID, store.StoreID, candsPL)
 		// Now candsPL is ready for computing the means.
 		candsPL.insert(store.StoreID)
 
@@ -770,7 +770,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		// INVARIANT: candsPL - {store.StoreID} \subset cands
 		if len(candsPL) == 0 || (len(candsPL) == 1 && candsPL[0] == store.StoreID) {
 			re.passObs.leaseShed(noHealthyCandidate)
-			log.KvDistribution.VEventf(ctx, 2,
+			log.KvDistribution.VEventf(ctx, 3,
 				"result(failed): no candidates to move lease from n%vs%v for r%v after retainReadyLeaseTargetStoresOnly",
 				ss.NodeID, ss.StoreID, rangeID)
 			continue
@@ -786,7 +786,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		if sls.dimSummary[CPURate] < overloadSlow {
 			// This store is not cpu overloaded relative to these candidates for
 			// this range.
-			log.KvDistribution.VEventf(ctx, 2, "result(failed): skipping r%d since store not overloaded relative to candidates", rangeID)
+			log.KvDistribution.VEventf(ctx, 3, "result(failed): skipping r%d since store not overloaded relative to candidates", rangeID)
 			re.passObs.leaseShed(notOverloaded)
 			continue
 		}
@@ -818,7 +818,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			re.fractionPendingIncreaseOrDecreaseThreshold, re.passObs.leaseShed)
 		if targetStoreID == 0 {
 			log.KvDistribution.VEventf(
-				ctx, 2,
+				ctx, 3,
 				"result(failed): no candidates to move lease from n%vs%v for r%v after sortTargetCandidateSetAndPick",
 				ss.NodeID, ss.StoreID, rangeID)
 			continue
@@ -901,9 +901,9 @@ func retainReadyLeaseTargetStoresOnly(
 		s := stores[storeID].status
 		switch {
 		case s.Disposition.Lease != LeaseDispositionOK:
-			log.KvDistribution.VEventf(ctx, 2, "skipping s%d for lease transfer: lease disposition %v (health %v)", storeID, s.Disposition.Lease, s.Health)
+			log.KvDistribution.VEventf(ctx, 3, "skipping s%d for lease transfer: lease disposition %v (health %v)", storeID, s.Disposition.Lease, s.Health)
 		case stores[storeID].adjusted.replicas[rangeID].LeaseDisposition != LeaseDispositionOK:
-			log.KvDistribution.VEventf(ctx, 2, "skipping s%d for lease transfer: replica lease disposition %v (health %v)", storeID, stores[storeID].adjusted.replicas[rangeID].LeaseDisposition, s.Health)
+			log.KvDistribution.VEventf(ctx, 3, "skipping s%d for lease transfer: replica lease disposition %v (health %v)", storeID, stores[storeID].adjusted.replicas[rangeID].LeaseDisposition, s.Health)
 		default:
 			out = append(out, storeID)
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_cpu_integer_granularity.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_cpu_integer_granularity.txt
@@ -118,6 +118,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
 [mmaid=1] load summary for dim=CPURate (n5): loadNormal, reason: load is within 5% of mean [load=6 meanLoad=6 fractionUsed=6.00% meanUtil=6.20% capacity=100]
 [mmaid=1] evaluating s5: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] sorted shedding stores: (s3: overloadSlow)
 [mmaid=1] start processing shedding store s3: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] skipping remote store s3: in lease shedding grace period
@@ -148,6 +149,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s5: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=2] sorted shedding stores: (s3: overloadSlow)
 [mmaid=2] start processing shedding store s3: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:1ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_write_bandwidth_transfer_spreads_overload.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/low_write_bandwidth_transfer_spreads_overload.txt
@@ -93,6 +93,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000000]
 [mmaid=1] load summary for dim=CPURate (n4): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=5.00% capacity=2000]
 [mmaid=1] evaluating s4: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] sorted shedding stores: (s2: overloadSlow)
 [mmaid=1] start processing shedding store s2: cpu node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
 [mmaid=1] top-K[WriteBandwidth] ranges for s2 with lease on local s1: r1:[cpu:1ns/s, write-bandwidth:800 kB/s, byte-size:0 B]
 [mmaid=1] attempting to shed replicas next
@@ -154,6 +155,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] evaluating s4: node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
 [mmaid=2] overload-continued s4 ((store=overloadSlow worst=WriteBandwidth cpu=loadNormal writes=overloadSlow bytes=loadNormal node=loadNormal frac_pending=0.09,0.00(false))) - within grace period
 [mmaid=2] skipping overloaded store s4 (worst dim: WriteBandwidth): pending decrease 0.00 >= threshold 10.00 or pending increase 0.09 >= epsilon
+[mmaid=2] sorted shedding stores: (s2: overloadSlow)
 [mmaid=2] start processing shedding store s2: cpu node load loadNormal, store load overloadSlow, worst dim WriteBandwidth
 [mmaid=2] top-K[WriteBandwidth] ranges for s2 with lease on local s1: r1:[cpu:1ns/s, write-bandwidth:800 kB/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
@@ -178,6 +178,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=1] load summary for dim=ByteSize (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
 [mmaid=1] load summary for dim=CPURate (n7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
 [mmaid=1] evaluating s7: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s1: overloadSlow) (s2: overloadSlow) (s3: overloadSlow)
 [mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r3:[cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
@@ -26,6 +26,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r3:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
@@ -66,6 +66,7 @@ rebalance-stores store-id=1
 [mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent) (s3: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_replica_refusing.txt
@@ -74,6 +74,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=800 meanLoad=866 fractionUsed=80.00% meanUtil=86.67% capacity=1000]
 [mmaid=1] evaluating s3: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
@@ -26,6 +26,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-tr
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r3:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
@@ -25,6 +25,7 @@ rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-t
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r3:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
@@ -13,6 +13,7 @@ rebalance-stores store-id=1 max-range-move-count=1 fraction-pending-decrease-thr
 [mmaid=2] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=2] sorted shedding stores: (s3: overloadUrgent)
 [mmaid=2] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
@@ -13,6 +13,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=2] sorted shedding stores: (s3: overloadUrgent)
 [mmaid=2] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
@@ -88,6 +88,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s3: overloadUrgent)
 [mmaid=1] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] skipping remote store s3: in lease shedding grace period

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_lateral.txt
@@ -71,6 +71,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadNormal, reason: load is within 5% of mean [load=100 meanLoad=100 fractionUsed=5.00% meanUtil=7.50% capacity=2000]
 [mmaid=1] evaluating s4: node load loadNormal, store load loadNormal, worst dim ByteSize
+[mmaid=1] sorted shedding stores: (s1: overloadSlow) (s2: overloadSlow) (s3: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load loadNoChange, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first
@@ -157,6 +158,7 @@ rebalance-stores store-id=1
 [mmaid=2] evaluating s3: node load loadNormal, store load overloadUrgent, worst dim WriteBandwidth
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadNormal, store load loadNormal, worst dim ByteSize
+[mmaid=2] sorted shedding stores: (s1: overloadSlow) (s2: overloadSlow) (s3: overloadUrgent)
 [mmaid=2] start processing shedding store s1: cpu node load loadNoChange, store load overloadSlow, worst dim CPURate
 [mmaid=2] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:10ns/s, write-bandwidth:10 MB/s, byte-size:0 B]
 [mmaid=2] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_refusing_target.txt
@@ -77,6 +77,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=775 fractionUsed=10.00% meanUtil=77.50% capacity=1000]
 [mmaid=1] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent) (s2: overloadUrgent) (s3: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
@@ -16,6 +16,7 @@ rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-t
 [mmaid=2] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=2] sorted shedding stores: (s3: overloadUrgent)
 [mmaid=2] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_nls_sls_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_nls_sls_mismatch.txt
@@ -88,6 +88,7 @@ rebalance-stores store-id=1
 [mmaid=1] evaluating s3: node load loadLow, store load overloadSlow, worst dim WriteBandwidth
 [mmaid=1] overload-continued s3 ((store=overloadSlow worst=WriteBandwidth cpu=loadLow writes=overloadSlow bytes=loadNormal node=loadLow frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
+[mmaid=1] sorted shedding stores: (s1: overloadSlow) (s2: overloadSlow) (s3: overloadSlow)
 [mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim WriteBandwidth
 [mmaid=1] top-K[WriteBandwidth] ranges for s1 with lease on local s1: r1:[cpu:100ms/s, write-bandwidth:10 MB/s, byte-size:0 B]
 [mmaid=1] skipping lease shedding for calling store s1: not cpu overloaded: loadLow

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
@@ -67,6 +67,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
 [mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
 [mmaid=1] evaluating s2: node load loadLow, store load loadLow, worst dim CPURate
+[mmaid=1] sorted shedding stores: (s1: overloadSlow)
 [mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:50ns/s, write-bandwidth:50 B/s, byte-size:50 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status_exclusion.txt
@@ -173,6 +173,7 @@ rebalance-stores store-id=1
 [mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
 [mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] sorted shedding stores: (s1: overloadUrgent)
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: bump per-range log level to V(3)**

This change bumps per-range and per-candidate log calls from V(2) to
V(3). Store-level log calls (cluster means, shedding store list,
overload status) remain at V(2). With many overloaded stores, the
per-range output dominates the log at V(2), drowning out the
store-level decisions that are more useful for debugging.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**mmaprototype: emit shedding stores via Infof**

This change replaces the `log.V(2)` guard on the sorted shedding
stores log with a `passObs != nil` check, emitting via `Infof`
during periodic rebalancing passes. This is store-level context
(not per-range), so the volume is low and always useful.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

