### PR TITLE
roachtest/pg_regress: accept the diffs in a few files

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/horology.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/horology.diffs
@@ -2923,7 +2923,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
   1997-01-02 00:00:00
   1997-01-02 03:04:05
   1997-02-10 17:32:01
-@@ -2667,846 +1168,426 @@
+@@ -2667,505 +1168,410 @@
   1997-02-10 17:32:01
   1997-06-10 17:32:01
   2001-09-22 18:19:20
@@ -2938,11 +2938,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 1997-02-10 17:32:01
 - 1997-02-10 17:32:01
 - 1997-02-10 17:32:01
+  1997-02-10 17:32:01
+  1997-02-10 17:32:01
+  1997-02-10 17:32:01
+  1997-02-10 17:32:01
 - 1997-02-10 17:32:01
-  1997-02-10 17:32:01
-  1997-02-10 17:32:01
-  1997-02-10 17:32:01
-  1997-02-10 17:32:01
 - 1997-02-10 17:32:01
 - 1997-06-10 18:32:01
 - 1997-02-10 17:32:01
@@ -3085,365 +3085,407 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 -         to_timestamp         
 -------------------------------
 - Sat Feb 16 08:14:30 0097 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 0097-02-16 08:14:30-08
+ (1 row)
+ 
  SELECT to_timestamp('97/2/16 8:14:30', 'FMYYYY/FMMM/FMDD FMHH:FMMI:FMSS');
 -         to_timestamp         
 -------------------------------
 - Sat Feb 16 08:14:30 0097 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 0097-02-16 08:14:30-08
+ (1 row)
+ 
  SELECT to_timestamp('2011$03!18 23_38_15', 'YYYY-MM-DD HH24:MI:SS');
 -         to_timestamp         
 -------------------------------
 - Fri Mar 18 23:38:15 2011 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-03-18 23:38:15-07
+ (1 row)
+ 
  SELECT to_timestamp('1985 January 12', 'YYYY FMMonth DD');
 -         to_timestamp         
 -------------------------------
 - Sat Jan 12 00:00:00 1985 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1985-01-12 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('1985 FMMonth 12', 'YYYY "FMMonth" DD');
 -         to_timestamp         
 -------------------------------
 - Sat Jan 12 00:00:00 1985 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1985-01-12 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('1985 \ 12', 'YYYY \\ DD');
 -         to_timestamp         
 -------------------------------
 - Sat Jan 12 00:00:00 1985 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1985-01-12 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('My birthday-> Year: 1976, Month: May, Day: 16',
                      '"My birthday-> Year:" YYYY, "Month:" FMMonth, "Day:" DD');
 -         to_timestamp         
 -------------------------------
 - Sun May 16 00:00:00 1976 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1976-05-16 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('1,582nd VIII 21', 'Y,YYYth FMRM DD');
 -         to_timestamp         
 -------------------------------
 - Sat Aug 21 00:00:00 1582 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1582-08-21 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('15 "text between quote marks" 98 54 45',
                      E'HH24 "\\"text between quote marks\\"" YY MI SS');
 -         to_timestamp         
 -------------------------------
 - Thu Jan 01 15:54:45 1998 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1998-01-01 15:54:45-08
+ (1 row)
+ 
  SELECT to_timestamp('05121445482000', 'MMDDHH24MISSYYYY');
 -         to_timestamp         
 -------------------------------
 - Fri May 12 14:45:48 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-05-12 14:45:48-07
+ (1 row)
+ 
  SELECT to_timestamp('2000January09Sunday', 'YYYYFMMonthDDFMDay');
 -         to_timestamp         
 -------------------------------
 - Sun Jan 09 00:00:00 2000 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-01-09 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('97/Feb/16', 'YYMonDD');
 -ERROR:  invalid value "/Feb/16" for "Mon"
 -DETAIL:  The given value did not match any of the allowed values for this field.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  invalid value for abbreviated month name
  SELECT to_timestamp('97/Feb/16', 'YY:Mon:DD');
 -         to_timestamp         
 -------------------------------
 - Sun Feb 16 00:00:00 1997 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1997-02-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('97/Feb/16', 'FXYY:Mon:DD');
 -         to_timestamp         
 -------------------------------
 - Sun Feb 16 00:00:00 1997 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1997-02-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('97/Feb/16', 'FXYY/Mon/DD');
 -         to_timestamp         
 -------------------------------
 - Sun Feb 16 00:00:00 1997 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1997-02-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('19971116', 'YYYYMMDD');
 -         to_timestamp         
 -------------------------------
 - Sun Nov 16 00:00:00 1997 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1997-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('20000-1116', 'YYYY-MMDD');
 -         to_timestamp          
 --------------------------------
 - Thu Nov 16 00:00:00 20000 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp       
