### PR TITLE
testutils: add better SucceedsSoon

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -7,7 +7,6 @@ package kvserver_test
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"runtime"
 	"strconv"
@@ -98,13 +97,13 @@ func TestStoreRangeLease(t *testing.T) {
 	// lease and getting an expiration based lease.
 	for _, key := range splitKeys {
 		repl := store.LookupReplica(roachpb.RKey(key))
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
 			status := repl.RaftStatus()
-			if status == nil || status.Lead == 0 {
-				return errors.Errorf("waiting for raft leadership on key %s (range %d): state=%v",
-					key, repl.RangeID, status.RaftState)
-			}
-			return nil
+			require.NotNil(t, status,
+				"waiting for raft status on key %s (range %d)", key, repl.RangeID)
+			require.NotZero(t, status.Lead,
+				"waiting for raft leadership on key %s (range %d): state=%v",
+				key, repl.RangeID, status.RaftState)
 		})
 	}
 
@@ -115,9 +114,9 @@ func TestStoreRangeLease(t *testing.T) {
 	for _, key := range splitKeys {
 		incArgs := incrementArgs(key, int64(5))
 
-		testutils.SucceedsSoon(t, func() error {
-			_, err := kv.SendWrapped(ctx, store.TestSender(), incArgs)
-			return err.GoError()
+		testutils.Soon(t, func(t *testutils.RetryT) {
+			_, pErr := kv.SendWrapped(ctx, store.TestSender(), incArgs)
+			require.NoError(t, pErr.GoError())
 		})
 	}
 
@@ -255,14 +254,11 @@ func TestGossipNodeLivenessOnLeaseChange(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	testutils.SucceedsSoon(t, func() error {
-		if tc.GetFirstStoreFromServer(t, initialServerId).Gossip().InfoOriginatedHere(nodeLivenessKey) {
-			return fmt.Errorf("%s still most recently gossiped by original leaseholder", nodeLivenessKey)
-		}
-		if !tc.GetFirstStoreFromServer(t, newServerIdx).Gossip().InfoOriginatedHere(nodeLivenessKey) {
-			return fmt.Errorf("%s not most recently gossiped by new leaseholder", nodeLivenessKey)
-		}
-		return nil
+	testutils.Soon(t, func(rt *testutils.RetryT) {
+		require.False(rt, tc.GetFirstStoreFromServer(t, initialServerId).Gossip().InfoOriginatedHere(nodeLivenessKey),
+			"%s still most recently gossiped by original leaseholder", nodeLivenessKey)
+		require.True(rt, tc.GetFirstStoreFromServer(t, newServerIdx).Gossip().InfoOriginatedHere(nodeLivenessKey),
+			"%s not most recently gossiped by new leaseholder", nodeLivenessKey)
 	})
 }
 
@@ -520,7 +516,7 @@ func TestTransferLeaseDuringJointConfigWithDeadIncomingVoter(t *testing.T) {
 	tc.StopServer(3)
 
 	// Wait for n1 to notice.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		// Manually report n4 as unreachable to speed up the test.
 		require.NoError(t, repl0.RaftReportUnreachable(4))
 		// Check the Raft progress.
@@ -529,10 +525,7 @@ func TestTransferLeaseDuringJointConfigWithDeadIncomingVoter(t *testing.T) {
 		p := s.Progress
 		require.Len(t, p, 4)
 		require.Contains(t, p, raftpb.PeerID(4))
-		if p[4].State != tracker.StateProbe {
-			return errors.Errorf("dead replica not state probe")
-		}
-		return nil
+		require.Equal(t, tracker.StateProbe, p[4].State, "dead replica not state probe")
 	})
 
 	// Run the range through the replicate queue on n1.
@@ -881,15 +874,10 @@ func TestLeasePreferencesRebalance(t *testing.T) {
 	// Manually move lease out of preference.
 	tc.TransferRangeLeaseOrFatal(t, desc, tc.Target(1))
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		lh, err := tc.FindRangeLeaseHolder(desc, nil)
-		if err != nil {
-			return err
-		}
-		if !lh.Equal(tc.Target(1)) {
-			return errors.Errorf("Expected leaseholder to be %s but was %s", tc.Target(1), lh)
-		}
-		return nil
+		require.NoError(t, err)
+		require.Equal(t, tc.Target(1), lh, "Expected leaseholder to be %s but was %s", tc.Target(1), lh)
 	})
 
 	tc.GetFirstStoreFromServer(t, 1).TestingSetReplicateQueueActive(true)
@@ -898,15 +886,10 @@ func TestLeasePreferencesRebalance(t *testing.T) {
 	require.NoError(t, tc.GetFirstStoreFromServer(t, 1).ForceLeaseQueueProcess())
 
 	// The lease should be moved back by the rebalance queue to us-west.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		lh, err := tc.FindRangeLeaseHolder(desc, nil)
-		if err != nil {
-			return err
-		}
-		if !lh.Equal(tc.Target(0)) {
-			return errors.Errorf("Expected leaseholder to be %s but was %s", tc.Target(0), lh)
-		}
-		return nil
+		require.NoError(t, err)
+		require.Equal(t, tc.Target(0), lh, "Expected leaseholder to be %s but was %s", tc.Target(0), lh)
 	})
 }
 
@@ -969,53 +952,36 @@ func TestLeaseholderRelocate(t *testing.T) {
 	// Make sure the lease is on 3 and is fully upgraded.
 	tc.TransferRangeLeaseOrFatal(t, rhsDesc, tc.Target(2))
 
-	var err error
 	var leaseHolder roachpb.ReplicationTarget
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		var err error
 		leaseHolder, err = tc.FindRangeLeaseHolder(rhsDesc, nil)
-		if err != nil {
-			return err
-		}
+		require.NoError(t, err)
 
 		// Check that the lease moved to 3.
-		if !leaseHolder.Equal(tc.Target(2)) {
-			return errors.Errorf("Leaseholder didn't move.")
-		}
-
-		return nil
+		require.True(t, leaseHolder.Equal(tc.Target(2)), "Leaseholder didn't move.")
 	})
 
 	gossipLiveness(t, tc)
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		// Relocate range 3 -> 4.
-		err = tc.Servers[2].DB().
+		require.NoError(t, tc.Servers[2].DB().
 			AdminRelocateRange(
 				context.Background(), rhsDesc.StartKey.AsRawKey(),
-				tc.Targets(0, 1, 3), nil, false)
-		if err != nil {
-			return err
-		}
+				tc.Targets(0, 1, 3), nil, false))
+		var err error
 		leaseHolder, err = tc.FindRangeLeaseHolder(rhsDesc, nil)
-		if err != nil {
-			return err
-		}
-		if leaseHolder.Equal(tc.Target(2)) {
-			return errors.Errorf("Leaseholder didn't move.")
-		}
-		return nil
+		require.NoError(t, err)
+		require.False(t, leaseHolder.Equal(tc.Target(2)), "Leaseholder didn't move.")
 	})
 
 	// Make sure lease moved to the preferred region.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		var err error
 		leaseHolder, err = tc.FindRangeLeaseHolder(rhsDesc, nil)
-		if err != nil {
-			return err
-		}
-		if !leaseHolder.Equal(tc.Target(3)) {
-			return errors.Errorf("Leaseholder didn't move.")
-		}
-		return nil
+		require.NoError(t, err)
+		require.True(t, leaseHolder.Equal(tc.Target(3)), "Leaseholder didn't move.")
 	})
 
 	// Double check that lease moved directly. The tail of the lease history
@@ -1040,23 +1006,20 @@ func TestLeaseholderRelocate(t *testing.T) {
 
 func gossipLiveness(t *testing.T, tc *testcluster.TestCluster) {
 	for i := range tc.Servers {
-		testutils.SucceedsSoon(t, tc.Servers[i].HeartbeatNodeLiveness)
+		testutils.Soon(t, func(rt *testutils.RetryT) {
+			require.NoError(rt, tc.Servers[i].HeartbeatNodeLiveness())
+		})
 	}
 	// Make sure that all store pools have seen liveness heartbeats from everyone.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		for i := range tc.Servers {
 			for j := range tc.Servers {
 				live, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().
 					StorePool.IsLive(tc.Target(j).StoreID)
-				if err != nil {
-					return err
-				}
-				if !live {
-					return errors.Errorf("Server %d is suspect on server %d", j, i)
-				}
+				require.NoError(rt, err)
+				require.True(rt, live, "Server %d is suspect on server %d", j, i)
 			}
 		}
-		return nil
 	})
 }
 
@@ -1197,16 +1160,16 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 			// allocator on server 0 may see everyone as temporarily dead due to the
 			// clock move above.
 			for _, i := range []int{0, 3, 4} {
-				testutils.SucceedsSoon(t, func() error {
+				testutils.Soon(t, func(rt *testutils.RetryT) {
 					err := tc.Servers[i].HeartbeatNodeLiveness()
 					if err != nil {
 						if errors.Is(err, liveness.ErrEpochIncremented) {
 							t.Logf("retrying heartbeat after err %s", err)
-							return err
+							require.NoError(rt, err)
+							return
 						}
 						t.Fatalf("unexpected error heartbeating liveness record for server %d: %s", i, err)
 					}
-					return nil
 				})
 				require.NoError(t, tc.GetFirstStoreFromServer(t, i).GossipStore(ctx, true))
 			}
@@ -1228,21 +1191,14 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 			return nil
 		}
 
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			store := tc.GetFirstStoreFromServer(t, 0)
 			sl, available, _ := store.GetStoreConfig().StorePool.TestingGetStoreList()
-			if available != 3 {
-				return errors.Errorf(
-					"expected all 3 remaining stores to be live, but only got %d, stores=%v",
-					available, sl)
-			}
-			if err := checkDead(store, 1); err != nil {
-				return err
-			}
-			if err := checkDead(store, 2); err != nil {
-				return err
-			}
-			return nil
+			require.Equal(rt, 3, available,
+				"expected all 3 remaining stores to be live, but only got %d, stores=%v",
+				available, sl)
+			require.NoError(rt, checkDead(store, 1))
+			require.NoError(rt, checkDead(store, 2))
 		})
 	}()
 
@@ -1253,18 +1209,13 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 	_, pErr := tc.Servers[0].DistSenderI().(kv.Sender).Send(ctx, ba)
 	require.NoError(t, pErr.GoError())
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		// Validate that the lease transferred to a preferred locality. n4 (us) and
 		// n5 (us) are the only valid stores to be leaseholders during the outage.
 		// n1 is the original leaseholder, expect it to not be the leaseholder now.
-		if !repl.OwnsValidLease(ctx, tc.Servers[0].Clock().NowAsClockTimestamp()) {
-			return nil
-		}
-
-		return errors.Errorf(
+		require.False(t, repl.OwnsValidLease(ctx, tc.Servers[0].Clock().NowAsClockTimestamp()),
 			"expected no leaseholder in region=us, but found %v",
-			repl.CurrentLeaseStatus(ctx),
-		)
+			repl.CurrentLeaseStatus(ctx))
 	})
 }
 
@@ -1378,35 +1329,30 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	}
 
 	// Make sure that all store pools have seen liveness heartbeats from everyone.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		for i := range tc.Servers {
 			for j := range tc.Servers {
 				live, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().StorePool.IsLive(tc.Target(j).StoreID)
-				if err != nil {
-					return err
-				}
-				if !live {
-					return errors.Errorf("Expected server %d to be suspect on server %d", j, i)
-				}
+				require.NoError(rt, err)
+				require.True(rt, live, "Expected server %d to be suspect on server %d", j, i)
 			}
 		}
