### PR TITLE
kvstorage: relax StateEngine key assertion

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -472,27 +472,18 @@ func validateIsStateEngineSpan(span spanset.TrickySpan) error {
 			"could not decode range ID for span: %s", span)
 	}
 
-	// If the span is inside RangeIDLocalSpans but outside RangeIDUnreplicated,
-	// it cannot overlap local raft keys.
-	rangeIDPrefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
+	// The only RangeID-local keys not belonging to StateEngine are unreplicated
+	// keys > RangeTombstoneKey, with one exception of the RaftReplicaIDKey.
+	rangeIDBuf := keys.MakeRangeIDPrefixBuf(rangeID)
+	unreplEnd := rangeIDBuf.UnreplicatedPrefix().PrefixEnd() // NB: copies
 	if !spanset.Overlaps(roachpb.Span{
-		Key:    rangeIDPrefixBuf.UnreplicatedPrefix(),
-		EndKey: rangeIDPrefixBuf.UnreplicatedPrefix().PrefixEnd(),
+		Key:    rangeIDBuf.RangeTombstoneKey().Next(),
+		EndKey: unreplEnd,
 	}, span) {
 		return nil
 	}
-
-	// RangeTombstoneKey and RaftReplicaIDKey belong to the StateEngine, and can
-	// be accessed as point keys.
-	if roachpb.Span(span).Equal(roachpb.Span{
-		Key: rangeIDPrefixBuf.RangeTombstoneKey(),
-	}) {
-		return nil
-	}
-
-	if roachpb.Span(span).Equal(roachpb.Span{
-		Key: rangeIDPrefixBuf.RaftReplicaIDKey(),
-	}) {
+	// RaftReplicaIDKey is in the StateEngine, and can be accessed as a point key.
+	if roachpb.Span(span).Equal(roachpb.Span{Key: rangeIDBuf.RaftReplicaIDKey()}) {
 		return nil
 	}
 

--- a/pkg/kv/kvserver/kvstorage/storage_test.go
+++ b/pkg/kv/kvserver/kvstorage/storage_test.go
@@ -30,6 +30,9 @@ func TestValidateIsStateEngineSpan(t *testing.T) {
 		// Full state engine spans.
 		{span: s(roachpb.KeyMin, keys.LocalRangeIDPrefix.AsRawKey())},
 		{span: s(keys.RangeForceFlushKey(1), keys.RangeLeaseKey(1))},
+		{span: s(keys.MakeRangeIDReplicatedPrefix(1), keys.RangeTombstoneKey(1))},
+		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1), nil)},
+		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd().Prevish(1), nil)},
 		{span: s(keys.LocalStoreMax, roachpb.KeyMax)},
 
 		// Full non-state engine spans.
@@ -64,10 +67,8 @@ func TestValidateIsStateEngineSpan(t *testing.T) {
 		{span: s(roachpb.KeyMax, nil)},
 
 		// Point non-state engine spans.
-		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1), nil), notOk: true},
 		{span: s(keys.RaftTruncatedStateKey(1), nil), notOk: true},
 		{span: s(keys.RaftTruncatedStateKey(2), nil), notOk: true},
-		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd().Prevish(1), nil), notOk: true},
 		{span: s(keys.LocalStorePrefix, nil), notOk: true},
 		{span: s(keys.StoreGossipKey(), nil), notOk: true},
 		{span: s(keys.LocalStoreMax.Prevish(1), nil), notOk: true},
@@ -76,13 +77,13 @@ func TestValidateIsStateEngineSpan(t *testing.T) {
 		{span: s(nil, keys.LocalRangeIDPrefix.AsRawKey())},
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1))},
 		{span: s(nil, keys.RangeForceFlushKey(1))},
+		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).Next())},
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd().Next())},
 		{span: s(nil, keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd().Next())},
 		{span: s(nil, keys.LocalStorePrefix)},
 		{span: s(nil, keys.LocalStoreMax.Next())},
 
 		// Tricky non-state engine spans.
-		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).Next()), notOk: true},
 		{span: s(nil, keys.RaftTruncatedStateKey(1).Next()), notOk: true},
 		{span: s(nil, keys.RaftTruncatedStateKey(2).Next()), notOk: true},
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd()), notOk: true},


### PR DESCRIPTION
The assertion in the `StateEngine` only allowed `RangeTombstone` accessed as a point key. However, all unreplicated keys <= `RangeTombstone` are in the `StateEngine`. Replica destruction code makes a shortcut to take advantage of this (crosses from replicated to unreplicated keyspace in one op). Relax the assertion so that this is allowed.

Resolves #164351