### PR TITLE
claude: add project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(./dev build *)",
+            "Bash(./dev generate *)",
+            "Bash(./dev test *)",
+            "Bash(./dev testlogic *)",
+            "Bash(crlfmt *)",
+            "Bash(cat *)",
+            "Bash(git diff *)",
+            "Bash(git log *)",
+            "Bash(git status *)"
+        ]
+    }
+}


### PR DESCRIPTION
The docs [suggest](https://code.claude.com/docs/en/settings) project
scope for permissions; this change adds basic allows to stop Claude Code
from prompting on select operations. If it conflicts with a user's
existing, unmerged settings those likely can be added to these project
settings or moved to the local scope (`.claude/settings.local.json`)
where they will take precedence.

Epic: none

Release note: None