### PR TITLE
release-26.2: server: add cluster setting to disable GC assist

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10178,6 +10178,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+    - name: sys.gc.assist.enabled
+      exported_name: sys_gc_assist_enabled
+      description: Indicates whether GC assist is currently enabled (1) or disabled (0)
+      y_axis_label: GC Assist
+      type: GAUGE
+      unit: CONST
+      aggregation: AVG
+      derivative: NONE
     - name: sys.gc.assist.ns
       exported_name: sys_gc_assist_ns
       description: Estimated total CPU time user goroutines spent to assist the GC process

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2902,6 +2902,7 @@ GO_TARGETS = [
     "//pkg/util/future:future_test",
     "//pkg/util/fuzzystrmatch:fuzzystrmatch",
     "//pkg/util/fuzzystrmatch:fuzzystrmatch_test",
+    "//pkg/util/gcassist:gcassist",
     "//pkg/util/goschedstats:goschedstats",
     "//pkg/util/goschedstats:goschedstats_test",
     "//pkg/util/growstack:growstack",

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2994,6 +2994,7 @@ sys_cpu_user_ns: sys.cpu.user.ns
 sys_cpu_user_percent: sys.cpu.user.percent
 sys_fd_open: sys.fd.open
 sys_fd_softlimit: sys.fd.softlimit
+sys_gc_assist_enabled: sys.gc.assist.enabled
 sys_gc_assist_ns: sys.gc.assist.ns
 sys_gc_count: sys.gc.count
 sys_gc_pause_ns: sys.gc.pause.ns

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -327,6 +327,7 @@ go_library(
         "//pkg/util/cidr",
         "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
+        "//pkg/util/gcassist",
         "//pkg/util/goschedstats",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/gcassist"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -38,6 +39,15 @@ var jemallocPurgePeriod = settings.RegisterDurationSettingWithExplicitUnit(
 	"server.jemalloc_purge_period",
 	"minimum amount of time that must pass between two jemalloc dirty page purges (0 disables purging)",
 	2*time.Minute,
+)
+
+var gcAssistEnabled = settings.RegisterBoolSetting(
+	settings.SystemVisible,
+	"server.gc_assist.enabled",
+	"set to false to dynamically disable GC assist in the Go runtime "+
+		"(requires CockroachDB's forked Go runtime; no-op otherwise); "+
+		"picks up the GODEBUG gcnoassist flag as its default",
+	gcassist.Enabled(), // default reflects GODEBUG=gcnoassist at startup
 )
 
 type sampleEnvironmentCfg struct {
@@ -147,6 +157,13 @@ func startSampleEnvironment(
 			log.Dev.Warningf(ctx, "failed to start flight recorder: %v", err)
 		}
 	}
+
+	// Apply the initial value of the GC assist setting and install a
+	// callback for dynamic updates.
+	gcassist.SetEnabled(gcAssistEnabled.Get(&cfg.st.SV))
+	gcAssistEnabled.SetOnChange(&cfg.st.SV, func(ctx context.Context) {
+		gcassist.SetEnabled(gcAssistEnabled.Get(&cfg.st.SV))
+	})
 
 	return cfg.stopper.RunAsyncTaskEx(ctx,
 		stop.TaskOpts{TaskName: "mem-logger", SpanOpt: stop.SterileRootSpan},

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/ts/tsutil",
         "//pkg/util/cgroups",
         "//pkg/util/envutil",
+        "//pkg/util/gcassist",
         "//pkg/util/goschedstats",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/cgroups"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/gcassist"
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -167,6 +168,12 @@ var (
 		Help:        "Estimated total CPU time user goroutines spent to assist the GC process",
 		Measurement: "CPU Time",
 		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaGCAssistEnabled = metric.Metadata{
+		Name:        "sys.gc.assist.enabled",
+		Help:        "Indicates whether GC assist is currently enabled (1) or disabled (0)",
+		Measurement: "GC Assist",
+		Unit:        metric.Unit_CONST,
 	}
 	metaGCTotalNS = metric.Metadata{
 		Name:        "sys.gc.total.ns",
@@ -846,6 +853,7 @@ type RuntimeStatSampler struct {
 	NonGcStopNS              *metric.Gauge
 	GcPausePercent           *metric.GaugeFloat64
 	GcAssistNS               *metric.Counter
+	GcAssistEnabled          *metric.Gauge
 	GcTotalNS                *metric.Counter
 	// CPU stats for the CRDB process usage.
 	CPUUserNS              *metric.Counter
@@ -954,6 +962,7 @@ func NewRuntimeStatSampler(ctx context.Context, clock hlc.WallClock) *RuntimeSta
 		GcStopNS:                 metric.NewGauge(metaGCStopNS),
 		GcPausePercent:           metric.NewGaugeFloat64(metaGCPausePercent),
 		GcAssistNS:               metric.NewCounter(metaGCAssistNS),
+		GcAssistEnabled:          metric.NewGauge(metaGCAssistEnabled),
 		GcTotalNS:                metric.NewCounter(metaGCTotalNS),
 		NonGcPauseNS:             metric.NewGauge(metaNonGCPauseNS),
 		NonGcStopNS:              metric.NewGauge(metaNonGCStopNS),
@@ -1269,6 +1278,11 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	rsr.GcStopNS.Update(gcStopTotalNs)
 	rsr.GcPausePercent.Update(gcPauseRatio)
 	rsr.GcAssistNS.Update(gcAssistNS)
+	if gcassist.Enabled() {
+		rsr.GcAssistEnabled.Update(1)
+	} else {
+		rsr.GcAssistEnabled.Update(0)
+	}
 	rsr.GcTotalNS.Update(int64(rsr.goRuntimeSampler.float64(runtimeMetricGCTotal) * 1e9))
 	rsr.NonGcPauseNS.Update(nonGcPauseTotalNs)
 	rsr.NonGcStopNS.Update(nonGcStopTotalNs)

--- a/pkg/util/gcassist/BUILD.bazel
+++ b/pkg/util/gcassist/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gcassist",
+    srcs = [
+        "enabled.go",
+        "gcassist.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/gcassist",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/gcassist/disabled.go
+++ b/pkg/util/gcassist/disabled.go
@@ -1,0 +1,11 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build !bazel
+
+package gcassist
+
+func setEnabled(v bool) {}
+func enabled() bool     { return true }

--- a/pkg/util/gcassist/enabled.go
+++ b/pkg/util/gcassist/enabled.go
@@ -1,0 +1,13 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build bazel
+
+package gcassist
+
+import "runtime"
+
+func setEnabled(v bool) { runtime.SetGCAssistEnabled(v) }
+func enabled() bool     { return runtime.GCAssistEnabled() }

--- a/pkg/util/gcassist/gcassist.go
+++ b/pkg/util/gcassist/gcassist.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package gcassist provides control over the Go runtime's GC assist mechanism.
+// It relies on CockroachDB's forked Go runtime which exposes
+// runtime.SetGCAssistEnabled and runtime.GCAssistEnabled. Under vanilla Go
+// (non-Bazel builds), these are no-ops.
+package gcassist
+
+// SetEnabled enables or disables the Go runtime's GC assist.
+// Under vanilla Go this is a no-op.
+func SetEnabled(v bool) {
+	setEnabled(v)
+}
+
+// Enabled reports whether GC assist is currently enabled.
+// Under vanilla Go this always returns true.
+func Enabled() bool {
+	return enabled()
+}


### PR DESCRIPTION
Backport 2/2 commits from #166306.

/cc @cockroachdb/release

---

## Summary

- Adds `pkg/util/gcassist`, a thin wrapper around the forked runtime's
  `SetGCAssistEnabled`/`GCAssistEnabled` with `bazel`/`!bazel` build tags
  (following the `grunning` pattern).
- Adds `server.gc_assist.enabled` cluster setting (bool, `SystemVisible`)
  that dynamically toggles GC assist. Defaults to the runtime's current
  state at startup (respecting `GODEBUG=gcnoassist=1`).
- Adds `sys.gc.assist.enabled` gauge metric (0/1) so the state is
  observable even without the setting being explicitly set.

Fixes: #166040

## Commits

1. **util/gcassist: add package for controlling GC assist** — new package
   with `SetEnabled`/`Enabled` and bazel/non-bazel stubs.
2. **server: add cluster setting and metric for GC assist** — setting
   registration, `SetOnChange` wiring in `startSampleEnvironment`, and
   gauge metric in `RuntimeStatSampler`.

Release justification: default-off change that can help improve foreground latencies.
