### PR TITLE
server: supplement missing console keys in Settings endpoint

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2005,25 +2005,40 @@ func (s *adminServer) Settings(
 				codes.PermissionDenied, "this operation requires the %s or %s system privileges",
 				privilege.VIEWCLUSTERSETTING.DisplayName(), privilege.MODIFYCLUSTERSETTING.DisplayName())
 		}
-		consoleKeys := settings.ConsoleKeys()
-		for _, k := range consoleKeys {
-			if consoleSetting, ok := settings.LookupForLocalAccessByKey(k, s.sqlServer.execCfg.Codec.ForSystemTenant()); ok {
-				if internalKey, found, _ := settings.NameToKey(consoleSetting.Name()); found &&
-					(len(keyFilter) == 0 || keyFilter[string(internalKey)]) {
-					var responseValue serverpb.SettingsResponse_Value
-					responseValue.Name = string(consoleSetting.Name())
-					responseValue.Value = consoleSetting.String(&s.st.SV)
-					responseValue.Type = consoleSetting.Typ()
-					responseValue.Description = consoleSetting.Description()
-					responseValue.Public = consoleSetting.Visibility() == settings.Public
-					if lastUpdated, found := alteredSettings[internalKey]; found {
-						responseValue.LastUpdated = lastUpdated
-					}
-					respSettings[string(internalKey)] = responseValue
-				}
-			}
-		}
+	}
 
+	// Supplement any missing console keys from in-memory settings. The
+	// ConsoleKeys list contains non-sensitive settings required by the DB
+	// Console UI. This covers two cases:
+	// 1. Users with only VIEWACTIVITY (query failed with InsufficientPrivilege,
+	//    all console keys are missing from respSettings).
+	// 2. Users with MODIFYSQLCLUSTERSETTING (query succeeded but only returned
+	//    sql.defaults.* settings, missing console keys like "version").
+	// See: https://github.com/cockroachdb/cockroach/issues/165444
+	for _, k := range settings.ConsoleKeys() {
+		if _, exists := respSettings[string(k)]; exists {
+			continue
+		}
+		consoleSetting, ok := settings.LookupForLocalAccessByKey(
+			k, s.sqlServer.execCfg.Codec.ForSystemTenant(),
+		)
+		if !ok {
+			continue
+		}
+		internalKey, found, _ := settings.NameToKey(consoleSetting.Name())
+		if !found || (len(keyFilter) > 0 && !keyFilter[string(internalKey)]) {
+			continue
+		}
+		var responseValue serverpb.SettingsResponse_Value
+		responseValue.Name = string(consoleSetting.Name())
+		responseValue.Value = consoleSetting.String(&s.st.SV)
+		responseValue.Type = consoleSetting.Typ()
+		responseValue.Description = consoleSetting.Description()
+		responseValue.Public = consoleSetting.Visibility() == settings.Public
+		if lastUpdated, found := alteredSettings[internalKey]; found {
+			responseValue.LastUpdated = lastUpdated
+		}
+		respSettings[string(internalKey)] = responseValue
 	}
 
 	resp.KeyValues = respSettings

--- a/pkg/server/application_api/config_test.go
+++ b/pkg/server/application_api/config_test.go
@@ -135,6 +135,28 @@ func TestAdminAPISettings(t *testing.T) {
 			})
 		}
 
+		// Regression test for #165444: a user with MODIFYSQLCLUSTERSETTING +
+		// VIEWACTIVITY should still see console keys like "version". The
+		// MODIFYSQLCLUSTERSETTING privilege causes the cluster_settings
+		// query to succeed but only return sql.defaults.* settings. The
+		// Settings endpoint must supplement missing ConsoleKeys.
+		t.Run("modify_sql_with_viewactivity", func(t *testing.T) {
+			userName := "modify_sql_viewactivity_user"
+			conn.Exec(t, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", userName))
+			conn.Exec(t, fmt.Sprintf("GRANT SYSTEM MODIFYSQLCLUSTERSETTING TO %s", userName))
+			conn.Exec(t, fmt.Sprintf("GRANT SYSTEM VIEWACTIVITY TO %s", userName))
+			authCtx := authserver.ForwardHTTPAuthInfoToRPCCalls(
+				authserver.ContextWithHTTPAuthInfo(ctx, userName, 1), nil,
+			)
+			resp, err := ts.GetAdminClient(t).Settings(authCtx, &serverpb.SettingsRequest{})
+			require.NoError(t, err)
+			// All console keys must be present, including "version".
+			for _, k := range settings.ConsoleKeys() {
+				require.Contains(t, resp.KeyValues, string(k),
+					"expected console key %q in settings response", k)
+			}
+		})
+
 		t.Run("no permission", func(t *testing.T) {
 			userName := "no_permission"
 			conn.Exec(t, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", userName))

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -81,7 +81,7 @@ export const selectClusterSettingVersion = createSelector(
     if (!settings) {
       return "";
     }
-    return settings["version"].value;
+    return settings["version"]?.value ?? "";
   },
 );
 


### PR DESCRIPTION
## Summary

Fixes #165444.

The Settings API endpoint only populated ConsoleKeys (like "version") in the
fallback path when the `crdb_internal.cluster_settings` query failed with
`InsufficientPrivilege`. Users with `MODIFYSQLCLUSTERSETTING` (but not
`VIEWCLUSTERSETTING`) caused the query to succeed with a filtered result
containing only `sql.defaults.*` settings. Since no error occurred, the
ConsoleKeys fallback was never reached, and "version" was missing from the
response — crashing the DB Console Overview page.

This moves the ConsoleKeys supplementation out of the error block so it always
runs. Missing console keys are filled from in-memory setting values without
overwriting keys already present in the response.

Release note (bug fix): Fixed a bug where the DB Console Overview page crashed
for users with MODIFYSQLCLUSTERSETTING and VIEWACTIVITY privileges but without
VIEWCLUSTERSETTING. The Settings API now always includes non-sensitive console
keys like "version" regardless of which privilege tier returned the settings.