++-------------------------
++ 20000-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('1997 AD 11 16', 'YYYY BC MM DD');
 -         to_timestamp         
 -------------------------------
 - Sun Nov 16 00:00:00 1997 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1997-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('1997 BC 11 16', 'YYYY BC MM DD');
 -          to_timestamp           
 ----------------------------------
 - Tue Nov 16 00:00:00 1997 PST BC
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++       to_timestamp        
++---------------------------
++ 1997-11-16 00:00:00-08 BC
+ (1 row)
+ 
  SELECT to_timestamp('1997 A.D. 11 16', 'YYYY B.C. MM DD');
 -         to_timestamp         
 -------------------------------
 - Sun Nov 16 00:00:00 1997 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1997-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('1997 B.C. 11 16', 'YYYY B.C. MM DD');
 -          to_timestamp           
 ----------------------------------
 - Tue Nov 16 00:00:00 1997 PST BC
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++       to_timestamp        
++---------------------------
++ 1997-11-16 00:00:00-08 BC
+ (1 row)
+ 
  SELECT to_timestamp('9-1116', 'Y-MMDD');
 -         to_timestamp         
 -------------------------------
 - Mon Nov 16 00:00:00 2009 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2009-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('95-1116', 'YY-MMDD');
 -         to_timestamp         
 -------------------------------
 - Thu Nov 16 00:00:00 1995 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1995-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('995-1116', 'YYY-MMDD');
 -         to_timestamp         
 -------------------------------
 - Thu Nov 16 00:00:00 1995 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1995-11-16 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2005426', 'YYYYWWD');
 -         to_timestamp         
 -------------------------------
 - Sat Oct 15 00:00:00 2005 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-10-15 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2005300', 'YYYYDDD');
 -         to_timestamp         
 -------------------------------
 - Thu Oct 27 00:00:00 2005 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-10-27 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2005527', 'IYYYIWID');
 -         to_timestamp         
 -------------------------------
 - Sun Jan 01 00:00:00 2006 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2006-01-01 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('005527', 'IYYIWID');
 -         to_timestamp         
 -------------------------------
 - Sun Jan 01 00:00:00 2006 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2006-01-01 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('05527', 'IYIWID');
 -         to_timestamp         
 -------------------------------
 - Sun Jan 01 00:00:00 2006 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2006-01-01 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('5527', 'IIWID');
 -         to_timestamp         
 -------------------------------
 - Sun Jan 01 00:00:00 2006 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2006-01-01 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2005364', 'IYYYIDDD');
 -         to_timestamp         
 -------------------------------
 - Sun Jan 01 00:00:00 2006 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-12-30 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('20050302', 'YYYYMMDD');
 -         to_timestamp         
 -------------------------------
 - Wed Mar 02 00:00:00 2005 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-03-02 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2005 03 02', 'YYYYMMDD');
 -         to_timestamp         
 -------------------------------
 - Wed Mar 02 00:00:00 2005 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-03-02 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp(' 2005 03 02', 'YYYYMMDD');
 -         to_timestamp         
 -------------------------------
 - Wed Mar 02 00:00:00 2005 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-03-02 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('  20050302', 'YYYYMMDD');
 -         to_timestamp         
 -------------------------------
 - Wed Mar 02 00:00:00 2005 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2005-03-02 00:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 AM', 'YYYY-MM-DD HH12:MI PM');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 11:38:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 11:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 PM', 'YYYY-MM-DD HH12:MI PM');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 A.M.', 'YYYY-MM-DD HH12:MI P.M.');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 11:38:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 11:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 P.M.', 'YYYY-MM-DD HH12:MI P.M.');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 +05',    'YYYY-MM-DD HH12:MI TZH');
 -         to_timestamp         
 -------------------------------
 - Sat Dec 17 22:38:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-17 22:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 -05',    'YYYY-MM-DD HH12:MI TZH');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 08:38:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 08:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 +05:20', 'YYYY-MM-DD HH12:MI TZH:TZM');
 -         to_timestamp         
 -------------------------------
 - Sat Dec 17 22:18:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-17 22:18:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 -05:20', 'YYYY-MM-DD HH12:MI TZH:TZM');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 08:58:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 08:58:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 20',     'YYYY-MM-DD HH12:MI TZM');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 03:18:00 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 11:38:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18 11:38 PST', 'YYYY-MM-DD HH12:MI TZ');  -- NYI
 -ERROR:  formatting field "TZ" is only supported in to_char
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  "TZ"/"tz" format patterns are not supported in to_date/to_timestamp
  SELECT to_timestamp('2018-11-02 12:34:56.025', 'YYYY-MM-DD HH24:MI:SS.MS');
 -           to_timestamp           
 -----------------------------------
 - Fri Nov 02 12:34:56.025 2018 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++        to_timestamp        
++----------------------------
++ 2018-11-02 12:34:56.025-07
+ (1 row)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |         to_timestamp         
 ----+------------------------------
@@ -3453,10 +3495,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56 2018 PDT
 - 5 | Fri Nov 02 12:34:56 2018 PDT
 - 6 | Fri Nov 02 12:34:56 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |      to_timestamp      
++---+------------------------
++ 1 | 2018-11-02 12:34:56-07
++ 2 | 2018-11-02 12:34:56-07
++ 3 | 2018-11-02 12:34:56-07
++ 4 | 2018-11-02 12:34:56-07
++ 5 | 2018-11-02 12:34:56-07
++ 6 | 2018-11-02 12:34:56-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.1', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |          to_timestamp          
 ----+--------------------------------
@@ -3466,10 +3514,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56.1 2018 PDT
 - 5 | Fri Nov 02 12:34:56.1 2018 PDT
 - 6 | Fri Nov 02 12:34:56.1 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |       to_timestamp       
++---+--------------------------
++ 1 | 2018-11-02 12:34:56.1-07
++ 2 | 2018-11-02 12:34:56.1-07
++ 3 | 2018-11-02 12:34:56.1-07
++ 4 | 2018-11-02 12:34:56.1-07
++ 5 | 2018-11-02 12:34:56.1-07
++ 6 | 2018-11-02 12:34:56.1-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.12', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |          to_timestamp           
 ----+---------------------------------
@@ -3479,10 +3533,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56.12 2018 PDT
 - 5 | Fri Nov 02 12:34:56.12 2018 PDT
 - 6 | Fri Nov 02 12:34:56.12 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |       to_timestamp        
++---+---------------------------
++ 1 | 2018-11-02 12:34:56.1-07
++ 2 | 2018-11-02 12:34:56.12-07
++ 3 | 2018-11-02 12:34:56.12-07
++ 4 | 2018-11-02 12:34:56.12-07
++ 5 | 2018-11-02 12:34:56.12-07
++ 6 | 2018-11-02 12:34:56.12-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.123', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |           to_timestamp           
 ----+----------------------------------
@@ -3492,10 +3552,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56.123 2018 PDT
 - 5 | Fri Nov 02 12:34:56.123 2018 PDT
 - 6 | Fri Nov 02 12:34:56.123 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |        to_timestamp        
++---+----------------------------
++ 1 | 2018-11-02 12:34:56.1-07
++ 2 | 2018-11-02 12:34:56.12-07
++ 3 | 2018-11-02 12:34:56.123-07
++ 4 | 2018-11-02 12:34:56.123-07
++ 5 | 2018-11-02 12:34:56.123-07
++ 6 | 2018-11-02 12:34:56.123-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.1234', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |           to_timestamp            
 ----+-----------------------------------
@@ -3505,10 +3571,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56.1234 2018 PDT
 - 5 | Fri Nov 02 12:34:56.1234 2018 PDT
 - 6 | Fri Nov 02 12:34:56.1234 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |        to_timestamp         
