### PR TITLE
release-26.2: sql: pin max_buffer_size in select_for_share_write_buffering test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
@@ -13,6 +13,12 @@ SET CLUSTER SETTING kv.transaction.write_buffering.transformations.get.enabled =
 statement ok
 SET CLUSTER SETTING kv.transaction.write_buffering.transformations.scans.enabled = true;
 
+# Pin the buffer size to avoid a small metamorphic max_buffer_size causing an
+# immediate flush, which would disable write buffering and its lock durability
+# transformations for the rest of the transaction.
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '2KiB';
+
 statement ok
 SET kv_transaction_buffered_writes_enabled = true;
 


### PR DESCRIPTION
Backport 1/1 commits from #166051.

/cc @cockroachdb/release

---

## Summary

Pin `kv.transaction.write_buffering.max_buffer_size` to `2KiB` in the
`select_for_share_write_buffering` logic test, matching what is already done in
`cluster_locks_write_buffering` and other write buffering tests.

Without this, a small metamorphic `max_buffer_size` (e.g. 34 bytes) causes the
write buffer to overflow on the first locking read, permanently disabling write
buffering and its lock durability transformations for the transaction. This makes
the `cluster_locks` assertions fail because locks remain `Replicated` instead of
being transformed to `Unreplicated`.

Fixes: #166019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Release justification: Test only fix
