### PR TITLE
roachtest/pg_regress: accept some more diffs

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/alter_generic.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/alter_generic.diffs
@@ -89,7 +89,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_generic.out
 +See: https://go.crdb.dev/issue-v/74775/_version_
  ALTER FUNCTION alt_func1(int) RENAME TO alt_func2;  -- failed (name conflict)
 -ERROR:  function alt_func2(integer) already exists in schema "alt_nsp1"
-+ERROR:  function alt_func2(INT8) already exists in schema "alt_nsp1"
++ERROR:  function alt_nsp1.alt_func2(INT8) already exists in schema "alt_nsp1"
  ALTER FUNCTION alt_func1(int) RENAME TO alt_func3;  -- OK
  ALTER FUNCTION alt_func2(int) OWNER TO regress_alter_generic_user2;  -- failed (no role membership)
 -ERROR:  must be able to SET ROLE "regress_alter_generic_user2"
@@ -165,7 +165,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_generic.out
  ALTER FUNCTION alt_func3(int) RENAME TO alt_func4;	-- failed (not owner)
 -ERROR:  must be owner of function alt_func3
  ALTER FUNCTION alt_func1(int) RENAME TO alt_func4;	-- OK
-+ERROR:  function alt_func4(INT8) already exists in schema "alt_nsp1"
++ERROR:  function alt_nsp1.alt_func4(INT8) already exists in schema "alt_nsp1"
  ALTER FUNCTION alt_func3(int) OWNER TO regress_alter_generic_user2;	-- failed (not owner)
 -ERROR:  must be owner of function alt_func3
 +ERROR:  unknown function: alt_func3()

--- a/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
@@ -299,7 +299,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (1 row)
  
  DROP TABLE _attmp_array;
-@@ -207,110 +308,153 @@
+@@ -207,106 +308,146 @@
  -- renaming to table's own array type's name is an interesting corner case
  CREATE TABLE attmp_array (id int);
  SELECT typname FROM pg_type WHERE oid = 'attmp_array[]'::regtype;
@@ -474,14 +474,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- renaming index should rename constraint as well
  ALTER TABLE onek ADD CONSTRAINT onek_unique1_constraint UNIQUE (unique1);
  ALTER INDEX onek_unique1_constraint RENAME TO onek_unique1_constraint_foo;
- ALTER TABLE onek DROP CONSTRAINT onek_unique1_constraint_foo;
-+ERROR:  unimplemented: cannot drop UNIQUE constraint "onek_unique1_constraint_foo" using ALTER TABLE DROP CONSTRAINT, use DROP INDEX CASCADE instead
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/42840/_version_
- -- renaming constraint
- ALTER TABLE onek ADD CONSTRAINT onek_check_constraint CHECK (unique1 >= 0);
- ALTER TABLE onek RENAME CONSTRAINT onek_check_constraint TO onek_check_constraint_foo;
-@@ -318,129 +462,127 @@
+@@ -318,129 +459,126 @@
  -- renaming constraint should rename index as well
  ALTER TABLE onek ADD CONSTRAINT onek_unique1_constraint UNIQUE (unique1);
  DROP INDEX onek_unique1_constraint;  -- to see whether it's there
@@ -494,8 +487,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP INDEX onek_unique1_constraint_foo;  -- to see whether it's there
 -ERROR:  cannot drop index onek_unique1_constraint_foo because constraint onek_unique1_constraint_foo on table onek requires it
 -HINT:  You can drop constraint onek_unique1_constraint_foo on table onek instead.
-+NOTICE:  the data for dropped indexes is reclaimed asynchronously
-+HINT:  The reclamation delay can be customized in the zone configuration for the table.
++ERROR:  index "onek_unique1_constraint_foo" does not exist
  ALTER TABLE onek DROP CONSTRAINT onek_unique1_constraint_foo;
 +ERROR:  constraint "onek_unique1_constraint_foo" of relation "onek" does not exist
  -- renaming constraints vs. inheritance
@@ -706,7 +698,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- renaming constraints with cache reset of target relation
  CREATE TABLE constraint_rename_cache (a int,
    CONSTRAINT chk_a CHECK (a > 0),
-@@ -452,15 +594,15 @@
+@@ -452,15 +590,15 @@
  CREATE TABLE like_constraint_rename_cache
    (LIKE constraint_rename_cache INCLUDING ALL);
  \d like_constraint_rename_cache
@@ -731,7 +723,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE constraint_rename_cache;
  DROP TABLE like_constraint_rename_cache;
  -- FOREIGN KEY CONSTRAINT adding TEST
-@@ -479,14 +621,12 @@
+@@ -479,14 +617,12 @@
  INSERT INTO attmp3 values (5,50);
  -- Try (and fail) to add constraint due to invalid source columns
  ALTER TABLE attmp3 add constraint attmpconstr foreign key(c) references attmp2 match full;
@@ -749,7 +741,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Delete failing row
  DELETE FROM attmp3 where a=5;
  -- Try (and succeed)
-@@ -495,20 +635,16 @@
+@@ -495,20 +631,16 @@
  INSERT INTO attmp3 values (5,50);
  -- Try NOT VALID and then VALIDATE CONSTRAINT, but fails. Delete failure then re-validate
  ALTER TABLE attmp3 add constraint attmpconstr foreign key (a) references attmp2 match full NOT VALID;
@@ -773,7 +765,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DELETE FROM attmp3 WHERE NOT b > 10;
  ALTER TABLE attmp3 VALIDATE CONSTRAINT b_greater_than_ten; -- succeeds
  ALTER TABLE attmp3 VALIDATE CONSTRAINT b_greater_than_ten; -- succeeds
-@@ -520,49 +656,77 @@
+@@ -520,49 +652,77 @@
  (1 row)
  
  CREATE TABLE attmp6 () INHERITS (attmp3);
@@ -860,7 +852,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE attmp5;
  DROP TABLE attmp4;
  DROP TABLE attmp3;
-@@ -570,85 +734,100 @@
+@@ -570,85 +730,100 @@
  -- NOT VALID with plan invalidation -- ensure we don't use a constraint for
  -- exclusion until validated
  set constraint_exclusion TO 'partition';
@@ -1023,7 +1015,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- we leave nv_parent and children around to help test pg_dump logic
  -- Foreign key adding test with mixed types
  -- Note: these tables are TEMP to avoid name conflicts when this test
-@@ -658,13 +837,11 @@
+@@ -658,13 +833,11 @@
  CREATE TEMP TABLE FKTABLE (ftest1 inet);
  -- This next should fail, because int=inet does not exist
  ALTER TABLE FKTABLE ADD FOREIGN KEY(ftest1) references pktable;
@@ -1039,7 +1031,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE FKTABLE;
  -- This should succeed, even though they are different types,
  -- because int=int8 exists and is a member of the integer opfamily
-@@ -673,7 +850,7 @@
+@@ -673,7 +846,7 @@
  -- Check it actually works
  INSERT INTO FKTABLE VALUES(42);		-- should succeed
  INSERT INTO FKTABLE VALUES(43);		-- should fail
@@ -1048,7 +1040,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DETAIL:  Key (ftest1)=(43) is not present in table "pktable".
  DROP TABLE FKTABLE;
  -- This should fail, because we'd have to cast numeric to int which is
-@@ -681,8 +858,7 @@
+@@ -681,8 +854,7 @@
  -- of the integer opfamily)
  CREATE TEMP TABLE FKTABLE (ftest1 numeric);
  ALTER TABLE FKTABLE ADD FOREIGN KEY(ftest1) references pktable;
@@ -1058,7 +1050,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE FKTABLE;
  DROP TABLE PKTABLE;
  -- On the other hand, this should work because int implicitly promotes to
-@@ -691,39 +867,48 @@
+@@ -691,39 +863,48 @@
  INSERT INTO PKTABLE VALUES(42);
  CREATE TEMP TABLE FKTABLE (ftest1 int);
  ALTER TABLE FKTABLE ADD FOREIGN KEY(ftest1) references pktable;
@@ -1117,7 +1109,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE FKTABLE;
  DROP TABLE PKTABLE;
  -- Test that ALTER CONSTRAINT updates trigger deferrability properly
-@@ -731,58 +916,91 @@
+@@ -731,58 +912,91 @@
  CREATE TEMP TABLE FKTABLE (ftest1 int);
  ALTER TABLE FKTABLE ADD CONSTRAINT fknd FOREIGN KEY(ftest1) REFERENCES pktable
    ON DELETE CASCADE ON UPDATE NO ACTION NOT DEFERRABLE;
@@ -1239,7 +1231,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  
  -- temp tables should go away by themselves, need not drop them.
  -- test check constraint adding
-@@ -791,8 +1009,7 @@
+@@ -791,8 +1005,7 @@
  alter table atacc1 add constraint atacc_test1 check (test>3);
  -- should fail
  insert into atacc1 (test) values (2);
@@ -1249,7 +1241,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- should succeed
  insert into atacc1 (test) values (4);
  drop table atacc1;
-@@ -801,8 +1018,7 @@
+@@ -801,8 +1014,7 @@
  -- insert a soon to be failing row
  insert into atacc1 (test) values (2);
  -- add a check constraint (fails)
@@ -1259,7 +1251,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  insert into atacc1 (test) values (4);
  drop table atacc1;
  -- let's do one where the check fails because the column doesn't exist
-@@ -810,7 +1026,6 @@
+@@ -810,7 +1022,6 @@
  -- add a check constraint (fails)
  alter table atacc1 add constraint atacc_test1 check (test1>3);
  ERROR:  column "test1" does not exist
@@ -1267,7 +1259,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- something a little more complicated
  create table atacc1 ( test int, test2 int, test3 int);
-@@ -818,8 +1033,7 @@
+@@ -818,8 +1029,7 @@
  alter table atacc1 add constraint atacc_test1 check (test+test2<test3*4);
  -- should fail
  insert into atacc1 (test,test2,test3) values (4,4,2);
@@ -1277,7 +1269,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- should succeed
  insert into atacc1 (test,test2,test3) values (4,4,5);
  drop table atacc1;
-@@ -828,37 +1042,58 @@
+@@ -828,37 +1038,58 @@
  alter table atacc1 add check (test2>test);
  -- should fail for $2
  insert into atacc1 (test2, test) values (3, 4);
@@ -1343,7 +1335,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select test2 from atacc2;
   test2 
  -------
-@@ -867,56 +1102,100 @@
+@@ -867,56 +1098,100 @@
  -- fail due to missing constraint
  alter table atacc2 add constraint foo check (test2>0);
  alter table atacc3 inherit atacc2;
@@ -1458,7 +1450,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- test unique constraint adding
  create table atacc1 ( test int ) ;
-@@ -932,8 +1211,11 @@
+@@ -932,8 +1207,11 @@
  insert into atacc1 (test) values (4);
  -- try to create duplicates via alter table using - should fail
  alter table atacc1 alter column test type integer using 0;
@@ -1472,7 +1464,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- let's do one where the unique constraint fails when added
  create table atacc1 ( test int );
-@@ -942,8 +1224,8 @@
+@@ -942,8 +1220,8 @@
  insert into atacc1 (test) values (2);
  -- add a unique constraint (fails)
  alter table atacc1 add constraint atacc_test1 unique (test);
@@ -1483,7 +1475,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  insert into atacc1 (test) values (3);
  drop table atacc1;
  -- let's do one where the unique constraint fails
-@@ -951,7 +1233,7 @@
+@@ -951,7 +1229,7 @@
  create table atacc1 ( test int );
  -- add a unique constraint (fails)
  alter table atacc1 add constraint atacc_test1 unique (test1);
@@ -1492,7 +1484,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- something a little more complicated
  create table atacc1 ( test int, test2 int);
-@@ -981,25 +1263,23 @@
+@@ -981,25 +1259,23 @@
  create table atacc1 ( id serial, test int) ;
  -- add a primary key constraint
  alter table atacc1 add constraint atacc_test1 primary key (test);
@@ -1521,7 +1513,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- let's do one where the primary key constraint fails when added
  create table atacc1 ( test int );
-@@ -1008,8 +1288,7 @@
+@@ -1008,8 +1284,7 @@
  insert into atacc1 (test) values (2);
  -- add a primary key (fails)
  alter table atacc1 add constraint atacc_test1 primary key (test);
@@ -1531,7 +1523,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  insert into atacc1 (test) values (3);
  drop table atacc1;
  -- let's do another one where the primary key constraint fails when added
-@@ -1018,7 +1297,7 @@
+@@ -1018,7 +1293,7 @@
  insert into atacc1 (test) values (NULL);
  -- add a primary key (fails)
  alter table atacc1 add constraint atacc_test1 primary key (test);
@@ -1540,7 +1532,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  insert into atacc1 (test) values (3);
  drop table atacc1;
  -- let's do one where the primary key constraint fails
-@@ -1026,7 +1305,7 @@
+@@ -1026,7 +1301,7 @@
  create table atacc1 ( test int );
  -- add a primary key constraint (fails)
  alter table atacc1 add constraint atacc_test1 primary key (test1);
@@ -1549,7 +1541,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- adding a new column as primary key to a non-empty table.
  -- should fail unless the column has a non-null default value.
-@@ -1034,9 +1313,10 @@
+@@ -1034,9 +1309,10 @@
  insert into atacc1 (test) values (0);
  -- add a primary key column without a default (fails).
  alter table atacc1 add column test2 int primary key;
