### PR TITLE
sql: only disable memo reuse for canary when query involves canary-window tables

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -16,9 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/prep"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -326,6 +328,17 @@ func (ex *connExecutor) populatePrepared(
 		if err := ex.handleAOST(ctx, p.stmt.AST); err != nil {
 			return 0, nil, err
 		}
+	}
+
+	// When the canary experiment is active (canary_fraction > 0), force
+	// StatsRolloutStable during PREPARE so the cached memo is built with
+	// stable (baseline) stats. During EXECUTE, the dice is rolled per
+	// query: stable executions reuse this memo; canary executions skip it
+	// and rebuild from scratch with canary stats (see the canary guard in
+	// chooseValidPreparedMemo).
+	if !p.SessionData().Internal &&
+		stats.CanaryFraction.Get(&p.EvalContext().Settings.SV) > 0 {
+		p.EvalContext().StatsRollout = eval.StatsRolloutStable
 	}
 
 	// PREPARE has a limited subset of statements it can be run with. Postgres

--- a/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
@@ -11,6 +11,10 @@ statement ok
 CREATE TABLE canary_table (x int primary key, y int, FAMILY (x, y)) WITH (sql_stats_canary_window = '20s');
 INSERT INTO canary_table VALUES (1, 1);
 
+statement ok
+CREATE TABLE no_canary_table (x int primary key);
+INSERT INTO no_canary_table VALUES (1);
+
 query TT
 SHOW CREATE TABLE canary_table
 ----
