### PR TITLE
sql: fix slow failure detection in schemachange/bulkingest roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -613,14 +613,16 @@ func makeSchemaChangeBulkIngestTest(
 				aNum, bNum, cNum, payloadBytes,
 			)
 
-			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
-
 			// Set up histogram exporter for performance metrics.
 			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
 			tickHistogram, perfBuf := initBulkJobPerfArtifacts(length*2, t, exporter)
 			defer roachtestutil.CloseExporter(ctx, exporter, t, c, perfBuf, c.Node(1), "")
 
+			// Create the monitor before running the workload so that disk stalls
+			// and other node failures are detected immediately.
 			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
 
 			indexDuration := length
 			if c.IsLocal() {
@@ -631,8 +633,7 @@ func makeSchemaChangeBulkIngestTest(
 				indexDuration.String(), c.Spec().NodeCount-1, aNum, bNum, cNum, payloadBytes,
 			)
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWriteAndRead)
-				return nil
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmdWriteAndRead)
 			})
 
 			m.Go(func(ctx context.Context) error {


### PR DESCRIPTION
Move monitor creation before the initial workload import so that node failures (e.g. disk stalls) are detected immediately rather than hanging unnoticed. Also propagate the error from the cmdWriteAndRead workload step so the test fails fast instead of running for hours when a node is down.

Informs: #165530

Release note: None