### PR TITLE
democluster: stop overriding allow_unsafe_internals to true

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1000,11 +1000,6 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		args.SSLCertsDir = demoDir
 	}
 
-	// Allow access to system and crdb_internal tables in demo mode.
-	// Demo mode is for development/testing, so we want to allow access
-	// to these tables for debugging and introspection.
-	serverutils.SetUnsafeOverride(&args.Knobs)
-
 	return args
 }
 
@@ -1648,16 +1643,30 @@ func (c *transientCluster) GetSQLCredentials() (
 	return c.adminUser, c.adminPassword, c.demoDir
 }
 
+// internalDBConn opens a SQL connection to the given server using an internal
+// application name. This allows the connection to access system tables and
+// crdb_internal without setting the allow_unsafe_internals session variable.
+func (c *transientCluster) internalDBConn(
+	ctx context.Context, target serverSelection,
+) (*gosql.DB, error) {
+	u, err := c.getNetworkURLForServer(ctx, 0, false /* includeAppName */, target)
+	if err != nil {
+		return nil, err
+	}
+	if err := u.SetOption(
+		"application_name", catconstants.InternalAppNamePrefix+" cockroach demo",
+	); err != nil {
+		return nil, err
+	}
+	return gosql.Open("postgres", u.ToPQ().String())
+}
+
 func (c *transientCluster) maybeEnableMultiTenantMultiRegion(ctx context.Context) error {
 	if !c.demoCtx.Multitenant {
 		return nil
 	}
 
-	storageURL, err := c.getNetworkURLForServer(ctx, 0, false /* includeAppName */, forSystemTenant)
-	if err != nil {
-		return err
-	}
-	db, err := gosql.Open("postgres", storageURL.ToPQ().String())
+	db, err := c.internalDBConn(ctx, forSystemTenant)
 	if err != nil {
 		return err
 	}
@@ -1674,11 +1683,7 @@ func (c *transientCluster) maybeEnableMultiTenantMultiRegion(ctx context.Context
 func (c *transientCluster) SetClusterSetting(
 	ctx context.Context, setting string, value interface{},
 ) error {
-	storageURL, err := c.getNetworkURLForServer(ctx, 0, false /* includeAppName */, forSystemTenant)
-	if err != nil {
-		return err
-	}
-	db, err := gosql.Open("postgres", storageURL.ToPQ().String())
+	db, err := c.internalDBConn(ctx, forSystemTenant)
 	if err != nil {
 		return err
 	}
@@ -1688,7 +1693,9 @@ func (c *transientCluster) SetClusterSetting(
 		return err
 	}
 	if c.demoCtx.Multitenant {
-		_, err = db.Exec(fmt.Sprintf("ALTER TENANT ALL SET CLUSTER SETTING %s = '%v'", setting, value))
+		_, err = db.Exec(fmt.Sprintf(
+			"ALTER TENANT ALL SET CLUSTER SETTING %s = '%v'", setting, value,
+		))
 	}
 	return err
 }
@@ -1702,7 +1709,13 @@ func (c *transientCluster) SetupWorkload(ctx context.Context) error {
 	// fixture.
 	gen := c.demoCtx.WorkloadGenerator
 	if gen != nil {
-		db, err := gosql.Open("postgres", c.connURL)
+		// Use an internal connection for workload setup because the
+		// workload initialization code may access crdb_internal tables.
+		targetServer := forSystemTenant
+		if c.demoCtx.Multitenant {
+			targetServer = forSecondaryTenant
+		}
+		db, err := c.internalDBConn(ctx, targetServer)
 		if err != nil {
 			return err
 		}
@@ -1726,13 +1739,13 @@ func (c *transientCluster) SetupWorkload(ctx context.Context) error {
 				fmt.Println("#\n# Partitioning the demo database, please wait...")
 			}
 
-			db, err := gosql.Open("postgres", c.connURL)
+			pdb, err := c.internalDBConn(ctx, targetServer)
 			if err != nil {
 				return err
 			}
-			defer db.Close()
+			defer pdb.Close()
 			// Based on validation done in setup, we know that this workload has a partitioning step.
-			if err := gen.(workload.Hookser).Hooks().Partition(db); err != nil {
+			if err := gen.(workload.Hookser).Hooks().Partition(pdb); err != nil {
 				return errors.Wrapf(err, "partitioning the demo database")
 			}
 		}
@@ -1889,12 +1902,7 @@ func (c *transientCluster) runWorkload(
 
 // EnableEnterprise enables enterprise features for this demo.
 func (c *transientCluster) EnableEnterprise(ctx context.Context) error {
-	purl, err := c.getNetworkURLForServer(ctx, 0, true /* includeAppName */, forSystemTenant)
-	if err != nil {
-		return err
-	}
-	connURL := purl.ToPQ().String()
-	db, err := gosql.Open("postgres", connURL)
+	db, err := c.internalDBConn(ctx, forSystemTenant)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -139,10 +139,6 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			actual.StoreSpecs = nil
 			actual.Knobs.JobsTestingKnobs = nil
 
-			// Copy the SQLEvalContext from actual to expected since it's set by SetUnsafeOverride
-			// and contains function pointers that we can't predict
-			tc.expected.Knobs.SQLEvalContext = actual.Knobs.SQLEvalContext
-
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/pkg/cli/democluster/session_persistence.go
+++ b/pkg/cli/democluster/session_persistence.go
@@ -67,6 +67,13 @@ func (c *transientCluster) doPersistence(
 		WithUsername(username.RootUser).
 		WithAuthn(pgurl.AuthnClientCert(rootCert, rootKey)).
 		WithTransport(pgurl.TransportTLS(pgurl.TLSRequire, caCert))
+	// Use an internal app name so that the connection is allowed to access
+	// system tables without the allow_unsafe_internals session variable.
+	if err := u.SetOption(
+		"application_name", catconstants.InternalAppNamePrefix+" cockroach demo",
+	); err != nil {
+		return err
+	}
 
 	apply := func(filename string, u *pgurl.URL) error {
 		db, err := gosql.Open("postgres", u.ToPQ().String())

--- a/pkg/cli/testdata/demo/test_demo_locality
+++ b/pkg/cli/testdata/demo/test_demo_locality
@@ -1,8 +1,10 @@
 exec
 demo
 --nodes=3
+--execute=SET allow_unsafe_internals = true
 --execute=select node_id, locality from crdb_internal.gossip_nodes order by node_id
 ----
+SET
 node_id	locality
 1	region=us-east1,az=b
 2	region=us-east1,az=c
@@ -11,8 +13,10 @@ node_id	locality
 exec
 demo
 --nodes=9
+--execute=SET allow_unsafe_internals = true
 --execute=select node_id, locality from crdb_internal.gossip_nodes order by node_id
 ----
+SET
 node_id	locality
 1	region=us-east1,az=b
 2	region=us-east1,az=c
@@ -28,8 +32,10 @@ exec
 demo
 --nodes=3
 --demo-locality=region=us-east1:region=us-east2:region=us-east3
+--execute=SET allow_unsafe_internals = true
 --execute=select node_id, locality from crdb_internal.gossip_nodes order by node_id
 ----
+SET
 node_id	locality
 1	region=us-east1
 2	region=us-east2


### PR DESCRIPTION
Remove the `serverutils.SetUnsafeOverride` call from the demo cluster's server args. Demo clusters should behave like real clusters with `allow_unsafe_internals` defaulting to false. The `AllowExecuteInternal` mechanism in clisqlclient already handles cases where the SQL shell needs to execute internal queries (e.g. statement diagnostics, connection metadata).

Users who need to access `crdb_internal` or `system` tables in a demo session can explicitly `SET allow_unsafe_internals = true`.

Closes #165969

Release note: None