### PR TITLE
sql: add aclitem type, implement acldefault and makeaclitem, enhance aclexplode

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1559,7 +1559,9 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
-<tr><td><a name="aclexplode"></a><code>aclexplode(aclitems: <a href="string.html">string</a>[]) &rarr; tuple{oid AS grantor, oid AS grantee, string AS privilege_type, bool AS is_grantable}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing aclitem stuff (returns no rows as this feature is unsupported in CockroachDB)</p>
+<tr><td><a name="aclexplode"></a><code>aclexplode(aclitems: <a href="string.html">string</a>[]) &rarr; tuple{oid AS grantor, oid AS grantee, string AS privilege_type, bool AS is_grantable}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing aclitem privileges.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="aclexplode"></a><code>aclexplode(aclitems: aclitem[]) &rarr; tuple{oid AS grantor, oid AS grantee, string AS privilege_type, bool AS is_grantable}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing aclitem privileges.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="generate_series"></a><code>generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Produces a virtual table containing the integer values from <code>start</code> to <code>end</code>, inclusive.</p>
 </span></td><td>Immutable</td></tr>
@@ -3458,6 +3460,8 @@ may increase either contention or retry errors, or both.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
+<tr><td><a name="acldefault"></a><code>acldefault(type: "char", ownerId: oid) &rarr; aclitem[]</code></td><td><span class="funcdesc"><p>Returns the default access privileges for an object of the given type belonging to the given owner.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="col_description"></a><code>col_description(table_oid: oid, column_number: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the comment for a table column, which is specified by the OID of its table and its column number. (obj_description cannot be used for table columns, since columns do not have OIDs of their own.)</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="current_setting"></a><code>current_setting(setting_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>System info</p>
@@ -3635,6 +3639,8 @@ may increase either contention or retry errors, or both.</p>
 <tr><td><a name="information_schema._pg_numeric_precision_radix"></a><code>information_schema._pg_numeric_precision_radix(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the radix of the given type with type modifier</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="information_schema._pg_numeric_scale"></a><code>information_schema._pg_numeric_scale(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the scale of the given type with type modifier</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="makeaclitem"></a><code>makeaclitem(grantee: oid, grantor: oid, privileges: <a href="string.html">string</a>, is_grantable: <a href="bool.html">bool</a>) &rarr; aclitem</code></td><td><span class="funcdesc"><p>Constructs an aclitem from the given grantee, grantor, privileges, and grant option.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="nameconcatoid"></a><code>nameconcatoid(name: <a href="string.html">string</a>, oid: oid) &rarr; name</code></td><td><span class="funcdesc"><p>Used in the information_schema to produce specific_name columns, which are supposed to be unique per schema. The result is the same as ($1::text || ‘_’ || $2::text)::name except that, if it would not fit in 63 characters, we make it do so by truncating the name input (not the oid).</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/colconv/BUILD.bazel
+++ b/pkg/sql/colconv/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/col/typeconv",  # keep
         "//pkg/sql/colexecerror",  # keep
         "//pkg/sql/execinfra/execreleasable",  # keep
+        "//pkg/sql/oidext",  # keep
         "//pkg/sql/rowenc",  # keep
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",  # keep

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -316,6 +317,29 @@ func ColVecToDatumAndDeselect(
 							continue
 						}
 						v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+						//gcassert:bce
+						converted[destIdx] = v
+					}
+					goto vecToDatum_true_true_true_return_0
+				}
+				if ct.Oid() == oidext.T_aclitem {
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+						if err != nil {
+							colexecerror.ExpectedError(err)
+						}
 						//gcassert:bce
 						converted[destIdx] = v
 					}
@@ -791,6 +815,24 @@ func ColVecToDatumAndDeselect(
 					}
 					goto vecToDatum_false_true_true_return_1
 				}
+				if ct.Oid() == oidext.T_aclitem {
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+						if err != nil {
+							colexecerror.ExpectedError(err)
+						}
+						//gcassert:bce
+						converted[destIdx] = v
+					}
+					goto vecToDatum_false_true_true_return_1
+				}
 				for idx = 0; idx < length; idx++ {
 					{
 						destIdx = idx
@@ -1194,6 +1236,28 @@ func ColVecToDatum(
 								continue
 							}
 							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							converted[destIdx] = v
+						}
+						goto vecToDatum_true_true_false_return_2
+					}
+					if ct.Oid() == oidext.T_aclitem {
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
 							converted[destIdx] = v
 						}
 						goto vecToDatum_true_true_false_return_2
@@ -1649,6 +1713,28 @@ func ColVecToDatum(
 								continue
 							}
 							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							//gcassert:bce
+							converted[destIdx] = v
+						}
+						goto vecToDatum_true_false_false_return_3
+					}
+					if ct.Oid() == oidext.T_aclitem {
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								//gcassert:bce
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
 							//gcassert:bce
 							converted[destIdx] = v
 						}
@@ -2128,6 +2214,24 @@ func ColVecToDatum(
 						}
 						goto vecToDatum_false_true_false_return_4
 					}
+					if ct.Oid() == oidext.T_aclitem {
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
+							converted[destIdx] = v
+						}
+						goto vecToDatum_false_true_false_return_4
+					}
 					for idx = 0; idx < length; idx++ {
 						{
 							//gcassert:bce
@@ -2506,6 +2610,23 @@ func ColVecToDatum(
 								srcIdx = idx
 							}
 							v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+							//gcassert:bce
+							converted[destIdx] = v
+						}
+						goto vecToDatum_false_false_false_return_5
+					}
+					if ct.Oid() == oidext.T_aclitem {
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+							if err != nil {
+								colexecerror.ExpectedError(err)
+							}
 							//gcassert:bce
 							converted[destIdx] = v
 						}

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -436,7 +436,10 @@ func vecToDatum(
 						continue
 					}
 				}
-				v := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+				v, err := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
+				if err != nil {
+					colexecerror.ExpectedError(err)
+				}
 				if !hasSel || deselect {
 					//gcassert:bce
 				}

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -415,6 +416,27 @@ func vecToDatum(
 					}
 				}
 				v := da.NewDName(tree.DString(bytes.Get(srcIdx)))
