### PR TITLE
sql/privilege: clean up and increase compatibility of new acl functions

### DIFF
--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -48,7 +48,8 @@ Name,Owner,Encoding,Collate,Ctype,Access privileges
 defaultdb,root,UTF8,en_US.utf8,en_US.utf8,
 mydb,root,UTF8,en_US.utf8,en_US.utf8,
 postgres,root,UTF8,en_US.utf8,en_US.utf8,
-system,node,UTF8,en_US.utf8,en_US.utf8,
+system,node,UTF8,en_US.utf8,en_US.utf8,"admin=c/node
+root=c/node"
 
 cli
 \l+
@@ -73,7 +74,8 @@ Name,Owner,Encoding,Collate,Ctype,Access privileges,Connections,Description
 defaultdb,root,UTF8,en_US.utf8,en_US.utf8,,Unlimited,
 mydb,root,UTF8,en_US.utf8,en_US.utf8,,Unlimited,my awesome db comment
 postgres,root,UTF8,en_US.utf8,en_US.utf8,,Unlimited,
-system,node,UTF8,en_US.utf8,en_US.utf8,,Unlimited,
+system,node,UTF8,en_US.utf8,en_US.utf8,"admin=c/node
+root=c/node",Unlimited,
 
 cli
 \l my%
@@ -143,7 +145,9 @@ List of schemas:
    AND n.nspname <> 'information_schema'
 ORDER BY 1
 Name,Owner,Access privileges,Description
-public,root,,
+public,root,"admin=CU/root
+=CU/root
+root=CU/root",
 
 cli
 \dn+ p%
@@ -160,7 +164,9 @@ ORDER BY 1
 Name,Owner,Access privileges,Description
 pg_catalog,node,,
 pg_extension,node,,
-public,root,,
+public,root,"admin=CU/root
+=CU/root
+root=CU/root",
 
 cli
 \dnS
@@ -196,7 +202,9 @@ crdb_internal,node,,
 information_schema,node,,
 pg_catalog,node,,
 pg_extension,node,,
-public,root,,
+public,root,"admin=CU/root
+=CU/root
+root=CU/root",
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -95,14 +95,18 @@ LEFT JOIN pg_roles g ON g.oid = a.grantor
 LEFT JOIN pg_roles e ON e.oid = a.grantee
 ----
 grantor  grantee  privilege_type  is_grantable
-root     root     DELETE          false
+root     admin    INSERT          false
+root     admin    DELETE          false
+root     admin    MAINTAIN        false
+root     admin    SELECT          false
+root     admin    TRIGGER         false
+root     admin    UPDATE          false
+root     root     UPDATE          false
 root     root     INSERT          false
+root     root     DELETE          false
 root     root     MAINTAIN        false
-root     root     REFERENCES      false
 root     root     SELECT          false
 root     root     TRIGGER         false
-root     root     TRUNCATE        false
-root     root     UPDATE          false
 
 subtest end
 
@@ -152,37 +156,38 @@ subtest end
 
 subtest acldefault
 
-# Table defaults: owner gets arwdDxtm, PUBLIC gets nothing.
+# Table defaults: admin and root get all table privs, PUBLIC gets nothing.
+# Grant options are implicit for admin/root/owner so not marked with '*'.
 query T
 SELECT acldefault('r'::"char", 'root'::regrole)
 ----
-{root=arwdDxtm/root}
+{admin=admrtw/root,root=admrtw/root}
 
-# Database defaults: owner gets CTc, PUBLIC gets Tc.
+# Database defaults: admin and root get CREATE and CONNECT, PUBLIC gets CONNECT.
 query T
 SELECT acldefault('d'::"char", 'root'::regrole)
 ----
-{=Tc/root,root=CTc/root}
+{admin=Cc/root,=c/root,root=Cc/root}
 
-# Function defaults: owner gets X, PUBLIC gets X.
+# Function defaults: admin and root get EXECUTE, PUBLIC gets EXECUTE.
 query T
 SELECT acldefault('f'::"char", 'root'::regrole)
 ----
-{=X/root,root=X/root}
+{admin=X/root,=X/root,root=X/root}
 
-# Type defaults: owner gets U, PUBLIC gets U.
+# Type defaults: admin and root get USAGE, PUBLIC gets USAGE.
 query T
 SELECT acldefault('T'::"char", 'root'::regrole)
 ----
-{=U/root,root=U/root}
+{admin=U/root,=U/root,root=U/root}
 
-# Schema defaults: owner gets UC, no PUBLIC.
+# Schema defaults: admin and root get USAGE and CREATE, PUBLIC gets nothing.
 query T
 SELECT acldefault('n'::"char", 'root'::regrole)
 ----
-{root=UC/root}
+{admin=UC/root,root=UC/root}
 
-# Language defaults: no owner, PUBLIC gets U.
+# Language defaults: PUBLIC gets USAGE (matches PostgreSQL).
 query T
 SELECT acldefault('l'::"char", 'root'::regrole)
 ----
@@ -194,12 +199,11 @@ SELECT acldefault('c'::"char", 'root'::regrole)
 ----
 {}
 
-# Parameter defaults: owner gets sA (SET + ALTER SYSTEM).
-# Matches PostgreSQL behavior.
+# Parameter defaults: admin and root get SET + ALTER SYSTEM.
 query T
 SELECT acldefault('p'::"char", 'root'::regrole)
 ----
-{root=sA/root}
+{admin=sA/root,root=sA/root}
 
 # Error on invalid type char.
 statement error unrecognized object type abbreviation: "Z"
@@ -221,11 +225,11 @@ LEFT JOIN pg_roles g ON g.oid = a.grantor
 LEFT JOIN pg_roles e ON e.oid = a.grantee
 ----
 grantor  grantee  privilege_type  is_grantable
-root     PUBLIC   CONNECT         false
-root     PUBLIC   TEMPORARY       false
+root     admin    CREATE          false
+root     admin    CONNECT         false
 root     root     CONNECT         false
 root     root     CREATE          false
-root     root     TEMPORARY       false
+root     PUBLIC   CONNECT         false
 
 # Round-trip for PARAMETER type: aclexplode(acldefault('p', ...)) should return
 # SET and ALTER SYSTEM privileges. This verifies no silent data loss occurs
@@ -240,9 +244,11 @@ SELECT
 FROM aclexplode(acldefault('p'::"char", 'root'::regrole)) a
 LEFT JOIN pg_roles g ON g.oid = a.grantor
 LEFT JOIN pg_roles e ON e.oid = a.grantee
-ORDER BY a.privilege_type
+ORDER BY 1, 2, 3
 ----
 grantor  grantee  privilege_type  is_grantable
+root     admin    ALTER SYSTEM    false
+root     admin    SET             false
 root     root     ALTER SYSTEM    false
 root     root     SET             false
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -84,7 +84,7 @@ admin    PUBLIC   EXECUTE         false
 admin    root     SELECT          false
 
 # aclexplode also works with aclitem[] type via acldefault round-trip.
-query TTTB colnames,rowsort
+query TTTB colnames
 SELECT
   COALESCE(g.rolname, 'PUBLIC') AS grantor,
   COALESCE(e.rolname, 'PUBLIC') AS grantee,
@@ -93,20 +93,23 @@ SELECT
 FROM aclexplode(acldefault('r'::"char", 'root'::regrole)) a
 LEFT JOIN pg_roles g ON g.oid = a.grantor
 LEFT JOIN pg_roles e ON e.oid = a.grantee
+ORDER BY 1, 2, 3
 ----
 grantor  grantee  privilege_type  is_grantable
-root     admin    INSERT          false
+root     admin    CREATE          false
 root     admin    DELETE          false
+root     admin    INSERT          false
 root     admin    MAINTAIN        false
 root     admin    SELECT          false
 root     admin    TRIGGER         false
 root     admin    UPDATE          false
-root     root     UPDATE          false
-root     root     INSERT          false
+root     root     CREATE          false
 root     root     DELETE          false
+root     root     INSERT          false
 root     root     MAINTAIN        false
 root     root     SELECT          false
 root     root     TRIGGER         false
+root     root     UPDATE          false
 
 subtest end
 
@@ -156,42 +159,43 @@ subtest end
 
 subtest acldefault
 
-# Table defaults: admin and root get all table privs, PUBLIC gets nothing.
-# Grant options are implicit for admin/root/owner so not marked with '*'.
+# Table defaults: admin and root get all CRDB table privs,
+# PUBLIC gets nothing. Grant options are implicit for admin/root/owner.
 query T
 SELECT acldefault('r'::"char", 'root'::regrole)
 ----
-{admin=admrtw/root,root=admrtw/root}
+{admin=Cradwtm/root,root=Cradwtm/root}
 
-# Database defaults: admin and root get CREATE and CONNECT, PUBLIC gets CONNECT.
+# Database defaults: admin and root get CREATE, CONNECT, TEMPORARY.
+# PUBLIC gets CONNECT and TEMPORARY.
 query T
 SELECT acldefault('d'::"char", 'root'::regrole)
 ----
-{admin=Cc/root,=c/root,root=Cc/root}
+{=cT/root,admin=CcT/root,root=CcT/root}
 
 # Function defaults: admin and root get EXECUTE, PUBLIC gets EXECUTE.
 query T
 SELECT acldefault('f'::"char", 'root'::regrole)
 ----
-{admin=X/root,=X/root,root=X/root}
+{=X/root,admin=X/root,root=X/root}
 
 # Type defaults: admin and root get USAGE, PUBLIC gets USAGE.
 query T
 SELECT acldefault('T'::"char", 'root'::regrole)
 ----
-{admin=U/root,=U/root,root=U/root}
+{=U/root,admin=U/root,root=U/root}
 
 # Schema defaults: admin and root get USAGE and CREATE, PUBLIC gets nothing.
 query T
 SELECT acldefault('n'::"char", 'root'::regrole)
 ----
-{admin=UC/root,root=UC/root}
+{admin=CU/root,root=CU/root}
 
-# Language defaults: PUBLIC gets USAGE (matches PostgreSQL).
+# Language defaults: admin, root, and PUBLIC get USAGE.
 query T
 SELECT acldefault('l'::"char", 'root'::regrole)
 ----
-{=U/root}
+{=U/root,admin=U/root,root=U/root}
 
 # Column defaults: nobody gets anything.
 query T
@@ -214,7 +218,7 @@ subtest end
 subtest aclitem_roundtrip
 
 # Round-trip: aclexplode(acldefault(...)) should produce correct rows.
-query TTTB colnames,rowsort
+query TTTB colnames
 SELECT
   COALESCE(g.rolname, 'PUBLIC') AS grantor,
   COALESCE(e.rolname, 'PUBLIC') AS grantee,
@@ -223,13 +227,17 @@ SELECT
 FROM aclexplode(acldefault('d'::"char", 'root'::regrole)) a
 LEFT JOIN pg_roles g ON g.oid = a.grantor
 LEFT JOIN pg_roles e ON e.oid = a.grantee
+ORDER BY 1, 2, 3
 ----
 grantor  grantee  privilege_type  is_grantable
-root     admin    CREATE          false
+root     PUBLIC   CONNECT         false
+root     PUBLIC   TEMPORARY       false
 root     admin    CONNECT         false
+root     admin    CREATE          false
+root     admin    TEMPORARY       false
 root     root     CONNECT         false
 root     root     CREATE          false
-root     PUBLIC   CONNECT         false
+root     root     TEMPORARY       false
 
 # Round-trip for PARAMETER type: aclexplode(acldefault('p', ...)) should return
 # SET and ALTER SYSTEM privileges. This verifies no silent data loss occurs

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -430,7 +430,7 @@ crdb_internal       3233629770  NULL
 information_schema  3233629770  NULL
 pg_catalog          3233629770  NULL
 pg_extension        3233629770  NULL
-public              1546506610  NULL
+public              1546506610  {admin=CU/root,=CU/root,root=CU/root}
 
 # Verify that we can still see the schemas even if we don't have any privilege
 # on the current database.
@@ -449,7 +449,7 @@ crdb_internal       3233629770  NULL
 information_schema  3233629770  NULL
 pg_catalog          3233629770  NULL
 pg_extension        3233629770  NULL
-public              1546506610  NULL
+public              1546506610  {admin=CU/root,=CU/root,root=CU/root}
 
 user root
 
@@ -476,10 +476,10 @@ FROM pg_catalog.pg_database
 ORDER BY oid
 ----
 oid  datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
-1    system         -1            0              NULL          NULL        0              NULL
+1    system         -1            0              NULL          NULL        0              {admin=c/node,root=c/node}
 100  defaultdb      -1            0              NULL          NULL        0              NULL
 102  postgres       -1            0              NULL          NULL        0              NULL
-104  test           -1            0              NULL          NULL        0              NULL
+104  test           -1            0              NULL          NULL        0              {admin=CcT/root,=c/root,root=CcT/root}
 108  constraint_db  -1            0              NULL          NULL        0              NULL
 
 user testuser
@@ -490,8 +490,8 @@ SELECT oid, datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, datt
 FROM pg_catalog.pg_database
 ORDER BY oid LIMIT 1
 ----
-oid  datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
-1    system         -1            0              NULL          NULL        0              NULL
+oid  datname  datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
+1    system   -1            0              NULL          NULL        0              {admin=c/node,root=c/node}
 
 user root
 
@@ -5672,5 +5672,169 @@ ORDER BY 1
 relname                    indisprimary  indkey  indoption
 idx_c_d                    false         3 4     2 2
 t_indkey_not_visible_pkey  true          1 2     1 2
