### PR TITLE
server: don't block node startup on secondary tenant server init

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2400,9 +2400,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.stopper)
 
 	// Let the server controller start watching tenant service mode changes.
-	if err := s.serverController.start(workersCtx,
-		s.node.execCfg.InternalDB.Executor(),
-	); err != nil {
+	if err := s.serverController.start(workersCtx); err != nil {
 		return errors.Wrap(err, "failed to start the server controller")
 	}
 

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
-	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
@@ -178,19 +177,11 @@ func (s *serverController) IsDraining() bool {
 
 // start monitors changes to the service mode and updates
 // the running servers accordingly.
-func (c *serverController) start(ctx context.Context, ie isql.Executor) error {
-	// If the SQL server is disabled there are no initial secondary tenants to
-	// start.
-	if !c.disableSQLServer {
-		// We perform one round of updates synchronously, to ensure that
-		// any tenants already in service mode SHARED get a chance to boot
-		// up before we signal readiness.
-		if err := c.startInitialSecondaryTenantServers(ctx, ie); err != nil {
-			return err
-		}
-	}
-
+func (c *serverController) start(ctx context.Context) error {
 	// Run the detection of which servers should be started or stopped.
+	// Secondary tenant servers are started asynchronously to avoid blocking
+	// the system tenant's startup if a tenant fails to initialize.
+	// See https://github.com/cockroachdb/cockroach/issues/96547.
 	return c.stopper.RunAsyncTask(ctx, "mark-tenant-services", func(ctx context.Context) {
 		// We receieve updates from the tenantcapabilities
 		// watcher, but we also refresh our state at a fixed
@@ -228,33 +219,6 @@ func (c *serverController) start(ctx context.Context, ie isql.Executor) error {
 			}
 		}
 	})
-}
-
-// startInitialSecondaryTenantServers starts the servers for secondary tenants
-// that should be started during server initialization.
-func (c *serverController) startInitialSecondaryTenantServers(
-	ctx context.Context, ie isql.Executor,
-) error {
-	// The list of tenants that should have a running server.
-	reqTenants, err := startup.RunIdempotentWithRetryEx(ctx,
-		c.stopper.ShouldQuiesce(),
-		"get expected running tenants",
-		func(ctx context.Context) ([]roachpb.TenantName, error) {
-			return c.getExpectedRunningTenants(ctx, ie)
-		})
-	if err != nil {
-		return err
-	}
-	for _, name := range reqTenants {
-		if name == catconstants.SystemTenantName {
-			// We already pre-initialize the entry for the system tenant.
-			continue
-		}
-		if _, err := c.startAndWaitForRunningServer(ctx, name); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (c *serverController) startMissingServers(


### PR DESCRIPTION
Previously, serverController.start() synchronously called startInitialSecondaryTenantServers(), which blocked on startAndWaitForRunningServer() for each tenant. If any secondary tenant failed to start (e.g., failed upgrade, corrupted state), the entire node's PreStart() would never return, preventing the system tenant SQL service from accepting connections.

This change removes the synchronous startup path. Secondary tenant servers are now started exclusively by the existing async "mark-tenant-services" loop, which already handles errors with logging and retry, and respects context cancellation. This loop fires ~1 second after PreStart() completes, so tenants still start promptly without risking node availability.

This change doesn't impact external tenants since server controller is only responsible to start shared tenants.

---

### Health endpoints behavior after this change

- Health endpoint for system tenant can be reached at http://localhost:8080/health?ready=1&nofallback=true
- In case of shared tenants HTTP requests are multiplexed over same listener. Health endpoints for a specific secondary tenant can be reached at http://localhost:8080/health?ready=1&cluster=t3&nofallback=true. 

As soon as system tenant is started, health endpoint for system tenant starts reporting healthy and is ready to accept SQL connections. Since secondary tenants are started asynchronously, there will be a _short_ period of time where the health checks for secondary tenants would return 503. SQL connection attempts with in this window will fail.

Prior to this change, since secondary tenants are started synchronously, health endpoint for system tenant starts reporting healthy only after all tenants are ready. With this change, each tenant reports its health depending on when it is ready to accept connections.

NB: `nofallback=false` health check request for a secondary tenant silently falls back and returns system tenant's health.

---

Fixes: #96547

Release note (bug fix): Fixed a bug where a CockroachDB node could hang during startup if a secondary tenant (shared-process) server failed to initialize, blocking the system tenant from accepting connections.