### PR TITLE
sql: add WITH ZONE option to SHOW RANGES

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3220,7 +3220,7 @@ show_job_options ::=
 	| 'RESOLVED' 'TIMESTAMP'
 
 show_ranges_options ::=
-	( 'TABLES' | 'INDEXES' | 'DETAILS' | 'KEYS' | 'EXPLAIN' ) ( ( ',' 'TABLES' | ',' 'INDEXES' | ',' 'DETAILS' | ',' 'EXPLAIN' | ',' 'KEYS' ) )*
+	( 'TABLES' | 'INDEXES' | 'DETAILS' | 'KEYS' | 'ZONE' | 'EXPLAIN' ) ( ( ',' 'TABLES' | ',' 'INDEXES' | ',' 'DETAILS' | ',' 'EXPLAIN' | ',' 'KEYS' | ',' 'ZONE' ) )*
 
 partition ::=
 	'PARTITION' partition_name

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -481,6 +481,19 @@ func StaticSplits() []roachpb.RKey {
 	return staticSplits
 }
 
+// StaticSplitAfter returns the first static split point strictly after key.
+// This is useful for determining the end of a named zone's key span: named
+// zones (meta, liveness, timeseries, system) are bounded by static splits,
+// so the next split after a key gives the zone's upper boundary.
+func StaticSplitAfter(key roachpb.RKey) (roachpb.RKey, bool) {
+	for _, split := range staticSplits {
+		if key.Less(split) {
+			return split, true
+		}
+	}
+	return nil, false
+}
+
 // ComputeSplitKey takes a start and end key and returns the first key at which
 // to split the span [start, end). Returns nil if no splits are required.
 //

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -429,6 +429,7 @@ all_span_stats AS (
 	// If zone config was requested, include it via the builtin.
 	if n.Options.Zone {
 		buf.WriteString(",\n  crdb_internal.zone_config_for_key(r.start_key) AS zone_config")
+		buf.WriteString(",\n  r.end_key <= crdb_internal.zone_config_span_end(r.start_key) AS zone_config_conformant")
 	}
 	buf.WriteString("\nFROM named_ranges r)\n")
 
@@ -720,9 +721,10 @@ all_span_stats AS (
 		buf.WriteString(",\n  span_stats")
 	}
 
-	// If zone config was requested, propagate the column.
+	// If zone config was requested, propagate the columns.
 	if n.Options.Zone {
 		buf.WriteString(",\n  zone_config")
+		buf.WriteString(",\n  zone_config_conformant")
 	}
 
 	// Complete this CTE. and add an order if needed.

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -426,6 +426,10 @@ all_span_stats AS (
 			endKey,
 		)
 	}
+	// If zone config was requested, include it via the builtin.
+	if n.Options.Zone {
+		buf.WriteString(",\n  crdb_internal.zone_config_for_key(r.start_key) AS zone_config")
+	}
 	buf.WriteString("\nFROM named_ranges r)\n")
 
 	// Time to assemble the final projection.
@@ -714,6 +718,11 @@ all_span_stats AS (
 			fmt.Fprintf(&buf, ",\n  %s", tree.NameString(colinfo.Ranges[i].Name))
 		}
 		buf.WriteString(",\n  span_stats")
+	}
+
+	// If zone config was requested, propagate the column.
+	if n.Options.Zone {
+		buf.WriteString(",\n  zone_config")
 	}
 
 	// Complete this CTE. and add an order if needed.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -695,6 +695,13 @@ func (ep *DummyPrivilegedAccessor) ResolvedZoneConfigForKey(
 	return nil, errors.WithStack(errEvalPrivileged)
 }
 
