### PR TITLE
sql: show table stats rollout mode in EXPLAIN and EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -120,6 +120,8 @@ func (e *explainPlanNode) startExec(params runParams) error {
 			}
 		}
 
+		ob.AddTableStatsMode(params.EvalContext().StatsRollout.String())
+
 		if len(params.p.stmt.Hints) > 0 {
 			var hintCount uint64
 			for _, hint := range params.p.stmt.Hints {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -159,6 +159,10 @@ type instrumentationHelper struct {
 	// optimized is true if the plan was optimized or re-optimized during the
 	// current execution.
 	optimized bool
+	// tableStatsRollout records the canary table stats rollout selection for
+	// this query. Used by EXPLAIN ANALYZE to emit the table stats mode
+	// annotation.
+	tableStatsRollout eval.StatsRolloutSelection
 
 	traceMetadata execNodeTraceMetadata
 
@@ -871,6 +875,7 @@ func (ih *instrumentationHelper) emitExplainAnalyzePlanToOutputBuilder(
 	ob.AddDistribution(ih.distribution.String())
 	ob.AddVectorized(ih.vectorized)
 	ob.AddPlanType(ih.generic, ih.optimized)
+	ob.AddTableStatsMode(ih.tableStatsRollout.String())
 	ob.AddStmtHintCount(ih.stmtHintsCount)
 	ob.AddRetryCount("transaction", ih.retryCount)
 	ob.AddRetryTime("transaction", phaseTimes.GetTransactionRetryLatency())

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -214,6 +214,11 @@ type Table interface {
 	// within the canary window. This is used solely to gate canary/stable
 	// experiment metric recording.
 	CanaryAndStableStatsDiffer() bool
+
+	// StatsCanaryWindow returns the configured canary window duration for
+	// this table. A non-zero value means the table participates in canary
+	// statistics rollout.
+	StatsCanaryWindow() time.Duration
 }
 
 // CheckConstraint represents a check constraint on a table. Check constraints

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -432,6 +432,10 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 					}
 				}
 			}
+			if tab.CanaryAndStableStatsDiffer() {
+				val.CanaryStatsActive = true
+				val.CanaryWindowSize = tab.StatsCanaryWindow()
+			}
 		}
 		ef.AnnotateNode(node, exec.EstimatedStatsID, &val)
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
@@ -355,6 +355,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: canary
 ·
 • group (scalar)
 │ columns: (count)
@@ -364,6 +365,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 10 (100% of the table; stats collected <hidden> ago)
+      canary window: 1m10s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -376,6 +378,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -385,6 +388,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 1,000 (missing stats)
+      canary window: 1m10s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -470,6 +474,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: canary
 ·
 • group (scalar)
 │ columns: (count)
@@ -479,6 +484,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 55 (100% of the table; stats collected <hidden> ago)
+      canary window: 1m10s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -494,6 +500,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -503,6 +510,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 40 (100% of the table; stats collected <hidden> ago)
+      canary window: 1m10s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -532,6 +540,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: canary
 ·
 • group (scalar)
 │ columns: (count)
@@ -541,6 +550,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 64 (100% of the table; stats collected <hidden> ago; using stats forecast)
+      canary window: 1m10s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -554,6 +564,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -563,6 +574,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 50 (100% of the table; stats collected <hidden> ago; using stats forecast)
+      canary window: 1m10s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -712,6 +724,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: canary
 ·
 • group (scalar)
 │ columns: (count)
@@ -721,6 +734,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 14 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -732,6 +746,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -741,6 +756,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 9 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -797,6 +813,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: canary
 ·
 • group (scalar)
 │ columns: (count)
@@ -806,6 +823,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 16 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -818,6 +836,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -827,6 +846,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 9 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -889,6 +909,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: canary
 ·
 • group (scalar)
 │ columns: (count)
