### PR TITLE
release-25.4: roachtest: reduce the number of concurrent works in tpcc/create

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -490,15 +490,15 @@ func TestLDRCreateTablesTPCC(
 	// - 15 mins of steady state. If the above scans take too long, the latency
 	// verifier may trip.
 	duration := 30 * time.Minute
-	warehouses := 1000
+	schemaWarehouses, workloadWarehouses := 1000, 500
 	if c.IsLocal() {
 		duration = 3 * time.Minute
-		warehouses = 10
+		schemaWarehouses, workloadWarehouses = 10, 10
 	}
 
 	workload := LDRWorkload{
 		workload: replicateTPCC{
-			warehouses:     warehouses,
+			warehouses:     workloadWarehouses,
 			duration:       duration,
 			repairOrderIDs: true,
 		},
@@ -511,7 +511,7 @@ func TestLDRCreateTablesTPCC(
 	setup.right.sysSQL.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.low_admission_priority.enabled = false")
 	c.Run(ctx,
 		option.WithNodes(setup.workloadNode),
-		fmt.Sprintf("./cockroach workload init tpcc --warehouses=%d --fks=false {pgurl:%d:system}", warehouses, setup.left.nodes[0]))
+		fmt.Sprintf("./cockroach workload init tpcc --warehouses=%d --fks=false {pgurl:%d:system}", schemaWarehouses, setup.left.nodes[0]))
 
 	workloadDoneCh := make(chan struct{})
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())


### PR DESCRIPTION
Backport 1/1 commits from #159175.

/cc @cockroachdb/release

Fixes: #166164
Informs: #162008

---

The tpcc/create tests is a bit of a stress test for the kv writer and it's an even bigger challenge for the crud writer. In steady state, the kv writer uses ~40% cpu to replicate the workload and the crud writer uses ~60% cpu. But this test isn't checking the steady state, its building up a backlog while the initial scan runs. So the workload needs to catch up using the remaining CPU headroom, which is what causes this test to fail due to high replication latency.

Now, the test uses 1/2 the warehouse count when running the workload. This lets us use a large data load when testing the create replicated table statement and produces a manageable backlog for the crud writer to catch up on.

Release note: none
Fixes: #156185
Part of: #158439

Release justification: test only change.
