### PR TITLE
sql: add remaining compatibility fixes for pg_dump

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -188,6 +188,7 @@ FILES = [
     "legacy_transaction_stmt",
     "like_table_option_list",
     "limit_clause",
+    "lock_stmt",
     "move_cursor_stmt",
     "nonpreparable_set_stmt",
     "not_null_column_level",

--- a/docs/generated/sql/bnf/lock_stmt.bnf
+++ b/docs/generated/sql/bnf/lock_stmt.bnf
@@ -1,0 +1,5 @@
+lock_stmt ::=
+	'LOCK' opt_table relation_expr_list 'IN' lock_mode 'MODE'
+	| 'LOCK' opt_table relation_expr_list 'IN' lock_mode 'MODE' 'NOWAIT'
+	| 'LOCK' opt_table relation_expr_list
+	| 'LOCK' opt_table relation_expr_list 'NOWAIT'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -31,6 +31,7 @@ stmt_without_legacy_transaction ::=
 	| declare_cursor_stmt
 	| fetch_cursor_stmt
 	| move_cursor_stmt
+	| lock_stmt
 	| unlisten_stmt
 	| show_commit_timestamp_stmt
 
@@ -179,6 +180,12 @@ fetch_cursor_stmt ::=
 
 move_cursor_stmt ::=
 	'MOVE' cursor_movement_specifier
+
+lock_stmt ::=
+	'LOCK' opt_table relation_expr_list 'IN' lock_mode 'MODE'
+	| 'LOCK' opt_table relation_expr_list 'IN' lock_mode 'MODE' 'NOWAIT'
+	| 'LOCK' opt_table relation_expr_list
+	| 'LOCK' opt_table relation_expr_list 'NOWAIT'
 
 unlisten_stmt ::=
 	'UNLISTEN' type_name
@@ -549,6 +556,23 @@ cursor_movement_specifier ::=
 	| 'RELATIVE' signed_iconst64 opt_from_or_in cursor_name
 	| 'FIRST' opt_from_or_in cursor_name
 	| 'LAST' opt_from_or_in cursor_name
+
+opt_table ::=
+	'TABLE'
+	| 
+
+relation_expr_list ::=
+	( relation_expr ) ( ( ',' relation_expr ) )*
+
+lock_mode ::=
+	'ACCESS' 'SHARE'
+	| 'ROW' 'SHARE'
+	| 'ROW' 'EXCLUSIVE'
+	| 'SHARE' 'UPDATE' 'EXCLUSIVE'
+	| 'SHARE' 'ROW' 'EXCLUSIVE'
+	| 'SHARE'
+	| 'EXCLUSIVE'
+	| 'ACCESS' 'EXCLUSIVE'
 
 opt_transaction ::=
 	'TRANSACTION'
@@ -1073,13 +1097,6 @@ show_default_privileges_stmt ::=
 show_inspect_errors_stmt ::=
 	'SHOW' 'INSPECT' 'ERRORS' opt_for_table_clause opt_for_job_clause opt_with_details
 
-opt_table ::=
-	'TABLE'
-	| 
-
-relation_expr_list ::=
-	( relation_expr ) ( ( ',' relation_expr ) )*
-
 set_clause_list ::=
 	( set_clause ) ( ( ',' set_clause ) )*
 
@@ -1236,6 +1253,7 @@ unreserved_keyword ::=
 	| 'ESCAPE'
 	| 'EXCLUDE'
 	| 'EXCLUDING'
+	| 'EXCLUSIVE'
 	| 'EXPLICIT'
 	| 'EXECUTE'
 	| 'EXECUTION'
@@ -1333,6 +1351,7 @@ unreserved_keyword ::=
 	| 'LINESTRINGZ'
 	| 'LINESTRINGZM'
 	| 'LIST'
+	| 'LOCK'
 	| 'LOCAL'
 	| 'LOCKED'
 	| 'LOGICAL'
@@ -1751,6 +1770,12 @@ opt_forward_backward ::=
 
 signed_iconst64 ::=
 	signed_iconst
+
+relation_expr ::=
+	table_name
+	| table_name '*'
+	| 'ONLY' table_name
+	| 'ONLY' '(' table_name ')'
 
 alter_table_stmt ::=
 	alter_onetable_stmt
@@ -2324,12 +2349,6 @@ opt_for_job_clause ::=
 opt_with_details ::=
 	'WITH' 'DETAILS'
 	| 
-
-relation_expr ::=
-	table_name
-	| table_name '*'
-	| 'ONLY' table_name
-	| 'ONLY' '(' table_name ')'
 
 set_clause ::=
 	single_set_clause
@@ -4233,6 +4252,7 @@ bare_label_keywords ::=
 	| 'ESCAPE'
 	| 'EXCLUDE'
 	| 'EXCLUDING'
+	| 'EXCLUSIVE'
 	| 'EXPLICIT'
 	| 'EXECUTE'
 	| 'EXECUTION'
@@ -4364,6 +4384,7 @@ bare_label_keywords ::=
 	| 'LINESTRINGZ'
 	| 'LINESTRINGZM'
 	| 'LIST'
+	| 'LOCK'
 	| 'LOCAL'
 	| 'LOCALITY'
 	| 'LOCALTIME'

--- a/docs/generated/sql/bnf/stmt_without_legacy_transaction.bnf
+++ b/docs/generated/sql/bnf/stmt_without_legacy_transaction.bnf
@@ -22,5 +22,6 @@ stmt_without_legacy_transaction ::=
 	| declare_cursor_stmt
 	| fetch_cursor_stmt
 	| move_cursor_stmt
+	| lock_stmt
 	| unlisten_stmt
 	| show_commit_timestamp_stmt

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -188,6 +188,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:legacy_transaction_stmt.bnf",
     "//docs/generated/sql/bnf:like_table_option_list.bnf",
     "//docs/generated/sql/bnf:limit_clause.bnf",
+    "//docs/generated/sql/bnf:lock_stmt.bnf",
     "//docs/generated/sql/bnf:move_cursor_stmt.bnf",
     "//docs/generated/sql/bnf:nonpreparable_set_stmt.bnf",
     "//docs/generated/sql/bnf:not_null_column_level.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -188,6 +188,7 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:legacy_transaction.html",
     "//docs/generated/sql/bnf:like_table_option_list.html",
     "//docs/generated/sql/bnf:limit_clause.html",
+    "//docs/generated/sql/bnf:lock.html",
     "//docs/generated/sql/bnf:move_cursor.html",
     "//docs/generated/sql/bnf:nonpreparable_set.html",
     "//docs/generated/sql/bnf:not_null_column_level.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -198,6 +198,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:legacy_transaction_stmt.bnf",
     "//docs/generated/sql/bnf:like_table_option_list.bnf",
     "//docs/generated/sql/bnf:limit_clause.bnf",
+    "//docs/generated/sql/bnf:lock_stmt.bnf",
     "//docs/generated/sql/bnf:move_cursor_stmt.bnf",
     "//docs/generated/sql/bnf:nonpreparable_set_stmt.bnf",
     "//docs/generated/sql/bnf:not_null_column_level.bnf",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -157,6 +157,7 @@ go_library(
         "join.go",
         "join_predicate.go",
         "limit.go",
+        "lock_table.go",
         "lookup_join.go",
         "max_one_row.go",
         "mem_metrics.go",

--- a/pkg/sql/lock_table.go
+++ b/pkg/sql/lock_table.go
@@ -1,0 +1,26 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+)
+
+func (p *planner) LockTable(ctx context.Context, n *tree.LockTable) (planNode, error) {
+	if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) {
+		// CockroachDB uses MVCC, so all lock modes are implicitly satisfied
+		// by the concurrency control system. This is a no-op for pg_dump
+		// compatibility.
+		return newZeroNode(nil /* columns */), nil
+	}
+	return nil, pgerror.New(pgcode.FeatureNotSupported,
+		"LOCK TABLE is not supported")
+}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -555,6 +555,24 @@ SELECT * FROM pg_catalog.pg_matviews
 schemaname  matviewname  matviewowner  tablespace  hasindexes  ispopulated  definition
 public      mv1          root          NULL        false       true         SELECT 1;
 