-		return nil
 	})
 
 	for _, key := range startKeys {
 		repl := tc.GetFirstStoreFromServer(t, 1).LookupReplica(roachpb.RKey(key))
 		tc.TransferRangeLeaseOrFatal(t, *repl.Desc(), tc.Target(1))
-		testutils.SucceedsSoon(t, func() error {
-			if !repl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()) {
-				return errors.Errorf("Expected lease to transfer to server 1 for replica %s", repl)
-			}
-			return nil
+		testutils.Soon(t, func(t *testutils.RetryT) {
+			require.True(t, repl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()),
+				"Expected lease to transfer to server 1 for replica %s", repl)
 		})
 	}
 
 	heartbeat := func(servers ...int) {
 		for _, i := range servers {
-			testutils.SucceedsSoon(t, tc.Servers[i].HeartbeatNodeLiveness)
+			testutils.Soon(t, func(rt *testutils.RetryT) {
+				require.NoError(rt, tc.Servers[i].HeartbeatNodeLiveness())
+			})
 		}
 	}
 
@@ -1423,17 +1369,12 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 		heartbeat(0, 2, 3)
 	}
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		for _, i := range []int{2, 3} {
 			suspect, err := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().StorePool.IsUnknown(tc.Target(1).StoreID)
-			if err != nil {
-				return err
-			}
-			if !suspect {
-				return errors.Errorf("Expected server 1 to be in `storeStatusUnknown` on server %d", i)
-			}
+			require.NoError(rt, err)
+			require.True(rt, suspect, "Expected server 1 to be in `storeStatusUnknown` on server %d", i)
 		}
-		return nil
 	})
 
 	runThroughTheLeaseQueue := func(key roachpb.Key) {
@@ -1448,9 +1389,9 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	}
 
 	for _, key := range startKeys {
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			runThroughTheLeaseQueue(key)
-			return leaseOnNonSuspectStores(key)
+			require.NoError(rt, leaseOnNonSuspectStores(key))
 		})
 	}
 	require.NoError(t, tc.RestartServer(1))
@@ -1463,7 +1404,9 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	for _, key := range startKeys {
 		runThroughTheLeaseQueue(key)
 	}
-	testutils.SucceedsSoon(t, allLeasesOnNonSuspectStores)
+	testutils.Soon(t, func(rt *testutils.RetryT) {
+		require.NoError(rt, allLeasesOnNonSuspectStores())
+	})
 	// Wait out the suspect time.
 	suspectDuration := liveness.TimeAfterNodeSuspect.Get(&tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().Settings.SV)
 	for i := 0; i < int(math.Ceil(suspectDuration.Seconds())); i++ {
@@ -1471,18 +1414,20 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 		heartbeat(0, 1, 2, 3)
 	}
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		// Server 1 should get some leases back as it's no longer suspect.
 		for _, key := range startKeys {
 			runThroughTheLeaseQueue(key)
 		}
+		hasLease := false
 		for _, key := range startKeys {
 			repl := tc.GetFirstStoreFromServer(t, 1).LookupReplica(roachpb.RKey(key))
 			if repl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()) {
-				return nil
+				hasLease = true
+				break
 			}
 		}
-		return errors.Errorf("Expected server 1 to have at lease 1 lease.")
+		require.True(rt, hasLease, "Expected server 1 to have at least 1 lease.")
 	})
 }
 
@@ -1512,16 +1457,13 @@ func TestAlterRangeRelocate(t *testing.T) {
 	// Move lease 1 -> 4.
 	_, err = db.Exec("ALTER RANGE $1 RELOCATE LEASE TO $2", rhsDesc.RangeID, 4)
 	require.NoError(t, err)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		repl := tc.GetFirstStoreFromServer(t, 3).LookupReplica(rhsDesc.StartKey)
-		if !repl.OwnsValidLease(ctx, tc.Servers[0].Clock().NowAsClockTimestamp()) {
-			return errors.Errorf("Expected lease to transfer to node 4")
-		}
+		require.True(rt, repl.OwnsValidLease(ctx, tc.Servers[0].Clock().NowAsClockTimestamp()),
+			"Expected lease to transfer to node 4")
 		// Do this to avoid snapshot problems below when we do another replica move.
-		if repl != tc.GetRaftLeader(t, rhsDesc.StartKey) {
-			return errors.Errorf("Expected node 4 to be the raft leader")
-		}
-		return nil
+		require.Same(rt, repl, tc.GetRaftLeader(t, rhsDesc.StartKey),
+			"Expected node 4 to be the raft leader")
 	})
 
 	// Move lease 3 -> 5.
@@ -1711,13 +1653,11 @@ func TestLeaseTransfersUseExpirationLeasesAndPromoteCorrectly(t *testing.T) {
 
 		// Transfer the lease from n1 to n2.
 		tc.TransferRangeLeaseOrFatal(t, desc, n2Target)
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
 			li, _, err := tc.FindRangeLeaseEx(ctx, desc, nil)
 			require.NoError(t, err)
-			if !li.Current().OwnedBy(n2.GetFirstStoreID()) {
-				return errors.New("lease still owned by n1")
-			}
-			return nil
+			require.True(t, li.Current().OwnedBy(n2.GetFirstStoreID()),
+				"lease still owned by n1")
 		})
 
 		// Expect it to be upgraded to an epoch based lease or leader lease, based
@@ -1860,15 +1800,10 @@ func TestLeaseRequestFromExpirationToEpochOrLeaderDoesNotRegressExpiration(t *te
 				// lease with this error: unable to get liveness record. This can happen
 				// if we pause the node liveness heartbeat before the record is even
 				// created.
-				testutils.SucceedsSoon(t, func() error {
+				testutils.Soon(t, func(t *testutils.RetryT) {
 					l, ok := l0.GetLiveness(tc.Server(0).NodeID())
-					if !ok {
-						return errors.New("liveness not found")
-					}
-					if l.Epoch == 0 {
-						return errors.New("liveness epoch not set")
-					}
-					return nil
+					require.True(t, ok, "liveness not found")
+					require.NotZero(t, l.Epoch, "liveness epoch not set")
 				})
 
 				l0.PauseHeartbeatLoopForTest()
@@ -1898,12 +1833,10 @@ func TestLeaseRequestFromExpirationToEpochOrLeaderDoesNotRegressExpiration(t *te
 
 			// Wait for the expiration-based lease to have a later expiration than the
 			// expiration timestamp in n1's liveness record.
-			testutils.SucceedsSoon(t, func() error {
+			testutils.Soon(t, func(t *testutils.RetryT) {
 				expLease = repl.CurrentLeaseStatus(ctx)
-				if expLease.Expiration().Less(ts) {
-					return errors.Errorf("lease %v not extended beyond liveness %v", expLease, ts)
-				}
-				return nil
+				require.False(t, expLease.Expiration().Less(ts),
+					"lease %v not extended beyond liveness %v", expLease, ts)
 			})
 
 			// Enable the specified lease type. This will cause automatic lease
@@ -2010,12 +1943,10 @@ func TestLeaseStartTimeIsLargerThanPrevLeaseEndTimeAfterRestart(t *testing.T) {
 
 			// Make sure that the lease is valid.
 			var curLease roachpb.Lease
-			testutils.SucceedsSoon(t, func() error {
+			testutils.Soon(t, func(rt *testutils.RetryT) {
 				repl = tc.GetFirstStoreFromServer(t, 0).GetReplicaIfExists(desc.RangeID)
-				if repl.CurrentLeaseStatus(ctx).State != kvserverpb.LeaseState_VALID {
-					return errors.Errorf("lease not valid")
-				}
-				return nil
+				require.Equal(rt, kvserverpb.LeaseState_VALID,
+					repl.CurrentLeaseStatus(ctx).State, "lease not valid")
 			})
 
 			// Make sure that the lease start time is larger than the prev lease end

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -543,18 +543,13 @@ func mergeCheckingTimestampCaches(
 
 	if disjointLeaseholders {
 		tc.TransferRangeLeaseOrFatal(t, *rhsDesc, tc.Target(1))
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
 			rhsRepl, err := rhsStore.GetReplica(rhsDesc.RangeID)
-			if err != nil {
-				return err
-			}
-			if !rhsRepl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()) {
-				return errors.New("rhs store does not own valid lease for rhs range")
-			}
-			if rhsRepl.CurrentLeaseStatus(ctx).Lease.Type() != roachpb.LeaseEpoch {
-				return errors.Errorf("lease still an expiration based lease")
-			}
-			return nil
+			require.NoError(t, err)
+			require.True(t, rhsRepl.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()),
+				"rhs store does not own valid lease for rhs range")
+			require.Equal(t, roachpb.LeaseEpoch, rhsRepl.CurrentLeaseStatus(ctx).Lease.Type(),
+				"lease still an expiration based lease")
 		})
 	}
 
@@ -753,16 +748,15 @@ func mergeCheckingTimestampCaches(
 			}()
 			// NB: the operation won't complete, so peek below Raft and wait for
 			// the result to apply on the majority quorum.
-			testutils.SucceedsSoon(t, func() error {
+			testutils.Soon(t, func(t *testutils.RetryT) {
 				for _, r := range lhsRepls[1:] {
 					// Loosely-coupled truncation requires the state engine flush to
 					// advance guaranteed durability.
 					require.NoError(t, r.Store().StateEngine().Flush())
-					if firstIndex := r.GetCompactedIndex() + 1; firstIndex < truncIndex {
-						return errors.Errorf("truncate not applied, %d < %d", firstIndex, truncIndex)
-					}
+					firstIndex := r.GetCompactedIndex() + 1
+					require.GreaterOrEqual(t, firstIndex, truncIndex,
+						"truncate not applied")
 				}
-				return nil
 			})
 		}
 
@@ -788,14 +782,11 @@ func mergeCheckingTimestampCaches(
 		}()
 		// NB: the operation won't complete, so peek below Raft and wait for
 		// the result to apply on the majority quorum.
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
 			for _, r := range lhsRepls[1:] {
 				desc := r.Desc()
-				if !desc.EndKey.Equal(rhsDesc.EndKey) {
-					return errors.Errorf("merge not applied")
-				}
+				require.True(t, desc.EndKey.Equal(rhsDesc.EndKey), "merge not applied")
 			}
-			return nil
 		})
 
 		// Remove the partition. A snapshot to the leaseholder should follow.
@@ -1021,20 +1012,15 @@ func TestStoreRangeMergeTimestampCacheCausality(t *testing.T) {
 		// clock, s3 must not send or receive any requests before it transfers the
 		// lease, as those requests could bump s3's clock through other code paths.
 		tc.TransferRangeLeaseOrFatal(t, *lhsRangeDesc, tc.Target(1))
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			lhsRepl1, err := tc.GetFirstStoreFromServer(t, 1).GetReplica(lhsRangeDesc.RangeID)
-			if err != nil {
-				return err
-			}
-			if !lhsRepl1.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()) {
-				return errors.New("s2 does not own valid lease for lhs range")
-			}
+			require.NoError(rt, err)
+			require.True(rt, lhsRepl1.OwnsValidLease(ctx, tc.Servers[1].Clock().NowAsClockTimestamp()),
+				"s2 does not own valid lease for lhs range")
 			if leaseType != roachpb.LeaseExpiration {
-				if lhsRepl1.CurrentLeaseStatus(ctx).Lease.Type() != leaseType {
-					return errors.Errorf("lease still an expiration based lease")
-				}
+				require.Equal(rt, leaseType, lhsRepl1.CurrentLeaseStatus(ctx).Lease.Type(),
+					"lease still an expiration based lease")
 			}
-			return nil
 		})
 
 		// Attempt to write at the same time as the read. The write's timestamp
@@ -2132,13 +2118,10 @@ func TestStoreRangeMergeLHSLeaseTransfersAfterFreezeTime(t *testing.T) {
 
 	store1 := tc.GetFirstStoreFromServer(t, 1)
 	lhsLeaseholder := store1.LookupReplica(lhsDesc.StartKey)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		// Wait for the new leaseholder to notice that it received the lease.
 		now := tc.Servers[1].Clock().NowAsClockTimestamp()
-		if !lhsLeaseholder.OwnsValidLease(ctx, now) {
-			return errors.New("not leaseholder")
-		}
-		return nil
+		require.True(t, lhsLeaseholder.OwnsValidLease(ctx, now), "not leaseholder")
 	})
 	lhsClosedTS := lhsLeaseholder.GetCurrentClosedTimestamp(ctx)
 	require.NotEmpty(t, lhsClosedTS)
@@ -2246,10 +2229,9 @@ func TestStoreRangeMergeCheckConsistencyAfterSubsumption(t *testing.T) {
 	require.IsType(t, (*kvpb.Error)(nil), pErr)
 	require.Regexp(t, "abort the merge for test", pErr.String())
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		pErr := <-checkConsistencyResp
 		require.Nil(t, pErr)
-		return nil
 	})
 }
 