+// ZoneConfigSpanEnd is part of the eval.PrivilegedAccessor interface.
+func (ep *DummyPrivilegedAccessor) ZoneConfigSpanEnd(
+	ctx context.Context, key roachpb.Key,
+) (roachpb.Key, error) {
+	return nil, errors.WithStack(errEvalPrivileged)
+}
+
 // DummySessionAccessor implements the eval.SessionAccessor interface by returning errors.
 type DummySessionAccessor struct{}
 

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -688,6 +688,13 @@ func (ep *DummyPrivilegedAccessor) IsSystemTable(ctx context.Context, id int64) 
 	return false, errors.WithStack(errEvalPrivileged)
 }
 
+// ResolvedZoneConfigForKey is part of the eval.PrivilegedAccessor interface.
+func (ep *DummyPrivilegedAccessor) ResolvedZoneConfigForKey(
+	ctx context.Context, key roachpb.Key,
+) (tree.Datum, error) {
+	return nil, errors.WithStack(errEvalPrivileged)
+}
+
 // DummySessionAccessor implements the eval.SessionAccessor interface by returning errors.
 type DummySessionAccessor struct{}
 

--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -494,11 +494,11 @@ SELECT index_name FROM crdb_internal.ranges
 
 subtest show_ranges_with_zone
 
-# Assert the schema: WITH ZONE adds a zone_config JSONB column.
-query TTITTTTTTT colnames
+# Assert the schema: WITH ZONE adds zone_config and zone_config_conformant.
+query TTITTTTTTTB colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH ZONE] LIMIT 0
 ----
-start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
 
 # Verify zone_config column contains valid JSON with expected fields.
 query ITB
@@ -511,28 +511,30 @@ ORDER BY range_id LIMIT 1
 1  5  true
 
 # Combinable with TABLES.
-query TTITTTITTTTTTTTT colnames
+query TTITTTITTTTTTTTTB colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH TABLES, ZONE] LIMIT 0
 ----
-start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
 
 # Combinable with KEYS.
-query TTTTITTTTTTT colnames
+query TTTTITTTTTTTB colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH KEYS, ZONE] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
 
-# WITH EXPLAIN + ZONE shows the generated SQL containing the builtin.
-query B
-SELECT (SELECT * FROM [SHOW CLUSTER RANGES WITH EXPLAIN, ZONE]) LIKE '%zone_config_for_key%'
+# WITH EXPLAIN + ZONE shows the generated SQL containing the builtins.
+query BB
+SELECT
+  (SELECT * FROM [SHOW CLUSTER RANGES WITH EXPLAIN, ZONE]) LIKE '%zone_config_for_key%',
+  (SELECT * FROM [SHOW CLUSTER RANGES WITH EXPLAIN, ZONE]) LIKE '%zone_config_span_end%'
 ----
-true
+true  true
 
 # SHOW RANGES FROM DATABASE with ZONE.
-query TTITTTTTTT colnames
+query TTITTTTTTTB colnames
 SELECT * FROM [SHOW RANGES FROM DATABASE test WITH ZONE] LIMIT 0
 ----
-start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
 
 # Zone config changes are immediately reflected (no propagation delay).
 # Note: zone_config_for_key resolves based on the range start key, which
@@ -564,6 +566,49 @@ query T
 SELECT crdb_internal.zone_config_for_key(crdb_internal.table_span($zone_inherit_id)[1])->>'numReplicas'
 ----
 3