+# When pg_dump_compatibility is enabled, view definitions should use
+# schema-qualified names (no database prefix).
+statement ok
+SET pg_dump_compatibility = 'postgres'
+
+query T
+SELECT definition FROM pg_catalog.pg_views WHERE viewname = 'v1'
+----
+SELECT p, a, b, c FROM public.t1;
+
+query T
+SELECT definition FROM pg_catalog.pg_matviews WHERE matviewname = 'mv1'
+----
+SELECT 1;
+
+statement ok
+SET pg_dump_compatibility = 'off'
+
 ## pg_catalog.pg_class
 
 query TTBOOOO colnames,rowsort

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -406,14 +406,19 @@ SELECT bool_and(tableoid = $is_tables_oid2) FROM information_schema.tables
 ----
 true
 
-# crdb_internal tables should also be unaffected.
-let $crdb_tables_oid
-SELECT oid FROM pg_class WHERE relname = 'tables' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'crdb_internal')
-
-query B
-SELECT bool_and(tableoid = $crdb_tables_oid) FROM crdb_internal.tables
+# crdb_internal tables should be hidden from pg_class so pg_dump does
+# not try to dump them.
+query I
+SELECT count(*) FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'crdb_internal')
 ----
-true
+0
+
+# crdb_internal and information_schema functions should be hidden from
+# pg_proc so pg_dump does not try to dump them.
+query I
+SELECT count(*) FROM pg_proc WHERE pronamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN ('crdb_internal', 'information_schema'))
+----
+0
 
 # Additional pg_catalog tables should also have remapped tableoids.
 query O

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -522,5 +522,4 @@ SET pg_dump_compatibility = 'off'
 
 statement ok
 DROP TABLE t_schema_locked
