### PR TITLE
roachtest: exclude lineitem from import/decommissioned test

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -191,6 +191,17 @@ func anyDataset(rng *rand.Rand) []string {
 	return nDatasets(rng, 1)
 }
 
+func anySmallDataset(rng *rand.Rand) []string {
+	all := allDatasets(rng)
+	small := slices.DeleteFunc(all, func(name string) bool {
+		return name == "tpch/lineitem"
+	})
+	rng.Shuffle(len(small), func(i, j int) {
+		small[i], small[j] = small[j], small[i]
+	})
+	return small[:1]
+}
+
 // importTestSpec represents a subtest within the import test.
 type importTestSpec struct {
 	// subtestName is the name to register for this test.
@@ -257,11 +268,12 @@ var tests = []importTestSpec{
 		nodes:        []int{4},
 		datasetNames: FromFunc(anyThreeDatasets),
 	},
-	// Test with a decommissioned node.
+	// Test with a decommissioned node. Exclude lineitem (the largest dataset)
+	// to avoid timeouts when running with only 3 active nodes.
 	{
 		subtestName:  "decommissioned",
 		nodes:        []int{4},
-		datasetNames: FromFunc(anyDataset),
+		datasetNames: FromFunc(anySmallDataset),
 		preTestHook: func(ctx context.Context, t test.Test, c cluster.Cluster, _ *rand.Rand) {
 			nodeToDecommission := 2
 			t.Status(fmt.Sprintf("decommissioning node %d", nodeToDecommission))


### PR DESCRIPTION
The import/decommissioned roachtest has been repeatedly timing out at
the 10-hour limit. The test decommissions one of 4 nodes then imports
a random TPC-H SF-100 dataset. When lineitem (the largest dataset) is
selected, the reduced cluster capacity (~3 active nodes) combined with
metamorphic encryption and expiration leases pushes the import +
fingerprint validation past the timeout.

Exclude lineitem from the dataset pool for this test, keeping the
remaining 5 datasets which complete comfortably within the time budget.

Resolves: #165786

Release note: None