### PR TITLE
ldrrandgen: allow virtual computed columns in indexes for crud writer

### DIFF
--- a/pkg/crosscluster/ldrrandgen/BUILD.bazel
+++ b/pkg/crosscluster/ldrrandgen/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlclustersettings",
         "//pkg/sql/types",
     ],
 )
@@ -27,6 +28,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlclustersettings",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/crosscluster/ldrrandgen/logical.go
+++ b/pkg/crosscluster/ldrrandgen/logical.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -40,7 +41,10 @@ func isSupportedType(t *types.T) bool {
 }
 
 func GenerateLDRTable(
-	ctx context.Context, rng *rand.Rand, tableName string, supportKVWriter bool,
+	ctx context.Context,
+	rng *rand.Rand,
+	tableName string,
+	writerType sqlclustersettings.LDRWriterType,
 ) *tree.CreateTable {
 	columnByName := func(name tree.Name, columnDefs []*tree.ColumnTableDef) *tree.ColumnTableDef {
 		for _, col := range columnDefs {
@@ -72,7 +76,7 @@ func GenerateLDRTable(
 					return false
 				}
 			}
-			if supportKVWriter && indexDef.Sharded != nil {
+			if writerType == sqlclustersettings.LDRWriterTypeLegacyKV && indexDef.Sharded != nil {
 				// The KV writer does not support hash sharded indexes.
 				return false
 			}
@@ -89,21 +93,19 @@ func GenerateLDRTable(
 				return false
 			case *tree.IndexTableDef:
 				for _, col := range indexDef.Columns {
-					if supportKVWriter && col.Expr != nil {
-						// Do not allow expression indexes. These cause SQL to generate a hidden computed column, which is not
-						// supported by the kv writer.
-						if col.Expr != nil {
-							return false
-						}
+					if writerType == sqlclustersettings.LDRWriterTypeLegacyKV && col.Expr != nil {
+						// Do not allow expression indexes. These cause SQL to generate a
+						// hidden computed column, which is not supported by the kv writer.
+						return false
 					}
 					columnDef := columnByName(col.Column, columnDefs)
-					if columnDef.IsVirtual() {
-						// Virtual computed columns are not supported in indexes by the classic sql writer or the kv writer.
-						// TODO(jeffswenson): remove this restriction once the crud writer is the only writer.
+					if columnDef != nil && columnDef.IsVirtual() {
+						// Virtual computed columns are not supported in indexes by the
+						// classic sql writer or the kv writer.
 						return false
 					}
 				}
-				if supportKVWriter && indexDef.Sharded != nil {
+				if writerType == sqlclustersettings.LDRWriterTypeLegacyKV && indexDef.Sharded != nil {
 					// The KV writer does not support hash sharded indexes.
 					return false
 				}

--- a/pkg/crosscluster/ldrrandgen/logical.go
+++ b/pkg/crosscluster/ldrrandgen/logical.go
@@ -99,9 +99,10 @@ func GenerateLDRTable(
 						return false
 					}
 					columnDef := columnByName(col.Column, columnDefs)
-					if columnDef != nil && columnDef.IsVirtual() {
-						// Virtual computed columns are not supported in indexes by the
-						// classic sql writer or the kv writer.
+					if columnDef != nil && columnDef.IsVirtual() &&
+						writerType == sqlclustersettings.LDRWriterTypeLegacyKV {
+						// Virtual computed columns in indexes are not supported by the
+						// legacy KV writer, which cannot evaluate expressions.
 						return false
 					}
 				}

--- a/pkg/crosscluster/ldrrandgen/logical_test.go
+++ b/pkg/crosscluster/ldrrandgen/logical_test.go
@@ -44,7 +44,9 @@ func TestGenerateLDRTable(t *testing.T) {
 	rndSrc, _ := randutil.NewTestRand()
 	rndSrc.Seed(time.Now().UnixNano())
 
-	stmt := GenerateLDRTable(ctx, rndSrc, "test_writer", sqlclustersettings.LDRWriterTypeLegacyKV)
+	writerType := sqlclustersettings.LDRWriterType(sqlclustersettings.LDRImmediateModeWriter.Default())
+	t.Logf("using writer type: %s", writerType)
+	stmt := GenerateLDRTable(ctx, rndSrc, "test_writer", writerType)
 	t.Logf("creating table: %s", stmt)
 	dbA.Exec(t, tree.AsStringWithFlags(stmt, tree.FmtParsable))
 

--- a/pkg/crosscluster/ldrrandgen/logical_test.go
+++ b/pkg/crosscluster/ldrrandgen/logical_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -43,7 +44,7 @@ func TestGenerateLDRTable(t *testing.T) {
 	rndSrc, _ := randutil.NewTestRand()
 	rndSrc.Seed(time.Now().UnixNano())
 
-	stmt := GenerateLDRTable(ctx, rndSrc, "test_writer", true)
+	stmt := GenerateLDRTable(ctx, rndSrc, "test_writer", sqlclustersettings.LDRWriterTypeLegacyKV)
 	t.Logf("creating table: %s", stmt)
 	dbA.Exec(t, tree.AsStringWithFlags(stmt, tree.FmtParsable))
 

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -137,7 +138,7 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	tableName := "rand_table"
 
-	stmt := tree.SerializeForDisplay(ldrrandgen.GenerateLDRTable(ctx, rng, tableName, true))
+	stmt := tree.SerializeForDisplay(ldrrandgen.GenerateLDRTable(ctx, rng, tableName, sqlclustersettings.LDRWriterTypeLegacyKV))
 	t.Logf("Creating table with schema: %s", stmt)
 	runner.Exec(t, stmt)
 

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -138,7 +138,8 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	tableName := "rand_table"
 
-	stmt := tree.SerializeForDisplay(ldrrandgen.GenerateLDRTable(ctx, rng, tableName, sqlclustersettings.LDRWriterTypeLegacyKV))
+	writerType := sqlclustersettings.LDRWriterType(sqlclustersettings.LDRImmediateModeWriter.Default())
+	stmt := tree.SerializeForDisplay(ldrrandgen.GenerateLDRTable(ctx, rng, tableName, writerType))
 	t.Logf("Creating table with schema: %s", stmt)
 	runner.Exec(t, stmt)
 

--- a/pkg/workload/conflict/BUILD.bazel
+++ b/pkg/workload/conflict/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/crosscluster/ldrrandgen",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlclustersettings",
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/workload",
@@ -40,6 +41,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlclustersettings",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/workload/conflict/conflict.go
+++ b/pkg/workload/conflict/conflict.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/ldrrandgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/jackc/pgx/v5/stdlib"
@@ -72,7 +73,7 @@ func (w *conflict) Hooks() workload.Hooks {
 func (w *conflict) Tables() []workload.Table {
 	rng := rand.New(rand.NewSource(RandomSeed.Seed()))
 
-	statement := ldrrandgen.GenerateLDRTable(context.TODO(), rng, "fonflict", true)
+	statement := ldrrandgen.GenerateLDRTable(context.TODO(), rng, "fonflict", sqlclustersettings.LDRWriterTypeLegacyKV)
 	ctx := tree.NewFmtCtx(tree.FmtParsable)
 	statement.FormatBody(ctx)
 	table := workload.Table{

--- a/pkg/workload/conflict/conflict.go
+++ b/pkg/workload/conflict/conflict.go
@@ -73,7 +73,8 @@ func (w *conflict) Hooks() workload.Hooks {
 func (w *conflict) Tables() []workload.Table {
 	rng := rand.New(rand.NewSource(RandomSeed.Seed()))
 
-	statement := ldrrandgen.GenerateLDRTable(context.TODO(), rng, "fonflict", sqlclustersettings.LDRWriterTypeLegacyKV)
+	writerType := sqlclustersettings.LDRWriterType(sqlclustersettings.LDRImmediateModeWriter.Default())
+	statement := ldrrandgen.GenerateLDRTable(context.TODO(), rng, "fonflict", writerType)
 	ctx := tree.NewFmtCtx(tree.FmtParsable)
 	statement.FormatBody(ctx)
 	table := workload.Table{

--- a/pkg/workload/conflict/writer_test.go
+++ b/pkg/workload/conflict/writer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/ldrrandgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -166,7 +167,7 @@ func TestWriterRandom(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 
 	rng, _ := randutil.NewTestRand()
-	stmt := ldrrandgen.GenerateLDRTable(ctx, rng, "test_writer", true)
+	stmt := ldrrandgen.GenerateLDRTable(ctx, rng, "test_writer", sqlclustersettings.LDRWriterTypeLegacyKV)
 	createStmt := tree.AsStringWithFlags(stmt, tree.FmtParsable)
 
 	runWriterTest(t, ctx, db, "test_writer", createStmt)

--- a/pkg/workload/conflict/writer_test.go
+++ b/pkg/workload/conflict/writer_test.go
@@ -167,7 +167,8 @@ func TestWriterRandom(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 
 	rng, _ := randutil.NewTestRand()
-	stmt := ldrrandgen.GenerateLDRTable(ctx, rng, "test_writer", sqlclustersettings.LDRWriterTypeLegacyKV)
+	writerType := sqlclustersettings.LDRWriterType(sqlclustersettings.LDRImmediateModeWriter.Default())
+	stmt := ldrrandgen.GenerateLDRTable(ctx, rng, "test_writer", writerType)
 	createStmt := tree.AsStringWithFlags(stmt, tree.FmtParsable)
 
 	runWriterTest(t, ctx, db, "test_writer", createStmt)


### PR DESCRIPTION
## Summary

The crud writer supports virtual computed columns in indexes, but the
random table generator was unconditionally filtering them out. This PR:

- Plumbs `LDRWriterType` through `GenerateLDRTable` so callers can
  express which writer they target, replacing the `supportKVWriter bool`
  parameter.
- Relaxes the virtual computed column restriction to only block them for
  the legacy KV and classic SQL writers.
- Updates `TestGenerateLDRTable` to use a random writer type.

Epic: none

Release note: None