### PR TITLE
cli,server: add --exclude-log-severities flag to debug zip

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3586,6 +3586,7 @@ Support status: [reserved](#support-status)
 | node_id | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
 | file | [string](#cockroach.server.serverpb.LogFileRequest-string) |  | file is the name of the log file to retrieve. Note that it must not be prefixed by a directory name. The full path to the file is computed by the server based on the base name and the logging configuration. | [reserved](#support-status) |
 | redact | [bool](#cockroach.server.serverpb.LogFileRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the retrieved log entries. Only admin users can send a request with redact = false. | [reserved](#support-status) |
+| exclude_severities | [cockroach.util.log.Severity](#cockroach.server.serverpb.LogFileRequest-cockroach.util.log.Severity) | repeated | exclude_severities, if non-empty, causes log entries with the given severities to be filtered out of the response. | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/log/logpb",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -393,6 +394,22 @@ func testTenantLogs(ctx context.Context, t *testing.T, helper serverccl.TenantTe
 			require.NotEqual(t, entry.TenantID, systemTenantIDStr)
 		}
 	}
+
+	// Verify ExcludeSeverities filtering: excluding INFO should return
+	// only non-INFO entries from the log file.
+	nodeID := helper.TestCluster().Tenant(0).GetTenant().SQLInstanceID().String()
+	filteredResp, err := tenantA.LogFile(ctx, &serverpb.LogFileRequest{
+		NodeId:            nodeID,
+		File:              logsFilesListResp.Files[0].Name,
+		ExcludeSeverities: []logpb.Severity{logpb.Severity_INFO},
+	})
+	require.NoError(t, err)
+	for _, entry := range filteredResp.Entries {
+		require.NotEqual(t, logpb.Severity_INFO, entry.Severity,
+			"INFO entry should have been filtered out: %s", entry.Message)
+	}
+	// The filtered response should be a subset of the unfiltered one.
+	require.LessOrEqual(t, len(filteredResp.Entries), len(logsFileResp.Entries))
 }
 
 func TestTenantCannotSeeNonTenantStats(t *testing.T) {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1881,6 +1881,21 @@ cluster.
 `,
 	}
 
+	ZipExcludeLogSeverity = FlagInfo{
+		Name: "exclude-log-severities",
+		Description: `
+List of log severities to exclude from the collected log files.
+The list can be specified as a comma-delimited list of severity
+names, or by using the flag multiple times. Valid severity names
+are: INFO, WARNING, ERROR, FATAL.
+<PRE>
+
+</PRE>
+For example, --exclude-log-severities=INFO will skip all INFO-level
+log entries, significantly reducing zip file size for large clusters.
+`,
+	}
+
 	ZipCPUProfileDuration = FlagInfo{
 		Name: "cpu-profile-duration",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -371,6 +371,10 @@ type zipContext struct {
 	// The log/heap/etc files to include.
 	files fileSelection
 
+	// excludeLogSeverities lists log severity names (e.g. "INFO") to
+	// exclude from log file collection.
+	excludeLogSeverities []string
+
 	// validateZipFile indicates whether the generated zip file should be validated
 	// post debug zip file generation.
 	validateZipFile bool

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -803,6 +803,7 @@ func init() {
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRangeInfo, cliflags.ZipIncludeRangeInfo)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeStacks, cliflags.ZipIncludeGoroutineStacks)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRunningJobTraces, cliflags.ZipIncludeRunningJobTraces)
+		cliflagcfg.StringSliceFlag(f, &zipCtx.excludeLogSeverities, cliflags.ZipExcludeLogSeverity)
 		cliflagcfg.BoolFlag(f, &zipCtx.validateZipFile, cliflags.ZipValidateFile)
 		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
 		_ = f.MarkHidden(cliflags.UseNewRPC.Name)

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -215,6 +216,16 @@ func validateZipFile(zipFilePath string, zr *zipReporter) error {
 func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 	if err := zipCtx.files.validate(); err != nil {
 		return err
+	}
+
+	// Validate excluded log severities.
+	for _, name := range zipCtx.excludeLogSeverities {
+		if _, ok := logpb.SeverityByName(name); !ok {
+			return errors.Newf(
+				"unknown log severity %q; valid values are INFO, WARNING, ERROR, FATAL",
+				name,
+			)
+		}
 	}
 
 	timeout := 60 * time.Second

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -418,6 +419,15 @@ func (zc *debugZipContext) getLogFiles(
 		// transfers somehow.
 
 		nodePrinter.info("%d log files found", len(logs.Files))
+
+		// Convert validated severity names to proto values for server-side
+		// filtering. These were already validated in runDebugZip.
+		var excludeSeverities []logpb.Severity
+		for _, name := range zipCtx.excludeLogSeverities {
+			sev, _ := logpb.SeverityByName(name)
+			excludeSeverities = append(excludeSeverities, sev)
+		}
+
 		var warnings []string
 		for _, file := range logs.Files {
 			ctime := extractTimeFromFileName(file.Name)
@@ -436,7 +446,10 @@ func (zc *debugZipContext) getLogFiles(
 					var err error
 					entries, err = zc.status.LogFile(
 						ctx, &serverpb.LogFileRequest{
-							NodeId: id, File: file.Name, Redact: zipCtx.redact,
+							NodeId:            id,
+							File:              file.Name,
+							Redact:            zipCtx.redact,
+							ExcludeSeverities: excludeSeverities,
 						})
 					return err
 				}); requestErr != nil {

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -387,6 +387,27 @@ func TestZipExcludeRangeInfo(t *testing.T) {
 	)
 }
 
+func TestZipExcludeLogSeverityValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	c := NewCLITest(TestCLIParams{
+		StoreSpecs: []base.StoreSpec{{
+			Path: dir,
+		}},
+	})
+	defer c.Cleanup()
+
+	// Invalid severity name should produce an error.
+	out, err := c.RunWithCapture(
+		"debug zip --exclude-log-severities=INVALID " + os.DevNull)
+	require.NoError(t, err)
+	require.Contains(t, out, `unknown log severity "INVALID"`)
+}
+
 // This tests the operation of zip running concurrently.
 func TestConcurrentZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -776,6 +776,9 @@ message LogFileRequest {
   // Only admin users can send a request with redact = false.
   bool redact = 3;
   reserved 4;
+  // exclude_severities, if non-empty, causes log entries with the
+  // given severities to be filtered out of the response.
+  repeated cockroach.util.log.Severity exclude_severities = 5;
 }
 
 enum StacksType {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1463,6 +1463,13 @@ func (s *statusServer) LogFile(
 	if s.rpcCtx.TenantID != roachpb.SystemTenantID {
 		tenantIDFilter = s.rpcCtx.TenantID.String()
 	}
+
+	// Build an exclusion set for severity-based filtering.
+	excludeSev := make(map[logpb.Severity]struct{}, len(req.ExcludeSeverities))
+	for _, sev := range req.ExcludeSeverities {
+		excludeSev[sev] = struct{}{}
+	}
+
 	for {
 		var entry logpb.Entry
 		if err := decoder.Decode(&entry); err != nil {
@@ -1490,6 +1497,9 @@ func (s *statusServer) LogFile(
 			return nil, srverrors.ServerError(ctx, err)
 		}
 		if tenantIDFilter != "" && entry.TenantID != tenantIDFilter {
+			continue
+		}
+		if _, excluded := excludeSev[entry.Severity]; excluded {
 			continue
 		}
 		resp.Entries = append(resp.Entries, entry)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -34,10 +35,12 @@ import (
 	tablemetadatacacheutil "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache/util"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
@@ -1075,4 +1078,118 @@ func TestHotRangesNodeLimit(t *testing.T) {
 		require.Equal(t, 5, len(resp.Ranges))
 		return nil
 	})
+}
+
+// TestLogFileExcludeSeverities verifies that the LogFile RPC filters
+// out entries whose severity is in the ExcludeSeverities set.
+func TestLogFileExcludeSeverities(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if log.V(3) {
+		skip.IgnoreLint(t, "Test only works with low verbosity levels")
+	}
+
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+	defer sc.SetupSingleFileLogging()()
+
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer srv.Stopper().Stop(context.Background())
+
+	logCtx := srv.ApplicationLayer().AnnotateCtx(context.Background())
+
+	// Write log entries at different severities.
+	log.Dev.Errorf(logCtx, "sev-filter-test error msg")
+	log.Dev.Warningf(logCtx, "sev-filter-test warning msg")
+	log.Dev.Infof(logCtx, "sev-filter-test info msg")
+	log.FlushAllSync()
+
+	// Find the log file.
+	files, err := log.ListLogFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	fileName := files[0].Name
+
+	ss := srv.StatusServer().(*systemStatusServer)
+	ctx := context.Background()
+
+	// Exclude INFO entries.
+	resp, err := ss.LogFile(ctx, &serverpb.LogFileRequest{
+		NodeId:            "local",
+		File:              fileName,
+		ExcludeSeverities: []logpb.Severity{logpb.Severity_INFO},
+	})
+	require.NoError(t, err)
+
+	for _, entry := range resp.Entries {
+		if entry.Severity == logpb.Severity_INFO &&
+			strings.Contains(entry.Message, "sev-filter-test") {
+			t.Errorf("INFO entry should have been filtered out: %s",
+				entry.Message)
+		}
+	}
+	var foundError, foundWarning bool
+	for _, entry := range resp.Entries {
+		msg := strings.TrimSpace(entry.Message)
+		switch {
+		case msg == "sev-filter-test error msg":
+			foundError = true
+		case msg == "sev-filter-test warning msg":
+			foundWarning = true
+		}
+	}
+	require.True(t, foundError, "ERROR entry should be present")
+	require.True(t, foundWarning, "WARNING entry should be present")
+
+	// Exclude both ERROR and WARNING.
+	resp, err = ss.LogFile(ctx, &serverpb.LogFileRequest{
+		NodeId: "local",
+		File:   fileName,
+		ExcludeSeverities: []logpb.Severity{
+			logpb.Severity_ERROR, logpb.Severity_WARNING,
+		},
+	})
+	require.NoError(t, err)
+	for _, entry := range resp.Entries {
+		if !strings.Contains(entry.Message, "sev-filter-test") {
+			continue
+		}
+		if entry.Severity == logpb.Severity_ERROR ||
+			entry.Severity == logpb.Severity_WARNING {
+			t.Errorf(
+				"entry with severity %s should have been filtered: %s",
+				entry.Severity, entry.Message,
+			)
+		}
+	}
+	var foundInfo bool
+	for _, entry := range resp.Entries {
+		if strings.TrimSpace(entry.Message) == "sev-filter-test info msg" {
+			foundInfo = true
+		}
+	}
+	require.True(t, foundInfo, "INFO entry should be present")
+
+	// Empty ExcludeSeverities returns everything (default behavior).
+	resp, err = ss.LogFile(ctx, &serverpb.LogFileRequest{
+		NodeId: "local",
+		File:   fileName,
+	})
+	require.NoError(t, err)
+	foundError, foundWarning, foundInfo = false, false, false
+	for _, entry := range resp.Entries {
+		msg := strings.TrimSpace(entry.Message)
+		switch {
+		case msg == "sev-filter-test error msg":
+			foundError = true
+		case msg == "sev-filter-test warning msg":
+			foundWarning = true
+		case msg == "sev-filter-test info msg":
+			foundInfo = true
+		}
+	}
+	require.True(t, foundError, "ERROR entry should be present")
+	require.True(t, foundWarning, "WARNING entry should be present")
+	require.True(t, foundInfo, "INFO entry should be present")
 }


### PR DESCRIPTION
Add an `--exclude-log-severities` flag to `debug zip` that filters out
log entries by severity server-side. For large clusters, INFO-level
logs can be extremely voluminous and often aren't needed for debugging.
This flag allows operators to exclude specific severity levels
(e.g. `--exclude-log-severities=INFO`) to reduce both network transfer
and zip file size.

The implementation adds a new `exclude_severities` repeated field to
the `LogFileRequest` protobuf message. The `LogFile()` RPC handler
builds an exclusion set and skips matching entries during the decode
loop. On the CLI side, severity names are validated early in
`runDebugZip` and converted to proto values before being passed in
each per-node `LogFileRequest`.

Rolling upgrade compatibility is maintained without a version gate:
old servers ignore the unknown protobuf field (graceful degradation),
and old clients send an empty field (no filtering).

Epic: none
Fixes: CRDB-61602

Release note (cli change): Added `--exclude-log-severities` flag to
`cockroach debug zip` that filters log entries by severity server-side.
For example, `--exclude-log-severities=INFO` excludes all INFO-level log
entries from the collected log files, which can significantly reduce
zip file size for large clusters. Valid severity names are INFO,
WARNING, ERROR, and FATAL. The flag accepts a comma-delimited list or
can be specified multiple times.