### PR TITLE
release-26.1: sql: fix slow failure detection in schemachange/bulkingest roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -392,14 +392,16 @@ func makeSchemaChangeBulkIngestTest(
 				aNum, bNum, cNum, payloadBytes,
 			)
 
-			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
-
 			// Set up histogram exporter for performance metrics.
 			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
 			tickHistogram, perfBuf := initBulkJobPerfArtifacts(length*2, t, exporter)
 			defer roachtestutil.CloseExporter(ctx, exporter, t, c, perfBuf, c.Node(1), "")
 
+			// Create the monitor before running the workload so that disk stalls
+			// and other node failures are detected immediately.
 			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
 
 			indexDuration := length
 			if c.IsLocal() {
@@ -410,8 +412,7 @@ func makeSchemaChangeBulkIngestTest(
 				indexDuration.String(), c.Spec().NodeCount-1, aNum, bNum, cNum, payloadBytes,
 			)
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWriteAndRead)
-				return nil
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmdWriteAndRead)
 			})
 
 			m.Go(func(ctx context.Context) error {


### PR DESCRIPTION
Backport 1/1 commits from #166064 on behalf of @shghasemi.

----

Move monitor creation before the initial workload import so that node failures (e.g. disk stalls) are detected immediately rather than hanging unnoticed. Also propagate the error from the cmdWriteAndRead workload step so the test fails fast instead of running for hours when a node is down.

Informs: #165530

Release note: None

----

Release justification: Test-only change.