### PR TITLE
changefeedccl: deflake TestParquetRows

### DIFF
--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -52,8 +53,9 @@ func TestParquetRows(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 
-	sysDB := sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t))
-	sysDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	for _, l := range []serverutils.ApplicationLayerInterface{s, srv.SystemLayer()} {
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
 
 	maxRowGroupSize := int64(4)
 


### PR DESCRIPTION
Use override instead of setting the cluster setting using a SQL 
statement to prevent a race condition.

Fixes: #158214
Release note: None