+
+## zone_config_span_end builtin
+
+# For a table, zone_config_span_end returns the table's key span end.
+query B
+SELECT crdb_internal.zone_config_span_end(crdb_internal.table_span($zone_test_id)[1])
+       = crdb_internal.table_span($zone_test_id)[2]
+----
+true
+
+# For a table without explicit zone config, same behavior (inherited zone).
+query B
+SELECT crdb_internal.zone_config_span_end(crdb_internal.table_span($zone_inherit_id)[1])
+       = crdb_internal.table_span($zone_inherit_id)[2]
+----
+true
+
+## Subzone false positive (known limitation)
+#
+# zone_config_span_end currently returns the table-level end key,
+# ignoring index/partition-level subzone boundaries. When a table
+# has index-level zone configs, zone_config_conformant may report
+# true even when a range spans a subzone boundary.
+
+statement ok
+CREATE TABLE zone_subzone_test (a INT PRIMARY KEY, b INT, INDEX idx(b))
+
+let $zone_subzone_id
+SELECT 'zone_subzone_test'::regclass::oid::int
+
+statement ok
+ALTER INDEX zone_subzone_test@idx CONFIGURE ZONE USING num_replicas = 5
+
+# zone_config_span_end returns the table end key, not the subzone
+# boundary — this documents the false positive.
+query B
+SELECT crdb_internal.zone_config_span_end(crdb_internal.table_span($zone_subzone_id)[1])
+       = crdb_internal.table_span($zone_subzone_id)[2]
+----
+true
+
+statement ok
+DROP TABLE zone_subzone_test
 
 statement ok
 DROP TABLE zone_test

