### PR TITLE
[release-24.3.29-rc] ci: add trunk branch on push trigger

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -30,6 +30,7 @@ on:
       - "release-*"
       - "staging-*"
       - "staging"
+      - "trunk-merge/**"
       - "trying"
       - "!release-1.0*"
       - "!release-1.1*"


### PR DESCRIPTION
Backport 1/1 commits from #161230.

---

## Summary
Backports the critical missing CI trigger for Trunk merge queue branches to release-24.3.29-rc.

This fixes the issue where Trunk creates `trunk-merge/**` branches but GitHub Actions doesn't run CI on them, causing PRs to timeout.

## Problem Fixed
- Trunk merge queue creates branches but CI doesn't run
- PRs timeout after 80 minutes with no CI activity
- Without this, Trunk won't work properly when multiple PRs are in queue

## Test Plan
After merging:
- Trunk merge queue will properly trigger CI on release-24.3.29-rc
- Multiple PRs can be tested in parallel without timeout

## Release Note
None

Release justification: Non-production code change. Critical fix for CI/CD infrastructure.

## Related
- Same fix for release-24.3: #166445
- Same fix for release-25.2: #166450