### PR TITLE
roachtest: enable Go execution traces in kv/restart/nodes=12

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -1063,6 +1063,11 @@ func registerKVRestartImpact(r registry.Registry) {
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=store_rebalancer=2,allocator=2,allocator_scorer=1,replicate_queue=2,lease=2")
 			settings := install.MakeClusterSettings()
+			// Enable continuous Go execution tracing to aid diagnosis of transient
+			// resource spikes (#166364).
+			settings.ClusterSettings["obs.execution_tracer.interval"] = "10s"
+			settings.ClusterSettings["obs.execution_tracer.duration"] = "10s"
+			settings.ClusterSettings["obs.execution_tracer.total_dump_size_limit"] = "10 GiB"
 
 			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 


### PR DESCRIPTION
Enable continuous Go execution tracing on all nodes in the
`kv/restart/nodes=12` test to aid diagnosis of transient resource
spikes like the one in #166364, where a CGO/memory spike on node 3
caused a TCP timeout but neither the Datadog logs nor pebble logs
revealed the trigger.

The execution tracer captures goroutine scheduling, syscalls, and
GC activity. Traces are written to disk and collected as artifacts
on test failure.

Settings added:
- `obs.execution_tracer.interval` = 10s
- `obs.execution_tracer.duration` = 10s
- `obs.execution_tracer.total_dump_size_limit` = 10 GiB

Closes https://github.com/cockroachdb/cockroach/issues/166364.