### PR TITLE
ui: `Canary vs Stable` Statement Times and Plan Distribution bar charts

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bars.ts
@@ -10,7 +10,7 @@ import { AxisUnits, AxisDomain } from "../utils/domain";
 
 import { barTooltipPlugin } from "./plugins";
 
-const seriesPalette = [
+export const seriesPalette = [
   "#003EBD",
   "#2AAF44",
   "#F16969",

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/groupedBars.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/groupedBars.ts
@@ -1,0 +1,576 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// This file implements grouped stacked bar charts for the canary stats
+// feature. It relies on uPlot internal APIs (series.show, delBand,
+// addBand, setData, u.root DOM queries for .u-legend / .u-series) that
+// are not part of uPlot's stable public API surface. These may break if
+// uPlot is upgraded — verify grouped bar behaviour after any uPlot
+// version bump.
+
+import merge from "lodash/merge";
+import uPlot, { Options, Band, AlignedData } from "uplot";
+
+import { AxisUnits, AxisDomain } from "../utils/domain";
+
+import { getBarsBuilder, seriesPalette } from "./bars";
+import { barTooltipPlugin, groupedStackedBarTooltipPlugin } from "./plugins";
+
+// Horizontally translate a Path2D by the given offset.
+function offsetPath2D(
+  path: Path2D | null | undefined,
+  transform: DOMMatrix2DInit,
+): Path2D | undefined {
+  if (!path) return undefined;
+  const p = new Path2D();
+  p.addPath(path, transform);
+  return p;
+}
+
+// Wraps a standard bars builder and shifts the resulting paths by
+// offsetCssPx CSS pixels horizontally, creating a visible gap
+// between grouped bar pairs.
+const getOffsetBarsBuilder = (
+  barWidthFactor: number,
+  maxWidth: number,
+  minWidth: number,
+  align: 0 | 1 | -1,
+  offsetCssPx: number,
+): uPlot.Series.PathBuilder => {
+  const baseBars = getBarsBuilder(barWidthFactor, maxWidth, minWidth, align);
+  if (offsetCssPx === 0) return baseBars;
+
+  return (u, seriesIdx, idx0, idx1) => {
+    const result = baseBars(u, seriesIdx, idx0, idx1);
+    if (!result) return result;
+
+    // Paths are in device-pixel space.
+    const offset = offsetCssPx * (window.devicePixelRatio || 1);
+    const tx: DOMMatrix2DInit = {
+      a: 1,
+      b: 0,
+      c: 0,
+      d: 1,
+      e: offset,
+      f: 0,
+    };
+
+    return {
+      flags: result.flags,
+      fill:
+        result.fill instanceof Path2D
+          ? offsetPath2D(result.fill, tx)
+          : result.fill,
+      stroke:
+        result.stroke instanceof Path2D
+          ? offsetPath2D(result.stroke, tx)
+          : result.stroke,
+      clip:
+        result.clip instanceof Path2D
+          ? offsetPath2D(result.clip, tx)
+          : result.clip,
+      band:
+        result.band instanceof Path2D
+          ? offsetPath2D(result.band, tx)
+          : result.band,
+    };
+  };
+};
+
+// pairGroupingPlugin draws alternating light background bands behind
+// every other timestamp bin so that each {group1 + group2} pair is
+// visually grouped together.
+function pairGroupingPlugin(): uPlot.Plugin {
+  return {
+    hooks: {
+      drawClear: (u: uPlot) => {
+        const ctx = u.ctx;
+        const timestamps = u.data[0] as number[];
+        if (!timestamps || timestamps.length < 2) return;
+
+        const { top, height } = u.bbox;
+
+        // Bin width in canvas-pixel space.
+        const x0 = u.valToPos(timestamps[0], "x", true);
+        const x1 = u.valToPos(timestamps[1], "x", true);
+        const binWidth = Math.abs(x1 - x0);
+        const halfBin = binWidth / 2;
+
+        ctx.save();
+        ctx.fillStyle = "rgba(0, 0, 0, 0.04)";
+
+        for (let i = 1; i < timestamps.length; i += 2) {
+          const cx = u.valToPos(timestamps[i], "x", true);
+          ctx.fillRect(cx - halfBin, top, binWidth, height);
+        }
+
+        ctx.restore();
+      },
+    },
+  };
+}
+
+// groupDividerPlugin draws light grey vertical dashed lines between
+// consecutive timestamp bins so that each {canary + stable} pair is
+// visually separated from its neighbours.
+function groupDividerPlugin(): uPlot.Plugin {
+  return {
+    hooks: {
+      draw: (u: uPlot) => {
+        const ctx = u.ctx;
+        const timestamps = u.data[0] as number[];
+        if (!timestamps || timestamps.length < 2) return;
+
+        const { top, height } = u.bbox;
+
+        ctx.save();
+        ctx.strokeStyle = "#c0c0c0";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 4]);
+
+        for (let i = 0; i < timestamps.length - 1; i++) {
+          const x0 = u.valToPos(timestamps[i], "x", true);
+          const x1 = u.valToPos(timestamps[i + 1], "x", true);
+          const midX = Math.round((x0 + x1) / 2);
+          ctx.beginPath();
+          ctx.moveTo(midX, top);
+          ctx.lineTo(midX, top + height);
+          ctx.stroke();
+        }
+
+        ctx.restore();
+      },
+    },
+  };
+}
+
+// groupLabelsPlugin draws text labels (e.g. "Canary", "Stable")
+// above each bar stack so the user can tell the two groups apart
+// without relying on the legend.
+function groupLabelsPlugin(
+  labels: [string, string],
+  labelColors: [string, string],
+  n: number,
+  unstackedData: AlignedData,
+  barWidthFactor: number,
+  gapCssPx: number,
+): uPlot.Plugin {
+  return {
+    hooks: {
+      draw: (u: uPlot) => {
+        const ctx = u.ctx;
+        const timestamps = u.data[0] as number[];
+        if (!timestamps || timestamps.length < 1) return;
+
+        const pxr = window.devicePixelRatio || 1;
+
+        // Approximate bar width in device pixels.
+        const colWid =
+          timestamps.length > 1
+            ? Math.abs(
+                u.valToPos(timestamps[1], "x", true) -
+                  u.valToPos(timestamps[0], "x", true),
+              )
+            : u.bbox.width;
+        const barWid = Math.min(
+          Math.max(colWid * barWidthFactor, 4 * pxr),
+          40 * pxr,
+        );
+        const gap = gapCssPx * pxr;
+
+        ctx.save();
+        ctx.font = `bold ${9 * pxr}px sans-serif`;
+        ctx.textAlign = "center";
+
+        for (let t = 0; t < timestamps.length; t++) {
+          const cx = u.valToPos(timestamps[t], "x", true);
+
+          // Sum unstacked values for each group at this ts.
+          let g1Total = 0;
+          for (let i = 0; i < n; i++) {
+            g1Total += unstackedData[1 + i]?.[t] || 0;
+          }
+          let g2Total = 0;
+          for (let i = 0; i < n; i++) {
+            g2Total += unstackedData[1 + n + i]?.[t] || 0;
+          }
+
+          // Bar centres: align=-1 shifts by -barWid/2,
+          // then the gap offset shifts further out.
+          const leftCX = cx - barWid / 2 - gap;
+          const rightCX = cx + barWid / 2 + gap;
+
+          if (g1Total > 0) {
+            const topY = u.valToPos(g1Total, "yAxis", true);
+            ctx.fillStyle = labelColors[0];
+            ctx.fillText(labels[0], leftCX, topY - 4 * pxr);
+          }
+          if (g2Total > 0) {
+            const topY = u.valToPos(g2Total, "yAxis", true);
+            ctx.fillStyle = labelColors[1];
+            ctx.fillText(labels[1], rightCX, topY - 4 * pxr);
+          }
+        }
+
+        ctx.restore();
+      },
+    },
+  };
+}
+
+// getGroupedStackedBarOpts creates options for a chart with two groups of
+// stacked bars side by side. Data layout:
+//   [timestamps, ...group1_series(N), ...group2_series(N)]
+// where groupSize = N is the number of stacked layers per group.
+// group1 bars are left-aligned, group2 bars are right-aligned.
+//
+// groupStrokeColors optionally provides distinct border colors for each
+// group (e.g. ["#c62828", "#1565c0"]) so the user can tell group1 from
+// group2 at a glance. Fill colors still come from colourPalette.
+//
+// groupLabels optionally provides text labels (e.g. ["Canary","Stable"])
+// drawn above each bar stack. When set, the built-in uPlot legend is
+// hidden (the caller should render its own gist-only legend).
+export const getGroupedStackedBarOpts = (
+  unstackedData: AlignedData,
+  userOptions: Partial<Options>,
+  xAxisDomain: AxisDomain,
+  yAxisDomain: AxisDomain,
+  yAxisUnits: AxisUnits,
+  colourPalette = seriesPalette,
+  timezone: string,
+  groupSize?: number,
+  groupStrokeColors?: [string, string],
+  groupLabels?: [string, string],
+  gistLabels?: string[],
+): { opts: Options; stackedData: AlignedData } => {
+  const { series, ...providedOpts } = userOptions;
+
+  // Default: half the data series belong to each group.
+  const n = groupSize ?? Math.floor((unstackedData.length - 1) / 2);
+
+  const barWidthFactor = 0.3;
+  const gapCssPx = 2;
+
+  // Offset bars so each group is shifted away from the centre,
+  // creating a visible gap between the two bars in every pair.
+  const leftBars = getOffsetBarsBuilder(barWidthFactor, 40, 4, -1, -gapCssPx);
+  const rightBars = getOffsetBarsBuilder(barWidthFactor, 40, 4, 1, gapCssPx);
+
+  const opts: Options = {
+    width: 947,
+    height: 300,
+    ms: 1,
+    legend: {
+      show: !groupLabels,
+      isolate: false,
+      live: false,
+    },
+    scales: {
+      x: {
+        range: () => [xAxisDomain.extent[0], xAxisDomain.extent[1]],
+      },
+      yAxis: {
+        range: () => [yAxisDomain.extent[0], yAxisDomain.extent[1]],
+      },
+    },
+    axes: [
+      {
+        values: (_u, vals) => vals.map(xAxisDomain.tickFormat),
+        splits: () => xAxisDomain.ticks,
+      },
+      {
+        values: (_u, vals) => vals.map(yAxisDomain.tickFormat),
+        splits: () => [
+          yAxisDomain.extent[0],
+          ...yAxisDomain.ticks,
+          yAxisDomain.extent[1],
+        ],
+        scale: "yAxis",
+      },
+    ],
+    series: [
+      {
+        value: (_u, millis) => xAxisDomain.guideFormat(millis),
+      },
+      // Group 1: left-aligned bars
+      ...series.slice(1, 1 + n).map((s, i) => ({
+        fill: colourPalette[i % colourPalette.length],
+        stroke: groupStrokeColors ? groupStrokeColors[0] : "#fff",
+        width: 1,
+        paths: leftBars,
+        points: { show: false },
+        scale: "yAxis",
+        ...s,
+      })),
+      // Group 2: right-aligned bars
+      ...series.slice(1 + n, 1 + 2 * n).map((s, i) => ({
+        fill: colourPalette[i % colourPalette.length],
+        stroke: groupStrokeColors ? groupStrokeColors[1] : "#fff",
+        width: 1,
+        paths: rightBars,
+        points: { show: false },
+        scale: "yAxis",
+        ...s,
+      })),
+    ],
+    plugins: [], // populated below after stackedData is computed
+  };
+
+  const combinedOpts = merge(opts, providedOpts);
+  combinedOpts.axes[1].label += ` ${yAxisDomain.label}`;
+
+  // Pre-stack each group independently by cumulatively summing layers.
+  const stackedData: AlignedData = [unstackedData[0]];
+  // Group 1 (series indices 1..n)
+  for (let i = 0; i < n; i++) {
+    if (i === 0) {
+      stackedData.push([...unstackedData[1]]);
+    } else {
+      stackedData.push(
+        unstackedData[1 + i].map((v, j) => v + (stackedData[i] as number[])[j]),
+      );
+    }
+  }
+  // Group 2 (series indices n+1..2n)
+  for (let i = 0; i < n; i++) {
+    if (i === 0) {
+      stackedData.push([...unstackedData[1 + n]]);
+    } else {
+      stackedData.push(
+        unstackedData[1 + n + i].map(
+          (v, j) => v + (stackedData[n + i] as number[])[j],
+        ),
+      );
+    }
+  }
+
+  // Build plugins now that stackedData is available.
+  const plugins: uPlot.Plugin[] = [];
+  if (gistLabels && groupLabels) {
+    plugins.push(
+      groupedStackedBarTooltipPlugin(
+        yAxisUnits,
+        timezone,
+        unstackedData,
+        stackedData,
+        n,
+        gistLabels,
+        groupLabels,
+        colourPalette,
+      ),
+    );
+  } else {
+    plugins.push(barTooltipPlugin(yAxisUnits, timezone));
+  }
+  plugins.push(pairGroupingPlugin());
+  plugins.push(groupDividerPlugin());
+  if (groupLabels && groupStrokeColors) {
+    plugins.push(
+      groupLabelsPlugin(
+        groupLabels,
+        groupStrokeColors,
+        n,
+        unstackedData,
+        barWidthFactor,
+        gapCssPx,
+      ),
+    );
+  }
+  combinedOpts.plugins = plugins;
+
+  // Bands fill between adjacent stacked layers within each group.
+  combinedOpts.bands = [];
+  for (let i = 1; i < n; i++) {
+    // Group 1: series i+1 on top of series i (1-indexed in uPlot)
+    combinedOpts.bands.push({ series: [i + 1, i] as Band.Bounds });
+  }
+  for (let i = 1; i < n; i++) {
+    // Group 2: series n+i+1 on top of series n+i
+    combinedOpts.bands.push({
+      series: [n + i + 1, n + i] as Band.Bounds,
+    });
+  }
+
+  // Show unstacked values in tooltip/legend.
+  combinedOpts.series.forEach((s, si) => {
+    s.value = (_u, _v, _si, i) => unstackedData[si]?.[i];
+    s.points = s.points || { show: false };
+    s.points.filter = (_u, seriesIdx, show) => {
+      if (show) {
+        const pts: number[] = [];
+        unstackedData[seriesIdx]?.forEach((v, i) => {
+          v && pts.push(i);
+        });
+        return pts;
+      }
+    };
+  });
+
+  // restackGroups recomputes the cumulative stacked data for both
+  // groups after a series visibility toggle. This is necessary because
+  // uPlot has no built-in support for grouped stacked bars — we
+  // manually maintain the stacking invariant by:
+  //   1. Syncing group 2 visibility to match group 1 (the two groups
+  //      always show the same set of layers).
+  //   2. Rebuilding cumulative sums for each group independently,
+  //      skipping hidden layers so visible bars sit flush on top of
+  //      each other.
+  //   3. Rebuilding bands (the filled regions between consecutive
+  //      visible layers) so uPlot's fill rendering stays correct.
+  //
+  // NOTE: This function depends on uPlot internal APIs (series.show,
+  // delBand, addBand, setData). It may break on uPlot version upgrades.
+  function restackGroups(u: uPlot): void {
+    // Step 1: sync group 2 show flags to match group 1.
+    // setSeries is NOT used here to avoid re-triggering hooks.
+    for (let i = 0; i < n; i++) {
+      u.series[1 + n + i].show = u.series[1 + i].show;
+    }
+
+    // Step 2: rebuild stacked data arrays.
+    const newData: AlignedData = [unstackedData[0]];
+    const zeros = new Array(unstackedData[0].length).fill(0);
+    const accum1 = new Array(unstackedData[0].length).fill(0);
+    for (let i = 0; i < n; i++) {
+      if (u.series[1 + i].show) {
+        newData.push(unstackedData[1 + i].map((v, j) => (accum1[j] += v)));
+      } else {
+        // When a legend click isolates a series, push zeros for
+        // hidden layers so the cumulative stack stays monotonically
+        // increasing. Without this, the tooltip's layer hit-test
+        // matches the wrong series name on hover.
+        newData.push([...zeros]);
+      }
+    }
+    const accum2 = new Array(unstackedData[0].length).fill(0);
+    for (let i = 0; i < n; i++) {
+      if (u.series[1 + i].show) {
+        newData.push(unstackedData[1 + n + i].map((v, j) => (accum2[j] += v)));
+      } else {
+        // Same as group 1: zeros keep the tooltip hit-test correct.
+        newData.push([...zeros]);
+      }
+    }
+
+    // Step 3: rebuild bands between consecutive visible series.
+    // Each band connects a layer to the nearest visible layer below
+    // it, creating the filled stacked region.
+    u.delBand(null);
+    for (let i = 1; i < n; i++) {
+      if (!u.series[1 + i].show) continue;
+      for (let j = i - 1; j >= 0; j--) {
+        if (u.series[1 + j].show) {
+          u.addBand({ series: [1 + i, 1 + j] as Band.Bounds });
+          break;
+        }
+      }
+    }
+    for (let i = 1; i < n; i++) {
+      if (!u.series[1 + i].show) continue;
+      for (let j = i - 1; j >= 0; j--) {
+        if (u.series[1 + j].show) {
+          u.addBand({
+            series: [1 + n + i, 1 + n + j] as Band.Bounds,
+          });
+          break;
+        }
+      }
+    }
+
+    u.setData(newData as AlignedData);
+  }
+
+  // Restack when series visibility changes from external sources.
+  combinedOpts.hooks = combinedOpts.hooks || {};
+  combinedOpts.hooks.setSeries = combinedOpts.hooks.setSeries || [];
+  let restacking = false;
+  combinedOpts.hooks.setSeries.push((u: uPlot) => {
+    if (restacking) return;
+    restacking = true;
+    restackGroups(u);
+    restacking = false;
+  });
+
+  // Custom click-to-isolate that handles both groups atomically.
+  // uPlot's built-in isolate fires setSeries one series at a time,
+  // which conflicts with our group syncing. Instead we intercept
+  // legend clicks, set all show flags at once, then restack.
+  plugins.push({
+    hooks: {
+      init: (u: uPlot) => {
+        const legendEl = u.root.querySelector(".u-legend");
+        if (!legendEl) return;
+
+        // uPlot may skip the x-axis legend row when series[0]
+        // has no label. Detect this to map row clicks to the
+        // correct series index.
+        const allRows = u.root.querySelectorAll(".u-legend .u-series");
+        const hasXAxisRow = allRows.length > 2 * n;
+        const g1Start = hasXAxisRow ? 1 : 0;
+
+        legendEl.addEventListener(
+          "click",
+          (e: Event) => {
+            const target = (e.target as Element).closest(".u-series");
+            if (!target) return;
+
+            const rows = u.root.querySelectorAll(".u-legend .u-series");
+            let rowIdx = -1;
+            rows.forEach((row, i) => {
+              if (row === target) rowIdx = i;
+            });
+
+            // Only handle group 1 entries.
+            if (rowIdx < g1Start || rowIdx >= g1Start + n) {
+              return;
+            }
+
+            // Prevent uPlot's default toggle from firing.
+            e.stopPropagation();
+
+            // Map row index to series index (1-based).
+            const seriesIdx = rowIdx - g1Start + 1;
+
+            // Check if the clicked series is already the only
+            // visible one (i.e. currently isolated).
+            let isIsolated = u.series[seriesIdx].show;
+            if (isIsolated) {
+              for (let j = 1; j <= n; j++) {
+                if (j !== seriesIdx && u.series[j].show) {
+                  isIsolated = false;
+                  break;
+                }
+              }
+            }
+
+            // Set show flags for both groups atomically.
+            restacking = true;
+            for (let j = 0; j < n; j++) {
+              const show = isIsolated || 1 + j === seriesIdx;
+              u.series[1 + j].show = show;
+              u.series[1 + n + j].show = show;
+
+              // Update legend CSS for group 1 entries.
+              const row = rows[g1Start + j] as HTMLElement;
+              if (row) {
+                if (show) {
+                  row.classList.remove("u-off");
+                } else {
+                  row.classList.add("u-off");
+                }
+              }
+            }
+            restackGroups(u);
+            restacking = false;
+          },
+          true,
+        ); // capture phase
+      },
+    },
+  });
+
+  return { opts: combinedOpts, stackedData };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -119,11 +119,13 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
 };
 
 // GroupedStackedBarGraphTimeSeries renders two groups of stacked bars
