### PR TITLE
spanconfigccl: deflake spanconfig sql translator datadriven test

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -222,8 +222,7 @@ func TestDataDriven(t *testing.T) {
 					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn)
 					var err error
 					records, err = sqlTranslator.Translate(ctx, descIDs, generateSystemSpanConfigs)
-					require.NoError(t, err)
-					return nil
+					return err
 				})
 				require.NoError(t, err)
 


### PR DESCRIPTION
DescsTxn has a built-in retry loop for retriable errors such as ReadWithinUncertaintyIntervalError. However, the test was calling require.NoError which caused the test flake.
Fix is to return the error to be handled by DescsTxn instead of an early panic.

Fixes: #165565

Release note: None