### PR TITLE
workload/schemachange: exclude hidden columns from policy expressions

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4305,7 +4305,8 @@ func (og *operationGenerator) tableColumnsShuffled(
 ) ([]string, error) {
 	q := fmt.Sprintf(`
 SELECT column_name
-FROM [SHOW COLUMNS FROM %s];
+FROM [SHOW COLUMNS FROM %s]
+WHERE NOT is_hidden;
 `, tableName)
 
 	rows, err := tx.Query(ctx, q)


### PR DESCRIPTION
This commit updates tableColumnsShuffled to filter out hidden columns when gathering available columns for random policy expression generation.

Previously, the workload generator could generate policies referencing hidden columns (e.g., from hash-sharded indexes). However, the dropColumn error screening logic (which uses information_schema.columns) is blind to hidden columns, leading to false negatives where a column drop was attempted without expecting the policy dependency error.

Since dropColumn already ignores hidden columns when selecting a target to drop, ensuring policies only reference visible columns prevents this class of false-negative dependency bugs.

Fixes: #164725
Epic: None
Release note: None