--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -583,12 +583,11 @@ SELECT crdb_internal.zone_config_span_end(crdb_internal.table_span($zone_inherit
 ----
 true
 
-## Subzone false positive (known limitation)
+## Subzone awareness
 #
-# zone_config_span_end currently returns the table-level end key,
-# ignoring index/partition-level subzone boundaries. When a table
-# has index-level zone configs, zone_config_conformant may report
-# true even when a range spans a subzone boundary.
+# zone_config_span_end detects index/partition-level subzone boundaries
+# within a table. When such boundaries exist, it returns the next
+# subzone split point rather than the table's end key.
 
 statement ok
 CREATE TABLE zone_subzone_test (a INT PRIMARY KEY, b INT, INDEX idx(b))
@@ -599,13 +598,13 @@ SELECT 'zone_subzone_test'::regclass::oid::int
 statement ok
 ALTER INDEX zone_subzone_test@idx CONFIGURE ZONE USING num_replicas = 5
 
-# zone_config_span_end returns the table end key, not the subzone
-# boundary — this documents the false positive.
+# zone_config_span_end returns a subzone boundary, not the table end
+# key, because the index has its own zone config.
 query B
 SELECT crdb_internal.zone_config_span_end(crdb_internal.table_span($zone_subzone_id)[1])
        = crdb_internal.table_span($zone_subzone_id)[2]
 ----
-true
+false
 
 statement ok
 DROP TABLE zone_subzone_test

--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -491,3 +491,84 @@ SELECT schema_name FROM crdb_internal.ranges
 
 statement error pgcode 42703 .*\nHINT.*To retrieve index.*with ranges
 SELECT index_name FROM crdb_internal.ranges
+
+subtest show_ranges_with_zone
+
+# Assert the schema: WITH ZONE adds a zone_config JSONB column.
+query TTITTTTTTT colnames
+SELECT * FROM [SHOW CLUSTER RANGES WITH ZONE] LIMIT 0
+----
+start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+
+# Verify zone_config column contains valid JSON with expected fields.
+query ITB
+SELECT range_id,
+       zone_config->>'numReplicas',
+       zone_config ? 'rangeMinBytes'
+FROM [SHOW CLUSTER RANGES WITH ZONE]
+ORDER BY range_id LIMIT 1
+----
+1  5  true
+
+# Combinable with TABLES.
+query TTITTTITTTTTTTTT colnames
+SELECT * FROM [SHOW CLUSTER RANGES WITH TABLES, ZONE] LIMIT 0
+----
+start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+
+# Combinable with KEYS.
+query TTTTITTTTTTT colnames
+SELECT * FROM [SHOW CLUSTER RANGES WITH KEYS, ZONE] LIMIT 0
+----
+start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+
+# WITH EXPLAIN + ZONE shows the generated SQL containing the builtin.
+query B
+SELECT (SELECT * FROM [SHOW CLUSTER RANGES WITH EXPLAIN, ZONE]) LIKE '%zone_config_for_key%'
+----
+true
+
+# SHOW RANGES FROM DATABASE with ZONE.
+query TTITTTTTTT colnames
+SELECT * FROM [SHOW RANGES FROM DATABASE test WITH ZONE] LIMIT 0
+----
+start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config
+
+# Zone config changes are immediately reflected (no propagation delay).
+# Note: zone_config_for_key resolves based on the range start key, which
+# may belong to a different table when multiple tables share a range.
+# Use the builtin directly with a known key to verify correctness.
+statement ok
+CREATE TABLE zone_test (id INT PRIMARY KEY)
+
+let $zone_test_id
+SELECT 'zone_test'::regclass::oid::int
+
+statement ok
+ALTER TABLE zone_test CONFIGURE ZONE USING num_replicas = 5
+
+# Verify the builtin returns the correct zone config for the table's key prefix.
+query T
+SELECT crdb_internal.zone_config_for_key(crdb_internal.table_span($zone_test_id)[1])->>'numReplicas'
+----
+5
+
+# Verify inheritance: table without explicit zone config inherits defaults.
+statement ok
+CREATE TABLE zone_inherit (id INT PRIMARY KEY)
+
+let $zone_inherit_id
+SELECT 'zone_inherit'::regclass::oid::int
+
+query T
+SELECT crdb_internal.zone_config_for_key(crdb_internal.table_span($zone_inherit_id)[1])->>'numReplicas'
+----
+3
+
+statement ok
+DROP TABLE zone_test
+
+statement ok
+DROP TABLE zone_inherit
+
+subtest end

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -10426,6 +10426,7 @@ show_range_for_row_stmt:
 //   TABLES:  list tables contained per range
 //   DETAILS: add range size, leaseholder and other details
 //   KEYS:    include binary start/end keys
+//   ZONE:    include the resolved zone configuration per range
 //   EXPLAIN: show the SQL queries that produces the result
 //
 // Note: the availability of some of the options listed above is subject
@@ -10472,6 +10473,7 @@ show_ranges_options:
 | INDEXES {  $$.val = &tree.ShowRangesOptions{Mode: tree.ExpandIndexes} }
 | DETAILS {  $$.val = &tree.ShowRangesOptions{Details: true} }
 | KEYS    {  $$.val = &tree.ShowRangesOptions{Keys: true} }
+| ZONE    {  $$.val = &tree.ShowRangesOptions{Zone: true} }
 | EXPLAIN {  $$.val = &tree.ShowRangesOptions{Explain: true} }
 | show_ranges_options ',' TABLES
   {
@@ -10503,6 +10505,12 @@ show_ranges_options:
   {
     o := $1.showRangesOpts()
     o.Keys = true
+    $$.val = o
+  }
+| show_ranges_options ',' ZONE
+  {
+    o := $1.showRangesOpts()
+    o.Zone = true
     $$.val = o
   }
 

--- a/pkg/sql/pgwire/testdata/pgtest/procedure
+++ b/pkg/sql/pgwire/testdata/pgtest/procedure
@@ -66,9 +66,9 @@ Query {"String": "CALL p()"}
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func397","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func397","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func397","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -84,8 +84,8 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func397","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func397","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func397","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -131,6 +131,28 @@ func (p *planner) ResolvedZoneConfigForKey(
 	return tree.NewDJSON(j), nil
 }
 
+// ZoneConfigSpanEnd implements eval.PrivilegedAccessor.
+//
+// It returns the end key of the zone config span that the given key
+// belongs to. For named zones (meta, liveness, timeseries, system,
+// tenants) this is the next static split point. For tables this is
+// the table's key span end.
+//
+// Note: this does not account for subzone (index/partition-level)
+// boundaries within a table.
+func (p *planner) ZoneConfigSpanEnd(ctx context.Context, key roachpb.Key) (roachpb.Key, error) {
+	objectID, _ := config.DecodeKeyIntoZoneIDAndSuffix(
+		keys.SystemSQLCodec, roachpb.RKey(key),
+	)
+	if _, ok := zonepb.NamedZonesByID[uint32(objectID)]; ok {
+		if end, ok := config.StaticSplitAfter(roachpb.RKey(key)); ok {
+			return end.AsRawKey(), nil
+		}
+		return keys.TableDataMin, nil
+	}
+	return keys.SystemSQLCodec.TableSpan(uint32(objectID)).EndKey, nil
+}
+
 // checkDescriptorPermissions returns nil if the executing user has permissions
 // to check the permissions of a descriptor given its ID, or the id given
 // is not a descriptor of a table or database.

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -9,14 +9,19 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/zoneconfig"
 	"github.com/cockroachdb/errors"
 )
 
@@ -79,6 +84,51 @@ func (p *planner) IsSystemTable(ctx context.Context, id int64) (bool, error) {
 		return false, err
 	}
 	return catalog.IsSystemDescriptor(tbl), nil
+}
+
+// ResolvedZoneConfigForKey implements eval.PrivilegedAccessor.
+//
+// It returns the fully resolved (inheritance-applied) zone configuration
+// for the given range start key as a JSONB datum. The key is mapped to a
+// zone via config.DecodeKeyIntoZoneIDAndSuffix (the canonical key-to-zone
+// translation used throughout the system), then hydrated via
+// GetHydratedForNamedZone or GetHydratedForTable to walk the full
+// inheritance chain (e.g. table -> database -> RANGE DEFAULT).
+//
+// This cannot reuse LookupZoneConfigByNamespaceID because that returns the
+// raw zone config bytes for a single descriptor without applying
+// inheritance; here we need the fully resolved config.
+func (p *planner) ResolvedZoneConfigForKey(
+	ctx context.Context, key roachpb.Key,
+) (tree.Datum, error) {
+	// Use the system codec: input keys are raw range keys from
+	// crdb_internal.ranges_no_leases, not tenant-scoped.
+	objectID, _ := config.DecodeKeyIntoZoneIDAndSuffix(
+		keys.SystemSQLCodec, roachpb.RKey(key),
+	)
+
+	var zc *zonepb.ZoneConfig
+	var err error
+	if zoneName, ok := zonepb.NamedZonesByID[uint32(objectID)]; ok {
+		zc, err = zoneconfig.GetHydratedForNamedZone(
+			ctx, p.Txn(), p.Descriptors(), zoneName,
+		)
+	} else {
+		zc, err = zoneconfig.GetHydratedForTable(
+			ctx, p.Txn(), p.Descriptors(), descpb.ID(objectID),
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := protoreflect.MessageToJSON(
+		zc, protoreflect.FmtFlags{EmitDefaults: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tree.NewDJSON(j), nil
 }
 
 // checkDescriptorPermissions returns nil if the executing user has permissions

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -6,6 +6,7 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -136,10 +137,9 @@ func (p *planner) ResolvedZoneConfigForKey(
 // It returns the end key of the zone config span that the given key
 // belongs to. For named zones (meta, liveness, timeseries, system,
 // tenants) this is the next static split point. For tables this is
-// the table's key span end.
-//
-// Note: this does not account for subzone (index/partition-level)
-// boundaries within a table.
+// the narrowest applicable boundary: the next subzone split point
+// within the table (for index/partition-level zone configs), or the
+// table's key span end if no subzone boundaries exist.
 func (p *planner) ZoneConfigSpanEnd(ctx context.Context, key roachpb.Key) (roachpb.Key, error) {
 	objectID, _ := config.DecodeKeyIntoZoneIDAndSuffix(
 		keys.SystemSQLCodec, roachpb.RKey(key),
@@ -148,9 +148,28 @@ func (p *planner) ZoneConfigSpanEnd(ctx context.Context, key roachpb.Key) (roach
 		if end, ok := config.StaticSplitAfter(roachpb.RKey(key)); ok {
 			return end.AsRawKey(), nil
 		}
+		// The tenants named zone extends to the end of the keyspace with
+		// no static split after it.
+		if bytes.HasPrefix(key, keys.TenantPrefix) {
+			return roachpb.KeyMax, nil
+		}
 		return keys.TableDataMin, nil
 	}
-	return keys.SystemSQLCodec.TableSpan(uint32(objectID)).EndKey, nil
+	tableSpan := keys.SystemSQLCodec.TableSpan(uint32(objectID))
+	// Check for subzone boundaries (index/partition-level zone configs).
+	zc, err := zoneconfig.GetHydratedForTable(
+		ctx, p.Txn(), p.Descriptors(), descpb.ID(objectID),
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, splitSuffix := range zc.SubzoneSplits() {
+		splitKey := append(tableSpan.Key.Clone(), splitSuffix...)
+		if key.Compare(splitKey) < 0 {
+			return splitKey, nil
+		}
+	}
+	return tableSpan.EndKey, nil
 }
 
 // checkDescriptorPermissions returns nil if the executing user has permissions

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6944,6 +6944,22 @@ SELECT
 		},
 	),
 
+	// Returns the fully resolved (inheritance-applied) zone configuration for
+	// the range that contains the given key, as JSONB. This is used by
+	// SHOW RANGES WITH ZONE to expose the desired zone config per range.
+	"crdb_internal.zone_config_for_key": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "key", Typ: types.Bytes}},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				key := roachpb.Key(tree.MustBeDBytes(args[0]))
+				return evalCtx.PrivilegedAccessor.ResolvedZoneConfigForKey(ctx, key)
+			},
+			Volatility: volatility.Stable,
+		},
+	),
+
 	"crdb_internal.set_vmodule": makeBuiltin(
 		tree.FunctionProperties{
 			Category: builtinconstants.CategorySystemInfo,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6960,6 +6960,24 @@ SELECT
 		},
 	),
 
+	"crdb_internal.zone_config_span_end": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "key", Typ: types.Bytes}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				key := roachpb.Key(tree.MustBeDBytes(args[0]))
+				endKey, err := evalCtx.PrivilegedAccessor.ZoneConfigSpanEnd(ctx, key)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBytes(tree.DBytes(endKey)), nil
+			},
+			Info:       "Returns the end key of the zone config span that the given key belongs to.",
+			Volatility: volatility.Stable,
+		},
+	),
+
 	"crdb_internal.set_vmodule": makeBuiltin(
 		tree.FunctionProperties{
 			Category: builtinconstants.CategorySystemInfo,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2903,6 +2903,7 @@ var builtinOidsArray = []string{
 	2948: `information_schema.crdb_delete_statement_hints(statement_fingerprint: string, database: string) -> int`,
 	2949: `information_schema.crdb_enable_statement_hints(enabled: bool, statement_fingerprint: string, database: string) -> int`,
 	2950: `pg_get_statisticsobjdef(statobj_oid: oid) -> string`,
+	2951: `crdb_internal.zone_config_for_key(key: bytes) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2904,6 +2904,7 @@ var builtinOidsArray = []string{
 	2949: `information_schema.crdb_enable_statement_hints(enabled: bool, statement_fingerprint: string, database: string) -> int`,
 	2950: `pg_get_statisticsobjdef(statobj_oid: oid) -> string`,
 	2951: `crdb_internal.zone_config_for_key(key: bytes) -> jsonb`,
+	2952: `crdb_internal.zone_config_span_end(key: bytes) -> bytes`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -703,8 +703,10 @@ type PrivilegedAccessor interface {
 	ResolvedZoneConfigForKey(ctx context.Context, key roachpb.Key) (tree.Datum, error)
 
 	// ZoneConfigSpanEnd returns the end key of the zone config span that
-	// the given key belongs to. For table zones this is the table's key
-	// span end; for named zones it is the next static split point.
+	// the given key belongs to. For named zones this is the next static
+	// split point. For table zones this is the next subzone
+	// (index/partition) boundary within the table, or the table's key
+	// span end if no subzone boundary follows the given key.
 	ZoneConfigSpanEnd(ctx context.Context, key roachpb.Key) (roachpb.Key, error)
 }
 

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -697,6 +697,10 @@ type PrivilegedAccessor interface {
 
 	// IsSystemTable returns if a given descriptor ID is a system table.s
 	IsSystemTable(ctx context.Context, id int64) (bool, error)
+
+	// ResolvedZoneConfigForKey returns the fully resolved (inheritance-applied)
+	// zone configuration for the given range start key, as JSONB.
+	ResolvedZoneConfigForKey(ctx context.Context, key roachpb.Key) (tree.Datum, error)
 }
 
 // RegionOperator gives access to the current region, validation for all

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -701,6 +701,11 @@ type PrivilegedAccessor interface {
 	// ResolvedZoneConfigForKey returns the fully resolved (inheritance-applied)
 	// zone configuration for the given range start key, as JSONB.
 	ResolvedZoneConfigForKey(ctx context.Context, key roachpb.Key) (tree.Datum, error)
+
+	// ZoneConfigSpanEnd returns the end key of the zone config span that
+	// the given key belongs to. For table zones this is the table's key
+	// span end; for named zones it is the next static split point.
+	ZoneConfigSpanEnd(ctx context.Context, key roachpb.Key) (roachpb.Key, error)
 }
 
 // RegionOperator gives access to the current region, validation for all

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -1143,6 +1143,7 @@ type ShowRangesOptions struct {
 	Details bool
 	Explain bool
 	Keys    bool
+	Zone    bool
 	Mode    ShowRangesMode
 }
 
@@ -1207,6 +1208,11 @@ func (node *ShowRangesOptions) Format(ctx *FmtCtx) {
 	if node.Explain {
 		ctx.WriteString(comma)
 		ctx.WriteString("EXPLAIN")
+		comma = ", "
+	}
+	if node.Zone {
+		ctx.WriteString(comma)
+		ctx.WriteString("ZONE")
 		comma = ", "
 	}
 	if node.Mode != UniqueRanges {


### PR DESCRIPTION
## Summary

Add a `WITH ZONE` option to `SHOW RANGES` that includes zone configuration
columns, enabling queries like "find all ranges below their desired replication
factor" directly from SQL.

The option is named `ZONE` (singular) rather than `ZONES` because there is
always exactly one zone config per range; `ZONES` would incorrectly suggest
multiplicity.

**Commit 1** adds `crdb_internal.zone_config_for_key(key BYTES) → JSONB`, a
builtin that maps a range start key to its fully resolved (inheritance-applied)
zone config using `zoneconfig.GetHydratedForTable/NamedZone`.

**Commit 2** wires the builtin into `SHOW RANGES` via a new `ZONE` grammar
option, combinable with all existing options (`TABLES`, `KEYS`, `DETAILS`,
`EXPLAIN`). Adds a `zone_config JSONB` column.

**Commit 3** adds `crdb_internal.zone_config_span_end(key BYTES) → BYTES`, a
builtin that returns the end key of the zone config span for a given key. This
powers a `zone_config_conformant BOOL` column that indicates whether a range is
entirely within a single zone config's key span, or straddles a boundary (e.g.
after `ALTER TABLE CONFIGURE ZONE` but before the range has been split).

**Commit 4** enhances `zone_config_span_end` to detect index/partition-level
subzone boundaries within a table, not just table-level boundaries.

Example:
```sql
SELECT range_id, start_key, end_key,
       array_length(replicas, 1) AS actual,
       (zone_config->>'numReplicas')::INT AS desired,
       zone_config_conformant
FROM [SHOW CLUSTER RANGES WITH ZONE]
WHERE array_length(replicas, 1) < (zone_config->>'numReplicas')::INT;
```

Epic: none