### PR TITLE
obs/ash: introduce WorkloadType for ASH workload attribution

### DIFF
--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -210,6 +211,7 @@ func (gt *grpcTransport) sendBatch(
 		WorkloadID:    ba.WorkloadID,
 		AppNameID:     ba.AppNameID,
 		GatewayNodeID: ba.GatewayNodeID,
+		WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 	}
 	var cleanup func()
 	if rpc.IsLocal(iface) {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -4138,6 +4138,8 @@ func TestBatchHeaderFieldsAreAccountedForInBufferedWrites(t *testing.T) {
 		"WorkloadID": iSwearFieldDoesNotNeedHandling,
 		// Observability label, doesn't affect batch processing.
 		"AppNameID": iSwearFieldDoesNotNeedHandling,
+		// Observability label, doesn't affect batch processing.
+		"WorkloadType": iSwearFieldDoesNotNeedHandling,
 	}
 
 	header := kvpb.Header{}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3033,9 +3033,14 @@ message Header {
   // enrich samples with more workload context.
   uint64 app_name_id = 40 [(gogoproto.customname) = "AppNameID"];
 
+  // workload_type distinguishes the kind of workload that workload_id
+  // represents (statement fingerprint, job ID, system task, etc.).
+  // Used by the ASH sampler to choose the right encoding.
+  uint32 workload_type = 41 [(gogoproto.customname) = "WorkloadType"];
+
   reserved 7, 10, 12, 14, 20, 24;
 
-  // Next ID: 41
+  // Next ID: 42
 }
 
 message WriteOptions {

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/kv/kvserver/spanset",
         "//pkg/kv/kvserver/txnwait",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -465,6 +466,7 @@ func (m *managerImpl) maybeInterceptReq(ctx context.Context, req Request) (Respo
 				WorkloadID:    req.Batch.WorkloadID,
 				AppNameID:     req.Batch.AppNameID,
 				GatewayNodeID: req.Batch.GatewayNodeID,
+				WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
 			}
 		}
 		cleanup := ash.SetWorkState(tenantID, info, ash.WorkLock, "TxnPushWait")
@@ -486,6 +488,7 @@ func (m *managerImpl) maybeInterceptReq(ctx context.Context, req Request) (Respo
 				WorkloadID:    req.Batch.WorkloadID,
 				AppNameID:     req.Batch.AppNameID,
 				GatewayNodeID: req.Batch.GatewayNodeID,
+				WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
 			}
 		}
 		cleanup := ash.SetWorkState(tenantID, info, ash.WorkLock, "TxnQueryWait")

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -121,6 +122,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 			WorkloadID:    req.Batch.WorkloadID,
 			AppNameID:     req.Batch.AppNameID,
 			GatewayNodeID: req.Batch.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
 		}
 	}
 	cleanup := ash.SetWorkState(

--- a/pkg/kv/kvserver/kvadmission/BUILD.bazel
+++ b/pkg/kv/kvserver/kvadmission/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/kv/kvserver/kvflowcontrol/replica_rac2",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -331,6 +332,7 @@ func (n *controllerImpl) AdmitKVWork(
 					WorkloadID:    admissionInfo.WorkloadID,
 					AppNameID:     admissionInfo.AppNameID,
 					GatewayNodeID: admissionInfo.GatewayNodeID,
+					WorkloadType:  admissionInfo.WorkloadType,
 				})
 			if err != nil {
 				return Handle{}, err
@@ -735,6 +737,7 @@ func workInfoForBatch(
 		WorkloadID:      ba.Header.WorkloadID,
 		AppNameID:       ba.Header.AppNameID,
 		GatewayNodeID:   ba.Header.GatewayNodeID,
+		WorkloadType:    workloadid.WorkloadType(ba.Header.WorkloadType),
 	}
 	return admissionInfo
 }

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -206,6 +207,7 @@ func (r *Replica) maybeBackpressureBatch(ctx context.Context, ba *kvpb.BatchRequ
 					WorkloadID:    ba.WorkloadID,
 					AppNameID:     ba.AppNameID,
 					GatewayNodeID: ba.GatewayNodeID,
+					WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 				},
 				ash.WorkOther, "Backpressure")
 			defer cleanup() //nolint:deferloop

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -215,6 +216,7 @@ func evaluateBatch(
 			WorkloadID:    ba.WorkloadID,
 			AppNameID:     ba.AppNameID,
 			GatewayNodeID: ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 		},
 		ash.WorkIO, "KVEval")
 	defer cleanup()

