### PR TITLE
cloud: deflake Azure fault injection test

### DIFF
--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -181,7 +181,7 @@ func TestAzureFaultInjection(t *testing.T) {
 
 	args := cloud.EarlyBootExternalStorageContext{
 		IOConf:          base.ExternalIODirConfig{},
-		Settings:        cluster.MakeTestingClusterSettings(),
+		Settings:        settings,
 		Options:         nil,
 		Limiters:        nil,
 		MetricsRecorder: cloud.NilMetrics,


### PR DESCRIPTION
The Azure fault injection test was timing out because the wrong cluster settings object was being used, which meant the try timeout of 1 minute was not being applied.

Fixes: #164602

Release note: None