### PR TITLE
workflows: assign and request review from autosolve trigger user

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -469,6 +469,8 @@ jobs:
         if: steps.push.conclusion == 'success'
         env:
           GH_TOKEN: ${{ secrets.AUTOSOLVER_CREATE_PRS_PAT }}
+          # The user who added the c-autosolve label, passed via env to avoid injection.
+          TRIGGER_USER: ${{ github.event.sender.login }}
         run: |
           # For single-commit PRs, the PR title matches the commit subject
           # and the PR body matches the commit body (per commit-helper guidelines).
@@ -491,7 +493,8 @@ jobs:
             echo "*Please review carefully before approving.*"
           )
 
-          # Create the PR from fork to upstream
+          # Create the PR from fork to upstream.
+          # Assign and request review from the user who triggered autosolve.
           PR_URL=$(gh pr create \
             --repo ${{ github.repository }} \
             --head "${AUTOSOLVER_FORK_OWNER}:${{ steps.push.outputs.branch_name }}" \
@@ -499,7 +502,9 @@ jobs:
             --draft \
             --title "$COMMIT_TITLE" \
             --body "$PR_BODY" \
-            --label "o-autosolver")
+            --label "o-autosolver" \
+            --assignee "$TRIGGER_USER" \
+            --reviewer "$TRIGGER_USER")
 
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "Created PR: $PR_URL"


### PR DESCRIPTION
When the autosolver bot creates a PR, it now assigns and requests a
review from the user who added the `c-autosolve` label on the source
issue. Previously the PR was created with no assignees, and review
requests only came from CODEOWNERS. The trigger user is the most
relevant reviewer since they triaged the issue.

`github.event.sender.login` is passed via env var to avoid injection.

Resolves: #166100
Epic: none

Release note: None

---

*Generated with [Claude Code](https://claude.com/claude-code)*