### PR TITLE
sqlproxyccl: use HashString for IP addresses in log calls

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_jackc_pgproto3_v2//:pgproto3",
         "@com_github_pires_go_proxyproto//:go-proxyproto",
         "@com_github_prometheus_common//expfmt",

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/jackc/pgproto3/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -123,7 +124,7 @@ func (c *connector) OpenTenantConnWithToken(
 		return nil, err
 	}
 	c.CancelInfo.setNewBackend(newBackendKeyData, serverConn.RemoteAddr().(*net.TCPAddr))
-	log.Dev.Infof(ctx, "connected to %s through token-based auth", serverConn.RemoteAddr())
+	log.Dev.Infof(ctx, "connected to %s through token-based auth", redact.HashString(serverConn.RemoteAddr().String()))
 	return serverConn, nil
 }
 
@@ -164,7 +165,7 @@ func (c *connector) OpenTenantConnWithAuth(
 	if err != nil {
 		return nil, true, err
 	}
-	log.Dev.Infof(ctx, "connected to %s through normal auth", serverConn.RemoteAddr())
+	log.Dev.Infof(ctx, "connected to %s through normal auth", redact.HashString(serverConn.RemoteAddr().String()))
 	c.CancelInfo.setNewBackend(crdbBackendKeyData, serverConn.RemoteAddr().(*net.TCPAddr))
 	return serverConn, false, nil
 }

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 	"github.com/jackc/pgproto3/v2"
 	proxyproto "github.com/pires/go-proxyproto"
 	"google.golang.org/grpc"
@@ -372,7 +373,7 @@ func (handler *proxyHandler) handle(
 			// fake cancel requests.
 			log.Dev.Warningf(
 				ctx, "could not handle cancel request from client %s: %v",
-				incomingConn.RemoteAddr().String(), err,
+				redact.HashString(incomingConn.RemoteAddr().String()), err,
 			)
 		}
 		return nil

--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/prometheus/common/expfmt"
 )
@@ -443,7 +444,7 @@ func (s *Server) shouldLogError(
 		log.Dev.Errorf(
 			ctx,
 			"unexpected error: cannot extract remote IP from connection; found: %v",
-			conn.RemoteAddr().String(),
+			redact.HashString(conn.RemoteAddr().String()),
 		)
 		return true
 	}


### PR DESCRIPTION
Convert IP addresses in SQL proxy log calls to use redact.HashString() instead of passing them as plain unsafe format arguments. When hash-based redaction is enabled (via log config), these values now produce deterministic 8-character hex hashes instead of being fully redacted to ×, enabling cross-entry correlation in support diagnostics without exposing the actual data.

Epic: CRDB-47199

Release note (ops change): When hash-based redaction is enabled in the logging configuration, IP addresses in SQL proxy logs now produce deterministic hashes instead of being fully redacted. This allows support engineers to correlate the same client across multiple log entries without seeing the actual values.