@@ -2661,13 +2643,10 @@ func TestStoreRangeMergeSlowUnabandonedFollower_NoSplit(t *testing.T) {
 	}
 
 	// Wait for store2 to hear about the split.
-	testutils.SucceedsSoon(t, func() error {
-		if rhsRepl2, err := store2.GetReplica(rhsDesc.RangeID); err != nil || !rhsRepl2.IsInitialized() {
-			// NB: errors.Wrapf(nil, ...) returns nil.
-			// nolint:errwrap
-			return errors.Errorf("store2 has not yet processed split. err: %v", err)
-		}
-		return nil
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		rhsRepl2, err := store2.GetReplica(rhsDesc.RangeID)
+		require.NoError(t, err)
+		require.True(t, rhsRepl2.IsInitialized(), "store2 has not yet processed split")
 	})
 
 	// Block Raft traffic to the LHS replica on store2, by holding its raftMu, so
@@ -2727,9 +2706,9 @@ func TestStoreRangeMergeSlowUnabandonedFollower_WithSplit(t *testing.T) {
 	}
 
 	// Wait for store2 to hear about the split.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		_, err := store2.GetReplica(rhsDesc.RangeID)
-		return err
+		require.NoError(t, err)
 	})
 
 	// Start dropping all Raft traffic to the LHS on store2 so that it won't be
@@ -2767,18 +2746,14 @@ func TestStoreRangeMergeSlowUnabandonedFollower_WithSplit(t *testing.T) {
 	// indirectly tests that the replica GC queue cleans up both the LHS replica
 	// and the old RHS replica. The replica may still be in StateSnapshot, so we
 	// retry the lease transfer until it succeeds.
-	testutils.SucceedsSoon(t, func() error {
-		return tc.TransferRangeLease(*newRHSDesc, tc.Target(2))
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		require.NoError(t, tc.TransferRangeLease(*newRHSDesc, tc.Target(2)))
 	})
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		rhsRepl, err := store2.GetReplica(newRHSDesc.RangeID)
-		if err != nil {
-			return err
-		}
-		if !rhsRepl.OwnsValidLease(ctx, tc.Servers[2].Clock().NowAsClockTimestamp()) {
-			return errors.New("rhs store does not own valid lease for rhs range")
-		}
-		return nil
+		require.NoError(t, err)
+		require.True(t, rhsRepl.OwnsValidLease(ctx, tc.Servers[2].Clock().NowAsClockTimestamp()),
+			"rhs store does not own valid lease for rhs range")
 	})
 }
 
@@ -2811,11 +2786,11 @@ func TestStoreRangeMergeSlowAbandonedFollower(t *testing.T) {
 
 	// Wait for store2 to hear about the split.
 	var rhsRepl2 *kvserver.Replica
-	testutils.SucceedsSoon(t, func() error {
-		if rhsRepl2, err = store2.GetReplica(rhsDesc.RangeID); err != nil || !rhsRepl2.IsInitialized() {
-			return errors.New("store2 has not yet processed split")
-		}
-		return nil
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		var err error
+		rhsRepl2, err = store2.GetReplica(rhsDesc.RangeID)
+		require.NoError(t, err)
+		require.True(t, rhsRepl2.IsInitialized(), "store2 has not yet processed split")
 	})
 
 	// Block Raft traffic to the LHS replica on store2, by holding its raftMu, so
@@ -2859,26 +2834,23 @@ func TestStoreRangeMergeSlowAbandonedFollower(t *testing.T) {
 	// In general this will happen due to receiving a ReplicaTooOldError but
 	// it may require the replica GC queue. In rare cases the LHS will never
 	// hear about the merge and may need to be GC'd on its own.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		// Make the LHS gets destroyed.
 		if lhsRepl, err := store2.GetReplica(lhsDesc.RangeID); err == nil {
 			if err := store2.ManualReplicaGC(lhsRepl); err != nil {
-				if !kvserver.IsReplicaGCDelayedDueToLeftNeighborError(err) {
-					t.Fatal(err)
-				}
-				return err // retry
+				require.True(t, kvserver.IsReplicaGCDelayedDueToLeftNeighborError(err),
+					"unexpected error: %+v", err)
+				require.NoError(t, err) // retry
 			}
 		}
 		if rhsRepl, err := store2.GetReplica(rhsDesc.RangeID); err == nil {
 			if err := store2.ManualReplicaGC(rhsRepl); err != nil {
-				if !kvserver.IsReplicaGCDelayedDueToLeftNeighborError(err) {
-					t.Fatal(err)
-				}
-				return err // retry
+				require.True(t, kvserver.IsReplicaGCDelayedDueToLeftNeighborError(err),
+					"unexpected error: %+v", err)
+				require.NoError(t, err) // retry
 			}
-			return errors.New("rhs not yet destroyed")
+			require.Fail(t, "rhs not yet destroyed")
 		}
-		return nil
 	})
 }
 
@@ -2917,16 +2889,15 @@ func TestStoreRangeMergeAbandonedFollowers(t *testing.T) {
 
 	// Wait for store2 to hear about all three splits.
 	var repls []*kvserver.Replica
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		repls = nil
 		for _, key := range keys {
 			repl := store2.LookupReplica(key) /* end */
-			if repl == nil || !repl.Desc().StartKey.Equal(key) {
-				return fmt.Errorf("replica for key %q is missing or has wrong start key: %s", key, repl)
-			}
+			require.NotNil(t, repl, "replica for key %q is missing", key)
+			require.True(t, repl.Desc().StartKey.Equal(key),
+				"replica for key %q has wrong start key: %s", key, repl)
 			repls = append(repls, repl)
 		}
-		return nil
 	})
 
 	// Remove all replicas from store2.
@@ -3023,22 +2994,17 @@ func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testi
 		// Make store2 the leaseholder for the RHS and wait for the lease transfer to
 		// apply.
 		tc.TransferRangeLeaseOrFatal(t, *rhsDesc, tc.Target(2))
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
 			rhsRepl, err := store2.GetReplica(rhsDesc.RangeID)
-			if err != nil {
-				return err
-			}
-			if !rhsRepl.OwnsValidLease(ctx, tc.Servers[2].Clock().NowAsClockTimestamp()) {
-				return errors.New("store2 does not own valid lease for rhs range")
-			}
+			require.NoError(t, err)
+			require.True(t, rhsRepl.OwnsValidLease(ctx, tc.Servers[2].Clock().NowAsClockTimestamp()),
+				"store2 does not own valid lease for rhs range")
 
 			// This is important for leader leases to avoid a race between us stopping
 			// Raft traffic below, and Raft attempting to transfer the lease leadership
 			// to the leaseholder.
-			if rhsRepl.RaftStatus().ID != rhsRepl.RaftStatus().Lead {
-				return errors.New("store2 isn't the leader for rhs range")
-			}
-			return nil
+			require.Equal(t, rhsRepl.RaftStatus().Lead, rhsRepl.RaftStatus().ID,
+				"store2 isn't the leader for rhs range")
 		})
 
 		// Start dropping all Raft traffic to the LHS replica on store2 so that it
@@ -3071,14 +3037,11 @@ func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testi
 		// calls replicaGCQueue.process directly, bypassing the logic in
 		// baseQueue.MaybeAdd and baseQueue.Add. We specifically want to test that
 		// queuing logic, which has been broken in the past.
-		testutils.SucceedsSoon(t, func() error {
-			if _, err := store2.GetReplica(lhsDesc.RangeID); err == nil {
-				return errors.New("lhs not destroyed")
-			}
-			if _, err := store2.GetReplica(rhsDesc.RangeID); err == nil {
-				return errors.New("rhs not destroyed")
-			}
-			return nil
+		testutils.Soon(t, func(t *testutils.RetryT) {
+			_, err := store2.GetReplica(lhsDesc.RangeID)
+			require.Error(t, err, "lhs not destroyed")
+			_, err = store2.GetReplica(rhsDesc.RangeID)
+			require.Error(t, err, "rhs not destroyed")
 		})
 	})
 }
@@ -3277,25 +3240,21 @@ func TestStoreRangeReadoptedLHSFollower(t *testing.T) {
 		// Abandon a replica of the LHS on store2.
 		tc.AddVotersOrFatal(t, lhsDesc.StartKey.AsRawKey(), tc.Target(2))
 		var lhsRepl2 *kvserver.Replica
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
+			var err error
 			lhsRepl2, err = store2.GetReplica(lhsDesc.RangeID)
-			if err != nil {
-				return err
-			}
-			if !lhsRepl2.IsInitialized() {
-				// Make sure the replica is initialized before unreplicating.
-				// Uninitialized replicas that have a replicaID are hard to
-				// GC (not implemented at the time of writing).
-				return errors.Errorf("%s not initialized", lhsRepl2)
-			}
-			return nil
+			require.NoError(t, err)
+			// Make sure the replica is initialized before unreplicating.
+			// Uninitialized replicas that have a replicaID are hard to
+			// GC (not implemented at the time of writing).
+			require.True(t, lhsRepl2.IsInitialized(), "%s not initialized", lhsRepl2)
 		})
 		// Need to retry because removing voters could fail while snapshots are
 		// still in flight and cause "cannot remove learner while snapshot is in
 		// flight" error.
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(t *testutils.RetryT) {
 			_, err := tc.RemoveVoters(lhsDesc.StartKey.AsRawKey(), tc.Target(2))
-			return err
+			require.NoError(t, err)
 		})
 
 		if withMerge {
@@ -3430,11 +3389,11 @@ func TestStoreRangeMergeUninitializedLHSFollower(t *testing.T) {
 	// Create range B and wait for store2 to process the split.
 	bRangeID := split(bKey)
 	var bRepl2 *kvserver.Replica
-	testutils.SucceedsSoon(t, func() (err error) {
-		if bRepl2, err = store2.GetReplica(bRangeID); err != nil || !bRepl2.IsInitialized() {
-			return errors.New("store2 has not yet processed split of c")
-		}
-		return nil
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		var err error
+		bRepl2, err = store2.GetReplica(bRangeID)
+		require.NoError(t, err)
+		require.True(t, bRepl2.IsInitialized(), "store2 has not yet processed split of c")
 	})
 
 	// Now we want to create range A, but we need to make sure store2's replica of
@@ -3478,14 +3437,10 @@ func TestStoreRangeMergeUninitializedLHSFollower(t *testing.T) {
 			t.Fatal(err)
 		}
 		tc.RemoveVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(2))
-		testutils.SucceedsSoon(t, func() error {
-			if err := store2.ManualReplicaGC(r1Repl2); err != nil {
-				return err
-			}
-			if _, err := store2.GetReplica(desc.RangeID); err == nil {
-				return errors.New("r1Repl2 still exists")
-			}
-			return nil
+		testutils.Soon(t, func(t *testutils.RetryT) {
+			require.NoError(t, store2.ManualReplicaGC(r1Repl2))
+			_, err := store2.GetReplica(desc.RangeID)
+			require.Error(t, err, "r1Repl2 still exists")
 		})
 	}
 
@@ -3620,11 +3575,8 @@ func testMergeWatcher(t *testing.T, injectFailures bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testutils.SucceedsSoon(t, func() error {
-		if !lhsRepl2.Desc().Equal(lhsDesc) {
-			return errors.New("store2 has not processed split")
-		}
-		return nil
+	testutils.Soon(t, func(t *testutils.RetryT) {
+		require.True(t, lhsRepl2.Desc().Equal(lhsDesc), "store2 has not processed split")
 	})
 	lhsRepl2.RaftLock()
 
@@ -4232,16 +4184,13 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		if rebalanceRHSAway {
 			scanEnd = keyD
 		}
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			afterRaftSnaps := store3.Metrics().RangeSnapshotsAppliedByVoters.Count()
-			if afterRaftSnaps <= beforeRaftSnaps {
-				return errors.New("expected store3 to apply at least 1 additional raft snapshot")
-			}
+			require.Greater(rt, afterRaftSnaps, beforeRaftSnaps,
+				"expected store3 to apply at least 1 additional raft snapshot")
 			getKeySet := func(engine storage.Engine) map[string]struct{} {
 				kvs, err := storage.Scan(context.Background(), engine, keyStart, scanEnd, 0)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				out := map[string]struct{}{}
 				for _, kv := range kvs {
 					out[string(kv.Key.Key)] = struct{}{}
@@ -4253,16 +4202,13 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			storeKeys1 := getKeySet(store1.StateEngine())
 			storeKeys3 := getKeySet(store3.StateEngine())
 			for k := range storeKeys1 {
-				if _, ok := storeKeys3[k]; !ok {
-					return fmt.Errorf("store3 missing key %s", roachpb.Key(k))
-				}
+				_, ok := storeKeys3[k]
+				require.True(rt, ok, "store3 missing key %s", roachpb.Key(k))
 			}
 			for k := range storeKeys3 {
-				if _, ok := storeKeys1[k]; !ok {
-					return fmt.Errorf("store3 has extra key %s", roachpb.Key(k))
-				}
+				_, ok := storeKeys1[k]
+				require.True(rt, ok, "store3 has extra key %s", roachpb.Key(k))
 			}
-			return nil
 		})
 	})
 }
@@ -4363,16 +4309,13 @@ func verifyMergedSoon(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStart
 		store.SetMergeQueueActive(false)
 		store.MustForceMergeScanAndProcess() // drain any merges that might already be queued
 	}()
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		store.MustForceMergeScanAndProcess()
 		repl := store.LookupReplica(rhsStartKey)
-		if repl == nil {
-			t.Fatal("replica doesn't exist")
-		}
-		if !repl.Desc().StartKey.Equal(lhsStartKey) {
-			return errors.Newf("ranges unexpectedly unmerged expected startKey %s, but got %s", lhsStartKey, repl.Desc().StartKey)
-		}
-		return nil
+		require.NotNil(t, repl, "replica doesn't exist")
+		require.True(t, repl.Desc().StartKey.Equal(lhsStartKey),
+			"ranges unexpectedly unmerged expected startKey %s, but got %s",
+			lhsStartKey, repl.Desc().StartKey)
 	})
 }
 
@@ -4385,16 +4328,12 @@ func verifyUnmergedSoon(
 		store.SetMergeQueueActive(false)
 		store.MustForceMergeScanAndProcess() // drain any merges that might already be queued
 	}()
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(t *testutils.RetryT) {
 		store.MustForceMergeScanAndProcess()
 		repl := store.LookupReplica(rhsStartKey)
-		if repl == nil {
-			t.Fatal("replica doesn't exist")
-		}
-		if repl.Desc().StartKey.Equal(lhsStartKey) {
-			return errors.Newf("ranges unexpectedly merged")
-		}
-		return nil
+		require.NotNil(t, repl, "replica doesn't exist")
+		require.False(t, repl.Desc().StartKey.Equal(lhsStartKey),
+			"ranges unexpectedly merged")
 	})
 }
 
@@ -5299,21 +5238,20 @@ func setupClusterWithSubsumedRange(
 	require.NoError(t, err)
 	add := func(desc *roachpb.RangeDescriptor) *roachpb.RangeDescriptor {
 		var newDesc roachpb.RangeDescriptor
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			var err error
 			newDesc, err = tc.AddVoters(desc.StartKey.AsRawKey(), tc.Target(1))
 			if kvtestutils.IsExpectedRelocateError(err) {
-				// Retry.
-				return errors.Wrap(err, "ChangeReplicas received error")
+				require.NoError(rt, err) // retriable
+				return
 			}
-			return nil
+			require.NoError(t, err) // fatal for unexpected errors
 		})
 		require.NoError(t, tc.(*testcluster.TestCluster).WaitForFullReplication())
-		testutils.SucceedsSoon(t, func() error {
-			if count := len(replsForRange(ctx, t, tc, newDesc)); count != 2 {
-				return errors.Newf("expected %d replicas for range %d; found %d", 2, newDesc.RangeID, count)
-			}
-			return nil
+		testutils.Soon(t, func(rt *testutils.RetryT) {
+			count := len(replsForRange(ctx, t, tc, newDesc))
+			require.Equal(rt, 2, count,
+				"unexpected replica count for range %d", newDesc.RangeID)
 		})
 		require.NoError(t, tc.(*testcluster.TestCluster).WaitForVoters(newDesc.StartKey.AsRawKey(), tc.Target(1)))
 		require.NoError(t, tc.(*testcluster.TestCluster).WaitForVoters(newDesc.StartKey.AsRawKey(), tc.Target(0)))
@@ -5349,11 +5287,10 @@ func setupClusterWithSubsumedRange(
 		require.NoError(t, <-errCh)
 	}
 	waitForBlocked = func() {
-		testutils.SucceedsSoon(t, func() error {
-			if actualBlocked := atomic.LoadInt32(&blockedRequestCount); actualBlocked < 1 {
-				return errors.Newf("expected at least 1 blocked request but found none")
-			}
-			return nil
+		testutils.Soon(t, func(t *testutils.RetryT) {
+			actualBlocked := atomic.LoadInt32(&blockedRequestCount)
+			require.GreaterOrEqual(t, actualBlocked, int32(1),
+				"expected at least 1 blocked request but found none")
 		})
 	}
 	return tc, store, rhsDesc, freezeStart, waitForBlocked, cleanupFunc

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3178,7 +3178,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 	// Wait for the removal to be processed.
 	testutils.SucceedsSoon(t, func() error {
 		for i := range tc.Servers[1:] {
-			store := tc.GetFirstStoreFromServer(t, i)
+			store := tc.GetFirstStoreFromServer(t, i+1)
 			_, err := store.GetReplica(desc.RangeID)
 			if !errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)) {
 				return errors.Wrapf(err, "range %d not yet removed from %s", desc.RangeID, store)

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -313,32 +313,26 @@ func TestReplicateRange(t *testing.T) {
 	}
 	// Verify that in time, no intents remain on meta addressing
 	// keys, and that range descriptor on the meta records is correct.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		meta2 := keys.RangeMetaKey(roachpb.RKeyMax)
 		meta1 := keys.RangeMetaKey(meta2)
 		for _, key := range []roachpb.RKey{meta2, meta1} {
 			metaDesc := roachpb.RangeDescriptor{}
-			if ok, err := storage.MVCCGetProto(ctx, store.StateEngine(), key.AsRawKey(),
-				store.Clock().Now(), &metaDesc, storage.MVCCGetOptions{}); err != nil {
-				return err
-			} else if !ok {
-				return errors.Errorf("failed to resolve %s", key.AsRawKey())
-			}
+			ok, err := storage.MVCCGetProto(ctx, store.StateEngine(), key.AsRawKey(),
+				store.Clock().Now(), &metaDesc, storage.MVCCGetOptions{})
+			require.NoError(rt, err)
+			require.True(rt, ok, "failed to resolve %s", key.AsRawKey())
 		}
-		return nil
 	})
 
 	// Verify that the same data is available on the replica.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		getArgs := getArgs(keyA)
-		if reply, err := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
+		reply, pErr := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
 			ReadConsistency: kvpb.INCONSISTENT,
-		}, getArgs); err != nil {
-			return errors.Errorf("failed to read data: %s", err)
-		} else if e, v := int64(5), mustGetInt(reply.(*kvpb.GetResponse).Value); v != e {
-			return errors.Errorf("failed to read correct data: expected %d, got %d", e, v)
-		}
-		return nil
+		}, getArgs)
+		require.Nil(rt, pErr, "failed to read data")
+		require.Equal(rt, int64(5), mustGetInt(reply.(*kvpb.GetResponse).Value), "failed to read correct data")
 	})
 }
 
@@ -397,30 +391,27 @@ func TestRestoreReplicas(t *testing.T) {
 	// bit, so we loop until we find the leaseholder and able to propose the
 	// second increment.
 	incArgs = incrementArgs(key, 5)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		var pErr *kvpb.Error
 		for i := 0; i < tc.NumServers(); i++ {
 			_, pErr = kv.SendWrapped(ctx, tc.GetFirstStoreFromServer(t, i).TestSender(), incArgs)
 			if pErr == nil {
-				return nil
+				return
 			}
-			require.IsType(t, &kvpb.NotLeaseHolderError{}, pErr.GetDetail())
+			require.IsType(rt, &kvpb.NotLeaseHolderError{}, pErr.GetDetail())
 		}
-		return pErr.GoError()
+		require.NoError(rt, pErr.GoError())
 	})
 
 	// Both servers should eventually observe the new value.
 	for i := 0; i < tc.NumServers(); i++ {
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			getArgs := getArgs(key)
-			if reply, err := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, i).TestSender(), kvpb.Header{
+			reply, pErr := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, i).TestSender(), kvpb.Header{
 				ReadConsistency: kvpb.INCONSISTENT,
-			}, getArgs); err != nil {
-				return errors.Errorf("failed to read data: %s", err)
-			} else if e, v := int64(28), mustGetInt(reply.(*kvpb.GetResponse).Value); v != e {
-				return errors.Errorf("failed to read correct data: expected %d, got %d", e, v)
-			}
-			return nil
+			}, getArgs)
+			require.Nil(rt, pErr, "failed to read data")
+			require.Equal(rt, int64(28), mustGetInt(reply.(*kvpb.GetResponse).Value), "failed to read correct data")
 		})
 	}
 
@@ -553,25 +544,20 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	tc.AddVotersOrFatal(t, key, tc.Target(1))
 
 	// Once it catches up, the effects of both commands can be seen.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		getArgs := getArgs([]byte("a"))
-		if reply, err := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
+		reply, pErr := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
 			ReadConsistency: kvpb.INCONSISTENT,
-		}, getArgs); err != nil {
-			return errors.Errorf("failed to read data: %s", err)
-		} else if e, v := int64(16), mustGetInt(reply.(*kvpb.GetResponse).Value); v != e {
-			return errors.Errorf("failed to read correct data: expected %d, got %d", e, v)
-		}
-		return nil
+		}, getArgs)
+		require.Nil(rt, pErr, "failed to read data")
+		require.Equal(rt, int64(16), mustGetInt(reply.(*kvpb.GetResponse).Value), "failed to read correct data")
 	})
 
 	repl2 := tc.GetFirstStoreFromServer(t, 1).LookupReplica(key)
 
-	testutils.SucceedsSoon(t, func() error {
-		if mvcc, mvcc2 := repl.GetMVCCStats(), repl2.GetMVCCStats(); mvcc2 != mvcc {
-			return errors.Errorf("expected stats on new range:\n%+v\not equal old:\n%+v", mvcc2, mvcc)
-		}
-		return nil
+	testutils.Soon(t, func(rt *testutils.RetryT) {
+		mvcc, mvcc2 := repl.GetMVCCStats(), repl2.GetMVCCStats()
+		require.Equal(rt, mvcc, mvcc2, "expected stats on new range to equal old")
 	})
 
 	// Send a third command to verify that the log states are synced up so the
@@ -581,16 +567,13 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		getArgs := getArgs([]byte("a"))
-		if reply, err := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
+		reply, pErr := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
 			ReadConsistency: kvpb.INCONSISTENT,
-		}, getArgs); err != nil {
-			return errors.Errorf("failed to read data: %s", err)
-		} else if e, v := int64(39), mustGetInt(reply.(*kvpb.GetResponse).Value); v != e {
-			return errors.Errorf("failed to read correct data: expected %d, got %d", e, v)
-		}
-		return nil
+		}, getArgs)
+		require.Nil(rt, pErr, "failed to read data")
+		require.Equal(rt, int64(39), mustGetInt(reply.(*kvpb.GetResponse).Value), "failed to read correct data")
 	})
 }
 
@@ -757,23 +740,21 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 				// election. In this case, a successful heartbeat won't be
 				// possible until we re-enable snapshots.
 				require.NoError(t, tc.RestartServer(stoppedStore))
-				testutils.SucceedsSoon(t, func() error {
+				testutils.Soon(t, func(rt *testutils.RetryT) {
 					hasLeader := false
 					term := uint64(0)
 					for i := 0; i < len(tc.Servers); i++ {
 						repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(key)
-						require.NotNil(t, repl)
+						require.NotNil(rt, repl)
 						status := repl.RaftStatus()
-						if status == nil {
-							return errors.New("raft status not initialized")
-						}
+						require.NotNil(rt, status, "raft status not initialized")
 						if status.RaftState == raftpb.StateLeader {
 							hasLeader = true
 						}
 						if term == 0 {
 							term = status.Term
-						} else if status.Term != term {
-							return errors.Errorf("terms do not agree: %d vs %d", status.Term, term)
+						} else {
+							require.Equal(rt, term, status.Term, "terms do not agree")
 						}
 						if !hasLeader {
 							// If we haven't been able to establish a  leader yet, send a get
@@ -783,14 +764,11 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 							// It should be fine if we get a NLHE for some reason.
 							nlhe := &kvpb.NotLeaseHolderError{}
 							if !errors.As(err.GetDetail(), &nlhe) {
-								return err.GetDetail()
+								require.NoError(rt, err.GetDetail())
 							}
 						}
 					}
-					if !hasLeader {
-						return errors.New("no leader")
-					}
-					return nil
+					require.True(rt, hasLeader, "no leader")
 				})
 
 				// Turn the queues back on and wait for the snapshot to be sent and processed.
@@ -805,47 +783,36 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 			}
 			tc.WaitForValues(t, key, []int64{incAB, incAB, incAB})
 
-			testutils.SucceedsSoon(t, func() error {
+			testutils.Soon(t, func(rt *testutils.RetryT) {
 				// Verify that the cached index and term (Replica.mu.last{Index,Term}))
 				// on all of the replicas is the same. #18327 fixed an issue where the
 				// cached term was left unchanged after applying a snapshot leading to a
 				// persistently unavailable range.
 				repl0 = tc.GetFirstStoreFromServer(t, otherStore1).LookupReplica(key)
-				require.NotNil(t, repl0)
+				require.NotNil(rt, repl0)
 				expectedLastIndex := repl0.GetLastIndex()
 				expectedLastTerm := repl0.GetCachedLastTerm()
 
-				verifyIndexAndTerm := func(i int) error {
+				verifyIndexAndTerm := func(i int) {
 					repl1 := tc.GetFirstStoreFromServer(t, i).LookupReplica(key)
-					require.NotNil(t, repl1)
-					if lastIndex := repl1.GetLastIndex(); expectedLastIndex != lastIndex {
-						return fmt.Errorf("%d: expected last index %d, but found %d", i, expectedLastIndex, lastIndex)
-					}
-					if lastTerm := repl1.GetCachedLastTerm(); expectedLastTerm != lastTerm {
-						return fmt.Errorf("%d: expected last term %d, but found %d", i, expectedLastTerm, lastTerm)
-					}
-					return nil
+					require.NotNil(rt, repl1)
+					require.Equal(rt, expectedLastIndex, repl1.GetLastIndex(),
+						"%d: unexpected last index", i)
+					require.Equal(rt, expectedLastTerm, repl1.GetCachedLastTerm(),
+						"%d: unexpected last term", i)
 				}
-				if err := verifyIndexAndTerm(otherStore2); err != nil {
-					return err
-				}
-				if err := verifyIndexAndTerm(stoppedStore); err != nil {
-					return err
-				}
-				return nil
+				verifyIndexAndTerm(otherStore2)
+				verifyIndexAndTerm(stoppedStore)
 			})
 		})
 	}
 }
 
 func waitForTruncationForTesting(t *testing.T, r *kvserver.Replica, compacted kvpb.RaftIndex) {
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		// Flush the engine to advance durability, which triggers truncation.
-		require.NoError(t, r.Store().StateEngine().Flush())
-		if index := r.GetCompactedIndex(); index != compacted {
-			return errors.Errorf("expected compacted index == %d, got %d", compacted, index)
-		}
-		return nil
+		require.NoError(rt, r.Store().StateEngine().Flush())
+		require.Equal(rt, compacted, r.GetCompactedIndex(), "unexpected compacted index")
 	})
 }
 
@@ -980,26 +947,21 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	// Have StoreLiveness support for the partitioned store expire.
 	manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 
-	testutils.SucceedsSoon(t, func() error {
-		if partRepl.RaftStatus().RaftState == raftpb.StateLeader {
-			return errors.New("partitioned replica should have stepped down")
-		}
+	testutils.Soon(t, func(rt *testutils.RetryT) {
+		require.NotEqual(rt, raftpb.StateLeader, partRepl.RaftStatus().RaftState,
+			"partitioned replica should have stepped down")
 		lead := otherRepl.RaftStatus().Lead
-		if lead == raft.None {
-			return errors.New("no leader yet")
-		}
-		if roachpb.ReplicaID(lead) == partReplDesc.ReplicaID {
-			return errors.New("partitioned replica is still leader")
-		}
+		require.NotEqual(rt, raft.None, lead, "no leader yet")
+		require.NotEqual(rt, partReplDesc.ReplicaID, roachpb.ReplicaID(lead),
+			"partitioned replica is still leader")
 
 		// Remember who the leader/leaseholder is and also send it a write request.
 		newLeaderReplDesc, found := desc.GetReplicaDescriptorByID(roachpb.ReplicaID(lead))
-		require.True(t, found)
+		require.True(rt, found)
 		newLeaderRepl = tc.GetFirstStoreFromServer(t, int(newLeaderReplDesc.NodeID-1)).LookupReplica(roachpb.RKey(key))
 		newLeaderReplSender = tc.GetFirstStoreFromServer(t, int(newLeaderReplDesc.NodeID-1)).TestSender()
 		_, pErr := kv.SendWrapped(ctx, newLeaderReplSender, incArgs)
-		require.Nil(t, pErr)
-		return nil
+		require.Nil(rt, pErr)
 	})
 
 	log.KvExec.Infof(ctx, "test: waiting for values...")
@@ -1013,15 +975,12 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	log.KvExec.Infof(ctx, "test: truncating log")
 	truncArgs := truncateLogArgs(index+1, partRepl.RangeID)
 	truncArgs.Key = partRepl.Desc().StartKey.AsRawKey()
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 		_, pErr := kv.SendWrappedWith(ctx, newLeaderReplSender, kvpb.Header{RangeID: partRepl.RangeID}, truncArgs)
-		if _, ok := pErr.GetDetail().(*kvpb.NotLeaseHolderError); ok {
-			return pErr.GoError()
-		} else if pErr != nil {
-			t.Fatal(pErr)
+		if pErr != nil {
+			require.IsType(rt, &kvpb.NotLeaseHolderError{}, pErr.GetDetail())
 		}
-		return nil
 	})
 	waitForTruncationForTesting(t, newLeaderRepl, index)
 
@@ -1054,12 +1013,10 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 	}
 
 	// The partitioned replica should catch up after a snapshot.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		snapsAfter := snapsMetric.Count()
-		if !(snapsAfter > snapsBefore) {
-			return errors.New("expected at least 1 snapshot to catch the partitioned replica up")
-		}
-		return nil
+		require.Greater(rt, snapsAfter, snapsBefore,
+			"expected at least 1 snapshot to catch the partitioned replica up")
 	})
 	tc.WaitForValues(t, key, []int64{incAB, incAB, incAB})
 
@@ -1228,13 +1185,10 @@ func TestRequestsOnLaggingReplica(t *testing.T) {
 			// In asymmetric partition, wait for the partitioned node to learn about
 			// the new leader before continuing. We do this because we expect it to
 			// reply with a speculative lease below.
-			testutils.SucceedsSoon(t, func() error {
+			testutils.Soon(t, func(rt *testutils.RetryT) {
 				status := partitionedReplica.RaftStatus()
-				if status.Lead != 2 && status.Lead != 3 {
-					return errors.Errorf("partitioned replica doesn't know about new leader yet: lead=%d",
-						status.Lead)
-				}
-				return nil
+				require.True(rt, status.Lead == 2 || status.Lead == 3,
+					"partitioned replica doesn't know about new leader yet: lead=%d", status.Lead)
 			})
 		}
 
@@ -1431,21 +1385,18 @@ func TestRequestsOnFollowerWithNonLiveLeaseholder(t *testing.T) {
 
 	// Wait until the lease expires.
 	log.KvExec.Infof(ctx, "test: waiting for lease expiration on r%d", store0Repl.RangeID)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		dur, _ := store0.GetStoreConfig().NodeLivenessDurations()
 		manualClock.Increment(dur.Nanoseconds())
 		leaseStatus = store0Repl.CurrentLeaseStatus(ctx)
 		// If we failed to pin the lease, it likely won't ever expire due to the particular
 		// partition we've set up. Bail early instead of wasting 45s.
-		require.True(t, leaseStatus.Lease.OwnedBy(store0.StoreID()), "failed to pin lease")
+		require.True(rt, leaseStatus.Lease.OwnedBy(store0.StoreID()), "failed to pin lease")
 
 		// Lease is on s1, and it should be invalid now. The only reason there's a
 		// retry loop is that there could be a race where we bump the clock while a
 		// heartbeat is inflight (and which picks up the new expiration).
-		if leaseStatus.IsValid() {
-			return errors.Errorf("lease still valid: %+v", leaseStatus)
-		}
-		return nil
+		require.False(rt, leaseStatus.IsValid(), "lease still valid: %+v", leaseStatus)
 	})
 	log.KvExec.Infof(ctx, "test: lease expired")
 
@@ -1980,17 +1931,16 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 			if !(leaseType == roachpb.LeaseLeader && proposeOnFollower) {
 				tc.MaybeWaitForLeaseUpgrade(ctx, t, *leaderRepl.Desc())
 			}
-			testutils.SucceedsSoon(t, func() error {
+			testutils.Soon(t, func(rt *testutils.RetryT) {
 				// Lease transfers may not be immediately observed by the new
 				// leaseholder. Wait until the new leaseholder is aware.
 				repl, err := tc.GetFirstStoreFromServer(t, propIdx).GetReplica(leaderRepl.RangeID)
-				require.NoError(t, err)
+				require.NoError(rt, err)
 				repDesc, err := repl.GetReplicaDescriptor()
-				require.NoError(t, err)
-				if lease, _ := repl.GetLease(); !lease.Replica.Equal(repDesc) {
-					return errors.Errorf("lease not transferred yet; found %v", lease)
-				}
-				return nil
+				require.NoError(rt, err)
+				lease, _ := repl.GetLease()
+				require.True(rt, lease.Replica.Equal(repDesc),
+					"lease not transferred yet; found %v", lease)
 			})
 
 			// Stop enough nodes to prevent a quorum.
@@ -2083,10 +2033,10 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 
 	// Wait until all under-replicated ranges are up-replicated to all nodes.
 	var replicaCount int64
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		var replicaCounts [numServers]int64
 		for i := range tc.Servers {
-			var err error
+			var notFullyInit bool
 			tc.GetFirstStoreFromServer(t, i).VisitReplicas(func(r *kvserver.Replica) bool {
 				replicaCounts[i]++
 				r.RaftLock()
@@ -2094,23 +2044,17 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 				if len(r.Desc().InternalReplicas) != 3 {
 					// This fails even after the snapshot has arrived and only
 					// goes through once the replica has applied the conf change.
-					err = errors.Errorf("not fully initialized")
+					notFullyInit = true
 					return false
 				}
 				return true
 			})
-			if err != nil {
-				return err
-			}
-			if replicaCounts[i] != replicaCounts[0] {
-				return errors.Errorf("not fully upreplicated")
-			}
-			if n := tc.GetFirstStoreFromServer(t, i).ReservationCount(); n != 0 {
-				return errors.Errorf("expected 0 reservations, but found %d", n)
-			}
+			require.False(rt, notFullyInit, "not fully initialized")
+			require.Equal(rt, replicaCounts[0], replicaCounts[i], "not fully upreplicated")
+			require.Zero(rt, tc.GetFirstStoreFromServer(t, i).ReservationCount(),
+				"expected 0 reservations")
 		}
 		replicaCount = replicaCounts[0]
-		return nil
 	})
 
 	var generated int64
@@ -2164,12 +2108,9 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	if err := addReplica(1, &origDesc); err != nil {
 		t.Fatal(err)
 	}
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		r := tc.GetFirstStoreFromServer(t, 1).LookupReplica(key)
-		if r == nil {
-			return errors.Errorf(`expected replica for key "a"`)
-		}
-		return nil
+		require.NotNil(rt, r, `expected replica for key "a"`)
 	})
 
 	before := store2.Metrics().RangeSnapshotsAppliedForInitialUpreplication.Count()
@@ -2194,19 +2135,13 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		after := store2.Metrics().RangeSnapshotsAppliedForInitialUpreplication.Count()
 		// The failed ChangeReplicas call should have applied a learner snapshot.
-		if after != before+1 {
-			return errors.Errorf(
-				"ChangeReplicas call should have applied a learner snapshot, before %d after %d",
-				before, after)
-		}
+		require.Equal(rt, before+1, after,
+			"ChangeReplicas call should have applied a learner snapshot")
 		r := store2.LookupReplica(key)
-		if r == nil {
-			return errors.Errorf(`expected replica for key "a"`)
-		}
-		return nil
+		require.NotNil(rt, r, `expected replica for key "a"`)
 	})
 }
 
@@ -2380,15 +2315,11 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 		// Verify old replica is GC'd. Wait out the replica gc queue
 		// inactivity threshold and force a gc scan.
 		manualClock.Increment(int64(kvserver.ReplicaGCQueueCheckInterval + 1))
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			tc.GetFirstStoreFromServer(t, 1).MustForceReplicaGCScanAndProcess()
 			_, err := tc.GetFirstStoreFromServer(t, 1).GetReplica(desc.RangeID)
-			if !errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)) {
-				// NB: errors.Wrapf(nil, ...) returns nil.
-				// nolint:errwrap
-				return errors.Errorf("expected replica to be garbage collected, got %v %T", err, err)
-			}
-			return nil
+			require.True(rt, errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)),
+				"expected replica to be garbage collected, got %v %T", err, err)
 		})
 
 		tc.AddVotersOrFatal(t, key, tc.Target(1))
@@ -2572,16 +2503,13 @@ func TestQuotaPool(t *testing.T) {
 	// Wait until the follower will is not ignored by updateProposalQuotaRaftMuLocked.
 	// Otherwise the quota gets prematurely released into the pool. We can use status.Applied
 	// instead of proposalQuotaBaseIndex because it's strictly ahead or the same.
-	testutils.SucceedsSoon(t, func() error {
-		var err error
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		status := leaderRepl.RaftStatus()
 		minIndex := status.Applied
 		for id, progress := range status.Progress {
-			if progress.Match < minIndex {
-				err = errors.Errorf("Replica %d is behind leader expected %d but was %d", id, minIndex, progress.Match)
-			}
+			require.GreaterOrEqual(rt, progress.Match, minIndex,
+				"Replica %d is behind leader", id)
 		}
-		return err
 	})
 
 	followerRepl := func() *kvserver.Replica {
@@ -2633,11 +2561,9 @@ func TestQuotaPool(t *testing.T) {
 			t.Fatalf("didn't observe the expected quota acquisition, available: %d", curQuota)
 		}
 
-		testutils.SucceedsSoon(t, func() error {
-			if qLen := leaderRepl.QuotaReleaseQueueLen(); qLen < 1 {
-				return errors.Errorf("expected at least 1 queued quota release, found: %d", qLen)
-			}
-			return nil
+		testutils.Soon(t, func(rt *testutils.RetryT) {
+			require.GreaterOrEqual(rt, leaderRepl.QuotaReleaseQueueLen(), 1,
+				"expected at least 1 queued quota release")
 		})
 
 		go func() {
@@ -2652,14 +2578,9 @@ func TestQuotaPool(t *testing.T) {
 		}()
 	}()
 
-	testutils.SucceedsSoon(t, func() error {
-		if curQuota := leaderRepl.QuotaAvailable(); curQuota != quota {
-			return errors.Errorf("expected available quota %d, got %d", quota, curQuota)
-		}
-		if qLen := leaderRepl.QuotaReleaseQueueLen(); qLen != 0 {
-			return errors.Errorf("expected no queued quota releases, found: %d", qLen)
-		}
-		return nil
+	testutils.Soon(t, func(rt *testutils.RetryT) {
+		require.Equal(rt, uint64(quota), leaderRepl.QuotaAvailable(), "unexpected available quota")
+		require.Zero(rt, leaderRepl.QuotaReleaseQueueLen(), "expected no queued quota releases")
 	})
 
 	if pErr := <-ch; pErr != nil {
@@ -2746,12 +2667,10 @@ func TestWedgedReplicaDetection(t *testing.T) {
 		// flakiness. It is possible that the WaitForValues call above returned as
 		// soon as one of the followers appended and applied a log entry, but before
 		// its response was delivered to the leader.
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			lastUpdateTimes := leaderRepl.LastUpdateTimes()
-			if len(lastUpdateTimes) == 3 {
-				return nil
-			}
-			return errors.Errorf("expected leader replica to have 3 entries in lastUpdateTimes map, found %s", lastUpdateTimes)
+			require.Len(rt, lastUpdateTimes, 3,
+				"expected leader replica to have 3 entries in lastUpdateTimes map")
 		})
 
 		// Lock the follower replica to prevent it from making progress from now
@@ -2799,24 +2718,22 @@ func TestWedgedReplicaDetection(t *testing.T) {
 		// followerRepl from before it was locked. The receipt of one of these
 		// would bump the last active timestamp on the leader. Because of this,
 		// we check whether the follower is eventually considered inactive.
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			// Increment the clock to past inactivityThreshold.
 			manual.Increment(inactivityThreshold.Nanoseconds() + 1)
 
 			// Send another request to the leader replica. followerRepl is locked
 			// so it will not respond.
 			if _, pErr := kvserver.ToSenderForTesting(leaderRepl).Send(ctx, ba); pErr != nil {
-				t.Fatal(pErr)
+				require.NoError(rt, pErr.GoError())
 			}
 
 			// The follower should no longer be considered active.
 			leaderNow = leaderClock.PhysicalTime()
-			if leaderRepl.IsFollowerActiveSince(followerID, leaderNow, inactivityThreshold) {
-				return errors.Errorf("expected follower to be considered inactive; "+
+			require.False(rt, leaderRepl.IsFollowerActiveSince(followerID, leaderNow, inactivityThreshold),
+				"expected follower to be considered inactive; "+
 					"follower id: %d, last update times: %s, leader clock: %s",
-					followerID, leaderRepl.LastUpdateTimes(), leaderNow)
-			}
-			return nil
+				followerID, leaderRepl.LastUpdateTimes(), leaderNow)
 		})
 	})
 }
@@ -2941,17 +2858,17 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 		// Find the Raft leader.
 		var leaderIdx int
 		var leaderRepl *kvserver.Replica
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			for idx := range tc.Servers {
 				repl := tc.GetFirstStoreFromServer(t, idx).LookupReplica(roachpb.RKey(key))
-				require.NotNil(t, repl)
+				require.NotNil(rt, repl)
 				if repl.RaftStatus().SoftState.RaftState == raftpb.StateLeader {
 					leaderIdx = idx
 					leaderRepl = repl
-					return nil
+					return
 				}
 			}
-			return errors.New("no Raft leader found")
+			require.Fail(rt, "no Raft leader found")
 		})
 
 		// Raft leader found. Make sure it doesn't have the lease (transferring it
@@ -2998,13 +2915,11 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 		// something on the order of a election timeout plus
 		// ReplicaGCQueueSuspectTimeout before replicaGC will be attempted (and will
 		// then succeed on the first try).
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			s := tc.GetFirstStoreFromServer(t, leaderIdx)
 			s.MustForceReplicaGCScanAndProcess()
-			if oldRepl := tc.GetFirstStoreFromServer(t, leaderIdx).LookupReplica(roachpb.RKey(key)); oldRepl != nil {
-				return errors.Errorf("Expected replica %s to be removed", oldRepl)
-			}
-			return nil
+			oldRepl := tc.GetFirstStoreFromServer(t, leaderIdx).LookupReplica(roachpb.RKey(key))
+			require.Nil(rt, oldRepl, "Expected replica to be removed")
 		})
 		t.Logf("re-adding leader")
 		tc.AddVotersOrFatal(t, key, tc.Target(leaderIdx))
@@ -3044,17 +2959,14 @@ func TestReplicateAfterSplit(t *testing.T) {
 		t.Error("Range MaxBytes is not set after snapshot applied")
 	}
 	// Once it catches up, the effects of increment commands can be seen.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		getArgs := getArgs(key)
 		// Reading on non-lease holder replica should use inconsistent read
-		if reply, err := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
+		reply, pErr := kv.SendWrappedWith(ctx, tc.GetFirstStoreFromServer(t, 1).TestSender(), kvpb.Header{
 			ReadConsistency: kvpb.INCONSISTENT,
-		}, getArgs); err != nil {
-			return errors.Errorf("failed to read data: %s", err)
-		} else if e, v := int64(11), mustGetInt(reply.(*kvpb.GetResponse).Value); v != e {
-			return errors.Errorf("failed to read correct data: expected %d, got %d", e, v)
-		}
-		return nil
+		}, getArgs)
+		require.Nil(rt, pErr, "failed to read data")
+		require.Equal(rt, int64(11), mustGetInt(reply.(*kvpb.GetResponse).Value), "failed to read correct data")
 	})
 }
 
@@ -3125,17 +3037,14 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 
 			var latestTerm uint64
 			if td.expectAdvance {
-				testutils.SucceedsSoon(t, func() error {
-					if raftStatus := replica2.RaftStatus(); raftStatus != nil {
-						if term := raftStatus.Term; term <= latestTerm {
-							return errors.Errorf("%d: raft term has not yet advanced: %d", i, term)
-						} else if latestTerm == 0 {
-							latestTerm = term
-						}
-					} else {
-						return errors.Errorf("%d: raft group is not yet initialized", i)
+				testutils.Soon(t, func(rt *testutils.RetryT) {
+					raftStatus := replica2.RaftStatus()
+					require.NotNil(rt, raftStatus, "%d: raft group is not yet initialized", i)
+					term := raftStatus.Term
+					require.Greater(rt, term, latestTerm, "%d: raft term has not yet advanced", i)
+					if latestTerm == 0 {
+						latestTerm = term
 					}
-					return nil
 				})
 			} else {
 				for start := timeutil.Now(); timeutil.Since(start) < time.Second; time.Sleep(10 * time.Millisecond) {
@@ -3176,15 +3085,13 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 	tc.RemoveVotersOrFatal(t, key, tc.Target(1))
 
 	// Wait for the removal to be processed.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		for i := range tc.Servers[1:] {
 			store := tc.GetFirstStoreFromServer(t, i+1)
 			_, err := store.GetReplica(desc.RangeID)
-			if !errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)) {
-				return errors.Wrapf(err, "range %d not yet removed from %s", desc.RangeID, store)
-			}
+			require.True(rt, errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)),
+				"range %d not yet removed from %s: %v", desc.RangeID, store, err)
 		}
-		return nil
 	})
 
 	target1 := tc.Target(1)
@@ -3424,21 +3331,16 @@ func TestReplicaGCRace(t *testing.T) {
 
 	// Wait for the victim's raft log to be non-empty, then configure the heartbeat
 	// with the raft state.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		status := repl.RaftStatus()
 		progressByID := status.Progress
 		progress, ok := progressByID[raftpb.PeerID(toReplicaDesc.ReplicaID)]
-		if !ok {
-			return errors.Errorf("%+v does not yet contain %s", progressByID, toReplicaDesc)
-		}
-		if progress.Match == 0 {
-			return errors.Errorf("%+v has not yet advanced", progress)
-		}
+		require.True(rt, ok, "%+v does not yet contain %s", progressByID, toReplicaDesc)
+		require.NotZero(rt, progress.Match, "%+v has not yet advanced", progress)
 		for i := range hbReq.Heartbeats {
 			hbReq.Heartbeats[i].Term = kvpb.RaftTerm(status.Term)
 			hbReq.Heartbeats[i].Commit = kvpb.RaftIndex(progress.Match)
 		}
-		return nil
 	})
 
 	// Remove the victim replica and manually GC it.
@@ -3631,7 +3533,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// TODO(bdarnell): if the call to RemoveReplica in replicaGCQueue.process can be
 	// moved under the lock, then the GC scan can be moved out of this loop.
 	tc.GetFirstStoreFromServer(t, 1).SetReplicaGCQueueActive(true)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 		manualClock.Increment(int64(
 			kvserver.ReplicaGCQueueCheckInterval) + 1)
@@ -3639,10 +3541,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 
 		actual := tc.ReadIntFromStores(key)
 		expected := []int64{16, 0, 0 /* stopped */}
-		if !reflect.DeepEqual(expected, actual) {
-			return errors.Errorf("expected %v, got %v", expected, actual)
-		}
-		return nil
+		require.Equal(rt, expected, actual)
 	})
 	// Partition nodes 1 and 2 from node 0. Otherwise they'd get a
 	// ReplicaTooOldError from node 0 and proceed to remove themselves.
@@ -3697,7 +3596,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// Now the tombstone on node 1 prevents it from rejoining the rogue
 	// copy of the group.
 	time.Sleep(100 * time.Millisecond)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		actual := tc.ReadIntFromStores(key)
 		// Normally, replica GC has not happened yet on store 2, so we
 		// expect {16, 0, 5}. However, it is possible (on a
@@ -3711,10 +3610,8 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 		// we should just combine this check with the following one.
 		expected1 := []int64{16, 0, 5}
 		expected2 := []int64{16, 0, 0}
-		if !reflect.DeepEqual(expected1, actual) && !reflect.DeepEqual(expected2, actual) {
-			return errors.Errorf("expected %v or %v, got %v", expected1, expected2, actual)
-		}
-		return nil
+		require.True(rt, reflect.DeepEqual(expected1, actual) || reflect.DeepEqual(expected2, actual),
+			"expected %v or %v, got %v", expected1, expected2, actual)
 	})
 
 	// Run garbage collection on node 2. The lack of an active lease holder
@@ -3803,19 +3700,13 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	tc.WaitForValues(t, key, []int64{0, value, value, value})
 
 	// 3. Wait for the lease holder to obtain raft leadership too.
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		hint := tc.Target(1)
 		leadReplica := tc.GetRaftLeader(t, roachpb.RKey(key))
 		leaseReplica, err := tc.FindRangeLeaseHolder(*leadReplica.Desc(), &hint)
-		if err != nil {
-			return err
-		}
-		if leaseReplica.StoreID != leadReplica.StoreID() {
-			return errors.Errorf("leaseReplica %s does not match leadReplica %s",
-				leaseReplica, leadReplica)
-		}
-
-		return nil
+		require.NoError(rt, err)
+		require.Equal(rt, leadReplica.StoreID(), leaseReplica.StoreID,
+			"leaseReplica %s does not match leadReplica %s", leaseReplica, leadReplica)
 	})
 
 	// Save the current term, which is the latest among the live stores.
@@ -3987,19 +3878,17 @@ func TestReplicaTooOldGC(t *testing.T) {
 	// to get created in order to get the replica talking to the other replicas.
 	tc.GetFirstStoreFromServer(t, 3).EnqueueRaftUpdateCheck(desc.RangeID)
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		replica, err := tc.GetFirstStoreFromServer(t, 3).GetReplica(desc.RangeID)
 		if err != nil {
-			if errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)) {
-				return nil
-			}
-			return err
-		} else if replica != nil {
-			// Make sure the replica is unquiesced so that it will tick and
-			// contact the leader to discover it's no longer part of the range.
-			replica.MaybeUnquiesce()
+			require.True(rt, errors.HasType(err, (*kvpb.RangeNotFoundError)(nil)),
+				"unexpected error: %v", err)
+			return
 		}
-		return errors.Errorf("found %s, waiting for it to be GC'd", replica)
+		// Make sure the replica is unquiesced so that it will tick and
+		// contact the leader to discover it's no longer part of the range.
+		replica.MaybeUnquiesce()
+		require.Fail(rt, "found replica, waiting for it to be GC'd", "%s", replica)
 	})
 }
 
@@ -4220,19 +4109,17 @@ func TestRemovedReplicaError(t *testing.T) {
 	// the commit quorum for the removal itself. That is to say, we will only
 	// start seeing the RangeNotFoundError after a little bit of time has passed.
 	getArgs := getArgs(key)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		_, pErr := kv.SendWrappedWith(ctx, kvserver.ToSenderForTesting(store), kvpb.Header{}, getArgs)
+		require.NotNil(rt, pErr, "expected RangeNotFoundError, got success")
 		switch pErr.GetDetail().(type) {
-		case *kvpb.AmbiguousResultError:
-			return pErr.GoError()
-		case *kvpb.NotLeaseHolderError:
-			return pErr.GoError()
+		case *kvpb.AmbiguousResultError, *kvpb.NotLeaseHolderError:
+			require.Fail(rt, "expected RangeNotFoundError", "got %v", pErr)
 		case *kvpb.RangeNotFoundError:
-			return nil
+			// Expected.
 		default:
+			t.Fatal(pErr)
 		}
-		t.Fatal(pErr)
-		return errors.New("unreachable")
 	})
 }
 
@@ -4292,13 +4179,11 @@ func TestTransferRaftLeadership(t *testing.T) {
 			require.NoError(t, pErr.GoError())
 
 			// Verify leadership is transferred.
-			testutils.SucceedsSoon(t, func() error {
-				if status := repl0.RaftStatus(); status == nil {
-					return errors.New("raft status is nil")
-				} else if a, e := status.Lead, raftpb.PeerID(rd1.ReplicaID); a != e {
-					return errors.Errorf("expected raft leader be %d; got %d", e, a)
-				}
-				return nil
+			testutils.Soon(t, func(rt *testutils.RetryT) {
+				status := repl0.RaftStatus()
+				require.NotNil(rt, status, "raft status is nil")
+				require.Equal(rt, raftpb.PeerID(rd1.ReplicaID), status.Lead,
+					"unexpected raft leader")
 			})
 			// And metrics are updated.
 			require.Greater(t, store0.Metrics().RangeRaftLeaderTransfers.Count(), origCount0)
@@ -4400,23 +4285,19 @@ func TestFollowersFallAsleep(t *testing.T) {
 	oldLeaderServerIdx := int(oldLeader.NodeID()) - 1
 
 	checkSleep := func(expected bool) {
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			for i := range tc.Servers {
 				rep := tc.GetFirstStoreFromServer(t, i).LookupReplica(roachpb.RKey(key))
-				require.NotNil(t, rep)
+				require.NotNil(rt, rep)
 				isLeader := rep.ID() == oldLeader.ID()
 				if isLeader {
-					require.False(t, rep.IsAsleep())
+					require.False(rt, rep.IsAsleep())
+				} else if expected {
+					require.True(rt, rep.IsAsleep(), "%s not asleep yet", rep)
 				} else {
-					if expected && !rep.IsAsleep() {
-						return errors.Errorf("%s not asleep yet", rep)
-					}
-					if !expected && rep.IsAsleep() {
-						return errors.Errorf("%s not awake yet", rep)
-					}
+					require.False(rt, rep.IsAsleep(), "%s not awake yet", rep)
 				}
 			}
-			return nil
 		})
 	}
 
@@ -4426,12 +4307,9 @@ func TestFollowersFallAsleep(t *testing.T) {
 	// Stop the leader, and ensure a new leader is elected.
 	tc.StopServer(oldLeaderServerIdx)
 	checkSleep(false /* expected */)
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		newLeader := tc.GetRaftLeader(t, roachpb.RKey(key))
-		if oldLeader.ID() == newLeader.ID() {
-			return errors.Errorf("no new leader yet")
-		}
-		return nil
+		require.NotEqual(rt, oldLeader.ID(), newLeader.ID(), "no new leader yet")
 	})
 }
 