-
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -694,3 +694,71 @@ query I
 SELECT estimated_row_count FROM crdb_internal.table_row_statistics WHERE table_name = 't'
 ----
 10
+
+subtest lock_table
+
+# LOCK TABLE is not supported by default.
+statement error pgcode 0A000 LOCK TABLE is not supported
+LOCK TABLE t IN ACCESS SHARE MODE
+
+# Bare LOCK (without IN ... MODE) is also not supported by default.
+statement error pgcode 0A000 LOCK TABLE is not supported
+LOCK t
+
+statement ok
+SET pg_dump_compatibility = 'postgres'
+
+# LOCK TABLE is a no-op when pg_dump_compatibility is enabled.
+statement ok
+LOCK TABLE t IN ACCESS SHARE MODE
+
+# Multiple tables work too (pg_dump batches locks).
+statement ok
+LOCK TABLE t, pg_class IN ACCESS SHARE MODE
+
+# NOWAIT variant also works.
+statement ok
+LOCK TABLE t IN ACCESS SHARE MODE NOWAIT
+
+# All lock modes are accepted.
+statement ok
+LOCK TABLE t IN ROW SHARE MODE
+
+statement ok
+LOCK TABLE t IN ROW EXCLUSIVE MODE
+
+statement ok
+LOCK TABLE t IN SHARE UPDATE EXCLUSIVE MODE
+
+statement ok
+LOCK TABLE t IN SHARE MODE
+
+statement ok
+LOCK TABLE t IN SHARE ROW EXCLUSIVE MODE
+
+statement ok
+LOCK TABLE t IN EXCLUSIVE MODE
+
+statement ok
+LOCK TABLE t IN ACCESS EXCLUSIVE MODE
+
+# Bare LOCK (no IN ... MODE) defaults to ACCESS EXCLUSIVE.
+statement ok
+LOCK t
+
+# Bare LOCK with NOWAIT.
+statement ok
+LOCK t NOWAIT
+
+# TABLE keyword is optional.
+statement ok
+LOCK TABLE t
+
+statement ok
+SET pg_dump_compatibility = 'off'
+
+# Verify LOCK TABLE is rejected again after disabling compat mode.
+statement error pgcode 0A000 LOCK TABLE is not supported
+LOCK TABLE t IN ACCESS SHARE MODE
+
+subtest end

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -313,6 +313,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.ShowCreateTrigger(ctx, n)
 	case *tree.Truncate:
 		return p.Truncate(ctx, n)
