### PR TITLE
roachtest: collect debug zip on cdc latency failure

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -704,6 +704,9 @@ func (ct *cdcTester) runFeedLatencyVerifierWithCallback(
 
 		err := verifier.pollLatencyUntilJobSucceeds(ctx, ct.DB(), cj.jobID, time.Second, ct.doneCh)
 		if err != nil {
+			if zipErr := ct.cluster.FetchDebugZip(context.Background(), ct.logger, fmt.Sprintf("latency_debug_%s.zip", cj.Label())); zipErr != nil {
+				ct.logger.Printf("failed to fetch debug zip on latency failure: %s", zipErr)
+			}
 			return err
 		}
 


### PR DESCRIPTION
A common pattern in cdc tests is to stick the workload and latency verifier goroutines in an error group and block the test on said error group. One side effect of this is that we may fail the test due to the latency verifier, but continue blocking for the workload to finish. This causes the debug zip taken by the framework on test failure to happen potentially 30+ minutes after the actual latency failure.

This changes the verifier to take its own debug zip on failure.

Release note: none
Epic: none
Fixes: none