### PR TITLE
build: fix docker-entrypoint-initdb.d execution when COCKROACH_USER is unset

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -160,7 +160,9 @@ setup_db() {
                       -e "GRANT admin TO "$COCKROACH_USER" " )
   fi
 
-  run_sql_query "${init_env_query[@]}"
+  if [[ -n "$COCKROACH_USER" ]]; then
+    run_sql_query "${init_env_query[@]}"
+  fi
 }
 
 # process_init_files run all the init scripts from /docker-entrypoint-initdb.d.


### PR DESCRIPTION
## Description

This PR fixes an issue where initialization scripts in `/docker-entrypoint-initdb.d` fail to proceed when `COCKROACH_USER` is unset. 

When `COCKROACH_USER` is empty, the `init_env_query` array contains no queries (no `-e` flags). Passing this to `run_sql_query` launches an interactive `cockroach sql` session, which blocks the entrypoint script execution and prevents initialization scripts from being processed.

This fix wraps the `run_sql_query` call in `setup_db()` with an `if` block to ensure it only executes when `COCKROACH_USER` is set.

Fixes #110997

### Release Notes
* build: Fixed a bug where docker-entrypoint initialization scripts would hang if `COCKROACH_USER` was not specified.