### PR TITLE
roachtest: make restore async in backup restore driver

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -44,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/version"
 )
 
 const (
@@ -214,6 +212,9 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 // that the contents after the restore match the contents when the backup was
 // taken. For cluster level backups, the cluster needs to be wiped before
 // verifyBackupCollection is called or else the cluster restore will fail.
+//
+// NB: Deprecated in favor of using Restore/RestoreSync and ValidateRestore
+// directly.
 func (d *BackupRestoreTestDriver) verifyBackupCollection(
 	ctx context.Context,
 	l *logger.Logger,
@@ -221,97 +222,12 @@ func (d *BackupRestoreTestDriver) verifyBackupCollection(
 	bc *backupCollection,
 	checkFiles bool,
 	internalSystemJobs bool,
-	mvHelper *mixedversion.Helper,
 ) error {
-	restoredTables, _, err := d.runRestore(ctx, l, rng, bc, checkFiles, internalSystemJobs, mvHelper)
+	rj, err := d.RestoreSync(ctx, l, rng, bc, checkFiles, internalSystemJobs)
 	if err != nil {
 		return fmt.Errorf("error restoring backup: %w", err)
 	}
-	restoredContents, err := d.getRestoredContents(
-		ctx, l, rng, restoredTables, bc, internalSystemJobs,
-	)
-	if err != nil {
-		return err
-	}
-
-	for j, contents := range bc.contents {
-		table := bc.tables[j]
-		restoredTableContents := restoredContents[j]
-		l.Printf("%s: verifying %s", bc.name, table)
-		if err := contents.ValidateRestore(ctx, l, restoredTableContents); err != nil {
-			return fmt.Errorf("backup %s: %w", bc.name, err)
-		}
-	}
-	_, db := d.testUtils.RandomDB(rng, d.testUtils.roachNodes)
-	if err := roachtestutil.CheckInvalidDescriptors(ctx, l, db); err != nil {
-		return fmt.Errorf("failed descriptor check: %w", err)
-	}
-
-	l.Printf("%s: OK", bc.name)
-	return nil
-}
-
-// runRestore runs the restore statement for the backup collection and waits for
-// a job success. It returns the tables that were restored and the database that
-// was restored into.
-func (d *BackupRestoreTestDriver) runRestore(
-	ctx context.Context,
-	l *logger.Logger,
-	rng *rand.Rand,
-	bc *backupCollection,
-	checkFiles bool,
-	internalSystemJobs bool,
-	mvHelper *mixedversion.Helper,
-) ([]string, string, error) {
-	restoreStmt, restoredTables, restoreDB := d.buildRestoreStatement(bc)
-	if _, isTableBackup := bc.btype.(*tableBackup); isTableBackup {
-		// If we are restoring a table backup , we need to create the database
-		// first.
-		if err := d.testUtils.Exec(ctx, rng, fmt.Sprintf("CREATE DATABASE %s", restoreDB)); err != nil {
-			return nil, "", fmt.Errorf("backup %s: error creating database %s: %w", bc.name, restoreDB, err)
-		}
-	}
-	// As a sanity check, make sure that a `check_files` check passes
-	// before attempting a restore.
-	if checkFiles {
-		if err := d.testUtils.checkFiles(ctx, rng, bc); err != nil {
-			return nil, "", fmt.Errorf("backup %s: check_files failed: %w", bc.name, err)
-		}
-	}
-	l.Printf("Running restore: %s", restoreStmt)
-	var jobID int
-	if err := d.testUtils.QueryRow(ctx, rng, restoreStmt).Scan(&jobID); err != nil {
-		return nil, "", fmt.Errorf("backup %s: error in restore statement: %w", bc.name, err)
-	}
-	if jobErr := d.testUtils.waitForJobSuccess(ctx, l, rng, jobID, internalSystemJobs); jobErr != nil {
-		if mvHelper == nil {
-			return nil, "", jobErr
-		}
-		v25_4 := version.MajorVersion{Year: 25, Ordinal: 4}
-		isUpgradeTo25_4 := mvHelper.System.ToVersion.Major().Equals(v25_4) &&
-			mvHelper.System.FromVersion.Major().LessThan(v25_4)
-		if !isUpgradeTo25_4 {
-			return nil, "", jobErr
-		}
-		// In the 25.4 upgrade, all descriptors are rewritten in the migration to use
-		// the new serialization format. If this upgrade occurs in the middle of the
-		// restore, we may encounter a version mismatch error. As a short-term fix for
-		// this test flake, we retry the restore if we encounter this error.
-		if !strings.Contains(jobErr.Error(), "version mismatch for descriptor") {
-			return nil, "", jobErr
-		}
-		l.Printf(
-			"encountered version mismatch error due to mixed-version upgrade, retrying restore: %v", jobErr,
-		)
-		if err := d.testUtils.QueryRow(ctx, rng, restoreStmt).Scan(&jobID); err != nil {
-			return nil, "", fmt.Errorf("backup %s: error in restore statement: %w", bc.name, err)
-		}
-		if jobErr = d.testUtils.waitForJobSuccess(ctx, l, rng, jobID, internalSystemJobs); jobErr != nil {
-			return nil, "", jobErr
-		}
-	}
-
-	return restoredTables, restoreDB, nil
+	return rj.ValidateRestore(ctx)
 }
 
 // getRestoredContents loads the contents (e.g. non system table fingerprints)
@@ -645,6 +561,136 @@ func (d *BackupRestoreTestDriver) deleteSSTFromBackupLayers(
 			)
 		}
 	}