@@ -1561,7 +1553,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- this combination used to have order-of-execution problems (bug #15580)
  create table atacc1 (a int);
-@@ -1044,6 +1324,7 @@
+@@ -1044,6 +1320,7 @@
  alter table atacc1
    add column b float8 not null default random(),
    add primary key(a);
@@ -1569,7 +1561,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc1;
  -- additionally, we've seen issues with foreign key validation not being
  -- properly delayed until after a table rewrite.  Check that works ok.
-@@ -1062,31 +1343,23 @@
+@@ -1062,31 +1339,23 @@
  create table atacc1 (a bigint, b int);
  insert into atacc1 values(1,2);
  alter table atacc1 add constraint atacc1_chk check(b = 1) not valid;
@@ -1604,7 +1596,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- should all succeed
  insert into atacc1 (test,test2) values (4,5);
  insert into atacc1 (test,test2) values (5,4);
-@@ -1100,15 +1373,14 @@
+@@ -1100,15 +1369,14 @@
  ERROR:  duplicate key value violates unique constraint "atacc1_pkey"
  DETAIL:  Key (test)=(3) already exists.
  insert into atacc1 (test2, test) values (1, NULL);
@@ -1623,7 +1615,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- try altering non-existent table, should fail
  alter table non_existent alter column bar set not null;
  ERROR:  relation "non_existent" does not exist
-@@ -1119,27 +1391,29 @@
+@@ -1119,27 +1387,29 @@
  create table atacc1 (test int not null);
  alter table atacc1 add constraint "atacc1_pkey" primary key (test);
  alter table atacc1 alter column test drop not null;
@@ -1661,7 +1653,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop view myview;
  drop table atacc1;
  -- set not null verified by constraints
-@@ -1147,13 +1421,11 @@
+@@ -1147,13 +1417,11 @@
  insert into atacc1 values (null, 1);
  -- constraint not cover all values, should fail
  alter table atacc1 add constraint atacc1_constr_or check(test_a is not null or test_b < 10);
@@ -1677,7 +1669,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  alter table atacc1 drop constraint atacc1_constr_invalid;
  -- with valid constraint
  update atacc1 set test_a = 1;
-@@ -1164,11 +1436,9 @@
+@@ -1164,11 +1432,9 @@
  alter table atacc1 alter test_a drop not null;
  -- test multiple set not null at same time
  -- test_a checked by atacc1_constr_a_valid, test_b should fail by table scan
@@ -1691,7 +1683,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- valid one by table scan, one by check constraints
  update atacc1 set test_b = 1;
  alter table atacc1 alter test_b set not null, alter test_a set not null;
-@@ -1179,36 +1449,41 @@
+@@ -1179,36 +1445,41 @@
  drop table atacc1;
  -- test inheritance
  create table parent (a int);
@@ -1747,7 +1739,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table parent;
  -- test setting and removing default values
  create table def_test (
-@@ -1234,11 +1509,12 @@
+@@ -1234,11 +1505,12 @@
  
  -- set defaults to an incorrect type: this should fail
  alter table def_test alter column c1 set default 'wrong_datatype';
@@ -1762,7 +1754,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- set defaults on views: we need to create a view, add a rule
  -- to allow insertions into it, and then alter the view to add
  -- a default
-@@ -1246,11 +1522,31 @@
+@@ -1246,11 +1518,31 @@
  create rule def_view_test_ins as
  	on insert to def_view_test
  	do instead insert into def_test select new.*;
@@ -1794,7 +1786,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select * from def_view_test;
   c1 |       c2        
  ----+-----------------
-@@ -1258,18 +1554,30 @@
+@@ -1258,18 +1550,30 @@
      | initial_default
      | 
   10 | new_default
@@ -1830,7 +1822,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- try altering non-existent table, should fail
  alter table nosuchtable drop column bar;
  ERROR:  relation "nosuchtable" does not exist
-@@ -1278,7 +1586,7 @@
+@@ -1278,7 +1582,7 @@
  insert into atacc1 values (1, 2, 3, 4);
  alter table atacc1 drop a;
  alter table atacc1 drop a;
@@ -1839,7 +1831,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- SELECTs
  select * from atacc1;
   b | c | d 
-@@ -1288,20 +1596,12 @@
+@@ -1288,20 +1592,12 @@
  
  select * from atacc1 order by a;
  ERROR:  column "a" does not exist
@@ -1860,7 +1852,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select atacc1.* from atacc1;
   b | c | d 
  ---+---+---
-@@ -1310,12 +1610,8 @@
+@@ -1310,12 +1606,8 @@
  
  select a from atacc1;
  ERROR:  column "a" does not exist
@@ -1874,7 +1866,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select b,c,d from atacc1;
   b | c | d 
  ---+---+---
-@@ -1324,111 +1620,74 @@
+@@ -1324,111 +1616,74 @@
  
  select a,b,c,d from atacc1;
  ERROR:  column "a" does not exist
@@ -2011,7 +2003,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- try creating a view and altering that, should fail
  create view myview as select * from atacc1;
  select * from myview;
-@@ -1437,71 +1696,98 @@
+@@ -1437,71 +1692,98 @@
  (0 rows)
  
  alter table myview drop d;
@@ -2138,7 +2130,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table atacc2;
  create index "testing_idx" on atacc1(a);
  ERROR:  column "a" does not exist
-@@ -1510,6 +1796,7 @@
+@@ -1510,6 +1792,7 @@
  -- test create as and select into
  insert into atacc1 values (21, 22, 23);
  create table attest1 as select * from atacc1;
@@ -2146,7 +2138,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select * from attest1;
   b  | c  | d  
  ----+----+----
-@@ -1518,13 +1805,14 @@
+@@ -1518,13 +1801,14 @@
  
  drop table attest1;
  select * into attest2 from atacc1;
@@ -2166,7 +2158,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- try dropping all columns
  alter table atacc1 drop c;
  alter table atacc1 drop d;
-@@ -1536,74 +1824,85 @@
+@@ -1536,74 +1820,85 @@
  drop table atacc1;
  -- test constraint error reporting in presence of dropped columns
  create table atacc1 (id serial primary key, value int check (value < 10));
@@ -2291,7 +2283,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- test copy in/out
  create table attest (a int4, b int4, c int4);
  insert into attest values (1,2,3);
-@@ -1611,12 +1910,11 @@
+@@ -1611,12 +1906,11 @@
  copy attest to stdout;
  2	3
  copy attest(a) to stdout;
@@ -2307,7 +2299,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select * from attest;
   b | c 
  ---+---
-@@ -1632,9 +1930,9 @@
+@@ -1632,9 +1926,9 @@
  (2 rows)
  
  copy attest(a) from stdin;
@@ -2319,7 +2311,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  copy attest(b,c) from stdin;
  select * from attest;
   b  | c  
-@@ -1648,124 +1946,162 @@
+@@ -1648,124 +1942,162 @@
  -- test inheritance
  create table dropColumn (a int, b int, e int);
  create table dropColumnChild (c int) inherits (dropColumn);
@@ -2524,7 +2516,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  
  -- should work
  alter table only p1 drop column name;
-@@ -1773,188 +2109,175 @@
+@@ -1773,188 +2105,175 @@
  alter table p2 drop column name;
  -- should be rejected since its inherited
  alter table gc1 drop column name;
@@ -2785,7 +2777,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  alter table anothertab drop constraint anothertab_chk;
  alter table anothertab drop constraint anothertab_chk; -- fails
  ERROR:  constraint "anothertab_chk" of relation "anothertab" does not exist
-@@ -1963,12 +2286,9 @@
+@@ -1963,12 +2282,9 @@
  alter table anothertab alter column atcol1 type boolean
          using case when atcol1 % 2 = 0 then true else false end;
  select * from anothertab;
@@ -2801,7 +2793,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  
  drop table anothertab;
  -- Test index handling in alter table column type (cf. bugs #15835, #15865)
-@@ -1976,33 +2296,45 @@
+@@ -1976,33 +2292,45 @@
                          f3 int, f4 int, f5 int);
  alter table anothertab
    add exclude using btree (f3 with =);
@@ -2865,7 +2857,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  alter table anothertab alter column f1 type bigint;
  alter table anothertab
    alter column f2 type bigint,
-@@ -2010,24 +2342,15 @@
+@@ -2010,24 +2338,15 @@
    alter column f4 type bigint;
  alter table anothertab alter column f5 type bigint;
  \d anothertab
@@ -2899,7 +2891,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop table anothertab;
  -- test that USING expressions are parsed before column alter type / drop steps
  create table another (f1 int, f2 text, f3 text);
-@@ -2046,12 +2369,15 @@
+@@ -2046,12 +2365,15 @@
    alter f1 type text using f2 || ' and ' || f3 || ' more',
    alter f2 type bigint using f1 * 10,
    drop column f3;
@@ -2920,7 +2912,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (3 rows)
  
  drop table another;
-@@ -2059,107 +2385,166 @@
+@@ -2059,107 +2381,166 @@
  -- rewriting the index.
  begin;
  create table skip_wal_skip_rewrite_index (c varchar(10) primary key);
@@ -3136,7 +3128,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  select relname,
    c.oid = oldoid as orig_oid,
    case relfilenode
-@@ -2172,27 +2557,19 @@
+@@ -2172,27 +2553,19 @@
    from pg_class c left join old_oids using (relname)
    where relname like 'at_partitioned%'
    order by relname;
@@ -3171,7 +3163,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Note: these tests currently show the wrong behavior for comments :-(
  select relname,
    c.oid = oldoid as orig_oid,
-@@ -2206,280 +2583,331 @@
+@@ -2206,280 +2579,331 @@
    from pg_class c left join old_oids using (relname)
    where relname like 'at_partitioned%'
    order by relname;
@@ -3673,7 +3665,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE check_fk_presence_1, check_fk_presence_2;
  -- check column addition within a view (bug #14876)
  create table at_base_table(id int, stuff text);
-@@ -2487,80 +2915,68 @@
+@@ -2487,80 +2911,68 @@
  create view at_view_1 as select * from at_base_table bt;
  create view at_view_2 as select *, to_json(v1) as j from at_view_1 v1;
  \d+ at_view_1
@@ -3806,7 +3798,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (1 row)
  
  drop view at_view_2;
-@@ -2569,32 +2985,54 @@
+@@ -2569,32 +2981,54 @@
  -- related case (bug #17811)
  begin;
  create temp table t1 as select * from int8_tbl;
@@ -3868,7 +3860,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check adding a column not itself requiring a rewrite, together with
  -- a column requiring a default (bug #16038)
  -- ensure that rewrites aren't silently optimized away, removing the
-@@ -2612,6 +3050,18 @@
+@@ -2612,6 +3046,18 @@
      RETURN v_relfilenode <> (SELECT relfilenode FROM pg_class WHERE oid = p_tablename);
  END;
  $$;
@@ -3887,7 +3879,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  CREATE TABLE rewrite_test(col text);
  INSERT INTO rewrite_test VALUES ('something');
  INSERT INTO rewrite_test VALUES (NULL);
-@@ -2621,42 +3071,26 @@
+@@ -2621,42 +3067,26 @@
        ADD COLUMN empty1 text,
        ADD COLUMN notempty1_rewrite serial;
  $$);
@@ -3934,7 +3926,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- then with rewrite
  SELECT check_ddl_rewrite('rewrite_test', $$
      ALTER TABLE rewrite_test
-@@ -2664,24 +3098,17 @@
+@@ -2664,24 +3094,17 @@
          ADD COLUMN notempty5_norewrite int default 42,
          ADD COLUMN notempty5_rewrite serial;
  $$);
@@ -3962,7 +3954,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE rewrite_test;
  --
  -- lock levels
-@@ -2700,7 +3127,7 @@
+@@ -2700,7 +3123,7 @@
  ,'AccessExclusiveLock'
  );
  drop view my_locks;
@@ -3971,7 +3963,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create or replace view my_locks as
  select case when c.relname like 'pg_toast%' then 'pg_toast' else c.relname end, max(mode::lockmodes) as max_lockmode
  from pg_locks l join pg_class c on l.relation = c.oid
-@@ -2712,158 +3139,135 @@
+@@ -2712,158 +3135,135 @@
  and relnamespace != (select oid from pg_namespace where nspname = 'pg_catalog')
  and c.relname != 'my_locks'
  group by c.relname;
@@ -4199,7 +4191,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create or replace view my_locks as
  select case when c.relname like 'pg_toast%' then 'pg_toast' else c.relname end, max(mode::lockmodes) as max_lockmode
  from pg_locks l join pg_class c on l.relation = c.oid
-@@ -2875,40 +3279,58 @@
+@@ -2875,40 +3275,58 @@
  and relnamespace != (select oid from pg_namespace where nspname = 'pg_catalog')
  and c.relname = 'my_locks'
  group by c.relname;
@@ -4218,10 +4210,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  alter table my_locks reset (autovacuum_enabled);
 +ERROR:  relation "my_locks" does not exist
  alter view my_locks reset (autovacuum_enabled);
-+ERROR:  at or near "reset": syntax error
++ERROR:  at or near "autovacuum_enabled": syntax error
 +DETAIL:  source SQL:
 +alter view my_locks reset (autovacuum_enabled)
-+                    ^
++                           ^
 +HINT:  try \h ALTER VIEW
  begin;
  alter view my_locks set (security_barrier=off);
@@ -4238,10 +4230,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 -
 +ERROR:  current transaction is aborted, commands ignored until end of transaction block
  alter view my_locks reset (security_barrier);
-+ERROR:  at or near "reset": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +alter view my_locks reset (security_barrier)
-+                    ^
++                           ^
 +HINT:  try \h ALTER VIEW
  rollback;
  -- this test intentionally applies the ALTER TABLE command against a view, but
@@ -4270,7 +4262,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop type lockmodes;
  --
  -- alter function
-@@ -2950,60 +3372,178 @@
+@@ -2950,60 +3368,178 @@
  --
  create schema alter1;
  create schema alter2;
@@ -4457,13 +4449,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 -  3 | 13
 -  4 | 14
 -(4 rows)
-+ 10 | 11
-+ 11 | 12
++  7 | 11
++  8 | 12
 +(2 rows)
  
  select alter2.plus1(41);
   plus1 
-@@ -3013,225 +3553,391 @@
+@@ -3013,225 +3549,391 @@
  
  -- clean up
  drop schema alter2 cascade;
@@ -5013,7 +5005,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE test_tblx;
  DROP TYPE test_typex;
  -- This test isn't that interesting on its own, but the purpose is to leave
-@@ -3239,7 +3945,14 @@
+@@ -3239,7 +3941,14 @@
  -- column in it, and the composite type has a dropped attribute.
  CREATE TYPE test_type3 AS (a int);
  CREATE TABLE test_tbl3 (c) AS SELECT '(1)'::test_type3;
@@ -5028,7 +5020,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  CREATE TYPE test_type_empty AS ();
  DROP TYPE test_type_empty;
  --
-@@ -3247,6 +3960,12 @@
+@@ -3247,6 +3956,12 @@
  --
  CREATE TYPE tt_t0 AS (z inet, x int, y numeric(8,2));
  ALTER TYPE tt_t0 DROP ATTRIBUTE z;
@@ -5041,7 +5033,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  CREATE TABLE tt0 (x int NOT NULL, y numeric(8,2));	-- OK
  CREATE TABLE tt1 (x int, y bigint);					-- wrong base type
  CREATE TABLE tt2 (x int, y numeric(9,2));			-- wrong typmod
-@@ -3254,76 +3973,128 @@
+@@ -3254,76 +3969,128 @@
  CREATE TABLE tt4 (x int);							-- too few columns
  CREATE TABLE tt5 (x int, y numeric(8,2), z int);	-- too few columns
  CREATE TABLE tt6 () INHERITS (tt0);					-- can't have a parent
@@ -5201,7 +5193,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE alter2.tt8;
  DROP SCHEMA alter2;
  --
-@@ -3334,32 +4105,28 @@
+@@ -3334,32 +4101,28 @@
  ALTER TABLE tt9 ADD CHECK(c > 2);  -- picks nonconflicting name
  ALTER TABLE tt9 ADD CONSTRAINT foo CHECK(c > 3);
  ALTER TABLE tt9 ADD CONSTRAINT foo CHECK(c > 4);  -- fail, dup name
@@ -5248,7 +5240,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE tt9;
  -- Check that comments on constraints and indexes are not lost at ALTER TABLE.
  CREATE TABLE comment_test (
-@@ -3371,6 +4138,7 @@
+@@ -3371,6 +4134,7 @@
  COMMENT ON COLUMN comment_test.id IS 'Column ''id'' on comment_test';
  COMMENT ON INDEX comment_test_index IS 'Simple index on comment_test';
  COMMENT ON CONSTRAINT comment_test_positive_col_check ON comment_test IS 'CHECK constraint on comment_test.positive_col';
@@ -5256,7 +5248,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  COMMENT ON CONSTRAINT comment_test_pk ON comment_test IS 'PRIMARY KEY constraint of comment_test';
  COMMENT ON INDEX comment_test_pk IS 'Index backing the PRIMARY KEY of comment_test';
  SELECT col_description('comment_test'::regclass, 1) as comment;
-@@ -3387,10 +4155,10 @@
+@@ -3387,10 +4151,10 @@
  (2 rows)
  
  SELECT conname as constraint, obj_description(oid, 'pg_constraint') as comment FROM pg_constraint where conrelid = 'comment_test'::regclass ORDER BY 1, 2;
@@ -5271,7 +5263,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (2 rows)
  
  -- Change the datatype of all the columns. ALTER TABLE is optimized to not
-@@ -3399,8 +4167,18 @@
+@@ -3399,8 +4163,18 @@
  -- first, to test that no-op codepath, and another one that does.
  ALTER TABLE comment_test ALTER COLUMN indexed_col SET DATA TYPE int;
  ALTER TABLE comment_test ALTER COLUMN indexed_col SET DATA TYPE text;
@@ -5290,7 +5282,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  ALTER TABLE comment_test ALTER COLUMN positive_col SET DATA TYPE int;
  ALTER TABLE comment_test ALTER COLUMN positive_col SET DATA TYPE bigint;
  -- Check that the comments are intact.
-@@ -3418,10 +4196,10 @@
+@@ -3418,10 +4192,10 @@
  (2 rows)
  
  SELECT conname as constraint, obj_description(oid, 'pg_constraint') as comment FROM pg_constraint where conrelid = 'comment_test'::regclass ORDER BY 1, 2;
@@ -5305,7 +5297,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (2 rows)
  
  -- Check compatibility for foreign keys and comments. This is done
-@@ -3429,34 +4207,35 @@
+@@ -3429,34 +4203,35 @@
  -- to an error and would reduce the test scope.
  CREATE TABLE comment_test_child (
    id text CONSTRAINT comment_test_child_fk REFERENCES comment_test);
@@ -5358,7 +5350,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Check that we map relation oids to filenodes and back correctly.  Only
  -- display bad mappings so the test output doesn't change all the time.  A
  -- filenode function call can return NULL for a relation dropped concurrently
-@@ -3468,31 +4247,28 @@
+@@ -3468,31 +4243,28 @@
  FROM pg_class,
      pg_filenode_relation(reltablespace, pg_relation_filenode(oid)) AS mapped_oid
  WHERE relkind IN ('r', 'i', 'S', 't', 'm') AND mapped_oid IS DISTINCT FROM oid;
@@ -5398,7 +5390,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  ALTER TABLE new_system_table RENAME TO old_system_table;
  CREATE INDEX old_system_table__othercol ON old_system_table (othercol);
  INSERT INTO old_system_table(othercol) VALUES ('somedata'), ('otherdata');
-@@ -3500,10 +4276,16 @@
+@@ -3500,10 +4272,16 @@
  DELETE FROM old_system_table WHERE othercol = 'somedata';
  TRUNCATE old_system_table;
  ALTER TABLE old_system_table DROP CONSTRAINT new_system_table_pkey;
@@ -5415,7 +5407,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check relpersistence of an unlogged table
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^unlogged1'
  UNION ALL
-@@ -3511,21 +4293,24 @@
+@@ -3511,21 +4289,24 @@
  UNION ALL
  SELECT r.relname || ' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^unlogged1'
  ORDER BY relname;
@@ -5449,7 +5441,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check relpersistence of an unlogged table after changing to permanent
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^unlogged1'
  UNION ALL
-@@ -3533,21 +4318,20 @@
+@@ -3533,21 +4314,20 @@
  UNION ALL
  SELECT r.relname || ' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^unlogged1'
  ORDER BY relname;
@@ -5478,7 +5470,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check relpersistence of a permanent table
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^logged1'
  UNION ALL
-@@ -3555,22 +4339,24 @@
+@@ -3555,22 +4335,24 @@
  UNION ALL
  SELECT r.relname ||' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^logged1'
  ORDER BY relname;
@@ -5512,7 +5504,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check relpersistence of a permanent table after changing to unlogged
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^logged1'
  UNION ALL
-@@ -3578,36 +4364,41 @@
+@@ -3578,36 +4360,41 @@
  UNION ALL
  SELECT r.relname || ' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^logged1'
  ORDER BY relname;
@@ -5573,7 +5565,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  ALTER TABLE test_add_column
  	ADD COLUMN c2 integer; -- fail because c2 already exists
  ERROR:  column "c2" of relation "test_add_column" already exists
-@@ -3615,159 +4406,132 @@
+@@ -3615,159 +4402,132 @@
  	ADD COLUMN c2 integer; -- fail because c2 already exists
  ERROR:  column "c2" of relation "test_add_column" already exists
  \d test_add_column
@@ -5825,7 +5817,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- assorted cases with multiple ALTER TABLE steps
  CREATE TABLE ataddindex(f1 INT);
  INSERT INTO ataddindex VALUES (42), (43);
-@@ -3775,100 +4539,134 @@
+@@ -3775,100 +4535,134 @@
  ALTER TABLE ataddindex
    ADD PRIMARY KEY USING INDEX ataddindexi0,
    ALTER f1 TYPE BIGINT;
@@ -6010,7 +6002,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  --
  -- ATTACH PARTITION
  --
-@@ -3878,7 +4676,11 @@
+@@ -3878,7 +4672,11 @@
  );
  CREATE TABLE fail_part (like unparted);
  ALTER TABLE unparted ATTACH PARTITION fail_part FOR VALUES IN ('a');
@@ -6023,7 +6015,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE unparted, fail_part;
  -- check that partition bound is compatible
  CREATE TABLE list_parted (
-@@ -3886,62 +4688,146 @@
+@@ -3886,62 +4684,146 @@
  	b char(2) COLLATE "C",
  	CONSTRAINT check_a CHECK (a > 0)
  ) PARTITION BY LIST (a);
@@ -6184,7 +6176,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE fail_part;
  -- check that columns match in type, collation and NOT NULL status
  CREATE TABLE fail_part (
-@@ -3949,158 +4835,335 @@
+@@ -3949,158 +4831,335 @@
  	a int NOT NULL
  );
  ALTER TABLE list_parted ATTACH PARTITION fail_part FOR VALUES IN (1);
@@ -6549,7 +6541,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Check the case where attnos of the partitioning columns in the table being
  -- attached differs from the parent.  It should not affect the constraint-
  -- checking logic that allows to skip the scan.
-@@ -4109,8 +5172,15 @@
+@@ -4109,8 +5168,15 @@
  	LIKE list_parted2,
  	CONSTRAINT check_a CHECK (a IS NOT NULL AND a = 6)
  );
@@ -6565,7 +6557,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Similar to above, but the table being attached is a partitioned table
  -- whose partition has still different attnos for the root partitioning
  -- columns.
-@@ -4118,6 +5188,14 @@
+@@ -4118,6 +5184,14 @@
  	LIKE list_parted2,
  	CONSTRAINT check_a CHECK (a IS NOT NULL AND a = 7)
  ) PARTITION BY LIST (b);
@@ -6580,7 +6572,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  CREATE TABLE part_7_a_null (
  	c int,
  	d int,
-@@ -4126,63 +5204,150 @@
+@@ -4126,63 +5200,150 @@
  	CONSTRAINT check_b CHECK (b IS NULL OR b = 'a'),
  	CONSTRAINT check_a CHECK (a IS NOT NULL AND a = 7)
  );
@@ -6744,7 +6736,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check validation when attaching hash partitions
  -- Use hand-rolled hash functions and operator class to get predictable result
  -- on different machines. part_test_int4_ops is defined in insert.sql.
-@@ -4191,233 +5356,430 @@
+@@ -4191,233 +5352,430 @@
  	a int,
  	b int
  ) PARTITION BY HASH (a part_test_int4_ops);
@@ -7259,7 +7251,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- attnum for key attribute 'a' is different in p, p1, and p11
  select attrelid::regclass, attname, attnum
  from pg_attribute
-@@ -4426,73 +5788,156 @@
+@@ -4426,73 +5784,156 @@
     or attrelid = 'p1'::regclass
     or attrelid = 'p11'::regclass)
  order by attrelid::regclass::text;
