### PR TITLE
storage: add delete to sorted disk map batch writer interface and implement it

### DIFF
--- a/pkg/kv/kvserver/diskmap/disk_map.go
+++ b/pkg/kv/kvserver/diskmap/disk_map.go
@@ -66,11 +66,17 @@ type SortedDiskMapBatchWriter interface {
 	// Flush flushes all writes to the underlying store. The batch can be reused
 	// after a call to Flush().
 	Flush() error
-	// The number of put calls since the last time the writer was flushed.
-	NumPutsSinceFlush() int
+	// The number of put and delete calls since the last time the writer was
+	// flushed.
+	NumMutationsSinceFlush() int
 	// Close flushes all writes to the underlying store and frees up resources
 	// held by the batch writer.
 	Close(context.Context) error
+
+	// DeleteRange removes all keys in the range [start, end) from the batch.
+	// The deletion is applied on Flush(), Close(), or when the batch writer
+	// reaches its capacity.
+	DeleteRange(start, end []byte) error
 }
 
 // SortedDiskMap is an on-disk map. Keys are iterated over in sorted order.

--- a/pkg/sql/rowcontainer/disk_row_container.go
+++ b/pkg/sql/rowcontainer/disk_row_container.go
@@ -241,7 +241,7 @@ func (d *DiskRowContainer) AddRow(ctx context.Context, row rowenc.EncDatumRow) e
 	// rows -- we need to track these in the de-dup cache so that later
 	// calls to AddRowWithDeDup() de-duplicate wrt this cache.
 	if d.deDuplicate {
-		if d.bufferedRows.NumPutsSinceFlush() == 0 {
+		if d.bufferedRows.NumMutationsSinceFlush() == 0 {
 			d.clearDeDupCache(ctx)
 		} else {
 			if err := d.memAcc.Grow(ctx, int64(len(d.scratchKey))); err != nil {
@@ -306,7 +306,7 @@ func (d *DiskRowContainer) AddRowWithDeDup(
 	if err := d.bufferedRows.Put(d.scratchKey, d.scratchVal); err != nil {
 		return 0, err
 	}
-	if d.bufferedRows.NumPutsSinceFlush() == 0 {
+	if d.bufferedRows.NumMutationsSinceFlush() == 0 {
 		d.clearDeDupCache(ctx)
 	} else {
 		if err = d.memAcc.Grow(ctx, int64(len(d.scratchKey))); err != nil {

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -334,7 +334,7 @@ func TestDiskRowContainer(t *testing.T) {
 			addRowCalls := rng.Intn(numRows)
 			for i := 0; i < addRowCalls; i++ {
 				require.NoError(t, d.AddRow(ctx, rows[i]))
-				require.Equal(t, d.bufferedRows.NumPutsSinceFlush(), len(d.deDupCache))
+				require.Equal(t, d.bufferedRows.NumMutationsSinceFlush(), len(d.deDupCache))
 			}
 			// Repeatedly add the same set of rows.
 			for i := 0; i < 3; i++ {

--- a/pkg/storage/disk_map.go
+++ b/pkg/storage/disk_map.go
@@ -40,10 +40,13 @@ type pebbleMapBatchWriter struct {
 	// makeKey is a function that transforms a key into a byte slice with a prefix
 	// to be written to the underlying store.
 	makeKey func(k []byte) []byte
-	batch   *pebble.Batch
+	// makeKeyNoSeq is the makeKey function without sequence numbers, used for
+	// delete range operations.
+	makeKeyNoSeq func(k []byte) []byte
+	batch        *pebble.Batch
 	// onFlush will be called after every batch commit.
-	onFlush           func()
-	numPutsSinceFlush int
+	onFlush                func()
+	numMutationsSinceFlush int
 }
 
 // pebbleMapIterator iterates over the keys of a pebbleMap in sorted order.
@@ -139,15 +142,16 @@ func (r *pebbleMap) NewBatchWriterCapacity(capacityBytes int) diskmap.SortedDisk
 		makeKey = r.makeKeyWithSequence
 	}
 	b := &pebbleMapBatchWriter{
-		capacity: capacityBytes,
-		makeKey:  makeKey,
-		batch:    r.store.NewBatch(),
+		capacity:     capacityBytes,
+		makeKey:      makeKey,
+		makeKeyNoSeq: r.makeKey,
+		batch:        r.store.NewBatch(),
 	}
 	b.onFlush = func() {
 		// If we happened to have Put very large keys, we want to lose
 		// references to them.
 		r.gcPrefixSlice()
-		b.numPutsSinceFlush = 0
+		b.numMutationsSinceFlush = 0
 		b.batch = r.store.NewBatch()
 	}
 	return b
@@ -242,7 +246,22 @@ func (b *pebbleMapBatchWriter) Put(k []byte, v []byte) error {
 	if err := b.batch.Set(key, v, nil); err != nil {
 		return err
 	}
-	b.numPutsSinceFlush++
+	b.numMutationsSinceFlush++
+	if len(b.batch.Repr()) >= b.capacity {
+		return b.Flush()
+	}
+	return nil
+}
+
+// DeleteRange implements the SortedDiskMapBatchWriter interface.
+// Deletes all keys in the range [start, end).
+func (b *pebbleMapBatchWriter) DeleteRange(start, end []byte) error {
+	startKey := slices.Clone(b.makeKeyNoSeq(start))
+	endKey := slices.Clone(b.makeKeyNoSeq(end))
+	if err := b.batch.DeleteRange(startKey, endKey, nil); err != nil {
+		return err
+	}
+	b.numMutationsSinceFlush++
 	if len(b.batch.Repr()) >= b.capacity {
 		return b.Flush()
 	}
@@ -258,9 +277,9 @@ func (b *pebbleMapBatchWriter) Flush() error {
 	return nil
 }
 
-// NumPutsSinceFlush implements the SortedDiskMapBatchWriter interface.
-func (b *pebbleMapBatchWriter) NumPutsSinceFlush() int {
-	return b.numPutsSinceFlush
+// NumMutationsSinceFlush implements the SortedDiskMapBatchWriter interface.
+func (b *pebbleMapBatchWriter) NumMutationsSinceFlush() int {
+	return b.numMutationsSinceFlush
 }
 
 // Close implements the SortedDiskMapBatchWriter interface.

--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 // Helper function to run a datadriven test for a provided diskMap
@@ -120,6 +121,19 @@ func runTestForEngine(ctx context.Context, t *testing.T, filename string, engine
 					if err != nil {
 						return err.Error()
 					}
+				case "delete-range":
+					if len(parts) != 3 {
+						return "delete-range <start> <end>\n"
+					}
+					start := []byte(strings.TrimSpace(parts[1]))
+					end := []byte(strings.TrimSpace(parts[2]))
+					// Use "_" as a placeholder for nil/empty keys.
+					if parts[1] == "_" {
+						start = nil
+					}
+					if err := batch.DeleteRange(start, end); err != nil {
+						return err.Error()
+					}
 				default:
 					return fmt.Sprintf("unknown op: %s", parts[0])
 				}
@@ -204,6 +218,38 @@ func TestPebbleMultiMap(t *testing.T) {
 
 	runTestForEngine(ctx, t, datapathutils.TestDataPath(t, "diskmap_duplicates_pebble"), e)
 
+}
+
+func TestPebbleMapNumMutationsSinceFlush(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	e, _, err := newTempEngine(ctx, base.TempStorageConfig{
+		Path:     dir,
+		Settings: cluster.MakeClusterSettings(),
+	}, disk.NewWriteStatsManager(vfs.Default))
+	require.NoError(t, err)
+	defer e.Close()
+
+	diskMap := newPebbleMap(e.db, false /* allowDuplicates */)
+	bw := diskMap.NewBatchWriter()
+	defer func() {
+		require.NoError(t, bw.Close(ctx))
+	}()
+
+	require.Equal(t, 0, bw.NumMutationsSinceFlush())
+	require.NoError(t, bw.Put([]byte("a"), []byte("1")))
+	require.Equal(t, 1, bw.NumMutationsSinceFlush())
+	require.NoError(t, bw.Put([]byte("b"), []byte("2")))
+	require.Equal(t, 2, bw.NumMutationsSinceFlush())
+	require.NoError(t, bw.DeleteRange([]byte("a"), []byte("a\x00")))
+	require.Equal(t, 3, bw.NumMutationsSinceFlush())
+	require.NoError(t, bw.Flush())
+	require.Equal(t, 0, bw.NumMutationsSinceFlush())
+	require.NoError(t, bw.DeleteRange([]byte("b"), []byte("b\x00")))
+	require.Equal(t, 1, bw.NumMutationsSinceFlush())
 }
 
 func TestPebbleMapClose(t *testing.T) {

--- a/pkg/storage/testdata/diskmap
+++ b/pkg/storage/testdata/diskmap
@@ -56,6 +56,81 @@ cd:2
 d3:3
 .
 
+batch main
+put e 1
+put f 2
+----
+
+iter main
+seek e
+next
+next
+----
+e:1
+f:2
+.
+
+batch main
+delete-range e f
+----
+
+iter main
+seek e
+----
+f:2
+
+batch main
+put x 1
+put y 2
+put z 3
+----
+
+iter main
+rewind
+next
+next
+next
+next
+next
+next
+next
+next
+next
+----
+a:3
+b:2
+c:1
+cd:2
+d3:3
+f:2
+x:1
+y:2
+z:3
+.
+
+batch main
+delete-range _ c
+----
+
+iter main
+rewind
+next
+next
+next
+next
+next
+next
+next
+----
+c:1
+cd:2
+d3:3
+f:2
+x:1
+y:2
+z:3
+.
+
 close-map main
 ----
 

--- a/pkg/storage/testdata/diskmap_duplicates_pebble
+++ b/pkg/storage/testdata/diskmap_duplicates_pebble
@@ -62,5 +62,16 @@ cd:2
 d3:3
 .
 
+batch dups
+put e 1
+put e 2
+delete-range e f
+----
+
+iter dups
+seek e
+----
+.
+
 close-map dups
 ----


### PR DESCRIPTION
We want to use sorted disk map as a temporary storage for transactional
LDR, but SortedDiskMapBatchWriter does not currently support delete. 
We don't want to keep iterating over the same KVs that have been read,
nor do we want it to hog up the disk space, and deleting would solve these
issues.

Resolves: #165967
Release note: None