### PR TITLE
release-25.2: kvserver: deflake TestRaftTracing

### DIFF
--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -182,6 +182,12 @@ func TestRaftTracing(t *testing.T) {
 		tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 		tc.WaitForVotersOrFatal(t, key, tc.Targets(1, 2)...)
 
+		// Exclude the possibility that the lease upgrade races with the writes
+		// below. A lease request can combine with a write request in one committed
+		// batch and prevent the early ack of the write at apply time, which we
+		// expect to find in the trace. See #165793 for the flake this fixes.
+		tc.MaybeWaitForLeaseUpgrade(context.Background(), t, tc.LookupRangeOrFatal(t, key))
+
 		for i := 0; i < 100; i++ {
 			var finish func() tracingpb.Recording
 			ctx := context.Background()


### PR DESCRIPTION
Backport 1/1 commits from #165831.

/cc @cockroachdb/release

---

Fixes-25.2 #165793
Fixes-25.3 #152666

Release justification: test deflake