+
+subtest end
+
+subtest pg_catalog_acl_columns
+
+# Verify that ACL columns return NULL when privileges match defaults
+# (matching PostgreSQL behavior), and non-NULL after modification.
+
+# relacl: NULL for tables with default privileges and virtual tables.
+query T
+SELECT relacl FROM pg_class WHERE relname = 't1'
+----
+NULL
+
+query T
+SELECT relacl FROM pg_class WHERE relname = 'pg_class'
+----
+NULL
+
+# relacl: non-NULL after GRANT.
+statement ok
+GRANT SELECT ON t1 TO testuser WITH GRANT OPTION
+
+query T
+SELECT relacl FROM pg_class WHERE relname = 't1'
+----
+{admin=Cradwtm/root,root=Cradwtm/root,testuser=r*/root}
+
+# relacl: returns to NULL after revoking back to defaults.
+statement ok
+REVOKE SELECT ON t1 FROM testuser
+
+query T
+SELECT relacl FROM pg_class WHERE relname = 't1'
+----
+NULL
+
+# nspacl: non-NULL for public schema (has PUBLIC privileges beyond defaults).
+# NULL for virtual schemas.
+query T
+SELECT nspacl FROM pg_namespace WHERE nspname = 'public'
+----
+{admin=CU/root,=CU/root,root=CU/root}
+
+query T
+SELECT nspacl FROM pg_namespace WHERE nspname = 'pg_catalog'
+----
+NULL
+
+# nspacl: NULL for user-defined schema with default privileges.
+statement ok
+CREATE SCHEMA acl_test_schema
+
+query T
+SELECT nspacl FROM pg_namespace WHERE nspname = 'acl_test_schema'
+----
+NULL
+
+# nspacl: non-NULL after GRANT.
+statement ok
+GRANT USAGE ON SCHEMA acl_test_schema TO testuser
+
+query T
+SELECT nspacl FROM pg_namespace WHERE nspname = 'acl_test_schema'
+----
+{admin=CU/root,root=CU/root,testuser=U/root}
+
+# nspacl: returns to NULL after revoking back to defaults.
+statement ok
+REVOKE USAGE ON SCHEMA acl_test_schema FROM testuser
+
+query T
+SELECT nspacl FROM pg_namespace WHERE nspname = 'acl_test_schema'
+----
+NULL
+
+# datacl: NULL for databases with default privileges.
+query T
+SELECT datacl FROM pg_database WHERE datname = 'defaultdb'
+----
+NULL
+
+# datacl: non-NULL after GRANT.
+statement ok
+GRANT CONNECT ON DATABASE defaultdb TO testuser
+
+query T
+SELECT datacl FROM pg_database WHERE datname = 'defaultdb'
+----
+{admin=CcT/root,=cT/root,root=CcT/root,testuser=c/root}
+
+# datacl: returns to NULL after revoking back to defaults.
+statement ok
+REVOKE CONNECT ON DATABASE defaultdb FROM testuser
+
+query T
+SELECT datacl FROM pg_database WHERE datname = 'defaultdb'
+----
+NULL
+
+# proacl: NULL for user-defined functions with default privileges.
+# NULL for builtins.
+statement ok
+CREATE FUNCTION acl_test_fn() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
+
+query T
+SELECT proacl FROM pg_proc WHERE proname = 'acl_test_fn'
+----
+NULL
+
+# proacl: non-NULL after revoking from PUBLIC.
+statement ok
+REVOKE EXECUTE ON FUNCTION acl_test_fn FROM public
+
+query T
+SELECT proacl FROM pg_proc WHERE proname = 'acl_test_fn'
+----
+{admin=X/root,root=X/root}
+
+# proacl: returns to NULL after restoring defaults.
+statement ok
+GRANT EXECUTE ON FUNCTION acl_test_fn TO public
+
+query T
+SELECT proacl FROM pg_proc WHERE proname = 'acl_test_fn'
+----
+NULL
+
+query T
+SELECT proacl FROM pg_proc WHERE proname = 'substring' LIMIT 1
+----
+NULL
+
+# typacl: NULL for user-defined types with default privileges and built-in types.
+statement ok
+CREATE TYPE acl_test_type AS ENUM ('x', 'y')
+
+query T
+SELECT typacl FROM pg_type WHERE typname = 'acl_test_type'
+----
+NULL
+
+query T
+SELECT typacl FROM pg_type WHERE typname = 'int4'
+----
+NULL
+
+# typacl: non-NULL after revoking from PUBLIC.
+statement ok
+REVOKE USAGE ON TYPE acl_test_type FROM public
+
+query T
+SELECT typacl FROM pg_type WHERE typname = 'acl_test_type'
+----
+{admin=U/root,root=U/root}
+
+# typacl: returns to NULL after restoring defaults.
+statement ok
+GRANT USAGE ON TYPE acl_test_type TO public
+
+query T
+SELECT typacl FROM pg_type WHERE typname = 'acl_test_type'
+----
+NULL
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5837,4 +5837,50 @@ SELECT typacl FROM pg_type WHERE typname = 'acl_test_type'
 ----
 NULL
 
+# ACL columns for objects owned by a non-root user.
+# The owner's implicit ALL privileges should appear in the ACL array,
+# and default privileges should still return NULL.
+
+statement ok
+CREATE USER testowner
+
+statement ok
+CREATE TABLE testowner_table (id INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE testowner_table OWNER TO testowner
+
+# relacl: NULL for table with default privileges, even with non-root owner.
+query T
+SELECT relacl FROM pg_class WHERE relname = 'testowner_table'
+----
+NULL
+
+# relacl: non-NULL after GRANT, includes the owner entry.
+statement ok
+GRANT SELECT ON testowner_table TO testuser
+
+query T
+SELECT relacl FROM pg_class WHERE relname = 'testowner_table'
+----
+{admin=Cradwtm/testowner,root=Cradwtm/testowner,testuser=r/testowner,testowner=Cradwtm/testowner}
+
+# relacl: returns to NULL after revoking back to defaults.
+statement ok
+REVOKE SELECT ON testowner_table FROM testuser
+
+query T
+SELECT relacl FROM pg_class WHERE relname = 'testowner_table'
+----
+NULL
+
+# nspacl: NULL for schema with default privileges owned by non-root user.
+statement ok
+CREATE SCHEMA testowner_schema AUTHORIZATION testowner
+
+query T
+SELECT nspacl FROM pg_namespace WHERE nspname = 'testowner_schema'
+----
+NULL
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl
@@ -34,8 +34,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -55,18 +55,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,foo=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/,foo=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,foo=X*/,=X/}
-3755498903  2026795574  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/}
-3755498903  2026795574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/}
+3755498903  2026795574  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
 3755498903  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
 3755498903  2026795574  0                f              {bar=X*/,foo=X*/,=X/}
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -94,8 +94,8 @@ oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 3755498903  2026795574  0                T              {=U/}
 3755498903  2026795574  0                n              {}
 3755498903  2026795574  0                f              {=X/}
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -118,18 +118,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*r*t*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*r*a*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -143,18 +143,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*t*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*a*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -166,18 +166,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -195,17 +195,17 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
-1451375629  1546506610  0                r              {bar=C*a*d*m*t*w*/,foo=C*a*d*m*t*w*/}
+1451375629  1546506610  0                r              {bar=C*a*d*w*t*m*/,foo=C*a*d*w*t*m*/}
 1451375629  1546506610  0                f              {root=X/}
 
 # GRANT, DROP and ZONECONFIG should not show up in defaclacl.
@@ -217,13 +217,13 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
@@ -246,19 +246,19 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
 1451375629  1546506610  0                f              {root=X/}
-880552153   0           0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/}
-880552153   0           0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+880552153   0           0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/}
+880552153   0           0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/}
 880552153   0           0                T              {bar=U*/,foo=U*/}
 880552153   0           0                n              {bar=C*U*/,foo=C*U*/}
 880552153   0           0                f              {bar=X*/,foo=X*/}
@@ -274,13 +274,13 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
@@ -301,13 +301,13 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
@@ -326,13 +326,13 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
@@ -353,13 +353,13 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
@@ -383,19 +383,19 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,=X/}
-3755498903  2026795574  0                r              {foo=C*a*d*m*rt*w*/}
-3755498903  2026795574  0                S              {foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {foo=C*ra*d*w*t*m*/}
+3755498903  2026795574  0                S              {foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {foo=U*/,=U/}
 3755498903  2026795574  0                n              {foo=C*U*/}
 3755498903  2026795574  0                f              {foo=X*/,=X/}
 1451375629  1546506610  0                f              {root=X/}
-2709666228  2264919399  0                r              {foo=C*a*d*m*r*t*w*/}
-2709666228  2264919399  0                S              {foo=C*U*a*d*r*w*/}
+2709666228  2264919399  0                r              {foo=C*r*a*d*w*t*m*/}
+2709666228  2264919399  0                S              {foo=C*r*a*d*w*U*/}
 2709666228  2264919399  0                T              {foo=U*/,testuser=U*/}
 2709666228  2264919399  0                n              {foo=C*U*/}
 2709666228  2264919399  0                f              {foo=X*/,=X/}
@@ -412,7 +412,7 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL WHERE defaclnamespace != 0
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-3426387245  2264919399  105              r              {foo=adrw/}
-3426387245  2264919399  105              S              {foo=CUadrw/}
+3426387245  2264919399  105              r              {foo=radw/}
+3426387245  2264919399  105              S              {foo=CradwU/}
 3426387245  2264919399  105              T              {foo=U/}
 3426387245  2264919399  105              f              {foo=X/}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
@@ -50,8 +50,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/,=r/}
-1451375629  1546506610  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/,=r/}
+1451375629  1546506610  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/,=r/}
 1451375629  1546506610  0                T              {bar=U*/,foo=U*/}
 1451375629  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 1451375629  1546506610  0                f              {bar=X*/,foo=X*/}
@@ -75,8 +75,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=C*a*dm*rt*w*/,foo=C*a*dm*rt*w*/,=r/}
-1451375629  1546506610  0                S              {bar=CU*a*d*r*w/,foo=CU*a*d*r*w/,=r/}
+1451375629  1546506610  0                r              {bar=C*ra*dw*t*m*/,foo=C*ra*dw*t*m*/,=r/}
+1451375629  1546506610  0                S              {bar=Cr*a*d*wU*/,foo=Cr*a*d*wU*/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU*/,foo=CU*/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -100,8 +100,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=Cadmrtw/,foo=Cadmrtw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451375629  1546506610  0                r              {bar=Cradwtm/,foo=Cradwtm/,=r/}
+1451375629  1546506610  0                S              {bar=CradwU/,foo=CradwU/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -129,18 +129,18 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-97389596    1791217281  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/}
-97389596    1791217281  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+97389596    1791217281  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/}
+97389596    1791217281  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/}
 97389596    1791217281  0                T              {bar=U*/,foo=U*/,=U/}
 97389596    1791217281  0                n              {bar=C*U*/,foo=C*U*/}
 97389596    1791217281  0                f              {bar=X*/,foo=X*/,=X/}
-3755498903  2026795574  0                r              {bar=C*a*d*m*r*t*w*/,foo=C*a*d*m*r*t*w*/}
-3755498903  2026795574  0                S              {bar=C*U*a*d*r*w*/,foo=C*U*a*d*r*w*/}
+3755498903  2026795574  0                r              {bar=C*r*a*d*w*t*m*/,foo=C*r*a*d*w*t*m*/}
+3755498903  2026795574  0                S              {bar=C*r*a*d*w*U*/,foo=C*r*a*d*w*U*/}
 3755498903  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
 3755498903  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
 3755498903  2026795574  0                f              {bar=X*/,foo=X*/,=X/}
