### PR TITLE
sql/schemachanger: add support for renaming of enum types

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -568,6 +568,20 @@ func TestBackupRollbacks_base_alter_type_owner(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacks_base_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_type_rename_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1454,6 +1468,20 @@ func TestBackupRollbacksMixedVersion_base_alter_type_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_owner"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2346,6 +2374,20 @@ func TestBackupSuccess_base_alter_type_owner(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccess_base_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_type_rename_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3232,6 +3274,20 @@ func TestBackupSuccessMixedVersion_base_alter_type_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_owner"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -53,12 +53,72 @@ COMMIT
 statement ok
 ALTER TYPE new__name RENAME TO newname
 
+# Renaming a type multiple times within a single declarative schema change.
+
+# Force the declarative schema changer for multi-statement explicit
+# transactions.
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+SET use_declarative_schema_changer = unsafe_always
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl=off
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+ALTER TYPE newname RENAME TO rename_once
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+ALTER TYPE rename_once RENAME TO rename_twice
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+query T
+SELECT 'hi'::rename_twice
+----
+hi
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+COMMIT
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+query T
+SELECT 'hi'::rename_twice
+----
+hi
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+ALTER TYPE rename_twice RENAME TO newname
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+RESET use_declarative_schema_changer
+
+statement error pq: type "test\.public\.newname" already exists
+ALTER TYPE newname RENAME TO newname
+
 # We shouldn't be able to rename into a conflicting type.
 statement ok
 CREATE TABLE conflict (x INT)
 
 statement error pq: relation "test\.public\.conflict" already exists
 ALTER TYPE newname RENAME TO conflict
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+CREATE DOMAIN domain_conflict AS INT
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement error pq: type "test\.public\.domain_conflict" already exists
+ALTER TYPE newname RENAME TO domain_conflict
+
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
+statement ok
+DROP DOMAIN domain_conflict
 
 # Renames should try and move around the array type to find a valid name.
 # This creates types _why and __why.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "alter_table_set_trigger.go",
         "alter_table_validate_constraint.go",
         "alter_type.go",
+        "alter_type_rename.go",
         "comment_on.go",
         "configure_zone.go",
         "create_database.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -36,7 +36,7 @@ type supportedAlterTypeCommand = supportedStatement
 var supportedAlterTypeStatements = map[reflect.Type]supportedAlterTypeCommand{
 	reflect.TypeOf((*tree.AlterTypeAddValue)(nil)):    {fn: alterTypeAddValue, on: true, checks: isV263Active},
 	reflect.TypeOf((*tree.AlterTypeRenameValue)(nil)): {fn: alterTypeRenameValue, on: true, checks: isV263Active},
-	reflect.TypeOf((*tree.AlterTypeRename)(nil)):      {fn: alterTypeRename, on: false, checks: nil},
+	reflect.TypeOf((*tree.AlterTypeRename)(nil)):      {fn: alterTypeRename, on: true, checks: isV263Active},
 	reflect.TypeOf((*tree.AlterTypeSetSchema)(nil)):   {fn: alterTypeSetSchema, on: false, checks: nil},
 	reflect.TypeOf((*tree.AlterTypeOwner)(nil)):       {fn: alterTypeOwner, on: true, checks: isV263Active},
 	reflect.TypeOf((*tree.AlterTypeDropValue)(nil)):   {fn: alterTypeDropValue, on: true, checks: isV263Active},
@@ -84,8 +84,11 @@ func alterTypeChecks(
 func AlterType(b BuildCtx, n *tree.AlterType) {
 	elts := b.ResolveUserDefinedTypeType(n.Type, ResolveParams{})
 
-	if !elts.FilterCompositeType().IsEmpty() {
-		panic(scerrors.NotImplementedErrorf(n, "ALTER TYPE on composite types"))
+	if !elts.FilterCompositeType().IsEmpty() || !elts.FilterDomainType().IsEmpty() {
+		panic(scerrors.NotImplementedErrorf(n, "ALTER TYPE on non-enum UDTs is not supported"))
+	} else if elts.FilterEnumType().IsEmpty() {
+		panic(pgerror.Newf(pgcode.WrongObjectType,
+			"%q is not an enum type", n.Type.Object()))
 	}
 
 	enumType := elts.FilterEnumType().MustGetOneElement()
@@ -272,12 +275,6 @@ func alterTypeRenameValue(
 	b.LogEventForExistingPayload(enumValue, &eventpb.AlterType{
 		TypeName: tn.FQString(),
 	})
-}
-
-func alterTypeRename(
-	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeRename,
-) {
-	panic(scerrors.NotImplementedErrorf(t, "ALTER TYPE RENAME is not supported"))
 }
 
 func alterTypeSetSchema(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type_rename.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type_rename.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+)
+
+func alterTypeRename(
+	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeRename,
+) {
+	newName := string(t.NewName)
+
+	typeElts := b.QueryByID(enumType.TypeID)
+	currentNS := typeElts.FilterNamespace().NotToAbsent().MustGetOneElement()
+
+	// Unlike table rename (which no-ops on self-rename), Postgres treats type
+	// rename to the same name as an error.
+	if currentNS.Name == newName {
+		typeName := tree.MakeTableNameFromPrefix(
+			b.NamePrefix(currentNS), tree.Name(newName),
+		)
+		panic(sqlerrors.NewTypeAlreadyExistsError(typeName.String()))
+	}
+
+	checkTypeNameConflicts(b, newName, currentNS)
+
+	newNS := &scpb.Namespace{
+		DatabaseID:   currentNS.DatabaseID,
+		SchemaID:     currentNS.SchemaID,
+		DescriptorID: currentNS.DescriptorID,
+		Name:         newName,
+	}
+	b.Drop(currentNS)
+	b.Add(newNS)
+
+	// Rename the implicit array type.
+	arrayElts := b.QueryByID(enumType.ArrayTypeID)
+	arrayNS := arrayElts.FilterNamespace().NotToAbsent().MustGetOneElement()
+
+	newArrayName := findFreeNameInSchema(b, b.NamePrefix(currentNS), "_"+newName)
+	newArrayNS := &scpb.Namespace{
+		DatabaseID:   arrayNS.DatabaseID,
+		SchemaID:     arrayNS.SchemaID,
+		DescriptorID: arrayNS.DescriptorID,
+		Name:         newArrayName,
+	}
+	b.Drop(arrayNS)
+	b.Add(newArrayNS)
+
+	b.LogEventForExistingPayload(newNS, &eventpb.RenameType{
+		TypeName:    tn.FQString(),
+		NewTypeName: newName,
+	})
+}
+
+// checkTypeNameConflicts checks if the new type name conflicts with an
+// existing object in the same schema.
+func checkTypeNameConflicts(b BuildCtx, newName string, currentNS *scpb.Namespace) {
+	tn := tree.MakeTableNameFromPrefix(
+		b.NamePrefix(currentNS),
+		tree.Name(newName),
+	)
+	ers := b.ResolveRelation(tn.ToUnresolvedObjectName(),
+		ResolveParams{
+			IsExistenceOptional: true,
+			WithOffline:         true,
+			ResolveTypes:        true,
+		})
+	if ers == nil || ers.IsEmpty() {
+		return
+	}
+
+	existingNS := ers.FilterNamespace().NotToAbsent().MustGetZeroOrOneElement()
+	if existingNS == nil {
+		if !ers.FilterNamespace().ToAbsent().IsEmpty() {
+			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"object %q being dropped, try again later", newName))
+		}
+		return
+	}
+
+	if !ers.FilterCompositeType().IsEmpty() || !ers.FilterEnumType().IsEmpty() || !ers.FilterDomainType().IsEmpty() {
+		panic(sqlerrors.NewTypeAlreadyExistsError(tn.String()))
+	}
+	panic(sqlerrors.NewRelationAlreadyExistsError(tn.String()))
+}
+
+// findFreeNameInSchema prepends underscores to candidateName until it doesn't
+// collide with any existing object in the given schema.
+func findFreeNameInSchema(b BuildCtx, prefix tree.ObjectNamePrefix, candidateName string) string {
+	for {
+		tn := tree.MakeTableNameFromPrefix(prefix, tree.Name(candidateName))
+		ers := b.ResolveRelation(tn.ToUnresolvedObjectName(),
+			ResolveParams{
+				IsExistenceOptional: true,
+				WithOffline:         true,
+				ResolveTypes:        true,
+			})
+		if ers == nil || ers.IsEmpty() {
+			return candidateName
+		}
+		candidateName = "_" + candidateName
+	}
+}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_type
@@ -21,3 +21,15 @@ ALTER TYPE defaultdb.climes RENAME VALUE 'tropical' TO 'equatorial'
   {logicalRepresentation: tropical, physicalRepresentation: QA==, typeId: 104}
 - [[EnumTypeValue:{DescID: 104, Name: equatorial}, PUBLIC], ABSENT]
   {logicalRepresentation: equatorial, physicalRepresentation: QA==, typeId: 104}
+
+build
+ALTER TYPE defaultdb.climes RENAME TO environs
+----
+- [[Namespace:{DescID: 104, Name: climes, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 104, name: climes, schemaId: 101}
+- [[Namespace:{DescID: 104, Name: environs, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT]
+  {databaseId: 100, descriptorId: 104, name: environs, schemaId: 101}
+- [[Namespace:{DescID: 105, Name: _climes, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 105, name: _climes, schemaId: 101}
+- [[Namespace:{DescID: 105, Name: _environs, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT]
+  {databaseId: 100, descriptorId: 105, name: _environs, schemaId: 101}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_type
@@ -3,9 +3,5 @@ CREATE TYPE defaultdb.climes AS ENUM ('tropical', 'arctic', 'mediterranean');
 ----
 
 unimplemented
-ALTER TYPE defaultdb.climes RENAME TO environs
-----
-
-unimplemented
 ALTER TYPE defaultdb.climes SET SCHEMA public
 ----

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -568,6 +568,20 @@ func TestEndToEndSideEffects_alter_type_owner(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_type_rename_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1454,6 +1468,20 @@ func TestExecuteWithDMLInjection_alter_type_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_owner"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2346,6 +2374,20 @@ func TestGenerateSchemaChangeCorpus_alter_type_owner(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_type_rename_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3232,6 +3274,20 @@ func TestPause_alter_type_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_owner"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -4124,6 +4180,20 @@ func TestPauseMixedVersion_alter_type_owner(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_type_rename_value(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5010,6 +5080,20 @@ func TestRollback_alter_type_owner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_owner"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_type_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_type_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value__rollback_1_of_1.explain
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TYPE salmon AS ENUM ('sockeye', 'king');
+CREATE TYPE salmon AS ENUM('chinook', 'sockeye');
 
 /* test */
 ALTER TYPE salmon ADD VALUE 'atlantic';

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+----
+
+test
+ALTER TYPE salmon RENAME TO trout;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.explain
@@ -1,0 +1,48 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+
+/* test */
+EXPLAIN (DDL) ALTER TYPE salmon RENAME TO trout;
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_trout+), Name: "_trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         └── 6 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"_trout"}
+ │              └── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_trout","SchemaID":101}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_trout+), Name: "_trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_trout+), Name: "_trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           └── 8 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"trout","TableID":104}
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":105,"Name":"_trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_trout","SchemaID":101}}
+                └── UpdateTTLScheduleMetadata {"NewName":"_trout","TableID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TYPE salmon RENAME TO trout;
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename/alter_type_rename.side_effects
@@ -1,0 +1,93 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
+
+/* test */
+ALTER TYPE salmon RENAME TO trout;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TYPE
+increment telemetry for sql.schema.alter_type.rename
+increment telemetry for sql.udts.alter_enum
+write *eventpb.RenameType to event log:
+  newTypeName: trout
+  sql:
+    descriptorId: 104
+    statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›
+    tag: ALTER TYPE
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 6 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 _trout} -> 105
+upsert descriptor #104
+  ...
+     id: 104
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: _trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 8 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 _trout} -> 105
+upsert descriptor #104
+  ...
+     id: 104
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: _trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.definition
@@ -1,0 +1,8 @@
+setup
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+CREATE TYPE _trout AS ENUM ('rainbow');
+----
+
+test
+ALTER TYPE salmon RENAME TO trout;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.explain
@@ -1,0 +1,49 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+CREATE TYPE _trout AS ENUM ('rainbow');
+
+/* test */
+EXPLAIN (DDL) ALTER TYPE salmon RENAME TO trout;
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-___trout+), Name: "___trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-___trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         └── 6 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"___trout"}
+ │              └── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"___trout","SchemaID":101}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-___trout+), Name: "___trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-___trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-___trout+), Name: "___trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-___trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           └── 8 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"trout","TableID":104}
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":105,"Name":"___trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"___trout","SchemaID":101}}
+                └── UpdateTTLScheduleMetadata {"NewName":"___trout","TableID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+CREATE TYPE _trout AS ENUM ('rainbow');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TYPE salmon RENAME TO trout;
+----
+Schema change plan for ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_collision/alter_type_rename_collision.side_effects
@@ -1,0 +1,96 @@
+/* setup */
+CREATE TYPE salmon AS ENUM ('sockeye', 'king', 'atlantic');
+CREATE TYPE _trout AS ENUM ('rainbow');
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
++object {100 101 _trout} -> 106
++object {100 101 __trout} -> 107
+
+/* test */
+ALTER TYPE salmon RENAME TO trout;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TYPE
+increment telemetry for sql.schema.alter_type.rename
+increment telemetry for sql.udts.alter_enum
+write *eventpb.RenameType to event log:
+  newTypeName: trout
+  sql:
+    descriptorId: 104
+    statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›
+    tag: ALTER TYPE
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 6 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 ___trout} -> 105
+upsert descriptor #104
+  ...
+     id: 104
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: ___trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 8 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 ___trout} -> 105
+upsert descriptor #104
+  ...
+     id: 104
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: ___trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1


### PR DESCRIPTION
This change implements the renaming of enum UDTs and rewires the command
to it.

Closes: #164215

Epic: CRDB-31325

Release note: None