### PR TITLE
build: use docker buildx for multi-arch docker images, consolidate docker builds

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -16,11 +16,15 @@ RUN microdnf update -y && microdnf install -y \
       xz \
     && rm -rf /var/cache/yum
 
+# TARGETARCH is set automatically by `docker buildx build --platform`.
+# The build context must place per-arch files under ${TARGETARCH}/ subdirectories
+# (e.g. amd64/cockroach, amd64/cockroach.sh, amd64/libgeos.so, etc.).
+ARG TARGETARCH
 RUN mkdir /usr/local/lib/cockroach /cockroach /licenses /docker-entrypoint-initdb.d
-COPY cockroach.sh cockroach /cockroach/
-COPY LICENSE THIRD-PARTY-NOTICES.txt /licenses/
+COPY ${TARGETARCH}/cockroach.sh ${TARGETARCH}/cockroach /cockroach/
+COPY ${TARGETARCH}/LICENSE ${TARGETARCH}/THIRD-PARTY-NOTICES.txt /licenses/
 # Install GEOS libraries.
-COPY libgeos.so libgeos_c.so /usr/local/lib/cockroach/
+COPY ${TARGETARCH}/libgeos.so ${TARGETARCH}/libgeos_c.so /usr/local/lib/cockroach/
 
 # Set working directory so that relative paths
 # are resolved appropriately when passed as args.

--- a/build/github/docker-image.sh
+++ b/build/github/docker-image.sh
@@ -28,14 +28,17 @@ esac
 build_arch=${1:-amd64}
 
 bazel build //pkg/cmd/cockroach //c-deps:libgeos --config $CROSSCONFIG --jobs 50 $(./build/github/engflow-args.sh)
-cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach build/deploy
+
+# The Dockerfile expects per-arch files under ${TARGETARCH}/ subdirectories.
+mkdir -p "build/deploy/${build_arch}"
+cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach "build/deploy/${build_arch}/"
 LIBDIR=$(bazel info execution_root --config $CROSSCONFIG)/external/$ARCHIVEDIR/lib
-cp $LIBDIR/libgeos.so build/deploy
-cp $LIBDIR/libgeos_c.so build/deploy
+cp $LIBDIR/libgeos.so "build/deploy/${build_arch}/"
+cp $LIBDIR/libgeos_c.so "build/deploy/${build_arch}/"
+cp build/deploy/cockroach.sh "build/deploy/${build_arch}/"
+cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy/${build_arch}/"
 
-cp LICENSE licenses/THIRD-PARTY-NOTICES.txt build/deploy/
-
-chmod 755 build/deploy/cockroach
+chmod 755 "build/deploy/${build_arch}/cockroach"
 
 docker_image_tar_name="cockroach-docker-image.tar"
 

--- a/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
@@ -43,7 +43,7 @@ tc_start_block "Configure docker"
 echo "${QUAY_REGISTRY_KEY}" | docker login --username $rhel_registry_username --password-stdin $rhel_registry
 tc_end_block "Configure docker"
 
-tc_start_block "Rebuild docker image"
+tc_start_block "Build and push multi-arch RedHat docker image"
 sed \
   -e "s,@repository@,${dockerhub_repository},g" \
   -e "s,@tag@,${version},g" \
@@ -51,28 +51,36 @@ sed \
 
 cat build/deploy-redhat/Dockerfile
 
-docker build --no-cache \
+# The base image (cockroachdb/cockroach:version) is already multi-arch, so
+# buildx will pull the correct platform variant automatically.
+builder_name="redhat-builder-$$"
+docker buildx rm "$builder_name" 2>/dev/null || true
+docker buildx create --name "$builder_name" --use
+cleanup_buildx() { docker buildx rm "$builder_name" || true; }
+trap 'cleanup_buildx; remove_files_on_exit' EXIT
+
+docker buildx build --no-cache \
   --pull \
+  --push \
+  --platform linux/amd64,linux/arm64,linux/s390x \
   --label release=$rhel_release \
   --label version=$version \
   --tag="${rhel_repository}:${version}" \
   build/deploy-redhat
-tc_end_block "Rebuild docker image"
-
-tc_start_block "Push RedHat docker image"
-retry docker push "${rhel_repository}:${version}"
-tc_end_block "Push RedHat docker image"
+tc_end_block "Build and push multi-arch RedHat docker image"
 
 tc_start_block "Tag docker image as latest"
 if [[ -n "${PUBLISH_LATEST}" ]]; then
