### PR TITLE
operations: fix crash in RLS cleanup and signal handling with piped o…

### DIFF
--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -81,6 +81,11 @@ if [ -z "${DD_API_KEY}" ]; then
   exit 1
 fi
 
+# Ignore SIGINT in the shell so that tee (which inherits the signal
+# disposition) stays alive when Ctrl+C is pressed. Only
+# roachtest-operations receives SIGINT and handles cleanup gracefully.
+trap '' INT
+
 ./roachtest-operations run-operation "${CLUSTER}" ".*" \
   --datadog-api-key "${DD_API_KEY}" \
   --datadog-app-key "unused" \

--- a/pkg/cmd/roachtest/operations/add_database.go
+++ b/pkg/cmd/roachtest/operations/add_database.go
@@ -30,7 +30,7 @@ func (cl *cleanupAddedDatabase) Cleanup(
 	defer conn.Close()
 
 	o.Status(fmt.Sprintf("dropping database %s", cl.db))
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE %s", cl.db))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s CASCADE", cl.db))
 	if err != nil {
 		o.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/operations/add_rls_policy.go
+++ b/pkg/cmd/roachtest/operations/add_rls_policy.go
@@ -52,15 +52,17 @@ func (cl *cleanupRLSPolicy) Cleanup(ctx context.Context, o operation.Operation, 
 		// Switch to the database where the table is located
 		o.Status(fmt.Sprintf("switching to database %s for cleanup", cl.db))
 		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", cl.db)); err != nil {
-			o.Fatal(err)
+			o.Error(err)
+			return
 		}
 
 		// Drop all policies that were created
 		for _, policy := range cl.policies {
 			o.Status(fmt.Sprintf("dropping policy %s on table %s.%s", policy, cl.db, cl.table))
-			_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP POLICY %s ON %s.%s", policy, cl.db, cl.table))
+			_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP POLICY IF EXISTS %s ON %s.%s", policy, cl.db, cl.table))
 			if err != nil {
-				o.Fatal(err)
+				o.Error(err)
+				return
 			}
 		}
 
@@ -69,14 +71,16 @@ func (cl *cleanupRLSPolicy) Cleanup(ctx context.Context, o operation.Operation, 
 			// Restore the original RLS state
 			o.Status(fmt.Sprintf("restoring original row level security state for %s.%s", cl.db, cl.table))
 			if _, err := conn.ExecContext(ctx, cl.originalRLSStmt); err != nil {
-				o.Fatal(err)
+				o.Error(err)
+				return
 			}
 		} else {
 			// If the table didn't have RLS before, disable it
 			o.Status(fmt.Sprintf("disabling row level security for %s.%s", cl.db, cl.table))
 			_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DISABLE ROW LEVEL SECURITY, NO FORCE ROW LEVEL SECURITY", cl.db, cl.table))
 			if err != nil {
-				o.Fatal(err)
+				o.Error(err)
+				return
 			}
 		}
 	}()

--- a/pkg/cmd/roachtest/operations/grant_revoke_all.go
+++ b/pkg/cmd/roachtest/operations/grant_revoke_all.go
@@ -41,7 +41,7 @@ func (cl *revoke) Cleanup(ctx context.Context, o operation.Operation, c cluster.
 		o.Fatal(err)
 	}
 	o.Status(fmt.Sprintf("Revoked ALL for user %s from table %s.%s", cl.dbUser, cl.db, cl.table))
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP USER %s", cl.dbUser))
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", cl.dbUser))
 	if err != nil {
 		o.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/operations/grant_role.go
+++ b/pkg/cmd/roachtest/operations/grant_role.go
@@ -36,15 +36,17 @@ func (cl *revokeRole) Cleanup(ctx context.Context, o operation.Operation, c clus
 
 	o.Status(fmt.Sprintf("Revoking role %s from role %s", cl.grantedRole, cl.granteeRole))
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("REVOKE %s FROM %s", cl.grantedRole, cl.granteeRole))
+	status := "succeeded"
 	if err != nil {
-		o.Fatal(err)
+		status = "failed"
+		o.Error(err)
 	}
-	o.Status(fmt.Sprintf("Revoked role %s from role %s", cl.grantedRole, cl.granteeRole))
+	o.Status(fmt.Sprintf("Revoked role %s from role %s, status: %s", cl.grantedRole, cl.granteeRole, status))
 
 	// Drop both roles
 	for _, role := range []string{cl.granteeRole, cl.grantedRole} {
 		o.Status(fmt.Sprintf("Dropping role %s", role))
-		_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP ROLE %s", role))
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s", role))
 		if err != nil {
 			o.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/operations/sql_objects.go
+++ b/pkg/cmd/roachtest/operations/sql_objects.go
@@ -36,7 +36,7 @@ func (cl *genericSQLCleanup) Cleanup(
 
 	o.Status(fmt.Sprintf("dropping %s %s", cl.objectType, cl.objectName))
 	_, err := conn.ExecContext(ctx,
-		fmt.Sprintf("DROP %s %s", cl.objectType, cl.objectName))
+		fmt.Sprintf("DROP %s IF EXISTS %s", cl.objectType, cl.objectName))
 	if err != nil {
 		o.Fatal(err)
 	}


### PR DESCRIPTION
The add-rls-policy cleanup runs in a background goroutine where o.Fatal() panics are not recovered by the runner's defer/recover, crashing the entire process. Use o.Error() instead.

When the operation runner is piped through tee (2>&1 | tee), Ctrl+C kills tee first, breaking the pipe and preventing cleanup from running. Trap SIGINT in the shell script so tee stays alive and cleanup output remains visible.

Operation cleanups can fail if the objects they try to drop were already removed (e.g. table dropped, role already revoked). Use IF EXISTS and CASCADE where appropriate so cleanups succeed even when the target objects no longer exist.

Epic: none
Release note: None