### PR TITLE
opt/memo: fix exponential behavior when formatting nested UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -643,3 +643,154 @@ SELECT now() > '2024-06-21 19:04:25.625514+00'
 false
 
 subtest end
+
+subtest regression_166024
+statement ok
+CREATE TABLE t166024 (
+  id INT8 NOT NULL DEFAULT 0,
+  k VARCHAR(50) NULL,
+  CONSTRAINT t1_pkey PRIMARY KEY (id ASC)
+)
+
+statement ok
+CREATE TABLE u166024 (
+  code VARCHAR(20) NOT NULL,
+  name VARCHAR NULL,
+  active BOOL NULL DEFAULT true,
+  flag BOOL NULL DEFAULT false,
+  CONSTRAINT u166024_pkey PRIMARY KEY (code ASC)
+)
+
+statement ok
+CREATE FUNCTION f161993(p_in JSONB, OUT p_out JSONB)
+  RETURNS JSONB
+  LANGUAGE plpgsql
+  AS $$
+  DECLARE
+  v1 BOOL;
+  v2 BOOL;
+  v3 TIMESTAMP;
+  v4 INT8;
+  v5 JSONB;
+  v6 JSONB;
+  v7 JSONB;
+  v8 VARCHAR;
+  v9 BOOL;
+  v10 VARCHAR;
+  v11 VARCHAR;
+  BEGIN
+  v2 := true;
+  v5 := p_in;
+  v8 := COALESCE(btrim(v5->>'code'), '1')::VARCHAR;
+  v10 := '';
+  v11 := '';
+  -- Block 1
+  IF v2 = true THEN
+    SELECT id FROM t166024 WHERE k = split_part(v10, '|', 5) INTO v4;
+    v2 := true;
+  END IF;
+  -- Block 2
+  IF v4 IN (11, 16, 89) THEN
+    v1 := COALESCE(btrim((v5->>'flag')), 'false')::BOOL;
+  END IF;
+  -- Block 3
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 4
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 5
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 6
+  IF (v2 = true) AND (v9::BOOL = true) THEN
+    SELECT COALESCE(flag, false) FROM u166024 WHERE name = split_part(v11, '|', 4) INTO v9;
+  END IF;
+  -- Block 7
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 8
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 9
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 10
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 11
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 12
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 13
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 14
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 15
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 16
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 17
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 18
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 19
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 20
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 21
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 22
+  IF v2 = true THEN
+    v7 := '{}'::JSONB;
+  END IF;
+  -- Block 23
+  IF v2 = true THEN
+    v8 := CASE WHEN EXISTS (SELECT 1 FROM u166024 AS x WHERE (x.code = v8) AND (x.active = true)) THEN v8 ELSE '1' END;
+  END IF;
+  -- Block 24
+  IF v2 = true THEN
+    v6 := '{}'::JSONB;
+  END IF;
+  -- Block 25
+  IF v2 = true THEN
+    v3 := clock_timestamp();
+    v7 := v7::JSONB || jsonb_build_object('key', split_part(v10, '|', 5));
+    p_out := '{}'::JSONB;
+  END IF;
+  END;
+$$
+
+statement ok
+EXPLAIN ANALYZE (DEBUG) SELECT f161993('{}')
+
+subtest end

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -166,9 +166,13 @@ type ExprFmtCtx struct {
 	// with the session variable `save_tables_prefix` set to the same value.
 	nameGen *ExprNameGenerator
 
-	// seenUDFs is used to ensure that formatting of recursive UDFs does not
-	// infinitely recurse.
+	// seenUDFs is used to ensure that formatting of repetitive UDF calls does
+	// not grow the output exponentially.
 	seenUDFs map[*UDFDefinition]struct{}
+
+	// withinUDFs is used to track within invocations of which UDFs we are when
+	// formatting.
+	withinUDFs map[*UDFDefinition]struct{}
 
 	// tailCalls allows for quick lookup of all the routines in tail-call position
 	// when the last body statement of a routine is formatted.
@@ -214,6 +218,7 @@ func MakeExprFmtCtxBuffer(
 		Catalog:          catalog,
 		nameGen:          nameGen,
 		seenUDFs:         make(map[*UDFDefinition]struct{}),
+		withinUDFs:       make(map[*UDFDefinition]struct{}),
 	}
 }
 
