### PR TITLE
bulkmerge: tolerate identical duplicates from checkpoint-and-resume overlap

### DIFF
--- a/pkg/sql/bulkmerge/BUILD.bazel
+++ b/pkg/sql/bulkmerge/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/jobs",
         "//pkg/keys",
         "//pkg/kv/bulk",
+        "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/sql/bulkmerge/merge.go
+++ b/pkg/sql/bulkmerge/merge.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -66,6 +67,20 @@ type MergeOptions struct {
 	OnProgress func(context.Context, *execinfrapb.ProducerMetadata) error
 }
 
+// MergeResult contains the output of a distributed merge operation.
+type MergeResult struct {
+	// SSTs contains output SSTs from intermediate merge iterations.
+	// Empty for the final iteration which writes directly to KV.
+	SSTs []execinfrapb.BulkMergeSpec_SST
+
+	// IngestSummary contains the BulkOpSummary from the final merge
+	// iteration's KV ingest. It reflects the actual row count written
+	// to KV (excluding skipped identical duplicates from
+	// checkpoint-and-resume overlap). Only populated for the final
+	// iteration.
+	IngestSummary kvpb.BulkOpSummary
+}
+
 // Merge creates and waits on a DistSQL flow that merges the provided SSTs into
 // the ranges defined by the input splits.
 func Merge(
@@ -75,26 +90,40 @@ func Merge(
 	spans []roachpb.Span,
 	genOutputURIAndRecordPrefix func(sqlInstance base.SQLInstanceID) (string, error),
 	opts MergeOptions,
-) ([]execinfrapb.BulkMergeSpec_SST, error) {
+) (MergeResult, error) {
 	logMergeInputs(ctx, ssts, opts.Iteration, opts.MaxIterations)
 
 	// Proactive availability gate: wait for all required nodes to be alive
 	// before planning or executing the merge.
 	if err := waitForRequiredInstances(ctx, execCtx, ssts); err != nil {
-		return nil, err
+		return MergeResult{}, err
 	}
 
 	plan, planCtx, err := newBulkMergePlan(ctx, execCtx, ssts, spans, genOutputURIAndRecordPrefix, opts)
 	if err != nil {
-		return nil, err
+		return MergeResult{}, err
 	}
 
+	var mergeResult MergeResult
 	var result execinfrapb.BulkMergeSpec_Output
 	rowWriter := sql.NewCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
 		return protoutil.Unmarshal([]byte(*row[0].(*tree.DBytes)), &result)
 	})
 
-	sqlReceiver := makeMergeReceiver(ctx, execCtx, rowWriter, opts.OnProgress)
+	// Wrap the caller's OnProgress callback to intercept the KV ingest
+	// summary emitted by the merge processor at the end of the final
+	// iteration.
+	onProgress := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
+		if meta.BulkProcessorProgress != nil {
+			mergeResult.IngestSummary.Add(meta.BulkProcessorProgress.BulkSummary)
+		}
+		if opts.OnProgress != nil {
+			return opts.OnProgress(ctx, meta)
+		}
+		return nil
+	}
+
+	sqlReceiver := makeMergeReceiver(ctx, execCtx, rowWriter, onProgress)
 	defer sqlReceiver.Release()
 
 	execCtx.DistSQLPlanner().Run(
@@ -108,12 +137,12 @@ func Merge(
 	)
 
 	if err := rowWriter.Err(); err != nil {
-		return nil, err
+		return MergeResult{}, err
 	}
 
 	if opts.Iteration == opts.MaxIterations {
 		// Final iteration writes directly to KV; no SST outputs expected.
-		return nil, nil
+		return mergeResult, nil
 	}
 
 	// Sort the SSTs by their range start key. Ingest requires that SSTs are
@@ -123,7 +152,8 @@ func Merge(
 		return bytes.Compare(i.StartKey, j.StartKey)
 	})
 
-	return result.SSTs, nil
+	mergeResult.SSTs = result.SSTs
+	return mergeResult, nil
 }
 
 // makeMergeReceiver creates a DistSQLReceiver for the merge flow. If an
