### PR TITLE
release-25.4: build: fix cloud-only docker publish for cross-platform pulls

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
@@ -28,8 +28,8 @@ tc_end_block "Variable Setup"
 
 
 docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
-docker pull "${gcr_staged_repository}:amd64-${version}"
-docker pull "${gcr_staged_repository}:arm64-${version}"
+docker pull --platform linux/amd64 "${gcr_staged_repository}:amd64-${version}"
+docker pull --platform linux/arm64 "${gcr_staged_repository}:arm64-${version}"
 
 cloud_release=
 for i in $(seq 1 10); do


### PR DESCRIPTION
Backport of #165594 (--platform fix only, without s390x support).

The cloud-only publish script was failing because `docker pull` without `--platform` refuses to pull images whose manifest doesn't match the host architecture. Add explicit `--platform` flags to all pulls.

Release note: None
Epic: None
Release justification: release automation changes