### PR TITLE
server: register Migration service with DRPC on tenant server

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -449,6 +449,9 @@ func newTenantServer(
 	// Instantiate the migration API server.
 	tms := newTenantMigrationServer(sqlServer)
 	serverpb.RegisterMigrationServer(args.grpc.Server, tms)
+	if err := serverpb.DRPCRegisterMigration(args.drpc.DRPCServer, tms); err != nil {
+		return nil, err
+	}
 	sqlServer.migrationServer = tms // only for testing via testTenant
 
 	// Tell the authz server how to connect to SQL.


### PR DESCRIPTION
The tenant server was missing DRPC registration for the Migration service, causing "unknown rpc" errors for ValidateTargetClusterVersion when DRPC is enabled. The system server already registered with both gRPC and DRPC, but the tenant path only registered with gRPC.

Epic: none
Fixes: #165799
Release note: None