### PR TITLE
crosscluster: fix mixed-version RangeStats type mismatch

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -110,7 +110,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
-        "@com_github_gogo_protobuf//types",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -40,14 +40,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/rangescanstats/rangescanstatspb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/lib/pq/oid"
 )
 
@@ -820,12 +818,12 @@ func (rh *rowHandler) handleMeta(ctx context.Context, meta *execinfrapb.Producer
 		return nil
 	}
 
-	var stats rangescanstatspb.RangeStats
-	if err := pbtypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &stats); err != nil {
-		return errors.Wrap(err, "unable to unmarshal progress details")
+	stats, err := replicationutils.UnmarshalRangeStats(&meta.BulkProcessorProgress.ProgressDetails)
+	if err != nil {
+		return err
 	}
 
-	rh.rangeStats.Add(meta.BulkProcessorProgress.ProcessorID, &stats)
+	rh.rangeStats.Add(meta.BulkProcessorProgress.ProcessorID, stats)
 
 	return nil
 }

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -406,7 +406,7 @@ func (lrw *logicalReplicationWriterProcessor) Next() (
 
 	case stats := <-lrw.rangeStatsCh:
 		meta, err := replicationutils.StreamRangeStatsToProgressMeta(
-			lrw.FlowCtx, lrw.ProcessorID, stats,
+			lrw.Ctx(), lrw.FlowCtx, lrw.ProcessorID, stats,
 		)
 		if err != nil {
 			lrw.MoveToDrainingAndLogError(err)

--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -279,7 +279,7 @@ func (o *offlineInitialScanProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.P
 			return nil, o.DrainHelper()
 		}
 
-		meta, err := replicationutils.StreamRangeStatsToProgressMeta(o.FlowCtx, o.ProcessorID, stats)
+		meta, err := replicationutils.StreamRangeStatsToProgressMeta(o.Ctx(), o.FlowCtx, o.ProcessorID, stats)
 		if err != nil {
 			o.MoveToDrainingAndLogError(err)
 			return nil, o.DrainHelper()

--- a/pkg/crosscluster/physical/BUILD.bazel
+++ b/pkg/crosscluster/physical/BUILD.bazel
@@ -93,7 +93,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
-        "@com_github_gogo_protobuf//types",
     ],
 )
 

--- a/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -27,12 +27,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/rangescanstats/rangescanstatspb"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-	pbtypes "github.com/gogo/protobuf/types"
 )
 
 const (
@@ -436,12 +434,12 @@ func (sf *streamIngestionFrontier) maybeCollectRangeStats(
 		return nil
 	}
 
-	var stats rangescanstatspb.RangeStats
-	if err := pbtypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &stats); err != nil {
-		return errors.Wrap(err, "unable to unmarshal progress details")
+	stats, err := replicationutils.UnmarshalRangeStats(&meta.BulkProcessorProgress.ProgressDetails)
+	if err != nil {
+		return err
 	}
 
-	sf.rangeStats.Add(meta.BulkProcessorProgress.ProcessorID, &stats)
+	sf.rangeStats.Add(meta.BulkProcessorProgress.ProcessorID, stats)
 	return nil
 }
 

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -542,7 +542,7 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 		return nil, bulkutil.ConstructTracingAggregatorProducerMeta(sip.Ctx(),
 			sip.FlowCtx.NodeID.SQLInstanceID(), sip.FlowCtx.ID, sip.agg)
 	case stats := <-sip.rangeStatsCh:
