### PR TITLE
ui: migrate DataDistribution page from Redux to SWR

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/dataDistributionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/dataDistributionApi.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { useSwrWithClusterId } from "../util";
+
+import { fetchData } from "./fetchData";
+
+type DataDistributionResponse =
+  cockroach.server.serverpb.DataDistributionResponse;
+
+const DATA_DISTRIBUTION_PATH = "_admin/v1/data_distribution";
+
+export const DATA_DISTRIBUTION_SWR_KEY = "dataDistribution";
+
+const getDataDistribution = (): Promise<DataDistributionResponse> => {
+  return fetchData(
+    cockroach.server.serverpb.DataDistributionResponse,
+    DATA_DISTRIBUTION_PATH,
+  );
+};
+
+export const useDataDistribution = () => {
+  const { data, isLoading, error } = useSwrWithClusterId(
+    DATA_DISTRIBUTION_SWR_KEY,
+    getDataDistribution,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60000, // 1 minute.
+    },
+  );
+
+  return {
+    data,
+    isLoading,
+    error,
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -27,3 +27,4 @@ export * from "./jobProfilerApi";
 export * from "./txnInsightDetailsApi";
 export * from "./healthApi";
 export * from "./connectivityApi";
+export * from "./dataDistributionApi";

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -328,13 +328,6 @@ export const invalidateStatementDiagnosticsRequests =
 export const RECEIVE_STATEMENT_DIAGNOSTICS_REPORT =
   statementDiagnosticsReportsReducerObj.RECEIVE;
 
-const dataDistributionReducerObj = new CachedDataReducer(
-  api.getDataDistribution,
-  "dataDistribution",
-  moment.duration(1, "m"),
-);
-export const refreshDataDistribution = dataDistributionReducerObj.refresh;
-
 const metricMetadataReducerObj = new CachedDataReducer(
   api.getAllMetricMetadata,
   "metricMetadata",
@@ -480,7 +473,6 @@ export interface APIReducersState {
   statements: CachedDataReducerState<clusterUiApi.SqlStatsResponse>;
   transactions: CachedDataReducerState<clusterUiApi.SqlStatsResponse>;
   statementDetails: KeyedCachedDataReducerState<api.StatementDetailsResponseMessage>;
-  dataDistribution: CachedDataReducerState<api.DataDistributionResponseMessage>;
   metricMetadata: CachedDataReducerState<api.MetricMetadataResponseMessage>;
   statementDiagnosticsReports: CachedDataReducerState<clusterUiApi.StatementDiagnosticsResponse>;
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
@@ -535,8 +527,6 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
     txnFingerprintStatsReducerObj.reducer,
   [statementDetailsReducerObj.actionNamespace]:
     statementDetailsReducerObj.reducer,
-  [dataDistributionReducerObj.actionNamespace]:
-    dataDistributionReducerObj.reducer,
   [metricMetadataReducerObj.actionNamespace]: metricMetadataReducerObj.reducer,
   [statementDiagnosticsReportsReducerObj.actionNamespace]:
     statementDiagnosticsReportsReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -155,9 +155,6 @@ export type StatementsResponseMessage =
 export type StatementDetailsResponseMessage =
   protos.cockroach.server.serverpb.StatementDetailsResponse;
 
-export type DataDistributionResponseMessage =
-  protos.cockroach.server.serverpb.DataDistributionResponse;
-
 export type EnqueueRangeRequestMessage =
   protos.cockroach.server.serverpb.EnqueueRangeRequest;
 export type EnqueueRangeResponseMessage =
@@ -733,18 +730,6 @@ export function getStatementDetails(
   return timeoutFetch(
     serverpb.StatementDetailsResponse,
     `${STATUS_PREFIX}/stmtdetails/${req.fingerprint_id}?${queryStr}`,
-    null,
-    timeout,
-  );
-}
-
-// getDataDistribution returns information about how replicas are distributed across nodes.
-export function getDataDistribution(
-  timeout?: moment.Duration,
-): Promise<DataDistributionResponseMessage> {
-  return timeoutFetch(
-    serverpb.DataDistributionResponse,
-    `${API_PREFIX}/data_distribution`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/dataDistribution/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/dataDistribution/index.tsx
@@ -3,30 +3,24 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Loading } from "@cockroachlabs/cluster-ui";
+import {
+  Loading,
+  api as clusterUiApi,
+  useNodesSummary,
+} from "@cockroachlabs/cluster-ui";
+import filter from "lodash/filter";
 import forEach from "lodash/forEach";
+import isNil from "lodash/isNil";
 import map from "lodash/map";
 import sortBy from "lodash/sortBy";
-import React, { useEffect } from "react";
+import React, { useMemo } from "react";
 import Helmet from "react-helmet";
-import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { createSelector } from "reselect";
 
 import { InfoTooltip } from "src/components/infoTooltip";
 import { cockroach } from "src/js/protos";
-import {
-  refreshDataDistribution,
-  refreshNodes,
-  refreshLiveness,
-  CachedDataReducerState,
-} from "src/redux/apiReducers";
 import { LocalityTree, selectLocalityTree } from "src/redux/localities";
-import {
-  selectLivenessRequestStatus,
-  selectNodeRequestStatus,
-} from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
+import { LivenessStatus } from "src/redux/nodes";
 import * as docsURL from "src/util/docs";
 import { FixLong } from "src/util/fixLong";
 import { BackToAdvanceDebug } from "src/views/reports/containers/util";
@@ -68,7 +62,7 @@ const RANGE_COALESCING_ADVICE = (
 );
 
 interface DataDistributionProps {
-  dataDistribution: CachedDataReducerState<DataDistributionResponse>;
+  dataDistribution: DataDistributionResponse;
   localityTree: LocalityTree;
   sortedZoneConfigs: ZoneConfig$Properties[];
 }
@@ -81,7 +75,7 @@ function DataDistribution({
   const getCellValue = (dbPath: TreePath, nodePath: TreePath): number => {
     const [dbName, tableName] = dbPath;
     const nodeID = nodePath[nodePath.length - 1];
-    const databaseInfo = dataDistribution.data.database_info;
+    const databaseInfo = dataDistribution.database_info;
 
     const res =
       databaseInfo[dbName].table_info[tableName].replica_count_by_node_id[
@@ -95,7 +89,7 @@ function DataDistribution({
 
   const nodeTree = nodeTreeFromLocalityTree("Cluster", localityTree);
 
-  const databaseInfo = dataDistribution.data.database_info;
+  const databaseInfo = dataDistribution.database_info;
   const dbTree: TreeNode<SchemaObject> = {
     name: "Cluster",
     data: {
@@ -149,31 +143,47 @@ function DataDistribution({
   );
 }
 
-interface DataDistributionPageProps {
-  dataDistribution: CachedDataReducerState<DataDistributionResponse>;
-  localityTree: LocalityTree;
-  localityTreeErrors: Error[];
-  sortedZoneConfigs: ZoneConfig$Properties[];
-  refreshDataDistribution: typeof refreshDataDistribution;
-  refreshNodes: typeof refreshNodes;
-  refreshLiveness: typeof refreshLiveness;
-}
-
 export function DataDistributionPage({
-  dataDistribution,
-  localityTree,
-  localityTreeErrors,
-  sortedZoneConfigs: sortedZoneConfigsProp,
-  refreshDataDistribution: refreshDataDistributionAction,
-  refreshNodes: refreshNodesAction,
-  refreshLiveness: refreshLivenessAction,
   history,
-}: DataDistributionPageProps & RouteComponentProps): React.ReactElement {
-  useEffect(() => {
-    refreshDataDistributionAction();
-    refreshNodesAction();
-    refreshLivenessAction();
-  });
+}: RouteComponentProps): React.ReactElement {
+  const {
+    nodeStatuses,
+    livenessStatusByNodeID,
+    isLoading: nodesLoading,
+    error: nodesError,
+  } = useNodesSummary();
+
+  const {
+    data: dataDistribution,
+    isLoading: ddLoading,
+    error: ddError,
+  } = clusterUiApi.useDataDistribution();
+
+  const commissioned = useMemo(
+    () =>
+      filter(nodeStatuses, node => {
+        const livenessStatus = livenessStatusByNodeID[`${node.desc.node_id}`];
+        return (
+          isNil(livenessStatus) ||
+          livenessStatus !== LivenessStatus.NODE_STATUS_DECOMMISSIONED
+        );
+      }),
+    [nodeStatuses, livenessStatusByNodeID],
+  );
+
+  const localityTree = useMemo(
+    () => selectLocalityTree.resultFunc(commissioned),
+    [commissioned],
+  );
+
+  const sortedZoneConfigs = useMemo(() => {
+    if (!dataDistribution) {
+      return null;
+    }
+    return sortBy(dataDistribution.zone_configs, zc => zc.target);
+  }, [dataDistribution]);
+
+  const isLoading = nodesLoading || ddLoading;
 
   return (
     <div>
@@ -190,14 +200,14 @@ export function DataDistributionPage({
       </section>
       <section className="section">
         <Loading
-          loading={!dataDistribution.data || !localityTree}
+          loading={isLoading || !dataDistribution || !localityTree}
           page={"data distribution"}
-          error={[dataDistribution.lastError, ...localityTreeErrors]}
+          error={[ddError, nodesError]}
           render={() => (
             <DataDistribution
               localityTree={localityTree}
               dataDistribution={dataDistribution}
-              sortedZoneConfigs={sortedZoneConfigsProp}
+              sortedZoneConfigs={sortedZoneConfigs}
             />
           )}
         />
@@ -206,39 +216,7 @@ export function DataDistributionPage({
   );
 }
 
-const sortedZoneConfigs = createSelector(
-  (state: AdminUIState) => state.cachedData.dataDistribution,
-  dataDistributionState => {
-    if (!dataDistributionState.data) {
-      return null;
-    }
-    return sortBy(dataDistributionState.data.zone_configs, zc => zc.target);
-  },
-);
-
-const localityTreeErrors = createSelector(
-  selectNodeRequestStatus,
-  selectLivenessRequestStatus,
-  (nodes, liveness) => [nodes.lastError, liveness.lastError],
-);
-
-const DataDistributionPageConnected = withRouter(
-  connect(
-    (state: AdminUIState, _: RouteComponentProps) => ({
-      dataDistribution: state.cachedData.dataDistribution,
-      sortedZoneConfigs: sortedZoneConfigs(state),
-      localityTree: selectLocalityTree(state),
-      localityTreeErrors: localityTreeErrors(state),
-    }),
-    {
-      refreshDataDistribution,
-      refreshNodes,
-      refreshLiveness,
-    },
-  )(DataDistributionPage),
-);
-
-export default DataDistributionPageConnected;
+export default withRouter(DataDistributionPage);
 
 // Helpers
 


### PR DESCRIPTION
Replace Redux-connected data fetching with SWR hooks for the data-distribution page. This is the only consumer of the dataDistribution reducer, so the reducer and its associated API function are deleted entirely.

- Create useDataDistribution SWR hook in cluster-ui wrapping the _admin/v1/data_distribution endpoint with a 1-minute deduping interval
- Replace connect/mapStateToProps/mapDispatchToProps with useNodesSummary() and useDataDistribution() hooks
- Compute locality tree and sorted zone configs via useMemo instead of reselect createSelector
- Remove dataDistributionReducerObj, refreshDataDistribution, and the dataDistribution field from APIReducersState
- Remove getDataDistribution and DataDistributionResponseMessage from db-console's api.ts

Epic: CRDB-48152

Release note: None