### PR TITLE
sql: audit zone config changes on SENSITIVE_ACCESS channel

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3905,6 +3905,53 @@ is a set of SchemaDescriptor messages sharing the same SnapshotID.
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
 
+## Zone Config Audit Events
+
+Events in this category are generated unconditionally when zone
+configuration changes are made. Unlike other SENSITIVE_ACCESS events,
+these do not require any audit setting to be enabled.
+
+Note: These events are not written to `system.eventlog`, even
+when the cluster setting `system.eventlog.enabled` is set. They
+are only emitted via external logging.
+
+Events in this category are logged to the `SENSITIVE_ACCESS` channel.
+
+
+### `zone_config_audit`
+
+An event of type `zone_config_audit` is recorded when any user executes a zone configuration
+change (ALTER ... CONFIGURE ZONE). These operations control data placement
+and are security-sensitive for compliance and geo-partitioning purposes.
+
+
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+| `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
+| `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
+| `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
+| `ErrorText` | The text of the error if any. | partially |
+| `Age` | Age of the query in milliseconds. | no |
+| `NumRetries` | Number of retries, when the txn was reretried automatically by the server. | no |
+| `FullTableScan` | Whether the query contains a full table scan. | no |
+| `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
+| `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
+| `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
+
 ## Zone config events
 
 Events in this category pertain to zone configuration changes on

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -191,6 +192,161 @@ COMMIT;
 		if !found {
 			t.Fatal(errors.Newf("no matching entry found for test case %s", tc.name))
 		}
