### PR TITLE
sql/schemachanger: add `ALTER TYPE ... ADD VALUE` to declarative schema changer

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2841,6 +2841,11 @@ func TestBackupRestoreDuringUserDefinedTypeChange(t *testing.T) {
 				})
 				defer cleanupFn()
 
+				// Use the legacy schema changer for the initial and restored
+				// jobs.
+				sqlDB.Exec(t, `SET use_declarative_schema_changer = 'off'`)
+				sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';`)
+
 				// Create a database with a type.
 				sqlDB.Exec(t, `
 CREATE DATABASE d;

--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -540,6 +540,13 @@ func TestBackupRollbacks_base_alter_table_validate_constraint(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1384,6 +1391,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_validate_constraint(t *tes
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2234,6 +2248,13 @@ func TestBackupSuccess_base_alter_table_validate_constraint(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3078,6 +3099,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_validate_constraint(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1209,7 +1209,7 @@ func (b *builderState) ResolveUserDefinedTypeType(
 	name *tree.UnresolvedObjectName, p scbuildstmt.ResolveParams,
 ) scbuildstmt.ElementResultSet {
 	p.ResolveTypes = true
-	prefix, typ := b.cr.MayResolveType(b.ctx, *name)
+	_, typ := b.cr.MayResolveType(b.ctx, *name)
 	if typ == nil {
 		if p.IsExistenceOptional {
 			return nil
@@ -1222,11 +1222,7 @@ func (b *builderState) ResolveUserDefinedTypeType(
 		panic(pgerror.Newf(pgcode.DependentObjectsStillExist,
 			"%q is an implicit array type and cannot be modified", typ.GetName()))
 	case descpb.TypeDescriptor_MULTIREGION_ENUM:
-		typeName := tree.MakeTypeNameWithPrefix(prefix.NamePrefix(), typ.GetName())
-		// Multi-region enums are not directly modifiable.
-		panic(errors.WithHintf(pgerror.Newf(pgcode.DependentObjectsStillExist,
-			"%q is a multi-region enum and cannot be modified directly", typeName.FQString()),
-			"try ALTER DATABASE %s DROP REGION %s", prefix.Database.GetName(), typ.GetName()))
+		b.ensureDescriptor(typ.GetID())
 	case descpb.TypeDescriptor_ENUM:
 		b.ensureDescriptor(typ.GetID())
 	case descpb.TypeDescriptor_COMPOSITE:
@@ -1240,6 +1236,9 @@ func (b *builderState) ResolveUserDefinedTypeType(
 	default:
 		panic(errors.AssertionFailedf("unknown type kind %s", typ.GetKind()))
 	}
+	// Check schema USAGE privilege before ownership for consistency with the
+	// legacy schema changer.
+	b.requirePrivilege(typ.GetParentSchemaID(), privilege.USAGE)
 	b.mustOwn(typ.GetID())
 	return b.QueryByID(typ.GetID())
 }

--- a/pkg/sql/schemachanger/scbuild/event_log.go
+++ b/pkg/sql/schemachanger/scbuild/event_log.go
@@ -566,5 +566,14 @@ func (pb payloadBuilder) build(b buildCtx) logpb.EventPayload {
 			SequenceName: fullyQualifiedName(b, seq),
 		}
 	}
+	if _, _, enumType := scpb.FindEnumType(b.QueryByID(screl.GetDescID(pb.Element()))); enumType != nil {
+		// If the enum type has a payload attached use that instead of ALTER TYPE.
+		if pb.maybePayload != nil {
+			return pb.maybePayload
+		}
+		return &eventpb.AlterType{
+			TypeName: fullyQualifiedName(b, enumType),
+		}
+	}
 	return nil
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -97,6 +97,7 @@ go_library(
         "//pkg/sql/catalog/zone",
         "//pkg/sql/covering",
         "//pkg/sql/decodeusername",
+        "//pkg/sql/enum",
         "//pkg/sql/paramparse",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -6,16 +6,22 @@
 package scbuildstmt
 
 import (
+	"bytes"
 	"reflect"
+	"slices"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -25,7 +31,7 @@ type supportedAlterTypeCommand = supportedStatement
 // the declarative schema changer. Operations marked as non-fully supported can
 // only be used with the use_declarative_schema_changer session variable.
 var supportedAlterTypeStatements = map[reflect.Type]supportedAlterTypeCommand{
-	reflect.TypeOf((*tree.AlterTypeAddValue)(nil)):    {fn: alterTypeAddValue, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeAddValue)(nil)):    {fn: alterTypeAddValue, on: true, checks: isV263Active},
 	reflect.TypeOf((*tree.AlterTypeRenameValue)(nil)): {fn: alterTypeRenameValue, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeRename)(nil)):      {fn: alterTypeRename, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeSetSchema)(nil)):   {fn: alterTypeSetSchema, on: false, checks: nil},
@@ -79,16 +85,29 @@ func AlterType(b BuildCtx, n *tree.AlterType) {
 		panic(pgerror.Newf(pgcode.WrongObjectType, "cannot modify composite type"))
 	}
 
-	enumTypeElts := elts.FilterEnumType()
-	_, target, enumType := enumTypeElts.Get(0)
-	if target != scpb.ToPublic {
-		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-			"type %q is being dropped, try again later", n.Type.Object()))
-	}
+	enumType := elts.FilterEnumType().MustGetOneElement()
+	elts.FilterEnumType().ForEach(func(_ scpb.Status, target scpb.TargetStatus, _ *scpb.EnumType) {
+		if target != scpb.ToPublic {
+			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"type %q is being dropped, try again later", n.Type.Object()))
+		}
+	})
 
 	tn := n.Type.ToTypeName()
 	tn.ObjectNamePrefix = b.NamePrefix(enumType)
 	b.SetUnresolvedNameAnnotation(n.Type, &tn)
+
+	if enumType.IsMultiRegion {
+		if _, isAlterTypeOwner := n.Cmd.(*tree.AlterTypeOwner); !isAlterTypeOwner {
+			panic(errors.WithHint(
+				pgerror.Newf(
+					pgcode.WrongObjectType,
+					"%q is a multi-region enum and can't be modified using the alter type command",
+					tn.FQString()),
+				"try adding/removing the region using ALTER DATABASE"))
+		}
+	}
+
 	b.IncrementSchemaChangeAlterCounter("type", n.Cmd.TelemetryName())
 	b.IncrementEnumCounter(sqltelemetry.EnumAlter)
 
@@ -105,7 +124,90 @@ func AlterType(b BuildCtx, n *tree.AlterType) {
 func alterTypeAddValue(
 	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeAddValue,
 ) {
-	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE ADD VALUE is not supported"))
+	newVal := string(t.NewVal)
+
+	type valueInfo struct {
+		physicalRep []byte
+		logicalRep  string
+		target      scpb.TargetStatus
+	}
+	var existingValues []valueInfo
+	b.QueryByID(enumType.TypeID).FilterEnumTypeValue().ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.EnumTypeValue) {
+			existingValues = append(existingValues, valueInfo{
+				physicalRep: e.PhysicalRepresentation,
+				logicalRep:  e.LogicalRepresentation,
+				target:      target,
+			})
+		},
+	)
+
+	// Handle adding a duplicate.
+	for _, v := range existingValues {
+		if v.logicalRep != newVal {
+			continue
+		}
+		if v.target == scpb.ToAbsent {
+			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"enum value %q is being dropped, try again later", newVal))
+		}
+		if t.IfNotExists {
+			b.EvalCtx().ClientNoticeSender.BufferClientNotice(
+				b, pgnotice.Newf("enum value %q already exists, skipping", newVal),
+			)
+			return
+		}
+		panic(pgerror.Newf(pgcode.DuplicateObject, "enum value %q already exists", newVal))
+	}
+
+	var activeValues []valueInfo
+	for _, v := range existingValues {
+		if v.target != scpb.ToAbsent {
+			activeValues = append(activeValues, v)
+		}
+	}
+	sort.Slice(activeValues, func(i, j int) bool {
+		return bytes.Compare(activeValues[i].physicalRep, activeValues[j].physicalRep) < 0
+	})
+
+	// Determine insertion position. By default the new value is appended.
+	//
+	// pos is the index of the value after which the new value will be inserted.
+	pos := len(activeValues) - 1
+	if t.Placement != nil {
+		existing := string(t.Placement.ExistingVal)
+		pos = slices.IndexFunc(activeValues, func(v valueInfo) bool {
+			return v.logicalRep == existing
+		})
+		if pos == -1 {
+			panic(pgerror.Newf(pgcode.InvalidParameterValue,
+				"%q is not an existing enum value", existing))
+		}
+		if t.Placement.Before {
+			pos--
+		}
+	}
+
+	getPhysicalRep := func(idx int) []byte {
+		if idx < 0 || idx >= len(activeValues) {
+			return nil
+		}
+		return activeValues[idx].physicalRep
+	}
+	physicalRep := enum.GenByteStringBetween(
+		getPhysicalRep(pos), getPhysicalRep(pos+1), enum.SpreadSpacing,
+	)
+
+	enumValue := &scpb.EnumTypeValue{
+		TypeID:                 enumType.TypeID,
+		PhysicalRepresentation: physicalRep,
+		LogicalRepresentation:  newVal,
+	}
+	b.Add(enumValue)
+
+	b.LogEventForExistingPayload(enumValue, &eventpb.AlterType{
+		TypeName: tn.FQString(),
+	})
 }
 
 func alterTypeRenameValue(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/errors"
 )
 
 // DropType implements DROP TYPE.
@@ -30,6 +31,14 @@ func DropType(b BuildCtx, n *tree.DropType) {
 		var typ scpb.Element
 		var typeID, arrayTypeID catid.DescID
 		if _, _, enum := scpb.FindEnumType(elts); enum != nil {
+			// Multi-region enums cannot be dropped directly.
+			if enum.IsMultiRegion {
+				prefix := b.NamePrefix(enum)
+				typeName := tree.MakeTypeNameWithPrefix(prefix, name.Object())
+				panic(errors.WithHintf(pgerror.Newf(pgcode.DependentObjectsStillExist,
+					"%q is a multi-region enum and cannot be modified directly", typeName.FQString()),
+					"try ALTER DATABASE DROP REGION %s", name.Object()))
+			}
 			b.IncrementEnumCounter(sqltelemetry.EnumDrop)
 			typeID, arrayTypeID = enum.TypeID, enum.ArrayTypeID
 			typ = enum

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -264,3 +264,7 @@ var isV261Active isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatap
 var isV262Active isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
 	return activeVersion.IsActive(clusterversion.V26_2)
 }
+
+var isV263Active isVersionActiveFunc = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
+	return activeVersion.IsActive(clusterversion.V26_3)
+}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_type
@@ -1,3 +1,9 @@
 setup
 CREATE TYPE defaultdb.climes AS ENUM ('tropical', 'arctic', 'mediterranean');
 ----
+
+build
+ALTER TYPE defaultdb.climes ADD VALUE 'desert'
+----
+- [[EnumTypeValue:{DescID: 104, Name: desert}, PUBLIC], ABSENT]
+  {logicalRepresentation: desert, physicalRepresentation: 4A==, typeId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
@@ -3,10 +3,6 @@ CREATE TYPE defaultdb.climes AS ENUM ('tropical', 'arctic', 'mediterranean');
 ----
 
 unimplemented
-ALTER TYPE defaultdb.climes ADD VALUE 'desert'
-----
-
-unimplemented
 ALTER TYPE defaultdb.climes RENAME VALUE 'tropical' TO 'equatorial'
 ----
 

--- a/pkg/sql/schemachanger/scexec/scmutationexec/type.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/type.go
@@ -8,6 +8,7 @@ package scmutationexec
 import (
 	"bytes"
 	"context"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
@@ -20,13 +21,10 @@ func (i *immediateVisitor) AddEnumTypeValue(ctx context.Context, op scop.AddEnum
 		return err
 	}
 
-	insertIdx := len(typ.EnumMembers)
-	for j, member := range typ.EnumMembers {
-		if bytes.Compare(op.PhysicalRepresentation, member.PhysicalRepresentation) < 0 {
-			insertIdx = j
-			break
-		}
-	}
+	insertIdx, _ := slices.BinarySearchFunc(typ.EnumMembers, op.PhysicalRepresentation,
+		func(member descpb.TypeDescriptor_EnumMember, target []byte) int {
+			return bytes.Compare(member.PhysicalRepresentation, target)
+		})
 
 	newMember := descpb.TypeDescriptor_EnumMember{
 		PhysicalRepresentation: op.PhysicalRepresentation,

--- a/pkg/sql/schemachanger/scplan/testdata/alter_type_add_value
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_type_add_value
@@ -1,0 +1,64 @@
+setup
+CREATE TYPE defaultdb.salmon AS ENUM('sockeye', 'king');
+----
+
+ops
+ALTER TYPE defaultdb.salmon ADD VALUE 'atlantic'
+----
+StatementPhase stage 1 of 1 with 1 MutationType op
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, PUBLIC], ABSENT] -> WRITE_ONLY
+  ops:
+    *scop.AddEnumTypeValue
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, PUBLIC], WRITE_ONLY] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 3 MutationType ops
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, PUBLIC], ABSENT] -> WRITE_ONLY
+  ops:
+    *scop.AddEnumTypeValue
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+      Initialize: true
+    *scop.CreateSchemaChangerJob
+      Authorization:
+        AppName: $ internal-test
+        UserName: root
+      DescriptorIDs:
+      - 104
+      JobID: 1
+      NonCancelable: true
+      RunningStatus: 'Pending: Updating schema metadata (1 operation) — PostCommitNonRevertible phase (stage 1 of 1).'
+      Statements:
+      - statement: ALTER TYPE defaultdb.salmon ADD VALUE 'atlantic'
+        redactedstatement: ALTER TYPE defaultdb.public.salmon ADD VALUE ‹'atlantic'›
+        statementtag: ALTER TYPE
+PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, PUBLIC], WRITE_ONLY] -> PUBLIC
+  ops:
+    *scop.PromoteEnumTypeValue
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 104
+      JobID: 1
+    *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      IsNonCancelable: true
+      JobID: 1

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -540,6 +540,13 @@ func TestEndToEndSideEffects_alter_table_validate_constraint(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1384,6 +1391,13 @@ func TestExecuteWithDMLInjection_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2234,6 +2248,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_validate_constraint(t *testing.T
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3078,6 +3099,13 @@ func TestPause_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3928,6 +3956,13 @@ func TestPauseMixedVersion_alter_table_validate_constraint(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4772,6 +4807,13 @@ func TestRollback_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_type_add_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye');
+----
+
+test
+ALTER TYPE salmon ADD VALUE 'atlantic';
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.explain
@@ -1,0 +1,34 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye');
+
+/* test */
+EXPLAIN (DDL) ALTER TYPE salmon ADD VALUE 'atlantic';
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› ADD VALUE ‹'atlantic'›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 1 Mutation operation
+ │              └── AddEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → ABSENT EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 3 Mutation operations
+ │              ├── AddEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── WRITE_ONLY → PUBLIC EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+           └── 3 Mutation operations
+                ├── PromoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TYPE salmon ADD VALUE 'atlantic';
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› ADD VALUE ‹'atlantic'›;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.side_effects
@@ -1,0 +1,132 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye');
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
+
+/* test */
+ALTER TYPE salmon ADD VALUE 'atlantic';
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TYPE
+increment telemetry for sql.schema.alter_type.add_value
+increment telemetry for sql.udts.alter_enum
+write *eventpb.AlterType to event log:
+  sql:
+    descriptorId: 104
+    statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› ADD VALUE ‹'atlantic'›
+    tag: ALTER TYPE
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert descriptor #104
+  ...
+     - logicalRepresentation: sockeye
+       physicalRepresentation: gA==
+  +  - capability: READ_ONLY
+  +    direction: ADD
+  +    logicalRepresentation: atlantic
+  +    physicalRepresentation: wA==
+     id: 104
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 104
+  +      name: salmon
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› ADD VALUE ‹'atlantic'›
+  +        statement: ALTER TYPE salmon ADD VALUE 'atlantic'
+  +        statementTag: ALTER TYPE
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: chinook
+  ...
+     - logicalRepresentation: sockeye
+       physicalRepresentation: gA==
+  +  - capability: READ_ONLY
+  +    direction: ADD
+  +    logicalRepresentation: atlantic
+  +    physicalRepresentation: wA==
+     id: 104
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: true): "ALTER TYPE defaultdb.public.salmon ADD VALUE 'atlantic'"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      id: 104
+  -      name: salmon
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› ADD VALUE ‹'atlantic'›
+  -        statement: ALTER TYPE salmon ADD VALUE 'atlantic'
+  -        statementTag: ALTER TYPE
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: chinook
+  ...
+     - logicalRepresentation: sockeye
+       physicalRepresentation: gA==
+  -  - capability: READ_ONLY
+  -    direction: ADD
+  -    logicalRepresentation: atlantic
+  +  - logicalRepresentation: atlantic
+       physicalRepresentation: wA==
+     id: 104
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #3
+# end PostCommitPhase

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -453,7 +453,7 @@ COMMIT`)
 }
 
 // TestTypeChangeJobCancelSemantics ensures that type change jobs that involve
-// en enum member being dropped are cancelable and those that don't are not
+// an enum member being dropped are cancelable and those that don't are not
 // cancelable.
 func TestTypeChangeJobCancelSemantics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -517,7 +517,9 @@ func TestTypeChangeJobCancelSemantics(t *testing.T) {
 			defer s.Stopper().Stop(ctx)
 
 			// Setup.
-			_, err := sqlDB.Exec(`
+			_, err := sqlDB.Exec(`SET use_declarative_schema_changer = 'off'`)
+			require.NoError(t, err)
+			_, err = sqlDB.Exec(`
 CREATE DATABASE db;
 CREATE TYPE db.greetings AS ENUM ('hi', 'yo');
 `)


### PR DESCRIPTION
This change implements the add value for enum
UDTs and rewires the command to it.

Epic: CRDB-31325
Closes: #164218

Release note: None