+	case *tree.LockTable:
+		return p.LockTable(ctx, n)
 	case *tree.Unlisten:
 		return p.Unlisten(ctx, n)
 	case *pgrepltree.IdentifySystem:
@@ -457,6 +459,7 @@ func init() {
 		&tree.ShowTransactionStatus{},
 		&tree.ShowTriggers{},
 		&tree.ShowCreateTrigger{},
+		&tree.LockTable{},
 		&tree.Truncate{},
 		&tree.Unlisten{},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -535,6 +535,9 @@ func (u *sqlSymUnion) lockingItem() *tree.LockingItem {
 func (u *sqlSymUnion) lockingStrength() tree.LockingStrength {
     return u.val.(tree.LockingStrength)
 }
+func (u *sqlSymUnion) lockMode() tree.LockMode {
+    return u.val.(tree.LockMode)
+}
 func (u *sqlSymUnion) lockingWaitPolicy() tree.LockingWaitPolicy {
     return u.val.(tree.LockingWaitPolicy)
 }
@@ -1026,7 +1029,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %token <str> DISABLE DISCARD DISTANCE DISTINCT DO DOMAIN DOUBLE DROP
 
 %token <str> EACH ELSE ENABLE ENCODING ENCRYPTED ENCRYPTION_PASSPHRASE END ENUM ENUMS ERRORS ESCAPE
-%token <str> EXCEPT EXCLUDE EXCLUDING EXPLICIT EXISTS EXECUTE EXECUTION EXPERIMENTAL
+%token <str> EXCEPT EXCLUDE EXCLUDING EXCLUSIVE EXPLICIT EXISTS EXECUTE EXECUTION EXPERIMENTAL
 %token <str> EXPERIMENTAL_FINGERPRINTS EXPERIMENTAL_REPLICA
 %token <str> EXPERIMENTAL_AUDIT EXPERIMENTAL_RELOCATE
 %token <str> EXPIRATION EXPLAIN EXPORT EXTENSION EXTERNAL EXTRACT EXTRACT_DURATION EXTREMES
@@ -1059,7 +1062,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %token <str> LABEL LANGUAGE LAST LATERAL LATEST LC_CTYPE LC_COLLATE
 %token <str> LEADING LEASE LEAST LEAKPROOF LEFT LESS LEVEL LIKE LIMIT
 %token <str> LINESTRING LINESTRINGM LINESTRINGZ LINESTRINGZM
-%token <str> LIST LOCAL LOCALITY LOCALTIME LOCALTIMESTAMP LOCKED LOGGED LOGICAL LOGICALLY LOGIN LOOKUP LOW LSHIFT
+%token <str> LIST LOCK LOCAL LOCALITY LOCALTIME LOCALTIMESTAMP LOCKED LOGGED LOGICAL LOGICALLY LOGIN LOOKUP LOW LSHIFT
 
 %token <str> MATCH MATERIALIZED MERGE MINVALUE MAXVALUE METHOD MINUTE MODIFYCLUSTERSETTING MODE MONTH MOVE
 %token <str> MULTILINESTRING MULTILINESTRINGM MULTILINESTRINGZ MULTILINESTRINGZM
@@ -1471,7 +1474,9 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 
 %type <tree.Statement> transaction_stmt legacy_transaction_stmt legacy_begin_stmt legacy_end_stmt
 %type <tree.Statement> truncate_stmt
+%type <tree.Statement> lock_stmt
 %type <tree.Statement> unlisten_stmt
+%type <tree.LockMode> lock_mode
 %type <tree.Statement> update_stmt
 %type <tree.Statement> upsert_stmt
 %type <tree.Statement> use_stmt
@@ -1982,6 +1987,7 @@ stmt_without_legacy_transaction:
 | fetch_cursor_stmt          // EXTEND WITH HELP: FETCH
 | move_cursor_stmt           // EXTEND WITH HELP: MOVE
 | reindex_stmt
+| lock_stmt                  /* SKIP DOC */
 | unlisten_stmt
 | show_commit_timestamp_stmt // EXTEND WITH HELP: SHOW COMMIT TIMESTAMP
 
@@ -15849,6 +15855,36 @@ relation_expr_list:
     $$.val = append($1.tableNames(), name)
   }
 
+// LOCK TABLE. PostgreSQL defaults to ACCESS EXCLUSIVE when no lock mode is
+// specified, but pg_dump always uses the explicit IN ... MODE form.
+lock_stmt:
+  LOCK opt_table relation_expr_list IN lock_mode MODE
+  {
+    $$.val = &tree.LockTable{Tables: $3.tableNames(), Mode: $5.lockMode()}
+  }
+| LOCK opt_table relation_expr_list IN lock_mode MODE NOWAIT
+  {
+    $$.val = &tree.LockTable{Tables: $3.tableNames(), Mode: $5.lockMode(), NoWait: true}
+  }
+| LOCK opt_table relation_expr_list
+  {
+    $$.val = &tree.LockTable{Tables: $3.tableNames(), Mode: tree.LockModeAccessExclusive}
+  }
+| LOCK opt_table relation_expr_list NOWAIT
+  {
+    $$.val = &tree.LockTable{Tables: $3.tableNames(), Mode: tree.LockModeAccessExclusive, NoWait: true}
+  }
+
+lock_mode:
+  ACCESS SHARE              { $$.val = tree.LockModeAccessShare }
+| ROW SHARE                 { $$.val = tree.LockModeRowShare }
+| ROW EXCLUSIVE             { $$.val = tree.LockModeRowExclusive }
+| SHARE UPDATE EXCLUSIVE    { $$.val = tree.LockModeShareUpdateExclusive }
+| SHARE ROW EXCLUSIVE       { $$.val = tree.LockModeShareRowExclusive }
+| SHARE                     { $$.val = tree.LockModeShare }
+| EXCLUSIVE                 { $$.val = tree.LockModeExclusive }
+| ACCESS EXCLUSIVE          { $$.val = tree.LockModeAccessExclusive }
+
 // UNLISTEN
 unlisten_stmt:
    UNLISTEN type_name
@@ -19036,6 +19072,7 @@ unreserved_keyword:
 | ESCAPE
 | EXCLUDE
 | EXCLUDING
+| EXCLUSIVE
 | EXPLICIT
 | EXECUTE
 | EXECUTION
@@ -19133,6 +19170,7 @@ unreserved_keyword:
 | LINESTRINGZ
 | LINESTRINGZM
 | LIST
+| LOCK
 | LOCAL
 | LOCKED
 | LOGICAL
@@ -19581,6 +19619,7 @@ bare_label_keywords:
 | ESCAPE
 | EXCLUDE
 | EXCLUDING
+| EXCLUSIVE
 | EXPLICIT
 | EXECUTE
 | EXECUTION
@@ -19712,6 +19751,7 @@ bare_label_keywords:
 | LINESTRINGZ
 | LINESTRINGZM
 | LIST
+| LOCK
 | LOCAL
 | LOCALITY
 | LOCALTIME

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/prep"
@@ -2508,6 +2509,33 @@ https://www.postgresql.org/docs/9.5/view-pg-indexes.html`,
 	},
 }
 
