### PR TITLE
opt: relax recently added requirement to `findExistingColInList`

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -622,7 +622,10 @@ func findExistingColInList(
 		if expr == col {
 			return col
 		}
-		if col.typ.Identical(expr.ResolvedType()) && exprStr == col.getExprStr() {
+		// TODO(yuzefovich): using equivalent type condition is not exactly the
+		// right thing to do. See discussion on PR #165860 the right fix in the
+		// type-checker.
+		if col.typ.Equivalent(expr.ResolvedType()) && exprStr == col.getExprStr() {
 			if allowSideEffects || col.scalar == nil {
 				return col
 			}
@@ -639,7 +642,7 @@ func findExistingColInList(
 // findExistingCol finds the given expression among the bound variables in this
 // scope. Returns nil if the expression is not found (or an expression is found
 // but it has side-effects and allowSideEffects is false). The types of the
-// given expression and the bound variable need to be identical.
+// given expression and the bound variable need to be equivalent.
 //
 // If a column is found and we are tracking view dependencies, we add the column
 // to the view dependencies since it means this column is being referenced.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -4829,3 +4829,33 @@ scalar-group-by
  └── aggregations
       └── const-agg [as=array_agg:6]
            └── array_agg:6
+
+exec-ddl
+CREATE TABLE t165002 (id INT PRIMARY KEY, b INT, c VARCHAR(255))
+----
+
+build
+SELECT string_agg(
+  CASE WHEN t165002.b < 10 THEN t165002.c ELSE NULL END,
+  ','
+  ORDER BY t165002.id DESC
+) FROM t165002
+----
+scalar-group-by
+ ├── columns: string_agg:8
+ ├── window partition=() ordering=-1
+ │    ├── columns: id:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5 column6:6 column7:7!null string_agg:8
+ │    ├── project
+ │    │    ├── columns: column6:6 column7:7!null id:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    │    ├── scan t165002
+ │    │    │    └── columns: id:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    │    └── projections
+ │    │         ├── CASE WHEN b:2 < 10 THEN c:3::VARCHAR ELSE NULL::VARCHAR END [as=column6:6]
+ │    │         └── ',' [as=column7:7]
+ │    └── windows
+ │         └── string-agg [as=string_agg:8, frame="range from unbounded to unbounded"]
+ │              ├── column6:6
+ │              └── column7:7
+ └── aggregations
+      └── const-agg [as=string_agg:8]
+           └── string_agg:8

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -3875,81 +3875,71 @@ upsert assn_cast
  │    └── d_comp_cast:19 => d_comp:7
  ├── update-mapping:
  │    ├── d_cast:12 => d:6
- │    └── upsert_d_comp:36 => d_comp:7
+ │    └── d_comp_cast:19 => d_comp:7
  └── project
-      ├── columns: upsert_k:31 upsert_c:32 upsert_qc:33 upsert_i:34 upsert_s:35 upsert_d_comp:36 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28 d_comp_cast:30
-      ├── project
-      │    ├── columns: d_comp_cast:30 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    ├── project
-      │    │    ├── columns: d_comp_comp:29 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19
-      │    │    │    │    ├── grouping columns: column1:10!null
+      ├── columns: upsert_k:29 upsert_c:30 upsert_qc:31 upsert_i:32 upsert_s:33 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      ├── left-join (hash)
+      │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19 k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    ├── ensure-upsert-distinct-on
+      │    │    ├── columns: column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19
+      │    │    ├── grouping columns: column1:10!null
+      │    │    ├── project
+      │    │    │    ├── columns: d_comp_cast:19 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: d_comp_comp:18 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: d_comp_cast:19 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: d_comp_comp:18 column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12 c_default:13 qc_default:14 s_default:16
-      │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12
-      │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: d_cast:12 column1:10!null
-      │    │    │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11
-      │    │    │    │    │    │    │    │    │    │    └── (1, 1.45::DECIMAL(10,2))
-      │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
-      │    │    │    │    │    │    │    │    │              └── column2:11
-      │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
-      │    │    │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
-      │    │    │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
-      │    │    │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
+      │    │    │    │    │    │    │    ├── columns: d_cast:12 column1:10!null
+      │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11
+      │    │    │    │    │    │    │    │    └── (1, 1.45::DECIMAL(10,2))
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
-      │    │    │    │    │    │    │              └── i_default:15
+      │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
+      │    │    │    │    │    │    │              └── column2:11
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
+      │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
+      │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
+      │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
+      │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
-      │    │    │    │    │              └── d_comp_comp:18
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── first-agg [as=d_cast:12]
-      │    │    │    │         │    └── d_cast:12
-      │    │    │    │         ├── first-agg [as=c_default:13]
-      │    │    │    │         │    └── c_default:13
-      │    │    │    │         ├── first-agg [as=qc_default:14]
-      │    │    │    │         │    └── qc_default:14
-      │    │    │    │         ├── first-agg [as=i_cast:17]
-      │    │    │    │         │    └── i_cast:17
-      │    │    │    │         ├── first-agg [as=s_default:16]
-      │    │    │    │         │    └── s_default:16
-      │    │    │    │         └── first-agg [as=d_comp_cast:19]
-      │    │    │    │              └── d_comp_cast:19
-      │    │    │    ├── scan assn_cast
-      │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    └── d_comp:26
-      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
-      │    │    │    │    │              └── d:25 + 10.0
-      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
-      │    │    │    └── filters
-      │    │    │         └── column1:10 = k:20
-      │    │    └── projections
-      │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:29]
-      │    └── projections
-      │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:30]
-      │              └── d_comp_comp:29
+      │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
+      │    │    │    │    │              └── i_default:15
+      │    │    │    │    └── projections
+      │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
+      │    │    │    └── projections
+      │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
+      │    │    │              └── d_comp_comp:18
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=d_cast:12]
+      │    │         │    └── d_cast:12
+      │    │         ├── first-agg [as=c_default:13]
+      │    │         │    └── c_default:13
+      │    │         ├── first-agg [as=qc_default:14]
+      │    │         │    └── qc_default:14
+      │    │         ├── first-agg [as=i_cast:17]
+      │    │         │    └── i_cast:17
+      │    │         ├── first-agg [as=s_default:16]
+      │    │         │    └── s_default:16
+      │    │         └── first-agg [as=d_comp_cast:19]
+      │    │              └── d_comp_cast:19
+      │    ├── scan assn_cast
+      │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    ├── computed column expressions
+      │    │    │    └── d_comp:26
+      │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │              └── d:25 + 10.0
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    └── filters
+      │         └── column1:10 = k:20
       └── projections
-           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:31]
-           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:32]
-           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:33]
-           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:34]
-           ├── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:35]
-           └── CASE WHEN k:20 IS NULL THEN d_comp_cast:19 ELSE d_comp_cast:30 END [as=upsert_d_comp:36]
+           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:29]
+           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:30]
+           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:31]
+           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:32]
+           └── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:33]
 
 # Test prepared upsert to a column that requires an assignment cast and a
 # computed column that depends on the new value.
