### PR TITLE
logictest: enable local-prepared on 4 more files

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists_index_acceleration
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists_index_acceleration
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 # Inverted index acceleration for jsonb_path_query.
 statement ok
 CREATE TABLE json_tab (

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 query T
 SELECT jsonb_path_query('{}', '$')
 ----

--- a/pkg/sql/logictest/testdata/logic_test/show_statement_hints
+++ b/pkg/sql/logictest/testdata/logic_test/show_statement_hints
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_unsupported
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 skip under race
 
 statement ok

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -937,11 +937,25 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_exists_index_acceleration(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists_index_acceleration")
+}
+
 func TestLogic_jsonb_path_match(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "jsonb_path_match")
+}
+
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
 }
 
 func TestLogic_jsonb_path_query_array(
@@ -1616,6 +1630,13 @@ func TestLogic_show_inspect_errors(
 	runLogicTest(t, "show_inspect_errors")
 }
 
+func TestLogic_show_statement_hints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_statement_hints")
+}
+
 func TestLogic_show_var(
 	t *testing.T,
 ) {
@@ -2076,6 +2097,13 @@ func TestLogic_vectorize_types(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "vectorize_types")
+}
+
+func TestLogic_vectorize_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_unsupported")
 }
 
 func TestLogic_views(


### PR DESCRIPTION
Remove the `!local-prepared` exclusion from 4 additional logictest
files that pass with the `local-prepared` config:
jsonb_path_exists_index_acceleration, jsonb_path_query,
show_statement_hints, vectorize_unsupported.

This completes testing all 122 files that had `!local-prepared`.
The remaining ~85 files that still exclude `local-prepared` have
genuine incompatibilities (type inference differences, OID mismatches,
transaction retry behavior, etc.).

Informs: #152139