--- a/pkg/kv/kvserver/replica_rate_limit.go
+++ b/pkg/kv/kvserver/replica_rate_limit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
@@ -33,6 +34,7 @@ func (r *Replica) maybeRateLimitBatch(
 			WorkloadID:    ba.WorkloadID,
 			AppNameID:     ba.AppNameID,
 			GatewayNodeID: ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 		},
 		ash.WorkOther, "TenantRateLimit")
 	defer cleanup()

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -121,6 +121,7 @@ func (r *Replica) SendWithWriteBytes(
 			WorkloadID:    ba.WorkloadID,
 			AppNameID:     ba.AppNameID,
 			GatewayNodeID: ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 		},
 		ash.WorkCPU, "ReplicaSend")
 	defer cleanup()
@@ -321,6 +322,7 @@ func (r *Replica) maybeCommitWaitBeforeCommitTrigger(
 			WorkloadID:    ba.WorkloadID,
 			AppNameID:     ba.AppNameID,
 			GatewayNodeID: ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 		},
 		ash.WorkOther, "CommitWaitSleep")
 	defer cleanup()
@@ -882,6 +884,7 @@ func (r *Replica) handleInvalidLeaseError(ctx context.Context, ba *kvpb.BatchReq
 			WorkloadID:    ba.WorkloadID,
 			AppNameID:     ba.AppNameID,
 			GatewayNodeID: ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 		},
 	)
 	// If we managed to get a lease (i.e. pErr == nil), the request evaluation
@@ -976,6 +979,7 @@ func (r *Replica) executeAdminBatch(
 					WorkloadID:    ba.WorkloadID,
 					AppNameID:     ba.AppNameID,
 					GatewayNodeID: ba.GatewayNodeID,
+					WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 				},
 			)
 			if pErr != nil {

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -219,6 +220,7 @@ func (r *Replica) executeWriteBatch(
 			WorkloadID:    ba.WorkloadID,
 			AppNameID:     ba.AppNameID,
 			GatewayNodeID: ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(ba.WorkloadType),
 		},
 		ash.WorkOther, "RaftProposalWait")
 	defer raftCleanup()

