### PR TITLE
ui: migrate statementInsightsView and transactionInsightsView from Redux to SWR

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -11,10 +11,11 @@ import {
   StatementStatus,
   StmtInsightEvent,
 } from "src/insights/types";
+import { TimeScale, timeScaleRangeToObj } from "src/timeScaleDropdown";
 import { INTERNAL_APP_NAME_PREFIX } from "src/util/constants";
 
 import { getInsightsFromProblemsAndCauses } from "../insights/utils";
-import { FixFingerprintHexValue } from "../util";
+import { FixFingerprintHexValue, useSwrWithClusterId } from "../util";
 
 import { getContentionDetailsApi } from "./contentionApi";
 import {
@@ -138,6 +139,30 @@ export const stmtInsightsByTxnExecutionQuery = (id: string): string => `
  FROM crdb_internal.cluster_execution_insights
  WHERE txn_id = '${id}'
 `;
+
+export function useStmtInsights(timeScale: TimeScale) {
+  const shouldPoll = timeScale?.key !== "Custom";
+  return useSwrWithClusterId<SqlApiResponse<StmtInsightEvent[]>>(
+    timeScale
+      ? {
+          name: "stmtInsights",
+          tsKey: timeScale.key,
+          tsEnd: timeScale.fixedWindowEnd
+            ? timeScale.fixedWindowEnd.toISOString()
+            : undefined,
+        }
+      : null,
+    () => {
+      const { start, end } = timeScaleRangeToObj(timeScale);
+      return getStmtInsightsApi({ start, end });
+    },
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshInterval: shouldPoll ? 10_000 : 0,
+    },
+  );
+}
 
 export async function getStmtInsightsApi(
   req?: StmtInsightsReq,

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
@@ -11,8 +11,9 @@ import {
   TransactionStatus,
   TxnInsightEvent,
 } from "src/insights";
+import { TimeScale, timeScaleRangeToObj } from "src/timeScaleDropdown";
 
-import { INTERNAL_APP_NAME_PREFIX } from "../util";
+import { INTERNAL_APP_NAME_PREFIX, useSwrWithClusterId } from "../util";
 
 import {
   executeInternalSql,
@@ -189,6 +190,30 @@ export type TxnInsightsRequest = {
   start?: moment.Moment;
   end?: moment.Moment;
 };
+
+export function useTxnInsights(timeScale: TimeScale) {
+  const shouldPoll = timeScale?.key !== "Custom";
+  return useSwrWithClusterId<SqlApiResponse<TxnInsightEvent[]>>(
+    timeScale
+      ? {
+          name: "txnInsights",
+          tsKey: timeScale.key,
+          tsEnd: timeScale.fixedWindowEnd
+            ? timeScale.fixedWindowEnd.toISOString()
+            : undefined,
+        }
+      : null,
+    () => {
+      const { start, end } = timeScaleRangeToObj(timeScale);
+      return getTxnInsightsApi({ start, end });
+    },
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshInterval: shouldPoll ? 10_000 : 0,
+    },
+  );
+}
 
 export async function getTxnInsightsApi(
   req?: TxnInsightsRequest,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -5,16 +5,14 @@
 
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import classNames from "classnames/bind";
-import moment from "moment-timezone";
 import React, { useEffect, useState, useCallback } from "react";
 import { useHistory } from "react-router-dom";
 
 import { Anchor } from "src/anchor";
-import { StmtInsightsReq } from "src/api/stmtInsightsApi";
+import { useStmtInsights } from "src/api/stmtInsightsApi";
 import { isSelectedColumn } from "src/columnsSelector/utils";
 import {
   filterStatementInsights,
-  StmtInsightEvent,
   getAppsFromStatementInsights,
   makeStatementInsightsColumns,
   WorkloadInsightEventFilters,
@@ -37,7 +35,6 @@ import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import { TableStatistics } from "src/tableStatistics";
 import { insights, usePagination } from "src/util";
-import { useScheduleFunction } from "src/util/hooks";
 import { queryByName, syncHistory } from "src/util/query";
 
 import ColumnsSelector from "../../../columnsSelector/columnsSelector";
@@ -47,7 +44,6 @@ import {
   defaultTimeScaleOptions,
   TimeScale,
   TimeScaleDropdown,
-  timeScaleRangeToObj,
 } from "../../../timeScaleDropdown";
 import { InsightsError } from "../../insightsErrorComponent";
 import { EmptyInsightsTablePlaceholder } from "../util";
@@ -60,22 +56,15 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 export type StatementInsightsViewStateProps = {
   filters: WorkloadInsightEventFilters;
   insightTypes: string[];
-  isDataValid: boolean;
-  lastUpdated: moment.Moment;
   selectedColumnNames: string[];
   sortSetting: SortSetting;
-  statements: StmtInsightEvent[];
-  statementsError: Error | null;
   dropDownSelect?: React.ReactElement;
-  isLoading?: boolean;
-  maxSizeApiReached?: boolean;
   timeScale?: TimeScale;
 };
 
 export type StatementInsightsViewDispatchProps = {
   onFiltersChange: (filters: WorkloadInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
-  refreshStatementInsights: (req: StmtInsightsReq) => void;
   onColumnsChange: (selectedColumns: string[]) => void;
   setTimeScale: (ts: TimeScale) => void;
 };
@@ -87,50 +76,31 @@ const INSIGHT_STMT_SEARCH_PARAM = "q";
 const INTERNAL_APP_NAME_PREFIX = "$ internal";
 
 export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
-  isDataValid,
-  lastUpdated,
   sortSetting,
-  statements,
-  statementsError,
   insightTypes,
   filters,
   timeScale,
-  isLoading,
-  refreshStatementInsights,
   onFiltersChange,
   onSortChange,
   onColumnsChange,
   setTimeScale,
   selectedColumnNames,
   dropDownSelect,
-  maxSizeApiReached,
 }: StatementInsightsViewProps) => {
+  const {
+    data: stmtInsightsResp,
+    error: statementsError,
+    isLoading,
+  } = useStmtInsights(timeScale);
+
+  const statements = stmtInsightsResp?.results;
+  const maxSizeApiReached = stmtInsightsResp?.maxSizeReached;
+
   const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, INSIGHT_STMT_SEARCH_PARAM),
   );
-
-  const refresh = useCallback(() => {
-    const ts = timeScaleRangeToObj(timeScale);
-    const req = {
-      start: ts.start,
-      end: ts.end,
-    };
-    refreshStatementInsights(req);
-  }, [refreshStatementInsights, timeScale]);
-
-  const shouldPoll = timeScale.key !== "Custom";
-  const [refetch, clearPolling] = useScheduleFunction(
-    refresh,
-    shouldPoll, // Don't reschedule refresh if we have a custom time interval.
-    10 * 1000, // 10s polling interval
-    lastUpdated,
-  );
-
-  useEffect(() => {
-    if (!isDataValid) refetch();
-  }, [isDataValid, refetch]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -193,10 +163,9 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
 
   const onSetTimeScale = useCallback(
     (ts: TimeScale) => {
-      clearPolling();
       setTimeScale(ts);
     },
-    [setTimeScale, clearPolling],
+    [setTimeScale],
   );
 
   const visibleColumns = defaultColumns.filter(x =>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -9,12 +9,11 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { Anchor } from "src/anchor";
-import { TxnInsightsRequest } from "src/api";
+import { useTxnInsights } from "src/api";
 import {
   filterTransactionInsights,
   getAppsFromTransactionInsights,
   WorkloadInsightEventFilters,
-  TxnInsightEvent,
 } from "src/insights";
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
@@ -34,7 +33,6 @@ import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import { TableStatistics } from "src/tableStatistics";
 import { insights } from "src/util";
-import { useScheduleFunction } from "src/util/hooks";
 import { queryByName, syncHistory } from "src/util/query";
 
 import { commonStyles } from "../../../common";
@@ -42,7 +40,6 @@ import {
   TimeScale,
   defaultTimeScaleOptions,
   TimeScaleDropdown,
-  timeScaleRangeToObj,
 } from "../../../timeScaleDropdown";
 import { usePagination } from "../../../util";
 import { InsightsError } from "../../insightsErrorComponent";
@@ -54,23 +51,16 @@ const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
 export type TransactionInsightsViewStateProps = {
-  isDataValid: boolean;
-  lastUpdated: moment.Moment;
-  transactions: TxnInsightEvent[];
-  transactionsError: Error | null;
   insightTypes: string[];
   filters: WorkloadInsightEventFilters;
   sortSetting: SortSetting;
-  isLoading?: boolean;
   dropDownSelect?: React.ReactElement;
   timeScale?: TimeScale;
-  maxSizeApiReached?: boolean;
 };
 
 export type TransactionInsightsViewDispatchProps = {
   onFiltersChange: (filters: WorkloadInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
-  refreshTransactionInsights: (req: TxnInsightsRequest) => void;
   setTimeScale: (ts: TimeScale) => void;
 };
 
@@ -84,45 +74,30 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
   props: TransactionInsightsViewProps,
 ) => {
   const {
-    isDataValid,
-    lastUpdated,
     sortSetting,
-    transactions,
-    transactionsError,
     insightTypes,
     filters,
     timeScale,
-    isLoading,
-    refreshTransactionInsights,
     onFiltersChange,
     onSortChange,
     setTimeScale,
     dropDownSelect,
-    maxSizeApiReached,
   } = props;
+
+  const {
+    data: txnInsightsResp,
+    error: transactionsError,
+    isLoading,
+  } = useTxnInsights(timeScale);
+
+  const transactions = txnInsightsResp?.results;
+  const maxSizeApiReached = txnInsightsResp?.maxSizeReached;
 
   const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, INSIGHT_TXN_SEARCH_PARAM),
   );
-
-  const refresh = useCallback(() => {
-    const req = timeScaleRangeToObj(timeScale);
-    refreshTransactionInsights(req);
-  }, [refreshTransactionInsights, timeScale]);
-
-  const shouldPoll = timeScale.key !== "Custom";
-  const [refetch, clearPolling] = useScheduleFunction(
-    refresh,
-    shouldPoll, // Don't reschedule refresh if we have a custom time interval.
-    10 * 1000, // 10s polling interval
-    lastUpdated,
-  );
-
-  useEffect(() => {
-    if (!isDataValid) refetch();
-  }, [isDataValid, refetch]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -202,10 +177,9 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
 
   const onTimeScaleChange = useCallback(
     (ts: TimeScale) => {
-      clearPolling();
       setTimeScale(ts);
     },
-    [clearPolling, setTimeScale],
+    [setTimeScale],
   );
 
   return (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -3,251 +3,196 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { connect } from "react-redux";
-import { RouteComponentProps, withRouter } from "react-router-dom";
-import { Dispatch } from "redux";
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
-import { selectStmtInsights } from "src/selectors/common";
+import { InsightEnumToLabel } from "src/insights";
 import { SortSetting } from "src/sortedtable";
-import { AppState } from "src/store";
-import {
-  actions as statementInsights,
-  selectColumns,
-  selectInsightTypes,
-  selectStmtInsightsError,
-  selectStmtInsightsLoading,
-  selectStmtInsightsMaxApiReached,
-} from "src/store/insights/statementInsights";
-import {
-  actions as txnInsights,
-  selectTransactionInsights,
-  selectTransactionInsightsError,
-  selectFilters,
-  selectSortSetting,
-  selectTransactionInsightsLoading,
-  selectTransactionInsightsMaxApiReached,
-} from "src/store/insights/transactionInsights";
 import { actions as localStorageActions } from "src/store/localStorage";
-import { actions as sqlActions } from "src/store/sqlStats";
+import { localStorageSelector } from "src/store/utils/selectors";
 
 import { actions as analyticsActions } from "../../store/analytics";
+import { actions as sqlActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { TimeScale } from "../../timeScaleDropdown";
 import { WorkloadInsightEventFilters } from "../types";
 
-import {
-  StatementInsightsViewDispatchProps,
-  StatementInsightsViewStateProps,
-} from "./statementInsights";
-import {
-  TransactionInsightsViewDispatchProps,
-  TransactionInsightsViewStateProps,
-} from "./transactionInsights";
-import {
-  WorkloadInsightsViewProps,
-  WorkloadInsightsRootControl,
-} from "./workloadInsightRootControl";
+import { WorkloadInsightsRootControl } from "./workloadInsightRootControl";
 
-const transactionMapStateToProps = (
-  state: AppState,
-  _props: RouteComponentProps,
-): TransactionInsightsViewStateProps => ({
-  isDataValid: state.adminUI?.txnInsights?.valid,
-  lastUpdated: state.adminUI?.txnInsights.lastUpdated,
-  transactions: selectTransactionInsights(state),
-  transactionsError: selectTransactionInsightsError(state),
-  insightTypes: selectInsightTypes(),
-  filters: selectFilters(state),
-  sortSetting: selectSortSetting(state),
-  timeScale: selectTimeScale(state),
-  isLoading: selectTransactionInsightsLoading(state),
-  maxSizeApiReached: selectTransactionInsightsMaxApiReached(state),
-});
-
-const statementMapStateToProps = (
-  state: AppState,
-  _props: RouteComponentProps,
-): StatementInsightsViewStateProps => ({
-  isDataValid: state.adminUI?.stmtInsights?.valid,
-  lastUpdated: state.adminUI?.stmtInsights.lastUpdated,
-  statements: selectStmtInsights(state),
-  statementsError: selectStmtInsightsError(state),
-  insightTypes: selectInsightTypes(),
-  filters: selectFilters(state),
-  sortSetting: selectSortSetting(state),
-  selectedColumnNames: selectColumns(state),
-  timeScale: selectTimeScale(state),
-  isLoading: selectStmtInsightsLoading(state),
-  maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
-});
-
-const TransactionDispatchProps = (
-  dispatch: Dispatch,
-): TransactionInsightsViewDispatchProps => ({
-  onFiltersChange: (filters: WorkloadInsightEventFilters) => {
-    dispatch(
-      localStorageActions.update({
-        key: "filters/InsightsPage",
-        value: filters,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "Filter Clicked",
-        page: "Workload Insights - Transaction",
-        filterName: "filters",
-        value: filters.toString(),
-      }),
-    );
-  },
-  onSortChange: (ss: SortSetting) => {
-    dispatch(
-      localStorageActions.update({
-        key: "sortSetting/InsightsPage",
-        value: ss,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "Column Sorted",
-        page: "Workload Insights - Transaction",
-        tableName: "Workload Transaction Insights Table",
-        columnName: ss.columnTitle,
-      }),
-    );
-  },
-  setTimeScale: (ts: TimeScale) => {
-    dispatch(
-      sqlActions.updateTimeScale({
-        ts: ts,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "TimeScale changed",
-        page: "Workload Insights - Transaction",
-        value: ts.key,
-      }),
-    );
-  },
-  refreshTransactionInsights: (req: TxnInsightsRequest) => {
-    dispatch(txnInsights.refresh(req));
-  },
-});
-
-const StatementDispatchProps = (
-  dispatch: Dispatch,
-): StatementInsightsViewDispatchProps => ({
-  onFiltersChange: (filters: WorkloadInsightEventFilters) => {
-    dispatch(
-      localStorageActions.update({
-        key: "filters/InsightsPage",
-        value: filters,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "Filter Clicked",
-        page: "Workload Insights - Statement",
-        filterName: "filters",
-        value: filters.toString(),
-      }),
-    );
-  },
-  onSortChange: (ss: SortSetting) => {
-    dispatch(
-      localStorageActions.update({
-        key: "sortSetting/InsightsPage",
-        value: ss,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "Column Sorted",
-        page: "Workload Insights - Statement",
-        tableName: "Workload Statement Insights Table",
-        columnName: ss.columnTitle,
-      }),
-    );
-  },
-  // We use `null` when the value was never set and it will show all columns.
-  // If the user modifies the selection and no columns are selected,
-  // the function will save the value as a blank space, otherwise
-  // it gets saved as `null`.
-  onColumnsChange: (value: string[]) => {
-    const columns = value.length === 0 ? " " : value.join(",");
-    dispatch(
-      localStorageActions.update({
-        key: "showColumns/StatementInsightsPage",
-        value: columns,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "Columns Selected change",
-        page: "Workload Insights - Statement",
-        value: columns,
-      }),
-    );
-  },
-  setTimeScale: (ts: TimeScale) => {
-    dispatch(
-      sqlActions.updateTimeScale({
-        ts: ts,
-      }),
-    );
-    dispatch(
-      analyticsActions.track({
-        name: "TimeScale changed",
-        page: "Workload Insights - Statement",
-        value: ts.key,
-      }),
-    );
-  },
-  refreshStatementInsights: (req: StmtInsightsReq) => {
-    dispatch(statementInsights.refresh(req));
-  },
-});
-
-type StateProps = {
-  transactionInsightsViewStateProps: TransactionInsightsViewStateProps;
-  statementInsightsViewStateProps: StatementInsightsViewStateProps;
+const selectInsightTypes = (): string[] => {
+  const insights: string[] = [];
+  InsightEnumToLabel.forEach(insight => {
+    insights.push(insight);
+  });
+  return insights;
 };
 
-type DispatchProps = {
-  transactionInsightsViewDispatchProps: TransactionInsightsViewDispatchProps;
-  statementInsightsViewDispatchProps: StatementInsightsViewDispatchProps;
-};
+export const WorkloadInsightsPageConnected: React.FC = () => {
+  const dispatch = useDispatch();
+  const timeScale = useSelector(selectTimeScale);
+  const localStorage = useSelector(localStorageSelector);
+  const filters = localStorage["filters/InsightsPage"];
+  const sortSetting = localStorage["sortSetting/InsightsPage"];
+  const selectedColumnNames = localStorage["showColumns/StatementInsightsPage"]
+    ? localStorage["showColumns/StatementInsightsPage"]?.split(",")
+    : null;
 
-export const WorkloadInsightsPageConnected = withRouter(
-  connect<
-    StateProps,
-    DispatchProps,
-    RouteComponentProps,
-    WorkloadInsightsViewProps,
-    AppState
-  >(
-    (state: AppState, props: RouteComponentProps) => ({
-      transactionInsightsViewStateProps: transactionMapStateToProps(
-        state,
-        props,
-      ),
-      statementInsightsViewStateProps: statementMapStateToProps(state, props),
-    }),
-    dispatch => ({
-      transactionInsightsViewDispatchProps: TransactionDispatchProps(dispatch),
-      statementInsightsViewDispatchProps: StatementDispatchProps(dispatch),
-    }),
-    (stateProps, dispatchProps) => ({
-      transactionInsightsViewProps: {
-        ...stateProps.transactionInsightsViewStateProps,
-        ...dispatchProps.transactionInsightsViewDispatchProps,
-      },
-      statementInsightsViewProps: {
-        ...stateProps.statementInsightsViewStateProps,
-        ...dispatchProps.statementInsightsViewDispatchProps,
-      },
-    }),
-  )(WorkloadInsightsRootControl),
-);
+  // --- Transaction tab handlers ---
+
+  const txnOnFiltersChange = useCallback(
+    (f: WorkloadInsightEventFilters) => {
+      dispatch(
+        localStorageActions.update({
+          key: "filters/InsightsPage",
+          value: f,
+        }),
+      );
+      dispatch(
+        analyticsActions.track({
+          name: "Filter Clicked",
+          page: "Workload Insights - Transaction",
+          filterName: "filters",
+          value: f.toString(),
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const txnOnSortChange = useCallback(
+    (ss: SortSetting) => {
+      dispatch(
+        localStorageActions.update({
+          key: "sortSetting/InsightsPage",
+          value: ss,
+        }),
+      );
+      dispatch(
+        analyticsActions.track({
+          name: "Column Sorted",
+          page: "Workload Insights - Transaction",
+          tableName: "Workload Transaction Insights Table",
+          columnName: ss.columnTitle,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const txnSetTimeScale = useCallback(
+    (ts: TimeScale) => {
+      dispatch(sqlActions.updateTimeScale({ ts }));
+      dispatch(
+        analyticsActions.track({
+          name: "TimeScale changed",
+          page: "Workload Insights - Transaction",
+          value: ts.key,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  // --- Statement tab handlers ---
+
+  const stmtOnFiltersChange = useCallback(
+    (f: WorkloadInsightEventFilters) => {
+      dispatch(
+        localStorageActions.update({
+          key: "filters/InsightsPage",
+          value: f,
+        }),
+      );
+      dispatch(
+        analyticsActions.track({
+          name: "Filter Clicked",
+          page: "Workload Insights - Statement",
+          filterName: "filters",
+          value: f.toString(),
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const stmtOnSortChange = useCallback(
+    (ss: SortSetting) => {
+      dispatch(
+        localStorageActions.update({
+          key: "sortSetting/InsightsPage",
+          value: ss,
+        }),
+      );
+      dispatch(
+        analyticsActions.track({
+          name: "Column Sorted",
+          page: "Workload Insights - Statement",
+          tableName: "Workload Statement Insights Table",
+          columnName: ss.columnTitle,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const stmtSetTimeScale = useCallback(
+    (ts: TimeScale) => {
+      dispatch(sqlActions.updateTimeScale({ ts }));
+      dispatch(
+        analyticsActions.track({
+          name: "TimeScale changed",
+          page: "Workload Insights - Statement",
+          value: ts.key,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const onColumnsChange = useCallback(
+    (value: string[]) => {
+      const columns = value.length === 0 ? " " : value.join(",");
+      dispatch(
+        localStorageActions.update({
+          key: "showColumns/StatementInsightsPage",
+          value: columns,
+        }),
+      );
+      dispatch(
+        analyticsActions.track({
+          name: "Columns Selected change",
+          page: "Workload Insights - Statement",
+          value: columns,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const insightTypes = selectInsightTypes();
+
+  return (
+    <WorkloadInsightsRootControl
+      transactionInsightsViewProps={{
+        insightTypes,
+        filters,
+        sortSetting,
+        timeScale,
+        onFiltersChange: txnOnFiltersChange,
+        onSortChange: txnOnSortChange,
+        setTimeScale: txnSetTimeScale,
+      }}
+      statementInsightsViewProps={{
+        insightTypes,
+        filters,
+        sortSetting,
+        selectedColumnNames,
+        timeScale,
+        onFiltersChange: stmtOnFiltersChange,
+        onSortChange: stmtOnSortChange,
+        onColumnsChange,
+        setTimeScale: stmtSetTimeScale,
+      }}
+    />
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
@@ -5,7 +5,6 @@
 
 import { createSelector } from "reselect";
 
-import { InsightEnumToLabel } from "src/insights";
 import {
   selectStatementFingerprintID,
   selectID,
@@ -29,14 +28,6 @@ export const selectStmtInsightDetails = createSelector(
   selectID,
   selectStatementInsightDetailsCombiner,
 );
-
-export const selectInsightTypes = (): string[] => {
-  const insights: string[] = [];
-  InsightEnumToLabel.forEach(insight => {
-    insights.push(insight);
-  });
-  return insights;
-};
 
 export const selectColumns = createSelector(
   localStorageSelector,

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -4,38 +4,17 @@
 // included in the /LICENSE file.
 
 import {
-  defaultFilters,
-  WorkloadInsightEventFilters,
-  SortSetting,
   selectID,
   selectTransactionFingerprintID,
   selectStatementInsightDetailsCombiner,
   selectTxnInsightDetailsCombiner,
-  InsightEnumToLabel,
   TxnInsightDetails,
   api,
   util,
 } from "@cockroachlabs/cluster-ui";
 import { createSelector } from "reselect";
 
-import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
-
-export const filtersLocalSetting = new LocalSetting<
-  AdminUIState,
-  WorkloadInsightEventFilters
->("filters/InsightsPage", (state: AdminUIState) => state.localSettings, {
-  app: defaultFilters.app,
-  workloadInsightType: defaultFilters.workloadInsightType,
-});
-
-export const sortSettingLocalSetting = new LocalSetting<
-  AdminUIState,
-  SortSetting
->("sortSetting/InsightsPage", (state: AdminUIState) => state.localSettings, {
-  ascending: false,
-  columnTitle: "startTime",
-});
 
 export const selectTransactionInsightsLoading = (state: AdminUIState) =>
   state.cachedData.txnInsights?.inFlight &&
@@ -138,14 +117,6 @@ export const selectTxnInsightsByFingerprint = createSelector(
     return execInsights?.filter(txn => txn.transactionFingerprintID === id);
   },
 );
-
-export const selectInsightTypes = () => {
-  const insights: string[] = [];
-  InsightEnumToLabel.forEach(insight => {
-    insights.push(insight);
-  });
-  return insights;
-};
 
 export const selectStatementInsightDetails = createSelector(
   selectStmtInsights,

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
@@ -6,33 +6,18 @@
 import {
   WorkloadInsightEventFilters,
   SortSetting,
-  StatementInsightsViewDispatchProps,
-  StatementInsightsViewStateProps,
-  TransactionInsightsViewDispatchProps,
-  TransactionInsightsViewStateProps,
   WorkloadInsightsRootControl,
-  WorkloadInsightsViewProps,
+  InsightEnumToLabel,
+  TimeScale,
+  defaultFilters,
 } from "@cockroachlabs/cluster-ui";
-import { connect } from "react-redux";
-import { RouteComponentProps, withRouter } from "react-router-dom";
-import { bindActionCreators } from "redux";
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-import { refreshStmtInsights, refreshTxnInsights } from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
-import {
-  filtersLocalSetting,
-  selectStmtInsights,
-  sortSettingLocalSetting,
-  selectTransactionInsights,
-  selectStmtInsightsLoading,
-  selectTransactionInsightsLoading,
-  selectInsightTypes,
-  selectStmtInsightsMaxApiReached,
-  selectTxnInsightsMaxApiReached,
-} from "src/views/insights/insightsSelectors";
 
 export const insightStatementColumnsLocalSetting = new LocalSetting<
   AdminUIState,
@@ -43,104 +28,94 @@ export const insightStatementColumnsLocalSetting = new LocalSetting<
   null,
 );
 
-const transactionMapStateToProps = (
-  state: AdminUIState,
-  _props: RouteComponentProps,
-): TransactionInsightsViewStateProps => ({
-  isDataValid: state.cachedData.txnInsights?.valid,
-  lastUpdated: state.cachedData.txnInsights?.setAt,
-  transactions: selectTransactionInsights(state),
-  insightTypes: selectInsightTypes(),
-  transactionsError: state.cachedData?.txnInsights?.lastError,
-  filters: filtersLocalSetting.selector(state),
-  sortSetting: sortSettingLocalSetting.selector(state),
-  timeScale: selectTimeScale(state),
-  isLoading: selectTransactionInsightsLoading(state),
-  maxSizeApiReached: selectTxnInsightsMaxApiReached(state),
+const filtersLocalSetting = new LocalSetting<
+  AdminUIState,
+  WorkloadInsightEventFilters
+>("filters/InsightsPage", (state: AdminUIState) => state.localSettings, {
+  app: defaultFilters.app,
+  workloadInsightType: defaultFilters.workloadInsightType,
 });
 
-const statementMapStateToProps = (
-  state: AdminUIState,
-  _props: RouteComponentProps,
-): StatementInsightsViewStateProps => ({
-  isDataValid: state.cachedData.stmtInsights?.valid,
-  lastUpdated: state.cachedData.stmtInsights?.setAt,
-  statements: selectStmtInsights(state),
-  statementsError: state.cachedData?.stmtInsights?.lastError,
-  filters: filtersLocalSetting.selector(state),
-  insightTypes: selectInsightTypes(),
-  sortSetting: sortSettingLocalSetting.selector(state),
-  selectedColumnNames:
-    insightStatementColumnsLocalSetting.selectorToArray(state),
-  timeScale: selectTimeScale(state),
-  isLoading: selectStmtInsightsLoading(state),
-  maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
-});
-
-const TransactionDispatchProps = {
-  onFiltersChange: (filters: WorkloadInsightEventFilters) =>
-    filtersLocalSetting.set(filters),
-  onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
-  setTimeScale: setGlobalTimeScaleAction,
-  refreshTransactionInsights: refreshTxnInsights,
-};
-
-const StatementDispatchProps: StatementInsightsViewDispatchProps = {
-  onFiltersChange: (filters: WorkloadInsightEventFilters) =>
-    filtersLocalSetting.set(filters),
-  onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
-  refreshStatementInsights: refreshStmtInsights,
-  onColumnsChange: (value: string[]) =>
-    insightStatementColumnsLocalSetting.set(value.join(",")),
-  setTimeScale: setGlobalTimeScaleAction,
-};
-
-type StateProps = {
-  transactionInsightsViewStateProps: TransactionInsightsViewStateProps;
-  statementInsightsViewStateProps: StatementInsightsViewStateProps;
-};
-
-type DispatchProps = {
-  transactionInsightsViewDispatchProps: TransactionInsightsViewDispatchProps;
-  statementInsightsViewDispatchProps: StatementInsightsViewDispatchProps;
-};
-
-const WorkloadInsightsPage = withRouter(
-  connect<
-    StateProps,
-    DispatchProps,
-    RouteComponentProps,
-    WorkloadInsightsViewProps,
-    AdminUIState
-  >(
-    (state: AdminUIState, props: RouteComponentProps) => ({
-      transactionInsightsViewStateProps: transactionMapStateToProps(
-        state,
-        props,
-      ),
-      statementInsightsViewStateProps: statementMapStateToProps(state, props),
-    }),
-    dispatch => ({
-      transactionInsightsViewDispatchProps: bindActionCreators(
-        TransactionDispatchProps,
-        dispatch,
-      ),
-      statementInsightsViewDispatchProps: bindActionCreators(
-        StatementDispatchProps,
-        dispatch,
-      ),
-    }),
-    (stateProps, dispatchProps) => ({
-      transactionInsightsViewProps: {
-        ...stateProps.transactionInsightsViewStateProps,
-        ...dispatchProps.transactionInsightsViewDispatchProps,
-      },
-      statementInsightsViewProps: {
-        ...stateProps.statementInsightsViewStateProps,
-        ...dispatchProps.statementInsightsViewDispatchProps,
-      },
-    }),
-  )(WorkloadInsightsRootControl),
+const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "sortSetting/InsightsPage",
+  (state: AdminUIState) => state.localSettings,
+  {
+    ascending: false,
+    columnTitle: "startTime",
+  },
 );
+
+const selectInsightTypes = (): string[] => {
+  const insights: string[] = [];
+  InsightEnumToLabel.forEach(insight => {
+    insights.push(insight);
+  });
+  return insights;
+};
+
+const WorkloadInsightsPage: React.FC = () => {
+  const dispatch = useDispatch();
+  const timeScale = useSelector(selectTimeScale);
+  const filters = useSelector(filtersLocalSetting.selector);
+  const sortSetting = useSelector(sortSettingLocalSetting.selector);
+  const selectedColumnNames = useSelector(
+    insightStatementColumnsLocalSetting.selectorToArray,
+  );
+
+  const onFiltersChange = useCallback(
+    (f: WorkloadInsightEventFilters) => {
+      dispatch(filtersLocalSetting.set(f));
+    },
+    [dispatch],
+  );
+
+  const onSortChange = useCallback(
+    (ss: SortSetting) => {
+      dispatch(sortSettingLocalSetting.set(ss));
+    },
+    [dispatch],
+  );
+
+  const setTimeScale = useCallback(
+    (ts: TimeScale) => {
+      dispatch(setGlobalTimeScaleAction(ts));
+    },
+    [dispatch],
+  );
+
+  const onColumnsChange = useCallback(
+    (value: string[]) => {
+      dispatch(insightStatementColumnsLocalSetting.set(value.join(",")));
+    },
+    [dispatch],
+  );
+
+  const insightTypes = selectInsightTypes();
+
+  return (
+    <WorkloadInsightsRootControl
+      transactionInsightsViewProps={{
+        insightTypes,
+        filters,
+        sortSetting,
+        timeScale,
+        onFiltersChange,
+        onSortChange,
+        setTimeScale,
+      }}
+      statementInsightsViewProps={{
+        insightTypes,
+        filters,
+        sortSetting,
+        selectedColumnNames,
+        timeScale,
+        onFiltersChange,
+        onSortChange,
+        onColumnsChange,
+        setTimeScale,
+      }}
+    />
+  );
+};
 
 export default WorkloadInsightsPage;


### PR DESCRIPTION
The insights overview page fetches statement and transaction insights
data via Redux thunks, with manual polling managed by useScheduleFunction.

Add useStmtInsights and useTxnInsights SWR hooks that wrap the existing
API functions with automatic caching, deduplication, and polling. These
hooks are not consumed yet.

-----

StatementInsightsView receives its data, loading state, and refresh
function as props from a Redux-connected parent container. It manages
polling manually via useScheduleFunction.

Replace the data/loading/error props with the useStmtInsights SWR hook,
which handles fetching, caching, and polling internally. Remove the
corresponding props from the StateProps and DispatchProps types.

-----

TransactionInsightsView receives its data, loading state, and refresh
function as props from a Redux-connected parent container. It manages
polling manually via useScheduleFunction.

Replace the data/loading/error props with the useTxnInsights SWR hook,
which handles fetching, caching, and polling internally. Remove the
corresponding props from the StateProps and DispatchProps types.

-----

The workload insights page containers in both cluster-ui and db-console
use the connect() HOC with mapStateToProps/mapDispatchToProps to wire up
Redux state and dispatch to the child views.

Replace connect()/withRouter with functional components using
useDispatch/useSelector/useCallback. Since the child views now fetch their
data via SWR, the containers no longer pass data, loading, or refresh props.
Use separate per-tab handler functions to preserve correct analytics
page names for transaction vs statement tabs.

-----

The SWR migration in prior commits made several selectors and local
settings dead code:
- filtersLocalSetting and sortSettingLocalSetting in insightsSelectors.ts
  (db-console) — redefined locally in workloadInsightsPage.tsx, no
  remaining imports from insightsSelectors.
- selectInsightTypes in insightsSelectors.ts (db-console) and
  statementInsights.selectors.ts (cluster-ui) — redefined locally in
  each container component, no remaining imports.

Remove the dead exports and their now-unused imports (defaultFilters,
WorkloadInsightEventFilters, SortSetting, InsightEnumToLabel,
LocalSetting).

Epic: CRDB-58145
Release Note: None