### PR TITLE
kvnemesis: continue executing txn ops after ConditionFailedError

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -254,9 +254,21 @@ func (a *Applier) applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 					}
 
 					applyClientOp(ctx, txn, op, true /* inTxn */, &spIDToToken)
-					// The KV api disallows use of a txn after an operation on it errors.
+					// The KV API disallows use of a txn after most errors.
+					// ConditionFailedError and LockConflictError are exceptions:
+					// they don't move the txn to the error state, so we can
+					// continue executing subsequent ops. We only do this for
+					// individual (non-batch) ops because batch errors propagate
+					// to all sub-ops and the validator can't distinguish which
+					// sub-ops actually executed.
 					if r := op.Result(); r.Type == ResultType_Error {
-						err = errors.DecodeError(ctx, *r.Err)
+						opErr := errors.DecodeError(ctx, *r.Err)
+						isCFE := errors.HasType(opErr, (*kvpb.ConditionFailedError)(nil))
+						isLCE := errors.HasType(opErr, (*kvpb.LockConflictError)(nil))
+						if op.Batch == nil && (isCFE || isLCE) {
+							continue
+						}
+						err = opErr
 					}
 				}
 			}

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -497,20 +497,16 @@ func (v *validator) processOp(op Operation) {
 			Value: roachpb.MakeValueFromString(t.Value()),
 		}
 		var shouldObserveWrite bool
-		// Consider two cases based on whether the CPut hit a ConditionFailedError.
+		// If the CPut hit a ConditionFailedError, we don't observe the read or
+		// the write. The CPut's condition-check read is not added to the txn's
+		// read refresh spans and no write lock is acquired, so nothing protects
+		// this read from becoming stale if the txn's write timestamp is later
+		// pushed.
+		//
+		// If the CPut succeeded, the expected value is observed, and the CPut's
+		// write is also observed.
 		err := errorFromResult(t.Result)
-		if e := (*kvpb.ConditionFailedError)(nil); errors.As(err, &e) {
-			// If the CPut failed, the actual value (in the ConditionFailedError) is
-			// observed, and the CPut's write is not observed.
-			observedVal := roachpb.Value{}
-			if e.ActualValue != nil {
-				observedVal.RawBytes = e.ActualValue.RawBytes
-			}
-			readObservation.Value = observedVal
-			shouldObserveRead = true
-		} else {
-			// If the CPut succeeded, the expected value is observed, and the CPut's
-			// write is also observed.
+		if !errors.HasType(err, (*kvpb.ConditionFailedError)(nil)) {
 			if !t.AllowIfDoesNotExist {
 				// If AllowIfDoesNotExist == true, we don't know if the read found the
 				// expected value or no value, so we can't add a read observation.


### PR DESCRIPTION
Previously, kvnemesis would stop executing a transaction's operations
after any error, including ConditionFailedError (CFE). However, CFE
doesn't move the KV txn to an error state — the txn remains usable.
By stopping early, kvnemesis missed coverage of operations that follow
a failed CPut within a transaction, which is where the write buffer
bug (#161722) manifests: a mid-txn flush sends buffered writes + the
CPut's locking Get in the same batch, and the CFE discards the entire
batch response, losing the buffered writes.

This commit makes two changes:

In the applier, continue executing subsequent ops after CFE or
LockConflictError for individual (non-batch) ops. Batch ops are
excluded because batch errors propagate to all sub-ops via
fillResults, and the validator can't distinguish which sub-ops
actually executed.

In the validator, stop observing the read from a failed CPut. The
CPut's condition-check read is not added to the txn's read refresh
spans, and no write lock is acquired, so nothing protects the read
from becoming stale if the txn's write timestamp is later pushed.
Previously the read was observed, which was harmless because the
txn would abort after the CFE. Now that we continue, the stale read
can cause spurious "non-atomic timestamps" validation failures.

Informs: #161722

Release note: None