### PR TITLE
sql: enable write buffering for transactions at weak isolation levels in tests

### DIFF
--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1871,6 +1871,13 @@ func TestReadCommittedLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestReadCommittedLogic_select_for_share_write_buffering(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_share_write_buffering")
+}
+
 func TestReadCommittedLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1830,6 +1830,13 @@ func TestRepeatableReadLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestRepeatableReadLogic_select_for_share_write_buffering(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_share_write_buffering")
+}
+
 func TestRepeatableReadLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/ccl/testccl/sqlccl/read_committed_test.go
+++ b/pkg/ccl/testccl/sqlccl/read_committed_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -54,18 +55,31 @@ func TestReadCommittedStmtRetry(t *testing.T) {
 			return nil
 		}
 		for _, arg := range ba.Requests {
-			if req := arg.GetInner(); req.Method() == kvpb.Put {
-				put := req.(*kvpb.PutRequest)
-				// Only count writes to the kv table.
-				_, tableID, err := codec.DecodeTablePrefix(put.Key)
-				if err != nil || tableID != kvTableId {
-					return nil
+			req := arg.GetInner()
+			var key roachpb.Key
+			switch t := req.(type) {
+			case *kvpb.PutRequest:
+				key = t.Key
+			case *kvpb.GetRequest:
+				// With write buffering, writes are decomposed into locking
+				// Get requests (to acquire locks) and buffered writes. Intercept
+				// locking Gets in addition to Puts.
+				if t.KeyLockingStrength != lock.Exclusive {
+					continue
 				}
-				trappedReadCommittedWritesOnce.Do(func() {
-					close(finishedReadCommittedScans)
-					<-finishedExternalTxn
-				})
+				key = t.Key
+			default:
+				continue
 			}
+			// Only count writes to the kv table.
+			_, tableID, err := codec.DecodeTablePrefix(key)
+			if err != nil || tableID != kvTableId {
+				return nil
+			}
+			trappedReadCommittedWritesOnce.Do(func() {
+				close(finishedReadCommittedScans)
+				<-finishedExternalTxn
+			})
 		}
 
 		return nil

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -82,6 +82,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -3761,7 +3762,9 @@ var allowBufferedWritesForWeakIsolation = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.txn.write_buffering_for_weak_isolation.enabled",
 	"set to true to allow write buffering for transactions at weak isolation levels",
-	false,
+	metamorphic.ConstantWithTestBool(
+		"sql.txn.write_buffering_for_weak_isolation.enabled", false, /* defaultValue */
+	),
 )
 
 func (ex *connExecutor) txnIsolationLevelToKV(

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -151,6 +151,12 @@ database_name schema_name table_name  lock_key_pretty     lock_strength   durabi
 # check that we can't see keys, potentially revealing PII, with VIEWACTIVITYREDACTED
 user testuser2
 
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
+statement ok
+SET default_transaction_isolation = 'SERIALIZABLE'
+
 query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
 ----

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks_write_buffering
@@ -1,6 +1,15 @@
 # LogicTest: local-read-committed
 
 statement ok
+SET CLUSTER SETTING sql.txn.write_buffering_for_weak_isolation.enabled = true;
+
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.transformations.get.enabled = true;
+
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.transformations.scans.enabled = true;
+
+statement ok
 SET kv_transaction_buffered_writes_enabled = true;
 
 statement ok
@@ -409,8 +418,8 @@ query TTTTTTTBB colnames,rowsort,retry
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, regexp_replace(isolation_level, 'READ COMMITTED', 'READ_COMMITTED') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name = 't'
 ----
 database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability  isolation_level  granted  contended
-test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  READ_COMMITTED   true     true
-test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  SERIALIZABLE     false    true
+test           public       t           /Table/106/1/"a"/0  Exclusive      Unreplicated  READ_COMMITTED   true     true
+test           public       t           /Table/106/1/"a"/0  Exclusive      Unreplicated  SERIALIZABLE     false    true
 
 statement ok
 COMMIT
@@ -442,8 +451,8 @@ query TTTTTTTBB colnames,rowsort,retry
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, regexp_replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name = 't'
 ----
 database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability  isolation_level  granted  contended
-test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  REPEATABLE_READ  true     true
-test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  READ_COMMITTED   false    true
+test           public       t           /Table/106/1/"a"/0  Exclusive      Unreplicated  REPEATABLE_READ  true     true
+test           public       t           /Table/106/1/"a"/0  Exclusive      Unreplicated  READ_COMMITTED   false    true
 
 statement ok
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/select_for_share
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share
@@ -1,6 +1,9 @@
 # LogicTest: !local-prepared
 
 statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
+statement ok
 CREATE TABLE t(a INT PRIMARY KEY);
 INSERT INTO t VALUES(1);
 GRANT ALL ON t TO testuser;
@@ -9,6 +12,9 @@ GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
 GRANT ALL ON t TO testuser2;
 
 user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
 
 statement ok
 SET enable_shared_locking_for_serializable = true;
@@ -38,6 +44,9 @@ SELECT * FROM t  WHERE a = 1 FOR SHARE;
 1
 
 user testuser2
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
 
 statement async writeReq count 1
 UPDATE t SET a = 2 WHERE a = 1

--- a/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
@@ -1,0 +1,228 @@
+# LogicTest: weak-iso-level-configs
+
+# This test mirrors select_for_share but with write buffering enabled, which
+# changes lock durability from Replicated to Unreplicated for weak isolation
+# transactions and affects lock visibility in crdb_internal.cluster_locks.
+
+statement ok
+SET CLUSTER SETTING sql.txn.write_buffering_for_weak_isolation.enabled = true;
+
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.transformations.get.enabled = true;
+
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.transformations.scans.enabled = true;
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
+statement ok
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES(1);
+GRANT ALL ON t TO testuser;
+CREATE USER testuser2 WITH VIEWACTIVITY;
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
+GRANT ALL ON t TO testuser2;
+
+user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t WHERE a = 1 FOR SHARE;
+----
+1
+
+# Start another transaction to show multiple transactions can acquire SHARED
+# locks at the same time.
+
+user root
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t  WHERE a = 1 FOR SHARE;
+----
+1
+
+user testuser2
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
+statement async writeReq count 1
+UPDATE t SET a = 2 WHERE a = 1
+
+onlyif config local-read-committed
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/1/0  Shared         Unreplicated  READ_COMMITTED   true     true
+test           public       t           /Table/106/1/1/0  Exclusive      Unreplicated  READ_COMMITTED   false    true
+test           public       t           /Table/106/1/1/0  Shared         Unreplicated  READ_COMMITTED   true     true
+
+onlyif config local-repeatable-read
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/1/0  Shared         Unreplicated  REPEATABLE_READ  true     true
+test           public       t           /Table/106/1/1/0  Exclusive      Unreplicated  REPEATABLE_READ  false    true
+test           public       t           /Table/106/1/1/0  Shared         Unreplicated  REPEATABLE_READ  true     true
+
+# Commit the first transaction and rollback the second.
+
+user testuser
+
+statement ok
+COMMIT
+
+user root
+
+statement ok
+ROLLBACK
+
+user testuser2
+
+# Now that both the transactions that issued shared lock reads have been
+# finalized, the write should be able to proceed.
+
+awaitstatement writeReq
+
+query I
+SELECT * FROM t;
+----
+2
+
+# Test that FOR SHARE acquires locks visible in cluster_locks with write
+# buffering (Unreplicated durability makes them always visible).
+
+user testuser
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t WHERE a = 2 FOR SHARE
+----
+2
+
+user testuser2
+
+onlyif config local-read-committed
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/2/0  Shared         Unreplicated  READ_COMMITTED   true     false
+
+onlyif config local-repeatable-read
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/2/0  Shared         Unreplicated  REPEATABLE_READ  true     false
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t FOR SHARE SKIP LOCKED
+----
+2
+
+user root
+
+onlyif config local-read-committed
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/2/0  Shared         Unreplicated  READ_COMMITTED   true     false
+test           public       t           /Table/106/1/2/0  Shared         Unreplicated  READ_COMMITTED   true     false
+
+onlyif config local-repeatable-read
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/2/0  Shared         Unreplicated  REPEATABLE_READ  true     false
+test           public       t           /Table/106/1/2/0  Shared         Unreplicated  REPEATABLE_READ  true     false
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+
+statement ok
+COMMIT
+
+# Complete the open transactions.
+user testuser
+
+statement ok
+COMMIT
+
+user testuser2
+
+statement ok
+COMMIT
+
+# Ensure FOR SHARE SKIP LOCKED works correctly with replicated locks.
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES(1), (2);
+GRANT ALL ON t TO testuser;
+
+user testuser
+
+query I
+BEGIN;
+SELECT * FROM t WHERE a = 1 FOR SHARE;
+----
+1
+
+user root
+
+# Locks:
+# 1: Shared
+# 2: None
+
+query I
+BEGIN;
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+2
+
+user testuser2
+
+# Locks:
+# 1: Shared
+# 2: Exclusive
+
+query I
+BEGIN;
+SELECT * FROM t FOR SHARE SKIP LOCKED;
+COMMIT;
+----
+1
+
+user root
+
+statement ok
+COMMIT
+
+user testuser
+
+statement ok
+COMMIT


### PR DESCRIPTION
Make write buffering for weak isolation levels (READ COMMITTED,
REPEATABLE READ) a metamorphic test setting that defaults to false in
production. This enables broader test coverage of write buffering
under weak isolation without changing production behavior.

Epic: none
Release note: None

---

See other commits for some test tweaks and additions. Most commits come from @stevendanna's branch [ssd/bw-weak-iso-test-compat](https://github.com/cockroachdb/cockroach/compare/master...stevendanna:cockroach:ssd/bw-weak-iso-test-compat).