### PR TITLE
txnapply: prototype distributed applier

### DIFF
--- a/pkg/crosscluster/logical/ldrdecoder/txn_decoder.go
+++ b/pkg/crosscluster/logical/ldrdecoder/txn_decoder.go
@@ -7,6 +7,7 @@ package ldrdecoder
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -32,6 +33,10 @@ func (t TxnID) Less(s TxnID) bool { return t.Timestamp.Less(s.Timestamp) }
 func (t TxnID) LessEq(s TxnID) bool { return t.Timestamp.LessEq(s.Timestamp) }
 
 func (t TxnID) IsSet() bool { return t.Timestamp.IsSet() }
+
+func (t TxnID) String() string {
+	return fmt.Sprintf("(%d,%d)", t.ApplierID, t.Timestamp.WallTime)
+}
 
 type Transaction struct {
 	TxnID    TxnID

--- a/pkg/crosscluster/logical/txnapply/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnapply/BUILD.bazel
@@ -3,6 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "txnapply",
     srcs = [
+        "committed_set.go",
+        "dependency_resolver.go",
         "latest.go",
         "txn_applier.go",
     ],
@@ -22,7 +24,10 @@ go_library(
 
 go_test(
     name = "txnapply_test",
-    srcs = ["txn_applier_test.go"],
+    srcs = [
+        "committed_set_test.go",
+        "txn_applier_test.go",
+    ],
     embed = [":txnapply"],
     deps = [
         "//pkg/crosscluster/logical/ldrdecoder",

--- a/pkg/crosscluster/logical/txnapply/committed_set.go
+++ b/pkg/crosscluster/logical/txnapply/committed_set.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package txnapply
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// committedSet tracks which transactions have been committed by an applier.
+// It combines a resolvedTime watermark with a set of individually completed
+// transactions whose timestamps are above the watermark. A transaction is
+// considered resolved if its timestamp is at or below the resolvedTime, or
+// if it appears in completedTxns. When the resolvedTime advances,
+// completedTxns entries that fall at or below the new watermark are pruned.
+type committedSet struct {
+	resolvedTime  hlc.Timestamp
+	completedTxns map[ldrdecoder.TxnID]struct{}
+}
+
+// makeCommittedSet returns an initialized committedSet.
+func makeCommittedSet() committedSet {
+	return committedSet{
+		completedTxns: make(map[ldrdecoder.TxnID]struct{}),
+	}
+}
+
+// IsResolved returns true if the given txn is resolved — either its
+// timestamp is at or below the resolvedTime, or it is in completedTxns.
+func (c *committedSet) IsResolved(txn ldrdecoder.TxnID) bool {
+	if txn.Timestamp.LessEq(c.resolvedTime) {
+		return true
+	}
+	_, ok := c.completedTxns[txn]
+	return ok
+}
+
+// IsResolvedAt returns true if the given timestamp is at or below the
+// resolvedTime.
+func (c *committedSet) IsResolvedAt(ts hlc.Timestamp) bool {
+	return ts.LessEq(c.resolvedTime)
+}
+
+// ResolvedTime returns the current resolvedTime watermark.
+func (c *committedSet) ResolvedTime() hlc.Timestamp {
+	return c.resolvedTime
+}
+
+// Resolve records a completed txn. If the txn's timestamp is above the
+// current resolvedTime, it is added to completedTxns for individual
+// tracking.
+func (c *committedSet) Resolve(txn ldrdecoder.TxnID) {
+	if !txn.Timestamp.LessEq(c.resolvedTime) {
+		c.completedTxns[txn] = struct{}{}
+	}
+}
+
+// UpdateResolvedTime advances the resolvedTime watermark. The watermark
+// only moves forward; if ts is not after the current resolvedTime, this
+// is a no-op. Transactions whose timestamps fall at or below the new
+// resolvedTime are pruned from completedTxns.
+func (c *committedSet) UpdateResolvedTime(ts hlc.Timestamp) {
+	if !c.resolvedTime.Less(ts) {
+		return
+	}
+	c.resolvedTime = ts
+	for completed := range c.completedTxns {
+		if completed.Timestamp.LessEq(ts) {
+			delete(c.completedTxns, completed)
+		}
+	}
+}

--- a/pkg/crosscluster/logical/txnapply/committed_set_test.go
+++ b/pkg/crosscluster/logical/txnapply/committed_set_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package txnapply
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func txnID(wall int64, applier int32) ldrdecoder.TxnID {
+	return ldrdecoder.TxnID{
+		Timestamp: hlc.Timestamp{WallTime: wall},
+		ApplierID: ldrdecoder.ApplierID(applier),
+	}
+}
+
+func TestCommittedSet(t *testing.T) {
+	t.Run("initial state", func(t *testing.T) {
+		cs := makeCommittedSet()
+		require.True(t, cs.ResolvedTime().IsEmpty())
+		require.False(t, cs.IsResolved(txnID(1, 0)))
+		require.False(t, cs.IsResolvedAt(hlc.Timestamp{WallTime: 1}))
+	})
+
+	t.Run("resolve individual txn", func(t *testing.T) {
+		cs := makeCommittedSet()
+		txn := txnID(10, 1)
+		require.False(t, cs.IsResolved(txn))
+
+		cs.Resolve(txn)
+		require.True(t, cs.IsResolved(txn))
+
+		// Different txn at same timestamp but different applier is not resolved.
+		require.False(t, cs.IsResolved(txnID(10, 2)))
+	})
+
+	t.Run("update resolved time", func(t *testing.T) {
+		cs := makeCommittedSet()
+		cs.UpdateResolvedTime(hlc.Timestamp{WallTime: 5})
+		require.Equal(t, hlc.Timestamp{WallTime: 5}, cs.ResolvedTime())
+
+		// Txn at or below watermark is resolved without explicit Resolve.
+		require.True(t, cs.IsResolved(txnID(5, 0)))
+		require.True(t, cs.IsResolved(txnID(3, 0)))
+		require.True(t, cs.IsResolvedAt(hlc.Timestamp{WallTime: 5}))
+
+		// Txn above watermark is not resolved.
+		require.False(t, cs.IsResolved(txnID(6, 0)))
+		require.False(t, cs.IsResolvedAt(hlc.Timestamp{WallTime: 6}))
+	})
+
+	t.Run("backward resolved time is no-op", func(t *testing.T) {
+		cs := makeCommittedSet()
+		cs.UpdateResolvedTime(hlc.Timestamp{WallTime: 10})
+		cs.UpdateResolvedTime(hlc.Timestamp{WallTime: 5})
+		require.Equal(t, hlc.Timestamp{WallTime: 10}, cs.ResolvedTime())
+	})
+
+	t.Run("resolve below watermark is no-op", func(t *testing.T) {
+		cs := makeCommittedSet()
+		cs.UpdateResolvedTime(hlc.Timestamp{WallTime: 10})
+
+		// Resolve a txn at the watermark — should not be added to map.
+		txn := txnID(10, 1)
+		cs.Resolve(txn)
+		require.Len(t, cs.completedTxns, 0)
+
+		// It's still resolved because it's at the watermark.
+		require.True(t, cs.IsResolved(txn))
+	})
+
+	t.Run("update resolved time prunes completed txns", func(t *testing.T) {
+		cs := makeCommittedSet()
+		cs.Resolve(txnID(5, 0))
+		cs.Resolve(txnID(10, 0))
+		cs.Resolve(txnID(15, 0))
+		require.Len(t, cs.completedTxns, 3)
+
+		// Advance watermark past the first two txns.
+		cs.UpdateResolvedTime(hlc.Timestamp{WallTime: 10})
+		require.Len(t, cs.completedTxns, 1)
+
+		// The pruned txns are still resolved (via watermark).
+		require.True(t, cs.IsResolved(txnID(5, 0)))
+		require.True(t, cs.IsResolved(txnID(10, 0)))
+
+		// The remaining txn is still resolved via completedTxns.
+		require.True(t, cs.IsResolved(txnID(15, 0)))
+	})
+}

--- a/pkg/crosscluster/logical/txnapply/dependency_resolver.go
+++ b/pkg/crosscluster/logical/txnapply/dependency_resolver.go
@@ -1,0 +1,223 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package txnapply
+
+import (
+	"slices"
+
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// DependencyUpdate is sent to an applier when a remote dependency is resolved.
+type DependencyUpdate struct {
+	TxnID        ldrdecoder.TxnID
+	ResolvedTime hlc.Timestamp
+}
+
+// DependencyResolver coordinates cross-applier transaction dependencies.
+type DependencyResolver interface {
+	// Wait registers that the calling applier is waiting on the given txns
+	// (owned by other appliers) to complete.
+	Wait(waitingID ldrdecoder.ApplierID, txns []ldrdecoder.TxnID)
+
+	// WaitHorizon registers that the calling applier (waitingID) is blocked
+	// on the given applier's (dependID) resolvedTime advancing past the given
+	// txnHorizon. If the dependency's resolvedTime already exceeds txnHorizon,
+	// the waiter is not registered and an update is sent eagerly.
+	WaitHorizon(waitingID, dependID ldrdecoder.ApplierID, txnHorizon hlc.Timestamp)
+
+	// Ready signals that the calling applier has completed the given txn
+	// and provides the applier's latest resolvedTime timestamp.
+	Ready(txn ldrdecoder.TxnID, resolvedTime hlc.Timestamp)
+
+	// Receive returns a channel that delivers resolved dependency
+	// notifications and resolvedTime updates for the given applier.
+	Receive(applier ldrdecoder.ApplierID) <-chan DependencyUpdate
+}
+
+// trackerServer holds the dependency tracking state for a single applier. It
+// stores the txns that this applier owns (and that other appliers may be
+// waiting on), along with the set of waiters to notify when txns complete.
+type trackerServer struct {
+	mu struct {
+		syncutil.Mutex
+
+		// waiters maps a txn (owned by this applier) to the set of applier
+		// IDs waiting for that txn to resolve.
+		waiters map[ldrdecoder.TxnID][]ldrdecoder.ApplierID
+
+		// horizonWaiters maps waiting applier IDs to the set of event
+		// horizon timestamps they are waiting on. Individual timestamps
+		// are cleared when the resolvedTime advances past them; a
+		// notification is sent whenever at least one is cleared.
+		horizonWaiters map[ldrdecoder.ApplierID][]hlc.Timestamp
+
+		// committed tracks which transactions have been committed.
+		committed committedSet
+	}
+}
+
+// maybeAddWaiter registers a waiter for the given txn unless the txn is
+// already resolved (at or below the resolvedTime, or in completedTxns). Returns
+// whether the txn is already resolved and the current resolvedTime.
+func (inst *trackerServer) maybeAddWaiter(
+	txn ldrdecoder.TxnID, waiter ldrdecoder.ApplierID,
+) (bool, hlc.Timestamp) {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	if inst.mu.committed.IsResolved(txn) {
+		return true, inst.mu.committed.ResolvedTime()
+	}
+	inst.mu.waiters[txn] = append(inst.mu.waiters[txn], waiter)
+	return false, hlc.Timestamp{}
+}
+
+func (inst *trackerServer) waitHorizon(
+	waitingID ldrdecoder.ApplierID, txnHorizon hlc.Timestamp,
+) (alreadyResolved bool, resolvedTime hlc.Timestamp) {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	if inst.mu.committed.IsResolvedAt(txnHorizon) {
+		return true, inst.mu.committed.ResolvedTime()
+	}
+	inst.mu.horizonWaiters[waitingID] = append(
+		inst.mu.horizonWaiters[waitingID], txnHorizon)
+	return false, hlc.Timestamp{}
+}
+
+// ready records the completion of a txn and returns a map of updates to send
+// to waiting appliers. The caller is responsible for delivering the updates
+// over the appropriate channels.
+func (inst *trackerServer) ready(
+	txn ldrdecoder.TxnID, resolvedTime hlc.Timestamp,
+) map[ldrdecoder.ApplierID]DependencyUpdate {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	inst.mu.committed.Resolve(txn)
+	inst.mu.committed.UpdateResolvedTime(resolvedTime)
+
+	waitingAppliers := inst.mu.waiters[txn]
+	delete(inst.mu.waiters, txn)
+
+	update := DependencyUpdate{TxnID: txn, ResolvedTime: resolvedTime}
+
+	updates := make(map[ldrdecoder.ApplierID]DependencyUpdate, len(waitingAppliers))
+
+	for _, applierID := range waitingAppliers {
+		updates[applierID] = update
+	}
+
+	// Notify horizon waiters whose required horizon is satisfied by the
+	// new resolvedTime. Clear individual timestamps that are at or below the
+	// resolvedTime, and notify if at least one was cleared.
+	for waiterID, horizons := range inst.mu.horizonWaiters {
+		remaining := slices.DeleteFunc(horizons, func(h hlc.Timestamp) bool {
+			return h.LessEq(resolvedTime)
+		})
+		if len(remaining) < len(horizons) {
+			if _, ok := updates[waiterID]; !ok {
+				updates[waiterID] = update
+			}
+		}
+		inst.mu.horizonWaiters[waiterID] = remaining
+	}
+
+	return updates
+}
+
+// trackerClient is a DependencyResolver that tracks cross-applier dependencies
+// and notifies waiting appliers via buffered channels when dependencies are
+// resolved.
+//
+// This prototype models the future distql flow we'll use for the distributed
+// applier: each applier processor will be able to communicate with each
+// applier's associated dependency tracker processor. In this prototype, the
+// trackerClient simply queries each tracker server via a map, and the tracker
+// client directly sends updates to the applier via the inbox channels. In the
+// distsql flow, the trackerClient will send Ready RPCs to an appliers
+// dependency tracker processor which will forward updates to the applier
+// processor.
+type trackerClient struct {
+	servers map[ldrdecoder.ApplierID]*trackerServer
+
+	// inboxes holds one buffered channel per applier for receiving
+	// DependencyUpdates. Populated at construction and never modified.
+	//
+	// TODO(msbutler): if these channels fill up, it could block Ready() leading
+	// to deadlock. In the productionized version, Ready will never be blocking,
+	// so we'll probably store some ring buffer of ready transactions on the
+	// tracker processor. Then, each processor will have some Run method that will
+	// watch the buffer state and send data to applier channels.
+	inboxes map[ldrdecoder.ApplierID]chan DependencyUpdate
+}
+
+// NewDependencyTracker creates a DependencyResolver for the given set of
+// applier IDs.
+func NewDependencyTracker(appliers []ldrdecoder.ApplierID) DependencyResolver {
+	inboxes := make(map[ldrdecoder.ApplierID]chan DependencyUpdate, len(appliers))
+	for _, id := range appliers {
+		// TODO(msbutler): the only reason this buffer has 1000 slots is to ensure
+		// the random dag test doesn't deadlock. This will be replaced by a ring
+		// buffer in a future PR.
+		inboxes[id] = make(chan DependencyUpdate, 1000)
+	}
+
+	instances := make(map[ldrdecoder.ApplierID]*trackerServer, len(appliers))
+	for _, id := range appliers {
+		inst := &trackerServer{}
+		inst.mu.waiters = make(map[ldrdecoder.TxnID][]ldrdecoder.ApplierID)
+		inst.mu.committed = makeCommittedSet()
+		inst.mu.horizonWaiters = make(map[ldrdecoder.ApplierID][]hlc.Timestamp)
+		instances[id] = inst
+	}
+
+	return &trackerClient{servers: instances, inboxes: inboxes}
+}
+
+// Wait implements DependencyResolver.
+//
+// TODO(msbutler): consider passing the waiting applier A's resolvedTime here, which
+// would allow the depending applier B to cache the resolvedTime timestamp,
+// potentially avoiding a WaitHorizon from B to A.
+func (d *trackerClient) Wait(waiter ldrdecoder.ApplierID, txns []ldrdecoder.TxnID) {
+	for _, txn := range txns {
+		resolved, resolvedTime := d.servers[txn.ApplierID].maybeAddWaiter(txn, waiter)
+		if resolved {
+			d.inboxes[waiter] <- DependencyUpdate{TxnID: txn, ResolvedTime: resolvedTime}
+		}
+	}
+}
+
+// WaitHorizon implements DependencyResolver.
+func (d *trackerClient) WaitHorizon(
+	applierID, dependID ldrdecoder.ApplierID, txnHorizon hlc.Timestamp,
+) {
+	resolved, resolvedTime := d.servers[dependID].waitHorizon(applierID, txnHorizon)
+	if resolved {
+		d.inboxes[applierID] <- DependencyUpdate{
+			TxnID:        ldrdecoder.TxnID{ApplierID: dependID},
+			ResolvedTime: resolvedTime,
+		}
+	}
+}
+
+// Ready implements DependencyResolver.
+func (d *trackerClient) Ready(txn ldrdecoder.TxnID, resolvedTime hlc.Timestamp) {
+	updates := d.servers[txn.ApplierID].ready(txn, resolvedTime)
+	for applierID, update := range updates {
+		d.inboxes[applierID] <- update
+	}
+}
+
+// Receive implements DependencyResolver.
+func (d *trackerClient) Receive(applier ldrdecoder.ApplierID) <-chan DependencyUpdate {
+	return d.inboxes[applier]
+}

--- a/pkg/crosscluster/logical/txnapply/txn_applier.go
+++ b/pkg/crosscluster/logical/txnapply/txn_applier.go
@@ -19,11 +19,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type transactionState struct {
-	ScheduledTransaction
-	applied bool
-}
-
 type appliedTransaction struct {
 	ldrdecoder.Transaction
 	applyResult txnwriter.ApplyResult
@@ -35,6 +30,31 @@ type ScheduledTransaction struct {
 	EventHorizon hlc.Timestamp
 }
 
+// ApplierEvent is an event that can be sent to the Applier's input channel.
+type ApplierEvent interface {
+	applierEvent()
+}
+
+func (ScheduledTransaction) applierEvent() {}
+func (Checkpoint) applierEvent()           {}
+
+// Checkpoint indicates that all transactions with timestamp ≤ Timestamp have
+// been sent (but not applied). This allows idle appliers to advance their
+// frontier.
+//
+// The coordinator sends a Checkpoint to every applier in two cases:
+//  1. Periodically, as an intermediate heartbeat so that idle appliers (those
+//     with no pending transactions) can advance their frontier.
+//  2. Deterministically, when an incoming transaction's EventHorizon is greater
+//     than the previous checkpoint. This ensures that every applier has seen
+//     the checkpoint before any applier attempts to apply the transaction that
+//     depends on it.
+//
+// The Timestamp is set to the incoming replication event's (upstream checkpoint
+// or txn) timestamp minus one, so that the checkpoint strictly precedes the
+// event it was derived from.
+type Checkpoint struct{ Timestamp hlc.Timestamp }
+
 // Applier coordinates applying transactions in parallel while ensuring that a
 // given txn's dependencies have applied first and that the replicated time has
 // advanced past the txn's EventHorizon before application. For example: if t5
@@ -45,61 +65,101 @@ type ScheduledTransaction struct {
 // Also note that the applier assumes it is sent transactions in increasing
 // timestamp order.
 type Applier struct {
+	id          ldrdecoder.ApplierID
+	depResolver DependencyResolver
+
 	mu struct {
 		syncutil.Mutex
-		replicatedTime hlc.Timestamp
 
-		// transactions maps a txn's TxnID to its state.
-		transactions map[ldrdecoder.TxnID]transactionState
+		// committed tracks which local transactions have been applied.
+		committed committedSet
 
-		// waiting maps a pending transaction to its dependents. I.e. if t5 depends
-		// on t2, then waiting[t2] will contain t5.
-		waiting map[ldrdecoder.TxnID][]ldrdecoder.TxnID
+		// transactions maps unapplied txn TxnIDs to their state.
+		transactions map[ldrdecoder.TxnID]ScheduledTransaction
+
+		// localWaiting maps a pending transaction to its dependents. I.e. if t5
+		// depends on t2, then localWaiting[t2] will contain t5.
+		localWaiting map[ldrdecoder.TxnID][]ldrdecoder.TxnID
+
+		// remoteWaiting maps a remote TxnID to the local txns
+		// waiting on it.
+		remoteWaiting map[ldrdecoder.TxnID][]ldrdecoder.TxnID
+
+		// remoteApplierResolvedTimes tracks the latest known resolved time per
+		// remote applier, updated via DependencyResolver notifications.
+		remoteApplierResolvedTimes map[ldrdecoder.ApplierID]hlc.Timestamp
 
 		// txnIDs buffers TxnIDs of transactions in the order they were
 		// received, to help with replicatedTime tracking.
 		txnIDs ring.Buffer[ldrdecoder.TxnID]
 
 		// horizonWaiting tracks transactions that have no remaining
-		// dependencies but cannot be applied yet because the applier's
-		// replicatedTime has not advanced past their EventHorizon.
+		// dependencies but cannot be applied yet because the global
+		// resolved time has not advanced past their EventHorizon.
 		//
 		// TODO(msbutler): consider making this a heap.
 		horizonWaiting []ldrdecoder.TxnID
 	}
 	txnWriters []txnwriter.TransactionWriter
 
-	frontier Latest[hlc.Timestamp]
+	// TODO(msbutler): consider removing and simply call commited.ResolvedTime().
+	localResolvedTime Latest[hlc.Timestamp]
 }
 
-func NewApplier(writers []txnwriter.TransactionWriter) *Applier {
-	a := &Applier{
-		txnWriters: writers,
-		frontier:   MakeLatest[hlc.Timestamp](),
+// NewApplier creates a new Applier with the given ID and writers. allApplierIDs
+// must include all applier IDs in the system (including this applier's own ID)
+// so that the applier can initialize the frontier map used to track when all
+// appliers have advanced past an EventHorizon.
+func NewApplier(
+	id ldrdecoder.ApplierID,
+	writers []txnwriter.TransactionWriter,
+	depResolver DependencyResolver,
+	allApplierIDs []ldrdecoder.ApplierID,
+) (*Applier, error) {
+	if id == 0 {
+		return nil, errors.New("applier ID must be nonzero")
 	}
-	a.mu.transactions = make(map[ldrdecoder.TxnID]transactionState)
-	a.mu.waiting = make(map[ldrdecoder.TxnID][]ldrdecoder.TxnID)
-	return a
+	if depResolver == nil {
+		return nil, errors.New("dependency resolver must not be nil")
+	}
+	a := &Applier{
+		id:                id,
+		depResolver:       depResolver,
+		txnWriters:        writers,
+		localResolvedTime: MakeLatest[hlc.Timestamp](),
+	}
+	a.mu.committed = makeCommittedSet()
+	a.mu.transactions = make(map[ldrdecoder.TxnID]ScheduledTransaction)
+	a.mu.localWaiting = make(map[ldrdecoder.TxnID][]ldrdecoder.TxnID)
+	a.mu.remoteWaiting = make(map[ldrdecoder.TxnID][]ldrdecoder.TxnID)
+	a.mu.remoteApplierResolvedTimes = make(map[ldrdecoder.ApplierID]hlc.Timestamp, len(allApplierIDs))
+	for _, applierID := range allApplierIDs {
+		if applierID == id {
+			continue
+		}
+		a.mu.remoteApplierResolvedTimes[applierID] = hlc.Timestamp{}
+	}
+	return a, nil
 }
 
 func (a *Applier) Close(ctx context.Context) {
-	a.frontier.Close()
+	a.localResolvedTime.Close()
 	for _, writer := range a.txnWriters {
 		writer.Close(ctx)
 	}
 }
 
 func (a *Applier) Frontier() chan hlc.Timestamp {
-	return a.frontier.Chan
+	return a.localResolvedTime.Chan
 }
 
-func (a *Applier) Run(ctx context.Context, input chan ScheduledTransaction) error {
+func (a *Applier) Run(ctx context.Context, input chan ApplierEvent) error {
 	ready := make(chan ldrdecoder.Transaction)
 	applied := make(chan appliedTransaction)
 
 	group := ctxgroup.WithContext(ctx)
 	group.GoCtx(func(ctx context.Context) error {
-		return a.coordinator(ctx, input, ready)
+		return a.coordinator(ctx, input, ready, applied)
 	})
 
 	// TODO make the number of writers a configuration option
@@ -117,23 +177,37 @@ func (a *Applier) Run(ctx context.Context, input chan ScheduledTransaction) erro
 }
 
 func (a *Applier) coordinator(
-	ctx context.Context, input chan ScheduledTransaction, ready chan ldrdecoder.Transaction,
+	ctx context.Context,
+	input chan ApplierEvent,
+	ready chan ldrdecoder.Transaction,
+	applied chan appliedTransaction,
 ) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case transaction := <-input:
-			appliable, err := a.recordTransaction(transaction)
-			if err != nil {
-				return err
-			}
-			if appliable {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case ready <- transaction.Transaction:
-					// done
+		case event := <-input:
+			switch e := event.(type) {
+			case ScheduledTransaction:
+				appliable, err := a.recordTransaction(e)
+				if err != nil {
+					return err
+				}
+				if appliable {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case ready <- e.Transaction:
+					}
+				}
+			case Checkpoint:
+				synthTxn, ok := a.processCheckpoint(e.Timestamp)
+				if ok {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case applied <- synthTxn:
+					}
 				}
 			}
 		}
@@ -144,43 +218,104 @@ func (a *Applier) recordTransaction(transaction ScheduledTransaction) (bool, err
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	if transaction.TxnID.ApplierID != a.id {
+		return false, errors.AssertionFailedf(
+			"transaction %+v has ApplierID %d, expected %d",
+			transaction.TxnID, transaction.TxnID.ApplierID, a.id)
+	}
+
 	var err error
 	// Clone the slice to avoid mutating the caller's slice.
+	//
+	// TODO(msbutler): once thses are sent over RPCs from the job coordinator, I
+	// don't think we need to clone here.
 	transaction.Dependencies = slices.Clone(transaction.Dependencies)
-	transaction.Dependencies = slices.DeleteFunc(transaction.Dependencies, func(txnID ldrdecoder.TxnID) bool {
-		if txnID.Timestamp.LessEq(a.mu.replicatedTime) {
-			return true
-		}
-		dependency, ok := a.mu.transactions[txnID]
-		if !ok {
-			err = errors.AssertionFailedf("missing dependency %+v", txnID)
-		}
-		return dependency.applied
-	})
+	transaction.Dependencies = slices.DeleteFunc(
+		transaction.Dependencies,
+		func(txnID ldrdecoder.TxnID) bool {
+			if txnID.ApplierID == a.id {
+				// Local dep: prune if already committed.
+				if a.mu.committed.IsResolved(txnID) {
+					return true
+				}
+				if _, ok := a.mu.transactions[txnID]; !ok {
+					err = errors.AssertionFailedf("missing dependency %+v", txnID)
+				}
+				return false
+			}
+			// Remote dep: prune if remote applier's resolvedTime has advanced
+			// past its timestamp.
+			resolvedTime := a.mu.remoteApplierResolvedTimes[txnID.ApplierID]
+			return txnID.Timestamp.LessEq(resolvedTime)
+		})
 	if err != nil {
 		return false, err
 	}
 
-	a.mu.transactions[transaction.TxnID] = transactionState{
-		ScheduledTransaction: transaction,
-		applied:              false,
-	}
+	a.mu.transactions[transaction.TxnID] = transaction
 	if a.mu.txnIDs.Len() != 0 && transaction.TxnID.LessEq(a.mu.txnIDs.GetLast()) {
-		return false, errors.AssertionFailedf("transactions must be sent in increasing timestamp order: got %s, last was %s", transaction.TxnID.Timestamp, a.mu.txnIDs.GetLast().Timestamp)
+		return false, errors.AssertionFailedf(
+			"transactions must be sent in increasing timestamp order: got %s, last was %s",
+			transaction.TxnID.Timestamp, a.mu.txnIDs.GetLast().Timestamp)
 	}
 	a.mu.txnIDs.AddLast(transaction.TxnID)
 
-	for _, dependency := range transaction.Dependencies {
-		a.mu.waiting[dependency] = append(a.mu.waiting[dependency], transaction.TxnID)
+	var newRemoteDeps []ldrdecoder.TxnID
+	for _, dep := range transaction.Dependencies {
+		if dep.ApplierID == a.id {
+			a.mu.localWaiting[dep] = append(a.mu.localWaiting[dep], transaction.TxnID)
+		} else {
+			a.mu.remoteWaiting[dep] = append(a.mu.remoteWaiting[dep], transaction.TxnID)
+			if len(a.mu.remoteWaiting[dep]) == 1 {
+				newRemoteDeps = append(newRemoteDeps, dep)
+			}
+		}
+	}
+
+	// Register remote deps with the dependency resolver.
+	if len(newRemoteDeps) > 0 {
+		a.depResolver.Wait(a.id, newRemoteDeps)
 	}
 
 	if len(transaction.Dependencies) == 0 {
-		if transaction.EventHorizon.LessEq(a.mu.replicatedTime) {
+		if transaction.EventHorizon.LessEq(a.getGlobalFrontierLocked()) {
 			return true, nil
 		}
 		a.mu.horizonWaiting = append(a.mu.horizonWaiting, transaction.TxnID)
+		a.registerHorizonWaitLocked(transaction.EventHorizon)
 	}
 	return false, nil
+}
+
+// processCheckpoint handles a checkpoint event. If the checkpoint is beyond the
+// last recorded txn, it synthesizes an already-applied transaction to advance
+// the frontier.
+func (a *Applier) processCheckpoint(checkpoint hlc.Timestamp) (appliedTransaction, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Drop if checkpoint ts ≤ last txnID ts (no synthetic txn needed;
+	// the real txn's completion will advance the frontier).
+	if a.mu.txnIDs.Len() != 0 &&
+		checkpoint.LessEq(a.mu.txnIDs.GetLast().Timestamp) {
+		return appliedTransaction{}, false
+	}
+
+	// Also drop if checkpoint ts ≤ current resolved time (the aggregator
+	// may have already drained txnIDs past this point).
+	if checkpoint.LessEq(a.mu.committed.ResolvedTime()) {
+		return appliedTransaction{}, false
+	}
+
+	// Synthesize an already-applied txn at the checkpoint timestamp.
+	// Only added to txnIDs (not transactions) since it is already resolved.
+	synthID := ldrdecoder.TxnID{ApplierID: a.id, Timestamp: checkpoint}
+	a.mu.committed.Resolve(synthID)
+	a.mu.txnIDs.AddLast(synthID)
+
+	return appliedTransaction{
+		Transaction: ldrdecoder.Transaction{TxnID: synthID},
+	}, true
 }
 
 func (a *Applier) writer(
@@ -223,6 +358,7 @@ func (a *Applier) aggregator(
 	// WARNING: there is a deadlock risk in aggregator because we are creating a
 	// loop between the channels. We avoid this deadlock by buffering newly ready
 	// transactions.
+	remoteUpdates := a.depResolver.Receive(a.id)
 	readyBuffer := ring.MakeBuffer[ldrdecoder.Transaction](nil)
 	for {
 		if readyBuffer.Len() == 0 {
@@ -232,6 +368,10 @@ func (a *Applier) aggregator(
 			case transaction := <-applied:
 				err := a.recordCompletion(ctx, transaction, &readyBuffer)
 				if err != nil {
+					return err
+				}
+			case update := <-remoteUpdates:
+				if err := a.processRemoteUpdate(update, &readyBuffer); err != nil {
 					return err
 				}
 			}
@@ -244,6 +384,10 @@ func (a *Applier) aggregator(
 			case transaction := <-applied:
 				err := a.recordCompletion(ctx, transaction, &readyBuffer)
 				if err != nil {
+					return err
+				}
+			case update := <-remoteUpdates:
+				if err := a.processRemoteUpdate(update, &readyBuffer); err != nil {
 					return err
 				}
 			}
@@ -260,54 +404,147 @@ func (a *Applier) recordCompletion(
 	defer a.mu.Unlock()
 
 	completedID := completedTxn.TxnID
-	for _, waitingID := range a.mu.waiting[completedID] {
+	if err := a.resolveDependencyLocked(
+		completedID, a.mu.localWaiting[completedID], readyBuffer,
+	); err != nil {
+		return err
+	}
+	delete(a.mu.localWaiting, completedID)
+
+	a.mu.committed.Resolve(completedID)
+	delete(a.mu.transactions, completedID)
+
+	// Advance the resolved time by draining applied txns from the front
+	// of the ordered txnIDs buffer.
+	prevResolvedTime := a.mu.committed.ResolvedTime()
+	for a.mu.txnIDs.Len() != 0 {
+		id := a.mu.txnIDs.GetFirst()
+		if !a.mu.committed.IsResolved(id) {
+			// Advance the resolved time through the gap before this
+			// unapplied txn. Since the coordinator records txns in
+			// timestamp order, if txnIDs contains a txn at timestamp T,
+			// there are no txns for this applier in the interval
+			// (resolvedTime, T). The resolved time can safely advance
+			// to T-1.
+			a.mu.committed.UpdateResolvedTime(id.Timestamp.FloorPrev())
+			break
+		}
+		a.mu.committed.UpdateResolvedTime(id.Timestamp)
+		a.mu.txnIDs.RemoveFirst()
+	}
+
+	resolvedTime := a.mu.committed.ResolvedTime()
+	if prevResolvedTime.Less(resolvedTime) {
+		a.localResolvedTime.Set(resolvedTime)
+	}
+
+	a.drainSatisfiedHorizonWaitersLocked(readyBuffer)
+	a.depResolver.Ready(completedTxn.TxnID, resolvedTime)
+	return nil
+}
+
+// resolveDependencyLocked processes the completion of completedID by removing
+// it from the dependency lists of all waitingIDs. Transactions that become
+// dependency-free are either added to readyBuffer (if their EventHorizon is
+// satisfied) or moved to horizonWaiting.
+//
+// REQUIRES: a.mu is held.
+func (a *Applier) resolveDependencyLocked(
+	completedID ldrdecoder.TxnID,
+	waitingIDs []ldrdecoder.TxnID,
+	readyBuffer *ring.Buffer[ldrdecoder.Transaction],
+) error {
+	for _, waitingID := range waitingIDs {
 		waitingTxn, ok := a.mu.transactions[waitingID]
 		if !ok {
 			return errors.AssertionFailedf("missing transaction %+v", waitingID)
 		}
 
-		waitingTxn.Dependencies = slices.DeleteFunc(waitingTxn.Dependencies, func(id ldrdecoder.TxnID) bool {
-			return id == completedID
-		})
+		waitingTxn.Dependencies = slices.DeleteFunc(
+			waitingTxn.Dependencies,
+			func(id ldrdecoder.TxnID) bool {
+				return id == completedID
+			})
 		a.mu.transactions[waitingID] = waitingTxn
 
 		if len(waitingTxn.Dependencies) == 0 {
-			if waitingTxn.EventHorizon.LessEq(a.mu.replicatedTime) {
+			if waitingTxn.EventHorizon.LessEq(a.getGlobalFrontierLocked()) {
 				readyBuffer.AddLast(waitingTxn.Transaction)
 			} else {
 				a.mu.horizonWaiting = append(a.mu.horizonWaiting, waitingID)
+				a.registerHorizonWaitLocked(waitingTxn.EventHorizon)
 			}
 		}
 	}
+	return nil
+}
 
-	delete(a.mu.waiting, completedID)
-	txnState := a.mu.transactions[completedID]
-	txnState.applied = true
-	a.mu.transactions[completedID] = txnState
-
-	var newReplicatedTime hlc.Timestamp
-	for a.mu.txnIDs.Len() != 0 {
-		id := a.mu.txnIDs.GetFirst()
-		if !a.mu.transactions[id].applied {
-			break
+// getGlobalFrontierLocked returns the minimum frontier across all applier
+// frontiers.
+//
+// REQUIRES: a.mu is held.
+func (a *Applier) getGlobalFrontierLocked() hlc.Timestamp {
+	minFrontier := a.mu.committed.ResolvedTime()
+	for _, frontier := range a.mu.remoteApplierResolvedTimes {
+		if frontier.Less(minFrontier) {
+			minFrontier = frontier
 		}
-		newReplicatedTime = id.Timestamp
-		delete(a.mu.transactions, id)
-		a.mu.txnIDs.RemoveFirst()
 	}
-	if newReplicatedTime.IsSet() {
-		a.mu.replicatedTime = newReplicatedTime
-		a.frontier.Set(newReplicatedTime)
+	return minFrontier
+}
 
-		// Drain transactions whose EventHorizon is now satisfied.
-		a.mu.horizonWaiting = slices.DeleteFunc(a.mu.horizonWaiting, func(id ldrdecoder.TxnID) bool {
+// registerHorizonWaitLocked identifies which remote appliers' frontiers are
+// blocking the given EventHorizon and registers horizon waits with the
+// dependency resolver.
+//
+// REQUIRES: a.mu is held.
+func (a *Applier) registerHorizonWaitLocked(horizon hlc.Timestamp) {
+	for applierID, remoteFrontier := range a.mu.remoteApplierResolvedTimes {
+		if horizon.After(remoteFrontier) {
+			a.depResolver.WaitHorizon(a.id, applierID, horizon)
+		}
+	}
+}
+
+// drainSatisfiedHorizonWaitersLocked checks all horizonWaiting txns and moves
+// any whose EventHorizon ≤ globalFrontier into readyBuffer.
+//
+// REQUIRES: a.mu is held.
+func (a *Applier) drainSatisfiedHorizonWaitersLocked(
+	readyBuffer *ring.Buffer[ldrdecoder.Transaction],
+) {
+	globalFrontier := a.getGlobalFrontierLocked()
+	a.mu.horizonWaiting = slices.DeleteFunc(a.mu.horizonWaiting,
+		func(id ldrdecoder.TxnID) bool {
 			txn := a.mu.transactions[id]
-			if txn.EventHorizon.LessEq(newReplicatedTime) {
+			if txn.EventHorizon.LessEq(globalFrontier) {
 				readyBuffer.AddLast(txn.Transaction)
 				return true
 			}
 			return false
 		})
+}
+
+func (a *Applier) processRemoteUpdate(
+	update DependencyUpdate, readyBuffer *ring.Buffer[ldrdecoder.Transaction],
+) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Only advance the frontier, never regress it. Out-of-order updates can
+	// arrive when a WaitHorizon eager response (with an older resolvedTime)
+	// races with a Ready notification (with a newer resolvedTime) from the
+	// same remote applier.
+	if a.mu.remoteApplierResolvedTimes[update.TxnID.ApplierID].Less(update.ResolvedTime) {
+		a.mu.remoteApplierResolvedTimes[update.TxnID.ApplierID] = update.ResolvedTime
 	}
+
+	if err := a.resolveDependencyLocked(
+		update.TxnID, a.mu.remoteWaiting[update.TxnID], readyBuffer,
+	); err != nil {
+		return err
+	}
+	delete(a.mu.remoteWaiting, update.TxnID)
+	a.drainSatisfiedHorizonWaitersLocked(readyBuffer)
 	return nil
 }

--- a/pkg/crosscluster/logical/txnapply/txn_applier_test.go
+++ b/pkg/crosscluster/logical/txnapply/txn_applier_test.go
@@ -48,7 +48,7 @@ func (w *testWriter) ApplyBatch(
 
 	results := make([]txnwriter.ApplyResult, len(txns))
 	for i, txn := range txns {
-		w.t.Logf("applied txn at %s", txn.TxnID.Timestamp)
+		w.t.Logf("applier %d applied txn at %d", txn.TxnID.ApplierID, txn.TxnID.Timestamp.WallTime)
 		w.mu.log = append(w.mu.log, txn.TxnID.Timestamp)
 		results[i] = txnwriter.ApplyResult{AppliedRows: len(txn.WriteSet)}
 	}
@@ -81,6 +81,30 @@ func (d depsOpt) add(n *txnNode) {
 
 func deps(wallTimes ...int64) depsOpt { return depsOpt(wallTimes) }
 
+// ddepsOpt is a dependency option that specifies (applierID, wallTime) pairs,
+// allowing dependencies on transactions owned by other appliers.
+type ddepsOpt []ldrdecoder.TxnID
+
+func (d ddepsOpt) add(n *txnNode) {
+	n.deps = append(n.deps, d...)
+}
+
+// ddeps creates cross-applier dependencies. Arguments are (applierID, wallTime)
+// pairs.
+func ddeps(pairs ...int64) ddepsOpt {
+	if len(pairs)%2 != 0 {
+		panic("ddeps requires (applierID, wallTime) pairs")
+	}
+	out := make(ddepsOpt, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		out[i/2] = ldrdecoder.TxnID{
+			ApplierID: ldrdecoder.ApplierID(pairs[i]),
+			Timestamp: hlc.Timestamp{WallTime: pairs[i+1]},
+		}
+	}
+	return out
+}
+
 type horizonOpt int64
 
 func (h horizonOpt) add(n *txnNode) {
@@ -100,6 +124,18 @@ func txn(wallTime int64, opts ...txnOpt) txnNode {
 	return n
 }
 
+// dtxn creates a txnNode assigned to a specific applier.
+func dtxn(applierID ldrdecoder.ApplierID, wallTime int64, opts ...txnOpt) txnNode {
+	n := txnNode{id: ldrdecoder.TxnID{
+		Timestamp: hlc.Timestamp{WallTime: wallTime},
+		ApplierID: applierID,
+	}}
+	for _, o := range opts {
+		o.add(&n)
+	}
+	return n
+}
+
 // generateRandomDAG creates a random DAG of transactions where each transaction
 // can depend on earlier transactions. Two invariants are maintained:
 //
@@ -108,23 +144,40 @@ func txn(wallTime int64, opts ...txnOpt) txnNode {
 //  2. EventHorizon values are monotonically non-decreasing with respect to
 //     transaction timestamps: if txn.ts > txn2.ts then
 //     txn.EventHorizon >= txn2.EventHorizon.
-func generateRandomDAG(rng *rand.Rand, numTxns int, maxDeps int) []txnNode {
+func generateRandomDAG(rng *rand.Rand, numTxns int, maxDeps int, numAppliers int) []txnNode {
 	nodes := make([]txnNode, numTxns)
 	var maxHorizonWallTime int64
+
+	// Mimic the transaction scheduler: pick a random capacity, then hold the
+	// event horizon fixed until that many txns share it. Once at capacity,
+	// advance the horizon to the timestamp of the earliest txn in the batch.
+	// This produces a sliding window where the horizon lags behind the latest
+	// txn by ~capacity, creating longer dependency chains.
+	capacity := 1 + rng.Intn(numTxns)
+	batchStart := 0 // index of the first txn in the current batch
+
 	for i := range nodes {
+		applierID := ldrdecoder.ApplierID(1)
+		if numAppliers > 1 {
+			applierID = ldrdecoder.ApplierID(rng.Intn(numAppliers) + 1)
+		}
 		nodes[i].id = ldrdecoder.TxnID{
 			Timestamp: hlc.Timestamp{WallTime: int64(i + 1)},
-			ApplierID: 1,
+			ApplierID: applierID,
 		}
 
-		horizonRange := int64(i) - maxHorizonWallTime + 1
-		horizonWallTime := maxHorizonWallTime + int64(rng.Intn(int(horizonRange)))
-		nodes[i].eventHorizon = hlc.Timestamp{WallTime: horizonWallTime}
-		maxHorizonWallTime = horizonWallTime
+		if i-batchStart >= capacity {
+			// Batch is full: advance the event horizon to the timestamp of
+			// the earliest txn in the previous batch.
+			maxHorizonWallTime = nodes[batchStart].id.Timestamp.WallTime
+			// Sliding window.
+			batchStart += 1
+		}
+		nodes[i].eventHorizon = hlc.Timestamp{WallTime: maxHorizonWallTime}
 
 		// Dependencies are restricted to transactions with timestamps
 		// strictly greater than the event horizon.
-		availableStart := int(horizonWallTime)
+		availableStart := int(maxHorizonWallTime)
 		availableCount := i - availableStart
 		if availableCount > 0 {
 			numDeps := min(rng.Intn(maxDeps+1), availableCount)
@@ -141,73 +194,11 @@ func logDAG(t *testing.T, dag []txnNode) {
 	t.Log("transaction dependency graph:")
 	for _, node := range dag {
 		if node.eventHorizon.IsSet() {
-			t.Logf("  %s depends on %v horizon=%s", node.id.Timestamp, node.deps, node.eventHorizon)
+			t.Logf("  txn %s; horizon=%d; depends on %v", node.id, node.eventHorizon.WallTime, node.deps)
 		} else {
-			t.Logf("  %s depends on %v", node.id.Timestamp, node.deps)
+			t.Logf("  txn %s; depends on %v", node.id, node.deps)
 		}
 	}
-}
-
-// runApplier runs the applier pipeline with the given DAG and number of
-// writers, returning the ordered log of applied transaction timestamps.
-func runApplier(t *testing.T, dag []txnNode, numWriters int, rngSeed int64) []hlc.Timestamp {
-	t.Helper()
-
-	rng := rand.New(randutil.NewLockedSource(rngSeed))
-	writer := &testWriter{t: t, rng: rng}
-	writers := make([]txnwriter.TransactionWriter, numWriters)
-	for i := range writers {
-		writers[i] = writer
-	}
-
-	input := make(chan ScheduledTransaction, len(dag))
-	for _, node := range dag {
-		input <- ScheduledTransaction{
-			Transaction:  ldrdecoder.Transaction{TxnID: node.id},
-			Dependencies: node.deps,
-			EventHorizon: node.eventHorizon,
-		}
-	}
-
-	applier := NewApplier(writers)
-	defer applier.Close(context.Background())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	group := ctxgroup.WithContext(ctx)
-	group.GoCtx(func(ctx context.Context) error {
-		return applier.Run(ctx, input)
-	})
-
-	lastTs := dag[len(dag)-1].id.Timestamp
-	group.GoCtx(func(ctx context.Context) error {
-		var prev hlc.Timestamp
-		for ts := range applier.Frontier() {
-			if prev.IsSet() && !prev.Less(ts) {
-				return errors.Newf("frontier regressed: %s -> %s", prev, ts)
-			}
-			prev = ts
-			t.Logf("frontier advanced to %s", ts)
-			if ts.Equal(lastTs) {
-				cancel()
-				return nil
-			}
-		}
-		return errors.New("frontier channel closed before reaching final transaction")
-	})
-
-	err := group.Wait()
-	require.True(t, err == nil || errors.Is(err, context.Canceled),
-		"unexpected error: %v", err)
-
-	checkApplierDrained(t, applier)
-
-	writer.mu.Lock()
-	applied := append([]hlc.Timestamp(nil), writer.mu.log...)
-	writer.mu.Unlock()
-
-	return applied
 }
 
 // checkApplierDrained verifies that the applier's internal buffers are empty
@@ -216,10 +207,28 @@ func checkApplierDrained(t *testing.T, applier *Applier) {
 	t.Helper()
 	applier.mu.Lock()
 	defer applier.mu.Unlock()
+	require.Empty(t, applier.mu.committed.completedTxns,
+		"committed completedTxns should be empty")
 	require.Empty(t, applier.mu.transactions, "transactions map should be empty")
-	require.Empty(t, applier.mu.waiting, "waiting map should be empty")
+	require.Empty(t, applier.mu.localWaiting, "local waiting map should be empty")
+	require.Empty(t, applier.mu.remoteWaiting, "remote waiting map should be empty")
 	require.Equal(t, 0, applier.mu.txnIDs.Len(), "txnIDs buffer should be empty")
 	require.Empty(t, applier.mu.horizonWaiting, "horizonWaiting should be empty")
+}
+
+// checkTrackerServerDrained verifies that the trackerServer's internal state is
+// empty after all transactions have been processed.
+func checkTrackerServerDrained(t *testing.T, ts *trackerServer) {
+	t.Helper()
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	for txn, waiters := range ts.mu.waiters {
+		require.Empty(t, waiters, "waiters for txn %s should be empty", txn)
+	}
+	for applier, horizons := range ts.mu.horizonWaiters {
+		require.Empty(t, horizons, "horizonWaiters for applier %d should be empty", applier)
+	}
+	require.Empty(t, ts.mu.committed.completedTxns, "completedTxns should be empty")
 }
 
 // checkApplyOrder verifies that all transactions were applied after their
@@ -264,16 +273,31 @@ func TestTxnApplierRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rng, seed := randutil.NewTestRand()
-	dag := generateRandomDAG(rng, 100, rng.Intn(10))
+	dag := generateRandomDAG(rng, 100, rng.Intn(10), 1 /* numAppliers */)
 	logDAG(t, dag)
 
 	numWriters := max(1, rng.Intn(len(dag)))
-	applied := runApplier(t, dag, numWriters, seed)
+	applied := runDistributedApplier(t, dag, numWriters, seed)
 	require.Equal(t, len(dag), len(applied), "not all transactions were applied")
 	checkApplyOrder(t, dag, applied)
 }
 
-func TestTxnApplierDeterministic(t *testing.T) {
+func TestDistributedTxnApplierRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng, seed := randutil.NewTestRand()
+	numAppliers := 2 + rng.Intn(4) // 2 to 5 appliers
+	dag := generateRandomDAG(rng, 100, rng.Intn(10), numAppliers)
+	logDAG(t, dag)
+	t.Logf("numAppliers=%d", numAppliers)
+
+	numWriters := max(1, rng.Intn(len(dag)))
+	applied := runDistributedApplier(t, dag, numWriters, seed)
+	require.Equal(t, len(dag), len(applied), "not all transactions were applied")
+	checkApplyOrder(t, dag, applied)
+}
+
+func TestTxnApplierSimple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tests := []struct {
@@ -315,7 +339,7 @@ func TestTxnApplierDeterministic(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			logDAG(t, tc.dag)
-			applied := runApplier(t, tc.dag, 3, 0)
+			applied := runDistributedApplier(t, tc.dag, 3, 0)
 			require.Equal(t, len(tc.dag), len(applied))
 			checkApplyOrder(t, tc.dag, applied)
 		})
@@ -332,12 +356,276 @@ func TestTxnApplierIndependent(t *testing.T) {
 	var sawT1First, sawT2First bool
 	for i := 0; !(sawT1First && sawT2First); i++ {
 		require.Less(t, i, 100, "expected both orderings within 100 iterations")
-		applied := runApplier(t, dag, 3, int64(i))
+		applied := runDistributedApplier(t, dag, 3, int64(i))
 		require.Equal(t, len(dag), len(applied))
 		if applied[0].WallTime == 1 {
 			sawT1First = true
 		} else {
 			sawT2First = true
 		}
+	}
+}
+
+// mockCoordinator simulates the coordinator's checkpoint behavior in tests.
+// It sends a checkpoint at txn.timestamp-1 to all appliers when a txn's
+// EventHorizon exceeds the previous checkpoint (required for correctness),
+// and also probabilistically sends intermediate checkpoints.
+type mockCoordinator struct {
+	rng            *rand.Rand
+	ids            []ldrdecoder.ApplierID
+	inputs         map[ldrdecoder.ApplierID]chan ApplierEvent
+	lastCheckpoint hlc.Timestamp
+	extraCPProb    float64
+}
+
+func newMockCoordinator(
+	rng *rand.Rand, ids []ldrdecoder.ApplierID, inputs map[ldrdecoder.ApplierID]chan ApplierEvent,
+) *mockCoordinator {
+	return &mockCoordinator{
+		rng:         rng,
+		ids:         ids,
+		inputs:      inputs,
+		extraCPProb: rng.Float64() * 0.5,
+	}
+}
+
+func (c *mockCoordinator) sendCheckpoint(ts hlc.Timestamp) {
+	cp := Checkpoint{Timestamp: ts}
+	for _, id := range c.ids {
+		c.inputs[id] <- cp
+	}
+	c.lastCheckpoint = ts
+}
+
+func (c *mockCoordinator) send(node txnNode) {
+	cpTs := hlc.Timestamp{WallTime: node.id.Timestamp.WallTime - 1}
+	if c.lastCheckpoint.Less(node.eventHorizon) {
+		c.sendCheckpoint(cpTs)
+	} else if c.rng.Float64() < c.extraCPProb {
+		c.sendCheckpoint(cpTs)
+	}
+	c.inputs[node.id.ApplierID] <- ScheduledTransaction{
+		Transaction:  ldrdecoder.Transaction{TxnID: node.id},
+		Dependencies: node.deps,
+		EventHorizon: node.eventHorizon,
+	}
+}
+
+func (c *mockCoordinator) finalize(maxCheckpoint hlc.Timestamp) {
+	c.sendCheckpoint(maxCheckpoint)
+}
+
+// runDistributedApplier runs multiple Applier instances sharing a single
+// DependencyTracker, routing each txnNode to the Applier matching its
+// ApplierID. Returns the globally ordered log of applied transaction
+// timestamps across all appliers.
+func runDistributedApplier(
+	t *testing.T, dag []txnNode, numWritersPerApplier int, rngSeed int64,
+) []hlc.Timestamp {
+	t.Helper()
+
+	// Group txns per applier, preserving order.
+	txnsByApplier := make(map[ldrdecoder.ApplierID][]txnNode)
+	for _, node := range dag {
+		txnsByApplier[node.id.ApplierID] = append(
+			txnsByApplier[node.id.ApplierID], node)
+	}
+
+	ids := make([]ldrdecoder.ApplierID, 0, len(txnsByApplier))
+	for id := range txnsByApplier {
+		ids = append(ids, id)
+	}
+
+	depTracker := NewDependencyTracker(ids)
+
+	// Shared writer so all appliers record to one log, giving us a global
+	// application order.
+	rng := rand.New(randutil.NewLockedSource(rngSeed))
+	sharedWriter := &testWriter{t: t, rng: rng}
+
+	// Compute maxTs across all txns for the checkpoint.
+	var maxTs hlc.Timestamp
+	for _, node := range dag {
+		if maxTs.Less(node.id.Timestamp) {
+			maxTs = node.id.Timestamp
+		}
+	}
+	// A final checkpoint beyond all txns is needed so that appliers whose last
+	// real txn is below maxTs can advance their frontiers to completion. Without
+	// it, those appliers would stall at their last txn's timestamp, holding back
+	// the global frontier. In production, the rangefeed source emits trailing
+	// resolved timestamps that serve this role.
+	maxCheckpoint := maxTs.Add(1, 0)
+
+	appliers := make(map[ldrdecoder.ApplierID]*Applier)
+	inputs := make(map[ldrdecoder.ApplierID]chan ApplierEvent)
+	for _, id := range ids {
+		writers := make([]txnwriter.TransactionWriter, numWritersPerApplier)
+		for i := range writers {
+			writers[i] = sharedWriter
+		}
+		a, err := NewApplier(id, writers, depTracker, ids)
+		require.NoError(t, err)
+
+		inputs[id] = make(chan ApplierEvent, 2*len(dag)+len(ids)+1)
+		appliers[id] = a
+	}
+
+	coord := newMockCoordinator(rng, ids, inputs)
+	for _, node := range dag {
+		coord.send(node)
+	}
+	coord.finalize(maxCheckpoint)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	group := ctxgroup.WithContext(ctx)
+
+	for id, a := range appliers {
+		group.GoCtx(func(ctx context.Context) error {
+			defer a.Close(context.Background())
+			return a.Run(ctx, inputs[id])
+		})
+	}
+
+	// Watch each applier's frontier; cancel once all have reached their
+	// final timestamp.
+	var frontierMu syncutil.Mutex
+	done := make(map[ldrdecoder.ApplierID]bool)
+	for id, a := range appliers {
+		lastTs := maxCheckpoint
+		_ = txnsByApplier[id] // ensure the applier has txns
+		group.GoCtx(func(ctx context.Context) error {
+			var prev hlc.Timestamp
+			for ts := range a.Frontier() {
+				if prev.IsSet() && !prev.Less(ts) {
+					return errors.Newf(
+						"applier %d frontier regressed: %s -> %s", id, prev, ts)
+				}
+				prev = ts
+				t.Logf("applier %d frontier advanced to %d", id, ts.WallTime)
+				if ts.Equal(lastTs) {
+					frontierMu.Lock()
+					done[id] = true
+					allDone := len(done) == len(appliers)
+					frontierMu.Unlock()
+					if allDone {
+						cancel()
+					}
+					return nil
+				}
+			}
+			return errors.Newf(
+				"applier %d frontier closed before reaching final txn", id)
+		})
+	}
+
+	err := group.Wait()
+	require.True(t, err == nil || errors.Is(err, context.Canceled),
+		"unexpected error: %v", err)
+
+	for _, a := range appliers {
+		checkApplierDrained(t, a)
+	}
+	for _, ts := range depTracker.(*trackerClient).servers {
+		checkTrackerServerDrained(t, ts)
+	}
+
+	sharedWriter.mu.Lock()
+	applied := append([]hlc.Timestamp(nil), sharedWriter.mu.log...)
+	sharedWriter.mu.Unlock()
+	return applied
+}
+
+func TestDistributedTxnApplierSimple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name string
+		dag  []txnNode
+	}{
+		{
+			// Txn 2 on applier 2 depends on txn 1 on applier 1.
+			// Exercises cross-applier dependency resolution via
+			// DependencyTracker.
+			name: "cross_applier_dependency",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(2, 2, ddeps(1, 1)),
+			},
+		},
+		{
+			// Txn 2 on applier 2 has an EventHorizon of ts=1. Applier 2
+			// cannot apply txn 2 until the global replicated time advances
+			// past ts=1, which requires applier 1's frontier to advance.
+			name: "cross_applier_event_horizon",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(2, 2, horizon(1)),
+			},
+		},
+		{
+			// Chain across 3 appliers: applier 1 -> applier 2 -> applier 3.
+			// Each applier waits for the previous one's txn to complete.
+			name: "cross_applier_chain",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(2, 2, ddeps(1, 1)),
+				dtxn(3, 3, ddeps(2, 2)),
+			},
+		},
+		{
+			// Txn 3 on applier 3 depends on txn 2 (applier 2) and has an
+			// EventHorizon of ts=1 (must wait for applier 1 to advance).
+			name: "cross_applier_horizon_and_dependency",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(2, 2),
+				dtxn(3, 3, ddeps(2, 2), horizon(1)),
+			},
+		},
+		{
+			// Txn 3 on applier 3 depends on txns from both applier 1 and
+			// applier 2. Must wait for both to complete.
+			name: "cross_applier_multiple_dependencies",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(2, 2),
+				dtxn(3, 3, ddeps(1, 1), ddeps(2, 2)),
+			},
+		},
+		{
+			// Applier 1 has two txns (ts=1 and ts=3). Applier 2 has one
+			// txn (ts=2). The third txn on applier 1 depends on applier 2's
+			// txn, so applier 1 must wait for applier 2 before applying it.
+			name: "cross_applier_dependency_back_to_source",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(2, 2),
+				dtxn(1, 3, ddeps(2, 2)),
+			},
+		},
+		{
+			// Two txns on applier 2 are both blocked by event horizons.
+			// Txn 2 waits for ts=1, txn 3 waits for ts=2. Both require
+			// applier 1's frontier to advance before they can be applied.
+			name: "cross_applier_event_horizon_two_blocked",
+			dag: []txnNode{
+				dtxn(1, 1),
+				dtxn(1, 2),
+				dtxn(2, 3, horizon(1)),
+				dtxn(2, 4, horizon(2)),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logDAG(t, tc.dag)
+			applied := runDistributedApplier(t, tc.dag, 3, 0)
+			require.Equal(t, len(tc.dag), len(applied))
+			checkApplyOrder(t, tc.dag, applied)
+		})
 	}
 }


### PR DESCRIPTION
This patch reworks the txn applier prototype such that multiple appliers can
run while maintaining the same dependent txn and event horizon guarantees.
Inter-applier coordination is now powered by a new DependencyResolver
interface. At a high level, when an applier is working on a txn that depends on
a txn getting applied by a different applier, the waiting applier will send a
Wait() request via the DependencyResolver. When the depending applier finishes
the txn, it will send a Ready message back to the waiting applier.

This approach reflects how we plan to set up a distributed sql flow: each node
will have a txn applier processor that can communicate with every node's
downstream DependencyResolver processor. Each DependencyResolver processor will
have a backchannel to send messages to the collocated txn applier processor.

Distributed appliers no longer track a global resolved time, and instead track
the resolved time of each applier in the flow. So, if an applier is attempting
to apply a txn with an event horizon that is lower than the resolved time of
another applier, the waiting applier will send a WaitHorizon message via the
dependency resolver. When the depending applier's resolved time advances, it
will send a Ready message back to the waiting applier.

Previously, an applier would advance its replicated time as it received
transactions to apply, but now that txn application is distributed, we could
have an idle applier that still needs to advance its resolved time. Thus, this
patch also introduces a new checkpoint event type, which contains the
timestamp-1 of the next txn sent to an applier. When an applier receives a
checkpoint, it can advance its own resolved time after it has applied all
transations older than the checkpoint.

An applier relies on the coordinator sending a checkpoint every time the
coordinator processes a txn whose event horizon exceeds the last checkpoint
timestamp sent. Also note that the coordinator will send the checkpoint to
every applier, and then send the incoming txn. The coordinator may send
intermediate checkpoints to advance the resolved time of an idle applier.

Epic: [CRDB-57649](https://cockroachlabs.atlassian.net/browse/CRDB-57649)

Release note: None