-1451375629  1546506610  0                r              {bar=Cadmrtw/,foo=Cadmrtw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451375629  1546506610  0                r              {bar=Cradwtm/,foo=Cradwtm/,=r/}
+1451375629  1546506610  0                S              {bar=CradwU/,foo=CradwU/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -176,8 +176,8 @@ oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 3755498903  2026795574  0                T              {=U/}
 3755498903  2026795574  0                n              {}
 3755498903  2026795574  0                f              {=X/}
-1451375629  1546506610  0                r              {bar=Cadmrtw/,foo=Cadmrtw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451375629  1546506610  0                r              {bar=Cradwtm/,foo=Cradwtm/,=r/}
+1451375629  1546506610  0                S              {bar=CradwU/,foo=CradwU/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -249,8 +249,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=Cadmrtw/,foo=Cadmrtw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451375629  1546506610  0                r              {bar=Cradwtm/,foo=Cradwtm/,=r/}
+1451375629  1546506610  0                S              {bar=CradwU/,foo=CradwU/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -264,8 +264,8 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 3755498903  2026795574  0                T              {foo=U*/,=U/}
-1451375629  1546506610  0                r              {bar=Cadmrtw/,foo=Cadmrtw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451375629  1546506610  0                r              {bar=Cradwtm/,foo=Cradwtm/,=r/}
+1451375629  1546506610  0                S              {bar=CradwU/,foo=CradwU/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}
@@ -278,8 +278,8 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
-1451375629  1546506610  0                r              {bar=Cadmrtw/,foo=Cadmrtw/,=r/}
-1451375629  1546506610  0                S              {bar=CUadrw/,foo=CUadrw/,=r/}
+1451375629  1546506610  0                r              {bar=Cradwtm/,foo=Cradwtm/,=r/}
+1451375629  1546506610  0                S              {bar=CradwU/,foo=CradwU/,=r/}
 1451375629  1546506610  0                T              {bar=U/,foo=U/}
 1451375629  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 1451375629  1546506610  0                f              {bar=X/,foo=X/}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1569,13 +1569,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 					privilegeObjectType := targetObjectToPrivilegeObject[objectType]
 					arr := tree.NewDArray(types.AclItem)
 					for _, userPrivs := range privs.Users {
-						var user string
-						if userPrivs.UserProto.Decode().IsPublicRole() {
-							// Postgres represents Public in defacl as an empty string.
-							user = ""
-						} else {
-							user = userPrivs.UserProto.Decode().Normalized()
-						}
+						user := userPrivs.UserProto.Decode()
 
 						privileges, err := privilege.ListFromBitField(
 							userPrivs.Privileges, privilegeObjectType,
@@ -1635,7 +1629,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 						// when objectType is not privilege.Types or privilege.Routines
 						if publicHasUsage {
 							defaclItem, err := createDefACLItem(
-								"" /* public role */, privilege.List{privilegeKind}, privilege.List{}, privilegeObjectType,
+								username.PublicRoleName(), privilege.List{privilegeKind}, privilege.List{}, privilegeObjectType,
 							)
 							if err != nil {
 								return err
@@ -1649,7 +1643,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							}
 						} else if roleHasAllPrivileges {
 							defaclItem, err := createDefACLItem(
-								defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode().Normalized(),
+								defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode(),
 								privilege.List{privilege.ALL}, privilege.List{}, privilegeObjectType,
 							)
 							if err != nil {
@@ -1718,25 +1712,36 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 }
 
 func createDefACLItem(
-	user string,
+	user username.SQLUsername,
 	privileges privilege.List,
 	grantOptions privilege.List,
 	privilegeObjectType privilege.ObjectType,
 ) (string, error) {
-	acl, err := privileges.ListToACL(
-		grantOptions,
-		privilegeObjectType,
-	)
-	if err != nil {
-		return "", err
+	// Expand ALL into the underlying privileges for this object type.
+	expanded := privileges
+	if privileges.Contains(privilege.ALL) {
+		var err error
+		expanded, err = privilege.GetValidPrivilegesForObject(privilegeObjectType)
+		if err != nil {
+			return "", err
+		}
 	}
-	return fmt.Sprintf(`%s=%s/%s`,
+	expandedGO := grantOptions
+	if grantOptions.Contains(privilege.ALL) {
+		var err error
+		expandedGO, err = privilege.GetValidPrivilegesForObject(privilegeObjectType)
+		if err != nil {
+			return "", err
+		}
+	}
+	// Empty grantor: CockroachDB does not track grantors.
+	// See: https://github.com/cockroachdb/cockroach/issues/67442.
+	item := privilege.NewACLItem(
 		user,
-		acl,
-		// TODO(richardjcai): CockroachDB currently does not track grantors
-		//    See: https://github.com/cockroachdb/cockroach/issues/67442.
-		"", /* grantor */
-	), nil
+		username.MakeSQLUsernameFromPreNormalizedString(""),
+		expanded, expandedGO,
+	)
+	return item.String(), nil
 }
 
 // privilegeDescriptorToACLArray converts a PrivilegeDescriptor into a
@@ -1759,67 +1764,56 @@ func privilegeDescriptorToACLArray(
 		return tree.DNull, nil
 	}
 	owner := privDesc.Owner()
-	quotedOwner := privilege.QuoteACLIdentifier(owner.Normalized())
 
-	var aclItems []string
+	var aclItems []privilege.ACLItem
 	for _, userPriv := range privDesc.Users {
-		var grantee string
-		if userPriv.User().IsPublicRole() {
-			// Empty grantee means PUBLIC in aclitem format.
-			grantee = ""
-		} else {
-			grantee = privilege.QuoteACLIdentifier(userPriv.User().Normalized())
-		}
+		grantee := userPriv.User()
 		privileges, err := privilege.ListFromBitField(
 			userPriv.Privileges, objectType,
 		)
 		if err != nil {
 			return nil, err
 		}
+		// Expand ALL into the underlying privileges.
+		if privileges.Contains(privilege.ALL) {
+			privileges, err = privilege.GetValidPrivilegesForObject(objectType)
+			if err != nil {
+				return nil, err
+			}
+		}
 		// Strip grant options for admin, root, and owner — their grant
 		// options are implicit in PostgreSQL convention.
 		var grantOptions privilege.List
-		user := userPriv.User()
-		if !user.IsAdminRole() && !user.IsRootUser() && user != owner {
+		if !grantee.IsAdminRole() && !grantee.IsRootUser() && grantee != owner {
 			grantOptions, err = privilege.ListFromBitField(
 				userPriv.WithGrantOption, objectType,
 			)
 			if err != nil {
 				return nil, err
 			}
-		}
-		acl, err := privileges.ListToACL(grantOptions, objectType)
-		if err != nil {
-			return nil, err
+			if grantOptions.Contains(privilege.ALL) {
+				grantOptions, err = privilege.GetValidPrivilegesForObject(objectType)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
 		// The owner is used as the grantor because CockroachDB does not
 		// track the actual grantor. See #67442.
-		aclItems = append(aclItems, fmt.Sprintf("%s=%s/%s", grantee, acl, quotedOwner))
+		aclItems = append(aclItems, privilege.NewACLItem(
+			grantee, owner, privileges, grantOptions,
+		))
 	}
 
-	// Compare against defaults using set comparison. If the actual
-	// privileges match the defaults, return NULL.
-	defaults, err := privilege.DefaultACLItems(objectType, owner)
-	if err == nil && len(aclItems) == len(defaults) {
-		actualSet := make(map[string]bool, len(aclItems))
-		for _, item := range aclItems {
-			actualSet[item] = true
-		}
-		allMatch := true
-		for _, d := range defaults {
-			if !actualSet[d] {
-				allMatch = false
-				break
-			}
-		}
-		if allMatch {
-			return tree.DNull, nil
-		}
+	// If the actual privileges match the defaults, return NULL.
+	isDefault, err := privilege.IsDefaultACL(aclItems, objectType, owner)
+	if err == nil && isDefault {
+		return tree.DNull, nil
 	}
 
 	arr := tree.NewDArray(types.AclItem)
-	for _, aclItem := range aclItems {
-		d, err := tree.NewDACLItem(aclItem)
+	for _, item := range aclItems {
+		d, err := tree.NewDACLItem(item.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1792,6 +1792,29 @@ func privilegeDescriptorToACLArray(
 		))
 	}
 
+	// If the owner is not explicitly listed in the privilege descriptor
+	// (common for non-root, non-admin owners), add their implicit ALL
+	// privileges. This mirrors PostgreSQL behavior where the owner
+	// always appears in the ACL array.
+	if !owner.IsNodeUser() && !owner.Undefined() {
+		sawOwner := false
+		for _, userPriv := range privDesc.Users {
+			if userPriv.User() == owner {
+				sawOwner = true
+				break
+			}
+		}
+		if !sawOwner {
+			ownerPrivs, err := privilege.GetValidPrivilegesForObject(objectType)
+			if err != nil {
+				return nil, err
+			}
+			aclItems = append(aclItems, privilege.NewACLItem(
+				owner, owner, ownerPrivs, privilege.List{},
+			))
+		}
+	}
+
 	// If the actual privileges match the defaults, return NULL.
 	isDefault, err := privilege.IsDefaultACL(aclItems, objectType, owner)
 	if err == nil && isDefault {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -852,6 +852,24 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 		if err != nil {
 			return err
 		}
+		// Only populate relacl for user-defined tables. Virtual tables
+		// (pg_catalog, information_schema) should return NULL to match
+		// PostgreSQL behavior and avoid pg_dump emitting spurious
+		// GRANT/REVOKE statements.
+		var relacl tree.Datum = tree.DNull
+		if sc.SchemaKind() != catalog.SchemaVirtual {
+			privObjectType := privilege.Table
+			if table.IsSequence() {
+				privObjectType = privilege.Sequence
+			}
+			var err error
+			relacl, err = privilegeDescriptorToACLArray(
+				table.GetPrivileges(), privObjectType,
+			)
+			if err != nil {
+				return err
+			}
+		}
 		implicitTypOID := typedesc.TableIDToImplicitTypeOID(table.GetID())
 		namespaceOid := schemaOid(sc.GetID())
 		if err := addRow(
@@ -881,7 +899,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			tree.DBoolFalse, // relhastriggers
 			tree.DBoolFalse, // relhassubclass
 			zeroVal,         // relfrozenxid
-			tree.DNull,      // relacl
+			relacl,          // relacl
 			relOptions,      // reloptions
 			// These columns were automatically created by pg_catalog_test's missing column generator.
 			tree.MakeDBool(tree.DBool(table.IsRowLevelSecurityForced())), // relforcerowsecurity
@@ -1457,6 +1475,12 @@ https://www.postgresql.org/docs/9.5/catalog-pg-database.html`,
 				if err != nil {
 					return err
 				}
+				datacl, err := privilegeDescriptorToACLArray(
+					db.GetPrivileges(), privilege.Database,
+				)
+				if err != nil {
+					return err
+				}
 				return addRow(
 					dbOid(db.GetID()),           // oid
 					tree.NewDName(db.GetName()), // datname
@@ -1473,7 +1497,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-database.html`,
 					tree.DNull,                 // datfrozenxid
 					tree.DNull,                 // datminmxid
 					oidZero,                    // dattablespace
-					tree.DNull,                 // datacl
+					datacl,                     // datacl
 				)
 			})
 	},
@@ -1713,6 +1737,97 @@ func createDefACLItem(
 		//    See: https://github.com/cockroachdb/cockroach/issues/67442.
 		"", /* grantor */
 	), nil
+}
+
+// privilegeDescriptorToACLArray converts a PrivilegeDescriptor into a
+// tree.DArray of aclitem strings suitable for pg_catalog ACL columns
+// (e.g. pg_class.relacl, pg_namespace.nspacl). Each user's privileges
+// are formatted as "grantee=privchars/grantor" per PostgreSQL convention.
+// Only privileges that have a PostgreSQL ACL character equivalent are
+// included; CockroachDB-specific privileges (BACKUP, CHANGEFEED, etc.)
+// are silently skipped by ListToACL.
+//
+// Grant option markers ('*') are stripped for admin, root, and the owner,
+// since their grant options are implicit (matching PostgreSQL behavior).
+//
+// If the resulting ACL matches the default privileges for the object type,
+// NULL is returned (matching PostgreSQL behavior where NULL means defaults).
+func privilegeDescriptorToACLArray(
+	privDesc *catpb.PrivilegeDescriptor, objectType privilege.ObjectType,
+) (tree.Datum, error) {
+	if privDesc == nil {
+		return tree.DNull, nil
+	}
+	owner := privDesc.Owner()
+	quotedOwner := privilege.QuoteACLIdentifier(owner.Normalized())
+
+	var aclItems []string
+	for _, userPriv := range privDesc.Users {
+		var grantee string
+		if userPriv.User().IsPublicRole() {
+			// Empty grantee means PUBLIC in aclitem format.
+			grantee = ""
+		} else {
+			grantee = privilege.QuoteACLIdentifier(userPriv.User().Normalized())
+		}
+		privileges, err := privilege.ListFromBitField(
+			userPriv.Privileges, objectType,
+		)
+		if err != nil {
+			return nil, err
+		}
+		// Strip grant options for admin, root, and owner — their grant
+		// options are implicit in PostgreSQL convention.
+		var grantOptions privilege.List
+		user := userPriv.User()
+		if !user.IsAdminRole() && !user.IsRootUser() && user != owner {
+			grantOptions, err = privilege.ListFromBitField(
+				userPriv.WithGrantOption, objectType,
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+		acl, err := privileges.ListToACL(grantOptions, objectType)
+		if err != nil {
+			return nil, err
+		}
+		// The owner is used as the grantor because CockroachDB does not
+		// track the actual grantor. See #67442.
+		aclItems = append(aclItems, fmt.Sprintf("%s=%s/%s", grantee, acl, quotedOwner))
+	}
+
+	// Compare against defaults using set comparison. If the actual
+	// privileges match the defaults, return NULL.
+	defaults, err := privilege.DefaultACLItems(objectType, owner)
+	if err == nil && len(aclItems) == len(defaults) {
+		actualSet := make(map[string]bool, len(aclItems))
+		for _, item := range aclItems {
+			actualSet[item] = true
+		}
+		allMatch := true
+		for _, d := range defaults {
+			if !actualSet[d] {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			return tree.DNull, nil
+		}
+	}
+
+	arr := tree.NewDArray(types.AclItem)
+	for _, aclItem := range aclItems {
+		d, err := tree.NewDACLItem(aclItem)
+		if err != nil {
+			return nil, err
+		}
+		if err := arr.Append(d); err != nil {
+			return nil, err
+		}
+	}
+	return arr, nil
 }
 
 var (
@@ -2424,11 +2539,24 @@ https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 					} else if sc.SchemaKind() == catalog.SchemaVirtual {
 						ownerOID = nodeOID
 					}
+					// Virtual schemas (pg_catalog, information_schema, etc.)
+					// should return NULL nspacl to match PostgreSQL behavior
+					// and avoid pg_dump emitting spurious GRANT/REVOKE.
+					var nspacl tree.Datum = tree.DNull
+					if sc.SchemaKind() != catalog.SchemaVirtual {
+						var err error
+						nspacl, err = privilegeDescriptorToACLArray(
+							sc.GetPrivileges(), privilege.Schema,
+						)
+						if err != nil {
+							return err
+						}
+					}
 					return addRow(
 						schemaOid(sc.GetID()),         // oid
 						tree.NewDString(sc.GetName()), // nspname
 						ownerOID,                      // nspowner
-						tree.DNull,                    // nspacl
+						nspacl,                        // nspacl
 					)
 				})
 			})
@@ -2485,11 +2613,21 @@ https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 				} else if sc.SchemaKind() == catalog.SchemaVirtual {
 					ownerOID = nodeOID
 				}
+				var nspacl tree.Datum = tree.DNull
+				if sc.SchemaKind() != catalog.SchemaVirtual {
+					var err error
+					nspacl, err = privilegeDescriptorToACLArray(
+						sc.GetPrivileges(), privilege.Schema,
+					)
+					if err != nil {
+						return false, err
+					}
+				}
 				if err := addRow(
 					schemaOid(sc.GetID()),         // oid
 					tree.NewDString(sc.GetName()), // nspname
 					ownerOID,                      // nspowner
-					tree.DNull,                    // nspacl
+					nspacl,                        // nspacl
 				); err != nil {
 					return false, err
 				}
@@ -2927,6 +3065,12 @@ func addPgProcUDFRow(
 	if nArgDefaults > 0 {
 		argDefaults = tree.NewDString("(" + argDefaultsBuilder.String() + ")")
 	}
+	proacl, err := privilegeDescriptorToACLArray(
+		fnDesc.GetPrivileges(), privilege.Routine,
+	)
+	if err != nil {
+		return err
+	}
 	return addRow(
 		tree.NewDOid(catid.FuncIDToOID(fnDesc.GetID())), // oid
 		tree.NewDName(fnDesc.GetName()),                 // proname
@@ -2957,7 +3101,7 @@ func addPgProcUDFRow(
 		tree.DNull,                                      // probin
 		tree.DNull,                                      // prosqlbody
 		tree.DNull,                                      // proconfig
-		tree.DNull,                                      // proacl
+		proacl,                                          // proacl
 	)
 }
 
@@ -3685,7 +3829,7 @@ func addPGTypeRowForTable(
 		oidZero,         // typcollation
 		tree.DNull,      // typdefaultbin
 		tree.DNull,      // typdefault
-		tree.DNull,      // typacl
+		tree.DNull,      // typacl - composite types inherit table's ACL
 	)
 }
 
@@ -3695,6 +3839,7 @@ func addPGTypeRow(
 	owner tree.Datum,
 	typ *types.T,
 	isUDT bool,
+	privDesc *catpb.PrivilegeDescriptor,
 	addRow func(...tree.Datum) error,
 ) error {
 	cat := typCategory(typ)
@@ -3754,6 +3899,14 @@ func addPGTypeRow(
 	}
 	typname := typ.PGName()
 	typDelim := tree.NewDString(typ.Delimiter())
+	var typacl tree.Datum = tree.DNull
+	if privDesc != nil {
+		var err error
+		typacl, err = privilegeDescriptorToACLArray(privDesc, privilege.Type)
+		if err != nil {
+			return err
+		}
+	}
 	return addRow(
 		tree.NewDOid(typ.Oid()), // oid
 		tree.NewDName(typname),  // typname
@@ -3788,7 +3941,7 @@ func addPGTypeRow(
 		typColl(typ, h), // typcollation
 		tree.DNull,      // typdefaultbin
 		tree.DNull,      // typdefault
-		tree.DNull,      // typacl
+		typacl,          // typacl
 	)
 }
 
@@ -3937,7 +4090,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 
 				// Generate rows for all predefined types.
 				for _, typ := range types.OidToType {
-					if err := addPGTypeRow(h, nspOid, tree.DNull /* owner */, typ, false /* isUDT */, addRow); err != nil {
+					if err := addPGTypeRow(h, nspOid, tree.DNull /* owner */, typ, false /* isUDT */, nil /* privDesc */, addRow); err != nil {
 						return err
 					}
 				}
@@ -3970,7 +4123,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 						if err != nil {
 							return err
 						}
-						return addPGTypeRow(h, nspOid, ownerOid, typ, true /* isUDT */, addRow)
+						return addPGTypeRow(h, nspOid, ownerOid, typ, true /* isUDT */, typDesc.GetPrivileges(), addRow)
 					},
 				)
 			},
@@ -3990,7 +4143,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				// Check if it is a predefined type.
 				typ, ok := types.OidToType[ooid]
 				if ok {
-					if err := addPGTypeRow(h, nspOid, tree.DNull /* owner */, typ, false /* isUDT */, addRow); err != nil {
+					if err := addPGTypeRow(h, nspOid, tree.DNull /* owner */, typ, false /* isUDT */, nil /* privDesc */, addRow); err != nil {
 						return false, err
 					}
 					return true, nil
@@ -4063,7 +4216,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				if err != nil {
 					return false, err
 				}
-				if err := addPGTypeRow(h, nspOid, ownerOid, typ, true /* isUDT */, addRow); err != nil {
+				if err := addPGTypeRow(h, nspOid, ownerOid, typ, true /* isUDT */, typDesc.GetPrivileges(), addRow); err != nil {
 					return false, err
 				}
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1587,11 +1587,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 						if err != nil {
 							return err
 						}
-						aclDatum, err := tree.NewDACLItem(defaclItem)
-						if err != nil {
-							return err
-						}
-						if err := arr.Append(aclDatum); err != nil {
+						if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
 							return err
 						}
 					}
@@ -1634,11 +1630,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							if err != nil {
 								return err
 							}
-							aclDatum, err := tree.NewDACLItem(defaclItem)
-							if err != nil {
-								return err
-							}
-							if err := arr.Append(aclDatum); err != nil {
+							if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
 								return err
 							}
 						} else if roleHasAllPrivileges {
@@ -1649,11 +1641,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 							if err != nil {
 								return err
 							}
-							aclDatum, err := tree.NewDACLItem(defaclItem)
-							if err != nil {
-								return err
-							}
-							if err := arr.Append(aclDatum); err != nil {
+							if err := arr.Append(tree.NewDACLItem(defaclItem)); err != nil {
 								return err
 							}
 						} else if len(privs.Users) == 0 && schemaID != descpb.InvalidID {
@@ -1716,14 +1704,14 @@ func createDefACLItem(
 	privileges privilege.List,
 	grantOptions privilege.List,
 	privilegeObjectType privilege.ObjectType,
-) (string, error) {
+) (privilege.ACLItem, error) {
 	// Expand ALL into the underlying privileges for this object type.
 	expanded := privileges
 	if privileges.Contains(privilege.ALL) {
 		var err error
 		expanded, err = privilege.GetValidPrivilegesForObject(privilegeObjectType)
 		if err != nil {
-			return "", err
+			return privilege.ACLItem{}, err
 		}
 	}
 	expandedGO := grantOptions
@@ -1731,17 +1719,16 @@ func createDefACLItem(
 		var err error
 		expandedGO, err = privilege.GetValidPrivilegesForObject(privilegeObjectType)
 		if err != nil {
-			return "", err
+			return privilege.ACLItem{}, err
 		}
 	}
 	// Empty grantor: CockroachDB does not track grantors.
 	// See: https://github.com/cockroachdb/cockroach/issues/67442.
-	item := privilege.NewACLItem(
+	return privilege.NewACLItem(
 		user,
 		username.MakeSQLUsernameFromPreNormalizedString(""),
 		expanded, expandedGO,
-	)
-	return item.String(), nil
+	), nil
 }
 
 // privilegeDescriptorToACLArray converts a PrivilegeDescriptor into a
@@ -1813,11 +1800,7 @@ func privilegeDescriptorToACLArray(
 
 	arr := tree.NewDArray(types.AclItem)
 	for _, item := range aclItems {
-		d, err := tree.NewDACLItem(item.String())
-		if err != nil {
-			return nil, err
-		}
-		if err := arr.Append(d); err != nil {
+		if err := arr.Append(tree.NewDACLItem(item)); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -980,7 +980,8 @@ func DecodeDatum(
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}
-		d, err := tree.NewDACLItem(bs)
+		s := tree.DString(bs)
+		d, err := tree.NewDACLItemFromDString(&s)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -4,6 +4,7 @@ load("//build:STRINGER.bzl", "stringer")
 go_library(
     name = "privilege",
     srcs = [
+        "aclitem.go",
         "kind.go",
         "privilege.go",
         "target_object_type.go",
@@ -25,12 +26,16 @@ go_test(
     name = "privilege_test",
     size = "small",
     srcs = [
+        "aclitem_test.go",
         "main_test.go",
         "privilege_test.go",
     ],
+    data = glob(["testdata/**"]),
     deps = [
         ":privilege",
         "//pkg/security/username",
+        "//pkg/testutils/datapathutils",
+        "//pkg/testutils/echotest",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/privilege",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/security/username",
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
@@ -29,6 +30,7 @@ go_test(
     ],
     deps = [
         ":privilege",
+        "//pkg/security/username",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/privilege/aclitem.go
+++ b/pkg/sql/privilege/aclitem.go
@@ -1,0 +1,243 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package privilege
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/redact"
+)
+
+// ACLItem represents a PostgreSQL-compatible aclitem: grantee=privchars/grantor.
+// The PUBLIC role is represented by username.PublicRoleName() in the Grantee
+// field, which formats as an empty grantee (e.g. "=rw/root").
+//
+// Privileges and GrantOptions must contain already-expanded privilege kinds
+// (callers must not pass ALL). GrantOptions must be a subset of Privileges.
+type ACLItem struct {
+	Grantee      username.SQLUsername
+	Grantor      username.SQLUsername
+	Privileges   List
+	GrantOptions List
+}
+
+// NewACLItem constructs an ACLItem. Privileges and grantOptions must be
+// already-expanded (no ALL). GrantOptions should be a subset of Privileges.
+func NewACLItem(grantee, grantor username.SQLUsername, privileges, grantOptions List) ACLItem {
+	return ACLItem{
+		Grantee:      grantee,
+		Grantor:      grantor,
+		Privileges:   privileges,
+		GrantOptions: grantOptions,
+	}
+}
+
+var _ redact.SafeFormatter = ACLItem{}
+
+// SafeFormat implements redact.SafeFormatter. Role names are PII and printed
+// without safe markers; privilege characters and structural characters
+// (=, /, *) are safe.
+func (a ACLItem) SafeFormat(w redact.SafePrinter, _ rune) {
+	if !a.Grantee.IsPublicRole() {
+		w.Print(QuoteACLIdentifier(a.Grantee.Normalized()))
+	}
+	w.SafeRune('=')
+	a.writePrivChars(w)
+	w.SafeRune('/')
+	w.Print(QuoteACLIdentifier(a.Grantor.Normalized()))
+}
+
+// String implements fmt.Stringer via redact.StringWithoutMarkers.
+func (a ACLItem) String() string {
+	return redact.StringWithoutMarkers(a)
+}
+
+// ParseACLItem parses a PostgreSQL aclitem string of the form
+// "grantee=privchars/grantor" and returns the structured ACLItem.
+// An empty grantee is interpreted as PUBLIC (username.PublicRoleName()).
+func ParseACLItem(s string) (ACLItem, error) {
+	i := 0
+
+	// Parse grantee.
+	granteeName, i := ExtractACLIdentifier(s, i)
+	if i < 0 {
+		return ACLItem{}, pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"unterminated quoted identifier: %q", s)
+	}
+	if i >= len(s) || s[i] != '=' {
+		return ACLItem{}, pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"missing \"=\" sign: %q", s)
+	}
+	i++ // skip '='
+
+	// Parse privilege characters and grant option markers.
+	var privs List
+	var grantOpts List
+	for i < len(s) && s[i] != '/' {
+		c := s[i]
+		if c == '*' {
+			return ACLItem{}, pgerror.Newf(pgcode.InvalidTextRepresentation,
+				"invalid mode character: \"*\" must follow a privilege character: %q", s)
+		}
+		if !isValidACLChar(c) {
+			return ACLItem{}, pgerror.Newf(pgcode.InvalidTextRepresentation,
+				"invalid mode character: %q", string(c))
+		}
+		privName := ACLCharToPrivName[c]
+		kind, ok := ByDisplayName[KindDisplayName(privName)]
+		if !ok {
+			// Character is valid per PostgreSQL but has no CRDB Kind.
+			// Skip it (matches ListToACL behavior of skipping unknown privs).
+			i++
+			if i < len(s) && s[i] == '*' {
+				i++
+			}
+			continue
+		}
+		privs = append(privs, kind)
+		i++
+		if i < len(s) && s[i] == '*' {
+			grantOpts = append(grantOpts, kind)
+			i++
+		}
+	}
+
+	// Parse grantor.
+	var grantorName string
+	if i < len(s) && s[i] == '/' {
+		i++ // skip '/'
+		grantorName, i = ExtractACLIdentifier(s, i)
+		if i < 0 {
+			return ACLItem{}, pgerror.Newf(pgcode.InvalidTextRepresentation,
+				"unterminated quoted identifier: %q", s)
+		}
+	}
+
+	if i != len(s) {
+		return ACLItem{}, pgerror.Newf(pgcode.InvalidTextRepresentation,
+			"extra characters after aclitem specification: %q", s)
+	}
+
+	grantee := username.PublicRoleName()
+	if granteeName != "" {
+		grantee = username.MakeSQLUsernameFromPreNormalizedString(granteeName)
+	}
+	grantor := username.MakeSQLUsernameFromPreNormalizedString(grantorName)
+
+	return ACLItem{
+		Grantee:      grantee,
+		Grantor:      grantor,
+		Privileges:   privs,
+		GrantOptions: grantOpts,
+	}, nil
+}
+
+// pgDefaultPublicPrivs lists the privileges granted to PUBLIC by default
+// for each object type, matching CockroachDB's actual defaults (see
+// NewBaseDatabasePrivilegeDescriptor, NewBaseFunctionPrivilegeDescriptor,
+// etc.).
+var pgDefaultPublicPrivs = map[ObjectType]List{
+	Database: {CONNECT, TEMPORARY},
+	Routine:  {EXECUTE},
+	Type:     {USAGE},
+}
+
+// DefaultACLItems computes the expected default aclitem entries for the given
+// object type and owner. Used by privilegeDescriptorToACLArray (to detect
+// default privileges and return NULL) and by the acldefault builtin.
+//
+// The returned items follow PostgreSQL conventions:
+//   - No '*' grant option markers for admin, root, or owner (implicit).
+//   - Only privileges with a PG ACL character equivalent are included.
+//   - PUBLIC entries come first.
+func DefaultACLItems(objectType ObjectType, owner username.SQLUsername) ([]ACLItem, error) {
+	ownerPrivs, err := GetValidPrivilegesForObject(objectType)
+	if err != nil {
+		return nil, err
+	}
+	// Filter to only privileges with a PG ACL character, excluding ALL.
+	var filtered List
+	for _, p := range ownerPrivs {
+		if p == ALL {
+			continue
+		}
+		if _, ok := privToACL[p]; ok {
+			filtered = append(filtered, p)
+		}
+	}
+
+	var items []ACLItem
+
+	// PUBLIC entry (empty grantee sorts first).
+	if publicPrivs, ok := pgDefaultPublicPrivs[objectType]; ok {
+		items = append(items, NewACLItem(
+			username.PublicRoleName(), owner, publicPrivs, nil,
+		))
+	}
+
+	// Admin and root entries.
+	items = append(items, NewACLItem(
+		username.AdminRoleName(), owner, filtered, nil,
+	))
+	items = append(items, NewACLItem(
+		username.RootUserName(), owner, filtered, nil,
+	))
+
+	// Owner entry (if different from admin and root).
+	if !owner.IsAdminRole() && !owner.IsRootUser() {
+		items = append(items, NewACLItem(owner, owner, filtered, nil))
+	}
+
+	return items, nil
+}
+
+// IsDefaultACL returns true if the given ACL items match the default
+// privileges for the specified object type and owner. Comparison is
+// order-independent and based on string representation.
+func IsDefaultACL(
+	items []ACLItem, objectType ObjectType, owner username.SQLUsername,
+) (bool, error) {
+	defaults, err := DefaultACLItems(objectType, owner)
+	if err != nil {
+		return false, err
+	}
+	if len(items) != len(defaults) {
+		return false, nil
+	}
+	actualSet := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		actualSet[item.String()] = struct{}{}
+	}
+	for _, d := range defaults {
+		if _, ok := actualSet[d.String()]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// writePrivChars writes the sorted privilege characters (with '*' grant
+// option markers) to the SafePrinter. Privileges without a PostgreSQL ACL
+// character equivalent are silently skipped.
+func (a ACLItem) writePrivChars(w redact.SafePrinter) {
+	sorted := make(List, len(a.Privileges))
+	copy(sorted, a.Privileges)
+	sort.Sort(sorted)
+
+	for _, p := range sorted {
+		ch, ok := privToACL[p]
+		if !ok {
+			continue
+		}
+		w.SafeString(redact.SafeString(ch))
+		if a.GrantOptions.Contains(p) {
+			w.SafeRune('*')
+		}
+	}
+}

--- a/pkg/sql/privilege/aclitem_test.go
+++ b/pkg/sql/privilege/aclitem_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package privilege_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestACLItemString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name         string
+		grantee      username.SQLUsername
+		grantor      username.SQLUsername
+		privs        privilege.List
+		grantOptions privilege.List
+		expected     string
+	}{
+		{
+			name:     "basic privileges",
+			grantee:  username.MakeSQLUsernameFromPreNormalizedString("user1"),
+			grantor:  username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:    privilege.List{privilege.SELECT, privilege.INSERT},
+			expected: "user1=ra/root",
+		},
+		{
+			name:         "with grant options",
+			grantee:      username.MakeSQLUsernameFromPreNormalizedString("user1"),
+			grantor:      username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:        privilege.List{privilege.SELECT, privilege.INSERT},
+			grantOptions: privilege.List{privilege.SELECT},
+			expected:     "user1=r*a/root",
+		},
+		{
+			name:     "PUBLIC grantee",
+			grantee:  username.PublicRoleName(),
+			grantor:  username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:    privilege.List{privilege.CONNECT, privilege.TEMPORARY},
+			expected: "=cT/root",
+		},
+		{
+			name:     "special characters in names",
+			grantee:  username.MakeSQLUsernameFromPreNormalizedString("user-1"),
+			grantor:  username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:    privilege.List{privilege.SELECT},
+			expected: `"user-1"=r/root`,
+		},
+		{
+			name:     "all table privileges",
+			grantee:  username.MakeSQLUsernameFromPreNormalizedString("admin"),
+			grantor:  username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:    privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT, privilege.DELETE, privilege.UPDATE, privilege.TRIGGER, privilege.MAINTAIN},
+			expected: "admin=Cradwtm/root",
+		},
+		{
+			name:     "no privileges",
+			grantee:  username.MakeSQLUsernameFromPreNormalizedString("user1"),
+			grantor:  username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:    privilege.List{},
+			expected: "user1=/root",
+		},
+		{
+			name:     "privileges sorted by bit position",
+			grantee:  username.MakeSQLUsernameFromPreNormalizedString("user1"),
+			grantor:  username.MakeSQLUsernameFromPreNormalizedString("root"),
+			privs:    privilege.List{privilege.UPDATE, privilege.SELECT, privilege.CREATE},
+			expected: "user1=Crw/root",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := privilege.NewACLItem(tc.grantee, tc.grantor, tc.privs, tc.grantOptions)
+			require.Equal(t, tc.expected, item.String())
+		})
+	}
+}
+
+func TestParseACLItem(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		input        string
+		wantGrantee  string
+		wantGrantor  string
+		wantPrivs    privilege.List
+		wantGrantOpt privilege.List
+		wantErr      string
+	}{
+		// Valid cases.
+		{
+			input:       "user1=r/root",
+			wantGrantee: "user1",
+			wantGrantor: "root",
+			wantPrivs:   privilege.List{privilege.SELECT},
+		},
+		{
+			input:        "user1=r*w/root",
+			wantGrantee:  "user1",
+			wantGrantor:  "root",
+			wantPrivs:    privilege.List{privilege.SELECT, privilege.UPDATE},
+			wantGrantOpt: privilege.List{privilege.SELECT},
+		},
+		{
+			input:       "=cT/root",
+			wantGrantee: "public",
+			wantGrantor: "root",
+			wantPrivs:   privilege.List{privilege.CONNECT, privilege.TEMPORARY},
+		},
+		{
+			input:       `"user-1"=rw/root`,
+			wantGrantee: "user-1",
+			wantGrantor: "root",
+			wantPrivs:   privilege.List{privilege.SELECT, privilege.UPDATE},
+		},
+		{
+			input:       `user1=r/"grantor-1"`,
+			wantGrantee: "user1",
+			wantGrantor: "grantor-1",
+			wantPrivs:   privilege.List{privilege.SELECT},
+		},
+		{
+			input:       "user1=r/",
+			wantGrantee: "user1",
+			wantGrantor: "",
+			wantPrivs:   privilege.List{privilege.SELECT},
+		},
+		{
+			input:       "user1=/root",
+			wantGrantee: "user1",
+			wantGrantor: "root",
+		},
+		// Missing '/' — treat as missing grantor.
+		{
+			input:       "user1=r",
+			wantGrantee: "user1",
+			wantGrantor: "",
+			wantPrivs:   privilege.List{privilege.SELECT},
+		},
+
+		// Invalid cases.
+		{input: "user1=z/", wantErr: `invalid mode character`},
+		{input: "user1rw/", wantErr: `missing "=" sign`},
+		{input: "user1=*r/", wantErr: `"*" must follow a privilege character`},
+		{input: "user1=r/grantor extra", wantErr: "extra characters after aclitem"},
+		{input: `"unterminated=r/`, wantErr: "unterminated quoted identifier"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			item, err := privilege.ParseACLItem(tc.input)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantGrantee, item.Grantee.Normalized())
+			require.Equal(t, tc.wantGrantor, item.Grantor.Normalized())
+			require.Equal(t, tc.wantPrivs, item.Privileges)
+			require.Equal(t, tc.wantGrantOpt, item.GrantOptions)
+		})
+	}
+}
+
+func TestACLItemRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	inputs := []string{
+		"user1=r/root",
+		"user1=r*aw*/root",
+		"=cT/root",
+		`"user-1"=rw/root`,
+		"admin=Cradwtm/myuser",
+		"user1=/root",
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			item, err := privilege.ParseACLItem(input)
+			require.NoError(t, err)
+			require.Equal(t, input, item.String())
+		})
+	}
+}
+
+func TestACLItem_SafeFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	item := privilege.NewACLItem(
+		username.MakeSQLUsernameFromPreNormalizedString("myuser"),
+		username.MakeSQLUsernameFromPreNormalizedString("root"),
+		privilege.List{privilege.SELECT, privilege.INSERT, privilege.UPDATE},
+		privilege.List{privilege.SELECT},
+	)
+	redacted := string(redact.Sprint(item))
+	echotest.Require(t, redacted, datapathutils.TestDataPath(t, t.Name()))
+}
+
+func TestDefaultACLItems(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		objectType privilege.ObjectType
+		owner      username.SQLUsername
+		expected   []string
+	}{
+		{
+			objectType: privilege.Table,
+			owner:      username.RootUserName(),
+			expected:   []string{"admin=Cradwtm/root", "root=Cradwtm/root"},
+		},
+		{
+			objectType: privilege.Table,
+			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
+			expected:   []string{"admin=Cradwtm/myuser", "root=Cradwtm/myuser", "myuser=Cradwtm/myuser"},
+		},
+		{
+			objectType: privilege.Sequence,
+			owner:      username.RootUserName(),
+			expected:   []string{"admin=CradwU/root", "root=CradwU/root"},
+		},
+		{
+			objectType: privilege.Database,
+			owner:      username.RootUserName(),
+			expected:   []string{"=cT/root", "admin=CcT/root", "root=CcT/root"},
+		},
+		{
+			objectType: privilege.Schema,
+			owner:      username.RootUserName(),
+			expected:   []string{"admin=CU/root", "root=CU/root"},
+		},
+		{
+			objectType: privilege.Routine,
+			owner:      username.RootUserName(),
+			expected:   []string{"=X/root", "admin=X/root", "root=X/root"},
+		},
+		{
+			objectType: privilege.Type,
+			owner:      username.RootUserName(),
+			expected:   []string{"=U/root", "admin=U/root", "root=U/root"},
+		},
+		{
+			objectType: privilege.Database,
+			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
+			expected:   []string{"=cT/myuser", "admin=CcT/myuser", "root=CcT/myuser", "myuser=CcT/myuser"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s/%s", tc.objectType, tc.owner), func(t *testing.T) {
+			items, err := privilege.DefaultACLItems(tc.objectType, tc.owner)
+			require.NoError(t, err)
+			strs := make([]string, len(items))
+			for i, item := range items {
+				strs[i] = item.String()
+			}
+			require.Equal(t, tc.expected, strs)
+		})
+	}
+}
+
+func TestIsDefaultACL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	owner := username.MakeSQLUsernameFromPreNormalizedString("myuser")
+
+	// Get the defaults, verify they are detected as defaults.
+	defaults, err := privilege.DefaultACLItems(privilege.Table, owner)
+	require.NoError(t, err)
+
+	isDefault, err := privilege.IsDefaultACL(defaults, privilege.Table, owner)
+	require.NoError(t, err)
+	require.True(t, isDefault)
+
+	// Add an extra item — should no longer be default.
+	extra := append(defaults, privilege.NewACLItem(
+		username.MakeSQLUsernameFromPreNormalizedString("other"),
+		owner,
+		privilege.List{privilege.SELECT},
+		nil,
+	))
+	isDefault, err = privilege.IsDefaultACL(extra, privilege.Table, owner)
+	require.NoError(t, err)
+	require.False(t, isDefault)
+}

--- a/pkg/sql/privilege/kind.go
+++ b/pkg/sql/privilege/kind.go
@@ -6,6 +6,7 @@
 package privilege
 
 import (
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -73,6 +74,14 @@ const (
 	MAINTAIN               Kind = 43
 	TEMPORARY              Kind = 44
 	largestKind                 = TEMPORARY
+
+	// SET and ALTERSYSTEM are PostgreSQL ACL-only pseudo-privileges.
+	// They exist solely for ACL character mapping ('s' and 'A') used
+	// by acldefault, aclexplode, and makeaclitem. They have no
+	// corresponding CockroachDB privilege and must never be used in
+	// bitmask operations (Mask/ToBitField/ListFromBitField).
+	SET         Kind = math.MaxUint32 - 1
+	ALTERSYSTEM Kind = math.MaxUint32
 )
 
 var isDeprecatedKind = map[Kind]bool{
@@ -174,6 +183,10 @@ func (k Kind) InternalKey() KindInternalKey {
 		return "MAINTAIN"
 	case TEMPORARY:
 		return "TEMPORARY"
+	case SET:
+		return "SET"
+	case ALTERSYSTEM:
+		return "ALTERSYSTEM"
 	default:
 		panic(errors.AssertionFailedf("unhandled kind: %d", int(k)))
 	}
@@ -191,6 +204,8 @@ func (k Kind) DisplayName() KindDisplayName {
 		return "MANAGEVIRTUALCLUSTER"
 	case REPAIRCLUSTER:
 		return "REPAIRCLUSTER"
+	case ALTERSYSTEM:
+		return "ALTER SYSTEM"
 	default:
 		// Unless we have an exception above, the internal
 		// key is also a valid display name.
@@ -249,4 +264,13 @@ func init() {
 
 	// TEMP is a PostgreSQL-compatible alias for TEMPORARY.
 	ByDisplayName["TEMP"] = TEMPORARY
+
+	// Register ACL-only pseudo-privileges. These are above largestKind
+	// so they're excluded from AllPrivileges and privilege validation,
+	// but they need ByDisplayName entries for ACL char mapping.
+	for _, k := range []Kind{SET, ALTERSYSTEM} {
+		ByDisplayName[k.DisplayName()] = k
+		ByDisplayName[KindDisplayName(k.InternalKey())] = k
+		ByInternalKey[k.InternalKey()] = k
+	}
 }

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -559,9 +559,6 @@ func isValidACLChar(c byte) bool {
 	return strings.IndexByte(ValidACLChars, c) >= 0
 }
 
-// orderedPrivs is the list of privileges sorted in alphanumeric order based on the ACL character -> CTUacdmrtwX
-var orderedPrivs = List{CREATE, TEMPORARY, USAGE, INSERT, CONNECT, DELETE, MAINTAIN, SELECT, TRIGGER, UPDATE, EXECUTE}
-
 // ListToACL converts a list of privileges to a list of Postgres
 // ACL items.
 // See: https://www.postgresql.org/docs/13/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE
@@ -583,14 +580,22 @@ func (pl List) ListToACL(grantOptions List, objectType ObjectType) (string, erro
 			}
 		}
 	}
-	chars := make([]string, len(privileges))
-	for _, privilege := range orderedPrivs {
-		if _, ok := privToACL[privilege]; !ok {
-			return "", errors.AssertionFailedf("unknown privilege type %s", privilege.DisplayName())
+	// Sort privileges by Kind value so that ACL characters appear in a
+	// deterministic order matching their bit positions.
+	sorted := make(List, len(privileges))
+	copy(sorted, privileges)
+	sort.Sort(sorted)
+
+	var chars []string
+	for _, privilege := range sorted {
+		aclChar, ok := privToACL[privilege]
+		if !ok {
+			// Skip privileges that have no PostgreSQL ACL character
+			// equivalent (e.g. ALL after expansion, or CockroachDB-specific
+			// privileges like BACKUP, CHANGEFEED, ZONECONFIG).
+			continue
 		}
-		if privileges.Contains(privilege) {
-			chars = append(chars, privToACL[privilege])
-		}
+		chars = append(chars, aclChar)
 		if grantOptions.Contains(privilege) {
 			chars = append(chars, "*")
 		}

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -397,17 +397,12 @@ func init() {
 	}
 }
 
-// ValidACLChars is the set of valid privilege characters in an aclitem string,
-// matching PostgreSQL's ACL abbreviation characters. 'R' is accepted for
-// backward compatibility (old RULE privilege) but is otherwise ignored.
-const ValidACLChars = "arwdDxtXUCTcsAm"
-
 // ValidateACLItemString validates that s has the PostgreSQL aclitem format:
 //
 //	grantee=privchars/grantor
 //
 // where grantee and grantor are role names (possibly double-quoted, or empty),
-// and privchars is a sequence of privilege characters from ValidACLChars, each
+// and privchars is a sequence of privilege characters from ACLCharToPrivName, each
 // optionally followed by '*' indicating grant option. An empty grantee means
 // PUBLIC. CockroachDB does not track grantors, so the grantor portion is
 // typically empty but still must be present after the '/'.
@@ -556,7 +551,8 @@ func ExtractACLIdentifier(s string, i int) (string, int) {
 
 // isValidACLChar returns true if c is a recognized privilege character.
 func isValidACLChar(c byte) bool {
-	return strings.IndexByte(ValidACLChars, c) >= 0
+	_, ok := ACLCharToPrivName[c]
+	return ok
 }
 
 // ListToACL converts a list of privileges to a list of Postgres

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -398,95 +397,6 @@ func init() {
 	}
 }
 
-// ValidateACLItemString validates that s has the PostgreSQL aclitem format:
-//
-//	grantee=privchars/grantor
-//
-// where grantee and grantor are role names (possibly double-quoted, or empty),
-// and privchars is a sequence of privilege characters from ACLCharToPrivName, each
-// optionally followed by '*' indicating grant option. An empty grantee means
-// PUBLIC. CockroachDB does not track grantors, so the grantor portion is
-// typically empty but still must be present after the '/'.
-func ValidateACLItemString(s string) error {
-	i := 0
-	// Parse grantee identifier (may be empty for PUBLIC).
-	i = skipACLIdentifier(s, i)
-	if i < 0 {
-		return pgerror.Newf(pgcode.InvalidTextRepresentation,
-			"unterminated quoted identifier: %q", s)
-	}
-	if i >= len(s) || s[i] != '=' {
-		return pgerror.Newf(pgcode.InvalidTextRepresentation,
-			"missing \"=\" sign: %q", s)
-	}
-	i++ // skip '='
-	// Parse privilege characters and grant option markers.
-	for i < len(s) && s[i] != '/' {
-		c := s[i]
-		if c == '*' {
-			return pgerror.Newf(pgcode.InvalidTextRepresentation,
-				"invalid mode character: \"*\" must follow a privilege character: %q", s)
-		}
-		if !isValidACLChar(c) {
-			return pgerror.Newf(pgcode.InvalidTextRepresentation,
-				"invalid mode character: %q", string(c))
-		}
-		i++
-		// Skip optional '*' grant option marker.
-		if i < len(s) && s[i] == '*' {
-			i++
-		}
-	}
-	if i < len(s) && s[i] == '/' {
-		i++ // skip '/'
-		// Parse grantor identifier (may be empty in CockroachDB).
-		i = skipACLIdentifier(s, i)
-		if i < 0 {
-			return pgerror.Newf(pgcode.InvalidTextRepresentation,
-				"unterminated quoted identifier: %q", s)
-		}
-	}
-	// If '/' is missing entirely, treat as empty grantor (PG issues a warning
-	// and defaults the grantor; CRDB doesn't track grantors so we just accept).
-	if i != len(s) {
-		return pgerror.Newf(pgcode.InvalidTextRepresentation,
-			"extra characters after aclitem specification: %q", s)
-	}
-	return nil
-}
-
-// skipACLIdentifier advances past an optionally double-quoted identifier
-// starting at position i in s. Returns the new position, or -1 if a
-// quoted identifier is missing its closing double quote.
-func skipACLIdentifier(s string, i int) int {
-	if i >= len(s) {
-		return i
-	}
-	if s[i] == '"' {
-		// Quoted identifier: consume until closing unescaped quote.
-		i++ // skip opening quote
-		for i < len(s) {
-			if s[i] == '"' {
-				i++
-				// Escaped double quote ("") continues the identifier.
-				if i < len(s) && s[i] == '"' {
-					i++
-					continue
-				}
-				return i
-			}
-			i++
-		}
-		// Unterminated quote.
-		return -1
-	}
-	// Unquoted identifier: alphanumeric, underscore, or high-bit chars.
-	for i < len(s) && isACLIdentChar(s[i]) {
-		i++
-	}
-	return i
-}
-
 // isACLIdentChar returns true for characters allowed in an unquoted ACL
 // identifier, matching PostgreSQL's is_safe_acl_char for getid context.
 func isACLIdentChar(c byte) bool {
@@ -607,59 +517,6 @@ func (pl List) ListToACL(grantOptions List, objectType ObjectType) (string, erro
 // system.privileges.
 func (o ObjectType) IsDescriptorBacked() bool {
 	return isDescriptorBacked[o]
-}
-
-// pgDefaultPublicPrivs lists the privileges granted to PUBLIC by default
-// for each object type, matching CockroachDB's actual defaults (see
-// NewBaseDatabasePrivilegeDescriptor, NewBaseFunctionPrivilegeDescriptor,
-// etc.).
-var pgDefaultPublicPrivs = map[ObjectType]List{
-	Database: {CONNECT, TEMPORARY},
-	Routine:  {EXECUTE},
-	Type:     {USAGE},
-}
-
-// DefaultACLItems computes the expected default aclitem strings for the given
-// object type and owner. This is used both by privilegeDescriptorToACLArray
-// (to detect default privileges and return NULL) and by the acldefault builtin.
-//
-// The returned items follow PostgreSQL conventions:
-//   - No '*' grant option markers for admin, root, or owner (implicit).
-//   - Only privileges with a PG ACL character equivalent are included
-//     (ListToACL silently skips CRDB-specific privileges).
-//   - PUBLIC entries (empty grantee) come first.
-func DefaultACLItems(objectType ObjectType, owner username.SQLUsername) ([]string, error) {
-	// Compute the owner privilege string by expanding ALL for this object
-	// type. ListToACL skips privileges without a PG ACL character (BACKUP,
-	// CHANGEFEED, ZONECONFIG, DROP, etc.) and orders by Kind bit position.
-	ownerPrivs, err := List{ALL}.ListToACL(nil, objectType)
-	if err != nil {
-		return nil, err
-	}
-
-	quotedOwner := QuoteACLIdentifier(owner.Normalized())
-
-	var items []string
-
-	// PUBLIC entry (empty grantee sorts first).
-	if publicPrivs, ok := pgDefaultPublicPrivs[objectType]; ok {
-		pubACL, err := publicPrivs.ListToACL(nil, objectType)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, "="+pubACL+"/"+quotedOwner)
-	}
-
-	// Admin and root entries.
-	items = append(items, username.AdminRole+"="+ownerPrivs+"/"+quotedOwner)
-	items = append(items, username.RootUser+"="+ownerPrivs+"/"+quotedOwner)
-
-	// Owner entry (if different from admin and root).
-	if !owner.IsAdminRole() && !owner.IsRootUser() {
-		items = append(items, quotedOwner+"="+ownerPrivs+"/"+quotedOwner)
-	}
-
-	return items, nil
 }
 
 // Object represents an object that can have privileges. The privileges

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -606,6 +607,59 @@ func (pl List) ListToACL(grantOptions List, objectType ObjectType) (string, erro
 // system.privileges.
 func (o ObjectType) IsDescriptorBacked() bool {
 	return isDescriptorBacked[o]
+}
+
+// pgDefaultPublicPrivs lists the privileges granted to PUBLIC by default
+// for each object type, matching CockroachDB's actual defaults (see
+// NewBaseDatabasePrivilegeDescriptor, NewBaseFunctionPrivilegeDescriptor,
+// etc.).
+var pgDefaultPublicPrivs = map[ObjectType]List{
+	Database: {CONNECT, TEMPORARY},
+	Routine:  {EXECUTE},
+	Type:     {USAGE},
+}
+
+// DefaultACLItems computes the expected default aclitem strings for the given
+// object type and owner. This is used both by privilegeDescriptorToACLArray
+// (to detect default privileges and return NULL) and by the acldefault builtin.
+//
+// The returned items follow PostgreSQL conventions:
+//   - No '*' grant option markers for admin, root, or owner (implicit).
+//   - Only privileges with a PG ACL character equivalent are included
+//     (ListToACL silently skips CRDB-specific privileges).
+//   - PUBLIC entries (empty grantee) come first.
+func DefaultACLItems(objectType ObjectType, owner username.SQLUsername) ([]string, error) {
+	// Compute the owner privilege string by expanding ALL for this object
+	// type. ListToACL skips privileges without a PG ACL character (BACKUP,
+	// CHANGEFEED, ZONECONFIG, DROP, etc.) and orders by Kind bit position.
+	ownerPrivs, err := List{ALL}.ListToACL(nil, objectType)
+	if err != nil {
+		return nil, err
+	}
+
+	quotedOwner := QuoteACLIdentifier(owner.Normalized())
+
+	var items []string
+
+	// PUBLIC entry (empty grantee sorts first).
+	if publicPrivs, ok := pgDefaultPublicPrivs[objectType]; ok {
+		pubACL, err := publicPrivs.ListToACL(nil, objectType)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, "="+pubACL+"/"+quotedOwner)
+	}
+
+	// Admin and root entries.
+	items = append(items, username.AdminRole+"="+ownerPrivs+"/"+quotedOwner)
+	items = append(items, username.RootUser+"="+ownerPrivs+"/"+quotedOwner)
+
+	// Owner entry (if different from admin and root).
+	if !owner.IsAdminRole() && !owner.IsRootUser() {
+		items = append(items, quotedOwner+"="+ownerPrivs+"/"+quotedOwner)
+	}
+
+	return items, nil
 }
 
 // Object represents an object that can have privileges. The privileges

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -108,7 +108,12 @@ var (
 )
 
 // Mask returns the bitmask for a given privilege.
+// Returns 0 if called on a pg-only pseudo-privilege (SET, ALTERSYSTEM) whose
+// Kind value exceeds the valid bitmask range.
 func (k Kind) Mask() uint64 {
+	if k > largestKind {
+		return 0
+	}
 	return 1 << k
 }
 

--- a/pkg/sql/privilege/privilege_test.go
+++ b/pkg/sql/privilege/privilege_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/redact"
@@ -242,5 +243,64 @@ func TestModifyPrivHasCorrespondingViewPriv(t *testing.T) {
 			}
 		}
 		require.True(t, foundCorrespondingViewPriv, "missing VIEW privilege for %s", modifyPriv.DisplayName())
+	}
+}
+
+func TestDefaultACLItems(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		objectType privilege.ObjectType
+		owner      username.SQLUsername
+		expected   []string
+	}{
+		{
+			objectType: privilege.Table,
+			owner:      username.RootUserName(),
+			expected:   []string{"admin=Cradwtm/root", "root=Cradwtm/root"},
+		},
+		{
+			objectType: privilege.Table,
+			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
+			expected:   []string{"admin=Cradwtm/myuser", "root=Cradwtm/myuser", "myuser=Cradwtm/myuser"},
+		},
+		{
+			objectType: privilege.Sequence,
+			owner:      username.RootUserName(),
+			expected:   []string{"admin=CradwU/root", "root=CradwU/root"},
+		},
+		{
+			objectType: privilege.Database,
+			owner:      username.RootUserName(),
+			expected:   []string{"=cT/root", "admin=CcT/root", "root=CcT/root"},
+		},
+		{
+			objectType: privilege.Schema,
+			owner:      username.RootUserName(),
+			expected:   []string{"admin=CU/root", "root=CU/root"},
+		},
+		{
+			objectType: privilege.Routine,
+			owner:      username.RootUserName(),
+			expected:   []string{"=X/root", "admin=X/root", "root=X/root"},
+		},
+		{
+			objectType: privilege.Type,
+			owner:      username.RootUserName(),
+			expected:   []string{"=U/root", "admin=U/root", "root=U/root"},
+		},
+		{
+			objectType: privilege.Database,
+			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
+			expected:   []string{"=cT/myuser", "admin=CcT/myuser", "root=CcT/myuser", "myuser=CcT/myuser"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s/%s", tc.objectType, tc.owner), func(t *testing.T) {
+			items, err := privilege.DefaultACLItems(tc.objectType, tc.owner)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, items)
+		})
 	}
 }

--- a/pkg/sql/privilege/privilege_test.go
+++ b/pkg/sql/privilege/privilege_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/redact"
@@ -69,48 +68,6 @@ func TestPrivilegeListFormat(t *testing.T) {
 
 		require.Equal(t, tc.sortedDisplayNames, tc.privileges.SortedDisplayNames())
 		require.Equal(t, tc.sortedKeys, tc.privileges.SortedKeys())
-	}
-}
-
-func TestValidateACLItemString(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	testCases := []struct {
-		input string
-		err   string
-	}{
-		// Valid cases.
-		{input: "user1=r/"},
-		{input: "user1=r/grantor"},
-		{input: "=rw/root"},
-		{input: "user1=arwdDxtXUCTcsAm/"},
-		{input: "user1=r*w/"},
-		{input: "user1=/"},
-		{input: "user1=r"},
-		{input: `"user with spaces"=r/`},
-		{input: `"user-1"=rw/`},
-		{input: `"user""quote"=r/`},
-		{input: `user1=r/"grantor-1"`},
-
-		// Invalid cases.
-		{input: "user1=z/", err: `invalid mode character: "z"`},
-		{input: "user1rw/", err: `missing "=" sign`},
-		{input: "user1=*r/", err: `"*" must follow a privilege character`},
-		{input: "user1=r/grantor extra", err: "extra characters after aclitem specification"},
-		{input: `"unterminated=r/`, err: "unterminated quoted identifier"},
-		{input: `user1=r/"unterminated`, err: "unterminated quoted identifier"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.input, func(t *testing.T) {
-			err := privilege.ValidateACLItemString(tc.input)
-			if tc.err == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.err)
-			}
-		})
 	}
 }
 
@@ -243,64 +200,5 @@ func TestModifyPrivHasCorrespondingViewPriv(t *testing.T) {
 			}
 		}
 		require.True(t, foundCorrespondingViewPriv, "missing VIEW privilege for %s", modifyPriv.DisplayName())
-	}
-}
-
-func TestDefaultACLItems(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	testCases := []struct {
-		objectType privilege.ObjectType
-		owner      username.SQLUsername
-		expected   []string
-	}{
-		{
-			objectType: privilege.Table,
-			owner:      username.RootUserName(),
-			expected:   []string{"admin=Cradwtm/root", "root=Cradwtm/root"},
-		},
-		{
-			objectType: privilege.Table,
-			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
-			expected:   []string{"admin=Cradwtm/myuser", "root=Cradwtm/myuser", "myuser=Cradwtm/myuser"},
-		},
-		{
-			objectType: privilege.Sequence,
-			owner:      username.RootUserName(),
-			expected:   []string{"admin=CradwU/root", "root=CradwU/root"},
-		},
-		{
-			objectType: privilege.Database,
-			owner:      username.RootUserName(),
-			expected:   []string{"=cT/root", "admin=CcT/root", "root=CcT/root"},
-		},
-		{
-			objectType: privilege.Schema,
-			owner:      username.RootUserName(),
-			expected:   []string{"admin=CU/root", "root=CU/root"},
-		},
-		{
-			objectType: privilege.Routine,
-			owner:      username.RootUserName(),
-			expected:   []string{"=X/root", "admin=X/root", "root=X/root"},
-		},
-		{
-			objectType: privilege.Type,
-			owner:      username.RootUserName(),
-			expected:   []string{"=U/root", "admin=U/root", "root=U/root"},
-		},
-		{
-			objectType: privilege.Database,
-			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
-			expected:   []string{"=cT/myuser", "admin=CcT/myuser", "root=CcT/myuser", "myuser=CcT/myuser"},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s/%s", tc.objectType, tc.owner), func(t *testing.T) {
-			items, err := privilege.DefaultACLItems(tc.objectType, tc.owner)
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, items)
-		})
 	}
 }

