### PR TITLE
backup: close restore task channels in runRestore

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -658,6 +658,10 @@ func restore(
 	tasks = append(tasks, tracingAggLoop)
 
 	runRestore := func(ctx context.Context) error {
+		defer close(progCh)
+		defer close(tracingAggCh)
+		defer close(procCompleteCh)
+
 		if details.OnlineImpl() {
 			log.Dev.Warningf(ctx, "EXPERIMENTAL ONLINE RESTORE being used")
 

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -196,8 +196,6 @@ func sendAddRemoteSSTs(
 	tracingAggCh chan *execinfrapb.TracingAggregatorEvents,
 	genSpan func(ctx context.Context, spanCh chan execinfrapb.RestoreSpanEntry) error,
 ) (approxRows int64, approxDataSize int64, err error) {
-	defer close(tracingAggCh)
-
 	const targetRangeSize = 440 << 20
 
 	kr, err := MakeKeyRewriterFromRekeys(execCtx.ExecCfg().Codec, dataToRestore.getRekeys(), dataToRestore.getTenantRekeys(),

--- a/pkg/backup/restore_processor_planning.go
+++ b/pkg/backup/restore_processor_planning.go
@@ -62,9 +62,6 @@ func distRestore(
 	tracingAggCh chan *execinfrapb.TracingAggregatorEvents,
 	procCompleteCh chan struct{},
 ) error {
-	defer close(progCh)
-	defer close(tracingAggCh)
-	defer close(procCompleteCh)
 	var noTxn *kv.Txn
 
 	if md.encryption != nil && md.encryption.Mode == jobspb.EncryptionMode_KMS {


### PR DESCRIPTION
The channels used to signal between tasks in the restore ctxgroup were
closed by the functions runRestore called (distRestore, sendAddRemoteSSTs)
rather than by runRestore itself. Since runRestore now has multiple
execution paths with early returns — notably the online restore pre-split
path that bypasses distRestore entirely — the channels could be left open,
hanging the consumer goroutines forever.

Move the closes into runRestore so they run regardless of which path is taken.

Fixes #165431

Release note: None