### PR TITLE
backup: add redaction markers to online restore URIs

### DIFF
--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -646,7 +646,7 @@ func (rd *restoreDataProcessor) linkFiles(
 		}
 
 		loc := kvpb.LinkExternalSSTableRequest_ExternalFile{
-			Locator:                 file.Dir.URI,
+			Locator:                 cloud.MakeRedactableLocatorURI(file.Dir.URI),
 			Path:                    file.Path,
 			ApproximatePhysicalSize: fileSize,
 			BackingFileSize:         file.BackingFileSize,

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -468,7 +468,7 @@ func sendRemoteAddSSTable(
 	}
 
 	loc := kvpb.LinkExternalSSTableRequest_ExternalFile{
-		Locator:                 file.Dir.URI,
+		Locator:                 cloud.MakeRedactableLocatorURI(file.Dir.URI),
 		Path:                    file.Path,
 		ApproximatePhysicalSize: fileSize,
 		BackingFileSize:         file.BackingFileSize,

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -1395,3 +1395,104 @@ func TestOnlineRestoreCleanupDroppedDescs(t *testing.T) {
 	sqlDB.Exec(t, fmt.Sprintf("CANCEL JOB %d", downloadJobID))
 	jobutils.WaitForJobToCancel(t, sqlDB, jobspb.JobID(downloadJobID))
 }
+
+// TestOnlineRestoreURIRedaction verifies that query parameters in backup URIs are redacted when
+// they appear in error messages during online restore.
+func TestOnlineRestoreURIRedaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	backuptestutils.EnableFastRestoreForTest(t)
+
+	const numAccounts = 1000
+	ts, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(
+		t, singleNode, numAccounts, InitManualReplication,
+	)
+	defer cleanupFn()
+
+	t.Run("params-redacted-in-errors", func(t *testing.T) {
+		// Use a backup URI with multiple fake query params. All of them should be
+		// redacted in error messages.
+		fakeSecrets := []string{"super_secret_value", "another_secret_token"}
+		backupURI := fmt.Sprintf(
+			"nodelocal://1/backup?FAKE_SECRET=%s&FAKE_TOKEN=%s",
+			fakeSecrets[0], fakeSecrets[1],
+		)
+
+		sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'")
+		defer sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
+
+		sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE data INTO '%s'", backupURI))
+
+		var linkJobID int
+		sqlDB.QueryRow(t, fmt.Sprintf(
+			"RESTORE DATABASE data FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY, new_db_name=data_redact, detached",
+			backupURI,
+		)).Scan(&linkJobID)
+		jobutils.WaitForJobToSucceed(t, sqlDB, jobspb.JobID(linkJobID))
+
+		var downloadJobID int
+		sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
+		jobutils.WaitForJobToPause(t, sqlDB, jobspb.JobID(downloadJobID))
+
+		// Delete the backing SST file so reads from the linked external SST fail.
+		corruptBackup(t, sqlDB, tmpDir, "nodelocal://1/backup")
+
+		// Query the restored data to trigger an error containing the locator URI.
+		_, err := sqlDB.DB.ExecContext(
+			context.Background(), "SELECT count(*) FROM data_redact.bank",
+		)
+		require.Error(t, err)
+
+		// Validate that the backup URI's query parameters are redacted in the error.
+		//
+		// The pebble locator stores the URI as a RedactableString with the query params wrapped in
+		// redaction markers (`‹›`).
+		//
+		// When this string is passed to an error, the query params in between the markers are replaced
+		// with `×` (utf8 multiplication sign), and the markers are replaced with `?` (for escaping purposes),
+		// resulting in a URI that looks like this:
+		//
+		//   nodelocal://1/backup/<subdir>??×?
+		//
+		// Where the first `?` is the URI query separator, the second `?` is the escaped `‹` marker,
+		// `×` is the redacted query params, and the trailing `?` is the escaped `›` marker.
+		//
+		// The regex below confirms the URI appears with the expected redaction pattern,
+		// and the NotContains checks verify no raw secrets are leaked.
+		require.Regexp(t,
+			`nodelocal://1/backup/[^?]+\?\?×\?`,
+			err.Error(),
+			"error message should contain the backup URI with redacted query params",
+		)
+		for _, secret := range fakeSecrets {
+			require.NotContains(t, err.Error(), secret,
+				"error message should not contain raw query parameter value",
+			)
+		}
+	})
+
+	// Sanity check that query params used during the backup/restore path still work with redaction.
+	// In this case a locality-aware online restore with COCKROACH_LOCALITY query params still works.
+	t.Run("locality-aware-still-works", func(t *testing.T) {
+		a := "nodelocal://1/a?COCKROACH_LOCALITY=default"
+		b := "nodelocal://1/b?COCKROACH_LOCALITY=dc%3Ddc2"
+		c := "nodelocal://1/c?COCKROACH_LOCALITY=dc%3Ddc3"
+
+		sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE data INTO ('%s', '%s', '%s')", a, b, c))
+
+		j := sqlDB.QueryStr(t, fmt.Sprintf(
+			`RESTORE DATABASE data FROM LATEST IN ('%s', '%s', '%s')
+			WITH new_db_name='d2', EXPERIMENTAL DEFERRED COPY`,
+			a, b, c,
+		))
+
+		ts.Servers[0].JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+		sqlDB.Exec(t, fmt.Sprintf(`SHOW JOB WHEN COMPLETE %s`, j[0][4]))
+
+		// Verify the restored data is accessible.
+		var rowCount int
+		sqlDB.QueryRow(t, "SELECT count(*) FROM d2.bank").Scan(&rowCount)
+		require.Equal(t, numAccounts, rowCount)
+	})
+}

--- a/pkg/cloud/uris.go
+++ b/pkg/cloud/uris.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -79,6 +80,29 @@ func SanitizeExternalStorageURI(path string, extraParams []string) (string, erro
 
 	uri.RawQuery = params.Encode()
 	return uri.String(), nil
+}
+
+// MakeRedactableLocatorURI builds a redact.RedactableString from a storage URI.
+// The query parameter section is treated as unsafe and surrounded with redaction markers.
+// Intended for use with pebble's remote.Locator.
+func MakeRedactableLocatorURI(uri string) redact.RedactableString {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return redact.Sprint(uri)
+	}
+
+	safePart := *parsed
+	safePart.RawQuery = ""
+
+	var b redact.StringBuilder
+	b.Printf("%s", redact.Safe(safePart.String()))
+
+	if parsed.RawQuery != "" {
+		b.Printf("%s", redact.Safe("?"))
+		b.Print(parsed.RawQuery)
+	}
+
+	return b.RedactableString()
 }
 
 // RedactKMSURI redacts the Master Key ID and the ExternalStorage secret