@@ -256,7 +286,7 @@ func init() {
 		onProgress func(context.Context, *execinfrapb.ProducerMetadata) error,
 		memoryMonitor execinfrapb.BulkMergeSpec_MemoryMonitor,
 	) ([]execinfrapb.BulkMergeSpec_SST, error) {
-		return Merge(ctx, execCtx, ssts, spans, genOutputURIAndRecordPrefix, MergeOptions{
+		result, err := Merge(ctx, execCtx, ssts, spans, genOutputURIAndRecordPrefix, MergeOptions{
 			Iteration:         iteration,
 			MaxIterations:     maxIterations,
 			WriteTimestamp:    writeTimestamp,
@@ -264,5 +294,6 @@ func init() {
 			MemoryMonitor:     memoryMonitor,
 			OnProgress:        onProgress,
 		})
+		return result.SSTs, err
 	})
 }

--- a/pkg/sql/bulkmerge/merge_processor.go
+++ b/pkg/sql/bulkmerge/merge_processor.go
@@ -377,10 +377,15 @@ func (m *bulkMergeProcessor) processMergedData(
 	duplicateInjected := false
 
 	// When enforcing uniqueness with multiple SSTs, keys are suffixed to prevent
-	// shadowing. Track previous base key for duplicate detection.
+	// shadowing. Track previous base key and value for duplicate detection.
 	var prevBaseKeyBuf []byte
+	var prevValBuf []byte
 	var baseKey roachpb.Key
 	var keyToWrite storage.MVCCKey
+	// injectedVal holds a value from the InjectDuplicateKey testing hook.
+	// When non-nil, it replaces the iterator value for the replayed key so
+	// the duplicate carries the test-specified value.
+	var injectedVal []byte
 
 	for {
 		ok, err := iter.Valid()
@@ -396,13 +401,21 @@ func (m *bulkMergeProcessor) processMergedData(
 		if err != nil {
 			return execinfrapb.BulkMergeSpec_Output{}, err
 		}
+		if injectedVal != nil {
+			val = injectedVal
+			injectedVal = nil
+		}
 
 		// Extract base key and check for duplicates when using suffixed iterators.
-		baseKey, keyToWrite, prevBaseKeyBuf, err = m.extractKeyAndCheckDuplicate(
-			key, val, prevBaseKeyBuf,
-		)
+		var skip bool
+		baseKey, keyToWrite, prevBaseKeyBuf, prevValBuf, skip, err =
+			m.extractKeyAndCheckDuplicate(key, val, prevBaseKeyBuf, prevValBuf)
 		if err != nil {
 			return execinfrapb.BulkMergeSpec_Output{}, err
+		}
+		if skip {
+			iter.NextKey()
+			continue
 		}
 
 		// Check span boundary using the base key (without suffix).
@@ -436,10 +449,12 @@ func (m *bulkMergeProcessor) processMergedData(
 		}
 
 		// Testing hook: if duplicate requested and not already injected for this
-		// key, skip advancing the iterator so the key is processed again.
+		// key, skip advancing the iterator so the key is processed again with
+		// the hook-provided value.
 		if !duplicateInjected && knobs != nil && knobs.InjectDuplicateKey != nil {
-			if knobs.InjectDuplicateKey(m.spec.Iteration, m.spec.MaxIterations) {
+			if v := knobs.InjectDuplicateKey(m.spec.Iteration, m.spec.MaxIterations); v != nil {
 				duplicateInjected = true
+				injectedVal = v
 				continue
 			}
 		}
@@ -453,11 +468,19 @@ func (m *bulkMergeProcessor) processMergedData(
 
 // extractKeyAndCheckDuplicate extracts the base key from a potentially
 // suffixed key and checks for duplicates when enforcing uniqueness.
+//
+// When a duplicate base key is found, the value is compared with the previous
+// entry. Identical duplicates (same key and value) are benign — they arise
+// from checkpoint-and-resume overlap where some input rows are re-processed,
+// producing SSTs that partially overlap with previously checkpointed SSTs.
+// These are signaled by returning skip=true so the caller can advance past
+// them. A true uniqueness violation (same key, different value) returns a
+// DuplicateKeyError.
 func (m *bulkMergeProcessor) extractKeyAndCheckDuplicate(
-	key storage.MVCCKey, val []byte, prevBaseKeyBuf []byte,
-) (roachpb.Key, storage.MVCCKey, []byte, error) {
+	key storage.MVCCKey, val []byte, prevBaseKeyBuf []byte, prevValBuf []byte,
+) (roachpb.Key, storage.MVCCKey, []byte, []byte, bool, error) {
 	if !m.spec.EnforceUniqueness {
-		return key.Key, key, prevBaseKeyBuf, nil
+		return key.Key, key, prevBaseKeyBuf, prevValBuf, false, nil
 	}
 
 	var baseKey roachpb.Key
@@ -468,7 +491,7 @@ func (m *bulkMergeProcessor) extractKeyAndCheckDuplicate(
 		var err error
 		baseKey, err = removeKeySuffix(key.Key)
 		if err != nil {
-			return nil, storage.MVCCKey{}, prevBaseKeyBuf, err
+			return nil, storage.MVCCKey{}, prevBaseKeyBuf, prevValBuf, false, err
 		}
 		keyToWrite = storage.MVCCKey{Key: baseKey, Timestamp: key.Timestamp}
 	} else {
@@ -478,11 +501,19 @@ func (m *bulkMergeProcessor) extractKeyAndCheckDuplicate(
 
 	// Check for duplicates.
 	if len(prevBaseKeyBuf) > 0 && baseKey.Equal(prevBaseKeyBuf) {
-		return nil, storage.MVCCKey{}, prevBaseKeyBuf, kvserverbase.NewDuplicateKeyError(baseKey, val)
+		if bytes.Equal(val, prevValBuf) {
+			// Identical duplicate from checkpoint-and-resume overlap. The same
+			// input row was processed in both the previous and current run,
+			// producing identical KVs in separate SSTs. Safe to skip.
+			return nil, storage.MVCCKey{}, prevBaseKeyBuf, prevValBuf, true, nil
+		}
+		return nil, storage.MVCCKey{}, prevBaseKeyBuf, prevValBuf, false,
+			kvserverbase.NewDuplicateKeyError(baseKey, val)
 	}
 
 	prevBaseKeyBuf = append(prevBaseKeyBuf[:0], baseKey...)
-	return baseKey, keyToWrite, prevBaseKeyBuf, nil
+	prevValBuf = append(prevValBuf[:0], val...)
+	return baseKey, keyToWrite, prevBaseKeyBuf, prevValBuf, false, nil
 }
 
 func (m *bulkMergeProcessor) ingestFinalIteration(

--- a/pkg/sql/bulkmerge/merge_processor.go
+++ b/pkg/sql/bulkmerge/merge_processor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -95,6 +96,11 @@ type bulkMergeProcessor struct {
 	// rpcMemAcct reserves memory for estimated in-flight RPC transport
 	// buffers when streaming remote SST files.
 	rpcMemAcct mon.BoundAccount
+	// kvIngestSummary accumulates the BulkOpSummary from the SSTBatcher
+	// during the final merge iteration. This tracks the actual number of
+	// rows ingested into KV (excluding skipped duplicates) and is emitted
+	// as metadata when the processor finishes draining.
+	kvIngestSummary kvpb.BulkOpSummary
 }
 
 type mergeProcessorInput struct {
@@ -161,6 +167,17 @@ func (m *bulkMergeProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMe
 		switch {
 		case row == nil && meta == nil:
 			m.MoveToDraining(nil /* err */)
+			// All input consumed. If this was the final iteration, emit
+			// the accumulated KV ingest summary as metadata so the caller
+			// can use the actual ingested row count rather than the
+			// map-phase count (which includes skipped duplicates).
+			if m.isFinalIteration() {
+				return nil, &execinfrapb.ProducerMetadata{
+					BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
+						BulkSummary: m.kvIngestSummary,
+					},
+				}
+			}
 		case meta != nil && meta.Err != nil:
 			m.MoveToDraining(meta.Err)
 		case meta != nil:
@@ -178,6 +195,10 @@ func (m *bulkMergeProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMe
 		}
 	}
 	return nil, m.DrainHelper()
+}
+
+func (m *bulkMergeProcessor) isFinalIteration() bool {
+	return m.spec.Iteration == m.spec.MaxIterations
 }
 
 func (m *bulkMergeProcessor) handleRow(row rowenc.EncDatumRow) (rowenc.EncDatumRow, error) {
@@ -216,13 +237,10 @@ func (m *bulkMergeProcessor) Start(ctx context.Context) {
 	ctx = m.StartInternal(ctx, "bulkMergeProcessor")
 	m.input.Start(ctx)
 
-	// Infer whether this is the final iteration from the spec fields.
 	// Non-final iterations only merge local SSTs to reduce cross-node traffic.
 	// This creates larger merged files locally before the final cross-node merge.
-	isFinal := m.spec.Iteration == m.spec.MaxIterations
-
 	var err error
-	if !isFinal {
+	if !m.isFinalIteration() {
 		localInstanceID := m.flowCtx.NodeID.SQLInstanceID()
 		log.Dev.Infof(ctx, "local iteration %d: filtering to local SSTs from instance %d",
 			m.spec.Iteration, localInstanceID)
@@ -334,7 +352,7 @@ func (m *bulkMergeProcessor) mergeSSTs(
 		m.iter.SeekGE(storage.MVCCKey{Key: mergeSpan.Key})
 	}
 
-	if m.spec.Iteration == m.spec.MaxIterations {
+	if m.isFinalIteration() {
 		return m.ingestFinalIteration(ctx, m.iter, mergeSpan)
 	}
 
@@ -554,7 +572,12 @@ func (m *bulkMergeProcessor) ingestFinalIteration(
 
 	writer := newKVStorageWriter(batcher, writeTS)
 	defer writer.Close(ctx)
-	return m.processMergedData(ctx, iter, mergeSpan, writer)
+	output, err := m.processMergedData(ctx, iter, mergeSpan, writer)
+	if err != nil {
+		return output, err
+	}
+	m.kvIngestSummary.Add(batcher.GetSummary())
+	return output, nil
 }
 
 // resolveMemoryMonitor returns the BytesMonitor indicated by the given

--- a/pkg/sql/bulkmerge/merge_test.go
+++ b/pkg/sql/bulkmerge/merge_test.go
@@ -783,11 +783,24 @@ func writeSpecificKeys(
 	codec keys.SQLCodec,
 ) {
 	t.Helper()
+	writeSpecificKeysWithValuePrefix(t, ctx, batcher, keyIndices, ts, codec, "value")
+}
+
+func writeSpecificKeysWithValuePrefix(
+	t *testing.T,
+	ctx context.Context,
+	batcher *bulksst.Writer,
+	keyIndices []int,
+	ts hlc.Timestamp,
+	codec keys.SQLCodec,
+	valuePrefix string,
+) {
+	t.Helper()
 	for _, i := range keyIndices {
 		keyStr := fmt.Sprintf("key-%d", i)
 		key := storageutils.PointKey(codec, keyStr, int(ts.WallTime))
 		// Properly encode the value as an MVCC value.
-		mvccVal := roachpb.MakeValueFromBytes([]byte(fmt.Sprintf("value-%d", i)))
+		mvccVal := roachpb.MakeValueFromBytes([]byte(fmt.Sprintf("%s-%d", valuePrefix, i)))
 		encMVCCVal, err := storage.EncodeMVCCValue(storage.MVCCValue{Value: mvccVal})
 		require.NoError(t, err)
 		require.NoError(t, batcher.AddMVCCKey(ctx, key, encMVCCVal))
@@ -795,8 +808,12 @@ func writeSpecificKeys(
 	require.NoError(t, batcher.CloseWithError(ctx))
 }
 
-// TestCrossSSTDuplicateHandling verifies that duplicate keys across SSTs are
-// detected when EnforceUniqueness is true and allowed when it is false.
+// TestCrossSSTDuplicateHandling verifies duplicate key behavior across SSTs
+// under various configurations of EnforceUniqueness.
+//
+// When EnforceUniqueness is true, identical duplicates (same key and value)
+// are tolerated because they arise naturally from checkpoint-and-resume
+// overlap. Only true conflicts (same key, different value) produce an error.
 func TestCrossSSTDuplicateHandling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -804,12 +821,22 @@ func TestCrossSSTDuplicateHandling(t *testing.T) {
 	testCases := []struct {
 		name              string
 		enforceUniqueness bool
-		expectDupError    bool
+		// useDifferentValues causes the overlapping key to have a different
+		// value in the second SST, simulating a real uniqueness violation
+		// rather than a checkpoint-and-resume repeat.
+		useDifferentValues bool
+		expectDupError     bool
 	}{
 		{
-			name:              "unique_enforcement_detects_duplicates",
+			name:              "identical_duplicates_skipped_with_uniqueness",
 			enforceUniqueness: true,
-			expectDupError:    true,
+			expectDupError:    false,
+		},
+		{
+			name:               "different_value_duplicates_detected_with_uniqueness",
+			enforceUniqueness:  true,
+			useDifferentValues: true,
+			expectDupError:     true,
 		},
 		{
 			name:              "non_unique_allows_duplicates",
@@ -856,7 +883,13 @@ func TestCrossSSTDuplicateHandling(t *testing.T) {
 			require.NoError(t, err)
 			fileAllocator2 := bulksst.NewExternalFileAllocator(store2, prefixURI2, s.Clock())
 			batcher2 := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator2)
-			writeSpecificKeys(t, ctx, batcher2, []int{2, 3, 4}, writeTS, s.Codec())
+			if tc.useDifferentValues {
+				writeSpecificKeysWithValuePrefix(
+					t, ctx, batcher2, []int{2, 3, 4}, writeTS, s.Codec(), "other-value",
+				)
+			} else {
+				writeSpecificKeys(t, ctx, batcher2, []int{2, 3, 4}, writeTS, s.Codec())
+			}
 
 			// Combine SSTs from both allocators.
 			ssts1 := importToMerge(fileAllocator1.GetFileList())

--- a/pkg/sql/bulkmerge/merge_test.go
+++ b/pkg/sql/bulkmerge/merge_test.go
@@ -185,7 +185,7 @@ func TestDistributedMergeMultiPassIngestsIntoKV(t *testing.T) {
 	spans := []roachpb.Span{{Key: start, EndKey: end}}
 
 	// First iteration produces merged SSTs to external storage.
-	iter1Out, err := Merge(
+	iter1Result, err := Merge(
 		ctx,
 		jobExecCtx,
 		inputSSTs,
@@ -199,14 +199,14 @@ func TestDistributedMergeMultiPassIngestsIntoKV(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.NotEmpty(t, iter1Out)
+	require.NotEmpty(t, iter1Result.SSTs)
 
 	// Second (final) iteration ingests directly into KV.
 	writeTS := execCfg.Clock.Now()
-	iter2Out, err := Merge(
+	iter2Result, err := Merge(
 		ctx,
 		jobExecCtx,
-		iter1Out,
+		iter1Result.SSTs,
 		spans,
 		func(instanceID base.SQLInstanceID) (string, error) {
 			return fmt.Sprintf("nodelocal://%d/merge/iter-2/", instanceID), nil
@@ -218,7 +218,7 @@ func TestDistributedMergeMultiPassIngestsIntoKV(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Nil(t, iter2Out, "final iteration should not produce SST outputs")
+	require.Nil(t, iter2Result.SSTs, "final iteration should not produce SST outputs")
 
 	rows, err := s.DB().Scan(ctx, start, end, 0 /* maxRows */)
 	require.NoError(t, err)

--- a/pkg/sql/bulkmerge/testing_knobs.go
+++ b/pkg/sql/bulkmerge/testing_knobs.go
@@ -25,9 +25,13 @@ type TestingKnobs struct {
 		spec execinfrapb.BulkMergeSpec,
 	) error
 
-	// InjectDuplicateKey is called for each key during merge. Returning true
-	// causes the key to be written twice, injecting a duplicate for testing.
-	InjectDuplicateKey func(iteration, maxIteration int32) bool
+	// InjectDuplicateKey is called for each key during merge. Returning a
+	// non-nil value causes the current key to be written again with that
+	// value, injecting a duplicate for testing. The returned value should
+	// differ from the original to simulate a real uniqueness violation;
+	// identical values are treated as benign checkpoint-and-resume repeats
+	// and silently skipped.
+	InjectDuplicateKey func(iteration, maxIteration int32) []byte
 }
 
 var _ base.ModuleTestingKnobs = &TestingKnobs{}

--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//objstorage",

--- a/pkg/sql/bulksst/sink.go
+++ b/pkg/sql/bulksst/sink.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -90,7 +91,14 @@ type SSTSink struct {
 	writeTS          hlc.Timestamp
 	emittedFileCount int
 	onFlush          func(summary kvpb.BulkOpSummary)
-	pendingManifests []jobspb.BulkSSTManifest
+
+	// mu protects pendingManifests which is appended during auto-flush
+	// (on the data-processing goroutine) and consumed by
+	// ConsumeFlushManifests (on the progress-reporting goroutine).
+	mu struct {
+		syncutil.Mutex
+		pendingManifests []jobspb.BulkSSTManifest
+	}
 }
 
 var _ BulkSink = (*SSTSink)(nil)
@@ -160,7 +168,13 @@ func (s *SSTSink) Flush(ctx context.Context) error {
 func (s *SSTSink) SetOnFlush(fn func(summary kvpb.BulkOpSummary)) {
 	s.onFlush = fn
 	s.writer.SetOnFlush(func(summary kvpb.BulkOpSummary) {
-		s.pendingManifests = append(s.pendingManifests, s.collectNewManifests()...)
+		func() {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.mu.pendingManifests = append(
+				s.mu.pendingManifests, s.collectNewManifests()...,
+			)
+		}()
 		if s.onFlush != nil {
 			s.onFlush(summary)
 		}
@@ -174,11 +188,13 @@ func (s *SSTSink) IsEmpty() bool {
 
 // ConsumeFlushManifests implements the BulkSink interface.
 func (s *SSTSink) ConsumeFlushManifests() []jobspb.BulkSSTManifest {
-	if len(s.pendingManifests) == 0 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.mu.pendingManifests) == 0 {
 		return nil
 	}
-	out := s.pendingManifests
-	s.pendingManifests = nil
+	out := s.mu.pendingManifests
+	s.mu.pendingManifests = nil
 	return out
 }
 

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -430,10 +430,6 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 
-			// Read the total imported row count from the job progress
-			// summary. This is the single source of truth that correctly
-			// accounts for rows across all distImport attempts (including
-			// retries within ingestWithRetry) and previous Resume runs.
 			prog := r.job.Progress()
 			var totalImportedRows int64
 			if importProgress := prog.GetImport(); importProgress != nil {

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -532,6 +532,9 @@ func ingestKvs(
 // BulkOpSummary deltas from sink flushes, and collects SST manifests for
 // the distributed merge path. Each registered BulkSink installs an OnFlush
 // callback that updates flushedRows and accumulates summaries under the lock.
+// SST manifests are collected separately in formatProgress rather than in the
+// OnFlush callback, so that they are paired with an up-to-date resume
+// position.
 //
 // Resume position is reported as the minimum flushed row across all sinks
 // for each file, since a file can only be skipped on resume if all sinks
@@ -557,8 +560,8 @@ type importProgressTracker struct {
 	// never reset. Used to report the final result.
 	totalSummary kvpb.BulkOpSummary
 
-	// manifests collects SST file metadata from sink flushes for the
-	// distributed merge path. Drained by formatProgress.
+	// manifests collects SST file metadata for the distributed merge
+	// path. Drained from sinks and reported by formatProgress.
 	manifests []jobspb.BulkSSTManifest
 
 	// nodeID identifies this processor's node in progress reports.
@@ -612,7 +615,6 @@ func (ipt *importProgressTracker) registerSink(sink bulksst.BulkSink) {
 		copy(thisSinksFlushedRows, ipt.unflushedRows)
 		ipt.summary.Add(summary)
 		ipt.totalSummary.Add(summary)
-		ipt.manifests = append(ipt.manifests, sink.ConsumeFlushManifests()...)
 	})
 }
 
@@ -644,6 +646,16 @@ func (ipt *importProgressTracker) formatProgress() (
 	ipt.summary.Reset()
 
 	prog.NodeID = ipt.nodeID
+
+	// Drain manifests from all sinks. Manifests are collected here rather
+	// than in the OnFlush callback so that they are paired with an
+	// up-to-date ResumePos. The OnFlush callback fires during auto-flush
+	// which can occur mid-batch before recordKVBatch has updated
+	// unflushedRows, so collecting manifests there would associate them
+	// with a stale position.
+	for _, s := range ipt.sinks {
+		ipt.manifests = append(ipt.manifests, s.ConsumeFlushManifests()...)
+	}
 	if len(ipt.manifests) > 0 {
 		manifests := append([]jobspb.BulkSSTManifest(nil), ipt.manifests...)
 		ipt.manifests = nil

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -187,8 +187,10 @@ func distImport(
 		}
 	}
 
+	lastSummary := getLastImportSummary(job)
+	priorRunSummary := lastSummary.DeepCopy()
 	checkpoint := newImportCheckpointTracker(
-		len(from), getLastImportSummary(job), nil, /* manifestBuf */
+		len(from), lastSummary, nil, /* manifestBuf */
 	)
 
 	var res kvpb.BulkOpSummary
@@ -353,7 +355,7 @@ func distImport(
 		}
 
 		writeTS := &hlc.Timestamp{WallTime: walltime}
-		_, err = bulkmerge.Merge(ctx, execCtx, inputSSTs, spans, func(instanceID base.SQLInstanceID) (string, error) {
+		mergeResult, err := bulkmerge.Merge(ctx, execCtx, inputSSTs, spans, func(instanceID base.SQLInstanceID) (string, error) {
 			// Record the storage prefix before any SSTs are written
 			prefix := fmt.Sprintf("nodelocal://%d/", instanceID)
 			if err := addStoragePrefix(ctx, prefix); err != nil {
@@ -367,8 +369,33 @@ func distImport(
 			EnforceUniqueness: true,
 			MemoryMonitor:     execinfrapb.BulkMergeSpec_BULK_MONITOR,
 		})
+		if err != nil {
+			return err
+		}
 
-		return err
+		// Correct res to exclude identical duplicates skipped during
+		// the merge. The map-phase res counts all rows produced in
+		// this run, including duplicates from checkpoint-and-resume
+		// overlap. The merge ingest summary counts all unique rows
+		// actually written to KV (from both old and new SSTs). To
+		// get the current run's contribution, subtract the rows
+		// already counted in prior runs (from the checkpointed
+		// progress summary).
+		if len(mergeResult.IngestSummary.EntryCounts) > 0 {
+			if res.EntryCounts == nil {
+				res.EntryCounts = make(map[uint64]int64)
+			}
+			for id, ingestCount := range mergeResult.IngestSummary.EntryCounts {
+				priorCount := priorRunSummary.EntryCounts[id]
+				res.EntryCounts[id] = ingestCount - priorCount
+			}
+			// Update the checkpoint's entry counts to reflect the
+			// actual KV-ingested totals so the final Persist writes
+			// the correct row count to the job progress.
+			checkpoint.CorrectEntryCounts(mergeResult.IngestSummary.EntryCounts)
+		}
+
+		return nil
 	})
 
 	g.GoCtx(replanChecker)

--- a/pkg/sql/importer/import_progress_tracker.go
+++ b/pkg/sql/importer/import_progress_tracker.go
@@ -7,6 +7,7 @@ package importer
 
 import (
 	"context"
+	"maps"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -56,6 +57,17 @@ func newImportCheckpointTracker(
 		manifestBuf:      manifestBuf,
 		numFiles:         numFiles,
 	}
+}
+
+// CorrectEntryCounts replaces the entry counts in the bulk summary with the
+// provided counts. This is used after distmerge to replace the inflated
+// map-phase counts with the actual ingested counts from the merge processor's
+// KV ingest summary, so that the next Persist writes correct row counts to
+// the job progress.
+func (t *importCheckpointTracker) CorrectEntryCounts(counts map[uint64]int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.bulkSummary.EntryCounts = maps.Clone(counts)
 }
 
 // RecordProcessorUpdate updates progress state from a single processor

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -204,8 +204,11 @@ func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
 				serverArgs.Knobs = base.TestingKnobs{
 					DistSQL: &execinfra.TestingKnobs{
 						BulkMergeTestingKnobs: &bulkmerge.TestingKnobs{
-							InjectDuplicateKey: func(iteration, maxIteration int32) bool {
-								return !injected.Swap(true)
+							InjectDuplicateKey: func(iteration, maxIteration int32) []byte {
+								if !injected.Swap(true) {
+									return []byte("injected-duplicate-value")
+								}
+								return nil
 							},
 						},
 					},

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -243,6 +243,59 @@ func TestImportDistributedMergeDuplicateDetection(t *testing.T) {
 	}
 }
 
+// TestImportIdenticalDuplicateRows verifies that importing a CSV containing
+// identical duplicate rows (same PK, same values) succeeds with both the
+// non-distmerge (BulkAdder/SSTBatcher) and distmerge paths. The non-distmerge
+// path has always tolerated these via SSTBatcher.skipDuplicates and KV's
+// DisallowShadowingBelow idempotent-write handling. The distmerge path now
+// matches this behavior by skipping identical duplicates in the merge
+// processor's extractKeyAndCheckDuplicate.
+func TestImportIdenticalDuplicateRows(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, distmerge := range []bool{false, true} {
+		name := "non-distmerge"
+		if distmerge {
+			name = "distmerge"
+		}
+		t.Run(name, func(t *testing.T) {
+			dirname := t.TempDir()
+			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+				ExternalIODir:     dirname,
+				DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
+			})
+			ctx := context.Background()
+			defer s.Stopper().Stop(ctx)
+			sqlDB := sqlutils.MakeSQLRunner(db)
+
+			if distmerge {
+				sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.distributed_merge.enabled = true`)
+				// Small batch size forces each key into its own SST so
+				// duplicates land in separate SSTs and exercise the merge
+				// processor's cross-SST duplicate detection.
+				sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.sst_writer.batch_size = '1B'`)
+			}
+			// CSV with 5 rows but only 3 distinct PKs. Rows 1,a and 2,b
+			// appear twice with identical values.
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dirname, "data.csv"),
+				[]byte("1,a\n2,b\n3,c\n1,a\n2,b"),
+				os.FileMode(0644),
+			))
+
+			sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'sync'`)
+			sqlDB.Exec(t, `CREATE TABLE t (id INT PRIMARY KEY, name STRING)`)
+			sqlDB.Exec(t, `IMPORT INTO t (id, name) CSV DATA ($1)`,
+				"nodelocal://1/data.csv")
+
+			var count int
+			sqlDB.QueryRow(t, `SELECT count(*) FROM t`).Scan(&count)
+			require.Equal(t, 3, count)
+		})
+	}
+}
+
 // importDataTest defines a single test case for the TestImportData* family
 // of tests. Tests are split across multiple top-level functions by format type
 // to avoid exceeding shard timeouts.

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -2044,15 +2044,15 @@ func TestMergeSameSSTDuplicateDetection(t *testing.T) {
 			var rowCounter atomic.Int64
 
 			bulkMergeKnobs := &bulkmerge.TestingKnobs{
-				InjectDuplicateKey: func(iteration, maxIteration int32) bool {
+				InjectDuplicateKey: func(iteration, maxIteration int32) []byte {
 					// Only count rows during the target iteration.
 					if iteration != tc.injectIteration {
-						return false
+						return nil
 					}
 
 					// Only inject if we haven't already done so.
 					if duplicateInjected.Load() {
-						return false
+						return nil
 					}
 
 					currentRow := rowCounter.Add(1) - 1 // Get and increment, 0-indexed.
@@ -2060,9 +2060,9 @@ func TestMergeSameSSTDuplicateDetection(t *testing.T) {
 					// Check if we've reached the target row count.
 					if tc.injectAfterRows == 0 || currentRow >= tc.injectAfterRows {
 						duplicateInjected.Store(true)
-						return true
+						return []byte("injected-duplicate-value")
 					}
-					return false
+					return nil
 				},
 			}
 


### PR DESCRIPTION
The import processor writes KVs to a BulkSink via sink.Add(), which
internally calls Writer.AddMVCCKey(). When the writer's internal buffer
(default 128MB) is full, AddMVCCKey auto-flushes BEFORE adding the new
KV. This auto-flush fires the OnFlush callback registered in
importProgressTracker.registerSink, which snapshots unflushedRows — the
progress position — and collects the flushed SST's manifest.

The race occurs because unflushedRows is only updated by
recordKVBatch() AFTER the entire kvBatch loop completes, but
auto-flush can fire mid-batch inside sink.Add(). When this happens:

1. The ingestion loop begins processing kvBatch N. It iterates over
   the KVs in the batch, calling sink.Add() for each one.
2. Partway through the batch, sink.Add() overflows the buffer.
3. AddMVCCKey auto-flushes, invoking OnFlush.
4. OnFlush copies unflushedRows into the checkpoint. But
   recordKVBatch has not yet been called for kvBatch N — it is
   only called after ALL KVs in the batch are written to the sink.
   So unflushedRows still holds the position from kvBatch N-1,
   i.e. the last row of the PREVIOUS batch.
5. The flushed SST's manifest is recorded alongside this stale
   position.
6. The SST actually contains KVs from kvBatch N that are beyond the
   recorded resume position.

On pause/resume or node failure, the job resumes from the checkpointed
position (which is behind the SST's actual contents). The overlapping
input rows are re-processed, producing new SSTs with keys that already
exist in the previously checkpointed SSTs. When EnforceUniqueness is
true, the merge processor flags these as DuplicateKeyErrors, causing
the job to fail.

The fix: when a duplicate base key is found during merge, compare the
values. If the values are identical, it's a benign checkpoint-and-resume
repeat — the same input row produced the same KV twice — and the
duplicate is silently skipped. If the values differ, it's a real
uniqueness violation and a DuplicateKeyError is returned as before.

This approach is consistent with the checkpoint system's existing design
philosophy: it is acceptable to redo work, as long as we never forget
to redo work. The same latent race exists in the index backfiller code
path which shares the merge infrastructure, though it rarely triggers
because index entries are small relative to the 128MB buffer.

Fixes: #165777
Epic: CRDB-48845

Release note: None