### PR TITLE
workflows: run `update_releases` on `release-26.2`

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -31,6 +31,7 @@ jobs:
           - "release-25.2"
           - "release-25.4"
           - "release-26.1"
+          - "release-26.2"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Epic: None
Release note: None
Release justification: non-production (release infra) change.