@@ -3971,81 +3961,71 @@ upsert assn_cast
  │    └── d_comp_cast:19 => d_comp:7
  ├── update-mapping:
  │    ├── d_cast:12 => d:6
- │    └── upsert_d_comp:36 => d_comp:7
+ │    └── d_comp_cast:19 => d_comp:7
  └── project
-      ├── columns: upsert_k:31 upsert_c:32 upsert_qc:33 upsert_i:34 upsert_s:35 upsert_d_comp:36!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28 d_comp_cast:30!null
-      ├── project
-      │    ├── columns: d_comp_cast:30!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    ├── project
-      │    │    ├── columns: d_comp_comp:29!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null
-      │    │    │    │    ├── grouping columns: column1:10!null
+      ├── columns: upsert_k:29 upsert_c:30 upsert_qc:31 upsert_i:32 upsert_s:33 column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      ├── left-join (hash)
+      │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    ├── ensure-upsert-distinct-on
+      │    │    ├── columns: column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null d_comp_cast:19!null
+      │    │    ├── grouping columns: column1:10!null
+      │    │    ├── project
+      │    │    │    ├── columns: d_comp_cast:19!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: d_comp_comp:18!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: d_comp_cast:19!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: d_comp_comp:18!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16 i_cast:17!null
+      │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12!null
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: i_cast:17!null column1:10!null d_cast:12!null c_default:13 qc_default:14 s_default:16
-      │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: c_default:13 qc_default:14 i_default:15!null s_default:16 column1:10!null d_cast:12!null
-      │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: d_cast:12!null column1:10!null
-      │    │    │    │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11!null
-      │    │    │    │    │    │    │    │    │    │    └── (1, 1.45)
-      │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
-      │    │    │    │    │    │    │    │    │              └── column2:11
-      │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
-      │    │    │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
-      │    │    │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
-      │    │    │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
+      │    │    │    │    │    │    │    ├── columns: d_cast:12!null column1:10!null
+      │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11!null
+      │    │    │    │    │    │    │    │    └── (1, 1.45)
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
-      │    │    │    │    │    │    │              └── i_default:15
+      │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:12]
+      │    │    │    │    │    │    │              └── column2:11
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
+      │    │    │    │    │    │         ├── NULL::CHAR [as=c_default:13]
+      │    │    │    │    │    │         ├── NULL::"char" [as=qc_default:14]
+      │    │    │    │    │    │         ├── 10::INT2 [as=i_default:15]
+      │    │    │    │    │    │         └── NULL::STRING [as=s_default:16]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
-      │    │    │    │    │              └── d_comp_comp:18
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── first-agg [as=d_cast:12]
-      │    │    │    │         │    └── d_cast:12
-      │    │    │    │         ├── first-agg [as=c_default:13]
-      │    │    │    │         │    └── c_default:13
-      │    │    │    │         ├── first-agg [as=qc_default:14]
-      │    │    │    │         │    └── qc_default:14
-      │    │    │    │         ├── first-agg [as=i_cast:17]
-      │    │    │    │         │    └── i_cast:17
-      │    │    │    │         ├── first-agg [as=s_default:16]
-      │    │    │    │         │    └── s_default:16
-      │    │    │    │         └── first-agg [as=d_comp_cast:19]
-      │    │    │    │              └── d_comp_cast:19
-      │    │    │    ├── scan assn_cast
-      │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    └── d_comp:26
-      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
-      │    │    │    │    │              └── d:25 + 10.0
-      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
-      │    │    │    └── filters
-      │    │    │         └── column1:10 = k:20
-      │    │    └── projections
-      │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:29]
-      │    └── projections
-      │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:30]
-      │              └── d_comp_comp:29
+      │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
+      │    │    │    │    │              └── i_default:15
+      │    │    │    │    └── projections
+      │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
+      │    │    │    └── projections
+      │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
+      │    │    │              └── d_comp_comp:18
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=d_cast:12]
+      │    │         │    └── d_cast:12
+      │    │         ├── first-agg [as=c_default:13]
+      │    │         │    └── c_default:13
+      │    │         ├── first-agg [as=qc_default:14]
+      │    │         │    └── qc_default:14
+      │    │         ├── first-agg [as=i_cast:17]
+      │    │         │    └── i_cast:17
+      │    │         ├── first-agg [as=s_default:16]
+      │    │         │    └── s_default:16
+      │    │         └── first-agg [as=d_comp_cast:19]
+      │    │              └── d_comp_cast:19
+      │    ├── scan assn_cast
+      │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
+      │    │    ├── computed column expressions
+      │    │    │    └── d_comp:26
+      │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │              └── d:25 + 10.0
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    └── filters
+      │         └── column1:10 = k:20
       └── projections