@@ -1067,9 +1072,10 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 ) {
 	formatUDFDefinition := func(def *UDFDefinition, tp treeprinter.Node) {
 		if _, seen := f.seenUDFs[def]; !seen {
-			// Ensure that the definition of the UDF is not printed out again if it
-			// is recursively called.
+			// Ensure that the definition of the UDF is not printed out again if
+			// it has already been seen.
 			f.seenUDFs[def] = struct{}{}
+			f.withinUDFs[def] = struct{}{}
 			if len(def.Params) > 0 {
 				f.formatColList(tp, "params:", def.Params, opt.ColSet{} /* notNullCols */)
 			}
@@ -1098,9 +1104,11 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 				f.formatExpr(def.Body[i], stmtNode)
 				f.tailCalls = prevTailCalls
 			}
-			delete(f.seenUDFs, def)
-		} else {
+			delete(f.withinUDFs, def)
+		} else if _, recursive := f.withinUDFs[def]; recursive {
 			tp.Child("recursive-call")
+		} else {
+			tp.Child("repetitive-call")
 		}
 		if def.ExceptionBlock != nil {
 			n := tp.Child("exception-handler")

--- a/pkg/sql/opt/memo/testdata/logprops/tail-calls
+++ b/pkg/sql/opt/memo/testdata/logprops/tail-calls
@@ -671,19 +671,7 @@ values
                                                    ├── tail-call
                                                    ├── args
                                                    │    └── variable: x
-                                                   ├── params: x
-                                                   └── body
-                                                        └── values
-                                                             └── tuple
-                                                                  └── udf: nested_arg
-                                                                       ├── tail-call
-                                                                       ├── args
-                                                                       │    └── variable: x
-                                                                       ├── params: x
-                                                                       └── body
-                                                                            └── values
-                                                                                 └── tuple
-                                                                                      └── variable: x
+                                                   └── repetitive-call
 
 # Tail-call within a loop.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -201,15 +201,7 @@ call
                 │                                                                                              │    ├── variable: new_i:43
                 │                                                                                              │    ├── variable: new_s:44
                 │                                                                                              │    └── variable: c:45
-                │                                                                                              ├── params: arg_k:19 new_i:20 new_s:21 c:22
-                │                                                                                              └── body
-                │                                                                                                   └── project
-                │                                                                                                        ├── columns: "_implicit_return":23
-                │                                                                                                        ├── values
-                │                                                                                                        │    └── tuple
-                │                                                                                                        └── projections
-                │                                                                                                             └── cast: VOID [as="_implicit_return":23]
-                │                                                                                                                  └── null
+                │                                                                                              └── repetitive-call
                 └── const: 1
 
 # Case with nested blocks.
@@ -597,44 +589,7 @@ call
                 │                                                      └── udf: post_nested_block_3 [as=post_nested_block_3:11]
                 │                                                           ├── args
                 │                                                           │    └── variable: x:10
-                │                                                           ├── params: x:4
-                │                                                           └── body
-                │                                                                └── project
-                │                                                                     ├── columns: "_stmt_raise_4":8
-                │                                                                     ├── values
-                │                                                                     │    └── tuple
-                │                                                                     └── projections
-                │                                                                          └── udf: _stmt_raise_4 [as="_stmt_raise_4":8]
-                │                                                                               ├── tail-call
-                │                                                                               ├── args
-                │                                                                               │    └── variable: x:4
-                │                                                                               ├── params: x:5
-                │                                                                               └── body
-                │                                                                                    ├── project
-                │                                                                                    │    ├── columns: stmt_raise_5:6
-                │                                                                                    │    ├── values
-                │                                                                                    │    │    └── tuple
-                │                                                                                    │    └── projections
-                │                                                                                    │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:6]
-                │                                                                                    │              ├── const: 'NOTICE'
-                │                                                                                    │              ├── concat
-                │                                                                                    │              │    ├── concat
-                │                                                                                    │              │    │    ├── const: ''
-                │                                                                                    │              │    │    └── coalesce
-                │                                                                                    │              │    │         ├── cast: STRING
-                │                                                                                    │              │    │         │    └── variable: x:5
-                │                                                                                    │              │    │         └── const: '<NULL>'
-                │                                                                                    │              │    └── const: ''
-                │                                                                                    │              ├── const: ''
-                │                                                                                    │              ├── const: ''
-                │                                                                                    │              └── const: '00000'
-                │                                                                                    └── project
-                │                                                                                         ├── columns: "_implicit_return":7
-                │                                                                                         ├── values
-                │                                                                                         │    └── tuple
-                │                                                                                         └── projections
-                │                                                                                              └── cast: VOID [as="_implicit_return":7]
-                │                                                                                                   └── null
+                │                                                           └── repetitive-call
                 └── const: 1
 
 # Build an implicit RETURN statement for a routine with OUT params.
@@ -720,17 +675,7 @@ call
                 │                                  ├── args
                 │                                  │    ├── variable: x:5
                 │                                  │    └── variable: y:4
-                │                                  ├── params: x:6 y:7
-                │                                  └── body
-                │                                       └── project
-                │                                            ├── columns: "_implicit_return":8
-                │                                            ├── values
-                │                                            │    └── tuple
-                │                                            └── projections
-                │                                                 └── cast: RECORD [as="_implicit_return":8]
-                │                                                      └── tuple
-                │                                                           ├── variable: x:6
-                │                                                           └── variable: y:7
+                │                                  └── repetitive-call
                 └── const: 1
 
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -278,14 +278,7 @@ project
                      │                                  │    ├── variable: a:1
                      │                                  │    ├── variable: b:2
                      │                                  │    └── variable: c:3
-                     │                                  ├── params: a:4 b:5 c:6
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:7
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │                                  └── repetitive-call
                      └── const: 1
 
 exec-ddl
@@ -375,14 +368,7 @@ project
                      │                                  │    ├── variable: a:1
                      │                                  │    ├── variable: b:2
                      │                                  │    └── variable: c:10
-                     │                                  ├── params: a:4 b:5 c:6
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:7
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │                                  └── repetitive-call
                      └── const: 1
 
 exec-ddl
@@ -1182,14 +1168,7 @@ project
                      │                                  │    ├── variable: b:2
                      │                                  │    ├── variable: sum:3
                      │                                  │    └── variable: i:4
-                     │                                  ├── params: a:5 b:6 sum:7 i:8
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:9
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: sum:7 [as=stmt_return_2:9]
+                     │                                  └── repetitive-call
                      └── const: 1
 
 exec-ddl
@@ -3374,53 +3353,7 @@ project
                      │                                                                                              ├── tail-call
                      │                                                                                              ├── args
                      │                                                                                              │    └── variable: i:8
-                     │                                                                                              ├── params: i:9
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_raise_8":14
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_raise_8 [as="_stmt_raise_8":14]
-                     │                                                                                                                  ├── tail-call
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    └── variable: i:9
-                     │                                                                                                                  ├── params: i:10
-                     │                                                                                                                  └── body
-                     │                                                                                                                       ├── project
-                     │                                                                                                                       │    ├── columns: stmt_raise_9:11
-                     │                                                                                                                       │    ├── values
-                     │                                                                                                                       │    │    └── tuple
-                     │                                                                                                                       │    └── projections
-                     │                                                                                                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:11]
-                     │                                                                                                                       │              ├── const: 'NOTICE'
-                     │                                                                                                                       │              ├── concat
-                     │                                                                                                                       │              │    ├── concat
-                     │                                                                                                                       │              │    │    ├── const: 'i = '
-                     │                                                                                                                       │              │    │    └── coalesce
-                     │                                                                                                                       │              │    │         ├── cast: STRING
-                     │                                                                                                                       │              │    │         │    └── variable: i:10
-                     │                                                                                                                       │              │    │         └── const: '<NULL>'
-                     │                                                                                                                       │              │    └── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              └── const: '00000'
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: stmt_loop_5:13
-                     │                                                                                                                            ├── project
-                     │                                                                                                                            │    ├── columns: i:12
-                     │                                                                                                                            │    ├── values
-                     │                                                                                                                            │    │    └── tuple
-                     │                                                                                                                            │    └── projections
-                     │                                                                                                                            │         └── plus [as=i:12]
-                     │                                                                                                                            │              ├── variable: i:10
-                     │                                                                                                                            │              └── const: 1
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── udf: stmt_loop_5 [as=stmt_loop_5:13]
-                     │                                                                                                                                      ├── tail-call
-                     │                                                                                                                                      ├── args
-                     │                                                                                                                                      │    └── variable: i:12
-                     │                                                                                                                                      └── recursive-call
+                     │                                                                                              └── repetitive-call
                      └── const: 1
 
 exec-ddl
