### PR TITLE
release-26.2: backup: clear default privileges on database and schema descriptors during restore

### DIFF
--- a/pkg/backup/testdata/backup-restore/restore-dangling-default-privileges
+++ b/pkg/backup/testdata/backup-restore/restore-dangling-default-privileges
@@ -1,6 +1,7 @@
 # Verify that restoring a database backup containing default privileges that
 # reference non-existent users does not leave dangling user references in the
-# restored database descriptor. This is a regression test for #164961.
+# restored database or schema descriptors. This is a regression test for
+# #164961.
 
 new-cluster name=s1 allow-implicit-access
 ----
@@ -14,8 +15,8 @@ CREATE DATABASE mydb;
 USE mydb;
 ----
 
-# Set default privileges where "max" appears as both a role (FOR ROLE max) and
-# a grantee (TO max).
+# Set database-level default privileges where "max" appears as both a role
+# (FOR ROLE max) and a grantee (TO max).
 exec-sql
 ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT SELECT ON TABLES TO max;
 ALTER DEFAULT PRIVILEGES FOR ROLE max GRANT INSERT ON TABLES TO root;
@@ -32,6 +33,17 @@ query-sql
 SELECT role, grantee, privilege_type FROM [SHOW DEFAULT PRIVILEGES FOR ROLE max] WHERE grantee = 'root' ORDER BY role, grantee, privilege_type;
 ----
 max root INSERT
+
+# Also set schema-level default privileges referencing "max".
+exec-sql
+CREATE SCHEMA sc;
+ALTER DEFAULT PRIVILEGES FOR ROLE root IN SCHEMA sc GRANT SELECT ON TABLES TO max;
+----
+
+query-sql
+SELECT role, grantee, privilege_type FROM [SHOW DEFAULT PRIVILEGES IN SCHEMA sc] WHERE grantee = 'max' ORDER BY role, grantee, privilege_type;
+----
+root max SELECT
 
 exec-sql
 BACKUP DATABASE mydb INTO 'nodelocal://1/test/';
@@ -63,5 +75,12 @@ SELECT count(*) FROM "".crdb_internal.invalid_objects WHERE id = (
 # up during restore.
 query-sql
 SELECT count(*) FROM [SHOW DEFAULT PRIVILEGES FOR ROLE root] WHERE grantee = 'max';
+----
+0
+
+# Schema-level default privileges referencing "max" should also have been
+# cleaned up during restore.
+query-sql
+SELECT count(*) FROM [SHOW DEFAULT PRIVILEGES IN SCHEMA sc] WHERE grantee = 'max';
 ----
 0

--- a/pkg/backup/testdata/backup-restore/restore-dangling-default-privileges
+++ b/pkg/backup/testdata/backup-restore/restore-dangling-default-privileges
@@ -1,0 +1,67 @@
+# Verify that restoring a database backup containing default privileges that
+# reference non-existent users does not leave dangling user references in the
+# restored database descriptor. This is a regression test for #164961.
+
+new-cluster name=s1 allow-implicit-access
+----
+
+exec-sql
+CREATE USER max;
+----
+
+exec-sql
+CREATE DATABASE mydb;
+USE mydb;
+----
+
+# Set default privileges where "max" appears as both a role (FOR ROLE max) and
+# a grantee (TO max).
+exec-sql
+ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT SELECT ON TABLES TO max;
+ALTER DEFAULT PRIVILEGES FOR ROLE max GRANT INSERT ON TABLES TO root;
+----
+
+# Verify that the default privileges referencing "max" as a grantee are set.
+query-sql
+SELECT role, grantee, privilege_type FROM [SHOW DEFAULT PRIVILEGES FOR ROLE root] WHERE grantee = 'max' ORDER BY role, grantee, privilege_type;
+----
+root max SELECT
+
+# Verify that "max" has default privileges as a role.
+query-sql
+SELECT role, grantee, privilege_type FROM [SHOW DEFAULT PRIVILEGES FOR ROLE max] WHERE grantee = 'root' ORDER BY role, grantee, privilege_type;
+----
+max root INSERT
+
+exec-sql
+BACKUP DATABASE mydb INTO 'nodelocal://1/test/';
+----
+
+# Restore into a new cluster where user "max" does not exist.
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+exec-sql
+RESTORE DATABASE mydb FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name='restored_db';
+----
+
+exec-sql
+USE restored_db;
+----
+
+# The restored database should not have any invalid descriptors. Regression
+# test for #164961, which reported dangling references to "max" in the default
+# privileges.
+query-sql
+SELECT count(*) FROM "".crdb_internal.invalid_objects WHERE id = (
+  SELECT id FROM system.namespace WHERE name = 'restored_db' AND "parentID" = 0
+);
+----
+0
+
+# Default privileges referencing "max" as a grantee should have been cleaned
+# up during restore.
+query-sql
+SELECT count(*) FROM [SHOW DEFAULT PRIVILEGES FOR ROLE root] WHERE grantee = 'max';
+----
+0

--- a/pkg/sql/catalog/ingesting/write_descs.go
+++ b/pkg/sql/catalog/ingesting/write_descs.go
@@ -128,6 +128,11 @@ func WriteDescriptors(
 		if updatedPrivileges != nil {
 			if mut, ok := sc.(*schemadesc.Mutable); ok {
 				mut.Privileges = updatedPrivileges
+				// Clear default privileges as well. Like regular privileges, we
+				// reset to defaults rather than selectively filtering since the
+				// backup's user set may not match this cluster's.
+				mut.DefaultPrivileges = catprivilege.MakeDefaultPrivilegeDescriptor(
+					catpb.DefaultPrivilegeDescriptor_SCHEMA)
 			} else {
 				log.Dev.Fatalf(ctx, "wrong type for schema %d, %T, expected Mutable",
 					sc.GetID(), sc)

--- a/pkg/sql/catalog/ingesting/write_descs.go
+++ b/pkg/sql/catalog/ingesting/write_descs.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -83,6 +85,11 @@ func WriteDescriptors(
 		if updatedPrivileges != nil {
 			if mut, ok := desc.(*dbdesc.Mutable); ok {
 				mut.Privileges = updatedPrivileges
+				// Clear default privileges as well. Like regular privileges, we
+				// reset to defaults rather than selectively filtering since the
+				// backup's user set may not match this cluster's.
+				mut.DefaultPrivileges = catprivilege.MakeDefaultPrivilegeDescriptor(
+					catpb.DefaultPrivilegeDescriptor_DATABASE)
 			} else {
 				log.Dev.Fatalf(ctx, "wrong type for database %d, %T, expected Mutable",
 					desc.GetID(), desc)


### PR DESCRIPTION
Backport 2/2 commits from #165997 on behalf of @spilchen.

----

During non-cluster restore, default privileges on database descriptors were carried over verbatim from the backup, potentially referencing users that don't exist on the target cluster. Clear them alongside regular privileges, which are already reset to defaults.

The second commit extends the first fix to also clear default privileges on schema
descriptors during non-cluster restore. Schemas can also carry default
privileges referencing users that don't exist on the target cluster.

Closes #164961
Epic: none
Release note (bug fix): Fixed a bug where restoring a database backup containing default privileges referencing non-existent users would leave dangling user references in the restored database descriptor.

----

Release justification: fix GA blocker