### PR TITLE
ui: add analytics tracking for custom metric selection

### DIFF
--- a/pkg/ui/workspaces/db-console/src/util/analytics/index.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/index.ts
@@ -15,4 +15,5 @@ export { default as trackFilter } from "./trackFilter";
 export { default as trackNetworkSort } from "./trackNetworkSort";
 export { default as trackCollapseNodes } from "./trackCollapseNodes";
 export { default as trackTimeScaleSelected } from "./trackTimeScaleSelected";
+export { default as trackMetricSelected } from "./trackMetricSelected";
 export { default as trackTimeFrameChange } from "./trackTimeFrameChange";

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackMetricSelected.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackMetricSelected.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (metric: string) => {
+  fn({
+    event: "Custom Metric Selected",
+    properties: {
+      metric,
+    },
+  });
+};
+
+export default function trackMetricSelected(metric: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(metric);
+}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
@@ -10,6 +10,7 @@ import Select, { Option } from "react-select";
 
 import * as protos from "src/js/protos";
 import { isSystemTenant } from "src/redux/tenants";
+import { trackMetricSelected } from "src/util/analytics";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 
 import { MetricOption } from "./metricOption";
@@ -111,9 +112,12 @@ export function CustomMetricRow({
             searchable={true}
             value={metric}
             options={metricOptions}
-            onChange={(opt: Option<string>) =>
-              changeState({ metric: opt.value })
-            }
+            onChange={(opt: Option<string>) => {
+              changeState({ metric: opt.value });
+              if (opt.value) {
+                trackMetricSelected(opt.value);
+              }
+            }}
             placeholder="Select a metric..."
             optionComponent={MetricOption}
             matchProp="label"


### PR DESCRIPTION
Track which metrics users select on the Custom Chart (/debug/chart) and Metrics Workspace (/debug/metrics_workspace) pages. Both pages share the CustomMetricRow component, so a single tracking call covers both. The page is distinguishable via the pagePath property automatically added by AnalyticsSync.

Epic: None
Release note: None