### PR TITLE
release-26.1: roachtest: handle FIPS architecture in Node.js install helpers

### DIFF
--- a/pkg/cmd/roachtest/tests/javascript_helpers.go
+++ b/pkg/cmd/roachtest/tests/javascript_helpers.go
@@ -51,7 +51,7 @@ sudo find /usr/local/lib/node_modules/npm/bin -type f -exec chmod 755 {} \;
 		tarball := ""
 		checksum := ""
 		switch c.Architecture() {
-		case vm.ArchAMD64:
+		case vm.ArchAMD64, vm.ArchFIPS:
 			tarball = fmt.Sprintf(NODE_TARBALL, "x64")
 			checksum = AMD64_SHA256SUM
 		case vm.ArchARM64:
@@ -154,7 +154,7 @@ func installNode22(
 	tarball := ""
 	checksum := ""
 	switch c.Architecture() {
-	case vm.ArchAMD64:
+	case vm.ArchAMD64, vm.ArchFIPS:
 		tarball = fmt.Sprintf(NODE22_TARBALL, "x64")
 		checksum = NODE22_AMD64_SHA256SUM
 	case vm.ArchARM64:


### PR DESCRIPTION
Backport 1/1 commits from #164845 on behalf of @dhartunian.

----

The `installNode18` and `installNode22` functions in `javascript_helpers.go` did not handle `vm.ArchFIPS` in their architecture switch statements, causing db-console cypress tests to fail on FIPS clusters with "unsupported architecture: fips".

FIPS is AMD64 with FIPS-compliant crypto, not a separate CPU architecture, so it should use the same x64 Node.js binaries.

Fixes: #164808
Release note: None

----

Release justification: roachtest only change, includes additional architecture type for roachtest