-           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:31]
-           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:32]
-           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:33]
-           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:34]
-           ├── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:35]
-           └── CASE WHEN k:20 IS NULL THEN d_comp_cast:19 ELSE d_comp_cast:30 END [as=upsert_d_comp:36]
+           ├── CASE WHEN k:20 IS NULL THEN column1:10 ELSE k:20 END [as=upsert_k:29]
+           ├── CASE WHEN k:20 IS NULL THEN c_default:13 ELSE c:21 END [as=upsert_c:30]
+           ├── CASE WHEN k:20 IS NULL THEN qc_default:14 ELSE qc:22 END [as=upsert_qc:31]
+           ├── CASE WHEN k:20 IS NULL THEN i_cast:17 ELSE i:23 END [as=upsert_i:32]
+           └── CASE WHEN k:20 IS NULL THEN s_default:16 ELSE s:24 END [as=upsert_s:33]
 
 # Test insert-do-nothing to a column that requires an assignment cast and a
 # computed column that depends on the new value.

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1303,16 +1303,16 @@ upsert transactiondetails
  ├── update-mapping:
  │    ├── numeric:20 => sellprice:7
  │    ├── numeric:21 => buyprice:8
- │    └── upsert_discount:45 => discount:10
+ │    └── discount_cast:24 => discount:10
  ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_dealerid:39 upsert_isbuy:40 upsert_transactiondate:41 upsert_cardid:42 upsert_discount:45!null "?column?":15!null bool:16!null current_timestamp:17!null int8:18!null int8:19!null numeric:20!null numeric:21!null version_default:22 discount_cast:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
