### PR TITLE
release-26.2: rttanalysis: fix timeout for BenchmarkVirtualTableQueries

### DIFF
--- a/pkg/bench/rttanalysis/alter_table_bench_test.go
+++ b/pkg/bench/rttanalysis/alter_table_bench_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkAlterTableAddColumn is a benchmark for the ALTER TABLE ADD COLUMN statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableAddColumn(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableAddColumn", []RoundTripBenchTestCase{
@@ -30,6 +32,8 @@ func init() {
 	})
 }
 
+// BenchmarkAlterTableAddCheckConstraint is a benchmark for the ALTER TABLE ADD CONSTRAINT CHECK statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableAddCheckConstraint(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableAddCheckConstraint", []RoundTripBenchTestCase{
@@ -53,6 +57,8 @@ func init() {
 	})
 }
 
+// BenchmarkAlterTableAddForeignKey is a benchmark for the ALTER TABLE ADD CONSTRAINT FOREIGN KEY statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableAddForeignKey(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableAddForeignKey", []RoundTripBenchTestCase{
@@ -93,6 +99,8 @@ CREATE TABLE referenced(x INT, y INT, z INT, PRIMARY KEY(x,y,z));`,
 	})
 }
 
+// BenchmarkAlterTableDropColumn is a benchmark for the ALTER TABLE DROP COLUMN statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableDropColumn(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableDropColumn", []RoundTripBenchTestCase{
@@ -115,6 +123,8 @@ func init() {
 	})
 }
 
+// BenchmarkAlterTableDropConstraint is a benchmark for the ALTER TABLE DROP CONSTRAINT statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableDropConstraint(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableDropConstraint", []RoundTripBenchTestCase{
@@ -140,6 +150,8 @@ c INT, CONSTRAINT ck3 CHECK (c > 0))`,
 	})
 }
 
+// BenchmarkAlterTableSplit is a benchmark for the ALTER TABLE SPLIT AT statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableSplit(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableSplit", []RoundTripBenchTestCase{
@@ -161,6 +173,8 @@ func init() {
 	})
 }
 
+// BenchmarkAlterTableUnsplit is a benchmark for the ALTER TABLE UNSPLIT AT statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableUnsplit(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableUnsplit", []RoundTripBenchTestCase{
@@ -185,6 +199,8 @@ ALTER TABLE alter_table SPLIT AT VALUES (1), (2), (3)`,
 	})
 }
 
+// BenchmarkAlterTableConfigureZone is a benchmark for the ALTER TABLE CONFIGURE ZONE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableConfigureZone(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterTableConfigureZone", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/audit_bench_test.go
+++ b/pkg/bench/rttanalysis/audit_bench_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkAudit is a benchmark for audited table operations.
+// benchmark-ci: benchtime=20x
 func BenchmarkAudit(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("Audit", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/create_alter_role_bench_test.go
+++ b/pkg/bench/rttanalysis/create_alter_role_bench_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
+// BenchmarkCreateRole is a benchmark for the CREATE ROLE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkCreateRole(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("CreateRole", []RoundTripBenchTestCase{
@@ -39,6 +41,8 @@ func init() {
 	})
 }
 
+// BenchmarkAlterRole is a benchmark for the ALTER ROLE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterRole(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("AlterRole", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/drop_bench_test.go
+++ b/pkg/bench/rttanalysis/drop_bench_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkDropRole is a benchmark for the DROP ROLE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkDropRole(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("DropRole", []RoundTripBenchTestCase{
@@ -28,6 +30,8 @@ func init() {
 	})
 }
 
+// BenchmarkDropTable is a benchmark for the DROP TABLE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkDropTable(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("DropTable", []RoundTripBenchTestCase{
@@ -49,6 +53,8 @@ func init() {
 	})
 }
 
+// BenchmarkDropView is a benchmark for the DROP VIEW statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkDropView(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("DropView", []RoundTripBenchTestCase{
@@ -75,6 +81,8 @@ CREATE VIEW vx3 AS SELECT x FROM t;`,
 	})
 }
 
+// BenchmarkDropSequence is a benchmark for the DROP SEQUENCE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkDropSequence(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("DropSequence", []RoundTripBenchTestCase{
@@ -96,6 +104,8 @@ func init() {
 	})
 }
 
