### PR TITLE
workload: enable multi-region random schema workload

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
         "//c-deps:libgeos",
     ],
     exec_properties = {"test.Pool": "heavy"},
+    shard_count = 2,
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -34,8 +34,26 @@ import (
 func TestWorkload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer ccl.TestingEnableEnterprise()()
+	defer schemachange.DisableMultiRegionOps()()
 	skip.UnderDeadlock(t, "test connections can be too slow under expensive configs")
 	skip.UnderRace(t, "test connections can be too slow under expensive configs")
+
+	runSchemaChangeWorkload(t, "CREATE DATABASE schemachange")
+}
+
+func TestWorkloadMultiRegion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer ccl.TestingEnableEnterprise()()
+	skip.UnderDeadlock(t, "test connections can be too slow under expensive configs")
+	skip.UnderRace(t, "test connections can be too slow under expensive configs")
+
+	runSchemaChangeWorkload(
+		t,
+		`CREATE DATABASE schemachange PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3"`,
+	)
+}
+
+func runSchemaChangeWorkload(t *testing.T, createDBStmt string) {
 
 	rng, _ := randutil.NewTestRand()
 	scope := log.Scope(t)
@@ -62,7 +80,7 @@ func TestWorkload(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(db)
 	reg := histogram.NewRegistry(20*time.Second, m.Name)
 	tdb.Exec(t, "CREATE USER testuser")
-	tdb.Exec(t, "CREATE DATABASE schemachange")
+	tdb.Exec(t, createDBStmt)
 	tdb.Exec(t, "GRANT admin TO testuser")
 	tdb.Exec(t, "SET CLUSTER SETTING sql.log.all_statements.enabled = true")
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
@@ -47,7 +47,7 @@ func AlterTableLocality(b BuildCtx, t *tree.AlterTableLocality) {
 	tableID := tbl.TableID
 	tableName := t.Name.Object()
 
-	if elts.Filter(notFilter(publicTargetFilter)) != nil {
+	if elts.Filter(notFilter(publicTargetFilter)).FilterTable() != nil {
 		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			"table %q is being dropped, try again later", tbl))
 	}

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1193,6 +1193,37 @@ SELECT
 	)
 }
 
