### PR TITLE
roachtest: fix unsupported architecture error for fips in javascript_…

### DIFF
--- a/pkg/cmd/roachtest/tests/javascript_helpers.go
+++ b/pkg/cmd/roachtest/tests/javascript_helpers.go
@@ -44,7 +44,7 @@ sudo find /usr/local/lib/node_modules/npm/bin -type f -exec chmod 755 {} \;
 		tarball := ""
 		checksum := ""
 		switch c.Architecture() {
-		case vm.ArchAMD64:
+		case vm.ArchAMD64, vm.ArchFIPS:
 			tarball = fmt.Sprintf(NODE_TARBALL, "x64")
 			checksum = AMD64_SHA256SUM
 		case vm.ArchARM64:


### PR DESCRIPTION
The `db-console/mixed-version-cypress` roachtest was failing on FIPS 
architecture with the error "unsupported architecture: fips". 

## Root Cause
The `installNode18` function in `javascript_helpers.go` had no case for 
`vm.ArchFIPS` in the architecture switch statement, causing it to fall 
through to the default error case.

## Fix
FIPS is not a separate hardware architecture — it runs on AMD64 hardware 
with FIPS mode enabled. Added `vm.ArchFIPS` alongside `vm.ArchAMD64` so 
it correctly uses the x64 Node.js tarball.

Fixes #158311

Release note: None

Epic: None