--- a/pkg/kv/kvserver/spanlatch/BUILD.bazel
+++ b/pkg/kv/kvserver/spanlatch/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/kv/kvserver/concurrency/poison",
         "//pkg/kv/kvserver/spanset",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -511,6 +512,7 @@ func (m *Manager) wait(ctx context.Context, lg *Guard, snap snapshot) error {
 			WorkloadID:    lg.ba.WorkloadID,
 			AppNameID:     lg.ba.AppNameID,
 			GatewayNodeID: lg.ba.GatewayNodeID,
+			WorkloadType:  workloadid.WorkloadType(lg.ba.WorkloadType),
 		}
 	}
 	cleanup := ash.SetWorkState(

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -99,6 +100,9 @@ type Txn struct {
 	// transaction. In that case, statements are executed sequentially, and the
 	// workloadID is updated after each statement.
 	workloadID uint64
+	// workloadType identifies the kind of workload that workloadID
+	// represents (statement fingerprint, job, system task).
+	workloadType workloadid.WorkloadType
 
 	// The following fields are not safe for concurrent modification.
 	// They should be set before operating on the transaction.
@@ -459,12 +463,15 @@ func (txn *Txn) debugNameLocked() string {
 	return fmt.Sprintf("%s (id: %s)", txn.mu.debugName, txn.mu.ID)
 }
 
-// SetWorkloadInfo sets the workload ID and app name ID for ASH
-// sampling. Both are automatically propagated to all BatchRequests
-// sent through this transaction.
-func (txn *Txn) SetWorkloadInfo(workloadID, appNameID uint64) {
+// SetWorkloadInfo sets the workload ID, app name ID, and workload
+// type for ASH sampling. All three are automatically propagated to
+// all BatchRequests sent through this transaction.
+func (txn *Txn) SetWorkloadInfo(
+	workloadID, appNameID uint64, workloadType workloadid.WorkloadType,
+) {
 	txn.workloadID = workloadID
 	txn.appNameID = appNameID
+	txn.workloadType = workloadType
 }
 
 // SetBufferedWritesEnabled toggles whether the writes are buffered on the
@@ -1385,6 +1392,10 @@ func (txn *Txn) Send(
 
 	if txn.appNameID != 0 && ba.Header.AppNameID == 0 {
 		ba.Header.AppNameID = txn.appNameID
+	}
+
+	if txn.workloadType != workloadid.WorkloadTypeUnknown && ba.Header.WorkloadType == 0 {
+		ba.Header.WorkloadType = txn.workloadType.ToUint32()
 	}
 
 	// Requests with a bounded staleness header should use NegotiateAndSend.

--- a/pkg/obs/ash/BUILD.bazel
+++ b/pkg/obs/ash/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
@@ -44,6 +45,7 @@ go_test(
     ],
     embed = [":ash"],
     deps = [
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/testutils",

--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"encoding/hex"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -132,8 +134,8 @@ type Sampler struct {
 	// interval caches the sample interval so the timer loop can read it
 	// without locking, while the SetOnChange callback updates it.
 	interval atomic.Int64
-	// workloadIDCache caches the result of encodeStmtFingerprintIDToString
-	// to avoid repeated allocations for the same workload ID.
+	// workloadIDCache caches workload ID string encodings keyed by
+	// (id, type) to avoid repeated allocations for the same workload.
 	workloadIDCache *cache.UnorderedCache
 	// resolver, when set, fetches app name mappings from remote nodes
 	// for work states whose app name could not be resolved locally.
@@ -255,11 +257,18 @@ func (s *Sampler) takeSample(ctx context.Context) {
 		// Encode the workloadID to a string for the ASHSample.
 		// Note(alyshan): Consider encoding at read time.
 		if ps.state.WorkloadInfo.WorkloadID != 0 {
-			if cached, ok := s.workloadIDCache.Get(ps.state.WorkloadInfo.WorkloadID); ok {
+			cacheKey := workloadCacheKey{
+				id:  ps.state.WorkloadInfo.WorkloadID,
+				typ: ps.state.WorkloadInfo.WorkloadType,
+			}
+			if cached, ok := s.workloadIDCache.Get(cacheKey); ok {
 				ps.workloadIDStr = cached.(string)
 			} else {
-				ps.workloadIDStr = encodeStmtFingerprintIDToString(ps.state.WorkloadInfo.WorkloadID)
-				s.workloadIDCache.Add(ps.state.WorkloadInfo.WorkloadID, ps.workloadIDStr)
+				ps.workloadIDStr = encodeWorkloadID(
+					ps.state.WorkloadInfo.WorkloadID,
+					ps.state.WorkloadInfo.WorkloadType,
+				)
+				s.workloadIDCache.Add(cacheKey, ps.workloadIDStr)
 			}
 		}
 
@@ -490,6 +499,27 @@ func GlobalSamplerMetrics() *Metrics {
 		return &s.metrics
 	}
 	return nil
+}
+
+// workloadCacheKey is the composite key for the workload ID string
+// cache. Using both the numeric ID and the type prevents collisions
+// when the same numeric value appears across different workload types.
+type workloadCacheKey struct {
+	id  uint64
+	typ workloadid.WorkloadType
+}
+
+// encodeWorkloadID returns the string representation of a workload ID,
+// choosing the encoding based on workload type.
+func encodeWorkloadID(id uint64, typ workloadid.WorkloadType) string {
+	switch typ {
+	case workloadid.WorkloadTypeJob:
+		return strconv.FormatUint(id, 10)
+	case workloadid.WorkloadTypeSystem:
+		return workloadid.WorkloadID(id).Name()
+	default: // WorkloadTypeUnknown + WorkloadTypeStatement
+		return encodeStmtFingerprintIDToString(id)
+	}
 }
 
 // encodeUint64ToBytes returns the []byte representation of a uint64 value.

--- a/pkg/obs/ash/sampler_test.go
+++ b/pkg/obs/ash/sampler_test.go
@@ -7,11 +7,13 @@ package ash
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -63,32 +65,135 @@ func TestSamplerTakeSample(t *testing.T) {
 }
 
 func TestSamplerWorkloadIDCache(t *testing.T) {
-	s, stopper := newTestSampler()
-	defer stopper.Stop(context.Background())
+	setup := func(t *testing.T) *Sampler {
+		t.Helper()
+		s, stopper := newTestSampler()
+		t.Cleanup(func() { stopper.Stop(context.Background()) })
+		enabled.Store(true)
+		t.Cleanup(func() { enabled.Store(false) })
+		return s
+	}
 
-	enabled.Store(true)
-	defer enabled.Store(false)
+	t.Run("cache hit", func(t *testing.T) {
+		s := setup(t)
+		tenantID := roachpb.MustMakeTenantID(3)
 
-	tenantID := roachpb.MustMakeTenantID(3)
+		// Take two samples with the same workload ID.
+		cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 99}, WorkIO, "BatchEval")
+		s.takeSample(context.Background())
+		cleanup()
 
-	// Take two samples with the same workload ID.
-	cleanup := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 99}, WorkIO, "BatchEval")
-	s.takeSample(context.Background())
-	cleanup()
+		cleanup = SetWorkState(tenantID, WorkloadInfo{WorkloadID: 99}, WorkIO, "BatchEval")
+		s.takeSample(context.Background())
+		cleanup()
 
-	cleanup = SetWorkState(tenantID, WorkloadInfo{WorkloadID: 99}, WorkIO, "BatchEval")
-	s.takeSample(context.Background())
-	cleanup()
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 2)
+		// Both samples should have the same encoded workload ID.
+		require.Equal(t, samples[0].WorkloadID, samples[1].WorkloadID)
+		require.Equal(t, encodeStmtFingerprintIDToString(99), samples[0].WorkloadID)
 
-	samples := s.GetSamples(nil)
-	require.Len(t, samples, 2)
-	// Both samples should have the same encoded workload ID.
-	require.Equal(t, samples[0].WorkloadID, samples[1].WorkloadID)
-	require.Equal(t, encodeStmtFingerprintIDToString(99), samples[0].WorkloadID)
+		// Verify the cache contains the entry (keyed by id + type).
+		_, ok := s.workloadIDCache.Get(workloadCacheKey{id: 99})
+		require.True(t, ok, "workload ID should be cached")
+	})
 
-	// Verify the cache contains the entry.
-	_, ok := s.workloadIDCache.Get(uint64(99))
-	require.True(t, ok, "workload ID should be cached")
+	t.Run("different types do not collide", func(t *testing.T) {
+		s := setup(t)
+		tenantID := roachpb.MustMakeTenantID(3)
+		const id uint64 = 42
+
+		// Sample with the same numeric ID but as a statement fingerprint.
+		cleanup := SetWorkState(tenantID, WorkloadInfo{
+			WorkloadID:   id,
+			WorkloadType: workloadid.WorkloadTypeStatement,
+		}, WorkIO, "BatchEval")
+		s.takeSample(context.Background())
+		cleanup()
+
+		// Sample with the same numeric ID but as a job.
+		cleanup = SetWorkState(tenantID, WorkloadInfo{
+			WorkloadID:   id,
+			WorkloadType: workloadid.WorkloadTypeJob,
+		}, WorkIO, "BatchEval")
+		s.takeSample(context.Background())
+		cleanup()
+
+		samples := s.GetSamples(nil)
+		require.Len(t, samples, 2)
+
+		// The encoded workload IDs must differ: hex vs decimal.
+		require.NotEqual(t, samples[0].WorkloadID, samples[1].WorkloadID,
+			"same numeric ID with different types should produce different encodings")
+
+		// Verify both cache entries exist independently.
+		_, ok := s.workloadIDCache.Get(workloadCacheKey{
+			id: id, typ: workloadid.WorkloadTypeStatement,
+		})
+		require.True(t, ok, "statement cache entry should exist")
+		_, ok = s.workloadIDCache.Get(workloadCacheKey{
+			id: id, typ: workloadid.WorkloadTypeJob,
+		})
+		require.True(t, ok, "job cache entry should exist")
+	})
+}
+
+func TestEncodeWorkloadID(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		id       uint64
+		typ      workloadid.WorkloadType
+		expected string
+	}{
+		{
+			name:     "statement fingerprint",
+			id:       42,
+			typ:      workloadid.WorkloadTypeStatement,
+			expected: encodeStmtFingerprintIDToString(42),
+		},
+		{
+			name:     "unknown type uses hex encoding",
+			id:       42,
+			typ:      workloadid.WorkloadTypeUnknown,
+			expected: encodeStmtFingerprintIDToString(42),
+		},
+		{
+			name:     "job ID uses decimal",
+			id:       12345,
+			typ:      workloadid.WorkloadTypeJob,
+			expected: "12345",
+		},
+		{
+			name:     "job ID zero",
+			id:       0,
+			typ:      workloadid.WorkloadTypeJob,
+			expected: "0",
+		},
+		{
+			name:     "system task LDR",
+			id:       uint64(workloadid.WORKLOAD_ID_LDR),
+			typ:      workloadid.WorkloadTypeSystem,
+			expected: "LDR",
+		},
+		{
+			name:     "system task unknown ID",
+			id:       0,
+			typ:      workloadid.WorkloadTypeSystem,
+			expected: "UNKNOWN",
+		},
+		{
+			name:     "zero ID with unknown type",
+			id:       0,
+			typ:      workloadid.WorkloadTypeUnknown,
+			expected: encodeStmtFingerprintIDToString(0),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := encodeWorkloadID(tc.id, tc.typ)
+			require.Equal(t, tc.expected, result,
+				fmt.Sprintf("encodeWorkloadID(%d, %s)", tc.id, tc.typ))
+		})
+	}
 }
 
 func TestSamplerMultipleGoroutines(t *testing.T) {

--- a/pkg/obs/ash/types.go
+++ b/pkg/obs/ash/types.go
@@ -8,6 +8,7 @@ package ash
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
@@ -57,6 +58,9 @@ type WorkloadInfo struct {
 	AppNameID uint64
 	// GatewayNodeID is the node that initiated the workload.
 	GatewayNodeID roachpb.NodeID
+	// WorkloadType distinguishes the kind of workload that WorkloadID
+	// represents, controlling how the sampler encodes the ID.
+	WorkloadType workloadid.WorkloadType
 }
 
 // ASHSample represents a single Active Session History sample.

--- a/pkg/obs/workloadid/workloadid.go
+++ b/pkg/obs/workloadid/workloadid.go
@@ -42,6 +42,24 @@ const (
 	WORKLOAD_ID_RPC_HEARTBEAT
 )
 
+// Name returns the human-readable name for a system task WorkloadID.
+// For IDs that don't correspond to a known system task, it returns
+// "UNKNOWN".
+func (id WorkloadID) Name() string {
+	switch id {
+	case WORKLOAD_ID_LDR:
+		return WORKLOAD_NAME_LDR
+	case WORKLOAD_ID_RAFT:
+		return WORKLOAD_NAME_RAFT
+	case WORKLOAD_ID_STORELIVENESS:
+		return WORKLOAD_NAME_STORELIVENESS
+	case WORKLOAD_ID_RPC_HEARTBEAT:
+		return WORKLOAD_NAME_RPC_HEARTBEAT
+	default:
+		return WORKLOAD_NAME_UNKNOWN
+	}
+}
+
 const (
 	WORKLOAD_NAME_UNKNOWN       = "UNKNOWN"
 	WORKLOAD_NAME_LDR           = "LDR"
@@ -49,3 +67,44 @@ const (
 	WORKLOAD_NAME_STORELIVENESS = "STORELIVENESS"
 	WORKLOAD_NAME_RPC_HEARTBEAT = "RPC_HEARTBEAT"
 )
+
+// WorkloadType distinguishes the kind of workload that a WorkloadID
+// represents. The sampler uses this to choose the right encoding
+// (hex for statement fingerprints, decimal for job IDs, name for
+// system tasks).
+type WorkloadType uint8
+
+const (
+	// WorkloadTypeUnknown is the zero value. Backward compatible:
+	// existing callers that don't set a type get hex encoding.
+	WorkloadTypeUnknown WorkloadType = iota
+	// WorkloadTypeStatement identifies a SQL statement fingerprint ID,
+	// hex-encoded by the sampler.
+	WorkloadTypeStatement
+	// WorkloadTypeJob identifies a job ID, decimal-encoded by the
+	// sampler.
+	WorkloadTypeJob
+	// WorkloadTypeSystem identifies a system task, encoded using
+	// WorkloadID.Name() by the sampler.
+	WorkloadTypeSystem
+)
+
+// ToUint32 converts a WorkloadType to uint32 for use in protobuf
+// fields.
+func (t WorkloadType) ToUint32() uint32 {
+	return uint32(t)
+}
+
+// String returns the human-readable name for a WorkloadType.
+func (t WorkloadType) String() string {
+	switch t {
+	case WorkloadTypeStatement:
+		return "STATEMENT"
+	case WorkloadTypeJob:
+		return "JOB"
+	case WorkloadTypeSystem:
+		return "SYSTEM"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -281,6 +281,7 @@ func (s *ParallelUnorderedSynchronizer) Init(ctx context.Context) {
 						WorkloadID:    s.flowCtx.EvalCtx.WorkloadID,
 						AppNameID:     s.flowCtx.EvalCtx.AppNameID,
 						GatewayNodeID: gatewayNodeID,
+						WorkloadType:  s.flowCtx.EvalCtx.WorkloadType,
 					},
 					ash.WorkOther, "ColExecSync")
 				defer cleanup()

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/col/coldata",
         "//pkg/col/colserde",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
         "//pkg/sql/colexec/colexecargs",

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -342,6 +342,7 @@ func (i *Inbox) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 				WorkloadID:    i.admissionInfo.WorkloadID,
 				AppNameID:     i.admissionInfo.AppNameID,
 				GatewayNodeID: i.admissionInfo.GatewayNodeID,
+				WorkloadType:  i.admissionInfo.WorkloadType,
 			},
 			ash.WorkNetwork, "InboxRecv")
 		m, err := i.stream.Recv()

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/colserde"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
@@ -170,6 +171,16 @@ func (o *Outbox) gatewayNodeID() roachpb.NodeID {
 	return 0
 }
 
+// workloadType returns the WorkloadType from the flow context's
+// EvalCtx, or WorkloadTypeUnknown if EvalCtx is nil (which happens in
+// tests).
+func (o *Outbox) workloadType() workloadid.WorkloadType {
+	if o.flowCtx != nil && o.flowCtx.EvalCtx != nil {
+		return o.flowCtx.EvalCtx.WorkloadType
+	}
+	return workloadid.WorkloadTypeUnknown
+}
+
 // Run starts an outbox by connecting to the provided node and pushing
 // coldata.Batches over the stream after sending a header with the provided flow
 // and stream ID. Note that an extra goroutine is spawned so that Recv may be
@@ -323,6 +334,7 @@ func (o *Outbox) sendBatches(
 						WorkloadID:    o.workloadID(),
 						AppNameID:     o.appNameID(),
 						GatewayNodeID: o.gatewayNodeID(),
+						WorkloadType:  o.workloadType(),
 					},
 					ash.WorkNetwork, "OutboxSend")
 				err := stream.Send(o.scratch.msg)
