### PR TITLE
build: update PGO profile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -690,6 +690,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "5a23c5b33325d5fc3dfa4e67d872aa8371756f8e4f8f159509e8cc522c298cb2",
-    url = "https://storage.googleapis.com/cockroach-profiles/20251204202750-818ff5108cdb1f16f69b3d915acdb4f669b848eb.pb.gz",
+    sha256 = "5440c285b70e46fa335a1b31c5fd15bf067eb907c2649d39095dd9b6721bc2dc",
+    url = "https://storage.googleapis.com/cockroach-profiles/20260318145757-19d40353156cc4621ebde30ad530ad2ce77ab97e.pb.gz",
 )


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ artifacts/benchstat_before.txt │    artifacts/benchstat_after.txt     │
                                                           │            ops/sec             │   ops/sec     vs base                │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          102.3 ± 6%    129.2 ± 13%  +26.28% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         1.024k ± 6%   1.292k ± 13%  +26.24% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       102.3 ± 6%    129.2 ± 13%  +26.28% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          1.023k ± 6%   1.292k ± 13%  +26.25% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        102.3 ± 6%    129.2 ± 13%  +26.28% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            2.354k ± 6%   2.972k ± 13%  +26.24% (p=0.000 n=20)
geomean                                                                          371.9         469.5        +26.26%

                                                           │ artifacts/benchstat_before.txt │    artifacts/benchstat_after.txt    │
                                                           │             ms/avg             │   ms/avg     vs base                │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          87.50 ± 5%   70.65 ± 16%  -19.26% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          142.2 ± 7%   112.0 ±  9%  -21.24% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       18.70 ± 3%   14.50 ±  8%  -22.46% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           41.00 ± 4%   31.70 ± 27%  -22.68% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        25.10 ± 3%   20.20 ± 15%  -19.52% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             85.00 ± 6%   67.35 ± 14%  -20.76% (p=0.000 n=20)
geomean                                                                          52.25        41.28        -21.00%

                                                           │ artifacts/benchstat_before.txt │    artifacts/benchstat_after.txt    │
                                                           │             ms/p50             │   ms/p50     vs base                │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          83.90 ± 5%   67.10 ± 19%  -20.02% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          142.6 ± 6%   109.1 ±  4%  -23.49% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      12.100 ± 5%   9.400 ± 12%  -22.31% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           36.70 ± 3%   27.80 ± 28%  -24.25% (p=0.001 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        19.90 ± 0%   15.70 ± 20%  -21.11% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             67.10 ± 6%   52.40 ± 20%  -21.91% (p=0.000 n=20)
geomean                                                                          43.83        34.11        -22.20%

                                                           │ artifacts/benchstat_before.txt │    artifacts/benchstat_after.txt    │
                                                           │             ms/p95             │   ms/p95     vs base                │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          146.8 ± 9%   117.4 ± 14%  -20.03% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          243.3 ± 3%   201.3 ± 17%  -17.26% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       54.50 ± 4%   44.00 ± 10%  -19.27% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           83.90 ± 5%   62.90 ± 27%  -25.03% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        60.80 ± 3%   49.25 ±  6%  -19.00% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             209.7 ± 8%   167.8 ± 15%  -19.98% (p=0.000 n=20)
geomean                                                                          113.0        90.25        -20.13%

                                                           │ artifacts/benchstat_before.txt │    artifacts/benchstat_after.txt    │
                                                           │             ms/p99             │   ms/p99     vs base                │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          184.5 ± 5%   151.0 ± 17%  -18.16% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          302.0 ± 6%   243.3 ± 24%  -19.44% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       83.90 ± 5%   67.10 ± 13%  -20.02% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          113.20 ± 4%   88.10 ± 24%  -22.17% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        92.30 ± 5%   75.50 ±  6%  -18.20% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             276.8 ± 3%   222.3 ± 17%  -19.69% (p=0.000 n=20)
geomean                                                                          154.3        124.1        -19.63%

                                                           │ artifacts/benchstat_before.txt │    artifacts/benchstat_after.txt    │
                                                           │             ms/max             │   ms/max     vs base                │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                         310.4 ±  3%   268.4 ± 13%  -13.53% (p=0.004 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         511.7 ±  5%   427.8 ± 18%  -16.40% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      209.7 ±  8%   176.2 ± 14%  -15.98% (p=0.002 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          268.4 ± 13%   234.9 ± 21%  -12.48% (p=0.018 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                       222.3 ± 13%   184.5 ±  9%  -17.00% (p=0.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            511.7 ±  5%   427.8 ± 18%  -16.40% (p=0.000 n=20)
geomean                                                                         317.1         268.5        -15.31%
```

Epic: none
Release note: none