-  docker tag "${rhel_repository}:${version}" "${rhel_repository}:latest"
-  retry docker push "${rhel_repository}:latest"
+  docker buildx imagetools create \
+    -t "${rhel_repository}:latest" "${rhel_repository}:${version}"
 else
   echo "Not required"
 fi
 tc_end_block "Tag docker images as latest"
 
 tc_start_block "Run preflight"
+# Preflight automatically detects the manifest list and runs certification
+# checks for all architectures found in it.
 mkdir -p artifacts
 docker run \
   --rm \

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -12,12 +12,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
 source "$dir/teamcity-support.sh"  # For log_into_gcloud
 source "$dir/release/teamcity-support.sh"
 
-# TODO: remove this block after we upgrade to Ubuntu 22.04+
-# this is needed to support s390x builds on Ubuntu 20.04 hosts
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
-# End of TODO
-
 tc_start_block "Variable Setup"
 version=$(grep -v "^#" "$dir/../pkg/build/version.txt" | head -n1)
 prerelease=false
@@ -118,33 +112,36 @@ tc_end_block "Copy binaries"
 
 
 tc_start_block "Make and push multiarch docker images"
-declare -a gcr_arch_tags
-declare -a dockerhub_arch_tags
 dockerhub_tag="${dockerhub_repository}:${version}"
 gcr_tag="${gcr_repository}:${version}"
 
-for platform_name in amd64 arm64 s390x; do
-  dockerhub_arch_tag="${dockerhub_repository}:${platform_name}-${version}"
-  gcr_arch_tag="${gcr_repository}:${platform_name}-${version}"
-  gcr_staged_arch_tag="${gcr_staged_repository}:${platform_name}-${version}"
-  # Update the packages before pushing to the final destination.
-  tmpdir=$(mktemp -d)
-  echo "FROM $gcr_staged_arch_tag" > "$tmpdir/Dockerfile"
-  echo "RUN microdnf -y --best --refresh upgrade && microdnf clean all && rm -rf /var/cache/yum" >> "$tmpdir/Dockerfile"
-  docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
-  docker build --pull --no-cache --platform "linux/$platform_name" \
-    --tag "$dockerhub_arch_tag" --tag "$gcr_arch_tag" "$tmpdir"
-  docker_login_gcr "$gcr_repository" "$gcr_credentials"
-  docker push "$gcr_arch_tag"
-  docker push "$dockerhub_arch_tag"
-  gcr_arch_tags+=("$gcr_arch_tag")
-  dockerhub_arch_tags+=("$dockerhub_arch_tag")
-done
+# Create a buildx builder for multi-platform builds.
+docker buildx rm "release-builder-$$" 2>/dev/null || true
+docker buildx create --name "release-builder-$$" --use
+cleanup_buildx() { docker buildx rm "release-builder-$$" || true; }
+tmpdir=$(mktemp -d)
+trap 'cleanup_buildx; rm -rf "$tmpdir"; remove_files_on_exit' EXIT
 
+# The staged image is already multi-arch; buildx pulls the right platform
+# automatically.
+cat > "$tmpdir/Dockerfile" <<DOCKERFILE
+FROM ${gcr_staged_repository}:${version}
+RUN microdnf -y --best --refresh upgrade && microdnf clean all && rm -rf /var/cache/yum
+DOCKERFILE
+
+# Build and push the multi-arch image to DockerHub. The staged repo (source)
+# is on us-docker.pkg.dev and DockerHub (destination) is on docker.io, so both
+# logins can coexist.
+docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
+docker buildx build --pull --push --no-cache \
+  --platform linux/amd64,linux/arm64,linux/s390x \
+  --tag "$dockerhub_tag" "$tmpdir"
+
+# Copy the multi-arch manifest from DockerHub to GCR. These are on different
+# hostnames so both logins can coexist.
 docker_login_gcr "$gcr_repository" "$gcr_credentials"
+docker buildx imagetools create -t "$gcr_tag" "$dockerhub_tag"
 
-create_and_push_multi_arch_manifest "${gcr_tag}" "${gcr_arch_tags[@]}"
-create_and_push_multi_arch_manifest "${dockerhub_tag}" "${dockerhub_arch_tags[@]}"
 tc_end_block "Make and push multiarch docker images"
 
 
