### PR TITLE
[release-24.3] ci: add trunk branch on push trigger

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -30,6 +30,7 @@ on:
       - "release-*"
       - "staging-*"
       - "staging"
+      - "trunk-merge/**"
       - "trying"
       - "!release-1.0*"
       - "!release-1.1*"


### PR DESCRIPTION
Backport 1/1 commits from #161230 on behalf of @rishabh7m.

---

## Summary
Backports the critical missing CI trigger for Trunk merge queue branches to release-24.3.

This fixes the issue where Trunk creates `trunk-merge/**` branches but GitHub Actions doesn't run CI on them, causing PRs to timeout and get stuck in an infinite loop with the auto-merge workflow.

## Problem Fixed
- Trunk merge queue creates branches but CI doesn't run
- PRs timeout after 80 minutes with no CI activity  
- Auto-merge workflow keeps retrying every hour creating infinite loop

## Test Plan
After merging:
- Trunk merge queue will properly trigger CI on release-24.3
- PRs like #166008 will be able to merge successfully

## Release Note
None

Release justification: Non-production code change. Critical fix for CI/CD infrastructure.

Fixes the Trunk merge queue issues reported in Slack thread.

cc @rail @ricky