### PR TITLE
stats: use worker pool of two goroutines for auto stats collection

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -121,7 +121,7 @@ const (
 	defaultConcurrencyVCPURequirement = 2
 	// We don't recommend running on fewer than 4 vCPUs, but we do have clusters
 	// with 2 vCPUs.
-	minViableProcs = 2
+	minViableProcs = 4
 )
 
 var automaticFullStatsConcurrencyLimit = settings.RegisterIntSetting(

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -230,10 +230,10 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 				ctx, nil /* job */, n.p, n.Name == jobspb.AutoPartialStatsName, n.p.ExecCfg().JobRegistry,
 				details.Table.ID,
 			); err != nil {
-				if errors.Is(err, stats.ConcurrentCreateStatsError) {
+				if stats.IsConcurrentCreateStatsError(err) {
 					n.handleConcurrentStatsErr(ctx, details.Table.ID)
 					if !errorOnConcurrentCreateStats.Get(n.p.ExecCfg().SV()) {
-						log.Dev.Infof(ctx, "concurrent create stats job found, skipping")
+						log.Dev.Infof(ctx, "table ID %d: %s, skipping", details.Table.ID, err)
 						return nil
 					}
 				}
@@ -278,10 +278,10 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 				log.Dev.Warningf(ctx, "failed to cleanup StartableJob: %v", cleanupErr)
 			}
 		}
