### PR TITLE
roachtest: increase kv-rangefeed catchup test duration to 35m

### DIFF
--- a/pkg/cmd/roachtest/tests/kv_rangefeed.go
+++ b/pkg/cmd/roachtest/tests/kv_rangefeed.go
@@ -423,8 +423,13 @@ func registerKVRangefeed(r registry.Registry) {
 	testConfigs := []kvRangefeedTest{
 		// Adequately provisioned sink
 		{
-			writeMaxRate:              10000,
-			duration:                  30 * time.Minute,
+			writeMaxRate: 10000,
+			// The theoretical catch-up rate is 2,000 events/sec (12,000 sink - 10,000
+			// writes), giving a 25min catch-up time. In practice, the changefeed
+			// achieves ~96% of the sink rate, reducing the effective catch-up rate to
+			// ~1,500/sec and extending catch-up to ~33min. The 35min duration
+			// accommodates this.
+			duration:                  35 * time.Minute,
 			sinkProvisioning:          1.2,
 			splits:                    splits,
 			expectChangefeedCatchesUp: true,


### PR DESCRIPTION
The kv-rangefeed catchup test was flaking because the changefeed's effective catch-up rate is ~75% of the theoretical rate (1,500 vs 2,000 events/sec), causing the catch-up to complete ~15 seconds after the 30-minute deadline. Increase the test duration from 30 to 35 minutes to provide comfortable margin.

Fixes: #165817