### PR TITLE
release-25.4: sql: add debug logging for lease upsert

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -128,6 +128,9 @@ func (t *descriptorState) upsertLeaseLocked(
 	session sqlliveness.Session,
 	regionEnumPrefix []byte,
 ) error {
+	if fn := t.m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+		fn(desc.GetID(), desc.GetVersion(), "attempting")
+	}
 	if t.mu.maxVersionSeen < desc.GetVersion() {
 		t.mu.maxVersionSeen = desc.GetVersion()
 	}
@@ -141,15 +144,24 @@ func (t *descriptorState) upsertLeaseLocked(
 			// If we don't have sufficient memory, then release the lease so
 			// that the system.lease table doesn't have a reference.
 			t.m.storage.release(ctx, t.m.stopper, descState.mu.lease)
+			if fn := t.m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+				fn(desc.GetID(), desc.GetVersion(), "memory budget exceeded, releasing lease")
+			}
 			return wrapMemoryError(err)
 		}
 		t.mu.active.insert(descState)
 		t.m.names.insert(ctx, descState)
+		if fn := t.m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+			fn(desc.GetID(), desc.GetVersion(), "inserted new version into active set")
+		}
 		return nil
 	}
 	// If the version already exists and the session ID matches nothing
 	// needs to be done.
 	if s.getSessionID() == session.ID() {
+		if fn := t.m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+			fn(desc.GetID(), desc.GetVersion(), "already exists with same session, skipping")
+		}
 		return nil
 	}
 
@@ -165,6 +177,9 @@ func (t *descriptorState) upsertLeaseLocked(
 	}()
 	// Delete the existing lease on behalf of the caller.
 	t.m.storage.release(ctx, t.m.stopper, &existingLease)
+	if fn := t.m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+		fn(desc.GetID(), desc.GetVersion(), "delete the existing lease on behalf of the caller")
+	}
 	return nil
 }
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1130,6 +1130,9 @@ func (m *Manager) acquireNodeLease(
 					return false, err
 				}
 				if desc == nil {
+					if fn := m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+						fn(id, currentVersion, "system table acquisition returned nil, already leased")
+					}
 					return true, nil
 				}
 			} else {
@@ -1140,6 +1143,9 @@ func (m *Manager) acquireNodeLease(
 				// If a nil descriptor is returned, then the latest version has already
 				// been leased. So, nothing needs to be done here.
 				if desc == nil {
+					if fn := m.testingKnobs.TestingLeaseUpsertEventForID; fn != nil {
+						fn(id, currentVersion, "acquisition returned nil, already leased")
+					}
 					return true, nil
 				}
 				err = doUpsertion(desc)

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -73,6 +73,12 @@ type ManagerTestingKnobs struct {
 	TestingOnUpdateReadTimestamp func(timestamp hlc.Timestamp)
 
 	LeaseStoreTestingKnobs StorageTestingKnobs
+	// TestingLeaseUpsertEventForID, if set, is called on every lease upsert
+	// attempt for the specified descriptor. The msg argument describes what
+	// happened (e.g. "attempting", "skipping", "already leased"). This knob
+	// was added for debugging #162173, and it can be removed when it's no
+	// longer needed.
+	TestingLeaseUpsertEventForID func(id descpb.ID, version descpb.DescriptorVersion, msg string)
 }
 
 var _ base.ModuleTestingKnobs = &ManagerTestingKnobs{}

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/lease",
         "//pkg/sql/parser",
         "//pkg/sql/schemachanger/rel",
         "//pkg/sql/schemachanger/scdeps/sctestdeps",

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
@@ -59,7 +60,18 @@ func TestBuildDataDrivenWithSQLDependencies(t *testing.T) {
 	}
 
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
-		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLLeaseManager: &lease.ManagerTestingKnobs{
+					// Debug knob for #162173, will be removed when the issue is resolved.
+					TestingLeaseUpsertEventForID: func(id descpb.ID, version descpb.DescriptorVersion, msg string) {
+						if id > 103 && id < 107 {
+							t.Logf("upsert lease: descriptor %d version %d: %s", id, version, msg)
+						}
+					},
+				},
+			},
+		})
 		defer s.Stopper().Stop(ctx)
 		tt := s.ApplicationLayer()
 		tdb := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/lease",
         "//pkg/sql/parser",
         "//pkg/sql/schemachanger/scbuild",
         "//pkg/sql/schemachanger/scdeps/sctestutils",

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps/sctestutils"
@@ -53,7 +54,18 @@ func TestPlanDataDriven(t *testing.T) {
 	ctx := context.Background()
 
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
-		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLLeaseManager: &lease.ManagerTestingKnobs{
+					// Debug knob for #162173, will be removed when the issue is resolved.
+					TestingLeaseUpsertEventForID: func(id descpb.ID, version descpb.DescriptorVersion, msg string) {
+						if id > 103 && id < 107 {
+							t.Logf("upsert lease: descriptor %d version %d: %s", id, version, msg)
+						}
+					},
+				},
+			},
+		})
 		defer s.Stopper().Stop(ctx)
 
 		tdb := sqlutils.MakeSQLRunner(sqlDB)


### PR DESCRIPTION
Backport 1/1 commits from #165419.

/cc @cockroachdb/release

---

Adds targeted debug logs to the lease acquisition path for descriptor 105 to help diagnose an issue, where a schema change fails because a new lease is never upserted. Logs are added at each point where the upsert could be skipped: when the version already exists with the same session, when a bulk acquire is waited on, and when storage.acquire returns nil (already leased).

Informs: #162173

Release note: None

Release justification: test-only changes for debugging