++---+-----------------------------
++ 1 | 2018-11-02 12:34:56.1-07
++ 2 | 2018-11-02 12:34:56.12-07
++ 3 | 2018-11-02 12:34:56.123-07
++ 4 | 2018-11-02 12:34:56.1234-07
++ 5 | 2018-11-02 12:34:56.1234-07
++ 6 | 2018-11-02 12:34:56.1234-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.12345', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |            to_timestamp            
 ----+------------------------------------
@@ -3518,10 +3590,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56.1235 2018 PDT
 - 5 | Fri Nov 02 12:34:56.12345 2018 PDT
 - 6 | Fri Nov 02 12:34:56.12345 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |         to_timestamp         
++---+------------------------------
++ 1 | 2018-11-02 12:34:56.1-07
++ 2 | 2018-11-02 12:34:56.12-07
++ 3 | 2018-11-02 12:34:56.123-07
++ 4 | 2018-11-02 12:34:56.1235-07
++ 5 | 2018-11-02 12:34:56.12345-07
++ 6 | 2018-11-02 12:34:56.12345-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.123456', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 - i |            to_timestamp             
 ----+-------------------------------------
@@ -3531,83 +3609,90 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 - 4 | Fri Nov 02 12:34:56.1235 2018 PDT
 - 5 | Fri Nov 02 12:34:56.12346 2018 PDT
 - 6 | Fri Nov 02 12:34:56.123456 2018 PDT
--(6 rows)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ i |         to_timestamp          
++---+-------------------------------
++ 1 | 2018-11-02 12:34:56.1-07
++ 2 | 2018-11-02 12:34:56.12-07
++ 3 | 2018-11-02 12:34:56.123-07
++ 4 | 2018-11-02 12:34:56.1235-07
++ 5 | 2018-11-02 12:34:56.12346-07
++ 6 | 2018-11-02 12:34:56.123456-07
+ (6 rows)
+ 
  SELECT i, to_timestamp('2018-11-02 12:34:56.123456789', 'YYYY-MM-DD HH24:MI:SS.FF' || i) FROM generate_series(1, 6) i;
 -ERROR:  date/time field value out of range: "2018-11-02 12:34:56.123456789"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range
  SELECT to_date('1 4 1902', 'Q MM YYYY');  -- Q is ignored
--  to_date   
--------------
+   to_date   
+ ------------
 - 04-01-1902
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 1902-04-01
+ (1 row)
+ 
  SELECT to_date('3 4 21 01', 'W MM CC YY');
--  to_date   
--------------
+   to_date   
+ ------------
 - 04-15-2001
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2001-04-15
+ (1 row)
+ 
  SELECT to_date('2458872', 'J');
--  to_date   
--------------
+   to_date   
+ ------------
 - 01-23-2020
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2020-01-23
+ (1 row)
+ 
  --
- -- Check handling of BC dates
- --
+@@ -3174,310 +1580,297 @@
  SELECT to_date('44-02-01 BC','YYYY-MM-DD BC');
--    to_date    
-----------------
+     to_date    
+ ---------------
 - 02-01-0044 BC
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 0044-02-01 BC
+ (1 row)
+ 
  SELECT to_date('-44-02-01','YYYY-MM-DD');
--    to_date    
-----------------
+     to_date    
+ ---------------
 - 02-01-0044 BC
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 0044-02-01 BC
+ (1 row)
+ 
  SELECT to_date('-44-02-01 BC','YYYY-MM-DD BC');
--  to_date   
--------------
+   to_date   
+ ------------
 - 02-01-0044
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 0044-02-01
+ (1 row)
+ 
  SELECT to_timestamp('44-02-01 11:12:13 BC','YYYY-MM-DD HH24:MI:SS BC');
 -          to_timestamp           
 ----------------------------------
 - Fri Feb 01 11:12:13 0044 PST BC
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++       to_timestamp        
++---------------------------
++ 0044-02-01 11:12:13-08 BC
+ (1 row)
+ 
  SELECT to_timestamp('-44-02-01 11:12:13','YYYY-MM-DD HH24:MI:SS');
 -          to_timestamp           
 ----------------------------------
 - Fri Feb 01 11:12:13 0044 PST BC
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++       to_timestamp        
++---------------------------
++ 0044-02-01 11:12:13-08 BC
+ (1 row)
+ 
  SELECT to_timestamp('-44-02-01 11:12:13 BC','YYYY-MM-DD HH24:MI:SS BC');
 -         to_timestamp         
 -------------------------------
 - Mon Feb 01 11:12:13 0044 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 0044-02-01 11:12:13-08
+ (1 row)
+ 
  --
  -- Check handling of multiple spaces in format and/or input
  --
@@ -3615,370 +3700,361 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/horology.out --la
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:15 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:15-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18  23:38:15', 'YYYY-MM-DD  HH24:MI:SS');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:15 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:15-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18   23:38:15', 'YYYY-MM-DD  HH24:MI:SS');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:15 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:15-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18  23:38:15', 'YYYY-MM-DD HH24:MI:SS');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:15 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:15-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18  23:38:15', 'YYYY-MM-DD  HH24:MI:SS');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:15 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:15-08
+ (1 row)
+ 
  SELECT to_timestamp('2011-12-18  23:38:15', 'YYYY-MM-DD   HH24:MI:SS');
 -         to_timestamp         
 -------------------------------
 - Sun Dec 18 23:38:15 2011 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2011-12-18 23:38:15-08
