### PR TITLE
roachtest: update cdc/initial-scan-rolling-restart

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -71,6 +71,13 @@ var IdleTimeout = settings.RegisterDurationSetting(
 
 // SpanCheckpointInterval controls how often span-level checkpoints
 // can be written.
+//
+// NB: This setting also controls how often a change aggregator will
+// send its frontier to the coordinator when its local frontier's
+// min timestamp is not advancing (because it's doing a backfill or
+// has lagging spans).
+//
+// TODO(#163256): We may want to rename or retire this setting.
 var SpanCheckpointInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"changefeed.frontier_checkpoint_frequency",
@@ -83,6 +90,13 @@ var SpanCheckpointInterval = settings.RegisterDurationSetting(
 // SpanCheckpointLagThreshold controls the amount of time a changefeed's
 // lagging spans must lag behind its leading spans before a span-level
 // checkpoint is written.
+//
+// NB: This threshold is also checked locally by each change aggregator to
+// determine if it should send its frontier to the coordinator when its
+// local frontier's min timestamp is not advancing and it's not currently
+// doing a backfill.
+//
+// TODO(#163256): We may want to rename or retire this setting.
 var SpanCheckpointLagThreshold = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"changefeed.frontier_highwater_lag_checkpoint_threshold",
@@ -109,6 +123,8 @@ var SpanCheckpointLagThreshold = settings.RegisterDurationSetting(
 //
 // Therefore, we should write at most 6 MB of checkpoint/hour; OR, based on the default
 // SpanCheckpointInterval setting, 1 MB per checkpoint.
+//
+// TODO(#163256): Retire this setting.
 var SpanCheckpointMaxBytes = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"changefeed.frontier_checkpoint_max_bytes",

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1094,20 +1094,11 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster, cfg cdcBank
 	m.Wait()
 }
 
-type cdcCheckpointType int
-
-const (
-	cdcNormalCheckpoint cdcCheckpointType = iota
-	cdcFrontierPersistence
-)
-
 // runCDCInitialScanRollingRestart runs multiple initial-scan-only changefeeds
 // on a 4-node cluster, using node 1 as the coordinator and continuously
 // restarting nodes 2-4 to hopefully force the changefeed to replan and exercise
 // the checkpoint restore logic.
-func runCDCInitialScanRollingRestart(
-	ctx context.Context, t test.Test, c cluster.Cluster, checkpointType cdcCheckpointType,
-) {
+func runCDCInitialScanRollingRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	startOpts := option.DefaultStartOpts()
 	ips, err := c.ExternalIP(ctx, t.L(), c.Node(1))
 	sinkURL := fmt.Sprintf("https://%s:%d", ips[0], debug.WebhookServerPort)
@@ -1163,18 +1154,13 @@ func runCDCInitialScanRollingRestart(
 		// Finish splitting, so that drained ranges spread out evenly.
 		fmt.Sprintf(`ALTER TABLE large SPLIT AT SELECT id FROM large ORDER BY random() LIMIT %d`, largeSplitCount),
 		`ALTER TABLE large SCATTER`,
-	}
-	switch checkpointType {
-	case cdcNormalCheckpoint:
-		setupStmts = append(setupStmts,
-			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '5s'`,
-			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '10m'`,
-		)
-	case cdcFrontierPersistence:
-		setupStmts = append(setupStmts,
-			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '0'`,
-			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '5s'`,
-		)
+		// Configure frequent checkpointing.
+		// NB: We set changefeed.span_checkpoint.interval because in addition
+		// to controlling how often we saved the now-deprecated legacy span-level
+		// checkpoint, it also controls how often a change aggregator will flush
+		// its frontier to the coordinator during a backfill.
+		`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '1s'`,
+		`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '5s'`,
 	}
 	for _, s := range setupStmts {
 		t.L().Printf(s)
@@ -2494,29 +2480,15 @@ CONFIGURE ZONE USING
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:             "cdc/initial-scan-rolling-restart/normal-checkpoint",
+		Name:             "cdc/initial-scan-rolling-restart",
 		Owner:            registry.OwnerCDC,
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          30 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runCDCInitialScanRollingRestart(ctx, t, c, cdcNormalCheckpoint)
+			runCDCInitialScanRollingRestart(ctx, t, c)
 		},
-	})
-	r.Add(registry.TestSpec{
-		Name:             "cdc/initial-scan-rolling-restart/frontier-persistence",
-		Owner:            registry.OwnerCDC,
-		Cluster:          r.MakeClusterSpec(4),
-		CompatibleClouds: registry.OnlyGCE,
-		Suites:           registry.Suites(registry.Nightly),
-		Timeout:          30 * time.Minute,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runCDCInitialScanRollingRestart(ctx, t, c, cdcFrontierPersistence)
-		},
-		// TODO(#155015): Unskip this test.
-		Skip: "frontier persistence will not happen during an initial-scan only changefeed " +
-			"without periodic aggregator frontier flushes",
 	})
 	r.Add(registry.TestSpec{
 		Name:             "cdc/rolling-restart",


### PR DESCRIPTION
This patch updates the `cdc/initial-scan-rolling-restart` roachtest
to do frequent frontier persistence now that the legacy span-level
checkpoint is no longer written.

Fixes #166395

Release note: None