### PR TITLE
sql/schemachanger: add support for dropping enum values

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -547,6 +547,13 @@ func TestBackupRollbacks_base_alter_type_add_value(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1398,6 +1405,13 @@ func TestBackupRollbacksMixedVersion_base_alter_type_add_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2255,6 +2269,13 @@ func TestBackupSuccess_base_alter_type_add_value(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3106,6 +3127,13 @@ func TestBackupSuccessMixedVersion_base_alter_type_add_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
@@ -109,9 +109,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"root"}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east1","PhysicalRepresentation":"QA==","TypeID":106}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east2","PhysicalRepresentation":"gA==","TypeID":106}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east3","PhysicalRepresentation":"wA==","TypeID":106}
  │              ├── MarkDescriptorAsDropped {"DescriptorID":105}
  │              ├── RemoveSchemaParent {"Parent":{"ParentDatabaseID":104,"SchemaID":105}}
  │              ├── NotImplementedForPublicObjects {"DescID":107,"ElementType":"scpb.Owner"}
@@ -128,6 +125,9 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967292,"TableID":108}
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"crdb_internal_re...","SchemaID":105}}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east1","PhysicalRepresentation":"QA==","TypeID":106}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east2","PhysicalRepresentation":"gA==","TypeID":106}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east3","PhysicalRepresentation":"wA==","TypeID":106}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":105,"Name":"public"}}
  │              ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
@@ -323,9 +323,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"root"}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east1","PhysicalRepresentation":"QA==","TypeID":106}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east2","PhysicalRepresentation":"gA==","TypeID":106}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east3","PhysicalRepresentation":"wA==","TypeID":106}
  │              ├── MarkDescriptorAsDropped {"DescriptorID":105}
  │              ├── RemoveSchemaParent {"Parent":{"ParentDatabaseID":104,"SchemaID":105}}
  │              ├── NotImplementedForPublicObjects {"DescID":107,"ElementType":"scpb.Owner"}
@@ -343,6 +340,9 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}
  │              ├── RemoveDatabaseRoleSettings {"DatabaseID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"crdb_internal_re...","SchemaID":105}}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east1","PhysicalRepresentation":"QA==","TypeID":106}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east2","PhysicalRepresentation":"gA==","TypeID":106}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"us-east3","PhysicalRepresentation":"wA==","TypeID":106}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":105,"Name":"public"}}
  │              ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1259,6 +1259,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		sql.ValidateForwardIndexes,
 		sql.ValidateInvertedIndexes,
 		sql.ValidateConstraint,
+		sql.ValidateEnumValueRemoval,
 		sql.NewInternalSessionData,
 	)
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -348,6 +348,9 @@ CREATE TYPE alphabets AS ENUM('a', 'b', 'c', 'd', 'e', 'f');
 CREATE TABLE uses_alphabets (k INT PRIMARY KEY, v1 alphabets, v2 alphabets);
 INSERT INTO uses_alphabets VALUES (1, 'a', 'a'), (2, 'b', 'c')
 
+statement error pq: enum value "nonexistent" does not exist
+ALTER TYPE alphabets DROP VALUE 'nonexistent'
+
 statement error pq: could not remove enum value "a" as it is being used by "uses_alphabets"
 ALTER TYPE alphabets DROP VALUE 'a'
 
@@ -504,13 +507,18 @@ ALTER TYPE ab_58710 ADD VALUE 'c';
 statement ok
 ALTER TYPE ab_58710 DROP VALUE 'a';
 
-# 'c' was added to the enum above and 'a' was dropped, so the array type alias
-# should reflect this.
-statement ok
-SELECT ARRAY['c']::_ab_58710;
+# 'c' was added to the enum above and 'a' was dropped, so the enum should
+# reflect this. The declarative schema changer processes ADD/DROP VALUE
+# asynchronously, so retry until the changes are visible.
+retry
+query T
+SELECT 'c'::ab_58710
+----
+c
 
+retry
 statement error invalid input value for enum ab_58710: "a"
-SELECT ARRAY['a']::_ab_58710
+SELECT 'a'::ab_58710
 
 subtest regression_60004_basic
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -36,7 +36,7 @@ var supportedAlterTypeStatements = map[reflect.Type]supportedAlterTypeCommand{
 	reflect.TypeOf((*tree.AlterTypeRename)(nil)):      {fn: alterTypeRename, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeSetSchema)(nil)):   {fn: alterTypeSetSchema, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeOwner)(nil)):       {fn: alterTypeOwner, on: false, checks: nil},
