### PR TITLE
claude: favor use of the go standard library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,9 @@ compatibility issues.  See `pkg/clusterversion` for more on this.
 When adding or reviewing a newly added file with a license header the year on
 the header should be the current year.
 
+Favor modern Go idioms in new or updated code and use the standard library (e.g.
+the `slices`, `maps`, and `cmp` packages) where appropriate.
+
 ### Resources
 
 - **Main Documentation**: https://cockroachlabs.com/docs/stable/


### PR DESCRIPTION
Claude often patterns its code after hand-rolled
implementations in the repo rather than using the
packages added in more recent versions of Go. This
change instructs Claude to update the code as it's
making changes.

Epic: none

Release note: None