+// BenchmarkDropDatabase is a benchmark for the DROP DATABASE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkDropDatabase(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("DropDatabase", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/generate_objects_bench_test.go
+++ b/pkg/bench/rttanalysis/generate_objects_bench_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkGenerateObjects is a benchmark for the generate_test_objects function.
+// benchmark-ci: benchtime=20x
 func BenchmarkGenerateObjects(b *testing.B) { reg.Run(b) }
 func init() {
 	// Note: we have 1 db auto-generated every time because it's just too

--- a/pkg/bench/rttanalysis/grant_revoke_bench_test.go
+++ b/pkg/bench/rttanalysis/grant_revoke_bench_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkGrant is a benchmark for the GRANT statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkGrant(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("Grant", []RoundTripBenchTestCase{
@@ -37,6 +39,8 @@ CREATE TABLE t2();`,
 	})
 }
 
+// BenchmarkRevoke is a benchmark for the REVOKE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkRevoke(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("Revoke", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/grant_revoke_role_bench_test.go
+++ b/pkg/bench/rttanalysis/grant_revoke_role_bench_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
+// BenchmarkGrantRole is a benchmark for the GRANT <role> statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkGrantRole(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("GrantRole", []RoundTripBenchTestCase{
@@ -32,6 +34,8 @@ CREATE ROLE c;`,
 	})
 }
 
+// BenchmarkShowGrants is a benchmark for the SHOW GRANTS statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkShowGrants(b *testing.B) {
 	skip.UnderShort(b, "skipping long benchmark")
 	reg.Run(b)
@@ -105,6 +109,8 @@ DROP ROLE a,b,c,d,e;
 	})
 }
 
+// BenchmarkRevokeRole is a benchmark for the REVOKE <role> statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkRevokeRole(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("RevokeRole", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/jobs_test.go
+++ b/pkg/bench/rttanalysis/jobs_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
+// BenchmarkJobs is a benchmark for job-related statements and internal queries.
+// benchmark-ci: benchtime=20x
 func BenchmarkJobs(b *testing.B) { reg.Run(b) }
 func init() {
 	// Create a minimal table descriptor for the import job.

--- a/pkg/bench/rttanalysis/multi_region_bench_test.go
+++ b/pkg/bench/rttanalysis/multi_region_bench_test.go
@@ -105,6 +105,8 @@ USE test;`)
 	return b.String()
 }
 
+// BenchmarkAlterRegions is a benchmark for adding and dropping regions in a multi-region database.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterRegions(b *testing.B) { multiRegionReg.Run(b) }
 func init() {
 	multiRegionReg.Register("AlterRegions", []RoundTripBenchTestCase{
@@ -135,6 +137,8 @@ func init() {
 	})
 }
 
+// BenchmarkAlterPrimaryRegion is a benchmark for setting and altering the primary region of a multi-region database.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterPrimaryRegion(b *testing.B) { multiRegionReg.Run(b) }
 func init() {
 	multiRegionReg.Register("AlterPrimaryRegion", []RoundTripBenchTestCase{
@@ -178,6 +182,8 @@ CREATE TABLE test10 (p int);
 	})
 }
 
+// BenchmarkAlterSurvivalGoals is a benchmark for altering the survival goals of a multi-region database.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterSurvivalGoals(b *testing.B) { multiRegionReg.Run(b) }
 func init() {
 	multiRegionReg.Register("AlterSurvivalGoals", []RoundTripBenchTestCase{
@@ -209,6 +215,8 @@ ALTER DATABASE test SURVIVE REGION FAILURE`,
 	})
 }
 
+// BenchmarkAlterTableLocality is a benchmark for altering the locality of a table in a multi-region database.
+// benchmark-ci: benchtime=20x
 func BenchmarkAlterTableLocality(b *testing.B) { multiRegionReg.Run(b) }
 func init() {
 	multiRegionReg.Register("AlterTableLocality", []RoundTripBenchTestCase{
@@ -275,6 +283,8 @@ CREATE TABLE test (p int) WITH (schema_locked = false) LOCALITY REGIONAL BY ROW;
 	})
 }
 
