### PR TITLE
sql: add UDF execution count metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -2705,6 +2705,24 @@ layers:
       aggregation: AVG
       derivative: NONE
       owner: cockroachdb/sql-queries
+    - name: sql.udf.count
+      exported_name: sql_udf_count
+      description: Number of SQL statements that invoked a user-defined function
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      owner: cockroachdb/sql-queries
+    - name: sql.udf.count.internal
+      exported_name: sql_udf_count_internal
+      description: Number of SQL statements that invoked a user-defined function (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      owner: cockroachdb/sql-queries
     - name: sql.update.count
       exported_name: sql_update_count
       labeled_name: 'sql.count{query_type: update}'

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -1148,6 +1148,7 @@ owners:
   sql_txn_rollback_started_count: cockroachdb/sql-queries
   sql_txn_upgraded_iso_level_count: cockroachdb/sql-queries
   sql_txns_open: cockroachdb/sql-queries
+  sql_udf_count: cockroachdb/sql-queries
   sql_update_count: cockroachdb/sql-queries
   sql_update_started_count: cockroachdb/sql-queries
   sql_vecindex_pending_splits_merges: cockroachdb/specialized-indexing

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2830,6 +2830,8 @@ sql_txn_upgraded_iso_level_count: sql.txn.upgraded_iso_level.count
 sql_txn_upgraded_iso_level_count_internal: sql.txn.upgraded_iso_level.count.internal
 sql_txns_open: sql.txns.open
 sql_txns_open_internal: sql.txns.open.internal
+sql_udf_count: sql.udf.count
+sql_udf_count_internal: sql.udf.count.internal
 sql_update_count: sql.update.count
 sql_update_count_internal: sql.update.internal
 sql_update_started_count: sql.update.started.count

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -686,6 +686,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			StatementIndexBytesWritten:        metric.NewCounter(getMetricMeta(MetaStatementIndexBytesWritten, internal)),
 			QueryWithStatementHintsCount:      metric.NewCounter(getMetricMeta(MetaQueryWithStatementHints, internal)),
 			RLSPoliciesAppliedCount:           metric.NewCounter(getMetricMeta(MetaRLSPoliciesApplied, internal)),
+			UDFCallCount:                      metric.NewCounter(getMetricMeta(MetaUDFCall, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3540,6 +3540,10 @@ func (ex *connExecutor) makeExecPlan(
 		ex.metrics.EngineMetrics.RLSPoliciesAppliedCount.Inc(1)
 	}
 
+	if flags.IsSet(planFlagContainsUDF) {
+		ex.metrics.EngineMetrics.UDFCallCount.Inc(1)
+	}
+
 	// TODO(knz): Remove this accounting if/when savepoint rollbacks
 	// support rolling back over DDL.
 	if flags.IsSet(planFlagIsDDL) {

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -128,6 +128,9 @@ func constructPlan(
 	if flags.IsSet(exec.PlanFlagCanaryAndStableStatsDiffer) {
 		res.flags.Set(planFlagCanaryAndStableStatsDiffer)
 	}
+	if flags.IsSet(exec.PlanFlagContainsUDF) {
+		res.flags.Set(planFlagContainsUDF)
+	}
 
 	return res, nil
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -954,6 +954,13 @@ var (
 		Unit:        metric.Unit_COUNT,
 		Category:    metric.Metadata_SQL,
 	}
+	MetaUDFCall = metric.Metadata{
+		Name:        "sql.udf.count",
+		Help:        "Number of SQL statements that invoked a user-defined function",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_SQL,
+	}
 	MetaTxnAbort = metric.Metadata{
 		Name:        "sql.txn.abort.count",
 		Help:        "Number of SQL transaction abort errors",

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -106,6 +106,12 @@ type EngineMetrics struct {
 	// RLSPoliciesAppliedCount counts the number of SQL statements where
 	// row-level security policies were applied during query planning.
 	RLSPoliciesAppliedCount *metric.Counter
+
+	// UDFCallCount counts the number of SQL statements that invoked at least
+	// one user-defined function. A statement is counted once regardless of how
+	// many UDFs it invokes or how many times each is evaluated, and regardless
+	// of whether the statement ultimately succeeds or fails during execution.
+	UDFCallCount *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -609,3 +609,89 @@ func TestMemMetricsCorrectlyRegistered(t *testing.T) {
 	})
 	require.ElementsMatch(t, expectedMetrics, registered)
 }
+
+func TestUDFCallMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.ApplicationLayer()
+
+	// Create UDFs and a table for testing.
+	for _, stmt := range []string{
+		"CREATE FUNCTION f_add(a INT, b INT) RETURNS INT LANGUAGE SQL AS 'SELECT a + b'",
+		"CREATE FUNCTION f_volatile(a INT) RETURNS INT VOLATILE LANGUAGE SQL AS 'SELECT a + 1'",
+		"CREATE PROCEDURE p_noop() LANGUAGE SQL AS 'SELECT 1'",
+		"CREATE TABLE t_udf (x INT, y INT)",
+		"INSERT INTO t_udf VALUES (1, 2), (3, 4)",
+	} {
+		if _, err := sqlDB.Exec(stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		query    string
+		udfDelta int64
+	}{
+		{
+			name:     "no UDF",
+			query:    "SELECT 1",
+			udfDelta: 0,
+		},
+		{
+			name:     "single UDF call",
+			query:    "SELECT f_add(1, 2)",
+			udfDelta: 1,
+		},
+		{
+			name:     "UDF over multiple rows counts once per statement",
+			query:    "SELECT f_add(x, y) FROM t_udf",
+			udfDelta: 1,
+		},
+		{
+			name:     "multiple UDF calls in one statement counts once",
+			query:    "SELECT f_add(1, 2), f_add(3, 4)",
+			udfDelta: 1,
+		},
+		{
+			name:     "volatile UDF that cannot be inlined",
+			query:    "SELECT f_volatile(1)",
+			udfDelta: 1,
+		},
+		{
+			name:     "stored procedure does not increment UDF counter",
+			query:    "CALL p_noop()",
+			udfDelta: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := s.MustGetSQLCounter(sql.MetaUDFCall.Name)
+			if _, err := sqlDB.Exec(tc.query); err != nil {
+				t.Fatal(err)
+			}
+			after := s.MustGetSQLCounter(sql.MetaUDFCall.Name)
+			require.Equal(t, tc.udfDelta, after-before, "UDF count delta")
+		})
+	}
+
+	// The counter is incremented at planning time and does not distinguish
+	// between executions that succeed and executions that fail. Use a volatile
+	// UDF with division by zero so the error occurs at execution time (after
+	// planning has already counted it) rather than during planning.
+	t.Run("counter increments even when execution fails", func(t *testing.T) {
+		_, err := sqlDB.Exec(
+			"CREATE FUNCTION f_div(a INT, b INT) RETURNS INT VOLATILE LANGUAGE SQL AS 'SELECT a / b'",
+		)
+		require.NoError(t, err)
+		before := s.MustGetSQLCounter(sql.MetaUDFCall.Name)
+		_, err = sqlDB.Exec("SELECT f_div(1, 0)")
+		require.Error(t, err)
+		after := s.MustGetSQLCounter(sql.MetaUDFCall.Name)
+		require.Equal(t, int64(1), after-before, "UDF count delta")
+	})
+}

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -300,6 +300,14 @@ func (b *Builder) Build() (_ exec.Plan, err error) {
 		return nil, err
 	}
 
+	// Check if the query references any user-defined functions via metadata.
+	// This handles inlined UDFs that buildUDF won't see.
+	b.mem.Metadata().ForEachUserDefinedRoutine(func(overload *tree.Overload) {
+		if overload.Type == tree.UDFRoutine {
+			b.flags.Set(exec.PlanFlagContainsUDF)
+		}
+	})
+
 	// Check if RLS policies were applied during query planning. This includes
 	// the case where no policies matched and all rows are filtered out.
 	rlsMeta := b.mem.Metadata().GetRLSMeta()

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1001,6 +1001,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	if udf.Def == nil {
 		return nil, errors.AssertionFailedf("expected non-nil UDF definition")
 	}
+	b.flags.Set(exec.PlanFlagContainsUDF)
 
 	// Build the argument expressions.
 	args, err := b.buildRoutineArgs(ctx, udf.Args)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -99,6 +99,10 @@ const (
 	// stable (second-newest) statistics within its canary window. This
 	// gates canary/stable experiment metric recording.
 	PlanFlagCanaryAndStableStatsDiffer
+
+	// PlanFlagContainsUDF is set if the plan invokes at least one
+	// user-defined function.
+	PlanFlagContainsUDF
 )
 
 // IsSet returns true if the receiver has all of the given flags set.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -710,6 +710,10 @@ const (
 	// recorded in canary/stable experiment buckets even if StatsRollout is
 	// Canary or Stable.
 	planFlagCanaryAndStableStatsDiffer
+
+	// planFlagContainsUDF is set if the plan invokes at least one
+	// user-defined function.
+	planFlagContainsUDF
 )
 
 // IsSet returns true if the receiver has all of the given flags set.


### PR DESCRIPTION
Add a sql.udf.count metric that tracks the number of SQL statements
that invoke a user-defined function.

UDFs are detected via the memo's metadata routine dependencies rather
than relying solely on the execbuilder's buildUDF method. This ensures
that UDFs optimized away by the InlineUDF normalization rule are still
counted.

The metric is modeled on sql.rls.policies_applied.count: it lives in
EngineMetrics and is incremented once per statement at planning time,
in makeExecPlan, when the plan invokes at least one UDF. A statement is
counted once regardless of how many UDFs it invokes or how many rows it
processes, and regardless of whether execution ultimately succeeds. This
mirrors other plan-property metrics such as RLS, statement hints, and
full scans, which likewise do not distinguish successful from failed
executions.

Release note (sql change): Added a sql.udf.count metric that tracks the
number of SQL statements that invoke a user-defined function.

fixes #164896
Fixes: CRDB-61063
Epic: CRDB-61570