+ (1 row)
+ 
  SELECT to_timestamp('2000+   JUN', 'YYYY/MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('  2000 +JUN', 'YYYY/MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp(' 2000 +JUN', 'YYYY//MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2000  +JUN', 'YYYY//MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2000 + JUN', 'YYYY MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2000 ++ JUN', 'YYYY  MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2000 + + JUN', 'YYYY  MON');
 -ERROR:  invalid value "+" for "MON"
 -DETAIL:  The given value did not match any of the allowed values for this field.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  invalid value for abbreviated month name
  SELECT to_timestamp('2000 + + JUN', 'YYYY   MON');
 -         to_timestamp         
 -------------------------------
 - Thu Jun 01 00:00:00 2000 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-06-01 00:00:00-07
+ (1 row)
+ 
  SELECT to_timestamp('2000 -10', 'YYYY TZH');
 -         to_timestamp         
 -------------------------------
 - Sat Jan 01 02:00:00 2000 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2000-01-01 02:00:00-08
+ (1 row)
+ 
  SELECT to_timestamp('2000 -10', 'YYYY  TZH');
 -         to_timestamp         
 -------------------------------
 - Fri Dec 31 06:00:00 1999 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1999-12-31 06:00:00-08
+ (1 row)
+ 
  SELECT to_date('2011 12  18', 'YYYY MM DD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011 12  18', 'YYYY MM  DD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011 12  18', 'YYYY MM   DD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011 12 18', 'YYYY  MM DD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011  12 18', 'YYYY  MM DD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011   12 18', 'YYYY  MM DD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011 12 18', 'YYYYxMMxDD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011x 12x 18', 'YYYYxMMxDD');
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-18-2011
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2011-12-18
+ (1 row)
+ 
  SELECT to_date('2011 x12 x18', 'YYYYxMMxDD');
--ERROR:  invalid value "x1" for "MM"
+ ERROR:  invalid value "x1" for "MM"
 -DETAIL:  Value must be an integer.
-+ERROR:  unknown function: to_date()
  --
  -- Check errors for some incorrect usages of to_timestamp() and to_date()
  --
  -- Mixture of date conventions (ISO week and Gregorian):
  SELECT to_timestamp('2005527', 'YYYYIWID');
--ERROR:  invalid combination of date conventions
+ ERROR:  invalid combination of date conventions
 -HINT:  Do not mix Gregorian and ISO week date conventions in a formatting template.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  -- Insufficient characters in the source string:
  SELECT to_timestamp('19971', 'YYYYMMDD');
--ERROR:  source string too short for "MM" formatting field
+ ERROR:  source string too short for "MM" formatting field
 -DETAIL:  Field requires 2 characters, but only 1 remain.
 -HINT:  If your source string is not fixed-width, try using the "FM" modifier.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  -- Insufficient digit characters for a single node:
  SELECT to_timestamp('19971)24', 'YYYYMMDD');
--ERROR:  invalid value "1)" for "MM"
+ ERROR:  invalid value "1)" for "MM"
 -DETAIL:  Field requires 2 characters, but only 1 could be parsed.
 -HINT:  If your source string is not fixed-width, try using the "FM" modifier.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  -- We don't accept full-length day or month names if short form is specified:
  SELECT to_timestamp('Friday 1-January-1999', 'DY DD MON YYYY');
--ERROR:  invalid value "da" for "DD"
+ ERROR:  invalid value "da" for "DD"
 -DETAIL:  Value must be an integer.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  SELECT to_timestamp('Fri 1-January-1999', 'DY DD MON YYYY');
--ERROR:  invalid value "uary" for "YYYY"
+ ERROR:  invalid value "uary" for "YYYY"
 -DETAIL:  Value must be an integer.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  SELECT to_timestamp('Fri 1-Jan-1999', 'DY DD MON YYYY');  -- ok
 -         to_timestamp         
 -------------------------------
 - Fri Jan 01 00:00:00 1999 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 1999-01-01 00:00:00-08
+ (1 row)
+ 
  -- Value clobbering:
  SELECT to_timestamp('1997-11-Jan-16', 'YYYY-MM-Mon-DD');
--ERROR:  conflicting values for "Mon" field in formatting string
+ ERROR:  conflicting values for "Mon" field in formatting string
 -DETAIL:  This value contradicts a previous setting for the same field type.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  -- Non-numeric input:
  SELECT to_timestamp('199711xy', 'YYYYMMDD');
--ERROR:  invalid value "xy" for "DD"
+ ERROR:  invalid value "xy" for "DD"
 -DETAIL:  Value must be an integer.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  -- Input that doesn't fit in an int:
  SELECT to_timestamp('10000000000', 'FMYYYY');
--ERROR:  value for "YYYY" in source string is out of range
+ ERROR:  value for "YYYY" in source string is out of range
 -DETAIL:  Value must be in the range -2147483648 to 2147483647.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  -- Out-of-range and not-quite-out-of-range fields:
  SELECT to_timestamp('2016-06-13 25:00:00', 'YYYY-MM-DD HH24:MI:SS');
 -ERROR:  date/time field value out of range: "2016-06-13 25:00:00"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: hour must be between 0 and 23, got 25
  SELECT to_timestamp('2016-06-13 15:60:00', 'YYYY-MM-DD HH24:MI:SS');
 -ERROR:  date/time field value out of range: "2016-06-13 15:60:00"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: minute must be between 0 and 59, got 60
  SELECT to_timestamp('2016-06-13 15:50:60', 'YYYY-MM-DD HH24:MI:SS');
 -ERROR:  date/time field value out of range: "2016-06-13 15:50:60"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: second must be between 0 and 59, got 60
  SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
 -         to_timestamp         
 -------------------------------
 - Mon Jun 13 15:50:55 2016 PDT
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2016-06-13 15:50:55-07
+ (1 row)
+ 
  SELECT to_timestamp('2016-06-13 15:50:55', 'YYYY-MM-DD HH:MI:SS');
--ERROR:  hour "15" is invalid for the 12-hour clock
+ ERROR:  hour "15" is invalid for the 12-hour clock
 -HINT:  Use the 24-hour clock, or give an hour between 1 and 12.
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  SELECT to_timestamp('2016-13-01 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
 -ERROR:  date/time field value out of range: "2016-13-01 15:50:55"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: month must be between 1 and 12, got 13
  SELECT to_timestamp('2016-02-30 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
 -ERROR:  date/time field value out of range: "2016-02-30 15:50:55"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: day must be between 1 and 29 for month 2, got 30
  SELECT to_timestamp('2016-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');  -- ok
 -         to_timestamp         
 -------------------------------
 - Mon Feb 29 15:50:55 2016 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2016-02-29 15:50:55-08
+ (1 row)
+ 
  SELECT to_timestamp('2015-02-29 15:50:55', 'YYYY-MM-DD HH24:MI:SS');
 -ERROR:  date/time field value out of range: "2015-02-29 15:50:55"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: day must be between 1 and 28 for month 2, got 29
  SELECT to_timestamp('2015-02-11 86000', 'YYYY-MM-DD SSSS');  -- ok
 -         to_timestamp         
 -------------------------------
 - Wed Feb 11 23:53:20 2015 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2015-02-11 23:53:20-08
+ (1 row)
+ 
  SELECT to_timestamp('2015-02-11 86400', 'YYYY-MM-DD SSSS');
 -ERROR:  date/time field value out of range: "2015-02-11 86400"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: hour must be between 0 and 23, got 24
  SELECT to_timestamp('2015-02-11 86000', 'YYYY-MM-DD SSSSS');  -- ok
 -         to_timestamp         
 -------------------------------
 - Wed Feb 11 23:53:20 2015 PST
--(1 row)
--
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++      to_timestamp      
++------------------------
++ 2015-02-11 23:53:20-08
+ (1 row)
+ 
  SELECT to_timestamp('2015-02-11 86400', 'YYYY-MM-DD SSSSS');
 -ERROR:  date/time field value out of range: "2015-02-11 86400"
-+ERROR:  unknown signature: to_timestamp(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  date/time field value out of range: hour must be between 0 and 23, got 24
  SELECT to_date('2016-13-10', 'YYYY-MM-DD');
 -ERROR:  date/time field value out of range: "2016-13-10"
-+ERROR:  unknown function: to_date()
++ERROR:  date/time field value out of range: month must be between 1 and 12, got 13
  SELECT to_date('2016-02-30', 'YYYY-MM-DD');
 -ERROR:  date/time field value out of range: "2016-02-30"
-+ERROR:  unknown function: to_date()
++ERROR:  date/time field value out of range: day must be between 1 and 29 for month 2, got 30
  SELECT to_date('2016-02-29', 'YYYY-MM-DD');  -- ok
--  to_date   
--------------
+   to_date   
+ ------------
 - 02-29-2016
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2016-02-29
+ (1 row)
+ 
  SELECT to_date('2015-02-29', 'YYYY-MM-DD');
 -ERROR:  date/time field value out of range: "2015-02-29"
-+ERROR:  unknown function: to_date()
++ERROR:  date/time field value out of range: day must be between 1 and 28 for month 2, got 29
  SELECT to_date('2015 365', 'YYYY DDD');  -- ok
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-31-2015
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2015-12-31
+ (1 row)
+ 
  SELECT to_date('2015 366', 'YYYY DDD');
 -ERROR:  date/time field value out of range: "2015 366"
-+ERROR:  unknown function: to_date()
++ERROR:  date/time field value out of range
  SELECT to_date('2016 365', 'YYYY DDD');  -- ok
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-30-2016
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2016-12-30
+ (1 row)
+ 
  SELECT to_date('2016 366', 'YYYY DDD');  -- ok
--  to_date   
--------------
+   to_date   
+ ------------
 - 12-31-2016
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 2016-12-31
+ (1 row)
+ 
  SELECT to_date('2016 367', 'YYYY DDD');
 -ERROR:  date/time field value out of range: "2016 367"
-+ERROR:  unknown function: to_date()
++ERROR:  date/time field value out of range
  SELECT to_date('0000-02-01','YYYY-MM-DD');  -- allowed, though it shouldn't be
--    to_date    
-----------------
+     to_date    
+ ---------------
 - 02-01-0001 BC
--(1 row)
--
-+ERROR:  unknown function: to_date()
++ 0001-02-01 BC
+ (1 row)
+ 
  --
- -- Check behavior with SQL-style fixed-GMT-offset time zone (cf bug #8572)
- --
+@@ -3486,27 +1879,27 @@
  SET TIME ZONE 'America/New_York';
  SET TIME ZONE '-1.5';
  SHOW TIME ZONE;

--- a/pkg/cmd/roachtest/testdata/pg_regress/numeric.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/numeric.diffs
@@ -738,7 +738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  -- Check cases that could trigger overflow or underflow within the calculation
  SELECT oper, low, high, cnt, width_bucket(oper, low, high, cnt)
  FROM
-@@ -1516,379 +1286,90 @@
+@@ -1516,27 +1286,14 @@
      (0, 0, 1, 2147483647),
      (1, 1, 0, 2147483647)
    ) as sample(oper, low, high, cnt);
@@ -771,268 +771,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- TO_CHAR()
  --
- SELECT to_char(val, '9G999G999G999G999G999')
- 	FROM num_data;
--        to_char         
--------------------------
--                      0
--                      0
--            -34,338,492
--                      4
--              7,799,461
--                 16,397
--                 93,902
--            -83,028,485
--                 74,881
--            -24,926,804
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, '9G999G999G999G999G999D999G999G999G999G999')
- 	FROM num_data;
--                  to_char                   
----------------------------------------------
--                       .000,000,000,000,000
--                       .000,000,000,000,000
--            -34,338,492.215,397,047,000,000
--                      4.310,000,000,000,000
--              7,799,461.411,900,000,000,000
--                 16,397.038,491,000,000,000
--                 93,901.577,630,260,000,000
--            -83,028,485.000,000,000,000,000
--                 74,881.000,000,000,000,000
--            -24,926,804.045,047,420,000,000
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, '9999999999999999.999999999999999PR')
- 	FROM num_data;
--              to_char               
--------------------------------------
--                  .000000000000000 
--                  .000000000000000 
--         <34338492.215397047000000>
--                 4.310000000000000 
--           7799461.411900000000000 
--             16397.038491000000000 
--             93901.577630260000000 
--         <83028485.000000000000000>
--             74881.000000000000000 
--         <24926804.045047420000000>
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, '9999999999999999.999999999999999S')
- 	FROM num_data;
--              to_char              
-------------------------------------
--                 .000000000000000+
--                 .000000000000000+
--         34338492.215397047000000-
--                4.310000000000000+
--          7799461.411900000000000+
--            16397.038491000000000+
--            93901.577630260000000+
--         83028485.000000000000000-
--            74881.000000000000000+
--         24926804.045047420000000-
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'MI9999999999999999.999999999999999')     FROM num_data;
--              to_char              
-------------------------------------
--                  .000000000000000
--                  .000000000000000
-- -        34338492.215397047000000
--                 4.310000000000000
--           7799461.411900000000000
--             16397.038491000000000
--             93901.577630260000000
-- -        83028485.000000000000000
--             74881.000000000000000
-- -        24926804.045047420000000
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FMS9999999999999999.999999999999999')    FROM num_data;
--       to_char       
-----------------------
-- +0.
-- +0.
-- -34338492.215397047
-- +4.31
-- +7799461.4119
-- +16397.038491
-- +93901.57763026
-- -83028485.
-- +74881.
-- -24926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM9999999999999999.999999999999999THPR') FROM num_data;
--       to_char        
------------------------
-- 0.
-- 0.
-- <34338492.215397047>
-- 4.31
-- 7799461.4119
-- 16397.038491
-- 93901.57763026
-- <83028485.>
-- 74881.
-- <24926804.04504742>
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'SG9999999999999999.999999999999999th')   FROM num_data;
--              to_char              
-------------------------------------
-- +                .000000000000000
-- +                .000000000000000
-- -        34338492.215397047000000
-- +               4.310000000000000
-- +         7799461.411900000000000
-- +           16397.038491000000000
-- +           93901.577630260000000
-- -        83028485.000000000000000
-- +           74881.000000000000000
-- -        24926804.045047420000000
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, '0999999999999999.999999999999999')       FROM num_data;
--              to_char              
-------------------------------------
--  0000000000000000.000000000000000
--  0000000000000000.000000000000000
-- -0000000034338492.215397047000000
--  0000000000000004.310000000000000
--  0000000007799461.411900000000000
--  0000000000016397.038491000000000
--  0000000000093901.577630260000000
-- -0000000083028485.000000000000000
--  0000000000074881.000000000000000
-- -0000000024926804.045047420000000
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'S0999999999999999.999999999999999')      FROM num_data;
--              to_char              
-------------------------------------
-- +0000000000000000.000000000000000
-- +0000000000000000.000000000000000
-- -0000000034338492.215397047000000
-- +0000000000000004.310000000000000
-- +0000000007799461.411900000000000
-- +0000000000016397.038491000000000
-- +0000000000093901.577630260000000
-- -0000000083028485.000000000000000
-- +0000000000074881.000000000000000
-- -0000000024926804.045047420000000
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM0999999999999999.999999999999999')     FROM num_data;
--           to_char           
-------------------------------
-- 0000000000000000.
-- 0000000000000000.
-- -0000000034338492.215397047
-- 0000000000000004.31
-- 0000000007799461.4119
-- 0000000000016397.038491
-- 0000000000093901.57763026
-- -0000000083028485.
-- 0000000000074881.
-- -0000000024926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM9999999999999999.099999999999999') 	FROM num_data;
--       to_char       
-----------------------
-- .0
-- .0
-- -34338492.215397047
-- 4.31
-- 7799461.4119
-- 16397.038491
-- 93901.57763026
-- -83028485.0
-- 74881.0
-- -24926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM9999999999990999.990999999999999') 	FROM num_data;
--       to_char       
-----------------------
-- 0000.000
-- 0000.000
-- -34338492.215397047
-- 0004.310
-- 7799461.4119
-- 16397.038491
-- 93901.57763026
-- -83028485.000
-- 74881.000
-- -24926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM0999999999999999.999909999999999') 	FROM num_data;
--           to_char           
-------------------------------
-- 0000000000000000.00000
-- 0000000000000000.00000
-- -0000000034338492.215397047
-- 0000000000000004.31000
-- 0000000007799461.41190
-- 0000000000016397.038491
-- 0000000000093901.57763026
-- -0000000083028485.00000
-- 0000000000074881.00000
-- -0000000024926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM9999999990999999.099999999999999') 	FROM num_data;
--       to_char       
-----------------------
-- 0000000.0
-- 0000000.0
-- -34338492.215397047
-- 0000004.31
-- 7799461.4119
-- 0016397.038491
-- 0093901.57763026
-- -83028485.0
-- 0074881.0
-- -24926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+@@ -1772,16 +1529,16 @@
  SELECT to_char(val, 'L9999999999999999.099999999999999')	FROM num_data;
