### PR TITLE
sql/stats: add mixed version test for stats delayed deletion

### DIFF
--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -239,8 +239,6 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 						statsRow.PartialPredicate = string(*r[partialPredicateIdx].(*tree.DString))
 						statsRow.FullStatisticID = (uint64)(*r[fullStatisticIDIdx].(*tree.DInt))
 					}
-					// TODO(janexing): add a mixed-version test that exercises the stats
-					// cache and show stats both before and after the migration (#161183).
 					statsRow.DelayDelete = (bool)(*r[delayDeleteIdx].(*tree.DBool))
 					if err := statsRow.DecodeAndSetHistogram(ctx, &p.semaCtx, r[histIdx]); err != nil {
 						v.Close(ctx)

--- a/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
+++ b/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
@@ -25,8 +25,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
+// TestTableStatisticsDelayDeleteColumnMigration verifies that the
+// V26_2_AddTableStatisticsDelayDeleteColumn migration correctly adds the
+// delayDelete column, and that SHOW STATISTICS and the stats cache work
+// correctly both before and after the migration. Before the migration,
+// GetTableStatisticsStmt uses `false AS "delayDelete"` as a fallback; after
+// the migration, it reads the real column.
 func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -78,9 +85,69 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 			expectExists,
 		)
 	}
-	// Validate that the table_statistics table has the old
-	// schema.
+	// Validate that the table_statistics table has the old schema.
 	validateSchemaExists(false)
+
+	// Create a test table with canary stats enabled (sql_stats_canary_window)
+	// and collect statistics before the migration. This exercises the
+	// pre-migration code path where GetTableStatisticsStmt uses
+	// `false AS "delayDelete"`.
+	_, err := sqlDB.Exec(
+		`CREATE TABLE t (k INT PRIMARY KEY, v STRING) WITH (sql_stats_canary_window = '15s')`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(
+		`INSERT INTO t SELECT i, 'val' || i::STRING FROM generate_series(1, 100) AS g(i)`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`ANALYZE t`)
+	require.NoError(t, err)
+
+	// Verify SHOW STATISTICS works before migration.
+	var statsCount int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
+	).Scan(&statsCount)
+	require.NoError(t, err)
+	require.Greater(t, statsCount, 0)
+
+	// Insert more data and collect stats again. Even though the table has
+	// canary_window set, the version gate prevents MarkDelayDelete from
+	// running, so all stats should remain delay_delete=false.
+	_, err = sqlDB.Exec(
+		`INSERT INTO t SELECT i, 'more' || i::STRING FROM generate_series(101, 200) AS g(i)`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`ANALYZE t`)
+	require.NoError(t, err)
+
+	// Record the total stats count after the second ANALYZE. Before the
+	// migration, old stats are immediately deleted by
+	// DeleteOldStatsForColumns (keeping up to 4 per column set), so the
+	// total count here reflects the pre-gate deletion behavior.
+	var statsCountAfterSecondAnalyze int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
+	).Scan(&statsCountAfterSecondAnalyze)
+	require.NoError(t, err)
+	require.Greater(t, statsCountAfterSecondAnalyze, 0)
+
+	var delayDeleteTrueCount int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t] WHERE delay_delete = true`,
+	).Scan(&delayDeleteTrueCount)
+	require.NoError(t, err)
+	require.Equal(t, 0, delayDeleteTrueCount,
+		"before migration: delay_delete should stay false even with canary_window set")
+
+	// Verify SHOW STATISTICS USING JSON works before migration.
+	var jsonStats string
+	err = sqlDB.QueryRow(
+		`SELECT statistics::STRING FROM [SHOW STATISTICS USING JSON FOR TABLE t]`,
+	).Scan(&jsonStats)
+	require.NoError(t, err)
+	require.NotEmpty(t, jsonStats)
+
 	// Run the upgrade.
 	upgrades.Upgrade(
 		t,
@@ -91,6 +158,63 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	)
 	// Validate that the table has new schema.
 	validateSchemaExists(true)
+
+	// Verify SHOW STATISTICS works after migration.
+	var statsCountAfter int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
+	).Scan(&statsCountAfter)
+	require.NoError(t, err)
+	require.Greater(t, statsCountAfter, 0)
+
+	// Now with the migration complete, the canary stats path is active.
+	// Collecting new stats should mark old ones with delay_delete=true.
+	_, err = sqlDB.Exec(
+		`INSERT INTO t SELECT i, 'post' || i::STRING FROM generate_series(201, 300) AS g(i)`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`ANALYZE t`)
+	require.NoError(t, err)
+
+	// After migration with canary_window set, old stats should be marked
+	// delay_delete=true while the freshest stats remain false. The total
+	// count includes both old (delay_delete=true) and new
+	// (delay_delete=false) stats, since old stats are now kept rather than
+	// immediately deleted.
+	var statsCountPostMigration int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
+	).Scan(&statsCountPostMigration)
+	require.NoError(t, err)
+
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t] WHERE delay_delete = true`,
+	).Scan(&delayDeleteTrueCount)
+	require.NoError(t, err)
+	require.Greater(t, delayDeleteTrueCount, 0,
+		"after migration: expected some stats with delay_delete=true when canary_window is set")
+	require.Greater(t, statsCountPostMigration, delayDeleteTrueCount,
+		"total stats should exceed delay_delete=true count (freshest stats have delay_delete=false)")
+
+	// The freshest stats should still have delay_delete=false.
+	var latestDelayDelete bool
+	err = sqlDB.QueryRow(
+		`SELECT delay_delete FROM [SHOW STATISTICS FOR TABLE t] ORDER BY created DESC LIMIT 1`,
+	).Scan(&latestDelayDelete)
+	require.NoError(t, err)
+	require.False(t, latestDelayDelete,
+		"freshest stats should have delay_delete=false")
+
+	// Verify SHOW STATISTICS USING JSON works after migration and includes
+	// the delay_delete field.
+	var jsonStatsAfter string
+	err = sqlDB.QueryRow(
+		`SELECT statistics::STRING FROM [SHOW STATISTICS USING JSON FOR TABLE t]`,
+	).Scan(&jsonStatsAfter)
+	require.NoError(t, err)
+	require.NotEmpty(t, jsonStatsAfter)
+	require.Contains(t, jsonStatsAfter, "delay_delete",
+		"expected JSON stats to contain delay_delete field")
 }
 
 // getOldTableStatisticsDescriptor returns the


### PR DESCRIPTION
Fixes: #161183

Extend TestTableStatisticsDelayDeleteColumnMigration to exercise the stats cache and SHOW STATISTICS both before and after the V26_2_AddTableStatisticsDelayDeleteColumn migration. The test creates a table with sql_stats_canary_window enabled and verifies that:

- Before migration: SHOW STATISTICS and SHOW STATISTICS USING JSON work correctly when GetTableStatisticsStmt falls back to `false AS "delayDelete"`. The canary delayed deletion path is gated on the version, so delay_delete stays false for all stats even with canary_window set.
- After migration: collecting new stats marks old ones with delay_delete=true (the canary two-phase deletion), while the freshest stats remain delay_delete=false.

Release note: None