### PR TITLE
kvserver,storage: prefer distinct txns in VIR pre-scan after condensing

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -328,7 +328,7 @@ func runBackup(ctx context.Context, t test.Test, c cluster.Cluster, abandon bool
 	defer conn.Close()
 
 	const totalRowCount = 1000000
-	const perTransactionRowCount = 1000
+	const perTransactionRowCount = 10000
 	numTxns := totalRowCount / perTransactionRowCount
 
 	// Disable automatic stats collection to avoid additional contention.
@@ -415,13 +415,17 @@ func runBackup(ctx context.Context, t test.Test, c cluster.Cluster, abandon bool
 		t.Fatalf(err.Error())
 	}
 
+	// Enable virtual intent resolution so that the pre-evaluation lock-table
+	// scan discovers distinct conflicting transactions for ranged resolution.
+	_, err = conn.ExecContext(ctx, "SET CLUSTER SETTING kv.concurrency.virtual_intent_resolution.enabled = true")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
 	// The backup runs with a timeout configured by bulkio.backup.read_timeout,
-	// which defaults to 5min. Currently, before the virtualized intent resolution
-	// work, this test takes ~2min for the pending case and ~3min for the
-	// abandoned case. The 5min timeout should be sufficient for this test, and
-	// if exceeded, will provide a signal that the intent resolution is taking
-	// longer than expected.
-	// TODO(mira): Adjust the timeout if the test flakes, and after the VIR work.
+	// which defaults to 5min. With VIR + preferDistinctTxns + ranged resolution,
+	// each ExportRequest should complete in seconds, but the timeout may need
+	// adjustment if the test flakes.
 	t.Status("running backup")
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP TABLE foo INTO 'nodelocal://1/%s'", destinationName(c)))
 	if err != nil {

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -522,6 +522,11 @@ type Guard interface {
 	// IntentsToResolveVirtually delegates listing the locks to be resolved to the
 	// lock table guard.
 	IntentsToResolveVirtually() []roachpb.LockUpdate
+
+	// HasCondensedIntents returns true if point intents have been condensed
+	// into range entries, indicating that the pre-scan should prefer
+	// discovering distinct conflicting transactions.
+	HasCondensedIntents() bool
 }
 
 // guardImpl implements the Guard interface.

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -522,11 +522,6 @@ type Guard interface {
 	// IntentsToResolveVirtually delegates listing the locks to be resolved to the
 	// lock table guard.
 	IntentsToResolveVirtually() []roachpb.LockUpdate
-
-	// PrepareForLockConflictRetry is called on the lock conflict error path,
-	// before the guard is re-sequenced. It condenses point resolve entries into
-	// range entries that persist across re-sequencing.
-	PrepareForLockConflictRetry(context.Context)
 }
 
 // guardImpl implements the Guard interface.
@@ -904,14 +899,13 @@ type lockTableGuard interface {
 	// virtually during evaluation rather than physically before re-scanning.
 	VirtuallyResolvesIntents() bool
 
+	// HasCondensedIntents returns true if point intents have been condensed
+	// into range entries.
+	HasCondensedIntents() bool
+
 	// AddReplicatedToResolveAndSignal adds a lock update for a replicated lock
 	// to the guard's resolve list and signals the guard to rescan.
 	AddReplicatedToResolveAndSignal(roachpb.LockUpdate)
-
-	// PrepareForLockConflictRetry is called when handling a LockConflictError
-	// after evaluation. It condenses point resolve entries into range entries
-	// that persist across re-sequencing.
-	PrepareForLockConflictRetry(context.Context)
 
 	// CheckOptimisticNoConflicts uses the LockSpanSet representing the spans that
 	// were actually read, to check for conflicting locks, after an optimistic

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -1024,6 +1024,14 @@ func (g *guardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return nil
 }
 
+// HasCondensedIntents implements the Guard interface.
+func (g *guardImpl) HasCondensedIntents() bool {
+	if g.ltg != nil {
+		return g.ltg.HasCondensedIntents()
+	}
+	return false
+}
+
 func (g *guardImpl) moveLatchGuard() latchGuard {
 	lg := g.lg
 	g.lg = nil

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -620,11 +620,6 @@ func (m *managerImpl) HandleLockConflictError(
 	// Either way, there is no possibility of the request entering an infinite
 	// loop without making progress.
 
-	// Condense point resolve entries into range entries before they are cleared
-	// by the next ScanAndEnqueue. This prevents livelock when the lock table
-	// evicts entries under memory pressure.
-	g.PrepareForLockConflictRetry(ctx)
-
 	consultTxnStatusCache :=
 		int64(len(t.Locks)) > DiscoveredLocksThresholdToConsultTxnStatusCache.Get(&m.st.SV)
 	var numAdded int
@@ -933,13 +928,6 @@ func (g *guardImpl) TakeSpanSets() (*spanset.SpanSet, *lockspanset.LockSpanSet) 
 // HoldingLatches implements the Guard interface.
 func (g *guardImpl) HoldingLatches() bool {
 	return g != nil && g.lg != nil
-}
-
-// PrepareForLockConflictRetry implements the Guard interface.
-func (g *guardImpl) PrepareForLockConflictRetry(ctx context.Context) {
-	if g != nil && g.ltg != nil {
-		g.ltg.PrepareForLockConflictRetry(ctx)
-	}
 }
 
 // AssertLatches implements the Guard interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -556,11 +556,11 @@ type lockTableGuardImpl struct {
 // and resolvableTxns persist across scans so the guard does not re-conflict on
 // locks whose txnStatusCache entry has been evicted.
 type resolvableLocks struct {
-	// toResolve holds point LockUpdates accumulated during scanning. This is
-	// cleared on every entry to ScanAndEnqueue.
-	//
-	// For VIR transactions, we rely on previously encountered transactions being
-	// in resolvableTxns
+	// toResolve holds point LockUpdates accumulated during scanning. For
+	// non-VIR guards, this is cleared on every entry to ScanAndEnqueue. For
+	// VIR guards, points persist across scans (since VIR results are
+	// ephemeral and must be re-applied) and are condensed into
+	// toResolveRange when exceeding condenseOnScanThreshold.
 	toResolve []roachpb.LockUpdate
 
 	// toResolveRange maps txn IDs to range LockUpdates that persist across
@@ -785,6 +785,11 @@ func (g *lockTableGuardImpl) IntentsToResolveVirtually() []roachpb.LockUpdate {
 // VirtuallyResolvesIntents implements the lockTableGuard interface.
 func (g *lockTableGuardImpl) VirtuallyResolvesIntents() bool {
 	return g.virtuallyResolveIntents
+}
+
+// HasCondensedIntents implements the lockTableGuard interface.
+func (g *lockTableGuardImpl) HasCondensedIntents() bool {
+	return len(g.toResolve.toResolveRange) > 0
 }
 
 func (g *lockTableGuardImpl) NewStateChan() chan struct{} {
@@ -1336,20 +1341,6 @@ func (g *lockTableGuardImpl) resumeScan(notify bool) error {
 		g.notify()
 	}
 	return nil
-}
-
-// PrepareForLockConflictRetry implements the lockTableGuard interface.
-func (g *lockTableGuardImpl) PrepareForLockConflictRetry(_ context.Context) {
-	// If we encountered a LockConflict during evaluation, we need to consider the
-	// possibility that we _won't_ encounter the lock again from the lock table.
-	//
-	// We handle that by condensing _everything_ into resolve ranges. We could
-	// have alternatively handled this by keep toResolve across invocations of
-	// ScanAndEnqueue. If we find that overzealous range resolutions are a
-	// problem, we can re-consider that decision.
-	if g.toResolve.maybeCondense(0) {
-		g.lt.virtualResolveCondenseCount.Inc(1)
-	}
 }
 
 func (g *lockTableGuardImpl) maybeDisableVIR(ctx context.Context) {
@@ -4546,17 +4537,19 @@ func (t *lockTableImpl) ScanAndEnqueue(
 		g.mu.mustComputeWaitingState = false
 		g.mu.Unlock()
 		if g.virtuallyResolveIntents {
-			// Condense accumulated point entries into range entries if the list has
-			// grown large.
-			//
-			// If we've also accumulated too many range resolves, give up trying to
-			// virtually resolve.
+			// Condense accumulated point entries into range entries if the list
+			// has grown large. Point entries are not cleared for VIR guards;
+			// they persist across scans so that they can be re-resolved
+			// virtually on each evaluation attempt (VIR results are ephemeral).
 			if g.toResolve.maybeCondense(g.condenseOnScanThreshold) {
 				g.lt.virtualResolveCondenseCount.Inc(1)
 			}
+			// If we've accumulated too many range resolves, give up trying to
+			// virtually resolve.
 			g.maybeDisableVIR(ctx)
+		} else {
+			g.toResolve.clear()
 		}
-		g.toResolve.clear()
 	}
 	t.doSnapshotForGuard(g)
 

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -608,7 +608,7 @@ func (rl *resolvableLocks) condense() {
 // maybeCondense condenses point entries into range entries if toResolve has
 // grown beyond the configured threshold.
 func (rl *resolvableLocks) maybeCondense(threshold int) bool {
-	if rl.virEnabled && len(rl.toResolve) > threshold {
+	if rl.virEnabled && threshold > 0 && len(rl.toResolve) >= threshold {
 		rl.condense()
 		return true
 	}
@@ -4579,6 +4579,7 @@ func (t *lockTableImpl) ScanAndEnqueue(
 
 // defaultMaxToResolveRangeTxns is the default maximum number of distinct txns
 // tracked in toResolveRange.
+// TODO(mira): consider making this tunable or increasing it.
 const defaultMaxToResolveRangeTxns = 128
 
 func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -2257,13 +2257,13 @@ func TestResolvableLocks(t *testing.T) {
 			makeLockUpdate(txn, roachpb.Key("b")),
 			makeLockUpdate(txn, roachpb.Key("c")),
 		)
-		// Threshold of 3: 3 points is not > 3, so no condensing.
-		require.False(t, rl.maybeCondense(3))
+		// Threshold of 4: 3 points < 4, so no condensing.
+		require.False(t, rl.maybeCondense(4))
 		require.Len(t, rl.toResolve, 3)
 		require.Nil(t, rl.toResolveRange)
 
-		// Threshold of 2: 3 points > 2, so condensing fires.
-		require.True(t, rl.maybeCondense(2))
+		// Threshold of 3: 3 points >= 3, so condensing fires.
+		require.True(t, rl.maybeCondense(3))
 		require.Empty(t, rl.toResolve)
 		require.Len(t, rl.toResolveRange, 1)
 	})
@@ -2275,9 +2275,11 @@ func TestResolvableLocks(t *testing.T) {
 		require.Nil(t, rl.toResolveRange)
 	})
 
-	t.Run("condense noop when empty", func(t *testing.T) {
-		rl := makeRL(true)
+	t.Run("condense noop with zero threshold", func(t *testing.T) {
+		rl := makeRL(true, makeLockUpdate(txn, roachpb.Key("a")))
+		// A zero threshold disables condensing.
 		require.False(t, rl.maybeCondense(0))
+		require.Len(t, rl.toResolve, 1)
 		require.Nil(t, rl.toResolveRange)
 	})
 
@@ -2287,7 +2289,7 @@ func TestResolvableLocks(t *testing.T) {
 			makeLockUpdate(txn, roachpb.Key("d")),
 			makeLockUpdate(txn, roachpb.Key("a")),
 		)
-		require.True(t, rl.maybeCondense(0))
+		require.True(t, rl.maybeCondense(1))
 		require.Empty(t, rl.toResolve)
 		require.Len(t, rl.toResolveRange, 1)
 		// Range should span [a, d.Next()).

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -2251,6 +2251,23 @@ func TestResolvableLocks(t *testing.T) {
 	}
 	txn := makeTxnMeta("txn1")
 
+	t.Run("condense respects threshold", func(t *testing.T) {
+		rl := makeRL(true,
+			makeLockUpdate(txn, roachpb.Key("a")),
+			makeLockUpdate(txn, roachpb.Key("b")),
+			makeLockUpdate(txn, roachpb.Key("c")),
+		)
+		// Threshold of 3: 3 points is not > 3, so no condensing.
+		require.False(t, rl.maybeCondense(3))
+		require.Len(t, rl.toResolve, 3)
+		require.Nil(t, rl.toResolveRange)
+
+		// Threshold of 2: 3 points > 2, so condensing fires.
+		require.True(t, rl.maybeCondense(2))
+		require.Empty(t, rl.toResolve)
+		require.Len(t, rl.toResolveRange, 1)
+	})
+
 	t.Run("condense noop when VIR disabled", func(t *testing.T) {
 		rl := makeRL(false, makeLockUpdate(txn, roachpb.Key("a")))
 		require.False(t, rl.maybeCondense(0))

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -92,6 +92,7 @@ func (g *mockLockTableGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
 func (g *mockLockTableGuard) VirtuallyResolvesIntents() bool {
 	return g.virtuallyResolveIntents
 }
+func (g *mockLockTableGuard) HasCondensedIntents() bool { return false }
 func (g *mockLockTableGuard) AddReplicatedToResolveAndSignal(up roachpb.LockUpdate) {
 	g.toResolve = append(g.toResolve, up)
 	// Use non-blocking send, matching the real lockTableGuardImpl.notify().
@@ -103,7 +104,6 @@ func (g *mockLockTableGuard) AddReplicatedToResolveAndSignal(up roachpb.LockUpda
 func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet) (ok bool) {
 	return true
 }
-func (g *mockLockTableGuard) PrepareForLockConflictRetry(context.Context) {}
 func (g *mockLockTableGuard) IsKeyLockedByConflictingTxn(
 	context.Context, roachpb.Key, lock.Strength,
 ) (bool, *enginepb.TxnMeta, error) {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -107,6 +107,22 @@ func (r *Replica) executeReadOnlyBatch(
 		// directly on the storage batch before evaluating the read-only batch request
 		// below. Depending on the result of the intent resolution, the read-only
 		// batch request may not conflict with the intents anymore.
+		//
+		// When intents have been condensed into range resolves, widen the
+		// resolve span to cover the full request span so that all of a txn's
+		// intents are resolved in one pass.
+		var reqSpan roachpb.Span
+		if g.HasCondensedIntents() {
+			reqSpan = ba.Requests[0].GetInner().Header().Span()
+			for _, ru := range ba.Requests[1:] {
+				reqSpan = reqSpan.Combine(ru.GetInner().Header().Span())
+			}
+			// Point requests (e.g. Get) have no EndKey. Ensure the span
+			// is a valid range for ResolveIntentRangeRequest.
+			if reqSpan.EndKey == nil {
+				reqSpan.EndKey = reqSpan.Key.Next()
+			}
+		}
 		for _, intent := range intentsToResolveVirtually {
 			var (
 				// It's ok to pass an empty header since during intent resolution it's only
@@ -119,8 +135,14 @@ func (r *Replica) executeReadOnlyBatch(
 			)
 			if len(intent.EndKey) > 0 {
 				// Range LockUpdate: resolve all intents for this txn in the span.
+				// Use the widened request span if available, otherwise fall back to
+				// the intent's own span.
+				span := reqSpan
+				if span.Key == nil {
+					span = intent.Span
+				}
 				req = &kvpb.ResolveIntentRangeRequest{
-					RequestHeader:     kvpb.RequestHeaderFromSpan(intent.Span),
+					RequestHeader:     kvpb.RequestHeaderFromSpan(span),
 					IntentTxn:         intent.Txn,
 					Status:            intent.Status,
 					IgnoredSeqNums:    intent.IgnoredSeqNums,
@@ -389,6 +411,11 @@ func (r *Replica) canDropLatchesBeforeEval(
 
 	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&r.store.cfg.Settings.SV)
 	targetLockConflictBytes := storage.TargetBytesPerLockConflictError.Get(&r.store.cfg.Settings.SV)
+	// After condensing, range resolves are widened to cover the full request
+	// span. In this regime, prefer discovering distinct conflicting transactions
+	// over accumulating many intents from the same transaction, since each
+	// distinct txn's range resolve will cover all its intents.
+	preferDistinctTxns := g.HasCondensedIntents()
 	var intents []roachpb.Intent
 	// Check if any of the requests within the batch need to resolve any intents
 	// or if any of them need to use an intent interleaving iterator.
@@ -401,6 +428,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 		}
 		needsIntentInterleavingForThisRequest, err := storage.ScanConflictingIntentsForDroppingLatchesEarly(
 			ctx, rw, txnID, ba.Header.Timestamp, start, end, &intents, maxLockConflicts, targetLockConflictBytes,
+			preferDistinctTxns,
 		)
 		if err != nil {
 			return false /* ok */, true /* stillNeedsIntentInterleaving */, kvpb.NewError(

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -125,7 +125,6 @@ func (mg mockGuard) IsKeyLockedByConflictingTxn(
 func (mg mockGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return mg.intentsToResolveVirtually
 }
-func (mg mockGuard) PrepareForLockConflictRetry(context.Context) {}
 
 var _ concurrency.Guard = (*mockGuard)(nil)
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -125,6 +125,7 @@ func (mg mockGuard) IsKeyLockedByConflictingTxn(
 func (mg mockGuard) IntentsToResolveVirtually() []roachpb.LockUpdate {
 	return mg.intentsToResolveVirtually
 }
+func (mg mockGuard) HasCondensedIntents() bool { return false }
 
 var _ concurrency.Guard = (*mockGuard)(nil)
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2809,6 +2809,83 @@ func TestStoreScanMultipleIntents(t *testing.T) {
 	}
 }
 
+// TestStoreScanVirtualIntentResolutionWithRangeResolves verifies that when VIR
+// accumulates enough conflicting intents, they are merged into ranged
+// ResolveIntent requests that span the entire read, allowing a scan to
+// complete even when there are many more intents than maxLockConflicts.
+func TestStoreScanVirtualIntentResolutionWithRangeResolves(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 123))
+	cfg := TestStoreConfig(hlc.NewClockForTesting(manual))
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	store := createTestStoreWithConfig(
+		ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg,
+	)
+
+	// Force VIR on and set maxLockConflicts=1 so the pre-evaluation scan
+	// discovers at most one intent per attempt. This also sets the threshold
+	// at which accumulated per-key resolves are merged into ranged resolves.
+	concurrency.VirtualIntentResolution.Override(ctx, &store.cfg.Settings.SV, true)
+	storage.MaxConflictsPerLockConflictError.Override(ctx, &store.cfg.Settings.SV, 1)
+
+	// Write ten intents from a single txn, then expire it.
+	key1 := roachpb.Key("key00")
+	key10 := roachpb.Key("key09")
+	txn := newTransaction("test", key1, 1, store.cfg.Clock)
+	ba := &kvpb.BatchRequest{}
+	for i := 0; i < 10; i++ {
+		pArgs := putArgs(roachpb.Key(fmt.Sprintf("key%02d", i)), []byte("value"))
+		ba.Add(&pArgs)
+		assignSeqNumsForReqs(txn, &pArgs)
+	}
+	ba.Header = kvpb.Header{Txn: txn}
+	_, pErr := store.TestSender().Send(ctx, ba)
+	require.Nil(t, pErr)
+	manual.Advance(time.Duration(txnwait.TxnLivenessThreshold.Load()) + 1)
+
+	m := store.Metrics()
+	pointBefore := m.VirtualResolveIntentCount.Count()
+	rangeBefore := m.VirtualResolveIntentRangeCount.Count()
+	batchesBefore := m.VirtualResolveBatches.Count()
+	condenseBefore := m.VirtualResolveCondenseCount.Count()
+
+	sArgs := scanArgs(key1, key10.Next())
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(), sArgs)
+	require.Nil(t, pErr)
+
+	// The scan completes in 3 evaluation attempts:
+	//
+	// Attempt 1: pre-scan discovers key00 → LockConflictError. Txn gets
+	//   pushed. key00 queued for per-key virtual resolution (1 entry, does
+	//   not exceed threshold).
+	//
+	// Attempt 2: key00 resolved virtually (point). Pre-scan discovers key01
+	//   → LockConflictError. key00 (persisted) + key00 + key01 (re-scanned
+	//   from lock table) = 3 entries, exceeds threshold → merged into a
+	//   single ranged resolve [key00, key01.Next()).
+	//
+	// Attempt 3: ranged resolve is expanded to cover the full scan span
+	//   [key00, key09.Next()), clearing all 10 intents. Pre-scan finds
+	//   nothing. Scan succeeds.
+	// The scan completes in 2 evaluation attempts:
+	//
+	// Attempt 1: pre-scan discovers key00 → LockConflictError. Txn gets
+	//   pushed. key00 queued for per-key virtual resolution (1 entry,
+	//   meets threshold of 1 → condensed into a ranged resolve).
+	//
+	// Attempt 2: ranged resolve is expanded to cover the full scan span
+	//   [key00, key09.Next()), clearing all 10 intents. Pre-scan finds
+	//   nothing. Scan succeeds.
+	require.Equal(t, int64(0), m.VirtualResolveIntentCount.Count()-pointBefore)
+	require.Equal(t, int64(1), m.VirtualResolveIntentRangeCount.Count()-rangeBefore)
+	require.Equal(t, int64(1), m.VirtualResolveBatches.Count()-batchesBefore)
+	require.Equal(t, int64(1), m.VirtualResolveCondenseCount.Count()-condenseBefore)
+}
+
 // TestStoreBadRequests verifies that Send returns errors for
 // bad requests that do not pass key verification.
 func TestStoreBadRequests(t *testing.T) {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -2153,6 +2154,14 @@ func TestStoreScanIntents(t *testing.T) {
 	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)
 
+	// Metamorphically lower the max conflicts per lock conflict error to exercise
+	// VIR intent condensing with fewer intents.
+	rng, _ := randutil.NewTestRand()
+	maxConflicts := []int64{1, 3, 5, 20, storage.MaxConflictsPerLockConflictErrorDefault}
+	storage.MaxConflictsPerLockConflictError.Override(
+		ctx, &store.cfg.Settings.SV, maxConflicts[rng.Intn(len(maxConflicts))],
+	)
+
 	testCases := []struct {
 		consistent bool
 		canPush    bool  // can the txn be pushed?
@@ -2402,10 +2411,16 @@ func TestVirtualIntentResolutionReentryAfterEvaluationLiveLock(t *testing.T) {
 
 	// Enable VIR, set low lock table size, and low max conflicts per error to
 	// force multi-round intent discovery with frequent lock table eviction.
+	// Setting DiscoveredLocksThresholdToConsultTxnStatusCache to 1 causes
+	// intents to bypass the lock table and go directly to toResolve when the
+	// txn is in the status cache. For VIR, this previously caused a livelock:
+	// toResolve was cleared on re-entry to ScanAndEnqueue, and without the
+	// lock in the lock table, the same intents were rediscovered every round.
 	st := tc.Server(0).ClusterSettings()
 	concurrency.VirtualIntentResolution.Override(ctx, &st.SV, true)
 	concurrency.DefaultLockTableSize.Override(ctx, &st.SV, 4)
 	storage.MaxConflictsPerLockConflictError.Override(ctx, &st.SV, 3)
+	concurrency.DiscoveredLocksThresholdToConsultTxnStatusCache.Override(ctx, &st.SV, 1)
 
 	store, err := tc.Server(0).GetStores().(*Stores).GetStore(tc.Server(0).GetFirstStoreID())
 	require.NoError(t, err)
@@ -2744,6 +2759,14 @@ func TestStoreScanMultipleIntents(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)
+
+	// Metamorphically lower the max conflicts per lock conflict error to exercise
+	// VIR intent condensing with fewer intents.
+	rng, _ := randutil.NewTestRand()
+	maxConflicts := []int64{1, 3, 5, 20, storage.MaxConflictsPerLockConflictErrorDefault}
+	storage.MaxConflictsPerLockConflictError.Override(
+		ctx, &store.cfg.Settings.SV, maxConflicts[rng.Intn(len(maxConflicts))],
+	)
 
 	// Lay down ten intents from a single txn.
 	key1 := roachpb.Key("key00")

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1974,6 +1974,7 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 	intents *[]roachpb.Intent,
 	maxLockConflicts int64,
 	targetLockConflictBytes int64,
+	preferDistinctTxns bool,
 ) (needIntentHistory bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -2017,6 +2018,16 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 	var meta enginepb.MVCCMetadata
 	var ok bool
 	intentSize := int64(0)
+	// When preferDistinctTxns is set, we skip intents from transactions we've
+	// already collected, maximizing the number of distinct conflicting txns
+	// discovered within the maxLockConflicts budget.
+	// TODO(mira): consider collecting the first and last intent per transaction
+	// so that range resolve requests can be constructed more precisely, rather
+	// than widening to the full request span.
+	var seenTxns map[uuid.UUID]struct{}
+	if preferDistinctTxns {
+		seenTxns = make(map[uuid.UUID]struct{})
+	}
 	for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: ltStart}); ok; ok, err = iter.NextEngineKey() {
 		if maxLockConflicts != 0 && int64(len(*intents)) >= maxLockConflicts {
 			// Return early if we're done accumulating intents; make no claims about
@@ -2071,6 +2082,12 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 		}
 		if intentConflicts := meta.Timestamp.ToTimestamp().LessEq(ts); !intentConflicts {
 			continue
+		}
+		if seenTxns != nil {
+			if _, seen := seenTxns[meta.Txn.ID]; seen {
+				continue
+			}
+			seenTxns[meta.Txn.ID] = struct{}{}
 		}
 		key, err := iter.EngineKey()
 		if err != nil {

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -2272,8 +2272,9 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 				tc.start,
 				tc.end,
 				&intents,
-				0, /* maxLockConflicts */
-				0, /* targetLockConflictBytes */
+				0,     /* maxLockConflicts */
+				0,     /* targetLockConflictBytes */
+				false, /* preferDistinctTxns */
 			)
 			if tc.expErr != "" {
 				require.Error(t, err)
@@ -2286,6 +2287,91 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			require.Equal(t, tc.expNumFoundIntents, len(intents))
 		})
 	}
+}
+
+// TestScanConflictingIntentsPreferDistinctTxns verifies the preferDistinctTxns
+// parameter of ScanConflictingIntentsForDroppingLatchesEarly, which collects at
+// most one intent per conflicting transaction.
+func TestScanConflictingIntentsPreferDistinctTxns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	ts := func(nanos int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: int64(nanos)}
+	}
+	newTxn := func(ts hlc.Timestamp) *roachpb.Transaction {
+		return &roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				ID:             uuid.MakeV4(),
+				Epoch:          1,
+				WriteTimestamp: ts,
+				MinTimestamp:   ts,
+			},
+			ReadTimestamp: ts,
+		}
+	}
+
+	eng := NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	val := roachpb.MakeValueFromString("v")
+	belowReaderTS := ts(1)
+
+	// Write 3 intents from txnA (at a, c, e) and 2 from txnB (at b, d).
+	txnA := newTxn(belowReaderTS)
+	txnB := newTxn(belowReaderTS)
+	for _, key := range []roachpb.Key{
+		roachpb.Key("a"), roachpb.Key("c"), roachpb.Key("e"),
+	} {
+		txnA.Sequence++
+		_, err := MVCCPut(ctx, eng, key, txnA.WriteTimestamp, val, MVCCWriteOptions{Txn: txnA})
+		require.NoError(t, err)
+	}
+	for _, key := range []roachpb.Key{
+		roachpb.Key("b"), roachpb.Key("d"),
+	} {
+		txnB.Sequence++
+		_, err := MVCCPut(ctx, eng, key, txnB.WriteTimestamp, val, MVCCWriteOptions{Txn: txnB})
+		require.NoError(t, err)
+	}
+
+	readerTxn := newTxn(ts(2))
+	start := roachpb.Key("a")
+	end := roachpb.Key("f")
+
+	scan := func(maxLockConflicts int64, preferDistinct bool) []roachpb.Intent {
+		var intents []roachpb.Intent
+		_, err := ScanConflictingIntentsForDroppingLatchesEarly(
+			ctx, eng, readerTxn.ID, readerTxn.ReadTimestamp,
+			start, end, &intents,
+			maxLockConflicts, 0 /* targetLockConflictBytes */, preferDistinct,
+		)
+		require.NoError(t, err)
+		return intents
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		intents := scan(0 /* maxLockConflicts */, false /* preferDistinctTxns */)
+		require.Len(t, intents, 5, "all intents collected without dedup")
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		intents := scan(0 /* maxLockConflicts */, true /* preferDistinctTxns */)
+		require.Len(t, intents, 2, "one intent per txn")
+		seenTxns := make(map[uuid.UUID]bool)
+		for _, intent := range intents {
+			seenTxns[intent.Txn.ID] = true
+		}
+		require.True(t, seenTxns[txnA.TxnMeta.ID])
+		require.True(t, seenTxns[txnB.TxnMeta.ID])
+	})
+
+	t.Run("enabled/with-limit", func(t *testing.T) {
+		intents := scan(1 /* maxLockConflicts */, true /* preferDistinctTxns */)
+		require.Len(t, intents, 1, "limited to 1 by maxLockConflicts")
+	})
 }
 
 // TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites constructs
@@ -2495,8 +2581,9 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 				keyA,
 				nil,
 				&intents,
-				0, /* maxLockConflicts */
-				0, /* targetLockConflictBytes */
+				0,     /* maxLockConflicts */
+				0,     /* targetLockConflictBytes */
+				false, /* preferDistinctTxns */
 			)
 			require.NoError(t, err)
 			if alwaysFallbackToIntentInterleavingIteratorForReadYourOwnWrites {


### PR DESCRIPTION
**concurrency: fix VIR livelock by persisting toResolve across scans**

Previously, the lock table guard's `toResolve` list of point intent resolutions was cleared on every re-entry to `ScanAndEnqueue`, including for VIR (virtual intent resolution) guards. This caused a livelock: the guard would discover intents, resolve them virtually during evaluation, hit a LockConflictError, re-enter `ScanAndEnqueue` (which cleared `toResolve`), and then rediscover the same intents — looping indefinitely without progress.

This commit fixes the livelock by:
1. Not clearing `toResolve` for VIR guards on re-entry to `ScanAndEnqueue`. VIR results are ephemeral (applied on a temporary pebble batch), so previously resolved intents must be re-resolved on each evaluation attempt.
2. Condensing accumulated point entries into range entries when the list exceeds `condenseOnScanThreshold` (derived from `MaxConflictsPerLockConflictError`, default 5000). This happens inside `ScanAndEnqueue`, after `AddDiscovered` has incorporated newly found intents.

`PrepareForLockConflictRetry` is removed as it is no longer needed. `VirtuallyResolvesIntents` is removed from the `Guard` interface as it is only used internally by the lock table.

Epic: none
Release note: None

---

**kvserver,storage: prefer distinct txns in VIR pre-scan after condensing**

After the lock table guard condenses point intent resolutions into range entries, this commit widens the range resolves to cover the full request span during virtual evaluation, so that all of a transaction's intents are resolved in one pass rather than requiring iterative discovery. Point requests (e.g. Get) whose spans have no EndKey get a synthesized range span for `ResolveIntentRangeRequest`.

In this regime, discovering many intents from the same transaction is wasteful — a single range resolve already covers all of that transaction's intents within the span. This commit adds a `preferDistinctTxns` parameter to `ScanConflictingIntentsForDroppingLatchesEarly`. When set, the pre-scan skips intents from transactions it has already collected, maximizing the number of distinct conflicting transactions discovered within the `maxLockConflicts` budget. This is signaled through the new `HasCondensedIntents()` method on the `Guard` interface.

Epic: none
Release note: None

---

**roachtest: tune backup/intents for VIR**

With virtual intent resolution, the backup/intents roachtest benefits from having fewer, larger transactions rather than many small ones. Increasing perTransactionRowCount from 1,000 to 10,000 (i.e. 100 txns instead of 1,000) means each ExportRequest encounters intents from fewer distinct transactions, which is resolved efficiently by the condensing + ranged VIR path.

VIR is explicitly enabled via cluster setting so the test exercises the preferDistinctTxns pre-scan and ranged virtual resolution.

Part of: [#156800](https://github.com/cockroachdb/cockroach/issues/156800)
Release note: None