### PR TITLE
sql/schemachanger: ensure CREATE TABLE/VIEW attempts to use the DSC

### DIFF
--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -1192,6 +1192,8 @@ EXECUTE FUNCTION trigger_func();
 `, i, i))
 	}
 	stmts = append(stmts, "COMMIT;")
+	stmts = append(stmts, "RESET use_declarative_schema_changer;")
+	stmts = append(stmts, "RESET autocommit_before_ddl;")
 	return stmts
 }
 

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -304,9 +304,9 @@ func TestCreateFunctionVisibilityInExplicitTransaction(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	tDB := sqlutils.MakeSQLRunner(sqlDB)
 
-	tDB.Exec(t, `SET use_declarative_schema_changer = 'unsafe_always'`)
 	tDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b INT NOT NULL)`)
 	tDB.Exec(t, `INSERT INTO t VALUES (1,1), (2,1)`)
+	tDB.Exec(t, `SET use_declarative_schema_changer = 'unsafe_always'`)
 
 	// Make sure that everything is rolled back if post commit job fails.
 	_, err := sqlDB.Exec(`

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1886,11 +1886,11 @@ subtest alter_dropped_col
 let $schema_changer_state
 SELECT value FROM information_schema.session_variables where variable='use_declarative_schema_changer'
 
-statement ok
-set use_declarative_schema_changer = 'unsafe_always';
-
 statement disable-cf-mutator ok
 create table t_droppedcol (dropme int);
+
+statement ok
+set use_declarative_schema_changer = 'unsafe_always';
 
 statement ok
 SET autocommit_before_ddl = false
@@ -1934,13 +1934,13 @@ let $schema_changer_state
 SELECT value FROM information_schema.session_variables where variable='use_declarative_schema_changer'
 
 statement ok
-set use_declarative_schema_changer = 'unsafe_always';
-
-statement ok
 CREATE TABLE t_multi_alter (c1 INT NOT NULL PRIMARY KEY, c2 TEXT NOT NULL, drop DATE, FAMILY F1 (c1, c2, drop));
 
 statement ok
 INSERT INTO t_multi_alter VALUES (10,'ten','1984-09-06'),(20,'twenty','2024-08-10');
+
+statement ok
+set use_declarative_schema_changer = 'unsafe_always';
 
 # The add column operation creates multiple primary keys, with all but one being
 # temporary. Previously, this caused the alter type to fail because it

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -5039,12 +5039,12 @@ subtest alter_dropped_col
 let $schema_changer_state
 SELECT value FROM information_schema.session_variables where variable='use_declarative_schema_changer'
 
+statement disable-cf-mutator ok
+create table t_droppedcol (dropme int);
+
 skipif config local-legacy-schema-changer
 statement ok
 set use_declarative_schema_changer = 'unsafe_always';
-
-statement disable-cf-mutator ok
-create table t_droppedcol (dropme int);
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1639,3 +1639,28 @@ statement ok
 SET use_declarative_schema_changer = $use_decl_sc
 
 subtest end
+
+subtest create_table_unsafe_always
+
+let $use_decl_sc
+SHOW use_declarative_schema_changer
+
+statement ok
+SET use_declarative_schema_changer = 'unsafe_always'
+
+statement error pq: \*tree.CreateTable not implemented in the new schema changer
+EXPLAIN (DDL) CREATE TABLE test_table(log int)
+
+statement error pq: \*tree.CreateTable not implemented in the new schema changer
+CREATE TABLE test_table(log int)
+
+statement error pq: \*tree.CreateTable not implemented in the new schema changer
+CREATE TABLE test_table_as AS SELECT 1 AS log
+
+statement error pq: \*tree.CreateView not implemented in the new schema changer
+CREATE VIEW test_view AS SELECT 1 AS log
+
+statement ok
+SET use_declarative_schema_changer = $use_decl_sc
+
+subtest end

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -2016,6 +2016,15 @@ func (ef *execFactory) ConstructCreateTable(
 	); err != nil {
 		return nil, err
 	}
+
+	plan, err := ef.planner.SchemaChange(ef.ctx, ct)
+	if err != nil {
+		return nil, err
+	}
+	if plan != nil {
+		return plan, nil
+	}
+
 	return &createTableNode{
 		n:      ct,
 		dbDesc: schema.(*optSchema).database,
@@ -2032,6 +2041,14 @@ func (ef *execFactory) ConstructCreateTableAs(
 		"CREATE TABLE",
 	); err != nil {
 		return nil, err
+	}
+
+	plan, err := ef.planner.SchemaChange(ef.ctx, ct)
+	if err != nil {
+		return nil, err
+	}
+	if plan != nil {
+		return plan, nil
 	}
 
 	return &createTableNode{
@@ -2058,6 +2075,14 @@ func (ef *execFactory) ConstructCreateView(
 		"CREATE VIEW",
 	); err != nil {
 		return nil, err
+	}
+
+	plan, err := ef.planner.SchemaChange(ef.ctx, createView)
+	if err != nil {
+		return nil, err
+	}
+	if plan != nil {
+		return plan, nil
 	}
 
 	planDeps, typeDepSet, funcDepSet, err := toPlanDependencies(deps, typeDeps, funcDeps)


### PR DESCRIPTION
Previously, these statements bypassed the declarative schema changer (DSC) checks entirely because the optimizer directly generated the plan nodes for these statements. To address this, the optimizer will attempt to generate the plan nodes via the declarative schema changer first, then use the legacy schema changer. These are all unimplemented, but this ensures correctness for the unsafe_always option.

Fixes: #147657
Release note: None