@@ -49,6 +53,25 @@ CREATE TABLE public.canary_table (
 
 subtest canary_stats_with_query_cache
 
+# This subtest verifies how canary executions interact with the query cache.
+#
+# cached memo exists (warm cache)?
+# ├─ yes → stale?
+# │         ├─ yes → rebuild via buildReusableMemo
+# │         │         (DisableMemoReuse decides whether to cache the rebuilt memo)
+# │         └─ no  → canary + canary-window table + stats differ?
+# │                   ├─ no  → use cached memo
+# │                   └─ yes → skip cached memo, build from scratch
+# │                             (DisableMemoReuse decides whether to cache)
+# └─ no (cold cache) → build fresh memo
+#                       canary + canary-window table + stats differ?
+#                       ├─ no  → add to cache (plans are identical)
+#                       └─ yes → do NOT add (protect stable baseline)
+
+# --------------------------------------------------------------------------
+# Phase 1: Warm-up — stable executions populate the cache normally.
+# --------------------------------------------------------------------------
+
 # Use a positive canary_fraction so that the experiment is active, but force
 # stable stats for this session via canary_stats_mode=off. (fraction=0 would
 # mean experiment-off, i.e. StatsRolloutDefault, not StatsRolloutStable.)
@@ -67,7 +90,6 @@ SELECT * FROM canary_table;
 statement ok
 SET TRACING = "off";
 
-# The first execution should miss the query cache.
 query T
 SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
@@ -83,14 +105,201 @@ SELECT * FROM canary_table;
 statement ok
 SET TRACING = "off";
 
-# The second execution should hit the query cache.
 query T
 SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache hit
 
-# Now we test the case where always use canary stats, which doesn't
-# interact with query cache at all.
+# Populate the cache for no_canary_table too.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM no_canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache miss
+query cache add
+
+# --------------------------------------------------------------------------
+# Phase 2a: Canary + warm cache + no stats — the read gate in action.
+# --------------------------------------------------------------------------
+# No table stats have been collected or injected yet, so canary and stable
+# stats are identical (there is nothing to canary).
+
+statement ok
+SET canary_stats_mode = on;
+
+# canary_table (has canary window but no stats injected yet, so canary
+# and stable are identical): the read gate does NOT fire and the cached
+# memo is reused directly.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+# no_canary_table (no canary window): unaffected, cache hit as normal.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM no_canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+# Switch back to stable. Both tables hit the cache — canary reused
+# the same cached memo (stats don't differ), so stable is unaffected.
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM no_canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+# --------------------------------------------------------------------------
+# Phase 2b: Canary + warm cache + stats differ — write gate blocks.
+# --------------------------------------------------------------------------
+# Now inject stats so canary and stable genuinely differ. Re-warm the cache
+# with a stable execution (injecting stats invalidates the old entry), then
+# verify a canary execution skips the cached memo AND does NOT cache the
+# from-scratch build (DisableMemoReuse fires because stats differ).
+
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+# Pin stats_as_of within the canary window so canary and stable stats differ.
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
+# Re-warm the cache: stable execution rebuilds the now-stale entry.
+# (The stale-rebuild path does not log "query cache add".)
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit (prepare)
+query cache hit but needed update
+
+# Canary execution: skips cached memo, builds from scratch, but does NOT
+# cache the result because canary and stable stats genuinely differ.
+# Contrast with Phase 2a above, where the same path produced a
+# "query cache add" because stats didn't differ there.
+statement ok
+SET canary_stats_mode = on;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' AND operation = 'optimizer';
+----
+query cache hit but needed update
+
+# Stable execution still hits the cache — canary did not corrupt it.
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+statement ok
+RESET stats_as_of
+
+# --------------------------------------------------------------------------
+# Phase 3: Canary + cold cache + no stats — the write gate passes.
+# --------------------------------------------------------------------------
+# The table has a canary window but no stats yet, so canary and stable stats
+# are identical. The read gate doesn't fire (nothing cached). The write gate
+# allows caching because there's nothing to canary.
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
 statement ok
 SET canary_stats_mode = on;
 
@@ -106,72 +315,207 @@ SET TRACING = "off";
 query T
 SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
-not using query cache
+query cache miss
+query cache add
+
+# --------------------------------------------------------------------------
+# Phase 4: Canary + cold cache + stats differ — the write gate blocks.
+# --------------------------------------------------------------------------
+# Inject stats and pin stats_as_of within the canary window so that canary
+# and stable stats genuinely differ. The canary memo must NOT be cached,
+# otherwise stable executions would reuse it and corrupt the baseline.
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+# stats_as_of within canary window (00:01:00 + 30s = 00:01:30 > 00:01:10),
+# so canary and stable stats genuinely differ.
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
 
 statement ok
-SET TRACING = "on", cluster;
-
-statement ok
-SELECT * FROM canary_table;
-
-statement ok
-SET TRACING = "off";
-
-query T
-SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
-----
-not using query cache
-
-# Switching back to using stable stats, and the same query should still be
-# able to hit the query cache.
-statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='0.0';
-
-statement ok
-SET TRACING = "on", cluster;
-
-statement ok
-SELECT * FROM canary_table;
-
-statement ok
-SET TRACING = "off";
-
-# We should see the original cache is still there.
-query T
-SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
-----
-query cache hit
-
-subtest end
-
-subtest prepared_statements
+SELECT crdb_internal.clear_query_plan_cache();
 
 statement ok
 SET canary_stats_mode = on;
 
 statement ok
-PREPARE p1 AS SELECT * FROM canary_table WHERE x = $1;
+SET TRACING = "on", cluster;
 
-query II
-EXECUTE p1(1);
-----
-1  1
-
-# Test with prepared statement without placeholder.
 statement ok
-PREPARE p2 AS SELECT * FROM canary_table WHERE x = 1;
+SELECT * FROM canary_table;
 
-query II
-EXECUTE p2;
+statement ok
+SET TRACING = "off";
+
+# Canary execution: miss but NO add — the write gate blocks because canary
+# and stable stats differ.
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' AND operation = 'optimizer';
 ----
-1  1
+query cache miss
+
+# Switch to stable. The cache is still empty, so stable gets a miss + add.
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache miss
+query cache add
+
+# Confirm the stable memo was cached correctly.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+# --------------------------------------------------------------------------
+# Phase 5: Canary + cold cache + canary window expired — write gate passes.
+# --------------------------------------------------------------------------
+# Unlike Phase 3 (no stats at all), here stats exist but stats_as_of is past
+# the canary window, so the newest stats have "ripened" and canary/stable see
+# the same thing. The canary memo is safe to cache.
+#
+# Reuses injected stats from Phase 4:
+#   stats at 2000-01-01 00:00:00 (row_count=10) and 00:01:00 (row_count=20)
+#
+# stats_as_of past the canary window (00:01:00 + 30s = 00:01:30 < 00:02:00),
+# so canary and stable stats are identical.
+statement ok
+SET stats_as_of = '2000-01-01 00:02:00.000000'
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+SET canary_stats_mode = on;
+
+# Confirm we are genuinely on the canary path (not accidentally default).
+# Both canary and stable see row_count=20 because stats_as_of is past the
+# canary window.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM canary_table
+----
+distribution: local
+vectorized: true
+table stats mode: canary
+·
+• scan
+  columns: (x, y)
+  estimated row count: 20 (100% of the table; stats collected <hidden> ago)
+  table: canary_table@canary_table_pkey
+  spans: FULL SCAN
 
 statement ok
 SET canary_stats_mode = off;
 
+query T
+EXPLAIN (VERBOSE) SELECT * FROM canary_table
+----
+distribution: local
+vectorized: true
+table stats mode: stable
+·
+• scan
+  columns: (x, y)
+  estimated row count: 20 (100% of the table; stats collected <hidden> ago)
+  table: canary_table@canary_table_pkey
+  spans: FULL SCAN
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+# Write gate passes — canary memo is cached since stats don't differ.
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache miss
+query cache add
+
+# Stable execution hits the cache that canary just populated (plans are
+# identical, so this is safe).
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+statement ok
+RESET stats_as_of
+
+statement ok
+RESET canary_stats_mode
+
 subtest end
 
 subtest prepared_statements_with_query_cache
+
+# This subtest verifies how canary executions interact with prepared
+# statement memos.
+#
+# PREPARE (no dice roll — always uses stable stats):
+#   Normal query cache behavior, no canary gating at all.
+#
+# EXECUTE (dice roll determines canary vs stable):
+#   canary + canary-window table + stats differ?
+#   ├─ no  → reuse prepared memo
+#   └─ yes → skip prepared memo, rebuild via buildReusableMemo
+#             (DisableMemoReuse decides whether to store the rebuilt memo)
+#
+# Tables without a canary window are always unaffected.
+
+# --------------------------------------------------------------------------
+# Phase 1: Warm-up — PREPARE populates query cache, stable EXECUTE reuses.
+# --------------------------------------------------------------------------
 
 statement ok
 DEALLOCATE ALL;
@@ -182,7 +526,7 @@ SELECT crdb_internal.clear_query_plan_cache();
 statement ok
 SET TRACING = "on", cluster;
 
-# We are using stable stats for every query, so the query cache should be used.
+# PREPARE uses the query cache normally (no canary gating).
 statement ok
 PREPARE p1 AS SELECT * from canary_table;
 PREPARE p2 AS SELECT * from canary_table;
@@ -199,6 +543,10 @@ query cache miss (prepare)
 query cache hit (prepare)
 query cache miss (prepare)
 query cache hit (prepare)
+
+# Stable EXECUTE reuses the prepared memo.
+statement ok
+SET canary_stats_mode = off;
 
 statement ok
 SET TRACING = "on", cluster;
@@ -224,25 +572,65 @@ reusing cached memo
 reusing cached memo
 reusing cached memo
 
-# We are using canary stats for all queries now, but we don't roll the dice
-# for prepared statement. I.e. the prepare stmt would still be cached,
-# and memo would still be built with stable stats and cached within the prepared
-# statement.
+# --------------------------------------------------------------------------
+# Phase 2a: Canary + stats differ — EXECUTE skips memo, rebuilds.
+# --------------------------------------------------------------------------
+# Pin stats_as_of within the canary window BEFORE PREPARE so the cached
+# memo has CanaryAndStableStatsDiffer=true. The read gate then fires
+# during canary EXECUTE.
+
+statement ok
+DEALLOCATE ALL;
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+# Show that the canary_table has canary window of 30s.
+query TT
+SHOW CREATE TABLE canary_table
+----
+canary_table  CREATE TABLE public.canary_table (
+                x INT8 NOT NULL,
+                y INT8 NULL,
+                CONSTRAINT canary_table_pkey PRIMARY KEY (x ASC),
+                FAMILY fam_0_x_y (x, y)
+              ) WITH (sql_stats_canary_window = '30s');
+
+# Inject stats with timestamps within the canary window.
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
 statement ok
 SET canary_stats_mode = on;
 
 statement ok
-SET TRACING = "on", cluster;
-
-# p5, p6 are based on the same queries as p1, p3 respectively, so they
-# should hit the query cache. p7 is a new query so it should see a query
-# cache miss, but itself would be cached. p8 is based on the same query as
-# p7, so it should hit the query cache.
-statement ok
 PREPARE p5 AS SELECT * from canary_table;
 PREPARE p6 AS SELECT * from canary_table WHERE x = $1;
-PREPARE p7 AS SELECT * from canary_table WHERE y = $1;
-PREPARE p8 AS SELECT * from canary_table WHERE y = $1;
+
+# Canary EXECUTE: stats differ, so the read gate fires — each EXECUTE
+# skips the prepared memo and rebuilds from scratch.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p5;
+EXECUTE p6(1);
 
 statement ok
 SET TRACING = "off";
@@ -250,27 +638,53 @@ SET TRACING = "off";
 query T
 SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
-query cache hit (prepare)
-query cache hit (prepare)
-query cache miss (prepare)
-query cache hit (prepare)
+skipping cached memo for canary exec
+rebuilding cached memo
+skipping cached memo for canary exec
+rebuilding cached memo
+
+# --------------------------------------------------------------------------
+# Phase 2b: Canary + stats don't differ — EXECUTE reuses memo.
+# --------------------------------------------------------------------------
+# Inject stats with old timestamps so the canary window (30s) is expired
+# from the wall clock's perspective (replacing any auto-collected stats).
+# PREPARE fresh statements so the cached memo has
+# CanaryAndStableStatsDiffer=false. The read gate does NOT fire.
+
+statement ok
+DEALLOCATE ALL;
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+RESET stats_as_of
+
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+statement ok
+PREPARE p7 AS SELECT * from canary_table;
+PREPARE p8 AS SELECT * from canary_table WHERE x = $1;
 
 statement ok
 SET TRACING = "on", cluster;
 
-# For execution, since canary_stats_mode=on forces canary for every execution,
-# the cached memo within the prepared statement cannot be reused (it was built
-# with stable stats), so each execution rebuilds the memo from scratch.
 statement ok
-EXECUTE p5;
-EXECUTE p5;
-EXECUTE p6(1);
-EXECUTE p6(1);
-EXECUTE p3(1);
-EXECUTE p3(1);
-EXECUTE p7(1);
-EXECUTE p7(1);
-EXECUTE p8(1);
+EXECUTE p7;
 EXECUTE p8(1);
 
 statement ok
@@ -281,18 +695,34 @@ SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message L
 ----
 reusing cached memo
 reusing cached memo
-reusing cached memo
-reusing cached memo
-reusing cached memo
-reusing cached memo
-reusing cached memo
-reusing cached memo
+
+# --------------------------------------------------------------------------
+# Phase 3: Canary + no canary window — EXECUTE reuses memo normally.
+# --------------------------------------------------------------------------
+
+statement ok
+PREPARE p9 AS SELECT * FROM no_canary_table WHERE x = $1;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p9(1);
+EXECUTE p9(1);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
 reusing cached memo
 reusing cached memo
 
-# We now switch back to stable stats. Executing a prepared stmt that was
-# created while canary_stats_mode=on should still be able to use the
-# cached memo.
+# --------------------------------------------------------------------------
+# Phase 4: Back to stable — canary never corrupted prepared memos.
+# --------------------------------------------------------------------------
+
 statement ok
 SET canary_stats_mode = off;
 
@@ -300,8 +730,8 @@ statement ok
 SET TRACING = "on", cluster;
 
 statement ok
-EXECUTE p7(1);
-EXECUTE p7(1);
+EXECUTE p7;
+EXECUTE p7;
 EXECUTE p8(1);
 EXECUTE p8(1);
 
@@ -315,6 +745,488 @@ reusing cached memo
 reusing cached memo
 reusing cached memo
 reusing cached memo
+
+subtest end
+
+subtest interleaved_canary_stable_execute
+
+# Test that interleaving canary and stable EXECUTEs does not corrupt the
+# prepared statement's cached memo. The sequence is:
+#   1. PREPARE with stable stats (canary_stats_mode=off).
+#   2. Stable EXECUTE → row_count=10 (stable stats).
+#   3. Canary EXECUTE → row_count=20 (canary stats), does NOT write back.
+#   4. Stable EXECUTE → row_count=10 (still the original stable memo).
+#
+# We inject stats that genuinely differ within the canary window so that
+# canary and stable plans are distinguishable. Step 4 asserts row_count=10;
+# if a bug allowed the canary to write back, it would show row_count=20.
+statement ok
+DEALLOCATE ALL;
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+# Pin stats_as_of within canary window so canary and stable stats differ.
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
+statement ok
+SET canary_stats_mode = off;
+
+# Use a full scan (no placeholder) so the row estimate directly reflects
+# which stats were used: stable=10, canary=20.
+statement ok
+PREPARE pinterleave AS SELECT * FROM canary_table;
+
+# Step 2: stable execute — should reuse the cached memo with row_count=10.
+# (Can be seen from "plan type: generic, reused")
+query T
+EXPLAIN ANALYZE (VERBOSE) EXECUTE pinterleave
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+table stats mode: stable
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  columns: (x, y)
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  vectorized batch count: 0
+  KV time: 0µs
+  KV rows decoded: 1
+  KV pairs read: 2
+  KV bytes read: 8 B
+  KV gRPC calls: 1
+  estimated max memory allocated: 0 B
+  MVCC step count (ext/int): 0/0
+  MVCC seek count (ext/int): 0/0
+  actual row count: 1
+  estimated row count: 10 (100% of the table; stats collected <hidden> ago)
+  canary window: 30s
+  table: canary_table@canary_table_pkey
+  spans: FULL SCAN
+
+# Step 3: canary execute — should rebuild from scratch with row_count=20.
+# (Can be seen from "plan type: generic, re-optimized")
+statement ok
+SET canary_stats_mode = on;
+
+query T
+EXPLAIN ANALYZE (VERBOSE) EXECUTE pinterleave
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+table stats mode: canary
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  columns: (x, y)
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  vectorized batch count: 0
+  KV time: 0µs
+  KV rows decoded: 1
+  KV pairs read: 2
+  KV bytes read: 8 B
+  KV gRPC calls: 1
+  estimated max memory allocated: 0 B
+  MVCC step count (ext/int): 0/0
+  MVCC seek count (ext/int): 0/0
+  actual row count: 1
+  estimated row count: 20 (100% of the table; stats collected <hidden> ago)
+  canary window: 30s
+  table: canary_table@canary_table_pkey
+  spans: FULL SCAN
+
+# Step 4: back to stable — the original cached memo (row_count = 10) must
+# still be intact.
+# (Can be seen from "plan type: generic, reused")
+statement ok
+SET canary_stats_mode = off;
+
+query T
+EXPLAIN ANALYZE (VERBOSE) EXECUTE pinterleave
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+table stats mode: stable
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  columns: (x, y)
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  vectorized batch count: 0
+  KV time: 0µs
+  KV rows decoded: 1
+  KV pairs read: 2
+  KV bytes read: 8 B
+  KV gRPC calls: 1
+  estimated max memory allocated: 0 B
+  MVCC step count (ext/int): 0/0
+  MVCC seek count (ext/int): 0/0
+  actual row count: 1
+  estimated row count: 10 (100% of the table; stats collected <hidden> ago)
+  canary window: 30s
+  table: canary_table@canary_table_pkey
+  spans: FULL SCAN
+
+statement ok
+RESET stats_as_of
+
+subtest end
+
+subtest prepare_uses_stable_with_canary_fraction
+
+# Verify that PREPARE always builds with stable stats when canary_fraction > 0,
+# even via the production canaryRollDice() path. This tests the fix in
+# populatePrepared that forces StatsRolloutStable during PREPARE.
+#
+# We inject stats that genuinely differ within the canary window. Without
+# the fix, PREPARE would roll canary (since fraction=1.0), the optbuilder
+# would set DisableMemoReuse (because canary and stable stats differ), and
+# the prepared memo would NOT be cached. With the fix, PREPARE forces
+# StatsRolloutStable, so memo caching works normally.
+statement ok
+DEALLOCATE ALL;
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+# Pin stats_as_of within canary window so canary and stable stats differ.
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
+# Production path: canary_fraction=1.0 means canaryRollDice() always
+# returns StatsRolloutCanary, but PREPARE overrides to StatsRolloutStable.
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='1.0';
+
+statement ok
+SET canary_stats_mode = auto;
+
+statement ok
+PREPARE pfrac AS SELECT * FROM canary_table WHERE x = $1;
+
+# Stable EXECUTE should reuse the cached memo, proving PREPARE built
+# and cached it with stable stats.
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE pfrac(1);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+
+# Canary EXECUTE (via production path) should rebuild since canary_table
+# has a canary window and stats genuinely differ.
+statement ok
+SET canary_stats_mode = auto;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE pfrac(1);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+skipping cached memo for canary exec
+rebuilding cached memo
+
+statement ok
+RESET stats_as_of;
+
+statement ok
+RESET canary_stats_mode;
+
+subtest end
+
+subtest rollout_mode_switch_invalidation
+
+# Verify that switching between Default and Stable stats rollout modes
+# (via canary_fraction cluster setting) correctly invalidates cached
+# memos through the IsStale check on statsRolloutAtBuildTime.
+#
+# The scenario:
+#   1. PREPARE with canary_fraction > 0 → memo built with StatsRolloutStable
+#   2. SET canary_fraction = 0           → rollout becomes StatsRolloutDefault
+#   3. EXECUTE                           → must NOT reuse the stale stable memo
+#
+
+statement ok
+DEALLOCATE ALL;
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+ALTER TABLE canary_table INJECT STATISTICS '[
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:00:00.000000",
+    "distinct_count": 10, "name": "__auto__",
+    "null_count": 0, "row_count": 10
+  },
+  {
+    "avg_size": 1, "columns": ["x"],
+    "created_at": "2000-01-01 00:01:00.000000",
+    "distinct_count": 20, "name": "__auto__",
+    "null_count": 0, "row_count": 20
+  }
+]'
+
+# Pin stats_as_of within canary window (00:01:00 + 30s > 00:01:10).
+statement ok
+SET stats_as_of = '2000-01-01 00:01:10.000000'
+
+# --------------------------------------------------------------------------
+# Phase 1: Query cache — Stable → Default.
+# --------------------------------------------------------------------------
+# Populate the query cache with a stable-built memo, then switch to Default
+# and verify that IsStale detects the mode change.
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='0.1';
+
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SELECT * FROM canary_table;
+
+# Confirm cache hit before the switch.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+# Switch to Default: canary_fraction = 0 makes canaryRollDice() return
+# StatsRolloutDefault regardless of canary_stats_mode.
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='0';
+
+# The cached memo was built with StatsRolloutStable — IsStale detects the
+# mode change and triggers a rebuild.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM canary_table;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit but needed update
+
+# --------------------------------------------------------------------------
+# Phase 2: Prepared statements — Stable → Default.
+# --------------------------------------------------------------------------
+
+statement ok
+DEALLOCATE ALL;
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='0.1';
+
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+PREPARE p_mode AS SELECT * FROM canary_table;
+
+# Stable EXECUTE reuses the prepared memo.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_mode;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+
+# Switch to Default: canary_fraction = 0.
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='0';
+
+# EXECUTE detects the stale prepared memo and rebuilds.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_mode;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+rebuilding cached memo
+
+# Subsequent EXECUTE reuses the rebuilt (Default) memo.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_mode;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+
+# --------------------------------------------------------------------------
+# Phase 3: Default → Stable (reverse direction).
+# --------------------------------------------------------------------------
+# Switch back to Stable and verify the Default-built memo is invalidated.
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction='0.1';
+
+statement ok
+SET canary_stats_mode = off;
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_mode;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+rebuilding cached memo
+
+# Subsequent stable EXECUTE reuses the rebuilt memo.
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_mode;
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+
+# --------------------------------------------------------------------------
+# Cleanup.
+# --------------------------------------------------------------------------
+
+statement ok
+RESET stats_as_of
+
+statement ok
+RESET canary_stats_mode
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = '0';
 
 subtest end
 