-		meta, err := replicationutils.StreamRangeStatsToProgressMeta(sip.FlowCtx, sip.ProcessorID, stats)
+		meta, err := replicationutils.StreamRangeStatsToProgressMeta(sip.Ctx(), sip.FlowCtx, sip.ProcessorID, stats)
 		if err != nil {
 			sip.MoveToDrainingAndLogError(err)
 			return nil, sip.DrainHelper()

--- a/pkg/crosscluster/replicationutils/BUILD.bazel
+++ b/pkg/crosscluster/replicationutils/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/crosscluster/streamclient",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/crosscluster/replicationutils/stats.go
+++ b/pkg/crosscluster/replicationutils/stats.go
@@ -6,8 +6,11 @@
 package replicationutils
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/rangescanstats/rangescanstatspb"
@@ -19,10 +22,27 @@ import (
 // StreamRangeStatsToProgressMeta converts a range statistics from a rangefeed
 // StreamEvent and converts it to a ProducerMetadata that can be passed through
 // the DistSQL pipeline.
+//
+// During a mixed-version upgrade from 26.1 to 26.2, we marshal using the old
+// streampb.StreamEvent_RangeStats type so that both 26.1 and 26.2 nodes can
+// unmarshal the Any proto. Once the cluster is fully on 26.2, we switch to
+// the canonical rangescanstatspb.RangeStats type.
 func StreamRangeStatsToProgressMeta(
-	flowCtx *execinfra.FlowCtx, procID int32, stats *rangescanstatspb.RangeStats,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, procID int32, stats *rangescanstatspb.RangeStats,
 ) (*execinfrapb.ProducerMetadata, error) {
-	asAny, err := pbtypes.MarshalAny(stats)
+	var asAny *pbtypes.Any
+	var err error
+	if flowCtx.Cfg.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
+		asAny, err = pbtypes.MarshalAny(stats)
+	} else {
+		// Use the old type for compatibility with 26.1 nodes.
+		oldStats := &streampb.StreamEvent_RangeStats{
+			RangeCount:         stats.RangeCount,
+			ScanningRangeCount: stats.ScanningRangeCount,
+			LaggingRangeCount:  stats.LaggingRangeCount,
+		}
+		asAny, err = pbtypes.MarshalAny(oldStats)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to convert range stats to any proto")
 	}
@@ -34,6 +54,28 @@ func StreamRangeStatsToProgressMeta(
 			ProgressDetails: *asAny,
 		},
 	}, nil
+}
+
+// UnmarshalRangeStats attempts to unmarshal range stats from an Any proto,
+// trying both the new rangescanstatspb.RangeStats type and the old
+// streampb.StreamEvent_RangeStats type for mixed-version compatibility.
+//
+// TODO(kev-cao): Remove the fallback to StreamEvent_RangeStats when deleting the 26.2 version gates.
+func UnmarshalRangeStats(any *pbtypes.Any) (*rangescanstatspb.RangeStats, error) {
+	var stats rangescanstatspb.RangeStats
+	if err := pbtypes.UnmarshalAny(any, &stats); err != nil {
+		// Try the old type for mixed-version compatibility with 26.1 nodes.
+		var oldStats streampb.StreamEvent_RangeStats
+		if err := pbtypes.UnmarshalAny(any, &oldStats); err != nil {
+			return nil, errors.Wrap(err, "unable to unmarshal progress details")
+		}
+		stats = rangescanstatspb.RangeStats{
+			RangeCount:         oldStats.RangeCount,
+			ScanningRangeCount: oldStats.ScanningRangeCount,
+			LaggingRangeCount:  oldStats.LaggingRangeCount,
+		}
+	}
+	return &stats, nil
 }
 
 // AggregateRangeStatsCollector collects rangefeed StreamEvent range stats from

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -238,6 +238,20 @@ message StreamEvent {
     repeated KV kvs = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVs"];
   }
 
+  // RangeStats contains statistics about ranges being scanned during initial
+  // and catchup scans. This message is kept for mixed-version compatibility
+  // with 26.1 nodes which marshal this type via MarshalAny/UnmarshalAny in
+  // DistSQL progress metadata. The canonical definition has moved to
+  // rangescanstatspb.RangeStats; this copy must remain until all nodes in
+  // the cluster are running 26.2.
+  //
+  // TODO(kev-cao): Remove when deleting the 26.2 version gates.
+  message RangeStats {
+    int64 range_count = 1;
+    int64 scanning_range_count = 2;
+    int64 lagging_range_count = 3;
+  }
+
   // Checkpoint represents stream checkpoint.
   message StreamCheckpoint {
     reserved 1;


### PR DESCRIPTION
PR #163427 extracted `StreamEvent.RangeStats` from `streampb` into `rangescanstatspb.RangeStats`. While the wire contents are identical, the nominal type changed, which causes `pbtypes.UnmarshalAny` type checks to fail. In a mixed 26.1/26.2 cluster, nodes pass around both types, blocking the resolved timestamp from progressing.

This commit adds back the `streampb.StreamEvent.RangeStats` message and uses it for marshaling DistSQL progress metadata until the cluster is fully on 26.2. The unmarshal path tries both types for compatibility in either direction.

Fixes: #164640

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>