### PR TITLE
roachtest: re-add descriptor version mismatch retry for mixed-version backup

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -43,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/version"
 )
 
 const (
@@ -222,10 +224,37 @@ func (d *BackupRestoreTestDriver) verifyBackupCollection(
 	bc *backupCollection,
 	checkFiles bool,
 	internalSystemJobs bool,
+	mvHelper *mixedversion.Helper,
 ) error {
-	rj, err := d.RestoreSync(ctx, l, rng, bc, checkFiles, internalSystemJobs)
+	rj, err := d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs)
 	if err != nil {
 		return fmt.Errorf("error restoring backup: %w", err)
+	}
+	if jobErr := rj.WaitForJobSuccess(ctx); jobErr != nil {
+		if mvHelper == nil {
+			return fmt.Errorf("error restoring backup: %w", jobErr)
+		}
+		v25_4 := version.MajorVersion{Year: 25, Ordinal: 4}
+		isUpgradeTo25_4 := mvHelper.System.ToVersion.Major().Equals(v25_4) &&
+			mvHelper.System.FromVersion.Major().LessThan(v25_4)
+		if !isUpgradeTo25_4 || !strings.Contains(jobErr.Error(), "version mismatch for descriptor") {
+			return fmt.Errorf("error restoring backup: %w", jobErr)
+		}
+		// In the 25.4 upgrade, all descriptors are rewritten in the migration to
+		// use the new serialization format. If this upgrade occurs in the middle of
+		// the restore, we may encounter a version mismatch error. Retry the restore
+		// if we encounter this error.
+		l.Printf(
+			"encountered version mismatch error due to mixed-version upgrade, retrying restore: %v",
+			jobErr,
+		)
+		rj, err = d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs)
+		if err != nil {
+			return fmt.Errorf("error restoring backup: %w", err)
+		}
+		if err := rj.WaitForJobSuccess(ctx); err != nil {
+			return fmt.Errorf("error restoring backup: %w", err)
+		}
 	}
 	return rj.ValidateRestore(ctx)
 }

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -211,7 +211,7 @@ func backupRestoreRoundTrip(
 			// Verify content in backups.
 			err = d.verifyBackupCollection(
 				ctx, t.L(), testRNG, collection,
-				true /* checkFiles */, true, /* internalSystemJobs */
+				true /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -415,7 +415,7 @@ func (mvb *mixedVersionBackup) verifySomeBackups(
 	for _, collection := range toBeRestored {
 		l.Printf("mixed-version: verifying %s", collection.name)
 		if err := mvb.backupRestoreTestDriver.verifyBackupCollection(
-			ctx, l, rng, collection, checkFiles, internalSystemJobs,
+			ctx, l, rng, collection, checkFiles, internalSystemJobs, h,
 		); err != nil {
 			return errors.Wrap(err, "mixed-version")
 		}
@@ -497,7 +497,7 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 			}
 
 			if err := mvb.backupRestoreTestDriver.verifyBackupCollection(
-				ctx, l, rng, collection, checkFiles, internalSystemJobs,
+				ctx, l, rng, collection, checkFiles, internalSystemJobs, h,
 			); err != nil {
 				err := errors.Wrapf(err, "%s", v)
 				l.Printf("restore error: %v", err)


### PR DESCRIPTION
The descriptor version mismatch check and restore retry was accidentally removed in #165848. This re-adds the retry logic so that the mixed-version backup test can handle the 25.4 upgrade descriptor rewrite race.

Fixes: #166147

Release note: None