### PR TITLE
workflows: add trunk auto-merge support for release-25.2

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -83,7 +83,7 @@ jobs:
               const baseRef = pr.baseRefName;
               console.log(`Processing PR #${pr.number}, Created at: ${pr.createdAt}, Approved: ${approved}, Target: ${baseRef}, Labels: ${labels}`);
 
-              const trunkBranches = ['release-24.3'];
+              const trunkBranches = ['release-24.3', 'release-25.2'];
               if (trunkBranches.includes(baseRef)) {
                 // Use comment to trigger trunk merge for trunk-enabled branches
                 console.log(`Adding /trunk merge comment for PR #${pr.number} (target: ${baseRef})`);


### PR DESCRIPTION
## Summary
Add release-25.2 to the list of trunk-enabled branches in the auto-merge backports workflow.

This ensures that approved backport PRs targeting release-25.2 will use the `/trunk merge` comment instead of direct merging, which is required for Trunk-enabled branches.

## Test Plan
After merging:
- Auto-merge workflow will add `/trunk merge` comments on approved backport PRs targeting release-25.2
- Trunk merge queue will handle the actual merging

## Related
Part of enabling Trunk merge queue for release-25.2 branch.