### PR TITLE
obs/ash: propagate WorkloadType through fetcher, streamer, and tablewriter admission paths

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/diskmap",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -404,6 +405,7 @@ func NewStreamer(
 	lockDurability lock.Durability,
 	reverse bool,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) *Streamer {
 	if txn.Type() != kv.LeafTxn {
 		panic(errors.AssertionFailedf("RootTxn is given to the Streamer"))
@@ -449,6 +451,7 @@ func NewStreamer(
 		requestAdmissionHeader: txn.AdmissionHeader(),
 		responseAdmissionQ:     txn.DB().SQLKVResponseAdmissionQ,
 		workloadID:             workloadID,
+		workloadType:           workloadType,
 	}
 	s.coordinator.asyncSem = quotapool.NewIntPool(
 		"single Streamer async concurrency",
@@ -923,6 +926,8 @@ type workerCoordinator struct {
 	// workloadID is the identifier for the workload that triggered this
 	// request (e.g. statement fingerprint ID) for ASH sampling.
 	workloadID uint64
+	// workloadType distinguishes the kind of workload for ASH sampling.
+	workloadType workloadid.WorkloadType
 }
 
 // mainLoop runs throughout the lifetime of the Streamer (from the first Enqueue
@@ -1559,10 +1564,11 @@ func (w *workerCoordinator) performRequestAsync(
 		// Do admission control after we've finalized the memory accounting.
 		if br != nil && w.responseAdmissionQ != nil {
 			responseAdmission := admission.WorkInfo{
-				TenantID:   roachpb.SystemTenantID,
-				Priority:   admissionpb.WorkPriority(w.requestAdmissionHeader.Priority),
-				CreateTime: w.requestAdmissionHeader.CreateTime,
-				WorkloadID: w.workloadID,
+				TenantID:     roachpb.SystemTenantID,
+				Priority:     admissionpb.WorkPriority(w.requestAdmissionHeader.Priority),
+				CreateTime:   w.requestAdmissionHeader.CreateTime,
+				WorkloadID:   w.workloadID,
+				WorkloadType: w.workloadType,
 			}
 			if _, err = w.responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
 				log.VEventf(ctx, 2, "dropping response: admission control: %v", err)

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -105,6 +105,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 			lock.Unreplicated,
 			reverse,
 			0, /* workloadID */
+			0, /* workloadType */
 		)
 		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		return s

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -75,6 +75,7 @@ func getStreamer(
 		lock.Unreplicated,
 		reverse,
 		0, /* workloadID */
+		0, /* workloadType */
 	)
 }
 
@@ -138,6 +139,7 @@ func TestStreamerLimitations(t *testing.T) {
 				lock.Unreplicated,
 				false, /* reverse */
 				0,     /* workloadID */
+				0,     /* workloadType */
 			)
 		})
 	})

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -837,6 +837,7 @@ go_test(
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptstorage",
         "//pkg/multitenant/tenantcapabilitiespb",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
         "//pkg/scheduledjobs",

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/kv",
         "//pkg/kv/kvclient/kvstreamer",
         "//pkg/kv/kvpb",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -226,6 +227,8 @@ type cFetcherArgs struct {
 	tenantID roachpb.TenantID
 	// workloadID is used for ASH sampling.
 	workloadID uint64
+	// workloadType distinguishes the kind of workload for ASH sampling.
+	workloadType workloadid.WorkloadType
 }
 
 // noOutputColumn is a sentinel value to denote that a system column is not
@@ -568,10 +571,11 @@ func (cf *cFetcher) Init(
 			cf.pacer = cf.txn.DB().AdmissionPacerFactory.NewPacer(
 				50*time.Millisecond, // Request a realistic per-batch amount.
 				admission.WorkInfo{
-					TenantID:   cf.tenantID,
-					Priority:   pri,
-					CreateTime: timeutil.Now().UnixNano(),
-					WorkloadID: cf.workloadID,
+					TenantID:     cf.tenantID,
+					Priority:     pri,
+					CreateTime:   timeutil.Now().UnixNano(),
+					WorkloadID:   cf.workloadID,
+					WorkloadType: cf.workloadType,
 				},
 			)
 		}

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/colserde"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -178,6 +179,7 @@ func newCFetcherWrapper(
 	startKey roachpb.Key,
 	mustSerialize bool,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) (_ storage.CFetcherWrapper, retErr error) {
 	// At the moment, we always serialize the columnar batches if they contain
 	// enums, so it is safe to handle enum types without proper hydration - we
@@ -241,6 +243,7 @@ func newCFetcherWrapper(
 		nil, /* txn; TODO(dt): this means no AC priority info is passed. */
 		tenantID,
 		workloadID,
+		workloadType,
 	}
 
 	// This memory monitor is not connected to the memory accounting system

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -239,6 +239,7 @@ func NewColBatchDirectScan(
 		flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 		spec.FetchSpec.External,
 		flowCtx.EvalCtx.WorkloadID,
+		flowCtx.EvalCtx.WorkloadType,
 	)
 	var hasDatumVec bool
 	for _, t := range tableArgs.typs {

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -381,6 +381,7 @@ func NewColBatchScan(
 		flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 		spec.FetchSpec.External,
 		flowCtx.EvalCtx.WorkloadID,
+		flowCtx.EvalCtx.WorkloadType,
 	)
 	fetcher := cFetcherPool.Get().(*cFetcher)
 	shouldCollectStats := execstats.ShouldCollectStats(ctx, flowCtx.CollectStats)
@@ -394,6 +395,7 @@ func NewColBatchScan(
 		flowCtx.Txn,
 		flowCtx.Codec().TenantID,
 		flowCtx.EvalCtx.WorkloadID,
+		flowCtx.EvalCtx.WorkloadType,
 	}
 	if err = fetcher.Init(fetcherAllocator, kvFetcher, tableArgs); err != nil {
 		fetcher.Release()

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -638,6 +638,7 @@ func NewColIndexJoin(
 			spec.FetchSpec.External,
 			tableArgs.RequiresRawMVCCValues(),
 			flowCtx.EvalCtx.WorkloadID,
+			flowCtx.EvalCtx.WorkloadType,
 		)
 	} else {
 		kvFetcher = row.NewKVFetcher(
@@ -654,6 +655,7 @@ func NewColIndexJoin(
 			flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 			spec.FetchSpec.External,
 			flowCtx.EvalCtx.WorkloadID,
+			flowCtx.EvalCtx.WorkloadType,
 		)
 	}
 
@@ -671,6 +673,7 @@ func NewColIndexJoin(
 		txn,
 		flowCtx.Codec().TenantID,
 		flowCtx.EvalCtx.WorkloadID,
+		flowCtx.EvalCtx.WorkloadType,
 	}
 	if err = fetcher.Init(
 		fetcherAllocator, kvFetcher, tableArgs,

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/kv/kvclient/kvstreamer",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -218,6 +219,8 @@ type txnKVFetcher struct {
 	admissionPacer         *admission.Pacer
 	// workloadID is the statement fingerprint ID or job ID for ASH sampling.
 	workloadID uint64
+	// workloadType distinguishes the kind of workload for ASH sampling.
+	workloadType workloadid.WorkloadType
 }
 
 var _ KVBatchFetcher = &txnKVFetcher{}
@@ -387,6 +390,7 @@ type newTxnKVFetcherArgs struct {
 	kvCPUTime                  *int64
 	rawMVCCValues              bool
 	workloadID                 uint64
+	workloadType               workloadid.WorkloadType
 
 	admission struct { // groups AC-related fields
 		requestHeader  kvpb.AdmissionHeader
@@ -418,6 +422,7 @@ func newTxnKVFetcherInternal(args newTxnKVFetcherArgs) *txnKVFetcher {
 		requestAdmissionHeader:     args.admission.requestHeader,
 		responseAdmissionQ:         args.admission.responseQ,
 		workloadID:                 args.workloadID,
+		workloadType:               args.workloadType,
 	}
 
 	f.maybeInitAdmissionPacer(
@@ -463,10 +468,11 @@ func (f *txnKVFetcher) maybeInitAdmissionPacer(
 				// nodes running colocated SQL+KV code where all SQL code is run
 				// on behalf of the one tenant. So from an AC perspective, the
 				// tenant ID we pass through here is irrelevant.
-				TenantID:   roachpb.SystemTenantID,
-				Priority:   admissionPri,
-				CreateTime: admissionHeader.CreateTime,
-				WorkloadID: f.workloadID,
+				TenantID:     roachpb.SystemTenantID,
+				Priority:     admissionPri,
+				CreateTime:   admissionHeader.CreateTime,
+				WorkloadID:   f.workloadID,
+				WorkloadType: f.workloadType,
 			})
 	}
 }
@@ -794,10 +800,11 @@ func (f *txnKVFetcher) maybeAdmitBatchResponse(ctx context.Context, br *kvpb.Bat
 		}
 	} else if f.responseAdmissionQ != nil {
 		responseAdmission := admission.WorkInfo{
-			TenantID:   roachpb.SystemTenantID,
-			Priority:   admissionpb.WorkPriority(f.requestAdmissionHeader.Priority),
-			CreateTime: f.requestAdmissionHeader.CreateTime,
-			WorkloadID: f.workloadID,
+			TenantID:     roachpb.SystemTenantID,
+			Priority:     admissionpb.WorkPriority(f.requestAdmissionHeader.Priority),
+			CreateTime:   f.requestAdmissionHeader.CreateTime,
+			WorkloadID:   f.workloadID,
+			WorkloadType: f.workloadType,
 		}
 		if _, err := f.responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
 			return err

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -62,6 +63,7 @@ func newTxnKVFetcher(
 	forceProductionKVBatchSize bool,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) *txnKVFetcher {
 	alloc := new(struct {
 		batchRequestsIssued int64
@@ -119,6 +121,7 @@ func newTxnKVFetcher(
 		batchRequestsIssued:        &alloc.batchRequestsIssued,
 		kvCPUTime:                  &alloc.kvCPUTime,
 		workloadID:                 workloadID,
+		workloadType:               workloadType,
 	}
 	fetcherArgs.admission.requestHeader = txn.AdmissionHeader()
 	fetcherArgs.admission.responseQ = txn.DB().SQLKVResponseAdmissionQ
@@ -151,10 +154,11 @@ func NewDirectKVBatchFetcher(
 	forceProductionKVBatchSize bool,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) KVBatchFetcher {
 	f := newTxnKVFetcher(
 		txn, bsHeader, reverse, rawMVCCValues, lockStrength, lockWaitPolicy, lockDurability,
-		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext, workloadID,
+		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext, workloadID, workloadType,
 	)
 	f.scanFormat = kvpb.COL_BATCH_RESPONSE
 	f.indexFetchSpec = spec
@@ -181,10 +185,11 @@ func NewKVFetcher(
 	forceProductionKVBatchSize bool,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) *KVFetcher {
 	return newKVFetcher(newTxnKVFetcher(
 		txn, bsHeader, reverse, rawMVCCValues, lockStrength, lockWaitPolicy, lockDurability,
-		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext, workloadID,
+		lockTimeout, deadlockTimeout, acc, forceProductionKVBatchSize, ext, workloadID, workloadType,
 	))
 }
 
@@ -213,6 +218,7 @@ func NewStreamingKVFetcher(
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
 	rawMVCCValues bool,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) *KVFetcher {
 	var kvPairsRead int64
 	var batchRequestsIssued int64
@@ -235,6 +241,7 @@ func NewStreamingKVFetcher(
 		GetKeyLockingDurability(lockDurability),
 		reverse,
 		workloadID,
+		workloadType,
 	)
 	mode := kvstreamer.OutOfOrder
 	if maintainOrdering {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -596,6 +596,7 @@ func newJoinReader(
 			spec.FetchSpec.External,
 			row.FetchSpecRequiresRawMVCCValues(spec.FetchSpec),
 			flowCtx.EvalCtx.WorkloadID,
+			flowCtx.EvalCtx.WorkloadType,
 		)
 	} else {
 		// When not using the Streamer API, we want to limit the batch size hint

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -94,6 +95,8 @@ type tableWriterBase struct {
 	originTimestamp hlc.Timestamp
 	// workloadID is the statement fingerprint ID or job ID for ASH sampling.
 	workloadID uint64
+	// workloadType distinguishes the kind of workload for ASH sampling.
+	workloadType workloadid.WorkloadType
 }
 
 var maxBatchBytes = settings.RegisterByteSizeSetting(
@@ -122,6 +125,7 @@ func (tb *tableWriterBase) init(
 		tb.originID = evalCtx.SessionData().OriginIDForLogicalDataReplication
 		tb.originTimestamp = evalCtx.SessionData().OriginTimestampForLogicalDataReplication
 		tb.workloadID = evalCtx.WorkloadID
+		tb.workloadType = evalCtx.WorkloadType
 	}
 	tb.forceProductionBatchSizes = evalCtx != nil && evalCtx.TestingKnobs.ForceProductionValues
 	tb.maxBatchSize = mutations.MaxBatchSize(tb.forceProductionBatchSizes)
@@ -211,10 +215,11 @@ func (tb *tableWriterBase) tryDoResponseAdmission(ctx context.Context) error {
 	if responseAdmissionQ != nil {
 		requestAdmissionHeader := tb.txn.AdmissionHeader()
 		responseAdmission := admission.WorkInfo{
-			TenantID:   roachpb.SystemTenantID,
-			Priority:   admissionpb.WorkPriority(requestAdmissionHeader.Priority),
-			CreateTime: requestAdmissionHeader.CreateTime,
-			WorkloadID: tb.workloadID,
+			TenantID:     roachpb.SystemTenantID,
+			Priority:     admissionpb.WorkPriority(requestAdmissionHeader.Priority),
+			CreateTime:   requestAdmissionHeader.CreateTime,
+			WorkloadID:   tb.workloadID,
+			WorkloadType: tb.workloadType,
 		}
 		if _, err := responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
 			return err

--- a/pkg/sql/workload_id_test.go
+++ b/pkg/sql/workload_id_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
@@ -48,6 +49,7 @@ func TestWorkloadIDPropagation(t *testing.T) {
 
 	var admissionMu syncutil.Mutex
 	seenAdmissionIDs := make(map[uint64]struct{})
+	seenAdmissionTypes := make(map[uint64]workloadid.WorkloadType)
 
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
@@ -66,6 +68,7 @@ func TestWorkloadIDPropagation(t *testing.T) {
 					if info.WorkloadID != 0 {
 						admissionMu.Lock()
 						seenAdmissionIDs[info.WorkloadID] = struct{}{}
+						seenAdmissionTypes[info.WorkloadID] = info.WorkloadType
 						admissionMu.Unlock()
 					}
 				},
@@ -99,6 +102,7 @@ func TestWorkloadIDPropagation(t *testing.T) {
 	clearAdmissionIDs := func() {
 		admissionMu.Lock()
 		seenAdmissionIDs = make(map[uint64]struct{})
+		seenAdmissionTypes = make(map[uint64]workloadid.WorkloadType)
 		admissionMu.Unlock()
 	}
 	getAdmissionIDs := func() map[uint64]struct{} {
@@ -106,6 +110,13 @@ func TestWorkloadIDPropagation(t *testing.T) {
 		defer admissionMu.Unlock()
 		result := make(map[uint64]struct{}, len(seenAdmissionIDs))
 		maps.Copy(result, seenAdmissionIDs)
+		return result
+	}
+	getAdmissionTypes := func() map[uint64]workloadid.WorkloadType {
+		admissionMu.Lock()
+		defer admissionMu.Unlock()
+		result := make(map[uint64]workloadid.WorkloadType, len(seenAdmissionTypes))
+		maps.Copy(result, seenAdmissionTypes)
 		return result
 	}
 
@@ -183,6 +194,12 @@ func TestWorkloadIDPropagation(t *testing.T) {
 			captured := getAdmissionIDs()
 			assertWorkloadIDMatch(t, runner, appName,
 				"SELECT * FROM t WHERE v", captured)
+			// Verify WorkloadType is set (not UNKNOWN) for all captured IDs.
+			for wid, wtype := range getAdmissionTypes() {
+				require.NotEqual(t, workloadid.WorkloadTypeUnknown, wtype,
+					"admission WorkInfo for workload ID %d has WorkloadType=UNKNOWN; "+
+						"fetcher should propagate the type", wid)
+			}
 		})
 
 		// Streamer path: a lookup join goes through the KV streamer's
@@ -194,6 +211,12 @@ func TestWorkloadIDPropagation(t *testing.T) {
 			runner.Exec(t, "SELECT count(*) FROM t INNER LOOKUP JOIN t2 ON t.v = t2.id")
 			captured := getAdmissionIDs()
 			assertWorkloadIDMatch(t, runner, appName, "LOOKUP JOIN t2", captured)
+			// Verify WorkloadType is set (not UNKNOWN) for all captured IDs.
+			for wid, wtype := range getAdmissionTypes() {
+				require.NotEqual(t, workloadid.WorkloadTypeUnknown, wtype,
+					"admission WorkInfo for workload ID %d has WorkloadType=UNKNOWN; "+
+						"streamer should propagate the type", wid)
+			}
 		})
 	})
 

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/diskmap",
         "//pkg/kv/kvserver/uncertainty",
+        "//pkg/obs/workloadid",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -11,6 +11,7 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb"
@@ -163,6 +164,7 @@ var GetCFetcherWrapper func(
 	startKey roachpb.Key,
 	mustSerialize bool,
 	workloadID uint64,
+	workloadType workloadid.WorkloadType,
 ) (CFetcherWrapper, error)
 
 // onNextKVFn represents the transition that the mvccScanFetchAdapter needs to
@@ -462,6 +464,7 @@ func mvccScanToCols(
 		key,
 		mustSerialize,
 		opts.WorkloadID,
+		opts.WorkloadType,
 	)
 	if err != nil {
 		return MVCCScanResult{}, err

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
+	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -4944,6 +4945,8 @@ type MVCCScanOptions struct {
 	// WorkloadID identifies the workload that triggered the scan (e.g.
 	// statement fingerprint ID, job ID). Used for ASH sampling.
 	WorkloadID uint64
+	// WorkloadType distinguishes the kind of workload for ASH sampling.
+	WorkloadType workloadid.WorkloadType
 }
 
 func (opts *MVCCScanOptions) validate() error {


### PR DESCRIPTION
Several DistSQL operator admission paths constructed `admission.WorkInfo` with `WorkloadID` set but `WorkloadType` omitted, causing ASH samples to show `workload_type = 'UNKNOWN'` and job IDs to be hex-encoded instead of decimal. The affected paths are:

- `kv_batch_fetcher` response admission and admission pacer
- `cFetcher` admission pacer
- `kvstreamer` response admission
- `tablewriter` response admission

Thread `workloadType` through the constructors (`NewStreamer`, `NewKVFetcher`, `NewStreamingKVFetcher`, `NewDirectKVBatchFetcher`, `newCFetcherWrapper`) alongside the existing `workloadID` parameter. All callers have access to `EvalCtx.WorkloadType`.

Also extend `TestWorkloadIDPropagation` to assert that `WorkloadType != UNKNOWN` on all admission `WorkInfo` entries captured via the `WorkQueueAdmitInterceptor`, which would have caught this regression.

Fixes: #166463
Release note: None