### PR TITLE
build: update PGO profile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -690,6 +690,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "5a23c5b33325d5fc3dfa4e67d872aa8371756f8e4f8f159509e8cc522c298cb2",
-    url = "https://storage.googleapis.com/cockroach-profiles/20251204202750-818ff5108cdb1f16f69b3d915acdb4f669b848eb.pb.gz",
+    sha256 = "d0d862680e57e20dfcd17072dee36e9ca424620120a3ca43e20002d283efceda",
+    url = "https://storage.googleapis.com/cockroach-profiles/20260318200320-da91cf2be917bbc3bac07ad6e6e214d5d1628c26.pb.gz",
 )


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │            ops/sec             │   ops/sec    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          101.9 ± 4%    104.7 ± 6%       ~ (p=0.337 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         1.019k ± 4%   1.047k ± 7%       ~ (p=0.355 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       101.9 ± 4%    104.7 ± 6%       ~ (p=0.337 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          1.019k ± 4%   1.047k ± 7%       ~ (p=0.355 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        101.9 ± 4%    104.7 ± 7%       ~ (p=0.344 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            2.344k ± 4%   2.409k ± 7%       ~ (p=0.355 n=20)
geomean                                                                          370.2         380.4       +2.76%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/avg             │   ms/avg    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          87.15 ± 6%   82.55 ± 9%       ~ (p=0.229 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          141.8 ± 7%   139.7 ± 5%       ~ (p=0.387 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       18.40 ± 4%   18.10 ± 6%       ~ (p=0.616 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           42.05 ± 6%   40.10 ± 9%       ~ (p=0.245 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        25.05 ± 3%   25.00 ± 4%       ~ (p=0.963 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             85.40 ± 4%   83.05 ± 7%       ~ (p=0.351 n=20)
geomean                                                                          52.30        50.89       -2.68%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/p50             │   ms/p50     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          83.90 ± 5%   79.70 ± 11%       ~ (p=0.298 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          134.2 ± 6%   134.2 ±  6%       ~ (p=0.350 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       12.10 ± 5%   11.50 ± 10%       ~ (p=0.268 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           37.70 ± 5%   35.70 ± 11%       ~ (p=0.278 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        19.90 ± 6%   19.90 ±  6%       ~ (p=0.837 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             66.05 ± 8%   65.00 ± 10%       ~ (p=0.224 n=20)
geomean                                                                          43.47        42.24        -2.84%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p95             │   ms/p95    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          146.8 ± 3%   142.6 ± 6%       ~ (p=0.627 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          251.7 ± 3%   243.3 ± 3%       ~ (p=0.266 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       54.50 ± 4%   54.50 ± 4%       ~ (p=0.582 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           83.90 ± 5%   79.70 ± 5%       ~ (p=0.204 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        60.80 ± 3%   59.75 ± 5%       ~ (p=0.719 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             218.1 ± 4%   209.7 ± 4%       ~ (p=0.244 n=20)
geomean                                                                          114.4        111.2       -2.81%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p99             │   ms/p99    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          184.5 ± 5%   184.5 ± 5%       ~ (p=0.404 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          302.0 ± 6%   302.0 ± 6%       ~ (p=0.490 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       83.90 ± 5%   83.90 ± 5%       ~ (p=0.676 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           113.2 ± 4%   111.2 ± 6%       ~ (p=0.264 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        92.30 ± 5%   90.20 ± 7%       ~ (p=0.609 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             285.2 ± 6%   268.4 ± 6%       ~ (p=0.397 n=20)
geomean                                                                          155.1        152.5       -1.69%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/max             │   ms/max     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                         318.8 ± 11%   318.8 ±  5%       ~ (p=0.416 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         520.1 ± 10%   511.7 ±  5%       ~ (p=0.246 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      213.9 ±  6%   213.9 ± 14%       ~ (p=0.898 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          268.4 ± 13%   285.2 ±  9%       ~ (p=0.876 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                       213.9 ± 10%   222.3 ±  9%       ~ (p=0.752 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            520.1 ± 10%   511.7 ±  5%       ~ (p=0.246 n=20)
geomean                                                                         319.3         322.8        +1.12%
```

Epic: none
Release note: none