### PR TITLE
release-26.2: backup: deflake Azure cloud unit tests

### DIFF
--- a/pkg/backup/backup_cloud_test.go
+++ b/pkg/backup/backup_cloud_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/amazon"
@@ -171,6 +172,9 @@ func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 func TestCloudBackupRestoreAzure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// Fast restore does not yet support encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
+
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	if accountName == "" {
 		skip.IgnoreLint(t, "AZURE_ACCOUNT_NAME env var must be set")
@@ -272,6 +276,8 @@ func TestCloudBackupRestoreAzure(t *testing.T) {
 func TestCloudBackupRestoreKMSInaccessibleMetric(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// Fast restore does not yet support encrypted backups.
+	backuptestutils.DisableFastRestoreForTest(t)
 
 	azureVaultName := os.Getenv("AZURE_VAULT_NAME")
 	if azureVaultName == "" {


### PR DESCRIPTION
Backport 1/1 commits from #166099.

/cc @cockroachdb/release

---

This deflakes the Azure Cloud unit test, which runs an encryption backup and restore. With the introduction of metamorphic fast restore in our test runs, this would ocassionally attempt to run a fast restore of an encrypted backup, which is not supported right now.

Fixes: #161658

Release note: None

---

Release justification: Test-only change.