+ │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39 upsert_cardid:40 "?column?":15!null bool:16!null current_timestamp:17!null int8:18!null int8:19!null numeric:20!null numeric:21!null version_default:22 discount_cast:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
  │    ├── cardinality: [1 - 2]
  │    ├── volatile
  │    ├── key: (18,19)
- │    ├── fd: ()-->(15-17,24), (18,19)-->(20-22,25-34,45), (25-29)-->(30-34), (25)-->(39), (25,26)-->(40), (25,27)-->(41), (18,25,28)-->(42)
+ │    ├── fd: ()-->(15-17,24), (18,19)-->(20-22,25-34), (25-29)-->(30-34), (25)-->(37), (25,26)-->(38), (25,27)-->(39), (18,25,28)-->(40)
  │    ├── left-join (lookup transactiondetails)
  │    │    ├── columns: "?column?":15!null bool:16!null current_timestamp:17!null int8:18!null int8:19!null numeric:20!null numeric:21!null version_default:22 discount_cast:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
  │    │    ├── key columns: [15 16 17 18 19] = [25 26 27 28 29]
@@ -1335,7 +1335,7 @@ upsert transactiondetails
  │    │    │    │    ├── volatile
  │    │    │    │    ├── fd: ()-->(15-17,24)
  │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: detail_b:69!null detail_c:70!null detail_q:71!null detail_s:72!null
+ │    │    │    │    │    ├── columns: detail_b:66!null detail_c:67!null detail_q:68!null detail_s:69!null
  │    │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    │    ├── ('2.29', '49833', '4', '2.89')
  │    │    │    │    │    └── ('17.59', '29483', '2', '18.93')
@@ -1345,10 +1345,10 @@ upsert transactiondetails
  │    │    │    │         ├── 1 [as="?column?":15]
  │    │    │    │         ├── false [as=bool:16]
  │    │    │    │         ├── '2017-05-10 13:00:00+00' [as=current_timestamp:17]
