### PR TITLE
release-26.2: sql/execstats: skip TestTraceAnalyzer under duress

### DIFF
--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/sql/sessiondatapb",
         "//pkg/storage/enginepb",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/admission/admissionpb",

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -41,6 +42,7 @@ import (
 func TestTraceAnalyzer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "slow test; times out under race with external process tenant")
 
 	const (
 		testStmt = "SELECT * FROM test.foo ORDER BY v"


### PR DESCRIPTION
Backport 1/1 commits from #166209 on behalf of @dhartunian.

----

Skip `TestTraceAnalyzer` under duress (race/stress) since it times out when the metamorphic external process virtual cluster is injected — startup takes ~4 minutes under race and the test gets killed during shutdown.

Fixes: #166166

----

Release justification: test-only change