### PR TITLE
logictest: enable local-prepared on 9 more files, fix URI redaction

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3895,7 +3895,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 				}
 			}
 
-			prep, execErr = t.db.Prepare(ast.String())
+			prep, execErr = t.db.Prepare(tree.AsStringWithFlags(ast, tree.FmtShowFullURIs))
 
 			if execErr != nil {
 				// Sometimes, it's impossible to prepare/execute a query with scalars

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 CREATE TABLE t (i INT)
 
@@ -87,6 +86,9 @@ statement ok
 EXPLAIN SELECT * FROM t AS OF SYSTEM TIME '-1us'
 
 skipif config 3node-tenant-default-configs
+# In local-prepared, the placeholder $1 is resolved differently, producing a
+# different error message about constant expressions in AOST.
+skipif config local-prepared
 # Regression test for out of bounds error during the type-checking of AOST with
 # a placeholder (#56488).
 statement error pq: no value provided for placeholder: \$1
@@ -147,9 +149,14 @@ statement error pq: AS OF SYSTEM TIME: expected timestamp, decimal, or interval,
 SELECT * FROM t AS OF SYSTEM TIME ('' BETWEEN '' AND '')
 
 # Check that AOST in multi-stmt implicit transaction has the proper error.
+# In local-prepared, multi-statement strings are prepared individually so
+# the cross-statement AOST consistency check does not apply.
+skipif config local-prepared
 statement error inconsistent AS OF SYSTEM TIME timestamp
 insert into t values(1); select * from t as of system time '-1s';
 
+# Same as above.
+skipif config local-prepared
 statement error inconsistent AS OF SYSTEM TIME timestamp
 select * from t as of system time '-1s'; select * from t as of system time '-2s';
 

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 let $ts
 SELECT now()
 
@@ -44,7 +43,7 @@ forks blue
 forks red
 forks green
 
-statement error pgcode 42P01 relation "stock" does not exist
+statement error pgcode 42P01 relation "(test\.public\.)?stock" does not exist
 CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns
@@ -672,9 +671,14 @@ statement ok
 DROP TABLE stock
 
 # Test that CTAS AOST works with a table that has been dropped.
+# In local-prepared, PREPARE resolves the dropped table name against the current
+# schema before AOST can redirect to the historical schema (#166124).
+skipif config local-prepared
 statement ok
 CREATE TABLE stockbeforedrop AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
 
+# Skipped because the CREATE TABLE above is also skipped.
+skipif config local-prepared
 query TII rowsort
 SELECT item, quantity, newcol FROM stockbeforedrop
 ----

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/export
+++ b/pkg/sql/logictest/testdata/logic_test/export
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # Regression test for incorrectly handling projection on top of the EXPORT
 # (#101733).
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,4 +1,4 @@
-# LogicTest: !local-prepared default-configs 3node-tenant
+# LogicTest: default-configs 3node-tenant
 statement ok
 SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE
 
@@ -4689,7 +4689,7 @@ ALTER TABLE drop_fk_during_addition
 	ADD CONSTRAINT fk FOREIGN KEY (name) REFERENCES drop_fk_during_addition_ref (name);
 DROP TABLE drop_fk_during_addition_ref;
 
-statement error pgcode XXA00 pq: transaction committed but schema change aborted with error: .* referenced table "drop_fk_during_addition_ref" \(271\) is dropped.*
+statement error pgcode XXA00 pq: transaction committed but schema change aborted with error: .* referenced table "drop_fk_during_addition_ref" \(\d+\) is dropped.*
 COMMIT;
 
 # Regression test for #80828. Do not attempt a fast path cascading delete when

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 # SELECT with no table.
 
 query I
@@ -245,9 +243,14 @@ SELECT * FROM xyzw LIMIT -100
 query error negative value for OFFSET
 SELECT * FROM xyzw OFFSET -100
 
+# In local-prepared, this value overflows int64 so it becomes a DECIMAL
+# placeholder, producing a type mismatch error instead of a range error.
+skipif config local-prepared
 query error numeric constant out of int64 range
 SELECT * FROM xyzw LIMIT 9223372036854775808
 
+# Same as above for OFFSET.
+skipif config local-prepared
 query error numeric constant out of int64 range
 SELECT * FROM xyzw OFFSET 9223372036854775808
 
@@ -370,6 +373,9 @@ SELECT a FROM MaxIntTest WHERE a = 9223372036854775807
 ----
 9223372036854775807
 
+# In local-prepared, $1 is treated as a placeholder from scalar replacement
+# rather than a literal in the SQL text, so the error differs.
+skipif config local-prepared
 query error no value provided for placeholder
 SELECT $1::int
 

--- a/pkg/sql/logictest/testdata/logic_test/txn_as_of
+++ b/pkg/sql/logictest/testdata/logic_test/txn_as_of
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 # This test makes use of 'kv.gc_ttl.strict_enforcement.enabled = false', which
 # is not available to tenants. We use a cluster option instead.
 # cluster-opt: ignore-tenant-strict-gc-enforcement

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -1,4 +1,3 @@
-# LogicTest: !local-prepared
 statement ok
 CREATE TABLE f (x FLOAT)
 
@@ -80,7 +79,10 @@ INSERT INTO i VALUES (COALESCE(1, 'foo'))
 query error incompatible COALESCE expressions: could not parse "foo" as type int
 SELECT COALESCE(1, 'foo')
 
-query error incompatible COALESCE expressions: could not parse "foo" as type int
+# The error regex is relaxed because local-prepared produces a different
+# prefix: "error in argument for $2:" instead of "incompatible COALESCE
+# expressions:".
+query error could not parse "foo" as type int
 SELECT COALESCE(1::INT, 'foo')
 
 query error expected 2.3 to be of type int, found type decimal

--- a/pkg/sql/logictest/testdata/logic_test/udf_params
+++ b/pkg/sql/logictest/testdata/logic_test/udf_params
@@ -1,5 +1,3 @@
-# LogicTest: !local-prepared
-
 subtest types
 
 statement error pgcode 42P13 pq: function result type must be specified
@@ -746,7 +744,14 @@ SELECT my_sum(1, 1);
 statement ok
 CREATE FUNCTION my_sum(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a; $$;
 
+# In local-prepared, function resolution produces an "ambiguous call" error
+# instead of "function name is not unique".
+skipif config local-prepared
 statement error pgcode 42725 function name "my_sum" is not unique
+SELECT my_sum(1);
+
+onlyif config local-prepared
+statement error pgcode 42725 ambiguous call: my_sum
 SELECT my_sum(1);
 
 statement ok

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -244,6 +244,13 @@ func TestLogic_apply_join(
 	runLogicTest(t, "apply_join")
 }
 
+func TestLogic_as_of(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "as_of")
+}
+
 func TestLogic_asyncpg(
 	t *testing.T,
 ) {
@@ -419,6 +426,13 @@ func TestLogic_crdb_internal_default_privileges(
 	runLogicTest(t, "crdb_internal_default_privileges")
 }
 
+func TestLogic_create_as(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as")
+}
+
 func TestLogic_create_statements(
 	t *testing.T,
 ) {
@@ -473,6 +487,13 @@ func TestLogic_default(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "default")
+}
+
+func TestLogic_delete(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "delete")
 }
 
 func TestLogic_delete_batch(
@@ -685,6 +706,13 @@ func TestLogic_experimental_distsql_planning(
 	runLogicTest(t, "experimental_distsql_planning")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_external_connection_privileges(
 	t *testing.T,
 ) {
@@ -697,6 +725,13 @@ func TestLogic_family(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "family")
+}
+
+func TestLogic_fk(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk")
 }
 
 func TestLogic_format(
@@ -1420,6 +1455,13 @@ func TestLogic_security_invoker_view(
 	runLogicTest(t, "security_invoker_view")
 }
 
+func TestLogic_select(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {
@@ -1805,6 +1847,13 @@ func TestLogic_tuple_local(
 	runLogicTest(t, "tuple_local")
 }
 
+func TestLogic_txn_as_of(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "txn_as_of")
+}
+
 func TestLogic_txn_stats(
 	t *testing.T,
 ) {
@@ -1817,6 +1866,13 @@ func TestLogic_type_privileges(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "type_privileges")
+}
+
+func TestLogic_typing(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "typing")
 }
 
 func TestLogic_udf_calling_udf(
@@ -1901,6 +1957,13 @@ func TestLogic_udf_options(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_options")
+}
+
+func TestLogic_udf_params(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_params")
 }
 
 func TestLogic_udf_polymorphic(

--- a/pkg/sql/sem/tree/replace_scalars.go
+++ b/pkg/sql/sem/tree/replace_scalars.go
@@ -20,29 +20,25 @@ func TestingReplaceScalarsWithPlaceholders(s Statement) (Statement, Exprs) {
 // scalarReplacer replaces scalar constants with placeholders. It implements
 // ExtendedVisitor so that WalkStmt also walks into table expressions, join
 // conditions, and statement nodes. The VisitStatementPre method collects
-// constant literals used in ORDER BY, GROUP BY, and DISTINCT ON positions
-// so that VisitPre can skip replacing them. This is necessary because
-// integer constants are interpreted as column ordinals, and non-integer
-// constants produce specific error messages that tests may expect.
+// constants that should not be replaced: column ordinals in ORDER BY,
+// GROUP BY, and DISTINCT ON, and expressions in AS OF SYSTEM TIME
+// clauses (which do not support placeholders).
 type scalarReplacer struct {
 	scalars Exprs
 	// skipExprs tracks specific AST nodes (by pointer identity) that should
-	// not be replaced with placeholders. These are constant literals in
-	// ORDER BY, GROUP BY, and DISTINCT ON positions. Because the map keys
-	// are pointers to the original AST nodes, other nodes with the same
-	// value in different parts of the AST (e.g. SELECT 1 FROM t ORDER BY 1)
-	// are not affected.
+	// not be replaced with placeholders. Because the map keys are pointers
+	// to the original AST nodes, other nodes with the same value in
+	// different parts of the AST (e.g. SELECT 1 FROM t ORDER BY 1) are
+	// not affected.
 	skipExprs map[Expr]struct{}
 }
 
 var _ ExtendedVisitor = &scalarReplacer{}
 
-// skipOrdinal adds expr to the skip set if it is a constant (NumVal,
-// StrVal, or other Constant/Datum). Integer constants in ORDER BY,
-// GROUP BY, and DISTINCT ON are interpreted as column ordinals, and
-// non-integer constants produce specific error messages — both cases
-// require the original literal to be preserved.
-func (s *scalarReplacer) skipOrdinal(expr Expr) {
+// skipConstant adds expr to the skip set if it is a constant (NumVal,
+// StrVal, or other Constant/Datum). This is used for expressions like
+// column ordinals in ORDER BY that must not be replaced.
+func (s *scalarReplacer) skipConstant(expr Expr) {
 	expr = StripParens(expr)
 	switch t := expr.(type) {
 	case Constant, Datum:
@@ -51,6 +47,19 @@ func (s *scalarReplacer) skipOrdinal(expr Expr) {
 		}
 		s.skipExprs[t] = struct{}{}
 	}
+}
+
+// skipAllConstants walks an expression tree and adds all constants found
+// to the skip set. This is used for AS OF SYSTEM TIME expressions, which
+// do not support placeholders.
+func (s *scalarReplacer) skipAllConstants(expr Expr) {
+	if expr == nil {
+		return
+	}
+	_, _ = SimpleVisit(expr, func(e Expr) (bool, Expr, error) {
+		s.skipConstant(e)
+		return true, e, nil
+	})
 }
 
 func (s *scalarReplacer) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
@@ -102,22 +111,23 @@ func (s *scalarReplacer) VisitStatementPre(stmt Statement) (recurse bool, newStm
 	switch t := stmt.(type) {
 	case *SelectClause:
 		for _, e := range t.GroupBy {
-			s.skipOrdinal(e)
+			s.skipConstant(e)
 		}
 		for _, e := range t.DistinctOn {
-			s.skipOrdinal(e)
+			s.skipConstant(e)
 		}
+		s.skipAllConstants(t.From.AsOf.Expr)
 	case *Select:
 		for _, o := range t.OrderBy {
-			s.skipOrdinal(o.Expr)
+			s.skipConstant(o.Expr)
 		}
 	case *Delete:
 		for _, o := range t.OrderBy {
-			s.skipOrdinal(o.Expr)
+			s.skipConstant(o.Expr)
 		}
 	case *Update:
 		for _, o := range t.OrderBy {
-			s.skipOrdinal(o.Expr)
+			s.skipConstant(o.Expr)
 		}
 	}
 	return true, stmt

--- a/pkg/sql/sem/tree/replace_scalars_test.go
+++ b/pkg/sql/sem/tree/replace_scalars_test.go
@@ -91,6 +91,10 @@ func TestReplaceScalarsWithPlaceholders(t *testing.T) {
 		name:     "order_by_bool_datum_not_replaced",
 		sql:      "SELECT * FROM t ORDER BY true",
 		expected: "SELECT * FROM t ORDER BY true",
+	}, {
+		name:     "as_of_system_time_not_replaced",
+		sql:      "SELECT x FROM t AS OF SYSTEM TIME 1",
+		expected: "SELECT x FROM t AS OF SYSTEM TIME 1",
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

- Enable `local-prepared` logictest config on 9 more files: `as_of`,
  `create_as`, `delete`, `export`, `fk`, `select`, `txn_as_of`, `typing`,
  and `udf_params`
- Improve the scalar replacer to skip AS OF SYSTEM TIME expressions (which
  don't support placeholders)
- Fix URI redaction bug in the logictest query path: `ast.String()` was
  redacting EXPORT URIs to `*****` via `FormatURI`; now uses
  `FmtShowFullURIs`
- Relax test regexes for hardcoded descriptor IDs (`fk`), COALESCE error
  prefix (`typing`), and table name qualification (`create_as`)
- Remaining skipifs cover expected differences due to prepared statement
  execution (e.g., multi-statement strings being prepared individually),
  scalar replacement (e.g., int64-overflowing constants becoming DECIMAL
  placeholders), and different error messages in the pgwire prepare path
  (e.g., ambiguous function calls). Two skipifs in `create_as` reference
  #166124 (PREPARE doesn't respect AOST for dropped table resolution).

Part of #152139.