@@ -372,6 +384,7 @@ func (o *Outbox) sendBatches(
 					WorkloadID:    o.workloadID(),
 					AppNameID:     o.appNameID(),
 					GatewayNodeID: o.gatewayNodeID(),
+					WorkloadType:  o.workloadType(),
 				},
 				ash.WorkNetwork, "OutboxSend")
 			err = stream.Send(o.scratch.msg)

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -275,6 +275,7 @@ func (f *BatchFlowCoordinator) Run(ctx context.Context) {
 				WorkloadID:    f.flowCtx.EvalCtx.WorkloadID,
 				AppNameID:     f.flowCtx.EvalCtx.AppNameID,
 				GatewayNodeID: gatewayNodeID,
+				WorkloadType:  f.flowCtx.EvalCtx.WorkloadType,
 			},
 			ash.WorkCPU, "BatchFlowCoordinator")
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -664,8 +664,11 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.extendedEvalCtx.WorkloadID = uint64(ih.fingerprintId)
 	appNameID := ash.GetOrStoreAppNameID(p.SessionData().ApplicationName)
 	p.extendedEvalCtx.AppNameID = appNameID
+	p.extendedEvalCtx.WorkloadType = workloadid.WorkloadTypeStatement
 	if p.txn != nil {
-		p.txn.SetWorkloadInfo(uint64(ih.fingerprintId), appNameID)
+		p.txn.SetWorkloadInfo(
+			uint64(ih.fingerprintId), appNameID, workloadid.WorkloadTypeStatement,
+		)
 	}
 
 	// Note that here we always unconditionally defer a function that takes care