-	reflect.TypeOf((*tree.AlterTypeDropValue)(nil)):   {fn: alterTypeDropValue, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeDropValue)(nil)):   {fn: alterTypeDropValue, on: true, checks: isV263Active},
 }
 
 func init() {
@@ -237,5 +237,31 @@ func alterTypeOwner(
 func alterTypeDropValue(
 	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeDropValue,
 ) {
-	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE DROP VALUE is not supported"))
+	dropVal := string(t.Val)
+
+	var found bool
+	b.QueryByID(enumType.TypeID).FilterEnumTypeValue().ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.EnumTypeValue) {
+			if e.LogicalRepresentation != dropVal {
+				return
+			}
+			if target == scpb.ToAbsent {
+				panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"enum value %q is already being dropped", dropVal))
+			}
+			if target != scpb.ToPublic {
+				panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"enum value %q is being added, try again later", dropVal))
+			}
+			found = true
+			b.Drop(e)
+			b.LogEventForExistingPayload(e, &eventpb.AlterType{
+				TypeName: tn.FQString(),
+			})
+		},
+	)
+	if !found {
+		panic(pgerror.Newf(pgcode.UndefinedObject,
+			"enum value %q does not exist", dropVal))
+	}
 }

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_type
@@ -7,3 +7,9 @@ ALTER TYPE defaultdb.climes ADD VALUE 'desert'
 ----
 - [[EnumTypeValue:{DescID: 104, Name: desert}, PUBLIC], ABSENT]
   {logicalRepresentation: desert, physicalRepresentation: 4A==, typeId: 104}
