### PR TITLE
sql: deflake TestScatterWithOneVoter

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -830,6 +830,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -251,6 +253,27 @@ func TestScatterWithOneVoter(t *testing.T) {
 	}
 	t.Logf("before scatter: replica distribution across stores: %v (total: %d)",
 		oldReplicaCounts, oldTotalReplicas)
+
+	// Ensure the allocator considers all the stores when scattering: wait until
+	// all store descriptors are in n1 StorePool, in "available" status.
+	// WaitForNStores in StartCluster is not sufficient. Additionally, stores can
+	// be transiently marked "suspect" after startup, and excluded from the store
+	// list during scatter. See #165936.
+	sl := tc.Server(0).StorageLayer()
+	store, err2 := sl.GetStores().(*kvserver.Stores).GetStore(sl.GetFirstStoreID())
+	require.NoError(t, err2)
+	sp := store.GetStoreConfig().StorePool
+	testutils.SucceedsSoon(t, func() error {
+		ss := sp.GetStoreStatuses()
+		for storeID := roachpb.StoreID(1); storeID <= 3; storeID++ {
+			if st, ok := ss[storeID]; !ok {
+				return errors.Newf("s%d status: not found", storeID)
+			} else if st != storepool.StoreStatusAvailable {
+				return errors.Newf("s%d status: %v, want available", storeID, st)
+			}
+		}
+		return nil
+	})
 
 	// Expect that the number of replicas on store 1 to have changed. We can't
 	// assert that the distribution will be even across all three stores, but s1


### PR DESCRIPTION
Wait for all stores to be available (not just present) in the store pool before running scatter. Two races existed:

1. `StartCluster.WaitForNStores` uses its own gossip callback worker, independent of the store pool's callback. The store pool may not have processed store descriptors yet when `WaitForNStores` returns.

2. Stores can be transiently marked "suspect" after startup due to node liveness flaps. Suspect stores are excluded from the store list used by the allocator, causing scatter to silently find no rebalance targets.

Fixes-25.4 #165936