### PR TITLE
pgwire: use HashString for usernames in auth log calls

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2882,11 +2882,11 @@ Events of this type are only emitted when the cluster setting
 | `EventType` | The type of the event. | no |
 | `InstanceID` | The instance ID (not tenant ID) of the SQL server where the event was originated. | no |
 | `Network` | The network protocol for this connection: tcp4, tcp6, unix, etc. | no |
-| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | yes |
+| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | partially |
 | `SessionID` | The connection's hex encoded session id. | no |
 | `Transport` | The connection type after transport negotiation. | no |
-| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | yes |
-| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | yes |
+| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | partially |
+| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | partially |
 
 ### `client_authentication_info`
 
@@ -2911,11 +2911,11 @@ Events of this type are only emitted when the cluster setting
 | `EventType` | The type of the event. | no |
 | `InstanceID` | The instance ID (not tenant ID) of the SQL server where the event was originated. | no |
 | `Network` | The network protocol for this connection: tcp4, tcp6, unix, etc. | no |
-| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | yes |
+| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | partially |
 | `SessionID` | The connection's hex encoded session id. | no |
 | `Transport` | The connection type after transport negotiation. | no |
-| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | yes |
-| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | yes |
+| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | partially |
+| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | partially |
 
 ### `client_authentication_ok`
 
@@ -2939,11 +2939,11 @@ Events of this type are only emitted when the cluster setting
 | `EventType` | The type of the event. | no |
 | `InstanceID` | The instance ID (not tenant ID) of the SQL server where the event was originated. | no |
 | `Network` | The network protocol for this connection: tcp4, tcp6, unix, etc. | no |
-| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | yes |
+| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | partially |
 | `SessionID` | The connection's hex encoded session id. | no |
 | `Transport` | The connection type after transport negotiation. | no |
-| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | yes |
-| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | yes |
+| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | partially |
+| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | partially |
 
 ### `client_connection_end`
 
@@ -2968,7 +2968,7 @@ Events of this type are only emitted when the cluster setting
 | `EventType` | The type of the event. | no |
 | `InstanceID` | The instance ID (not tenant ID) of the SQL server where the event was originated. | no |
 | `Network` | The network protocol for this connection: tcp4, tcp6, unix, etc. | no |
-| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | yes |
+| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | partially |
 | `SessionID` | The connection's hex encoded session id. | no |
 
 ### `client_connection_start`
@@ -2991,7 +2991,7 @@ Events of this type are only emitted when the cluster setting
 | `EventType` | The type of the event. | no |
 | `InstanceID` | The instance ID (not tenant ID) of the SQL server where the event was originated. | no |
 | `Network` | The network protocol for this connection: tcp4, tcp6, unix, etc. | no |
-| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | yes |
+| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | partially |
 | `SessionID` | The connection's hex encoded session id. | no |
 
 ### `client_session_end`
@@ -3016,11 +3016,11 @@ Events of this type are only emitted when the cluster setting
 | `EventType` | The type of the event. | no |
 | `InstanceID` | The instance ID (not tenant ID) of the SQL server where the event was originated. | no |
 | `Network` | The network protocol for this connection: tcp4, tcp6, unix, etc. | no |
-| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | yes |
+| `RemoteAddress` | The remote address of the SQL client. Note that when using a proxy or other intermediate server, this field will contain the address of the intermediate server. | partially |
 | `SessionID` | The connection's hex encoded session id. | no |
 | `Transport` | The connection type after transport negotiation. | no |
-| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | yes |
-| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | yes |
+| `User` | The database username the session is for. This username will have undergone case-folding and Unicode normalization. | partially |
+| `SystemIdentity` | The original system identity provided by the client, if an identity mapping was used per Host-Based Authentication rules. This may be a GSSAPI or X.509 principal or any other external value, so no specific assumptions should be made about the contents of this field. | partially |
 
 ## SQL Slow Query Log
 

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -145,7 +145,7 @@ func (c *conn) handleAuthentication(
 	// client-provided username matches one of the mappings.
 	matchedIdentity, err := c.checkClientUsernameMatchesMapping(ctx, ac, behaviors, systemIdentity)
 	if err != nil {
-		log.Dev.Warningf(ctx, "unable to map incoming identity %q, or san identities %q to any database user: %+v", systemIdentity, behaviors.GetSANIdentities(), err)
+		log.Dev.Warningf(ctx, "unable to map incoming identity %q, or san identities %q to any database user: %+v", redact.HashString(systemIdentity), behaviors.GetSANIdentities(), err)
 		ac.LogAuthFailed(ctx, eventpb.AuthFailReason_USER_NOT_FOUND, err)
 		return connClose, c.sendError(ctx, pgerror.WithCandidateCode(err, pgcode.InvalidAuthorizationSpecification))
 	}
@@ -162,6 +162,7 @@ func (c *conn) handleAuthentication(
 	// Once chooseDbRole() returns, we know that the actual DB username
 	// will be present in c.sessionArgs.User.
 	dbUser := c.sessionArgs.User
+	hashedUser := redact.HashString(dbUser.Normalized())
 
 	// Check that the requested user exists and retrieve the hashed
 	// password in case password authentication is needed.
@@ -173,7 +174,7 @@ func (c *conn) handleAuthentication(
 			c.sessionArgs.SessionDefaults["database"],
 		)
 	if err != nil {
-		log.Dev.Warningf(ctx, "user retrieval failed for user=%q: %+v", dbUser, err)
+		log.Dev.Warningf(ctx, "user retrieval failed for user=%q: %+v", hashedUser, err)
 		ac.LogAuthFailed(ctx, eventpb.AuthFailReason_USER_RETRIEVAL_ERROR, err)
 		return connClose, c.sendError(ctx, pgerror.WithCandidateCode(err, pgcode.InvalidAuthorizationSpecification))
 	}
@@ -182,7 +183,7 @@ func (c *conn) handleAuthentication(
 		if behaviors.IsProvisioningEnabled(execCfg.Settings, hbaEntry.Method.String()) {
 			err := behaviors.MaybeProvisionUser(ctx, execCfg.Settings, hbaEntry.Method.String())
 			if err != nil {
-				log.Dev.Warningf(ctx, "user provisioning failed for user=%q: %+v", dbUser, err)
+				log.Dev.Warningf(ctx, "user provisioning failed for user=%q: %+v", hashedUser, err)
 				ac.LogAuthFailed(ctx, eventpb.AuthFailReason_PROVISIONING_ERROR, err)
 				return connClose, c.sendError(ctx, pgerror.WithCandidateCode(err, pgcode.InvalidAuthorizationSpecification))
 			}
@@ -194,7 +195,7 @@ func (c *conn) handleAuthentication(
 					c.sessionArgs.SessionDefaults["database"],
 				)
 			if err != nil {
-				log.Dev.Warningf(ctx, "user retrieval failed for user=%q: %+v", dbUser, err)
+				log.Dev.Warningf(ctx, "user retrieval failed for user=%q: %+v", hashedUser, err)
 				ac.LogAuthFailed(ctx, eventpb.AuthFailReason_USER_RETRIEVAL_ERROR, err)
 				return connClose, c.sendError(ctx, pgerror.WithCandidateCode(err, pgcode.InvalidAuthorizationSpecification))
 			}
@@ -251,11 +252,11 @@ func (c *conn) handleAuthentication(
 		for _, setting := range settingEntry.Settings {
 			keyVal := strings.SplitN(setting, "=", 2)
 			if len(keyVal) != 2 {
-				log.Ops.Warningf(ctx, "%s has malformed default setting: %q", dbUser, setting)
+				log.Ops.Warningf(ctx, "%s has malformed default setting: %q", hashedUser, setting)
 				continue
 			}
 			if err := sql.CheckSessionVariableValueValid(ctx, execCfg.Settings, keyVal[0], keyVal[1]); err != nil {
-				log.Ops.Warningf(ctx, "%s has invalid default setting: %v", dbUser, err)
+				log.Ops.Warningf(ctx, "%s has invalid default setting: %v", hashedUser, err)
 				continue
 			}
 			if _, ok := c.sessionArgs.SessionDefaults[keyVal[0]]; !ok {
@@ -594,12 +595,14 @@ func newAuthPipe(c *conn, logAuthn bool, authOpt authOptions, systemIdentity str
 		log:         logAuthn,
 		connDetails: authOpt.connDetails,
 		authDetails: eventpb.CommonSessionDetails{
-			SystemIdentity: systemIdentity,
-			Transport:      authOpt.connType.String(),
+			Transport: authOpt.connType.String(),
 		},
 		ch:         make(chan []byte),
 		writerDone: make(chan struct{}),
 		readerDone: make(chan authRes, 1),
+	}
+	if systemIdentity != "" {
+		ap.authDetails.SystemIdentity = redact.Sprintf("%s", redact.HashString(systemIdentity))
 	}
 	return ap
 }
@@ -650,11 +653,19 @@ func (p *authPipe) SetAuthMethod(method redact.SafeString) {
 }
 
 func (p *authPipe) SetDbUser(dbUser username.SQLUsername) {
-	p.authDetails.User = dbUser.Normalized()
+	if n := dbUser.Normalized(); n != "" {
+		p.authDetails.User = redact.Sprintf("%s", redact.HashString(n))
+	} else {
+		p.authDetails.User = ""
+	}
 }
 
 func (p *authPipe) SetSystemIdentity(systemIdentity string) {
-	p.authDetails.SystemIdentity = systemIdentity
+	if systemIdentity != "" {
+		p.authDetails.SystemIdentity = redact.Sprintf("%s", redact.HashString(systemIdentity))
+	} else {
+		p.authDetails.SystemIdentity = ""
+	}
 }
 
 func (p *authPipe) LogAuthOK(ctx context.Context) {

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -1110,7 +1110,7 @@ func AuthorizeLDAPHelper(
 			return redact.Sprint(detailedErr), clientErr
 		}
 		if !found {
-			log.Dev.VInfof(ctx, 1, "LDAP authorization: skipping group %s for user %s as it lacks a common name (CN)", ldapGroup.String(), user.Normalized())
+			log.Dev.VInfof(ctx, 1, "LDAP authorization: skipping group %s for user %s as it lacks a common name (CN)", ldapGroup.String(), redact.HashString(user.Normalized()))
 			continue
 		}
 		sqlRoles = append(sqlRoles, sqlRole)
@@ -1118,7 +1118,7 @@ func AuthorizeLDAPHelper(
 
 	// Assign roles to the user.
 	if err := sql.EnsureUserOnlyBelongsToRoles(ctx, execCfg, user, sqlRoles); err != nil {
-		detailedErr := errors.Wrapf(err, "LDAP authorization: error assigning roles to user %s", user)
+		detailedErr := errors.Wrapf(err, "LDAP authorization: error assigning roles to user %s", redact.HashString(user.Normalized()))
 		clientErr := errors.New("LDAP authorization: failed to synchronize roles")
 		return redact.Sprint(detailedErr), clientErr
 	}

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -932,10 +932,11 @@ func (s *Server) ServeConn(
 	defer onCloseFn()
 
 	sessionID := s.execCfg.GenerateID()
+	remoteAddr := conn.RemoteAddr().String()
 	connDetails := eventpb.CommonConnectionDetails{
 		InstanceID:    int32(s.execCfg.NodeInfo.NodeID.SQLInstanceID()),
 		Network:       conn.RemoteAddr().Network(),
-		RemoteAddress: conn.RemoteAddr().String(),
+		RemoteAddress: redact.Sprintf("%s", redact.HashString(remoteAddr)),
 		SessionID:     sessionID.String(),
 	}
 
@@ -989,14 +990,15 @@ func (s *Server) ServeConn(
 	// shared struct for structured logging.
 	// Only now do we know the remote client address for sure (it may have
 	// been overridden by a status parameter).
-	connDetails.RemoteAddress = sArgs.RemoteAddr.String()
+	remoteAddr = sArgs.RemoteAddr.String()
+	connDetails.RemoteAddress = redact.Sprintf("%s", redact.HashString(remoteAddr))
 	sp := tracing.SpanFromContext(ctx)
 	tags := logtags.BuildBuffer()
-	tags.Add("client", log.SafeOperational(connDetails.RemoteAddress))
+	tags.Add("client", log.SafeOperational(remoteAddr))
 	tags.Add(preServeStatus.ConnType.String(), nil)
 	ctx = logtags.AddTags(ctx, tags.Finish())
 	sp.SetTag("conn_type", attribute.StringValue(preServeStatus.ConnType.String()))
-	sp.SetTag("client", attribute.StringValue(connDetails.RemoteAddress))
+	sp.SetTag("client", attribute.StringValue(remoteAddr))
 
 	// If a test is hooking in some authentication option, load it.
 	var testingAuthHook func(context.Context) error

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1884,9 +1884,7 @@ func (m *CommonConnectionDetails) AppendJSONFields(printComma bool, b redact.Red
 		}
 		printComma = true
 		b = append(b, "\"RemoteAddress\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RemoteAddress)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.RemoteAddress)))
 		b = append(b, '"')
 	}
 
@@ -2408,9 +2406,7 @@ func (m *CommonSessionDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"User\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.User)))
 		b = append(b, '"')
 	}
 
@@ -2420,9 +2416,7 @@ func (m *CommonSessionDetails) AppendJSONFields(printComma bool, b redact.Redact
 		}
 		printComma = true
 		b = append(b, "\"SystemIdentity\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.SystemIdentity)))))
-		b = append(b, redact.EndMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SystemIdentity)))
 		b = append(b, '"')
 	}
 

--- a/pkg/util/log/eventpb/session_events.proto
+++ b/pkg/util/log/eventpb/session_events.proto
@@ -38,7 +38,7 @@ message CommonConnectionDetails {
   // The remote address of the SQL client. Note that when using a
   // proxy or other intermediate server, this field will contain the
   // address of the intermediate server.
-  string remote_address = 3 [(gogoproto.jsontag) = ",omitempty"];
+  string remote_address = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\""];
   // The connection's hex encoded session id.
   string session_id = 4 [(gogoproto.customname) = "SessionID", (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
@@ -53,13 +53,13 @@ message CommonSessionDetails {
   string transport = 1 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
   // The database username the session is for. This username will have
   // undergone case-folding and Unicode normalization.
-  string user = 2 [(gogoproto.jsontag) = ",omitempty"];
+  string user = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\""];
   // The original system identity provided by the client, if an identity
   // mapping was used per Host-Based Authentication rules. This may be a
   // GSSAPI or X.509 principal or any other external value, so no
   // specific assumptions should be made about the contents of this
   // field.
-  string system_identity = 3 [(gogoproto.jsontag) = ",omitempty"];
+  string system_identity = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\""];
 }
 
 // ClientConnectionStart is reported when a client connection

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base/serverident"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/errors"
@@ -386,6 +388,86 @@ func TestHashRedaction(t *testing.T) {
 
 		require.Equal(t, "user=‹×›", hashAlice())
 	})
+}
+
+// TestHashRedactionPerSink verifies that hash-based redaction respects
+// per-sink redaction settings: a sink with redact=true should hash
+// HashString values while a sink with redact=false should show cleartext.
+func TestHashRedactionPerSink(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	redact.DisableHashing()
+	t.Cleanup(redact.DisableHashing)
+
+	s := ScopeWithoutShowLogs(t)
+	defer s.Close(t)
+
+	// Configure two file sinks:
+	//   "redacted" on SESSIONS channel with redact=true
+	//   "unredacted" on OPS channel with redact=false
+	cfg := logconfig.DefaultConfig()
+	bt, bf := true, false
+	cfg.Sinks.FileGroups = map[string]*logconfig.FileSinkConfig{
+		"redacted": {
+			FileDefaults: logconfig.FileDefaults{
+				CommonSinkConfig: logconfig.CommonSinkConfig{
+					Redact:     &bt,
+					Redactable: &bt,
+				},
+			},
+			Channels: logconfig.SelectChannels(channel.SESSIONS),
+		},
+		"unredacted": {
+			FileDefaults: logconfig.FileDefaults{
+				CommonSinkConfig: logconfig.CommonSinkConfig{
+					Redact:     &bf,
+					Redactable: &bt,
+				},
+			},
+			Channels: logconfig.SelectChannels(channel.OPS),
+		},
+	}
+	cfg.Redaction.Hashing.Enabled = true
+	cfg.Redaction.Hashing.Salt = "test-salt"
+	if err := cfg.Validate(&s.logDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup, err := ApplyConfigForReconfig(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	// Log the same HashString value to both channels.
+	Sessions.Infof(context.Background(), "user=%s", redact.HashString("alice"))
+	Ops.Infof(context.Background(), "user=%s", redact.HashString("alice"))
+
+	FlushFiles()
+
+	// Read back the redacted sink — should contain a hash, not cleartext.
+	redactedLogger := logging.getLogger(channel.SESSIONS)
+	redactedFile := redactedLogger.getFileSink().getFileName(t)
+	redactedContents, err := os.ReadFile(redactedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.NotContains(t, string(redactedContents), "alice",
+		"redacted sink should not contain cleartext")
+	require.NotContains(t, string(redactedContents), "‹×›",
+		"redacted sink should contain hash, not full redaction marker")
+	require.Contains(t, string(redactedContents), "user=‹",
+		"redacted sink should contain hashed value in markers")
+
+	// Read back the unredacted sink — should contain cleartext.
+	unredactedLogger := logging.getLogger(channel.OPS)
+	unredactedFile := unredactedLogger.getFileSink().getFileName(t)
+	unredactedContents, err := os.ReadFile(unredactedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Contains(t, string(unredactedContents), "alice",
+		"unredacted sink should contain cleartext")
 }
 
 func BenchmarkDefaultSafeRedaction(b *testing.B) {


### PR DESCRIPTION
Convert usernames in authentication log calls to use redact.HashString() instead of passing them as plain unsafe format arguments. When hash-based redaction is enabled (via log config), these values now produce deterministic 8-character hex hashes instead of being fully redacted to ×, enabling cross-entry correlation in support diagnostics without exposing the actual data.

Also adds TestHashRedactionPerSink which verifies that hash-based redaction respects per-sink settings: a sink with redact=true hashes HashString values while a sink with redact=false shows cleartext.

Epic: CRDB-47199

Release note (ops change): When hash-based redaction is enabled in the logging configuration, usernames in authentication logs now produce deterministic hashes instead of being fully redacted. This allows support engineers to correlate the same user across multiple log entries without seeing the actual values.