### PR TITLE
kvserver: use sep Engines/Batch in lifecycle dd test

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -372,7 +372,10 @@ func (b *Batch[B]) State() B {
 
 // Raft returns the LogEngine writer. When engines are separated, the raft
 // batch is lazily created on first access.
-func (b *Batch[B]) Raft() RaftWO {
+//
+// TODO(pav-kv): return RaftWO when the callers needing the Repr() of the batch
+// find a workaround.
+func (b *Batch[B]) Raft() storage.WriteBatch {
 	if b.raft == nil {
 		assertTrue(b.separated(), "raft batch unexpectedly nil with non-separated engines")
 		b.raft = b.logEngine.NewWriteBatch()

--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -389,6 +389,21 @@ func (b *Batch[B]) WagWriter() *wag.Writer {
 	return &b.w
 }
 
+// TestingFlushWAG flushes the WAG node to the Raft() batch and empties the
+// staged WAG events. The batch can be then committed with the Commit method.
+//
+// Used only in tests for introspecting into the Raft() batch before the commit.
+func (b *Batch[B]) TestingFlushWAG() error {
+	if !b.separated() || b.w.Empty() {
+		return nil
+	}
+	if err := b.w.Flush(b.Raft(), b.state.Repr()); err != nil {
+		return err
+	}
+	b.w.Clear()
+	return nil
+}
+
 // Commit commits the batch to storage.
 //
 // The sync flag is one-way. If true, the sync is guaranteed. If false, syncing

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -65,3 +65,9 @@ func (w *Writer) Flush(raftBatch storage.Writer, stateBatchRepr []byte) error {
 		Mutation: wagpb.Mutation{Batch: stateBatchRepr},
 	})
 }
+
+// Clear empties the staged WAG events.
+func (w *Writer) Clear() {
+	clear(w.events)
+	w.events = w.events[:0]
+}

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -239,7 +239,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				}
 
 				require.NoError(t, kvstorage.MakeStateLoader(rangeID).SetHardState(
-					ctx, tc.raftStorage, rs.replica.hs,
+					ctx, tc.eng.LogEngine(), rs.replica.hs,
 				))
 				return fmt.Sprintf("HardState %+v", rs.replica.hs)
 
@@ -303,7 +303,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				// generated for replication. Stash it away. This represents the
 				// raft log entry that will be applied as part of split
 				// application.
-				batch := tc.stateStorage.NewBatch()
+				batch := tc.eng.StateEngine().NewBatch()
 				rec := tc.makeEvalCtx(rs, &desc)
 
 				in := batcheval.SplitTriggerHelperInput{
@@ -419,7 +419,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					RightDesc: rhsRS.desc,
 				}
 
-				batch := tc.stateStorage.NewBatch()
+				batch := tc.eng.StateEngine().NewBatch()
 				rec := tc.makeEvalCtx(lhsRS, &lhsDesc)
 
 				var ms enginepb.MVCCStats
@@ -671,8 +671,7 @@ type testCtx struct {
 	// The storage engines correspond to a single store, (n1, s1). The engines
 	// are logically separated into two -- one for the state machine, and one
 	// for Raft.
-	stateStorage storage.Engine
-	raftStorage  storage.Engine
+	eng kvstorage.Engines
 
 	wagSeq wag.Seq
 }
@@ -687,12 +686,14 @@ func newTestCtx() *testCtx {
 		clock:              clock,
 		rangeLeaseDuration: 99 * time.Nanosecond,
 
-		nextRangeID:  1,
-		ranges:       make(map[roachpb.RangeID]*rangeState),
-		splits:       make(map[roachpb.RangeID]pendingSplit),
-		merges:       make(map[roachpb.RangeID]pendingMerge),
-		stateStorage: storage.NewDefaultInMemForTesting(),
-		raftStorage:  storage.NewDefaultInMemForTesting(),
+		nextRangeID: 1,
+		ranges:      make(map[roachpb.RangeID]*rangeState),
+		splits:      make(map[roachpb.RangeID]pendingSplit),
+		merges:      make(map[roachpb.RangeID]pendingMerge),
+		eng: kvstorage.MakeSeparatedEnginesForTesting(
+			storage.NewDefaultInMemForTesting(),
+			storage.NewDefaultInMemForTesting(),
+		),
 	}
 }
 
