### PR TITLE
workflows: pass PR description to autosolve comment handler

### DIFF
--- a/.github/workflows/pr-autosolve-comments-trigger.yml
+++ b/.github/workflows/pr-autosolve-comments-trigger.yml
@@ -59,6 +59,8 @@ jobs:
           cp "$GITHUB_EVENT_PATH" /tmp/event-context/event.json
           echo "${{ github.event_name }}" > /tmp/event-context/event_name.txt
           echo "${{ github.actor }}" > /tmp/event-context/actor.txt
+          # Save PR description: .pull_request.body for review events, .issue.body for issue_comment events
+          jq -r '.pull_request.body // .issue.body // empty' "$GITHUB_EVENT_PATH" > /tmp/event-context/pr_body.txt
 
       # For issue_comment events, the PR head repo/ref aren't in the payload.
       # Fetch them via API and verify the head repo matches the expected fork.

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -230,6 +230,7 @@ jobs:
           printf '%s' "$REVIEW_USER" > "$CONTEXT_DIR/review_user.txt"
           printf '%s' "$REVIEW_BODY" > "$CONTEXT_DIR/review_body.txt"
           printf '%s' "$ALL_COMMENTS" > "$CONTEXT_DIR/all_comments.json"
+          cp /tmp/event-context/pr_body.txt "$CONTEXT_DIR/pr_body.txt" 2>/dev/null || true
 
       - name: Parse Reviewable comments from review body
         id: parse_reviewable
@@ -371,6 +372,7 @@ jobs:
             - /tmp/review-context/comment_body.txt: The comment text (no file/line context)
 
             /tmp/review-context/all_comments.json: JSON array of all native review comments on this PR
+            /tmp/review-context/pr_body.txt: The PR description (commit record), providing context about the change
             </untrusted_user_content>
 
             <task>


### PR DESCRIPTION
The pr-autosolve-comments workflow invokes Claude to address review
feedback, but Claude had no access to the PR description (commit record).
This made it harder to understand the intent behind changes when
addressing review comments.

Save the PR body as `pr_body.txt` in the trigger workflow artifact for all
event types: extracted from the event payload for `pull_request_review` and
`pull_request_review_comment` events, and from the API response for
`issue_comment` events (which already fetches PR details). The handler
copies it into the review context directory and the Claude prompt
documents it.

Release note: None