@@ -1752,8 +1755,11 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	p.extendedEvalCtx.WorkloadID = uint64(ih.fingerprintId)
 	appNameID2 := ash.GetOrStoreAppNameID(p.SessionData().ApplicationName)
 	p.extendedEvalCtx.AppNameID = appNameID2
+	p.extendedEvalCtx.WorkloadType = workloadid.WorkloadTypeStatement
 	if p.txn != nil {
-		p.txn.SetWorkloadInfo(uint64(ih.fingerprintId), appNameID2)
+		p.txn.SetWorkloadInfo(
+			uint64(ih.fingerprintId), appNameID2, workloadid.WorkloadTypeStatement,
+		)
 	}
 
 	if buildutil.CrdbTestBuild {

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/gossip",
         "//pkg/kv",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/catsessiondata",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
@@ -283,7 +284,11 @@ func (ds *ServerImpl) setupFlow(
 		// Txn to heartbeat the transaction.
 		nodeID := roachpb.NodeID(req.Flow.Gateway)
 		leafTxn := kv.NewLeafTxn(ctx, ds.DB.KV(), nodeID, tis, &req.LeafTxnAdmissionHeader)
-		leafTxn.SetWorkloadInfo(req.EvalContext.WorkloadID, req.EvalContext.AppNameID)
+		leafTxn.SetWorkloadInfo(
+			req.EvalContext.WorkloadID,
+			req.EvalContext.AppNameID,
+			workloadid.WorkloadType(req.EvalContext.WorkloadType),
+		)
 		return leafTxn, nil
 	}
 
@@ -390,6 +395,7 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.TestingKnobs.ForceProductionValues = req.EvalContext.TestingKnobsForceProductionValues
 		evalCtx.WorkloadID = req.EvalContext.WorkloadID
 		evalCtx.AppNameID = req.EvalContext.AppNameID
+		evalCtx.WorkloadType = workloadid.WorkloadType(req.EvalContext.WorkloadType)
 
 		// In DistSQL flows, we eagerly store the app name on remote nodes to reduce
 		// cache misses when the local ASH sampler resolves the app name ID.

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -397,6 +397,7 @@ func serializeEvalContext(evalCtx *eval.Context) execinfrapb.EvalContext {
 		TestingKnobsForceProductionValues: evalCtx.TestingKnobs.ForceProductionValues,
 		WorkloadID:                        evalCtx.WorkloadID,
 		AppNameID:                         evalCtx.AppNameID,
+		WorkloadType:                      evalCtx.WorkloadType.ToUint32(),
 	}
 }
 
