### PR TITLE
ui: refactor useClusterSettings SWR hook and migrate 5 consumers from Redux

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
@@ -8,7 +8,7 @@ import moment from "moment-timezone";
 
 import { fetchData } from "src/api";
 
-import { TimestampToMoment, useSwrImmutableWithClusterId } from "../util";
+import { TimestampToMoment, useSwrWithClusterId } from "../util";
 
 import { ADMIN_API_PREFIX } from "./util";
 
@@ -38,9 +38,6 @@ export function getClusterSettings(
   );
 }
 
-// Usage of this request with the useClusterSettings hook
-// is preferred over using getClusterSettings and its corresponding
-// redux values and sagas.
 export type GetClusterSettingRequest = {
   names: string[];
 };
@@ -63,6 +60,7 @@ export type ClusterSetting = {
   type: ClusterSettingType;
   description: string;
   lastUpdated: moment.Moment | null;
+  public: boolean;
 };
 
 const formatProtoResponse = (
@@ -78,6 +76,7 @@ const formatProtoResponse = (
       type: kv.type as ClusterSettingType,
       description: kv.description,
       lastUpdated: TimestampToMoment(kv.last_updated),
+      public: kv.public ?? false,
     };
   });
 
@@ -90,34 +89,43 @@ const emptyClusterSetting: ClusterSetting = {
   type: ClusterSettingType.UNKNOWN,
   description: "",
   lastUpdated: null,
+  public: false,
 };
 
