### PR TITLE
release-24.3: backport trunk.yaml configuration

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -19,7 +19,6 @@ merge:
     - "check_generated_code"
     - "docker_image_amd64"
     - "examples_orms"
-    - "label_validation"
     - "lint"
     - "linux_amd64_build"
     - "linux_amd64_fips_build"

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -1,0 +1,49 @@
+# Trunk configuration file
+# This configuration replicates the bors.toml settings for merge queue functionality
+
+version: 0.1
+
+# CLI configuration
+cli:
+  version: 1.22.2
+
+# Merge queue configuration (equivalent to bors.toml)
+merge:
+  # Use Trunk's merge queue service
+  service: queue
+  
+  # Required status checks that must pass before merging
+  # These correspond to the job names in github-actions-essential-ci.yml
+  required_statuses:
+    - "acceptance"
+    - "check_generated_code"
+    - "docker_image_amd64"
+    - "examples_orms"
+    - "label_validation"
+    - "lint"
+    - "linux_amd64_build"
+    - "linux_amd64_fips_build"
+    - "local_roachtest"
+    - "local_roachtest_fips"
+    - "unit_tests"
+  
+# Actions configuration
+actions:
+  enabled:
+    - merge-queue
+
+  # Disable for other branches to avoid conflicts
+  disabled: []
+
+# Plugins configuration (if needed for additional functionality)
+plugins:
+  sources: []
+
+# Lint configuration (keeping minimal for merge queue focus)
+lint:
+  enabled: []
+
+# Runtimes (if needed)
+runtimes:
+  enabled: []
+


### PR DESCRIPTION
Backport:
* 1/4 commits from "build: add Trunk merge queue configuration" (#161230)
* 1/1 commits from "ci: Move trunk to .trunk folder" (#161281)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: infrastructure config for Trunk merge queue