### PR TITLE
roachtest: disable SST batcher elastic control in bulkingest

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -651,6 +651,9 @@ func makeSchemaChangeBulkIngestTest(
 				if _, err := db.Exec("SET CLUSTER SETTING bulkio.index_backfill.elastic_control.enabled = $1", enableElasticCPUControl); err != nil {
 					t.Fatal(err)
 				}
+				if _, err := db.Exec("SET CLUSTER SETTING bulkio.ingest.sst_batcher_elastic_control.enabled = $1", enableElasticCPUControl); err != nil {
+					t.Fatal(err)
+				}
 
 				t.L().Printf("Computing table statistics manually")
 				if _, err := db.Exec("CREATE STATISTICS stats from bulkingest.bulkingest"); err != nil {


### PR DESCRIPTION
The elastic=false variant of the bulkingest roachtest was only disabling two of the three elastic CPU control settings relevant to index backfills. While bulkio.index_backfill.elastic_control.enabled and kvadmission.elastic_control_bulk_low_priority.enabled were disabled, the SST batcher's own pacer (bulkio.ingest.sst_batcher_elastic_control.enabled) remained active. Since every index entry flows through the BulkAdder into the SSTBatcher, this meant the bulk of the elastic CPU pacing was still in effect even with elastic=false.

Closes #165339

Release note: None
Epic: None