### PR TITLE
release-26.1: changefeedccl: fix sink not closed when newEventConsumer fails in Start

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -471,7 +471,13 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		return
 	}
 	ca.sink = &errorWrapperSink{wrapped: ca.sink}
-	ca.eventConsumer, ca.sink, err = newEventConsumer(
+
+	// Use local variables so that ca.sink is not overwritten with nil on error.
+	// newEventConsumer returns (nil, nil, err) on failure, and overwriting
+	// ca.sink would prevent close() from cleaning up the already-dialed sink.
+	var consumer eventConsumer
+	var s EventSink
+	consumer, s, err = newEventConsumer(
 		ctx, ca.FlowCtx.Cfg, ca.spec, feed, ca.frontier, kvFeedHighWater,
 		ca.sink, ca.metrics, ca.sliMetrics, ca.knobs)
 	if err != nil {
@@ -480,6 +486,9 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		ca.cancel()
 		return
 	}
+	ca.eventConsumer = consumer
+	// Reassign sink, since s may be a wrapped version of the original sink.
+	ca.sink = s
 
 	// Init heartbeat timer.
 	ca.lastPush = timeutil.Now()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -13475,3 +13475,122 @@ func TestChangefeedServerlessLocalityFilter(t *testing.T) {
 		`foo: [1]->{"after": {"pk": 1}}`,
 	})
 }