@@ -712,8 +713,7 @@ func (tc *testCtx) makeEvalCtx(
 
 // close closes the test context's storage engines.
 func (tc *testCtx) close() {
-	tc.stateStorage.Close()
-	tc.raftStorage.Close()
+	tc.eng.Close()
 }
 
 // mutate executes a write operation on both state and raft storage batches
@@ -721,9 +721,9 @@ func (tc *testCtx) close() {
 // string for the benefit of the datadriven test output, with explicit labels
 // for each engine.
 func (tc *testCtx) mutate(t *testing.T, write func(stateBatch, raftBatch storage.Batch)) string {
-	stateBatch := tc.stateStorage.NewBatch()
+	stateBatch := tc.eng.StateEngine().NewBatch()
 	defer stateBatch.Close()
-	raftBatch := tc.raftStorage.NewBatch()
+	raftBatch := tc.eng.LogEngine().NewBatch()
 	defer raftBatch.Close()
 
 	write(stateBatch, raftBatch)

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -669,12 +669,13 @@ type testCtx struct {
 	ranges      map[roachpb.RangeID]*rangeState
 	splits      map[roachpb.RangeID]pendingSplit
 	merges      map[roachpb.RangeID]pendingMerge
+
 	// The storage engines correspond to a single store, (n1, s1). The engines
 	// are logically separated into two -- one for the state machine, and one
 	// for Raft.
-	eng kvstorage.Engines
-
+	eng    kvstorage.Engines
 	wagSeq wag.Seq
+	bf     kvstorage.BatchFactory
 }
 
 // newTestCtx constructs and returns a new testCtx.
@@ -682,7 +683,7 @@ func newTestCtx() *testCtx {
 	st := cluster.MakeTestingClusterSettings()
 	manual := timeutil.NewManualTime(timeutil.Unix(0, 10))
 	clock := hlc.NewClockForTesting(manual)
-	return &testCtx{
+	tc := &testCtx{
 		st:                 st,
 		clock:              clock,
 		rangeLeaseDuration: 99 * time.Nanosecond,
@@ -696,6 +697,8 @@ func newTestCtx() *testCtx {
 			storage.NewDefaultInMemForTesting(),
 		),
 	}
+	tc.bf = kvstorage.MakeBatchFactory(&tc.eng, &tc.wagSeq)
+	return tc
 }
 
 // makeEvalCtx constructs a batcheval.EvalContext for the given range.

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -215,8 +215,8 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 							roachpb.FullReplicaID{RangeID: rs.desc.RangeID, ReplicaID: repl.ReplicaID},
 						)
 					}
-					tc.updateReplicaStateFromStorage(t, ctx, rs, stateBatch, raftBatch, true /* justCreated */)
 				})
+				tc.updateReplicaStateFromStorage(ctx, t, rs, true /* justCreated */)
 				// CreateUninitializedReplica can return an error if the replica is
 				// already destroyed.
 				if errors.HasType(err, &kvpb.RaftGroupDeletedError{}) {
@@ -374,7 +374,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					lhsLastReplicaGC:    hlc.Timestamp{},              // dummy timestamp
 				}
 				wagWriter := wag.MakeWriter(&tc.wagSeq)
-				return tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
+				output := tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
 					// First, apply the stashed batch from split trigger
 					// evaluation.
 					require.NoError(t, stateBatch.ApplyBatchRepr(ps.batchRepr, false /* sync */))
@@ -386,12 +386,13 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					require.NoError(t, wagWriter.Flush(
 						kvstorage.WrapRaft(raftBatch).WO, stateBatch.Repr(),
 					))
-					// If the RHS replica wasn't destroyed, it is now initialized.
-					// Update the in-memory state to reflect this.
-					if !rhsDestroyed {
-						tc.updateReplicaStateFromStorage(t, ctx, rhsRangeState, stateBatch, raftBatch, false /* justCreated */)
-					}
 				})
+				// If the RHS replica wasn't destroyed, it is now initialized. Update
+				// the in-memory state to reflect this.
+				if !rhsDestroyed {
+					tc.updateReplicaStateFromStorage(ctx, t, rhsRangeState, false /* justCreated */)
+				}
+				return output
 
 			case "eval-merge":
 				lhsRangeID := dd.ScanArg[roachpb.RangeID](t, d, "lhs-range-id")
