### PR TITLE
 server,grpcutil: fix nil panic in TestDrain with DRPC

### DIFF
--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -127,7 +127,7 @@ func doTestDrain(tt *testing.T, secondaryTenants bool) {
 	// Now expect the server to be shut down.
 	testutils.SucceedsSoon(t, func() error {
 		_, err := t.c.Drain(context.Background(), &serverpb.DrainRequest{Shutdown: false})
-		if grpcutil.IsClosedConnection(err) {
+		if err != nil && grpcutil.IsClosedConnection(err) { //nolint:returnerrcheck
 			return nil
 		}
 		// It is incorrect to use errors.Wrap since that will result in a nil

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -80,6 +80,9 @@ func IsContextCanceled(err error) bool {
 // IsClosedConnection returns true if err's Cause is an error produced by gRPC
 // on closed connections.
 func IsClosedConnection(err error) bool {
+	if err == nil {
+		return false
+	}
 	if errors.Is(err, ErrConnectionInterrupted) {
 		return true
 	}


### PR DESCRIPTION
Previously, `grpcutil.IsClosedConnection` would panic with a nil pointer dereference when called with a nil error, because it called `err.Error()` without a nil guard. This was exposed by a race condition specific to DRPC: after server shutdown, the DRPC connection can remain alive (unlike gRPC which tears down immediately via `grpc.Stop()`), allowing `Drain()` to return a nil error during the shutdown window.

cockroachdb/drpc#36 widened this race by introducing a heap allocation (`ClosedError.New`) in the manager's stream cancellation path, slightly delaying `stream.Cancel()` and making it more likely for `CloseSend()` to complete before termination signals are set.

This change adds a nil guard to `IsClosedConnection` and a nil check in `drain_test.go` before calling it.

For more details: https://github.com/cockroachdb/cockroach/issues/165377#issuecomment-4116252691

Epic: None
Fixes: #165377
Fixes: #166117 
Release note: None