### PR TITLE
release-24.3: crosscluster/physical: avoid frontier processor deadlock during cutover

### DIFF
--- a/pkg/ccl/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -220,6 +220,11 @@ func (sf *streamIngestionFrontier) Next() (
 			}
 			sf.MoveToDrainingAndLogError(err)
 			return nil, sf.DrainHelper()
+		default:
+			// If the heartbeat sender is not ready to receive a frontier
+			// update (e.g. it's blocked on a network call to a partitioned
+			// source cluster), skip this update to avoid blocking the
+			// frontier processor. The next iteration will try again.
 		}
 	}
 	return nil, sf.DrainHelper()


### PR DESCRIPTION
Backport 1/2 commits from #166110 on behalf of @msbutler.

----

Informs  #166109

Release note: none

----

Release justification: low risk change to prevent PCR hang during cutover