### PR TITLE
release-26.2: sql/importer: skip TestImportData

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -244,6 +244,7 @@ func TestImportData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 166199)
 	skip.UnderRace(t, "takes >1min under race")
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{


### PR DESCRIPTION
Backport 1/1 commits from #166443 on behalf of @msbutler.

----

Skip TestImportData due to test flake.

Informs: #166199

Release note: None

----

Release justification: Skip flacky test to unblock development