### PR TITLE
release-26.2: restore: skip dropped/missing descriptors during restore revert

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -3594,9 +3594,15 @@ func (r *restoreResumer) dropDescriptors(
 		// TypeDescriptors don't have a GC job process, so we can just write them
 		// as dropped here.
 		typDesc := details.TypeDescs[i]
-		mutType, err := descsCol.MutableByID(txn.KV()).Type(ctx, typDesc.ID)
+		mutType, err := descsCol.MutableByID(txn.KV()).Desc(ctx, typDesc.ID)
 		if err != nil {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				continue
+			}
 			return err
+		}
+		if mutType.Dropped() {
+			continue
 		}
 		mutType.SetDropped()
 
@@ -3618,9 +3624,15 @@ func (r *restoreResumer) dropDescriptors(
 
 	for i := range details.FunctionDescs {
 		fnDesc := details.FunctionDescs[i]
-		mutFn, err := descsCol.MutableByID(txn.KV()).Function(ctx, fnDesc.ID)
+		mutFn, err := descsCol.MutableByID(txn.KV()).Desc(ctx, fnDesc.ID)
 		if err != nil {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				continue
+			}
 			return err
+		}
+		if mutFn.Dropped() {
+			continue
 		}
 		mutFn.SetDropped()
 		if err := descsCol.DeleteDescToBatch(ctx, kvTrace, fnDesc.ID, b); err != nil {
@@ -3692,7 +3704,13 @@ func (r *restoreResumer) dropDescriptors(
 
 		mutSchema, err := descsCol.MutableByID(txn.KV()).Desc(ctx, schemaDesc.GetID())
 		if err != nil {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				continue
+			}
 			return err
+		}
+		if mutSchema.Dropped() {
+			continue
 		}
 		entry, hasEntry := dbsWithDeletedSchemas[schemaDesc.GetParentID()]
 		if !hasEntry {
@@ -3777,7 +3795,13 @@ func (r *restoreResumer) dropDescriptors(
 
 		db, err := descsCol.MutableByID(txn.KV()).Desc(ctx, dbDesc.GetID())
 		if err != nil {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				continue
+			}
 			return err
+		}
+		if db.Dropped() {
+			continue
 		}
 
 		// Mark db as dropped and add uncommitted version to pass pre-txn

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -976,52 +976,39 @@ func setDescriptorsOffline(
 		return nil
 	}
 
-	mutableTables, err := getUndroppedTablesFromRestore(ctx, txn.KV(), details, descCol)
-	if err != nil {
-		return errors.Wrapf(err, "set descriptors offline: getting undropped tables from restore")
+	var descIDs []descpb.ID
+	for _, desc := range details.TableDescs {
+		descIDs = append(descIDs, desc.ID)
 	}
-	for _, mutableTable := range mutableTables {
-		if err := writeDesc(mutableTable); err != nil {
-			return err
-		}
-	}
-
 	for i := range details.FunctionDescs {
-		mutableFunc, err := descCol.MutableByID(txn.KV()).Function(ctx, details.FunctionDescs[i].ID)
-		if err != nil {
-			return err
-		}
-		if err := writeDesc(mutableFunc); err != nil {
-			return err
-		}
+		descIDs = append(descIDs, details.FunctionDescs[i].ID)
 	}
-
 	for i := range details.DatabaseDescs {
-		mutableDB, err := descCol.MutableByID(txn.KV()).Database(ctx, details.DatabaseDescs[i].ID)
-		if err != nil {
-			return err
-		}
-		if err := writeDesc(mutableDB); err != nil {
-			return err
-		}
+		descIDs = append(descIDs, details.DatabaseDescs[i].ID)
 	}
-
 	for i := range details.TypeDescs {
-		mutableType, err := descCol.MutableByID(txn.KV()).Type(ctx, details.TypeDescs[i].ID)
-		if err != nil {
-			return err
-		}
-		if err := writeDesc(mutableType); err != nil {
-			return err
-		}
+		descIDs = append(descIDs, details.TypeDescs[i].ID)
+	}
+	for i := range details.SchemaDescs {
+		descIDs = append(descIDs, details.SchemaDescs[i].ID)
 	}
 
-	for i := range details.SchemaDescs {
-		mutableSchema, err := descCol.MutableByID(txn.KV()).Schema(ctx, details.SchemaDescs[i].ID)
+	for _, id := range descIDs {
+		// We use Desc over the type-specific lookups because the latter replaces
+		// the shared catalog.ErrDescriptorNotFound with a more specific pgcode.
+		// Uinsg the former allows us to match on one error type for all
+		// descriptors.
+		desc, err := descCol.MutableByID(txn.KV()).Desc(ctx, id)
 		if err != nil {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				continue
+			}
 			return err
 		}
-		if err := writeDesc(mutableSchema); err != nil {
+		if desc.Dropped() {
+			continue
+		}
+		if err := writeDesc(desc); err != nil {
 			return err
 		}
 	}

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -1348,3 +1348,50 @@ func TestOnlineRestoreWithDistFlow(t *testing.T) {
 			"expected non-zero approx_bytes from coordinator path")
 	})
 }
+
+// TestOnlineRestoreCleanupDroppedDescs verifies that reverting an online
+// restore's download job succeeds even if the restored descriptors (table,
+// function, schema, type) have been dropped.
+func TestOnlineRestoreCleanupDroppedDescs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	backuptestutils.EnableFastRestoreForTest(t)
+
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
+	defer cleanupFn()
+
+	trueExternalStorage := "nodelocal://1/backup"
+	externalStorage := backuptestutils.GetExternalStorageURI(t, trueExternalStorage, "backup", sqlDB)
+
+	sqlDB.Exec(t, "CREATE SCHEMA data.myschema")
+	sqlDB.Exec(t, "CREATE TYPE data.mytype AS ENUM ('a', 'b', 'c')")
+	sqlDB.Exec(t, "CREATE TABLE data.mytable (id INT PRIMARY KEY, val data.mytype)")
+	sqlDB.Exec(t, "INSERT INTO data.mytable VALUES (1, 'a'), (2, 'b')")
+	sqlDB.Exec(t, "CREATE FUNCTION data.myfunc() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$")
+
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE data INTO '%s'", externalStorage))
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'")
+	var linkJobID int
+	sqlDB.QueryRow(t, fmt.Sprintf(
+		"RESTORE DATABASE data FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY, new_db_name=restored, detached",
+		externalStorage,
+	)).Scan(&linkJobID)
+	jobutils.WaitForJobToSucceed(t, sqlDB, jobspb.JobID(linkJobID))
+
+	var downloadJobID int
+	sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
+	jobutils.WaitForJobToPause(t, sqlDB, jobspb.JobID(downloadJobID))
+	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
+
+	sqlDB.Exec(t, "USE restored")
+	sqlDB.Exec(t, "DROP FUNCTION myfunc")
+	sqlDB.Exec(t, "DROP TABLE mytable")
+	sqlDB.Exec(t, "DROP TYPE mytype")
+	sqlDB.Exec(t, "DROP SCHEMA myschema")
+	sqlDB.Exec(t, "USE data")
+
+	sqlDB.Exec(t, fmt.Sprintf("CANCEL JOB %d", downloadJobID))
+	jobutils.WaitForJobToCancel(t, sqlDB, jobspb.JobID(downloadJobID))
+}


### PR DESCRIPTION
Backport 1/1 commits from #166116.

/cc @cockroachdb/release

---

Previously, if a user dropped descriptors (tables, types, functions, schemas) that were created by an online restore while the download job was paused, canceling the download job would get stuck in the reverting state. This happened because both `setDescriptorsOffline` and `dropDescriptors` would fail when trying to look up descriptors that had already been dropped.

Fix this by skipping descriptors that are already dropped or not found.

Fixes: #165789

Release note: None

---

Release justification: Cleanup of online restore on dropped descriptors blocks cleanup and prevents descriptors from being set offline.