+// viewQueryWithoutDatabasePrefix parses the view query and re-formats it
+// without database-qualified table names (e.g. "db.public.t" becomes
+// "public.t"). PostgreSQL does not have cross-database references, so
+// view definitions should only use schema-qualified names.
+func viewQueryWithoutDatabasePrefix(viewQuery string) (string, error) {
+	stmt, err := parser.ParseOne(viewQuery)
+	if err != nil {
+		return "", err
+	}
+	fmtCtx := tree.NewFmtCtx(
+		tree.FmtSimple,
+		tree.FmtReformatTableNames(func(fCtx *tree.FmtCtx, tn *tree.TableName) {
+			// Print only schema.table, omitting the database catalog.
+			// We format the parts directly because ObjectNamePrefix.Format
+			// always includes the catalog when a tableNameFormatter is set
+			// (via alwaysFormatTablePrefix).
+			if tn.ExplicitSchema {
+				fCtx.FormatNode(&tn.SchemaName)
+				fCtx.WriteByte('.')
+			}
+			fCtx.FormatNode(&tn.ObjectName)
+		}),
+	)
+	fmtCtx.FormatNode(stmt.AST)
+	return fmtCtx.CloseAndGetString(), nil
+}
+
 // indexDefFromDescriptor creates an index definition (`CREATE INDEX ... ON (...)`) from
 // an index descriptor by reconstructing a CreateIndex parser node and calling its
 // String method. The table name is schema-qualified only (no database prefix),
