### PR TITLE
ttljob: flush progress before job completion to fix lost row counts

### DIFF
--- a/pkg/sql/ttl/ttljob/progress.go
+++ b/pkg/sql/ttl/ttljob/progress.go
@@ -61,6 +61,9 @@ type progressTracker interface {
 	handleProgressUpdate(ctx context.Context, meta *execinfrapb.ProducerMetadata) error
 	// terminateTracker performs any necessary cleanup when the job completes or fails.
 	terminateTracker()
+	// flushFinalProgress flushes the progress one last time before job completion. This
+	// also terminates the tracker's background flushes.
+	flushFinalProgress(ctx context.Context) error
 }
 
 // legacyProgressTracker tracks TTL job progress without span checkpointing.
@@ -229,6 +232,11 @@ func (t *legacyProgressTracker) handleProgressUpdate(
 
 // terminateTracker implements the progressTracker interface.
 func (t *legacyProgressTracker) terminateTracker() {
+}
+
+// flushFinalProgress implements the progressTracker interface.
+func (t *legacyProgressTracker) flushFinalProgress(ctx context.Context) error {
+	return nil
 }
 
 // checkpointProgressTracker tracks TTL job progress with span checkpointing.
@@ -477,6 +485,10 @@ func (t *checkpointProgressTracker) startPeriodicUpdates(ctx context.Context) (s
 		write func(context.Context) error,
 		interval func() time.Duration,
 	) error {
+		// Always do an initial flush, so that a valid baseline exists in the job record.
+		if err := write(ctx); err != nil {
+			log.Dev.Warningf(ctx, "could not write initial progress: %v", err)
+		}
 		timer := t.clock.NewTimer()
 		defer timer.Stop()
 		for {
@@ -623,4 +635,11 @@ func (t *checkpointProgressTracker) flushCheckpointUpdate(ctx context.Context) e
 		defer frontier.Release()
 		return jobfrontier.Store(ctx, txn, t.jobID, ttlCompletedSpansKey, frontier)
 	})
+}
+
+// flushFinalProgress implements the progressTracker interface.
+func (t *checkpointProgressTracker) flushFinalProgress(ctx context.Context) error {
+	// Stop periodic flushes in the background, and push one final flush.
+	t.terminateTracker()
+	return errors.CombineErrors(t.flushCheckpointUpdate(ctx), t.flushProgress(ctx))
 }

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -371,6 +371,13 @@ func (t *rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (r
 		return err
 	}
 
+	// Flush the progress before the job terminates, so that an up-to-date
+	// state is written into the job.
+	// Note: This is also a persistent flush when the Drain flag has been set.
+	if err := t.progressTracker.flushFinalProgress(ctx); err != nil {
+		log.Dev.Warningf(ctx, "failed to flush final progress: %v", err)
+	}
+
 	if err := statsGroup.Wait(); err != nil {
 		// If the stats group was cancelled, use that error instead.
 		err = errors.CombineErrors(context.Cause(statsCtx), err)


### PR DESCRIPTION
The checkpointProgressTracker relied solely on periodic background flushes and the Drained=true metadata flush to persist JobDeletedRowCount to the job record. If the job completed before a periodic flush fired (e.g., job finishes in ~12s with a 30s flush interval) and the Drained=true flush failed or was lost in the DistSQL plumbing, the job record would retain JobDeletedRowCount=0 despite all rows being deleted.

Fix this with two changes:

1. Add flushFinalProgress to the progressTracker interface, called in Resume() after g.Wait() returns. This guarantees the final in-memory cache (with the correct deleted row count) is written to the job record before Resume() returns and the job framework marks it succeeded.

2. Perform an initial flush when the periodic update goroutines start, so a valid baseline RowLevelTTLProgress is always persisted in the job record even if the job fails early.

Fixes #164446