### PR TITLE
release: fix stdout pollution in update-workflow-branches --print-branch

### DIFF
--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -36,7 +36,9 @@ func init() {
 
 // updateWorkflowBranches is the main command handler.
 func updateWorkflowBranches(_ *cobra.Command, _ []string) error {
-	fmt.Println("Finding latest release branch...")
+	if !printBranchOnly {
+		fmt.Fprintln(os.Stderr, "Finding latest release branch...")
+	}
 	latestBranch, err := findLatestReleaseBranch()
 	if err != nil {
 		return fmt.Errorf("failed to find latest release branch: %w", err)
@@ -47,14 +49,14 @@ func updateWorkflowBranches(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	fmt.Printf("Latest release branch: %s\n", latestBranch)
+	fmt.Fprintf(os.Stderr, "Latest release branch: %s\n", latestBranch)
 
-	fmt.Println("Updating workflow file...")
+	fmt.Fprintln(os.Stderr, "Updating workflow file...")
 	if err := addBranchToWorkflow(latestBranch); err != nil {
 		return fmt.Errorf("failed to update workflow file: %w", err)
 	}
 
-	fmt.Println("Successfully updated workflow file")
+	fmt.Fprintln(os.Stderr, "Successfully updated workflow file")
 	return nil
 }
 
@@ -95,7 +97,7 @@ func selectLatestBranch(branches []string) (string, error) {
 		// add .0 for patch to make it a valid semantic version
 		v, err := version.Parse("v" + versionStr + ".0")
 		if err != nil {
-			fmt.Printf("WARNING: cannot parse version from branch %s: %v\n", branch, err)
+			// Silently skip branches with non-parseable version strings (e.g. release-1.0, release-2.0).
 			continue
 		}
 		versions = append(versions, branchVersion{branch, v})
@@ -179,7 +181,7 @@ func addBranchToWorkflowFile(branch, path string) error {
 
 	// check if branch already exists
 	if slices.Contains(currentBranches, branch) {
-		fmt.Printf("Branch %s is already in the workflow file\n", branch)
+		fmt.Fprintf(os.Stderr, "Branch %s is already in the workflow file\n", branch)
 		return nil
 	}
 
@@ -213,7 +215,7 @@ func addBranchToWorkflowFile(branch, path string) error {
 		return fmt.Errorf("failed to write workflow file: %w", err)
 	}
 
-	fmt.Printf("Added branch %s to workflow file\n", branch)
+	fmt.Fprintf(os.Stderr, "Added branch %s to workflow file\n", branch)
 	return nil
 }
 


### PR DESCRIPTION
This PR prevents version-parse warnings from contaminating the PR title for updating the `update_releases` workflow. See original PR title for #166125

<img width="500" alt="image" src="https://github.com/user-attachments/assets/483350d3-9c2e-4a6f-96d6-e2a0db051675" />

---

## Problem

When the TeamCity script captures the release branch name via:

```sh
RELEASE_BRANCH=$("$RELEASE_BIN" update-workflow-branches --print-branch)
```

progress messages and version-parse warnings were written to stdout instead of stderr, contaminating `RELEASE_BRANCH`. This produced malformed PR titles like:

```
workflows: run `update_releases` on `Finding latest release branch...
WARNING: cannot parse version from branch release-1.0: invalid version string 'v1.0.0'
WARNING: cannot parse version from branch release-2.0: invalid version string 'v2.0.0'
release-26.2`
```

instead of:

```
workflows: run `update_releases` on `release-26.2`
```



## Fix

- Route all progress/diagnostic output to `os.Stderr`
- Remove the `WARNING` for branches like `release-1.0`/`release-2.0` that use pre-semver naming — they're silently skipped (the correct latest branch is still found)
- When `--print-branch` is set, suppress the "Finding latest release branch..." message entirely (no progress output needed in capture mode)

Epic: None
Release note: None
Release justification: non-production (release infra) change.