+
+build
+ALTER TYPE defaultdb.climes DROP VALUE 'arctic'
+----
+- [[EnumTypeValue:{DescID: 104, Name: arctic}, ABSENT], PUBLIC]
+  {logicalRepresentation: arctic, physicalRepresentation: gA==, typeId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
@@ -7,10 +7,6 @@ ALTER TYPE defaultdb.climes RENAME VALUE 'tropical' TO 'equatorial'
 ----
 
 unimplemented
-ALTER TYPE defaultdb.climes DROP VALUE 'arctic'
-----
-
-unimplemented
 ALTER TYPE defaultdb.climes RENAME TO environs
 ----
 

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1253,6 +1253,19 @@ func (s *TestState) ValidateConstraint(
 	return nil
 }
 
+// ValidateEnumTypeValueRemoval implements the validator interface.
+func (s *TestState) ValidateEnumTypeValueRemoval(
+	ctx context.Context,
+	typeDesc catalog.TypeDescriptor,
+	physicalRep []byte,
+	logicalRep string,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	s.LogSideEffectf("validate enum value %q removal in type #%d",
+		logicalRep, typeDesc.GetID())
+	return nil
+}
+
 func (s *TestState) ValidateForeignKeyConstraint(
 	ctx context.Context,
 	out catalog.TableDescriptor,

--- a/pkg/sql/schemachanger/scdeps/validator.go
+++ b/pkg/sql/schemachanger/scdeps/validator.go
@@ -60,20 +60,33 @@ type ValidateConstraintFn func(
 	execOverride sessiondata.InternalExecutorOverride,
 ) error
 
+// ValidateEnumTypeValueRemovalFn is a callback function for validating
+// that an enum value is safe to remove.
+type ValidateEnumTypeValueRemovalFn func(
+	ctx context.Context,
+	codec keys.SQLCodec,
+	typeDesc catalog.TypeDescriptor,
+	physicalRep []byte,
+	logicalRep string,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
+	execOverride sessiondata.InternalExecutorOverride,
+) error
+
 // NewFakeSessionDataFn callback function used to create session data
 // for the internal executor.
 type NewFakeSessionDataFn func(ctx context.Context, settings *cluster.Settings, opName redact.SafeString) *sessiondata.SessionData
 
 type validator struct {
-	db                         *kv.DB
-	codec                      keys.SQLCodec
-	settings                   *cluster.Settings
-	ieFactory                  isql.DB
-	validateForwardIndexes     ValidateForwardIndexesFn
-	validateInvertedIndexes    ValidateInvertedIndexesFn
-	validateConstraint         ValidateConstraintFn
-	newFakeSessionData         NewFakeSessionDataFn
-	protectedTimestampProvider scexec.ProtectedTimestampManager
+	db                           *kv.DB
+	codec                        keys.SQLCodec
+	settings                     *cluster.Settings
+	ieFactory                    isql.DB
+	validateForwardIndexes       ValidateForwardIndexesFn
+	validateInvertedIndexes      ValidateInvertedIndexesFn
+	validateConstraint           ValidateConstraintFn
+	validateEnumTypeValueRemoval ValidateEnumTypeValueRemovalFn
+	newFakeSessionData           NewFakeSessionDataFn
+	protectedTimestampProvider   scexec.ProtectedTimestampManager
 }
 
 // ValidateForwardIndexes checks that the indexes have entries for all the rows.
@@ -120,6 +133,21 @@ func (vd validator) ValidateConstraint(
 		vd.makeHistoricalInternalExecTxnRunner(), override)
 }
 
+// ValidateEnumTypeValueRemoval checks that an enum value can be safely removed
+// with no table rows referencing it.
+func (vd validator) ValidateEnumTypeValueRemoval(
+	ctx context.Context,
+	typeDesc catalog.TypeDescriptor,
+	physicalRep []byte,
+	logicalRep string,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	return vd.validateEnumTypeValueRemoval(
+		ctx, vd.codec, typeDesc, physicalRep, logicalRep,
+		vd.makeHistoricalInternalExecTxnRunner(), override,
+	)
+}
+
 // makeHistoricalInternalExecTxnRunner creates a new transaction runner which
 // always runs at the same time and that time is the current time as of when
 // this constructor was called.
@@ -148,17 +176,19 @@ func NewValidator(
 	validateForwardIndexes ValidateForwardIndexesFn,
 	validateInvertedIndexes ValidateInvertedIndexesFn,
 	validateCheckConstraint ValidateConstraintFn,
+	validateEnumTypeValueRemoval ValidateEnumTypeValueRemovalFn,
 	newFakeSessionData NewFakeSessionDataFn,
 ) scexec.Validator {
 	return validator{
-		db:                         db,
-		codec:                      codec,
-		settings:                   settings,
-		ieFactory:                  ieFactory,
-		validateForwardIndexes:     validateForwardIndexes,
-		validateInvertedIndexes:    validateInvertedIndexes,
-		validateConstraint:         validateCheckConstraint,
-		newFakeSessionData:         newFakeSessionData,
-		protectedTimestampProvider: protectedTimestampProvider,
+		db:                           db,
+		codec:                        codec,
+		settings:                     settings,
+		ieFactory:                    ieFactory,
+		validateForwardIndexes:       validateForwardIndexes,
+		validateInvertedIndexes:      validateInvertedIndexes,
+		validateConstraint:           validateCheckConstraint,
+		validateEnumTypeValueRemoval: validateEnumTypeValueRemoval,
+		newFakeSessionData:           newFakeSessionData,
+		protectedTimestampProvider:   protectedTimestampProvider,
 	}
 }

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -220,7 +220,8 @@ type Merger interface {
 	MergeIndexes(context.Context, *jobs.Job, MergeProgress, BackfillerProgressWriter, catalog.TableDescriptor) error
 }
 
-// Validator provides interfaces that allow indexes and check constraints to be validated.
+// Validator provides interfaces that allow indexes, check constraints,
+// and enum type values to be validated.
 type Validator interface {
 	ValidateForwardIndexes(
 		ctx context.Context,
@@ -243,6 +244,14 @@ type Validator interface {
 		tbl catalog.TableDescriptor,
 		constraint catalog.Constraint,
 		indexIDForValidation descpb.IndexID,
+		override sessiondata.InternalExecutorOverride,
+	) error
+
+	ValidateEnumTypeValueRemoval(
+		ctx context.Context,
+		typeDesc catalog.TypeDescriptor,
+		physicalRep []byte,
+		logicalRep string,
 		override sessiondata.InternalExecutorOverride,
 	) error
 }

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -131,6 +131,30 @@ func executeValidateColumnNotNull(
 	return nil
 }
 
+func executeValidateEnumTypeValueRemoval(
+	ctx context.Context, deps Dependencies, op *scop.ValidateEnumTypeValueRemoval,
+) error {
+	descs, err := deps.Catalog().MustReadImmutableDescriptors(ctx, op.TypeID)
+	if err != nil {
+		return err
+	}
+	desc := descs[0]
+	typeDesc, err := catalog.AsTypeDescriptor(desc)
+	if err != nil {
+		return err
+	}
+
+	// Execute the validation operation as a node user.
+	execOverride := sessiondata.NodeUserSessionDataOverride
+	err = deps.Validator().ValidateEnumTypeValueRemoval(
+		ctx, typeDesc, op.PhysicalRepresentation, op.LogicalRepresentation, execOverride,
+	)
+	if err != nil {
+		return scerrors.SchemaChangerUserError(err)
+	}
+	return nil
+}
+
 func executeValidationOps(ctx context.Context, deps Dependencies, ops []scop.Op) (err error) {
 	v := makeValidationAccumulator(ops)
 	return v.validate(ctx, deps)
@@ -139,9 +163,10 @@ func executeValidationOps(ctx context.Context, deps Dependencies, ops []scop.Op)
 // validationAccumulator batches validation operations on a per-table basis, so
 // that index validations can be batched together.
 type validationAccumulator struct {
-	indexes     map[descpb.ID][]*scop.ValidateIndex
-	constraints map[descpb.ID][]*scop.ValidateConstraint
-	notNulls    map[descpb.ID][]*scop.ValidateColumnNotNull
+	indexes        map[descpb.ID][]*scop.ValidateIndex
+	constraints    map[descpb.ID][]*scop.ValidateConstraint
+	notNulls       map[descpb.ID][]*scop.ValidateColumnNotNull
+	enumValueDrops []*scop.ValidateEnumTypeValueRemoval
 }
 
 // makeValidationAccumulator creates a validationAccumulator from a list of
@@ -160,6 +185,8 @@ func makeValidationAccumulator(ops []scop.Op) validationAccumulator {
 			v.constraints[op.TableID] = append(v.constraints[op.TableID], op)
 		case *scop.ValidateColumnNotNull:
 			v.notNulls[op.TableID] = append(v.notNulls[op.TableID], op)
+		case *scop.ValidateEnumTypeValueRemoval:
+			v.enumValueDrops = append(v.enumValueDrops, op)
 		default:
 			panic("unimplemented")
 		}
@@ -195,6 +222,14 @@ func (v validationAccumulator) validate(ctx context.Context, deps Dependencies) 
 				}
 				return errors.Wrapf(err, "%T: %v", constraint, constraint)
 			}
+		}
+	}
+	for _, enumDrop := range v.enumValueDrops {
+		if err := executeValidateEnumTypeValueRemoval(ctx, deps, enumDrop); err != nil {
+			if scerrors.HasSchemaChangerUserError(err) {
+				return err
+			}
+			return errors.Wrapf(err, "%T: %v", enumDrop, enumDrop)
 		}
 	}
 	return nil

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -503,6 +503,16 @@ func (noopValidator) ValidateConstraint(
 	return nil
 }
 
