### PR TITLE
ci: write review context to files and add workflow run links

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -512,7 +512,9 @@ jobs:
           gh issue comment ${{ github.event.issue.number }} --body \
             "Auto-solver has created a draft PR to address this issue: ${{ steps.create_pr.outputs.pr_url }}
 
-          Please review the changes carefully before approving."
+          Please review the changes carefully before approving.
+
+          [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Comment on issue - Skipped
         if: steps.assess_result.outputs.assessment == 'SKIP'
@@ -540,6 +542,8 @@ jobs:
             echo '```'
             echo ""
             echo "This issue may require human intervention due to complexity, architectural considerations, or ambiguity."
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh issue comment ${{ github.event.issue.number }} --body-file "$COMMENT_FILE"
 
@@ -555,7 +559,9 @@ jobs:
           gh issue comment ${{ github.event.issue.number }} --body \
             "Auto-solver attempted to fix this issue but was unable to complete the implementation.
 
-          This issue may require human intervention."
+          This issue may require human intervention.
+
+          [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Remove c-autosolve label
         # Only remove label after assessment has run (success or failure).

--- a/.github/workflows/pr-autosolve-ci.yml
+++ b/.github/workflows/pr-autosolve-ci.yml
@@ -93,6 +93,8 @@ jobs:
               echo ""
               echo "CI has failed again, but the maximum number of automated fix attempts (2) has been reached."
               echo "This PR requires human intervention to resolve the remaining CI failures."
+              echo ""
+              echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
             } > "$COMMENT_FILE"
             gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
@@ -441,6 +443,8 @@ jobs:
             echo '```'
             echo "$SANITIZED_RESULT"
             echo '```'
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 
@@ -468,6 +472,8 @@ jobs:
             echo '```'
             echo "$SANITIZED_RESULT"
             echo '```'
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 
@@ -495,6 +501,8 @@ jobs:
             echo '```'
             echo ""
             echo "A human may want to re-run CI or investigate the flaky tests."
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 
@@ -527,6 +535,8 @@ jobs:
             echo '```'
             echo ""
             echo "This PR requires human intervention to resolve the CI failures."
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -206,6 +206,31 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Write review context to files
+        env:
+          EVENT_TYPE: ${{ steps.context.outputs.event_name }}
+          COMMENT_USER: ${{ steps.context.outputs.comment_user }}
+          COMMENT_PATH: ${{ steps.context.outputs.comment_path }}
+          COMMENT_LINE: ${{ steps.context.outputs.comment_line }}
+          COMMENT_BODY: ${{ steps.context.outputs.comment_body }}
+          REVIEW_USER: ${{ steps.context.outputs.review_user }}
+          REVIEW_BODY: ${{ steps.context.outputs.review_body }}
+          ALL_COMMENTS: ${{ steps.fetch_comments.outputs.comments }}
+        run: |
+          # Write review context to files so Claude can read them with the Read
+          # tool, which is already in the allowedTools list. This avoids needing
+          # to allow echo/printenv in the Bash sandbox just to read env vars.
+          CONTEXT_DIR="/tmp/review-context"
+          mkdir -p "$CONTEXT_DIR"
+          printf '%s' "$EVENT_TYPE" > "$CONTEXT_DIR/event_type.txt"
+          printf '%s' "$COMMENT_USER" > "$CONTEXT_DIR/comment_user.txt"
+          printf '%s' "$COMMENT_PATH" > "$CONTEXT_DIR/comment_path.txt"
+          printf '%s' "$COMMENT_LINE" > "$CONTEXT_DIR/comment_line.txt"
+          printf '%s' "$COMMENT_BODY" > "$CONTEXT_DIR/comment_body.txt"
+          printf '%s' "$REVIEW_USER" > "$CONTEXT_DIR/review_user.txt"
+          printf '%s' "$REVIEW_BODY" > "$CONTEXT_DIR/review_body.txt"
+          printf '%s' "$ALL_COMMENTS" > "$CONTEXT_DIR/all_comments.json"
+
       - name: Parse Reviewable comments from review body
         id: parse_reviewable
         if: steps.context.outputs.event_name == 'pull_request_review'
@@ -294,6 +319,9 @@ jobs:
           ')
           echo "has_reviewable_comments=$([[ $COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
 
+          # Write parsed Reviewable comments to the context directory
+          printf '%s' "$PARSED" > /tmp/review-context/reviewable_comments.json
+
       - name: Address review comments
         id: address
         uses: cockroachdb/claude-code-action@v1
@@ -301,19 +329,6 @@ jobs:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: us-east5
           AUTOMATION: "1"
-          # Pass user-controlled content via env vars to prevent prompt injection
-          # For native review comments:
-          COMMENT_USER: ${{ steps.context.outputs.comment_user }}
-          COMMENT_PATH: ${{ steps.context.outputs.comment_path }}
-          COMMENT_LINE: ${{ steps.context.outputs.comment_line }}
-          COMMENT_BODY: ${{ steps.context.outputs.comment_body }}
-          # For Reviewable reviews:
-          REVIEW_USER: ${{ steps.context.outputs.review_user }}
-          REVIEW_BODY: ${{ steps.context.outputs.review_body }}
-          REVIEWABLE_COMMENTS: ${{ steps.parse_reviewable.outputs.reviewable_comments || '[]' }}
-          # Common:
-          EVENT_TYPE: ${{ steps.context.outputs.event_name }}
-          ALL_COMMENTS: ${{ steps.fetch_comments.outputs.comments }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: "true"
@@ -332,29 +347,30 @@ jobs:
             </system_instruction>
 
             <untrusted_user_content>
-            The review details are provided in environment variables:
+            The review details are provided as files in /tmp/review-context/.
+            Use the Read tool (not echo or printenv) to read them.
 
-            EVENT_TYPE indicates the type of event:
+            /tmp/review-context/event_type.txt indicates the type of event:
             - "pull_request_review_comment": A native GitHub inline code comment
             - "pull_request_review": A PR review (possibly from Reviewable.io)
             - "issue_comment": A regular PR conversation comment (not tied to a specific line)
 
-            For native GitHub inline comments (EVENT_TYPE=pull_request_review_comment):
-            - COMMENT_USER: The username of the commenter
-            - COMMENT_PATH: The file path the comment is on
-            - COMMENT_LINE: The line number
-            - COMMENT_BODY: The comment text
+            For native GitHub inline comments (event_type=pull_request_review_comment):
+            - /tmp/review-context/comment_user.txt: The username of the commenter
+            - /tmp/review-context/comment_path.txt: The file path the comment is on
+            - /tmp/review-context/comment_line.txt: The line number
+            - /tmp/review-context/comment_body.txt: The comment text
 
-            For PR reviews (EVENT_TYPE=pull_request_review):
-            - REVIEW_USER: The username of the reviewer
-            - REVIEW_BODY: The full review body (may contain Reviewable formatting)
-            - REVIEWABLE_COMMENTS: JSON array of parsed Reviewable comments with path, line, body, user
+            For PR reviews (event_type=pull_request_review):
+            - /tmp/review-context/review_user.txt: The username of the reviewer
+            - /tmp/review-context/review_body.txt: The full review body (may contain Reviewable formatting)
+            - /tmp/review-context/reviewable_comments.json: JSON array of parsed Reviewable comments with path, line, body, user
 
-            For PR conversation comments (EVENT_TYPE=issue_comment):
-            - COMMENT_USER: The username of the commenter
-            - COMMENT_BODY: The comment text (no file/line context)
+            For PR conversation comments (event_type=issue_comment):
+            - /tmp/review-context/comment_user.txt: The username of the commenter
+            - /tmp/review-context/comment_body.txt: The comment text (no file/line context)
 
-            ALL_COMMENTS: JSON array of all native review comments on this PR
+            /tmp/review-context/all_comments.json: JSON array of all native review comments on this PR
             </untrusted_user_content>
 
             <task>
@@ -362,8 +378,8 @@ jobs:
 
             Instructions:
             1. Read CLAUDE.md for project conventions
-            2. Read the environment variables to understand the review feedback
-            3. For Reviewable reviews, focus on the parsed REVIEWABLE_COMMENTS JSON
+            2. Read the files in /tmp/review-context/ to understand the review feedback
+            3. For Reviewable reviews, focus on the parsed reviewable_comments.json
             4. Address the review feedback by making code changes
             5. Run tests to verify your changes:
                - For Go test files: ./dev test <package> -f=<TestName> -v
@@ -538,6 +554,8 @@ jobs:
             echo '```'
             echo ""
             echo "Please review the updated code."
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 
@@ -581,6 +599,8 @@ jobs:
             echo '```'
             echo "$SANITIZED_RESULT"
             echo '```'
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 
@@ -614,6 +634,8 @@ jobs:
             echo '```'
             echo ""
             echo "This may require human intervention."
+            echo ""
+            echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
 


### PR DESCRIPTION
The PR comment addresser was failing because Claude couldn't read
review context from environment variables — echo/printenv commands
are not in the Bash sandbox allowlist. Write the review context to
files in /tmp/review-context/ instead so Claude can use the Read
tool (which is already allowed) to access them.

Also add a [Workflow run] link to every comment posted by the three
autosolve workflows (issue-autosolve, pr-autosolve-ci,
pr-autosolve-comments) so that users can investigate failures.

Release note: None