@@ -3720,14 +3653,7 @@ project
                      │                                  ├── args
                      │                                  │    ├── variable: n:1
                      │                                  │    └── variable: i:2
-                     │                                  ├── params: n:3 i:4
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:5
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: i:4 [as=stmt_return_2:5]
+                     │                                  └── repetitive-call
                      └── const: 1
 
 # Testing EXCEPTION blocks.
@@ -4438,14 +4364,7 @@ project
                      │              │                                                                               ├── args
                      │              │                                                                               │    ├── variable: i:23
                      │              │                                                                               │    └── variable: x:24
-                     │              │                                                                               ├── params: i:8 x:9
-                     │              │                                                                               └── body
-                     │              │                                                                                    └── project
-                     │              │                                                                                         ├── columns: stmt_return_5:10!null
-                     │              │                                                                                         ├── values
-                     │              │                                                                                         │    └── tuple
-                     │              │                                                                                         └── projections
-                     │              │                                                                                              └── const: 0 [as=stmt_return_5:10]
+                     │              │                                                                               └── repetitive-call
                      │              └── exception-handler
                      │                   └── SQLSTATE '22012'
                      │                        └── project


### PR DESCRIPTION
This commit fixes seemingly exponential behavior when formatting nested UDFs when `ExprFmtHideScalars` flag is not set (which is the case for `EXPLAIN (OPT, TYPES)` and `opt-vv.txt` file of the stmt bundle). This is done by keeping track of "repetitive calls" in addition to already being tracked "recursive calls". Once we've seen a call to a UDF, the UDF's future invocation aren't formatted and are simply replaced with `repetitive-call`.

The impact of the old behavior is that it can easily lead to OOMs. For example, running the regression test for issue 161993 via EXPLAIN ANALYZE (DEBUG) on my laptop consumes 50GiB and doesn't finish within 30s.

Fixes: #166024.

Release note (bug fix): Previously, running `EXPLAIN ANALYZE (DEBUG)` on a query that invokes a UDF with many blocks in some cases could cause OOMs, and this is now fixed.