### PR TITLE
sql: clean up column deps during rollback of CREATE TABLE in ADD state

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1394,16 +1394,20 @@ ORDER BY
 	tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), childDesc.TableSpan(codec), 0)
 }
 
-// TestCreateTableFKRollbackCleansBackrefs verifies that when a CREATE TABLE
-// with an inline FOREIGN KEY constraint is rolled back (because the schema
-// change job fails), the InboundFK back-reference on the referenced table is
-// properly cleaned up.
+// TestCreateTableRollbackCleansBackrefs verifies that when a CREATE TABLE
+// with an inline FOREIGN KEY constraint, a user-defined type column, a
+// sequence default, and a UDF default is rolled back (because the schema change
+// job fails), the InboundFK back-reference on the referenced table, the type
+// descriptor's back-reference, the sequence's DependedOnBy, and the function
+// descriptor's DependedOnBy are all properly cleaned up.
 //
-// This is a regression test for a bug where rollbackSchemaChange() would mark
+// This is a regression test for bugs where rollbackSchemaChange() would mark
 // the new table as Dropped and GC it, but never remove the InboundFK entry
-// from the referenced table, leaving an orphaned back-reference to a
+// from the referenced table, the table's ID from the type descriptor's
+// ReferencingDescriptorIDs, the sequence's DependedOnBy entry, or the function
+// descriptor's DependedOnBy entry, leaving orphaned back-references to a
 // non-existent descriptor.
-func TestCreateTableFKRollbackCleansBackrefs(t *testing.T) {
+func TestCreateTableRollbackCleansBackrefs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -1465,13 +1469,30 @@ func TestCreateTableFKRollbackCleansBackrefs(t *testing.T) {
 	_, err = systemDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s'`)
 	require.NoError(t, err)
 
-	// Create the referenced (parent) table.
+	// Create the referenced (parent) table, a user-defined type, a sequence,
+	// and a user-defined function.
 	sqlRun.Exec(t, `CREATE DATABASE t`)
+	sqlRun.Exec(t, `USE t`)
 	sqlRun.Exec(t, `CREATE TABLE t.parent (id INT PRIMARY KEY)`)
+	sqlRun.Exec(t, `CREATE TYPE t.my_enum AS ENUM ('a', 'b', 'c')`)
+	sqlRun.Exec(t, `CREATE SEQUENCE t.my_seq`)
+	sqlRun.Exec(t, `CREATE FUNCTION t.my_func() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$`)
 
 	parentDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "parent")
 	require.Empty(t, parentDesc.InboundForeignKeys(),
 		"parent should have no InboundFKs before child creation")
+
+	typDesc := desctestutils.TestingGetPublicTypeDescriptor(kvDB, codec, "t", "my_enum")
+	require.Zero(t, typDesc.NumReferencingDescriptors(),
+		"type should have no back-references before child creation")
+
+	seqDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "my_seq")
+	require.Empty(t, seqDesc.GetDependedOnBy(),
+		"sequence should have no DependedOnBy before child creation")
+
+	fnDesc := desctestutils.TestingGetFunctionDescriptor(kvDB, codec, "t", "public", "my_func")
+	require.Empty(t, fnDesc.GetDependedOnBy(),
+		"function should have no DependedOnBy before child creation")
 
 	// Now create the child table with an inline FK. The CREATE TABLE will
 	// succeed (the SQL transaction commits), but the async schema change job
@@ -1485,10 +1506,14 @@ func TestCreateTableFKRollbackCleansBackrefs(t *testing.T) {
 	sqlRun.QueryRow(t, `SELECT max(id) + 1 FROM system.descriptor`).Scan(&nextID)
 	atomic.StoreUint32(&childTableID, nextID)
 
-	// CREATE TABLE with inline FK. This will fail because the schema change
-	// job is injected with a permanent error.
+	// CREATE TABLE with inline FK, a UDT column, a sequence default, and a UDF
+	// default. This will fail because the schema change job is injected with a
+	// permanent error.
 	_, err = sqlDB.Exec(`CREATE TABLE t.child (
 		id INT PRIMARY KEY,
+		val t.my_enum,
+		seq_val INT DEFAULT nextval('t.my_seq'),
+		fn_val INT DEFAULT my_func(),
 		parent_id INT,
 		CONSTRAINT fk_child_parent FOREIGN KEY (parent_id) REFERENCES t.parent (id)
 	)`)
@@ -1527,11 +1552,13 @@ func TestCreateTableFKRollbackCleansBackrefs(t *testing.T) {
 		[][]string{{"1"}},
 	)
 
-	// Verify via crdb_internal.invalid_objects that the parent is valid.
+	// Verify via crdb_internal.invalid_objects that neither the parent table,
+	// the type, the sequence, nor the function have orphaned references.
 	rows, err := sqlDB.Query(`
 		SELECT id, database_name, schema_name, obj_name, error
 		FROM "".crdb_internal.invalid_objects
-		WHERE database_name = 't' AND obj_name = 'parent'
+		WHERE database_name = 't'
+		  AND obj_name IN ('parent', 'my_enum', 'my_seq', 'my_func')
 	`)
 	require.NoError(t, err)
 	defer rows.Close()
@@ -1546,14 +1573,29 @@ func TestCreateTableFKRollbackCleansBackrefs(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, 0, invalidCount,
-		"parent table should not appear in invalid_objects")
+		"parent table, type, sequence, and function should not appear in invalid_objects")
 
