### PR TITLE
coldata,colexec,parser: remove `no-remote-exec` from some build actions

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -63,14 +63,14 @@ genrule(
 GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 export PATH=$$GO_ABS_PATH:$$PATH
+export GOROOT=`dirname $$GO_ABS_PATH`
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
-export GOROOT=
+export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
 $(location //pkg/sql/colexec/execgen/cmd/execgen) \
     -fmt=false pkg/col/coldata/$@ > $@
 $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) -w $@
 """,
-    tags = ["no-remote-exec"],  # keep
     tools = [
         "//pkg/sql/colexec/execgen/cmd/execgen",
         "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",

--- a/pkg/sql/colexec/COLEXEC.bzl
+++ b/pkg/sql/colexec/COLEXEC.bzl
@@ -5,16 +5,15 @@ def gen_sort_partitioner_rule(name, target, visibility = ["//visibility:private"
         name = name,
         srcs = ["//pkg/sql/colexec/colexecbase:distinct_tmpl.go"],
         outs = [target],
-	tags = ["no-remote-exec"],
         cmd = """\
 GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
 export PATH=$$GO_ABS_PATH:$$PATH
+export GOROOT=`dirname $$GO_ABS_PATH`
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
 export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
-export GOROOT=
 $(location :execgen) -template $(SRCS) -fmt=false pkg/sql/colexec/$@ > $@
 $(location :goimports) -w $@
 """,
@@ -38,6 +37,7 @@ GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
 export PATH=$$GO_ABS_PATH:$$PATH
+export GOROOT=`dirname $$GO_ABS_PATH`
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
 export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true

--- a/pkg/sql/colexecop/EXECGEN.bzl
+++ b/pkg/sql/colexecop/EXECGEN.bzl
@@ -30,15 +30,14 @@ def gen_eg_go_rules(targets):
             name = name,
             srcs = [template],
             outs = [target],
-            tags = ["no-remote-exec"],
             cmd = """
 GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 export PATH=$$GO_ABS_PATH:$$PATH
+export GOROOT=`dirname $$GO_ABS_PATH`
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
 export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
-export GOROOT=
 $(location :execgen) -template $(SRCS) \
         -fmt=false pkg/sql/colexec/$@ > $@
 $(location :goimports) -w $@

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -100,19 +100,11 @@ genrule(
     ],
     outs = ["sql.go"],
     cmd = """
-GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
-GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-export PATH=$$GO_ABS_PATH:$$PATH
-export HOME=$(GENDIR)
-export GOPATH=/nonexist-gopath
-export GOROOT=
 $(location :sql-gen) $(location sql.y) sql $(location replace_help_rules.awk) \
     $(location sql.go) $(location @org_golang_x_tools//cmd/goyacc)
 """,
-    tags = ["no-remote-exec"],  # keep
     tools = [
         ":sql-gen",
-        "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/goyacc",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This improves cacheability, performance, etc. in CI.

Closes #104627

Release note: none
Epic: none