@@ -7428,7 +7420,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create or replace function func_part_attach() returns trigger
    language plpgsql as $$
    begin
-@@ -4500,14 +5945,28 @@
+@@ -4500,14 +5941,28 @@
      execute 'alter table tab_part_attach attach partition tab_part_attach_1 for values in (1)';
      return null;
    end $$;
@@ -7460,7 +7452,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- test case where the partitioning operator is a SQL function whose
  -- evaluation results in the table's relcache being rebuilt partway through
  -- the execution of an ATTACH PARTITION command
-@@ -4517,11 +5976,43 @@
+@@ -4517,11 +5972,43 @@
      operator 1 < (int4, int4), operator 2 <= (int4, int4),
      operator 3 = (int4, int4), operator 4 >= (int4, int4),
      operator 5 > (int4, int4), function 1 at_test_sql_partop(int4, int4);
@@ -7504,7 +7496,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop function at_test_sql_partop;
  /* Test case for bug #16242 */
  -- We create a parent and child where the child has missing
-@@ -4529,18 +6020,25 @@
+@@ -4529,18 +6016,25 @@
  -- tuple conversion from the child to the parent tupdesc
  create table bar1 (a integer, b integer not null default 1)
    partition by range (a);
@@ -7535,7 +7527,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- this exercises tuple conversion:
  create function xtrig()
    returns trigger language plpgsql
-@@ -4554,22 +6052,50 @@
+@@ -4554,22 +6048,50 @@
      return NULL;
    end;
  $$;
@@ -7587,7 +7579,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create table atref (c1 int references attbl(p1));
  alter table attbl alter column p1 set data type bigint;
  alter table atref alter column c1 set data type bigint;
-@@ -4579,15 +6105,21 @@
+@@ -4579,15 +6101,21 @@
  -- for normal indexes and indexes on constraints.
  create table alttype_cluster (a int);
  alter table alttype_cluster add primary key (a);
@@ -7610,7 +7602,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
   alttype_cluster_pkey | f
  (2 rows)
  
-@@ -4597,19 +6129,24 @@
+@@ -4597,19 +6125,24 @@
    order by indexrelid::regclass::text;
        indexrelid      | indisclustered 
  ----------------------+----------------
@@ -7637,7 +7629,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (2 rows)
  
  alter table alttype_cluster alter a type int;
-@@ -4619,7 +6156,7 @@
+@@ -4619,7 +6152,7 @@
        indexrelid      | indisclustered 
  ----------------------+----------------
   alttype_cluster_ind  | f
@@ -7646,7 +7638,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (2 rows)
  
  drop table alttype_cluster;
-@@ -4628,38 +6165,97 @@
+@@ -4628,38 +6161,97 @@
  -- to its partitions' constraint being updated to reflect the parent's
  -- newly added/removed constraint
  create table target_parted (a int, b int) partition by list (a);

--- a/pkg/cmd/roachtest/testdata/pg_regress/int8.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/int8.diffs
@@ -181,220 +181,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  (5 rows)
  
  SELECT q2, abs(q2) FROM INT8_TBL;
-@@ -478,178 +448,59 @@
- --
- SELECT to_char(q1, '9G999G999G999G999G999'), to_char(q2, '9,999,999,999,999,999')
- 	FROM INT8_TBL;
--        to_char         |        to_char         
--------------------------+------------------------
--                    123 |                    456
--                    123 |  4,567,890,123,456,789
--  4,567,890,123,456,789 |                    123
--  4,567,890,123,456,789 |  4,567,890,123,456,789
--  4,567,890,123,456,789 | -4,567,890,123,456,789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q1, '9G999G999G999G999G999D999G999'), to_char(q2, '9,999,999,999,999,999.999,999')
- 	FROM INT8_TBL;
--            to_char             |            to_char             
----------------------------------+--------------------------------
--                    123.000,000 |                    456.000,000
--                    123.000,000 |  4,567,890,123,456,789.000,000
--  4,567,890,123,456,789.000,000 |                    123.000,000
--  4,567,890,123,456,789.000,000 |  4,567,890,123,456,789.000,000
--  4,567,890,123,456,789.000,000 | -4,567,890,123,456,789.000,000
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char( (q1 * -1), '9999999999999999PR'), to_char( (q2 * -1), '9999999999999999.999PR')
- 	FROM INT8_TBL;
--      to_char       |        to_char         
----------------------+------------------------
--              <123> |              <456.000>
--              <123> | <4567890123456789.000>
-- <4567890123456789> |              <123.000>
-- <4567890123456789> | <4567890123456789.000>
-- <4567890123456789> |  4567890123456789.000 
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char( (q1 * -1), '9999999999999999S'), to_char( (q2 * -1), 'S9999999999999999')
- 	FROM INT8_TBL;
--      to_char      |      to_char      
---------------------+-------------------
--              123- |              -456
--              123- | -4567890123456789
-- 4567890123456789- |              -123
-- 4567890123456789- | -4567890123456789
-- 4567890123456789- | +4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'MI9999999999999999')     FROM INT8_TBL;
--      to_char      
---------------------
--               456
--  4567890123456789
--               123
--  4567890123456789
-- -4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'FMS9999999999999999')    FROM INT8_TBL;
--      to_char      
---------------------
-- +456
-- +4567890123456789
-- +123
-- +4567890123456789
-- -4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'FM9999999999999999THPR') FROM INT8_TBL;
--      to_char       
----------------------
-- 456TH
-- 4567890123456789TH
-- 123RD
-- 4567890123456789TH
-- <4567890123456789>
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'SG9999999999999999th')   FROM INT8_TBL;
--       to_char       
-----------------------
-- +             456th
-- +4567890123456789th
-- +             123rd
-- +4567890123456789th
-- -4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, '0999999999999999')       FROM INT8_TBL;
--      to_char      
---------------------
--  0000000000000456
--  4567890123456789
--  0000000000000123
--  4567890123456789
-- -4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'S0999999999999999')      FROM INT8_TBL;
--      to_char      
---------------------
-- +0000000000000456
-- +4567890123456789
-- +0000000000000123
-- +4567890123456789
-- -4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'FM0999999999999999')     FROM INT8_TBL;
--      to_char      
---------------------
-- 0000000000000456
-- 4567890123456789
-- 0000000000000123
-- 4567890123456789
-- -4567890123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'FM9999999999999999.000') FROM INT8_TBL;
--        to_char        
-------------------------
-- 456.000
-- 4567890123456789.000
-- 123.000
-- 4567890123456789.000
-- -4567890123456789.000
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+@@ -603,11 +573,11 @@
  SELECT to_char(q2, 'L9999999999999999.000')  FROM INT8_TBL;
--        to_char         
--------------------------
+         to_char         
+ ------------------------
 -                456.000
 -   4567890123456789.000
 -                123.000
 -   4567890123456789.000
 -  -4567890123456789.000
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ $              456.000
++ $ 4567890123456789.000
++ $              123.000
++ $ 4567890123456789.000
++ $-4567890123456789.000
+ (5 rows)
+ 
  SELECT to_char(q2, 'FM9999999999999999.999') FROM INT8_TBL;
