### PR TITLE
cdc: dial canary sink when creating external connection

### DIFF
--- a/pkg/ccl/changefeedccl/external_connection_validation_test.go
+++ b/pkg/ccl/changefeedccl/external_connection_validation_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -26,8 +28,8 @@ func TestValidateExternalConnectionSinkURI(t *testing.T) {
 	defer stopServer()
 
 	env := externalconn.ExternalConnEnv{
-		ServerCfg: &s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).ServerConfig,
-		Username:  "root",
+		ServerCfg: &s.DistSQLServer().(*distsql.ServerImpl).ServerConfig,
+		Username:  username.RootUserName(),
 	}
 
 	t.Run("fails-when-dial-fails", func(t *testing.T) {

--- a/pkg/ccl/changefeedccl/external_connection_validation_test.go
+++ b/pkg/ccl/changefeedccl/external_connection_validation_test.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestValidateExternalConnectionSinkURI(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, stopServer := makeServer(t)
+	defer stopServer()
+
+	env := externalconn.ExternalConnEnv{
+		ServerCfg: &s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).ServerConfig,
+		Username:  "root",
+	}
+
+	t.Run("fails-when-dial-fails", func(t *testing.T) {
+		// Using a port that is unlikely to be listening.
+		uri := "kafka://127.0.0.1:1"
+		err := validateExternalConnectionSinkURI(ctx, env, uri)
+		if err == nil {
+			t.Fatal("expected error when dialing invalid sink, got nil")
+		}
+		// Verify it's a connection error, not a validation error.
+		expectedErr := "dial"
+		if !testutils.IsError(err, expectedErr) && !testutils.IsError(err, "connection") && !testutils.IsError(err, "broker") {
+			t.Fatalf("expected connection error, got: %v", err)
+		}
+		fmt.Printf("Successfully caught expected error: %v\n", err)
+	})
+
+	t.Run("succeeds-when-well-formed-null-sink", func(t *testing.T) {
+		// Null sink dial should always succeed.
+		uri := "null:///"
+		err := validateExternalConnectionSinkURI(ctx, env, uri)
+		if err != nil {
+			t.Fatalf("expected success for null sink, got: %v", err)
+		}
+	})
+}

--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -77,7 +77,7 @@ func validateExternalConnectionSinkURI(
 	//
 	// TODO(adityamaru): When we add `CREATE EXTERNAL CONNECTION ... WITH` support
 	// to accept JSONConfig we should validate that here too.
-	s, err := getSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
+	s, err := getAndDialSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
 		jobspb.JobID(0), (*sliMetrics)(nil), changefeedbase.Targets{}, true /* initialValidation */)
 	if err != nil {
 		return errors.Wrap(err, "invalid changefeed sink URI")


### PR DESCRIPTION
## Description

When creating an external connection, we should dial the canary sink to ensure that the connection is valid. Previously, we only created the sink object using `getSink` without establishing an actual connection (using `Dial`). This could allow misconfigurations or connectivity-level failures to pass unnoticed during the `CREATE EXTERNAL CONNECTION` phase.

This PR switches from `getSink` to `getAndDialSink` in the `validateExternalConnectionSinkURI` function, ensuring that an actual connection attempt is made during validation.

Fixes #126992

### Release Notes
* cdc: `CREATE EXTERNAL CONNECTION` statements now establish a test connection to the sink to verify its validity.