### PR TITLE
claude: document hash-based redaction in redactability guide

### DIFF
--- a/.claude/rules/redactability.md
+++ b/.claude/rules/redactability.md
@@ -35,6 +35,45 @@ defining a type that will appear in log or error output.
 Prefer `SafeFormatter` over `SafeValue` — it's more precise and doesn't
 require linter allowlist changes.
 
+**Hash-based redaction:** CockroachDB supports hash-based redaction via
+`cockroachdb/redact`. Instead of replacing sensitive values with `×`,
+hashing produces a deterministic truncated hash (e.g. `‹2bd806c9›`),
+allowing correlation across log entries without exposing raw PII.
+
+- Wrap values with the appropriate `Hash*` type for hash-based redaction.
+  When hashing is enabled, the value is replaced by its hash; when
+  disabled, it falls back to full redaction (`×`). Choose the type that
+  matches your value:
+  | Value type       | Hash wrapper          |
+  |------------------|-----------------------|
+  | `string`         | `redact.HashString`   |
+  | `int64`          | `redact.HashInt`      |
+  | `uint64`         | `redact.HashUint`     |
+  | `float64`        | `redact.HashFloat`    |
+  | `[]byte`         | `redact.HashBytes`    |
+  | `byte`           | `redact.HashByte`     |
+  | `rune`           | `redact.HashRune`     |
+- For custom types, implement the `redact.HashValue` marker interface so
+  the redact package hashes them instead of replacing with `×`. Types implementing this interface should alias a base Go type — the hash is computed on the value's string representation during `Redact()`:
+  ```go
+  type UserID string
+  func (UserID) HashValue() {}
+  var _ redact.HashValue = UserID("")
+  ```
+- Hashing is controlled globally via `redact.EnableHashing(salt)` /
+  `redact.DisableHashing()`. In CockroachDB, this is configured through
+  the log config (`redaction.hashing.enabled` / `redaction.hashing.salt`
+  in `pkg/util/log/logconfig/config.go`).
+- Always provide a salt in production to resist brute-force reversal.
+- Regular unsafe values (not wrapped with a `Hash*` type or `HashValue`)
+  are still fully redacted even when hashing is enabled — hashing is
+  opt-in per value.
+
+**When to use hash-based redaction:** use it for values where you need to
+correlate occurrences across log lines (e.g. usernames, session IDs) but
+must not expose the raw value. Do not use it for values that should never
+appear in any form (e.g. passwords, tokens).
+
 **Testing:** nontrivial `SafeFormat` implementations need an `echotest`
 unit test to lock down both the redacted and unredacted output:
 ```go
@@ -46,3 +85,26 @@ func TestMyType_SafeFormat(t *testing.T) {
 ```
 Run with `-rewrite` to generate the initial testdata file, then inspect
 it to verify markers appear around unsafe fields.
+
+For hash-based redaction, verify both hashing-enabled and hashing-disabled
+outputs:
+```go
+func TestMyType_HashRedaction(t *testing.T) {
+    redact.DisableHashing()
+    t.Cleanup(redact.DisableHashing)
+
+    hashAlice := func() string {
+        return string(redact.Sprintf("user=%s", redact.HashString("alice")).Redact())
+    }
+
+    t.Run("hashing enabled", func(t *testing.T) {
+        redact.EnableHashing([]byte("salt"))
+        defer redact.DisableHashing()
+        require.Equal(t, "user=‹dc663a1d›", hashAlice())
+    })
+
+    t.Run("hashing disabled", func(t *testing.T) {
+        require.Equal(t, "user=‹×›", hashAlice())
+    })
+}
+```


### PR DESCRIPTION
Update the redactability Claude rule to cover the recently enabled hash-based redaction support from cockroachdb/redact. Documents all Hash* wrapper types (HashString, HashInt, HashUint, etc.), the HashValue marker interface for custom types, configuration via the log config, and testing guidance.

Epic: CC-35037
Release note: None