### PR TITLE
changefeedccl: fix data race in TestChangefeedIdleness

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -912,7 +912,7 @@ func TestChangefeedProgressMetrics(t *testing.T) {
 	})
 }
 
-func TestChangefeedIdleness(t *testing.T) {
+func TestChangefeedIdlenessPauseResumeCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -923,33 +923,13 @@ func TestChangefeedIdleness(t *testing.T) {
 
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		currentlyIdle := registry.MetricsStruct().JobMetrics[jobspb.TypeChangefeed].CurrentlyIdle
-		// Use a wait group for cases when the number of idle changefeeds temporarily
-		// decreases, to avoid a race condition where the changefeed becomes idle
-		// before the idleness is checked.
-		var wg sync.WaitGroup
 		waitForIdleCount := func(numIdle int64) {
-			wg.Add(1)
 			testutils.SucceedsSoon(t, func() error {
 				if currentlyIdle.Value() != numIdle {
-					return fmt.Errorf("expected (%+v) idle changefeeds, found (%+v)", numIdle, currentlyIdle.Value())
+					return fmt.Errorf("expected (%d) idle changefeeds, found (%d)", numIdle, currentlyIdle.Value())
 				}
 				return nil
 			})
-			wg.Done()
-		}
-		done := make(chan bool)
-		workload := func() {
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					sqlDB.Exec(t, `INSERT INTO foo VALUES (0)`)
-					sqlDB.Exec(t, `DELETE FROM foo WHERE a = 0`)
-					sqlDB.Exec(t, `INSERT INTO bar VALUES (0)`)
-					sqlDB.Exec(t, `DELETE FROM bar WHERE b = 0`)
-				}
-			}
 		}
 
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
@@ -958,10 +938,6 @@ func TestChangefeedIdleness(t *testing.T) {
 		cf2 := feed(t, f, "CREATE CHANGEFEED FOR TABLE bar WITH resolved='10ms'")
 		defer closeFeed(t, cf1)
 
-		go workload()
-		go waitForIdleCount(0)
-		wg.Wait()
-		done <- true
 		waitForIdleCount(2) // Both should eventually be considered idle
 
 		jobFeed := cf2.(cdctest.EnterpriseTestFeed)
@@ -973,13 +949,64 @@ func TestChangefeedIdleness(t *testing.T) {
 
 		closeFeed(t, cf2)
 		waitForIdleCount(1) // The cancelled changefeed isn't considered idle
+	}, feedTestEnterpriseSinks)
+}
 
-		go workload()
-		go waitForIdleCount(0)
-		wg.Wait()
-		done <- true
-		waitForIdleCount(1)
+func TestChangefeedIdlenessWithWorkload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
+	cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		changefeedbase.IdleTimeout.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 3*time.Second)
+
+		registry := s.Server.JobRegistry().(*jobs.Registry)
+
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (b INT PRIMARY KEY)`)
+		cf1 := feed(t, f, "CREATE CHANGEFEED FOR TABLE foo WITH resolved='10ms'")
+		cf2 := feed(t, f, "CREATE CHANGEFEED FOR TABLE bar WITH resolved='10ms'")
+		defer closeFeed(t, cf1)
+		defer closeFeed(t, cf2)
+
+		currentlyIdle := registry.MetricsStruct().JobMetrics[jobspb.TypeChangefeed].CurrentlyIdle
+		waitForIdleCount := func(numIdle int64) {
+			testutils.SucceedsSoon(t, func() error {
+				if currentlyIdle.Value() != numIdle {
+					return fmt.Errorf("expected (%d) idle changefeeds, found (%d)", numIdle, currentlyIdle.Value())
+				}
+				return nil
+			})
+		}
+
+		waitForIdleCount(2)
+
+		// Keep the feed active so we can observe it transitioning out of idle.
+		done := make(chan struct{})
+		stopWorkload := sync.OnceFunc(func() { close(done) })
+		defer stopWorkload()
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					sqlDB.Exec(t, `INSERT INTO foo VALUES (0)`)
+					sqlDB.Exec(t, `DELETE FROM foo WHERE a = 0`)
+					sqlDB.Exec(t, `INSERT INTO bar VALUES (0)`)
+					sqlDB.Exec(t, `DELETE FROM bar WHERE b = 0`)
+					// We sleep between iterations to avoid overwhelming the
+					// feed with KV events.
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+		}()
+		waitForIdleCount(0)
+
+		// Stop the workload and observe the changefeed going idle again.
+		stopWorkload()
+		waitForIdleCount(2)
 	}, feedTestEnterpriseSinks)
 }
 


### PR DESCRIPTION
changefeedccl: fix data race in TestChangefeedIdleness
Previously, we saw a failure under race between WaitGroup
Add and Wait calls. The fix removes the WaitGroup pattern
entirely (avoiding the race) and splits the test into two
focused tests for better isolation of future failures:

- TestChangefeedIdlenessPauseResumeCancel: tests idle count transitions
  during pause/resume/cancel operations.
- TestChangefeedIdlenessWithWorkload: tests non-idle
  transitions with a throttled workload.

Fixes: https://github.com/cockroachdb/cockroach/issues/148204
Release note: None