@@ -476,11 +477,13 @@ func (dsp *DistSQLPlanner) setupFlows(
 		StatementSQL:      statementSQL,
 	}
 	if localState.IsLocal {
-		// VectorizeMode, workloadID, and appNameID are the only fields
-		// that the setup code expects to be set in the local flows.
+		// VectorizeMode, workloadID, appNameID, and workloadType are
+		// the only fields that the setup code expects to be set in the
+		// local flows.
 		setupReq.EvalContext.SessionData.VectorizeMode = evalCtx.SessionData().VectorizeMode
 		setupReq.EvalContext.WorkloadID = evalCtx.WorkloadID
 		setupReq.EvalContext.AppNameID = evalCtx.AppNameID
+		setupReq.EvalContext.WorkloadType = evalCtx.WorkloadType.ToUint32()
 	} else {
 		// In distributed plans populate some extra state.
 		setupReq.EvalContext = serializeEvalContext(evalCtx)

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -946,6 +946,7 @@ func (pb *ProcessorBaseNoHelper) StartInternal(
 				WorkloadID:    pb.FlowCtx.EvalCtx.WorkloadID,
 				AppNameID:     pb.FlowCtx.EvalCtx.AppNameID,
 				GatewayNodeID: gatewayNodeID,
+				WorkloadType:  pb.FlowCtx.EvalCtx.WorkloadType,
 			},
 			ash.WorkCPU, name)
 	}

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -96,6 +96,10 @@ message EvalContext {
   // enrich samples with more workload context.
   optional uint64 app_name_id = 18 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "AppNameID"];