--              to_char               
--------------------------------------
+               to_char               
+ ------------------------------------
 -                   .000000000000000
 -                   .000000000000000
 -          -34338492.215397047000000
@@ -1043,133 +785,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
 -          -83028485.000000000000000
 -              74881.000000000000000
 -          -24926804.045047420000000
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ $                 .000000000000000
++ $                 .000000000000000
++ $        -34338492.215397047000000
++ $                4.310000000000000
++ $          7799461.411900000000000
++ $            16397.038491000000000
++ $            93901.577630260000000
++ $        -83028485.000000000000000
++ $            74881.000000000000000
++ $        -24926804.045047420000000
+ (10 rows)
+ 
  SELECT to_char(val, 'FM9999999999999999.99999999999999')	FROM num_data;
--       to_char       
-----------------------
-- 0.
-- 0.
-- -34338492.215397047
-- 4.31
-- 7799461.4119
-- 16397.038491
-- 93901.57763026
-- -83028485.
-- 74881.
-- -24926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'S 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 . 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9') FROM num_data;
--                                to_char                                
-------------------------------------------------------------------------
--                                  +. 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
--                                  +. 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
--                  -3 4 3 3 8 4 9 2 . 2 1 5 3 9 7 0 4 7 0 0 0 0 0 0 0 0
--                                +4 . 3 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
--                    +7 7 9 9 4 6 1 . 4 1 1 9 0 0 0 0 0 0 0 0 0 0 0 0 0
--                        +1 6 3 9 7 . 0 3 8 4 9 1 0 0 0 0 0 0 0 0 0 0 0
--                        +9 3 9 0 1 . 5 7 7 6 3 0 2 6 0 0 0 0 0 0 0 0 0
--                  -8 3 0 2 8 4 8 5 . 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
--                        +7 4 8 8 1 . 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
--                  -2 4 9 2 6 8 0 4 . 0 4 5 0 4 7 4 2 0 0 0 0 0 0 0 0 0
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FMS 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 . 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9') FROM num_data;
--                        to_char                        
---------------------------------------------------------
--                 +0 .                 
--                 +0 .                 
--          -3 4 3 3 8 4 9 2 . 2 1 5 3 9 7 0 4 7        
--                 +4 . 3 1               
--           +7 7 9 9 4 6 1 . 4 1 1 9             
--             +1 6 3 9 7 . 0 3 8 4 9 1           
--             +9 3 9 0 1 . 5 7 7 6 3 0 2 6         
--          -8 3 0 2 8 4 8 5 .                 
--             +7 4 8 8 1 .                 
--          -2 4 9 2 6 8 0 4 . 0 4 5 0 4 7 4 2         
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, E'99999 "text" 9999 "9999" 999 "\\"text between quote marks\\"" 9999') FROM num_data;
--                          to_char                          
-------------------------------------------------------------
--       text      9999     "text between quote marks"     0
--       text      9999     "text between quote marks"     0
--       text    -3 9999 433 "text between quote marks" 8492
--       text      9999     "text between quote marks"     4
--       text      9999  779 "text between quote marks" 9461
--       text      9999    1 "text between quote marks" 6397
--       text      9999    9 "text between quote marks" 3902
--       text    -8 9999 302 "text between quote marks" 8485
--       text      9999    7 "text between quote marks" 4881
--       text    -2 9999 492 "text between quote marks" 6804
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, '999999SG9999999999')			FROM num_data;
--      to_char      
---------------------
--       +         0
--       +         0
--       -  34338492
--       +         4
--       +   7799461
--       +     16397
--       +     93902
--       -  83028485
--       +     74881
--       -  24926804
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, 'FM9999999999999999.999999999999999')	FROM num_data;
--       to_char       
-----------------------
-- 0.
-- 0.
-- -34338492.215397047
-- 4.31
-- 7799461.4119
-- 16397.038491
-- 93901.57763026
-- -83028485.
-- 74881.
-- -24926804.04504742
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char(val, '9.999EEEE')				FROM num_data;
--  to_char   
--------------
--  0.000e+00
--  0.000e+00
-- -3.434e+07
--  4.310e+00
--  7.799e+06
--  1.640e+04
--  9.390e+04
-- -8.303e+07
--  7.488e+04
-- -2.493e+07
--(10 rows)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- WITH v(val) AS
-   (VALUES('0'::numeric),('-4.2'),('4.2e9'),('1.2e-5'),('inf'),('-inf'),('nan'))
- SELECT val,
-@@ -1896,49 +1377,15 @@
+@@ -1896,49 +1653,14 @@
    to_char(val::float8, '9.999EEEE') as float8,
    to_char(val::float4, '9.999EEEE') as float4
  FROM v;
