### PR TITLE
optbuilder: prohibit usage of `st_asmvt` as a window function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4397,3 +4397,11 @@ NULL  4  4
 
 statement ok
 RESET null_ordered_last
+
+# Regression test for #165754 - st_asmvt cannot be used as a window function
+# (which matches postgres).
+statement ok
+CREATE TABLE t165754 (geom GEOMETRY)
+
+query error pgcode 0A000 aggregate function st_asmvt does not support use as a window function
+SELECT st_asmvt(t165754) OVER () FROM t165754

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -771,6 +771,10 @@ func (b *Builder) buildAggregateFunction(
 	return &info
 }
 
+var stAsMVTWindowFunctionErr = pgerror.New(
+	pgcode.FeatureNotSupported, "aggregate function st_asmvt does not support use as a window function",
+)
+
 func (b *Builder) constructWindowFn(name string, args []opt.ScalarExpr) opt.ScalarExpr {
 	switch name {
 	case "rank":
@@ -795,6 +799,8 @@ func (b *Builder) constructWindowFn(name string, args []opt.ScalarExpr) opt.Scal
 		return b.factory.ConstructLastValue(args[0])
 	case "nth_value":
 		return b.factory.ConstructNthValue(args[0], args[1])
+	case "st_asmvt":
+		panic(stAsMVTWindowFunctionErr)
 	default:
 		return b.constructAggregate(name, args)
 	}


### PR DESCRIPTION
Currently we hit an internal error when using this aggregate as a window function. We could've adjusted the code to handle it, but postgres prohibits using this builtin as a window function, so we'll now do the same.

Fixes: #165687.
Release note: None