+func (noopValidator) ValidateEnumTypeValueRemoval(
+	ctx context.Context,
+	typeDesc catalog.TypeDescriptor,
+	physicalRep []byte,
+	logicalRep string,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	return nil
+}
+
 type noopStatsReferesher struct{}
 
 var _ scexec.StatsRefresher = noopStatsReferesher{}

--- a/pkg/sql/schemachanger/scop/validation.go
+++ b/pkg/sql/schemachanger/scop/validation.go
@@ -54,5 +54,18 @@ func (ValidateColumnNotNull) Description() redact.RedactableString {
 	return "Validating NOT NULL constraint"
 }
 
+// ValidateEnumTypeValueRemoval validates that an enum value is unused before
+// it's removed.
+type ValidateEnumTypeValueRemoval struct {
+	validationOp
+	TypeID                 descpb.ID
+	PhysicalRepresentation []byte
+	LogicalRepresentation  string
+}
+
+func (ValidateEnumTypeValueRemoval) Description() redact.RedactableString {
+	return "Validating removal of enum type value"
+}
+
 // Make sure baseOp is used for linter.
 var _ = validationOp{baseOp: baseOp{}}

--- a/pkg/sql/schemachanger/scop/validation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/validation_visitor_generated.go
@@ -20,6 +20,7 @@ type ValidationVisitor interface {
 	ValidateIndex(context.Context, ValidateIndex) error
 	ValidateConstraint(context.Context, ValidateConstraint) error
 	ValidateColumnNotNull(context.Context, ValidateColumnNotNull) error
+	ValidateEnumTypeValueRemoval(context.Context, ValidateEnumTypeValueRemoval) error
 }
 
 // Visit is part of the ValidationOp interface.
@@ -35,4 +36,9 @@ func (op ValidateConstraint) Visit(ctx context.Context, v ValidationVisitor) err
 // Visit is part of the ValidationOp interface.
 func (op ValidateColumnNotNull) Visit(ctx context.Context, v ValidationVisitor) error {
 	return v.ValidateColumnNotNull(ctx, op)
+}
+
+// Visit is part of the ValidationOp interface.
+func (op ValidateEnumTypeValueRemoval) Visit(ctx context.Context, v ValidationVisitor) error {
+	return v.ValidateEnumTypeValueRemoval(ctx, op)
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
@@ -191,6 +191,17 @@ func checkIfDescriptorIsWithoutData(id descpb.ID, md *opGenContext) bool {
 	return !doesDescriptorHaveData
 }
 
+// isEnumTypeBeingDropped checks if the EnumType element for the given
+// type ID has a target status of ABSENT.
+func isEnumTypeBeingDropped(typeID descpb.ID, md *opGenContext) bool {
+	for _, t := range md.Targets {
+		if et, ok := t.Element().(*scpb.EnumType); ok && et.TypeID == typeID {
+			return t.TargetStatus == scpb.Status_ABSENT
+		}
+	}
+	return false
+}
+
 // checkIfZoneConfigHasGCDependents will determine if a table/database
 // descriptor has data dependencies it still needs to GC. This allows us to
 // determine when we need to skip certain operations like deleting a zone

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_enum_type_value.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_enum_type_value.go
@@ -23,6 +23,7 @@ func init() {
 					}
 				}),
 			),