@@ -898,6 +919,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 18 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -910,6 +932,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -919,6 +942,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 16 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -963,6 +987,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM t;
 ----
 distribution: local
 vectorized: true
+table stats mode: stable
 ·
 • group (scalar)
 │ columns: (count)
@@ -972,6 +997,7 @@ vectorized: true
 └── • scan
       columns: ()
       estimated row count: 1,000 (100% of the table; stats collected <hidden> ago)
+      canary window: 1h0m0s
       table: t@t_pkey
       spans: FULL SCAN
 
@@ -1215,6 +1241,211 @@ SET CLUSTER SETTING sql.stats.flush.enabled = true
 
 statement ok
 DEALLOCATE ALL
+
+subtest end
+
+subtest multi_table_canary_window
+
+# Verify that when a query joins two tables, only the table with a canary
+# window configured shows the per-scan "canary window" annotation, while
+# the query-level "table stats mode" still reflects the dice roll.
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = '0.1'
+
+statement ok
+SET optimizer_use_forecasts = off
+
+statement ok
+DROP TABLE IF EXISTS t_canary;
+
+statement ok
+DROP TABLE IF EXISTS t_normal;
+
+statement ok
+CREATE TABLE t_canary (k INT PRIMARY KEY, v INT) WITH (sql_stats_canary_window = '60s')
+
+statement ok
+CREATE TABLE t_normal (k INT PRIMARY KEY, v INT)
+
+# Inject two generations of stats for t_canary so canary != stable.
+statement ok
+ALTER TABLE t_canary INJECT STATISTICS '[
+  {
+    "avg_size": 1,
+    "columns": ["k"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 100,
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "avg_size": 1,
+    "columns": ["k"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 200,
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 200
+  }
+]'
+
+# Inject stats for t_normal (no canary window, single generation).
+statement ok
+ALTER TABLE t_normal INJECT STATISTICS '[
+  {
+    "avg_size": 1,
+    "columns": ["k"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 50,
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 50
+  }
+]'
+
+statement ok
+SET stats_as_of = '2000-01-01 00:01:30.000000'
+
+# Canary path: t_canary shows "canary window", t_normal does not.
+statement ok
+SET canary_stats_mode = on
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t_canary JOIN t_normal ON t_canary.k = t_normal.k;
+----
+distribution: local
+vectorized: true
+table stats mode: canary
+·
+• merge join (inner)
+│ columns: (k, v, k, v)
+│ estimated row count: 50
+│ equality: (k) = (k)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(k=k)"
+│
+├── • scan
+│     columns: (k, v)
+│     ordering: +k
+│     estimated row count: 200 (100% of the table; stats collected <hidden> ago)
+│     canary window: 1m0s
+│     table: t_canary@t_canary_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (k, v)
+      ordering: +k
+      estimated row count: 50 (100% of the table; stats collected <hidden> ago)
+      table: t_normal@t_normal_pkey
+      spans: FULL SCAN
+
+# Stable path: t_canary still shows "canary window", t_normal still does not.
+statement ok
+SET canary_stats_mode = off
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t_canary JOIN t_normal ON t_canary.k = t_normal.k;
+----
+distribution: local
+vectorized: true
+table stats mode: stable
+·
+• merge join (inner)
+│ columns: (k, v, k, v)
+│ estimated row count: 50
+│ equality: (k) = (k)
+│ left cols are key
+│ right cols are key
+│ merge ordering: +"(k=k)"
+│
+├── • scan
+│     columns: (k, v)
+│     ordering: +k
+│     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+│     canary window: 1m0s
+│     table: t_canary@t_canary_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (k, v)
+      ordering: +k
+      estimated row count: 50 (100% of the table; stats collected <hidden> ago)
+      table: t_normal@t_normal_pkey
+      spans: FULL SCAN
+
+# EXPLAIN ANALYZE (VERBOSE) should show both the query-level table stats
+# mode and the per-scan canary window annotation.
+statement ok
+SET canary_stats_mode = on
+
+query T
+EXPLAIN ANALYZE (VERBOSE) SELECT count(*) FROM t_canary;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+table stats mode: canary
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• group (scalar)
+│ columns: (count)
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ vectorized batch count: 0
+│ execution time: 0µs
+│ actual row count: 1
+│ estimated row count: 1
+│ aggregate 0: count_rows()
+│
+└── • scan
+      columns: ()
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      vectorized batch count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV pairs read: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      MVCC step count (ext/int): 0/0
+      MVCC seek count (ext/int): 0/0
+      actual row count: 0
+      estimated row count: 200 (100% of the table; stats collected <hidden> ago)
+      canary window: 1m0s
+      table: t_canary@t_canary_pkey  ----------------------  WARNING: the row count estimate is inaccurate, consider running 'ANALYZE t_canary'
+      spans: FULL SCAN
+·
+WARNING: the row count estimate on table "t_canary" is inaccurate, consider running 'ANALYZE t_canary'
+
+statement ok
+RESET canary_stats_mode
+
+statement ok
+RESET stats_as_of
+
+statement ok
+RESET optimizer_use_forecasts
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = 0
+
+statement ok
+DROP TABLE IF EXISTS t_canary;
+
+statement ok
+DROP TABLE IF EXISTS t_normal;
 
 subtest end
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -708,6 +708,12 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 				}
 			}
 		}
