### PR TITLE
sql: add pg_get_triggerdef builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3654,6 +3654,10 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_function_is_visible"></a><code>pg_function_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the function with the given OID belongs to one of the schemas on the search path.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_constraintdef"></a><code>pg_get_constraintdef(constraint_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the definition of the specified constraint.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_constraintdef"></a><code>pg_get_constraintdef(constraint_oid: oid, pretty_bool: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the definition of the specified constraint.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_arg_default"></a><code>pg_get_function_arg_default(func_oid: oid, arg_num: int4) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Get textual representation of a function argument’s default value. The second argument of this function is the argument number among all arguments (i.e. proallargtypes, <em>not</em> proargtypes), starting with 1, because that’s how information_schema.sql uses it.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_arguments"></a><code>pg_get_function_arguments(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the argument list (with defaults) necessary to identify a function, in the form it would need to appear in within CREATE FUNCTION.</p>
@@ -3669,6 +3673,10 @@ may increase either contention or retry errors, or both.</p>
 <tr><td><a name="pg_get_indexdef"></a><code>pg_get_indexdef(index_oid: oid, column_no: <a href="int.html">int</a>, pretty_bool: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Gets the CREATE INDEX command for index, or definition of just one index column when given a non-zero column number</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_serial_sequence"></a><code>pg_get_serial_sequence(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the name of the sequence used by the given column_name in the table table_name.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_triggerdef"></a><code>pg_get_triggerdef(trigger_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE TRIGGER statement for the specified trigger.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_triggerdef"></a><code>pg_get_triggerdef(trigger_oid: oid, pretty_bool: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE TRIGGER statement for the specified trigger.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_viewdef"></a><code>pg_get_viewdef(view_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE statement for an existing view.</p>
 </span></td><td>Stable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -1080,3 +1080,49 @@ query T
 SELECT to_regclass(c) FROM t144384;
 ----
 i144384
+
+subtest pg_get_triggerdef
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE TABLE trig_test (id INT PRIMARY KEY, val TEXT)
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE FUNCTION trig_fn() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END; $$
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE TRIGGER test_trig BEFORE INSERT ON trig_test FOR EACH ROW EXECUTE FUNCTION trig_fn()
+
+skipif config local-legacy-schema-changer
+query T
+SELECT pg_get_triggerdef(oid) FROM pg_trigger WHERE tgname = 'test_trig'
+----
+CREATE TRIGGER test_trig BEFORE INSERT ON test.public.trig_test FOR EACH ROW EXECUTE FUNCTION test.public.trig_fn()
+
+skipif config local-legacy-schema-changer
+query T
+SELECT pg_get_triggerdef(oid, true) FROM pg_trigger WHERE tgname = 'test_trig'
+----
+CREATE TRIGGER test_trig BEFORE INSERT ON test.public.trig_test FOR EACH ROW EXECUTE FUNCTION test.public.trig_fn()
+
+# Invalid OID returns NULL.
+query T nosort
+SELECT pg_get_triggerdef(0)
+----
+NULL
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP TRIGGER test_trig ON trig_test
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP FUNCTION trig_fn
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP TABLE trig_test
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2887,6 +2887,8 @@ var builtinOidsArray = []string{
 	2932: `st_asmvt(arg1: tuple, arg2: string, arg3: int, arg4: string) -> bytes`,
 	2933: `st_asmvt(arg1: tuple, arg2: string, arg3: int, arg4: string, arg5: string) -> bytes`,
 	2934: `information_schema.crdb_set_session_variable_hint(statement_fingerprint: string, variable_name: string, variable_value: string, database: string) -> int`,
+	2935: `pg_get_triggerdef(trigger_oid: oid) -> string`,
+	2936: `pg_get_triggerdef(trigger_oid: oid, pretty_bool: bool) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -352,7 +352,24 @@ func makePGGetConstraintDef(paramTypes tree.ParamTypes) tree.Overload {
 		Types:      paramTypes,
 		ReturnType: tree.FixedReturnType(types.String),
 		Body:       `SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1 LIMIT 1`,
-		Info:       notUsableInfo,
+		Info:       "Returns the definition of the specified constraint.",
+		Volatility: volatility.Stable,
+		Language:   tree.RoutineLangSQL,
+	}
+}
+
+// makePGGetTriggerDef makes a pg_get_triggerdef function with the given arguments.
+func makePGGetTriggerDef(paramTypes tree.ParamTypes) tree.Overload {
+	return tree.Overload{
+		Types:      paramTypes,
+		ReturnType: tree.FixedReturnType(types.String),
+		Body: `SELECT c.create_statement
+           FROM pg_catalog.pg_trigger t
+           JOIN crdb_internal.create_trigger_statements c
+             ON c.table_id = t.tgrelid::INT8 AND c.trigger_name = t.tgname
+           WHERE t.oid = $1
+           LIMIT 1`,
+		Info:       "Returns the CREATE TRIGGER statement for the specified trigger.",
 		Volatility: volatility.Stable,
 		Language:   tree.RoutineLangSQL,
 	}
@@ -730,6 +747,13 @@ var pgBuiltins = map[string]builtinDefinition{
 		makePGGetConstraintDef(tree.ParamTypes{
 			{Name: "constraint_oid", Typ: types.Oid}, {Name: "pretty_bool", Typ: types.Bool}}),
 		makePGGetConstraintDef(tree.ParamTypes{{Name: "constraint_oid", Typ: types.Oid}}),
+	),
+
+	// pg_get_triggerdef functions like SHOW CREATE TRIGGER.
+	"pg_get_triggerdef": makeBuiltin(tree.FunctionProperties{DistsqlBlocklist: true},
+		makePGGetTriggerDef(tree.ParamTypes{{Name: "trigger_oid", Typ: types.Oid}}),
+		makePGGetTriggerDef(tree.ParamTypes{
+			{Name: "trigger_oid", Typ: types.Oid}, {Name: "pretty_bool", Typ: types.Bool}}),
 	),
 
 	// pg_get_partkeydef is only provided for compatibility and always returns


### PR DESCRIPTION
pg_dump calls pg_catalog.pg_get_triggerdef(oid, bool) when reading triggers, which previously failed with "unknown function". Add the builtin with both the 1-arg and 2-arg overloads, joining pg_trigger against crdb_internal.create_trigger_statements to produce the CREATE TRIGGER SQL. The pretty_bool parameter is accepted but not differentiated, matching our approach for pg_get_constraintdef.

Also update pg_get_constraintdef's info string from the generic notUsableInfo placeholder to a real description.

Informs: #20296
Epic: CRDB-42942

Release note (sql change): Added the pg_get_triggerdef builtin function, which returns the CREATE TRIGGER statement for a given trigger OID. This improves PostgreSQL compatibility for databases that contain triggers.