+// BenchmarkMultiRegionVirtualTableQueries is a benchmark for virtual table queries in a multi-region setup.
+// benchmark-ci: benchtime=20x
 func BenchmarkMultiRegionVirtualTableQueries(b *testing.B) { multiRegionReg.Run(b) }
 func init() {
 	multiRegionReg.Register("MultiRegionVirtualTableQueries", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 )
 
+// BenchmarkORMQueries is a benchmark for various ORM-generated introspection queries.
+// benchmark-ci: benchtime=20x
 func BenchmarkORMQueries(b *testing.B) { reg.Run(b) }
 func init() {
 	liquibaseSetup, liquibaseReset := buildNDatabasesWithMTables(15, 40)
@@ -1154,9 +1156,13 @@ func buildNFunctions(n int) string {
 	return b.String()
 }
 
-func buildNTablesWithTriggers(n int) string {
-	b := strings.Builder{}
-	b.WriteString(`
+// buildNTablesWithTriggers returns a SetupEx slice for creating n tables
+// with triggers.
+func buildNTablesWithTriggers(n int) []string {
+	var stmts []string
+	stmts = append(stmts, "SET autocommit_before_ddl = false;")
+	stmts = append(stmts, "BEGIN;")
+	stmts = append(stmts, `
 CREATE OR REPLACE FUNCTION trigger_func()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -1166,16 +1172,27 @@ END;
 $$ LANGUAGE plpgsql;
 `)
 	for i := 0; i < n; i++ {
-		b.WriteString(fmt.Sprintf(`
+		stmts = append(stmts, fmt.Sprintf(`
 CREATE TABLE t%d (a INT, b INT);
+`, i))
+	}
+	stmts = append(stmts, "COMMIT;")
 
+	// Second Exec: SET first so session has unsafe_always, then BEGIN; COMMIT; so
+	// resetExtraTxnState runs and schemaChangerState is recreated with that mode,
+	// then BEGIN; CREATE TRIGGER... COMMIT; so triggers use the declarative schema changer.
+	stmts = append(stmts, "SET use_declarative_schema_changer = 'unsafe_always';")
+	stmts = append(stmts, "BEGIN;")
+	for i := 0; i < n; i++ {
+		stmts = append(stmts, fmt.Sprintf(`
 CREATE TRIGGER trigger_%d
 AFTER INSERT ON t%d
 FOR EACH ROW
 EXECUTE FUNCTION trigger_func();
-`, i, i, i))
+`, i, i))
 	}
-	return b.String()
+	stmts = append(stmts, "COMMIT;")
+	return stmts
 }
 
 func buildNTypes(n int) string {

--- a/pkg/bench/rttanalysis/system_bench_test.go
+++ b/pkg/bench/rttanalysis/system_bench_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
+// BenchmarkSystemDatabaseQueries is a benchmark for queries against system tables.
+// benchmark-ci: benchtime=20x
 func BenchmarkSystemDatabaseQueries(b *testing.B) {
 	skip.UnderShort(b, "skipping long benchmark")
 	reg.Run(b)

--- a/pkg/bench/rttanalysis/truncate_bench_test.go
+++ b/pkg/bench/rttanalysis/truncate_bench_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkTruncate is a benchmark for the TRUNCATE statement.
+// benchmark-ci: benchtime=20x
 func BenchmarkTruncate(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("Truncate", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/udf_resolution_test.go
+++ b/pkg/bench/rttanalysis/udf_resolution_test.go
@@ -7,6 +7,8 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkUDFResolution is a benchmark for user-defined function resolution.
+// benchmark-ci: benchtime=20x
 func BenchmarkUDFResolution(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("UDFResolution", []RoundTripBenchTestCase{

--- a/pkg/bench/rttanalysis/virtual_table_bench_test.go
+++ b/pkg/bench/rttanalysis/virtual_table_bench_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging"
 )
 
+// BenchmarkVirtualTableQueries is a benchmark for the crdb_internal virtual tables.
+// It is used to test the performance of the crdb_internal virtual tables used by
+// SHOW CREATE ALL ROUTINES, SHOW CREATE ALL TRIGGERS, and scheduled telemetry logging.
+// Limit the number of iterations to 20x to avoid timing out on CI.
+// benchmark-ci: benchtime=20x
 func BenchmarkVirtualTableQueries(b *testing.B) { reg.Run(b) }
 func init() {
 	reg.Register("VirtualTableQueries", []RoundTripBenchTestCase{
@@ -75,9 +80,9 @@ SELECT * FROM t2;`,
 		// This test checks the performance of the crdb_internal virtual tables used by
 		// SHOW CREATE ALL TRIGGERS.
 		{
-			Name:  "show_create_all_triggers",
-			Setup: buildNTablesWithTriggers(100),
-			Stmt:  `SHOW CREATE ALL TRIGGERS;`,
+			Name:    "show_create_all_triggers",
+			SetupEx: buildNTablesWithTriggers(100),
+			Stmt:    `SHOW CREATE ALL TRIGGERS;`,
 		},
 		// This test checks the performance of the query to capture index usage
 		// stats that is executed by scheduled telemetry logging.


### PR DESCRIPTION
Backport 1/1 commits from #165823 on behalf of @fqazi.

----

Previously, versions of BenchmarkVirtualTableQueries ran for nightly benchmark comparisons could fail because this test is fairly slow. To address this, this patch limits the number of iterations, and improves logic inside the create trigger test. The show_create_trigger test would previously create a 100 triggers serially, which would take a long time, versus a single transaction. With these changes the benchmark completes in ~700 seconds.

Fixes: #161766

Release note: None

----

Release justification: