### PR TITLE
admission: register SQL goroutines for CPU accounting

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1557,6 +1557,8 @@ func (w *workerCoordinator) performRequestAsync(
 		}
 
 		// Do admission control after we've finalized the memory accounting.
+		// Note: this goroutine is registered for SQL CPU accounting via
+		// RegisterGoroutine in performRequestAsync.
 		if br != nil && w.responseAdmissionQ != nil {
 			responseAdmission := admission.WorkInfo{
 				TenantID:   roachpb.SystemTenantID,
@@ -1601,6 +1603,12 @@ func (w *workerCoordinator) performRequestAsync(
 	}
 	go func(ctx context.Context) {
 		defer hdl.Activate(ctx).Release(ctx)
+		// Register this goroutine for CPU accounting. The SQLCPUHandle is
+		// on the context from the SQL execution path.
+		if cpuHandle := admission.SQLCPUHandleFromContext(ctx); cpuHandle != nil {
+			gh := cpuHandle.RegisterGoroutine()
+			defer gh.Close(ctx)
+		}
 		work(ctx)
 	}(ctx)
 }

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -404,7 +404,9 @@ func (i *Inbox) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 		// for now.
 		i.allocator.AdjustMemoryUsageAfterAllocation(numSerializedBytes)
 		// Do admission control after memory accounting for the serialized bytes
-		// and before deserialization.
+		// and before deserialization. Note: this goroutine (the operator chain
+		// goroutine) is registered for SQL CPU accounting via RegisterGoroutine
+		// in FlowBase.StartInternal or accumulateAsyncComponent.
 		if i.admissionQ != nil {
 			if _, err := i.admissionQ.Admit(i.Ctx, i.admissionInfo); err != nil {
 				// err includes the case of context cancellation while waiting for

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -253,6 +253,11 @@ type FlowBase struct {
 	spec *execinfrapb.FlowSpec
 
 	admissionInfo admission.WorkInfo
+
+	// cpuHandle is the SQLCPUHandle for CPU accounting. It is stored here so
+	// that inbound stream handler goroutines (which receive the RPC handler's
+	// context, not the flow's context) can access it.
+	cpuHandle *admission.SQLCPUHandle
 }
 
 func (f *FlowBase) getStatus() flowStatus {
@@ -456,6 +461,11 @@ func (f *FlowBase) GetAdmissionInfo() admission.WorkInfo {
 	return f.admissionInfo
 }
 
+// GetCPUHandle returns the SQLCPUHandle for this flow, or nil if none was set.
+func (f *FlowBase) GetCPUHandle() *admission.SQLCPUHandle {
+	return f.cpuHandle
+}
+
 // StartInternal starts the flow. All processors are started, each in their own
 // goroutine. The caller must forward any returned error to rowSyncFlowConsumer if
 // set.
@@ -467,6 +477,7 @@ func (f *FlowBase) StartInternal(
 	)
 
 	cpuHandle := admission.SQLCPUHandleFromContext(ctx)
+	f.cpuHandle = cpuHandle
 	// Only register the flow if it is a part of the distributed plan. This is
 	// needed to satisfy two different use cases:
 	// 1. there are inbound stream connections that need to look up this flow in

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -132,6 +132,13 @@ func processInboundStreamHelper(
 	f.GetWaitGroup().Add(1)
 	go func() {
 		defer f.GetWaitGroup().Done()
+		// Register this goroutine for CPU accounting. The context here is the
+		// RPC handler's context (not the flow's context), so we get the handle
+		// from FlowBase directly.
+		if cpuHandle := f.GetCPUHandle(); cpuHandle != nil {
+			gh := cpuHandle.RegisterGoroutine()
+			defer gh.Close(ctx)
+		}
 		admissionInfo := f.GetAdmissionInfo()
 		for {
 			recvCleanup := ash.SetWorkState(
@@ -216,6 +223,8 @@ func processProducerMessage(
 			consumerClosed: false,
 		}
 	}
+	// Note: this goroutine is registered for SQL CPU accounting via
+	// RegisterGoroutine in processInboundStreamHelper.
 	var admissionQ *admission.WorkQueue
 	if flowBase.Cfg != nil {
 		admissionQ = flowBase.Cfg.SQLSQLResponseAdmissionQ

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -191,6 +191,12 @@ func (f *hookFnNode) startExec(params runParams) error {
 		},
 		func(ctx context.Context) {
 			defer close(f.run.errCh)
+			// TODO(wenyihu): Register this goroutine for CPU accounting. Plan
+			// hooks (BACKUPs, IMPORTs, etc.) run at the gateway, so the
+			// SQLCPUHandle should have atGateway=true. Additionally, each hook
+			// may spawn further goroutines that would also need registration.
+			// Follow up on this once the overall CPU accounting strategy for
+			// plan hooks is clearer.
 			err := f.f(ctx, f.run.resultsCh)
 			select {
 			case <-ctx.Done():

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -793,6 +793,10 @@ func (f *txnKVFetcher) maybeAdmitBatchResponse(ctx context.Context, br *kvpb.Bat
 			return err
 		}
 	} else if f.responseAdmissionQ != nil {
+		// Note: this runs on the processor goroutine, which is registered for
+		// SQL CPU accounting via RegisterGoroutine in FlowBase.StartInternal,
+		// or on the conn_executor goroutine which has a SQLCPUHandle on its
+		// context via MakeCPUHandle in conn_executor_exec.go.
 		responseAdmission := admission.WorkInfo{
 			TenantID:   roachpb.SystemTenantID,
 			Priority:   admissionpb.WorkPriority(f.requestAdmissionHeader.Priority),

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -98,6 +98,12 @@ func (cb *columnBackfiller) Run(ctx context.Context, output execinfra.RowReceive
 	defer span.Finish()
 	defer output.ProducerDone()
 	defer execinfra.SendTraceData(ctx, cb.flowCtx, output)
+
+	// TODO(wenyihu): Evaluate whether SQLCPUHandle integration is needed here.
+	// All work runs on a single goroutine (row scan + column value computation
+	// + KV write-back at BulkNormalPri), so SQL CPU and bulk write CPU cannot
+	// be separated without refactoring.
+
 	meta := cb.doRun(ctx)
 	output.Push(nil /* row */, meta)
 }

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -566,6 +566,13 @@ func (ib *indexBackfiller) Run(ctx context.Context, output execinfra.RowReceiver
 	defer execinfra.SendTraceData(ctx, ib.flowCtx, output)
 	defer ib.Close(ctx)
 
+	// TODO(wenyihu): Evaluate whether SQLCPUHandle integration is needed here.
+	// Currently, all CPU work under Run is already governed by elastic CPU
+	// admission: ingestIndexEntries is directly paced by admission.Pacer, and
+	// constructIndexEntries is indirectly throttled via KV admission
+	// (BulkNormalPri) and backpressure from the Pacer-controlled ingestion
+	// channel. The Run goroutine itself only forwards progress metadata.
+
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 	var err error
 	// We don't have to worry about this go routine leaking because next we loop

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -206,7 +206,9 @@ func (tb *tableWriterBase) finalize(ctx context.Context) (err error) {
 
 func (tb *tableWriterBase) tryDoResponseAdmission(ctx context.Context) error {
 	// Do admission control for response processing. This is the shared write
-	// path for most SQL mutations.
+	// path for most SQL mutations. Note: this runs on the conn_executor
+	// goroutine, which has a SQLCPUHandle injected into its context via
+	// MakeCPUHandle in conn_executor_exec.go.
 	responseAdmissionQ := tb.txn.DB().SQLKVResponseAdmissionQ
 	if responseAdmissionQ != nil {
 		requestAdmissionHeader := tb.txn.AdmissionHeader()

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -111,6 +112,11 @@ func setupGenerator(
 		},
 		func(ctx context.Context) {
 			defer wg.Done()
+			// Register this goroutine for CPU accounting.
+			if cpuHandle := admission.SQLCPUHandleFromContext(ctx); cpuHandle != nil {
+				gh := cpuHandle.RegisterGoroutine()
+				defer gh.Close(ctx)
+			}
 			// We wait until a call to next before starting the worker. This prevents
 			// concurrent transaction usage during the startup phase. We also have to
 			// wait on done here if cleanup is called before any calls to next() to


### PR DESCRIPTION
SQL CPU time token admission will replace the existing
`SQLKVResponseAdmissionQ` and `SQLSQLResponseAdmissionQ` response
admission queues. For this to work, every goroutine performing SQL work
must be registered with a `SQLCPUHandle` via `RegisterGoroutine` so that
`GoroutineCPUHandle.MeasureAndAdmit` can measure CPU consumption and
acquire tokens.

This change registers four additional goroutine sites:

1. The inbound stream reader goroutine in `processInboundStreamHelper`.
   This goroutine receives the RPC handler's context rather than the
   flow's context, so the `SQLCPUHandle` is not available via
   `SQLCPUHandleFromContext`. A `cpuHandle` field and `GetCPUHandle`
   accessor are added to `FlowBase` to make the handle accessible.

2. The async worker goroutine in
   `workerCoordinator.performRequestAsync`. This goroutine inherits
   the SQL execution context and retrieves the handle directly via
   `SQLCPUHandleFromContext`.

3. The virtual table generator goroutine in `setupGenerator`. Same
   context inheritance pattern as (2).

4. The vectorized async component goroutines (routers, outboxes) in
   `accumulateAsyncComponent`, which were already registered in a
   prior commit on master.

This change also documents, at each `SQLKVResponseAdmissionQ` and
`SQLSQLResponseAdmissionQ` `.Admit()` call site, which goroutine
executes the code and where its CPU accounting registration occurs.
These annotations serve as a guide for the future replacement of
response admission with CPU time token admission.

Note that `FlowBase.cpuHandle` is safe to read from inbound stream
handler goroutines without synchronization: `StartInternal` writes the
field before `RegisterFlow` makes the flow discoverable, and inbound
stream handlers cannot run until `ConnectInboundStream` finds the flow.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>