--      to_char       
----------------------
-- 456.
-- 4567890123456789.
-- 123.
-- 4567890123456789.
-- -4567890123456789.
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, 'S 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 . 9 9 9') FROM INT8_TBL;
--                  to_char                  
---------------------------------------------
--                            +4 5 6 . 0 0 0
--  +4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 . 0 0 0
--                            +1 2 3 . 0 0 0
--  +4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 . 0 0 0
--  -4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 . 0 0 0
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, E'99999 "text" 9999 "9999" 999 "\\"text between quote marks\\"" 9999') FROM INT8_TBL;
--                          to_char                          
-------------------------------------------------------------
--       text      9999     "text between quote marks"   456
--  45678 text 9012 9999 345 "text between quote marks" 6789
--       text      9999     "text between quote marks"   123
--  45678 text 9012 9999 345 "text between quote marks" 6789
-- -45678 text 9012 9999 345 "text between quote marks" 6789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(q2, '999999SG9999999999')     FROM INT8_TBL;
--      to_char      
---------------------
--       +       456
-- 456789+0123456789
--       +       123
-- 456789+0123456789
-- 456789-0123456789
--(5 rows)
--
-+ERROR:  unknown signature: to_char(int, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- -- check min/max values and overflow behavior
- select '-9223372036854775808'::int8;
-          int8         
-@@ -658,9 +509,7 @@
+@@ -658,9 +628,7 @@
  (1 row)
  
  select '-9223372036854775809'::int8;
@@ -405,7 +209,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  select '9223372036854775807'::int8;
          int8         
  ---------------------
-@@ -668,9 +517,7 @@
+@@ -668,9 +636,7 @@
  (1 row)
  
  select '9223372036854775808'::int8;
@@ -416,7 +220,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  select -('-9223372036854775807'::int8);
        ?column?       
  ---------------------
-@@ -678,49 +525,49 @@
+@@ -678,49 +644,49 @@
  (1 row)
  
  select -('-9223372036854775808'::int8);
@@ -485,7 +289,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  select '100'::int2 / '0'::int8;
  ERROR:  division by zero
  SELECT CAST(q1 AS int4) FROM int8_tbl WHERE q2 = 456;
-@@ -730,7 +577,7 @@
+@@ -730,7 +696,7 @@
  (1 row)
  
  SELECT CAST(q1 AS int4) FROM int8_tbl WHERE q2 <> 456;
@@ -494,7 +298,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT CAST(q1 AS int2) FROM int8_tbl WHERE q2 = 456;
   q1  
  -----
-@@ -738,7 +585,7 @@
+@@ -738,7 +704,7 @@
  (1 row)
  
  SELECT CAST(q1 AS int2) FROM int8_tbl WHERE q2 <> 456;
@@ -503,7 +307,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT CAST('42'::int2 AS int8), CAST('-37'::int2 AS int8);
   int8 | int8 
  ------+------
-@@ -758,17 +605,17 @@
+@@ -758,17 +724,17 @@
  SELECT CAST('36854775807.0'::float4 AS int8);
      int8     
  -------------
@@ -523,11 +327,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
 - 1259
 +    oid     
 +------------
-+ 4294967079
++ 4294967077
  (1 row)
  
  -- bit operations
-@@ -810,7 +657,7 @@
+@@ -810,7 +776,7 @@
  (11 rows)
  
  SELECT * FROM generate_series('+4567890123456789'::int8, '+4567890123456799'::int8, 0);
@@ -536,7 +340,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT * FROM generate_series('+4567890123456789'::int8, '+4567890123456799'::int8, 2);
   generate_series  
  ------------------
-@@ -837,9 +684,13 @@
+@@ -837,9 +803,13 @@
  
  -- check sane handling of INT64_MIN overflow cases
  SELECT (-9223372036854775808)::int8 * (-1)::int8;
@@ -552,7 +356,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT (-9223372036854775808)::int8 % (-1)::int8;
   ?column? 
  ----------
-@@ -847,9 +698,13 @@
+@@ -847,9 +817,13 @@
  (1 row)
  
  SELECT (-9223372036854775808)::int8 * (-1)::int4;
@@ -568,7 +372,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT (-9223372036854775808)::int8 % (-1)::int4;
   ?column? 
  ----------
-@@ -857,9 +712,13 @@
+@@ -857,9 +831,13 @@
  (1 row)
  
  SELECT (-9223372036854775808)::int8 * (-1)::int2;
@@ -584,7 +388,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT (-9223372036854775808)::int8 % (-1)::int2;
   ?column? 
  ----------
-@@ -915,21 +774,11 @@
+@@ -915,21 +893,11 @@
               ((-9223372036854775808)::int8, 1::int8),
               ((-9223372036854775808)::int8, 9223372036854775807::int8),
               ((-9223372036854775808)::int8, 4611686018427387904::int8)) AS v(a, b);
@@ -609,7 +413,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  -- test lcm()
  SELECT a, b, lcm(a, b), lcm(a, -b), lcm(b, a), lcm(-b, a)
  FROM (VALUES (0::int8, 0::int8),
-@@ -938,20 +787,11 @@
+@@ -938,20 +906,11 @@
               (288484263558::int8, 29893644334::int8),
               (-288484263558::int8, 29893644334::int8),
               ((-9223372036854775808)::int8, 0::int8)) AS v(a, b);
@@ -633,7 +437,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  -- non-decimal literals
  SELECT int8 '0b100101';
   int8 
-@@ -972,17 +812,11 @@
+@@ -972,17 +931,11 @@
  (1 row)
  
  SELECT int8 '0b';
@@ -654,7 +458,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  -- cases near overflow
  SELECT int8 '0b111111111111111111111111111111111111111111111111111111111111111';
          int8         
-@@ -991,9 +825,7 @@
+@@ -991,9 +944,7 @@
  (1 row)
  
  SELECT int8 '0b1000000000000000000000000000000000000000000000000000000000000000';
@@ -665,7 +469,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT int8 '0o777777777777777777777';
          int8         
  ---------------------
-@@ -1001,9 +833,7 @@
+@@ -1001,9 +952,7 @@
  (1 row)
  
  SELECT int8 '0o1000000000000000000000';
@@ -676,7 +480,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT int8 '0x7FFFFFFFFFFFFFFF';
          int8         
  ---------------------
-@@ -1011,9 +841,7 @@
+@@ -1011,9 +960,7 @@
  (1 row)
  
  SELECT int8 '0x8000000000000000';
@@ -687,7 +491,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT int8 '-0b1000000000000000000000000000000000000000000000000000000000000000';
           int8         
  ----------------------
-@@ -1021,9 +849,7 @@
+@@ -1021,9 +968,7 @@
  (1 row)
  
  SELECT int8 '-0b1000000000000000000000000000000000000000000000000000000000000001';
@@ -698,7 +502,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT int8 '-0o1000000000000000000000';
           int8         
  ----------------------
-@@ -1031,9 +857,7 @@
+@@ -1031,9 +976,7 @@
  (1 row)
  
  SELECT int8 '-0o1000000000000000000001';
@@ -709,7 +513,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  SELECT int8 '-0x8000000000000000';
           int8         
  ----------------------
-@@ -1041,9 +865,7 @@
+@@ -1041,9 +984,7 @@
  (1 row)
  
  SELECT int8 '-0x8000000000000001';
@@ -720,7 +524,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
  -- underscores
  SELECT int8 '1_000_000';
    int8   
-@@ -1077,14 +899,8 @@
+@@ -1077,14 +1018,8 @@
  
  -- error cases
  SELECT int8 '_100';

--- a/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
@@ -262,37 +262,42 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE INSERT on all slots
  -- *	- Check name prefix
-@@ -336,14 +434,29 @@
+@@ -336,14 +434,34 @@
  ' language plpgsql;
  create trigger tg_chkslotname before insert
      on PSlot for each row execute procedure tg_chkslotname('PS');
-+ERROR:  unimplemented: referencing the TG_ARGV trigger function parameter is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/135311/_version_
++ERROR:  no data source matches prefix: new in this context
++HINT:  to access a field of a composite-typed column or variable, surround the column/variable name in parentheses: (varName).fieldName
++--
++See: https://go.crdb.dev/issue-v/114687/_version_
  create trigger tg_chkslotname before insert
      on WSlot for each row execute procedure tg_chkslotname('WS');
-+ERROR:  unimplemented: referencing the TG_ARGV trigger function parameter is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/135311/_version_
++ERROR:  no data source matches prefix: new in this context
++HINT:  to access a field of a composite-typed column or variable, surround the column/variable name in parentheses: (varName).fieldName
++--
++See: https://go.crdb.dev/issue-v/114687/_version_
  create trigger tg_chkslotname before insert
      on PLine for each row execute procedure tg_chkslotname('PL');
-+ERROR:  unimplemented: referencing the TG_ARGV trigger function parameter is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/135311/_version_
++ERROR:  no data source matches prefix: new in this context
++HINT:  to access a field of a composite-typed column or variable, surround the column/variable name in parentheses: (varName).fieldName
++--
++See: https://go.crdb.dev/issue-v/114687/_version_
  create trigger tg_chkslotname before insert
      on IFace for each row execute procedure tg_chkslotname('IF');
-+ERROR:  unimplemented: referencing the TG_ARGV trigger function parameter is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/135311/_version_
++ERROR:  no data source matches prefix: new in this context
++HINT:  to access a field of a composite-typed column or variable, surround the column/variable name in parentheses: (varName).fieldName
++--
++See: https://go.crdb.dev/issue-v/114687/_version_
  create trigger tg_chkslotname before insert
      on PHone for each row execute procedure tg_chkslotname('PH');
-+ERROR:  unimplemented: referencing the TG_ARGV trigger function parameter is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/135311/_version_
++ERROR:  no data source matches prefix: new in this context
++HINT:  to access a field of a composite-typed column or variable, surround the column/variable name in parentheses: (varName).fieldName
++--
++See: https://go.crdb.dev/issue-v/114687/_version_
  -- ************************************************************
  -- * BEFORE INSERT or UPDATE on all slots with slotlink
  -- *	- Set slotlink to empty string if NULL value given
-@@ -358,14 +471,34 @@
+@@ -358,14 +476,34 @@
  ' language plpgsql;
  create trigger tg_chkslotlink before insert or update
      on PSlot for each row execute procedure tg_chkslotlink();
@@ -327,7 +332,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE INSERT or UPDATE on all slots with backlink
  -- *	- Set backlink to empty string if NULL value given
-@@ -380,10 +513,22 @@
+@@ -380,10 +518,22 @@
  ' language plpgsql;
  create trigger tg_chkbacklink before insert or update
      on PSlot for each row execute procedure tg_chkbacklink();
@@ -350,7 +355,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE UPDATE on PSlot
  -- *	- do delete/insert instead of update if name changes
-@@ -410,6 +555,10 @@
+@@ -410,6 +560,10 @@
  ' language plpgsql;
  create trigger tg_pslot_bu before update
      on PSlot for each row execute procedure tg_pslot_bu();
@@ -361,7 +366,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE UPDATE on WSlot
  -- *	- do delete/insert instead of update if name changes
-@@ -436,6 +585,10 @@
+@@ -436,6 +590,10 @@
  ' language plpgsql;
  create trigger tg_wslot_bu before update
      on WSlot for each row execute procedure tg_Wslot_bu();
@@ -372,7 +377,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE UPDATE on PLine
  -- *	- do delete/insert instead of update if name changes
-@@ -462,6 +615,10 @@
+@@ -462,6 +620,10 @@
  ' language plpgsql;
  create trigger tg_pline_bu before update
      on PLine for each row execute procedure tg_pline_bu();
@@ -383,7 +388,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE UPDATE on IFace
  -- *	- do delete/insert instead of update if name changes
-@@ -488,6 +645,10 @@
+@@ -488,6 +650,10 @@
  ' language plpgsql;
  create trigger tg_iface_bu before update
      on IFace for each row execute procedure tg_iface_bu();
@@ -394,7 +399,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE UPDATE on HSlot
  -- *	- do delete/insert instead of update if name changes
-@@ -514,6 +675,10 @@
+@@ -514,6 +680,10 @@
  ' language plpgsql;
  create trigger tg_hslot_bu before update
      on HSlot for each row execute procedure tg_hslot_bu();
@@ -405,7 +410,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * BEFORE UPDATE on PHone
  -- *	- do delete/insert instead of update if name changes
-@@ -538,6 +703,10 @@
+@@ -538,6 +708,10 @@
  ' language plpgsql;
  create trigger tg_phone_bu before update
      on PHone for each row execute procedure tg_phone_bu();
@@ -416,7 +421,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * AFTER INSERT or UPDATE or DELETE on slot with backlink
  -- *	- Ensure that the opponent correctly points back to us
-@@ -577,10 +746,13 @@
+@@ -577,10 +751,13 @@
  ' language plpgsql;
  create trigger tg_backlink_a after insert or update or delete
      on PSlot for each row execute procedure tg_backlink_a('PS');
@@ -430,7 +435,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Support function to set the opponents backlink field
  -- * if it does not already point to the requested slot
-@@ -635,6 +807,9 @@
+@@ -635,6 +812,9 @@
      raise exception ''illegal backlink beginning with %'', mytype;
  end;
  ' language plpgsql;
@@ -440,7 +445,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Support function to clear out the backlink field if
  -- * it still points to specific slot
-@@ -680,6 +855,11 @@
+@@ -680,6 +860,11 @@
      end if;
  end
  ' language plpgsql;
@@ -452,7 +457,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * AFTER INSERT or UPDATE or DELETE on slot with slotlink
  -- *	- Ensure that the opponent correctly points back to us
-@@ -719,14 +899,19 @@
+@@ -719,14 +904,19 @@
  ' language plpgsql;
  create trigger tg_slotlink_a after insert or update or delete
      on PSlot for each row execute procedure tg_slotlink_a('PS');
@@ -472,7 +477,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Support function to set the opponents slotlink field
  -- * if it does not already point to the requested slot
-@@ -811,6 +996,11 @@
+@@ -811,6 +1001,11 @@
      raise exception ''illegal slotlink beginning with %'', mytype;
  end;
  ' language plpgsql;
@@ -484,7 +489,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Support function to clear out the slotlink field if
  -- * it still points to specific slot
-@@ -876,6 +1066,11 @@
+@@ -876,6 +1071,11 @@
      end if;
  end;
  ' language plpgsql;
@@ -496,7 +501,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Describe the backside of a patchfield slot
  -- ************************************************************
-@@ -919,6 +1114,9 @@
+@@ -919,6 +1119,9 @@
      return rec.backlink;
  end;
  ' language plpgsql;
@@ -506,7 +511,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Describe the front of a patchfield slot
  -- ************************************************************
-@@ -953,54 +1151,83 @@
+@@ -953,54 +1156,83 @@
      return psrec.slotlink;
  end;
  ' language plpgsql;
