### PR TITLE
roachtest: upload runner-level logs to Datadog

### DIFF
--- a/pkg/cmd/roachtest/datadog/BUILD.bazel
+++ b/pkg/cmd/roachtest/datadog/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     embed = [":datadog"],
     deps = [
         "//pkg/cmd/roachtest/roachtestflags",
+        "//pkg/cmd/roachtest/spec",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "@com_github_datadog_datadog_api_client_go_v2//api/datadog",

--- a/pkg/cmd/roachtest/datadog/datadog.go
+++ b/pkg/cmd/roachtest/datadog/datadog.go
@@ -3,6 +3,20 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+// Package datadog uploads roachtest log files to Datadog.
+//
+// Log uploads are organized by category. Each category implements:
+//   - NewXxxMetadata: constructs a LogMetadata for that category
+//   - ShouldUploadXxx: decides whether to upload based on branch/flags
+//   - discoverXxxLogFiles: finds the files to upload
+//   - MaybeUploadXxx: orchestrates discovery, parsing, and upload
+//
+// The core parsing and upload infrastructure (parseAndUploadLogFile,
+// selectParser, uploadBatch) is shared across all categories.
+//
+// Current categories:
+//   - Test logs: per-test artifacts (test.log, run_*.log, node logs, etc.)
+//   - Runner logs: run-level logs (test_runner-*.log, w*.log)
 package datadog
 
 import (
@@ -178,18 +192,54 @@ func formatTags(tags map[string]string) string {
 }
 
 // makeTags makes a map of tag names and values to be added to Datadog log
-// entries. Empty tag values do not cause errors.
+// entries. Tags with empty values are omitted to avoid blank entries in
+// Datadog's tag facet dropdowns.
 func (m LogMetadata) makeTags() map[string]string {
 	tagMap := map[string]string{
-		envTagName:      defaultEnv,
+		envTagName: defaultEnv,
+	}
+	for k, v := range map[string]string{
 		testNameTagName: m.TestName,
 		ownerTagName:    m.Owner,
 		cloudTagName:    m.Cloud,
 		platformTagName: m.Platform,
 		versionTagName:  m.Version,
 		logFileTagName:  m.LogName,
+	} {
+		if v != "" {
+			tagMap[k] = v
+		}
 	}
 	return tagMap
+}
+
+// readTCBuildProperties reads TeamCity build properties from the
+// properties file and populates the corresponding fields on m.
+func readTCBuildProperties(l *logger.Logger, m *LogMetadata) {
+	l.Printf("teamcity build properties file: %s", tcBuildPropertyFile)
+	if tcBuildPropertyFile == "" {
+		return
+	}
+	file, err := os.Open(tcBuildPropertyFile)
+	if err != nil {
+		// Reading the properties file is best effort. If it fails, we will
+		// continue to process log events without the teamcity metadata.
+		l.Printf("failed to open teamcity build properties file: %s", err)
+		return
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, tcSystemBuildPropertyAgentNamePrefix):
+			m.TCHost = strings.TrimPrefix(line, tcSystemBuildPropertyAgentNamePrefix)
+		case strings.HasPrefix(line, tcSystemBuildPropertyBuildNumberPrefix):
+			m.TCBuildNumber = strings.TrimPrefix(line, tcSystemBuildPropertyBuildNumberPrefix)
+		case strings.HasPrefix(line, tcSystemBuildConfigurationPrefix):
+			m.TCBuildConfName = strings.TrimPrefix(line, tcSystemBuildConfigurationPrefix)
+		}
+	}
 }
 
 // NewLogMetadata creates a LogMetadata from test execution information
