### PR TITLE
cli: support lock table keys in debug decode-key

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -452,6 +452,7 @@ go_test(
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",

--- a/pkg/cli/cli_debug_test.go
+++ b/pkg/cli/cli_debug_test.go
@@ -6,14 +6,19 @@
 package cli
 
 import (
+	gohex "encoding/hex"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -116,4 +121,21 @@ func TestDebugDecodeKeys(t *testing.T) {
 			require.Contains(t, out, "\n"+d.result+"\n")
 		})
 	}
+
+	t.Run("lock-table-engine-key", func(t *testing.T) {
+		u := uuid.Must(uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+		lk := storage.LockTableKey{Key: roachpb.Key("foo"), Strength: lock.Shared, TxnUUID: u}
+		ek, _ := lk.ToEngineKey(nil)
+		lockHex := gohex.EncodeToString(ek.Encode())
+		out, err := TestCLI{}.RunWithCaptureArgs([]string{
+			"debug",
+			"decode-key",
+			"--encoding",
+			"hex",
+			fmt.Sprintf("--user-key=%t", false),
+			lockHex,
+		})
+		require.NoError(t, err)
+		require.Contains(t, out, "\n"+fmt.Sprint(lk)+"\n")
+	})
 }

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -637,7 +637,8 @@ var debugDecodeKeyCmd = &cobra.Command{
 	Long: `
 Decode encoded keys provided as command arguments and pretty-print them.
 Decode command could be used with either encoded engine keys that contain
-timestamp or user keys used in range descriptors, range keys etc.
+timestamp, lock table keys (engine keys with a lock version suffix), or user
+keys used in range descriptors, range keys etc.
 Key encoding type could be changed using encoding flag.
 For example:
 
@@ -663,11 +664,30 @@ For example:
 			if decodeKeyOptions.userKey {
 				fmt.Println(roachpb.Key(b))
 			} else {
-				k, err := storage.DecodeMVCCKey(b)
-				if err != nil {
+				if k, err := storage.DecodeMVCCKey(b); err == nil {
+					fmt.Println(k)
+				} else if ek, ok := storage.DecodeEngineKey(b); ok {
+					switch {
+					case ek.IsMVCCKey():
+						mvccKey, err := ek.ToMVCCKey()
+						if err != nil {
+							return errors.Wrap(err, "decode engine key as MVCC")
+						}
+						fmt.Println(mvccKey)
+					case ek.IsLockTableKey():
+						lk, err := ek.ToLockTableKey()
+						if err != nil {
+							return errors.Wrap(err, "decode lock table engine key")
+						}
+						fmt.Println(lk)
+					default:
+						s := print.SprintEngineKey(ek)
+						s = strings.TrimSuffix(s, ": ")
+						fmt.Println(s)
+					}
+				} else {
 					return err
 				}
-				fmt.Println(k)
 			}
 		}
 		return nil

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -58,6 +58,10 @@ func SprintEngineKey(key storage.EngineKey) string {
 		if mvccKey, err := key.ToMVCCKey(); err == nil {
 			return SprintMVCCKey(mvccKey)
 		}
+	} else if key.IsLockTableKey() {
+		if lk, err := key.ToLockTableKey(); err == nil {
+			return fmt.Sprintf("%v (%#x): ", lk, key.Encode())
+		}
 	}
 
 	return fmt.Sprintf("%s %x (%#x): ", key.Key, key.Version, key.Encode())


### PR DESCRIPTION
decode-key previously only accepted MVCC keys or raw user keys. Lock table keys are stored as engine keys with a lock version suffix; try DecodeEngineKey after DecodeMVCCKey and print lock table keys consistently with other debug tooling.

Fixes #114425

Release note (cli change): The debug decode-key command can now decode lock table engine keys, not only MVCC keys and unversioned user keys.

**Testing:** `./dev test pkg/cli -f=TestDebugDecodeKeys -v`