### PR TITLE
sql: fix TestTrace flake from statement hints spans

### DIFF
--- a/pkg/sql/hints/hint_table.go
+++ b/pkg/sql/hints/hint_table.go
@@ -23,6 +23,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// nodeUserLocalOnly is a session data override that forces local (non-DistSQL)
+// execution. Statement hint queries are simple point lookups that should not
+// incur the overhead of distributed execution.
+var nodeUserLocalOnly = sessiondata.InternalExecutorOverride{
+	User:          sessiondata.NodeUserSessionDataOverride.User,
+	MultiOverride: "distsql=off",
+}
+
 // Hint represents an unmarshaled hint that is ready to apply to statements.
 type Hint struct {
 	hintpb.StatementHintUnion
@@ -52,7 +60,7 @@ func CheckForStatementHintsInDB(
 	const opName = "get-plan-hints"
 	const getHintsStmt = `SELECT hash FROM system.statement_hints WHERE "hash" = $1 LIMIT 1`
 	it, err := ex.QueryIteratorEx(
-		ctx, opName, nil /* txn */, sessiondata.NodeUserSessionDataOverride,
+		ctx, opName, nil /* txn */, nodeUserLocalOnly,
 		getHintsStmt, statementHash,
 	)
 	if err != nil {
@@ -103,7 +111,7 @@ func GetStatementHintsFromDB(
     ORDER BY "created_at" DESC, "row_id" DESC`
 	}
 	it, queryErr := ex.QueryIteratorEx(
-		ctx, opName, nil /* txn */, sessiondata.NodeUserSessionDataOverride,
+		ctx, opName, nil /* txn */, nodeUserLocalOnly,
 		getHintsStmt, statementHash,
 	)
 	if queryErr != nil {

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -53,6 +53,10 @@ func TestTrace(t *testing.T) {
 		"admissionWorkQueueWait",
 		"index recommendation",
 		"/cockroach.roachpb.Internal/Batch",
+		// Internal queries (e.g. statement hints lookups) may produce
+		// spans in the session trace before their cache is initialized.
+		"get-plan-hints",
+		"prepare stmt",
 	}
 	// Depending on whether the data is local or not, we may not see these
 	// spans. Only applicable with distsql=on.


### PR DESCRIPTION
## Summary

Fixes a flake in `TestTrace` caused by the statement hints feature introducing
internal query spans that leak into the session trace.

- **Commit 1**: Force `distsql=off` for statement hint queries
  (`CheckForStatementHintsInDB`, `GetStatementHintsFromDB`). These are simple
  point lookups that don't need distributed execution.

- **Commit 2**: Add `get-plan-hints` and `prepare stmt` to the always-optional
  spans list in `TestTrace` to handle the case where the hints cache rangefeed
  hasn't initialized yet and the internal query runs.

The root cause: before the `StatementHintsCache` rangefeed initializes
`hintedHashes` on a node, every statement falls through to querying
`system.statement_hints` via the internal executor. This internal query was
being distributed (due to `ORDER BY` with no stats), producing DistSQL spans
(`/cockroach.sql.distsqlrun.DistSQL/SetupFlow`) that the test didn't expect
when `distsql=off`.

Fixes #166212

🤖 Generated with [Claude Code](https://claude.com/claude-code)