### PR TITLE
sql: ensure internal executor uses FROM_SQL admission source

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -2026,21 +2027,20 @@ func (ief *InternalDB) txn(
 		return nil
 	}
 
-	run := db.Txn
-	if priority, hasPriority := cfg.GetAdmissionPriority(); hasPriority {
-		steppingMode := kv.SteppingDisabled
-		if cfg.GetSteppingEnabled() {
-			steppingMode = kv.SteppingEnabled
-		}
-		run = func(ctx context.Context, f kvTxnFunc) error {
-			return db.TxnWithAdmissionControl(
-				ctx, kvpb.AdmissionHeader_FROM_SQL, priority, steppingMode, f,
-			)
-		}
-	} else if cfg.GetSteppingEnabled() {
-		run = func(ctx context.Context, f kvTxnFunc) error {
-			return db.TxnWithSteppingEnabled(ctx, sessiondatapb.Normal, f)
-		}
+	steppingMode := kv.SteppingDisabled
+	if cfg.GetSteppingEnabled() {
+		steppingMode = kv.SteppingEnabled
+	}
+	priority := admissionpb.NormalPri
+	if p, hasPriority := cfg.GetAdmissionPriority(); hasPriority {
+		priority = p
+	}
+
+	// Always set the source in AdmissionHeader to FROM_SQL. Using the db.Txn API
+	// would cause the source to default to OTHER, which bypasses admission
+	// control.
+	run := func(ctx context.Context, f kvTxnFunc) error {
+		return db.TxnWithAdmissionControl(ctx, kvpb.AdmissionHeader_FROM_SQL, priority, steppingMode, f)
 	}
 
 	cf := ief.server.cfg.CollectionFactory

--- a/pkg/sql/isql/options.go
+++ b/pkg/sql/isql/options.go
@@ -62,7 +62,7 @@ func (tc *TxnConfig) GetAdmissionPriority() (admissionpb.WorkPriority, bool) {
 	if tc.priority != nil {
 		return *tc.priority, true
 	}
-	return 0, false
+	return admissionpb.NormalPri, false
 }
 
 func (tc *TxnConfig) Init(opts ...TxnOption) {


### PR DESCRIPTION
Previously, when InternalDB.txn() was called without an explicit WithPriority option, it fell through to kv.DB.Txn which sets the admission header source to OTHER. In the KV admission control layer (kvadmission.go), requests from the system tenant with source OTHER have bypassAdmission set to true — meaning they skip admission queuing entirely. This effectively exempted the vast majority of internal executor transactions from admission control.

Only ~10 out of ~580+ callers across InternalDB.Txn, InternalDB.DescsTxn, and isql.DB.Txn explicitly set a priority (and thus used FROM_SQL). The major subsystems affected include:

  Area                        | Examples
  --------------------------- | ----------------------------------
  Jobs                        | adopt, registry, scheduler, progress
  Backup/Restore              | backup jobs, restore jobs, compaction
  Cross-cluster replication   | stream ingestion, producer, LDR
  Schema changes              | type changes, plan node, new SC
  GC jobs                     | table/index/tenant GC
  Import                      | import job, planning, rollback
  Stats collection            | automatic stats, stats cache
  Span config                 | reconciler
  Upgrades                    | schema changes, descriptor utils
  Session/auth caches         | session init, role membership

Now, InternalDB.txn() always uses db.TxnWithAdmissionControl with FROM_SQL as the source. When no WithPriority option is specified, the priority defaults to NormalPri, matching the priority that kv.DB.Txn was already using — the only behavioral change is that these transactions are now properly admitted rather than bypassing admission control.

informs #79212
Epic: None
Release note: None