### PR TITLE
release-25.4: sql: fix ALTER FUNCTION RENAME duplicate detection in non-public schemas

### DIFF
--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -188,6 +188,8 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 		return err
 	}
 	maybeExistingFuncObj.FuncName.ObjectName = n.n.NewName
+	maybeExistingFuncObj.FuncName.SchemaName = tree.Name(scDesc.GetName())
+	maybeExistingFuncObj.FuncName.ExplicitSchema = true
 	existing, err := params.p.matchRoutine(
 		params.ctx, maybeExistingFuncObj, false, /* required */
 		tree.UDFRoutine|tree.ProcedureRoutine, false, /* inDropContext */

--- a/pkg/sql/logictest/testdata/logic_test/procedure_schema_change
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_schema_change
@@ -13,16 +13,16 @@ CREATE PROCEDURE p_int(INT) LANGUAGE SQL AS 'SELECT 1'
 statement ok
 CREATE FUNCTION p_func() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 
-statement error pgcode 42723 pq: procedure p\(\) already exists in schema "public"
+statement error pgcode 42723 pq: procedure public.p\(\) already exists in schema "public"
 ALTER PROCEDURE p RENAME TO p
 
-statement error pgcode 42723 pq: function p_func\(\) already exists in schema "public"
+statement error pgcode 42723 pq: function public.p_func\(\) already exists in schema "public"
 ALTER PROCEDURE p RENAME TO p_func
 
 statement error pgcode 42883 pq: could not find a function named "p"
 ALTER FUNCTION p RENAME TO p_new
 
-statement error pgcode 42723 pq: procedure p2\(\) already exists in schema "public"
+statement error pgcode 42723 pq: procedure public.p2\(\) already exists in schema "public"
 ALTER PROCEDURE p RENAME TO p2
 
 statement ok
@@ -96,6 +96,38 @@ DROP PROCEDURE p_int();
 DROP PROCEDURE p2();
 DROP FUNCTION p_func();
 
+# Regression test: renaming a procedure in a non-public schema should
+# detect duplicate (name, arguments) within that schema. Two procedure
+# with different arguments can have the same name.
+# Overloaded procedure cannot be dropped or renamed without specifying
+# the procedure signature.
+statement ok
+CREATE SCHEMA rename_dup_sc;
+CREATE PROCEDURE rename_dup_sc.pa(a INT) LANGUAGE SQL AS $$ SELECT a $$;
+CREATE PROCEDURE rename_dup_sc.pb(a INT) LANGUAGE SQL AS $$ SELECT a $$;
+CREATE PROCEDURE rename_dup_sc.pc(a INT, b INT) LANGUAGE SQL AS $$ SELECT a + b $$
+
+statement error pgcode 42723 pq: procedure rename_dup_sc.pa\(INT8\) already exists in schema "rename_dup_sc"
+ALTER PROCEDURE rename_dup_sc.pb RENAME TO pa
+
+statement ok
+ALTER PROCEDURE rename_dup_sc.pb RENAME TO pc
+
+statement error pgcode 42725 pq: function name "pc" is not unique
+ALTER PROCEDURE rename_dup_sc.pc RENAME TO pb
+
+statement error pgcode 42725 pq: procedure name "pc" is not unique
+DROP PROCEDURE rename_dup_sc.pc
+
+statement ok
+ALTER PROCEDURE rename_dup_sc.pc(INT) RENAME TO pb
+
+statement ok
+DROP PROCEDURE rename_dup_sc.pa;
+DROP PROCEDURE rename_dup_sc.pb;
+DROP PROCEDURE rename_dup_sc.pc;
+DROP SCHEMA rename_dup_sc
+
 subtest end
 
 
@@ -136,9 +168,9 @@ SELECT oid, proname, prosrc
 FROM pg_catalog.pg_proc WHERE proname IN ('p')
 ORDER BY oid
 ----
-100110  p  SELECT 1;
-100111  p  SELECT 2;
-100113  p  SELECT 3;
+100114  p  SELECT 1;
+100115  p  SELECT 2;
+100117  p  SELECT 3;
 
 query TT
 WITH procs AS (
@@ -148,9 +180,9 @@ WITH procs AS (
 )
 SELECT proc->>'id' AS id, proc->'parentSchemaId' FROM procs ORDER BY id
 ----
-110  105
-111  105
-113  112
+114  105
+115  105
+117  116
 
 statement error pgcode 0A000 pq: cannot move objects into or out of virtual schemas
 ALTER PROCEDURE p() SET SCHEMA pg_catalog
@@ -173,9 +205,9 @@ WITH procs AS (
 )
 SELECT proc->>'id' AS id, proc->'parentSchemaId' FROM procs ORDER BY id
 ----
-110  105
-111  105
-113  112
+114  105
+115  105
+117  116
 
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE public.p] ORDER BY 1
@@ -206,9 +238,9 @@ WITH procs AS (
 )
 SELECT proc->>'id' AS id, proc->'parentSchemaId' FROM procs ORDER BY id
 ----
-110  105
-111  112
-113  112
+114  105
+115  116
+117  116
 
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE public.p];

