### PR TITLE
build/deploy: fix initdb scripts blocked when COCKROACH_USER unset

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -154,13 +154,15 @@ setup_db() {
   create_defaultdb
   create_default_user
 
-  local init_env_query=( --certs-dir="$certs_dir" )
+  # Only run GRANT queries when COCKROACH_USER is set. Without a user to
+  # grant privileges to, calling run_sql_query with no -e flag opens an
+  # interactive SQL session that blocks the entrypoint from proceeding to
+  # process_init_files.
   if [[ -n "$COCKROACH_USER" ]]; then
-    init_env_query+=( -e "GRANT ALL ON DATABASE "$COCKROACH_DATABASE" TO "$COCKROACH_USER"" \
-                      -e "GRANT admin TO "$COCKROACH_USER" " )
+    run_sql_query --certs-dir="$certs_dir" \
+      -e "GRANT ALL ON DATABASE "$COCKROACH_DATABASE" TO "$COCKROACH_USER"" \
+      -e "GRANT admin TO "$COCKROACH_USER" "
   fi
-
-  run_sql_query "${init_env_query[@]}"
 }
 
 # process_init_files run all the init scripts from /docker-entrypoint-initdb.d.


### PR DESCRIPTION
## Summary

When `COCKROACH_USER` is not set, `setup_db()` calls `run_sql_query` with no `-e` flags, which opens an interactive SQL session that blocks the entrypoint indefinitely. This prevents scripts in `/docker-entrypoint-initdb.d/` from running.

The fix moves the `run_sql_query` call inside the existing `COCKROACH_USER` guard so it only runs when there are GRANT statements to execute.

Fixes #110997

## Changes

- `build/deploy/cockroach.sh`: Moved `run_sql_query` call inside the `[[ -n "$COCKROACH_USER" ]]` conditional in `setup_db()`

## Test plan

- Start a container with `start-single-node --insecure` and a mounted init script, without setting `COCKROACH_USER`
- Verify the init script executes and the database is created
- Start with `COCKROACH_USER` set and verify GRANT statements still execute correctly