### PR TITLE
workflows: add trunk auto-merge support for backport PRs

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -30,6 +30,7 @@ jobs:
                     ... on PullRequest {
                       number
                       createdAt
+                      baseRefName
                       labels(first: 10) {
                         nodes {
                           name
@@ -79,18 +80,35 @@ jobs:
               }
 
               const labels = pr.labels.nodes.map(l => l.name).join(', ');
-              console.log(`Merging PR #${pr.number}, Created at: ${pr.createdAt}, Approved: ${approved}, Labels: ${labels}`);
+              const baseRef = pr.baseRefName;
+              console.log(`Processing PR #${pr.number}, Created at: ${pr.createdAt}, Approved: ${approved}, Target: ${baseRef}, Labels: ${labels}`);
 
-              // Merge the PR
-              try {
-                console.log(`Merging PR #${pr.number}`);
-                await github.rest.pulls.merge({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                  merge_method: "merge",
-                });
-              } catch (err) {
-                console.warn(`Failed to merge PR #${pr.number}: ${err.message}`);
+              const trunkBranches = ['release-24.3'];
+              if (trunkBranches.includes(baseRef)) {
+                // Use comment to trigger trunk merge for trunk-enabled branches
+                console.log(`Adding /trunk merge comment for PR #${pr.number} (target: ${baseRef})`);
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: '/trunk merge'
+                  });
+                } catch (err) {
+                  console.warn(`Failed to comment on PR #${pr.number}: ${err.message}`);
+                }
+              } else {
+                // Direct merge for all other branches
+                console.log(`Directly merging PR #${pr.number} (target: ${baseRef})`);
+                try {
+                  await github.rest.pulls.merge({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    merge_method: "merge",
+                  });
+                } catch (err) {
+                  console.warn(`Failed to merge PR #${pr.number}: ${err.message}`);
+                }
               }
             }


### PR DESCRIPTION
## Summary

- For the trunk-enabled `release-24.3` branch, post a `/trunk merge` comment instead of directly merging, since only the Trunk.io app has push access to that branch.
- For all other branches, keep existing direct merge behavior.
- Added `baseRefName` to the GraphQL query to identify each PR's target branch.

Note: This is a re-apply of #162003.

## Test plan

- [ ] Verify `/trunk merge` comment is posted on qualifying PRs targeting `release-24.3`
- [ ] Verify direct merge still works for non-trunk branches

Epic: CODESYS-206
Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)