### PR TITLE
release-25.4: multiregionccl: retry follower read assertions in regional_by_table test

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/regional_by_table
+++ b/pkg/ccl/multiregionccl/testdata/regional_by_table
@@ -73,7 +73,7 @@ SELECT * FROM db.rbt WHERE k = 1
 ----
 served locally: false
 
-trace-sql idx=7
+trace-sql idx=7 retry
 SELECT * FROM db.rbt AS OF SYSTEM TIME follower_read_timestamp() WHERE k = 1
 ----
 served locally: true
@@ -223,19 +223,19 @@ LAG_BY_CLUSTER_SETTING
 
 # Perform follower reads from all regions.
 
-trace-sql idx=6
+trace-sql idx=6 retry
 SELECT * FROM db.rbt AS OF SYSTEM TIME follower_read_timestamp() WHERE k = 1
 ----
 served locally: true
 served via follower read: true
 
-trace-sql idx=7
+trace-sql idx=7 retry
 SELECT * FROM db.rbt AS OF SYSTEM TIME follower_read_timestamp() WHERE k = 1
 ----
 served locally: true
 served via follower read: true
 
-trace-sql idx=8
+trace-sql idx=8 retry
 SELECT * FROM db.rbt AS OF SYSTEM TIME follower_read_timestamp() WHERE k = 1
 ----
 served locally: true


### PR DESCRIPTION
Backport 1/1 commits from #166469 on behalf of @shghasemi.

----

Add retry to trace-sql assertions that verify follower reads are served locally from non-leaseholder replicas. Background replicate queue operations can race with the test and temporarily remove a non-voter between wait-for-zone-config-changes passing and the trace-sql assertion running. The replicate queue self-heals the under-replicated range within seconds, so retrying the assertion is sufficient.

Fixes #165420

Release note: None

----

Release justification: Test-only change.