### PR TITLE
release-25.2: sql: fix TestRelocateNonVoters flake

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -347,15 +347,24 @@ func (tc testCase) runTest(
 		fn()
 	}
 
-	execQueries(testCluster, systemDB, "system", tc.system)
+	// Re-enable queues before each execQueries call so that queues
+	// disabled by a prior tenant's run don't block replication.
+	runExecQueries := func(db *gosql.DB, tenant string, tExp tenantExpected) {
+		testCluster.ToggleReplicateQueues(true)
+		testCluster.ToggleSplitQueues(true)
+		testCluster.ToggleLeaseQueues(true)
+		execQueries(testCluster, db, tenant, tExp)
+	}
+
+	runExecQueries(systemDB, "system", tc.system)
 	if tc.secondary.isSet() {
-		execQueries(testCluster, secondaryDB, "secondary", tc.secondary)
+		runExecQueries(secondaryDB, "secondary", tc.secondary)
 	}
 	if tc.secondaryWithoutClusterSetting.isSet() {
-		execQueries(testCluster, secondaryWithoutClusterSettingDB, "secondary_without_cluster_setting", tc.secondaryWithoutClusterSetting)
+		runExecQueries(secondaryWithoutClusterSettingDB, "secondary_without_cluster_setting", tc.secondaryWithoutClusterSetting)
 	}
 	if tc.secondaryWithoutCapability.isSet() {
-		execQueries(testCluster, secondaryWithoutCapabilityDB, "secondary_without_capability", tc.secondaryWithoutCapability)
+		runExecQueries(secondaryWithoutCapabilityDB, "secondary_without_capability", tc.secondaryWithoutCapability)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #165985 on behalf of @spilchen.

----

The execQueries callback is called sequentially for each tenant on the same testCluster. The callback disables replicate/lease/split queues, but they were never re-enabled between runs. When the secondary tenant's callback ran, queues were already off from the system tenant's run, so WaitForFullReplication and LEARNER cleanup could never complete.

Re-enable all three queues before each execQueries invocation in runTest.

Closes #164791
Release note: none
Epic: none

----

Release justification: test only fix