### PR TITLE
logictestccl: fix as_of flake by increasing closed timestamp target

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -19,6 +19,14 @@ statement ok
 INSERT INTO t VALUES (2);
 INSERT INTO t2 VALUES (2);
 
+# Increase the closed timestamp target duration so that follower_read_timestamp()
+# goes far enough back in time to reliably predate cluster bootstrap, even in
+# slow (race) builds. The default 3s target yields follower_read_timestamp() =
+# now()-4.2s, which in race builds can land mid-bootstrap (after database
+# creation but before table creation), producing flaky error messages.
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1m'
+
 statement error pgcode 3D000 pq: database "test" does not exist
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 
@@ -124,6 +132,11 @@ RESET autocommit_before_ddl
 
 statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
+
+# Reset the closed timestamp target duration now that follower read tests are
+# done, so the bounded staleness tests below work correctly.
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '3s'
 
 query B
 SELECT with_min_timestamp(statement_timestamp()) = statement_timestamp()


### PR DESCRIPTION
The TestCCLLogic_as_of test has been repeatedly flaking (deflaked 6+
times) because follower_read_timestamp() returns now()-4.2s by default,
which in race builds can land mid-bootstrap — after database creation
but before table creation — producing "relation t does not exist"
instead of the expected "database test does not exist".

Rather than continuing to widen error regexes (whack-a-mole), this
patch increases kv.closed_timestamp.target_duration to 1m for the
follower read portion of the test. This makes follower_read_timestamp()
go back ~62s, reliably predating cluster bootstrap even in slow builds.
The setting is reset to 3s before the bounded staleness tests that
follow.

Fixes: https://github.com/cockroachdb/cockroach/issues/166055

Epic: none
Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>