### PR TITLE
sql: disable test tenant for tests using TestingDisableTableLeases

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -209,7 +209,13 @@ func TestOldBitColumnMetadata(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	defer s.Stopper().Stop(ctx)
 
 	// The descriptor changes made must have an immediate effect
@@ -425,7 +431,13 @@ func TestInvalidObjects(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	var params base.TestServerArgs
+	params := base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	}
 	params.Knobs = base.TestingKnobs{
 		Store: &kvserver.StoreTestingKnobs{
 			DisableMergeQueue: true,

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -247,7 +247,13 @@ func TestDeletePreservingIndexEncodingUsesNormalDeletesInDeleteOnly(t *testing.T
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	defer server.Stopper().Stop(context.Background())
 
 	// The descriptor changes made must have an immediate effect
@@ -311,7 +317,13 @@ func TestDeletePreservingIndexEncodingWithEmptyValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	defer server.Stopper().Stop(context.Background())
 
 	// The descriptor changes made must have an immediate effect
@@ -608,7 +620,13 @@ func TestMergeProcessor(t *testing.T) {
 	}
 
 	run := func(t *testing.T, test TestCase) {
-		server, tdb, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+		server, tdb, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+			// This test directly manipulates descriptors via KV and relies on
+			// TestingDisableTableLeases to make those changes immediately visible.
+			// This is incompatible with external process virtual clusters where
+			// the lease disable doesn't take effect.
+			DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+		})
 		defer server.Stopper().Stop(context.Background())
 		defer lease.TestingDisableTableLeases()()
 

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -165,7 +165,13 @@ func TestUpsertWithColumnMutationAndNotNullDefault(t *testing.T) {
 	// no job associated with the added mutations, those mutations stay on the
 	// table descriptor but don't do anything, which is what we want.
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	ctx := context.Background()
 	defer server.Stopper().Stop(ctx)
 	// The descriptor changes made must have an immediate effect
@@ -225,7 +231,13 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 
 	// Disable external processing of mutations.
 	ctx := context.Background()
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	defer server.Stopper().Stop(ctx)
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
 
@@ -491,7 +503,13 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	// no job associated with the added mutations, those mutations stay on the
 	// table descriptor but don't do anything, which is what we want.
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	defer server.Stopper().Stop(context.Background())
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
 	// The descriptor changes made must have an immediate effect.
@@ -656,7 +674,13 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 	// no job associated with the added mutations, those mutations stay on the
 	// table descriptor but don't do anything, which is what we want.
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	})
 	ctx := context.Background()
 	defer server.Stopper().Stop(ctx)
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
@@ -872,7 +896,13 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Disable external processing of mutations.
-	var params base.TestServerArgs
+	params := base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	}
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			SchemaChangeJobNoOp: func() bool {

--- a/pkg/sql/index_mutation_test.go
+++ b/pkg/sql/index_mutation_test.go
@@ -35,7 +35,13 @@ func TestIndexMutationKVOps(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	var params base.TestServerArgs
+	params := base.TestServerArgs{
+		// This test directly manipulates descriptors via KV and relies on
+		// TestingDisableTableLeases to make those changes immediately visible.
+		// This is incompatible with external process virtual clusters where
+		// the lease disable doesn't take effect.
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
+	}
 	// Decrease the adopt loop interval so that retries happen quickly.
 	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.Knobs.SQLEvalContext = &eval.TestingKnobs{


### PR DESCRIPTION
## Summary

Several tests directly manipulate table descriptors via KV writes and rely on
`lease.TestingDisableTableLeases()` to make those changes immediately visible
to the SQL layer. This process-global atomic bool only takes effect within the
test process; when an external process virtual cluster is metamorphically
injected, the external SQL server's lease manager still caches descriptors
normally and never sees the direct KV writes, causing intermittent failures.

This PR disables the default test tenant for all tests that combine
`TestingDisableTableLeases` with direct KV descriptor manipulation:

- `descriptor_mutation_test.go`: 5 tests
- `index_mutation_test.go`: 1 test
- `delete_preserving_index_test.go`: 3 test sites
- `crdb_internal_test.go`: 2 tests

Fixes: #165980

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)