+// tableHasIncompatibleIndexesForRBR checks whether the table has any indexes
+// that would be incompatible with REGIONAL BY ROW. Specifically:
+//  1. A secondary index that stores the region column.
+//  2. Any index (primary or secondary) with the region column as a non-leading
+//     key column.
+//  3. A hash-sharded index that includes the region column as a key column.
+func (og *operationGenerator) tableHasIncompatibleIndexesForRBR(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, regionColName tree.Name,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `
+SELECT EXISTS(
+  SELECT 1
+  FROM information_schema.statistics AS s
+  JOIN crdb_internal.table_indexes AS ti
+    ON ti.descriptor_id = $1::REGCLASS
+   AND ti.index_name = s.index_name
+  WHERE s.table_schema = $2
+    AND s.table_name = $3
+    AND s.column_name = $4
+    AND (
+      -- region col stored in a secondary index
+      (s.storing = 'YES' AND ti.index_type != 'primary')
+      -- region col as a non-leading key column
+      OR (s.storing = 'NO' AND s.seq_in_index > 1)
+      -- region col in a hash-sharded index
+      OR (s.storing = 'NO' AND ti.is_sharded)
+    )
+)`,
+		tableName.String(), tableName.Schema(), tableName.Object(), string(regionColName))
+}
+
 // databaseHasMultiRegion determines whether the database is multi-region
 // enabled.
 func (og *operationGenerator) databaseIsMultiRegion(ctx context.Context, tx pgx.Tx) (bool, error) {
@@ -1279,7 +1310,7 @@ SELECT (
 			mut
 		FROM
 			(
-				-- no schema changes on regional by row tables
+				-- no schema change mutations on regional by row tables
 				SELECT
 					json_array_elements(d->'mutations')
 						AS mut
@@ -1293,7 +1324,7 @@ SELECT (
 				)
 			)
 	) OR EXISTS (
-		-- no primary key swaps in the current database
+		-- no legacy primary key swaps in the current database
 		SELECT mut FROM (
 			SELECT
 				json_array_elements(d->'mutations')
@@ -1302,6 +1333,18 @@ SELECT (
 		)
 		WHERE
 			(mut->'primaryKeySwap') IS NOT NULL
+	) OR EXISTS (
+		-- no declarative schema changes involving a primary index swap
+		-- (includes a change to/from regional by row)
+		SELECT 1 FROM descriptors
+		WHERE d->'declarativeSchemaChangerState' IS NOT NULL
+			AND EXISTS (
+				SELECT 1
+				FROM jsonb_array_elements(
+					d->'declarativeSchemaChangerState'->'targets'
+				) AS target
+				WHERE target->'elementProto'->'primaryIndex' IS NOT NULL
+			)
 	)
 );
 		`,

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -395,12 +395,13 @@ func (og *operationGenerator) addUniqueConstraint(ctx context.Context, tx pgx.Tx
 	if err != nil {
 		return nil, err
 	}
+
 	stmt := makeOpStmt(OpStmtDDL)
 	stmt.expectedExecErrors.addAll(codesWithConditions{
 		{code: pgcode.UndefinedColumn, condition: !columnExistsOnTable},
 		{code: pgcode.DuplicateRelation, condition: constraintExists},
 		{code: pgcode.FeatureNotSupported, condition: columnExistsOnTable && !colinfo.ColumnTypeIsIndexable(columnForConstraint.typ)},
-		{pgcode.FeatureNotSupported, hasAlterPKSchemaChange && !og.useDeclarativeSchemaChanger},
+		{code: pgcode.FeatureNotSupported, condition: hasAlterPKSchemaChange && !og.useDeclarativeSchemaChanger},
 		{code: pgcode.ObjectNotInPrerequisiteState, condition: databaseHasRegionChange && tableIsRegionalByRow},
 	})
 
@@ -513,6 +514,20 @@ func (og *operationGenerator) alterTableLocality(ctx context.Context, tx pgx.Tx)
 						stmt.expectedExecErrors.add(pgcode.InvalidTableDefinition)
 					}
 				}
+			}
+
+			// Check if any existing indexes are incompatible with the region
+			// column becoming an implicit partitioning column.
+			regionCol := tree.Name(tree.RegionalByRowRegionDefaultCol)
+			if columnForAsUsed {
+				regionCol = columnForAs.name
+			}
+			hasIncompat, err := og.tableHasIncompatibleIndexesForRBR(ctx, tx, tableName, regionCol)
+			if err != nil {
+				return "", err
+			}
+			if hasIncompat {
+				stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
 			}
 
 			return ret, nil
@@ -802,19 +817,30 @@ func (og *operationGenerator) primaryRegion(ctx context.Context, tx pgx.Tx) (*op
 			pgcode.InvalidName, pgcode.InvalidDatabaseDefinition), nil
 	}
 
-	// Conversion to multi-region is only allowed if the data is not already
-	// partitioned.
 	stmt := makeOpStmt(OpStmtDDL)
-	hasPartitioning, err := og.databaseHasTablesWithPartitioning(ctx, tx, database)
+
+	// Changing the primary region is blocked while a REGIONAL BY ROW transition
+	// is in progress on any table in the database. This is a potential error
+	// because the RBR change may complete before the primary region change executes.
+	databaseHasRegionalByRowChange, err := og.databaseHasRegionalByRowChange(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
-	if hasPartitioning {
-		stmt.expectedExecErrors.add(pgcode.ObjectNotInPrerequisiteState)
-	}
+	stmt.potentialExecErrors.addAll(codesWithConditions{
+		{code: pgcode.ObjectNotInPrerequisiteState, condition: databaseHasRegionalByRowChange},
+	})
 
 	// No regions in database, set a random region to be the PRIMARY REGION.
+	// Conversion to multi-region is only allowed if the data is not already
+	// partitioned.
 	if len(regionsInDB) == 0 {
+		hasPartitioning, err := og.databaseHasTablesWithPartitioning(ctx, tx, database)
+		if err != nil {
+			return nil, err
+		}
+		if hasPartitioning {
+			stmt.expectedExecErrors.add(pgcode.ObjectNotInPrerequisiteState)
+		}
 		idx := og.params.rng.Intn(len(regionInfos))
 		stmt.sql = fmt.Sprintf(
 			`ALTER DATABASE %s PRIMARY REGION "%s"`,
@@ -1070,18 +1096,12 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	// as stored columns.
 	stmt := makeOpStmt(OpStmtDDL)
 	isStoringVirtualComputed := false
-	regionColStored := false
 	storingPKCol := false
 	columnNames = columnNames[len(def.Columns):]
 	if n := len(columnNames); n > 0 {
 		def.Storing = make(tree.NameList, og.randIntn(1+n))
 		for i := range def.Storing {
 			def.Storing[i] = columnNames[i].name
-
-			// The region column can not be stored.
-			if tableIsRegionalByRow && columnNames[i].name == regionColumn {
-				regionColStored = true
-			}
 
 			colIsPK, err := og.colIsPrimaryKey(ctx, tx, tableName, columnNames[i].name)
 			if err != nil {
@@ -1159,7 +1179,6 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 			{code: pgcode.InvalidSQLStatementName, condition: def.Unique && def.Type == idxtype.INVERTED},
 			{code: pgcode.InvalidSQLStatementName, condition: def.Type == idxtype.INVERTED && len(def.Storing) > 0},
 			{code: pgcode.FeatureNotSupported, condition: nonIndexableType},
-			{code: pgcode.FeatureNotSupported, condition: regionColStored},
 			{code: pgcode.FeatureNotSupported, condition: duplicateRegionColumn},
 			{code: pgcode.FeatureNotSupported, condition: isStoringVirtualComputed},
 			{code: pgcode.FeatureNotSupported, condition: hasAlterPKSchemaChange && !og.useDeclarativeSchemaChanger},
@@ -2226,6 +2245,7 @@ func (og *operationGenerator) alterTypeDropValue(ctx context.Context, tx pgx.Tx)
 				COALESCE(member->>'direction' = 'REMOVE', false) AS dropping,
 				COALESCE(json_array_length(descriptor->'referencingDescriptorIds') > 0, false) AS has_references
 			FROM enum_members
+			WHERE name NOT LIKE 'crdb_internal_region'
 	`)
 
 	enumMembers, err := Collect(ctx, og, tx, pgx.RowToMap, query)
