### PR TITLE
sql/schemachanger: add support for renaming enum values

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -554,6 +554,13 @@ func TestBackupRollbacks_base_alter_type_drop_value(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1419,6 +1426,13 @@ func TestBackupRollbacksMixedVersion_base_alter_type_drop_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2290,6 +2304,13 @@ func TestBackupSuccess_base_alter_type_drop_value(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3155,6 +3176,13 @@ func TestBackupSuccessMixedVersion_base_alter_type_drop_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -526,15 +526,29 @@ func (desc *immutable) validateEnumMembers(vea catalog.ValidationErrorAccumulato
 		vea.Report(errors.AssertionFailedf("enum members are not sorted %v", desc.EnumMembers))
 	}
 	// Ensure there are no duplicate enum physical and logical reps.
-	physicalMap := make(map[string]struct{}, len(desc.EnumMembers))
+	// Track physical reps along with their transition direction so that
+	// renames (one member being added and one being removed with the same
+	// physical representation) are allowed.
+	type physicalRepInfo struct {
+		direction descpb.TypeDescriptor_EnumMember_Direction
+	}
+	physicalMap := make(map[string]physicalRepInfo, len(desc.EnumMembers))
 	logicalMap := make(map[string]struct{}, len(desc.EnumMembers))
 	for _, member := range desc.EnumMembers {
-		// Ensure there are no duplicate enum physical reps.
-		_, duplicatePhysical := physicalMap[string(member.PhysicalRepresentation)]
-		if duplicatePhysical {
-			vea.Report(errors.AssertionFailedf("duplicate enum physical rep %v", member.PhysicalRepresentation))
+		// Ensure there are no duplicate enum physical reps. Two members may
+		// share the same physical representation during a rename transition,
+		// where one member is being removed and another is being added.
+		key := string(member.PhysicalRepresentation)
+		if existing, ok := physicalMap[key]; ok {
+			isRename := (existing.direction == descpb.TypeDescriptor_EnumMember_REMOVE &&
+				member.Direction == descpb.TypeDescriptor_EnumMember_ADD) ||
+				(existing.direction == descpb.TypeDescriptor_EnumMember_ADD &&
+					member.Direction == descpb.TypeDescriptor_EnumMember_REMOVE)
+			if !isRename {
+				vea.Report(errors.AssertionFailedf("duplicate enum physical rep %v", member.PhysicalRepresentation))
+			}
 		}
-		physicalMap[string(member.PhysicalRepresentation)] = struct{}{}
+		physicalMap[key] = physicalRepInfo{direction: member.Direction}
 		// Ensure there are no duplicate enum logical reps.
 		_, duplicateLogical := logicalMap[member.LogicalRepresentation]
 		if duplicateLogical {

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -945,6 +945,9 @@ DROP USER u
 subtest regression_57734
 
 statement ok
+USE defaultdb
+
+statement ok
 CREATE TYPE eventlog AS ENUM ('event', 'log')
 
 query ITT

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -32,7 +32,7 @@ type supportedAlterTypeCommand = supportedStatement
 // only be used with the use_declarative_schema_changer session variable.
 var supportedAlterTypeStatements = map[reflect.Type]supportedAlterTypeCommand{
 	reflect.TypeOf((*tree.AlterTypeAddValue)(nil)):    {fn: alterTypeAddValue, on: true, checks: isV263Active},
-	reflect.TypeOf((*tree.AlterTypeRenameValue)(nil)): {fn: alterTypeRenameValue, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeRenameValue)(nil)): {fn: alterTypeRenameValue, on: true, checks: isV263Active},
 	reflect.TypeOf((*tree.AlterTypeRename)(nil)):      {fn: alterTypeRename, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeSetSchema)(nil)):   {fn: alterTypeSetSchema, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeOwner)(nil)):       {fn: alterTypeOwner, on: false, checks: nil},
@@ -213,7 +213,62 @@ func alterTypeAddValue(
 func alterTypeRenameValue(
 	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeRenameValue,
 ) {
-	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE RENAME VALUE is not supported"))
+	oldVal := string(t.OldVal)
+	newVal := string(t.NewVal)
+
+	enumTypeValues := b.QueryByID(enumType.TypeID).FilterEnumTypeValue()
+
+	var found bool
+	var physicalRep []byte
+	enumTypeValues.ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.EnumTypeValue) {
+			if e.LogicalRepresentation != oldVal {
+				return
+			}
+			if target == scpb.ToAbsent {
+				panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"enum value %q is being dropped", oldVal))
+			}
+			if target != scpb.ToPublic {
+				panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"enum value %q is being added, try again later", oldVal))
+			}
+			found = true
+			physicalRep = e.PhysicalRepresentation
+		},
+	)
+	if !found {
+		panic(pgerror.Newf(pgcode.InvalidParameterValue,
+			"%s is not an existing enum value", oldVal))
+	}
+
+	enumTypeValues.ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.EnumTypeValue) {
+			if e.LogicalRepresentation == newVal && target != scpb.ToAbsent {
+				panic(pgerror.Newf(pgcode.DuplicateObject,
+					"enum value %s already exists", newVal))
+			}
+		},
+	)
+
+	enumTypeValues.ForEach(
+		func(_ scpb.Status, target scpb.TargetStatus, e *scpb.EnumTypeValue) {
+			if e.LogicalRepresentation == oldVal && target == scpb.ToPublic {
+				b.Drop(e)
+			}
+		},
+	)
+
+	enumValue := &scpb.EnumTypeValue{
+		TypeID:                 enumType.TypeID,
+		PhysicalRepresentation: physicalRep,
+		LogicalRepresentation:  newVal,
+	}
+	b.Add(enumValue)
+
+	b.LogEventForExistingPayload(enumValue, &eventpb.AlterType{
+		TypeName: tn.FQString(),
+	})
 }
 
 func alterTypeRename(

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_type
@@ -13,3 +13,11 @@ ALTER TYPE defaultdb.climes DROP VALUE 'arctic'
 ----
 - [[EnumTypeValue:{DescID: 104, Name: arctic}, ABSENT], PUBLIC]
   {logicalRepresentation: arctic, physicalRepresentation: gA==, typeId: 104}
+
+build
+ALTER TYPE defaultdb.climes RENAME VALUE 'tropical' TO 'equatorial'
+----
+- [[EnumTypeValue:{DescID: 104, Name: tropical}, ABSENT], PUBLIC]
+  {logicalRepresentation: tropical, physicalRepresentation: QA==, typeId: 104}
+- [[EnumTypeValue:{DescID: 104, Name: equatorial}, PUBLIC], ABSENT]
+  {logicalRepresentation: equatorial, physicalRepresentation: QA==, typeId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
@@ -3,10 +3,6 @@ CREATE TYPE defaultdb.climes AS ENUM ('tropical', 'arctic', 'mediterranean');
 ----
 
 unimplemented
-ALTER TYPE defaultdb.climes RENAME VALUE 'tropical' TO 'equatorial'
-----
-
-unimplemented
 ALTER TYPE defaultdb.climes RENAME TO environs
 ----
 

--- a/pkg/sql/schemachanger/scexec/scmutationexec/type.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/type.go
@@ -50,7 +50,8 @@ func (i *immediateVisitor) PromoteEnumTypeValue(
 
 	for j := range typ.EnumMembers {
 		member := &typ.EnumMembers[j]
-		if bytes.Equal(member.PhysicalRepresentation, op.PhysicalRepresentation) {
+		if member.LogicalRepresentation == op.LogicalRepresentation &&
+			bytes.Equal(member.PhysicalRepresentation, op.PhysicalRepresentation) {
 			member.Capability = descpb.TypeDescriptor_EnumMember_ALL
 			member.Direction = descpb.TypeDescriptor_EnumMember_NONE
 			return nil
@@ -73,7 +74,8 @@ func (i *immediateVisitor) DemoteEnumTypeValue(
 
 	for j := range typ.EnumMembers {
 		member := &typ.EnumMembers[j]
-		if bytes.Equal(member.PhysicalRepresentation, op.PhysicalRepresentation) {
+		if member.LogicalRepresentation == op.LogicalRepresentation &&
+			bytes.Equal(member.PhysicalRepresentation, op.PhysicalRepresentation) {
 			member.Capability = descpb.TypeDescriptor_EnumMember_READ_ONLY
 			member.Direction = descpb.TypeDescriptor_EnumMember_REMOVE
 			return nil

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "dep_generated_column.go",
         "dep_rename_column.go",
         "dep_rename_constraint.go",
+        "dep_rename_enum_value.go",
         "dep_rename_table.go",
         "dep_schema_locked.go",
         "dep_storage_param.go",

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_enum_value.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_enum_value.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package current
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	. "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+)
+
+// These rules ensure that when renaming an enum value, the old EnumTypeValue
+// element is dropped before the new EnumTypeValue element is added. This
+// prevents conflicts and ensures proper rollback behavior.
+func init() {
+	registerDepRule(
+		"old enum type value is dropped before new enum type value is added",
+		scgraph.Precedence,
+		"old-enum-value", "new-enum-value",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.EnumTypeValue)(nil)),
+				to.Type((*scpb.EnumTypeValue)(nil)),
+				JoinOnDescID(from, to, "type-id"),
+				FilterElements("SamePhysicalRepresentation", from, to,
+					func(from, to *scpb.EnumTypeValue) bool {
+						return bytes.Equal(from.PhysicalRepresentation, to.PhysicalRepresentation)
+					},
+				),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4556,6 +4556,21 @@ deprules
     - $new-constraint-name-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-constraint-name, $old-constraint-name-Target, $old-constraint-name-Node)
     - joinTargetNode($new-constraint-name, $new-constraint-name-Target, $new-constraint-name-Node)
+- name: old enum type value is dropped before new enum type value is added
+  from: old-enum-value-Node
+  kind: Precedence
+  to: new-enum-value-Node
+  query:
+    - $old-enum-value[Type] = '*scpb.EnumTypeValue'
+    - $new-enum-value[Type] = '*scpb.EnumTypeValue'
+    - joinOnDescID($old-enum-value, $new-enum-value, $type-id)
+    - SamePhysicalRepresentation(*scpb.EnumTypeValue, *scpb.EnumTypeValue)($old-enum-value, $new-enum-value)
+    - $old-enum-value-Target[TargetStatus] = ABSENT
+    - $old-enum-value-Node[CurrentStatus] = ABSENT
+    - $new-enum-value-Target[TargetStatus] = PUBLIC
+    - $new-enum-value-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-enum-value, $old-enum-value-Target, $old-enum-value-Node)
+    - joinTargetNode($new-enum-value, $new-enum-value-Target, $new-enum-value-Node)
 - name: old index absent before new index public when swapping with transient
   from: old-primary-index-Node
   kind: Precedence
@@ -10173,6 +10188,21 @@ deprules
     - $new-constraint-name-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-constraint-name, $old-constraint-name-Target, $old-constraint-name-Node)
     - joinTargetNode($new-constraint-name, $new-constraint-name-Target, $new-constraint-name-Node)
+- name: old enum type value is dropped before new enum type value is added
+  from: old-enum-value-Node
+  kind: Precedence
+  to: new-enum-value-Node
+  query:
+    - $old-enum-value[Type] = '*scpb.EnumTypeValue'
+    - $new-enum-value[Type] = '*scpb.EnumTypeValue'
+    - joinOnDescID($old-enum-value, $new-enum-value, $type-id)
+    - SamePhysicalRepresentation(*scpb.EnumTypeValue, *scpb.EnumTypeValue)($old-enum-value, $new-enum-value)
+    - $old-enum-value-Target[TargetStatus] = ABSENT
+    - $old-enum-value-Node[CurrentStatus] = ABSENT
+    - $new-enum-value-Target[TargetStatus] = PUBLIC
+    - $new-enum-value-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-enum-value, $old-enum-value-Target, $old-enum-value-Node)
+    - joinTargetNode($new-enum-value, $new-enum-value-Target, $new-enum-value-Node)
 - name: old index absent before new index public when swapping with transient
   from: old-primary-index-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -554,6 +554,13 @@ func TestEndToEndSideEffects_alter_type_drop_value(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1419,6 +1426,13 @@ func TestExecuteWithDMLInjection_alter_type_drop_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2290,6 +2304,13 @@ func TestGenerateSchemaChangeCorpus_alter_type_drop_value(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3155,6 +3176,13 @@ func TestPause_alter_type_drop_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -4026,6 +4054,13 @@ func TestPauseMixedVersion_alter_type_drop_value(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_comment_on_type_composite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4891,6 +4926,13 @@ func TestRollback_alter_type_drop_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_type_rename_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+----
+
+test
+ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho';
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.explain
@@ -1,0 +1,51 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+
+/* test */
+EXPLAIN (DDL) ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho';
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME VALUE ‹'atlantic'› TO ‹'coho'›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "coho"}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 2 Mutation operations
+ │              ├── DemoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ │              └── AddEnumTypeValue {"LogicalRepresentation":"coho","PhysicalRepresentation":"wA==","TypeID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → ABSENT EnumTypeValue:{DescID: 104 (salmon), Name: "coho"}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── WRITE_ONLY → PUBLIC EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "coho"}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → WRITE_ONLY EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 4 Mutation operations
+ │              ├── DemoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ │              ├── AddEnumTypeValue {"LogicalRepresentation":"coho","PhysicalRepresentation":"wA==","TypeID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
+ ├── PostCommitPhase
+ │    └── Stage 1 of 1 in PostCommitPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── WRITE_ONLY → VALIDATED EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+ │         └── 1 Validation operation
+ │              └── ValidateEnumTypeValueRemoval {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── WRITE_ONLY → PUBLIC EnumTypeValue:{DescID: 104 (salmon), Name: "coho"}
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED  → ABSENT EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+           └── 4 Mutation operations
+                ├── RemoveEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── PromoteEnumTypeValue {"LogicalRepresentation":"coho","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho';
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME VALUE ‹'atlantic'› TO ‹'coho'›;
+ ├── execute 1 system table mutations transaction
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.side_effects
@@ -1,0 +1,153 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
+
+/* test */
+ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho';
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TYPE
+increment telemetry for sql.schema.alter_type.rename_value
+increment telemetry for sql.udts.alter_enum
+write *eventpb.AlterType to event log:
+  sql:
+    descriptorId: 104
+    statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME VALUE ‹'atlantic'› TO ‹'coho'›
+    tag: ALTER TYPE
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+  ...
+     - logicalRepresentation: king
+       physicalRepresentation: gA==
+  -  - logicalRepresentation: atlantic
+  +  - capability: READ_ONLY
+  +    direction: ADD
+  +    logicalRepresentation: coho
+       physicalRepresentation: wA==
+  +  - capability: READ_ONLY
+  +    direction: REMOVE
+  +    logicalRepresentation: atlantic
+  +    physicalRepresentation: wA==
+     id: 104
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 4 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 104
+  +      name: salmon
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME VALUE ‹'atlantic'› TO ‹'coho'›
+  +        statement: ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho'
+  +        statementTag: ALTER TYPE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: sockeye
+  ...
+     - logicalRepresentation: king
+       physicalRepresentation: gA==
+  -  - logicalRepresentation: atlantic
+  +  - capability: READ_ONLY
+  +    direction: ADD
+  +    logicalRepresentation: coho
+       physicalRepresentation: wA==
+  +  - capability: READ_ONLY
+  +    direction: REMOVE
+  +    logicalRepresentation: atlantic
+  +    physicalRepresentation: wA==
+     id: 104
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TYPE defaultdb.public.salmon RENAME VALUE 'atlantic' TO 'coho'"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 1 ValidationType op
+validate enum value "atlantic" removal in type #104
+commit transaction #3
+begin transaction #4
+## PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      id: 104
+  -      name: salmon
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME VALUE ‹'atlantic'› TO ‹'coho'›
+  -        statement: ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho'
+  -        statementTag: ALTER TYPE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: sockeye
+  ...
+     - logicalRepresentation: king
+       physicalRepresentation: gA==
+  -  - capability: READ_ONLY
+  -    direction: ADD
+  -    logicalRepresentation: coho
+  +  - logicalRepresentation: coho
+       physicalRepresentation: wA==
+  -  - capability: READ_ONLY
+  -    direction: REMOVE
+  -    logicalRepresentation: atlantic
+  -    physicalRepresentation: wA==
+     id: 104
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #4
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value__rollback_1_of_1.explain
@@ -1,0 +1,24 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+
+/* test */
+ALTER TYPE salmon RENAME VALUE 'atlantic' TO 'coho';
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TYPE defaultdb.public.salmon RENAME VALUE ‹'atlantic'› TO ‹'coho'›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY → VALIDATED EnumTypeValue:{DescID: 104 (salmon), Name: "coho"}
+      │    └── 1 Validation operation
+      │         └── ValidateEnumTypeValueRemoval {"LogicalRepresentation":"coho","PhysicalRepresentation":"wA==","TypeID":104}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── WRITE_ONLY → PUBLIC EnumTypeValue:{DescID: 104 (salmon), Name: "atlantic"}
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED  → ABSENT EnumTypeValue:{DescID: 104 (salmon), Name: "coho"}
+           └── 4 Mutation operations
+                ├── PromoteEnumTypeValue {"LogicalRepresentation":"atlantic","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveEnumTypeValue {"LogicalRepresentation":"coho","PhysicalRepresentation":"wA==","TypeID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1151,6 +1151,12 @@ func ValidateEnumValueRemoval(
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	override sessiondata.InternalExecutorOverride,
 ) error {
+	// If this removal is part of a rename (another member with the same physical
+	// representation exists and is not being removed), skip validation. The value
+	// is being renamed, not deleted, so data referencing it remains valid.
+	if isEnumValueRename(typeDesc, physicalRep, logicalRep) {
+		return nil
+	}
 	member := descpb.TypeDescriptor_EnumMember{
 		PhysicalRepresentation: physicalRep,
 		LogicalRepresentation:  logicalRep,
@@ -1168,6 +1174,24 @@ func ValidateEnumValueRemoval(
 		}
 		return t.canRemoveEnumValue(ctx, mutableType, txn, &member, txn.Descriptors())
 	})
+}
+
+// isEnumValueRename returns true if the enum value being removed is part of a
+// rename operation rather than an actual deletion. This is detected by checking
+// whether the type descriptor contains another member with the same physical
+// representation that is not being removed (i.e., has ADD or NONE direction).
+func isEnumValueRename(
+	typeDesc catalog.TypeDescriptor, physicalRep []byte, logicalRep string,
+) bool {
+	for _, member := range typeDesc.TypeDesc().EnumMembers {
+		if member.LogicalRepresentation == logicalRep {
+			continue
+		}
+		if bytes.Equal(member.PhysicalRepresentation, physicalRep) {
+			return true
+		}
+	}
+	return false
 }
 
 // findUsagesOfEnumValueInPartitioning is a recursive function to explore all of


### PR DESCRIPTION
This change implements the rename value for enum UDTs and rewires the
command to it.

Closes: #164220

Epic: CRDB-31325

Release note: None