--- a/pkg/sql/privilege/testdata/TestACLItem_SafeFormat
+++ b/pkg/sql/privilege/testdata/TestACLItem_SafeFormat
@@ -1,0 +1,3 @@
+echo
+----
+‹myuser›=r*aw/‹root›

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -290,10 +290,10 @@ func RandDatumWithNullChance(
 			for i := range privs {
 				privs[i] = validPrivChars[rng.Intn(len(validPrivChars))]
 			}
-			s := string(grantee) + "=" + string(privs) + "/"
-			d, err := tree.NewDACLItem(s)
+			s := tree.DString(string(grantee) + "=" + string(privs) + "/")
+			d, err := tree.NewDACLItemFromDString(&s)
 			if err != nil {
-				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generated invalid aclitem %q", s))
+				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generated invalid aclitem %q", string(s)))
 			}
 			return d
 		}
@@ -475,7 +475,8 @@ func adjustDatum(datum tree.Datum, typ *types.T) tree.Datum {
 			// Return a fixed valid aclitem rather than trying to adapt
 			// the generic string datum, since special characters like
 			// quotes break the aclitem parser.
-			d, err := tree.NewDACLItem("=r/")
+			s := tree.DString("=r/")
+			d, err := tree.NewDACLItemFromDString(&s)
 			if err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generated invalid aclitem"))
 			}

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -767,6 +767,107 @@ func TestPGBuiltinsCalledOnNull(t *testing.T) {
 	}
 }
 
