### PR TITLE
kvserver: add timeout to mma change application

### DIFF
--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -45,10 +46,11 @@ type replicaToApplyChanges interface {
 // TODO(wenyihu6): add allocator sync which coordinates with replicate queue
 // and store rebalancer and store pool.
 type mmaStoreRebalancer struct {
-	store *mmaStore
-	mma   mmaprototype.Allocator
-	st    *cluster.Settings
-	as    *mmaintegration.AllocatorSync
+	store              *mmaStore
+	mma                mmaprototype.Allocator
+	st                 *cluster.Settings
+	as                 *mmaintegration.AllocatorSync
+	processTimeoutFunc queueProcessTimeoutFunc
 }
 
 func newMMAStoreRebalancer(
@@ -58,10 +60,11 @@ func newMMAStoreRebalancer(
 	opts := allocatorimpl.MakeDiskCapacityOptions(&st.SV)
 	mma.SetDiskUtilThresholds(opts.RebalanceToThreshold, opts.ShedAndBlockAllThreshold)
 	return &mmaStoreRebalancer{
-		store: (*mmaStore)(s),
-		mma:   mma,
-		st:    st,
-		as:    s.cfg.AllocatorSync,
+		store:              (*mmaStore)(s),
+		mma:                mma,
+		st:                 st,
+		as:                 s.cfg.AllocatorSync,
+		processTimeoutFunc: makeRateLimitedTimeoutFunc(rebalanceSnapshotRate),
 	}
 }
 
@@ -180,33 +183,45 @@ func (m *mmaStoreRebalancer) applyChange(
 	return err
 }
 
+// processTimeout computes the timeout for applying a change to a replica,
+// using the same rate-limited timeout function as the replicate queue and the
+// old store rebalancer.
+func (m *mmaStoreRebalancer) processTimeout(repl replicaToApplyChanges) time.Duration {
+	return m.processTimeoutFunc(m.st, repl.(*Replica))
+}
+
 // applyLeaseTransfer applies a lease transfer change.
 func (m *mmaStoreRebalancer) applyLeaseTransfer(
 	ctx context.Context, repl replicaToApplyChanges, change mmaprototype.ExternalRangeChange,
 ) error {
-	return repl.AdminTransferLease(
-		ctx,
-		change.LeaseTransferTarget(),
-		false, /* bypassSafetyChecks */
-	)
+	timeout := m.processTimeout(repl)
+	return timeutil.RunWithTimeout(ctx, "mma transfer lease", timeout,
+		func(ctx context.Context) error {
+			return repl.AdminTransferLease(
+				ctx,
+				change.LeaseTransferTarget(),
+				false, /* bypassSafetyChecks */
+			)
+		})
 }
 
 // applyReplicaChanges applies replica membership changes.
 func (m *mmaStoreRebalancer) applyReplicaChanges(
 	ctx context.Context, repl replicaToApplyChanges, change mmaprototype.ExternalRangeChange,
 ) error {
-	// TODO(mma): We should be setting a timeout on the ctx here, in the case
-	// where rebalancing takes a long time (stuck behind other snapshots).
-	// See replicateQueue.processTimeoutFunc.
 	// TODO(wenyihu6): store rebalancer uses RelocateRange
-	_, err := repl.changeReplicasImpl(
-		ctx,
-		repl.Desc(),
-		kvserverpb.SnapshotRequest_REPLICATE_QUEUE,
-		0,
-		kvserverpb.ReasonRebalance,
-		"todo: this is the rebalance detail for the range log",
-		change.ReplicationChanges(),
-	)
-	return err
+	timeout := m.processTimeout(repl)
+	return timeutil.RunWithTimeout(ctx, "mma change replicas", timeout,
+		func(ctx context.Context) error {
+			_, err := repl.changeReplicasImpl(
+				ctx,
+				repl.Desc(),
+				kvserverpb.SnapshotRequest_REPLICATE_QUEUE,
+				0,
+				kvserverpb.ReasonRebalance,
+				"todo: this is the rebalance detail for the range log",
+				change.ReplicationChanges(),
+			)
+			return err
+		})
 }


### PR DESCRIPTION
Neither `AdminTransferLease` nor `changeReplicasImpl` enforces an
internal timeout. `changeReplicasImpl` can block waiting for a
snapshot send semaphore permit in `throttleSnapshot`.
`AdminTransferLease` is mostly bounded (~6s retry cap on transfer
rejections), but its outer loop waiting on in-progress lease
extensions has no retry limit and can theoretically cycle indefinitely.

This change wraps both `applyLeaseTransfer` and `applyReplicaChanges`
with `timeutil.RunWithTimeout`, using the same
`makeRateLimitedTimeoutFunc(rebalanceSnapshotRate)` timeout as the
replicate queue and the old store rebalancer.

Note that the same rate-limited formula is used for both lease transfers
and replica changes. This is generous for lease transfers, but
acceptable since the goal is to prevent indefinite blocking rather than
enforce a tight deadline.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>