@@ -2625,14 +2653,22 @@ https://www.postgresql.org/docs/9.6/view-pg-matviews.html`,
 				// while postgres would more accurately print `SELECT b AS a FROM foo`.
 				// TODO(SQL Features): Insert column aliases into view query once we
 				// have a semantic query representation to work with (#10083).
+				viewQuery := desc.GetViewQuery()
+				if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) {
+					var err error
+					viewQuery, err = viewQueryWithoutDatabasePrefix(viewQuery)
+					if err != nil {
+						return err
+					}
+				}
 				return addRow(
 					tree.NewDName(sc.GetName()),   // schemaname
 					tree.NewDName(desc.GetName()), // matviewname
 					owner,                         // matviewowner
 					tree.DNull,                    // tablespace
 					tree.MakeDBool(len(desc.PublicNonPrimaryIndexes()) > 0), // hasindexes
-					tree.DBoolTrue, // ispopulated,
-					tree.NewDString(desc.GetViewQuery()+";"), // definition
+					tree.DBoolTrue,                 // ispopulated
+					tree.NewDString(viewQuery+";"), // definition
 				)
 			})
 	},
@@ -5660,11 +5696,19 @@ https://www.postgresql.org/docs/9.5/view-pg-views.html`,
 				// while postgres would more accurately print `SELECT b AS a FROM foo`.
 				// TODO(SQL Features): Insert column aliases into view query once we
 				// have a semantic query representation to work with (#10083).
+				viewQuery := desc.GetViewQuery()
+				if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) {
+					var err error
+					viewQuery, err = viewQueryWithoutDatabasePrefix(viewQuery)
+					if err != nil {
+						return err
+					}
+				}
 				return addRow(
-					tree.NewDName(sc.GetName()),   // schemaname
-					tree.NewDName(desc.GetName()), // viewname
-					owner,                         // viewowner
-					tree.NewDString(desc.GetViewQuery()+";"), // definition
+					tree.NewDName(sc.GetName()),    // schemaname
+					tree.NewDName(desc.GetName()),  // viewname
+					owner,                          // viewowner
+					tree.NewDString(viewQuery+";"), // definition
 				)
 			})
 	},

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -883,6 +883,12 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 	func(ctx context.Context, p *planner, h oidHasher, db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor,
 		table catalog.TableDescriptor, _ simpleSchemaResolver, addRow func(...tree.Datum) error,
 	) error {
+		// When pg_dump_compatibility is on, skip crdb_internal tables/views.
+		// pg_dump treats non-pg_catalog schemas as user-defined and tries to
+		// dump their contents, which fails for virtual tables.
+		if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) && sc.GetID() == catconstants.CrdbInternalID {
+			return nil
+		}
 		// The only difference between tables, views and sequences are the relkind and relam columns.
 		relKind := relKindTable
 		relAm := forwardIndexOid