+
+// TestSinkClosedOnEventConsumerError verifies that when newEventConsumer fails
+// during changeAggregator.Start(), the sink is still properly closed. This is a
+// regression test for #144102 where newEventConsumer's error path returned
+// (nil, nil, err), overwriting ca.sink with nil and preventing cleanup.
+func TestSinkClosedOnEventConsumerError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, stopServer := makeServer(t,
+		withAllowChangefeedErr("injected event consumer error expected"))
+	defer stopServer()
+
+	sqlDB := sqlutils.MakeSQLRunner(s.DB)
+	knobs := s.TestingKnobs.
+		DistSQL.(*execinfra.TestingKnobs).
+		Changefeed.(*TestingKnobs)
+
+	// Track how many times Dial and Close are called across retries.
+	var dialCount, closeCount atomic.Int32
+	knobs.WrapSink = func(s Sink, _ jobspb.JobID) Sink {
+		return &closeTrackingSink{
+			wrapped:    s,
+			dialCount:  &dialCount,
+			closeCount: &closeCount,
+		}
+	}
+
+	// Only inject errors a fixed number of times so the changefeed eventually
+	// stabilises and the counters stop moving.
+	const numErrors = 3
+	var errorCount atomic.Int32
+	knobs.EventConsumerError = func() error {
+		if errorCount.Add(1) <= numErrors {
+			return errors.New("injected event consumer error")
+		}
+		return nil
+	}
+
+	sqlDB.Exec(t, `CREATE TABLE foo (pk INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+
+	// The changefeed will retry numErrors times, then succeed. Wait for all
+	// injected errors to fire before cancelling.
+	sqlDB.Exec(t, `CREATE CHANGEFEED FOR foo INTO 'null://'`)
+
+	testutils.SucceedsSoon(t, func() error {
+		if errorCount.Load() < numErrors {
+			return errors.Newf("waiting for all injected errors (errorCount=%d)", errorCount.Load())
+		}
+		return nil
+	})
+
+	// Verify the minimum expected dials occurred: 1 (validateSink) +
+	// numErrors (failed) + 1 (successful). Under stress there may be more
+	// due to other retriable errors (e.g. enriched envelope descriptor lookups).
+	require.GreaterOrEqual(t, dialCount.Load(), int32(numErrors+2))
+
+	// Cancel the changefeed so all sinks are closed and counters stabilize.
+	var jobID int64
+	sqlDB.QueryRow(t,
+		`SELECT job_id FROM [SHOW CHANGEFEED JOBS] ORDER BY created DESC LIMIT 1`,
+	).Scan(&jobID)
+	sqlDB.Exec(t, `CANCEL JOB $1`, jobID)
+
+	// After cancellation, every dialed sink must have been closed.
+	testutils.SucceedsSoon(t, func() error {
+		d := dialCount.Load()
+		c := closeCount.Load()
+		if c != d {
+			return errors.Newf("sink dialed %d times but closed only %d times", d, c)
+		}
+		return nil
+	})
+}
+
+// closeTrackingSink wraps a Sink and counts Dial and Close calls.
+type closeTrackingSink struct {
+	wrapped    Sink
+	dialCount  *atomic.Int32
+	closeCount *atomic.Int32
+}
+
+var _ Sink = (*closeTrackingSink)(nil)
+
+func (s *closeTrackingSink) Dial() error {
+	s.dialCount.Add(1)
+	return s.wrapped.Dial()
+}
+
+func (s *closeTrackingSink) Close() error {
+	s.closeCount.Add(1)
+	return s.wrapped.Close()
+}
+
+func (s *closeTrackingSink) EmitRow(
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+	headers rowHeaders,
+) error {
+	return s.wrapped.EmitRow(ctx, topic, key, value, updated, mvcc, alloc, headers)
+}
+
+func (s *closeTrackingSink) Flush(ctx context.Context) error {
+	return s.wrapped.Flush(ctx)
+}
+
+func (s *closeTrackingSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	return s.wrapped.EmitResolvedTimestamp(ctx, encoder, resolved)
+}
+
+func (s *closeTrackingSink) getConcreteType() sinkType {
+	return s.wrapped.getConcreteType()
+}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -96,6 +96,11 @@ func newEventConsumer(
 	sliMetrics *sliMetrics,
 	knobs TestingKnobs,
 ) (eventConsumer, EventSink, error) {
+	if knobs.EventConsumerError != nil {
+		if err := knobs.EventConsumerError(); err != nil {
+			return nil, nil, err
+		}
+	}
 	encodingOpts, err := feed.Opts.GetEncodingOptions()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1343,8 +1343,7 @@ func maybeForceEnrichedEnvelope(
 	// - sinkless feeds can't be tracked by job id
 	// - sql & pulsar are not supported
 	// - cloudstorage uses parquet sometimes which complicates things
-	// - pubsub feeds have an issue with leaking goroutines; see #144102
-	case *sinklessFeedFactory, *tableFeedFactory, *pulsarFeedFactory, *cloudFeedFactory, *pubsubFeedFactory:
+	case *sinklessFeedFactory, *tableFeedFactory, *pulsarFeedFactory, *cloudFeedFactory:
 		t.Logf("did not force enriched envelope for %s because %T is not supported", create, f)
 		return create, args, false, nil
 	}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -130,6 +130,11 @@ type TestingKnobs struct {
 	// OverrideCursorAge is used to change how old a cursor is. Returns time in nanoseconds.
 	OverrideCursorAge func() int64
 
+	// EventConsumerError, if set, is called before creating the event consumer.
+	// If it returns a non-nil error, newEventConsumer returns that error.
+	// This is useful for testing error handling in changeAggregator.Start().
+	EventConsumerError func() error
+
 	// MakeKVFeedToAggregatorBufferKnobs is used to make a fresh set of testing knobs
 	// to pass to the constructor of the kv feed to change aggregator buffer.
 	MakeKVFeedToAggregatorBufferKnobs func() kvevent.BlockingBufferTestingKnobs


### PR DESCRIPTION
Backport 1/1 commits from #165753.

/cc @cockroachdb/release

---

Previously, in changeAggregator.Start(), the call to newEventConsumer used a multi-value assignment directly into ca.eventConsumer and ca.sink:

    ca.eventConsumer, ca.sink, err = newEventConsumer(...)

When newEventConsumer returned an error, it also returned nil for the sink, which overwrote ca.sink with nil. This meant that when the changeAggregator's close() method ran, the nil check `if ca.sink != nil` would skip closing the sink. The underlying sink (which had already been dialed/connected at line 379) was never closed, leaking the goroutine from the gRPC connection — specifically the fakePubsubServer.Dial goroutine in tests.

This was most visible in enriched envelope tests because creating the enriched event consumer can fail under stress (due to descriptor lookups), and only pubsub's mock sink actually requires Close to prevent goroutine leaks.

The fix uses temporary variables so that ca.sink and ca.eventConsumer are only assigned on the success path, preserving the original sink reference for proper cleanup on error.

Also removes the pubsub skip workaround that was added to maybeForceEnrichedEnvelope in helpers_test.go.

Resolves: #144102
Fixes: #144102                                                                                                                                     
Fixes: #144354                                                                                                                                     
Fixes: #144587                                                                                                                                     
Fixes: #145442
Fixes: #146436
Fixes: #150396
Fixes: #155215
Fixes: #155548
Fixes: #159329
Fixes: #159720
Fixes: #163886
Fixes: #165788
Fixes: #158035 
Fixes: #152378

Release note: Fixes a rare, minimal goroutine leak in changefeeds.

Generated by Claude Code Auto-Solver

Release justification: bug fix for goroutine leak in changefeeds; low risk change