+			equiv(scpb.Status_VALIDATED),
 			to(scpb.Status_PUBLIC,
 				revertible(false),
 				emit(func(this *scpb.EnumTypeValue) *scop.PromoteEnumTypeValue {
@@ -39,6 +40,18 @@ func init() {
 			to(scpb.Status_WRITE_ONLY,
 				emit(func(this *scpb.EnumTypeValue) *scop.DemoteEnumTypeValue {
 					return &scop.DemoteEnumTypeValue{
+						TypeID:                 this.TypeID,
+						PhysicalRepresentation: this.PhysicalRepresentation,
+						LogicalRepresentation:  this.LogicalRepresentation,
+					}
+				}),
+			),
+			to(scpb.Status_VALIDATED,
+				emit(func(this *scpb.EnumTypeValue, md *opGenContext) *scop.ValidateEnumTypeValueRemoval {
+					if isEnumTypeBeingDropped(this.TypeID, md) {
+						return nil
+					}
+					return &scop.ValidateEnumTypeValueRemoval{
 						TypeID:                 this.TypeID,
 						PhysicalRepresentation: this.PhysicalRepresentation,
 						LogicalRepresentation:  this.LogicalRepresentation,

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -721,7 +721,23 @@ deprules
     - descriptorIsNotBeingDropped-26.3($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'EnumTypeValue transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->ABSENT'
+- name: 'EnumTypeValue transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
+  from: prev-Node
+  kind: PreviousTransactionPrecedence
+  to: next-Node
+  query:
+    - $prev[Type] = '*scpb.EnumTypeValue'
+    - $next[Type] = '*scpb.EnumTypeValue'
+    - $prev[DescID] = $descID
+    - $prev[Self] = $next
+    - $prev-Target[Self] = $next-Target
+    - $prev-Target[TargetStatus] = ABSENT
+    - $prev-Node[CurrentStatus] = VALIDATED
+    - $next-Node[CurrentStatus] = ABSENT
+    - descriptorIsNotBeingDropped-26.3($prev)
+    - joinTargetNode($prev, $prev-Target, $prev-Node)
+    - joinTargetNode($next, $next-Target, $next-Node)
+- name: 'EnumTypeValue transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
   from: prev-Node
   kind: PreviousTransactionPrecedence
   to: next-Node
@@ -733,7 +749,7 @@ deprules
     - $prev-Target[Self] = $next-Target
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = ABSENT
+    - $next-Node[CurrentStatus] = VALIDATED
     - descriptorIsNotBeingDropped-26.3($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -753,6 +769,22 @@ deprules
     - descriptorIsNotBeingDropped-26.3($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
+- name: 'EnumTypeValue transitions to PUBLIC uphold 2-version invariant: VALIDATED->WRITE_ONLY'
+  from: prev-Node
+  kind: PreviousTransactionPrecedence
+  to: next-Node
+  query:
+    - $prev[Type] = '*scpb.EnumTypeValue'
+    - $next[Type] = '*scpb.EnumTypeValue'
+    - $prev[DescID] = $descID
+    - $prev[Self] = $next
+    - $prev-Target[Self] = $next-Target
+    - $prev-Target[TargetStatus] = PUBLIC
+    - $prev-Node[CurrentStatus] = VALIDATED
+    - $next-Node[CurrentStatus] = WRITE_ONLY
+    - descriptorIsNotBeingDropped-26.3($prev)
+    - joinTargetNode($prev, $prev-Target, $prev-Node)
+    - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'EnumTypeValue transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC'
   from: prev-Node
   kind: PreviousTransactionPrecedence
@@ -767,6 +799,7 @@ deprules
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = PUBLIC
     - descriptorIsNotBeingDropped-26.3($prev)
+    - nodeNotExistsWithStatusIn_VALIDATED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: Final compute expression is always added after transient compute expression
@@ -6135,7 +6168,23 @@ deprules
     - descriptorIsNotBeingDropped-26.3($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'EnumTypeValue transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->ABSENT'
+- name: 'EnumTypeValue transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
+  from: prev-Node
+  kind: PreviousTransactionPrecedence
+  to: next-Node
+  query:
+    - $prev[Type] = '*scpb.EnumTypeValue'
+    - $next[Type] = '*scpb.EnumTypeValue'
+    - $prev[DescID] = $descID
+    - $prev[Self] = $next
+    - $prev-Target[Self] = $next-Target
+    - $prev-Target[TargetStatus] = ABSENT
+    - $prev-Node[CurrentStatus] = VALIDATED
+    - $next-Node[CurrentStatus] = ABSENT
+    - descriptorIsNotBeingDropped-26.3($prev)
+    - joinTargetNode($prev, $prev-Target, $prev-Node)
+    - joinTargetNode($next, $next-Target, $next-Node)
+- name: 'EnumTypeValue transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
   from: prev-Node
   kind: PreviousTransactionPrecedence
   to: next-Node
@@ -6147,7 +6196,7 @@ deprules
     - $prev-Target[Self] = $next-Target
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = ABSENT
+    - $next-Node[CurrentStatus] = VALIDATED
     - descriptorIsNotBeingDropped-26.3($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -6167,6 +6216,22 @@ deprules
     - descriptorIsNotBeingDropped-26.3($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
+- name: 'EnumTypeValue transitions to PUBLIC uphold 2-version invariant: VALIDATED->WRITE_ONLY'
+  from: prev-Node
+  kind: PreviousTransactionPrecedence
+  to: next-Node
+  query:
+    - $prev[Type] = '*scpb.EnumTypeValue'
+    - $next[Type] = '*scpb.EnumTypeValue'
+    - $prev[DescID] = $descID
+    - $prev[Self] = $next
+    - $prev-Target[Self] = $next-Target
+    - $prev-Target[TargetStatus] = PUBLIC
+    - $prev-Node[CurrentStatus] = VALIDATED
+    - $next-Node[CurrentStatus] = WRITE_ONLY
+    - descriptorIsNotBeingDropped-26.3($prev)
+    - joinTargetNode($prev, $prev-Target, $prev-Node)
+    - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'EnumTypeValue transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC'
   from: prev-Node
   kind: PreviousTransactionPrecedence
@@ -6181,6 +6246,7 @@ deprules
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = PUBLIC
     - descriptorIsNotBeingDropped-26.3($prev)
+    - nodeNotExistsWithStatusIn_VALIDATED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: Final compute expression is always added after transient compute expression

--- a/pkg/sql/schemachanger/scplan/testdata/alter_type_drop_value
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_type_drop_value
@@ -1,0 +1,72 @@
+setup
+CREATE TYPE defaultdb.salmon AS ENUM('sockeye', 'king', 'atlantic');
+----
+
+ops
+ALTER TYPE defaultdb.salmon DROP VALUE 'atlantic'
+----
+StatementPhase stage 1 of 1 with 1 MutationType op
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, ABSENT], PUBLIC] -> WRITE_ONLY
+  ops:
+    *scop.DemoteEnumTypeValue
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, ABSENT], WRITE_ONLY] -> PUBLIC
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 3 MutationType ops
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, ABSENT], PUBLIC] -> WRITE_ONLY
+  ops:
+    *scop.DemoteEnumTypeValue
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+      Initialize: true
+    *scop.CreateSchemaChangerJob
+      Authorization:
+        AppName: $ internal-test
+        UserName: root
+      DescriptorIDs:
+      - 104
+      JobID: 1
+      RunningStatus: 'Pending: Validating removal of enum type value (1 operation) — PostCommit phase (stage 1 of 1).'
+      Statements:
+      - statement: ALTER TYPE defaultdb.salmon DROP VALUE 'atlantic'
+        redactedstatement: ALTER TYPE defaultdb.public.salmon DROP VALUE ‹'atlantic'›
+        statementtag: ALTER TYPE
+PostCommitPhase stage 1 of 1 with 1 ValidationType op
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, ABSENT], WRITE_ONLY] -> VALIDATED
+  ops:
+    *scop.ValidateEnumTypeValueRemoval
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops
+  transitions:
+    [[EnumTypeValue:{DescID: 104, Name: atlantic}, ABSENT], VALIDATED] -> ABSENT
+  ops:
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: atlantic
+      PhysicalRepresentation:
+      - 192
+      TypeID: 104
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 104
+      JobID: 1
+    *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      IsNonCancelable: true
+      JobID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -1001,11 +1001,6 @@ StatementPhase stage 1 of 1 with 326 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 115
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 115
     *scop.NotImplementedForPublicObjects
       DescID: 116
       ElementType: scpb.Owner
@@ -1250,6 +1245,11 @@ StatementPhase stage 1 of 1 with 326 MutationType ops
         DescriptorID: 115
         Name: typ
         SchemaID: 106
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 115
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 104
@@ -2618,11 +2618,6 @@ PreCommitPhase stage 2 of 2 with 342 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 115
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 115
     *scop.NotImplementedForPublicObjects
       DescID: 116
       ElementType: scpb.Owner
@@ -2869,6 +2864,11 @@ PreCommitPhase stage 2 of 2 with 342 MutationType ops
         DescriptorID: 115
         Name: typ
         SchemaID: 106
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 115
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 104

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -651,11 +651,6 @@ StatementPhase stage 1 of 1 with 203 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 111
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 111
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -780,6 +775,11 @@ StatementPhase stage 1 of 1 with 203 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 110
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 111
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 113
@@ -1667,11 +1667,6 @@ PreCommitPhase stage 2 of 2 with 215 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 111
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 111
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -1796,6 +1791,11 @@ PreCommitPhase stage 2 of 2 with 215 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 110
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 111
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 113

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -3420,11 +3420,6 @@ StatementPhase stage 1 of 1 with 256 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 111
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 111
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -3584,6 +3579,11 @@ StatementPhase stage 1 of 1 with 256 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 110
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 111
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 113
@@ -4687,11 +4687,6 @@ PreCommitPhase stage 2 of 2 with 268 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 111
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 111
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -4851,6 +4846,11 @@ PreCommitPhase stage 2 of 2 with 268 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 110
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 111
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 113

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -57,11 +57,6 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 104
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -80,6 +75,11 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 105
       User: root
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 104
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100, IntValue: 101}, ABSENT], ABSENT] -> PUBLIC
@@ -151,11 +151,6 @@ PreCommitPhase stage 2 of 2 with 19 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
-    *scop.RemoveEnumTypeValue
-      LogicalRepresentation: a
-      PhysicalRepresentation:
-      - 128
-      TypeID: 104
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -174,6 +169,11 @@ PreCommitPhase stage 2 of 2 with 19 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 105
       User: root
+    *scop.RemoveEnumTypeValue
+      LogicalRepresentation: a
+      PhysicalRepresentation:
+      - 128
+      TypeID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -547,6 +547,13 @@ func TestEndToEndSideEffects_alter_type_add_value(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1398,6 +1405,13 @@ func TestExecuteWithDMLInjection_alter_type_add_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2255,6 +2269,13 @@ func TestGenerateSchemaChangeCorpus_alter_type_add_value(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3106,6 +3127,13 @@ func TestPause_alter_type_add_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3963,6 +3991,13 @@ func TestPauseMixedVersion_alter_type_add_value(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4814,6 +4849,13 @@ func TestRollback_alter_type_add_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_type_drop_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value__rollback_1_of_1.explain
@@ -1,0 +1,21 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king');
+
+/* test */
+ALTER TYPE salmon ADD VALUE 'atlantic';
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TYPE defaultdb.public.salmon ADD VALUE ‹'atlantic'›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY → VALIDATED EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+      │    └── 1 Validation operation
+      │         └── ValidateEnumTypeValueRemoval {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED → ABSENT EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+           └── 3 Mutation operations
+                ├── RemoveEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye', 'atlantic');
+----
+
+test
+ALTER TYPE salmon DROP VALUE 'atlantic';
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.explain
@@ -1,0 +1,40 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye', 'atlantic');
+
+/* test */
+EXPLAIN (DDL) ALTER TYPE salmon DROP VALUE 'atlantic';
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› DROP VALUE ‹'atlantic'›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 1 Mutation operation
+ │              └── DemoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── WRITE_ONLY → PUBLIC EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 3 Mutation operations
+ │              ├── DemoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
+ ├── PostCommitPhase
+ │    └── Stage 1 of 1 in PostCommitPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── WRITE_ONLY → VALIDATED EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 1 Validation operation
+ │              └── ValidateEnumTypeValueRemoval {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED → ABSENT EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+           └── 3 Mutation operations
+                ├── RemoveEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye', 'atlantic');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TYPE salmon DROP VALUE 'atlantic';
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› DROP VALUE ‹'atlantic'›;
+ ├── execute 1 system table mutations transaction
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.side_effects
@@ -1,0 +1,138 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye', 'atlantic');
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
+
+/* test */
+ALTER TYPE salmon DROP VALUE 'atlantic';
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TYPE
+increment telemetry for sql.schema.alter_type.drop_value
+increment telemetry for sql.udts.alter_enum
+write *eventpb.AlterType to event log:
+  sql:
+    descriptorId: 104
+    statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› DROP VALUE ‹'atlantic'›
+    tag: ALTER TYPE
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert descriptor #104
+  ...
+     - logicalRepresentation: sockeye
+       physicalRepresentation: gA==
+  -  - logicalRepresentation: atlantic
+  +  - capability: READ_ONLY
+  +    direction: REMOVE
+  +    logicalRepresentation: atlantic
+       physicalRepresentation: wA==
+     id: 104
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 104
+  +      name: salmon
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› DROP VALUE ‹'atlantic'›
+  +        statement: ALTER TYPE salmon DROP VALUE 'atlantic'
+  +        statementTag: ALTER TYPE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: chinook
+  ...
+     - logicalRepresentation: sockeye
+       physicalRepresentation: gA==
+  -  - logicalRepresentation: atlantic
+  +  - capability: READ_ONLY
+  +    direction: REMOVE
+  +    logicalRepresentation: atlantic
+       physicalRepresentation: wA==
+     id: 104
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TYPE defaultdb.public.salmon DROP VALUE 'atlantic'"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 1 ValidationType op
+validate enum value "atlantic" removal in type #104
+commit transaction #3
+begin transaction #4
+## PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      id: 104
+  -      name: salmon
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› DROP VALUE ‹'atlantic'›
+  -        statement: ALTER TYPE salmon DROP VALUE 'atlantic'
+  -        statementTag: ALTER TYPE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: chinook
+  ...
+     - logicalRepresentation: sockeye
+       physicalRepresentation: gA==
+  -  - capability: READ_ONLY
+  -    direction: REMOVE
+  -    logicalRepresentation: atlantic
+  -    physicalRepresentation: wA==
+     id: 104
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #4
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value__rollback_1_of_1.explain
@@ -1,0 +1,16 @@
+/* setup */
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye', 'atlantic');
+
+/* test */
+ALTER TYPE salmon DROP VALUE 'atlantic';
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TYPE defaultdb.public.salmon DROP VALUE ‹'atlantic'›;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── WRITE_ONLY → PUBLIC EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+           └── 3 Mutation operations
+                ├── PromoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.explain
@@ -34,12 +34,12 @@ Schema change plan for DROP TYPE ‹defaultdb›.‹public›.‹blue_fish›;
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"root"}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"salmon","PhysicalRepresentation":"gA==","TypeID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_blue_fish","SchemaID":101}}
  │              ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"public"}
- │              └── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
+ │              └── RemoveEnumTypeValue {"LogicalRepresentation":"salmon","PhysicalRepresentation":"gA==","TypeID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 15 elements transitioning toward ABSENT
@@ -88,12 +88,12 @@ Schema change plan for DROP TYPE ‹defaultdb›.‹public›.‹blue_fish›;
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"root"}
- │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"salmon","PhysicalRepresentation":"gA==","TypeID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_blue_fish","SchemaID":101}}
  │              ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
+ │              ├── RemoveEnumTypeValue {"LogicalRepresentation":"salmon","PhysicalRepresentation":"gA==","TypeID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1141,6 +1141,35 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 	return t.canRemoveEnumValueFromArrayUsages(ctx, arrayTypeDesc, member, txn, descsCol)
 }
 
+// ValidateEnumValueRemoval checks that the given enum value is unused and safe to remove.
+func ValidateEnumValueRemoval(
+	ctx context.Context,
+	codec keys.SQLCodec,
+	typeDesc catalog.TypeDescriptor,
+	physicalRep []byte,
+	logicalRep string,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	member := descpb.TypeDescriptor_EnumMember{
+		PhysicalRepresentation: physicalRep,
+		LogicalRepresentation:  logicalRep,
+		Capability:             descpb.TypeDescriptor_EnumMember_READ_ONLY,
+		Direction:              descpb.TypeDescriptor_EnumMember_REMOVE,
+	}
+	return runHistoricalTxn.Exec(ctx, func(ctx context.Context, txn descs.Txn) error {
+		mutableType, err := txn.Descriptors().MutableByID(txn.KV()).Type(ctx, typeDesc.GetID())
+		if err != nil {
+			return err
+		}
+		t := &typeSchemaChanger{
+			typeID:  typeDesc.GetID(),
+			execCfg: &ExecutorConfig{Codec: codec},
+		}
+		return t.canRemoveEnumValue(ctx, mutableType, txn, &member, txn.Descriptors())
+	})
+}
+
 // findUsagesOfEnumValueInPartitioning is a recursive function to explore all of
 // the values used in partitioning and its subpartitions. The fakePrefixDatums
 // should be nil when first calling this function. They are needed to support


### PR DESCRIPTION
This change implements the drop value for enum
UDTs and rewires the command to it.

Closes: #164219
Epic: CRDB-31325

Release note: None