### PR TITLE
ui: import job profiler API functions directly

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.spec.tsx
@@ -11,13 +11,14 @@ import React from "react";
 import { MemoryRouter, Route } from "react-router";
 import { SWRConfig } from "swr";
 
+import * as jobProfilerApi from "src/api/jobProfilerApi";
 import * as jobApi from "src/api/jobsApi";
 import * as userApi from "src/api/userApi";
 import { CockroachCloudContext } from "src/contexts";
 
 import { JOB_STATUS_RUNNING, JOB_STATUS_SUCCEEDED } from "../util";
 
-import { JobDetailsPropsV2, JobDetailsV2 } from "./jobDetails";
+import { JobDetailsV2 } from "./jobDetails";
 
 const mockGetJob = (jobStatus: string | null) => {
   jest.spyOn(jobApi, "getJob").mockResolvedValue({
@@ -39,24 +40,24 @@ const mockGetJob = (jobStatus: string | null) => {
   });
 };
 
-const mockFetchExecutionDetailFiles = jest.fn().mockResolvedValue({
-  files: ["file1", "file2"],
-});
+const mockFetchExecutionDetailFiles = jest
+  .spyOn(jobProfilerApi, "listExecutionDetailFiles")
+  .mockResolvedValue({
+    files: ["file1", "file2"],
+  } as any);
 
-const mockCollectExecutionDetails = jest.fn().mockImplementation(() => {
-  mockFetchExecutionDetailFiles.mockResolvedValue({
-    files: ["file1", "file2", "file3"],
+const _mockCollectExecutionDetails = jest
+  .spyOn(jobProfilerApi, "collectExecutionDetails")
+  .mockImplementation(() => {
+    mockFetchExecutionDetailFiles.mockResolvedValue({
+      files: ["file1", "file2", "file3"],
+    } as any);
+    return Promise.resolve({ req_resp: true } as any);
   });
-  return Promise.resolve({ req_resp: true });
-});
 
-const createJobDetailsPageProps = (): JobDetailsPropsV2 => {
-  return {
-    onFetchExecutionDetailFiles: mockFetchExecutionDetailFiles,
-    onCollectExecutionDetails: mockCollectExecutionDetails,
-    onDownloadExecutionFile: jest.fn(),
-  };
-};
+jest
+  .spyOn(jobProfilerApi, "getExecutionDetailFile")
+  .mockResolvedValue({} as any);
 
 describe("JobDetailsV2", () => {
   beforeEach(() => {
@@ -80,7 +81,7 @@ describe("JobDetailsV2", () => {
         <CockroachCloudContext.Provider value={false}>
           <MemoryRouter initialEntries={["/job/1"]}>
             <Route path="/job/:id">
-              <JobDetailsV2 {...createJobDetailsPageProps()} />
+              <JobDetailsV2 />
             </Route>
           </MemoryRouter>
         </CockroachCloudContext.Provider>

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -27,14 +27,6 @@ import { SqlBox, SqlBoxSize } from "src/sql";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import { idAttr } from "src/util";
 
-import {
-  CollectExecutionDetailsRequest,
-  CollectExecutionDetailsResponse,
-  GetJobProfilerExecutionDetailRequest,
-  GetJobProfilerExecutionDetailResponse,
-  ListJobProfilerExecutionDetailsRequest,
-  ListJobProfilerExecutionDetailsResponse,
-} from "../../api";
 import { isTerminalState } from "../util";
 
 import { JobProfilerView } from "./jobProfilerView";
@@ -48,23 +40,7 @@ enum TabKeysEnum {
   PROFILER = "Advanced Debugging",
 }
 
-export interface JobDetailsPropsV2 {
-  onFetchExecutionDetailFiles: (
-    req: ListJobProfilerExecutionDetailsRequest,
-  ) => Promise<ListJobProfilerExecutionDetailsResponse>;
-  onCollectExecutionDetails: (
-    req: CollectExecutionDetailsRequest,
-  ) => Promise<CollectExecutionDetailsResponse>;
-  onDownloadExecutionFile: (
-    req: GetJobProfilerExecutionDetailRequest,
-  ) => Promise<GetJobProfilerExecutionDetailResponse>;
-}
-
-export function JobDetailsV2({
-  onFetchExecutionDetailFiles,
-  onCollectExecutionDetails,
-  onDownloadExecutionFile,
-}: JobDetailsPropsV2): React.ReactElement {
+export function JobDetailsV2(): React.ReactElement {
   const history = useHistory();
   const match = useRouteMatch();
   const ccContext = useContext(CockroachCloudContext);
@@ -156,16 +132,7 @@ export function JobDetailsV2({
                     hasAdminRole && {
                       key: "profiler",
                       label: TabKeysEnum.PROFILER,
-                      children: (
-                        <JobProfilerView
-                          jobID={jobId}
-                          onFetchExecutionDetailFiles={
-                            onFetchExecutionDetailFiles
-                          }
-                          onCollectExecutionDetails={onCollectExecutionDetails}
-                          onDownloadExecutionFile={onDownloadExecutionFile}
-                        />
-                      ),
+                      children: <JobProfilerView jobID={jobId} />,
                     },
                 ]}
               />

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
@@ -3,22 +3,6 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import React from "react";
-
-import {
-  listExecutionDetailFiles,
-  collectExecutionDetails,
-  getExecutionDetailFile,
-} from "src/api";
-
 import { JobDetailsV2 } from "./jobDetails";
 
-export const JobDetailsPageConnected: React.FC = () => {
-  return (
-    <JobDetailsV2
-      onFetchExecutionDetailFiles={listExecutionDetailFiles}
-      onCollectExecutionDetails={collectExecutionDetails}
-      onDownloadExecutionFile={getExecutionDetailFile}
-    />
-  );
-};
+export const JobDetailsPageConnected = JobDetailsV2;

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
@@ -12,12 +12,11 @@ import long from "long";
 import React, { useState } from "react";
 
 import {
-  CollectExecutionDetailsRequest,
-  CollectExecutionDetailsResponse,
+  collectExecutionDetails,
+  getExecutionDetailFile,
   GetJobProfilerExecutionDetailRequest,
   GetJobProfilerExecutionDetailResponse,
-  ListJobProfilerExecutionDetailsRequest,
-  ListJobProfilerExecutionDetailsResponse,
+  listExecutionDetailFiles,
 } from "src/api/jobProfilerApi";
 import { DownloadFile, DownloadFileRef } from "src/downloadFile";
 import { EmptyTable } from "src/empty";
@@ -36,26 +35,14 @@ const cx = classnames.bind(styles);
 
 export interface JobProfilerViewProps {
   jobID: long;
-  onFetchExecutionDetailFiles: (
-    req: ListJobProfilerExecutionDetailsRequest,
-  ) => Promise<ListJobProfilerExecutionDetailsResponse>;
-  onCollectExecutionDetails: (
-    req: CollectExecutionDetailsRequest,
-  ) => Promise<CollectExecutionDetailsResponse>;
-  onDownloadExecutionFile: (
-    req: GetJobProfilerExecutionDetailRequest,
-  ) => Promise<GetJobProfilerExecutionDetailResponse>;
 }
 
 export function JobProfilerView({
   jobID,
-  onFetchExecutionDetailFiles,
-  onCollectExecutionDetails,
-  onDownloadExecutionFile,
 }: JobProfilerViewProps): React.ReactElement {
   const { data: detailFiles, mutate: refreshFiles } = useSwrWithClusterId(
     { name: "jobProfilerExecutionFiles", jobID },
-    () => onFetchExecutionDetailFiles({ job_id: jobID }),
+    () => listExecutionDetailFiles({ job_id: jobID }),
     {
       refreshInterval: 10 * 1000, // 10s polling interval
     },
@@ -63,14 +50,14 @@ export function JobProfilerView({
   const { trigger } = useSwrMutationWithClusterId(
     { name: "collectExecutionDetails", jobID },
     async () => {
-      const resp = await onCollectExecutionDetails({ job_id: jobID });
+      const resp = await collectExecutionDetails({ job_id: jobID });
       if (resp.req_resp) {
         refreshFiles();
       }
     },
   );
 
-  const columns = makeJobProfilerViewColumns(jobID, onDownloadExecutionFile);
+  const columns = makeJobProfilerViewColumns(jobID, getExecutionDetailFile);
   const [sortSetting, setSortSetting] = useState<SortSetting>({
     ascending: true,
     columnTitle: "executionDetailFiles",

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -2,19 +2,6 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
-import { api as clusterUiApi, JobDetailsV2 } from "@cockroachlabs/cluster-ui";
-import React from "react";
+import { JobDetailsV2 } from "@cockroachlabs/cluster-ui";
 
-import { listExecutionDetailFiles } from "src/util/api";
-
-const JobDetailsPage: React.FC = () => {
-  return (
-    <JobDetailsV2
-      onFetchExecutionDetailFiles={listExecutionDetailFiles}
-      onCollectExecutionDetails={clusterUiApi.collectExecutionDetails}
-      onDownloadExecutionFile={clusterUiApi.getExecutionDetailFile}
-    />
-  );
-};
-
-export default JobDetailsPage;
+export default JobDetailsV2;


### PR DESCRIPTION
Both the cluster-ui connected component and the db-console wrapper passed the same API functions (listExecutionDetailFiles, collectExecutionDetails, getExecutionDetailFile) as props.

Since there's only one implementation, this change imports them directly in JobProfilerView and removes the props.

this simplifies JobDetailsPageConnected and the db-console wrapper to re-exports, and updates tests to use jest.spyOn on the API modules instead of passing mock functions as props.

Epic: None
Release note: None