### PR TITLE
cli: fix flaky TestZipExcludeRangeInfo by stripping ASH report lines

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -697,6 +697,8 @@ func eraseNonDeterministicZipOutput(out string) string {
 	out = re.ReplaceAllString(out, ``)
 	re = regexp.MustCompile(`(?m)^\[node \d+\] retrieving goroutine_dump.*$` + "\n")
 	out = re.ReplaceAllString(out, ``)
+	re = regexp.MustCompile(`(?m)^\[node \d+\] retrieving ash_report.*$` + "\n")
+	out = re.ReplaceAllString(out, ``)
 	re = regexp.MustCompile(`(?m)^\[node \d+\] \d+ execution traces found$`)
 	out = re.ReplaceAllString(out, `[node ?] ? execution traces found`)
 


### PR DESCRIPTION
The ASH report profiler (added in 84fefdbfb33) writes ash_report files to the heap profile directory. When `debug zip` collects heap profiles, it picks up these files non-deterministically depending on whether a goroutine dump triggered an ASH report during the test.

Strip ash_report retrieval lines from the zip test output, following the same pattern used for goroutine_dump, cpuprof, and memprof lines.

Fixes #165940