### PR TITLE
sql: refresh table zone configs on primary region switch

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_primary_region_switch_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_primary_region_switch_zone_configs
@@ -1,0 +1,330 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+# Regression test: switching the primary region and survival goal should keep
+# zone configs consistent for all tables.
+
+statement ok
+CREATE DATABASE mr_test PRIMARY REGION "us-east-1" REGIONS "ca-central-1", "ap-southeast-2"
+
+statement ok
+USE mr_test
+
+statement ok
+CREATE TABLE t1 (k INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY);
+ALTER TABLE t2 CONFIGURE ZONE USING gc.ttlseconds=10;
+
+# Validate after initial setup.
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t1
+----
+DATABASE mr_test  ALTER DATABASE mr_test CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 14400,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=us-east-1]',
+                    lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=us-east-1]',
+                    lease_preferences = '[[+region=us-east-1]]'
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true
+
+# Switch primary region.
+statement ok
+ALTER DATABASE mr_test PRIMARY REGION "ca-central-1"
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t1
+----
+DATABASE mr_test  ALTER DATABASE mr_test CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 14400,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ca-central-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ca-central-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true
+
+# Switch survival goal to region failure.
+statement ok
+ALTER DATABASE mr_test SURVIVE REGION FAILURE
+
+query TT
+SHOW ZONE CONFIGURATION FROM DATABASE mr_test
+----
+DATABASE mr_test  ALTER DATABASE mr_test CONFIGURE ZONE USING
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 5,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '{+region=ca-central-1: 2}',
+                lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t1
+----
+TABLE t1  ALTER TABLE t1 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 14400,
+            num_replicas = 5,
+            num_voters = 5,
+            constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+            voter_constraints = '{+region=ca-central-1: 2}',
+            lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 10,
+            num_replicas = 5,
+            num_voters = 5,
+            constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+            voter_constraints = '{+region=ca-central-1: 2}',
+            lease_preferences = '[[+region=ca-central-1]]'
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true
+
+# Switch primary region again while under region failure survival.
+statement ok
+ALTER DATABASE mr_test PRIMARY REGION "ap-southeast-2"
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t1
+----
+TABLE t1  ALTER TABLE t1 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 14400,
+            num_replicas = 5,
+            num_voters = 5,
+            constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+            voter_constraints = '{+region=ap-southeast-2: 2}',
+            lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 10,
+            num_replicas = 5,
+            num_voters = 5,
+            constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+            voter_constraints = '{+region=ap-southeast-2: 2}',
+            lease_preferences = '[[+region=ap-southeast-2]]'
+
+# Switch back to zone failure survival.
+statement ok
+ALTER DATABASE mr_test SURVIVE ZONE FAILURE
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t1
+----
+DATABASE mr_test  ALTER DATABASE mr_test CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 14400,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ap-southeast-2]',
+                    lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ap-southeast-2]',
+                    lease_preferences = '[[+region=ap-southeast-2]]'
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true
+
+# Switch primary region once more under zone failure survival.
+statement ok
+ALTER DATABASE mr_test PRIMARY REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t1
+----
+DATABASE mr_test  ALTER DATABASE mr_test CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 14400,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=us-east-1]',
+                    lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=us-east-1]',
+                    lease_preferences = '[[+region=us-east-1]]'
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true
+
+# Switch primary region when overriding table zone config.
+# Note that crdb_internal.validate_multi_region_zone_configs() will always return true
+# when override_multi_region_zone_config = true.
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE t2 CONFIGURE ZONE USING num_replicas=10, num_voters = 1, voter_constraints = '[+region=us-east-1]';
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 10,
+                    num_voters = 1,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=us-east-1]',
+                    lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER DATABASE mr_test PRIMARY REGION "ca-central-1"
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 10,
+                    num_voters = 1,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=us-east-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+# Switch survival goal to region failure.
+statement ok
+ALTER DATABASE mr_test SURVIVE REGION FAILURE
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 5,
+                    num_voters = 5,
+                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                    voter_constraints = '{+region=ca-central-1: 2}',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE t2 CONFIGURE ZONE USING num_replicas=10, num_voters = 3, voter_constraints = '{+region=ca-central-1: 2}';
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 10,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                    voter_constraints = '{+region=ca-central-1: 2}',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER DATABASE mr_test PRIMARY REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE t2
+----
+TABLE t2  ALTER TABLE t2 CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 10,
+                    num_replicas = 5,
+                    num_voters = 5,
+                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 2}',
+                    voter_constraints = '{+region=us-east-1: 2}',
+                    lease_preferences = '[[+region=us-east-1]]'
+
+query B
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+true

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:4"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -149,6 +149,13 @@ func TestCCLLogic_multi_region_locality_optimized_search_query_behavior(
 	runCCLLogicTest(t, "multi_region_locality_optimized_search_query_behavior")
 }
 
+func TestCCLLogic_multi_region_primary_region_switch_zone_configs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "multi_region_primary_region_switch_zone_configs")
+}
+
 func TestCCLLogic_multi_region_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1063,19 +1063,28 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		params.p.BufferClientNotice(params.ctx, pgnotice.Newf("all REGIONAL BY TABLE tables without a region explicitly set are no longer part of the super region %s", superRegionOfOldPrimaryRegion))
 	}
 