- │    │    │    │         ├── detail_c:70::STRING::INT8 [as=int8:18, outer=(70), immutable]
- │    │    │    │         ├── detail_q:71::STRING::INT8 [as=int8:19, outer=(71), immutable]
- │    │    │    │         ├── detail_s:72::STRING::DECIMAL(10,4) [as=numeric:20, outer=(72), immutable]
- │    │    │    │         └── detail_b:69::STRING::DECIMAL(10,4) [as=numeric:21, outer=(69), immutable]
+ │    │    │    │         ├── detail_c:67::STRING::INT8 [as=int8:18, outer=(67), immutable]
+ │    │    │    │         ├── detail_q:68::STRING::INT8 [as=int8:19, outer=(68), immutable]
+ │    │    │    │         ├── detail_s:69::STRING::DECIMAL(10,4) [as=numeric:20, outer=(69), immutable]
+ │    │    │    │         └── detail_b:66::STRING::DECIMAL(10,4) [as=numeric:21, outer=(66), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=numeric:20, outer=(20)]
  │    │    │         │    └── numeric:20
@@ -1366,36 +1366,35 @@ upsert transactiondetails
  │    │    │              └── current_timestamp:17
  │    │    └── filters (true)
  │    └── projections
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":15 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:39, outer=(15,25)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:16 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:40, outer=(16,25,26)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:17 ELSE transactiondetails.transactiondate:27 END [as=upsert_transactiondate:41, outer=(17,25,27)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:18 ELSE transactiondetails.cardid:28 END [as=upsert_cardid:42, outer=(18,25,28)]
- │         └── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount_cast:24 ELSE 0.0000 END [as=upsert_discount:45, outer=(24,25)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":15 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:37, outer=(15,25)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:16 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:38, outer=(16,25,26)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:17 ELSE transactiondetails.transactiondate:27 END [as=upsert_transactiondate:39, outer=(17,25,27)]
+ │         └── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:18 ELSE transactiondetails.cardid:28 END [as=upsert_cardid:40, outer=(18,25,28)]
  └── f-k-checks
       ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
       │    └── anti-join (lookup transactions)
-      │         ├── columns: dealerid:46 isbuy:47 transactiondate:48
-      │         ├── key columns: [46 47 48] = [49 50 51]
+      │         ├── columns: dealerid:43 isbuy:44 transactiondate:45
+      │         ├── key columns: [43 44 45] = [46 47 48]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 2]
       │         ├── with-scan &2
-      │         │    ├── columns: dealerid:46 isbuy:47 transactiondate:48
+      │         │    ├── columns: dealerid:43 isbuy:44 transactiondate:45
       │         │    ├── mapping:
-      │         │    │    ├──  upsert_dealerid:39 => dealerid:46
-      │         │    │    ├──  upsert_isbuy:40 => isbuy:47
-      │         │    │    └──  upsert_transactiondate:41 => transactiondate:48
+      │         │    │    ├──  upsert_dealerid:37 => dealerid:43
+      │         │    │    ├──  upsert_isbuy:38 => isbuy:44
+      │         │    │    └──  upsert_transactiondate:39 => transactiondate:45
       │         │    └── cardinality: [1 - 2]
       │         └── filters (true)
       └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
            └── anti-join (lookup cards)
-                ├── columns: cardid:60
-                ├── key columns: [60] = [61]
+                ├── columns: cardid:57
+                ├── key columns: [57] = [58]
                 ├── lookup columns are key
                 ├── cardinality: [0 - 2]
                 ├── with-scan &2
-                │    ├── columns: cardid:60
+                │    ├── columns: cardid:57
                 │    ├── mapping:
-                │    │    └──  upsert_cardid:42 => cardid:60
+                │    │    └──  upsert_cardid:40 => cardid:57
                 │    └── cardinality: [1 - 2]
                 └── filters (true)
 


### PR DESCRIPTION
We just merged 12ad4b6316b97e56f812498a18e7c4cde8a18a20 which fixed overly-permissive check in `findExistingColInList`, but it looks like we made it too restrictive now - hibernate roachtest surfaced a query which started failing. This commit relaxes the requirement of Identical types to Equivalent.

Fixes: #165002.
Release note: None