### PR TITLE
release-24.3: roachtest: jepsen - ignore analysis timeouts

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
@@ -428,6 +429,20 @@ func runJepsen(ctx context.Context, t test.Test, c cluster.Cluster, testName, ne
 		if ignoreErr {
 			t.Skip("recognized known error", testErr.Error())
 		}
+
+		// Check for timeouts where the Jepsen workload completed but analysis took too long.
+		// This typically happens when the history is large (e.g., due to many transaction retries
+		// under chaos nemeses), making linearizability checking slow.
+		// We still capture the logs above, but we want to classify this as a transient failure
+		// and not a test failure, since it's a known flake.
+		if testErr.Error() == "timed out" {
+			if err := runE(c, ctx, controller,
+				`grep -q "Run complete" /mnt/data1/jepsen/cockroachdb/store/latest/jepsen.log`,
+			); err == nil {
+				t.Fatal(rperrors.TransientFailure(testErr, "jepsen workload completed, but analysis timed out"))
+			}
+		}
+
 		t.Fatal(testErr)
 	} else {
 		collectFiles := []string{


### PR DESCRIPTION
Backport 1/1 commits from #165127.

/cc @cockroachdb/release

---

During its run, Jepsen can accumulate a very large operation history (e.g., due to transaction retries that Jepsen does not handle at the client level).

This causes the post-run linearizability analysis to exceed the 40 min. roachtest timeout, generating numerous issues that are test flakes.

This patch detects scenarios in which the test times out, but the Jepsen workload succeeded (indicated by "Run complete" in jepsen.log). This situation means the timeout happened during the analysis phase, which is known to be flaky. We return a `TransientFailure` to file the failure as an X-Infra-Flake.

Epic: none
Fixes: #164919
Release note: None

----

Release justification: test-change only