### PR TITLE
sql/importer: fix TestUniqueUUID timeout

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -4069,6 +4069,10 @@ func TestUniqueUUID(t *testing.T) {
 	connDB := tc.ServerConn(0)
 	sqlDB := sqlutils.MakeSQLRunner(connDB)
 
+	// Disable elastic CPU control to avoid timeout — elastic CPU throttling
+	// can push this test past the 15m timeout.
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.elastic_control.enabled = false`)
+
 	dataSize := parallelImporterReaderBatchSize * 100
 
 	sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE data AS SELECT * FROM generate_series(1, %d);`, dataSize))


### PR DESCRIPTION
## Summary

Disable elastic CPU control in `TestUniqueUUID` to prevent the test from
exceeding the 15m timeout. The test imports 50,000 rows across three
tables with UUID/random primary key defaults.

When the metamorphic constant `import-row-count-validation` selects
`sync` mode, each import synchronously waits for an INSPECT validation
job that scans the imported data. Combined with elastic CPU throttling
(which was recently enabled for import jobs), the cumulative scan time
across the three imports can exceed the test timeout.

This mirrors the fix applied to other import tests in bda9189736f.

Resolves: #166130
Epic: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)