### PR TITLE
release-26.2: ccl/multiregionccl: deflake TestMrSystemDatabase

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -73,7 +73,10 @@ func TestMrSystemDatabase(t *testing.T) {
 	// deletes old stats, but automatic stats collection can re-insert stats with
 	// the old column type before the async refresh completes, causing
 	// "unsupported comparison: bytes to crdb_internal_region" errors.
+	// Also wait for any in-flight auto stats jobs that were already running before
+	// the setting was disabled.
 	tDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
+	tDB.Exec(t, `SHOW JOBS WHEN COMPLETE (SELECT job_id FROM crdb_internal.jobs WHERE job_type = 'AUTO CREATE STATS' AND status = 'running')`)
 
 	// Generate stats for system.sqlinstances. See the "QueryByEnum" test for
 	// details.
@@ -94,6 +97,7 @@ func TestMrSystemDatabase(t *testing.T) {
 	sDB := sqlutils.MakeSQLRunner(systemSQL)
 
 	sDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
+	sDB.Exec(t, `SHOW JOBS WHEN COMPLETE (SELECT job_id FROM crdb_internal.jobs WHERE job_type = 'AUTO CREATE STATS' AND status = 'running')`)
 	sDB.Exec(t, `ANALYZE system.sqlliveness;`)
 	sDB.Exec(t, `SET CLUSTER SETTING sql.multiregion.system_database_multiregion.enabled = true`)
 	sDB.Exec(t, `ALTER DATABASE system SET PRIMARY REGION "us-east1"`)

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2149,6 +2149,8 @@ func (p *planner) optimizeSystemDatabase(ctx context.Context) error {
 		// Delete statistics for the table because the statistics materialize
 		// the column type for `crdb_region` and the column type is changing
 		// from bytes to an enum.
+		log.Dev.Infof(ctx, "deleting statistics for table %s (id %d) during multi-region system database optimization",
+			tableName, descriptor.GetID())
 		if _, err := p.InternalSQLTxn().Exec(ctx, "delete-stats", p.txn,
 			`DELETE FROM system.table_statistics WHERE "tableID" = $1;`,
 			descriptor.GetID(),


### PR DESCRIPTION
Backport 1/1 commits from #166337 on behalf of @shghasemi.

----

Previously, automatic stats collection was disabled in TestMrSystemDatabase to prevent a race condition during the multi-region system database conversion. However, disabling the cluster setting doesn't affect the jobs that are already created and running which could cause the race condition. This fix checks for auto stats jobs and wait for them to succeeded before running the multi-region change.

Fixes: #165493

Release note: None

----

Release justification: Test-only change.