### PR TITLE
logictest: enable local-prepared on 12 more files

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # All dimensions
 statement ok
 CREATE TABLE geom_all(geom geometry)

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_json_array
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # Test cases for using invertedFilterer on an inverted json or array index.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 statement ok
 CREATE TABLE ltable(
   lk int primary key,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 statement ok
 CREATE TABLE json_tab (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_multi_column
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 # Tests for inverted joins with multi-column inverted indexes.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 # Disable declarative schema changer for this test and schema locked by
 # default for this test.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/json_index
+++ b/pkg/sql/logictest/testdata/logic_test/json_index
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # Add JSON columns as primary index.
 statement ok
 CREATE TABLE t (x JSONB PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 query T
 SELECT pg_typeof(JSONPATH '$.a')
 ----

--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 subtest regression_93083
 
 # Regression test for #93083. UDFs with empty bodies should execute successfully

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 statement ok
 CREATE TABLE t_onecol (a INT);
 INSERT INTO t_onecol VALUES (1)

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # knob-opt: allow-unsafe
 # TODO(andyk): Remove this once 25.3 is our minimum supported version.
 

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -1,4 +1,4 @@
-# LogicTest: default-configs !3node-tenant-default-configs !local-prepared
+# LogicTest: default-configs !3node-tenant-default-configs
 # Zone config logic tests that are only meant to work for the system tenant.
 
 # Verify that the timeseries range has a zone config after bootstrap. It should

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -741,6 +741,13 @@ func TestLogic_geospatial_regression(
 	runLogicTest(t, "geospatial_regression")
 }
 
+func TestLogic_geospatial_zm(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "geospatial_zm")
+}
+
 func TestLogic_grant_database(
 	t *testing.T,
 ) {
@@ -874,11 +881,53 @@ func TestLogic_inverted_filter_geospatial(
 	runLogicTest(t, "inverted_filter_geospatial")
 }
 
+func TestLogic_inverted_filter_json_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inverted_filter_json_array")
+}
+
+func TestLogic_inverted_join_geospatial(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inverted_join_geospatial")
+}
+
+func TestLogic_inverted_join_json_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inverted_join_json_array")
+}
+
+func TestLogic_inverted_join_multi_column(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inverted_join_multi_column")
+}
+
+func TestLogic_jobs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jobs")
+}
+
 func TestLogic_join(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "join")
+}
+
+func TestLogic_json_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "json_index")
 }
 
 func TestLogic_jsonb_path_exists(
@@ -907,6 +956,13 @@ func TestLogic_jsonb_path_query_first(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "jsonb_path_query_first")
+}
+
+func TestLogic_jsonpath(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonpath")
 }
 
 func TestLogic_kv_builtin_functions(
@@ -1882,6 +1938,13 @@ func TestLogic_udf_record(
 	runLogicTest(t, "udf_record")
 }
 
+func TestLogic_udf_regressions(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_regressions")
+}
+
 func TestLogic_udf_rewrite(
 	t *testing.T,
 ) {
@@ -1901,6 +1964,13 @@ func TestLogic_udf_setof(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_setof")
+}
+
+func TestLogic_udf_star(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_star")
 }
 
 func TestLogic_udf_subquery(
@@ -1978,6 +2048,13 @@ func TestLogic_values(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "values")
+}
+
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
 }
 
 func TestLogic_vectorize_agg(
@@ -2069,4 +2146,11 @@ func TestLogic_zigzag_join(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "zigzag_join")
+}
+
+func TestLogic_zone_config_system_tenant(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "zone_config_system_tenant")
 }


### PR DESCRIPTION
Remove the `!local-prepared` exclusion from 12 additional logictest
files that pass with the `local-prepared` config:
geospatial_zm, inverted_filter_json_array, inverted_join_geospatial,
inverted_join_json_array, inverted_join_multi_column, jobs,
json_index, jsonpath, udf_regressions, udf_star, vector_index,
zone_config_system_tenant.

Informs: #152139