@@ -3066,6 +3086,17 @@ func (og *operationGenerator) survive(ctx context.Context, tx pgx.Tx) (*opStmt, 
 		},
 	})
 
+	// Changing the survival goal is blocked while a REGIONAL BY ROW transition
+	// is in progress on any table in the database. This is a potential error
+	// because the RBR change may complete before the survival goal change executes.
+	databaseHasRegionalByRowChange, err := og.databaseHasRegionalByRowChange(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	stmt.potentialExecErrors.addAll(codesWithConditions{
+		{code: pgcode.ObjectNotInPrerequisiteState, condition: databaseHasRegionalByRowChange},
+	})
+
 	dbName, err := og.getDatabase(ctx, tx)
 	if err != nil {
 		return nil, err
@@ -3085,7 +3116,8 @@ func (og *operationGenerator) commentOn(ctx context.Context, tx pgx.Tx) (*opStmt
 	  JOIN pg_catalog.pg_namespace AS nsp ON (types.typnamespace = nsp.oid)
 	  WHERE types.typtype IN ('e','c')
 	    AND types.typrelid IN (0, types.oid)
-	    AND nsp.nspname NOT IN ('information_schema', 'pg_catalog', 'crdb_internal', 'pg_extension')`
+	    AND nsp.nspname NOT IN ('information_schema', 'pg_catalog', 'crdb_internal', 'pg_extension')
+	    AND types.typname != 'crdb_internal_region'`
 	}
 	q := With([]CTE{
 		{"descriptors", descJSONQuery},

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -292,8 +292,8 @@ var opWeights = []int{
 	alterDatabaseAddRegion:            1,
 	alterDatabaseAddSuperRegion:       0, // Disabled and tracked with #111299
 	alterDatabaseDropSuperRegion:      0, // Disabled and tracked with #111299
-	alterDatabasePrimaryRegion:        0, // Disabled and tracked with #83831
-	alterDatabaseSurvivalGoal:         0, // Disabled and tracked with #83831
+	alterDatabasePrimaryRegion:        1,
+	alterDatabaseSurvivalGoal:         1,
 	alterFunctionRename:               1,
 	alterFunctionSetSchema:            1,
 	alterPolicy:                       1,
@@ -344,6 +344,23 @@ var opWeights = []int{
 	truncateTable:                     1,
 }
 
+// DisableMultiRegionOps sets the weight of alterDatabasePrimaryRegion and
+// alterDatabaseSurvivalGoal to 0, disabling them. It returns a cleanup
+// function that restores the original weights.
+func DisableMultiRegionOps() func() {
+	ops := []opType{alterDatabasePrimaryRegion, alterDatabaseSurvivalGoal}
+	saved := make(map[opType]int, len(ops))
+	for _, op := range ops {
+		saved[op] = opWeights[op]
+		opWeights[op] = 0
+	}
+	return func() {
+		for op, w := range saved {
+			opWeights[op] = w
+		}
+	}
+}
+
 // This workload will maintain its own list of minimal supported versions for
 // the declarative schema changer, since the cluster we are running against can
 // be downlevel. The declarative schema changer builder does have a supported
@@ -364,6 +381,7 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	alterTableSetColumnNotNull:        clusterversion.MinSupported,
 	alterTableSetStorageParams:        clusterversion.V26_1,
 	alterTableResetStorageParams:      clusterversion.V26_1,
+	alterTableLocality:                clusterversion.V26_2,
 	alterTableDropNotNull:             clusterversion.MinSupported,
 	alterTableRLS:                     clusterversion.MinSupported,
 	alterTypeDropValue:                clusterversion.MinSupported,


### PR DESCRIPTION
workload: enable multi-region random schema workload
    
Previously, the random schema change workload only ran against a
single-region database because alterDatabasePrimaryRegion and
alterDatabaseSurvivalGoal were disabled (#83831). This change re-enables
those operations and adds a dedicated TestWorkloadMultiRegion test that
creates a multi-region database.
    
Several fixes were needed to support the multi-region workload:
    
1. The concurrent-schema-change screening query now detects declarative
    schema changer state involving primary index swaps (which includes
    REGIONAL BY ROW transitions).
2. alterTableLocality checks for indexes incompatible with REGIONAL BY
    ROW (e.g. region column stored or used as a non-leading key column
    in a hash-sharded index) and expects the appropriate error.
3. The region column is no longer rejected as a stored index column,
     since this is permitted by the engine.
4. COMMENT ON TYPE and alterTypeDropValue now filter out the
     crdb_internal_region enum to avoid errors on the internal type.
5. alterDatabasePrimaryRegion and alterDatabaseSurvivalGoal add
     potential errors for concurrent REGIONAL BY ROW transitions
6. alterDatabasePrimaryRegion check for partitioning is scoped to the
     initial single-region to multi-region conversion only.
    
Fixes: #83831
Fixes: #149491
    
Release note: None