+	}
+}
+
+// TestAuditLogZoneConfig verifies that zone config changes produce
+// zone_config_audit events on the SENSITIVE_ACCESS channel for both admin
+// and non-admin users, across all CONFIGURE ZONE syntax variants.
+//
+// Regression test for CRDB-1180: zone config changes are security-sensitive
+// operations that control data placement (for compliance/geo-partitioning).
+// zone_config_audit events are emitted unconditionally, without requiring
+// sql.log.admin_audit.enabled.
+func TestAuditLogZoneConfig(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := installSensitiveAccessLogFileSink(sc, t)
+	defer cleanup()
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Intentionally NOT setting sql.log.admin_audit.enabled to prove that
+	// zone_config_audit events are emitted unconditionally.
+
+	// Set up a non-admin user with ZONECONFIG privilege on all test objects.
+	db.Exec(t, `CREATE USER testuser`)
+	db.Exec(t, `CREATE DATABASE audit_zone_db`)
+	db.Exec(t, `CREATE TABLE audit_zone_test(id INT PRIMARY KEY, val STRING)`)
+	db.Exec(t, `CREATE INDEX audit_zone_idx ON audit_zone_test(val)`)
+	db.Exec(t, `GRANT ZONECONFIG ON TABLE audit_zone_test TO testuser`)
+	db.Exec(t, `GRANT ZONECONFIG ON DATABASE audit_zone_db TO testuser`)
+
+	// Create a table that testuser does NOT have ZONECONFIG privilege on,
+	// to test that failed zone config changes are also audited.
+	db.Exec(t, `CREATE TABLE audit_zone_noperm(id INT PRIMARY KEY)`)
+
+	testuserConn := s.ApplicationLayer().SQLConn(t, serverutils.User("testuser"))
+
+	testCases := []struct {
+		name      string
+		useAdmin  bool
+		setup     string
+		stmt      string
+		user      string // expected username in log entry
+		expectErr bool   // if true, the statement is expected to fail
+	}{
+		{
+			name:     "admin/table/using",
+			useAdmin: true,
+			stmt:     `ALTER TABLE audit_zone_test CONFIGURE ZONE USING num_replicas = 5`,
+			user:     "root",
+		},
+		{
+			name:     "non-admin/table/using",
+			useAdmin: false,
+			stmt:     `ALTER TABLE audit_zone_test CONFIGURE ZONE USING num_replicas = 3`,
+			user:     "testuser",
+		},
+		{
+			name:     "admin/table/discard",
+			useAdmin: true,
+			stmt:     `ALTER TABLE audit_zone_test CONFIGURE ZONE DISCARD`,
+			user:     "root",
+		},
+		{
+			name:     "non-admin/table/discard",
+			useAdmin: false,
+			setup:    `ALTER TABLE audit_zone_test CONFIGURE ZONE USING num_replicas = 5`,
+			stmt:     `ALTER TABLE audit_zone_test CONFIGURE ZONE DISCARD`,
+			user:     "testuser",
+		},
+		{
+			name:     "admin/table/using-default",
+			useAdmin: true,
+			setup:    `ALTER TABLE audit_zone_test CONFIGURE ZONE USING num_replicas = 5`,
+			stmt:     `ALTER TABLE audit_zone_test CONFIGURE ZONE USING DEFAULT`,
+			user:     "root",
+		},
+		{
+			name:     "admin/database/using",
+			useAdmin: true,
+			stmt:     `ALTER DATABASE audit_zone_db CONFIGURE ZONE USING gc.ttlseconds = 7200`,
+			user:     "root",
+		},
+		{
+			name:     "non-admin/database/using",
+			useAdmin: false,
+			stmt:     `ALTER DATABASE audit_zone_db CONFIGURE ZONE USING gc.ttlseconds = 3600`,
+			user:     "testuser",
+		},
+		{
+			name:     "admin/index/using",
+			useAdmin: true,
+			stmt:     `ALTER INDEX audit_zone_test@audit_zone_idx CONFIGURE ZONE USING gc.ttlseconds = 3600`,
+			user:     "root",
+		},
+		{
+			name:      "non-admin/table/permission-denied",
+			useAdmin:  false,
+			stmt:      `ALTER TABLE audit_zone_noperm CONFIGURE ZONE USING num_replicas = 5`,
+			user:      "testuser",
+			expectErr: true,
+		},
+		{
+			name:      "admin/database/alter-locality",
+			useAdmin:  true,
+			stmt:      `ALTER DATABASE audit_zone_db ALTER LOCALITY GLOBAL CONFIGURE ZONE USING num_replicas = 5`,
+			user:      "root",
+			expectErr: true, // database is not multi-region
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != "" {
+				db.Exec(t, tc.setup)
+			}
+
+			beforeExec := timeutil.Now().UnixNano()
+
+			if tc.useAdmin {
+				if tc.expectErr {
+					if _, err := sqlDB.Exec(tc.stmt); err == nil {
+						t.Fatal("expected error but statement succeeded")
+					}
+				} else {
+					db.Exec(t, tc.stmt)
+				}
+			} else {
+				_, err := testuserConn.Exec(tc.stmt)
+				if tc.expectErr && err == nil {
+					t.Fatal("expected error but statement succeeded")
+				}
+				if !tc.expectErr && err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			log.FlushFiles()
+
+			entries, err := log.FetchEntriesFromFiles(
+				beforeExec, math.MaxInt64, 10000,
+				regexp.MustCompile(`"EventType":"zone_config_audit".*`+tc.user),
+				log.WithMarkedSensitiveData,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) == 0 {
+				t.Fatalf("no zone_config_audit entry found for %q (user=%s)", tc.stmt, tc.user)
+			}
+		})
 	}
 }
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -184,8 +184,13 @@ func (p *planner) maybeLogStatementInternal(
 	// a user and the user has admin privilege (is directly or indirectly a
 	// member of the admin role).
 
+	// Zone config changes are always audit-logged on the SENSITIVE_ACCESS
+	// channel because they control data placement (CRDB-1180).
+	_, isZoneConfigChange := p.stmt.AST.(tree.ZoneConfigStatement)
+	shouldLogZoneConfigAudit := isZoneConfigChange && execType != executorTypeInternal
+
 	if !logV && !logExecuteEnabled && !auditEventsDetected && !slowQueryLogEnabled &&
-		!shouldLogToAdminAuditLog && !telemetryLoggingEnabled {
+		!shouldLogToAdminAuditLog && !telemetryLoggingEnabled && !shouldLogZoneConfigAudit {
 		// Shortcut: avoid the expense of computing anything log-related
 		// if logging is not enabled by configuration.
 		return
@@ -295,6 +300,14 @@ func (p *planner) maybeLogStatementInternal(
 
 	if shouldLogToAdminAuditLog {
 		p.logEventsOnlyExternally(ctx, &eventpb.AdminQuery{CommonSQLExecDetails: execDetails})
+	}
+
+	// Note: for admin users, both admin_query (above) and zone_config_audit
+	// (below) are emitted. This is intentional — admin_query captures all
+	// admin activity, while zone_config_audit enables filtering specifically
+	// for zone config changes across all users.
+	if shouldLogZoneConfigAudit {
+		p.logEventsOnlyExternally(ctx, &eventpb.ZoneConfigAudit{CommonSQLExecDetails: execDetails})
 	}
 
 	if telemetryLoggingEnabled && !p.SessionData().TroubleshootingMode {

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -273,6 +273,17 @@ type CCLOnlyStatement interface {
 	cclOnlyStatement()
 }
 
+// ZoneConfigStatement is a marker interface for statements that modify
+// zone configurations. This includes SetZoneConfig (ALTER TABLE/DATABASE/
+// INDEX/RANGE ... CONFIGURE ZONE) and AlterDatabaseSetZoneConfigExtension
+// (ALTER DATABASE ... ALTER LOCALITY ... CONFIGURE ZONE).
+type ZoneConfigStatement interface {
+	zoneConfigStatement()
+}
+
+var _ ZoneConfigStatement = &SetZoneConfig{}
+var _ ZoneConfigStatement = &AlterDatabaseSetZoneConfigExtension{}
+
 var _ CCLOnlyStatement = &AlterBackup{}
 var _ CCLOnlyStatement = &AlterBackupSchedule{}
 var _ CCLOnlyStatement = &Backup{}
@@ -451,6 +462,7 @@ func (*AlterDatabaseSetZoneConfigExtension) StatementTag() string {
 }
 
 func (*AlterDatabaseSetZoneConfigExtension) hiddenFromShowQueries() {}
+func (*AlterDatabaseSetZoneConfigExtension) zoneConfigStatement()   {}
 
 // StatementReturnType implements the Statement interface.
 func (*AlterDefaultPrivileges) StatementReturnType() StatementReturnType { return DDL }
@@ -1757,6 +1769,8 @@ func (*SetZoneConfig) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*SetZoneConfig) StatementTag() string { return "CONFIGURE ZONE" }
+
+func (*SetZoneConfig) zoneConfigStatement() {}
 
 // StatementReturnType implements the Statement interface.
 func (*SetSessionAuthorizationDefault) StatementReturnType() StatementReturnType { return Ack }

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -420,6 +420,9 @@ func (m *SchemaDescriptor) LoggingChannel() logpb.Channel { return logpb.Channel
 func (m *SchemaSnapshotMetadata) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ZoneConfigAudit) LoggingChannel() logpb.Channel { return logpb.Channel_SENSITIVE_ACCESS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *RemoveZoneConfig) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -7250,3 +7250,15 @@ func (m *UnsafeUpsertNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 
 	return printComma, b
 }
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *ZoneConfigAudit) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLExecDetails.AppendJSONFields(printComma, b)
+
+	return printComma, b
+}

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -105,6 +105,26 @@ message UnsafeInternalsDenied {
   string query = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"mixed\""];
 }
 
+// Category: Zone Config Audit Events
+// Channel: SENSITIVE_ACCESS
+//
+// Events in this category are generated unconditionally when zone
+// configuration changes are made. Unlike other SENSITIVE_ACCESS events,
+// these do not require any audit setting to be enabled.
+//
+// Note: These events are not written to `system.eventlog`, even
+// when the cluster setting `system.eventlog.enabled` is set. They
+// are only emitted via external logging.
+
+// ZoneConfigAudit is recorded when any user executes a zone configuration
+// change (ALTER ... CONFIGURE ZONE). These operations control data placement
+// and are security-sensitive for compliance and geo-partitioning purposes.
+message ZoneConfigAudit {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLExecDetails exec = 3 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+}
+
 
 // Category: Sampled SQL Events
 // Channel: SQL_EXEC


### PR DESCRIPTION
## Summary
- Adds a new `ZoneConfigAudit` event type on the `SENSITIVE_ACCESS` log channel under its own "Zone Config Audit Events" category
- Emitted unconditionally for all non-internal `CONFIGURE ZONE` statements, regardless of user role or audit settings
- Uses a `ZoneConfigStatement` marker interface (on `SetZoneConfig` and `AlterDatabaseSetZoneConfigExtension`) for extensible AST detection
- Closes the gap where non-admin users with `ZONECONFIG` privilege could change data placement without any SENSITIVE_ACCESS audit trail

## Background
Zone config changes (`ALTER ... CONFIGURE ZONE`) control where data is physically stored, making them security-sensitive for compliance and geo-partitioning. Previously these were only logged on the OPS channel. A non-admin user with `ZONECONFIG` privilege could silently move data across regions with no audit trail on `SENSITIVE_ACCESS`.

Epic: CRDB-1180

This PR attempts to fix [CRDB-1180](https://cockroachlabs.atlassian.net/browse/CRDB-1180).

## Changes
- **`pkg/sql/sem/tree/stmt.go`** — New `ZoneConfigStatement` marker interface implemented by `SetZoneConfig` and `AlterDatabaseSetZoneConfigExtension`
- **`pkg/sql/exec_log.go`** — Single interface check to detect zone config statements and emit `ZoneConfigAudit` events
- **`pkg/util/log/eventpb/sql_audit_events.proto`** — New `ZoneConfigAudit` message under its own "Zone Config Audit Events" category on `SENSITIVE_ACCESS` channel, separate from `EXPERIMENTAL_AUDIT`-tied events
- **`pkg/sql/admin_audit_log_test.go`** — Comprehensive test coverage

## Test plan
`TestAuditLogZoneConfig` — single table-driven test covering all combinations:

**Admin user (root):**
- [x] `admin/table/using` — `ALTER TABLE ... CONFIGURE ZONE USING num_replicas = 5`
- [x] `admin/table/discard` — `ALTER TABLE ... CONFIGURE ZONE DISCARD`
- [x] `admin/table/using-default` — `ALTER TABLE ... CONFIGURE ZONE USING DEFAULT`
- [x] `admin/database/using` — `ALTER DATABASE ... CONFIGURE ZONE USING gc.ttlseconds = 7200`
- [x] `admin/index/using` — `ALTER INDEX ... CONFIGURE ZONE USING gc.ttlseconds = 3600`
- [x] `admin/database/alter-locality` — `ALTER DATABASE ... ALTER LOCALITY GLOBAL CONFIGURE ZONE` (fails: not multi-region, still audited)

**Non-admin user (testuser with ZONECONFIG privilege):**
- [x] `non-admin/table/using` — `ALTER TABLE ... CONFIGURE ZONE USING num_replicas = 3`
- [x] `non-admin/table/discard` — `ALTER TABLE ... CONFIGURE ZONE DISCARD`
- [x] `non-admin/database/using` — `ALTER DATABASE ... CONFIGURE ZONE USING gc.ttlseconds = 3600`
- [x] `non-admin/table/permission-denied` — `ALTER TABLE` on table without ZONECONFIG privilege (fails, still audited)

**Regression tests (no changes):**
- [x] `TestAdminAuditLogBasic`
- [x] `TestAdminAuditLogRegularUser`
- [x] `TestAdminAuditLogTransaction`
- [x] `TestAdminAuditLogMultipleTransactions`

Release note (security update): Zone configuration changes
(ALTER ... CONFIGURE ZONE) are now logged on the SENSITIVE_ACCESS
audit log channel for all users, not just admin users. A new
zone_config_audit event is emitted whenever any user sets or
discards a zone configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)