-// side by side per timestamp. The data must have 5 series:
-// [timestamps, group1_bottom, group1_top, group2_bottom, group2_top].
+// side by side per timestamp. Data layout:
+//   [timestamps, ...group1_series(N), ...group2_series(N)]
+// groupSize specifies N (layers per group). Defaults to half the data series.
 export type GroupedStackedBarGraphProps = {
   alignedData?: AlignedData;
   colourPalette?: string[];
+  groupSize?: number;
   preCalcGraphSize?: boolean;
   title: string;
   tooltip?: React.ReactNode;
@@ -137,6 +139,7 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
 > = ({
   alignedData,
   colourPalette,
+  groupSize,
   preCalcGraphSize = true,
   title,
   tooltip,
@@ -165,13 +168,22 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
       timezone,
     );
 
-    // Pre-compute stacked values for y-axis domain calculation.
-    // Group 1 (series 1+2) and group 2 (series 3+4) stack independently.
-    const preStackedTops = [
-      ...alignedData[1].map((v, i) => v + alignedData[2][i]),
-      ...alignedData[3].map((v, i) => v + alignedData[4][i]),
-    ];
-    const yAxisDomain = calculateYAxisDomain(yAxisUnits, preStackedTops);
+    // Compute y-axis domain from stacked tops of both groups.
+    const n = groupSize ?? Math.floor((alignedData.length - 1) / 2);
+    const group1Top = alignedData[1].map((_, j) => {
+      let sum = 0;
+      for (let i = 0; i < n; i++) sum += alignedData[1 + i][j];
+      return sum;
+    });
+    const group2Top = alignedData[1].map((_, j) => {
+      let sum = 0;
+      for (let i = 0; i < n; i++) sum += alignedData[1 + n + i][j];
+      return sum;
+    });
+    const yAxisDomain = calculateYAxisDomain(yAxisUnits, [
+      ...group1Top,
+      ...group2Top,
+    ]);
 
     const { opts, stackedData } = getGroupedStackedBarOpts(
       alignedData,
@@ -181,6 +193,7 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
       yAxisUnits,
       colourPalette,
       timezone,
+      groupSize,
     );
 
     const plot = new uPlot(opts, stackedData, graphRef.current);
@@ -191,6 +204,7 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
   }, [
     alignedData,
     colourPalette,
+    groupSize,
     uPlotOptions,
     yAxisUnits,
     samplingIntervalMillis,

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -17,6 +17,7 @@ import { Visualization } from "../visualization";
 
 import styles from "./bargraph.module.scss";
 import { getStackedBarOpts, stack } from "./bars";
+import { getGroupedStackedBarOpts } from "./groupedBars";
 import { categoricalBarTooltipPlugin, BarMetadata } from "./plugins";
 
 const cx = classNames.bind(styles);
@@ -53,16 +54,16 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
 }) => {
   const graphRef = useRef<HTMLDivElement>(null);
   const samplingIntervalMillis =
-    alignedData[0].length > 1 ? alignedData[0][1] - alignedData[0][0] : 1e3;
+    alignedData?.[0]?.length > 1 ? alignedData[0][1] - alignedData[0][0] : 1e3;
   const timezone = useContext(TimezoneContext);
 
   useEffect(() => {
     if (!alignedData) return;
 
-    const start = xScale.graphTsStartMillis
+    const start = xScale?.graphTsStartMillis
       ? xScale.graphTsStartMillis
       : alignedData[0][0];
-    const end = xScale.graphTsEndMillis
+    const end = xScale?.graphTsEndMillis
       ? xScale.graphTsEndMillis
       : alignedData[0][alignedData[0].length - 1];
     const xAxisDomain = calculateXAxisDomainBarChart(
@@ -79,6 +80,100 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
     const yAxisDomain = calculateYAxisDomain(yAxisUnits, allYDomainPoints);
 
     const opts = getStackedBarOpts(
+      alignedData,
+      uPlotOptions,
+      xAxisDomain,
+      yAxisDomain,
+      yAxisUnits,
+      colourPalette,
+      timezone,
+    );
+
+    const plot = new uPlot(opts, stackedData, graphRef.current);
+
+    return () => {
+      plot?.destroy();
+    };
+  }, [
+    alignedData,
+    colourPalette,
+    uPlotOptions,
+    yAxisUnits,
+    samplingIntervalMillis,
+    timezone,
+    xScale,
+  ]);
+
+  return (
+    <Visualization
+      title={title}
+      loading={!alignedData}
+      preCalcGraphSize={preCalcGraphSize}
+      tooltip={tooltip}
+    >
+      <div className={cx("bargraph")}>
+        <div ref={graphRef} />
+      </div>
+    </Visualization>
+  );
+};
+
+// GroupedStackedBarGraphTimeSeries renders two groups of stacked bars
+// side by side per timestamp. The data must have 5 series:
+// [timestamps, group1_bottom, group1_top, group2_bottom, group2_top].
+export type GroupedStackedBarGraphProps = {
+  alignedData?: AlignedData;
+  colourPalette?: string[];
+  preCalcGraphSize?: boolean;
+  title: string;
+  tooltip?: React.ReactNode;
+  uPlotOptions: Partial<Options>;
+  yAxisUnits: AxisUnits;
+  xScale?: XScale;
+};
+
+export const GroupedStackedBarGraphTimeSeries: React.FC<
+  GroupedStackedBarGraphProps
+> = ({
+  alignedData,
+  colourPalette,
+  preCalcGraphSize = true,
+  title,
+  tooltip,
+  uPlotOptions,
+  yAxisUnits,
+  xScale,
+}) => {
+  const graphRef = useRef<HTMLDivElement>(null);
+  const samplingIntervalMillis =
+    alignedData?.[0]?.length > 1 ? alignedData[0][1] - alignedData[0][0] : 1e3;
+  const timezone = useContext(TimezoneContext);
+
+  useEffect(() => {
+    if (!alignedData) return;
+
+    const start = xScale?.graphTsStartMillis
+      ? xScale.graphTsStartMillis
+      : alignedData[0][0];
+    const end = xScale?.graphTsEndMillis
+      ? xScale.graphTsEndMillis
+      : alignedData[0][alignedData[0].length - 1];
+    const xAxisDomain = calculateXAxisDomainBarChart(
+      start,
+      end,
+      samplingIntervalMillis,
+      timezone,
+    );
+
+    // Pre-compute stacked values for y-axis domain calculation.
+    // Group 1 (series 1+2) and group 2 (series 3+4) stack independently.
+    const preStackedTops = [
+      ...alignedData[1].map((v, i) => v + alignedData[2][i]),
+      ...alignedData[3].map((v, i) => v + alignedData[4][i]),
+    ];
+    const yAxisDomain = calculateYAxisDomain(yAxisUnits, preStackedTops);
+
+    const { opts, stackedData } = getGroupedStackedBarOpts(
       alignedData,
       uPlotOptions,
       xAxisDomain,

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -126,6 +126,15 @@ export type GroupedStackedBarGraphProps = {
   alignedData?: AlignedData;
   colourPalette?: string[];
   groupSize?: number;
+  // Text labels drawn above each bar stack (e.g. ["Canary","Stable"]).
+  // When set, the built-in uPlot legend is hidden.
+  groupLabels?: [string, string];
+  // Distinct border colours for group 1 / group 2 bars
+  // (e.g. ["#c62828", "#1565c0"] for canary vs stable).
+  groupStrokeColors?: [string, string];
+  // Layer labels (e.g. plan gist IDs). When provided together with
+  // groupLabels, the tooltip shows only the hovered sub-bar layer.
+  gistLabels?: string[];
   preCalcGraphSize?: boolean;
   title: string;
   tooltip?: React.ReactNode;
@@ -139,7 +148,10 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
 > = ({
   alignedData,
   colourPalette,
+  gistLabels,
+  groupLabels,
   groupSize,
+  groupStrokeColors,
   preCalcGraphSize = true,
   title,
   tooltip,
@@ -194,7 +206,52 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
       colourPalette,
       timezone,
       groupSize,
+      groupStrokeColors,
+      groupLabels,
+      gistLabels,
     );
+
+    // When groupLabels is set but the caller overrides the legend to be
+    // visible (e.g. for the Statement Times or Plan Distribution chart),
+    // hide group 2's duplicate legend entries so only one set of labels
+    // appears. Visibility syncing between groups is handled by the
+    // setSeries hook in getGroupedStackedBarOpts.
+    if (groupLabels && opts.legend?.show) {
+      const nn = groupSize ?? Math.floor((alignedData.length - 1) / 2);
+      opts.plugins.push({
+        hooks: {
+          init: (u: uPlot) => {
+            const rows = u.root.querySelectorAll(".u-legend .u-series");
+            // uPlot may skip the x-axis legend row when series[0]
+            // has no label. Detect this to index rows correctly.
+            const hasXAxisRow = rows.length > 2 * nn;
+            const g1Start = hasXAxisRow ? 1 : 0;
+            const g2Start = g1Start + nn;
+
+            // Hide the x-axis row if it exists.
+            if (hasXAxisRow && rows[0]) {
+              (rows[0] as HTMLElement).style.display = "none";
+            }
+            // Hide all group 2 (duplicate) rows.
+            for (let i = g2Start; i < g2Start + nn; i++) {
+              if (rows[i]) {
+                (rows[i] as HTMLElement).style.display = "none";
+              }
+            }
+            // Remove the group-stroke border from legend markers so
+            // they show only the fill colour.
+            for (let i = g1Start; i < g1Start + nn; i++) {
+              const marker = rows[i]?.querySelector(
+                ".u-marker",
+              ) as HTMLElement | null;
+              if (marker) {
+                marker.style.borderColor = "transparent";
+              }
+            }
+          },
+        },
+      });
+    }
 
     const plot = new uPlot(opts, stackedData, graphRef.current);
 
@@ -204,7 +261,10 @@ export const GroupedStackedBarGraphTimeSeries: React.FC<
   }, [
     alignedData,
     colourPalette,
+    gistLabels,
+    groupLabels,
     groupSize,
+    groupStrokeColors,
     uPlotOptions,
     yAxisUnits,
     samplingIntervalMillis,

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import moment from "moment-timezone";
-import uPlot, { Plugin } from "uplot";
+import uPlot, { AlignedData, Plugin } from "uplot";
 
 import {
   Bytes,
@@ -217,6 +217,162 @@ export function categoricalBarTooltipPlugin(
     tooltip.style.lineHeight = "1.4";
 
     plot?.appendChild(tooltip);
+  }
+
+  return {
+    hooks: {
+      init,
+      ready,
+      setCursor,
+    },
+  };
+}
+
+// Tooltip plugin for grouped stacked bar charts that shows only the
+// specific sub-bar layer being hovered, instead of all series.
+// It determines which group (left/right) via cursor X relative to
+// the bin centre, and which layer via cursor Y against stacked
+// cumulative boundaries.
+export function groupedStackedBarTooltipPlugin(
+  yAxis: AxisUnits,
+  timezone: string,
+  unstackedData: AlignedData,
+  stackedData: AlignedData,
+  n: number,
+  gistLabels: string[],
+  groupLabels: [string, string],
+  colourPalette: string[],
+): Plugin {
+  const tooltipEl = document.createElement("div");
+
+  function setCursor(u: uPlot) {
+    const { left = 0, top = 0 } = u.cursor;
+    const idx = u.posToIdx(left);
+
+    if (idx === null || idx === undefined || idx < 0) {
+      tooltipEl.style.display = "none";
+      return;
+    }
+
+    // Which group? Compare cursor x to the bin centre.
+    const binCenterX = u.valToPos(u.data[0][idx], "x");
+    const groupIdx = left < binCenterX ? 0 : 1;
+
+    // Which layer? Compare cursor y (in data coords) against the
+    // cumulative stacked boundaries for the selected group.
+    const yVal = u.posToVal(top, "yAxis");
+    // In u.data: group 0 occupies indices 1..n,
+    //            group 1 occupies indices n+1..2n.
+    // n is the total number of layers per group in the data array and
+    // stays constant even when series are toggled off — toggling only
+    // changes visibility and restacks the data (see restackGroups in
+    // bars.ts) without altering the array layout. Hidden layers
+    // collapse to zero height so the hit-test naturally skips them.
+    const groupOffset = groupIdx === 0 ? 1 : 1 + n;
+
+    let hitLayer = -1;
+    for (let i = 0; i < n; i++) {
+      const layerBottom =
+        i === 0 ? 0 : (u.data[groupOffset + i - 1][idx] as number);
+      const layerTop = u.data[groupOffset + i][idx] as number;
+      if (yVal >= layerBottom && yVal <= layerTop) {
+        hitLayer = i;
+        break;
+      }
+    }
+
+    if (hitLayer < 0 || yVal < 0) {
+      tooltipEl.style.display = "none";
+      return;
+    }
+
+    // Get the unstacked (raw) value for this single layer.
+    const rawValue = unstackedData[groupOffset + hitLayer][idx];
+    if (!rawValue || rawValue === 0) {
+      tooltipEl.style.display = "none";
+      return;
+    }
+
+    const gistLabel = gistLabels[hitLayer] || "unknown";
+    const groupLabel = groupLabels[groupIdx];
+    const color =
+      colourPalette[hitLayer % colourPalette.length] || DEFAULT_STROKE;
+
+    // Format timestamp header.
+    const closestDataPointTimeMillis = u.data[0][idx];
+    const timeStr = FormatWithTimezone(
+      moment(closestDataPointTimeMillis as number),
+      DATE_WITH_SECONDS_FORMAT_24_TZ,
+      timezone,
+    );
+
+    tooltipEl.innerHTML = "";
+
+    const header = document.createElement("div");
+    header.style.paddingTop = "12px";
+    header.style.marginBottom = "8px";
+    header.textContent = timeStr;
+    tooltipEl.appendChild(header);
+
+    const groupDiv = document.createElement("div");
+    groupDiv.style.fontWeight = "bold";
+    groupDiv.style.marginBottom = "8px";
+    groupDiv.textContent = groupLabel;
+    tooltipEl.appendChild(groupDiv);
+
+    const container = document.createElement("div");
+    container.style.display = "flex";
+    container.style.alignItems = "center";
+
+    const colorBox = document.createElement("span");
+    colorBox.style.height = "12px";
+    colorBox.style.width = "12px";
+    colorBox.style.background = color;
+    colorBox.style.display = "inline-block";
+    colorBox.style.marginRight = "12px";
+    colorBox.style.borderRadius = "2px";
+
+    const label = document.createElement("span");
+    label.textContent = gistLabel;
+
+    const value = document.createElement("div");
+    value.style.textAlign = "right";
+    value.style.flex = "1";
+    value.style.fontFamily = "'Source Sans Pro', sans-serif";
+    value.style.marginLeft = "16px";
+    value.textContent = getFormattedValue(rawValue, yAxis);
+
+    container.appendChild(colorBox);
+    container.appendChild(label);
+    container.appendChild(value);
+    tooltipEl.appendChild(container);
+
+    // Position tooltip offset from the cursor.
+    tooltipEl.style.left = `${left + 20}px`;
+    tooltipEl.style.top = `${top - 10}px`;
+    tooltipEl.style.display = "";
+  }
+
+  function ready(u: uPlot) {
+    const plot = u.root.querySelector(".u-over");
+    plot?.addEventListener("mouseleave", () => {
+      tooltipEl.style.display = "none";
+    });
+  }
+
+  function init(u: uPlot) {
+    const plot = u.root.querySelector(".u-over");
+    tooltipEl.style.display = "none";
+    tooltipEl.style.pointerEvents = "none";
+    tooltipEl.style.position = "absolute";
+    tooltipEl.style.padding = "0 16px 16px";
+    tooltipEl.style.minWidth = "200px";
+    tooltipEl.style.background = "#fff";
+    tooltipEl.style.borderRadius = "5px";
+    tooltipEl.style.boxShadow = "0px 7px 13px rgba(71, 88, 114, 0.3)";
+    tooltipEl.style.zIndex = "100";
+    tooltipEl.style.whiteSpace = "nowrap";
+    plot?.appendChild(tooltipEl);
   }
 
   return {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -1038,12 +1038,31 @@ export function StatementDetails(
       ],
     };
 
+    // Build a map from plan_gist → average run latency (seconds)
+    // for heat map coloring. If multiple plan_hashes share a gist,
+    // use a count-weighted average.
+    const latencyByGist = new Map<string, number>();
+    const countByGist = new Map<string, number>();
+    (statementStatisticsPerPlanHash || []).forEach(plan => {
+      const gist = plan.stats?.plan_gists?.[0] || "unknown";
+      const count = longToInt(plan.stats?.count) || 1;
+      const lat = plan.stats?.run_lat?.mean || 0;
+      latencyByGist.set(gist, (latencyByGist.get(gist) || 0) + count * lat);
+      countByGist.set(gist, (countByGist.get(gist) || 0) + count);
+    });
+    latencyByGist.forEach((totalLat, gist) => {
+      latencyByGist.set(gist, totalLat / (countByGist.get(gist) || 1));
+    });
+
     const {
       alignedData: canaryPlanDistData,
       planGists: canaryPlanGists,
       groupSize: canaryPlanGroupSize,
+      colourPalette: canaryColourPalette,
+      latencyRange: canaryLatencyRange,
     } = generateCanaryVsStablePlanDistributionTimeseries(
       statementStatisticsPerAggregatedTsAndPlanHash || [],
+      latencyByGist,
     );
     const hasCanaryPlanData = canaryPlanDistData[0].length > 0;
     const canaryPlanDistOps: Partial<Options> = {
@@ -1052,13 +1071,14 @@ export function StatementDetails(
         {},
         // Canary group: one series per plan gist
         ...canaryPlanGists.map(gist => ({
-          label: `Canary ${gist}`,
+          label: gist,
         })),
         // Stable group: one series per plan gist
         ...canaryPlanGists.map(gist => ({
-          label: `Stable ${gist}`,
+          label: gist,
         })),
       ],
+      legend: { show: true },
     };
 
     const [chartsStart, chartsEnd] = toRoundedDateRange(timeScale);
@@ -1124,22 +1144,70 @@ export function StatementDetails(
           {hasCanaryPlanData && (
             <Row gutter={24}>
               <Col className="gutter-row" span={24}>
-                <GroupedStackedBarGraphTimeSeries
-                  title="Canary vs Stable Plan Distribution"
-                  tooltip={
-                    <>
-                      Compares plan distribution between canary (newest table
-                      statistics) and stable (second-newest) executions. Left
-                      bars show canary execution counts, right bars show stable.
-                      Each color represents a different plan gist.
-                    </>
-                  }
-                  alignedData={canaryPlanDistData}
-                  uPlotOptions={canaryPlanDistOps}
-                  groupSize={canaryPlanGroupSize}
-                  yAxisUnits={AxisUnits.Count}
-                  xScale={xScale}
-                />
+                <div style={{ display: "inline-flex", alignItems: "stretch" }}>
+                  <div>
+                    <GroupedStackedBarGraphTimeSeries
+                      title="Canary vs Stable Plan Distribution"
+                      tooltip={
+                        <>
+                          Compares plan distribution between canary (newest
+                          table statistics) and stable (second-newest)
+                          executions. Left bars show canary execution counts,
+                          right bars show stable. Color intensity indicates
+                          average execution latency: darker purple = higher
+                          latency, lighter purple = lower latency.
+                        </>
+                      }
+                      alignedData={canaryPlanDistData}
+                      uPlotOptions={canaryPlanDistOps}
+                      colourPalette={canaryColourPalette}
+                      gistLabels={canaryPlanGists}
+                      groupLabels={["Canary", "Stable"]}
+                      groupStrokeColors={["#c62828", "#1565c0"]}
+                      groupSize={canaryPlanGroupSize}
+                      yAxisUnits={AxisUnits.Count}
+                      xScale={xScale}
+                    />
+                  </div>
+                  {canaryLatencyRange && (
+                    <div
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        marginLeft: 12,
+                        paddingTop: 40,
+                        paddingBottom: 24,
+                        fontSize: 11,
+                        color: "#475872",
+                      }}
+                    >
+                      <span>{Duration(canaryLatencyRange.max * 1e9)}</span>
+                      <div
+                        style={{
+                          width: 14,
+                          flex: 1,
+                          minHeight: 60,
+                          margin: "4px 0",
+                          borderRadius: 3,
+                          background:
+                            "linear-gradient(to bottom, hsl(261,97%,35%), hsl(261,97%,85%))",
+                        }}
+                      />
+                      <span>{Duration(canaryLatencyRange.min * 1e9)}</span>
+                      <span
+                        style={{
+                          marginTop: 4,
+                          fontSize: 10,
+                          color: "#8b96a9",
+                        }}
+                      >
+                        Avg Latency
+                      </span>
+                    </div>
+                  )}
+                </div>
               </Col>
             </Row>
           )}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -60,7 +60,11 @@ import {
 import { CockroachCloudContext } from "../contexts";
 import { Delayed } from "../delayed";
 import { AxisUnits } from "../graphs";
-import { BarGraphTimeSeries, XScale } from "../graphs/bargraph";
+import {
+  BarGraphTimeSeries,
+  GroupedStackedBarGraphTimeSeries,
+  XScale,
+} from "../graphs/bargraph";
 import {
   getStmtInsightRecommendations,
   InsightType,
@@ -99,6 +103,7 @@ import {
   generateRowsProcessedTimeseries,
   generateCPUTimeseries,
   generateClientWaitTimeseries,
+  generateCanaryVsStableTimeseries,
   generatePlanDistributionTimeseries,
 } from "./timeseriesUtils";
 
@@ -667,6 +672,22 @@ export function StatementDetails(
       width: cardWidth,
     };
 
+    const canaryVsStableTimeseries: AlignedData =
+      generateCanaryVsStableTimeseries(statsPerAggregatedTs);
+    const canaryVsStableOps: Partial<Options> = {
+      axes: [{}, { label: "Time Spent" }],
+      series: [
+        {},
+        { label: "Execution" },
+        { label: "Planning" },
+        { label: "Execution" },
+        { label: "Planning" },
+      ],
+      legend: { show: true },
+      width: cardWidth,
+    };
+    const hasCanaryData = canaryVsStableTimeseries[0].length > 0;
+
     const insightsColumns = makeInsightsColumns(
       isCockroachCloud,
       hasAdminRole,
@@ -886,6 +907,32 @@ export function StatementDetails(
               />
             </Col>
           </Row>
+          {hasCanaryData && (
+            <Row gutter={24}>
+              <Col className="gutter-row" span={12}>
+                <GroupedStackedBarGraphTimeSeries
+                  title="Canary vs Stable Statement Times"
+                  alignedData={canaryVsStableTimeseries}
+                  uPlotOptions={canaryVsStableOps}
+                  yAxisUnits={AxisUnits.Duration}
+                  xScale={xScale}
+                  gistLabels={["Execution", "Planning"]}
+                  groupLabels={["Canary", "Stable"]}
+                  groupStrokeColors={["#c62828", "#1565c0"]}
+                  tooltip={
+                    <>
+                      Compares execution latency between canary (newest table
+                      statistics) and stable (second-newest table statistics)
+                      paths. Each bar is split into execution (bottom) and
+                      planning (top) time, matching the Statement Times chart
+                      colors. This helps identify performance regressions caused
+                      by newly collected table statistics.
+                    </>
+                  }
+                />
+              </Col>
+            </Row>
+          )}
           <Row gutter={24}>
             <Col className="gutter-row" span={12}>
               <BarGraphTimeSeries

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -105,6 +105,7 @@ import {
   generateClientWaitTimeseries,
   generateCanaryVsStableTimeseries,
   generatePlanDistributionTimeseries,
+  generateCanaryVsStablePlanDistributionTimeseries,
 } from "./timeseriesUtils";
 
 type StatementDetailsResponse =
@@ -1037,6 +1038,29 @@ export function StatementDetails(
       ],
     };
 
+    const {
+      alignedData: canaryPlanDistData,
+      planGists: canaryPlanGists,
+      groupSize: canaryPlanGroupSize,
+    } = generateCanaryVsStablePlanDistributionTimeseries(
+      statementStatisticsPerAggregatedTsAndPlanHash || [],
+    );
+    const hasCanaryPlanData = canaryPlanDistData[0].length > 0;
+    const canaryPlanDistOps: Partial<Options> = {
+      axes: [{}, { label: "Execution Count" }],
+      series: [
+        {},
+        // Canary group: one series per plan gist
+        ...canaryPlanGists.map(gist => ({
+          label: `Canary ${gist}`,
+        })),
+        // Stable group: one series per plan gist
+        ...canaryPlanGists.map(gist => ({
+          label: `Stable ${gist}`,
+        })),
+      ],
+    };
+
     const [chartsStart, chartsEnd] = toRoundedDateRange(timeScale);
     const xScale = {
       graphTsStartMillis: chartsStart.valueOf(),
@@ -1096,6 +1120,28 @@ export function StatementDetails(
                 </Col>
               </Row>
             </>
+          )}
+          {hasCanaryPlanData && (
+            <Row gutter={24}>
+              <Col className="gutter-row" span={24}>
+                <GroupedStackedBarGraphTimeSeries
+                  title="Canary vs Stable Plan Distribution"
+                  tooltip={
+                    <>
+                      Compares plan distribution between canary (newest table
+                      statistics) and stable (second-newest) executions. Left
+                      bars show canary execution counts, right bars show stable.
+                      Each color represents a different plan gist.
+                    </>
+                  }
+                  alignedData={canaryPlanDistData}
+                  uPlotOptions={canaryPlanDistOps}
+                  groupSize={canaryPlanGroupSize}
+                  yAxisUnits={AxisUnits.Count}
+                  xScale={xScale}
+                />
+              </Col>
+            </Row>
           )}
           <PlanDetails
             statementFingerprintID={statementFingerprintID}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -198,3 +198,73 @@ export function generatePlanDistributionTimeseries(
 
   return { alignedData, planGists };
 }
+
+// generateCanaryVsStablePlanDistributionTimeseries builds a grouped bar
+// chart with two bars per timestamp: canary (left) and stable (right).
+// Each bar is stacked by plan gist, showing execution counts.
+//
+// Returns data as [timestamps, gist1_canary, gist2_canary, ..., gist1_stable, gist2_stable, ...]
+// along with the plan gist list and the number of gists (groupSize).
+export function generateCanaryVsStablePlanDistributionTimeseries(
+  stats: StatementStatisticsPerAggregatedTsAndPlanHash[],
+): { alignedData: AlignedData; planGists: string[]; groupSize: number } {
+  // Two maps: one for canary counts, one for stable counts.
+  const canaryMap = new Map<number, Map<string, number>>();
+  const stableMap = new Map<number, Map<string, number>>();
+  const planGistSet = new Set<string>();
+  let hasCanary = false;
+
+  stats.forEach(stat => {
+    const ts = TimestampToNumber(stat.aggregated_ts) * 1e3;
+    const planGist = stat.plan_gist || "unknown";
+    planGistSet.add(planGist);
+
+    const canaryCount = Number(stat.canary_execution_count || 0);
+    // Use the explicitly tracked stable count rather than deriving it
+    // from (total - canary), since executions where the canary experiment
+    // is off should not be counted as stable.
+    const stableCount = Number(stat.stable_execution_count || 0);
+
+    if (canaryCount > 0 || stableCount > 0) {
+      hasCanary = true;
+    }
+
+    if (!canaryMap.has(ts)) {
+      canaryMap.set(ts, new Map());
+      stableMap.set(ts, new Map());
+    }
+
+    const existingCanary = canaryMap.get(ts).get(planGist) || 0;
+    canaryMap.get(ts).set(planGist, existingCanary + canaryCount);
+
+    const existingStable = stableMap.get(ts).get(planGist) || 0;
+    stableMap.get(ts).set(planGist, existingStable + stableCount);
+  });
+
+  if (!hasCanary) {
+    return { alignedData: [[]], planGists: [], groupSize: 0 };
+  }
+
+  const timestamps = Array.from(canaryMap.keys()).sort((a, b) => a - b);
+  const planGists = Array.from(planGistSet).sort();
+  const groupSize = planGists.length;
+
+  // Data layout: [timestamps, ...canary_gists, ...stable_gists]
+  const alignedData: AlignedData = [timestamps];
+
+  // Canary series (one per plan gist)
+  planGists.forEach(planGist => {
+    alignedData.push(
+      timestamps.map(ts => canaryMap.get(ts)?.get(planGist) || 0),
+    );
+  });
+
+  // Stable series (one per plan gist)
+  planGists.forEach(planGist => {
+    alignedData.push(
+      timestamps.map(ts => stableMap.get(ts)?.get(planGist) || 0),
+    );
+  });
+
+  return { alignedData, planGists, groupSize };
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -199,15 +199,37 @@ export function generatePlanDistributionTimeseries(
   return { alignedData, planGists };
 }
 
+// latencyToColor maps a latency value to a purple-tone HSL color.
+// Lower latency → lighter (higher lightness), higher → darker.
+function latencyToColor(lat: number, min: number, max: number): string {
+  const t = max === min ? 0.5 : (lat - min) / (max - min);
+  // Lightness ranges from 85% (light purple) to 35% (dark purple).
+  const lightness = 85 - t * 50;
+  return `hsl(261, 97%, ${lightness}%)`;
+}
+
 // generateCanaryVsStablePlanDistributionTimeseries builds a grouped bar
 // chart with two bars per timestamp: canary (left) and stable (right).
 // Each bar is stacked by plan gist, showing execution counts.
+//
+// When latencyByGist is provided, plan gists are sorted by latency
+// ascending (lowest latency at the bottom of the stack) and each gist
+// is assigned a heat-map color (light purple = low latency, dark
+// purple = high latency). The colour palette and latency range are
+// returned so the caller can render a legend.
 //
 // Returns data as [timestamps, gist1_canary, gist2_canary, ..., gist1_stable, gist2_stable, ...]
 // along with the plan gist list and the number of gists (groupSize).
 export function generateCanaryVsStablePlanDistributionTimeseries(
   stats: StatementStatisticsPerAggregatedTsAndPlanHash[],
-): { alignedData: AlignedData; planGists: string[]; groupSize: number } {
+  latencyByGist?: Map<string, number>,
+): {
+  alignedData: AlignedData;
+  planGists: string[];
+  groupSize: number;
+  colourPalette: string[];
+  latencyRange?: { min: number; max: number };
+} {
   // Two maps: one for canary counts, one for stable counts.
   const canaryMap = new Map<number, Map<string, number>>();
   const stableMap = new Map<number, Map<string, number>>();
@@ -242,11 +264,55 @@ export function generateCanaryVsStablePlanDistributionTimeseries(
   });
 
   if (!hasCanary) {
-    return { alignedData: [[]], planGists: [], groupSize: 0 };
+    return {
+      alignedData: [[]],
+      planGists: [],
+      groupSize: 0,
+      colourPalette: [],
+    };
   }
 
   const timestamps = Array.from(canaryMap.keys()).sort((a, b) => a - b);
-  const planGists = Array.from(planGistSet).sort();
+
+  // Sort plan gists by latency ascending when a latency map is
+  // provided, so lower-latency plans sit at the bottom of the stack
+  // and receive lighter colors. Always generate a purple heat-map
+  // palette — if no latency data is available, use evenly-spaced
+  // purple shades so the chart never falls back to the default
+  // multi-colour palette.
+  let planGists: string[];
+  let colourPalette: string[];
+  let latencyRange: { min: number; max: number } | undefined;
+
+  // Check whether latencyByGist has entries that actually match gists
+  // in this chart's data.
+  const hasLatencyData =
+    latencyByGist &&
+    latencyByGist.size > 0 &&
+    Array.from(planGistSet).some(g => latencyByGist.has(g));
+
+  if (hasLatencyData) {
+    planGists = Array.from(planGistSet).sort((a, b) => {
+      return (latencyByGist.get(a) || 0) - (latencyByGist.get(b) || 0);
+    });
+    const lats = planGists.map(g => latencyByGist.get(g) || 0);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    colourPalette = planGists.map(g =>
+      latencyToColor(latencyByGist.get(g) || 0, minLat, maxLat),
+    );
+    latencyRange = { min: minLat, max: maxLat };
+  } else {
+    planGists = Array.from(planGistSet).sort();
+    // Evenly-spaced purple shades as fallback.
+    const n = planGists.length;
+    colourPalette = planGists.map((_, i) => {
+      const t = n <= 1 ? 0.5 : i / (n - 1);
+      const lightness = 85 - t * 50;
+      return `hsl(261, 97%, ${lightness}%)`;
+    });
+  }
+
   const groupSize = planGists.length;
 
   // Data layout: [timestamps, ...canary_gists, ...stable_gists]
@@ -266,5 +332,5 @@ export function generateCanaryVsStablePlanDistributionTimeseries(
     );
   });
 
-  return { alignedData, planGists, groupSize };
+  return { alignedData, planGists, groupSize, colourPalette, latencyRange };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -118,6 +118,48 @@ export function generateCPUTimeseries(
   return [ts, count];
 }
 
+// generateCanaryVsStableTimeseries builds a time series with four data
+// series for a grouped+stacked bar chart. For each aggregated timestamp,
+// two side-by-side bars are shown: one for canary and one for stable.
+// Each bar is split into execution (bottom) and planning (top) portions,
+// matching the color order of the "Statement Times" chart (execution =
+// blue at index 0, planning = green at index 1).
+//
+// Returns [timestamps, canaryRun, canaryPlan, stableRun, stablePlan].
+// Both canary and stable latencies are tracked explicitly in the backend
+// rather than deriving stable from (total - canary), because executions
+// where the canary experiment is off should not be counted as stable.
+export function generateCanaryVsStableTimeseries(
+  stats: StatementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const canaryRun: Array<number> = [];
+  const canaryPlan: Array<number> = [];
+  const stableRun: Array<number> = [];
+  const stablePlan: Array<number> = [];
+
+  stats.forEach(function (stat: StatementStatisticsPerAggregatedTs) {
+    const canaryStats = stat.stats?.canary_stats;
+    const stableStats = stat.stats?.stable_stats;
+    const canaryCount = longToInt(canaryStats?.count) || 0;
+    const stableCount = longToInt(stableStats?.count) || 0;
+
+    // Skip timestamps where the canary experiment was not active.
+    if (canaryCount === 0 && stableCount === 0) {
+      return;
+    }
+
+    ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+
+    canaryRun.push((canaryStats?.run_lat?.mean || 0) * 1e9);
+    canaryPlan.push((canaryStats?.plan_lat?.mean || 0) * 1e9);
+    stableRun.push((stableStats?.run_lat?.mean || 0) * 1e9);
+    stablePlan.push((stableStats?.plan_lat?.mean || 0) * 1e9);
+  });
+
+  return [ts, canaryRun, canaryPlan, stableRun, stablePlan];
+}
+
 type StatementStatisticsPerAggregatedTsAndPlanHash =
   cockroach.server.serverpb.StatementDetailsResponse.IStatementPlanDistribution;
 export function generatePlanDistributionTimeseries(

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
@@ -3,8 +3,11 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import Long from "long";
+
 import {
   aggregateNumericStats,
+  addExperimentStatsInfo,
   NumericStat,
   flattenStatementStats,
 } from "./appStats";
@@ -74,6 +77,86 @@ describe("addNumericStats", () => {
     const reversed = aggregateNumericStats(b, a, countB, countA);
 
     expect(reversed).toEqual(combined);
+  });
+});
+
+describe("addExperimentStatsInfo", () => {
+  it("returns empty object when both inputs are null/undefined", () => {
+    expect(addExperimentStatsInfo(null, null)).toEqual({});
+    expect(addExperimentStatsInfo(undefined, undefined)).toEqual({});
+  });
+
+  it("returns b when a is null", () => {
+    const b = {
+      count: Long.fromInt(3),
+      run_lat: { mean: 1.5, squared_diffs: 0.5 },
+      plan_lat: { mean: 0.8, squared_diffs: 0.2 },
+    };
+    expect(addExperimentStatsInfo(null, b)).toBe(b);
+  });
+
+  it("returns a when b is null", () => {
+    const a = {
+      count: Long.fromInt(2),
+      run_lat: { mean: 1.0, squared_diffs: 0.3 },
+      plan_lat: { mean: 0.5, squared_diffs: 0.1 },
+    };
+    expect(addExperimentStatsInfo(a, null)).toBe(a);
+  });
+
+  it("aggregates two non-null inputs", () => {
+    const a = {
+      count: Long.fromInt(3),
+      run_lat: { mean: 2.0, squared_diffs: 1.0 },
+      plan_lat: { mean: 1.0, squared_diffs: 0.5 },
+    };
+    const b = {
+      count: Long.fromInt(2),
+      run_lat: { mean: 3.0, squared_diffs: 0.5 },
+      plan_lat: { mean: 1.5, squared_diffs: 0.2 },
+    };
+
+    const result = addExperimentStatsInfo(a, b);
+
+    // count should be summed.
+    expect(result.count.toInt()).toBe(5);
+
+    // run_lat and plan_lat should produce finite, non-NaN values.
+    expect(Number.isFinite(result.run_lat.mean)).toBe(true);
+    expect(Number.isNaN(result.run_lat.mean)).toBe(false);
+    expect(Number.isFinite(result.run_lat.squared_diffs)).toBe(true);
+    expect(Number.isNaN(result.run_lat.squared_diffs)).toBe(false);
+
+    expect(Number.isFinite(result.plan_lat.mean)).toBe(true);
+    expect(Number.isNaN(result.plan_lat.mean)).toBe(false);
+    expect(Number.isFinite(result.plan_lat.squared_diffs)).toBe(true);
+    expect(Number.isNaN(result.plan_lat.squared_diffs)).toBe(false);
+
+    // Weighted mean: (2.0*3 + 3.0*2) / 5 = 2.4
+    expect(result.run_lat.mean).toBeCloseTo(2.4, 6);
+    // Weighted mean: (1.0*3 + 1.5*2) / 5 = 1.2
+    expect(result.plan_lat.mean).toBeCloseTo(1.2, 6);
+  });
+
+  it("handles zero counts without producing NaN", () => {
+    const a = {
+      count: Long.fromInt(0),
+      run_lat: { mean: 0, squared_diffs: 0 },
+      plan_lat: { mean: 0, squared_diffs: 0 },
+    };
+    const b = {
+      count: Long.fromInt(0),
+      run_lat: { mean: 0, squared_diffs: 0 },
+      plan_lat: { mean: 0, squared_diffs: 0 },
+    };
+
+    const result = addExperimentStatsInfo(a, b);
+
+    expect(result.count.toInt()).toBe(0);
+    // With zero counts the function uses countA || 1 / countB || 1
+    // to avoid division by zero — verify no NaN.
+    expect(Number.isNaN(result.run_lat.mean)).toBe(false);
+    expect(Number.isNaN(result.plan_lat.mean)).toBe(false);
   });
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -162,6 +162,32 @@ export function addExecStats(a: ExecStats, b: ExecStats): ExecStats {
   };
 }
 
+export function addExperimentStatsInfo(
+  a: cockroach.sql.IExperimentStatsInfo,
+  b: cockroach.sql.IExperimentStatsInfo,
+): cockroach.sql.IExperimentStatsInfo {
+  if (!a && !b) return {};
+  if (!a) return b;
+  if (!b) return a;
+  const countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  return {
+    count: FixLong(a.count).add(FixLong(b.count)),
+    run_lat: aggregateNumericStats(
+      a.run_lat,
+      b.run_lat,
+      countA || 1,
+      countB || 1,
+    ),
+    plan_lat: aggregateNumericStats(
+      a.plan_lat,
+      b.plan_lat,
+      countA || 1,
+      countB || 1,
+    ),
+  };
+}
+
 export function addStatementStats(
   a: StatementStatistics,
   b: StatementStatistics,
@@ -270,31 +296,8 @@ export function addStatementStats(
     indexes: indexes,
     latency_info: aggregateLatencyInfo(a, b),
     last_error_code: "",
-    canary_stats: addExperimentStats(a.canary_stats, b.canary_stats),
-    stable_stats: addExperimentStats(a.stable_stats, b.stable_stats),
-  };
-}
-
-function addExperimentStats(
-  a: cockroach.sql.IExperimentStatsInfo | null | undefined,
-  b: cockroach.sql.IExperimentStatsInfo | null | undefined,
-): cockroach.sql.IExperimentStatsInfo {
-  const countA = FixLong(a?.count).toInt();
-  const countB = FixLong(b?.count).toInt();
-  return {
-    count: Long.fromInt(countA + countB),
-    run_lat: aggregateNumericStats(
-      a?.run_lat ?? { mean: 0, squared_diffs: 0 },
-      b?.run_lat ?? { mean: 0, squared_diffs: 0 },
-      countA,
-      countB,
-    ),
-    plan_lat: aggregateNumericStats(
-      a?.plan_lat ?? { mean: 0, squared_diffs: 0 },
-      b?.plan_lat ?? { mean: 0, squared_diffs: 0 },
-      countA,
-      countB,
-    ),
+    canary_stats: addExperimentStatsInfo(a.canary_stats, b.canary_stats),
+    stable_stats: addExperimentStatsInfo(a.stable_stats, b.stable_stats),
   };
 }
 


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/156817
Fixes: #165850
Fixes: #150015

This PR introduce 2 charts that helps differentiate performance of canary and stable table stats for a statement.  Both charts live under the `Statement Fingerprint` page, which can be accessed via the `SQL Activity` panel.

### 1. Canary vs Stable Statement Times

Similar to the existing `Statement Times`, the new `Canary vs Stable Statement Times` dual-bar chart shows the aggregated planning and execution latency for the statement, but also differentiate the canary and stable exections.

<img width="1146" height="611" alt="Screenshot 2026-03-16 at 9 33 26 PM" src="https://github.com/user-attachments/assets/5669c3bf-ac87-4401-a316-296c4c7325d7" />


Supports the "hovering to show details" and "click legend to isolate" effect.

### 2. Canary vs Stable Plan Distribution

Similar to the existing `Plan Distribution Over Time`, the `Canary vs Stable Plan Distribution` dual bar chart shows the aggregated plan distribution for the statement, but also differentiate the canary and stable exections. Also, the plan gist are colored according to their average execution time duration, with the longer the durtion, the darker the plan gist. 

<img width="1537" height="638" alt="Screenshot 2026-03-16 at 9 33 14 PM" src="https://github.com/user-attachments/assets/c4fe56d9-67ea-45bd-9e61-4304e4c247cd" />

Supports the "hovering to show details" and "click legend to isolate" effect.

Release note (sql ops): Introduce "Canary vs Stable Statement Times" and "Canary vs Stable Plan Distribution" dual-bar charts in the dbconsole's statement fingerprint page, which only shows up when the statement is enrolled in canary stats rollout feature. These bar charts can help differentiate the performance brought by the canary and stable table statistics, which facilitate troubleshooting possible regression caused by freshly collected table statistics.