@@ -871,22 +872,18 @@ func (tc *testCtx) preMergeRHSIsSubsumed(rangeID roachpb.RangeID) bool {
 }
 
 func (tc *testCtx) updateReplicaStateFromStorage(
-	t *testing.T,
-	ctx context.Context,
-	rs *rangeState,
-	stateReader, raftReader storage.Reader,
-	justCreated bool,
+	ctx context.Context, t *testing.T, rs *rangeState, justCreated bool,
 ) {
 	if justCreated {
 		// Sanity check that we're not overwriting an existing replica.
 		require.Nil(t, rs.replica)
 	}
 	sl := kvstorage.MakeStateLoader(rs.desc.RangeID)
-	hs, err := sl.LoadHardState(ctx, raftReader)
+	hs, err := sl.LoadHardState(ctx, tc.eng.LogEngine())
 	require.NoError(t, err)
-	ts, err := sl.LoadRaftTruncatedState(ctx, raftReader)
+	ts, err := sl.LoadRaftTruncatedState(ctx, tc.eng.LogEngine())
 	require.NoError(t, err)
-	replID, err := sl.LoadRaftReplicaID(ctx, stateReader)
+	replID, err := sl.LoadRaftReplicaID(ctx, tc.eng.StateEngine())
 	require.NoError(t, err)
 	rs.replica = &replicaInfo{
 		FullReplicaID: roachpb.FullReplicaID{

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -315,6 +316,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					ctx, rec, batch, enginepb.MVCCStats{}, &split, in, hlc.Timestamp{})
 				require.NoError(t, err)
 				if legacy {
+					batch := spanset.DisableForbiddenSpanAssertions(batch)
 					writeLegacySplitTriggerKeys(ctx, t, batch, rightDesc.RangeID)
 				}
 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -203,15 +203,16 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				}
 
 				var err error
-				output := tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
+				output := tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
 					if initialized {
 						require.NoError(t, kvstorage.WriteInitialRangeState(
-							ctx, stateBatch, raftBatch,
+							ctx, b.State(), b.Raft(),
 							rs.desc, repl.ReplicaID, rs.version,
 						))
 					} else {
 						err = kvstorage.CreateUninitializedReplica(
-							ctx, kvstorage.WrapState(stateBatch), raftBatch, 1, /* StoreID */
+							ctx, kvstorage.WrapState(b.State()), kvstorage.RaftRO(tc.eng.LogEngine()),
+							1, /* StoreID */
 							roachpb.FullReplicaID{RangeID: rs.desc.RangeID, ReplicaID: repl.ReplicaID},
 						)
 					}
@@ -374,17 +375,20 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					lhsLastReplicaGC:    hlc.Timestamp{},              // dummy timestamp
 				}
 				wagWriter := wag.MakeWriter(&tc.wagSeq)
-				output := tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
+				output := tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
 					// First, apply the stashed batch from split trigger
 					// evaluation.
-					require.NoError(t, stateBatch.ApplyBatchRepr(ps.batchRepr, false /* sync */))
+					require.NoError(t, b.State().ApplyBatchRepr(ps.batchRepr, false /* sync */))
 					// Then run splitPreApply which does the apply-time tweaks
 					// and stages WAG nodes on the writer.
-					splitPreApply(ctx, kvstorage.StateRW(stateBatch), kvstorage.WrapRaft(raftBatch), &wagWriter, in)
+					splitPreApply(ctx, kvstorage.StateRW(b.State()), kvstorage.Raft{
+						RO: tc.eng.LogEngine(),
+						WO: b.Raft(),
+					}, &wagWriter, in)
 					// Flush WAG nodes to the raft batch, mirroring what
 					// ApplyToStateMachine does in production.
 					require.NoError(t, wagWriter.Flush(
-						kvstorage.WrapRaft(raftBatch).WO, stateBatch.Repr(),
+						b.Raft(), b.State().Repr(),
 					))
 				})
 				// If the RHS replica wasn't destroyed, it is now initialized. Update
@@ -461,11 +465,11 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				require.NotNil(t, rhsRS.replica, "rhs replica must exist for merge application")
 
 				lhsRS.desc = merge.LeftDesc // update to post-merge descriptor
