### PR TITLE
ui: fix TypeError crash in sumNodeStats when liveness data is undefined

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/nodes/nodeSummaryStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/nodes/nodeSummaryStats.ts
@@ -66,7 +66,11 @@ export function sumNodeStats(
     replicas: 0,
   };
 
-  if (!nodeStatuses?.length || !Object.keys(livenessStatusByNodeID).length) {
+  if (
+    !nodeStatuses?.length ||
+    !livenessStatusByNodeID ||
+    !Object.keys(livenessStatusByNodeID).length
+  ) {
     return result;
   }
 


### PR DESCRIPTION
When PR #165430 moved sumNodeStats from db-console/src/redux/nodes.ts to cluster-ui/src/nodes/nodeSummaryStats.ts, the guard condition was rewritten from `isArray(nodeStatuses) && !isEmpty(livenessStatusByNodeID)` to `!nodeStatuses?.length || !Object.keys(livenessStatusByNodeID).length`.

These are not equivalent when `livenessStatusByNodeID` is undefined (before the liveness API responds): `isEmpty(undefined)` safely returns true, but `Object.keys(undefined)` throws a `TypeError`. This creates a race condition on the metrics page — if the nodes API response arrives before liveness, `nodeSumsSelector` recomputes and crashes, preventing the page from rendering. A browser refresh works because both responses are cached by then.

Add a null guard before the `Object.keys` call so the function returns the empty result when liveness data hasn't loaded yet.

Fixes #165771
Epic: None
Release Note: None