--- a/pkg/cloud/uris_test.go
+++ b/pkg/cloud/uris_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +62,60 @@ func TestSanitizeExternalStorageURI(t *testing.T) {
 			actualOutput, err := cloud.SanitizeExternalStorageURI(tc.inputURI, tc.inputExtraParams)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, actualOutput)
+		})
+	}
+}
+
+func TestMakeRedactableLocatorURI(t *testing.T) {
+	unsafe := func(s string) string {
+		return string(redact.Sprintf("%s", s))
+	}
+	redactedMarker := string(redact.RedactableString(redact.RedactedMarker()))
+
+	for _, tc := range []struct {
+		name     string
+		inputURI string
+		marked   string
+		redacted string
+	}{
+		{
+			name:     "no-query-params",
+			inputURI: "nodelocal://1/backup",
+			marked:   "nodelocal://1/backup",
+			redacted: "nodelocal://1/backup",
+		},
+		{
+			name:     "single-query-param",
+			inputURI: "nodelocal://1/backup?AUTH=specified",
+			marked:   "nodelocal://1/backup?" + unsafe("AUTH=specified"),
+			redacted: "nodelocal://1/backup?" + redactedMarker,
+		},
+		{
+			name:     "multiple-query-params",
+			inputURI: "nodelocal://1/backup?COCKROACH_LOCALITY=east-1&SUPER_SECRET_PASSWORD=password",
+			marked:   "nodelocal://1/backup?" + unsafe("COCKROACH_LOCALITY=east-1&SUPER_SECRET_PASSWORD=password"),
+			redacted: "nodelocal://1/backup?" + redactedMarker,
+		},
+		{
+			name:     "s3-uri-with-credentials",
+			inputURI: "s3://my-bucket/path?AWS_ACCESS_KEY_ID=AKID&AWS_SECRET_ACCESS_KEY=secret",
+			marked:   "s3://my-bucket/path?" + unsafe("AWS_ACCESS_KEY_ID=AKID&AWS_SECRET_ACCESS_KEY=secret"),
+			redacted: "s3://my-bucket/path?" + redactedMarker,
+		},
+		{
+			// url.Parse fails on this URI, so MakeRedactableLocatorURI falls back to treating the
+			// entire string as unsafe.
+			name:     "unparseable-uri-fully-redacted",
+			inputURI: "%%invalid?SECRET=dont-leak-this",
+			marked:   unsafe("%%invalid?SECRET=dont-leak-this"),
+			redacted: redactedMarker,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actualMarked := cloud.MakeRedactableLocatorURI(tc.inputURI)
+			require.Equal(t, tc.marked, string(actualMarked))
+			require.Equal(t, tc.redacted, string(actualMarked.Redact()))
+			require.Equal(t, tc.inputURI, actualMarked.StripMarkers())
 		})
 	}
 }

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2194,7 +2194,7 @@ message LinkExternalSSTableRequest {
     RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 
   message  ExternalFile {
-    string locator = 1;
+    string locator = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
     string path = 2;
     uint64 backing_file_size = 3;
     uint64 approximate_physical_size = 4;

--- a/pkg/kv/kvserver/deleted_external_sstable_test.go
+++ b/pkg/kv/kvserver/deleted_external_sstable_test.go
@@ -200,7 +200,7 @@ func (etc *externalSSTTestCluster) linkExternalSSTableToFile(
 		Key:    startKey,
 		EndKey: endKey,
 	}, kvpb.LinkExternalSSTableRequest_ExternalFile{
-		Locator: URI,
+		Locator: cloud.MakeRedactableLocatorURI(URI),
 		Path:    fileName,
 		// Use a dummy file sizes.
 		ApproximatePhysicalSize: uint64(512 * 1024 * 1024),

--- a/pkg/kv/kvserver/kvserverpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverpb/BUILD.bazel
@@ -69,6 +69,7 @@ go_proto_library(
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",  # keep
         "@com_github_cockroachdb_errors//errorspb",
+        "@com_github_cockroachdb_redact//:redact",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -271,7 +271,7 @@ message ReplicatedEvalResult {
   // has empty payload.
   message LinkExternalSSTable {
     roachpb.Span span = 1 [(gogoproto.nullable) = false];
-    string remote_file_loc = 2;
+    string remote_file_loc = 2 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];;
     string remote_file_path = 3;
     uint64 backing_file_size = 4;
     uint64 approximate_physical_size = 5;

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -786,7 +786,7 @@ func linkExternalSStablePreApply(
 	}
 
 	externalFile := pebble.ExternalFile{
-		Locator:           remote.MakeLocator(redact.RedactableString(sst.RemoteFileLoc)),
+		Locator:           remote.MakeLocator(sst.RemoteFileLoc),
 		ObjName:           sst.RemoteFilePath,
 		Size:              sst.ApproximatePhysicalSize,
 		StartKey:          start.Encode(),


### PR DESCRIPTION
This patch adds redaction markers to URIs passed to pebble in online
restore. Specifically, all query params in the URIs are marked as unsafe
and as such will be redacted in logs and error messages.

Informs: #161169

Release note: None