### PR TITLE
release-25.2: stmtdiagnostics,tenantcostclient: enable remote execution

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":tenantcostclient"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
         "statement_diagnostics_test.go",
     ],
     embed = [":stmtdiagnostics"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
Backport 1/1 commits from #165824.

/cc @cockroachdb/release

---

Release justification: Non-production code changes

Closes: #109181
Release note: none
Epic: CRDB-14596

Release justification: Non-production code changes