--- a/pkg/sql/logictest/testdata/logic_test/udf_schema_change
+++ b/pkg/sql/logictest/testdata/logic_test/udf_schema_change
@@ -75,13 +75,13 @@ CREATE FUNCTION public.f_test_alter_name(INT8)
   SELECT 1;
 $$
 
-statement error pgcode 42723 pq: function f_test_alter_name\(INT8\) already exists in schema "public"
+statement error pgcode 42723 pq: function public.f_test_alter_name\(INT8\) already exists in schema "public"
 ALTER FUNCTION f_test_alter_name RENAME TO f_test_alter_name
 
-statement error pgcode 42723 pq: function f_test_alter_name_same_in\(INT8\) already exists in schema "public"
+statement error pgcode 42723 pq: function public.f_test_alter_name_same_in\(INT8\) already exists in schema "public"
 ALTER FUNCTION f_test_alter_name RENAME TO f_test_alter_name_same_in
 
-statement error pgcode 42723 pq: procedure p\(INT8\) already exists in schema "public"
+statement error pgcode 42723 pq: procedure public.p\(INT8\) already exists in schema "public"
 ALTER FUNCTION f_test_alter_name RENAME TO p
 
 statement error pgcode 42883 could not find a procedure named "f_test_alter_name"
@@ -140,6 +140,38 @@ $$
 statement ok
 DROP PROCEDURE p
 
+# Regression test: renaming a function in a non-public schema should
+# detect duplicate (name, arguments) within that schema. Two functions
+# with different arguments can have the same name.
+# Overloaded functions cannot be dropped or renamed without specifying
+# the function signature.
+statement ok
+CREATE SCHEMA rename_dup_sc;
+CREATE FUNCTION rename_dup_sc.fa(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a $$;
+CREATE FUNCTION rename_dup_sc.fb(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a $$;
+CREATE FUNCTION rename_dup_sc.fc(a INT, b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b $$
+
+statement error pgcode 42723 pq: function rename_dup_sc.fa\(INT8\) already exists in schema "rename_dup_sc"
+ALTER FUNCTION rename_dup_sc.fb RENAME TO fa
+
+statement ok
+ALTER FUNCTION rename_dup_sc.fb RENAME TO fc
+
+statement error pgcode 42725 pq: function name "fc" is not unique
+ALTER FUNCTION rename_dup_sc.fc RENAME TO fb
+
+statement error pgcode 42725 pq: function name "fc" is not unique
+DROP FUNCTION rename_dup_sc.fc
+
+statement ok
+ALTER FUNCTION rename_dup_sc.fc(INT) RENAME TO fb
+
+statement ok
+DROP FUNCTION rename_dup_sc.fa;
+DROP FUNCTION rename_dup_sc.fb;
+DROP FUNCTION rename_dup_sc.fc;
+DROP SCHEMA rename_dup_sc
+
 subtest end
 
 subtest alter_function_set_schema
@@ -176,9 +208,9 @@ SELECT oid, proname, prosrc
 FROM pg_catalog.pg_proc WHERE proname IN ('f_test_sc')
 ORDER BY oid
 ----
-100113  f_test_sc  SELECT 1;
-100114  f_test_sc  SELECT 2;
-100116  f_test_sc  SELECT 3;
+100117  f_test_sc  SELECT 1;
+100118  f_test_sc  SELECT 2;
+100120  f_test_sc  SELECT 3;
 
 query TT
   WITH fns AS (
@@ -199,9 +231,9 @@ SELECT fn->>'id' AS id, fn->'parentSchemaId'
   FROM fns
   ORDER BY id;
 ----
-113  105
-114  105
-116  115
+117  105
+118  105
+120  119
 
 statement error pgcode 0A000 pq: cannot move objects into or out of virtual schemas
 ALTER FUNCTION f_test_sc() SET SCHEMA pg_catalog;
@@ -235,9 +267,9 @@ SELECT fn->>'id' AS id, fn->'parentSchemaId'
   FROM fns
   ORDER BY id;
 ----
-113  105
-114  105
-116  115
+117  105
+118  105
+120  119
 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION public.f_test_sc] ORDER BY 1
@@ -287,9 +319,9 @@ SELECT fn->>'id' AS id, fn->'parentSchemaId'
   FROM fns
   ORDER BY id;
 ----
-113  105
-114  115
-116  115
+117  105
+118  119
+120  119
 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION public.f_test_sc];


### PR DESCRIPTION
Backport 1/1 commits from #166570 on behalf of @shghasemi.

----

Previously, renaming a function or procedure to a name that already existed with the same signature in a non-public schema was incorrectly allowed. This happened because the duplicate check did not set ExplicitSchema on the routine name, causing matchRoutine to search the session search path instead of the specific schema. If the schema was not on the search path, the duplicate was not found and the rename succeeded, leaving two functions with the same name and signature that could not be dropped.

Fix by setting SchemaName and ExplicitSchema on the lookup object.

Fixes #166361

Release note (bug fix): Fixed a bug where ALTER FUNCTION ... RENAME TO and ALTER PROCEDURE ... RENAME TO could create duplicate functions in non-public schemas.

----

Release justification: Fixes a serious issue to avoid customer escalations.