### PR TITLE
roachtest: unify metamorphic cdc settings

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1431,6 +1431,7 @@ GO_TARGETS = [
     "//pkg/cmd/roachtest/registry:registry_test",
     "//pkg/cmd/roachtest/roachtestflags:roachtestflags",
     "//pkg/cmd/roachtest/roachtestflags:roachtestflags_test",
+    "//pkg/cmd/roachtest/roachtestutil/cdcutil:cdcutil",
     "//pkg/cmd/roachtest/roachtestutil/clusterupgrade:clusterupgrade",
     "//pkg/cmd/roachtest/roachtestutil/mixedversion:mixedversion",
     "//pkg/cmd/roachtest/roachtestutil/mixedversion:mixedversion_test",

--- a/pkg/cmd/roachtest/roachtestutil/cdcutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/cdcutil/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cdcutil",
+    srcs = ["metamorphic.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/cdcutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/ccl/changefeedccl",
+        "//pkg/roachprod/logger",
+        "//pkg/util/randutil",
+    ],
+)

--- a/pkg/cmd/roachtest/roachtestutil/cdcutil/metamorphic.go
+++ b/pkg/cmd/roachtest/roachtestutil/cdcutil/metamorphic.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cdcutil
+
+import (
+	"math/rand"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// MetamorphicSetting describes a single metamorphic setting for CDC roachtests.
+type MetamorphicSetting struct {
+	Name    string
+	Resolve func(*rand.Rand) (string, bool)
+}
+
+// Convenience helper to metamorphically resolve bool settings as a string
+// with 50/50 distribution. As of writing, all use cases for metamorphic
+// settings are cluster settings, i.e. we need to cast to a string to apply them.
+func metamorphicBool(rng *rand.Rand) (string, bool) {
+	return strconv.FormatBool(rng.Intn(2) == 0), true
+}
+
+var (
+	RangeFeedSchedulerEnabled = MetamorphicSetting{
+		Name:    "kv.rangefeed.scheduler.enabled",
+		Resolve: metamorphicBool,
+	}
+	SchemaLockTables = MetamorphicSetting{
+		Name:    "schema_lock_tables",
+		Resolve: metamorphicBool,
+	}
+	PerTableTrackingEnabled = MetamorphicSetting{
+		Name:    "changefeed.progress.per_table_tracking.enabled",
+		Resolve: metamorphicBool,
+	}
+	ResolvedTSGranularity = MetamorphicSetting{
+		Name: "changefeed.resolved_timestamp.granularity",
+		Resolve: func(rng *rand.Rand) (string, bool) {
+			return strconv.Itoa(rng.Intn(30)) + "s", true
+		},
+	}
+	// DistributionStrategy resolves to a random strategy 50% of the time,
+	// or disabled the other 50%.
+	DistributionStrategy = MetamorphicSetting{
+		Name: "changefeed.default_range_distribution_strategy",
+		Resolve: func(rng *rand.Rand) (string, bool) {
+			if rng.Intn(2) == 0 {
+				return "", false
+			}
+			vals := changefeedccl.RangeDistributionStrategy.GetAvailableValues()
+			return vals[rng.Intn(len(vals))], true
+		},
+	}
+)
+
+// resolvedSetting represents a metamorphic setting that has been
+// accessed via Get() before and resolved to a value. It may be disabled
+// as determined by the Resolve method, or explicitly disabled via Disable().
+type resolvedSetting struct {
+	value string
+	// enabled is false if the setting should not be applied.
+	enabled bool
+}
+
+// MetamorphicSettings holds lazily-resolved metamorphic decisions for
+// CDC roachtests.
+type MetamorphicSettings struct {
+	rng    *rand.Rand
+	Seed   int64
+	values map[string]resolvedSetting
+}
+
+// NewMetamorphicSettings creates a MetamorphicSettings with a random seed.
+// The seed can be overridden via the COCKROACH_RANDOM_SEED environment
+// variable to reproduce a specific run.
+func NewMetamorphicSettings(l *logger.Logger) *MetamorphicSettings {
+	rng, seed := randutil.NewLockedPseudoRand()
+	l.Printf("metamorphic settings seed: %d (use COCKROACH_RANDOM_SEED to reproduce)", seed)
+	return &MetamorphicSettings{
+		rng:    rng,
+		Seed:   seed,
+		values: make(map[string]resolvedSetting),
+	}
+}
+
+// Get returns the resolved value and whether the setting is enabled.
+// On first access the value is randomly chosen and cached.
+func (s *MetamorphicSettings) Get(setting MetamorphicSetting) (string, bool) {
+	if v, ok := s.values[setting.Name]; ok {
+		return v.value, v.enabled
+	}
+	value, enabled := setting.Resolve(s.rng)
+	s.values[setting.Name] = resolvedSetting{value: value, enabled: enabled}
+	return value, enabled
+}
+
+// Disable prevents a specific setting from being applied.
+func (s *MetamorphicSettings) Disable(setting MetamorphicSetting) {
+	s.values[setting.Name] = resolvedSetting{value: "", enabled: false}
+}
+
+// Resolved returns all resolved and enabled settings as a map.
+func (s *MetamorphicSettings) Resolved() map[string]string {
+	result := make(map[string]string)
+	for name, v := range s.values {
+		if v.enabled {
+			result[name] = v.value
+		}
+	}
+	return result
+}

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -252,6 +252,7 @@ go_library(
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestutil",
+        "//pkg/cmd/roachtest/roachtestutil/cdcutil",
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
         "//pkg/cmd/roachtest/roachtestutil/mixedversion",
         "//pkg/cmd/roachtest/roachtestutil/task",

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"maps"
 	"math/big"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -54,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/cdcutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -122,6 +122,8 @@ type cdcTester struct {
 
 	workloadWg *sync.WaitGroup
 	doneCh     chan struct{}
+
+	metamorphic *cdcutil.MetamorphicSettings
 }
 
 // startStatsCollection sets the start point of the stats collection window
@@ -352,7 +354,6 @@ type tpccArgs struct {
 	tolerateErrors bool
 	conns          int
 	noWait         bool
-	cdcFeatureFlags
 }
 
 func (ct *cdcTester) lockSchema(targets []string) {
@@ -378,7 +379,7 @@ func (ct *cdcTester) runTPCCWorkload(args tpccArgs) {
 	if !ct.t.SkipInit() {
 		ct.t.Status("installing TPCC workload")
 		tpcc.install(ct.ctx, ct.cluster)
-		if args.SchemaLockTables.enabled(globalEntropy) == featureEnabled {
+		if v, ok := ct.metamorphic.Get(cdcutil.SchemaLockTables); ok && v == "true" {
 			ct.t.Status(fmt.Sprintf("Setting schema_locked for %s", allTpccTargets))
 			ct.lockSchema(allTpccTargets)
 		}
@@ -434,6 +435,11 @@ func (ct *cdcTester) DB() *gosql.DB {
 func (ct *cdcTester) Close() {
 	ct.t.Status("cdcTester closing")
 	close(ct.doneCh)
+	// Add our metamorphic settings to the test parameters so they are
+	// easily visible in the github issue for comparison across failures.
+	for name, value := range ct.metamorphic.Resolved() {
+		ct.t.AddParam(name, value)
+	}
 	ct.mon.Wait()
 
 	_, _ = ct.DB().Exec(`CANCEL ALL CHANGEFEED JOBS;`)
@@ -485,84 +491,6 @@ var allLedgerTargets []string = []string{
 	`ledger.session`,
 }
 
-type featureFlag struct {
-	v *featureState
-}
-
-type featureState int
-
-var (
-	featureUnset    featureState = 0
-	featureDisabled featureState = 1
-	featureEnabled  featureState = 2
-)
-
-type entropy struct {
-	*rand.Rand
-}
-
-func (r *entropy) Bool() bool {
-	if r.Rand == nil {
-		return rand.Int()%2 == 0
-	}
-	return r.Rand.Int()%2 == 0
-}
-
-func (r *entropy) Intn(n int) int {
-	if r.Rand == nil {
-		return rand.Intn(n)
-	}
-	return r.Rand.Intn(n)
-}
-
-var globalRand *rand.Rand
-var globalEntropy entropy
-
-func (f *featureFlag) enabled(r entropy) featureState {
-	if f.v != nil {
-		return *f.v
-	}
-
-	if r.Bool() {
-		f.v = &featureEnabled
-		return featureEnabled
-	}
-	f.v = &featureDisabled
-	return featureDisabled
-}
-
-type enumFeatureFlag struct {
-	state string
-	v     *featureState
-}
-
-// enabled returns a valid string if the returned featureState is featureEnabled.
-func (f *enumFeatureFlag) enabled(r entropy, choose func(entropy) string) (string, featureState) {
-	if f.v != nil {
-		return f.state, *f.v
-	}
-
-	if r.Bool() {
-		f.v = &featureEnabled
-		f.state = choose(r)
-		return f.state, featureEnabled
-	}
-	f.v = &featureDisabled
-	return f.state, featureDisabled
-}
-
-// cdcFeatureFlags describes various cdc feature flags.
-// zero value cdcFeatureFlags uses metamorphic settings for features.
-type cdcFeatureFlags struct {
-	RangeFeedScheduler   featureFlag
-	SchemaLockTables     featureFlag
-	DistributionStrategy enumFeatureFlag
-}
-
-func makeDefaultFeatureFlags() cdcFeatureFlags {
-	return cdcFeatureFlags{}
-}
-
 type feedArgs struct {
 	sinkType        sinkType
 	targets         []string
@@ -571,8 +499,7 @@ type feedArgs struct {
 	assumeRole      string
 	tolerateErrors  bool
 	sinkURIOverride string
-	cdcFeatureFlags
-	kafkaArgs kafkaFeedArgs
+	kafkaArgs       kafkaFeedArgs
 }
 
 // kafkaFeedArgs are args that are specific to kafkaSink changefeeds.
@@ -625,7 +552,7 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 		args.sinkType, args.targets, feedOptions,
 	))
 	db := ct.DB()
-	jobID, err := newChangefeedCreator(db, db, ct.logger, globalRand, targetsStr, sinkURI, makeDefaultFeatureFlags()).
+	jobID, err := newChangefeedCreator(db, db, ct.logger, targetsStr, sinkURI, ct.metamorphic).
 		With(feedOptions).Create()
 	if err != nil {
 		ct.t.Fatalf("failed to create changefeed: %s", err.Error())
@@ -795,6 +722,14 @@ func withNumSinkNodes(num int) opt {
 	}
 }
 
+func disableMetamorphicSettings(settings ...cdcutil.MetamorphicSetting) opt {
+	return func(ct *cdcTester) {
+		for _, s := range settings {
+			ct.metamorphic.Disable(s)
+		}
+	}
+}
+
 // Silence staticcheck.
 var _ = withNumSinkNodes
 
@@ -818,6 +753,7 @@ func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster, opts ...o
 		doneCh:       make(chan struct{}),
 		sinkCache:    make(map[sinkType]string),
 		workloadWg:   &sync.WaitGroup{},
+		metamorphic:  cdcutil.NewMetamorphicSettings(t.L()),
 	}
 
 	for _, opt := range opts {
@@ -841,14 +777,11 @@ func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster, opts ...o
 
 	// Set cluster settings that we want to test metamorphically to random values
 	// since metamorphic settings don't extend to roachtests.
-	{
-		quantization := fmt.Sprintf("%ds", rand.Intn(30))
-		settings.ClusterSettings["changefeed.resolved_timestamp.granularity"] = quantization
-		t.Status(fmt.Sprintf("changefeed.resolved_timestamp.granularity: %s", quantization))
-
-		perTableTracking := fmt.Sprintf("%t", rand.Intn(2) == 0)
-		settings.ClusterSettings["changefeed.progress.per_table_tracking.enabled"] = perTableTracking
-		t.Status(fmt.Sprintf("changefeed.progress.per_table_tracking.enabled: %s", perTableTracking))
+	if v, ok := tester.metamorphic.Get(cdcutil.ResolvedTSGranularity); ok {
+		settings.ClusterSettings["changefeed.resolved_timestamp.granularity"] = v
+	}
+	if v, ok := tester.metamorphic.Get(cdcutil.PerTableTrackingEnabled); ok {
+		settings.ClusterSettings["changefeed.progress.per_table_tracking.enabled"] = v
 	}
 
 	settings.Env = append(settings.Env, envVars...)
@@ -952,7 +885,8 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster, cfg cdcBank
 		"min_checkpoint_frequency": "'2s'",
 		"diff":                     "",
 	}
-	_, err := newChangefeedCreator(db, db, t.L(), globalRand, "bank.bank", kafka.sinkURL(ctx), makeDefaultFeatureFlags()).
+	metamorphic := cdcutil.NewMetamorphicSettings(t.L())
+	_, err := newChangefeedCreator(db, db, t.L(), "bank.bank", kafka.sinkURL(ctx), metamorphic).
 		With(options).
 		Create()
 	if err != nil {
@@ -1854,7 +1788,8 @@ func runCDCSchemaRegistry(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"diff":                      "",
 	}
 
-	_, err := newChangefeedCreator(db, db, t.L(), globalRand, "foo", kafka.sinkURL(ctx), makeDefaultFeatureFlags()).
+	metamorphic := cdcutil.NewMetamorphicSettings(t.L())
+	_, err := newChangefeedCreator(db, db, t.L(), "foo", kafka.sinkURL(ctx), metamorphic).
 		With(options).
 		Args(kafka.schemaRegistryURL(ctx)).
 		Create()
@@ -1994,9 +1929,10 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 		},
 	}
 
+	metamorphic := cdcutil.NewMetamorphicSettings(t.L())
 	for _, f := range feeds {
 		t.Status(fmt.Sprintf("running:%s, query:%s", f.desc, f.queryArg))
-		_, err := newChangefeedCreator(db, db, t.L(), globalRand, "auth_test_table", f.queryArg, makeDefaultFeatureFlags()).Create()
+		_, err := newChangefeedCreator(db, db, t.L(), "auth_test_table", f.queryArg, metamorphic).Create()
 		if err != nil {
 			t.Fatalf("%s: %s", f.desc, err.Error())
 		}
@@ -3167,8 +3103,9 @@ CONFIGURE ZONE USING
 			tdb := sqlutils.MakeSQLRunner(db)
 			tdb.Exec(t, `CREATE TABLE auth_test_table (a INT PRIMARY KEY)`)
 
+			metamorphic := cdcutil.NewMetamorphicSettings(t.L())
 			t.L().Printf("creating changefeed with iam: %s", brokers.connectURI)
-			_, err := newChangefeedCreator(db, db, t.L(), globalRand, "auth_test_table", brokers.connectURI, makeDefaultFeatureFlags()).Create()
+			_, err := newChangefeedCreator(db, db, t.L(), "auth_test_table", brokers.connectURI, metamorphic).Create()
 			if err != nil {
 				t.Fatalf("creating changefeed: %v", err)
 			}
@@ -3532,7 +3469,10 @@ CONFIGURE ZONE USING
 				Suites:           registry.Suites(registry.Nightly),
 				Timeout:          2 * time.Hour,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					ct := newCDCTester(ctx, t, c)
+					// This is a latency sensitive scale test, use the default granularity.
+					// The benchmark has a 2 minute latency threshold, and up to 30
+					// seconds of quantization delay eats into that budget significantly.
+					ct := newCDCTester(ctx, t, c, disableMetamorphicSettings(cdcutil.ResolvedTSGranularity))
 					defer ct.Close()
 
 					db := ct.DB()
@@ -3550,11 +3490,6 @@ CONFIGURE ZONE USING
 						"spanconfig.range_coalescing.application.enabled": "'false'",
 						// TODO(#158779): When we add back per-table PTS, make sure that this test
 						// turns it off, to avoid it impacting the results.
-						//
-						// This is a latency sensitive scale test, use the default granularity.
-						// The benchmark has a 2 minute latency threshold, and up to 30
-						// seconds of quantization delay eats into that budget significantly.
-						"changefeed.resolved_timestamp.granularity": "'1s'",
 					} {
 						stmt := fmt.Sprintf(`SET CLUSTER SETTING %s = %s`, name, value)
 						if _, err := db.ExecContext(ctx, stmt); err != nil {
@@ -4782,27 +4717,24 @@ type changefeedCreator struct {
 	sinkURL         string
 	options         map[string]string
 	extraArgs       []interface{}
-	flags           cdcFeatureFlags
-	rng             entropy
+	metamorphic     *cdcutil.MetamorphicSettings
 	settingsApplied bool
 }
 
 func newChangefeedCreator(
 	db, systemDB *gosql.DB,
 	logger *logger.Logger,
-	r *rand.Rand,
 	targets, sinkURL string,
-	flags cdcFeatureFlags,
+	metamorphic *cdcutil.MetamorphicSettings,
 ) *changefeedCreator {
 	return &changefeedCreator{
-		db:       db,
-		systemDB: systemDB,
-		logger:   logger,
-		targets:  targets,
-		sinkURL:  sinkURL,
-		options:  make(map[string]string),
-		flags:    flags,
-		rng:      entropy{Rand: r},
+		db:          db,
+		systemDB:    systemDB,
+		logger:      logger,
+		targets:     targets,
+		sinkURL:     sinkURL,
+		options:     make(map[string]string),
+		metamorphic: metamorphic,
 	}
 }
 
@@ -4825,13 +4757,8 @@ func (cfc *changefeedCreator) Args(args ...interface{}) *changefeedCreator {
 	return cfc
 }
 
-func chooseDistributionStrategy(r entropy) string {
-	vals := changefeedccl.RangeDistributionStrategy.GetAvailableValues()
-	return vals[r.Intn(len(vals))]
-}
-
 // applySettings aplies various settings to the cluster -- once per the
-// lifetime of changefeedCreator
+// lifetime of changefeedCreator.
 func (cfc *changefeedCreator) applySettings() error {
 	if cfc.settingsApplied {
 		return nil
@@ -4841,26 +4768,24 @@ func (cfc *changefeedCreator) applySettings() error {
 		return err
 	}
 
-	schedEnabled := cfc.flags.RangeFeedScheduler.enabled(cfc.rng)
-	if schedEnabled != featureUnset {
-		cfc.logger.Printf("Setting kv.rangefeed.scheduler.enabled to %t", schedEnabled == featureEnabled)
+	if enabled, ok := cfc.metamorphic.Get(cdcutil.RangeFeedSchedulerEnabled); ok {
+		cfc.logger.Printf("Setting kv.rangefeed.scheduler.enabled to %s", enabled)
 		if _, err := cfc.systemDB.Exec(
-			"SET CLUSTER SETTING kv.rangefeed.scheduler.enabled = $1", schedEnabled == featureEnabled,
+			"SET CLUSTER SETTING kv.rangefeed.scheduler.enabled = $1", enabled,
 		); err != nil {
 			return err
 		}
 	}
 
-	rangeDistribution, rangeDistributionEnabled := cfc.flags.DistributionStrategy.enabled(cfc.rng,
-		chooseDistributionStrategy)
-	if rangeDistributionEnabled == featureEnabled {
-		cfc.logger.Printf("Setting changefeed.default_range_distribution_strategy to %s", rangeDistribution)
+	if strategy, ok := cfc.metamorphic.Get(cdcutil.DistributionStrategy); ok {
+		cfc.logger.Printf("Setting changefeed.default_range_distribution_strategy to %s", strategy)
 		if _, err := cfc.db.Exec(fmt.Sprintf(
-			"SET CLUSTER SETTING changefeed.default_range_distribution_strategy = '%s'", rangeDistribution)); err != nil {
+			"SET CLUSTER SETTING changefeed.default_range_distribution_strategy = '%s'", strategy)); err != nil {
 			return err
 		}
 	}
 
+	cfc.settingsApplied = true
 	return nil
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/cdcutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -402,13 +403,14 @@ func (cmvt *cdcMixedVersionTester) createChangeFeed(
 		"min_checkpoint_frequency": fmt.Sprintf("'%s'", minCheckpointFrequency),
 	}
 
-	var ff cdcFeatureFlags
+	metamorphic := cdcutil.NewMetamorphicSettings(l)
+	// Disable settings not supported at the current cluster version.
 	rangefeedSchedulerSupported, err := cmvt.rangefeedSchedulerSupported(r, h)
 	if err != nil {
 		return err
 	}
 	if !rangefeedSchedulerSupported {
-		ff.RangeFeedScheduler.v = &featureUnset
+		metamorphic.Disable(cdcutil.RangeFeedSchedulerEnabled)
 	}
 
 	distributionStrategySupported, err := cmvt.distributionStrategySupported(r, h)
@@ -416,11 +418,11 @@ func (cmvt *cdcMixedVersionTester) createChangeFeed(
 		return err
 	}
 	if !distributionStrategySupported {
-		ff.DistributionStrategy.v = &featureUnset
+		metamorphic.Disable(cdcutil.DistributionStrategy)
 	}
 
-	jobID, err := newChangefeedCreator(db, systemDB, l, r, fmt.Sprintf("%s.%s", targetDB, targetTable),
-		cmvt.kafka.manager.sinkURL(ctx), ff).
+	jobID, err := newChangefeedCreator(db, systemDB, l, fmt.Sprintf("%s.%s", targetDB, targetTable),
+		cmvt.kafka.manager.sinkURL(ctx), metamorphic).
 		With(options).
 		Create()
 	if err != nil {


### PR DESCRIPTION
Previously cdc roachtests metamorphically set various cluster settings in two main places, inside newCDCTester and inside newChangefeedCreator.

The former settings were not seeded with the test rng or overridable while the latter had hard to find logs for which metamorphic settings were chosen.

This change unifies the settings under a new cdcutil MetamorphicSetting which allows for all settings to be logged in the same place (params.log or github issue) as well allows for overriding metamorphic settings using the same mechanism.

Fixes: none
Epic: none
Release note: none