-export const useClusterSettings = (req: GetClusterSettingRequest) => {
-  const protoReq = new cockroach.server.serverpb.SettingsRequest({
-    keys: req.names,
-  });
-  const { data, isLoading, error } = useSwrImmutableWithClusterId(
-    {
-      name: "clusterSettings",
-      settings: req.names,
-    },
+const CLUSTER_SETTINGS_SWR_KEY = "clusterSettings";
+
+/**
+ * useClusterSettings fetches all cluster settings via SWR. All callers
+ * share the same cache entry regardless of the names requested.
+ *
+ * When `req` is provided, only the requested settings are returned
+ * (with missing entries filled with defaults). When omitted, all
+ * settings are returned.
+ */
+export const useClusterSettings = (req?: GetClusterSettingRequest) => {
+  const protoReq = new cockroach.server.serverpb.SettingsRequest({});
+  const { data, isLoading, error } = useSwrWithClusterId(
+    CLUSTER_SETTINGS_SWR_KEY,
     () => getClusterSettings(protoReq, "1M").then(formatProtoResponse),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 30_000,
+    },
   );
 
-  // If we don't have data we'll return a map of empty settings.
-  const settingValues =
-    data ??
-    req.names.reduce(
-      (acc, name) => {
-        acc[name] = { ...emptyClusterSetting };
-        return acc;
-      },
-      {} as Record<string, ClusterSetting>,
-    );
+  const allSettings = data ?? {};
 
-  return {
-    settingValues,
-    isLoading,
-    error,
-  };
+  if (!req?.names) {
+    return { settingValues: allSettings, isLoading, error };
+  }
+
+  const settingValues = req.names.reduce(
+    (acc, name) => {
+      acc[name] = allSettings[name] ?? { ...emptyClusterSetting };
+      return acc;
+    },
+    {} as Record<string, ClusterSetting>,
+  );
+
+  return { settingValues, isLoading, error };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -29,4 +29,5 @@ export * from "./txnInsightDetailsApi";
 export * from "./healthApi";
 export * from "./connectivityApi";
 export * from "./locationsApi";
+export * from "./clusterSettingsApi";
 export * from "./dataDistributionApi";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -47,6 +47,8 @@ export { useNodes } from "./api/nodesApi";
 export { useNodesSummary } from "./api/nodesSummaryApi";
 export { useHealth } from "./api/healthApi";
 export type { NodesSummary } from "./api/nodesSummaryApi";
+export { useClusterSettings } from "./api/clusterSettingsApi";
+export type { ClusterSetting } from "./api/clusterSettingsApi";
 export { useConnectivity } from "./api/connectivityApi";
 export { useLocations, buildLocalityTree } from "./api/locationsApi";
 export type {

--- a/pkg/ui/workspaces/db-console/src/contexts/timezoneProvider.tsx
+++ b/pkg/ui/workspaces/db-console/src/contexts/timezoneProvider.tsx
@@ -3,26 +3,21 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { TimezoneContext } from "@cockroachlabs/cluster-ui";
-import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-
-import { refreshSettings } from "src/redux/apiReducers";
 import {
-  selectClusterSettings,
-  selectTimezoneSetting,
-} from "src/redux/clusterSettings";
+  TimezoneContext,
+  CoordinatedUniversalTime,
+  useClusterSettings,
+} from "@cockroachlabs/cluster-ui";
+import React from "react";
 
 export const TimezoneProvider = (props: any) => {
-  // Refresh cluster settings if needed.
-  const dispatch = useDispatch();
-  const settings = useSelector(selectClusterSettings);
-  useEffect(() => {
-    dispatch(refreshSettings());
-  }, [settings, dispatch]);
-
-  // Grab the timezone value from the store, and pass it to our context.
-  const timezone = useSelector(selectTimezoneSetting);
+  const { settingValues } = useClusterSettings({
+    names: ["ui.default_timezone", "ui.display_timezone"],
+  });
+  const timezone =
+    settingValues["ui.default_timezone"]?.value ||
+    settingValues["ui.display_timezone"]?.value ||
+    CoordinatedUniversalTime;
   return (
     <TimezoneContext.Provider value={timezone}>
       {props.children}

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -3,76 +3,15 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { CoordinatedUniversalTime, util } from "@cockroachlabs/cluster-ui";
-import moment from "moment-timezone";
 import { createSelector } from "reselect";
 
 import { cockroach } from "src/js/protos";
 import { AdminUIState } from "src/redux/state";
-import { indexUnusedDuration } from "src/util/constants";
 
 export const selectClusterSettings = createSelector(
   (state: AdminUIState) => state.cachedData.settings?.data,
   (settings: cockroach.server.serverpb.SettingsResponse) =>
     settings?.key_values,
-);
-
-export const selectTimezoneSetting = createSelector(
-  selectClusterSettings,
-  settings => {
-    if (!settings) {
-      return CoordinatedUniversalTime;
-    }
-    return (
-      settings["ui.default_timezone"]?.value ||
-      settings["ui.display_timezone"]?.value ||
-      CoordinatedUniversalTime
-    );
-  },
-);
-
-export const selectResolution10sStorageTTL = createSelector(
-  selectClusterSettings,
-  (settings): moment.Duration | undefined => {
-    if (!settings) {
-      return undefined;
-    }
-    const value = settings["timeseries.storage.resolution_10s.ttl"]?.value;
-    return util.durationFromISO8601String(value);
-  },
-);
-
-export const selectResolution30mStorageTTL = createSelector(
-  selectClusterSettings,
-  settings => {
-    if (!settings) {
-      return undefined;
-    }
-    const value = settings["timeseries.storage.resolution_30m.ttl"]?.value;
-    return util.durationFromISO8601String(value);
-  },
-);
-
-export const selectAutomaticStatsCollectionEnabled = createSelector(
-  selectClusterSettings,
-  (settings): boolean | undefined => {
-    if (!settings) {
-      return undefined;
-    }
-    const value = settings["sql.stats.automatic_collection.enabled"]?.value;
-    return value === "true";
-  },
-);
-
-export const selectIndexRecommendationsEnabled = createSelector(
-  selectClusterSettings,
-  (settings): boolean => {
-    if (!settings) {
-      return false;
-    }
-    const value = settings["version"]?.value || "";
-    return util.greaterOrEqualThanVersion(value, [22, 2, 0]);
-  },
 );
 
 export const selectClusterSettingVersion = createSelector(
@@ -82,29 +21,5 @@ export const selectClusterSettingVersion = createSelector(
       return "";
     }
     return settings["version"]?.value ?? "";
-  },
-);
-
-export const selectIndexUsageStatsEnabled = createSelector(
-  selectClusterSettings,
-  (settings): boolean => {
-    if (!settings) {
-      return false;
-    }
-    const value = settings["version"]?.value || "";
-    return util.greaterOrEqualThanVersion(value, [22, 1, 0]);
-  },
-);
-
-export const selectDropUnusedIndexDuration = createSelector(
-  selectClusterSettings,
-  (settings): string => {
-    if (!settings) {
-      return indexUnusedDuration;
-    }
-    return (
-      settings["sql.index_recommendation.drop_unused_duration"]?.value ||
-      indexUnusedDuration
-    );
   },
 );

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -3,10 +3,14 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Anchor, TimeScale } from "@cockroachlabs/cluster-ui";
+import {
+  Anchor,
+  TimeScale,
+  useClusterSettings,
+  util,
+} from "@cockroachlabs/cluster-ui";
 import has from "lodash/has";
 import map from "lodash/map";
-import moment from "moment-timezone";
 import React, { useCallback, useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
@@ -18,13 +22,8 @@ import { PayloadAction } from "src/interfaces/action";
 import {
   refreshNodes,
   refreshLiveness,
-  refreshSettings,
   refreshTenantsList,
 } from "src/redux/apiReducers";
-import {
-  selectResolution10sStorageTTL,
-  selectResolution30mStorageTTL,
-} from "src/redux/clusterSettings";
 import { getCookieValue } from "src/redux/cookies";
 import {
   hoverStateSelector,
@@ -177,8 +176,6 @@ const dashboardDropdownOptions = map(dashboards, (dashboard, key) => {
 
 type MapStateToProps = {
   hoverState: HoverState;
-  resolution10sStorageTTL: moment.Duration;
-  resolution30mStorageTTL: moment.Duration;
   timeScale: TimeScale;
   nodeDropdownOptions: ReturnType<
     typeof nodeDropdownOptionsSelector.resultFunc
@@ -195,7 +192,6 @@ type MapStateToProps = {
 type MapDispatchToProps = {
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
-  refreshNodeSettings: typeof refreshSettings;
   refreshTenantsList: typeof refreshTenantsList;
   hoverOn: typeof hoverOn;
   hoverOff: typeof hoverOff;
@@ -216,8 +212,6 @@ export function NodeGraphs({
   hoverState,
   hoverOn: hoverOnAction,
   hoverOff: hoverOffAction,
-  resolution10sStorageTTL,
-  resolution30mStorageTTL,
   timeScale,
   nodeDropdownOptions,
   nodeIds,
@@ -227,13 +221,29 @@ export function NodeGraphs({
   currentTenant,
   refreshNodes: refreshNodesAction,
   refreshLiveness: refreshLivenessAction,
-  refreshNodeSettings: refreshNodeSettingsAction,
   refreshTenantsList: refreshTenantsListAction,
   setMetricsFixedWindow: setMetricsFixedWindowAction,
   setTimeScale: setTimeScaleAction,
 }: NodeGraphsProps): React.ReactElement {
   const [showLowResolutionAlert, setShowLowResolutionAlert] = useState(false);
   const [showDeletedDataAlert, setShowDeletedDataAlert] = useState(false);
+
+  const { settingValues } = useClusterSettings({
+    names: [
+      "timeseries.storage.resolution_10s.ttl",
+      "timeseries.storage.resolution_30m.ttl",
+    ],
+  });
+  const sTTLValue =
+    settingValues["timeseries.storage.resolution_10s.ttl"]?.value;
+  const resolution10sStorageTTL = sTTLValue
+    ? util.durationFromISO8601String(sTTLValue)
+    : undefined;
+  const mTTLValue =
+    settingValues["timeseries.storage.resolution_30m.ttl"]?.value;
+  const resolution30mStorageTTL = mTTLValue
+    ? util.durationFromISO8601String(mTTLValue)
+    : undefined;
 
   // Refresh nodes and liveness data on every render so stale data triggers
   // a re-fetch (these calls short-circuit internally when data is fresh).
@@ -242,14 +252,13 @@ export function NodeGraphs({
     refreshLivenessAction();
   });
 
-  // Settings and tenants list only need to be fetched once on mount —
-  // they don't change frequently.
+  // Tenants list only needs to be fetched once on mount —
+  // it doesn't change frequently.
   useEffect(() => {
-    refreshNodeSettingsAction();
     if (isSystemTenant(currentTenant)) {
       refreshTenantsListAction();
     }
-  }, [refreshNodeSettingsAction, refreshTenantsListAction, currentTenant]);
+  }, [refreshTenantsListAction, currentTenant]);
 
   const setClusterPath = useCallback(
     (key: string, selected: DropdownOption) => {
@@ -525,8 +534,6 @@ const nodeDropdownOptionsSelector = createSelector(
 
 const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   hoverState: hoverStateSelector(state),
-  resolution10sStorageTTL: selectResolution10sStorageTTL(state),
-  resolution30mStorageTTL: selectResolution30mStorageTTL(state),
   timeScale: selectTimeScale(state),
   nodeIds: nodeIDsStringifiedSelector(state),
   storeIDsByNodeID: selectStoreIDsByNodeID(state),
@@ -539,7 +546,6 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
 const mapDispatchToProps: MapDispatchToProps = {
   refreshNodes,
   refreshLiveness,
-  refreshNodeSettings: refreshSettings,
   refreshTenantsList,
   hoverOn,
   hoverOff,

--- a/pkg/ui/workspaces/db-console/src/views/keyVisualizer/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVisualizer/index.tsx
@@ -7,6 +7,7 @@ import {
   TimeScale,
   TimeScaleDropdown,
   TimeScaleOptions,
+  useClusterSettings,
   util,
 } from "@cockroachlabs/cluster-ui";
 import moment from "moment-timezone";
@@ -15,8 +16,6 @@ import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 
 import { cockroach } from "src/js/protos";
-import { refreshSettings } from "src/redux/apiReducers";
-import { selectClusterSettings } from "src/redux/clusterSettings";
 import { AdminUIState } from "src/redux/state";
 import { selectTimeScale, setTimeScale } from "src/redux/timeScale";
 import { getKeyVisualizerSamples } from "src/util/api";
@@ -103,23 +102,6 @@ function encodeToHexString(bytes: Uint8Array): string {
 
 // buildYAxis returns a mapping of pretty keys to the y coordinate of the key.
 function buildYAxis(sortedPrettyKeys: string[]): Record<string, number> {
-  // TODO(zachlite): make this faster
-  // const sortedPrettyKeysInWindow = state.response.sorted_pretty_keys.filter((prettyKey) => {
-  //   // is this key in the time window?
-  //   for (const sample of samples) {
-  //     for (const bucket of sample.buckets) {
-  //
-  //       const startPretty = state.response.pretty_key_for_uuid[bucket.start_key_id]
-  //       const endPretty = state.response.pretty_key_for_uuid[bucket.end_key_id]
-  //
-  //       if (startPretty === prettyKey || endPretty === prettyKey) {
-  //         return true
-  //       }
-  //     }
-  //   }
-  //   return false;
-  // })
-
   // compute y offset for each key
   const yOffsetsForKey = {} as Record<string, number>;
   sortedPrettyKeys.forEach((key, i) => {
@@ -237,10 +219,6 @@ const KeyVisualizerContainer: React.FC<
 };
 
 interface KeyVisualizerPageProps {
-  clusterSettings?: {
-    [key: string]: cockroach.server.serverpb.SettingsResponse.IValue;
-  };
-  refreshSettings: typeof refreshSettings;
   setTimeScale: typeof setTimeScale;
   timeScale: TimeScale;
 }
@@ -248,12 +226,15 @@ interface KeyVisualizerPageProps {
 const KeyVisualizerPage: React.FunctionComponent<
   KeyVisualizerPageProps & RouteComponentProps
 > = props => {
-  if (props.clusterSettings === undefined) {
-    props.refreshSettings();
+  const { settingValues, isLoading } = useClusterSettings({
+    names: [EnabledSetting, IntervalSetting],
+  });
+
+  if (isLoading) {
     return null;
   }
 
-  const enabled = props.clusterSettings[EnabledSetting].value === "true";
+  const enabled = settingValues[EnabledSetting]?.value === "true";
 
   if (!enabled) {
     return (
@@ -265,9 +246,10 @@ const KeyVisualizerPage: React.FunctionComponent<
     );
   }
 
-  const refreshInterval = util
-    .durationFromISO8601String(props.clusterSettings[IntervalSetting].value)
-    .asMilliseconds();
+  const intervalValue = settingValues[IntervalSetting]?.value;
+  const refreshInterval = intervalValue
+    ? util.durationFromISO8601String(intervalValue).asMilliseconds()
+    : 60_000;
 
   return (
     <KeyVisualizerContainer
@@ -280,11 +262,9 @@ const KeyVisualizerPage: React.FunctionComponent<
 
 export default connect(
   (state: AdminUIState) => ({
-    clusterSettings: selectClusterSettings(state),
     timeScale: selectTimeScale(state),
   }),
   {
-    refreshSettings,
     setTimeScale,
   },
 )(KeyVisualizerPage);

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.tsx
@@ -10,26 +10,17 @@ import {
   SortSetting,
   util,
   Timestamp,
+  useClusterSettings,
+  ClusterSetting,
 } from "@cockroachlabs/cluster-ui";
-import isNil from "lodash/isNil";
-import React, { useEffect, useState } from "react";
+import moment from "moment-timezone";
+import React, { useState } from "react";
 import { Helmet } from "react-helmet";
-import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-
-import * as protos from "src/js/protos";
-import { refreshSettings } from "src/redux/apiReducers";
-import { CachedDataReducerState } from "src/redux/cachedDataReducer";
-import { AdminUIState } from "src/redux/state";
 
 import { BackToAdvanceDebug } from "../util";
 
 import "./index.scss";
-
-interface SettingsOwnProps {
-  settings: CachedDataReducerState<protos.cockroach.server.serverpb.SettingsResponse>;
-  refreshSettings: typeof refreshSettings;
-}
 
 interface IterableSetting {
   key: string;
@@ -39,8 +30,6 @@ interface IterableSetting {
   public?: boolean;
   last_updated?: moment.Moment;
 }
-
-type SettingsProps = SettingsOwnProps & RouteComponentProps;
 
 const columns: ColumnDescriptor<IterableSetting>[] = [
   {
@@ -73,48 +62,36 @@ const columns: ColumnDescriptor<IterableSetting>[] = [
   },
 ];
 
+function settingsToIterableArray(
+  allSettings: Record<string, ClusterSetting>,
+): IterableSetting[] {
+  return Object.entries(allSettings).map(([key, cs]) => ({
+    key,
+    description: cs.description,
+    type: cs.type,
+    value: cs.value,
+    public: cs.public,
+    last_updated: cs.lastUpdated,
+  }));
+}
+
 /**
  * Renders the Cluster Settings Report page.
  */
-export function Settings({
-  settings,
-  refreshSettings: refreshSettingsAction,
-  history,
-}: SettingsProps): React.ReactElement {
+export function Settings({ history }: RouteComponentProps): React.ReactElement {
   const [sortSetting, setSortSetting] = useState({
     ascending: true,
     columnTitle: "lastUpdated",
   });
 
-  useEffect(() => {
-    refreshSettingsAction(
-      new protos.cockroach.server.serverpb.SettingsRequest(),
-    );
-  }, [refreshSettingsAction]);
+  const { settingValues, isLoading, error } = useClusterSettings();
 
   const renderTable = (wantPublic: boolean) => {
-    if (isNil(settings.data)) {
-      return null;
-    }
-
-    const { key_values } = settings.data;
-    const dataArray: IterableSetting[] = Object.keys(key_values)
-      .map(key => ({
-        key,
-        ...key_values[key],
-      }))
-      .map(obj => ({
-        ...obj,
-        last_updated: obj.last_updated
-          ? util.TimestampToMoment(obj.last_updated)
-          : null,
-      }));
+    const dataArray = settingsToIterableArray(settingValues);
 
     return (
       <SortedTable
-        data={dataArray.filter(obj =>
-          wantPublic ? obj.public : obj.public === undefined,
-        )}
+        data={dataArray.filter(obj => (wantPublic ? obj.public : !obj.public))}
         columns={columns}
         sortSetting={sortSetting}
         onChangeSortSetting={(ss: SortSetting) =>
@@ -133,9 +110,9 @@ export function Settings({
       <BackToAdvanceDebug history={history} />
       <h1 className="base-heading">Cluster Settings</h1>
       <Loading
-        loading={!settings.data}
+        loading={isLoading}
         page={"container settings"}
-        error={settings.lastError}
+        error={error}
         render={() => (
           <div>
             <p className="settings-note">
@@ -156,16 +133,4 @@ export function Settings({
   );
 }
 
-const mapStateToProps = (state: AdminUIState) => ({
-  // RootState contains declaration for whole state
-  settings: state.cachedData.settings,
-});
-
-const mapDispatchToProps = {
-  // actionCreators returns objects with type and payload
-  refreshSettings,
-};
-
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(Settings),
-);
+export default withRouter(Settings);

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -9,6 +9,7 @@ import {
   TimeScale,
   findClosestTimeScale,
   defaultTimeScaleOptions,
+  useClusterSettings,
 } from "@cockroachlabs/cluster-ui";
 import { History } from "history";
 import isNil from "lodash/isNil";
@@ -16,19 +17,12 @@ import isObject from "lodash/isObject";
 import map from "lodash/map";
 import Long from "long";
 import moment from "moment-timezone";
-import React, { useEffect, useMemo } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { createSelector } from "reselect";
+import React, { useMemo } from "react";
+import { useSelector } from "react-redux";
 
 import { useMetrics } from "src/hooks/useMetrics";
 import { PayloadAction } from "src/interfaces/action";
 import * as protos from "src/js/protos";
-import { refreshSettings } from "src/redux/apiReducers";
-import {
-  selectResolution10sStorageTTL,
-  selectResolution30mStorageTTL,
-} from "src/redux/clusterSettings";
-import { AdminUIState } from "src/redux/state";
 import { adjustTimeScale, selectMetricsTime } from "src/redux/timeScale";
 import { findChildrenOfType } from "src/util/find";
 import {
@@ -110,44 +104,7 @@ interface MetricsDataProviderProps {
   history?: History;
 }
 
-// timeInfoSelector converts the current global time window into a set of Long
-// timestamps, which can be sent with requests to the server.
-const timeInfoSelector = createSelector(
-  selectResolution10sStorageTTL,
-  selectResolution30mStorageTTL,
-  selectMetricsTime,
-  (sTTL, mTTL, metricsTime) => {
-    if (!isObject(metricsTime.currentWindow)) {
-      return null;
-    }
-    const { start: startMoment, end: endMoment } = metricsTime.currentWindow;
-    const start = startMoment.valueOf();
-    const end = endMoment.valueOf();
-    const syncedScale = findClosestTimeScale(
-      defaultTimeScaleOptions,
-      util.MilliToSeconds(end - start),
-    );
-    // Call adjustTimeScale to handle the case where the sample size
-    // (also known as resolution) is too small for a start and end time
-    // that is before the data's ttl.
-    const adjusted = adjustTimeScale(
-      { ...syncedScale, fixedWindowEnd: false },
-      { start: startMoment, end: endMoment },
-      sTTL,
-      mTTL,
-    );
-
-    return {
-      start: Long.fromNumber(util.MilliToNano(start)),
-      end: Long.fromNumber(util.MilliToNano(end)),
-      sampleDuration: Long.fromNumber(
-        util.MilliToNano(adjusted.timeScale.sampleSize.asMilliseconds()),
-      ),
-    };
-  },
-);
-
-const current = () => {
+const currentTimeInfo = () => {
   let now = moment();
   // Round to the nearest 10 seconds. There are 10000 ms in 10 s.
   now = moment(Math.floor(now.valueOf() / 10000) * 10000);
@@ -188,10 +145,54 @@ function MetricsDataProvider({
   setTimeScale,
   history,
 }: MetricsDataProviderProps): React.ReactElement {
-  const dispatch = useDispatch();
-  const timeInfo = useSelector((state: AdminUIState) =>
-    isCurrent ? current() : timeInfoSelector(state),
-  );
+  const { settingValues } = useClusterSettings({
+    names: [
+      "timeseries.storage.resolution_10s.ttl",
+      "timeseries.storage.resolution_30m.ttl",
+    ],
+  });
+  const sTTLValue =
+    settingValues["timeseries.storage.resolution_10s.ttl"]?.value;
+  const sTTL = sTTLValue
+    ? util.durationFromISO8601String(sTTLValue)
+    : undefined;
+  const mTTLValue =
+    settingValues["timeseries.storage.resolution_30m.ttl"]?.value;
+  const mTTL = mTTLValue
+    ? util.durationFromISO8601String(mTTLValue)
+    : undefined;
+
+  const metricsTime = useSelector(selectMetricsTime);
+
+  const timeInfo = useMemo(() => {
+    if (isCurrent) {
+      return currentTimeInfo();
+    }
+    if (!isObject(metricsTime.currentWindow)) {
+      return null;
+    }
+    const { start: startMoment, end: endMoment } = metricsTime.currentWindow;
+    const start = startMoment.valueOf();
+    const end = endMoment.valueOf();
+    const syncedScale = findClosestTimeScale(
+      defaultTimeScaleOptions,
+      util.MilliToSeconds(end - start),
+    );
+    const adjusted = adjustTimeScale(
+      { ...syncedScale, fixedWindowEnd: false },
+      { start: startMoment, end: endMoment },
+      sTTL,
+      mTTL,
+    );
+
+    return {
+      start: Long.fromNumber(util.MilliToNano(start)),
+      end: Long.fromNumber(util.MilliToNano(end)),
+      sampleDuration: Long.fromNumber(
+        util.MilliToNano(adjusted.timeScale.sampleSize.asMilliseconds()),
+      ),
+    };
+  }, [isCurrent, metricsTime, sTTL, mTTL]);
 
   // MetricsDataProvider should contain only one direct child.
   const child = React.Children.only(children);
@@ -227,11 +228,6 @@ function MetricsDataProvider({
   // MetricsDataProviders rendering in the same cycle have their
   // requests coalesced into a single API call.
   const { data } = useMetrics(requestMsg);
-
-  // Refresh node settings on mount.
-  useEffect(() => {
-    dispatch(refreshSettings());
-  }, [dispatch]);
 
   const dataProps: MetricsDataComponentProps = {
     data,

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
@@ -3,14 +3,21 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import {
+  util,
+  findClosestTimeScale,
+  defaultTimeScaleOptions,
+} from "@cockroachlabs/cluster-ui";
 import { render } from "@testing-library/react";
 import map from "lodash/map";
 import Long from "long";
+import moment from "moment-timezone";
 import React from "react";
 import * as reactRedux from "react-redux";
 
 import { UseMetricsResult } from "src/hooks/useMetrics";
 import * as protos from "src/js/protos";
+import { adjustTimeScale } from "src/redux/timeScale";
 import {
   Axis,
   Metric,
@@ -20,7 +27,7 @@ import {
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 
 // Mock react-redux hooks so the component can render without a real store.
-// useSelector now only returns timeInfo (no longer used for metrics state).
+// useSelector now returns metricsTime (the raw time state).
 const mockDispatch = jest.fn();
 jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
@@ -35,11 +42,19 @@ jest.mock("src/hooks/useMetrics", () => ({
   useMetrics: (req: any) => mockUseMetrics(req),
 }));
 
-// Mock refreshSettings to return a simple action (avoid loading the full
-// apiReducers dependency tree).
-jest.mock("src/redux/apiReducers", () => ({
-  ...jest.requireActual("src/redux/apiReducers"),
-  refreshSettings: jest.fn(() => ({ type: "MOCK_REFRESH_SETTINGS" })),
+// Mock useClusterSettings — return empty settings so TTL values are
+// undefined. This is sufficient for testing the data flow.
+jest.mock("@cockroachlabs/cluster-ui", () => ({
+  ...jest.requireActual("@cockroachlabs/cluster-ui"),
+  useClusterSettings: (): {
+    settingValues: Record<string, never>;
+    isLoading: boolean;
+    error: Error | undefined;
+  } => ({
+    settingValues: {},
+    isLoading: false,
+    error: undefined,
+  }),
 }));
 
 // TextGraph captures the props that MetricsDataProvider passes to its child
@@ -67,8 +82,44 @@ const childrenJSX = (
   </TextGraph>
 );
 
-function mockTimeInfo(timeInfoVal: QueryTimeInfo | null) {
-  (reactRedux.useSelector as jest.Mock).mockReturnValue(timeInfoVal);
+// Create a metricsTime-shaped object with a currentWindow that will
+// produce a deterministic timeInfo through the inline computation.
+function createMetricsTime(startMs: number, endMs: number) {
+  return {
+    currentWindow: {
+      start: moment(startMs),
+      end: moment(endMs),
+    },
+  };
+}
+
+// Compute the expected timeInfo for a given metricsTime, matching the
+// component's inline computation with undefined TTL values.
+function computeExpectedTimeInfo(
+  startMs: number,
+  endMs: number,
+): QueryTimeInfo {
+  const syncedScale = findClosestTimeScale(
+    defaultTimeScaleOptions,
+    util.MilliToSeconds(endMs - startMs),
+  );
+  const adjusted = adjustTimeScale(
+    { ...syncedScale, fixedWindowEnd: false },
+    { start: moment(startMs), end: moment(endMs) },
+    undefined,
+    undefined,
+  );
+  return {
+    start: Long.fromNumber(util.MilliToNano(startMs)),
+    end: Long.fromNumber(util.MilliToNano(endMs)),
+    sampleDuration: Long.fromNumber(
+      util.MilliToNano(adjusted.timeScale.sampleSize.asMilliseconds()),
+    ),
+  };
+}
+
+function mockTimeInfo(metricsTimeVal: any) {
+  (reactRedux.useSelector as jest.Mock).mockReturnValue(metricsTimeVal);
 }
 
 function makeMetricsRequest(
@@ -145,16 +196,18 @@ function withData(timeInfo: QueryTimeInfo): UseMetricsResult {
 }
 
 describe("<MetricsDataProvider>", () => {
-  const timespan1: QueryTimeInfo = {
-    start: Long.fromNumber(0),
-    end: Long.fromNumber(100),
-    sampleDuration: Long.fromNumber(300),
-  };
-  const timespan2: QueryTimeInfo = {
-    start: Long.fromNumber(100),
-    end: Long.fromNumber(200),
-    sampleDuration: Long.fromNumber(300),
-  };
+  // Use realistic millisecond values for constructing metricsTime objects.
+  // 10-minute window starting from epoch.
+  const start1Ms = 0;
+  const end1Ms = 10 * 60 * 1000;
+  const metricsTime1 = createMetricsTime(start1Ms, end1Ms);
+  const timespan1 = computeExpectedTimeInfo(start1Ms, end1Ms);
+
+  const start2Ms = 10 * 60 * 1000;
+  const end2Ms = 20 * 60 * 1000;
+  const metricsTime2 = createMetricsTime(start2Ms, end2Ms);
+  const timespan2 = computeExpectedTimeInfo(start2Ms, end2Ms);
+
   const graphid = "testgraph";
 
   beforeEach(() => {
@@ -166,7 +219,7 @@ describe("<MetricsDataProvider>", () => {
 
   describe("request construction", () => {
     it("passes correct request to useMetrics on mount", () => {
-      mockTimeInfo(timespan1);
+      mockTimeInfo(metricsTime1);
       mockUseMetrics.mockReturnValue(noData);
       render(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
@@ -177,7 +230,7 @@ describe("<MetricsDataProvider>", () => {
     });
 
     it("passes undefined request when timeInfo is null", () => {
-      mockTimeInfo(null);
+      mockTimeInfo({ currentWindow: null });
       mockUseMetrics.mockReturnValue(noData);
       render(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
@@ -186,7 +239,7 @@ describe("<MetricsDataProvider>", () => {
     });
 
     it("passes updated request when timespan changes", () => {
-      mockTimeInfo(timespan1);
+      mockTimeInfo(metricsTime1);
       mockUseMetrics.mockReturnValue(noData);
       const { rerender } = render(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
@@ -196,7 +249,7 @@ describe("<MetricsDataProvider>", () => {
       );
 
       // Rerender with a different timespan.
-      mockTimeInfo(timespan2);
+      mockTimeInfo(metricsTime2);
       rerender(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
       );
@@ -208,7 +261,7 @@ describe("<MetricsDataProvider>", () => {
 
   describe("attach", () => {
     it("attaches metrics data to contained component", () => {
-      mockTimeInfo(timespan1);
+      mockTimeInfo(metricsTime1);
       mockUseMetrics.mockReturnValue(withData(timespan1));
       render(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
@@ -218,7 +271,7 @@ describe("<MetricsDataProvider>", () => {
     });
 
     it("passes undefined data when loading", () => {
-      mockTimeInfo(timespan1);
+      mockTimeInfo(metricsTime1);
       mockUseMetrics.mockReturnValue(noData);
       render(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
@@ -227,7 +280,7 @@ describe("<MetricsDataProvider>", () => {
     });
 
     it("passes timeInfo to contained component", () => {
-      mockTimeInfo(timespan1);
+      mockTimeInfo(metricsTime1);
       mockUseMetrics.mockReturnValue(noData);
       render(
         <MetricsDataProvider id={graphid}>{childrenJSX}</MetricsDataProvider>,
@@ -240,7 +293,7 @@ describe("<MetricsDataProvider>", () => {
       const consoleSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      mockTimeInfo(timespan1);
+      mockTimeInfo(metricsTime1);
       mockUseMetrics.mockReturnValue(noData);
       expect(() => {
         render(


### PR DESCRIPTION
## Summary

- Refactor the `useClusterSettings` SWR hook in cluster-ui to fetch all cluster settings in a single request and return them as `Record<string, ClusterSetting>`. The request parameter is now optional: when a `{ names: [...] }` filter is provided only those settings are returned, when omitted all settings are returned. All callers share the same SWR cache entry.
- Migrate 5 React component consumers in db-console from Redux `refreshSettings` dispatching to the refactored hook: `TimezoneProvider`, `MetricsDataProvider`, `NodeGraphs`, `KeyVisualizerPage`, and the Settings report page.
- Remove 7 now-unused Redux selectors from `clusterSettings.selectors.ts`.
- `alertDataProvider` in `alerts.ts` is left on Redux because it's a store subscriber, not a React component.

### Commits

1. **ui/cluster-ui: refactor useClusterSettings to fetch all settings** — reworks the hook to fetch all settings in one request with an optional name filter, adds `public` field to `ClusterSetting` type, exports from public API.
2. **ui/db-console: migrate 5 consumers from refreshSettings to useClusterSettings** — replaces Redux patterns in all React component consumers, updates tests, removes unused selectors.

Epic: CRDB-58145
Release note: None