+				if !hasSel || deselect {
+					//gcassert:bce
+				}
+				converted[destIdx] = v
+			}
+			return
+		}
+		if ct.Oid() == oidext.T_aclitem {
+			for idx = 0; idx < length; idx++ {
+				setDestIdx(destIdx, idx, sel, hasSel, deselect)
+				setSrcIdx(srcIdx, idx, sel, hasSel)
+				if hasNulls {
+					if nulls.NullAt(srcIdx) {
+						if !hasSel || deselect {
+							//gcassert:bce
+						}
+						converted[destIdx] = tree.DNull
+						continue
+					}
+				}
+				v := da.NewDACLItem(tree.DString(bytes.Get(srcIdx)))
 				if !hasSel || deselect {
 					//gcassert:bce
 				}

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/colmem",  # keep
         "//pkg/sql/execinfrapb",
         "//pkg/sql/lex",  # keep
+        "//pkg/sql/oidext",  # keep
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc",  # keep

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -48,6 +49,7 @@ var (
 	_ = lex.DecodeRawBytesToByteArrayAuto
 	_ = uuid.FromBytes
 	_ = oid.T_name
+	_ = oidext.T_aclitem
 	_ = util.TruncateString
 	_ = pgcode.Syntax
 	_ = pgdate.ParseTimestamp
@@ -2132,7 +2134,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2178,7 +2180,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2224,7 +2226,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2270,7 +2272,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2353,7 +2355,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2399,7 +2401,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2447,7 +2449,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2493,7 +2495,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3460,7 +3462,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3510,7 +3512,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3560,7 +3562,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3610,7 +3612,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4733,7 +4735,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4779,7 +4781,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4825,7 +4827,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4871,7 +4873,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4958,7 +4960,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5007,7 +5009,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5058,7 +5060,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5107,7 +5109,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5945,7 +5947,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5993,7 +5995,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6041,7 +6043,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6089,7 +6091,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6878,7 +6880,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6937,7 +6939,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6996,7 +6998,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7055,7 +7057,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7868,7 +7870,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7927,7 +7929,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7986,7 +7988,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -8045,7 +8047,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -8882,7 +8884,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -8941,7 +8943,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9000,7 +9002,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9059,7 +9061,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9144,7 +9146,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9194,7 +9196,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9244,7 +9246,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9294,7 +9296,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9375,7 +9377,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9419,7 +9421,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9465,7 +9467,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9509,7 +9511,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11419,7 +11421,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11463,7 +11465,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11509,7 +11511,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11553,7 +11555,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12147,7 +12149,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12193,7 +12195,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12239,7 +12241,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12285,7 +12287,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12375,7 +12377,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12430,7 +12432,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12485,7 +12487,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12540,7 +12542,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12626,7 +12628,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12675,7 +12677,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12726,7 +12728,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12775,7 +12777,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name {
+							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -53,6 +54,7 @@ var (
 	_ = lex.DecodeRawBytesToByteArrayAuto
 	_ = uuid.FromBytes
 	_ = oid.T_name
+	_ = oidext.T_aclitem
 	_ = util.TruncateString
 	_ = pgcode.Syntax
 	_ = pgdate.ParseTimestamp

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -529,7 +529,7 @@ func toString(conv, to, toType string) string {
 	// tree.AdjustValueToType.
 	convStr := `
 		%[1]s
-		if %[3]s.Oid() != oid.T_name {
+		if %[3]s.Oid() != oid.T_name && %[3]s.Oid() != oidext.T_aclitem {
 			// bpchar types truncate trailing whitespace.
 			if %[3]s.Oid() == oid.T_bpchar {
 				%[2]s = bytes.TrimRight(%[2]s, " ")

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -125,6 +125,12 @@ test           pg_catalog          "char"                                 type  
 test           pg_catalog          "char"[]                               type         admin    ALL             false
 test           pg_catalog          "char"[]                               type         public   USAGE           false
 test           pg_catalog          "char"[]                               type         root     ALL             false
+test           pg_catalog          aclitem                                type         admin    ALL             false
+test           pg_catalog          aclitem                                type         public   USAGE           false
+test           pg_catalog          aclitem                                type         root     ALL             false
+test           pg_catalog          aclitem[]                              type         admin    ALL             false
+test           pg_catalog          aclitem[]                              type         public   USAGE           false
+test           pg_catalog          aclitem[]                              type         root     ALL             false
 test           pg_catalog          any                                    type         admin    ALL             false
 test           pg_catalog          any                                    type         public   USAGE           false
 test           pg_catalog          any                                    type         root     ALL             false
@@ -555,6 +561,10 @@ test           pg_catalog   "char"          type         admin    ALL           
 test           pg_catalog   "char"          type         root     ALL             false
 test           pg_catalog   "char"[]        type         admin    ALL             false
 test           pg_catalog   "char"[]        type         root     ALL             false
+test           pg_catalog   aclitem         type         admin    ALL             false
+test           pg_catalog   aclitem         type         root     ALL             false
+test           pg_catalog   aclitem[]       type         admin    ALL             false
+test           pg_catalog   aclitem[]       type         root     ALL             false
 test           pg_catalog   any             type         admin    ALL             false
 test           pg_catalog   any             type         root     ALL             false
 test           pg_catalog   anyarray        type         admin    ALL             false
@@ -815,6 +825,10 @@ a              pg_catalog   "char"          type         admin    ALL           
 a              pg_catalog   "char"          type         root     ALL             false
 a              pg_catalog   "char"[]        type         admin    ALL             false
 a              pg_catalog   "char"[]        type         root     ALL             false
+a              pg_catalog   aclitem         type         admin    ALL             false
+a              pg_catalog   aclitem         type         root     ALL             false
+a              pg_catalog   aclitem[]       type         admin    ALL             false
+a              pg_catalog   aclitem[]       type         root     ALL             false
 a              pg_catalog   any             type         admin    ALL             false
 a              pg_catalog   any             type         root     ALL             false
 a              pg_catalog   anyarray        type         admin    ALL             false
@@ -1013,6 +1027,10 @@ defaultdb      pg_catalog   "char"          type         admin    ALL           
 defaultdb      pg_catalog   "char"          type         root     ALL             false
 defaultdb      pg_catalog   "char"[]        type         admin    ALL             false
 defaultdb      pg_catalog   "char"[]        type         root     ALL             false
+defaultdb      pg_catalog   aclitem         type         admin    ALL             false
+defaultdb      pg_catalog   aclitem         type         root     ALL             false
+defaultdb      pg_catalog   aclitem[]       type         admin    ALL             false
+defaultdb      pg_catalog   aclitem[]       type         root     ALL             false
 defaultdb      pg_catalog   any             type         admin    ALL             false
 defaultdb      pg_catalog   any             type         root     ALL             false
 defaultdb      pg_catalog   anyarray        type         admin    ALL             false
@@ -1211,6 +1229,10 @@ postgres       pg_catalog   "char"          type         admin    ALL           
 postgres       pg_catalog   "char"          type         root     ALL             false
 postgres       pg_catalog   "char"[]        type         admin    ALL             false
 postgres       pg_catalog   "char"[]        type         root     ALL             false
+postgres       pg_catalog   aclitem         type         admin    ALL             false
+postgres       pg_catalog   aclitem         type         root     ALL             false
+postgres       pg_catalog   aclitem[]       type         admin    ALL             false
+postgres       pg_catalog   aclitem[]       type         root     ALL             false
 postgres       pg_catalog   any             type         admin    ALL             false
 postgres       pg_catalog   any             type         root     ALL             false
 postgres       pg_catalog   anyarray        type         admin    ALL             false
@@ -1417,6 +1439,10 @@ test           pg_catalog   "char"          type         admin    ALL           
 test           pg_catalog   "char"          type         root     ALL             false
 test           pg_catalog   "char"[]        type         admin    ALL             false
 test           pg_catalog   "char"[]        type         root     ALL             false
+test           pg_catalog   aclitem         type         admin    ALL             false
+test           pg_catalog   aclitem         type         root     ALL             false
+test           pg_catalog   aclitem[]       type         admin    ALL             false
+test           pg_catalog   aclitem[]       type         root     ALL             false
 test           pg_catalog   any             type         admin    ALL             false
 test           pg_catalog   any             type         root     ALL             false
 test           pg_catalog   anyarray        type         admin    ALL             false

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -1,14 +1,325 @@
-query T
-SELECT aclexplode(NULL)
-----
+subtest aclexplode
 
-query T
+query empty
+SELECT aclexplode(NULL::text[])
+
+query empty
 SELECT aclexplode(ARRAY[]::text[])
+
+# aclexplode with an invalid ACL string produces no rows (graceful skip).
+query empty
+SELECT aclexplode(ARRAY['foo']::text[])
+
+# aclexplode with a valid ACL string using role names.
+# Use COALESCE with pg_roles to convert OIDs back to names for stable output.
+query TTTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(ARRAY['root=r/admin']::text[]) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
 ----
+grantor  grantee  privilege_type  is_grantable
+admin    root     SELECT          false
+
+# aclexplode with grant option indicated by '*'.
+query TTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(ARRAY['root=r*/admin']::text[]) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+----
+grantor  privilege_type  is_grantable
+admin    SELECT          true
+
+# aclexplode with multiple privileges.
+query TTTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(ARRAY['root=arw/admin']::text[]) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+----
+grantor  grantee  privilege_type  is_grantable
+admin    root     INSERT          false
+admin    root     SELECT          false
+admin    root     UPDATE          false
+
+# aclexplode with PUBLIC grantee (empty before '=').
+query TTTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(ARRAY['=rw/root']::text[]) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+----
+grantor  grantee  privilege_type  is_grantable
+root     PUBLIC   SELECT          false
+root     PUBLIC   UPDATE          false
+
+# aclexplode with multiple ACL items.
+query TTTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(ARRAY['root=r/admin', '=X/admin']::text[]) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+----
+grantor  grantee  privilege_type  is_grantable
+admin    PUBLIC   EXECUTE         false
+admin    root     SELECT          false
+
+# aclexplode also works with aclitem[] type via acldefault round-trip.
+query TTTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(acldefault('r'::"char", 'root'::regrole)) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+----
+grantor  grantee  privilege_type  is_grantable
+root     root     DELETE          false
+root     root     INSERT          false
+root     root     MAINTAIN        false
+root     root     REFERENCES      false
+root     root     SELECT          false
+root     root     TRIGGER         false
+root     root     TRUNCATE        false
+root     root     UPDATE          false
+
+subtest end
+
+subtest makeaclitem
+
+# Single privilege.
+query T
+SELECT makeaclitem('root'::regrole, 'admin'::regrole, 'SELECT', false)
+----
+root=r/admin
+
+# Multiple privileges (comma-separated).
+query T
+SELECT makeaclitem('root'::regrole, 'admin'::regrole, 'SELECT,INSERT,UPDATE', false)
+----
+root=raw/admin
+
+# With grant option.
+query T
+SELECT makeaclitem('root'::regrole, 'admin'::regrole, 'SELECT,INSERT', true)
+----
+root=r*a*/admin
+
+# PUBLIC grantee (OID 0).
+query T
+SELECT makeaclitem(0::oid, 'root'::regrole, 'EXECUTE', false)
+----
+=X/root
+
+# Error on invalid privilege.
+statement error unrecognized privilege type: "BOGUS"
+SELECT makeaclitem('root'::regrole, 'admin'::regrole, 'BOGUS', false)
+
+subtest end
+
+subtest acldefault
+
+# Table defaults: owner gets arwdDxtm, PUBLIC gets nothing.
+query T
+SELECT acldefault('r'::"char", 'root'::regrole)
+----
+{root=arwdDxtm/root}
+
+# Database defaults: owner gets CTc, PUBLIC gets Tc.
+query T
+SELECT acldefault('d'::"char", 'root'::regrole)
+----
+{=Tc/root,root=CTc/root}
+
+# Function defaults: owner gets X, PUBLIC gets X.
+query T
+SELECT acldefault('f'::"char", 'root'::regrole)
+----
+{=X/root,root=X/root}
+
+# Type defaults: owner gets U, PUBLIC gets U.
+query T
+SELECT acldefault('T'::"char", 'root'::regrole)
+----
+{=U/root,root=U/root}
+
+# Schema defaults: owner gets UC, no PUBLIC.
+query T
+SELECT acldefault('n'::"char", 'root'::regrole)
+----
+{root=UC/root}
+
+# Language defaults: no owner, PUBLIC gets U.
+query T
+SELECT acldefault('l'::"char", 'root'::regrole)
+----
+{=U/root}
+
+# Column defaults: nobody gets anything.
+query T
+SELECT acldefault('c'::"char", 'root'::regrole)
+----
+{}
+
+# Error on invalid type char.
+statement error unrecognized object type abbreviation: "Z"
+SELECT acldefault('Z'::"char", 'root'::regrole)
+
+subtest end
+
+subtest aclitem_roundtrip
+
+# Round-trip: aclexplode(acldefault(...)) should produce correct rows.
+query TTTB colnames,rowsort
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(acldefault('d'::"char", 'root'::regrole)) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+----
+grantor  grantee  privilege_type  is_grantable
+root     PUBLIC   CONNECT         false
+root     PUBLIC   TEMPORARY       false
+root     root     CONNECT         false
+root     root     CREATE          false
+root     root     TEMPORARY       false
+
+subtest end
+
+subtest aclitem_type
+
+# aclitem can be used as a column type.
+statement ok
+CREATE TABLE aclitem_test (a aclitem)
+
+statement ok
+INSERT INTO aclitem_test VALUES ('root=r/admin')
 
 query T
-SELECT aclexplode(ARRAY['foo'])
+SELECT * FROM aclitem_test
 ----
+root=r/admin
+
+statement ok
+DROP TABLE aclitem_test
+
+# Cast string to aclitem.
+query T
+SELECT 'root=rw*/admin'::aclitem
+----
+root=rw*/admin
+
+# Array containment works for aclitem arrays.
+query B
+SELECT ARRAY['root=r/admin']::aclitem[] @> ARRAY['root=r/admin']::aclitem[]
+----
+true
+
+query B
+SELECT ARRAY['root=rw/admin', '=X/admin']::aclitem[] @> ARRAY['root=rw/admin']::aclitem[]
+----
+true
+
+query B
+SELECT ARRAY['root=r/admin']::aclitem[] @> ARRAY['root=rw/admin']::aclitem[]
+----
+false
+
+subtest end
+
+subtest aclitem_validation
+
+# Valid: empty grantee (PUBLIC).
+query T
+SELECT '=r/'::aclitem
+----
+=r/
+
+# Valid: grant option markers.
+query T
+SELECT 'user1=r*w/'::aclitem
+----
+user1=r*w/
+
+# Valid: all privilege characters.
+query T
+SELECT 'user1=arwdDxtXUCTcsAm/'::aclitem
+----
+user1=arwdDxtXUCTcsAm/
+
+# Valid: empty privileges.
+query T
+SELECT 'user1=/'::aclitem
+----
+user1=/
+
+# Valid: missing slash (grantor defaults to empty).
+query T
+SELECT 'user1=r'::aclitem
+----
+user1=r
+
+# Valid: quoted identifiers.
+query T
+SELECT '"user with spaces"=r/'::aclitem
+----
+"user with spaces"=r/
+
+# Valid: grantor present.
+query T
+SELECT 'user1=r/grantor1'::aclitem
+----
+user1=r/grantor1
+
+# Invalid: bad privilege character.
+statement error pgcode 22P02 invalid mode character: "z"
+SELECT 'user1=z/'::aclitem
+
+# Invalid: missing equals sign.
+statement error pgcode 22P02 missing "=" sign
+SELECT 'user1rw/'::aclitem
+
+# Invalid: star without preceding privilege.
+statement error pgcode 22P02 "\*" must follow a privilege character
+SELECT 'user1=*r/'::aclitem
+
+# Invalid: extra characters after aclitem.
+statement error pgcode 22P02 extra characters after aclitem specification
+SELECT 'user1=r/grantor extra'::aclitem
+
+# Invalid: unterminated quoted identifier in grantee.
+statement error pgcode 22P02 unterminated quoted identifier
+SELECT '"unterminated=r/'::aclitem
+
+# Invalid: unterminated quoted identifier in grantor.
+statement error pgcode 22P02 unterminated quoted identifier
+SELECT 'user1=r/"unterminated'::aclitem
+
+subtest end
 
 # Regression test for #43166.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -132,6 +132,18 @@ SELECT makeaclitem(0::oid, 'root'::regrole, 'EXECUTE', false)
 ----
 =X/root
 
+# SET privilege produces 's' character.
+query T
+SELECT makeaclitem(0::oid, 'root'::regrole, 'SET', false)
+----
+=s/root
+
+# ALTER SYSTEM privilege produces 'A' character.
+query T
+SELECT makeaclitem(0::oid, 'root'::regrole, 'ALTER SYSTEM', false)
+----
+=A/root
+
 # Error on invalid privilege.
 statement error unrecognized privilege type: "BOGUS"
 SELECT makeaclitem('root'::regrole, 'admin'::regrole, 'BOGUS', false)
@@ -182,6 +194,13 @@ SELECT acldefault('c'::"char", 'root'::regrole)
 ----
 {}
 
+# Parameter defaults: owner gets sA (SET + ALTER SYSTEM).
+# Matches PostgreSQL behavior.
+query T
+SELECT acldefault('p'::"char", 'root'::regrole)
+----
+{root=sA/root}
+
 # Error on invalid type char.
 statement error unrecognized object type abbreviation: "Z"
 SELECT acldefault('Z'::"char", 'root'::regrole)
@@ -207,6 +226,25 @@ root     PUBLIC   TEMPORARY       false
 root     root     CONNECT         false
 root     root     CREATE          false
 root     root     TEMPORARY       false
+
+# Round-trip for PARAMETER type: aclexplode(acldefault('p', ...)) should return
+# SET and ALTER SYSTEM privileges. This verifies no silent data loss occurs
+# (previously aclexplode returned 0 rows because 's' and 'A' were missing from
+# ACLCharToPrivName).
+query TTTB colnames
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(acldefault('p'::"char", 'root'::regrole)) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+ORDER BY a.privilege_type
+----
+grantor  grantee  privilege_type  is_grantable
+root     root     ALTER SYSTEM    false
+root     root     SET             false
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1934,6 +1934,8 @@ oid     typname                typnamespace  typowner  typlen  typbyval  typtype
 1021    _float4                __OID__       NULL      -1      false     b
 1022    _float8                __OID__       NULL      -1      false     b
 1028    _oid                   __OID__       NULL      -1      false     b
+1033    aclitem                __OID__       NULL      -1      false     b
+1034    _aclitem               __OID__       NULL      -1      false     b
 1041    _inet                  __OID__       NULL      -1      false     b
 1042    bpchar                 __OID__       NULL      -1      false     b
 1043    varchar                __OID__       NULL      -1      false     b
@@ -2059,6 +2061,8 @@ oid     typname                typcategory  typispreferred  typisdefined  typdel
 1021    _float4                A            false           true          ,         0         700      0
 1022    _float8                A            false           true          ,         0         701      0
 1028    _oid                   A            false           true          ,         0         26       0
+1033    aclitem                S            false           true          ,         0         0        1034
+1034    _aclitem               A            false           true          ,         0         1033     0
 1041    _inet                  A            false           true          ,         0         869      0
 1042    bpchar                 S            false           true          ,         0         0        1014
 1043    varchar                S            false           true          ,         0         0        1015
@@ -2184,6 +2188,8 @@ oid     typname                typinput        typoutput        typreceive      
 1021    _float4                array_in        array_out        array_recv        array_send        0         0          0
 1022    _float8                array_in        array_out        array_recv        array_send        0         0          0
 1028    _oid                   array_in        array_out        array_recv        array_send        0         0          0
+1033    aclitem                aclitemin       aclitemout       aclitemrecv       aclitemsend       0         0          0
+1034    _aclitem               array_in        array_out        array_recv        array_send        0         0          0
 1041    _inet                  array_in        array_out        array_recv        array_send        0         0          0
 1042    bpchar                 bpcharin        bpcharout        bpcharrecv        bpcharsend        0         0          0
 1043    varchar                varcharin       varcharout       varcharrecv       varcharsend       0         0          0
@@ -2309,6 +2315,8 @@ oid     typname                typalign  typstorage  typnotnull  typbasetype  ty
 1021    _float4                NULL      NULL        false       0            -1
 1022    _float8                NULL      NULL        false       0            -1
 1028    _oid                   NULL      NULL        false       0            -1
+1033    aclitem                NULL      NULL        false       0            -1
+1034    _aclitem               NULL      NULL        false       0            -1
 1041    _inet                  NULL      NULL        false       0            -1
 1042    bpchar                 NULL      NULL        false       0            -1
 1043    varchar                NULL      NULL        false       0            -1
@@ -2434,6 +2442,8 @@ oid     typname                typndims  typcollation  typdefaultbin  typdefault
 1021    _float4                0         0             NULL           NULL        NULL
 1022    _float8                0         0             NULL           NULL        NULL
 1028    _oid                   0         0             NULL           NULL        NULL
+1033    aclitem                0         3403232968    NULL           NULL        NULL
+1034    _aclitem               0         3403232968    NULL           NULL        NULL
 1041    _inet                  0         0             NULL           NULL        NULL
 1042    bpchar                 0         3403232968    NULL           NULL        NULL
 1043    varchar                0         3403232968    NULL           NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -639,7 +639,7 @@ PREPARE new_table_in_search_path_2 AS
 query TT
 EXECUTE new_table_in_search_path_2
 ----
-_bit _bit
+_aclitem  _aclitem
 
 statement ok
 CREATE TABLE pg_type(typname STRING); INSERT INTO pg_type VALUES('test')
@@ -647,7 +647,7 @@ CREATE TABLE pg_type(typname STRING); INSERT INTO pg_type VALUES('test')
 query TT
 EXECUTE new_table_in_search_path_2
 ----
-test _bit
+test  _aclitem
 
 statement ok
 DROP TABLE pg_type

--- a/pkg/sql/oidext/oidext.go
+++ b/pkg/sql/oidext/oidext.go
@@ -40,6 +40,8 @@ const (
 // OIDs in this block are not extensions of postgres, but are not supported in
 // github.com/lib/pq/oid. See postgres/src/include/catalog/pg_type.dat for oids.
 const (
+	T_aclitem   = oid.Oid(1033)
+	T__aclitem  = oid.Oid(1034)
 	T_jsonpath  = oid.Oid(4072)
 	T__jsonpath = oid.Oid(4073)
 )
@@ -55,6 +57,8 @@ var ExtensionTypeName = map[oid.Oid]string{
 	T__box2d:     "_BOX2D",
 	T_pgvector:   "VECTOR",
 	T__pgvector:  "_VECTOR",
+	T_aclitem:    "ACLITEM",
+	T__aclitem:   "_ACLITEM",
 	T_jsonpath:   "JSONPATH",
 	T__jsonpath:  "_JSONPATH",
 	T_citext:     "CITEXT",

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1543,7 +1543,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 						c = "f"
 					}
 					privilegeObjectType := targetObjectToPrivilegeObject[objectType]
-					arr := tree.NewDArray(types.String)
+					arr := tree.NewDArray(types.AclItem)
 					for _, userPrivs := range privs.Users {
 						var user string
 						if userPrivs.UserProto.Decode().IsPublicRole() {
@@ -1570,7 +1570,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							return err
 						}
 						if err := arr.Append(
-							tree.NewDString(defaclItem)); err != nil {
+							tree.NewDACLItem(defaclItem)); err != nil {
 							return err
 						}
 					}
@@ -1613,7 +1613,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							if err != nil {
 								return err
 							}
-							if err := arr.Append(tree.NewDString(defaclItem)); err != nil {
+							if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
 								return err
 							}
 						} else if roleHasAllPrivileges {
@@ -1624,7 +1624,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							if err != nil {
 								return err
 							}
-							if err := arr.Append(tree.NewDString(defaclItem)); err != nil {
+							if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
 								return err
 							}
 						} else if len(privs.Users) == 0 && schemaID != descpb.InvalidID {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1569,8 +1569,11 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 						if err != nil {
 							return err
 						}
-						if err := arr.Append(
-							tree.NewDACLItem(defaclItem)); err != nil {
+						aclDatum, err := tree.NewDACLItem(defaclItem)
+						if err != nil {
+							return err
+						}
+						if err := arr.Append(aclDatum); err != nil {
 							return err
 						}
 					}
@@ -1613,7 +1616,11 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							if err != nil {
 								return err
 							}
-							if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
+							aclDatum, err := tree.NewDACLItem(defaclItem)
+							if err != nil {
+								return err
+							}
+							if err := arr.Append(aclDatum); err != nil {
 								return err
 							}
 						} else if roleHasAllPrivileges {
@@ -1624,7 +1631,11 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							if err != nil {
 								return err
 							}
-							if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
+							aclDatum, err := tree.NewDACLItem(defaclItem)
+							if err != nil {
+								return err
+							}
+							if err := arr.Append(aclDatum); err != nil {
 								return err
 							}
 						} else if len(privs.Users) == 0 && schemaID != descpb.InvalidID {

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -976,6 +976,11 @@ func DecodeDatum(
 			return nil, err
 		}
 		return da.NewDName(tree.DString(bs)), nil
+	case oidext.T_aclitem:
+		if err := validateStringBytes(b); err != nil {
+			return nil, err
+		}
+		return tree.NewDACLItem(bs), nil
 	case oidext.T_citext:
 		if err := validateStringBytes(b); err != nil {
 			return nil, err

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -980,7 +980,11 @@ func DecodeDatum(
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}
-		return tree.NewDACLItem(bs), nil
+		d, err := tree.NewDACLItem(bs)
+		if err != nil {
+			return nil, err
+		}
+		return d, nil
 	case oidext.T_citext:
 		if err := validateStringBytes(b); err != nil {
 			return nil, err

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/privilege",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -352,22 +352,11 @@ func GetValidPrivilegesForObject(objectType ObjectType) (List, error) {
 	}
 }
 
-// privToACL is a map of privilege -> ACL character
-var privToACL = map[Kind]string{
-	CREATE:   "C",
-	SELECT:   "r",
-	INSERT:   "a",
-	DELETE:   "d",
-	UPDATE:   "w",
-	USAGE:    "U",
-	CONNECT:  "c",
-	EXECUTE:  "X",
-	MAINTAIN: "m",
-	TRIGGER:  "t",
-}
-
 // ACLCharToPrivName maps PostgreSQL ACL abbreviation characters to privilege
-// names as used in aclexplode output.
+// names as used in aclexplode output. This is the single source of truth for
+// all ACL character ↔ privilege name mappings; the reverse map
+// PrivNameToACLChar and the Kind-based map privToACL are derived from it in
+// init().
 var ACLCharToPrivName = map[byte]string{
 	'r': "SELECT",
 	'a': "INSERT",
@@ -382,24 +371,30 @@ var ACLCharToPrivName = map[byte]string{
 	'T': "TEMPORARY",
 	'c': "CONNECT",
 	'm': "MAINTAIN",
+	's': "SET",
+	'A': "ALTER SYSTEM",
 }
 
 // PrivNameToACLChar maps privilege names (uppercase) to PostgreSQL ACL
-// abbreviation characters, for use in makeaclitem.
-var PrivNameToACLChar = map[string]byte{
-	"SELECT":     'r',
-	"INSERT":     'a',
-	"UPDATE":     'w',
-	"DELETE":     'd',
-	"TRUNCATE":   'D',
-	"REFERENCES": 'x',
-	"TRIGGER":    't',
-	"EXECUTE":    'X',
-	"USAGE":      'U',
-	"CREATE":     'C',
-	"TEMPORARY":  'T',
-	"CONNECT":    'c',
-	"MAINTAIN":   'm',
+// abbreviation characters. Derived from ACLCharToPrivName in init().
+var PrivNameToACLChar map[string]byte
+
+// privToACL maps a CockroachDB privilege Kind to its PostgreSQL ACL
+// abbreviation character string. Derived from ACLCharToPrivName in init().
+var privToACL map[Kind]string
+
+func init() {
+	PrivNameToACLChar = make(map[string]byte, len(ACLCharToPrivName))
+	for ch, name := range ACLCharToPrivName {
+		PrivNameToACLChar[name] = ch
+	}
+
+	privToACL = make(map[Kind]string)
+	for ch, name := range ACLCharToPrivName {
+		if kind, ok := ByDisplayName[KindDisplayName(name)]; ok {
+			privToACL[kind] = string(ch)
+		}
+	}
 }
 
 // ValidACLChars is the set of valid privilege characters in an aclitem string,

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
@@ -363,6 +364,204 @@ var privToACL = map[Kind]string{
 	EXECUTE:  "X",
 	MAINTAIN: "m",
 	TRIGGER:  "t",
+}
+
+// ACLCharToPrivName maps PostgreSQL ACL abbreviation characters to privilege
+// names as used in aclexplode output.
+var ACLCharToPrivName = map[byte]string{
+	'r': "SELECT",
+	'a': "INSERT",
+	'w': "UPDATE",
+	'd': "DELETE",
+	'D': "TRUNCATE",
+	'x': "REFERENCES",
+	't': "TRIGGER",
+	'X': "EXECUTE",
+	'U': "USAGE",
+	'C': "CREATE",
+	'T': "TEMPORARY",
+	'c': "CONNECT",
+	'm': "MAINTAIN",
+}
+
+// PrivNameToACLChar maps privilege names (uppercase) to PostgreSQL ACL
+// abbreviation characters, for use in makeaclitem.
+var PrivNameToACLChar = map[string]byte{
+	"SELECT":     'r',
+	"INSERT":     'a',
+	"UPDATE":     'w',
+	"DELETE":     'd',
+	"TRUNCATE":   'D',
+	"REFERENCES": 'x',
+	"TRIGGER":    't',
+	"EXECUTE":    'X',
+	"USAGE":      'U',
+	"CREATE":     'C',
+	"TEMPORARY":  'T',
+	"CONNECT":    'c',
+	"MAINTAIN":   'm',
+}
+
+// ValidACLChars is the set of valid privilege characters in an aclitem string,
+// matching PostgreSQL's ACL abbreviation characters. 'R' is accepted for
+// backward compatibility (old RULE privilege) but is otherwise ignored.
+const ValidACLChars = "arwdDxtXUCTcsAm"
+
+// ValidateACLItemString validates that s has the PostgreSQL aclitem format:
+//
+//	grantee=privchars/grantor
+//
+// where grantee and grantor are role names (possibly double-quoted, or empty),
+// and privchars is a sequence of privilege characters from ValidACLChars, each
+// optionally followed by '*' indicating grant option. An empty grantee means
+// PUBLIC. CockroachDB does not track grantors, so the grantor portion is
+// typically empty but still must be present after the '/'.
+func ValidateACLItemString(s string) error {
+	i := 0
+	// Parse grantee identifier (may be empty for PUBLIC).
+	i = skipACLIdentifier(s, i)
+	if i < 0 {
+		return pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"unterminated quoted identifier: %q", s)
+	}
+	if i >= len(s) || s[i] != '=' {
+		return pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"missing \"=\" sign: %q", s)
+	}
+	i++ // skip '='
+	// Parse privilege characters and grant option markers.
+	for i < len(s) && s[i] != '/' {
+		c := s[i]
+		if c == '*' {
+			return pgerror.Newf(pgcode.InvalidTextRepresentation,
+				"invalid mode character: \"*\" must follow a privilege character: %q", s)
+		}
+		if !isValidACLChar(c) {
+			return pgerror.Newf(pgcode.InvalidTextRepresentation,
+				"invalid mode character: %q", string(c))
+		}
+		i++
+		// Skip optional '*' grant option marker.
+		if i < len(s) && s[i] == '*' {
+			i++
+		}
+	}
+	if i < len(s) && s[i] == '/' {
+		i++ // skip '/'
+		// Parse grantor identifier (may be empty in CockroachDB).
+		i = skipACLIdentifier(s, i)
+		if i < 0 {
+			return pgerror.Newf(pgcode.InvalidTextRepresentation,
+				"unterminated quoted identifier: %q", s)
+		}
+	}
+	// If '/' is missing entirely, treat as empty grantor (PG issues a warning
+	// and defaults the grantor; CRDB doesn't track grantors so we just accept).
+	if i != len(s) {
+		return pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"extra characters after aclitem specification: %q", s)
+	}
+	return nil
+}
+
+// skipACLIdentifier advances past an optionally double-quoted identifier
+// starting at position i in s. Returns the new position, or -1 if a
+// quoted identifier is missing its closing double quote.
+func skipACLIdentifier(s string, i int) int {
+	if i >= len(s) {
+		return i
+	}
+	if s[i] == '"' {
+		// Quoted identifier: consume until closing unescaped quote.
+		i++ // skip opening quote
+		for i < len(s) {
+			if s[i] == '"' {
+				i++
+				// Escaped double quote ("") continues the identifier.
+				if i < len(s) && s[i] == '"' {
+					i++
+					continue
+				}
+				return i
+			}
+			i++
+		}
+		// Unterminated quote.
+		return -1
+	}
+	// Unquoted identifier: alphanumeric, underscore, or high-bit chars.
+	for i < len(s) && isACLIdentChar(s[i]) {
+		i++
+	}
+	return i
+}
+
+// isACLIdentChar returns true for characters allowed in an unquoted ACL
+// identifier, matching PostgreSQL's is_safe_acl_char for getid context.
+func isACLIdentChar(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') || c == '_' || c >= 128
+}
+
+// QuoteACLIdentifier quotes a role name for use in an aclitem string,
+// matching PostgreSQL's putid() behavior. The name is double-quoted if it
+// contains any character that is not alphanumeric, underscore, or a high-bit
+// byte. Internal double quotes are escaped by doubling them. An empty name
+// is returned as-is (it represents PUBLIC in aclitem format).
+func QuoteACLIdentifier(name string) string {
+	if len(name) == 0 {
+		return name
+	}
+	needsQuoting := false
+	for i := 0; i < len(name); i++ {
+		if !isACLIdentChar(name[i]) {
+			needsQuoting = true
+			break
+		}
+	}
+	if !needsQuoting {
+		return name
+	}
+	return lexbase.EscapeSQLIdent(name)
+}
+
+// ExtractACLIdentifier extracts and unquotes a (possibly double-quoted)
+// identifier from s starting at position i, matching PostgreSQL's getid()
+// behavior. Returns the unquoted name and the position after the identifier.
+// If a quoted identifier has no closing quote, returns ("", -1).
+func ExtractACLIdentifier(s string, i int) (string, int) {
+	if i >= len(s) {
+		return "", i
+	}
+	if s[i] == '"' {
+		i++ // skip opening quote
+		var buf strings.Builder
+		for i < len(s) {
+			if s[i] == '"' {
+				i++
+				// Doubled double quote is an escape; single one ends the identifier.
+				if i < len(s) && s[i] == '"' {
+					buf.WriteByte('"')
+					i++
+					continue
+				}
+				return buf.String(), i
+			}
+			buf.WriteByte(s[i])
+			i++
+		}
+		return "", -1
+	}
+	start := i
+	for i < len(s) && isACLIdentChar(s[i]) {
+		i++
+	}
+	return s[start:i], i
+}
+
+// isValidACLChar returns true if c is a recognized privilege character.
+func isValidACLChar(c byte) bool {
+	return strings.IndexByte(ValidACLChars, c) >= 0
 }
 
 // orderedPrivs is the list of privileges sorted in alphanumeric order based on the ACL character -> CUacdmrtwX

--- a/pkg/sql/privilege/privilege_test.go
+++ b/pkg/sql/privilege/privilege_test.go
@@ -7,6 +7,7 @@ package privilege_test
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -67,6 +68,132 @@ func TestPrivilegeListFormat(t *testing.T) {
 
 		require.Equal(t, tc.sortedDisplayNames, tc.privileges.SortedDisplayNames())
 		require.Equal(t, tc.sortedKeys, tc.privileges.SortedKeys())
+	}
+}
+
+func TestValidateACLItemString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		input string
+		err   string
+	}{
+		// Valid cases.
+		{input: "user1=r/"},
+		{input: "user1=r/grantor"},
+		{input: "=rw/root"},
+		{input: "user1=arwdDxtXUCTcsAm/"},
+		{input: "user1=r*w/"},
+		{input: "user1=/"},
+		{input: "user1=r"},
+		{input: `"user with spaces"=r/`},
+		{input: `"user-1"=rw/`},
+		{input: `"user""quote"=r/`},
+		{input: `user1=r/"grantor-1"`},
+
+		// Invalid cases.
+		{input: "user1=z/", err: `invalid mode character: "z"`},
+		{input: "user1rw/", err: `missing "=" sign`},
+		{input: "user1=*r/", err: `"*" must follow a privilege character`},
+		{input: "user1=r/grantor extra", err: "extra characters after aclitem specification"},
+		{input: `"unterminated=r/`, err: "unterminated quoted identifier"},
+		{input: `user1=r/"unterminated`, err: "unterminated quoted identifier"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			err := privilege.ValidateACLItemString(tc.input)
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.err)
+			}
+		})
+	}
+}
+
+func TestQuoteACLIdentifier(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{input: "root", expected: "root"},
+		{input: "user1", expected: "user1"},
+		{input: "User1", expected: "User1"},
+		{input: "user_name", expected: "user_name"},
+		// Names with special characters get quoted.
+		{input: "user-1", expected: `"user-1"`},
+		{input: "user name", expected: `"user name"`},
+		{input: "user=weird", expected: `"user=weird"`},
+		{input: "user/slash", expected: `"user/slash"`},
+		// Internal double quotes are doubled.
+		{input: `user"quote`, expected: `"user""quote"`},
+		// Empty name is returned as-is (represents PUBLIC).
+		{input: "", expected: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.input), func(t *testing.T) {
+			result := privilege.QuoteACLIdentifier(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractACLIdentifier(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		input    string
+		pos      int
+		wantName string
+		wantPos  int
+	}{
+		// Unquoted identifiers.
+		{input: "root=r/", pos: 0, wantName: "root", wantPos: 4},
+		{input: "user_1=r/", pos: 0, wantName: "user_1", wantPos: 6},
+		{input: "=r/root", pos: 3, wantName: "root", wantPos: 7},
+		// Empty identifier (e.g. PUBLIC grantee).
+		{input: "=r/root", pos: 0, wantName: "", wantPos: 0},
+		// Quoted identifiers.
+		{input: `"user-1"=r/`, pos: 0, wantName: "user-1", wantPos: 8},
+		{input: `"user name"=r/`, pos: 0, wantName: "user name", wantPos: 11},
+		// Doubled double quote inside a quoted identifier.
+		{input: `"user""quote"=r/`, pos: 0, wantName: `user"quote`, wantPos: 13},
+		// Unterminated quote returns -1.
+		{input: `"unterminated`, pos: 0, wantName: "", wantPos: -1},
+		// Past end of string.
+		{input: "abc", pos: 3, wantName: "", wantPos: 3},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s@%d", tc.input, tc.pos), func(t *testing.T) {
+			name, pos := privilege.ExtractACLIdentifier(tc.input, tc.pos)
+			require.Equal(t, tc.wantName, name)
+			require.Equal(t, tc.wantPos, pos)
+		})
+	}
+}
+
+// TestQuoteACLIdentifierRoundTrip verifies that quoting a name and then
+// extracting it produces the original name.
+func TestQuoteACLIdentifierRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	names := []string{
+		"root", "user1", "user-1", "user name", `user"quote`,
+		"user=weird", "user/slash",
+	}
+	for _, name := range names {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			quoted := privilege.QuoteACLIdentifier(name)
+			extracted, pos := privilege.ExtractACLIdentifier(quoted, 0)
+			require.Equal(t, name, extracted)
+			require.Equal(t, len(quoted), pos)
+		})
 	}
 }
 

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -290,7 +290,12 @@ func RandDatumWithNullChance(
 			for i := range privs {
 				privs[i] = validPrivChars[rng.Intn(len(validPrivChars))]
 			}
-			return tree.NewDString(string(grantee) + "=" + string(privs) + "/")
+			s := string(grantee) + "=" + string(privs) + "/"
+			d, err := tree.NewDACLItem(s)
+			if err != nil {
+				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generated invalid aclitem %q", s))
+			}
+			return d
 		}
 		return tree.NewDString(string(p))
 	case types.BytesFamily:
@@ -470,7 +475,11 @@ func adjustDatum(datum tree.Datum, typ *types.T) tree.Datum {
 			// Return a fixed valid aclitem rather than trying to adapt
 			// the generic string datum, since special characters like
 			// quotes break the aclitem parser.
-			datum = tree.NewDString("=r/")
+			d, err := tree.NewDACLItem("=r/")
+			if err != nil {
+				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generated invalid aclitem"))
+			}
+			datum = d
 		}
 		return datum
 

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -274,6 +274,24 @@ func RandDatumWithNullChance(
 		if typ.Oid() == oid.T_bpchar {
 			return tree.NewDString(strings.TrimRight(string(p), " "))
 		}
+		if typ.Oid() == oidext.T_aclitem {
+			// Generate a valid aclitem string: grantee=privchars/grantor.
+			// Use only alphanumeric chars for the grantee to avoid special
+			// characters (=, /, ") that break the aclitem format.
+			const alphanums = "abcdefghijklmnopqrstuvwxyz0123456789"
+			granteeLen := 1 + rng.Intn(6)
+			grantee := make([]byte, granteeLen)
+			for i := range grantee {
+				grantee[i] = alphanums[rng.Intn(len(alphanums))]
+			}
+			const validPrivChars = "arwdDxtXUCTcsAm"
+			numPrivs := 1 + rng.Intn(4)
+			privs := make([]byte, numPrivs)
+			for i := range privs {
+				privs[i] = validPrivChars[rng.Intn(len(validPrivChars))]
+			}
+			return tree.NewDString(string(grantee) + "=" + string(privs) + "/")
+		}
 		return tree.NewDString(string(p))
 	case types.BytesFamily:
 		p := make([]byte, rng.Intn(10))
@@ -448,6 +466,11 @@ func adjustDatum(datum tree.Datum, typ *types.T) tree.Datum {
 	case types.StringFamily:
 		if typ.Oid() == oid.T_name {
 			datum = tree.NewDName(string(*datum.(*tree.DString)))
+		} else if typ.Oid() == oidext.T_aclitem {
+			// Return a fixed valid aclitem rather than trying to adapt
+			// the generic string datum, since special characters like
+			// quotes break the aclitem parser.
+			datum = tree.NewDString("=r/")
 		}
 		return datum
 

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -187,6 +187,10 @@ func IsLegalColumnType(typ *types.T) bool {
 		// unlikely to use these types of columns, so disabling their generation
 		// is low risk.
 		return false
+	case oidext.T_aclitem, oidext.T__aclitem:
+		// aclitem has strict format requirements (grantee=privchars/grantor) that
+		// make random generation unreliable for workloads like schemachange.
+		return false
 	}
 	ctx := context.Background()
 	st := clustersettings.MakeTestingClusterSettings()

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -116,8 +116,11 @@ func Decode(
 		} else {
 			rkey, r, err = encoding.DecodeUnsafeStringDescending(key, nil)
 		}
-		if valType.Oid() == oid.T_name {
+		switch valType.Oid() {
+		case oid.T_name:
 			return a.NewDName(tree.DString(r)), rkey, err
+		case oidext.T_aclitem:
+			return a.NewDACLItem(tree.DString(r)), rkey, err
 		}
 		return a.NewDString(tree.DString(r)), rkey, err
 	case types.CollatedStringFamily:

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -120,7 +120,11 @@ func Decode(
 		case oid.T_name:
 			return a.NewDName(tree.DString(r)), rkey, err
 		case oidext.T_aclitem:
-			return a.NewDACLItem(tree.DString(r)), rkey, err
+			d, aclErr := a.NewDACLItem(tree.DString(r))
+			if aclErr != nil {
+				return nil, rkey, aclErr
+			}
+			return d, rkey, err
 		}
 		return a.NewDString(tree.DString(r)), rkey, err
 	case types.CollatedStringFamily:

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -69,7 +69,11 @@ func DecodeUntaggedDatum(
 		case oid.T_name:
 			return a.NewDName(tree.DString(data)), b, nil
 		case oidext.T_aclitem:
-			return a.NewDACLItem(tree.DString(data)), b, nil
+			d, err := a.NewDACLItem(tree.DString(data))
+			if err != nil {
+				return nil, b, err
+			}
+			return d, b, nil
 		}
 		return a.NewDString(tree.DString(data)), b, nil
 	case types.CollatedStringFamily:

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -65,8 +65,11 @@ func DecodeUntaggedDatum(
 		if err != nil {
 			return nil, b, err
 		}
-		if t.Oid() == oid.T_name {
+		switch t.Oid() {
+		case oid.T_name:
 			return a.NewDName(tree.DString(data)), b, nil
+		case oidext.T_aclitem:
+			return a.NewDACLItem(tree.DString(data)), b, nil
 		}
 		return a.NewDString(tree.DString(data)), b, nil
 	case types.CollatedStringFamily:

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -292,7 +292,7 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 			return a.NewDName(tree.DString(v)), nil
 		}
 		if typ.Oid() == oidext.T_aclitem {
-			return a.NewDACLItem(tree.DString(v)), nil
+			return a.NewDACLItem(tree.DString(v))
 		}
 		return a.NewDString(tree.DString(v)), nil
 	case types.BytesFamily:

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -291,6 +291,9 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		if typ.Oid() == oid.T_name {
 			return a.NewDName(tree.DString(v)), nil
 		}
+		if typ.Oid() == oidext.T_aclitem {
+			return a.NewDACLItem(tree.DString(v)), nil
+		}
 		return a.NewDString(tree.DString(v)), nil
 	case types.BytesFamily:
 		v, err := value.GetBytes()

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2889,6 +2889,15 @@ var builtinOidsArray = []string{
 	2934: `information_schema.crdb_set_session_variable_hint(statement_fingerprint: string, variable_name: string, variable_value: string, database: string) -> int`,
 	2935: `pg_get_triggerdef(trigger_oid: oid) -> string`,
 	2936: `pg_get_triggerdef(trigger_oid: oid, pretty_bool: bool) -> string`,
+	2937: `makeaclitem(grantee: oid, grantor: oid, privileges: string, is_grantable: bool) -> aclitem`,
+	2938: `acldefault(type: "char", ownerId: oid) -> aclitem[]`,
+	2939: `aclexplode(aclitems: aclitem[]) -> tuple{oid AS grantor, oid AS grantee, string AS privilege_type, bool AS is_grantable}`,
+	2940: `aclitemrecv(input: anyelement) -> aclitem`,
+	2941: `aclitemsend(aclitem: aclitem) -> bytes`,
+	2942: `aclitemin(input: anyelement) -> aclitem`,
+	2943: `aclitemout(aclitem: aclitem) -> bytes`,
+	2944: `aclitem(string: string) -> aclitem`,
+	2945: `aclitem(citext: citext) -> aclitem`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/lib/pq/oid"
 )
 
 // See the comments at the start of generators.go for details about
@@ -113,14 +114,153 @@ var aclexplodeGeneratorType = types.MakeLabeledTuple(
 	[]string{"grantor", "grantee", "privilege_type", "is_grantable"},
 )
 
-// aclExplodeGenerator supports the execution of aclexplode.
-type aclexplodeGenerator struct{}
+// aclexplodeGenerator supports the execution of aclexplode.
+type aclexplodeGenerator struct {
+	// items holds the parsed ACL item rows to emit.
+	items []aclexplodeRow
+	// nextIdx is the index of the next row to emit.
+	nextIdx int
+}
 
-func (aclexplodeGenerator) ResolvedType() *types.T                   { return aclexplodeGeneratorType }
-func (aclexplodeGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
-func (aclexplodeGenerator) Close(_ context.Context)                  {}
-func (aclexplodeGenerator) Next(_ context.Context) (bool, error)     { return false, nil }
-func (aclexplodeGenerator) Values() (tree.Datums, error)             { return nil, nil }
+type aclexplodeRow struct {
+	grantor       tree.Datum
+	grantee       tree.Datum
+	privilegeType tree.Datum
+	isGrantable   tree.Datum
+}
+
+// resolveRoleOid resolves a role name to its OID by querying
+// pg_catalog.pg_roles. Returns 0 for empty string (PUBLIC).
+func resolveRoleOid(ctx context.Context, evalCtx *eval.Context, roleName string) (oid.Oid, error) {
+	if roleName == "" {
+		return 0, nil
+	}
+	r, err := evalCtx.Planner.QueryRowEx(
+		ctx, "aclexplode-resolve-role",
+		sessiondata.NoSessionDataOverride,
+		"SELECT oid FROM pg_catalog.pg_roles WHERE rolname = $1 LIMIT 1",
+		tree.NewDString(roleName),
+	)
+	if err != nil {
+		return 0, err
+	}
+	if r == nil {
+		// Role not found — return 0 rather than erroring, matching
+		// graceful behavior for stale ACL strings.
+		return 0, nil
+	}
+	return tree.MustBeDOid(r[0]).Oid, nil
+}
+
+func newAclexplodeGenerator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	aclArr := tree.MustBeDArray(args[0])
+	var items []aclexplodeRow
+	// Cache role name → OID lookups to avoid repeated queries for the
+	// same role across multiple aclitem entries.
+	roleOidCache := make(map[string]oid.Oid)
+	cachedResolveRoleOid := func(roleName string) (oid.Oid, error) {
+		if roleName == "" {
+			return 0, nil
+		}
+		if cached, ok := roleOidCache[roleName]; ok {
+			return cached, nil
+		}
+		resolved, err := resolveRoleOid(ctx, evalCtx, roleName)
+		if err != nil {
+			return 0, err
+		}
+		roleOidCache[roleName] = resolved
+		return resolved, nil
+	}
+
+	for _, aclDatum := range aclArr.Array {
+		// Each aclitem is a string in the format "grantee=privchars/grantor".
+		// An empty grantee means PUBLIC (OID 0).
+		var aclStr string
+		switch d := tree.UnwrapDOidWrapper(aclDatum).(type) {
+		case *tree.DString:
+			aclStr = string(*d)
+		default:
+			continue
+		}
+
+		// Parse grantee (possibly quoted), then expect '='.
+		granteeStr, i := privilege.ExtractACLIdentifier(aclStr, 0)
+		if i < 0 || i >= len(aclStr) || aclStr[i] != '=' {
+			continue
+		}
+		i++ // skip '='
+
+		// Parse privchars until '/' or end of string.
+		privStart := i
+		for i < len(aclStr) && aclStr[i] != '/' {
+			i++
+		}
+		privChars := aclStr[privStart:i]
+
+		// Parse grantor (possibly quoted) after '/'.
+		var grantorStr string
+		if i < len(aclStr) && aclStr[i] == '/' {
+			i++ // skip '/'
+			grantorStr, i = privilege.ExtractACLIdentifier(aclStr, i)
+			if i < 0 {
+				continue
+			}
+		}
+
+		// Resolve role names to OIDs.
+		granteeOid, err := cachedResolveRoleOid(granteeStr)
+		if err != nil {
+			return nil, err
+		}
+		grantorOid, err := cachedResolveRoleOid(grantorStr)
+		if err != nil {
+			return nil, err
+		}
+
+		// Iterate over privilege characters. A '*' after a character means
+		// the privilege is grantable.
+		for j := 0; j < len(privChars); j++ {
+			ch := privChars[j]
+			if ch == '*' {
+				continue
+			}
+			privName, ok := privilege.ACLCharToPrivName[ch]
+			if !ok {
+				continue
+			}
+			grantable := j+1 < len(privChars) && privChars[j+1] == '*'
+			items = append(items, aclexplodeRow{
+				grantor:       tree.NewDOid(grantorOid),
+				grantee:       tree.NewDOid(granteeOid),
+				privilegeType: tree.NewDString(privName),
+				isGrantable:   tree.MakeDBool(tree.DBool(grantable)),
+			})
+		}
+	}
+	return &aclexplodeGenerator{items: items}, nil
+}
+
+func (g *aclexplodeGenerator) ResolvedType() *types.T { return aclexplodeGeneratorType }
+
+func (g *aclexplodeGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
+
+func (g *aclexplodeGenerator) Close(_ context.Context) {}
+
+func (g *aclexplodeGenerator) Next(_ context.Context) (bool, error) {
+	if g.nextIdx >= len(g.items) {
+		return false, nil
+	}
+	g.nextIdx++
+	return true, nil
+}
+
+func (g *aclexplodeGenerator) Values() (tree.Datums, error) {
+	row := g.items[g.nextIdx-1]
+	return tree.Datums{row.grantor, row.grantee, row.privilegeType, row.isGrantable}, nil
+}
 
 // generators is a map from name to slice of Builtins for all built-in
 // generators.
@@ -131,13 +271,17 @@ var generators = map[string]builtinDefinition{
 	// See https://www.postgresql.org/docs/9.6/static/functions-info.html.
 	"aclexplode": makeBuiltin(genProps(),
 		makeGeneratorOverload(
+			tree.ParamTypes{{Name: "aclitems", Typ: types.MakeArray(types.AclItem)}},
+			aclexplodeGeneratorType,
+			newAclexplodeGenerator,
+			"Produces a virtual table containing aclitem privileges.",
+			volatility.Stable,
+		),
+		makeGeneratorOverload(
 			tree.ParamTypes{{Name: "aclitems", Typ: types.StringArray}},
 			aclexplodeGeneratorType,
-			func(_ context.Context, _ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
-				return aclexplodeGenerator{}, nil
-			},
-			"Produces a virtual table containing aclitem stuff ("+
-				"returns no rows as this feature is unsupported in CockroachDB)",
+			newAclexplodeGenerator,
+			"Produces a virtual table containing aclitem privileges.",
 			volatility.Stable,
 		),
 	),

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2548,7 +2548,7 @@ SELECT
 				result.WriteByte('/')
 				result.WriteString(privilege.QuoteACLIdentifier(grantorName))
 
-				return tree.NewDACLItem(result.String()), nil
+				return tree.NewDACLItem(result.String())
 			},
 			Info: "Constructs an aclitem from the given grantee, grantor, privileges, and grant option.",
 			// Marked immutable to match postgres. Our implementation resolves
@@ -2617,14 +2617,22 @@ SELECT
 				// If PUBLIC has privileges, add that first.
 				if def.publicPrivs != "" {
 					item := "=" + def.publicPrivs + "/" + quotedOwner
-					if err := arr.Append(tree.NewDACLItem(item)); err != nil {
+					d, err := tree.NewDACLItem(item)
+					if err != nil {
+						return nil, err
+					}
+					if err := arr.Append(d); err != nil {
 						return nil, err
 					}
 				}
 				// If owner has privileges, add that next.
 				if def.ownerPrivs != "" {
 					item := quotedOwner + "=" + def.ownerPrivs + "/" + quotedOwner
-					if err := arr.Append(tree.NewDACLItem(item)); err != nil {
+					d, err := tree.NewDACLItem(item)
+					if err != nil {
+						return nil, err
+					}
+					if err := arr.Append(d); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2475,6 +2475,168 @@ SELECT
 			Language:          tree.RoutineLangSQL,
 		},
 	),
+
+	"makeaclitem": makeBuiltin(
+		tree.FunctionProperties{DistsqlBlocklist: true},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "grantee", Typ: types.Oid},
+				{Name: "grantor", Typ: types.Oid},
+				{Name: "privileges", Typ: types.String},
+				{Name: "is_grantable", Typ: types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.AclItem),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				granteeOid := tree.MustBeDOid(args[0]).Oid
+				grantorOid := tree.MustBeDOid(args[1]).Oid
+				privileges := string(tree.MustBeDString(args[2]))
+				isGrantable := bool(tree.MustBeDBool(args[3]))
+
+				// Parse privilege names and convert to ACL characters.
+				var privChars strings.Builder
+				privNames := strings.Split(privileges, ",")
+				for _, name := range privNames {
+					name = strings.TrimSpace(name)
+					if name == "" {
+						continue
+					}
+					ch, ok := privilege.PrivNameToACLChar[strings.ToUpper(name)]
+					if !ok {
+						return nil, pgerror.Newf(pgcode.InvalidParameterValue,
+							"unrecognized privilege type: %q", name)
+					}
+					privChars.WriteByte(ch)
+					if isGrantable {
+						privChars.WriteByte('*')
+					}
+				}
+
+				// Resolve OIDs to role names. OID 0 = PUBLIC (empty grantee).
+				// Like postgres, fall back to the numeric OID if the role
+				// doesn't exist.
+				granteeName := ""
+				if granteeOid != 0 {
+					name, err := getNameForArg(
+						ctx, evalCtx, tree.NewDOid(granteeOid), "pg_roles", "rolname",
+					)
+					if err != nil {
+						return nil, err
+					}
+					if name == "" {
+						granteeName = fmt.Sprintf("%d", granteeOid)
+					} else {
+						granteeName = name
+					}
+				}
+				grantorName, err := getNameForArg(
+					ctx, evalCtx, tree.NewDOid(grantorOid), "pg_roles", "rolname",
+				)
+				if err != nil {
+					return nil, err
+				}
+				if grantorName == "" {
+					grantorName = fmt.Sprintf("%d", grantorOid)
+				}
+
+				// Build the aclitem string: "grantee=privchars/grantor".
+				// Role names that contain special characters (e.g. hyphens,
+				// spaces) must be double-quoted, matching PostgreSQL's putid().
+				var result strings.Builder
+				result.WriteString(privilege.QuoteACLIdentifier(granteeName))
+				result.WriteByte('=')
+				result.WriteString(privChars.String())
+				result.WriteByte('/')
+				result.WriteString(privilege.QuoteACLIdentifier(grantorName))
+
+				return tree.NewDACLItem(result.String()), nil
+			},
+			Info: "Constructs an aclitem from the given grantee, grantor, privileges, and grant option.",
+			// Marked immutable to match postgres. Our implementation resolves
+			// OIDs to role names (a catalog lookup), but the risk of stale
+			// results from constant-folding is low: these functions are
+			// almost always called with column references, and CRDB does
+			// not support role renames.
+			Volatility: volatility.Immutable,
+		},
+	),
+
+	"acldefault": makeBuiltin(
+		tree.FunctionProperties{DistsqlBlocklist: true},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "type", Typ: types.QChar},
+				{Name: "ownerId", Typ: types.Oid},
+			},
+			ReturnType: tree.FixedReturnType(types.MakeArray(types.AclItem)),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				typeChar := string(tree.MustBeDString(tree.UnwrapDOidWrapper(args[0])))
+				ownerOid := tree.MustBeDOid(args[1]).Oid
+
+				// Resolve owner OID to role name. Like postgres, fall back to
+				// the numeric OID if the role doesn't exist.
+				ownerName, err := getNameForArg(
+					ctx, evalCtx, tree.NewDOid(ownerOid), "pg_roles", "rolname",
+				)
+				if err != nil {
+					return nil, err
+				}
+				if ownerName == "" {
+					ownerName = fmt.Sprintf("%d", ownerOid)
+				}
+
+				// PostgreSQL hard-wired default ACLs per object type.
+				// See src/backend/catalog/aclchk.c acldefault().
+				type aclDefault struct {
+					ownerPrivs  string
+					publicPrivs string
+				}
+				defaults := map[string]aclDefault{
+					"r": {ownerPrivs: "arwdDxtm"},               // TABLE
+					"s": {ownerPrivs: "rwU"},                    // SEQUENCE
+					"d": {ownerPrivs: "CTc", publicPrivs: "Tc"}, // DATABASE
+					"f": {ownerPrivs: "X", publicPrivs: "X"},    // FUNCTION
+					"l": {publicPrivs: "U"},                     // LANGUAGE
+					"n": {ownerPrivs: "UC"},                     // SCHEMA
+					"T": {ownerPrivs: "U", publicPrivs: "U"},    // TYPE
+					"c": {},                                     // COLUMN
+					"L": {ownerPrivs: "rw"},                     // LARGE OBJECT
+					"t": {ownerPrivs: "C"},                      // TABLESPACE
+					"F": {ownerPrivs: "U"},                      // FDW
+					"S": {ownerPrivs: "U"},                      // FOREIGN SERVER
+					"p": {ownerPrivs: "sA"},                     // PARAMETER
+				}
+
+				def, ok := defaults[typeChar]
+				if !ok {
+					return nil, pgerror.Newf(pgcode.InvalidParameterValue,
+						"unrecognized object type abbreviation: %q", typeChar)
+				}
+
+				arr := tree.NewDArray(types.AclItem)
+				quotedOwner := privilege.QuoteACLIdentifier(ownerName)
+				// If PUBLIC has privileges, add that first.
+				if def.publicPrivs != "" {
+					item := "=" + def.publicPrivs + "/" + quotedOwner
+					if err := arr.Append(tree.NewDACLItem(item)); err != nil {
+						return nil, err
+					}
+				}
+				// If owner has privileges, add that next.
+				if def.ownerPrivs != "" {
+					item := quotedOwner + "=" + def.ownerPrivs + "/" + quotedOwner
+					if err := arr.Append(tree.NewDACLItem(item)); err != nil {
+						return nil, err
+					}
+				}
+
+				return arr, nil
+			},
+			Info: "Returns the default access privileges for an object of the given type belonging to the given owner.",
+			// Marked immutable to match postgres. See the comment on
+			// makeaclitem for justification.
+			Volatility: volatility.Immutable,
+		},
+	),
 }
 
 func getSessionVar(

--- a/pkg/sql/sem/cast/cast_map.go
+++ b/pkg/sql/sem/cast/cast_map.go
@@ -38,6 +38,14 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_varchar:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 	},
+	oidext.T_aclitem: {
+		oid.T_bpchar:    {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_name:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_text:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_varchar:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+	},
 	oid.T_bool: {
 		oid.T_bpchar:    {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		oid.T_float4:    {MaxContext: ContextExplicit, origin: ContextOriginLegacyConversion, Volatility: volatility.Immutable},
@@ -80,12 +88,13 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 	},
 	oid.T_bpchar: {
-		oid.T_bpchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_name:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_text:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_varchar:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_bpchar:     {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_name:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_text:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_varchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from bpchar to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -175,16 +184,17 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_text:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		oid.T_varchar: {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from citext to other types.
-		oid.T_char:     {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_name:     {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_bool:     {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_inet:     {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_regrole:  {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
-		oid.T_pg_lsn:   {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_regclass: {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
-		oidext.T_box2d: {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_bit:      {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_bytea:    {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_name:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bool:       {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_inet:       {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_regrole:    {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
+		oid.T_pg_lsn:     {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_regclass:   {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
+		oidext.T_box2d:   {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bit:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bytea:      {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_date: {
 			MaxContext:     ContextExplicit,
 			origin:         ContextOriginAutomaticIOConversion,
@@ -252,8 +262,9 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_text:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		oid.T_varchar: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		// Automatic I/O conversions to string types.
-		oid.T_name:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_name:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from "char" to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -616,8 +627,9 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_text:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Leakproof},
 		oid.T_varchar: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		// Automatic I/O conversions to string types.
-		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from NAME to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -876,9 +888,10 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		//
 		// TODO(#72980): If we use the VARCHAR OID for STRING(n) types rather
 		// then the TEXT OID, and we can remove this entry.
-		oid.T_text:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_varchar:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_text:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_varchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from TEXT to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -1129,13 +1142,14 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 	},
 	oid.T_varchar: {
-		oid.T_bpchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_name:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_regclass:  {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Stable},
-		oid.T_text:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_varchar:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_bpchar:     {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_name:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_regclass:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Stable},
+		oid.T_text:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_varchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from VARCHAR to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -1282,9 +1296,19 @@ func init() {
 				}
 			}
 
+			// Some types like aclitem are exempt from the automatic I/O
+			// conversion context rules below. PostgreSQL treats these as
+			// user-defined types (typcategory='U') with no pg_cast entries,
+			// relying solely on I/O functions for conversion. We allow
+			// implicit casts for these types so that INSERT and assignment
+			// contexts work.
+			ioConversionExemptTypes := map[oid.Oid]bool{
+				oidext.T_aclitem: true,
+			}
+
 			// Automatic I/O conversions to string types are assignment casts.
 			if isStringType(tgt) && ent.origin == ContextOriginAutomaticIOConversion &&
-				ent.MaxContext != ContextAssignment {
+				ent.MaxContext != ContextAssignment && !ioConversionExemptTypes[src] {
 				panic(errors.AssertionFailedf(
 					"automatic conversion from %s to %s must be an assignment cast",
 					srcStr, tgtStr,
@@ -1293,7 +1317,7 @@ func init() {
 
 			// Automatic I/O conversions from string types are explicit casts.
 			if isStringType(src) && !isStringType(tgt) && ent.origin == ContextOriginAutomaticIOConversion &&
-				ent.MaxContext != ContextExplicit {
+				ent.MaxContext != ContextExplicit && !ioConversionExemptTypes[tgt] {
 				panic(errors.AssertionFailedf(
 					"automatic conversion from %s to %s must be an explicit cast",
 					srcStr, tgtStr,

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -514,6 +515,12 @@ func performCastWithoutPrecisionTruncation(
 		case types.StringFamily:
 			if t.Oid() == oid.T_name {
 				return tree.NewDName(s), nil
+			}
+			if t.Oid() == oidext.T_aclitem {
+				if err := privilege.ValidateACLItemString(s); err != nil {
+					return nil, err
+				}
+				return tree.NewDACLItem(s), nil
 			}
 
 			// bpchar types truncate trailing whitespace.

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -517,10 +516,7 @@ func performCastWithoutPrecisionTruncation(
 				return tree.NewDName(s), nil
 			}
 			if t.Oid() == oidext.T_aclitem {
-				if err := privilege.ValidateACLItemString(s); err != nil {
-					return nil, err
-				}
-				return tree.NewDACLItem(s), nil
+				return tree.NewDACLItem(s)
 			}
 
 			// bpchar types truncate trailing whitespace.

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -634,6 +635,8 @@ func (expr *StrVal) ResolveAsType(
 		fallthrough
 	case types.StringFamily:
 		switch typ.Oid() {
+		case oidext.T_aclitem:
+			return NewDACLItem(expr.s)
 		case oid.T_name:
 			expr.resString = DString(expr.s)
 			return NewDNameFromDString(&expr.resString), nil

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgrepl/lsn"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -5833,15 +5834,21 @@ func NewDName(d string) Datum {
 }
 
 // NewDACLItemFromDString is a helper routine to create a *DOidWrapper with
-// aclitem OID, initialized from an existing *DString.
-func NewDACLItemFromDString(d *DString) Datum {
-	return wrapWithOid(d, oidext.T_aclitem)
+// aclitem OID, initialized from an existing *DString. It validates the format
+// and returns an error if the string is not a valid aclitem.
+func NewDACLItemFromDString(d *DString) (Datum, error) {
+	if err := privilege.ValidateACLItemString(string(*d)); err != nil {
+		return nil, err
+	}
+	return wrapWithOid(d, oidext.T_aclitem), nil
 }
 
 // NewDACLItem is a helper routine to create a *DOidWrapper with aclitem OID,
 // initialized from a string in the format "grantee=privchars/grantor".
-func NewDACLItem(d string) Datum {
-	return NewDACLItemFromDString(NewDString(d))
+// It validates the format and returns an error if the string is not valid.
+func NewDACLItem(d string) (Datum, error) {
+	s := DString(d)
+	return NewDACLItemFromDString(&s)
 }
 
 // NewDCIText is a helper routine to create a *DCIText (implemented as a *DOidWrapper)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5655,6 +5655,7 @@ func (d *DOid) Name() string {
 // Types that currently benefit from DOidWrapper are:
 // - DName => DOidWrapper(*DString, oid.T_name)
 // - DRefCursor => DOidWrapper(*DString, oid.T_refcursor)
+// - DACLItem => DOidWrapper(*DString, oidext.T_aclitem)
 // - DCIText => DOidWrapper(*DCollatedString, oidext.T_citext)
 type DOidWrapper struct {
 	Wrapped Datum
@@ -5829,6 +5830,18 @@ func NewDNameFromDString(d *DString) Datum {
 // initialized from a string.
 func NewDName(d string) Datum {
 	return NewDNameFromDString(NewDString(d))
+}
+
+// NewDACLItemFromDString is a helper routine to create a *DOidWrapper with
+// aclitem OID, initialized from an existing *DString.
+func NewDACLItemFromDString(d *DString) Datum {
+	return wrapWithOid(d, oidext.T_aclitem)
+}
+
+// NewDACLItem is a helper routine to create a *DOidWrapper with aclitem OID,
+// initialized from a string in the format "grantee=privchars/grantor".
+func NewDACLItem(d string) Datum {
+	return NewDACLItemFromDString(NewDString(d))
 }
 
 // NewDCIText is a helper routine to create a *DCIText (implemented as a *DOidWrapper)

--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -270,7 +270,7 @@ func (a *DatumAlloc) NewDRefCursor(v DString) Datum {
 }
 
 // NewDACLItem allocates a DACLItem.
-func (a *DatumAlloc) NewDACLItem(v DString) Datum {
+func (a *DatumAlloc) NewDACLItem(v DString) (Datum, error) {
 	return NewDACLItemFromDString(a.NewDString(v))
 }
 

--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -269,6 +269,11 @@ func (a *DatumAlloc) NewDRefCursor(v DString) Datum {
 	return NewDRefCursorFromDString(a.NewDString(v))
 }
 
+// NewDACLItem allocates a DACLItem.
+func (a *DatumAlloc) NewDACLItem(v DString) Datum {
+	return NewDACLItemFromDString(a.NewDString(v))
+}
+
 // NewDBytes allocates a DBytes.
 func (a *DatumAlloc) NewDBytes(v DBytes) *DBytes {
 	if a == nil {

--- a/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
+++ b/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
@@ -1155,8 +1155,8 @@
       ],
       "columns": {
         "defaclacl": {
-          "oid": 1009,
-          "dataType": "_TEXT"
+          "oid": 1034,
+          "dataType": "_aclitem"
         },
         "defaclnamespace": {
           "oid": 26,

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -102,6 +102,7 @@ var OidToType = map[oid.Oid]*T{
 	oid.T_varchar:      VarChar,
 	oid.T_void:         Void,
 
+	oidext.T_aclitem:   AclItem,
 	oidext.T_geometry:  Geometry,
 	oidext.T_geography: Geography,
 	oidext.T_box2d:     Box2D,
@@ -153,6 +154,7 @@ var oidToArrayOid = map[oid.Oid]oid.Oid{
 	oid.T_varbit:       oid.T__varbit,
 	oid.T_varchar:      oid.T__varchar,
 
+	oidext.T_aclitem:   oidext.T__aclitem,
 	oidext.T_geometry:  oidext.T__geometry,
 	oidext.T_geography: oidext.T__geography,
 	oidext.T_box2d:     oidext.T__box2d,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -234,8 +234,12 @@ func (t *T) Canonical() *T {
 		return Interval
 	case StringFamily:
 		if t.Oid() == oid.T_name {
-			// Name uses StringFamily and DOidWrapper
+			// Name uses StringFamily and DOidWrapper.
 			return Name
+		}
+		if t.Oid() == oidext.T_aclitem {
+			// AclItem uses StringFamily and DOidWrapper.
+			return AclItem
 		}
 		return String
 	case BytesFamily:

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -455,6 +455,12 @@ var (
 	Name = &T{InternalType: InternalType{
 		Family: StringFamily, Oid: oid.T_name, Locale: &emptyLocale}}
 
+	// AclItem is a type-alias for String with a different OID (T_aclitem).
+	// It represents a PostgreSQL access control list item in the format
+	// "grantee=privchars/grantor".
+	AclItem = &T{InternalType: InternalType{
+		Family: StringFamily, Oid: oidext.T_aclitem, Locale: &emptyLocale}}
+
 	// Bytes is the type of a list of raw byte values.
 	Bytes = &T{InternalType: InternalType{
 		Family: BytesFamily, Oid: oid.T_bytea, Locale: &emptyLocale}}
@@ -1763,6 +1769,8 @@ func (t *T) Name() string {
 			return "name"
 		case oidext.T_citext:
 			return "citext"
+		case oidext.T_aclitem:
+			return "aclitem"
 		}
 		panic(errors.AssertionFailedf("unexpected OID: %d", t.Oid()))
 
@@ -1980,6 +1988,8 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 			return "name"
 		case oidext.T_citext:
 			return "citext"
+		case oidext.T_aclitem:
+			return "aclitem"
 		default:
 			panic(errors.AssertionFailedf("unexpected OID: %d", t.Oid()))
 		}
@@ -3020,6 +3030,8 @@ func (t *T) stringTypeSQL() string {
 		typName = `"char"`
 	case oid.T_name:
 		typName = "NAME"
+	case oidext.T_aclitem:
+		typName = "ACLITEM"
 	}
 
 	// In general, if there is a specified width we want to print it next to the

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -291,7 +291,7 @@ CREATE TABLE pg_catalog.pg_default_acl (
 	defaclrole OID,
 	defaclnamespace OID,
 	defaclobjtype "char",
-	defaclacl STRING[]
+	defaclacl ACLITEM[]
 )`
 
 // PGCatalogDepend describes the schema of the pg_catalog.pg_depend table.


### PR DESCRIPTION


Add a proper `aclitem` type (StringFamily with OID 1033, following the same pattern as `name`) and implement three PostgreSQL-compatible ACL functions:

- `makeaclitem(grantee oid, grantor oid, privileges text, is_grantable bool) → aclitem`: constructs an aclitem string from its components.
- `acldefault(type text, ownerId oid) → aclitem[]`: returns the hard-wired default ACL for a given object type, matching PostgreSQL's defaults for all 13 object type characters.
- `aclexplode(aclitems) → setof record`: previously a stub that always returned no rows. Now parses ACL strings and emits (grantor, grantee, privilege_type, is_grantable) rows. Supports both `text[]` and `aclitem[]` input.

These functions are needed for pg-compatibility with ORMs and tools that inspect PostgreSQL access control lists.

Resolves: #91070
informs: #20296 

Release note (sql change): Added support for the `aclitem` type and the `makeaclitem` and `acldefault` built-in functions for PostgreSQL compatibility. The existing `aclexplode` function, which previously always returned no rows, now correctly parses ACL strings and returns the individual privilege grants they contain.