@@ -535,9 +540,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      end if;
 -    if rec.slotlink = '''' then
 -        return ''-'';
-+    if psrec.slotlink = '' then
-+        return '-';
-     end if;
+-    end if;
 -    sltype := substr(rec.slotlink, 1, 2);
 -    if sltype = ''PH'' then
 -        select into rec * from PHone where slotname = rec.slotlink;
@@ -548,7 +551,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -	    retval := retval || '')'';
 -	end if;
 -	return retval;
--    end if;
++    if psrec.slotlink = '' then
++        return '-';
+     end if;
 -    if sltype = ''IF'' then
 -	declare
 -	    syrow	System%RowType;
@@ -630,7 +635,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * View of a patchfield describing backside and patches
  -- ************************************************************
-@@ -1008,6 +1235,7 @@
+@@ -1008,6 +1240,7 @@
  	pslot_backlink_view(PF.slotname) as backside,
  	pslot_slotlink_view(PF.slotname) as patch
      from PSlot PF;
@@ -638,7 +643,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- First we build the house - so we create the rooms
  --
-@@ -1146,8 +1374,8 @@
+@@ -1146,8 +1379,8 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -649,7 +654,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2a            | 001      |                      |                     
   WS.001.2b            | 001      |                      |                     
   WS.001.3a            | 001      |                      |                     
-@@ -1169,9 +1397,9 @@
+@@ -1169,9 +1402,9 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -661,7 +666,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      |                     
   WS.001.3a            | 001      |                      |                     
   WS.001.3b            | 001      |                      |                     
-@@ -1192,9 +1420,9 @@
+@@ -1192,9 +1425,9 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -674,7 +679,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      |                     
   WS.001.3a            | 001      |                      |                     
   WS.001.3b            | 001      |                      |                     
-@@ -1221,9 +1449,9 @@
+@@ -1221,9 +1454,9 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -687,7 +692,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      | PS.base.a4          
   WS.001.3a            | 001      |                      | PS.base.a6          
   WS.001.3b            | 001      |                      |                     
-@@ -1235,20 +1463,20 @@
+@@ -1235,20 +1468,20 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -714,7 +719,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.3b            | 001      |                      | PS.base.a6          
  (6 rows)
  
-@@ -1258,18 +1486,18 @@
+@@ -1258,18 +1491,18 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -738,7 +743,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      | PS.base.a4          
   WS.001.3a            | 001      |                      | PS.base.a5          
   WS.001.3b            | 001      |                      | PS.base.a6          
-@@ -1281,9 +1509,9 @@
+@@ -1281,9 +1514,9 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -751,7 +756,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (6 rows)
  
  insert into PField values ('PF1_2', 'Phonelines first floor');
-@@ -1309,9 +1537,9 @@
+@@ -1309,9 +1542,9 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -764,7 +769,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   PS.base.b1           | PF0_1  |                      | WS.002.1a           
   PS.base.b2           | PF0_1  |                      | WS.002.1b           
   PS.base.b3           | PF0_1  |                      | WS.002.2a           
-@@ -1324,18 +1552,18 @@
+@@ -1324,18 +1557,18 @@
   PS.base.c4           | PF0_1  |                      | WS.003.2b           
   PS.base.c5           | PF0_1  |                      | WS.003.3a           
   PS.base.c6           | PF0_1  |                      | WS.003.3b           
@@ -795,7 +800,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   PS.first.a1          | PF1_1  |                      | WS.101.1a           
   PS.first.a2          | PF1_1  |                      | WS.101.1b           
   PS.first.a3          | PF1_1  |                      | WS.101.2a           
-@@ -1377,48 +1605,48 @@
+@@ -1377,48 +1610,48 @@
  select * from WSlot order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -883,7 +888,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (42 rows)
  
  --
-@@ -1471,82 +1699,22 @@
+@@ -1471,82 +1704,22 @@
  -- Now we take a look at the patchfield
  --
  select * from PField_v1 where pfname = 'PF0_1' order by slotname;
@@ -968,7 +973,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- The following tests are unrelated to the scenario outlined above;
  -- they merely exercise specific parts of PL/pgSQL
-@@ -1564,12 +1732,9 @@
+@@ -1564,12 +1737,9 @@
      END IF;
      RETURN rslt;
  END;' LANGUAGE plpgsql;
@@ -983,7 +988,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test the FOUND magic variable
  --
-@@ -1609,22 +1774,13 @@
+@@ -1609,22 +1779,13 @@
    end if;
    return true;
    end;' language plpgsql;
@@ -1011,7 +1016,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  --
  -- Test set-returning functions for PL/pgSQL
-@@ -1638,17 +1794,26 @@
+@@ -1638,17 +1799,26 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
@@ -1033,14 +1038,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +	FOR rec IN select * from found_test_tbl LOOP
 +         ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select * from test_table_func_rec();
@@ -1048,7 +1053,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_table_func_row() returns setof found_test_tbl as '
  DECLARE
  	row found_test_tbl%ROWTYPE;
-@@ -1658,17 +1823,16 @@
+@@ -1658,17 +1828,16 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
@@ -1075,7 +1080,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_set_scalar(int,int) returns setof int as '
  DECLARE
  	i int;
-@@ -1678,21 +1842,13 @@
+@@ -1678,21 +1847,13 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
@@ -1103,7 +1108,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_set_rec_dyn(int) returns setof record as '
  DECLARE
  	retval RECORD;
-@@ -1708,20 +1864,13 @@
+@@ -1708,20 +1869,13 @@
  	END IF;
  	RETURN;
  END;' language plpgsql;
@@ -1129,7 +1134,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_rec_dyn(int) returns record as '
  DECLARE
  	retval RECORD;
-@@ -1734,18 +1883,13 @@
+@@ -1734,18 +1888,13 @@
  		RETURN retval;
  	END IF;
  END;' language plpgsql;
@@ -1153,7 +1158,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test some simple polymorphism cases.
  --
-@@ -1753,31 +1897,37 @@
+@@ -1753,31 +1902,37 @@
  begin
    return x + 1;
  end$$ language plpgsql;
@@ -1207,7 +1212,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(x anyarray) returns anyelement as $$
  begin
    return x[1];
-@@ -1789,7 +1939,10 @@
+@@ -1789,7 +1944,10 @@
  (1 row)
  
  select f1(stavalues1) from pg_statistic;  -- fail, can't infer element type
@@ -1219,7 +1224,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function f1(x anyarray);
  create function f1(x anyarray) returns anyarray as $$
  begin
-@@ -1802,72 +1955,61 @@
+@@ -1802,72 +1960,61 @@
  (1 row)
  
  select f1(stavalues1) from pg_statistic;  -- fail, can't infer element type
@@ -1311,7 +1316,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(a anyelement, b anyarray,
                     c anycompatible, d anycompatible,
                     OUT x anyarray, OUT y anycompatiblearray)
-@@ -1876,35 +2018,30 @@
+@@ -1876,35 +2023,30 @@
    x := a || b;
    y := array[c, d];
  end$$ language plpgsql;
@@ -1361,7 +1366,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of OUT parameters, including polymorphic cases.
  -- Note that RETURN is optional with OUT params; we try both ways.
-@@ -1915,8 +2052,6 @@
+@@ -1915,8 +2057,6 @@
    return i+1;
  end$$ language plpgsql;
  ERROR:  RETURN cannot have a parameter in function with OUT parameters
@@ -1370,7 +1375,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(in i int, out j int) as $$
  begin
    j := i+1;
-@@ -2028,19 +2163,13 @@
+@@ -2028,19 +2168,13 @@
    k := array[lower(i),upper(i)];
    return;
  end$$ language plpgsql;
@@ -1394,7 +1399,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test PERFORM
  --
-@@ -2057,6 +2186,7 @@
+@@ -2057,6 +2191,7 @@
  		RETURN FALSE;
  	END IF;
  END;' language plpgsql;
@@ -1402,7 +1407,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function perform_test_func() returns void as '
  BEGIN
  	IF FOUND then
-@@ -2077,19 +2207,32 @@
+@@ -2077,19 +2212,32 @@
  
  	RETURN;
  END;' language plpgsql;
@@ -1446,7 +1451,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  drop table perform_test;
  --
-@@ -2103,19 +2246,12 @@
+@@ -2103,19 +2251,12 @@
    if found then return x; end if;
    return 0;
  end$$ language plpgsql stable;
@@ -1469,7 +1474,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function sp_add_user(a_login text) returns int as $$
  declare my_id_user int;
  begin
-@@ -2130,38 +2266,21 @@
+@@ -2130,38 +2271,21 @@
    END IF;
    RETURN my_id_user;
  end$$ language plpgsql;
@@ -1516,7 +1521,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- tests for refcursors
  --
-@@ -2185,12 +2304,13 @@
+@@ -2185,12 +2309,13 @@
      return x.a;
  end
  $$ language plpgsql;
@@ -1535,7 +1540,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function return_refcursor(rc refcursor) returns refcursor as $$
  begin
      open rc for select a from rc_test;
-@@ -2203,33 +2323,31 @@
+@@ -2203,33 +2328,31 @@
      return $1;
  end
  $$ language plpgsql;
@@ -1589,7 +1594,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  commit;
  -- should fail
  fetch next from test1;
-@@ -2249,13 +2367,25 @@
+@@ -2249,13 +2372,25 @@
      end if;
  end
  $$ language plpgsql;
@@ -1620,7 +1625,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- should fail
  create function constant_refcursor() returns refcursor as $$
  declare
-@@ -2266,8 +2396,11 @@
+@@ -2266,8 +2401,11 @@
  end
  $$ language plpgsql;
  select constant_refcursor();
@@ -1634,7 +1639,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- but it's okay like this
  create or replace function constant_refcursor() returns refcursor as $$
  declare
-@@ -2301,13 +2434,25 @@
+@@ -2301,13 +2439,25 @@
      end if;
  end
  $$ language plpgsql;
@@ -1665,7 +1670,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional argument notations
  create function namedparmcursor_test2(int, int) returns boolean as $$
  declare
-@@ -2324,12 +2469,24 @@
+@@ -2324,12 +2474,24 @@
      end if;
  end
  $$ language plpgsql;
@@ -1695,7 +1700,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional: param2 is given twice, once in named notation
  -- and second time in positional notation. Should throw an error at parse time
  create function namedparmcursor_test3() returns void as $$
-@@ -2339,9 +2496,22 @@
+@@ -2339,9 +2501,22 @@
      open c1(param2 := 20, 21);
  end
  $$ language plpgsql;
@@ -1721,7 +1726,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional: same as previous test, but param1 is duplicated
  create function namedparmcursor_test4() returns void as $$
  declare
-@@ -2350,9 +2520,22 @@
+@@ -2350,9 +2525,22 @@
      open c1(20, param1 := 21);
  end
  $$ language plpgsql;
@@ -1747,7 +1752,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- duplicate named parameter, should throw an error at parse time
  create function namedparmcursor_test5() returns void as $$
  declare
-@@ -2362,9 +2545,22 @@
+@@ -2362,9 +2550,22 @@
    open c1 (p2 := 77, p2 := 42);
  end
  $$ language plpgsql;
@@ -1773,7 +1778,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- not enough parameters, should throw an error at parse time
  create function namedparmcursor_test6() returns void as $$
  declare
-@@ -2374,9 +2570,22 @@
+@@ -2374,9 +2575,22 @@
    open c1 (p2 := 77);
  end
  $$ language plpgsql;
@@ -1799,7 +1804,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- division by zero runtime error, the context given in the error message
  -- should be sensible
  create function namedparmcursor_test7() returns void as $$
-@@ -2386,10 +2595,24 @@
+@@ -2386,10 +2600,24 @@
  begin
    open c1 (p2 := 77, p1 := 42/0);
  end $$ language plpgsql;
@@ -1827,7 +1832,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check that line comments work correctly within the argument list (there
  -- is some special handling of this case in the code: the newline after the
  -- comment must be preserved when the argument-evaluating query is
-@@ -2406,12 +2629,24 @@
+@@ -2406,12 +2634,24 @@
    fetch c1 into n;
    return n;
  end $$ language plpgsql;
@@ -1849,15 +1854,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select namedparmcursor_test8();
 +ERROR:  unknown function: namedparmcursor_test8()
  -- cursor parameter name can match plpgsql variable or unreserved keyword
  create function namedparmcursor_test9(p1 int) returns int4 as $$
  declare
-@@ -2425,12 +2660,24 @@
+@@ -2425,12 +2665,24 @@
    fetch c1 into n;
    return n;
  end $$ language plpgsql;
@@ -1879,15 +1884,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select namedparmcursor_test9(6);
 +ERROR:  unknown function: namedparmcursor_test9()
  --
  -- tests for "raise" processing
  --
-@@ -2441,28 +2688,22 @@
+@@ -2441,28 +2693,22 @@
  end;
  $$ language plpgsql;
  ERROR:  too many parameters specified for RAISE
@@ -1919,7 +1924,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test re-RAISE inside a nested exception block.  This case is allowed
  -- by Oracle's PL/SQL but was handled differently by PG before 9.1.
  CREATE FUNCTION reraise_test() RETURNS void AS $$
-@@ -2484,14 +2725,30 @@
+@@ -2484,14 +2730,30 @@
         raise notice 'WRONG - exception % caught in outer block', sqlerrm;
  END;
  $$ LANGUAGE plpgsql;
@@ -1949,15 +1954,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +SELECT reraise_test();
 +ERROR:  unknown function: reraise_test()
  --
  -- reject function definitions that contain malformed SQL queries at
  -- compile-time, where possible
-@@ -2504,9 +2761,17 @@
+@@ -2504,9 +2766,17 @@
      a := 10;
      return a;
  end$$ language plpgsql;
@@ -1978,7 +1983,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function bad_sql2() returns int as $$
  declare r record;
  begin
-@@ -2515,81 +2780,116 @@
+@@ -2515,81 +2785,116 @@
      end loop;
      return 5;
  end;$$ language plpgsql;
@@ -2035,7 +2040,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +    perform 2+2;
 +               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -2044,7 +2049,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select void_return_expr();
 +ERROR:  unknown function: void_return_expr()
  -- but ordinary functions are not
@@ -2137,7 +2142,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- SQLSTATE and SQLERRM test
  --
-@@ -2597,14 +2897,11 @@
+@@ -2597,14 +2902,11 @@
  begin
      raise notice '% %', sqlstate, sqlerrm;
  end; $$ language plpgsql;
@@ -2154,7 +2159,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test2() returns void as $$
  begin
      begin
-@@ -2613,13 +2910,10 @@
+@@ -2613,13 +2915,10 @@
          end;
      end;
  end; $$ language plpgsql;
@@ -2170,7 +2175,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test3() returns void as $$
  begin
      begin
-@@ -2639,31 +2933,61 @@
+@@ -2639,31 +2938,61 @@
  	    raise notice '% %', sqlstate, sqlerrm;
      end;
  end; $$ language plpgsql;
@@ -2202,9 +2207,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select excpt_test3();
 +ERROR:  unknown function: excpt_test3()
  create function excpt_test4() returns text as $$
@@ -2230,9 +2235,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select excpt_test4();
 +ERROR:  unknown function: excpt_test4()
  drop function excpt_test1();
@@ -2246,7 +2251,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- parameters of raise stmt can be expressions
  create function raise_exprs() returns void as $$
  declare
-@@ -2714,13 +3038,11 @@
+@@ -2714,13 +3043,11 @@
    insert into foo values(5,6) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2264,7 +2269,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2728,10 +3050,11 @@
+@@ -2728,10 +3055,11 @@
    insert into foo values(7,8),(9,10) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2279,7 +2284,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2739,13 +3062,11 @@
+@@ -2739,13 +3067,11 @@
    execute 'insert into foo values(5,6) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2297,7 +2302,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2753,23 +3074,17 @@
+@@ -2753,23 +3079,17 @@
    execute 'insert into foo values(7,8),(9,10) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2326,7 +2331,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  create or replace function stricttest() returns void as $$
  declare x record;
-@@ -2778,13 +3093,11 @@
+@@ -2778,13 +3098,11 @@
    select * from foo where f1 = 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2344,7 +2349,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2792,9 +3105,11 @@
+@@ -2792,9 +3110,11 @@
    select * from foo where f1 = 0 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2358,7 +2363,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2802,10 +3117,11 @@
+@@ -2802,10 +3122,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2373,7 +2378,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2813,13 +3129,11 @@
+@@ -2813,13 +3134,11 @@
    execute 'select * from foo where f1 = 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2391,7 +2396,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2827,9 +3141,11 @@
+@@ -2827,9 +3146,11 @@
    execute 'select * from foo where f1 = 0' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2405,7 +2410,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2837,12 +3153,17 @@
+@@ -2837,12 +3158,17 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2425,7 +2430,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2853,10 +3174,11 @@
+@@ -2853,10 +3179,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2440,7 +2445,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2867,10 +3189,11 @@
+@@ -2867,10 +3194,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2455,7 +2460,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2881,11 +3204,11 @@
+@@ -2881,11 +3209,11 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2471,7 +2476,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2893,10 +3216,11 @@
+@@ -2893,10 +3221,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2486,7 +2491,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2904,10 +3228,11 @@
+@@ -2904,10 +3233,11 @@
    execute 'select * from foo where f1 = $1 or f1::text = $2' using 0, 'foo' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2501,7 +2506,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2915,10 +3240,11 @@
+@@ -2915,10 +3245,11 @@
    execute 'select * from foo where f1 > $1' using 1 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2516,7 +2521,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2926,9 +3252,11 @@
+@@ -2926,9 +3257,11 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2530,7 +2535,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  -- override the global
  #print_strict_params off
-@@ -2941,10 +3269,12 @@
+@@ -2941,10 +3274,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2546,7 +2551,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.print_strict_params;
  create or replace function stricttest() returns void as $$
  -- override the global
-@@ -2958,11 +3288,12 @@
+@@ -2958,11 +3293,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2563,7 +2568,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test warnings and errors
  set plpgsql.extra_warnings to 'all';
  set plpgsql.extra_warnings to 'none';
-@@ -2979,23 +3310,16 @@
+@@ -2979,23 +3315,16 @@
  begin
  end
  $$ language plpgsql;
@@ -2594,7 +2599,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function shadowtest(in1 int)
  	returns table (out1 int) as $$
  declare
-@@ -3004,18 +3328,15 @@
+@@ -3004,18 +3333,15 @@
  begin
  end
  $$ language plpgsql;
@@ -2620,7 +2625,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in a second DECLARE block
  create or replace function shadowtest()
  	returns void as $$
-@@ -3027,10 +3348,13 @@
+@@ -3027,10 +3353,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2637,7 +2642,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- several levels of shadowing
  create or replace function shadowtest(in1 int)
  	returns void as $$
-@@ -3042,13 +3366,13 @@
+@@ -3042,13 +3371,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2657,7 +2662,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in cursor definitions
  create or replace function shadowtest()
  	returns void as $$
-@@ -3057,34 +3381,49 @@
+@@ -3057,34 +3386,49 @@
  c1 cursor (f1 int) for select 1;
  begin
  end$$ language plpgsql;
@@ -2722,7 +2727,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- runtime extra checks
  set plpgsql.extra_warnings to 'too_many_rows';
  do $$
-@@ -3093,8 +3432,6 @@
+@@ -3093,8 +3437,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2731,7 +2736,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'too_many_rows';
  do $$
  declare x int;
-@@ -3102,9 +3439,6 @@
+@@ -3102,9 +3444,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2741,7 +2746,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
  set plpgsql.extra_warnings to 'strict_multi_assignment';
-@@ -3118,12 +3452,6 @@
+@@ -3118,12 +3457,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2754,7 +2759,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'strict_multi_assignment';
  do $$
  declare
-@@ -3135,10 +3463,6 @@
+@@ -3135,10 +3468,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2765,7 +2770,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create table test_01(a int, b int, c int);
  alter table test_01 drop column a;
  -- the check is active only when source table is not empty
-@@ -3154,10 +3478,6 @@
+@@ -3154,10 +3483,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2776,7 +2781,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3168,10 +3488,6 @@
+@@ -3168,10 +3493,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2787,7 +2792,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3179,10 +3495,6 @@
+@@ -3179,10 +3500,6 @@
    select 1 into t; -- should fail;
  end;
  $$;
@@ -2798,7 +2803,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table test_01;
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
-@@ -3201,16 +3513,9 @@
+@@ -3201,16 +3518,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2817,7 +2822,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c no scroll cursor for select f1 from int4_tbl;
-@@ -3225,10 +3530,9 @@
+@@ -3225,10 +3535,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2830,7 +2835,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3243,16 +3547,11 @@
+@@ -3243,16 +3552,11 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2851,7 +2856,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3267,14 +3566,27 @@
+@@ -3267,14 +3571,27 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2875,18 +2880,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select * from sc_test();
 +ERROR:  unknown function: sc_test()
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3290,13 +3602,27 @@
+@@ -3290,13 +3607,27 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2905,7 +2910,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  open c scroll for execute 'select f1 from int4_tbl';
 +                    ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -2914,13 +2919,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select * from sc_test();
 +ERROR:  unknown function: sc_test()
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3316,14 +3642,9 @@
+@@ -3316,14 +3647,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2937,7 +2942,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3338,13 +3659,11 @@
+@@ -3338,13 +3664,11 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2954,7 +2959,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test qualified variable names
  create function pl_qual_names (param1 int) returns void as $$
  <<outerblock>>
-@@ -3362,17 +3681,15 @@
+@@ -3362,17 +3686,15 @@
    end;
  end;
  $$ language plpgsql;
@@ -2979,7 +2984,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- tests for RETURN QUERY
  create function ret_query1(out int, out int) returns setof record as $$
  begin
-@@ -3383,24 +3700,13 @@
+@@ -3383,24 +3705,13 @@
      return next;
  end;
  $$ language plpgsql;
@@ -3010,7 +3015,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type record_type as (x text, y int, z boolean);
  create or replace function ret_query2(lim int) returns setof record_type as $$
  begin
-@@ -3408,20 +3714,9 @@
+@@ -3408,20 +3719,9 @@
                   from generate_series(-8, lim) s (x) where s.x % 2 = 0;
  end;
  $$ language plpgsql;
@@ -3033,7 +3038,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test EXECUTE USING
  create function exc_using(int, text) returns int as $$
  declare i int;
-@@ -3433,19 +3728,27 @@
+@@ -3433,19 +3733,27 @@
    return i;
  end
  $$ language plpgsql;
@@ -3072,7 +3077,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function exc_using(int) returns void as $$
  declare
    c refcursor;
-@@ -3461,19 +3764,29 @@
+@@ -3461,19 +3769,29 @@
    return;
  end;
  $$ language plpgsql;
@@ -3096,7 +3101,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  open c for execute 'select * from generate_series(1,$1)' using $1+1;
 +             ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -3105,7 +3110,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select exc_using(5);
 +ERROR:  unknown function: exc_using()
  drop function exc_using(int);
@@ -3113,7 +3118,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test FOR-over-cursor
  create or replace function forc01() returns void as $$
  declare
-@@ -3513,32 +3826,28 @@
+@@ -3513,32 +3831,28 @@
    return;
  end;
  $$ language plpgsql;
@@ -3149,10 +3154,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select forc01();
@@ -3164,7 +3169,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function forc01() returns void as $$
  declare
    c cursor for select * from forc_test;
-@@ -3549,35 +3858,39 @@
+@@ -3549,35 +3863,39 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3195,12 +3200,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select forc01();
 +ERROR:  unknown function: forc01()
  select * from forc_test;
@@ -3231,7 +3236,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (10 rows)
  
  -- same, with a cursor whose portal name doesn't match variable name
-@@ -3595,38 +3908,42 @@
+@@ -3595,38 +3913,42 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3301,7 +3306,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- it's okay to re-use a cursor variable name, even when bound
  do $$
  declare cnt int := 0;
-@@ -3642,7 +3959,24 @@
+@@ -3642,7 +3964,24 @@
    end loop;
    raise notice 'cnt = %', cnt;
  end $$;
@@ -3327,7 +3332,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail because cursor has no query bound to it
  create or replace function forc_bad() returns void as $$
  declare
-@@ -3653,9 +3987,24 @@
+@@ -3653,9 +3992,24 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3355,7 +3360,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY EXECUTE
  create or replace function return_dquery()
  returns setof int as $$
-@@ -3664,16 +4013,26 @@
+@@ -3664,16 +4018,26 @@
    return query execute 'select * from (values($1),($2)) f' using 40,50;
  end;
  $$ language plpgsql;
@@ -3390,7 +3395,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY with dropped columns
  create table tabwithcols(a int, b int, c int, d int);
  insert into tabwithcols values(10,20,30,40),(50,60,70,80);
-@@ -3684,46 +4043,36 @@
+@@ -3684,46 +4048,36 @@
    return query execute 'select * from tabwithcols';
  end;
  $$ language plpgsql;
@@ -3459,7 +3464,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table tabwithcols;
  --
  -- Tests for composite-type results
-@@ -3753,6 +4102,9 @@
+@@ -3753,6 +4107,9 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3469,7 +3474,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select compos();
    compos   
  -----------
-@@ -3778,9 +4130,11 @@
+@@ -3778,9 +4135,11 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3484,7 +3489,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ... but this does
  create or replace function compos() returns compostype as $$
  begin
-@@ -3803,12 +4157,11 @@
+@@ -3803,12 +4162,11 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3501,7 +3506,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: return row expr in return statement.
  create or replace function composrec() returns record as $$
  begin
-@@ -3850,9 +4203,9 @@
+@@ -3850,9 +4208,9 @@
    return 1 + 1;
  end;
  $$ language plpgsql;
@@ -3513,7 +3518,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- RETURN variable is a different code path ...
  create or replace function compos() returns compostype as $$
  declare x int := 42;
-@@ -3861,8 +4214,7 @@
+@@ -3861,8 +4219,7 @@
  end;
  $$ language plpgsql;
  select * from compos();
@@ -3523,7 +3528,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  -- test: invalid use of composite variable in scalar-returning function
  create or replace function compos() returns int as $$
-@@ -3874,8 +4226,7 @@
+@@ -3874,8 +4231,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3533,7 +3538,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: invalid use of composite expression in scalar-returning function
  create or replace function compos() returns int as $$
  begin
-@@ -3883,8 +4234,7 @@
+@@ -3883,8 +4239,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3543,7 +3548,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  drop type compostype;
  --
-@@ -3904,7 +4254,6 @@
+@@ -3904,7 +4259,6 @@
  HINT:  some hint
  ERROR:  1 2 3
  DETAIL:  some detail info
@@ -3551,7 +3556,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Since we can't actually see the thrown SQLSTATE in default psql output,
  -- test it like this; this also tests re-RAISE
  create or replace function raise_test() returns void as $$
-@@ -3917,11 +4266,33 @@
+@@ -3917,11 +4271,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3588,7 +3593,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise 'check me'
-@@ -3932,11 +4303,33 @@
+@@ -3932,11 +4308,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3625,7 +3630,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- SQLSTATE specification in WHEN
  create or replace function raise_test() returns void as $$
  begin
-@@ -3948,11 +4341,33 @@
+@@ -3948,11 +4346,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3662,7 +3667,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using detail = 'some detail info';
-@@ -3962,11 +4377,32 @@
+@@ -3962,11 +4382,32 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3698,7 +3703,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero;
-@@ -3974,7 +4410,6 @@
+@@ -3974,7 +4415,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  division_by_zero
@@ -3706,7 +3711,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise sqlstate '1234F';
-@@ -3982,7 +4417,6 @@
+@@ -3982,7 +4422,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  1234F
@@ -3714,7 +3719,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using message = 'custom' || ' message';
-@@ -3990,7 +4424,6 @@
+@@ -3990,7 +4429,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3722,7 +3727,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise using message = 'custom' || ' message', errcode = '22012';
-@@ -3998,34 +4431,48 @@
+@@ -3998,34 +4436,48 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3778,7 +3783,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test access to exception data
  create function zero_divide() returns int as $$
  declare v int := 0;
-@@ -4033,6 +4480,7 @@
+@@ -4033,6 +4485,7 @@
    return 10 / v;
  end;
  $$ language plpgsql;
@@ -3786,7 +3791,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise exception 'custom exception'
-@@ -4055,13 +4503,27 @@
+@@ -4055,13 +4508,27 @@
      _sqlstate, _message, replace(_context, E'\n', ' <- ');
  end;
  $$ language plpgsql;
@@ -3805,7 +3810,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  perform zero_divide();
 +                       ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
- 
++
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -3814,13 +3819,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select stacked_diagnostics_test();
 +ERROR:  unknown function: stacked_diagnostics_test()
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
          _hint text;
-@@ -4076,13 +4538,27 @@
+@@ -4076,13 +4543,27 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3839,14 +3844,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  perform raise_test();
 +                      ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
- 
++
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select stacked_diagnostics_test();
@@ -3854,7 +3859,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail, cannot use stacked diagnostics statement outside handler
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
-@@ -4096,11 +4572,25 @@
+@@ -4096,11 +4577,25 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3882,7 +3887,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check cases where implicit SQLSTATE variable could be confused with
  -- SQLSTATE as a keyword, cf bug #5524
  create or replace function raise_test() returns void as $$
-@@ -4112,10 +4602,26 @@
+@@ -4112,10 +4607,26 @@
      raise sqlstate '22012' using message = 'substitute message';
  end;
  $$ language plpgsql;
@@ -3912,7 +3917,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function raise_test();
  -- test passing column_name, constraint_name, datatype_name, table_name
  -- and schema_name error fields
-@@ -4143,14 +4649,23 @@
+@@ -4143,14 +4654,23 @@
      _column_name, _constraint_name, _datatype_name, _table_name, _schema_name;
  end;
  $$ language plpgsql;
@@ -3929,12 +3934,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select stacked_diagnostics_test();
 +ERROR:  unknown function: stacked_diagnostics_test()
  drop function stacked_diagnostics_test();
@@ -3942,7 +3947,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test variadic functions
  create or replace function vari(variadic int[])
  returns void as $$
-@@ -4159,36 +4674,34 @@
+@@ -4159,36 +4679,34 @@
      raise notice '%', $1[i];
    end loop; end;
  $$ language plpgsql;
@@ -4002,7 +4007,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- coercion test
  create or replace function pleast(variadic numeric[])
  returns numeric as $$
-@@ -4200,30 +4713,20 @@
+@@ -4200,30 +4718,20 @@
    return aux;
  end;
  $$ language plpgsql immutable strict;
@@ -4043,7 +4048,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- in case of conflict, non-variadic version is preferred
  create or replace function pleast(numeric)
  returns numeric as $$
-@@ -4232,15 +4735,13 @@
+@@ -4232,15 +4740,13 @@
    return $1;
  end;
  $$ language plpgsql immutable strict;
@@ -4063,7 +4068,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test table functions
  create function tftest(int) returns table(a int, b int) as $$
  begin
-@@ -4248,13 +4749,13 @@
+@@ -4248,13 +4754,13 @@
  end;
  $$ language plpgsql immutable strict;
  select * from tftest(10);
@@ -4084,7 +4089,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (5 rows)
  
  create or replace function tftest(a1 int) returns table(a int, b int) as $$
-@@ -4291,19 +4792,31 @@
+@@ -4291,19 +4797,31 @@
    raise notice '% %', found, rc;
  end;
  $$ language plpgsql;
@@ -4117,18 +4122,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select * from rttest();
 +ERROR:  unknown function: rttest()
  -- check some error cases, too
  create or replace function rttest()
  returns setof int as $$
-@@ -4311,25 +4824,45 @@
+@@ -4311,25 +4829,45 @@
    return query select 10 into no_such_table;
  end;
  $$ language plpgsql;
@@ -4182,7 +4187,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test for proper cleanup at subtransaction exit.  This example
  -- exposed a bug in PG 8.2.
  CREATE FUNCTION leaker_1(fail BOOL) RETURNS INTEGER AS $$
-@@ -4344,6 +4877,7 @@
+@@ -4344,6 +4882,7 @@
    RETURN 1;
  END;
  $$ LANGUAGE plpgsql;
@@ -4190,7 +4195,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION leaker_2(fail BOOL, OUT error_code INTEGER, OUT new_id INTEGER)
    RETURNS RECORD AS $$
  BEGIN
-@@ -4356,18 +4890,11 @@
+@@ -4356,18 +4895,11 @@
  END;
  $$ LANGUAGE plpgsql;
  SELECT * FROM leaker_1(false);
@@ -4212,7 +4217,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DROP FUNCTION leaker_2(bool);
  -- Test for appropriate cleanup of non-simple expression evaluations
  -- (bug in all versions prior to August 2010)
-@@ -4385,13 +4912,27 @@
+@@ -4385,13 +4917,27 @@
    RETURN arr;
  END;
  $$ LANGUAGE plpgsql;
@@ -4245,7 +4250,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION nonsimple_expr_test() RETURNS integer AS $$
  declare
     i integer NOT NULL := 0;
-@@ -4405,13 +4946,13 @@
+@@ -4405,13 +4951,13 @@
    return i;
  end;
  $$ LANGUAGE plpgsql;
@@ -4264,7 +4269,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test cases involving recursion and error recovery in simple expressions
  -- (bugs in all versions before October 2010).  The problems are most
-@@ -4427,15 +4968,13 @@
+@@ -4427,15 +4973,13 @@
    end if;
  end;
  $$ language plpgsql;
@@ -4283,7 +4288,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function error1(text) returns text language sql as
  $$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $$;
  create function error2(p_name_table text) returns text language plpgsql as $$
-@@ -4444,12 +4983,13 @@
+@@ -4444,12 +4988,13 @@
  end$$;
  BEGIN;
  create table public.stuffs (stuff text);
@@ -4300,7 +4305,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select error2('public.stuffs');
   error2 
  --------
-@@ -4457,70 +4997,72 @@
+@@ -4457,70 +5002,72 @@
  (1 row)
  
  rollback;
@@ -4412,7 +4417,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test handling of cast cache inside DO blocks
  -- (to check the original crash case, this must be a cast not previously
  -- used in this session)
-@@ -4534,45 +5076,29 @@
+@@ -4534,45 +5081,29 @@
    return 1/0;
  end
  $$;
@@ -4469,7 +4474,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  create or replace function strtest() returns text as $$
-@@ -4625,21 +5151,26 @@
+@@ -4625,21 +5156,26 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4509,7 +4514,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DO $$
  DECLARE r record;
  BEGIN
-@@ -4648,11 +5179,23 @@
+@@ -4648,11 +5184,23 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4538,7 +4543,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of errors thrown from/into anonymous code blocks.
  do $outer$
  begin
-@@ -4672,16 +5215,19 @@
+@@ -4672,16 +5220,19 @@
    end loop;
  end;
  $outer$;
@@ -4568,7 +4573,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check variable scoping -- a var is not available in its own or prior
  -- default expressions, but it is available in later ones.
  do $$
-@@ -4691,10 +5237,6 @@
+@@ -4691,10 +5242,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4579,7 +4584,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare y int := x + 1;  -- error
          x int := 42;
-@@ -4703,10 +5245,6 @@
+@@ -4703,10 +5250,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4590,7 +4595,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare x int := 42;
          y int := x + 1;
-@@ -4726,7 +5264,11 @@
+@@ -4726,7 +5269,11 @@
    end;
  end;
  $$;
@@ -4603,7 +4608,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of conflicts between plpgsql vars and table columns.
  set plpgsql.variable_conflict = error;
  create function conflict_test() returns setof int8_tbl as $$
-@@ -4738,13 +5280,26 @@
+@@ -4738,13 +5285,26 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4636,7 +4641,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_variable
  declare r record;
-@@ -4755,16 +5310,12 @@
+@@ -4755,16 +5315,12 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4658,7 +4663,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_column
  declare r record;
-@@ -4775,17 +5326,14 @@
+@@ -4775,17 +5331,14 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4682,7 +4687,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check that an unreserved keyword can be used as a variable name
  create function unreserved_test() returns int as $$
  declare
-@@ -4795,12 +5343,15 @@
+@@ -4795,12 +5348,15 @@
    return forward;
  end
  $$ language plpgsql;
@@ -4703,7 +4708,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    return int := 42;
-@@ -4809,12 +5360,20 @@
+@@ -4809,12 +5365,20 @@
    return return;
  end
  $$ language plpgsql;
@@ -4729,7 +4734,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    comment int := 21;
-@@ -4824,19 +5383,26 @@
+@@ -4824,19 +5388,26 @@
    return comment;
  end
  $$ language plpgsql;
@@ -4766,7 +4771,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test FOREACH over arrays
  --
-@@ -4850,26 +5416,27 @@
+@@ -4850,26 +5421,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4799,12 +4804,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4812,7 +4817,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int;
-@@ -4880,13 +5447,28 @@
+@@ -4880,13 +5452,28 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4845,7 +4850,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int[];
-@@ -4897,21 +5479,27 @@
+@@ -4897,21 +5484,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4876,9 +4881,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4886,7 +4891,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- higher level of slicing
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -4923,26 +5511,31 @@
+@@ -4923,26 +5516,31 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4933,7 +4938,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type xy_tuple AS (x int, y int);
  -- iteration over array of records
  create or replace function foreach_test(anyarray)
-@@ -4955,25 +5548,27 @@
+@@ -4955,25 +5553,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4965,12 +4970,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[(10,20),(40,69)],[(35,78),(88,76)]]::xy_tuple[]);
@@ -4978,7 +4983,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int; y int;
-@@ -4984,25 +5579,27 @@
+@@ -4984,25 +5584,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5010,10 +5015,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
@@ -5023,7 +5028,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- slicing over array of composite types
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -5014,22 +5611,29 @@
+@@ -5014,22 +5616,29 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5051,10 +5056,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
@@ -5066,7 +5071,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop type xy_tuple;
  --
  -- Assorted tests for array subscript assignment
-@@ -5043,28 +5647,30 @@
+@@ -5043,28 +5652,30 @@
    r.ar[2] := 'replace';
    return r.ar;
  end$$;
@@ -5113,7 +5118,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function testoa(x1 int, x2 int, x3 int) returns orderedarray
  language plpgsql as $$
  declare res orderedarray;
-@@ -5073,26 +5679,19 @@
+@@ -5073,26 +5684,19 @@
    res[2] := x3;
    return res;
  end$$;
@@ -5147,7 +5152,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of expanded arrays
  --
-@@ -5101,72 +5700,48 @@
+@@ -5101,72 +5705,48 @@
    declare r int[];
    begin r := array[$1, $1]; return r; end;
  $$ stable;
@@ -5241,7 +5246,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare a int[] := array[1,2];
  begin
-@@ -5190,6 +5765,19 @@
+@@ -5190,6 +5770,19 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5261,7 +5266,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5201,6 +5789,7 @@
+@@ -5201,6 +5794,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5269,7 +5274,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5212,44 +5801,18 @@
+@@ -5212,44 +5806,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5320,7 +5325,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- access to call stack from exception
  create function inner_func(int)
  returns int as $$
-@@ -5272,6 +5835,26 @@
+@@ -5272,6 +5840,26 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5347,7 +5352,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5283,6 +5866,7 @@
+@@ -5283,6 +5871,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5355,7 +5360,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5294,44 +5878,18 @@
+@@ -5294,44 +5883,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5406,7 +5411,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test pg_routine_oid
  create function current_function(text)
  returns regprocedure as $$
-@@ -5342,13 +5900,17 @@
+@@ -5342,13 +5905,17 @@
    return fn_oid;
  end;
  $$ language plpgsql;
@@ -5429,7 +5434,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shouldn't fail in DO, even though there's no useful data
  do $$
  declare
-@@ -5358,7 +5920,13 @@
+@@ -5358,7 +5925,13 @@
    raise notice 'pg_routine_oid = %', fn_oid;
  end;
  $$;
@@ -5444,7 +5449,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test ASSERT
  --
-@@ -5367,20 +5935,55 @@
+@@ -5367,20 +5940,55 @@
    assert 1=1;  -- should succeed
  end;
  $$;
@@ -5504,7 +5509,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check controlling GUC
  set plpgsql.check_asserts = off;
  do $$
-@@ -5388,6 +5991,19 @@
+@@ -5388,6 +5996,19 @@
    assert 1=0;  -- won't be tested
  end;
  $$;
@@ -5524,7 +5529,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.check_asserts;
  -- test custom message
  do $$
-@@ -5396,8 +6012,19 @@
+@@ -5396,8 +6017,19 @@
    assert 1=0, format('assertion failed, var = "%s"', var);
  end;
  $$;
@@ -5546,7 +5551,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ensure assertions are not trapped by 'others'
  do $$
  begin
-@@ -5406,32 +6033,55 @@
+@@ -5406,32 +6038,55 @@
    null; -- do nothing
  end;
  $$;
@@ -5606,7 +5611,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare v_test plpgsql_arr_domain;
  begin
-@@ -5439,14 +6089,14 @@
+@@ -5439,14 +6094,14 @@
    v_test := v_test || 2;
  end;
  $$;
@@ -5623,7 +5628,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test usage of transition tables in AFTER triggers
  --
-@@ -5472,25 +6122,40 @@
+@@ -5472,25 +6127,40 @@
    RETURN new;
  END;
  $$;
@@ -5671,7 +5676,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION transition_table_base_upd_func()
    RETURNS trigger
    LANGUAGE plpgsql
-@@ -5512,30 +6177,42 @@
+@@ -5512,30 +6182,42 @@
    RETURN new;
  END;
  $$;
@@ -5724,7 +5729,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_level2
  (
        level2_no serial NOT NULL ,
-@@ -5543,6 +6220,7 @@
+@@ -5543,6 +6225,7 @@
        level1_node_name varchar(255),
         PRIMARY KEY (level2_no)
  ) WITHOUT OIDS;
@@ -5732,7 +5737,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_status
  (
        level int NOT NULL,
-@@ -5563,11 +6241,29 @@
+@@ -5563,11 +6246,29 @@
      RETURN NULL;
    END;
  $$;
@@ -5762,7 +5767,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level1_ri_parent_upd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5595,6 +6291,9 @@
+@@ -5595,6 +6296,9 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level1_ri_parent_upd_func();
@@ -5772,7 +5777,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level2_ri_child_insupd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5610,16 +6309,37 @@
+@@ -5610,16 +6314,37 @@
      RETURN NULL;
    END;
  $$;
@@ -5810,7 +5815,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- create initial test data
  INSERT INTO transition_table_level1 (level1_no)
    SELECT generate_series(1,200);
-@@ -5627,6 +6347,7 @@
+@@ -5627,6 +6352,7 @@
  INSERT INTO transition_table_level2 (level2_no, parent_no)
    SELECT level2_no, level2_no / 50 + 1 AS parent_no
      FROM generate_series(1,9999) level2_no;
@@ -5818,7 +5823,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  ANALYZE transition_table_level2;
  INSERT INTO transition_table_status (level, node_no, status)
    SELECT 1, level1_no, 0 FROM transition_table_level1;
-@@ -5651,30 +6372,23 @@
+@@ -5651,30 +6377,23 @@
    REFERENCING OLD TABLE AS dx
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level2_bad_usage_func();
@@ -5853,7 +5858,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- attempt modifications which would not break RI (should all succeed)
  DELETE FROM transition_table_level1
    WHERE level1_no BETWEEN 201 AND 1000;
-@@ -5683,7 +6397,7 @@
+@@ -5683,7 +6402,7 @@
  SELECT count(*) FROM transition_table_level1;
   count 
  -------
@@ -5862,7 +5867,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  DELETE FROM transition_table_level2
-@@ -5691,7 +6405,7 @@
+@@ -5691,7 +6410,7 @@
  SELECT count(*) FROM transition_table_level2;
   count 
  -------
@@ -5871,7 +5876,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  CREATE TABLE alter_table_under_transition_tables
-@@ -5717,36 +6431,30 @@
+@@ -5717,36 +6436,30 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      alter_table_under_transition_tables_upd_func();
@@ -5912,7 +5917,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test multiple reference to a transition table
  --
-@@ -5764,19 +6472,37 @@
+@@ -5764,19 +6477,37 @@
  CREATE TRIGGER my_trigger AFTER UPDATE ON multi_test
    REFERENCING NEW TABLE AS new_test OLD TABLE as old_test
    FOR EACH STATEMENT EXECUTE PROCEDURE multi_test_trig();
@@ -5952,7 +5957,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION get_from_partitioned_table(partitioned_table.a%type)
  RETURNS partitioned_table AS $$
  DECLARE
-@@ -5787,13 +6513,13 @@
+@@ -5787,13 +6518,13 @@
      SELECT * INTO result FROM partitioned_table WHERE a = a_val;
      RETURN result;
  END; $$ LANGUAGE plpgsql;
@@ -5972,7 +5977,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION list_partitioned_table()
  RETURNS SETOF partitioned_table.a%TYPE AS $$
  DECLARE
-@@ -5806,14 +6532,13 @@
+@@ -5806,14 +6537,13 @@
      END LOOP;
      RETURN;
  END; $$ LANGUAGE plpgsql;
@@ -5993,7 +5998,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Check argument name is used instead of $n in error message
  --
-@@ -5822,6 +6547,16 @@
+@@ -5822,6 +6552,16 @@
    GET DIAGNOSTICS x = ROW_COUNT;
    RETURN;
  END; $$ LANGUAGE plpgsql;

--- a/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
@@ -1235,7 +1235,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- table functions
  --
-@@ -1661,100 +1200,77 @@
+@@ -1661,27 +1200,29 @@
  --
  -- some tests on SQL functions with RETURNING
  --
@@ -1270,10 +1270,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (2 rows)
  
  -- insert will execute to completion even if function needs just 1 row
- create or replace function insert_tt(text) returns int as
- $$ insert into tt(data) values($1),($1||$1) returning f1 $$
- language sql;
-+ERROR:  cannot create function using temp tables
+@@ -1691,16 +1232,16 @@
  select insert_tt('fool');
   insert_tt 
  -----------
@@ -1282,44 +1279,41 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (1 row)
  
  select * from tt;
-- f1 |   data   
------+----------
+  f1 |   data   
+ ----+----------
 -  1 | foo
 -  2 | bar
 -  3 | fool
 -  4 | foolfool
--(4 rows)
-+ f1 | data 
-+----+------
 +  7 | foo
 +  8 | bar
 +  9 | fool
-+(3 rows)
++ 10 | foolfool
+ (4 rows)
  
  -- setof does what's expected
- create or replace function insert_tt2(text,text) returns setof int as
- $$ insert into tt(data) values($1),($2) returning f1 $$
- language sql;
-+ERROR:  cannot create function using temp tables
+@@ -1710,50 +1251,50 @@
  select insert_tt2('foolish','barrish');
-- insert_tt2 
--------------
+  insert_tt2 
+ ------------
 -          5
 -          6
--(2 rows)
--
-+ERROR:  unknown function: insert_tt2()
++         11
++         12
+ (2 rows)
+ 
  select * from insert_tt2('baz','quux');
-- insert_tt2 
--------------
+  insert_tt2 
+ ------------
 -          7
 -          8
--(2 rows)
--
-+ERROR:  unknown function: insert_tt2()
++         13
++         14
+ (2 rows)
+ 
  select * from tt;
-- f1 |   data   
------+----------
+  f1 |   data   
+ ----+----------
 -  1 | foo
 -  2 | bar
 -  3 | fool
@@ -1328,25 +1322,27 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 -  6 | barrish
 -  7 | baz
 -  8 | quux
--(8 rows)
-+ f1 | data 
-+----+------
 +  7 | foo
 +  8 | bar
 +  9 | fool
-+(3 rows)
++ 10 | foolfool
++ 11 | foolish
++ 12 | barrish
++ 13 | baz
++ 14 | quux
+ (8 rows)
  
  -- limit doesn't prevent execution to completion
  select insert_tt2('foolish','barrish') limit 1;
-- insert_tt2 
--------------
+  insert_tt2 
+ ------------
 -          9
--(1 row)
--
-+ERROR:  unknown function: insert_tt2()
++         15
+ (1 row)
+ 
  select * from tt;
-- f1 |   data   
------+----------
+  f1 |   data   
+ ----+----------
 -  1 | foo
 -  2 | bar
 -  3 | fool
@@ -1357,17 +1353,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 -  8 | quux
 -  9 | foolish
 - 10 | barrish
--(10 rows)
-+ f1 | data 
-+----+------
 +  7 | foo
 +  8 | bar
 +  9 | fool
-+(3 rows)
++ 10 | foolfool
++ 11 | foolish
++ 12 | barrish
++ 13 | baz
++ 14 | quux
++ 15 | foolish
++ 16 | barrish
+ (10 rows)
  
  -- triggers will fire, too
- create function noticetrigger() returns trigger as $$
-@@ -1764,70 +1280,55 @@
+@@ -1764,70 +1305,83 @@
  end $$ language plpgsql;
  create trigger tnoticetrigger after insert on tt for each row
  execute procedure noticetrigger();
@@ -1378,15 +1377,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select insert_tt2('foolme','barme') limit 1;
 -NOTICE:  noticetrigger 11 foolme
 -NOTICE:  noticetrigger 12 barme
-- insert_tt2 
--------------
+  insert_tt2 
+ ------------
 -         11
--(1 row)
--
-+ERROR:  unknown function: insert_tt2()
++         17
+ (1 row)
+ 
  select * from tt;
-- f1 |   data   
------+----------
+  f1 |   data   
+ ----+----------
 -  1 | foo
 -  2 | bar
 -  3 | fool
@@ -1399,25 +1398,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 - 10 | barrish
 - 11 | foolme
 - 12 | barme
--(12 rows)
-+ f1 | data 
-+----+------
 +  7 | foo
 +  8 | bar
 +  9 | fool
-+(3 rows)
++ 10 | foolfool
++ 11 | foolish
++ 12 | barrish
++ 13 | baz
++ 14 | quux
++ 15 | foolish
++ 16 | barrish
++ 17 | foolme
++ 18 | barme
+ (12 rows)
  
  -- and rules work
  create temp table tt_log(f1 int, data text);
  create rule insert_tt_rule as on insert to tt do also
    insert into tt_log values(new.*);
--select insert_tt2('foollog','barlog') limit 1;
--NOTICE:  noticetrigger 13 foollog
--NOTICE:  noticetrigger 14 barlog
-- insert_tt2 
--------------
--         13
--(1 row)
 +ERROR:  at or near "insert_tt_rule": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +create rule insert_tt_rule as on insert to tt do also
@@ -1427,17 +1425,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
 +
-+select insert_tt2('foollog','barlog') limit 1;
-+ERROR:  unknown function: insert_tt2()
+ select insert_tt2('foollog','barlog') limit 1;
+-NOTICE:  noticetrigger 13 foollog
+-NOTICE:  noticetrigger 14 barlog
+  insert_tt2 
+ ------------
+-         13
++         19
+ (1 row)
+ 
  select * from tt;
-- f1 |   data   
------+----------
+  f1 |   data   
+ ----+----------
 -  1 | foo
 -  2 | bar
 -  3 | fool
@@ -1452,13 +1457,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 - 12 | barme
 - 13 | foollog
 - 14 | barlog
--(14 rows)
-+ f1 | data 
-+----+------
 +  7 | foo
 +  8 | bar
 +  9 | fool
-+(3 rows)
++ 10 | foolfool
++ 11 | foolish
++ 12 | barrish
++ 13 | baz
++ 14 | quux
++ 15 | foolish
++ 16 | barrish
++ 17 | foolme
++ 18 | barme
++ 19 | foollog
++ 20 | barlog
+ (14 rows)
  
  -- note that nextval() gets executed a second time in the rule expansion,
  -- which is expected.
@@ -1474,7 +1487,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  
  -- test case for a whole-row-variable bug
  create function rngfunc1(n integer, out a text, out b text)
-@@ -1835,6 +1336,18 @@
+@@ -1835,6 +1389,18 @@
    language sql
    as $$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $$;
  set work_mem='64kB';
@@ -1493,7 +1506,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1842,6 +1355,18 @@
+@@ -1842,6 +1408,18 @@
  (1 row)
  
  reset work_mem;
@@ -1512,7 +1525,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1871,8 +1396,6 @@
+@@ -1871,8 +1449,6 @@
  
  select * from array_to_set(array['one', 'two']); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1521,7 +1534,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- after-the-fact coercion of the columns is now possible, too
  select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
    f1  | f2  
-@@ -1883,19 +1406,20 @@
+@@ -1883,19 +1459,20 @@
  
  -- and if it doesn't work, you get a compile-time not run-time error
  select * from array_to_set(array['one', 'two']) as t(f1 point,f2 text);
@@ -1552,7 +1565,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- but without, it can be:
  create or replace function array_to_set(anyarray) returns setof record as $$
    select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
-@@ -1922,18 +1446,19 @@
+@@ -1922,18 +1499,19 @@
  (2 rows)
  
  select * from array_to_set(array['one', 'two']) as t(f1 point,f2 text);
@@ -1582,7 +1595,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  create temp table rngfunc(f1 int8, f2 int8);
  create function testrngfunc() returns record as $$
    insert into rngfunc values (1,2) returning *;
-@@ -1952,8 +1477,6 @@
+@@ -1952,8 +1530,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1591,7 +1604,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  create function testrngfunc() returns setof record as $$
    insert into rngfunc values (1,2), (3,4) returning *;
-@@ -1974,8 +1497,6 @@
+@@ -1974,8 +1550,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1600,7 +1613,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  -- Check that typmod imposed by a composite type is honored
  create type rngfunc_type as (f1 numeric(35,6), f2 numeric(35,2));
-@@ -1984,12 +1505,11 @@
+@@ -1984,12 +1558,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1618,7 +1631,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -1998,13 +1518,11 @@
+@@ -1998,13 +1571,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1637,7 +1650,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2016,12 +1534,11 @@
+@@ -2016,12 +1587,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1655,7 +1668,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2030,13 +1547,11 @@
+@@ -2030,13 +1600,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1674,7 +1687,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2049,13 +1564,11 @@
+@@ -2049,13 +1617,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1693,7 +1706,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2064,12 +1577,11 @@
+@@ -2064,12 +1630,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1711,7 +1724,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2081,13 +1593,11 @@
+@@ -2081,13 +1646,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1730,7 +1743,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2096,13 +1606,11 @@
+@@ -2096,13 +1659,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1749,7 +1762,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2112,62 +1620,45 @@
+@@ -2112,62 +1673,45 @@
  create or replace function testrngfunc() returns setof rngfunc_type as $$
    select 1, 2 union select 3, 4 order by 1;
  $$ language sql immutable;
@@ -1833,29 +1846,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- Check some cases involving added/dropped columns in a rowtype result
  --
-@@ -2178,79 +1669,36 @@
- create or replace function get_first_user() returns users as
- $$ SELECT * FROM users ORDER BY userid LIMIT 1; $$
- language sql stable;
-+ERROR:  cannot create function using temp tables
- SELECT get_first_user();
--  get_first_user   
---------------------
-- (id,1,email,11,t)
--(1 row)
--
-+ERROR:  unknown function: get_first_user()
- SELECT * FROM get_first_user();
-- userid | seq | email | moredrop | enabled 
----------+-----+-------+----------+---------
-- id     |   1 | email |       11 | t
--(1 row)
--
-+ERROR:  unknown function: get_first_user()
+@@ -2193,64 +1737,29 @@
  create or replace function get_users() returns setof users as
  $$ SELECT * FROM users ORDER BY userid; $$
  language sql stable;
-+ERROR:  cannot create function using temp tables
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
  SELECT get_users();
 -      get_users      
 ----------------------
@@ -1922,10 +1917,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 -ERROR:  cannot drop column moredrop of table users because other objects depend on it
 -DETAIL:  view usersview depends on column moredrop of table users
 -HINT:  Use DROP ... CASCADE to drop the dependent objects too.
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -2264,18 +1712,14 @@
+@@ -2264,18 +1773,15 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -1944,11 +1940,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  alter table users alter column seq type numeric;  -- fail, view has reference
 -ERROR:  cannot alter type of a column used by a view or rule
 -DETAIL:  rule _RETURN on view usersview depends on column "seq"
-+ERROR:  ALTER COLUMN TYPE is only implemented in the declarative schema changer
++ERROR:  cannot alter type of column "seq" because function "get_first_user" depends on it
++HINT:  consider dropping "get_first_user" first.
  -- likewise, check we don't crash if the dependency goes wrong
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -2286,19 +1730,18 @@
+@@ -2286,173 +1792,128 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -1968,14 +1965,32 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop view usersview;
 +ERROR:  relation "usersview" does not exist
  drop function get_first_user();
-+ERROR:  unknown function: get_first_user()
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
  drop function get_users();
 +ERROR:  unknown function: get_users()
  drop table users;
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
  -- check behavior with type coercion required for a set-op
  create or replace function rngfuncbar() returns setof text as
-@@ -2320,17 +1763,11 @@
- 
+ $$ select 'foo'::varchar union all select 'bar'::varchar ; $$
+ language sql stable;
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
+ select rngfuncbar();
+- rngfuncbar 
+-------------
+- foo
+- bar
+-(2 rows)
+-
++ERROR:  unknown function: rngfuncbar()
+ select * from rngfuncbar();
+- rngfuncbar 
+-------------
+- foo
+- bar
+-(2 rows)
+-
++ERROR:  unknown function: rngfuncbar()
  -- this function is now inlinable, too:
  explain (verbose, costs off) select * from rngfuncbar();
 -                   QUERY PLAN                   
@@ -1995,19 +2010,25 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +                        ^
 +HINT:  try \h <SELECTCLAUSE>
  drop function rngfuncbar();
++ERROR:  unknown function: rngfuncbar()
  -- check handling of a SQL function with multiple OUT params (bug #5777)
  create or replace function rngfuncbar(out integer, out numeric) as
-@@ -2344,115 +1781,93 @@
+ $$ select (1, 2.1) $$ language sql;
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
+ select * from rngfuncbar();
+- column1 | column2 
+----------+---------
+-       1 |     2.1
+-(1 row)
+-
++ERROR:  unknown function: rngfuncbar()
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2) $$ language sql;
++ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
  select * from rngfuncbar();  -- fail
 -ERROR:  function return row and query-specified return row do not match
 -DETAIL:  Returned type integer at ordinal position 2, but query expects numeric.
-+ column1 | column2 
-+---------+---------
-+       1 |       2
-+(1 row)
-+
++ERROR:  unknown function: rngfuncbar()
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2.1, 3) $$ language sql;
 +ERROR:  return type mismatch in function declared to return record
@@ -2015,12 +2036,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from rngfuncbar();  -- fail
 -ERROR:  function return row and query-specified return row do not match
 -DETAIL:  Returned row contains 3 attributes, but query expects 2.
-+ column1 | column2 
-+---------+---------
-+       1 |       2
-+(1 row)
-+
++ERROR:  unknown function: rngfuncbar()
  drop function rngfuncbar();
++ERROR:  unknown function: rngfuncbar()
  -- check whole-row-Var handling in nested lateral functions (bug #11703)
  create function extractq2(t int8_tbl) returns int8 as $$
    select t.q2
@@ -2164,7 +2182,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (0 rows)
  
  drop type rngfunc2;
-@@ -2463,18 +1878,11 @@
+@@ -2463,18 +1924,11 @@
     from unnest(array['{"lectures": [{"id": "1"}]}'::jsonb])
          as unnested_modules(module)) as ss,
    jsonb_to_recordset(ss.lecture) as j (id text);

--- a/pkg/cmd/roachtest/testdata/pg_regress/reloptions.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/reloptions.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/reloptions.out --label=/mnt/data1/postgres/src/test/regress/results/reloptions.out /mnt/data1/postgres/src/test/regress/expected/reloptions.out /mnt/data1/postgres/src/test/regress/results/reloptions.out
 --- /mnt/data1/postgres/src/test/regress/expected/reloptions.out
 +++ /mnt/data1/postgres/src/test/regress/results/reloptions.out
-@@ -1,226 +1,240 @@
+@@ -1,226 +1,232 @@
  -- Simple create
  CREATE TABLE reloptions_test(i INT) WITH (FiLLFaCToR=30,
  	autovacuum_enabled = false, autovacuum_analyze_scale_factor = 0.2);
@@ -337,11 +337,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/reloptions.out --
 +ERROR:  relation "reloptions_test" does not exist
  -- Check ALTER
  ALTER INDEX reloptions_test_idx SET (fillfactor=40);
-+ERROR:  at or near "set": syntax error
-+DETAIL:  source SQL:
-+ALTER INDEX reloptions_test_idx SET (fillfactor=40)
-+                                ^
-+HINT:  try \h ALTER INDEX
++ERROR:  index "reloptions_test_idx" does not exist
  SELECT reloptions FROM pg_class WHERE oid = 'reloptions_test_idx'::regclass;
 -   reloptions    
 ------------------
@@ -353,11 +349,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/reloptions.out --
  CREATE INDEX reloptions_test_idx3 ON reloptions_test (s);
 +ERROR:  relation "reloptions_test" does not exist
  ALTER INDEX reloptions_test_idx3 SET (fillfactor=40);
-+ERROR:  at or near "set": syntax error
-+DETAIL:  source SQL:
-+ALTER INDEX reloptions_test_idx3 SET (fillfactor=40)
-+                                 ^
-+HINT:  try \h ALTER INDEX
++ERROR:  index "reloptions_test_idx3" does not exist
  SELECT reloptions FROM pg_class WHERE oid = 'reloptions_test_idx3'::regclass;
 -   reloptions    
 ------------------

--- a/pkg/cmd/roachtest/testdata/pg_regress/text.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/text.diffs
@@ -24,33 +24,25 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/text.out --label=
  /*
   * various string functions
   */
-@@ -59,11 +54,7 @@
- (1 row)
- 
+@@ -61,7 +56,7 @@
  select concat(1,2,3,'hello',true, false, to_date('20100309','YYYYMMDD'));
--        concat        
------------------------
+         concat        
+ ----------------------
 - 123hellotf03-09-2010
--(1 row)
--
-+ERROR:  unknown function: to_date()
- select concat_ws('#','one');
-  concat_ws 
- -----------
-@@ -71,11 +62,7 @@
++ 123hellotf2010-03-09
  (1 row)
  
+ select concat_ws('#','one');
+@@ -73,7 +68,7 @@
  select concat_ws('#',1,2,3,'hello',true, false, to_date('20100309','YYYYMMDD'));
--         concat_ws          
------------------------------
+          concat_ws          
+ ----------------------------
 - 1#2#3#hello#t#f#03-09-2010
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 1#2#3#hello#t#f#2010-03-09
+ (1 row)
+ 
  select concat_ws(',',10,20,null,30);
-  concat_ws 
- -----------
-@@ -125,51 +112,113 @@
+@@ -125,51 +120,113 @@
  select quote_literal('abc''');
   quote_literal 
  ---------------
