### PR TITLE
ci: handle issue_comment events in autosolve PR comment addresser

### DIFF
--- a/.github/workflows/pr-autosolve-comments-trigger.yml
+++ b/.github/workflows/pr-autosolve-comments-trigger.yml
@@ -14,24 +14,42 @@ on:
   # PR reviews (used by Reviewable.io - comments are embedded in review body)
   pull_request_review:
     types: [submitted]
+  # Regular PR conversation comments (not tied to a specific line of code)
+  issue_comment:
+    types: [created]
 
 jobs:
   save-context:
     runs-on: ubuntu-latest
     # Only trigger for:
     # - PRs from the autosolver bot's fork (security: prevents force-push to other branches)
+    #   Note: for issue_comment events, head repo is not in the payload so we check it in a step
     # - PRs with 'o-autosolver' label
     # - Comments/reviews NOT from the bot itself
-    # - For review_comment events: comments NOT containing our response marker
+    # - For review_comment/issue_comment events: comments NOT containing our response marker
     # - For review events: only COMMENTED or CHANGES_REQUESTED (not APPROVED/DISMISSED)
     if: |
-      github.event.pull_request.head.repo.full_name == 'cockroach-teamcity/cockroach' &&
-      contains(github.event.pull_request.labels.*.name, 'o-autosolver') &&
       github.actor != 'github-actions[bot]' &&
       github.actor != 'cockroach-teamcity' &&
       (
-        (github.event_name == 'pull_request_review_comment' && !contains(github.event.comment.body, '[autosolve-response]')) ||
-        (github.event_name == 'pull_request_review' && (github.event.review.state == 'commented' || github.event.review.state == 'changes_requested'))
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          github.event.pull_request.head.repo.full_name == 'cockroach-teamcity/cockroach' &&
+          contains(github.event.pull_request.labels.*.name, 'o-autosolver') &&
+          !contains(github.event.comment.body, '[autosolve-response]')
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          github.event.pull_request.head.repo.full_name == 'cockroach-teamcity/cockroach' &&
+          contains(github.event.pull_request.labels.*.name, 'o-autosolver') &&
+          (github.event.review.state == 'commented' || github.event.review.state == 'changes_requested')
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          contains(github.event.issue.labels.*.name, 'o-autosolver') &&
+          !contains(github.event.comment.body, '[autosolve-response]')
+        )
       )
 
     steps:
@@ -41,6 +59,24 @@ jobs:
           cp "$GITHUB_EVENT_PATH" /tmp/event-context/event.json
           echo "${{ github.event_name }}" > /tmp/event-context/event_name.txt
           echo "${{ github.actor }}" > /tmp/event-context/actor.txt
+
+      # For issue_comment events, the PR head repo/ref aren't in the payload.
+      # Fetch them via API and verify the head repo matches the expected fork.
+      - name: Fetch PR details for issue comments
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+          HEAD_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')
+          if [ "$HEAD_REPO" != "cockroach-teamcity/cockroach" ]; then
+            echo "::error::PR head repo ($HEAD_REPO) is not the autosolver fork - skipping"
+            exit 1
+          fi
+          HEAD_REF=$(echo "$PR_JSON" | jq -r '.head.ref')
+          echo "$HEAD_REPO" > /tmp/event-context/head_repo.txt
+          echo "$HEAD_REF" > /tmp/event-context/head_ref.txt
 
       - name: Upload context
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -73,10 +73,17 @@ jobs:
           echo "event_name=$EVENT_NAME" >> "$GITHUB_OUTPUT"
           echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
 
-          # PR metadata
-          echo "pr_number=$(jq -r '.pull_request.number' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
-          echo "head_repo=$(jq -r '.pull_request.head.repo.full_name' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$(jq -r '.pull_request.head.ref' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
+          # PR metadata - for issue_comment events, PR details come from separate
+          # files saved by the trigger (since issue_comment payloads don't include them).
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            echo "pr_number=$(jq -r '.issue.number' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
+            echo "head_repo=$(cat /tmp/event-context/head_repo.txt)" >> "$GITHUB_OUTPUT"
+            echo "head_ref=$(cat /tmp/event-context/head_ref.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=$(jq -r '.pull_request.number' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
+            echo "head_repo=$(jq -r '.pull_request.head.repo.full_name' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
+            echo "head_ref=$(jq -r '.pull_request.head.ref' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
+          fi
 
           # Native review comment fields
           echo "comment_user=$(jq -r '.comment.user.login // empty' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
@@ -330,17 +337,22 @@ jobs:
             EVENT_TYPE indicates the type of event:
             - "pull_request_review_comment": A native GitHub inline code comment
             - "pull_request_review": A PR review (possibly from Reviewable.io)
+            - "issue_comment": A regular PR conversation comment (not tied to a specific line)
 
-            For native GitHub comments (EVENT_TYPE=pull_request_review_comment):
+            For native GitHub inline comments (EVENT_TYPE=pull_request_review_comment):
             - COMMENT_USER: The username of the commenter
             - COMMENT_PATH: The file path the comment is on
             - COMMENT_LINE: The line number
             - COMMENT_BODY: The comment text
 
-            For Reviewable reviews (EVENT_TYPE=pull_request_review):
+            For PR reviews (EVENT_TYPE=pull_request_review):
             - REVIEW_USER: The username of the reviewer
             - REVIEW_BODY: The full review body (may contain Reviewable formatting)
             - REVIEWABLE_COMMENTS: JSON array of parsed Reviewable comments with path, line, body, user
+
+            For PR conversation comments (EVENT_TYPE=issue_comment):
+            - COMMENT_USER: The username of the commenter
+            - COMMENT_BODY: The comment text (no file/line context)
 
             ALL_COMMENTS: JSON array of all native review comments on this PR
             </untrusted_user_content>


### PR DESCRIPTION
The PR Comment Addresser workflows only triggered on
`pull_request_review_comment` and `pull_request_review` events. Regular
PR conversation comments (`issue_comment`) were silently ignored, so
feedback left as normal PR comments on autosolve PRs was never
addressed (e.g. #165721).

This adds `issue_comment` as a trigger event. Since the `issue_comment`
payload doesn't include PR head repo/ref metadata, the trigger workflow
fetches these via API and saves them as artifact files for the handler
to consume. The head repo check against the expected fork is enforced
in the trigger step to maintain the same security posture.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>