-	// If the old or new primary region is a member of a super region, we also
-	// have to update regional tables that are part of the default region.
+	// With exactly 3 regions and SURVIVE REGION FAILURE, tables get explicit
+	// zone configs that must be updated when the primary region changes.
+	hasImplicitSuperRegion := updatedRegionConfig.HasImplicitSuperRegion()
+	if hasImplicitSuperRegion {
+		params.p.BufferClientNotice(params.ctx, pgnotice.Newf("all REGIONAL BY TABLE zone configurations in the old primary region have been updated to reflect the new primary region"))
+	}
+
+	// Refresh table zone configurations when any of the following hold:
+	// 1. PLACEMENT RESTRICTED: GLOBAL tables have explicit zone configs that
+	//    must be rebuilt to reflect the new primary region.
+	// 2. Super region membership change: regional tables in the primary region
+	//    need updated zone configs when the primary region moves into or out
+	//    of a super region.
+	// 3. SURVIVE REGION FAILURE with 3 regions: tables get explicit zone
+	//    configs with tighter replica constraints (2+2+1 vs 1+1+1) whose
+	//    voter_constraints and lease_preferences must track the primary region.
 	opts := WithOnlyGlobalTables
-	if isNewPrimaryRegionMemberOfASuperRegion || isOldPrimaryRegionMemberOfASuperRegion {
+	if isNewPrimaryRegionMemberOfASuperRegion || isOldPrimaryRegionMemberOfASuperRegion || hasImplicitSuperRegion {
 		opts = WithOnlyRegionalTablesAndGlobalTables
 	}
 
-	// Update all GLOBAL tables' zone configurations. This is required as if
-	// LOCALITY GLOBAL is used with PLACEMENT RESTRICTED, the global tables' zone
-	// configs must be explicitly rebuilt so as to move their primary region.
-	// If there are super regions defined on the database, we may have to update
-	// the zone config for regional tables.
-	if updatedRegionConfig.IsPlacementRestricted() || isNewPrimaryRegionMemberOfASuperRegion || isOldPrimaryRegionMemberOfASuperRegion {
+	if updatedRegionConfig.IsPlacementRestricted() || isNewPrimaryRegionMemberOfASuperRegion || isOldPrimaryRegionMemberOfASuperRegion || hasImplicitSuperRegion {
 		if err := params.p.refreshZoneConfigsForTables(
 			params.ctx,
 			n.desc,

--- a/pkg/sql/catalog/multiregion/region_config.go
+++ b/pkg/sql/catalog/multiregion/region_config.go
@@ -86,11 +86,17 @@ func (r *RegionConfig) IsMemberOfSuperRegion(region catpb.RegionName) bool {
 			}
 		}
 	}
+	return r.HasImplicitSuperRegion()
+}
 
+// HasImplicitSuperRegion returns true if the survival goal is
+// SURVIVE_REGION_FAILURE and we have 3 regions configured.
+// In this case, tables get explicit zone configs with tighter replica constraints
+// (2+2+1 instead of 1+1+1) to prevent replica leak to other regions.
+func (r *RegionConfig) HasImplicitSuperRegion() bool {
 	if len(r.regions) == 3 && r.survivalGoal == descpb.SurvivalGoal_REGION_FAILURE {
 		return true
 	}
-
 	return false
 }
 

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
@@ -206,8 +205,6 @@ func (r *databaseRegionChangeFinalizer) updateSystemTableRegionReferences(
 		return err
 	}
 
-	primaryRegion := regionConfig.PrimaryRegion()
-
 	// Collect tables that need to be updated.
 	var tablesToUpdate []*tabledesc.Mutable
 
@@ -227,21 +224,12 @@ func (r *databaseRegionChangeFinalizer) updateSystemTableRegionReferences(
 				return err
 			}
 
-			// If already set to primary (explicit or implicit), nothing to do.
-			if currentRegion == primaryRegion || currentRegion == catpb.RegionName(tree.PrimaryRegionNotSpecifiedName) {
-				return nil
-			}
-
-			// If the table's current region still exists in the database, leave
-			// it alone.
-			if regionConfig.IsValidRegionNameString(string(currentRegion)) {
-				return nil
-			}
-
 			// The table references a region that no longer exists. Reset it to
 			// implicitly follow the primary region.
-			tableDesc.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
-			tablesToUpdate = append(tablesToUpdate, tableDesc)
+			if !regionConfig.IsValidRegionNameString(string(currentRegion)) {
+				tableDesc.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
+				tablesToUpdate = append(tablesToUpdate, tableDesc)
+			}
 
 			// Also regenerate the zone config to match the new region.
 			return ApplyZoneConfigForMultiRegionTable(


### PR DESCRIPTION
Previously, `ALTER DATABASE ... PRIMARY REGION` only refreshed table
zone configurations when placement was restricted or super regions
were involved. This was based on the assumption that REGIONAL BY TABLE
tables in the primary region never have explicit zone configs and can
always inherit from the database.

However, `ALTER DATABASE ... SURVIVE REGION FAILURE` writes explicit
zone configs on all tables (including RBT) because region failure
survival requires a tighter replica distribution. Additionally, users
can explicitly modify a table zone config. When the primary region is
changed, those explicit table zone configs retain stale voter_constraints
and lease_preferences pointing to the old primary region.

Fix this by calling `refreshZoneConfigsForTables` when switching the
primary region on `SURVIVE REGION FAILURE`. For tables without explicit
zone configs, the refresh is a no-op. For tables with stale explicit configs
(from a prior survival goal change), it updates them to reflect the new
primary region.

Informs: #149491
Informs: #83831

Release note (bug fix): Fixed a bug where `ALTER DATABASE ... PRIMARY REGION` could leave stale zone configurations on tables, causing voter constraints and lease preferences to reference the old primary region.