### PR TITLE
ui: fix transaction insights max API size selector

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
@@ -20,7 +20,7 @@ export const selectTransactionInsightsError = (state: AppState): Error | null =>
 
 export const selectTransactionInsightsMaxApiReached = (
   state: AppState,
-): boolean => state.adminUI?.stmtInsights?.data?.maxSizeReached;
+): boolean => state.adminUI?.txnInsights?.data?.maxSizeReached;
 
 export const selectTxnInsightsByFingerprint = createSelector(
   selectTransactionInsights,


### PR DESCRIPTION
`selectTransactionInsightsMaxApiReached` was reading from `state.adminUI.stmtInsights` (statement insights) instead of `state.adminUI.txnInsights` (transaction insights). This meant the "not all results are shown" warning was never displayed on the transaction insights page, even when the result set exceeded the max API response size.

Fixes the selector to read from the correct store slice.

Epic: None
Release note: None