@@ -1553,7 +2465,7 @@ SET TRACING = "off"
 query T
 SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%cached memo%'
 ----
-rebuilding cached memo
+reusing cached memo
 
 # Second EXECUTE: fast path sees matching digest → memo reused (row_count=10).
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/canary_stats
@@ -49,9 +49,14 @@ CREATE TABLE public.canary_table (
 
 subtest canary_stats_with_query_cache
 
-# Test with stable stats, which should have the normal usage of query cache.
+# Use a positive canary_fraction so that the experiment is active, but force
+# stable stats for this session via canary_stats_mode=off. (fraction=0 would
+# mean experiment-off, i.e. StatsRolloutDefault, not StatsRolloutStable.)
 statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='0';
+SET CLUSTER SETTING sql.stats.canary_fraction='0.1';
+
+statement ok
+SET canary_stats_mode = off;
 
 statement ok
 SET TRACING = "on", cluster;
@@ -87,7 +92,7 @@ query cache hit
 # Now we test the case where always use canary stats, which doesn't
 # interact with query cache at all.
 statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='1.0';
+SET canary_stats_mode = on;
 
 statement ok
 SET TRACING = "on", cluster;
@@ -142,7 +147,7 @@ subtest end
 subtest prepared_statements
 
 statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='1.0';
+SET canary_stats_mode = on;
 
 statement ok
 PREPARE p1 AS SELECT * FROM canary_table WHERE x = $1;
@@ -162,7 +167,7 @@ EXECUTE p2;
 1  1
 
 statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='0';
+SET canary_stats_mode = off;
 
 subtest end
 
@@ -224,7 +229,7 @@ reusing cached memo
 # and memo would still be built with stable stats and cached within the prepared
 # statement.
 statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='1.0';
+SET canary_stats_mode = on;
 
 statement ok
 SET TRACING = "on", cluster;
@@ -253,9 +258,9 @@ query cache hit (prepare)
 statement ok
 SET TRACING = "on", cluster;
 
-# For execution, we roll the dice for every one. Since we have canary_fraction=1.0,
-# all execution will not use the query cache nor the cached memo within
-# the prepared statement. Thus we should see "not using query cache" for all executions.
+# For execution, since canary_stats_mode=on forces canary for every execution,
+# the cached memo within the prepared statement cannot be reused (it was built
+# with stable stats), so each execution rebuilds the memo from scratch.
 statement ok
 EXECUTE p5;
 EXECUTE p5;
@@ -274,22 +279,22 @@ SET TRACING = "off";
 query T
 SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
-not using query cache
-not using query cache
-not using query cache
-not using query cache
-not using query cache
-not using query cache
-not using query cache
-not using query cache
-not using query cache
-not using query cache
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
+reusing cached memo
 
-# We now switch back to the "everyone use stable stats" mode. At this moment
-# executing a prepared stmt that is created while canary_fration == 1.0 should
-# still be able to use the cached memo.
+# We now switch back to stable stats. Executing a prepared stmt that was
+# created while canary_stats_mode=on should still be able to use the
+# cached memo.
 statement ok
-SET CLUSTER SETTING sql.stats.canary_fraction='0';
+SET canary_stats_mode = off;
 
 statement ok
 SET TRACING = "on", cluster;

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -223,6 +223,25 @@ type Memo struct {
 	inlineAnyUnnestSubquery                    bool
 	useMinRowCountAntiJoinFix                  bool
 	useBackupsWithIDs                          bool
+	// builtWithStatsRollout records the stats rollout mode under which
+	// this memo was built.
+	//
+	// Motivation: consider PREPARE with StatsRolloutStable, then SET
+	// canary_fraction = 0 (making the rollout mode Default), then
+	// EXECUTE. Without this field the prepared memo would be silently
+	// reused even though it was planned against different (older) stats.
+	//
+	// IsStale uses this field to detect Default↔Stable transitions and
+	// invalidate the memo so it is rebuilt with the correct stats.
+	//
+	// Canary↔Default is not stale because both use the newest stats.
+	//
+	// Canary↔Stable is not checked here because a canary-built memo is
+	// only cached when canary and stable stats are identical (the
+	// write-side guard prevents caching otherwise). The Stable→Canary
+	// direction is handled by the read-side guard
+	// (skipMemoReuseForCanaryExec).
+	builtWithStatsRollout eval.StatsRolloutSelection
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -353,6 +372,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		skipUnderlyingViewPrivilegeChecks:          sqlclustersettings.SkipUnderlyingViewPrivilegeChecks.Get(&evalCtx.Settings.SV),
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 		useBackupsWithIDs:                          evalCtx.SessionData().UseBackupsWithIDs,
+		builtWithStatsRollout:                      evalCtx.StatsRollout,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(ctx, evalCtx, m)
@@ -540,6 +560,25 @@ func (m *Memo) IsStale(
 		m.skipUnderlyingViewPrivilegeChecks != sqlclustersettings.SkipUnderlyingViewPrivilegeChecks.Get(&evalCtx.Settings.SV) ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel ||
 		m.useBackupsWithIDs != evalCtx.SessionData().UseBackupsWithIDs {
+		return true, nil
+	}
+
+	// Memo is stale if the stats rollout mode changed between Default and
+	// Stable. Default uses the newest stats while Stable uses the
+	// second-newest (older-generation) stats. Switching between these
+	// modes (e.g. canary_fraction going from >0 to 0 or vice versa)
+	// means the memo was planned against the wrong stats.
+	//
+	// Canary↔Default is not stale because both use the newest stats.
+	//
+	// Canary↔Stable is not checked here. A canary-built memo is only
+	// cached when canary and stable stats are identical (the write-side
+	// guard prevents caching otherwise), so reuse is correct. The
+	// Stable→Canary direction is handled by the read-side guard
+	// (skipMemoReuseForCanaryExec) which skips the memo without
+	// evicting it, avoiding cache thrashing.
+	if (m.builtWithStatsRollout == eval.StatsRolloutStable && evalCtx.StatsRollout == eval.StatsRolloutDefault) ||
+		(m.builtWithStatsRollout == eval.StatsRolloutDefault && evalCtx.StatsRollout == eval.StatsRolloutStable) {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -728,6 +728,47 @@ func TestMemoIsStale(t *testing.T) {
 	stale()
 	evalCtx.SessionData().RowSecurity = false
 	notStale()
+
+	// Stale stats rollout mode: Default → Stable.
+	evalCtx.StatsRollout = eval.StatsRolloutStable
+	stale()
+	evalCtx.StatsRollout = eval.StatsRolloutDefault
+	notStale()
+
+	// Default→Canary: not stale (both use newest stats).
+	evalCtx.StatsRollout = eval.StatsRolloutCanary
+	notStale()
+	evalCtx.StatsRollout = eval.StatsRolloutDefault
+	notStale()
+
+	// A canary-built memo can legitimately be cached when the query
+	// doesn't reference canary-window tables (canary and default use
+	// the same stats). Verify IsStale handles this correctly.
+	evalCtx.StatsRollout = eval.StatsRolloutCanary
+	var o2 xform.Optimizer
+	opttestutils.BuildQuery(t, &o2, catalog, &evalCtx, query)
+	// Canary→Canary: not stale.
+	if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		t.Fatal(err)
+	} else if isStale {
+		t.Errorf("canary-built memo should not be stale for canary execution")
+	}
+	// Canary→Stable: not stale. A canary-built memo is only cached when
+	// canary and stable stats are identical (write-side guard prevents
+	// caching otherwise), so reuse is safe.
+	evalCtx.StatsRollout = eval.StatsRolloutStable
+	if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		t.Fatal(err)
+	} else if isStale {
+		t.Errorf("canary-built memo should not be stale for stable execution")
+	}
+	// Canary→Default: not stale (canary and default use the same stats).
+	evalCtx.StatsRollout = eval.StatsRolloutDefault
+	if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		t.Fatal(err)
+	} else if isStale {
+		t.Errorf("canary-built memo should not be stale for default execution")
+	}
 }
 
 // TestStatsAvailable tests that the statisticsBuilder correctly identifies

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -1052,6 +1052,21 @@ func (md *Metadata) NumTables() int {
 	return len(md.tables)
 }
 
+// HasCanaryWindowTables returns true if any table in the metadata has a
+// positive StatsCanaryWindow and genuinely different canary and stable
+// stats. When canary and stable stats are identical (e.g. the canary
+// window has expired or stats have ripened), the canary plan equals the
+// stable plan so memo reuse is safe.
+func (md *Metadata) HasCanaryWindowTables() bool {
+	for i := range md.tables {
+		if md.tables[i].Table.StatsCanaryWindow() > 0 &&
+			md.tables[i].Table.CanaryAndStableStatsDiffer() {
+			return true
+		}
+	}
+	return false
+}
+
 // AddColumn assigns a new unique id to a column within the query and records
 // its alias and type. If the alias is empty, a "column<ID>" alias is created.
 func (md *Metadata) AddColumn(alias string, typ *types.T) ColumnID {

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -300,7 +300,7 @@ func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias 
 	mb.vectorIndexDelPartitionColIDs = getSlice(numVectorIndexes)
 
 	// Add the table and its columns (including mutation columns) to metadata.
-	mb.tabID = mb.md.AddTable(tab, &mb.alias)
+	mb.tabID = mb.b.addTable(tab, &mb.alias).MetaID
 }
 
 // setFetchColIDs sets the list of columns that are fetched in order to provide

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -525,6 +525,18 @@ func (b *Builder) buildScanFromTableRef(
 func (b *Builder) addTable(tab cat.Table, alias *tree.TableName) *opt.TableMeta {
 	md := b.factory.Metadata()
 	tabID := md.AddTable(tab, alias)
+	// If this is a canary execution and any of the referenced tables has
+	// a canary window with genuinely different canary and stable stats,
+	// disable memo reuse so the canary-built memo is never written to the
+	// query cache or prepared-statement cache. When stats don't actually
+	// differ (e.g., the canary window has expired), the canary plan
+	// equals the stable plan, so caching it is safe.
+	if !b.DisableMemoReuse &&
+		tab.StatsCanaryWindow() > 0 &&
+		tab.CanaryAndStableStatsDiffer() &&
+		b.evalCtx.StatsRollout == eval.StatsRolloutCanary {
+		b.DisableMemoReuse = true
+	}
 	return md.TableMeta(tabID)
 }
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -506,9 +506,7 @@ func (opc *optPlanningCtx) reset(ctx context.Context) {
 		// are multiple DDL operations; and transactions can be aborted leading to
 		// potential reuse of versions. To avoid these issues, we prevent saving a
 		// memo (for prepare) or reusing a saved memo (for execute).
-		// We only allow reusing memo if this plan is not going to use canary stats.
-		opc.allowMemoReuse = !p.Descriptors().HasUncommittedDescriptors() &&
-			p.EvalContext().StatsRollout != eval.StatsRolloutCanary
+		opc.allowMemoReuse = !p.Descriptors().HasUncommittedDescriptors()
 		opc.useCache = opc.allowMemoReuse && queryCacheEnabled.Get(&p.execCfg.Settings.SV)
 
 		if _, isCanned := p.stmt.AST.(*tree.CannedOptPlan); isCanned {
@@ -781,6 +779,18 @@ func (opc *optPlanningCtx) chooseGenericPlan(ctx context.Context) bool {
 func (opc *optPlanningCtx) chooseValidPreparedMemo(ctx context.Context) (*memo.Memo, error) {
 	prep := opc.p.stmt.Prepared
 
+	// For canary executions that reference canary-window tables, return
+	// nil without running the staleness check. This is critical because
+	// the staleness check itself could nil the cached stable memo that
+	// future stable executions need, which violates the idea that a
+	// canary execution should never touch the cached stable memo: it
+	// builds a fresh one-time memo and discards it.
+	if opc.skipMemoReuseForCanaryExec(prep.GenericMemo) ||
+		opc.skipMemoReuseForCanaryExec(prep.BaseMemo) {
+		opc.log(ctx, "skipping cached memo for canary exec")
+		return nil, nil
+	}
+
 	if prep.GenericMemo != nil {
 		isStale, err := prep.GenericMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
 		if err != nil {
@@ -817,6 +827,20 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(ctx context.Context) (*memo.M
 		return prep.GenericMemo, nil
 	}
 	return prep.BaseMemo, nil
+}
+
+// skipMemoReuseForCanaryExec reports whether a previously cached memo
+// should NOT be reused for the current execution. It returns true when
+// the execution is a canary execution and the memo touches tables with
+// a canary window. This is a read-side guard: it prevents a canary
+// execution from reusing a stable-built cached memo. After skipping,
+// a fresh memo is built; the write-side guard (DisableMemoReuse in the
+// optbuilder) then decides whether that fresh memo should be cached,
+// based on whether canary and stable stats actually differ.
+func (opc *optPlanningCtx) skipMemoReuseForCanaryExec(m *memo.Memo) bool {
+	return m != nil &&
+		opc.p.EvalContext().StatsRollout == eval.StatsRolloutCanary &&
+		m.Metadata().HasCanaryWindowTables()
 }
 
 // fetchPreparedMemo attempts to fetch a memo from the prepared statement
@@ -939,13 +963,26 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 				// Update the plan in the cache. If the cache entry had Metadata
 				// populated, it may no longer be valid.
 				cachedData.Metadata = nil
-				p.execCfg.QueryCache.Add(&p.queryCacheSession, &cachedData)
+				// Re-check opc.useCache: buildReusableMemo may have cleared it
+				// (via DisableMemoReuse) when the rebuilt memo touches
+				// canary-window tables during a canary execution.
+				if opc.useCache {
+					p.execCfg.QueryCache.Add(&p.queryCacheSession, &cachedData)
+				}
 				opc.flags.Set(planFlagOptCacheMiss)
+				return opc.reuseMemo(cachedData.Memo)
+			} else if opc.skipMemoReuseForCanaryExec(cachedData.Memo) {
+				// The memo is not stale, but this is a canary execution
+				// that should not reuse the cached stable memo. Fall
+				// through to build from scratch. The cached entry remains
+				// valid for future stable executions; DisableMemoReuse in
+				// the from-scratch build will handle caching correctly.
+				opc.log(ctx, "query cache hit but skipping for canary exec")
 			} else {
 				opc.log(ctx, "query cache hit")
 				opc.flags.Set(planFlagOptCacheHit)
+				return opc.reuseMemo(cachedData.Memo)
 			}
-			return opc.reuseMemo(cachedData.Memo)
 		}
 		opc.flags.Set(planFlagOptCacheMiss)
 		opc.log(ctx, "query cache miss")
@@ -995,12 +1032,12 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 	// placeholders.
 	if opc.useCache && !bld.HadPlaceholders && !bld.DisableMemoReuse &&
 		!f.FoldingControl().PermittedStableFold() {
-		opc.log(ctx, "query cache add")
 		memo := opc.optimizer.DetachMemo(ctx)
 		cachedData := querycache.CachedData{
 			SQL:  opc.p.stmt.SQL,
 			Memo: memo,
 		}
+		opc.log(ctx, "query cache add")
 		p.execCfg.QueryCache.Add(&p.queryCacheSession, &cachedData)
 		return memo, nil
 	}

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -359,9 +359,9 @@ type Context struct {
 	// roll for this query execution. It has three possible values:
 	//
 	//   - StatsRolloutDefault: the canary experiment is not active
-	//     (sql.stats.canary_fraction = 0 or mode is off). The optimizer
-	//     uses whatever stats are available (default behavior). The
-	//     execution is not classified as canary or stable.
+	//     (sql.stats.canary_fraction = 0). The optimizer uses whatever
+	//     stats are available (default behavior). The execution is not
+	//     classified as canary or stable.
 	//
 	//   - StatsRolloutCanary: the canary experiment is active and this
 	//     execution was selected to use canary (newest) table statistics.
@@ -381,9 +381,12 @@ type Context struct {
 	// Only set for non-internal, non-prepared queries. Internal queries
 	// and prepared statements always use StatsRolloutDefault.
 	//
-	// When StatsRolloutCanary, the optimizer bypasses the query cache and
-	// the cached memo within a prepared stmt, building a one-off memo for
-	// this execution. Cached memos are always built with stable stats.
+	// When StatsRolloutCanary and the query references tables with a
+	// positive sql_stats_canary_window setting, the optimizer bypasses
+	// the query cache and the cached memo within a prepared stmt,
+	// building a one-off memo for this execution. For queries that do
+	// not reference any canary-window tables, caching proceeds normally
+	// since canary and stable stats are identical.
 	StatsRollout StatsRolloutSelection
 
 	// WorkloadID for ASH sampling.


### PR DESCRIPTION
Previously, when the canary dice roll resulted in StatsRolloutCanary, memo
reuse would be unconditionally disabled in `optPlanningCtx.reset()`. This was
done to avoid random cache churn: since canary/stable choices participated
in memo staleness check, the random dice rolls would cause frequent cache
invalidations and rebuilds, and allowing canary memos into the cache
risks reusing a canary-optimized plan for a stable execution (or vice
versa). Therefore, the rule was:
- cache = stable-only;
- canary = fresh optimization per execution, never saved.

However, the unconditional disable overkill queries that don't reference
any canary-window table (i.e. tables with a positive
`sql_stats_canary_window` storage param set). For such queries, there's
nothing to "canary", so there is no reason to skip caching.

This commit defers the `allowMemoReuse/useCache` disabling from reset()
(where we don't yet know which tables the query touches) to the points
where we actually attempt memo reuse. At these points, we inspect the
memo's metadata via the `Metadata.HasCanaryWindowTables()` helper and
only disable reuse when at least one referenced table has a canary
window configured.

Fixes: https://github.com/cockroachdb/cockroach/issues/157954

Release note (sql change): only disable memo reuse if query is on canary path AND the
query references any tables with positive `sql_stats_canary_window`
storage parameter.