-	// Also, verify the parent table has no orphaned InboundFKs (reads directly
+	// Verify the parent table has no orphaned InboundFKs (reads directly
 	// from KV, bypassing descriptor leases).
 	parentDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "parent")
 	require.Empty(t, parentDesc.InboundForeignKeys(),
 		"parent should have no InboundFKs after child rollback, but has %d",
 		len(parentDesc.InboundForeignKeys()))
+
+	// Verify the type has no orphaned back-references.
+	typDesc = desctestutils.TestingGetPublicTypeDescriptor(kvDB, codec, "t", "my_enum")
+	require.Zero(t, typDesc.NumReferencingDescriptors(),
+		"type should have no back-references after child rollback")
+
+	// Verify the sequence has no orphaned DependedOnBy entries.
+	seqDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "my_seq")
+	require.Empty(t, seqDesc.GetDependedOnBy(),
+		"sequence should have no DependedOnBy after child rollback")
+
+	// Verify the function has no orphaned DependedOnBy entries.
+	fnDesc = desctestutils.TestingGetFunctionDescriptor(kvDB, codec, "t", "public", "my_func")
+	require.Empty(t, fnDesc.GetDependedOnBy(),
+		"function should have no DependedOnBy after child rollback")
 }
 
 // Test that non-physical table deletions like DROP VIEW are immediate instead

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1208,8 +1208,8 @@ func (sc *SchemaChanger) dropViewDeps(
 	}
 	viewDesc.DependsOn = nil
 	// If anything depends on this table clean up references from that object as well.