-		if errors.Is(err, stats.ConcurrentCreateStatsError) {
+		if stats.IsConcurrentCreateStatsError(err) {
 			n.handleConcurrentStatsErr(ctx, details.Table.ID)
 			if !errorOnConcurrentCreateStats.Get(n.p.ExecCfg().SV()) {
-				log.Dev.Infof(ctx, "concurrent create stats job found, skipping")
+				log.Dev.Infof(ctx, "table ID %d: %s, skipping", details.Table.ID, err)
 				return nil
 			}
 		}
@@ -291,7 +291,7 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 		return err
 	}
 	if err = job.AwaitCompletion(ctx); err != nil {
-		if errors.Is(err, stats.ConcurrentCreateStatsError) {
+		if stats.IsConcurrentCreateStatsError(err) {
 			// Delete the job so users don't see it and get confused by the error.
 			if delErr := n.p.ExecCfg().JobRegistry.DeleteTerminalJobByID(ctx, job.ID()); delErr != nil {
 				log.Dev.Warningf(ctx, "failed to delete job: %v", delErr)
@@ -406,7 +406,7 @@ func (n *createStatsNode) checkConcurrencyLimit(
 	if row[0] != tree.DNull {
 		globalJobIDs = tree.MustBeDArray(row[0]).Array
 		if len(globalJobIDs) >= globalLimit {
-			return stats.ConcurrentCreateStatsError
+			return stats.ConcurrentCreateStatsLimitError
 		}
 	}
 	// We can start this auto stats job, so claim the locks accordingly.
@@ -1251,7 +1251,7 @@ func checkRunningJobsInTxnImpl(
 	}
 
 	if exists {
-		return stats.ConcurrentCreateStatsError
+		return stats.ConcurrentCreateStatsLimitError
 	}
 
 	return nil

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -1102,7 +1102,7 @@ func (r *Refresher) maybeRefreshStats(
 		// ConcurrentCreateStatsError is expected, so simply ignore it (it's
 		// handled by RescheduleRefresh called by the stats job). Log all
 		// others.
-		if errors.Is(err, ConcurrentCreateStatsError) {
+		if IsConcurrentCreateStatsError(err) {
 			return
 		}
 		log.Dev.Warningf(ctx, "failed to create statistics on table %d: %v", tableID, err)
@@ -1194,9 +1194,26 @@ type concurrentCreateStatisticsError struct{}
 var _ error = concurrentCreateStatisticsError{}
 
 func (concurrentCreateStatisticsError) Error() string {
-	return "another CREATE STATISTICS job is already running"
+	return "another automatic CREATE STATISTICS job is already running on this table"
 }
 
 // ConcurrentCreateStatsError is reported when two CREATE STATISTICS jobs
-// are issued concurrently. This is a sentinel error.
+// are issued concurrently on the same table. This is a sentinel error.
 var ConcurrentCreateStatsError error = concurrentCreateStatisticsError{}
+
+type concurrentCreateStatsLimitError struct{}
+
+var _ error = concurrentCreateStatsLimitError{}
+
+func (concurrentCreateStatsLimitError) Error() string {
+	return "global limit on concurrent automatic CREATE STATISTICS jobs has been reached"
+}
+
+// ConcurrentCreateStatsError is reported when the limit on the global
+// concurrency of automatic CREATE STATISTICS jobs has been reached. This is a
+// sentinel error.
+var ConcurrentCreateStatsLimitError error = concurrentCreateStatsLimitError{}
+
+func IsConcurrentCreateStatsError(err error) bool {
+	return errors.Is(err, ConcurrentCreateStatsError) || errors.Is(err, ConcurrentCreateStatsLimitError)
+}

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -340,6 +340,15 @@ type settingOverride struct {
 	settings catpb.AutoStatsSettings
 }
 
+// refreshWorkItem contains the parameters needed to execute a stats refresh
+// on a specific table. It is sent from the maybeRefreshStats goroutine to
+// worker goroutines via the refreshWork channel.
+type refreshWorkItem struct {
+	tableID   descpb.ID
+	asOf      time.Duration
+	isPartial bool
+}
+
 // TableStatsTestingKnobs contains testing knobs for table statistics.
 type TableStatsTestingKnobs struct {
 	// DisableInitialTableCollection, if set, indicates that the "initial table
@@ -622,6 +631,50 @@ func (r *Refresher) Start(
 							return
 						}
 
+						// Create an unbuffered channel for this batch of
+						// refresh work. Sending to this channel will block
+						// until a worker is available.
+						refreshWork := make(chan refreshWorkItem)
+						// Use a separate wait group to block until all workers
+						// exit.
+						var workersWG sync.WaitGroup
+						defer func() {
+							close(refreshWork)
+							workersWG.Wait()
+							timer.Reset(refreshInterval)
+						}()
+
+						// TODO(yuzefovich): consider starting more workers in
+						// the future, configurable based on a cluster setting.
+						numWorkers := 2
+						if len(mutationCounts) <= 1 {
+							numWorkers = 1
+						}
+						// Assuming every worker on each node tries to run an
+						// auto full job, we'll have 2 * N concurrent attempts
+						// (where N is the number of nodes in the cluster). Yet
+						// the cluster-wide concurrency limit is determined by
+						// the cluster setting which is P / 2 (where P is the
+						// number of vCPUs on the machine), so we are very
+						// likely to hit the limit on medium to large clusters.
+						//
+						// To partially alleviate this, we will short-circuit
+						// all but first workers whenever
+						// ConcurrentCreateStatsLimitError is encountered.
+						for i := 0; i < numWorkers; i++ {
+							exitOnLimitError := i > 0
+							workersWG.Add(1)
+							if err := stopper.RunAsyncTask(
+								ctx, "stats-refresh-worker", func(ctx context.Context) {
+									defer workersWG.Done()
+									r.refreshWorker(ctx, refreshWork, exitOnLimitError)
+								}); err != nil {
+								workersWG.Done()
+								log.Dev.Errorf(ctx, "failed to start stats refresh worker: %v", err)
+								return
+							}
+						}
+
 						for tableID, rowsAffected := range mutationCounts {
 							var desc catalog.TableDescriptor
 							now := timeutil.Now()
@@ -664,6 +717,7 @@ func (r *Refresher) Start(
 							}
 							r.maybeRefreshStats(
 								ctx,
+								refreshWork,
 								tableID,
 								explicitSettings,
 								rowsAffected,
@@ -673,14 +727,13 @@ func (r *Refresher) Start(
 							)
 
 							select {
-							case <-ctx.Done():
-								return
 							case <-r.drainAutoStats:
+								return
+							case <-ctx.Done():
 								return
 							default:
 							}
 						}
-						timer.Reset(refreshInterval)
 					}); err != nil {
 					r.startedTasksWG.Done()
 					log.Dev.Errorf(ctx, "failed to start async stats task: %v", err)
@@ -1042,6 +1095,7 @@ func (r *Refresher) mustDoFullRefresh(
 // for this table.
 func (r *Refresher) maybeRefreshStats(
 	ctx context.Context,
+	refreshWork chan<- refreshWorkItem,
 	tableID descpb.ID,
 	explicitSettings *catpb.AutoStatsSettings,
 	rowsAffected int64,
@@ -1098,14 +1152,48 @@ func (r *Refresher) maybeRefreshStats(
 		isPartial = true
 	}
 
-	if err := r.refreshStats(ctx, tableID, asOf, isPartial); err != nil {
-		// ConcurrentCreateStatsError is expected, so simply ignore it (it's
-		// handled by RescheduleRefresh called by the stats job). Log all
-		// others.
-		if IsConcurrentCreateStatsError(err) {
+	// Send work to one of the worker goroutines. This will block until a worker
+	// is available to process the request.
+	select {
+	case refreshWork <- refreshWorkItem{
+		tableID:   tableID,
+		asOf:      asOf,
+		isPartial: isPartial,
+	}:
+	case <-r.drainAutoStats:
+	case <-ctx.Done():
+	}
+}
+
+// refreshWorker is the body of the worker goroutine that actually collects auto
+// table stats. It exits whenever the refreshWork channel is closed. If
+// exitOnLimitError is true, then it'll also exit if
+// ConcurrentCreateStatsLimitError is observed.
+func (r *Refresher) refreshWorker(
+	ctx context.Context, refreshWork <-chan refreshWorkItem, exitOnLimitError bool,
+) {
+	for {
+		select {
+		case work, ok := <-refreshWork:
+			if !ok {
+				return
+			}
+			if err := r.refreshStats(ctx, work.tableID, work.asOf, work.isPartial); err != nil {
+				// ConcurrentCreateStatsError is expected, so simply ignore it
+				// (it's handled by RescheduleRefresh called by the stats job).
+				// Log all others.
+				if !IsConcurrentCreateStatsError(err) {
+					log.Dev.Warningf(ctx, "failed to create statistics on table %d: %v", work.tableID, err)
+				}
+				if exitOnLimitError && errors.Is(err, ConcurrentCreateStatsLimitError) {
+					return
+				}
+			}
+		case <-r.drainAutoStats:
+			return
+		case <-ctx.Done():
 			return
 		}
-		log.Dev.Warningf(ctx, "failed to create statistics on table %d: %v", tableID, err)
 	}
 }
 

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -38,6 +38,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testMaybeRefreshStats is a test helper that calls maybeRefreshStats and
+// processes any refresh work synchronously.
+func testMaybeRefreshStats(
+	r *Refresher,
+	ctx context.Context,
+	tableID descpb.ID,
+	explicitSettings *catpb.AutoStatsSettings,
+	rowsAffected int64,
+	asOf time.Duration,
+	partialStatsEnabled bool,
+	fullStatsEnabled bool,
+) {
+	// Create a buffered channel with capacity 1 to receive work.
+	refreshWork := make(chan refreshWorkItem, 1)
+	defer close(refreshWork)
+
+	// Call maybeRefreshStats which may send work to the channel.
+	r.maybeRefreshStats(
+		ctx, refreshWork, tableID, explicitSettings, rowsAffected, asOf,
+		partialStatsEnabled, fullStatsEnabled,
+	)
+
+	// Process any work that was sent.
+	select {
+	case work := <-refreshWork:
+		_ = r.refreshStats(ctx, work.tableID, work.asOf, work.isPartial)
+	default:
+		// No work was sent, which is fine.
+	}
+}
+
 func TestMaybeRefreshStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -83,7 +114,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// There are no stats yet, so this must refresh the full statistics on table t
 	// even though rowsAffected=0.
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), nil /* explicitSettings */, 0, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -97,7 +128,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// Try to refresh again. With rowsAffected=0, the probability of a refresh
 	// is 0, so refreshing will not succeed.
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), nil /* explicitSettings */, 0, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -109,7 +140,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// occurring, but partial stats must be refreshed.
 	minStaleRows := int64(100000000)
 	explicitSettings := catpb.AutoStatsSettings{MinStaleRows: &minStaleRows}
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), &explicitSettings, 10, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -119,7 +150,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// Do the same for partialMinStaleRows to also prevent a partial refresh.
 	explicitSettings.PartialMinStaleRows = &minStaleRows
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), &explicitSettings, 10, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -132,7 +163,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// Partial stats will still be refreshed.
 	fractionStaleRows := float64(100000000)
 	explicitSettings = catpb.AutoStatsSettings{FractionStaleRows: &fractionStaleRows}
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), &explicitSettings, 10, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -142,7 +173,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// Do the same for partialFractionStaleRows to also prevent a partial refresh.
 	explicitSettings.PartialFractionStaleRows = &fractionStaleRows
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), &explicitSettings, 10, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -154,7 +185,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// updated than exist in the table, the probability of a refresh is 100%.
 	// Partial stats should not be refreshed since full stats are being refreshed,
 	// and stale partial stats should be cleared.
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descA.GetID(), nil /* explicitSettings */, 10, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -166,7 +197,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// system.table_statistics should succeed.
 	descRoleOptions :=
 		desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "system", "role_options")
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descRoleOptions.GetID(), nil /* explicitSettings */, 10000, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -177,7 +208,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// Auto stats collection on system.lease should fail (no stats should be collected).
 	descLease :=
 		desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "system", "lease")
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descLease.GetID(), nil /* explicitSettings */, 10000, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -188,7 +219,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// Auto stats collection on system.table_statistics should fail (no stats should be collected).
 	descTableStats :=
 		desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "system", "table_statistics")
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descTableStats.GetID(), nil /* explicitSettings */, 10000, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -200,7 +231,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// enqueuing the attempt.
 	// TODO(rytaft): Should not enqueue views to begin with.
 	descVW := desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "t", "vw")
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, descVW.GetID(), nil /* explicitSettings */, 0, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -569,7 +600,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// average time between refreshes, so this call is not required to refresh
 	// the statistics on table t. With rowsAffected=0, the probability of refresh
 	// is 0.
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, table.GetID(), nil /* explicitSettings */, 0, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -620,7 +651,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// on table t even though rowsAffected=0. After refresh, only 10 stats should
 	// remain (5 from column k and 5 from column v), since the old stats on k
 	// and v were deleted.
-	refresher.maybeRefreshStats(
+	testMaybeRefreshStats(refresher,
 		ctx, table.GetID(), nil /* explicitSettings */, 0, /* rowsAffected */
 		time.Microsecond /* asOf */, true /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)
@@ -769,7 +800,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 	r := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */, false /* readOnlyTenant */)
 
 	// Try to refresh stats on a table that doesn't exist.
-	r.maybeRefreshStats(
+	testMaybeRefreshStats(r,
 		ctx, 100 /* tableID */, nil /* explicitSettings */, math.MaxInt32,
 		time.Microsecond /* asOfTime */, false /* partialStatsEnabled */, true, /* fullStatsEnabled */
 	)

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -1061,7 +1061,7 @@ func runAutoStatsJob(
 	beforeCount := getNumberOfTableStats(t, sqlDB, tableName, statsName)
 
 	if shouldError {
-		sqlDB.ExpectErr(t, "another CREATE STATISTICS job is already running", query)
+		sqlDB.ExpectNonNilErr(t, query)
 		return
 	}
 


### PR DESCRIPTION
See each commit for details.

Fixes: #165271.
Release note: None