@@ -203,7 +253,6 @@ func NewLogMetadata(
 	arch vm.CPUArch,
 	clusterName string,
 ) LogMetadata {
-
 	m := LogMetadata{
 		TestName: spec.Name,
 		Result:   makeResult(result),
@@ -214,50 +263,34 @@ func NewLogMetadata(
 		Cluster:  clusterName,
 		Version:  os.Getenv(envTCBuildBranch),
 	}
-
-	// Teamcity System Properties are available in the build properties file
-	// separated by line as key value pairs, i.e., agent.name=gce-agent
-	// On TC UI, these properties are prefixed with "system."
-	// In the properties file that prefix is omitted.
-	l.Printf("teamcity build properties file: %s", tcBuildPropertyFile)
-	if tcBuildPropertyFile != "" {
-		file, err := os.Open(tcBuildPropertyFile)
-		if err != nil {
-			// Reading the properties file is best effort. If it fails, we will
-			// continue to process log events without the teamcity metadata.
-			l.Printf("failed to open teamcity build properties file: %s", err)
-		} else {
-			defer file.Close()
-			scanner := bufio.NewScanner(file)
-			for scanner.Scan() {
-				line := scanner.Text()
-				switch {
-				case strings.HasPrefix(line, tcSystemBuildPropertyAgentNamePrefix):
-					m.TCHost = strings.TrimPrefix(line, tcSystemBuildPropertyAgentNamePrefix)
-				case strings.HasPrefix(line, tcSystemBuildPropertyBuildNumberPrefix):
-					m.TCBuildNumber = strings.TrimPrefix(line, tcSystemBuildPropertyBuildNumberPrefix)
-				case strings.HasPrefix(line, tcSystemBuildConfigurationPrefix):
-					m.TCBuildConfName = strings.TrimPrefix(line, tcSystemBuildConfigurationPrefix)
-				}
-			}
-		}
-	}
-
-	// Make tag map from metadata fields
+	readTCBuildProperties(l, &m)
 	m.Tags = m.makeTags()
-
 	l.Printf("Datadog Log Entry Metadata: %+v", m)
 	return m
 }
 
-// ShouldUploadLogsToDatadog determines if test logs should be uploaded to Datadog based
+// NewRunnerLogMetadata creates a LogMetadata for runner-level logs
+// (test_runner-*.log, w*.log). Test-specific fields (TestName, Owner,
+// Cluster, Result, Duration) are left empty.
+func NewRunnerLogMetadata(l *logger.Logger, cloud spec.Cloud) LogMetadata {
+	m := LogMetadata{
+		Version: os.Getenv(envTCBuildBranch),
+		Cloud:   cloud.String(),
+	}
+	readTCBuildProperties(l, &m)
+	m.Tags = m.makeTags()
+	l.Printf("Datadog Runner Log Entry Metadata: %+v", m)
+	return m
+}
+
+// ShouldUploadTestLogsToDatadog determines if test logs should be uploaded to Datadog based
 // on flag settings, branch, and test result.
 //
 // Default behavior: Upload logs only from failed tests on master/release branches.
 // --datadog-send-logs-any-branch: Upload from any branch.
 // --datadog-send-logs-any-result: Upload any result from master/release branches.
 // Both flags: Upload any result from any branch.
-func ShouldUploadLogsToDatadog(testFailed bool) bool {
+func ShouldUploadTestLogsToDatadog(testFailed bool) bool {
 	// Determine if we're on a branch that should upload
 	branch := os.Getenv(envTCBuildBranch)
 	isReleaseBranch := branch == "master" || strings.HasPrefix(branch, "release-")
@@ -270,6 +303,112 @@ func ShouldUploadLogsToDatadog(testFailed bool) bool {
 
 	// Upload if both checks pass
 	return branchCheckPassed && resultCheckPassed
+}
+
+// ShouldUploadRunnerLogsToDatadog determines if runner-level logs should be
+// uploaded to Datadog. Unlike per-test uploads, runner logs are always uploaded
+// on master/release branches regardless of individual test results.
+// --datadog-send-logs-any-branch: Upload from any branch.
+func ShouldUploadRunnerLogsToDatadog() bool {
+	branch := os.Getenv(envTCBuildBranch)
+	isReleaseBranch := branch == "master" || strings.HasPrefix(branch, "release-")
+	return roachtestflags.DatadogSendLogsAnyBranch || isReleaseBranch
+}
+
+// shouldUploadRunnerFile returns true if the given file in the
+// _runner-logs/ directory should be uploaded to Datadog. Currently
+// uploads test_runner-*.log and w*.log files.
+func shouldUploadRunnerFile(name string) bool {
+	if strings.HasPrefix(name, "test_runner-") && strings.HasSuffix(name, ".log") {
+		return true
+	}
+	if strings.HasSuffix(name, ".log") && name[0] == 'w' && name[1] >= '0' && name[1] <= '9' {
+		return true
+	}
+	return false
+}
+
+// discoverRunnerLogFiles returns the list of file paths in runnerLogsDir
+// that should be uploaded to Datadog, filtered by shouldUploadRunnerFile.
+func discoverRunnerLogFiles(runnerLogsDir string) ([]string, error) {
+	entries, err := os.ReadDir(runnerLogsDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading runner logs directory %s", runnerLogsDir)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if shouldUploadRunnerFile(entry.Name()) {
+			files = append(files, filepath.Join(runnerLogsDir, entry.Name()))
+		}
+	}
+	return files, nil
+}
+
+// MaybeUploadRunnerLogs discovers runner-level log files in runnerLogsDir
+// and uploads them to Datadog. These include the test_runner-*.log and
+// per-worker w*.log files from _runner-logs/.
+func MaybeUploadRunnerLogs(
+	ctx context.Context, l *logger.Logger, runnerLogsDir string, cfg LogMetadata,
+) error {
+	uploadCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	datadogCtx, err := newDatadogContext(uploadCtx)
+	if err != nil {
+		return err
+	}
+
+	datadogLogger, err := l.ChildLogger("datadog-runner", logger.QuietStdout)
+	if err != nil {
+		return err
+	}
+
+	// Create Datadog Logs API client
+	// Default timeout is 60 seconds per HTTP request
+	configuration := datadog.NewConfiguration()
+	apiClient := datadog.NewAPIClient(configuration)
+	logsAPI := datadogV2.NewLogsApi(apiClient)
+
+	files, err := discoverRunnerLogFiles(runnerLogsDir)
+	if err != nil {
+		return err
+	}
+
+	l.Printf("discovered %d runner log files to upload from %s", len(files), runnerLogsDir)
+	l.Printf("files: %v", files)
+	overallStart := timeutil.Now()
+	var totalBytes int64
+	for _, logPath := range files {
+		logName, err := filepath.Rel(runnerLogsDir, logPath)
+		if err != nil {
+			l.Printf("failed to compute relative path for %s and %s: %v", runnerLogsDir, logPath, err)
+		}
+
+		if info, statErr := os.Stat(logPath); statErr == nil {
+			totalBytes += info.Size()
+		}
+
+		fileCfg := cfg
+		fileCfg.LogName = logName
+		fileCfg.Tags = fileCfg.makeTags()
+
+		parser := selectParser(filepath.Base(logPath))
+		fileStart := timeutil.Now()
+		totalEntries, uploadErr := parseAndUploadLogFile(
+			datadogCtx, datadogLogger, logsAPI, logPath, fileCfg, parser,
+		)
+		if uploadErr != nil {
+			l.Printf("error uploading %s to Datadog (%d entries uploaded): %v",
+				logName, totalEntries, uploadErr)
+		}
+		l.Printf("uploaded %d log events from %s in %s", totalEntries, logName, timeutil.Since(fileStart))
+	}
+	l.Printf("finished uploading runner log files to Datadog in %s (%s total)",
+		timeutil.Since(overallStart), humanizeBytes(totalBytes))
+	return nil
 }
 
 // shouldUploadArtifactFile returns true if the given top-level artifact file
@@ -354,7 +493,7 @@ func nodeFileChannel(name string) string {
 // shouldUploadNodeFile returns true if the given file name from a
 // logs/N.unredacted/ directory should be uploaded. This covers
 // non-log files and special cockroach files. Segment vs base-name
-// filtering is handled by discoverLogFiles.
+// filtering is handled by discoverTestLogFiles.
 func shouldUploadNodeFile(name string) bool {
 	if name == "diskusage.txt" {
 		return true
@@ -371,11 +510,11 @@ func shouldUploadNodeFile(name string) bool {
 	return false
 }
 
-// discoverLogFiles returns the list of file paths in artifactsDir that should
+// discoverTestLogFiles returns the list of file paths in artifactsDir that should
 // be uploaded to Datadog. Top-level files are filtered by shouldUploadArtifactFile.
 // Additionally, node-level logs from logs/N.unredacted/ directories are
 // included, filtered by shouldUploadNodeFile.
-func discoverLogFiles(l *logger.Logger, artifactsDir string) ([]string, error) {
+func discoverTestLogFiles(l *logger.Logger, artifactsDir string) ([]string, error) {
 	entries, err := os.ReadDir(artifactsDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading artifacts directory %s", artifactsDir)
@@ -468,7 +607,7 @@ func MaybeUploadTestLogs(
 	apiClient := datadog.NewAPIClient(configuration)
 	logsAPI := datadogV2.NewLogsApi(apiClient)
 
-	files, err := discoverLogFiles(l, artifactsDir)
+	files, err := discoverTestLogFiles(l, artifactsDir)
 	if err != nil {
 		return err
 	}
@@ -761,12 +900,18 @@ func parseAndUploadLogFile(
 		entry.SetService(defaultService)
 		entry.SetDdtags(formatTags(logMeta.Tags))
 		entry.SetHostname(logMeta.TCHost)
-		entry.AdditionalProperties = map[string]string{
+		entry.AdditionalProperties = make(map[string]string)
+		// Skip empty attributes to avoid blank entries in Datadog's UI.
+		for k, v := range map[string]string{
 			clusterAttributeName:            logMeta.Cluster,
 			buildNumberAttributeName:        logMeta.TCBuildNumber,
 			buildConfigurationAttributeName: logMeta.TCBuildConfName,
 			resultAttributeName:             logMeta.Result,
 			durationAttributeName:           logMeta.Duration,
+		} {
+			if v != "" {
+				entry.AdditionalProperties[k] = v
+			}
 		}
 		for k, v := range logMeta.Tags {
 			entry.AdditionalProperties[k] = v
@@ -837,6 +982,10 @@ func parseCrdbV2Timestamp(ts string) (string, error) {
 }
 
 // selectParser returns the appropriate logFileParser for the given file name.
+// Explicitly lists parsers for specific file types, and defaults to
+// roachtestParser for everything else. In the event that a file is selected
+// during discovery, and its parser does not match any lines, the entire file
+// will be uploaded as a single raw log entry without an extracted timestamp.
 func selectParser(fileName string) logFileParser {
 	if strings.HasSuffix(fileName, ".dmesg.txt") {
 		return dmesgParser
@@ -880,12 +1029,20 @@ func parseLogLine(
 	entry.SetDdtags(formatTags(logMeta.Tags))
 	entry.SetHostname(logMeta.TCHost)
 	entry.AdditionalProperties = map[string]string{
-		timestampAttributeName:          timestamp,
+		timestampAttributeName: timestamp,
+	}
+	// Skip empty attributes to avoid blank entries in Datadog's UI.
+	// Runner logs leave test-specific fields empty (cluster, result, etc.).
+	for k, v := range map[string]string{
 		clusterAttributeName:            logMeta.Cluster,
 		buildNumberAttributeName:        logMeta.TCBuildNumber,
 		buildConfigurationAttributeName: logMeta.TCBuildConfName,
 		resultAttributeName:             logMeta.Result,
 		durationAttributeName:           logMeta.Duration,
+	} {
+		if v != "" {
+			entry.AdditionalProperties[k] = v
+		}
 	}
 	// Duplicate tags into attributes for an improved UI experience
 	for k, v := range logMeta.Tags {

--- a/pkg/cmd/roachtest/datadog/datadog_test.go
+++ b/pkg/cmd/roachtest/datadog/datadog_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/stretchr/testify/require"
@@ -377,7 +378,7 @@ func TestDiscoverLogFiles(t *testing.T) {
 
 	l, err := logger.RootLogger(os.DevNull, logger.NoTee)
 	require.NoError(t, err)
-	files, err := discoverLogFiles(l, tmpDir)
+	files, err := discoverTestLogFiles(l, tmpDir)
 	require.NoError(t, err)
 
 	// Convert to relative paths for readability.
@@ -400,6 +401,54 @@ func TestDiscoverLogFiles(t *testing.T) {
 		"logs/1.unredacted/diskusage.txt",
 		"run_073000.log",
 		"test.log",
+	}
+	require.Equal(t, expected, relPaths)
+}
+
+func TestDiscoverRunnerLogFiles(t *testing.T) {
+	// Create a representative _runner-logs/ directory structure:
+	//
+	//   tmpDir/
+	//   ├── test_runner-1773642173.log  ✓ runner log
+	//   ├── w0.log                      ✓ worker log
+	//   ├── w1.log                      ✓ worker log
+	//   ├── w15.log                     ✓ worker log
+	//   ├── params.log                  ✗ excluded
+	//   ├── cluster-create/             ✗ directory, skipped
+	//   │   └── teamcity-xxx.log
+	//   └── ssh/                        ✗ directory, skipped
+	tmpDir := t.TempDir()
+
+	touch := func(relPath string) {
+		absPath := filepath.Join(tmpDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0777))
+		require.NoError(t, os.WriteFile(absPath, nil, 0666))
+	}
+
+	touch("test_runner-1773642173.log")
+	touch("w0.log")
+	touch("w1.log")
+	touch("w15.log")
+	touch("params.log")                      // excluded
+	touch("cluster-create/teamcity-xxx.log") // excluded (in subdir)
+	touch("ssh/some-host.log")               // excluded (in subdir)
+
+	files, err := discoverRunnerLogFiles(tmpDir)
+	require.NoError(t, err)
+
+	var relPaths []string
+	for _, f := range files {
+		rel, relErr := filepath.Rel(tmpDir, f)
+		require.NoError(t, relErr)
+		relPaths = append(relPaths, rel)
+	}
+	sort.Strings(relPaths)
+
+	expected := []string{
+		"test_runner-1773642173.log",
+		"w0.log",
+		"w1.log",
+		"w15.log",
 	}
 	require.Equal(t, expected, relPaths)
 }
@@ -565,7 +614,7 @@ func TestNewDatadogContextDatadogSiteSet(t *testing.T) {
 	require.Equal(t, "1234", apiKeyMap["apiKeyAuth"].Key)
 }
 
-func TestShouldUploadLogsToDatadog(t *testing.T) {
+func TestShouldUploadTestLogsToDatadog(t *testing.T) {
 	// Save and restore env var and flags
 	originalBranch := os.Getenv(envTCBuildBranch)
 	originalSendLogsAnyBranch := roachtestflags.DatadogSendLogsAnyBranch
@@ -691,7 +740,7 @@ func TestShouldUploadLogsToDatadog(t *testing.T) {
 			_ = os.Setenv(envTCBuildBranch, tt.branch)
 			roachtestflags.DatadogSendLogsAnyBranch = tt.sendLogsAnyBranch
 			roachtestflags.DatadogSendLogsAnyResult = tt.sendLogsAnyResult
-			result := ShouldUploadLogsToDatadog(tt.testFailed)
+			result := ShouldUploadTestLogsToDatadog(tt.testFailed)
 			require.Equal(t, tt.expectedShouldUpload, result)
 		})
 	}
@@ -731,6 +780,12 @@ func TestShouldUploadLogsToDatadog(t *testing.T) {
 //	        ├── cockroach.exit.log                         crdbV2Parser (raw fallback)
 //	        ├── diskusage.txt                              roachtestParser (raw fallback)
 //	        └── roachprod.log                              roachtestParser
+//
+// Runner-level logs (uploaded via MaybeUploadRunnerLogs):
+//
+//	_runner-logs/
+//	├── test_runner-<unix_ts>.log                          roachtestParser
+//	└── w<N>.log                                           roachtestParser
 
 // parseTestLogResult holds the output of parseTestLog.
 type parseTestLogResult struct {
@@ -1021,7 +1076,7 @@ func TestParseLogFileJournalctl(t *testing.T) {
 //
 //	cockroach-health.teamcity-21260621-1773728561-75-n10cpu2-0001.ubuntu.2026-03-17T09_44_19Z.003965.log
 //
-// Both segment and base-name files are discovered by discoverLogFiles, and base-name files are only uploaded if no segment files exist for the same channel.
+// Both segment and base-name files are discovered by discoverTestLogFiles, and base-name files are only uploaded if no segment files exist for the same channel.
 func TestParseLogFileCockroach(t *testing.T) {
 	r := parseTestLog(t, "test_cockroach_log", crdbV2Parser,
 		"cockroach.teamcity-xxx.ubuntu.2026-02-11T00_19_40Z.log")
@@ -1072,4 +1127,147 @@ func TestParseLogFileCockroachStderr(t *testing.T) {
 		require.Equal(t, 0, len(r.validEntries), "no lines should match crdb-v2 format")
 		require.Equal(t, 11, r.skipCount, "all lines should be skipped")
 	})
+}
+
+// TestParseLogFileTestRunner tests the parsing of a _runner-logs/test_runner-*.log file.
+// These contain global orchestration events and may include worker-prefixed
+// lines ([wN]) interleaved with unprefixed runner lines.
+func TestParseLogFileTestRunner(t *testing.T) {
+	r := parseTestLog(t, "test_runner_log", roachtestParser, "test_runner-1773642173.log")
+
+	// All 12 lines match the roachtest timestamp pattern (both plain
+	// and [wN]-prefixed variants). No lines are skipped.
+	require.Equal(t, 12, len(r.validEntries), "expected 12 entries")
+	require.Equal(t, 0, r.skipCount, "no lines should be skipped")
+
+	// Verify first entry.
+	require.Contains(t, r.validEntries[0].Message, "test runner logs in:")
+
+	// Verify a worker-prefixed entry is parsed correctly.
+	require.Contains(t, r.validEntries[5].Message, "[w5]")
+	require.Contains(t, r.validEntries[5].Message, "roachprod.go")
+
+	// Verify last entry (summary line).
+	last := r.validEntries[len(r.validEntries)-1]
+	require.Contains(t, last.Message, "runTests destroying all clusters")
+
+	// Verify timestamp parsing.
+	ts, ok := r.validEntries[0].AdditionalProperties["timestamp"]
+	require.True(t, ok)
+	require.Equal(t, "2026-03-16T06:22:53Z", ts)
+}
+
+// TestParseLogFileWorker tests the parsing of a _runner-logs/w*.log file.
+// These contain per-worker lifecycle events with a [wN] prefix on most
+// lines, plus unprefixed roachprod stdout lines (no timestamp).
+func TestParseLogFileWorker(t *testing.T) {
+	r := parseTestLog(t, "test_worker_log", roachtestParser, "w0.log")
+
+	// 8 lines match the roachtest timestamp pattern ([w0]-prefixed).
+	// 3 lines are unprefixed roachprod stdout absorbed as continuations
+	// of the preceding entry.
+	require.Equal(t, 8, len(r.validEntries), "expected 8 entries")
+	require.Equal(t, 0, r.skipCount, "no lines should be skipped")
+
+	// Verify first entry.
+	require.Contains(t, r.validEntries[0].Message, "Acquired quota for 16 CPUs")
+
+	// Verify multiline entry: the "Wiping" entry should absorb the
+	// unprefixed continuation lines (stopping, wiping, Destroying).
+	require.Contains(t, r.validEntries[6].Message, "Wiping")
+	require.Contains(t, r.validEntries[6].Message, "stopping and waiting")
+	require.Contains(t, r.validEntries[6].Message, "wiping")
+	require.Contains(t, r.validEntries[6].Message, "Destroying Prometheus configs")
+
+	// Verify timestamp parsing.
+	ts, ok := r.validEntries[0].AdditionalProperties["timestamp"]
+	require.True(t, ok)
+	require.Equal(t, "2026-03-16T06:22:53Z", ts)
+}
+
+func TestShouldUploadRunnerLogsToDatadog(t *testing.T) {
+	originalBranch := os.Getenv(envTCBuildBranch)
+	originalSendLogsAnyBranch := roachtestflags.DatadogSendLogsAnyBranch
+	defer func() {
+		_ = os.Setenv(envTCBuildBranch, originalBranch)
+		roachtestflags.DatadogSendLogsAnyBranch = originalSendLogsAnyBranch
+	}()
+
+	tests := []struct {
+		name              string
+		branch            string
+		sendLogsAnyBranch bool
+		expected          bool
+	}{
+		{"master", "master", false, true},
+		{"release branch", "release-24.1", false, true},
+		{"feature branch", "feature-new-stuff", false, false},
+		{"feature branch with flag", "feature-new-stuff", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv(envTCBuildBranch, tt.branch)
+			roachtestflags.DatadogSendLogsAnyBranch = tt.sendLogsAnyBranch
+			require.Equal(t, tt.expected, ShouldUploadRunnerLogsToDatadog())
+		})
+	}
+}
+
+func TestShouldUploadRunnerFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		expected bool
+	}{
+		{"test_runner log", "test_runner-1773642173.log", true},
+		{"worker 0", "w0.log", true},
+		{"worker 15", "w15.log", true},
+		{"params.log excluded", "params.log", false},
+		{"directory excluded", "cluster-create", false},
+		{"non-log excluded", "something.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, shouldUploadRunnerFile(tt.fileName))
+		})
+	}
+}
+
+func TestNewRunnerLogMetadata(t *testing.T) {
+	l, err := logger.RootLogger(os.DevNull, logger.NoTee)
+	require.NoError(t, err)
+	defer l.Close()
+
+	originalBranch := os.Getenv(envTCBuildBranch)
+	defer func() { _ = os.Setenv(envTCBuildBranch, originalBranch) }()
+	_ = os.Setenv(envTCBuildBranch, "master")
+
+	m := NewRunnerLogMetadata(l, spec.GCE)
+
+	// Version and Cloud should be set.
+	require.Equal(t, "master", m.Version)
+	require.Equal(t, "gce", m.Cloud)
+
+	// Test-specific fields should be empty.
+	require.Empty(t, m.TestName)
+	require.Empty(t, m.Owner)
+	require.Empty(t, m.Cluster)
+	require.Empty(t, m.Result)
+	require.Empty(t, m.Duration)
+
+	// Tags should be populated.
+	require.NotNil(t, m.Tags)
+	require.Equal(t, defaultEnv, m.Tags[envTagName])
+	require.Equal(t, "master", m.Tags[versionTagName])
+	require.Equal(t, "gce", m.Tags[cloudTagName])
+
+	// Test-specific tags should be omitted (not present with empty values).
+	_, hasName := m.Tags[testNameTagName]
+	_, hasOwner := m.Tags[ownerTagName]
+	_, hasPlatform := m.Tags[platformTagName]
+	require.False(t, hasName, "empty test name tag should be omitted")
+	require.False(t, hasOwner, "empty owner tag should be omitted")
+	require.False(t, hasPlatform, "empty platform tag should be omitted")
 }

--- a/pkg/cmd/roachtest/datadog/testdata/test_runner_log
+++ b/pkg/cmd/roachtest/datadog/testdata/test_runner_log
@@ -1,0 +1,12 @@
+2026/03/16 06:22:53 run.go:421: test runner logs in: /artifacts/_runner-logs/test_runner-1773642173.log
+2026/03/16 06:22:53 run.go:177: global random seed: -2881847130721865594
+2026/03/16 06:22:53 test_runner.go:500: using spot VMs to run test acceptance/cli/node-status
+2026/03/16 06:22:53 test_runner.go:500: using spot VMs to run test acceptance/version-upgrade
+2026/03/16 06:22:53 test_runner.go:500: using spot VMs to run test backup/minio
+[w5] 2026/03/16 21:20:39 roachprod.go:1601: OK
+[w5] 2026/03/16 21:20:39 cluster.go:1846: destroying cluster teamcity-xxx-184-n12cpu4 [tag:] (12 nodes)... done
+[w5] 2026/03/16 21:20:39 test_runner.go:768: Worker exiting; no cluster to destroy.
+2026/03/16 21:20:39 test_runner.go:579: FAIL (13 fails)
+2026/03/16 21:20:39 test_runner.go:589: 3 clusters could not be created
+2026/03/16 21:20:39 test_runner.go:593: 13 tests failed
+2026/03/16 21:20:39 run.go:229: runTests destroying all clusters

--- a/pkg/cmd/roachtest/datadog/testdata/test_worker_log
+++ b/pkg/cmd/roachtest/datadog/testdata/test_worker_log
@@ -1,0 +1,11 @@
+[w0] 2026/03/16 06:22:53 work_pool.go:198: Acquired quota for 16 CPUs
+[w0] 2026/03/16 06:22:53 cluster.go:3238: Using randomly chosen arch="amd64", acceptance/version-upgrade
+[w0] 2026/03/16 06:25:29 test_runner.go:932: Created new cluster for test acceptance/version-upgrade: teamcity-xxx-08-n4cpu4 (arch="amd64")
+[w0] 2026/03/16 06:25:29 test_runner.go:1018: Starting test: acceptance/version-upgrade:1 on cluster=teamcity-xxx-08-n4cpu4 (arch="amd64")
+[w0] 2026/03/16 06:25:31 cluster_synced.go:1794: teamcity-xxx-08-n4cpu4: putting (dist) cockroach on nodes [1 2 3 4]
+[w0] 2026/03/16 06:42:51 test_runner.go:1140: test passed: acceptance/version-upgrade (run 1)
+[w0] 2026/03/16 06:42:51 cluster.go:3144: Using existing cluster: teamcity-xxx-08-n4cpu4 (arch="amd64"). Wiping
+teamcity-xxx-08-n4cpu4: stopping and waiting
+teamcity-xxx-08-n4cpu4: wiping
+Destroying Prometheus configs
+[w0] 2026/03/16 06:43:10 test_runner.go:1018: Starting test: import/colfam/distmerge=false/nodes=4:1 on cluster=teamcity-xxx-08-n4cpu4 (arch="amd64")

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -89,9 +89,9 @@ func generateHelpCommand(
 				renderer.Escaped(fmt.Sprintf("_Grafana is not yet available for %s clusters_", cloud))
 			}
 			// Link to the Datadog Log Explorer with logs for this test run.
-			// ShouldUploadLogsToDatadog(true) is correct because we only
+			// ShouldUploadTestLogsToDatadog(true) is correct because we only
 			// generate help commands for failed tests (which file issues).
-			if datadog.ShouldUploadLogsToDatadog(true /* testFailed */) {
+			if datadog.ShouldUploadTestLogsToDatadog(true /* testFailed */) {
 				ddQuery := fmt.Sprintf("service:roachtest @cluster:%s", clusterName)
 				issues.HelpCommandAsLink(
 					"Datadog Logs",

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/cockroachdb/cockroach/pkg/cmd/bazci/githubpost/issues"
+	roachtestdd "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/datadog"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -234,6 +235,15 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 		fmt.Printf("##teamcity[publishArtifacts '%s' => '%s']\n", filepath.Join(literalArtifactsDir, runnerLogsDir), runnerLogsDir)
 	}
 	runner.writeTestReports(ctx, runnerL, artifactsDir)
+
+	// Upload runner-level logs to Datadog (best effort).
+	if roachtestdd.ShouldUploadRunnerLogsToDatadog() {
+		m := roachtestdd.NewRunnerLogMetadata(runnerL, roachtestflags.Cloud)
+		runnerDir := filepath.Join(artifactsDir, runnerLogsDir)
+		if uploadErr := roachtestdd.MaybeUploadRunnerLogs(ctx, runnerL, runnerDir, m); uploadErr != nil {
+			runnerL.Printf("error uploading runner logs to Datadog: %v", uploadErr)
+		}
+	}
 
 	return err
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1428,7 +1428,7 @@ func (r *testRunner) runTest(
 		}
 
 		// Upload test logs to Datadog for failed tests on master/release branches (configurable via flags)
-		if datadog.ShouldUploadLogsToDatadog(t.Failed()) {
+		if datadog.ShouldUploadTestLogsToDatadog(t.Failed()) {
 			m := datadog.NewLogMetadata(
 				t.L(), t.spec, !t.Failed(), fmt.Sprintf("%.2f", timeutil.Since(t.start).Seconds()), c.cloud, c.os, c.arch,
 				c.name)
@@ -1842,7 +1842,7 @@ func (r *testRunner) teardownTest(
 	// collection below).
 	r.maybeSaveClusterDueToInvariantProblems(ctx, t, c)
 
-	if timedOut || t.Failed() || roachtestflags.AlwaysCollectArtifacts || datadog.ShouldUploadLogsToDatadog(t.Failed()) {
+	if timedOut || t.Failed() || roachtestflags.AlwaysCollectArtifacts || datadog.ShouldUploadTestLogsToDatadog(t.Failed()) {
 		err := r.collectArtifacts(ctx, t, c, timedOut, time.Hour)
 		if err != nil {
 			t.L().Printf("error collecting artifacts: %v", err)


### PR DESCRIPTION
Extends roachtest's datadog integration by adding support for uploading test runner level logs (`test_runner-*.log`, `w*.log`) to Datadog. Previously, these were ignored.