### PR TITLE
sql/schemachanger: add end-to-end test for `DROP TYPE`

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -848,6 +848,13 @@ func TestBackupRollbacks_base_drop_table_udf_default(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_truncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1685,6 +1692,13 @@ func TestBackupRollbacksMixedVersion_base_drop_table_udf_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2528,6 +2542,13 @@ func TestBackupSuccess_base_drop_table_udf_default(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_truncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3365,6 +3386,13 @@ func TestBackupSuccessMixedVersion_base_drop_table_udf_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -848,6 +848,13 @@ func TestEndToEndSideEffects_drop_table_udf_default(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_truncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1685,6 +1692,13 @@ func TestExecuteWithDMLInjection_drop_table_udf_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2528,6 +2542,13 @@ func TestGenerateSchemaChangeCorpus_drop_table_udf_default(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_truncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3365,6 +3386,13 @@ func TestPause_drop_table_udf_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -4208,6 +4236,13 @@ func TestPauseMixedVersion_drop_table_udf_default(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_truncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5045,6 +5080,13 @@ func TestRollback_drop_table_udf_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_drop_type(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_type"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DATABASE db;
+CREATE TYPE db.blue_fish AS ENUM('salmon');
+----
+
+test
+DROP TYPE db.blue_fish;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.explain
@@ -1,0 +1,109 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TYPE db.blue_fish AS ENUM('salmon');
+
+/* test */
+EXPLAIN (DDL) DROP TYPE db.blue_fish;
+----
+Schema change plan for DROP TYPE ‹db›.‹public›.‹blue_fish›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 15 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (blue_fish-), Name: "blue_fish", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (blue_fish-)}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (blue_fish-), Name: "admin"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (blue_fish-), Name: "public"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (blue_fish-), Name: "root"}
+ │         │    ├── PUBLIC → DROPPED EnumType:{DescID: 106 (blue_fish-)}
+ │         │    ├── PUBLIC → ABSENT  EnumTypeValue:{DescID: 106 (blue_fish-), Name: "salmon"}
+ │         │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 106 (blue_fish-), ReferencedDescID: 105 (public)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (_blue_fish-), Name: "_blue_fish", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (_blue_fish-)}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_blue_fish-), Name: "admin"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_blue_fish-), Name: "public"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_blue_fish-), Name: "root"}
+ │         │    ├── PUBLIC → DROPPED AliasType:{DescID: 107 (_blue_fish-), ReferencedTypeIDs: [106 (blue_fish-), 107 (_blue_fish-)]}
+ │         │    └── PUBLIC → ABSENT  SchemaChild:{DescID: 107 (_blue_fish-), ReferencedDescID: 105 (public)}
+ │         └── 15 Mutation operations
+ │              ├── MarkDescriptorAsDropped {"DescriptorID":106}
+ │              ├── NotImplementedForPublicObjects {"DescID":106,"ElementType":"scpb.EnumTypeVal..."}
+ │              ├── RemoveObjectParent {"ObjectID":106,"ParentSchemaID":105}
+ │              ├── MarkDescriptorAsDropped {"DescriptorID":107}
+ │              ├── RemoveObjectParent {"ObjectID":107,"ParentSchemaID":105}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"blue_fish","SchemaID":105}}
+ │              ├── NotImplementedForPublicObjects {"DescID":106,"ElementType":"scpb.Owner"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"admin"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"public"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"root"}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_blue_fish","SchemaID":105}}
+ │              ├── NotImplementedForPublicObjects {"DescID":107,"ElementType":"scpb.Owner"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"admin"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"public"}
+ │              └── RemoveUserPrivileges {"DescriptorID":107,"User":"root"}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 15 elements transitioning toward ABSENT
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (blue_fish-), Name: "blue_fish", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 106 (blue_fish-)}
+ │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (blue_fish-), Name: "admin"}
+ │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (blue_fish-), Name: "public"}
+ │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (blue_fish-), Name: "root"}
+ │    │    │    ├── DROPPED → PUBLIC EnumType:{DescID: 106 (blue_fish-)}
+ │    │    │    ├── ABSENT  → PUBLIC EnumTypeValue:{DescID: 106 (blue_fish-), Name: "salmon"}
+ │    │    │    ├── ABSENT  → PUBLIC SchemaChild:{DescID: 106 (blue_fish-), ReferencedDescID: 105 (public)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (_blue_fish-), Name: "_blue_fish", ReferencedDescID: 104 (db), IntValue: 105}
+ │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 107 (_blue_fish-)}
+ │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (_blue_fish-), Name: "admin"}
+ │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (_blue_fish-), Name: "public"}
+ │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (_blue_fish-), Name: "root"}
+ │    │    │    ├── DROPPED → PUBLIC AliasType:{DescID: 107 (_blue_fish-), ReferencedTypeIDs: [106 (blue_fish-), 107 (_blue_fish-)]}
+ │    │    │    └── ABSENT  → PUBLIC SchemaChild:{DescID: 107 (_blue_fish-), ReferencedDescID: 105 (public)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 15 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (blue_fish-), Name: "blue_fish", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (blue_fish-)}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (blue_fish-), Name: "admin"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (blue_fish-), Name: "public"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (blue_fish-), Name: "root"}
+ │         │    ├── PUBLIC → DROPPED EnumType:{DescID: 106 (blue_fish-)}
+ │         │    ├── PUBLIC → ABSENT  EnumTypeValue:{DescID: 106 (blue_fish-), Name: "salmon"}
+ │         │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 106 (blue_fish-), ReferencedDescID: 105 (public)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (_blue_fish-), Name: "_blue_fish", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (_blue_fish-)}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_blue_fish-), Name: "admin"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_blue_fish-), Name: "public"}
+ │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_blue_fish-), Name: "root"}
+ │         │    ├── PUBLIC → DROPPED AliasType:{DescID: 107 (_blue_fish-), ReferencedTypeIDs: [106 (blue_fish-), 107 (_blue_fish-)]}
+ │         │    └── PUBLIC → ABSENT  SchemaChild:{DescID: 107 (_blue_fish-), ReferencedDescID: 105 (public)}
+ │         └── 18 Mutation operations
+ │              ├── MarkDescriptorAsDropped {"DescriptorID":106}
+ │              ├── NotImplementedForPublicObjects {"DescID":106,"ElementType":"scpb.EnumTypeVal..."}
+ │              ├── RemoveObjectParent {"ObjectID":106,"ParentSchemaID":105}
+ │              ├── MarkDescriptorAsDropped {"DescriptorID":107}
+ │              ├── RemoveObjectParent {"ObjectID":107,"ParentSchemaID":105}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"blue_fish","SchemaID":105}}
+ │              ├── NotImplementedForPublicObjects {"DescID":106,"ElementType":"scpb.Owner"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"admin"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"public"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"root"}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_blue_fish","SchemaID":105}}
+ │              ├── NotImplementedForPublicObjects {"DescID":107,"ElementType":"scpb.Owner"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"admin"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"public"}
+ │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"root"}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":107,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT EnumType:{DescID: 106 (blue_fish-)}
+           │    └── DROPPED → ABSENT AliasType:{DescID: 107 (_blue_fish-), ReferencedTypeIDs: [106 (blue_fish-), 107 (_blue_fish-)]}
+           └── 5 Mutation operations
+                ├── DeleteDescriptor {"DescriptorID":106}
+                ├── DeleteDescriptor {"DescriptorID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TYPE db.blue_fish AS ENUM('salmon');
+
+/* test */
+EXPLAIN (DDL, SHAPE) DROP TYPE db.blue_fish;
+----
+Schema change plan for DROP TYPE ‹db›.‹public›.‹blue_fish›;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_type/drop_type.side_effects
@@ -1,0 +1,124 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TYPE db.blue_fish AS ENUM('salmon');
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
++object {104 105 blue_fish} -> 106
++object {104 105 _blue_fish} -> 107
+
+/* test */
+DROP TYPE db.blue_fish;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: DROP TYPE
+increment telemetry for sql.udts.drop_enum
+write *eventpb.DropType to event log:
+  sql:
+    descriptorId: 106
+    statement: DROP TYPE ‹db›.‹public›.‹blue_fish›
+    tag: DROP TYPE
+    user: root
+  typeName: db.public.blue_fish
+## StatementPhase stage 1 of 1 with 15 MutationType ops
+delete object namespace entry {104 105 blue_fish} -> 106
+delete object namespace entry {104 105 _blue_fish} -> 107
+upsert descriptor #106
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  state: DROP
+  +  version: "2"
+upsert descriptor #107
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  state: DROP
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 18 MutationType ops
+delete object namespace entry {104 105 blue_fish} -> 106
+delete object namespace entry {104 105 _blue_fish} -> 107
+upsert descriptor #106
+   type:
+     arrayTypeId: 107
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 106
+  +      name: blue_fish
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP TYPE ‹db›.‹public›.‹blue_fish›
+  +        statement: DROP TYPE db.blue_fish
+  +        statementTag: DROP TYPE
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: salmon
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  state: DROP
+  +  version: "2"
+upsert descriptor #107
+  ...
+       family: ArrayFamily
+       oid: 100107
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 107
+  +      name: _blue_fish
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP TYPE ‹db›.‹public›.‹blue_fish›
+  +        statement: DROP TYPE db.blue_fish
+  +        statementTag: DROP TYPE
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     id: 107
+     kind: ALIAS
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  state: DROP
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: true): "DROP TYPE db.public.blue_fish"
+  descriptor IDs: [106 107]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
+delete descriptor #106
+delete descriptor #107
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 106
+commit transaction #3
+# end PostCommitPhase


### PR DESCRIPTION
This change adds test coverage for the `DROP TYPE` statement.

Epic: CRDB-31325

Part of: #164214

Release note: None