+		// Canary window is a table property, shown regardless of whether
+		// the current stats path found usable stats (e.g. helps explain
+		// "missing stats" on the stable path).
+		if n.op == scanOp && s.CanaryStatsActive {
+			e.ob.AddField("canary window", s.CanaryWindowSize.String())
+		}
 		// TODO(radu): we may want to emit estimated cost in Verbose mode.
 	}
 

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -305,6 +305,16 @@ func (ob *OutputBuilder) AddVectorized(value bool) {
 	}
 }
 
+// AddTableStatsMode adds a top-level field indicating which table
+// statistics rollout path was used for planning. Only emitted when the
+// canary experiment is active (mode is "canary" or "stable"). Cannot
+// be called while inside a node.
+func (ob *OutputBuilder) AddTableStatsMode(mode string) {
+	if mode != "default" {
+		ob.AddTopLevelField("table stats mode", mode)
+	}
+}
+
 // AddPlanType adds a top-level generic field, if value is true. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddPlanType(generic, optimized bool) {

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"encoding/binary"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -673,6 +674,9 @@ func (u *unknownTable) Policies() *cat.Policies { return nil }
 
 // CanaryAndStableStatsDiffer is part of the cat.Table interface.
 func (u *unknownTable) CanaryAndStableStatsDiffer() bool { return false }