+  // WorkloadType distinguishes the kind of workload that workload_id
+  // represents. Used by the ASH sampler to choose the right encoding.
+  optional uint32 workload_type = 19 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "WorkloadType"];
 }
 
 message SimpleResponse {

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -335,6 +335,7 @@ func NewFlowBase(
 	admissionInfo.WorkloadID = flowCtx.EvalCtx.WorkloadID
 	admissionInfo.AppNameID = flowCtx.EvalCtx.AppNameID
 	admissionInfo.GatewayNodeID = roachpb.NodeID(flowCtx.NodeID.SQLInstanceID())
+	admissionInfo.WorkloadType = flowCtx.EvalCtx.WorkloadType
 	if flowCtx.Txn == nil {
 		admissionInfo.Priority = admissionpb.NormalPri
 		admissionInfo.CreateTime = timeutil.Now().UnixNano()

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -140,6 +140,7 @@ func processInboundStreamHelper(
 					WorkloadID:    admissionInfo.WorkloadID,
 					AppNameID:     admissionInfo.AppNameID,
 					GatewayNodeID: admissionInfo.GatewayNodeID,
+					WorkloadType:  admissionInfo.WorkloadType,
 				},
 				ash.WorkNetwork, "InboxRecv")
 			msg, err := stream.Recv()

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -182,6 +182,7 @@ func (m *Outbox) flush(ctx context.Context) error {
 				WorkloadID:    m.flowCtx.EvalCtx.WorkloadID,
 				AppNameID:     m.flowCtx.EvalCtx.AppNameID,
 				GatewayNodeID: roachpb.NodeID(m.flowCtx.NodeID.SQLInstanceID()),
+				WorkloadType:  m.flowCtx.EvalCtx.WorkloadType,
 			},
 			ash.WorkNetwork, "OutboxSend")
 	}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -300,6 +300,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 			WorkloadID:    p.extendedEvalCtx.WorkloadID,
 			AppNameID:     p.extendedEvalCtx.AppNameID,
 			GatewayNodeID: roachpb.NodeID(p.extendedEvalCtx.NodeID.SQLInstanceID()),