@@ -189,7 +181,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/text.out --label=
  /*
   * format
   */
-@@ -205,12 +254,11 @@
+@@ -205,12 +262,11 @@
  
  -- should fail
  select format('Hello %s %s', 'World');
@@ -205,7 +197,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/text.out --label=
  -- check literal and sql identifiers
  select format('INSERT INTO %I VALUES(%L,%L)', 'mytab', 10, 'Hello');
                   format                 
-@@ -238,7 +286,7 @@
+@@ -238,7 +294,7 @@
  
  -- should fail, sql identifier cannot be NULL
  select format('INSERT INTO %I VALUES(%L,%L)', NULL, 10, 'Hello');
@@ -214,7 +206,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/text.out --label=
  -- check positional placeholders
  select format('%1$s %3$s', 1, 2, 3);
   format 
-@@ -254,19 +302,17 @@
+@@ -254,19 +310,17 @@
  
  -- should fail
  select format('%1$s %4$s', 1, 2, 3);
@@ -240,7 +232,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/text.out --label=
  -- check mix of positional and ordered placeholders
  select format('Hello %s %1$s %s', 'World', 'Hello again');
              format             
-@@ -282,56 +328,136 @@
+@@ -282,56 +336,136 @@
  
  -- check variadic labeled arguments
  select format('%s, %s', variadic array['Hello','World']);

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -1424,8 +1424,8 @@ index 2c0f87a651..26bd75bbf0 100644
  
  -- **************** pg_class ****************
 `},
-	// TODO(#114676): Remove the patch around wslot_slotlink_view when
-	// the internal error is fixed.
+	// TODO(yuzefovich): this no longer hits an internal error so no need to
+	// comment it out.
 	{"plpgsql.sql", `diff --git a/src/test/regress/sql/plpgsql.sql b/src/test/regress/sql/plpgsql.sql
 index 924d524094..eb7bc0cf87 100644
 --- a/src/test/regress/sql/plpgsql.sql

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -362,7 +362,8 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"temp",
 		// TODO(#28296): Reenable copy2 when triggers and COPY [view] FROM are supported.
 		// "copy2",
-		"rangefuncs",
+		// TODO(#166495): uncomment when fixed.
+		// "rangefuncs",
 		"sequence",
 		"truncate",
 		"alter_table",


### PR DESCRIPTION
**roachtest/pg_regress: skip rangefuncs because it breaks catalog**

A test case from `rangefuncs` file seemingly breaks the catalog which affects also files that run after it, so skip the file until this is addressed. This is tracked by issue #166495.

**roachtest/pg_regress: accept more simple diffs**

Note that in `text` and `int8` files we accept some differences between us and PG 16.0 since those are incorrect in PG (I confirmed against PG 17.7 that I have locally).

In `plpgsql` test there is one weird difference in the UDF body which I don't immediately understand, but this should be commented out via the patch, and that patch is no longer needed. I left a TODO to follow up on this.

Informs: #162636.
Release note: None