@@ -4490,16 +4368,14 @@ func TestUninitializedReplicaQuiescence(t *testing.T) {
 			case <-tc.Stopper().ShouldQuiesce():
 			}
 		}()
-		testutils.SucceedsSoon(t, func() error {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			repl, err := s2.GetReplica(desc.RangeID)
-			if err == nil {
-				// IMPORTANT: the replica should always be quiescent while uninitialized.
-				require.False(t, repl.IsInitialized())
-				require.True(t, repl.IsQuiescent())
-				// But it's always awake for the purposes of store liveness quiescence.
-				require.False(t, repl.IsAsleep())
-			}
-			return err
+			require.NoError(rt, err)
+			// IMPORTANT: the replica should always be quiescent while uninitialized.
+			require.False(rt, repl.IsInitialized())
+			require.True(rt, repl.IsQuiescent())
+			// But it's always awake for the purposes of store liveness quiescence.
+			require.False(rt, repl.IsAsleep())
 		})
 
 		// Let the snapshot through. The up-replication attempt should succeed. The
@@ -4515,22 +4391,16 @@ func TestUninitializedReplicaQuiescence(t *testing.T) {
 		require.False(t, repl.IsQuiescent())
 		switch leaseType {
 		case roachpb.LeaseEpoch:
-			testutils.SucceedsSoon(t, func() error {
-				if !repl.IsQuiescent() {
-					return errors.Errorf("%s not quiescent", repl)
-				}
-				return nil
+			testutils.Soon(t, func(rt *testutils.RetryT) {
+				require.True(rt, repl.IsQuiescent(), "%s not quiescent", repl)
 			})
 		case roachpb.LeaseLeader:
 			require.Never(t, func() bool {
 				return repl.IsQuiescent()
 			},
 				time.Second*3, 100*time.Millisecond, "replica shouldn't quiesce")
-			testutils.SucceedsSoon(t, func() error {
-				if !repl.IsAsleep() {
-					return errors.Errorf("%s not asleep", repl)
-				}
-				return nil
+			testutils.Soon(t, func(rt *testutils.RetryT) {
+				require.True(rt, repl.IsAsleep(), "%s not asleep", repl)
 			})
 		case roachpb.LeaseExpiration:
 			require.Never(t, func() bool {
@@ -4617,16 +4487,12 @@ func TestFailedConfChange(t *testing.T) {
 	// Transfer leadership to the second node and wait for it to become leader.
 	tc.TransferRangeLeaseOrFatal(t, desc, tc.Target(1))
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.Soon(t, func(rt *testutils.RetryT) {
 		repl, err := tc.GetFirstStoreFromServer(t, 1).GetReplica(desc.RangeID)
-		if err != nil {
-			return err
-		}
+		require.NoError(rt, err)
 		status := repl.RaftStatus()
-		if status.RaftState != raftpb.StateLeader {
-			return errors.Errorf("store %d: expected StateLeader, was %s", 1, status.RaftState)
-		}
-		return nil
+		require.Equal(rt, raftpb.StateLeader, status.RaftState,
+			"store %d: unexpected raft state", 1)
 	})
 
 	if err := checkLeaderStore(1); err != nil {
@@ -4870,7 +4736,7 @@ func TestStoreWaitForReplicaInit(t *testing.T) {
 		// before does the trick.
 		const unusedRangeID = 1234
 		var repl *kvserver.Replica
-		testutils.SucceedsSoon(t, func() (err error) {
+		testutils.Soon(t, func(rt *testutils.RetryT) {
 			// Try several times, as the message may be dropped (see #18355).
 			tc.Servers[0].RaftTransport().(*kvserver.RaftTransport).SendAsync(&kvserverpb.RaftMessageRequest{
 				ToReplica: roachpb.ReplicaDescriptor{
@@ -4879,8 +4745,9 @@ func TestStoreWaitForReplicaInit(t *testing.T) {
 				},
 				Heartbeats: []kvserverpb.RaftHeartbeat{{RangeID: unusedRangeID, ToReplicaID: 1}},
 			}, rpcbase.DefaultClass)
+			var err error
 			repl, err = store.GetReplica(unusedRangeID)
-			return err
+			require.NoError(rt, err)
 		})
 		if repl.IsInitialized() {
 			t.Fatalf("test bug: range %d is initialized", unusedRangeID)
@@ -6097,11 +5964,9 @@ func TestRaftCheckQuorum(t *testing.T) {
 
 			// Wait for the followers to wake up.
 			if sleep {
-				testutils.SucceedsSoon(t, func() error {
-					if repl2.IsAsleep() || repl3.IsAsleep() {
-						return errors.Errorf("at least one follower still asleep")
-					}
-					return nil
+				testutils.Soon(t, func(rt *testutils.RetryT) {
+					require.False(rt, repl2.IsAsleep() || repl3.IsAsleep(),
+						"at least one follower still asleep")
 				})
 				t.Logf("n2 and n3 woke up")
 			} else {

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/util/netutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -7,6 +7,8 @@ package testutils
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -88,3 +90,90 @@ func SucceedsSoonDuration() time.Duration {
 	}
 	return DefaultSucceedsSoonDuration
 }
+
+// Soon retries the fn closure until it succeeds (no assertion failures) or the
+// SucceedsSoonDuration elapses, failing the test on timeout.
+//
+// The fn receives a *RetryT that supports both testify assert and require
+// idioms, with the following semantics:
+//   - assert failures are collected, and cause a retry when the closure returns
+//   - require failures (FailNow) abort the closure and cause a retry
+//
+// Within the closure, use rt (RetryT) for "retryable" assertions, and the outer
+// t for assertions that must fail the test immediately:
+//
+//	testutils.Soon(t, func(rt *testutils.RetryT) {
+//		x, y, err := someCall()
+//		require.NoError(t, err)    // fatal: unexpected error / bug
+//		assert.Equal(rt, 123, x)   // retryable, keep going if fails
+//		require.Equal(rt, 456, y)  // retryable, value should converge
+//	})
+//
+// Panics within the closure escape to the caller.
+func Soon(t TestFataler, fn func(t *RetryT)) {
+	t.Helper()
+	SoonDuration(t, fn, SucceedsSoonDuration())
+}
+
+// SoonDuration is like Soon but with a custom timeout duration.
+func SoonDuration(t TestFataler, fn func(t *RetryT), duration time.Duration) {
+	t.Helper()
+	if err := soonErr(fn, duration); err != nil {
+		dumpFile := WriteGoroutineDump()
+		t.Fatalf(
+			"condition failed to evaluate within %s: %s\n\ngoroutine dump: %s",
+			duration, err, dumpFile,
+		)
+	}
+}
+
+func soonErr(fn func(t *RetryT), duration time.Duration) error {
+	return SucceedsWithinError(func() (retErr error) {
+		var rt RetryT
+		defer func() {
+			if r := recover(); r == nil {
+				return
+			} else if _, ok := r.(retryPanic); !ok {
+				panic(r) // it was a real panic
+			} else if retErr = rt.toError(); retErr == nil {
+				// No errors collected, FailNow was called directly.
+				retErr = errors.New("FailNow called")
+			}
+		}()
+		fn(&rt)
+		return rt.toError()
+	}, duration)
+}
+
+// RetryT implements testify's TestingT interface (Errorf, FailNow, Helper) and
+// collects assertion failures as errors. FailNow calls, and assertion failures
+// collected via Errorf, cause the enclosing Soon* call to retry the closure.
+type RetryT struct {
+	errors []string
+}
+
+// Helper is a no-op to satisfy testify's TestingT interface.
+func (r *RetryT) Helper() {}
+
+// Errorf records an assertion failure message.
+func (r *RetryT) Errorf(format string, args ...interface{}) {
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+}
+
+// FailNow panics with a sentinel retryPanic value. This stops the current
+// closure execution and lets Soon* catch the panic and retry.
+func (r *RetryT) FailNow() {
+	panic(retryPanic{})
+}
+
+func (r *RetryT) toError() error {
+	if len(r.errors) == 0 {
+		return nil
+	}
+	return errors.Newf("%s", strings.Join(r.errors, "\n"))
+}
+
+// retryPanic is a sentinel value used by RetryT.FailNow to abort the current
+// attempt via panic/recover without killing the test goroutine. This lets
+// require.* calls trigger a retry instead of a fatal exit.
+type retryPanic struct{}

--- a/pkg/testutils/soon_test.go
+++ b/pkg/testutils/soon_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSucceedsSoon(t *testing.T) {
@@ -26,5 +28,45 @@ func TestSucceedsSoon(t *testing.T) {
 			return nil
 		}
 		return errors.Errorf("%s elapsed, waiting until %s elapses", elapsed, duration)
+	})
+}
+
+func TestSoon(t *testing.T) {
+	t.Run("succeed-immediately", func(t *testing.T) {
+		Soon(t, func(t *RetryT) {
+			require.Equal(t, 1, 1)
+		})
+	})
+	t.Run("succeed-after-retries-require", func(t *testing.T) {
+		countdown := 3
+		Soon(t, func(t *RetryT) {
+			countdown--
+			require.Equal(t, 0, countdown, "not zero yet")
+		})
+	})
+	t.Run("succeed-after-retries-assert", func(t *testing.T) {
+		countdown := 3
+		Soon(t, func(t *RetryT) {
+			countdown--
+			assert.Equal(t, 0, countdown, "not zero yet")
+			require.GreaterOrEqual(t, countdown, 0)
+		})
+	})
+	t.Run("times-out", func(t *testing.T) {
+		require.Error(t, soonErr(func(t *RetryT) {
+			require.Equal(t, "never", "gonna match")
+		}, 10*time.Millisecond))
+	})
+	t.Run("honours-fail-now", func(t *testing.T) {
+		require.Error(t, soonErr(func(t *RetryT) {
+			t.FailNow()
+		}, 10*time.Millisecond))
+	})
+	t.Run("panics-escape", func(t *testing.T) {
+		require.Panics(t, func() {
+			Soon(t, func(*RetryT) {
+				panic("real bug")
+			})
+		})
 	})
 }


### PR DESCRIPTION
This PR introduces a more ergonomic variant of `testutils.SucceedsSoon`, compatible with the `testify/assert` and `require` packages used in tests.

This makes `Soon` closures concise and consistent with how the rest of the test is written. It also makes "add SucceedsSoon" test flake fixes produce a trivial/obvious diff:

```golang
// Say we want to wrap this code.
x, err := someCall()
require.NoError(t, err)
require.Equal(t, 1234, x)

// before: a complete rewrite
testutils.SucceedsSoon(t, func() error {
	x, err := someCall()
	if err != nil {
		return err
	}
	if x != 1234 {
		return errors.New("still waiting for 1234")
	}
	return nil
})

// after: clean trivial change
testutils.Soon(t, func(t *testutils.RetryT) {
	x, err := someCall()       // no changes
	require.NoError(t, err)    // in these
	require.Equal(t, 1234, x)  // lines
})
```

A few test files are converted, but there are a lot more to come (can also be done lazily).

Discussion: https://cockroachlabs.slack.com/archives/C023S0V4YEB/p1773779192809469

Related to #100796