+			WorkloadType:  p.extendedEvalCtx.WorkloadType,
 		},
 		ash.WorkCPU, "Optimize")
 	defer cleanup()

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
+        "//pkg/obs/workloadid",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/username",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -370,6 +371,10 @@ type Context struct {
 	// enrichment_id field which will enable the ASH sampler to
 	// enrich samples with more workload context.
 	AppNameID uint64
+
+	// WorkloadType distinguishes the kind of workload that WorkloadID
+	// represents (statement fingerprint, job ID, system task).
+	WorkloadType workloadid.WorkloadType
 }
 
 // RoutineStatementCounters encapsulates metrics for tracking the execution

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/obs/ash",
+        "//pkg/obs/workloadid",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -197,6 +198,9 @@ type WorkInfo struct {
 	// GatewayNodeID is the node that initiated the workload. Used for ASH
 	// sampling.
 	GatewayNodeID roachpb.NodeID
+	// WorkloadType distinguishes the kind of workload that WorkloadID
+	// represents. Used for ASH sampling.
+	WorkloadType workloadid.WorkloadType
 }
 
 // ReplicatedWorkInfo groups everything needed to admit replicated writes, done
@@ -896,6 +900,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 			WorkloadID:    info.WorkloadID,
 			AppNameID:     info.AppNameID,
 			GatewayNodeID: info.GatewayNodeID,
+			WorkloadType:  info.WorkloadType,
 		},
 		ash.WorkAdmission, string(q.queueKind))
 	defer cleanup()


### PR DESCRIPTION
The ASH sampler currently always hex-encodes workload IDs, treating them as statement fingerprint IDs. This doesn't work for job IDs or system task IDs, which need different encodings (decimal and name string, respectively). This commit introduces a WorkloadType to distinguish the kind of workload a WorkloadID represents, enabling type-aware encoding throughout the stack.

Specifically this commit:

- Defines WorkloadType (uint8) in the workloadid package with constants WorkloadTypeUnknown, WorkloadTypeStatement, WorkloadTypeJob, and WorkloadTypeSystem.
- Adds a Name() method to WorkloadID for system task name encoding.
- Adds a workload_type field to the BatchRequest proto header and the DistSQL EvalContext proto.
- Plumbs WorkloadType through Txn.SetWorkloadInfo, eval.Context, ash.WorkloadInfo, and admission.WorkInfo.
- Updates the ASH sampler to use a composite (id, type) cache key and choose encoding based on WorkloadType: hex for statements, decimal for jobs, name string for system tasks.
- Updates all existing callers to set WorkloadTypeStatement and forward WorkloadType from proto headers through the KV and DistSQL stacks.

Epic: none
Release note: None