### PR TITLE
build: remove bors references and migrate to trunk

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,4 +1,5 @@
 # Trunk configuration file
+# Trunk merge queue configuration
 
 version: 0.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ change, as they can cause merge conflicts in ongoing development.
    commit message is the primary record, not the PR description.
    Include release note annotations.
 7. Push and [create a PR](https://help.github.com/articles/creating-a-pull-request).
-8. Merge via the merge queue.
+8. Merge via `/trunk merge` (not the green button).
 
 ## Code Review
 

--- a/pkg/cmd/kv/ghsearchdump/main.go
+++ b/pkg/cmd/kv/ghsearchdump/main.go
@@ -479,8 +479,9 @@ func cleanPRDetail(repo string, pr *PRDetail, lastPush time.Time) CleanPR {
 		if body == "" {
 			continue
 		}
-		// Skip "bors r+" type comments.
-		if strings.HasPrefix(strings.ToLower(body), "bors r") {
+		// Skip merge queue command comments (bors and trunk).
+		if strings.HasPrefix(strings.ToLower(body), "bors r") ||
+			strings.HasPrefix(strings.ToLower(body), "/trunk") {
 			continue
 		}
 		// Skip Reviewable status-only comments.

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -246,7 +246,7 @@ fixannot = re.compile(r'^([fF]ix(es|ed)?|[cC]lose(d|s)?) #', flags=re.M)
 #
 # Merge pull request #XXXXX from ...      <- GitHub merges
 # .... (#XXXX)                            <- GitHub merges (alt format)
-# Merge #XXXXX #XXXXX #XXXXX              <- Bors merges
+# Merge #XXXXX #XXXXX #XXXXX              <- Bors/Trunk merges
 merge_numbers = re.compile(r'^Merge( pull request)?(?P<numbers>( #[0-9]+)+)')
 simple_merge = re.compile(r'.*\((?P<numbers>#[0-9]+)\)$', re.M)
 
@@ -670,7 +670,7 @@ def analyze_pr(merge, pr, parent_idx):
         # GitHub merge
         title = merge.message.split('\n', 3)[2]
     else:
-        # Bors merge
+        # Bors merge (historical, uses r=... a=... format)
         title = m.group('message')
     title = title.strip()
 


### PR DESCRIPTION
CockroachDB has deprecated bors (a merge queue tool) and migrated to Trunk. This change updates all documentation and code references from bors to trunk to reflect the current workflow.

Changes:
- Delete `.github/bors.toml` configuration file
- Rename `tc_bors_branch()` to `tc_trunk_branch()` in teamcity-support.sh
- Update branch pattern to include `trunk-merge/*` branches
- Update comments in testrace.sh and unit_tests_impl.sh

Epic: CODESYS-84

Release note: None