@@ -1217,12 +846,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
 - 131071 |  1.235e+131071
 -(22 rows)
 -
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ERROR:  could not parse "1.2345e-16379" as type decimal: underflow, subnormal
  WITH v(val) AS
    (VALUES('0'::numeric),('-4.2'),('4.2e9'),('1.2e-5'),('inf'),('-inf'),('nan'))
  SELECT val,
-@@ -1946,17 +1393,7 @@
+@@ -1946,17 +1668,7 @@
    to_char(val::float8, 'MI9999999999.99') as float8,
    to_char(val::float4, 'MI9999999999.99') as float4
  FROM v;
@@ -1241,7 +869,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  WITH v(val) AS
    (VALUES('0'::numeric),('-4.2'),('4.2e9'),('1.2e-5'),('inf'),('-inf'),('nan'))
  SELECT val,
-@@ -1964,237 +1401,100 @@
+@@ -1964,17 +1676,7 @@
    to_char(val::float8, 'MI99.99') as float8,
    to_char(val::float4, 'MI99.99') as float4
  FROM v;
@@ -1258,118 +886,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
 -
 +ERROR:  VALUES types string and decimal cannot be matched
  SELECT to_char('100'::numeric, 'FM999.9');
-- to_char 
-----------
-- 100.
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'FM999.');
-- to_char 
-----------
-- 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'FM999');
-- to_char 
-----------
-- 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('12345678901'::float8, 'FM9999999999D9999900000000000000000');
--     to_char     
-------------------
-- ##########.####
--(1 row)
--
-+ERROR:  unknown signature: to_char(float, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- -- Check parsing of literal text in a format string
- SELECT to_char('100'::numeric, 'foo999');
-- to_char 
-----------
-- foo 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f\oo999');
-- to_char  
------------
-- f\oo 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f\\oo999');
--  to_char  
-------------
-- f\\oo 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f\"oo999');
-- to_char  
------------
-- f"oo 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f\\"oo999');
--  to_char  
-------------
-- f\"oo 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f"ool"999');
-- to_char  
------------
-- fool 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f"\ool"999');
-- to_char  
------------
-- fool 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f"\\ool"999');
--  to_char  
-------------
-- f\ool 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f"ool\"999');
-- to_char  
------------
-- fool"999
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- SELECT to_char('100'::numeric, 'f"ool\\"999');
--  to_char  
-------------
-- fool\ 100
--(1 row)
--
-+ERROR:  unknown signature: to_char(decimal, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+  to_char 
+ ---------
+@@ -2063,6 +1765,9 @@
  -- TO_NUMBER()
  --
  SET lc_numeric = 'C';
@@ -1377,163 +896,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
 +DETAIL:  this parameter is currently recognized only for compatibility and has no effect in CockroachDB.
 +HINT:  Available values: c.utf-8
  SELECT to_number('-34,338,492', '99G999G999');
-- to_number 
-------------
-- -34338492
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('-34,338,492.654,878', '99G999G999D999G999');
--    to_number     
--------------------
-- -34338492.654878
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('<564646.654564>', '999999.999999PR');
--   to_number    
------------------
-- -564646.654564
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('0.00001-', '9.999999S');
-- to_number 
-------------
--  -0.00001
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('5.01-', 'FM9.999999S');
-- to_number 
-------------
--     -5.01
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('5.01-', 'FM9.999999MI');
-- to_number 
-------------
--     -5.01
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('5 4 4 4 4 8 . 7 8', '9 9 9 9 9 9 . 9 9');
-- to_number 
-------------
-- 544448.78
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('.01', 'FM9.99');
-- to_number 
-------------
--      0.01
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('.0', '99999999.99999999');
-- to_number 
-------------
--       0.0
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('0', '99.99');
-- to_number 
-------------
--         0
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('.-01', 'S99.99');
-- to_number 
-------------
--     -0.01
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('.01-', '99.99S');
-- to_number 
-------------
--     -0.01
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number(' . 0 1-', ' 9 9 . 9 9 S');
-- to_number 
-------------
--     -0.01
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('34,50','999,99');
-- to_number 
-------------
--      3450
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('123,000','999G');
-- to_number 
-------------
--       123
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('123456','999G999');
-- to_number 
-------------
--    123456
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('$1234.56','L9,999.99');
-- to_number 
-------------
--   1234.56
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('$1234.56','L99,999.99');
-- to_number 
-------------
--   1234.56
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('$1,234.56','L99,999.99');
-- to_number 
-------------
--   1234.56
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('1234.56','L99,999.99');
-- to_number 
-------------
--   1234.56
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('1,234.56','L99,999.99');
-- to_number 
-------------
--   1234.56
--(1 row)
--
-+ERROR:  unknown function: to_number()
- SELECT to_number('42nd', '99th');
-- to_number 
-------------
--        42
--(1 row)
--
-+ERROR:  unknown function: to_number()
- RESET lc_numeric;
- --
- -- Input syntax
-@@ -2215,203 +1515,117 @@
+  to_number 
+ -----------
+@@ -2215,203 +1920,117 @@
  INSERT INTO num_input_test(n1) VALUES (' +inFinity ');
  INSERT INTO num_input_test(n1) VALUES (' -INFINITY ');
  INSERT INTO num_input_test(n1) VALUES ('12_000_000_000');
@@ -1799,7 +1164,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- Test precision and scale typemods
  --
-@@ -2422,59 +1636,56 @@
+@@ -2422,59 +2041,56 @@
    thousandths numeric(3, 3),
    millionths numeric(3, 6)
  );
@@ -1890,7 +1255,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- Test some corner cases for multiplication
  --
-@@ -2503,11 +1714,7 @@
+@@ -2503,11 +2119,7 @@
  (1 row)
  
  select trim_scale((0.1 - 2e-16383) * (0.1 - 3e-16383));
@@ -1903,7 +1268,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- Test some corner cases for division
  --
-@@ -2560,9 +1767,9 @@
+@@ -2560,9 +2172,9 @@
  (1 row)
  
  select 70.0 / 70 ;
@@ -1916,7 +1281,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  select 12345678901234567890 % 123;
-@@ -2572,9 +1779,9 @@
+@@ -2572,9 +2184,9 @@
  (1 row)
  
  select 12345678901234567890 / 123;
@@ -1929,7 +1294,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  select div(12345678901234567890, 123);
-@@ -2593,239 +1800,183 @@
+@@ -2593,239 +2205,183 @@
  -- Test some corner cases for square root
  --
  select sqrt(1.000000000000003::numeric);
@@ -2251,7 +1616,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  -- NaNs
-@@ -2866,34 +2017,34 @@
+@@ -2866,34 +2422,34 @@
  ERROR:  a negative number raised to a non-integer power yields a complex result
  -- cases that used to generate inaccurate results
  select 32.1 ^ 9.8;
@@ -2301,7 +1666,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  --
-@@ -2901,21 +2052,21 @@
+@@ -2901,21 +2457,21 @@
  --
  -- special cases
  select exp(0.0);
@@ -2332,7 +1697,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  select exp('nan'::numeric);
-@@ -2937,145 +2088,92 @@
+@@ -2937,145 +2493,92 @@
  (1 row)
  
  select coalesce(nullif(exp(-5000::numeric), 0), 0) as rounds_to_zero;
@@ -2523,7 +1888,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- Tests for LN()
  --
-@@ -3086,51 +2184,51 @@
+@@ -3086,51 +2589,51 @@
  ERROR:  cannot take logarithm of zero
  -- Some random tests
  select ln(1.2345678e-28);
@@ -2599,7 +1964,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  --
-@@ -3139,45 +2237,43 @@
+@@ -3139,45 +2642,43 @@
  -- invalid inputs
  select log(-12.34);
  ERROR:  cannot take logarithm of a negative number
@@ -2663,7 +2028,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  (1 row)
  
  --
-@@ -3198,230 +2294,102 @@
+@@ -3198,230 +2699,102 @@
  ERROR:  division by zero
  -- some random tests
  select log(1.23e-89, 6.4689e45);
@@ -2938,7 +2303,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- Tests for SUM()
  --
-@@ -3446,47 +2414,100 @@
+@@ -3446,47 +2819,100 @@
  INSERT INTO num_variance VALUES (3e-500);
  INSERT INTO num_variance VALUES (-3e-500);
  INSERT INTO num_variance VALUES (4e-500 - 1e-16383);
@@ -3055,7 +2420,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  DROP TABLE num_variance;
  --
  -- Tests for GCD()
-@@ -3502,19 +2523,7 @@
+@@ -3502,19 +2928,7 @@
               ('inf', '42'),
               ('inf', 'inf')
       ) AS v(a, b);
@@ -3076,7 +2441,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/numeric.out --lab
  --
  -- Tests for LCM()
  --
-@@ -3530,71 +2539,40 @@
+@@ -3530,71 +2944,40 @@
               ('inf', '42'),
               ('inf', 'inf')
       ) AS v(a, b);

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -221,6 +221,8 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"comments",
 		"geometry",
 		"xid",
+		// TODO(yuzefovich): add a patch to explicitly set the time zone in the
+		// 'horology' so that time zone handling is unified between two DBs.
 		"horology",
 		"type_sanity",
 		"expressions",


### PR DESCRIPTION
**roachtest/pg_regress: accept the diff in `numeric`**

Here we have a deviation with the `$` sign - the PG has incorrect result, but we match PG 17.7.

**roachtest/pg_regress: accept the diff in `horology`**

We now have support for `to_timestamp` builtin. Note that this commit accepts some deviations from PG (i.e. the diff is larger than we would like) due to two differences:
- we hard-code PG 16.0 version of the regress suite, so the "expected" result is actually wrong
- we behave differently in regards to handling the time zone. Namely, PG defaults to using the server's time zone whereas we default to using UTC. A TODO is left to adjust the file by explicitly setting the UTC timezone in PG too.

Informs: #162636.
Release note: None