### PR TITLE
sql: support tableoid system column on virtual tables

### DIFF
--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 func constructPlan(
@@ -293,13 +294,46 @@ func constructVirtualScan(
 		// We shouldn't have allowed SELECT FOR UPDATE for a virtual table.
 		return nil, errors.AssertionFailedf("locking cannot be used with virtual table")
 	}
-	if needed := params.NeededCols; needed.Len() != len(columns) {
+
+	// Check if the tableoid system column is needed. The tableoid ordinal is
+	// after all public columns + the dummy PK column. Since the virtual table
+	// generator doesn't produce system columns, we handle tableoid separately
+	// by rendering it as a constant after the scan.
+	tableoidOrd := len(columns) + 1 // +1 for dummy PK
+	needTableoid := params.NeededCols.Contains(tableoidOrd)
+	needed := params.NeededCols.Copy()
+	needed.Remove(tableoidOrd)
+
+	if needed.Len() != len(columns) {
 		// We are selecting a subset of columns; we need a projection.
 		cols := make([]exec.NodeColumnOrdinal, 0, needed.Len())
 		for ord, ok := needed.Next(0); ok; ord, ok = needed.Next(ord + 1) {
 			cols = append(cols, exec.NodeColumnOrdinal(ord-1))
 		}
 		n, err = ef.ConstructSimpleProject(n, cols, nil /* reqOrdering */)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if needTableoid {
+		// Add the tableoid system column as a constant render. The tableoid
+		// has the highest ordinal, so it always appears last in the output.
+		inputCols := planColumns(n.(planNode))
+		renderCols := make(colinfo.ResultColumns, len(inputCols)+1)
+		copy(renderCols, inputCols)
+		renderCols[len(inputCols)] = colinfo.ResultColumn{
+			Name:    colinfo.TableOIDColumnName,
+			Typ:     types.Oid,
+			Hidden:  true,
+			TableID: table.(*optVirtualTable).desc.GetID(),
+		}
+		exprs := make(tree.TypedExprs, len(inputCols)+1)
+		for i := range inputCols {
+			exprs[i] = tree.NewTypedOrdinalReference(i, inputCols[i].Typ)
+		}
+		tableID := table.(*optVirtualTable).desc.GetID()
+		exprs[len(inputCols)] = tree.NewDOid(oid.Oid(tableID))
+		n, err = ef.ConstructRender(n, renderCols, exprs, nil /* reqOrdering */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -199,6 +199,87 @@ SELECT tableoid, x FROM tab3@i WHERE x = 1
 statement error pq: relation "bad" \([0-9]+\): column name "tableoid" conflicts with a system column name
 CREATE TABLE bad (tableoid int)
 
+subtest tableoid_virtual_tables
+
+# Verify that tableoid works on virtual tables (pg_catalog, information_schema, etc.).
+
+# The tableoid should be the descriptor ID of the virtual table. Each virtual
+# table has a stable descriptor ID, so we can verify the value is consistent
+# across rows and matches the table's OID.
+
+# pg_catalog tables.
+let $pg_class_oid
+SELECT oid FROM pg_class WHERE relname = 'pg_class' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog')
+
+query B
+SELECT bool_and(tableoid = $pg_class_oid) FROM pg_class
+----
+true
+
+let $pg_namespace_oid
+SELECT oid FROM pg_class WHERE relname = 'pg_namespace' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog')
+
+query B
+SELECT bool_and(tableoid = $pg_namespace_oid) FROM pg_namespace
+----
+true
+
+# Verify tableoid is different for different virtual tables.
+query B
+SELECT (SELECT tableoid FROM pg_class LIMIT 1) != (SELECT tableoid FROM pg_namespace LIMIT 1)
+----
+true
+
+# information_schema tables.
+let $is_tables_oid
+SELECT oid FROM pg_class WHERE relname = 'tables' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'information_schema')
+
+query B
+SELECT bool_and(tableoid = $is_tables_oid) FROM information_schema.tables
+----
+true
+
+# Test the pg_dump pattern that motivated this change:
+# SELECT x.tableoid, ... FROM pg_extension x
+query OT
+SELECT x.tableoid, x.extname FROM pg_extension x
+----
+
+# Verify tableoid is preserved correctly in joins between virtual tables.
+# The tableoid for pg_class rows should differ from the tableoid for
+# pg_namespace rows, even when the tables are joined.
+query B
+SELECT bool_and(c.tableoid != n.tableoid) FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+----
+true
+
+# Verify that tableoid works with column aliases.
+query OT colnames
+SELECT t.tableoid, t.nspname FROM pg_namespace t WHERE t.nspname = 'pg_catalog'
+----
+tableoid    nspname
+4294967048  pg_catalog
+
+# Verify tableoid works with WHERE clause filtering.
+query B
+SELECT tableoid IS NOT NULL FROM pg_namespace WHERE nspname = 'pg_catalog'
+----
+true
+
+# Verify tableoid works with LIMIT.
+query B
+SELECT tableoid IS NOT NULL FROM pg_class LIMIT 1
+----
+true
+
+# Verify tableoid works when a secondary index is used on a virtual table.
+# pg_class has a secondary index on oid. Querying tableoid with a filter on oid
+# should not cause an index join (which would panic for virtual tables).
+query BT
+SELECT tableoid = $pg_class_oid, relname FROM pg_class WHERE oid = 'pg_class'::regclass
+----
+true  pg_class
+
 subtest origin_id
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -280,6 +280,24 @@ SELECT tableoid = $pg_class_oid, relname FROM pg_class WHERE oid = 'pg_class'::r
 ----
 true  pg_class
 
+# Verify tableoid works in a virtual table lookup join. This is the pattern
+# pg_dump uses: joining an unnested array against a virtual table's index.
+# Previously this caused an index-out-of-bounds panic in pushRow because the
+# lookup join tried to read the tableoid column from the looked-up row, but
+# the virtual table generator does not produce system columns.
+statement ok
+CREATE TABLE IF NOT EXISTS attrdef_test (id INT PRIMARY KEY, val TEXT DEFAULT 'hello')
+
+query B
+SELECT bool_and(a.tableoid IS NOT NULL)
+FROM unnest(ARRAY[(SELECT 'attrdef_test'::regclass::oid)]::oid[]) AS src(tbloid)
+JOIN pg_catalog.pg_attrdef a ON (src.tbloid = a.adrelid)
+----
+true
+
+statement ok
+DROP TABLE IF EXISTS attrdef_test
+
 subtest origin_id
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -369,12 +369,12 @@ distribution: local
 └── • render
     │
     └── • hash join (left outer)
-        │ equality: (column80) = (table_id)
+        │ equality: (column85) = (table_id)
         │
         ├── • render
         │   │
         │   └── • hash join (left outer)
-        │       │ equality: (column62) = (table_id)
+        │       │ equality: (column66) = (table_id)
         │       │ right cols are key
         │       │
         │       ├── • render
@@ -423,12 +423,12 @@ distribution: local
 └── • render
     │
     └── • hash join (left outer)
-        │ equality: (column95) = (table_id)
+        │ equality: (column102) = (table_id)
         │
         ├── • render
         │   │
         │   └── • hash join (left outer)
-        │       │ equality: (column77) = (table_id)
+        │       │ equality: (column83) = (table_id)
         │       │ right cols are key
         │       │
         │       ├── • render

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -87,7 +87,7 @@ regions: <hidden>
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ execution time: 0µs
-        │ equality: (column80) = (table_id)
+        │ equality: (column85) = (table_id)
         │
         ├── • render
         │   │ execution time: 0µs
@@ -96,7 +96,7 @@ regions: <hidden>
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
         │       │ execution time: 0µs
-        │       │ equality: (column62) = (table_id)
+        │       │ equality: (column66) = (table_id)
         │       │ right cols are key
         │       │
         │       ├── • render

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_tables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_tables
@@ -8,12 +8,12 @@ distribution: local
 • render
 │
 └── • hash join (left outer)
-    │ equality: (column80) = (table_id)
+    │ equality: (column85) = (table_id)
     │
     ├── • render
     │   │
     │   └── • hash join (left outer)
-    │       │ equality: (column62) = (table_id)
+    │       │ equality: (column66) = (table_id)
     │       │ right cols are key
     │       │
     │       ├── • render
@@ -60,7 +60,7 @@ distribution: local
 • render
 │
 └── • hash join (left outer)
-    │ equality: (column80) = (table_id)
+    │ equality: (column85) = (table_id)
     │
     ├── • render
     │   │

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -135,12 +135,12 @@ distribution: local
         └── • virtual table lookup join
             │ table: pg_attribute@pg_attribute_attrelid_idx
             │ equality: (oid) = (attrelid)
-            │ pred: column158 = attnum
+            │ pred: column163 = attnum
             │
             └── • render
                 │
                 └── • hash join
-                    │ equality: (attrelid, attnum) = (oid, column130)
+                    │ equality: (attrelid, attnum) = (oid, column134)
                     │
                     ├── • filter
                     │   │ filter: attrelid = 'b'::REGCLASS

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -2522,7 +2523,8 @@ func newOptVirtualTable(
 		name: *name,
 	}
 
-	ot.columns = make([]cat.Column, len(desc.PublicColumns())+1)
+	// Allocate space for public columns + 1 dummy PK + tableoid system column.
+	ot.columns = make([]cat.Column, len(desc.PublicColumns())+1+1)
 	// Init dummy PK column.
 	ot.columns[0].Init(
 		0,
@@ -2556,6 +2558,25 @@ func newOptVirtualTable(
 		)
 	}
 
+	// Add the tableoid system column. Other system columns
+	// (crdb_internal_mvcc_timestamp, etc.) are not meaningful for virtual
+	// tables since they don't have MVCC data.
+	tableoidOrd := len(desc.PublicColumns()) + 1
+	ot.columns[tableoidOrd].Init(
+		tableoidOrd,
+		cat.StableID(colinfo.TableOIDColumnID),
+		colinfo.TableOIDColumnName,
+		cat.System,
+		types.Oid,
+		true,       /* nullable */
+		cat.Hidden, /* hidden */
+		nil,        /* defaultExpr */
+		nil,        /* computedExpr */
+		nil,        /* onUpdateExpr */
+		cat.NotGeneratedAsIdentity,
+		nil, /* generatedAsIdentitySequenceOption */
+	)
+
 	// Create the table's column mapping from descpb.ColumnID to column ordinal.
 	for i := range ot.columns {
 		ot.colMap.Set(descpb.ColumnID(ot.columns[i].ColID()), i)
@@ -2569,7 +2590,9 @@ func newOptVirtualTable(
 	// Build the indexes (add 1 to account for lack of primary index in
 	// indexes slice).
 	ot.indexes = make([]optVirtualIndex, len(ot.desc.ActiveIndexes()))
-	// Set up the primary index.
+	// Set up the primary index. Include the tableoid system column in
+	// numCols so the optimizer considers all indexes as covering for
+	// tableoid queries.
 	ot.indexes[0] = optVirtualIndex{
 		tab:          ot,
 		indexOrdinal: 0,
@@ -2581,7 +2604,6 @@ func newOptVirtualTable(
 			panic(errors.AssertionFailedf("virtual indexes with more than 1 col not supported"))
 		}
 
-		// Add 1, since the 0th index will the primary that we added above.
 		ot.indexes[idx.Ordinal()] = optVirtualIndex{
 			tab:          ot,
 			idx:          idx,
@@ -2954,9 +2976,16 @@ func (oi *optVirtualIndex) Column(i int) cat.IndexColumn {
 		return cat.IndexColumn{Column: oi.tab.Column(0)}
 	}
 
-	i -= length + 1
-	ord, _ := oi.tab.LookupColumnOrdinal(oi.idx.GetStoredColumnID(i))
-	return cat.IndexColumn{Column: oi.tab.Column(ord)}
+	storedIdx := i - length - 1
+	if storedIdx < oi.idx.NumSecondaryStoredColumns() {
+		ord, _ := oi.tab.LookupColumnOrdinal(oi.idx.GetStoredColumnID(storedIdx))
+		return cat.IndexColumn{Column: oi.tab.Column(ord)}
+	}
+
+	// The tableoid system column is the last column in the index, after all
+	// key columns, the bogus PK column, and all stored columns.
+	tableoidOrd := oi.tab.ColumnCount() - 1
+	return cat.IndexColumn{Column: oi.tab.Column(tableoidOrd)}
 }
 
 // InvertedColumn is part of the cat.Index interface.

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 // virtualTableGenerator is the function signature for the virtualTableNode
@@ -355,8 +356,17 @@ func (v *vTableLookupJoinNode) Next(params runParams) (bool, error) {
 func (v *vTableLookupJoinNode) pushRow(lookedUpRow ...tree.Datum) error {
 	// Reset our output row to just the contents of the input row.
 	v.run.row = v.run.row[:len(v.inputCols)]
+	// The tableoid system column ordinal is after all public columns + the
+	// dummy PK column.
+	tableoidOrd := len(v.vtableCols) + 1
 	// Append the looked up row to the right of the input row.
 	for i, ok := v.lookupCols.Next(0); ok; i, ok = v.lookupCols.Next(i + 1) {
+		if i == tableoidOrd {
+			// The tableoid system column is not part of the looked-up row.
+			// Produce it as a constant from the table descriptor.
+			v.run.row = append(v.run.row, tree.NewDOid(oid.Oid(v.table.GetID())))
+			continue
+		}
 		// Subtract 1 from the requested column position, to avoid the virtual
 		// table's fake primary key which won't be present in the row.
 		v.run.row = append(v.run.row, lookedUpRow[i-1])


### PR DESCRIPTION
Previously, the `tableoid` system column was only supported on regular
tables but not on virtual tables (pg_catalog, information_schema, etc.).
This caused `pg_dump` to fail when connecting to CockroachDB because
pg_dump queries `SELECT x.tableoid, ... FROM pg_extension x ...` as
one of its first introspection queries.

This commit adds `tableoid` support for virtual tables by:

1. Adding the `tableoid` column to `optVirtualTable`'s column list in
   the optimizer catalog, registered as a `cat.System` column (hidden
   by default, like on regular tables).

2. Handling the `tableoid` column in `constructVirtualScan` by rendering
   it as a constant value (the table's descriptor ID) after the virtual
   table scan, since virtual table generators don't produce system
   column values.

3. Including the `tableoid` system column in all indexes' `numCols`
   (both primary and secondary) so the optimizer considers every index
   as covering for tableoid queries. The `Column()` method on
   `optVirtualIndex` is updated to return the tableoid column after all
   stored columns for secondary indexes.

informs https://github.com/cockroachdb/cockroach/issues/20296

Release note (sql change): The `tableoid` system column is now
supported on virtual tables such as those in `pg_catalog` and
`information_schema`. This improves compatibility with PostgreSQL
tools like `pg_dump` that reference `tableoid` in their introspection
queries.
