### PR TITLE
investigate: analyze heap profiles on OOM failures

### DIFF
--- a/.github/prompts/investigate-smoke.md
+++ b/.github/prompts/investigate-smoke.md
@@ -38,6 +38,7 @@ mkdir -p artifacts
 13. **Grep tool**: Search for "package" in `pkg/util/log/`
 14. **Glob tool**: Find `*.go` files in `pkg/util/log/`
 15. **WebFetch tool**: Fetch `https://httpbin.org/get`
+16. **Bash(go tool pprof)**: `go tool pprof -top -inuse_space -nodecount=5 /dev/null 2>&1 || true` (confirms the command is allowed; an error about the input file is fine)
 
 ## Output
 

--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -229,6 +229,20 @@ your findings rather than failing the investigation.
 If there is no TeamCity build ID and no EngFlow invocation URL, work
 with what is available in the issue.
 
+**Heap profile analysis (OOM failures):**
+
+When a node is OOM-killed, the `debug.zip` profile for that node will
+be an error (node is dead), but the node's heap profiler typically
+wrote profiles to disk before the crash. Look in `artifacts.zip` under
+`logs/<node>.unredacted/heap_profiler/` for `memprof.*.pprof` files
+(the filename suffix is Go heap in-use bytes — scan these to see the
+growth trajectory). Use `go tool pprof -top -inuse_space` on the
+latest profile, and diff the earliest vs latest with `-base` to
+isolate the runaway allocation sites. Include the diff in your
+findings. Also check the `memmonitoring.*.txt` files in the same
+directory to see whether the growth is tracked by CockroachDB's
+memory accounting.
+
 ### Step 5: Write Your Findings
 
 Write your findings to `artifacts/findings.md` (create the

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -168,7 +168,7 @@ jobs:
           # based permissions may work after upgrading the action.
           claude_args: |
             --model ${{ inputs.cheap == true && 'claude-sonnet-4-5' || 'claude-opus-4-6' }}
-            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(python3 .claude/skills/engflow-artifacts/engflow_artifacts.py:*)"
+            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(python3 .claude/skills/engflow-artifacts/engflow_artifacts.py:*),Bash(go tool pprof:*)"
           prompt: |
             Read and follow the instructions in the prompt file
             `.github/prompts/${{ inputs.smoke_test == true && 'investigate-smoke' || 'investigate' }}.md`.


### PR DESCRIPTION
## Summary

Teaches the `/investigate` agent to analyze heap profiler artifacts when a node
is OOM-killed:

- Look for `memprof.*.pprof` files in `artifacts.zip` (not `debug.zip`, which
  errors for dead nodes)
- Diff earliest vs latest profiles with `go tool pprof -base` to isolate
  runaway allocation sites
- Cross-reference with `memmonitoring` files to check memory accounting gaps
- Adds `go tool pprof` to the workflow's allowed tools
- Adds a smoke test entry for the new permission

Motivated by [#166476](https://github.com/cockroachdb/cockroach/issues/166476)
where the investigation identified the OOM but didn't analyze the heap profiles
that were available in the artifacts.

Release note: None
Epic: none