### PR TITLE
storage: re-enable drpc in `TestNetworkConnectivity`

### DIFF
--- a/pkg/server/storage_api/network_test.go
+++ b/pkg/server/storage_api/network_test.go
@@ -26,12 +26,6 @@ func TestNetworkConnectivity(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	numNodes := 3
 	testCluster := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			// TODO(server): enabling DRPC for this test may require some
-			// refactoring to srvtestutils. Enable the test for DRPC
-			// once the refactoring is done.
-			DefaultDRPCOption: base.TestDRPCDisabled,
-		},
 		ReplicationMode: base.ReplicationManual,
 	})
 	ctx := context.Background()


### PR DESCRIPTION
VerifyDialback now supports DRPC (#165520), so this test no longer needs to be skipped. The fix ensures peers are added to the correct peer map (drpcPeers vs peers) based on the active protocol, allowing connection health tracking to work correctly with DRPC.

Epic: CRDB-55382
Fixes: #161596
Release note: None