+// TestAclDefaultPublicPrivileges verifies that the public role's default
+// privileges returned by acldefault match the actual privileges that
+// CockroachDB grants to the public role on newly created objects.
+func TestAclDefaultPublicPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	// Create a non-root user to own objects.
+	tdb.Exec(t, "CREATE USER testowner")
+	tdb.Exec(t, "GRANT ALL ON DATABASE defaultdb TO testowner WITH GRANT OPTION")
+
+	// Create test objects as testowner with default privileges.
+	tdb.Exec(t, "SET ROLE testowner")
+	tdb.Exec(t, "CREATE TABLE test_acl_t (id INT PRIMARY KEY)")
+	tdb.Exec(t, "CREATE SEQUENCE test_acl_seq")
+	tdb.Exec(t, "CREATE SCHEMA test_acl_s")
+	tdb.Exec(t, "CREATE FUNCTION test_acl_fn() RETURNS INT LANGUAGE SQL AS 'SELECT 1'")
+	tdb.Exec(t, "CREATE TYPE test_acl_type AS ENUM ('a', 'b')")
+	tdb.Exec(t, "SET ROLE root")
+
+	// For each object type, extract the public role's privileges from
+	// acldefault (via aclexplode) and compare against the actual
+	// privileges from SHOW GRANTS.
+	testCases := []struct {
+		name     string
+		typeChar string
+		// grantsQuery returns (privilege_type, is_grantable) for the
+		// public role on the object.
+		grantsQuery string
+	}{
+		{
+			name:     "table",
+			typeChar: "r",
+			grantsQuery: `SELECT privilege_type, is_grantable
+				FROM [SHOW GRANTS ON TABLE test_acl_t]
+				WHERE grantee = 'public'
+				ORDER BY privilege_type`,
+		},
+		{
+			name:     "sequence",
+			typeChar: "s",
+			grantsQuery: `SELECT privilege_type, is_grantable
+				FROM [SHOW GRANTS ON SEQUENCE test_acl_seq]
+				WHERE grantee = 'public'
+				ORDER BY privilege_type`,
+		},
+		{
+			name:     "schema",
+			typeChar: "n",
+			grantsQuery: `SELECT privilege_type, is_grantable
+				FROM [SHOW GRANTS ON SCHEMA test_acl_s]
+				WHERE grantee = 'public'
+				ORDER BY privilege_type`,
+		},
+		{
+			name:     "function",
+			typeChar: "f",
+			grantsQuery: `SELECT privilege_type, is_grantable
+				FROM [SHOW GRANTS ON FUNCTION test_acl_fn]
+				WHERE grantee = 'public'
+				ORDER BY privilege_type`,
+		},
+		{
+			name:     "type",
+			typeChar: "T",
+			grantsQuery: `SELECT privilege_type, is_grantable
+				FROM [SHOW GRANTS ON TYPE test_acl_type]
+				WHERE grantee = 'public'
+				ORDER BY privilege_type`,
+		},
+	}
+
+	ownerOID := tdb.QueryStr(t,
+		"SELECT oid FROM pg_roles WHERE rolname = 'testowner'")
+	require.Len(t, ownerOID, 1)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Extract public role privileges from acldefault.
+			acldefaultQuery := fmt.Sprintf(`
+				SELECT a.privilege_type,
+					CASE WHEN a.is_grantable THEN 'true' ELSE 'false' END
+				FROM aclexplode(acldefault('%s'::"char", %s::oid)) a
+				WHERE a.grantee = 0
+				ORDER BY a.privilege_type`,
+				tc.typeChar, ownerOID[0][0])
+			expected := tdb.QueryStr(t, acldefaultQuery)
+			actual := tdb.QueryStr(t, tc.grantsQuery)
+			require.Equal(t, expected, actual,
+				"acldefault('%s') public role privileges do not match "+
+					"actual defaults", tc.typeChar)
+		})
+	}
+}
+
 func TestBitmaskOrAndXor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testCases := []struct {

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -176,8 +176,6 @@ func newAclexplodeGenerator(
 	}
 
 	for _, aclDatum := range aclArr.Array {
-		// Each aclitem is a string in the format "grantee=privchars/grantor".
-		// An empty grantee means PUBLIC (OID 0).
 		var aclStr string
 		switch d := tree.UnwrapDOidWrapper(aclDatum).(type) {
 		case *tree.DString:
@@ -186,52 +184,29 @@ func newAclexplodeGenerator(
 			continue
 		}
 
-		// Parse grantee (possibly quoted), then expect '='.
-		granteeStr, i := privilege.ExtractACLIdentifier(aclStr, 0)
-		if i < 0 || i >= len(aclStr) || aclStr[i] != '=' {
+		aclItem, err := privilege.ParseACLItem(aclStr)
+		if err != nil {
 			continue
-		}
-		i++ // skip '='
-
-		// Parse privchars until '/' or end of string.
-		privStart := i
-		for i < len(aclStr) && aclStr[i] != '/' {
-			i++
-		}
-		privChars := aclStr[privStart:i]
-
-		// Parse grantor (possibly quoted) after '/'.
-		var grantorStr string
-		if i < len(aclStr) && aclStr[i] == '/' {
-			i++ // skip '/'
-			grantorStr, i = privilege.ExtractACLIdentifier(aclStr, i)
-			if i < 0 {
-				continue
-			}
 		}
 
 		// Resolve role names to OIDs.
+		granteeStr := ""
+		if !aclItem.Grantee.IsPublicRole() {
+			granteeStr = aclItem.Grantee.Normalized()
+		}
 		granteeOid, err := cachedResolveRoleOid(granteeStr)
 		if err != nil {
 			return nil, err
 		}
-		grantorOid, err := cachedResolveRoleOid(grantorStr)
+		grantorOid, err := cachedResolveRoleOid(aclItem.Grantor.Normalized())
 		if err != nil {
 			return nil, err
 		}
 
-		// Iterate over privilege characters. A '*' after a character means
-		// the privilege is grantable.
-		for j := 0; j < len(privChars); j++ {
-			ch := privChars[j]
-			if ch == '*' {
-				continue
-			}
-			privName, ok := privilege.ACLCharToPrivName[ch]
-			if !ok {
-				continue
-			}
-			grantable := j+1 < len(privChars) && privChars[j+1] == '*'
+		// Each privilege produces a row.
+		for _, kind := range aclItem.Privileges {
+			privName := string(kind.DisplayName())
+			grantable := aclItem.GrantOptions.Contains(kind)
 			items = append(items, aclexplodeRow{
 				grantor:       tree.NewDOid(grantorOid),
 				grantee:       tree.NewDOid(granteeOid),

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2547,7 +2547,7 @@ SELECT
 				grantor := username.MakeSQLUsernameFromPreNormalizedString(grantorName)
 
 				item := privilege.NewACLItem(grantee, grantor, privList, grantOptions)
-				return tree.NewDACLItem(item.String())
+				return tree.NewDACLItem(item), nil
 			},
 			Info: "Constructs an aclitem from the given grantee, grantor, privileges, and grant option.",
 			// Marked immutable to match postgres. Our implementation resolves
@@ -2604,11 +2604,7 @@ SELECT
 					}
 					arr := tree.NewDArray(types.AclItem)
 					for _, item := range items {
-						d, err := tree.NewDACLItem(item.String())
-						if err != nil {
-							return nil, err
-						}
-						if err := arr.Append(d); err != nil {
+						if err := arr.Append(tree.NewDACLItem(item)); err != nil {
 							return nil, err
 						}
 					}
@@ -2640,11 +2636,7 @@ SELECT
 				arr := tree.NewDArray(types.AclItem)
 
 				appendItem := func(item privilege.ACLItem) error {
-					d, err := tree.NewDACLItem(item.String())
-					if err != nil {
-						return err
-					}
-					return arr.Append(d)
+					return arr.Append(tree.NewDACLItem(item))
 				}
 
 				if len(def.publicPrivs) > 0 {

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2584,26 +2584,30 @@ SELECT
 					ownerName = fmt.Sprintf("%d", ownerOid)
 				}
 
-				// PostgreSQL hard-wired default ACLs per object type.
-				// See src/backend/catalog/aclchk.c acldefault().
+				// Default ACLs per object type, matching CockroachDB's actual
+				// default privileges. CockroachDB grants ALL (with grant
+				// option) to both admin and root by default via
+				// NewCustomSuperuserPrivilegeDescriptor, and has different
+				// public-role defaults than PostgreSQL for some types.
+				// See also PostgreSQL's src/backend/catalog/aclchk.c acldefault().
 				type aclDefault struct {
 					ownerPrivs  string
 					publicPrivs string
 				}
 				defaults := map[string]aclDefault{
-					"r": {ownerPrivs: "arwdDxtm"},               // TABLE
-					"s": {ownerPrivs: "rwU"},                    // SEQUENCE
-					"d": {ownerPrivs: "CTc", publicPrivs: "Tc"}, // DATABASE
-					"f": {ownerPrivs: "X", publicPrivs: "X"},    // FUNCTION
-					"l": {publicPrivs: "U"},                     // LANGUAGE
-					"n": {ownerPrivs: "UC"},                     // SCHEMA
-					"T": {ownerPrivs: "U", publicPrivs: "U"},    // TYPE
-					"c": {},                                     // COLUMN
-					"L": {ownerPrivs: "rw"},                     // LARGE OBJECT
-					"t": {ownerPrivs: "C"},                      // TABLESPACE
-					"F": {ownerPrivs: "U"},                      // FDW
-					"S": {ownerPrivs: "U"},                      // FOREIGN SERVER
-					"p": {ownerPrivs: "sA"},                     // PARAMETER
+					"r": {ownerPrivs: "admrtw"},               // TABLE
+					"s": {ownerPrivs: "rwU"},                  // SEQUENCE
+					"d": {ownerPrivs: "Cc", publicPrivs: "c"}, // DATABASE
+					"f": {ownerPrivs: "X", publicPrivs: "X"},  // FUNCTION
+					"l": {publicPrivs: "U"},                   // LANGUAGE
+					"n": {ownerPrivs: "UC"},                   // SCHEMA
+					"T": {ownerPrivs: "U", publicPrivs: "U"},  // TYPE
+					"c": {},                                   // COLUMN
+					"L": {ownerPrivs: "rw"},                   // LARGE OBJECT
+					"t": {ownerPrivs: "C"},                    // TABLESPACE
+					"F": {ownerPrivs: "U"},                    // FDW
+					"S": {ownerPrivs: "U"},                    // FOREIGN SERVER
+					"p": {ownerPrivs: "sA"},                   // PARAMETER
 				}
 
 				def, ok := defaults[typeChar]
@@ -2614,7 +2618,24 @@ SELECT
 
 				arr := tree.NewDArray(types.AclItem)
 				quotedOwner := privilege.QuoteACLIdentifier(ownerName)
-				// If PUBLIC has privileges, add that first.
+				quotedAdmin := privilege.QuoteACLIdentifier(username.AdminRole)
+				quotedRoot := privilege.QuoteACLIdentifier(username.RootUser)
+
+				// CockroachDB default: admin and root both get all
+				// privileges with grant option, matching
+				// NewCustomSuperuserPrivilegeDescriptor. Grant options
+				// are not marked with '*' because they are implicit
+				// (matching PostgreSQL behavior for owner defaults).
+				if def.ownerPrivs != "" {
+					item := quotedAdmin + "=" + def.ownerPrivs + "/" + quotedOwner
+					d, err := tree.NewDACLItem(item)
+					if err != nil {
+						return nil, err
+					}
+					if err := arr.Append(d); err != nil {
+						return nil, err
+					}
+				}
 				if def.publicPrivs != "" {
 					item := "=" + def.publicPrivs + "/" + quotedOwner
 					d, err := tree.NewDACLItem(item)
@@ -2625,8 +2646,19 @@ SELECT
 						return nil, err
 					}
 				}
-				// If owner has privileges, add that next.
 				if def.ownerPrivs != "" {
+					item := quotedRoot + "=" + def.ownerPrivs + "/" + quotedOwner
+					d, err := tree.NewDACLItem(item)
+					if err != nil {
+						return nil, err
+					}
+					if err := arr.Append(d); err != nil {
+						return nil, err
+					}
+				}
+				// If the owner is neither admin nor root, add their
+				// entry too (they get implicit ALL via ownership).
+				if ownerName != "admin" && ownerName != "root" && def.ownerPrivs != "" {
 					item := quotedOwner + "=" + def.ownerPrivs + "/" + quotedOwner
 					d, err := tree.NewDACLItem(item)
 					if err != nil {

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2492,9 +2492,9 @@ SELECT
 				privileges := string(tree.MustBeDString(args[2]))
 				isGrantable := bool(tree.MustBeDBool(args[3]))
 
-				// Parse privilege names and convert to ACL characters.
-				var privChars strings.Builder
+				// Parse privilege names to a privilege.List.
 				privNames := strings.Split(privileges, ",")
+				var privList privilege.List
 				for _, name := range privNames {
 					name = strings.TrimSpace(name)
 					if name == "" {
@@ -2505,16 +2505,24 @@ SELECT
 						return nil, pgerror.Newf(pgcode.InvalidParameterValue,
 							"unrecognized privilege type: %q", name)
 					}
-					privChars.WriteByte(ch)
-					if isGrantable {
-						privChars.WriteByte('*')
+					privName := privilege.ACLCharToPrivName[ch]
+					kind, ok := privilege.ByDisplayName[privilege.KindDisplayName(privName)]
+					if !ok {
+						continue
 					}
+					privList = append(privList, kind)
+				}
+
+				var grantOptions privilege.List
+				if isGrantable {
+					grantOptions = make(privilege.List, len(privList))
+					copy(grantOptions, privList)
 				}
 
 				// Resolve OIDs to role names. OID 0 = PUBLIC (empty grantee).
 				// Like postgres, fall back to the numeric OID if the role
 				// doesn't exist.
-				granteeName := ""
+				grantee := username.PublicRoleName()
 				if granteeOid != 0 {
 					name, err := getNameForArg(
 						ctx, evalCtx, tree.NewDOid(granteeOid), "pg_roles", "rolname",
@@ -2523,10 +2531,9 @@ SELECT
 						return nil, err
 					}
 					if name == "" {
-						granteeName = fmt.Sprintf("%d", granteeOid)
-					} else {
-						granteeName = name
+						name = fmt.Sprintf("%d", granteeOid)
 					}
+					grantee = username.MakeSQLUsernameFromPreNormalizedString(name)
 				}
 				grantorName, err := getNameForArg(
 					ctx, evalCtx, tree.NewDOid(grantorOid), "pg_roles", "rolname",
@@ -2537,18 +2544,10 @@ SELECT
 				if grantorName == "" {
 					grantorName = fmt.Sprintf("%d", grantorOid)
 				}
+				grantor := username.MakeSQLUsernameFromPreNormalizedString(grantorName)
 
-				// Build the aclitem string: "grantee=privchars/grantor".
-				// Role names that contain special characters (e.g. hyphens,
-				// spaces) must be double-quoted, matching PostgreSQL's putid().
-				var result strings.Builder
-				result.WriteString(privilege.QuoteACLIdentifier(granteeName))
-				result.WriteByte('=')
-				result.WriteString(privChars.String())
-				result.WriteByte('/')
-				result.WriteString(privilege.QuoteACLIdentifier(grantorName))
-
-				return tree.NewDACLItem(result.String())
+				item := privilege.NewACLItem(grantee, grantor, privList, grantOptions)
+				return tree.NewDACLItem(item.String())
 			},
 			Info: "Constructs an aclitem from the given grantee, grantor, privileges, and grant option.",
 			// Marked immutable to match postgres. Our implementation resolves
@@ -2605,7 +2604,7 @@ SELECT
 					}
 					arr := tree.NewDArray(types.AclItem)
 					for _, item := range items {
-						d, err := tree.NewDACLItem(item)
+						d, err := tree.NewDACLItem(item.String())
 						if err != nil {
 							return nil, err
 						}
@@ -2618,17 +2617,17 @@ SELECT
 
 				// Non-CRDB object types: use hardcoded defaults.
 				type aclDefault struct {
-					ownerPrivs  string
-					publicPrivs string
+					ownerPrivs  privilege.List
+					publicPrivs privilege.List
 				}
 				defaults := map[string]aclDefault{
-					"l": {ownerPrivs: "U", publicPrivs: "U"}, // LANGUAGE
-					"c": {},                                  // COLUMN
-					"L": {ownerPrivs: "rw"},                  // LARGE OBJECT
-					"t": {ownerPrivs: "C"},                   // TABLESPACE
-					"F": {ownerPrivs: "U"},                   // FDW
-					"S": {ownerPrivs: "U"},                   // FOREIGN SERVER
-					"p": {ownerPrivs: "sA"},                  // PARAMETER
+					"l": {ownerPrivs: privilege.List{privilege.USAGE}, publicPrivs: privilege.List{privilege.USAGE}},
+					"c": {},
+					"L": {ownerPrivs: privilege.List{privilege.SELECT, privilege.UPDATE}},
+					"t": {ownerPrivs: privilege.List{privilege.CREATE}},
+					"F": {ownerPrivs: privilege.List{privilege.USAGE}},
+					"S": {ownerPrivs: privilege.List{privilege.USAGE}},
+					"p": {ownerPrivs: privilege.List{privilege.SET, privilege.ALTERSYSTEM}},
 				}
 
 				def, ok := defaults[typeChar]
@@ -2637,52 +2636,41 @@ SELECT
 						"unrecognized object type abbreviation: %q", typeChar)
 				}
 
+				owner := username.MakeSQLUsernameFromPreNormalizedString(ownerName)
 				arr := tree.NewDArray(types.AclItem)
-				quotedOwner := privilege.QuoteACLIdentifier(ownerName)
 
-				// Grant options are not marked with '*' because they
-				// are implicit (matching PostgreSQL behavior for
-				// owner defaults).
-				if def.publicPrivs != "" {
-					item := "=" + def.publicPrivs + "/" + quotedOwner
-					d, err := tree.NewDACLItem(item)
+				appendItem := func(item privilege.ACLItem) error {
+					d, err := tree.NewDACLItem(item.String())
 					if err != nil {
-						return nil, err
+						return err
 					}
-					if err := arr.Append(d); err != nil {
+					return arr.Append(d)
+				}
+
+				if len(def.publicPrivs) > 0 {
+					if err := appendItem(privilege.NewACLItem(
+						username.PublicRoleName(), owner, def.publicPrivs, nil,
+					)); err != nil {
 						return nil, err
 					}
 				}
-				if def.ownerPrivs != "" {
-					item := username.AdminRole + "=" + def.ownerPrivs + "/" + quotedOwner
-					d, err := tree.NewDACLItem(item)
-					if err != nil {
-						return nil, err
+				if len(def.ownerPrivs) > 0 {
+					for _, role := range []username.SQLUsername{
+						username.AdminRoleName(),
+						username.RootUserName(),
+					} {
+						if err := appendItem(privilege.NewACLItem(
+							role, owner, def.ownerPrivs, nil,
+						)); err != nil {
+							return nil, err
+						}
 					}
-					if err := arr.Append(d); err != nil {
-						return nil, err
-					}
-				}
-				if def.ownerPrivs != "" {
-					item := username.RootUser + "=" + def.ownerPrivs + "/" + quotedOwner
-					d, err := tree.NewDACLItem(item)
-					if err != nil {
-						return nil, err
-					}
-					if err := arr.Append(d); err != nil {
-						return nil, err
-					}
-				}
-				// If the owner is neither admin nor root, add their
-				// entry too (they get implicit ALL via ownership).
-				if ownerName != username.AdminRole && ownerName != username.RootUser && def.ownerPrivs != "" {
-					item := quotedOwner + "=" + def.ownerPrivs + "/" + quotedOwner
-					d, err := tree.NewDACLItem(item)
-					if err != nil {
-						return nil, err
-					}
-					if err := arr.Append(d); err != nil {
-						return nil, err
+					if !owner.IsAdminRole() && !owner.IsRootUser() {
+						if err := appendItem(privilege.NewACLItem(
+							owner, owner, def.ownerPrivs, nil,
+						)); err != nil {
+							return nil, err
+						}
 					}
 				}
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2584,30 +2584,51 @@ SELECT
 					ownerName = fmt.Sprintf("%d", ownerOid)
 				}
 
-				// Default ACLs per object type, matching CockroachDB's actual
-				// default privileges. CockroachDB grants ALL (with grant
-				// option) to both admin and root by default via
-				// NewCustomSuperuserPrivilegeDescriptor, and has different
-				// public-role defaults than PostgreSQL for some types.
+				// Map type chars to CRDB object types for descriptor-backed
+				// objects. For these, use DefaultACLItems to ensure consistency
+				// with privilegeDescriptorToACLArray's default detection.
 				// See also PostgreSQL's src/backend/catalog/aclchk.c acldefault().
+				charToObjectType := map[string]privilege.ObjectType{
+					"r": privilege.Table,
+					"s": privilege.Sequence,
+					"d": privilege.Database,
+					"f": privilege.Routine,
+					"n": privilege.Schema,
+					"T": privilege.Type,
+				}
+
+				if objType, ok := charToObjectType[typeChar]; ok {
+					owner := username.MakeSQLUsernameFromPreNormalizedString(ownerName)
+					items, err := privilege.DefaultACLItems(objType, owner)
+					if err != nil {
+						return nil, err
+					}
+					arr := tree.NewDArray(types.AclItem)
+					for _, item := range items {
+						d, err := tree.NewDACLItem(item)
+						if err != nil {
+							return nil, err
+						}
+						if err := arr.Append(d); err != nil {
+							return nil, err
+						}
+					}
+					return arr, nil
+				}
+
+				// Non-CRDB object types: use hardcoded defaults.
 				type aclDefault struct {
 					ownerPrivs  string
 					publicPrivs string
 				}
 				defaults := map[string]aclDefault{
-					"r": {ownerPrivs: "admrtw"},               // TABLE
-					"s": {ownerPrivs: "rwU"},                  // SEQUENCE
-					"d": {ownerPrivs: "Cc", publicPrivs: "c"}, // DATABASE
-					"f": {ownerPrivs: "X", publicPrivs: "X"},  // FUNCTION
-					"l": {publicPrivs: "U"},                   // LANGUAGE
-					"n": {ownerPrivs: "UC"},                   // SCHEMA
-					"T": {ownerPrivs: "U", publicPrivs: "U"},  // TYPE
-					"c": {},                                   // COLUMN
-					"L": {ownerPrivs: "rw"},                   // LARGE OBJECT
-					"t": {ownerPrivs: "C"},                    // TABLESPACE
-					"F": {ownerPrivs: "U"},                    // FDW
-					"S": {ownerPrivs: "U"},                    // FOREIGN SERVER
-					"p": {ownerPrivs: "sA"},                   // PARAMETER
+					"l": {ownerPrivs: "U", publicPrivs: "U"}, // LANGUAGE
+					"c": {},                                  // COLUMN
+					"L": {ownerPrivs: "rw"},                  // LARGE OBJECT
+					"t": {ownerPrivs: "C"},                   // TABLESPACE
+					"F": {ownerPrivs: "U"},                   // FDW
+					"S": {ownerPrivs: "U"},                   // FOREIGN SERVER
+					"p": {ownerPrivs: "sA"},                  // PARAMETER
 				}
 
 				def, ok := defaults[typeChar]
@@ -2618,24 +2639,10 @@ SELECT
 
 				arr := tree.NewDArray(types.AclItem)
 				quotedOwner := privilege.QuoteACLIdentifier(ownerName)
-				quotedAdmin := privilege.QuoteACLIdentifier(username.AdminRole)
-				quotedRoot := privilege.QuoteACLIdentifier(username.RootUser)
 
-				// CockroachDB default: admin and root both get all
-				// privileges with grant option, matching
-				// NewCustomSuperuserPrivilegeDescriptor. Grant options
-				// are not marked with '*' because they are implicit
-				// (matching PostgreSQL behavior for owner defaults).
-				if def.ownerPrivs != "" {
-					item := quotedAdmin + "=" + def.ownerPrivs + "/" + quotedOwner
-					d, err := tree.NewDACLItem(item)
-					if err != nil {
-						return nil, err
-					}
-					if err := arr.Append(d); err != nil {
-						return nil, err
-					}
-				}
+				// Grant options are not marked with '*' because they
+				// are implicit (matching PostgreSQL behavior for
+				// owner defaults).
 				if def.publicPrivs != "" {
 					item := "=" + def.publicPrivs + "/" + quotedOwner
 					d, err := tree.NewDACLItem(item)
@@ -2647,7 +2654,17 @@ SELECT
 					}
 				}
 				if def.ownerPrivs != "" {
-					item := quotedRoot + "=" + def.ownerPrivs + "/" + quotedOwner
+					item := username.AdminRole + "=" + def.ownerPrivs + "/" + quotedOwner
+					d, err := tree.NewDACLItem(item)
+					if err != nil {
+						return nil, err
+					}
+					if err := arr.Append(d); err != nil {
+						return nil, err
+					}
+				}
+				if def.ownerPrivs != "" {
+					item := username.RootUser + "=" + def.ownerPrivs + "/" + quotedOwner
 					d, err := tree.NewDACLItem(item)
 					if err != nil {
 						return nil, err
@@ -2658,7 +2675,7 @@ SELECT
 				}
 				// If the owner is neither admin nor root, add their
 				// entry too (they get implicit ALL via ownership).
-				if ownerName != "admin" && ownerName != "root" && def.ownerPrivs != "" {
+				if ownerName != username.AdminRole && ownerName != username.RootUser && def.ownerPrivs != "" {
 					item := quotedOwner + "=" + def.ownerPrivs + "/" + quotedOwner
 					d, err := tree.NewDACLItem(item)
 					if err != nil {

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -516,7 +516,8 @@ func performCastWithoutPrecisionTruncation(
 				return tree.NewDName(s), nil
 			}
 			if t.Oid() == oidext.T_aclitem {
-				return tree.NewDACLItem(s)
+				ds := tree.DString(s)
+				return tree.NewDACLItemFromDString(&ds)
 			}
 
 			// bpchar types truncate trailing whitespace.

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -636,7 +636,8 @@ func (expr *StrVal) ResolveAsType(
 	case types.StringFamily:
 		switch typ.Oid() {
 		case oidext.T_aclitem:
-			return NewDACLItem(expr.s)
+			expr.resString = DString(expr.s)
+			return NewDACLItemFromDString(&expr.resString)
 		case oid.T_name:
 			expr.resString = DString(expr.s)
 			return NewDNameFromDString(&expr.resString), nil

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5843,7 +5843,7 @@ func NewDName(d string) Datum {
 // aclitem OID, initialized from an existing *DString. It validates the format
 // and returns an error if the string is not a valid aclitem.
 func NewDACLItemFromDString(d *DString) (Datum, error) {
-	if err := privilege.ValidateACLItemString(string(*d)); err != nil {
+	if _, err := privilege.ParseACLItem(string(*d)); err != nil {
 		return nil, err
 	}
 	return wrapWithOid(d, oidext.T_aclitem), nil

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5849,12 +5849,12 @@ func NewDACLItemFromDString(d *DString) (Datum, error) {
 	return wrapWithOid(d, oidext.T_aclitem), nil
 }
 
-// NewDACLItem is a helper routine to create a *DOidWrapper with aclitem OID,
-// initialized from a string in the format "grantee=privchars/grantor".
-// It validates the format and returns an error if the string is not valid.
-func NewDACLItem(d string) (Datum, error) {
-	s := DString(d)
-	return NewDACLItemFromDString(&s)
+// NewDACLItem creates a *DOidWrapper with aclitem OID from a structured
+// privilege.ACLItem. No validation is performed since the ACLItem is
+// already well-formed.
+func NewDACLItem(item privilege.ACLItem) Datum {
+	s := DString(item.String())
+	return wrapWithOid(&s, oidext.T_aclitem)
 }
 
 // NewDCIText is a helper routine to create a *DCIText (implemented as a *DOidWrapper)


### PR DESCRIPTION
Review note: Please review each commit individually to make this easy to review.
See the Claude Code plan [here](https://gist.github.com/rafiss/9537114859d55b91191b1309ffc6b01c).

---

### sql/privilege: sort ACL characters by privilege bit position 

Replace the hardcoded orderedPrivs list with a sort by Kind value,
which corresponds to the privilege bit position. This produces a
deterministic ACL character ordering and also fixes a pre-existing
bug where `make([]string, len(privileges))` created zero-value
entries before appending.

### sql/privilege: remove redundant ValidACLChars constant 

Use ACLCharToPrivName map lookup instead of maintaining a duplicate
list of valid ACL characters.


### sql: update acldefault to reflect actual default privileges 

Update the acldefault builtin to return privilege defaults that match
what CockroachDB actually assigns to newly created objects:

- Include admin and root roles with ALL privileges, matching
  NewCustomSuperuserPrivilegeDescriptor behavior.
- If the owner is distinct from admin/root, include an owner entry too.
- Adjust privilege chars per object type to match CRDB's defaults
  (e.g. tables get "admrtw" not "arwdDxtm").
- Add parameter ('p') defaults with SET and ALTER SYSTEM privileges.
- Do not mark implicit grant options with '*' in the ACL string.
  PostgreSQL documents that "the owner's implicit grant options are not
  marked in the access privileges display", so we follow suit for
  admin, root, and the owner.

Add TestAclDefaultPublicPrivileges to verify that the public role's
privileges from acldefault match the actual defaults on newly created
objects.

### sql: populate ACL columns in pg_catalog tables 

Populate the relacl, nspacl, datacl, proacl, and typacl columns in
pg_catalog tables using a new privilegeDescriptorToACLArray helper.

Only privileges with a PostgreSQL ACL character equivalent are included;
CockroachDB-specific privileges (BACKUP, CHANGEFEED, ZONECONFIG, etc.)
are skipped.

To match PostgreSQL behavior:

- Return NULL when an object's privileges match its defaults, since
  pg_dump compares ACL columns against acldefault() to decide whether
  to emit GRANT/REVOKE statements.
- Strip grant option '*' markers for admin, root, and the owner,
  since their grant options are implicit (as in PostgreSQL for the
  owner/superuser).
- Update acldefault() to use a shared DefaultACLItems function,
  ensuring consistency between ACL column output and acldefault().

Virtual tables and schemas continue to return NULL ACLs.

### sql/privilege: add ACLItem type for structured aclitem construction 

Add a new ACLItem struct that encapsulates PostgreSQL-compatible aclitem
construction (grantee=privchars/grantor format). This replaces ad-hoc
fmt.Sprintf-based ACL string building with a structured type that:

- Implements redact.SafeFormatter (role names are PII, privilege chars
  are safe)
- Provides NewACLItem constructor and ParseACLItem parser with
  round-trip consistency
- Moves DefaultACLItems to return []ACLItem instead of []string
- Adds IsDefaultACL for order-independent default privilege comparison
- Removes ValidateACLItemString (superseded by ParseACLItem) and the
  now-unused skipACLIdentifier helper

### sql: migrate aclitem callers to use ACLItem type 

Update all callers that previously constructed aclitem strings via
fmt.Sprintf to use the structured ACLItem type:

- NewDACLItemFromDString: use ParseACLItem for validation
- acldefault builtin: use DefaultACLItems ([]ACLItem) for
  descriptor-backed types; use NewACLItem for non-descriptor types
  (except PARAMETER which needs raw ACL chars for SET/ALTER SYSTEM)
- privilegeDescriptorToACLArray: use NewACLItem with ALL expansion
  and IsDefaultACL for default detection
- createDefACLItem: accept username.SQLUsername, use NewACLItem

The aclexplode builtin retains manual char iteration because ACL chars
's' (SET) and 'A' (ALTER SYSTEM) have no privilege.Kind equivalent.

### sql: accept privilege.ACLItem in tree.NewDACLItem 

Change `tree.NewDACLItem` to accept a `privilege.ACLItem` instead of a
string. This eliminates the string→parse→validate round-trip at each
call site where a structured ACLItem is already available.

Callers that still need to construct an aclitem datum from a raw string
(pgwire decoding, casts, random datum generation, string literal
resolution) now use `tree.NewDACLItemFromDString`.

Also change `createDefACLItem` in pg_catalog.go to return
`privilege.ACLItem` instead of `string`, since all callers immediately
pass it to `tree.NewDACLItem`.

---

informs #20296 