### PR TITLE
backup: deflake besteffort getBackupFnTelemetry

### DIFF
--- a/pkg/backup/schedule_exec.go
+++ b/pkg/backup/schedule_exec.go
@@ -176,6 +176,12 @@ func invokeBackup(
 		select {
 		case res := <-resultCh:
 			event, err = getBackupFnTelemetry(ctx, registry, txn, res)
+			if sql.ErrIsRetryable(err) {
+				log.Dev.Warningf(ctx,
+					"best effort operation 'get-backup-telemetry' failed with retryable error: %+v", err,
+				)
+				return nil
+			}
 			return err
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
This besteffort block will occasionally cause a test flake when encountering a retryable error (such as a missing intent) because during tests, the besteffort utility throws a panic rather than logging the error. Under normal operation, ignoring these errors would cause downstream errors which would eventually propagate up to a retry loop. This patch adds a check on the error to see if it is retryable, and ignores the error if it is.

Fixes: #164922, #164505

Release note: None