@@ -152,16 +149,19 @@ tc_start_block "Make and push FIPS docker image"
 gcr_staged_tag_fips="${gcr_staged_repository}:${version}-fips"
 gcr_tag_fips="${gcr_repository}:${version}-fips"
 dockerhub_tag_fips="${dockerhub_repository}:${version}-fips"
-# Update the packages before pushing to the final destination.
-tmpdir=$(mktemp -d)
-echo "FROM $gcr_staged_tag_fips" > "$tmpdir/Dockerfile"
-echo "RUN microdnf -y --best --refresh upgrade && microdnf clean all && rm -rf /var/cache/yum" >> "$tmpdir/Dockerfile"
+
+cat > "$tmpdir/Dockerfile" <<DOCKERFILE
+FROM $gcr_staged_tag_fips
+RUN microdnf -y --best --refresh upgrade && microdnf clean all && rm -rf /var/cache/yum
+DOCKERFILE
+
 docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
-docker build --pull --no-cache --platform "linux/amd64" \
-  --tag "$dockerhub_tag_fips" --tag "$gcr_tag_fips" "$tmpdir"
+docker buildx build --pull --push --no-cache \
+  --platform linux/amd64 \
+  --tag "$dockerhub_tag_fips" "$tmpdir"
+
 docker_login_gcr "$gcr_repository" "$gcr_credentials"
-docker push "$gcr_tag_fips"
-docker push "$dockerhub_tag_fips"
+docker buildx imagetools create -t "$gcr_tag_fips" "$dockerhub_tag_fips"
 tc_end_block "Make and push FIPS docker image"
 
 
@@ -199,7 +199,8 @@ tc_end_block "Publish binaries and archive as latest"
 
 tc_start_block "Tag docker image as latest-RELEASE_BRANCH"
 if [[ $prerelease == false ]]; then
-  create_and_push_multi_arch_manifest "${dockerhub_repository}:latest-${release_branch}" "${dockerhub_arch_tags[@]}"
+  docker buildx imagetools create \
+    -t "${dockerhub_repository}:latest-${release_branch}" "$dockerhub_tag"
 else
   echo "The ${dockerhub_repository}:latest-${release_branch} docker image tags were _not_ pushed."
 fi
@@ -212,7 +213,8 @@ tc_start_block "Tag docker images as latest"
 # https://github.com/cockroachdb/cockroach/issues/41067
 # https://github.com/cockroachdb/cockroach/issues/48309
 if [[ -n "${PUBLISH_LATEST}" || $prerelease == true ]]; then
-  create_and_push_multi_arch_manifest "${dockerhub_repository}:latest" "${dockerhub_arch_tags[@]}"
+  docker buildx imagetools create \
+    -t "${dockerhub_repository}:latest" "$dockerhub_tag"
 else
   echo "The ${dockerhub_repository}:latest docker image tags were _not_ pushed."
 fi

--- a/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
@@ -11,12 +11,6 @@ set -euxo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 
-# TODO: remove this block after we upgrade to Ubuntu 22.04+
-# this is needed to support s390x builds on Ubuntu 20.04 hosts
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
-# End of TODO
-
 tc_start_block "Variable Setup"
 telemetry_disabled="${TELEMETRY_DISABLED:-false}"
 cockroach_archive_prefix="${COCKROACH_ARCHIVE_PREFIX:-cockroach}"
@@ -26,19 +20,100 @@ if [[ $telemetry_disabled == true && $cockroach_archive_prefix == "cockroach" ]]
 fi
 
 version=$(grep -v "^#" "$dir/../pkg/build/version.txt" | head -n1)
+version_label=$(echo "${version}" | sed -e 's/^v//' | cut -d- -f 1)
+
 if [[ -z "${DRY_RUN}" ]] ; then
-  gcr_credentials="$GCS_CREDENTIALS_PROD"
+  gcs_bucket="cockroach-release-artifacts-staged-prod"
+  export gcp_credentials="$GCS_CREDENTIALS_PROD"
   gcr_staged_repository="us-docker.pkg.dev/releases-prod/cockroachdb-staged-releases/${cockroach_archive_prefix}"
 else
-  gcr_credentials="$GCS_CREDENTIALS_DEV"
+  gcs_bucket="cockroach-release-artifacts-staged-dryrun"
+  export gcp_credentials="$GCS_CREDENTIALS_DEV"
   gcr_staged_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/${cockroach_archive_prefix}"
 fi
 tc_end_block "Variable Setup"
 
 