-				output := tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
-					require.NoError(t, stateBatch.ApplyBatchRepr(pm.batchRepr, false /* sync */))
+				output := tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
+					require.NoError(t, b.State().ApplyBatchRepr(pm.batchRepr, false /* sync */))
 					require.NoError(t, kvstorage.SubsumeReplica(ctx, kvstorage.ReadWriter{
-						State: kvstorage.WrapState(stateBatch),
-						Raft:  kvstorage.WrapRaft(raftBatch),
+						State: kvstorage.WrapState(b.State()),
+						Raft:  kvstorage.Raft{RO: tc.eng.LogEngine(), WO: b.Raft()},
 					}, kvstorage.DestroyReplicaInfo{
 						FullReplicaID: rhsRS.replica.FullReplicaID,
 						Keys:          rhsRS.desc.RSpan(),
@@ -487,17 +491,11 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					destroyInfo.Keys = rs.desc.RSpan()
 				}
 
-				output := tc.mutate(t, func(stateBatch, raftBatch storage.Batch) {
-					rw := kvstorage.ReadWriter{
-						State: kvstorage.WrapState(stateBatch),
-						Raft:  kvstorage.WrapRaft(raftBatch),
-					}
-					require.NoError(t, kvstorage.DestroyReplica(
-						ctx,
-						rw,
-						destroyInfo,
-						rs.desc.NextReplicaID,
-					))
+				output := tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
+					require.NoError(t, kvstorage.DestroyReplica(ctx, kvstorage.ReadWriter{
+						State: kvstorage.WrapState(b.State()),
+						Raft:  kvstorage.Raft{RO: tc.eng.LogEngine(), WO: b.Raft()},
+					}, destroyInfo, rs.desc.NextReplicaID))
 				})
 				rs.replica = nil // clear the replica from the range state
 				return output
@@ -513,11 +511,11 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				rs.replica.lastIdx += kvpb.RaftIndex(numEntries)
 				term := rs.replica.hs.Term
 
-				return tc.mutate(t, func(_, raftBatch storage.Batch) {
+				return tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
 					for i := 0; i < numEntries; i++ {
 						entryIndex := lastIndex + 1 + kvpb.RaftIndex(i)
 						require.NoError(t, storage.MVCCBlindPutProto(
-							ctx, raftBatch,
+							ctx, b.Raft(),
 							sl.RaftLogKey(entryIndex), hlc.Timestamp{},
 							&raftpb.Entry{Index: uint64(entryIndex), Term: term},
 							storage.MVCCWriteOptions{},
@@ -545,17 +543,17 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					return append(baseKey, strconv.Itoa(i)...)
 				}
 
-				return tc.mutate(t, func(stateBatch, _ storage.Batch) {
+				return tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
 					// 1. User keys.
 					for i := 0; i < numUserKeys; i++ {
-						require.NoError(t, stateBatch.PutMVCC(
+						require.NoError(t, b.State().PutMVCC(
 							storage.MVCCKey{Key: getUserKey(i), Timestamp: ts}, storage.MVCCValue{},
 						))
 					}
 					// 2. System keys.
 					for i := 0; i < numSystemKeys; i++ {
 						key := keys.TransactionKey(getUserKey(i), uuid.NamespaceDNS)
-						require.NoError(t, stateBatch.PutMVCC(
+						require.NoError(t, b.State().PutMVCC(
 							storage.MVCCKey{Key: key, Timestamp: ts}, storage.MVCCValue{},
 						))
 					}
@@ -564,7 +562,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 						ek, _ := storage.LockTableKey{
 							Key: getUserKey(i), Strength: lock.Intent, TxnUUID: uuid.UUID{},
 						}.ToEngineKey(nil)
-						require.NoError(t, stateBatch.PutEngineKey(ek, nil))
+						require.NoError(t, b.State().PutEngineKey(ek, nil))
 					}
 				})
 
@@ -572,10 +570,10 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
 				numEntries := dd.ScanArgOr(t, d, "num-entries", 1)
 				rs := tc.mustGetRangeState(t, rangeID)
-				return tc.mutate(t, func(stateBatch, _ storage.Batch) {
+				return tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
 					for i := 0; i < numEntries; i++ {
 						txnID := uuid.FromUint128(uint128.FromInts(0, uint64(i+1)))
-						require.NoError(t, rs.abortspan.Put(ctx, stateBatch, nil, /* ms */
+						require.NoError(t, rs.abortspan.Put(ctx, b.State(), nil, /* ms */
 							txnID, &roachpb.AbortSpanEntry{
 								Key:       rs.desc.StartKey.AsRawKey(),
 								Timestamp: hlc.Timestamp{WallTime: 10},
@@ -724,16 +722,13 @@ func (tc *testCtx) close() {
 // and commits them. All KVs written as part of both batches are returned as a
 // string for the benefit of the datadriven test output, with explicit labels
 // for each engine.
-func (tc *testCtx) mutate(t *testing.T, write func(stateBatch, raftBatch storage.Batch)) string {
-	stateBatch := tc.eng.StateEngine().NewBatch()
-	defer stateBatch.Close()
-	raftBatch := tc.eng.LogEngine().NewBatch()
-	defer raftBatch.Close()
+func (tc *testCtx) mutate(t *testing.T, write func(b *kvstorage.Batch[storage.Batch])) string {
+	b := tc.bf.NewBatch()
+	defer b.Close()
+	write(&b)
 
-	write(stateBatch, raftBatch)
-
-	stateRepr := stateBatch.Repr()
-	raftRepr := raftBatch.Repr()
+	stateRepr := b.State().Repr()
+	raftRepr := b.Raft().Repr()
 
 	// If the raft batch contains a WAG node with an embedded state engine
 	// batch, verify it matches and omit the state engine output — the WAG
@@ -749,8 +744,7 @@ func (tc *testCtx) mutate(t *testing.T, write func(stateBatch, raftBatch storage
 	raftOutput, err := print.DecodeWriteBatch(raftRepr)
 	require.NoError(t, err)
 
-	require.NoError(t, raftBatch.Commit(false))
-	require.NoError(t, stateBatch.Commit(false))
+	require.NoError(t, b.Commit(false /* sync */))
 
 	// TODO(arul): There may be double new lines in the output (see tryTxn in
 	// debug_print.go) that we need to strip out for the benefit of the

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -374,22 +374,15 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					initClosedTimestamp: hlc.Timestamp{WallTime: 100}, // dummy timestamp
 					lhsLastReplicaGC:    hlc.Timestamp{},              // dummy timestamp
 				}
-				wagWriter := wag.MakeWriter(&tc.wagSeq)
 				output := tc.mutate(t, func(b *kvstorage.Batch[storage.Batch]) {
-					// First, apply the stashed batch from split trigger
-					// evaluation.
+					// First, apply the stashed batch from split trigger evaluation.
 					require.NoError(t, b.State().ApplyBatchRepr(ps.batchRepr, false /* sync */))
-					// Then run splitPreApply which does the apply-time tweaks
-					// and stages WAG nodes on the writer.
+					// Then run splitPreApply which does the apply-time tweaks and stages
+					// a WAG event in the batch.
 					splitPreApply(ctx, kvstorage.StateRW(b.State()), kvstorage.Raft{
 						RO: tc.eng.LogEngine(),
 						WO: b.Raft(),
-					}, &wagWriter, in)
-					// Flush WAG nodes to the raft batch, mirroring what
-					// ApplyToStateMachine does in production.
-					require.NoError(t, wagWriter.Flush(
-						b.Raft(), b.State().Repr(),
-					))
+					}, b.WagWriter(), in)
 				})
 				// If the RHS replica wasn't destroyed, it is now initialized. Update
 				// the in-memory state to reflect this.
@@ -728,6 +721,7 @@ func (tc *testCtx) mutate(t *testing.T, write func(b *kvstorage.Batch[storage.Ba
 	write(&b)
 
 	stateRepr := b.State().Repr()
+	require.NoError(t, b.TestingFlushWAG())
 	raftRepr := b.Raft().Repr()
 
 	// If the raft batch contains a WAG node with an embedded state engine


### PR DESCRIPTION
Refactor `TestReplicaLifecycleDataDriven` to use the canonical `kvstorage` types for working with separated engines.

Epic: none
Release note: none