### PR TITLE
release-26.2: sql/unsafesql: fix panic in SafeFormatQuery with nil annotations

### DIFF
--- a/pkg/sql/sem/tree/redact_ast.go
+++ b/pkg/sql/sem/tree/redact_ast.go
@@ -22,7 +22,12 @@ var redactNamesInSQLStatementLog = settings.RegisterBoolSetting(
 func FormatAstAsRedactableString(
 	statement Statement, annotations *Annotations, sv *settings.Values,
 ) redact.RedactableString {
-	fs := FmtSimple | FmtAlwaysQualifyTableNames | FmtMarkRedactionNode
+	fs := FmtSimple | FmtMarkRedactionNode
+	// Only qualify table names when annotations are available, since
+	// qualification requires annotation lookups that panic on nil.
+	if annotations != nil {
+		fs = fs | FmtAlwaysQualifyTableNames
+	}
 	if !redactNamesInSQLStatementLog.Get(sv) {
 		fs = fs | FmtOmitNameRedaction
 	}

--- a/pkg/sql/unsafesql/BUILD.bazel
+++ b/pkg/sql/unsafesql/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings",
         "//pkg/sql/isql",
+        "//pkg/sql/parser",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",

--- a/pkg/sql/unsafesql/unsafesql.go
+++ b/pkg/sql/unsafesql/unsafesql.go
@@ -93,6 +93,9 @@ func CheckInternalsAccess(
 	return sqlerrors.ErrUnsafeTableAccess
 }
 
+// PanickedQueryFormat is the placeholder used when query formatting panics.
+const PanickedQueryFormat = "<panicked query format>"
+
 // SafeFormatQuery attempts to format the query for logging, but recovers from
 // any panics that may occur during formatting.
 func SafeFormatQuery(
@@ -104,7 +107,7 @@ func SafeFormatQuery(
 	defer func() {
 		if r := recover(); r != nil {
 			log.Dev.Errorf(context.TODO(), "panic in SafeFormatQuery: %v", r)
-			s = "<panicked query format>"
+			s = PanickedQueryFormat
 		}
 	}()
 	return tree.FormatAstAsRedactableString(stmt, ann, sv)

--- a/pkg/sql/unsafesql/unsafesql_test.go
+++ b/pkg/sql/unsafesql/unsafesql_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -340,7 +341,20 @@ func TestPanickingSQLFormat(t *testing.T) {
 	result := unsafesql.SafeFormatQuery(panickingStatement{}, nil, &settings.Values{})
 	require.Equal(
 		t,
-		"<panicked query format>",
+		unsafesql.PanickedQueryFormat,
 		string(result),
 	)
+}
+
+func TestSafeFormatQueryNilAnnotations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	stmts, err := parser.Parse("SELECT * FROM system.namespace")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	result := unsafesql.SafeFormatQuery(stmts[0].AST, nil, &settings.Values{})
+	require.NotEqual(t, unsafesql.PanickedQueryFormat, result)
+	require.Contains(t, string(result), "system.namespace")
 }


### PR DESCRIPTION
Backport 1/1 commits from #166057.

/cc @cockroachdb/release

---

## Summary

- `FormatAstAsRedactableString` unconditionally set `FmtAlwaysQualifyTableNames`, which requires annotation lookups to resolve fully qualified table names. When `SafeFormatQuery` was called with nil annotations (as happens in the unsafesql logging path), the formatter panicked on a nil pointer dereference inside `Annotations.Get()`.
- The panic was caught by `SafeFormatQuery`'s recover handler, replacing the query text with `<panicked query format>` in log output and losing useful diagnostic information.
- Now `FmtAlwaysQualifyTableNames` is only set when annotations are non-nil. Without annotations, table names are printed unqualified (e.g. `namespace` instead of `system.public.namespace`), which is strictly better than a panic placeholder.

Resolves: #165998
Epic: CRDB-61709

Release note: None
Release justification: Prevents a panic from occurring during unsafe sql gate formatting.