### PR TITLE
ui: guard against missing version in cluster settings

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -81,7 +81,7 @@ export const selectClusterSettingVersion = createSelector(
     if (!settings) {
       return "";
     }
-    return settings["version"].value;
+    return settings["version"]?.value ?? "";
   },
 );
 


### PR DESCRIPTION
## Summary
Fixes #165444.
**Root cause:** `selectClusterSettingVersion` accessed `settings["version"].value` without checking if the `"version"` key exists. Users with `MODIFYSQLCLUSTERSETTING` but not `VIEWCLUSTERSETTING` get a filtered settings response that omits `"version"`, causing a `TypeError: Cannot read properties of undefined (reading 'value')` crash on the DB Console Overview page.
**Fix:** Added optional chaining to safely access the version setting value.
## Changes
- Added `?.` optional chaining and `?? ""` fallback for the version setting access
## Testing
- Verified fix addresses reported crash scenario
- Change is minimal (one-line fix)

Made with [Cursor](https://cursor.com)