### PR TITLE
sql: set BulkNormalPri admission priority for bulk job IE transactions

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1126,7 +1127,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) (r
 		}
 
 		return nil
-	}); err != nil {
+	}, isql.WithPriority(admissionpb.BulkNormalPri)); err != nil {
 		return err
 	}
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3614,10 +3614,11 @@ func DescsTxn(
 	ctx context.Context,
 	execCfg *ExecutorConfig,
 	f func(ctx context.Context, txn isql.Txn, col *descs.Collection) error,
+	opts ...isql.TxnOption,
 ) error {
 	return execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
 		return f(ctx, txn, txn.Descriptors())
-	})
+	}, opts...)
 }
 
 // NewRowMetrics creates a rowinfra.Metrics struct for either internal or user

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/besteffort",
         "//pkg/util/bufalloc",
         "//pkg/util/ctxgroup",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -280,7 +281,7 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			}
 
 			return updateDetails(txn, rowCountDetails)
-		}); err != nil {
+		}, isql.WithPriority(admissionpb.BulkNormalPri)); err != nil {
 			return err
 		}
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -547,7 +547,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			}
 		})
 		return planAndRunErr
-	})
+	}, isql.WithPriority(admissionpb.BulkNormalPri))
 
 	// BatchTimestampBeforeGCError is retryable for the schema changer, but we
 	// will not ever move the timestamp forward so this will fail forever. Mark


### PR DESCRIPTION
Set explicit admission priority for several internal executor callers that perform bulk/background work. These callers were previously using the default path which, depending on the InternalDB implementation, may not set an appropriate admission source or priority.

By explicitly passing isql.WithPriority(admissionpb.BulkNormalPri), these callers are correctly classified as bulk work in the admission control system. This is consistent with how the TTL job processor and schema change backfills already set their priority.

Callers updated:
- CREATE STATISTICS job resumer
- Schema changer backfillQueryIntoTable (CTAS, materialized views)
- IMPORT initial row count

Also updates the sql.DescsTxn helper to accept variadic TxnOption arguments so callers using that shim can pass through options.

Part of: #79212
Epic: None
Release note: None