+tc_start_block "Download and extract tarballs"
+google_credentials="$gcp_credentials"
+log_into_gcloud
+
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir; remove_files_on_exit" EXIT
+
+# Download and extract per-arch tarballs into a build context laid out as
+# ${arch}/ subdirectories, matching what build/deploy/Dockerfile expects.
+context="$tmpdir/context"
+mkdir -p "$context"
+cp build/deploy/Dockerfile "$context/Dockerfile"
+
+for platform in linux-amd64 linux-arm64 linux-s390x; do
+  arch="${platform#linux-}"
+  archive="${cockroach_archive_prefix}-${version}.${platform}.tgz"
+  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_bucket/$archive" "$tmpdir/$archive"
+  # Extract into a staging directory, then copy the files the Dockerfile needs
+  # into the ${arch}/ subdirectory of the build context.
+  staging="$tmpdir/staging-${platform}"
+  mkdir -p "$staging"
+  tar \
+    --directory="$staging" \
+    --extract \
+    --file="$tmpdir/$archive" \
+    --ungzip \
+    --ignore-zeros \
+    --strip-components=1
+  mkdir -p "$context/${arch}"
+  cp build/deploy/cockroach.sh "$context/${arch}/"
+  cp "$staging/cockroach" "$context/${arch}/"
+  cp "$staging"/lib/libgeos.so "$staging"/lib/libgeos_c.so "$context/${arch}/"
+  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "$context/${arch}/"
+done
+
+# FIPS is amd64-only; prepare its own build context.
+fips_context="$tmpdir/fips-context"
+mkdir -p "$fips_context/amd64"
+cp build/deploy/Dockerfile "$fips_context/Dockerfile"
+fips_archive="${cockroach_archive_prefix}-${version}.linux-amd64-fips.tgz"
+gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_bucket/$fips_archive" "$tmpdir/$fips_archive"
+fips_staging="$tmpdir/staging-linux-amd64-fips"
+mkdir -p "$fips_staging"
+tar \
+  --directory="$fips_staging" \
+  --extract \
+  --file="$tmpdir/$fips_archive" \
+  --ungzip \
+  --ignore-zeros \
+  --strip-components=1
+cp build/deploy/cockroach.sh "$fips_context/amd64/"
+cp "$fips_staging/cockroach" "$fips_context/amd64/"
+cp "$fips_staging"/lib/libgeos.so "$fips_staging"/lib/libgeos_c.so "$fips_context/amd64/"
+cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "$fips_context/amd64/"
+tc_end_block "Download and extract tarballs"
+
+
+tc_start_block "Build and push multi-arch docker image"
+docker_login_gcr "$gcr_staged_repository" "$gcp_credentials"
+
+# Create a buildx builder for multi-platform builds.
+docker buildx rm "release-builder-$$" 2>/dev/null || true
+docker buildx create --name "release-builder-$$" --use
+cleanup_buildx() { docker buildx rm "release-builder-$$" || true; }
+trap "cleanup_buildx; rm -rf $tmpdir; remove_files_on_exit" EXIT
+
 gcr_tag="${gcr_staged_repository}:${version}"
-docker_login_gcr "$gcr_staged_repository" "$gcr_credentials"
-create_and_push_multi_arch_manifest "${gcr_tag}" "${gcr_staged_repository}:amd64-${version}" "${gcr_staged_repository}:arm64-${version}" "${gcr_staged_repository}:s390x-${version}"
+docker buildx build --label version="$version_label" --pull --push --no-cache \
+  --platform linux/amd64,linux/arm64,linux/s390x \
+  --tag "$gcr_tag" "$context"
+tc_end_block "Build and push multi-arch docker image"
+
+
+tc_start_block "Build and push FIPS docker image"
+gcr_tag_fips="${gcr_staged_repository}:${version}-fips"
+docker buildx build --label version="$version_label" --pull --push --no-cache \
+  --platform linux/amd64 \
+  --tag "$gcr_tag_fips" "$fips_context"
+tc_end_block "Build and push FIPS docker image"
+
 
 tc_start_block "Verify docker images"
 error=0
@@ -49,6 +124,12 @@ for arch in amd64 arm64 s390x; do
     fi
     tc_end_block "Verify $gcr_tag on $arch"
 done
+
+tc_start_block "Verify FIPS docker image"
+if ! verify_docker_image "$gcr_tag_fips" "linux/amd64" "$BUILD_VCS_NUMBER" "$version" true "$telemetry_disabled"; then
+  error=1
+fi
+tc_end_block "Verify FIPS docker image"
 
 if [ $error = 1 ]; then
   echo "ERROR: Docker image verification failed, see logs above"

