### PR TITLE
release-25.4: sql: clean up FK back-references during rollback of CREATE TABLE

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1385,6 +1386,168 @@ ORDER BY
 	// Check that the data was cleaned up.
 	tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), parentDesc.TableSpan(codec), 0)
 	tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), childDesc.TableSpan(codec), 0)
+}
+
+// TestCreateTableFKRollbackCleansBackrefs verifies that when a CREATE TABLE
+// with an inline FOREIGN KEY constraint is rolled back (because the schema
+// change job fails), the InboundFK back-reference on the referenced table is
+// properly cleaned up.
+//
+// This is a regression test for a bug where rollbackSchemaChange() would mark
+// the new table as Dropped and GC it, but never remove the InboundFK entry
+// from the referenced table, leaving an orphaned back-reference to a
+// non-existent descriptor.
+func TestCreateTableFKRollbackCleansBackrefs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// injectedJobError is a permanent error that will cause the schema change
+	// job for the new table to fail permanently and trigger rollback.
+	injectedJobError := jobs.MarkAsPermanentJobError(
+		errors.New("injected error to force rollback"),
+	)
+
+	// Track the ID of the child table so we can target its schema change job.
+	var childTableID uint32
+	var srv serverutils.TestServerInterface
+
+	params := base.TestServerArgs{}
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeResume: func(jobID jobspb.JobID) error {
+				id := atomic.LoadUint32(&childTableID)
+				if id == 0 {
+					return nil
+				}
+				// Only fail schema change jobs that target our child table.
+				scJob, err := srv.ApplicationLayer().JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
+				if err != nil {
+					return err
+				}
+				for _, descID := range scJob.Payload().DescriptorIDs {
+					if uint32(descID) == id {
+						return injectedJobError
+					}
+				}
+				return nil
+			},
+		},
+		// Decrease the adopt loop interval so that retries happen quickly.
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+
+	var sqlDB *gosql.DB
+	var kvDB *kv.DB
+	srv, sqlDB, kvDB = serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(ctx)
+	codec := srv.ApplicationLayer().Codec()
+	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+	systemDB := srv.SystemLayer().SQLConn(t)
+
+	// Disable the declarative schema changer so we exercise the legacy path.
+	sqlRun.Exec(t, `SET use_declarative_schema_changer = 'off'`)
+	sqlRun.Exec(t, `SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off'`)
+
+	// Configure fast GC so the child descriptor is fully deleted (not just
+	// DROPPED) before we check invalid_objects. This reproduces the exact
+	// production error: "referenced descriptor not found" vs "is dropped".
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, systemDB)()
+	_, err := systemDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s'`)
+	require.NoError(t, err)
+	_, err = systemDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s'`)
+	require.NoError(t, err)
+
+	// Create the referenced (parent) table.
+	sqlRun.Exec(t, `CREATE DATABASE t`)
+	sqlRun.Exec(t, `CREATE TABLE t.parent (id INT PRIMARY KEY)`)
+
+	parentDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "parent")
+	require.Empty(t, parentDesc.InboundForeignKeys(),
+		"parent should have no InboundFKs before child creation")
+
+	// Now create the child table with an inline FK. The CREATE TABLE will
+	// succeed (the SQL transaction commits), but the async schema change job
+	// will be failed by our injected error, triggering rollback.
+	//
+	// We need to set childTableID BEFORE executing the CREATE TABLE so that
+	// the RunBeforeResume knob can target the right job.
+	//
+	// First, figure out what the next descriptor ID will be by querying.
+	var nextID uint32
+	sqlRun.QueryRow(t, `SELECT max(id) + 1 FROM system.descriptor`).Scan(&nextID)
+	atomic.StoreUint32(&childTableID, nextID)
+
+	// CREATE TABLE with inline FK. This will fail because the schema change
+	// job is injected with a permanent error.
+	_, err = sqlDB.Exec(`CREATE TABLE t.child (
+		id INT PRIMARY KEY,
+		parent_id INT,
+		CONSTRAINT fk_child_parent FOREIGN KEY (parent_id) REFERENCES t.parent (id)
+	)`)
+	require.Error(t, err)
+
+	// Wait for the schema change job to reach a terminal state (failed).
+	sqlRun.CheckQueryResultsRetry(t,
+		`SELECT count(*) FROM [SHOW JOBS]
+			 WHERE job_type = 'SCHEMA CHANGE'
+			   AND description LIKE '%CREATE TABLE t.public.child%'
+			   AND status = 'failed'`,
+		[][]string{{"1"}},
+	)
+
+	// The child table should not exist anymore (it was in ADD state and
+	// got rolled back).
+	var tableCount int
+	sqlRun.QueryRow(t, `
+		SELECT count(*) FROM crdb_internal.tables
+		WHERE database_name = 't' AND name = 'child' AND state != 'DROP'
+	`).Scan(&tableCount)
+	require.Equal(t, 0, tableCount, "child table should not exist after rollback")
+
+	// Set an immediate GC zone config on the database so the child
+	// descriptor is fully deleted (not just marked DROPPED).
+	parentDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "parent")
+	_, err = sqltestutils.AddImmediateGCZoneConfig(sqlDB, parentDesc.GetParentID())
+	require.NoError(t, err)
+
+	// Wait for the GC job to complete, fully removing the child descriptor.
+	sqlRun.CheckQueryResultsRetry(t, `
+		SELECT count(*) FROM [SHOW JOBS]
+		WHERE job_type = 'SCHEMA CHANGE GC'
+		  AND description LIKE '%ROLLBACK OF CREATE TABLE%child%'
+		  AND status = 'succeeded'`,
+		[][]string{{"1"}},
+	)
+
+	// Verify via crdb_internal.invalid_objects that the parent is valid.
+	rows, err := sqlDB.Query(`
+		SELECT id, database_name, schema_name, obj_name, error
+		FROM "".crdb_internal.invalid_objects
+		WHERE database_name = 't' AND obj_name = 'parent'
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var invalidCount int
+	for rows.Next() {
+		var id int
+		var dbName, schemaName, objName, errMsg string
+		require.NoError(t, rows.Scan(&id, &dbName, &schemaName, &objName, &errMsg))
+		t.Logf("invalid_objects row: id=%d db=%s schema=%s obj=%s error=%s",
+			id, dbName, schemaName, objName, errMsg)
+		invalidCount++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, 0, invalidCount,
+		"parent table should not appear in invalid_objects")
+
+	// Also, verify the parent table has no orphaned InboundFKs (reads directly
+	// from KV, bypassing descriptor leases).
+	parentDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "parent")
+	require.Empty(t, parentDesc.InboundForeignKeys(),
+		"parent should have no InboundFKs after child rollback, but has %d",
+		len(parentDesc.InboundForeignKeys()))
 }
 
 // Test that non-physical table deletions like DROP VIEW are immediate instead

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1260,6 +1260,78 @@ func (sc *SchemaChanger) dropViewDeps(
 	return nil
 }
 
+// dropFKDeps cleans up foreign key references when rolling back a table that
+// was in ADD state. For each outbound FK, it removes the corresponding
+// InboundFK from the referenced table. For each inbound FK, it removes the
+// corresponding OutboundFK from the origin table. Without this cleanup,
+// rolling back a CREATE TABLE with inline FOREIGN KEY constraints leaves
+// orphaned back-references on the referenced tables.
+func (sc *SchemaChanger) dropFKDeps(
+	ctx context.Context,
+	descsCol *descs.Collection,
+	txn *kv.Txn,
+	b *kv.Batch,
+	tableDesc *tabledesc.Mutable,
+) error {
+	for i := range tableDesc.OutboundFKs {
+		fk := &tableDesc.OutboundFKs[i]
+		if fk.ReferencedTableID == tableDesc.ID {
+			continue // self-reference, will be dropped with the table
+		}
+		backrefTable, err := descsCol.MutableByID(txn).Table(ctx, fk.ReferencedTableID)
+		if err != nil {
+			log.Dev.Warningf(ctx, "error resolving referenced table %d for FK cleanup during rollback: %v",
+				fk.ReferencedTableID, err)
+			continue
+		}
+		if backrefTable.Dropped() {
+			continue
+		}
+		if err := removeFKBackReferenceFromTable(backrefTable, fk.Name, tableDesc); err != nil {
+			log.Dev.Warningf(ctx, "error removing FK backreference %q during rollback: %v", fk.Name, err)
+			continue
+		}
+		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, backrefTable, b); err != nil {
+			return err
+		}
+	}
+	tableDesc.OutboundFKs = nil
+
+	for i := range tableDesc.InboundFKs {
+		fk := &tableDesc.InboundFKs[i]
+		if fk.OriginTableID == tableDesc.ID {
+			continue // self-reference
+		}
+		originTable, err := descsCol.MutableByID(txn).Table(ctx, fk.OriginTableID)
+		if err != nil {
+			log.Dev.Warningf(ctx, "error resolving origin table %d for FK cleanup during rollback: %v",
+				fk.OriginTableID, err)
+			continue
+		}
+		if originTable.Dropped() {
+			continue
+		}
+		matchIdx := -1
+		for j, outFK := range originTable.OutboundFKs {
+			if outFK.ReferencedTableID == tableDesc.ID && outFK.Name == fk.Name {
+				matchIdx = j
+				break
+			}
+		}
+		if matchIdx != -1 {
+			originTable.OutboundFKs = append(
+				originTable.OutboundFKs[:matchIdx],
+				originTable.OutboundFKs[matchIdx+1:]...)
+			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, originTable, b); err != nil {
+				return err
+			}
+		}
+	}
+	tableDesc.InboundFKs = nil
+
+	return nil
+}
+
 func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) error {
 	log.Dev.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", sc.job.ID(), err)
 	if errReverse := sc.maybeReverseMutations(ctx, err); errReverse != nil {
@@ -1298,6 +1370,11 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 				return err
 			}
 		}
+
+		if err := sc.dropFKDeps(ctx, txn.Descriptors(), txn.KV(), b, scTable); err != nil {
+			return err
+		}
+
 		scTable.SetDropped()
 		scTable.DropTime = timeutil.Now().UnixNano()
 		const kvTrace = false

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1266,6 +1266,10 @@ func (sc *SchemaChanger) dropViewDeps(
 // corresponding OutboundFK from the origin table. Without this cleanup,
 // rolling back a CREATE TABLE with inline FOREIGN KEY constraints leaves
 // orphaned back-references on the referenced tables.
+//
+// Errors during cleanup are logged as warnings and skipped because this
+// function is only called during rollback, where the descriptor state may be
+// inconsistent or partially committed.
 func (sc *SchemaChanger) dropFKDeps(
 	ctx context.Context,
 	descsCol *descs.Collection,


### PR DESCRIPTION
Backport 2/2 commits from #165551 on behalf of @spilchen.

----

Previously, when a CREATE TABLE with inline FOREIGN KEY constraints had its schema change job fail permanently, rollbackSchemaChange() would mark the new table as Dropped and queue it for GC, but never remove the InboundFK entries that had been added to the referenced table(s) during the SQL transaction. This left orphaned FK back-references pointing to a descriptor that no longer exists, causing descriptor validation errors like:
```
relation "parent" (209): invalid foreign key backreference: missing table=264: referenced descriptor not found
```

The fix adds FK back-reference cleanup in the ADD-state rollback path of rollbackSchemaChange(), alongside the existing view dependency cleanup. For each outbound FK on the table being rolled back, we remove the corresponding InboundFK from the referenced table. Similarly, for any inbound FKs (other tables referencing this one), we remove the corresponding OutboundFK from the origin table.

This reuses the existing removeFKBackReferenceFromTable() helper already used by dropTableImpl() and maybeReverseMutations(). Errors during cleanup are logged as warnings and skipped (best-effort), matching the pattern used by dropViewDeps().

Closes #165548

Epic: None
Release note (bug fix): Fixed a bug in the legacy schema changer where rolling back a CREATE TABLE with inline FOREIGN KEY constraints could leave orphaned FK back-references on the referenced table, causing descriptor validation errors.


----

Fixes ENGREQ-326
Release justification: fixes schema change bug that could leave descriptor in a corrupt state; the fix is low risk and only changes rollback scenarios where a failure already occurred.