### PR TITLE
cli: deflake/strengthen TestLossOfQuorumRecovery

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -173,8 +173,7 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderDeadlock(t, "slow under deadlock")
-	skip.UnderStress(t, "slow under stress")
+	skip.UnderDuress(t, "slow test")
 
 	ctx := context.Background()
 	dir, cleanupFn := testutils.TempDir(t)
@@ -283,32 +282,41 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 
 	require.NoError(t, runDecommissionNodeImpl(
 		ctx, adminClient, nodeDecommissionWaitNone, nodeDecommissionChecksSkip, false,
-		[]roachpb.NodeID{roachpb.NodeID(2), roachpb.NodeID(3)}, tcAfter.Server(0).NodeID()),
-		"Failed to decommission removed nodes")
+		[]roachpb.NodeID{roachpb.NodeID(2), roachpb.NodeID(3)}, tcAfter.Server(0).NodeID(),
+	))
 
 	for i := 0; i < len(tcAfter.Servers); i++ {
-		require.NoError(t, tcAfter.Servers[i].GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.TestingSetReplicateQueueActive(true)
+		require.NoError(t, tcAfter.Servers[i].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+			s.TestingSetReplicateQueueActive(true)
 			return nil
-		}), "Failed to activate replication queue")
+		}))
 	}
-	require.NoError(t, tcAfter.WaitForZoneConfigPropagation(),
-		"Failed to ensure zone configs are propagated")
-	require.NoError(t, tcAfter.WaitForFullReplication(), "Failed to perform full replication")
+	require.NoError(t, tcAfter.WaitForZoneConfigPropagation())
+	require.NoError(t, tcAfter.WaitForFullReplication())
+
+	// Wait until all ranges have moved to the new nodes.
+	const wantReplicas = "{1,4,5}"
+	s = sqlutils.MakeSQLRunner(tcAfter.Conns[0])
+	testutils.SucceedsWithin(t, func() error {
+		rows := s.Query(t, "select range_id, replicas from crdb_internal.ranges")
+		defer rows.Close()
+		for rows.Next() {
+			var rangeID int
+			var replicas string
+			if err := rows.Scan(&rangeID, &replicas); err != nil {
+				return err
+			} else if replicas != wantReplicas {
+				return errors.Errorf("r%d not reconfigured, replicas: %s", rangeID, replicas)
+			}
+		}
+		return rows.Err()
+	}, testutils.SucceedsSoonDuration()*2)
 
 	for i := 0; i < len(tcAfter.Servers); i++ {
 		require.NoError(t, tcAfter.Servers[i].GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
 			return store.ForceConsistencyQueueProcess()
 		}), "Failed to force replicas to consistency queue")
 	}
-
-	// As a validation step we will just pick one range and get its replicas to see
-	// if they were up-replicated to the new nodes.
-	s = sqlutils.MakeSQLRunner(tcAfter.Conns[0])
-	r := s.QueryRow(t, "select replicas from crdb_internal.ranges limit 1")
-	var replicas string
-	r.Scan(&replicas)
-	require.Equal(t, "{1,4,5}", replicas, "Replicas after loss of quorum recovery")
 
 	// Validate that rangelog is updated by recovery records after cluster restarts.
 	testutils.SucceedsSoon(t, func() error {


### PR DESCRIPTION
The test flakes when `WaitForFullReplication` returns too early. Under overload, nodes become unavailable and skew replica counter metrics which this function relies on. Don't rely on it too much: wait for the final "interesting" condition to materialize: all ranges are moved from the decommissioned nodes to the new ones.

Fixes #161502