--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -12,12 +12,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 #
-# TODO: remove this block after we upgrade to Ubuntu 22.04+
-# this is needed to support s390x builds on Ubuntu 20.04 hosts
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
-# End of TODO
-
 tc_start_block "Variable Setup"
 platform="${PLATFORM:?PLATFORM must be specified}"
 telemetry_disabled="${TELEMETRY_DISABLED:-false}"
@@ -27,7 +21,6 @@ if [[ $telemetry_disabled == true && $cockroach_archive_prefix == "cockroach" ]]
   exit 1
 fi
 version=$(grep -v "^#" "$dir/../pkg/build/version.txt" | head -n1)
-version_label=$(echo "${version}" | sed -e 's/^v//' | cut -d- -f 1)
 
 if ! echo "${version}" | grep -E -o '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[-.0-9A-Za-z]+)?$'; then
   #                                    ^major           ^minor           ^patch         ^preRelease
@@ -41,16 +34,12 @@ fi
 
 if [[ -z "${DRY_RUN}" ]] ; then
   gcs_bucket="cockroach-release-artifacts-staged-prod"
-  gcr_credentials="$GCS_CREDENTIALS_PROD"
   # export the variable to avoid shell escaping
   export gcs_credentials="$GCS_CREDENTIALS_PROD"
-  gcr_staged_repository="us-docker.pkg.dev/releases-prod/cockroachdb-staged-releases/${cockroach_archive_prefix}"
 else
   gcs_bucket="cockroach-release-artifacts-staged-dryrun"
-  gcr_credentials="$GCS_CREDENTIALS_DEV"
   # export the variable to avoid shell escaping
   export gcs_credentials="$GCS_CREDENTIALS_DEV"
-  gcr_staged_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/${cockroach_archive_prefix}"
 fi
 
 tc_end_block "Variable Setup"
@@ -84,47 +73,8 @@ done
 
 tr -d '\r' < /tmp/THIRD-PARTY-NOTICES.txt.tmp > /tmp/THIRD-PARTY-NOTICES.txt
 
-$BAZEL_BIN/pkg/cmd/publish-artifacts/publish-artifacts_/publish-artifacts release --gcs-bucket="$gcs_bucket" --output-directory=artifacts --platform=$platform --third-party-notices-file=/tmp/THIRD-PARTY-NOTICES.txt --telemetry-disabled=$telemetry_disabled --cockroach-archive-prefix=$cockroach_archive_prefix
+$BAZEL_BIN/pkg/cmd/publish-artifacts/publish-artifacts_/publish-artifacts release --gcs-bucket="$gcs_bucket" --platform=$platform --third-party-notices-file=/tmp/THIRD-PARTY-NOTICES.txt --telemetry-disabled=$telemetry_disabled --cockroach-archive-prefix=$cockroach_archive_prefix
 EOF
 tc_end_block "Make and publish release artifacts"
 
 
-if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "linux-amd64-fips" || $platform == "linux-s390x" ]]; then
-  tc_start_block "Make and push docker image"
-  docker_login_gcr "$gcr_staged_repository" "$gcr_credentials"
-  arch="amd64"
-  if [[ $platform == "linux-arm64" ]]; then
-    arch="arm64"
-  fi
-  if [[ $platform == "linux-s390x" ]]; then
-    arch="s390x"
-  fi
-  cp --recursive "build/deploy" "build/deploy-${platform}"
-  tar \
-    --directory="build/deploy-${platform}" \
-    --extract \
-    --file="artifacts/${cockroach_archive_prefix}-${version}.${platform}.tgz" \
-    --ungzip \
-    --ignore-zeros \
-    --strip-components=1
-  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
-  # Move the libs where Dockerfile expects them to be
-  mv build/deploy-${platform}/lib/* build/deploy-${platform}/
-  rmdir build/deploy-${platform}/lib
-
-  build_docker_tag="${gcr_staged_repository}:${arch}-${version}"
-  if [[ $platform == "linux-amd64-fips" ]]; then
-    build_docker_tag="${gcr_staged_repository}:${version}-fips"
-  fi
-  docker build --label version="$version_label" --no-cache --pull --platform="linux/${arch}" --tag="${build_docker_tag}" "build/deploy-${platform}"
-  docker push "$build_docker_tag"
-  tc_end_block "Make and push docker image"
-fi
-
-
-# Here we verify the FIPS image only. The multi-arch image will be verified in the job it's created.
-if [[ $platform == "linux-amd64-fips" ]]; then
-  tc_start_block "Verify FIPS docker image"
-  verify_docker_image "$build_docker_tag" "linux/amd64" "$BUILD_VCS_NUMBER" "$version" true $telemetry_disabled
-  tc_end_block "Verify FIPS docker image"
-fi

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -11,12 +11,6 @@ set -euxo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 #
-# TODO: remove this block after we upgrade to Ubuntu 22.04+
-# this is needed to support s390x builds on Ubuntu 20.04 hosts
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
-# End of TODO
-
 tc_start_block "Variable Setup"
 
 build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
@@ -31,20 +25,22 @@ release_build_match="$(is_release_or_master_build "$TC_BUILD_BRANCH")"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   if [[ -z "${release_build_match}" ]] ; then
-    google_credentials=$GOOGLE_CREDENTIALS_CUSTOMIZED
+    export gcp_credentials=$GOOGLE_CREDENTIALS_CUSTOMIZED
+    gcs_bucket="cockroach-customized-builds-artifacts-prod"
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb-customized/${cockroach_archive_prefix}-customized"
-    gcr_hostname="us-docker.pkg.dev"
   else
-    google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS
+    export gcp_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS
+    gcs_bucket="cockroach-builds-artifacts-prod"
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/${cockroach_archive_prefix}"
-    # Used for docker login for gcloud
-    gcr_hostname="us-docker.pkg.dev"
+    # GCS uses different credentials for build artifact uploads
+    gcs_credentials="$GCS_CREDENTIALS_PROD"
   fi
 else
   build_name="${build_name}.dryrun"
-  google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
+  export gcp_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
+  gcs_bucket="cockroach-builds-artifacts-dryrun"
   gcr_repository="us.gcr.io/cockroach-release/${cockroach_archive_prefix}-test"
-  gcr_hostname="us.gcr.io"
+  gcs_credentials="$GCS_CREDENTIALS_DEV"
 fi
 
 cat << EOF
@@ -56,8 +52,108 @@ cat << EOF
 EOF
 tc_end_block "Variable Setup"
 
-tc_start_block "Make and push multi-arch docker image"
-docker_login_with_google
+
+tc_start_block "Download and extract tarballs"
+# For release builds, GCS artifact buckets and the container registry use
+# different service accounts (GCS_CREDENTIALS_PROD vs
+# GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS). For customized and
+# dry-run builds, a single credential covers both. Use the GCS-specific
+# credential when set, otherwise fall back to the unified one.
+google_credentials="${gcs_credentials:-$gcp_credentials}"
+log_into_gcloud
+
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir; remove_files_on_exit" EXIT
+
+# Download and extract per-arch tarballs into a build context laid out as
+# ${arch}/ subdirectories, matching what build/deploy/Dockerfile expects.
+context="$tmpdir/context"
+mkdir -p "$context"
+cp build/deploy/Dockerfile "$context/Dockerfile"
+
+for platform in linux-amd64 linux-arm64 linux-s390x; do
+  arch="${platform#linux-}"
+  archive="${cockroach_archive_prefix}-${build_name}.${platform}.tgz"
+  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_bucket/$archive" "$tmpdir/$archive"
+  staging="$tmpdir/staging-${platform}"
+  mkdir -p "$staging"
+  tar \
+    --directory="$staging" \
+    --extract \
+    --file="$tmpdir/$archive" \
+    --ungzip \
+    --ignore-zeros \
+    --strip-components=1
+  mkdir -p "$context/${arch}"
+  cp build/deploy/cockroach.sh "$context/${arch}/"
+  cp "$staging/cockroach" "$context/${arch}/"
+  cp "$staging"/lib/libgeos.so "$staging"/lib/libgeos_c.so "$context/${arch}/"
+  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "$context/${arch}/"
+done
+
+# FIPS is amd64-only; prepare its own build context.
+fips_context="$tmpdir/fips-context"
+mkdir -p "$fips_context/amd64"
+cp build/deploy/Dockerfile "$fips_context/Dockerfile"
+fips_archive="${cockroach_archive_prefix}-${build_name}.linux-amd64-fips.tgz"
+gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_bucket/$fips_archive" "$tmpdir/$fips_archive"
+fips_staging="$tmpdir/staging-linux-amd64-fips"
+mkdir -p "$fips_staging"
+tar \
+  --directory="$fips_staging" \
+  --extract \
+  --file="$tmpdir/$fips_archive" \
+  --ungzip \
+  --ignore-zeros \
+  --strip-components=1
+cp build/deploy/cockroach.sh "$fips_context/amd64/"
+cp "$fips_staging/cockroach" "$fips_context/amd64/"
+cp "$fips_staging"/lib/libgeos.so "$fips_staging"/lib/libgeos_c.so "$fips_context/amd64/"
+cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "$fips_context/amd64/"
+tc_end_block "Download and extract tarballs"
+
+
+tc_start_block "Build and push multi-arch docker image"
+docker_login_gcr "$gcr_repository" "$gcp_credentials"
+
+docker buildx rm "build-artifacts-builder-$$" 2>/dev/null || true
+docker buildx create --name "build-artifacts-builder-$$" --use
+cleanup_buildx() { docker buildx rm "build-artifacts-builder-$$" || true; }
+trap "cleanup_buildx; rm -rf $tmpdir; remove_files_on_exit" EXIT
+
 gcr_tag="${gcr_repository}:${build_name}"
-create_and_push_multi_arch_manifest "${gcr_tag}" "${gcr_repository}:amd64-${build_name}" "${gcr_repository}:arm64-${build_name}" "${gcr_repository}:s390x-${build_name}"
-tc_end_block "Make and push multi-arch docker images"
+docker buildx build --pull --push --no-cache \
+  --platform linux/amd64,linux/arm64,linux/s390x \
+  --tag "$gcr_tag" "$context"
+tc_end_block "Build and push multi-arch docker image"
+
+
+tc_start_block "Build and push FIPS docker image"
+gcr_tag_fips="${gcr_repository}:${build_name}-fips"
+docker buildx build --pull --push --no-cache \
+  --platform linux/amd64 \
+  --tag "$gcr_tag_fips" "$fips_context"
+tc_end_block "Build and push FIPS docker image"
+
+
+tc_start_block "Verify docker images"
+error=0
+for arch in amd64 arm64 s390x; do
+    tc_start_block "Verify $gcr_tag on $arch"
+    if ! verify_docker_image "$gcr_tag" "linux/$arch" "$BUILD_VCS_NUMBER" "$build_name" false "$telemetry_disabled"; then
+      error=1
+    fi
+    tc_end_block "Verify $gcr_tag on $arch"
+done
+
+tc_start_block "Verify FIPS docker image"
+if ! verify_docker_image "$gcr_tag_fips" "linux/amd64" "$BUILD_VCS_NUMBER" "$build_name" true "$telemetry_disabled"; then
+  error=1
+fi
+tc_end_block "Verify FIPS docker image"
+
+if [ $error = 1 ]; then
+  echo "ERROR: Docker image verification failed, see logs above"
+  exit 1
+fi
+tc_end_block "Verify docker images"

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -12,11 +12,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 
-# TODO: remove this block after we upgrade to Ubuntu 22.04+
-# this is needed to support s390x builds on Ubuntu 20.04 hosts
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --uninstall qemu-s390x
-docker run --privileged --rm tonistiigi/binfmt@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541 --install s390x
-# End of TODO
 #
 tc_start_block "Variable Setup"
 
@@ -38,25 +33,18 @@ if [[ -z "${DRY_RUN}" ]] ; then
   if [[ -z "${is_release_build}" ]] ; then
     # export the variable to avoid shell escaping
     export gcs_credentials="$GOOGLE_CREDENTIALS_CUSTOMIZED"
-    google_credentials=$GOOGLE_CREDENTIALS_CUSTOMIZED
     gcs_bucket="cockroach-customized-builds-artifacts-prod"
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb-customized/${cockroach_archive_prefix}-customized"
-    gcr_hostname="us-docker.pkg.dev"
   else
     gcs_bucket="cockroach-builds-artifacts-prod"
-    google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/${cockroach_archive_prefix}"
-    # Used for docker login for gcloud
-    gcr_hostname="us-docker.pkg.dev"
     # export the variable to avoid shell escaping
     export gcs_credentials="$GCS_CREDENTIALS_PROD"
   fi
 else
   gcs_bucket="cockroach-builds-artifacts-dryrun"
-  google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
-  gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
+  gcr_repository="us.gcr.io/cockroach-release/${cockroach_archive_prefix}-test"
   build_name="${build_name}.dryrun"
-  gcr_hostname="us.gcr.io"
   # export the variable to avoid shell escaping
   export gcs_credentials="$GCS_CREDENTIALS_DEV"
 fi
@@ -109,45 +97,11 @@ done
 
 tr -d '\r' < /tmp/THIRD-PARTY-NOTICES.txt.tmp > /tmp/THIRD-PARTY-NOTICES.txt
 
-$BAZEL_BIN/pkg/cmd/publish-artifacts/publish-artifacts_/publish-artifacts release --gcs-bucket="$gcs_bucket" --output-directory=artifacts --build-tag-override="$build_name" --platform $platform --third-party-notices-file=/tmp/THIRD-PARTY-NOTICES.txt --telemetry-disabled=$telemetry_disabled --cockroach-archive-prefix=$cockroach_archive_prefix
+$BAZEL_BIN/pkg/cmd/publish-artifacts/publish-artifacts_/publish-artifacts release --gcs-bucket="$gcs_bucket" --build-tag-override="$build_name" --platform $platform --third-party-notices-file=/tmp/THIRD-PARTY-NOTICES.txt --telemetry-disabled=$telemetry_disabled --cockroach-archive-prefix=$cockroach_archive_prefix
 
 EOF
 tc_end_block "Compile and publish artifacts"
 
-if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "linux-amd64-fips" || $platform == "linux-s390x" ]]; then
-  arch="amd64"
-  if [[ $platform == "linux-arm64" ]]; then
-    arch="arm64"
-  fi
-  if [[ $platform == "linux-s390x" ]]; then
-    arch="s390x"
-  fi
-
-  tc_start_block "Make and push docker image"
-  docker_login_with_google
-
-  cp --recursive "build/deploy" "build/deploy-${platform}"
-  tar \
-    --directory="build/deploy-${platform}" \
-    --extract \
-    --file="artifacts/${cockroach_archive_prefix}-${build_name}.${platform}.tgz" \
-    --ungzip \
-    --ignore-zeros \
-    --strip-components=1
-  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
-  # Move the libs where Dockerfile expects them to be
-  mv build/deploy-${platform}/lib/* build/deploy-${platform}/
-  rmdir build/deploy-${platform}/lib
-
-  build_docker_tag="${gcr_repository}:${arch}-${build_name}"
-  if [[ $platform == "linux-amd64-fips" ]]; then
-    build_docker_tag="${gcr_repository}:${build_name}-fips"
-  fi
-  docker build --no-cache --pull --platform "linux/${arch}" --tag="${build_docker_tag}" "build/deploy-${platform}"
-  docker push "$build_docker_tag"
-
-  tc_end_block "Make and push docker images"
-fi
 
 # Make finding the tag name easy.
 cat << EOF


### PR DESCRIPTION

Modernize the release docker image pipeline:

1. Move docker image builds from per-platform CI jobs into the docker/manifest jobs. Previously, each per-platform job built a single-arch docker image and pushed it (e.g., amd64-v24.1.0), then the manifest job stitched them together. Now the docker jobs download per-arch tarballs from GCS (with 5 retries) and use `docker buildx build --platform` to build and push proper multi-arch images in a single step. This eliminates orphan single-arch manifests and centralizes docker logic.

2. Update build/deploy/Dockerfile to use `ARG TARGETARCH` so buildx can select the correct per-arch binaries from ${TARGETARCH}/ subdirectories in the build context.

3. Use `docker buildx imagetools create` in publish-staged-cockroach-release.sh to copy multi-arch manifests between registries server-side and to create latest/release-branch tags. The staged image is now referenced as a multi-arch manifest directly (`FROM repo:version`) instead of per-arch tags.

4. Add docker image verification to the build artifacts pipeline (previously only the release pipeline verified images).

5. Remove the binfmt TODO workaround for s390x QEMU on Ubuntu 20.04, since agents have been upgraded to Ubuntu 24.04.

6. Add multi-arch support for Red Hat certified images. Update publish-redhat-release.sh to build and push multi-arch (amd64, arm64, s390x) images using docker buildx. Preflight automatically certifies all architectures in the manifest list.

The per-platform jobs now only build and upload tarballs — no docker credentials or registry interaction needed. Remove --output-directory=artifacts since local tarball copies are no longer consumed by a downstream docker build.

Epic: None
Release note (ops change): Red Hat certified CockroachDB container images are now published as multi-arch manifests supporting linux/amd64, linux/arm64, and linux/s390x. Previously only linux/amd64 was published to the Red Hat registry.