### PR TITLE
testcluster: fix CrashNode isolation using Partitioner

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -329,6 +329,13 @@ type TestClusterArgs struct {
 	// that field, RestartServer will return an error to guide the developer
 	// towards a non-flaky pattern.
 	ReusableListenerReg *listenerutil.ListenerRegistry
+
+	// EnablePartitioner, when true, installs RPC interceptors on each node that
+	// allow injecting network partitions via TestCluster.Partitioner(). This is
+	// required for CrashNode and tests that use the Partitioner directly. Because
+	// the interceptors overwrite RPC ContextTestingKnobs' client interceptors,
+	// this should only be enabled by tests that need it.
+	EnablePartitioner bool
 }
 
 // DefaultTestTenantOptions specifies the conditions under which a

--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -80,7 +80,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",
-        "//pkg/gossip",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvnemesis/kvnemesisutil",
@@ -98,7 +97,6 @@ go_test(
         "//pkg/kv/kvserver/protectedts/ptutil",
         "//pkg/kv/kvtestutils",
         "//pkg/roachpb",
-        "//pkg/rpc",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -34,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -65,12 +63,7 @@ import (
 var defaultNumSteps = envutil.EnvOrDefaultInt("COCKROACH_KVNEMESIS_STEPS", 100)
 
 func (cfg kvnemesisTestCfg) testClusterArgs(
-	ctx context.Context,
-	t testing.TB,
-	rng *rand.Rand,
-	tr *SeqTracker,
-	partitioner *rpc.Partitioner,
-	mode TestMode,
+	ctx context.Context, t testing.TB, rng *rand.Rand, tr *SeqTracker, mode TestMode,
 ) (base.TestClusterArgs, stop.Closer) {
 	storeKnobs := &kvserver.StoreTestingKnobs{
 		DisableRaftLogQueue:                   true,
@@ -304,12 +297,12 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 	lisReg := listenerutil.NewListenerRegistry()
 	args := base.TestClusterArgs{
 		ReusableListenerReg: lisReg,
+		EnablePartitioner:   true,
 		ServerArgs:          commonServerArgs,
 		ServerArgsPerNode: func() map[int]base.TestServerArgs {
 			perNode := make(map[int]base.TestServerArgs)
 			for i := 0; i < cfg.numNodes; i++ {
 				nodeId := i + 1
-				ctk := rpc.ContextTestingKnobs{}
 				// Test clock injection
 				//
 				// We need to stay away within 80% of the max offset, so we set our
@@ -322,12 +315,10 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 				period := 1 * time.Second
 				clock := NewTestClock(maxOffset, period, rng)
 				t.Logf("n%d using %s", nodeId, clock)
-				partitioner.RegisterTestingKnobs(roachpb.NodeID(nodeId), &ctk)
 				perNodeServerArgs := commonServerArgs
 				perNodeServerArgs.Knobs.Server = &server.TestingKnobs{
-					StickyVFSRegistry:   reg,
-					WallClock:           clock,
-					ContextTestingKnobs: ctk,
+					StickyVFSRegistry: reg,
+					WallClock:         clock,
 				}
 				perNodeServerArgs.Locality = roachpb.Locality{
 					Tiers: []roachpb.Tier{{Key: "node", Value: fmt.Sprintf("n%d", nodeId)}},
@@ -750,17 +741,10 @@ func testKVNemesisImpl(t testing.TB, cfg kvnemesisTestCfg) {
 	// 4 nodes so we have somewhere to move 3x replicated ranges to.
 	ctx := context.Background()
 	tr := &SeqTracker{}
-	var partitioner rpc.Partitioner
-	args, closer := cfg.testClusterArgs(ctx, t, rng, tr, &partitioner, cfg.mode)
+	args, closer := cfg.testClusterArgs(ctx, t, rng, tr, cfg.mode)
 	tc := testcluster.StartTestCluster(t, cfg.numNodes, args)
 	tc.Stopper().AddCloser(closer)
 	defer tc.Stopper().Stop(ctx)
-	for i := 0; i < cfg.numNodes; i++ {
-		g := tc.Servers[i].StorageLayer().GossipI().(*gossip.Gossip)
-		addr := g.GetNodeAddr().String()
-		nodeID := g.NodeID.Get()
-		partitioner.RegisterNodeAddr(addr, nodeID)
-	}
 	dbs, sqlDBs := make([]*kv.DB, cfg.numNodes), make([]*gosql.DB, cfg.numNodes)
 	for i := 0; i < cfg.numNodes; i++ {
 		dbs[i] = tc.Server(i).DB()
@@ -801,7 +785,7 @@ func testKVNemesisImpl(t testing.TB, cfg kvnemesisTestCfg) {
 		SQLDBs:           sqlDBs,
 		Tracker:          tr,
 		L:                logger,
-		Partitioner:      &partitioner,
+		Partitioner:      tc.Partitioner(),
 		ServerController: tc,
 		MvccGCController: testClusterGCController{tc},
 		PtsController:    makePtsController(t, tc),

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -196,13 +196,9 @@ func (p *Partitioner) EnablePartitions(enable bool) {
 	p.partitionsEnabled.Store(enable)
 }
 
-// RegisterNodeAddr is called after the cluster is started, but before
-// EnablePartitions is called on every node to register the mapping from the
-// address of the node to the NodeID.
+// RegisterNodeAddr registers the mapping from the address of the node to its
+// ID. Usually called after the node is started and its address is known.
 func (p *Partitioner) RegisterNodeAddr(addr string, id roachpb.NodeID) {
-	if p.partitionsEnabled.Load() {
-		panic("Can not register node addresses with a partition enabled")
-	}
 	p.nodeAddrMap.Store(addr, &id)
 }
 

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -269,6 +269,8 @@ func (p *Partitioner) RegisterTestingKnobs(id roachpb.NodeID, knobs *ContextTest
 		}
 		return nil
 	}
+	// TODO(pav-kv): fail if the interceptors are already set, instead of silently
+	// overriding them.
 	knobs.UnaryClientInterceptor =
 		func(target string, class rpcbase.ConnectionClass) grpc.UnaryClientInterceptor {
 			return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/rpc/nodedialer",
         "//pkg/rpc/rpcbase",
         "//pkg/server",

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -2175,43 +2175,20 @@ func (tc *TestCluster) RestartServerWithInspect(
 		})
 }
 
-// isolateNodeFromPeers trips circuit breakers on the crashed node's dialer to
-// isolate it from all peer nodes. This simulates network partition behavior
-// during a crash. The circuit breakers will automatically reset when the node
-// is restarted and connections are successfully re-established via the
-// background `AsyncProbe` mechanism; manual undo is not needed.
-func (tc *TestCluster) isolateNodeFromPeers(idx int) {
-	nodeDialer, ok := tc.Servers[idx].NodeDialer().(*nodedialer.Dialer)
-	if !ok {
-		return
-	}
-	for peerIdx := range tc.Servers {
-		if peerIdx == idx {
-			continue
-		}
-		peerNodeID := tc.Servers[peerIdx].NodeID()
-		for c := 0; c < rpcbase.NumConnectionClasses; c++ {
-			if brk, found := nodeDialer.GetCircuitBreaker(
-				peerNodeID,
-				rpcbase.ConnectionClass(c),
-			); found {
-				brk.Report(errors.New("connection terminated by crash emulation"))
-			}
-		}
-	}
-}
-
 // CrashNode emulates a crash of the server at the given index by stopping it
 // and creating a snapshot of its in-memory filesystems (capturing state at the
 // last sync point). This allows testing crash recovery scenarios. Requires all
-// stores to use sticky VFS with in-memory storage. Also reports connection
-// failures to peer nodes' circuit breakers to simulate network disconnection.
+// stores to use sticky VFS with in-memory storage. Requires EnablePartitioner
+// to be set in TestClusterArgs so the crashing node can be isolated from peers.
 func (tc *TestCluster) CrashNode(idx int) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
 	if tc.mu.serverStoppers[idx] == nil {
 		tc.t.Fatalf("server %d is already stopped", idx)
+	}
+	if !tc.clusterArgs.EnablePartitioner {
+		tc.t.Fatalf("CrashNode requires EnablePartitioner in TestClusterArgs")
 	}
 
 	serverArgs := tc.serverArgs[idx]
@@ -2222,17 +2199,23 @@ func (tc *TestCluster) CrashNode(idx int) {
 			"server %d does not have sticky VFS registry; crash emulation requires sticky VFS", idx)
 	}
 
-	// Isolate the crashed node from its peers by tripping circuit breakers.
-	// This simulates network partition behavior during a crash. Circuit breakers
-	// will automatically reset when the node is restarted and connections are
-	// successfully re-established (via background probe mechanisms), so no manual
-	// undo is needed.
+	// Isolate the crashed node from its peers to prevent any messages from
+	// escaping after the CrashClone calls on VFS below. Without this, durability
+	// signals (such as MsgAppResp messages) after CrashClone could leak.
 	//
-	// This step is first because we want to prevent any message sent after the
-	// CrashClone of the VFS. Otherwise it would be able to leak false durability
-	// signal into the cluster, such as with raft messages like
-	// MsgVoteResp / MsgAppResp.
-	tc.isolateNodeFromPeers(idx)
+	// Use bidirectional partitions because the partitioner's stream interceptors
+	// block RecvMsg on existing client streams that peers have open to the
+	// crashing node, preventing them from reading responses sent by the crashing
+	// node's server-side handlers.
+	crashingNodeID := tc.Servers[idx].NodeID()
+	for peerIdx := range tc.Servers {
+		if peerIdx == idx {
+			continue
+		}
+		peerNodeID := tc.Servers[peerIdx].NodeID()
+		require.NoError(tc.t, tc.partitioner.AddPartition(crashingNodeID, peerNodeID))
+		require.NoError(tc.t, tc.partitioner.AddPartition(peerNodeID, crashingNodeID))
+	}
 
 	crashedVFSesMap := make(map[string]*vfs.MemFS)
 	for i, spec := range serverArgs.StoreSpecs {
@@ -2257,6 +2240,18 @@ func (tc *TestCluster) CrashNode(idx int) {
 	// real crash where only synced data persists.
 	for stickyID, crashFS := range crashedVFSesMap {
 		serverKnobs.StickyVFSRegistry.Set(stickyID, crashFS)
+	}
+
+	// Remove all partitions that were added above.
+	// TODO(pav-kv): this cancels any pre-existing partitions. We could fix that
+	// by remembering the previous partitions and restoring them.
+	for peerIdx := range tc.Servers {
+		if peerIdx == idx {
+			continue
+		}
+		peerNodeID := tc.Servers[peerIdx].NodeID()
+		require.NoError(tc.t, tc.partitioner.RemovePartition(crashingNodeID, peerNodeID))
+		require.NoError(tc.t, tc.partitioner.RemovePartition(peerNodeID, crashingNodeID))
 	}
 }
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -71,8 +72,13 @@ import (
 type TestCluster struct {
 	Servers []serverutils.TestServerInterface
 	Conns   []*gosql.DB
-	// reusableListeners is populated if (and only if) TestClusterArgs.reusableListeners is set.
-	reusableListeners map[int] /* idx */ *listenerutil.ReusableListener
+
+	// reusableListeners is populated iff clusterArgs.ReusableListenerReg is set.
+	reusableListeners map[int]*listenerutil.ReusableListener // idx -> listener
+
+	// partitioner allows injecting network partitions between the cluster nodes.
+	// Used only if clusterArgs.EnablePartitioner is set.
+	partitioner rpc.Partitioner
 
 	stopper *stop.Stopper
 	mu      struct {
@@ -98,6 +104,16 @@ func (tc *TestCluster) ClusterName() string {
 // NumServers is part of TestClusterInterface.
 func (tc *TestCluster) NumServers() int {
 	return len(tc.Servers)
+}
+
+// Partitioner returns the cluster's Partitioner, which can be used to inject
+// network partitions between nodes at the RPC layer. Requires EnablePartitioner
+// to be set in TestClusterArgs.
+func (tc *TestCluster) Partitioner() *rpc.Partitioner {
+	if !tc.clusterArgs.EnablePartitioner {
+		panic("Partitioner() requires EnablePartitioner in TestClusterArgs")
+	}
+	return &tc.partitioner
 }
 
 // Server is part of TestClusterInterface.
@@ -555,6 +571,16 @@ func (tc *TestCluster) Start(t serverutils.TestFataler) {
 		}
 	}
 
+	// Register node addresses with the partitioner now that all nodes are started
+	// and have their addresses assigned.
+	if tc.clusterArgs.EnablePartitioner {
+		for _, s := range tc.Servers {
+			addr := s.SystemLayer().AdvRPCAddr()
+			tc.partitioner.RegisterNodeAddr(addr, s.StorageLayer().NodeID())
+		}
+		tc.partitioner.EnablePartitions(true)
+	}
+
 	// Wait until a NodeStatus is persisted for every node (see #25488, #25649, #31574).
 	tc.WaitForNodeStatuses(t)
 	testutils.SucceedsSoon(t, func() error {
@@ -717,6 +743,20 @@ func (tc *TestCluster) AddServer(
 		serverArgs.Addr = serverArgs.Listener.Addr().String()
 	}
 
+	// Register the partitioner's RPC interceptors on this node so that CrashNode
+	// and other callers of Partitioner() can inject network partitions.
+	if tc.clusterArgs.EnablePartitioner {
+		if serverArgs.Knobs.Server == nil {
+			serverArgs.Knobs.Server = &server.TestingKnobs{}
+		}
+		sk := serverArgs.Knobs.Server.(*server.TestingKnobs)
+		// TODO(pav-kv): it's not great that we are guessing the NodeID here. This
+		// is because we need to install the testing knobs / RPC interceptors before
+		// the server is started. Find a way around this.
+		nodeID := roachpb.NodeID(len(tc.Servers) + 1)
+		tc.partitioner.RegisterTestingKnobs(nodeID, &sk.ContextTestingKnobs)
+	}
+
 	// Inject the decisions that were made about test configuration
 	// into this new server's configuration.
 	serverArgs.DefaultTestTenant = tc.defaultTestTenantOptions
@@ -742,6 +782,13 @@ func (tc *TestCluster) startServer(idx int, serverArgs base.TestServerArgs) erro
 	server := tc.Servers[idx]
 	if err := server.Start(context.Background()); err != nil {
 		return err
+	}
+
+	// Register the node's address with the partitioner if enabled, so that
+	// dynamically added nodes can also participate in partition tests.
+	if tc.clusterArgs.EnablePartitioner {
+		addr := server.SystemLayer().AdvRPCAddr()
+		tc.partitioner.RegisterNodeAddr(addr, server.StorageLayer().NodeID())
 	}
 
 	dbConn, err := server.ApplicationLayer().SQLConnE(serverutils.DBName(serverArgs.UseDatabase))


### PR DESCRIPTION
`CrashNode`'s circuit breaker isolation is insufficient: it only blocks outbound RPCs from the crashing node. Server-side responses on *existing* gRPC streams (e.g. `MsgAppResp` sent during raft snapshot application) can still escape after `CrashClone`, leaking false durability signals into the cluster.

This PR replaces circuit breakers with the `Partitioner`'s bidirectional stream interceptors, which block both `SendMsg` and `RecvMsg` on client streams.

**Commit 2** moves the `Partitioner` from `kvnemesis` into `TestCluster`:
- New `EnablePartitioner` flag on `TestClusterArgs`
- `TestCluster` handles interceptor registration (`AddServer`) and address mapping (`Start`, `startServer`)
- `kvnemesis` no longer manages the `Partitioner` directly; uses `tc.Partitioner()`

**Commit 3** fixes `CrashNode` isolation:
- Replaces `isolateNodeFromPeers` (circuit breakers) with bidirectional partitions via `AddPartition`/`RemovePartition`
- Partitions are added before `CrashClone` and removed after `stopServerLocked`


Fixes-26.2 #166145