-	DependedOnBy := append([]descpb.TableDescriptor_Reference(nil), viewDesc.DependedOnBy...)
-	for _, depRef := range DependedOnBy {
+	dependedOnBy := append([]descpb.TableDescriptor_Reference(nil), viewDesc.DependedOnBy...)
+	for _, depRef := range dependedOnBy {
 		dependencyDesc, err := descsCol.MutableByID(txn).Table(ctx, depRef.ID)
 		if err != nil {
 			log.Dev.Warningf(ctx, "error resolving dependency relation ID %d", depRef.ID)
@@ -1223,41 +1223,76 @@ func (sc *SchemaChanger) dropViewDeps(
 			return err
 		}
 	}
-	// Clean up sequence and type references from the view.
-	for _, col := range viewDesc.DeletableColumns() {
+	// Clean up sequence, type, and function references from the view.
+	return sc.dropColumnDeps(ctx, descsCol, txn, b, viewDesc)
+}
+
+// dropColumnDeps cleans up per-column dependencies (type back-references,
+// function back-references, and sequence back-references) for a table or view.
+// For each column, it removes the descriptor's ID from any referenced type
+// descriptor's ReferencingDescriptorIDs, any referenced function descriptor's
+// DependedOnBy, and any referenced sequence's DependedOnBy.
+//
+// Errors during cleanup are logged as warnings and skipped because this
+// function is called during rollback or view teardown, where the descriptor
+// state may be inconsistent or partially committed.
+func (sc *SchemaChanger) dropColumnDeps(
+	ctx context.Context,
+	descsCol *descs.Collection,
+	txn *kv.Txn,
+	b *kv.Batch,
+	tableDesc *tabledesc.Mutable,
+) error {
+	for _, col := range tableDesc.DeletableColumns() {
 		typeClosure := typedesc.GetTypeDescriptorClosure(col.GetType())
+		// Clean up type back-references.
 		for _, id := range typeClosure.Ordered() {
 			typeDesc, err := descsCol.MutableByID(txn).Type(ctx, id)
 			if err != nil {
-				log.Dev.Warningf(ctx, "error resolving type dependency %d", id)
+				log.Dev.Warningf(ctx, "error resolving type dependency %d during rollback: %v", id, err)
 				continue
 			}
-			if typeDesc.RemoveReferencingDescriptorID(viewDesc.GetID()) {
-				if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, typeDesc, b); err != nil {
-					log.Dev.Warningf(ctx, "error removing dependency from type ID %d", id)
+			if typeDesc.RemoveReferencingDescriptorID(tableDesc.GetID()) {
+				if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, typeDesc, b); err != nil {
+					log.Dev.Warningf(ctx, "error removing dependency from type ID %d during rollback: %v", id, err)
 					return err
 				}
 			}
 		}
-		for i := 0; i < col.NumUsesSequences(); i++ {
-			id := col.GetUsesSequenceID(i)
-			seqDesc, err := descsCol.MutableByID(txn).Table(ctx, id)
+		// Clean up function back-references.
+		for i := 0; i < col.NumUsesFunctions(); i++ {
+			fnID := col.GetUsesFunctionID(i)
+			fnDesc, err := descsCol.MutableByID(txn).Function(ctx, fnID)
 			if err != nil {
-				log.Dev.Warningf(ctx, "error resolving sequence dependency %d", id)
+				log.Dev.Warningf(ctx, "error resolving function dependency %d: %v", fnID, err)
+				continue
+			}
+			fnDesc.RemoveReference(tableDesc.GetID())
+			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, fnDesc, b); err != nil {
+				log.Dev.Warningf(ctx, "error removing dependency from function ID %d: %v", fnID, err)
+				return err
+			}
+		}
+		// Clean up sequence back-references.
+		for i := 0; i < col.NumUsesSequences(); i++ {
+			seqID := col.GetUsesSequenceID(i)
+			seqDesc, err := descsCol.MutableByID(txn).Table(ctx, seqID)
+			if err != nil {
+				log.Dev.Warningf(ctx, "error resolving sequence dependency %d during rollback: %v", seqID, err)
 				continue
 			}
 			if seqDesc.Dropped() {
 				continue
 			}
-			DependedOnBy := seqDesc.DependedOnBy
+			dependedOnBy := seqDesc.DependedOnBy
 			seqDesc.DependedOnBy = seqDesc.DependedOnBy[:0]
-			for _, dep := range DependedOnBy {
-				if dep.ID != viewDesc.ID {
+			for _, dep := range dependedOnBy {
+				if dep.ID != tableDesc.ID {
 					seqDesc.DependedOnBy = append(seqDesc.DependedOnBy, dep)
 				}
 			}
 			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, seqDesc, b); err != nil {
-				log.Dev.Warningf(ctx, "error removing dependency from sequence ID %d", id)
+				log.Dev.Warningf(ctx, "error removing dependency from sequence ID %d during rollback: %v", seqID, err)
 				return err
 			}
 		}
@@ -1382,6 +1417,13 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 
 		if err := sc.dropFKDeps(ctx, txn.Descriptors(), txn.KV(), b, scTable); err != nil {
 			return err
+		}
+
+		// Column dependencies are cleaned up in dropViewDeps for view.
+		if !scTable.IsView() {
+			if err := sc.dropColumnDeps(ctx, txn.Descriptors(), txn.KV(), b, scTable); err != nil {
+				return err
+			}
 		}
 
 		scTable.SetDropped()


### PR DESCRIPTION
Previously, when a CREATE TABLE with user-defined type columns or sequence defaults was rolled back (e.g., due to a schema change job failure), the table's ID was left in the type descriptor's ReferencingDescriptorIDs and the sequence's DependedOnBy. After GC removed the table descriptor, these descriptors would have orphaned back-references to a non-existent descriptor, causing them to appear in crdb_internal.invalid_objects.

The fix adds a dropColumnDeps method that iterates over the table's columns, finds all referenced user-defined type descriptors and sequences, and removes the table's ID from their back-references. This is called during rollbackSchemaChange alongside the existing dropFKDeps.

Fixes: #165836

Release note (bug fix): Fixed a bug where rolling back a CREATE TABLE that referenced user-defined types or sequences would leave orphaned back-references on the type and sequence descriptors, causing them to appear in crdb_internal.invalid_objects after the table was GC'd.