### PR TITLE
release-26.1: roachtest: deflake multitenant-upgrade by disabling lease mutator

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -94,6 +94,9 @@ func runMultitenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) 
 		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 		// Closer to a Serverless deployment.
 		mixedversion.AlwaysUseLatestPredecessors,
+		// Disable mutators for expiration-based leases. We have seen transient
+		// failures after toggling this setting in this test.
+		mixedversion.DisableMutators(mixedversion.ClusterSettingMutator("kv.expiration_leases_only.enabled")),
 	)
 
 	tenants := makeTenants(mvt.RNG(), minTenants, maxTenants, tenantNodes)


### PR DESCRIPTION
Backport 1/1 commits from #166426 on behalf of @fqazi.

----

We have seen transient failures when the expiration-based lease mutator is enabled in this test. This commit disables the mutator to avoid test flakes.

Fixes: #164087
Release note: None

----

Release justification: test only change