+
+// StatsCanaryWindow is part of the cat.Table interface.
+func (u *unknownTable) StatsCanaryWindow() time.Duration { return 0 }
 
 var _ cat.Table = &unknownTable{}
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -453,6 +453,12 @@ type EstimatedStats struct {
 	// ForecastAt is set only for scans with forecasted stats; it is the time the
 	// forecast was for (which could be in the past, present, or future).
 	ForecastAt time.Time
+	// CanaryStatsActive is set only for scans; it is true if the table has
+	// divergent canary vs. stable statistics within its canary window.
+	CanaryStatsActive bool
+	// CanaryWindowSize is set only for scans with CanaryStatsActive; it is
+	// the configured canary window duration for the table.
+	CanaryWindowSize time.Duration
 }
 
 // ExecutionStats contain statistics about a given operator gathered from the

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1250,6 +1250,9 @@ func (tt *Table) Policies() *cat.Policies {
 // CanaryAndStableStatsDiffer is part of the cat.Table interface.
 func (tt *Table) CanaryAndStableStatsDiffer() bool { return false }
 
+// StatsCanaryWindow is part of the cat.Table interface.
+func (tt *Table) StatsCanaryWindow() time.Duration { return 0 }
+
 // findPolicyByName will lookup the policy by its name. It returns it's policy
 // type and index within that policy type slice so that callers can do removal
 // if needed.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -970,6 +970,10 @@ type optTable struct {
 	// canary window.
 	canaryAndStableStatsDiffer bool
 
+	// statsCanaryWindow is the configured canary window duration for this
+	// table.
+	statsCanaryWindow time.Duration
+
 	// Row-level security (RLS) fields
 	rlsEnabled bool
 	rlsForced  bool
@@ -996,6 +1000,7 @@ func newOptTable(
 		rawStats:                   stats,
 		zone:                       tblZone,
 		canaryAndStableStatsDiffer: canaryAndStableStatsDiffer,
+		statsCanaryWindow:          desc.TableDesc().StatsCanaryWindow,
 	}
 
 	// Determine the primary key columns.
@@ -1712,6 +1717,11 @@ func (ot *optTable) Policies() *cat.Policies {
 // CanaryAndStableStatsDiffer is part of the cat.Table interface.
 func (ot *optTable) CanaryAndStableStatsDiffer() bool {
 	return ot.canaryAndStableStatsDiffer
+}
+
+// StatsCanaryWindow is part of the cat.Table interface.
+func (ot *optTable) StatsCanaryWindow() time.Duration {
+	return ot.statsCanaryWindow
 }
 
 // LookupColumnOrdinal returns the ordinal of the column with the given ID. A
@@ -2883,6 +2893,9 @@ func (ot *optVirtualTable) Policies() *cat.Policies { return nil }
 
 // CanaryAndStableStatsDiffer is part of the cat.Table interface.
 func (ot *optVirtualTable) CanaryAndStableStatsDiffer() bool { return false }
+
+// StatsCanaryWindow is part of the cat.Table interface.
+func (ot *optVirtualTable) StatsCanaryWindow() time.Duration { return 0 }
 
 // optVirtualIndex is a dummy implementation of cat.Index for the indexes
 // reported by a virtual table. The index assumes that table column 0 is a dummy

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -1060,6 +1060,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 		result = explainPlan.WrappedPlan.(*planComponents)
 		planTop.instrumentation.RecordExplainPlan(explainPlan)
 	}
+	planTop.instrumentation.tableStatsRollout = evalCtx.StatsRollout
 	planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
 	planTop.instrumentation.totalScanRows = bld.TotalScanRows
 	planTop.instrumentation.totalScanRowsWithoutForecasts = bld.TotalScanRowsWithoutForecasts

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -68,6 +68,18 @@ const (
 	StatsRolloutStable
 )
 
+// String returns the string representation for the stats rollout selection.
+func (s StatsRolloutSelection) String() string {
+	switch s {
+	case StatsRolloutCanary:
+		return "canary"
+	case StatsRolloutStable:
+		return "stable"
+	default:
+		return "default"
+	}
+}
+
 // Context defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
 //


### PR DESCRIPTION
When the canary stats experiment is active (`sql.stats.canary_fraction > 0`),
`EXPLAIN` and `EXPLAIN ANALYZE` now emit a "table stats mode" field indicating
whether the plan was built using "canary" (newest) or "stable"
(second-newest) table statistics. The field is omitted when the
experiment is off (i.e. `sql.stats.canary_fraction == 0`).

Individual scan nodes also show the table's canary window duration
(`canary window: <duration>`) when the table has divergent canary vs.
stable statistics. This is a table-level property indicating the table
participates in the experiment; the query-level `table stats mode`
field indicates which stats path was actually used.

Part of: https://github.com/cockroachdb/cockroach/issues/156817

Release note (sql change): EXPLAIN and EXPLAIN ANALYZE now display
a "table stats mode" field ("canary" or "stable") when the canary
statistics rollout experiment is active, indicating which table
statistics were used for query planning. Scan nodes for tables with
active canary stats also show the configured canary window duration.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>