+	return nil
+}
+
+// Restore starts a restore of the given backup collection and returns a
+// RestoreJob that can be used to wait for completion and validate the results.
+// For cluster level backups, the cluster needs to be wiped before calling
+// Restore or else the cluster restore will fail.
+func (d *BackupRestoreTestDriver) Restore(
+	ctx context.Context,
+	l *logger.Logger,
+	rng *rand.Rand,
+	bc *backupCollection,
+	checkFiles bool,
+	internalSystemJobs bool,
+) (*RestoreJob, error) {
+	restoreStmt, restoredTables, restoreDB := d.buildRestoreStatement(bc)
+	if _, isTableBackup := bc.btype.(*tableBackup); isTableBackup {
+		if err := d.testUtils.Exec(
+			ctx, rng, fmt.Sprintf("CREATE DATABASE %s", restoreDB),
+		); err != nil {
+			return nil, fmt.Errorf(
+				"backup %s: error creating database %s: %w", bc.name, restoreDB, err,
+			)
+		}
+	}
+	if checkFiles {
+		if err := d.testUtils.checkFiles(ctx, rng, bc); err != nil {
+			return nil, fmt.Errorf("backup %s: check_files failed: %w", bc.name, err)
+		}
+	}
+	l.Printf("Running restore: %s", restoreStmt)
+	var jobID int
+	if err := d.testUtils.QueryRow(ctx, rng, restoreStmt).Scan(&jobID); err != nil {
+		return nil, fmt.Errorf("backup %s: error in restore statement: %w", bc.name, err)
+	}
+
+	return &RestoreJob{
+		driver:             d,
+		l:                  l,
+		rng:                rng,
+		bc:                 bc,
+		jobID:              jobID,
+		restoredTables:     restoredTables,
+		internalSystemJobs: internalSystemJobs,
+	}, nil
+}
+
+// RestoreSync starts a restore and waits for it to complete successfully.
+func (d *BackupRestoreTestDriver) RestoreSync(
+	ctx context.Context,
+	l *logger.Logger,
+	rng *rand.Rand,
+	bc *backupCollection,
+	checkFiles bool,
+	internalSystemJobs bool,
+) (*RestoreJob, error) {
+	rj, err := d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs)
+	if err != nil {
+		return nil, err
+	}
+	if err := rj.WaitForJobSuccess(ctx); err != nil {
+		return nil, err
+	}
+	return rj, nil
+}
+
+type RestoreJob struct {
+	driver             *BackupRestoreTestDriver
+	l                  *logger.Logger
+	rng                *rand.Rand
+	bc                 *backupCollection
+	jobID              int
+	restoredTables     []string
+	internalSystemJobs bool
+	succeeded          bool
+}
+
+func (rj *RestoreJob) ID() int {
+	return rj.jobID
+}
+
+// WaitForJobSuccess waits for the restore job to complete successfully.
+// Returns an error if the job does not succeed.
+func (rj *RestoreJob) WaitForJobSuccess(ctx context.Context) error {
+	if rj.succeeded {
+		return nil
+	}
+
+	if err := rj.driver.testUtils.waitForJobSuccess(
+		ctx, rj.l, rj.rng, rj.jobID, rj.internalSystemJobs,
+	); err != nil {
+		return err
+	}
+
+	rj.succeeded = true
+	return nil
+}
+
+// ValidateRestore validates that the contents of the restored tables match
+// the contents that were captured when the backup was taken. For an
+// asynchronous restore, WaitForJobSuccess must be called successfully before
+// ValidateRestore.
+func (rj *RestoreJob) ValidateRestore(ctx context.Context) error {
+	if !rj.succeeded {
+		return errors.New(
+			"cannot validate restore: job has not succeeded; call WaitForJobSuccess first",
+		)
+	}
+
+	restoredContents, err := rj.driver.getRestoredContents(
+		ctx, rj.l, rj.rng, rj.restoredTables, rj.bc, rj.internalSystemJobs,
+	)
+	if err != nil {
+		return err
+	}
+
+	for j, contents := range rj.bc.contents {
+		table := rj.bc.tables[j]
+		restoredTableContents := restoredContents[j]
+		rj.l.Printf("%s: verifying %s", rj.bc.name, table)
+		if err := contents.ValidateRestore(ctx, rj.l, restoredTableContents); err != nil {
+			return fmt.Errorf("backup %s: %w", rj.bc.name, err)
+		}
+	}
+	_, db := rj.driver.testUtils.RandomDB(rj.rng, rj.driver.testUtils.roachNodes)
+	if err := roachtestutil.CheckInvalidDescriptors(ctx, rj.l, db); err != nil {
+		return fmt.Errorf("failed descriptor check: %w", err)
+	}
+
+	rj.l.Printf("%s: OK", rj.bc.name)
 	return nil
 }
 

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -211,7 +211,7 @@ func backupRestoreRoundTrip(
 			// Verify content in backups.
 			err = d.verifyBackupCollection(
 				ctx, t.L(), testRNG, collection,
-				true /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
+				true /* checkFiles */, true, /* internalSystemJobs */
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -415,7 +415,7 @@ func (mvb *mixedVersionBackup) verifySomeBackups(
 	for _, collection := range toBeRestored {
 		l.Printf("mixed-version: verifying %s", collection.name)
 		if err := mvb.backupRestoreTestDriver.verifyBackupCollection(
-			ctx, l, rng, collection, checkFiles, internalSystemJobs, h,
+			ctx, l, rng, collection, checkFiles, internalSystemJobs,
 		); err != nil {
 			return errors.Wrap(err, "mixed-version")
 		}
@@ -497,7 +497,7 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 			}
 
 			if err := mvb.backupRestoreTestDriver.verifyBackupCollection(
-				ctx, l, rng, collection, checkFiles, internalSystemJobs, h,
+				ctx, l, rng, collection, checkFiles, internalSystemJobs,
 			); err != nil {
 				err := errors.Wrapf(err, "%s", v)
 				l.Printf("restore error: %v", err)

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -941,9 +941,9 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 		}
 
 		t.L().Printf("performing online restore of backup")
-		if _, _, err := d.runRestore(
+		if _, err := d.RestoreSync(
 			ctx, t.L(), testRNG, collection,
-			false /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
+			false /* checkFiles */, true, /* internalSystemJobs */
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit splits up the backup validation logic in the `BackupRestoreTestDriver` into a restore step and a validation step. This allows us to run restores asynchronously, which allows us to perform chaos testing during restores.

Informs: #163231

Release note: None