### PR TITLE
security: fix data race in certificate expiration metric closures

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -104,7 +104,7 @@ func makeCertificateManager(
 		timeSource:       o.timeSource,
 		tlsSettings:      tlsSettings,
 	}
-	cm.certMetrics = createMetricsLocked(cm)
+	cm.certMetrics = createMetrics(cm)
 	return cm
 }
 
@@ -284,6 +284,30 @@ func (cm *CertificateManager) NodeCert() *CertInfo {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 	return cm.nodeCert
+}
+
+// NodeClientCert returns the client cert for the 'node' user. May be nil.
+// Callers should check for an internal Error field.
+func (cm *CertificateManager) NodeClientCert() *CertInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.nodeClientCert
+}
+
+// TenantCert returns the tenant client cert. May be nil.
+// Callers should check for an internal Error field.
+func (cm *CertificateManager) TenantCert() *CertInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.tenantCert
+}
+
+// TenantCACert returns the tenant CA cert. May be nil.
+// Callers should check for an internal Error field.
+func (cm *CertificateManager) TenantCACert() *CertInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.tenantCACert
 }
 
 // ClientCerts returns the Client certs.

--- a/pkg/security/certificate_metrics.go
+++ b/pkg/security/certificate_metrics.go
@@ -256,11 +256,11 @@ func ttlGauge(
 
 var defaultTimeSource = timeutil.DefaultTimeSource{}
 
-// createMetricsLocked makes metrics using the certificate values on the manager.
+// createMetrics makes metrics using the certificate values on the manager.
 // If the corresponding certificate is missing or invalid (Error != nil), we reset the
 // metric to zero.
-// cm.mu must be held to protect the certificates. Metrics do their own atomicity.
-func createMetricsLocked(cm *CertificateManager) *Metrics {
+// The returned FunctionalGauge closures acquire cm.mu internally when read.
+func createMetrics(cm *CertificateManager) *Metrics {
 	ts := cm.timeSource
 	if ts == nil {
 		ts = defaultTimeSource
@@ -268,23 +268,23 @@ func createMetricsLocked(cm *CertificateManager) *Metrics {
 	b := aggmetric.MakeBuilder(SQLUserLabel)
 	return &Metrics{
 		CAExpiration:         expirationGauge(metaCAExpiration, cm.CACert),
-		TenantExpiration:     expirationGauge(metaTenantExpiration, func() *CertInfo { return cm.tenantCert }),
-		TenantCAExpiration:   expirationGauge(metaTenantCAExpiration, func() *CertInfo { return cm.tenantCACert }),
+		TenantExpiration:     expirationGauge(metaTenantExpiration, cm.TenantCert),
+		TenantCAExpiration:   expirationGauge(metaTenantCAExpiration, cm.TenantCACert),
 		UIExpiration:         expirationGauge(metaUIExpiration, cm.UICert),
 		UICAExpiration:       expirationGauge(metaUICAExpiration, cm.UICACert),
 		ClientExpiration:     b.Gauge(metaClientExpiration),
 		ClientCAExpiration:   expirationGauge(metaClientCAExpiration, cm.ClientCACert),
 		NodeExpiration:       expirationGauge(metaNodeExpiration, cm.NodeCert),
-		NodeClientExpiration: expirationGauge(metaNodeClientExpiration, func() *CertInfo { return cm.nodeClientCert }),
+		NodeClientExpiration: expirationGauge(metaNodeClientExpiration, cm.NodeClientCert),
 
 		CATTL:         ttlGauge(metaCATTL, cm.CACert, ts),
-		TenantTTL:     ttlGauge(metaTenantTTL, func() *CertInfo { return cm.tenantCert }, ts),
-		TenantCATTL:   ttlGauge(metaTenantCATTL, func() *CertInfo { return cm.tenantCACert }, ts),
+		TenantTTL:     ttlGauge(metaTenantTTL, cm.TenantCert, ts),
+		TenantCATTL:   ttlGauge(metaTenantCATTL, cm.TenantCACert, ts),
 		UITTL:         ttlGauge(metaUITTL, cm.UICert, ts),
 		UICATTL:       ttlGauge(metaUICATTL, cm.UICACert, ts),
 		ClientTTL:     b.FunctionalGauge(metaClientTTL, func(cvs []int64) int64 { return 0 }),
 		ClientCATTL:   ttlGauge(metaClientCATTL, cm.ClientCACert, ts),
 		NodeTTL:       ttlGauge(metaNodeTTL, cm.NodeCert, ts),
-		NodeClientTTL: ttlGauge(metaNodeClientTTL, func() *CertInfo { return cm.nodeClientCert }, ts),
+		NodeClientTTL: ttlGauge(metaNodeClientTTL, cm.NodeClientCert, ts),
 	}
 }

--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -8,11 +8,13 @@ package security_test
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
@@ -156,4 +158,98 @@ func TestCertificateReload(t *testing.T) {
 	// expiration = 1000, ttl = 999.
 	require.Equal(t, 1000, int(caCertExpiration.Value()))
 	require.Equal(t, 999, int(caCertTTL.Value()))
+}
+
+// TestCertificateMetricsReloadRace verifies that all certificate expiration and
+// TTL metrics update correctly after certificate rotation, and that reading the
+// metrics concurrently with LoadCertificates does not race. Before the fix,
+// some metric closures (NodeClientExpiration, TenantExpiration,
+// TenantCAExpiration and their TTL counterparts) read CertificateManager fields
+// without holding cm.mu, which is a data race detectable with -race.
+func TestCertificateMetricsReloadRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	now := timeutil.Unix(1, 0)
+	certsDir := t.TempDir()
+	writeTestCerts(t, certsDir)
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(timeutil.NewManualTime(now)),
+		security.ForTenant(1),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+
+	// Each entry maps a cert file to its expiration/TTL metrics and the
+	// initial values assigned by writeTestCerts (expiration = offset + 2,
+	// TTL = expiration - now = expiration - 1).
+	type metricCheck struct {
+		name          string
+		certFile      string
+		expiration    *metric.FunctionalGauge
+		ttl           *metric.FunctionalGauge
+		initialExp    int64
+		initialTTL    int64
+		newExpiration int64
+	}
+	checks := []metricCheck{
+		{"CA", "ca.crt", metrics.CAExpiration, metrics.CATTL, 2, 1, 1000},
+		{"ClientCA", "ca-client.crt", metrics.ClientCAExpiration, metrics.ClientCATTL, 3, 2, 1001},
+		{"TenantCA", "ca-client-tenant.crt", metrics.TenantCAExpiration, metrics.TenantCATTL, 4, 3, 1002},
+		{"UICA", "ca-ui.crt", metrics.UICAExpiration, metrics.UICATTL, 5, 4, 1003},
+		{"Node", "node.crt", metrics.NodeExpiration, metrics.NodeTTL, 6, 5, 1004},
+		{"UI", "ui.crt", metrics.UIExpiration, metrics.UITTL, 7, 6, 1005},
+		{"Tenant", "client-tenant.1.crt", metrics.TenantExpiration, metrics.TenantTTL, 8, 7, 1006},
+		{"NodeClient", "client.node.crt", metrics.NodeClientExpiration, metrics.NodeClientTTL, 9, 8, 1007},
+	}
+
+	// Verify initial values.
+	for _, c := range checks {
+		require.Equal(t, c.initialExp, c.expiration.Value(), "%s expiration before reload", c.name)
+		require.Equal(t, c.initialTTL, c.ttl.Value(), "%s TTL before reload", c.name)
+	}
+
+	// Overwrite every certificate with a new expiration.
+	for _, c := range checks {
+		_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(c.newExpiration, 0))
+		require.NoError(t, os.WriteFile(filepath.Join(certsDir, c.certFile), certBytes, 0700))
+	}
+
+	// Read all metrics concurrently with LoadCertificates to trigger the
+	// race detector on any unsynchronized field access. The stop channel
+	// ensures the reader goroutine stays active throughout the entire
+	// LoadCertificates call.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := range checks {
+					checks[i].expiration.Value()
+					checks[i].ttl.Value()
+				}
+			}
+		}
+	}()
+
+	require.NoError(t, cm.LoadCertificates())
+	close(stop)
+	wg.Wait()
+
+	// After reload, every metric must reflect the new certificate.
+	for _, c := range checks {
+		require.Equal(t, c.newExpiration, c.expiration.Value(), "%s expiration after reload", c.name)
+		require.Equal(t, c.newExpiration-1, c.ttl.Value(), "%s TTL after reload", c.name)
+	}
 }


### PR DESCRIPTION
Several certificate metric closures in createMetricsLocked() read CertificateManager fields (nodeClientCert, tenantCert, tenantCACert) directly without acquiring cm.mu, while LoadCertificates() writes these fields under the lock. This data race caused metrics like NodeClientExpiration to not reflect updated values after certificate rotation via SIGHUP.

Add locked getter methods (NodeClientCert, TenantCert, TenantCACert) matching the existing pattern used by CACert, NodeCert, etc., and update the six affected metric closures to use them.

Resolves: #166648

Release note (bug fix): Fixed a data race that could cause certificate expiration metrics (security.certificate.expiration.node-client, security.certificate.expiration.client-tenant,
security.certificate.expiration.ca-client-tenant and their TTL counterparts) to not update after certificate rotation via SIGHUP.