### PR TITLE
storeliveness: fix flaky TestTransportClusterSettingToggle

### DIFF
--- a/pkg/kv/kvserver/storeliveness/transport_test.go
+++ b/pkg/kv/kvserver/storeliveness/transport_test.go
@@ -919,32 +919,15 @@ func TestTransportClusterSettingToggle(t *testing.T) {
 	// Now toggle back to heartbeat smearing mode.
 	HeartbeatSmearingEnabled.Override(ctx, &st.SV, true)
 
-	// Now enqueue msg3 - processQueue should have re-read the setting and be in
-	// heartbeat smearing mode.
+	// Enqueue msg3 after toggling back to smearing mode. The message is routed
+	// through the smearing sender path (sendAllMessages -> smearingSenderLoop ->
+	// processQueue). We don't assert on transient SendQueueSize here because
+	// the smearing sender drains the queue asynchronously and the metric is not
+	// guaranteed to be observable at any particular value.
 	msg3 := slpb.Message{Type: slpb.MsgHeartbeat, From: sender, To: receiver}
 	require.True(t, tt.transports[sender.NodeID].EnqueueMessage(ctx, msg3))
 
-	// Verify the message is enqueued but NOT delivered (waiting in smearing mode).
-	// Use SucceedsSoon to give the system time to stabilize in the correct state.
-	testutils.SucceedsSoon(t, func() error {
-		// Message should be in the queue.
-		if tt.transports[sender.NodeID].metrics.SendQueueSize.Value() != 1 {
-			return errors.Newf("expected queue size 1, got %d",
-				tt.transports[sender.NodeID].metrics.SendQueueSize.Value())
-		}
-		// But should NOT have been received yet.
-		select {
-		case <-handler.messages:
-			return errors.New(
-				"message should not have been sent yet in heartbeat smearing mode")
-		default:
-		}
-		return nil
-	})
-
-	// Signal to send messages.
-
-	// Verify the message is received.
+	// Verify msg3 is delivered.
 	testutils.SucceedsSoon(
 		t, func() error {
 			select {


### PR DESCRIPTION
The test asserted that after toggling the heartbeat smearing setting back to enabled and enqueuing a message, `SendQueueSize` should be 1 (message queued but not yet delivered). This is inherently racy: `EnqueueMessage` signals `sendAllMessages`, which wakes `smearingSenderLoop`, which after ~10ms signals `processQueue`, which after another ~10ms drains the queue and decrements the metric. On a loaded CI machine, this entire pipeline completes before `SucceedsSoon` observes the intermediate queue state, causing the test to spin for 45s and fail with "expected queue size 1, got 0".

Remove the mid-test assertion on transient `SendQueueSize`. The test's purpose is to verify no messages are lost during setting toggles, which is already covered by the final assertions: 0 dropped, 3 sent, 3 received.

Fixes: #165968