### PR TITLE
ui: add inline iframe viewer on advanced debug for detail files

### DIFF
--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -36,6 +36,7 @@ const (
 	cspHeader = "default-src 'self'; " +
 		"style-src 'self' 'unsafe-inline'; " +
 		"font-src 'self' data:; " +
+		"frame-src 'self' blob: https://cockroachdb.github.io; " +
 		"img-src 'self' data:; " +
 		"connect-src 'self' https://register.cockroachdb.com;"
 )

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/executionDetailViewer.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/executionDetailViewer.tsx
@@ -1,0 +1,66 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Button, Icon } from "@cockroachlabs/ui-components";
+import classnames from "classnames/bind";
+import React, { useCallback } from "react";
+
+import styles from "./jobProfilerView.module.scss";
+
+const cx = classnames.bind(styles);
+
+interface ExecutionDetailViewerProps {
+  filename: string;
+  blobUrl: string;
+  onClose: () => void;
+}
+
+export const ExecutionDetailViewer: React.FC<ExecutionDetailViewerProps> = ({
+  filename,
+  blobUrl,
+  onClose,
+}) => {
+  const openInNewTab = useCallback(() => {
+    // Blob URL already exists so this is synchronous and won't
+    // trigger popup blockers.
+    window.open(blobUrl, "_blank");
+  }, [blobUrl]);
+
+  return (
+    <div className={cx("viewer-overlay")} onClick={onClose}>
+      <div className={cx("viewer-panel")} onClick={e => e.stopPropagation()}>
+        <div className={cx("viewer-header")}>
+          <span className={cx("viewer-filename")}>{filename}</span>
+          <span className={cx("viewer-actions")}>
+            <Button
+              as="a"
+              size="small"
+              intent="tertiary"
+              onClick={openInNewTab}
+              aria-label="Open in new tab"
+            >
+              <Icon iconName="Open" />
+            </Button>
+            <Button
+              as="a"
+              size="small"
+              intent="tertiary"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <Icon iconName="Cancel" />
+            </Button>
+          </span>
+        </div>
+        <iframe
+          src={blobUrl}
+          className={cx("viewer-iframe")}
+          sandbox="allow-same-origin allow-scripts"
+          title={filename}
+        />
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
@@ -6,34 +6,96 @@
 @import "src/core/index.module";
 
 .crl-job-profiler-view {
-    &__actions-column {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        justify-content: flex-end;
-    }
+  &__actions-column {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+  }
 }
 
 .column-size-medium {
-    width: 230px;
+  width: 230px;
 }
 
 .view-execution-detail-button {
-    white-space: nowrap;
+  white-space: nowrap;
 
-    >svg {
-        margin-right: $spacing-x-small;
-    }
+  > svg {
+    margin-right: $spacing-x-small;
+  }
 }
 
 .download-execution-detail-button {
-    white-space: nowrap;
+  white-space: nowrap;
 
-    >svg {
-        margin-right: $spacing-x-small;
-    }
+  > svg {
+    margin-right: $spacing-x-small;
+  }
 }
 
 .full-width {
   width: 100%;
+}
+
+// Execution detail viewer overlay and panel.
+.viewer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.viewer-panel {
+  background-color: white;
+  border: 0.5px solid $colors--neutral-2;
+  border-radius: 8px;
+  box-shadow: 0 0 4px rgba(154, 161, 171, 0.33);
+  width: 98vw;
+  height: 98vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 0.5px solid $colors--neutral-2;
+}
+
+.viewer-filename {
+  font-family: $font-family--base;
+  font-weight: $font-weight--bold;
+  font-size: $font-size--small;
+  line-height: $line-height--small;
+  letter-spacing: 0.3px;
+  color: $colors--neutral-7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.viewer-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: 16px;
+}
+
+.viewer-iframe {
+  width: 100%;
+  border: none;
+  display: block;
+  flex: 1;
+  min-height: 0;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
@@ -9,13 +9,11 @@ import { Space } from "antd";
 import classNames from "classnames";
 import classnames from "classnames/bind";
 import long from "long";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import {
   collectExecutionDetails,
   getExecutionDetailFile,
-  GetJobProfilerExecutionDetailRequest,
-  GetJobProfilerExecutionDetailResponse,
   listExecutionDetailFiles,
 } from "src/api/jobProfilerApi";
 import { DownloadFile, DownloadFileRef } from "src/downloadFile";
@@ -28,6 +26,7 @@ import {
   useSwrWithClusterId,
 } from "src/util/hooks";
 
+import { ExecutionDetailViewer } from "./executionDetailViewer";
 import styles from "./jobProfilerView.module.scss";
 
 const cardCx = classNames.bind(summaryCardStyles);
@@ -35,6 +34,33 @@ const cx = classnames.bind(styles);
 
 export interface JobProfilerViewProps {
   jobID: long;
+}
+
+function extractFileExtension(filename: string): string {
+  const parts = filename.split(".");
+  // The extension is the last part after the last dot (if it exists).
+  return parts.length > 1 ? parts[parts.length - 1] : "";
+}
+
+function getContentTypeForFile(filename: string): string {
+  const extension = extractFileExtension(filename);
+  switch (extension) {
+    case "txt":
+      return "text/plain";
+    case "zip":
+      return "application/zip";
+    case "html":
+      return "text/html";
+    default:
+      return "";
+  }
+}
+
+// Files with these extensions can be rendered inline in an iframe.
+const VIEWABLE_EXTENSIONS = new Set(["html", "txt"]);
+
+function isViewableFile(filename: string): boolean {
+  return VIEWABLE_EXTENSIONS.has(extractFileExtension(filename));
 }
 
 export function JobProfilerView({
@@ -57,7 +83,106 @@ export function JobProfilerView({
     },
   );
 
-  const columns = makeJobProfilerViewColumns(jobID, getExecutionDetailFile);
+  const [viewingFile, setViewingFile] = useState<string | null>(null);
+  const [viewingBlobUrl, setViewingBlobUrl] = useState<string | null>(null);
+
+  const closeViewer = useCallback(() => {
+    if (viewingBlobUrl) {
+      URL.revokeObjectURL(viewingBlobUrl);
+    }
+    setViewingFile(null);
+    setViewingBlobUrl(null);
+  }, [viewingBlobUrl]);
+
+  const openViewer = useCallback(
+    (filename: string) => {
+      setViewingFile(filename);
+      const req =
+        new cockroach.server.serverpb.GetJobProfilerExecutionDetailRequest({
+          job_id: jobID,
+          filename: filename,
+        });
+      getExecutionDetailFile(req)
+        .then(resp => {
+          const contentType = getContentTypeForFile(filename);
+          const blob = new Blob([resp?.data], { type: contentType });
+          setViewingBlobUrl(URL.createObjectURL(blob));
+        })
+        .catch(() => {
+          setViewingFile(null);
+        });
+    },
+    [jobID],
+  );
+
+  const downloadRef: React.RefObject<DownloadFileRef> =
+    React.createRef<DownloadFileRef>();
+
+  const columns: ColumnDescriptor<string>[] = [
+    {
+      name: "executionDetailFiles",
+      title: "Execution Detail Files",
+      hideTitleUnderline: true,
+      cell: (executionDetails: string) => executionDetails,
+    },
+    {
+      name: "actions",
+      title: "",
+      hideTitleUnderline: true,
+      className: cx("column-size-medium"),
+      cell: (executionDetailFile: string) => {
+        const viewable = isViewableFile(executionDetailFile);
+        return (
+          <div className={cx("crl-job-profiler-view__actions-column")}>
+            <DownloadFile ref={downloadRef} />
+            {viewable && (
+              <Button
+                as="a"
+                size="small"
+                intent="tertiary"
+                className={cx("view-execution-detail-button")}
+                onClick={() => openViewer(executionDetailFile)}
+              >
+                <Icon iconName="Open" />
+                View
+              </Button>
+            )}
+            <Button
+              as="a"
+              size="small"
+              intent="tertiary"
+              className={cx("download-execution-detail-button")}
+              onClick={() => {
+                const req =
+                  new cockroach.server.serverpb.GetJobProfilerExecutionDetailRequest(
+                    {
+                      job_id: jobID,
+                      filename: executionDetailFile,
+                    },
+                  );
+                getExecutionDetailFile(req).then(resp => {
+                  const type = getContentTypeForFile(executionDetailFile);
+                  const executionFileBytes = new Blob([resp?.data], {
+                    type: type,
+                  });
+                  Promise.resolve().then(() => {
+                    downloadRef.current.download(
+                      executionDetailFile,
+                      executionFileBytes,
+                    );
+                  });
+                });
+              }}
+            >
+              <Icon iconName="Download" />
+              Download
+            </Button>
+          </div>
+        );
+      },
+    },
+  ];
+
   const [sortSetting, setSortSetting] = useState<SortSetting>({
     ascending: true,
     columnTitle: "executionDetailFiles",
@@ -95,123 +220,13 @@ export function JobProfilerView({
         onChangeSortSetting={onChangeSortSetting}
         renderNoResult={<EmptyTable title="No execution detail files found." />}
       />
+      {viewingFile && viewingBlobUrl && (
+        <ExecutionDetailViewer
+          filename={viewingFile}
+          blobUrl={viewingBlobUrl}
+          onClose={closeViewer}
+        />
+      )}
     </Space>
   );
-}
-
-function extractFileExtension(filename: string): string {
-  const parts = filename.split(".");
-  // The extension is the last part after the last dot (if it exists).
-  return parts.length > 1 ? parts[parts.length - 1] : "";
-}
-
-function getContentTypeForFile(filename: string): string {
-  const extension = extractFileExtension(filename);
-  switch (extension) {
-    case "txt":
-      return "text/plain";
-    case "zip":
-      return "application/zip";
-    case "html":
-      return "text/html";
-    default:
-      return "";
-  }
-}
-
-function makeJobProfilerViewColumns(
-  jobID: long,
-  onDownloadExecutionFileClicked: (
-    req: GetJobProfilerExecutionDetailRequest,
-  ) => Promise<GetJobProfilerExecutionDetailResponse>,
-): ColumnDescriptor<string>[] {
-  const downloadRef: React.RefObject<DownloadFileRef> =
-    React.createRef<DownloadFileRef>();
-  return [
-    {
-      name: "executionDetailFiles",
-      title: "Execution Detail Files",
-      hideTitleUnderline: true,
-      cell: (executionDetails: string) => executionDetails,
-    },
-    {
-      name: "actions",
-      title: "",
-      hideTitleUnderline: true,
-      className: cx("column-size-medium"),
-      cell: (executionDetailFile: string) => {
-        return (
-          <div className={cx("crl-job-profiler-view__actions-column")}>
-            <DownloadFile ref={downloadRef} />
-            <Button
-              as="a"
-              size="small"
-              intent="tertiary"
-              className={cx("view-execution-detail-button")}
-              onClick={async () => {
-                // Open the window synchronously to avoid popup blockers.
-                // Async calls to window.open() are blocked by most browsers.
-                const newWindow = window.open("", "_blank");
-                try {
-                  const req =
-                    new cockroach.server.serverpb.GetJobProfilerExecutionDetailRequest(
-                      {
-                        job_id: jobID,
-                        filename: executionDetailFile,
-                      },
-                    );
-                  const resp = await onDownloadExecutionFileClicked(req);
-                  const type = getContentTypeForFile(executionDetailFile);
-                  const blob = new Blob([resp?.data], {
-                    type: type,
-                  });
-                  const url = URL.createObjectURL(blob);
-                  if (newWindow) {
-                    newWindow.location.href = url;
-                  }
-                } catch {
-                  if (newWindow) {
-                    newWindow.close();
-                  }
-                }
-              }}
-            >
-              <Icon iconName="Open" />
-              View
-            </Button>
-            <Button
-              as="a"
-              size="small"
-              intent="tertiary"
-              className={cx("download-execution-detail-button")}
-              onClick={() => {
-                const req =
-                  new cockroach.server.serverpb.GetJobProfilerExecutionDetailRequest(
-                    {
-                      job_id: jobID,
-                      filename: executionDetailFile,
-                    },
-                  );
-                onDownloadExecutionFileClicked(req).then(resp => {
-                  const type = getContentTypeForFile(executionDetailFile);
-                  const executionFileBytes = new Blob([resp?.data], {
-                    type: type,
-                  });
-                  Promise.resolve().then(() => {
-                    downloadRef.current.download(
-                      executionDetailFile,
-                      executionFileBytes,
-                    );
-                  });
-                });
-              }}
-            >
-              <Icon iconName="Download" />
-              Download
-            </Button>
-          </div>
-        );
-      },
-    },
-  ];
 }


### PR DESCRIPTION
Add an ExecutionDetailViewer modal component that renders viewable
execution detail files (html, txt) inline in an iframe using blob URLs.
This avoids the popup blocker issue entirely for the inline case and
provides a better UX than opening a new tab.

The View button is now shown only for viewable file types (html, txt).

Non-viewable files (zip, binpb) show only the Download button. The
viewer modal includes maximize and open-in-new-tab controls.

Epic: None
Release note: None