@@ -2643,6 +2649,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(ctx context.Context, db catalog.DatabaseDescriptor) error {
 				return forEachSchema(ctx, p, db, true /* requiresPrivileges */, false /* includeMetadata */, func(ctx context.Context, sc catalog.SchemaDescriptor) error {
+					if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) && sc.GetID() == catconstants.CrdbInternalID {
+						return nil
+					}
 					ownerOID := tree.DNull
 					if sc.SchemaKind() == catalog.SchemaUserDefined {
 						var err error
@@ -3234,6 +3243,7 @@ https://www.postgresql.org/docs/16/catalog-pg-proc.html`,
 		// is selected from a different database. But this is probably fine for
 		// builtin function since they don't really belong to any database.
 
+		pgDumpCompat := sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility)
 		err := forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(ctx context.Context, db catalog.DatabaseDescriptor) error {
 				for _, name := range builtins.AllBuiltinNames() {
@@ -3246,6 +3256,16 @@ https://www.postgresql.org/docs/16/catalog-pg-proc.html`,
 					}
 					if unicode.IsUpper(first) {
 						continue
+					}
+					// When pg_dump_compatibility is on, skip crdb_internal and
+					// information_schema functions. pg_dump treats non-pg_catalog
+					// functions with OIDs below 16384 as user-defined and tries to
+					// dump them, which fails.
+					if pgDumpCompat {
+						if strings.HasPrefix(name, catconstants.CRDBInternalSchemaName+".") ||
+							strings.HasPrefix(name, catconstants.InformationSchemaName+".") {
+							continue
+						}
 					}
 					err := addPgProcBuiltinRow(name, addRow)
 					if err != nil {
@@ -4226,6 +4246,11 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				opts := forEachTableDescOptions{virtualOpts: virtualCurrentDB}
 				if err := forEachTableDesc(ctx, p, dbContext, opts, func(
 					ctx context.Context, descCtx tableDescContext) error {
+					// When pg_dump_compatibility is on, skip crdb_internal tables
+					// to avoid emitting composite types for internal virtual tables.
+					if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) && descCtx.schema.GetID() == catconstants.CrdbInternalID {
+						return nil
+					}
 					return addPGTypeRowForTable(ctx, p, h, descCtx.database, descCtx.schema, descCtx.table, addRow)
 				},
 				); err != nil {
@@ -4536,6 +4561,15 @@ https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html`,
 		statTgt := tree.NewDInt(-1)
 
 		for _, row := range rows {
+			// When pg_dump_compatibility is on, skip internal statistics objects
+			// (e.g. __auto__, __auto_partial__, __forecast__, __merged__) to
+			// prevent pg_dump from emitting CREATE STATISTICS statements for them.
+			if sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility) {
+				name := string(tree.MustBeDString(row[1]))
+				if strings.HasPrefix(name, "__") {
+					continue
+				}
+			}
 			tableID := tree.MustBeDInt(row[0])
 			columnIDs := tree.MustBeDArray(row[2])
 			statisticsID := tree.MustBeDInt(row[3])

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -102,7 +102,7 @@ func (p *planner) prepareUsingOptimizerInternal(
 		*tree.CreateStats,
 		*tree.Deallocate, *tree.Discard, *tree.DropDatabase, *tree.DropIndex,
 		*tree.DropTable, *tree.DropView, *tree.DropSequence, *tree.DropType,
-		*tree.Grant, *tree.GrantRole,
+		*tree.Grant, *tree.GrantRole, *tree.LockTable,
 		*tree.Prepare, *tree.PrepareTransaction,
 		*tree.ReleaseSavepoint, *tree.RenameColumn, *tree.RenameDatabase,
 		*tree.RenameIndex, *tree.RenameTable, *tree.Revoke, *tree.RevokeRole,

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "inject_hints.go",
         "insert.go",
         "inspect.go",
+        "lock.go",
         "name_part.go",
         "name_resolution.go",
         "object_name.go",

--- a/pkg/sql/sem/tree/lock.go
+++ b/pkg/sql/sem/tree/lock.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tree
+
+// LockMode represents the lock strength in a LOCK TABLE statement.
+type LockMode int
+
+const (
+	LockModeAccessShare LockMode = iota + 1
+	LockModeRowShare
+	LockModeRowExclusive
+	LockModeShareUpdateExclusive
+	LockModeShare
+	LockModeShareRowExclusive
+	LockModeExclusive
+	LockModeAccessExclusive
+)
+
+func (m LockMode) String() string {
+	switch m {
+	case LockModeAccessShare:
+		return "ACCESS SHARE"
+	case LockModeRowShare:
+		return "ROW SHARE"
+	case LockModeRowExclusive:
+		return "ROW EXCLUSIVE"
+	case LockModeShareUpdateExclusive:
+		return "SHARE UPDATE EXCLUSIVE"
+	case LockModeShare:
+		return "SHARE"
+	case LockModeShareRowExclusive:
+		return "SHARE ROW EXCLUSIVE"
+	case LockModeExclusive:
+		return "EXCLUSIVE"
+	case LockModeAccessExclusive:
+		return "ACCESS EXCLUSIVE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// LockTable represents a LOCK TABLE statement.
+type LockTable struct {
+	Tables TableNames
+	Mode   LockMode
+	NoWait bool
+}
+
+var _ Statement = &LockTable{}
+
+// Format implements the NodeFormatter interface.
+func (node *LockTable) Format(ctx *FmtCtx) {
+	ctx.WriteString("LOCK TABLE ")
+	for i := range node.Tables {
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		ctx.FormatNode(&node.Tables[i])
+	}
+	ctx.WriteString(" IN ")
+	ctx.WriteString(node.Mode.String())
+	ctx.WriteString(" MODE")
+	if node.NoWait {
+		ctx.WriteString(" NOWAIT")
+	}
+}
+
+// String implements the Statement interface.
+func (node *LockTable) String() string {
+	return AsString(node)
+}
+
+// StatementReturnType implements the Statement interface.
+func (*LockTable) StatementReturnType() StatementReturnType { return Ack }
+
+// StatementType implements the Statement interface.
+func (*LockTable) StatementType() StatementType { return TypeTCL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*LockTable) StatementTag() string { return "LOCK TABLE" }


### PR DESCRIPTION
Three changes to make pg_dump work better against CockroachDB when
`pg_dump_compatibility` is enabled:

1. **LOCK TABLE parsing** — pg_dump issues `LOCK TABLE ... IN ACCESS SHARE
   MODE` for every table it discovers. CockroachDB didn't parse `LOCK` at
   all, so this would immediately fail. Since CockroachDB uses MVCC (reads
   never block), all lock modes are accepted as no-ops when
   `pg_dump_compatibility` is set. Otherwise, `LOCK TABLE` returns a
   FeatureNotSupported error.

2. **Hide internal objects** — pg_dump discovers objects through pg_catalog
   and treats anything it finds as user-defined. This filters
   crdb_internal schemas, tables, functions, types, and auto-generated
   statistics from pg_namespace, pg_class, pg_proc, pg_type, and
   pg_statistic_ext so pg_dump doesn't try to dump them.

3. **Strip database prefix from view definitions** — CockroachDB stores
   view queries as `db.schema.table` but PostgreSQL has no cross-database
   references. In compat mode, pg_views and pg_matviews now emit
   `schema.table` so restored views don't reference the source database
   name.

Informs #20296

Epic: none