### PR TITLE
security: removing curve preference of FIPS

### DIFF
--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -6,7 +6,6 @@
 package security
 
 import (
-	"crypto/fips140"
 	"crypto/tls"
 	"crypto/x509"
 
@@ -134,13 +133,6 @@ func newBaseTLSConfig(settings TLSSettings, caPEM []byte) (*tls.Config, error) {
 		CipherSuites: RecommendedCipherSuites(),
 
 		MinVersion: tls.VersionTLS12,
-	}
-
-	// If the binary is compiled in FIPS mode, Go will refuse to use the
-	// default X25519 curve. We switch to a FIPS-friendly curve in this
-	// mode.
-	if fips140.Enabled() {
-		baseCfg.CurvePreferences = []tls.CurveID{tls.CurveP256}
 	}
 
 	// Allow tests to override curve preferences.


### PR DESCRIPTION
* Previously, when running in FIPS mode, we restricted TLS curve preferences to only P-256. This was both redundant and overly restrictive: Go 1.25.5 already filters curves to FIPS-approved values internally (crypto/tls/defaults_fips140.go)
* Remove the explicit curve preference and let Go handle FIPS curve selection natively.
    
Release note (security update): Removed an overly restrictive TLS curve preference that limited FIPS mode to P-256. CockroachDB now uses Go's native FIPS curve selection, improving interoperability with clients that prefer other Go's native FIPS curves.

Epic: [CRDB-61940](https://cockroachlabs.atlassian.net/browse/CRDB-61940)
Fixes: #166494