### PR TITLE
opt: fix SetBestProps panic when memo group is visited twice

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1074,3 +1074,62 @@ WHERE NOT (
   )
 )
 ----
+
+# Regression test for #166646 / #116022. Exploration rules can duplicate scalar
+# expressions containing subqueries, causing the same memo group to be visited
+# twice with different physical properties in setLowestCostTree, which
+# previously caused a panic in SetBestProps ("cannot overwrite").
+statement ok
+CREATE TABLE t166646_apps (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    name STRING NOT NULL,
+    CONSTRAINT t166646_apps_pkey PRIMARY KEY (id ASC)
+);
+
+statement ok
+CREATE TABLE t166646_app_versions (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    app_id UUID NOT NULL,
+    version INT8 NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT t166646_app_versions_pkey PRIMARY KEY (id ASC),
+    CONSTRAINT t166646_fk_app_id_v FOREIGN KEY (app_id) REFERENCES t166646_apps(id),
+    INDEX idx_t166646_app_versions_app (app_id ASC, version DESC)
+);
+
+statement ok
+CREATE TABLE t166646_app_events (
+    id UUID NOT NULL DEFAULT gen_random_uuid(),
+    app_id UUID NOT NULL,
+    event STRING NOT NULL,
+    metadata JSONB NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT t166646_app_events_pkey PRIMARY KEY (id ASC),
+    CONSTRAINT t166646_fk_app_id_e FOREIGN KEY (app_id) REFERENCES t166646_apps(id),
+    INDEX idx_t166646_app_events_app (app_id ASC, event ASC, created_at DESC)
+);
+
+statement ok
+INSERT INTO t166646_apps (name) SELECT 'app-' || i FROM generate_series(1, 326) AS i;
+
+statement ok
+INSERT INTO t166646_app_versions (app_id, version)
+  SELECT a.id, v.n FROM t166646_apps a, generate_series(1, 15) AS v(n);
+
+statement ok
+INSERT INTO t166646_app_events (app_id, event, metadata)
+  SELECT a.id,
+         CASE WHEN i % 5 = 0 THEN 'github.sync' ELSE 'view' END,
+         CASE WHEN i % 5 = 0 THEN jsonb_build_object('version', (i % 15) + 1) ELSE NULL END
+  FROM t166646_apps a, generate_series(1, 65) AS s(i);
+
+statement ok
+SELECT v.version, v.created_at,
+       e.metadata->>'commit' AS github_commit
+FROM t166646_app_versions v
+LEFT JOIN t166646_app_events e ON e.app_id = v.app_id
+    AND e.event = 'github.sync'
+    AND (e.metadata->>'version')::int = v.version
+WHERE v.app_id = (SELECT id FROM t166646_apps LIMIT 1)
+ORDER BY v.version DESC
+LIMIT 3

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -783,10 +783,14 @@ func (o *Optimizer) shouldExplore(required *physical.Required) bool {
 // Note that a memo group can have multiple lowest cost expressions, each for a
 // different set of physical properties. During optimization, these are retained
 // in the groupState map. However, only one of those lowest cost expressions
-// will be used in the final tree; the others are simply discarded. This is
-// because there is never a case where a relational expression is referenced
-// multiple times in the final tree, but with different physical properties
-// required by each of those references.
+// will be used in the final tree; the others are simply discarded. Normally a
+// given memo group is only referenced once in the final tree. However,
+// exploration rules like PushFilterIntoJoinLeftAndRight can duplicate scalar
+// expressions containing subqueries, causing two paths in the tree to
+// reference the same relational memo group. When this happens, the group may
+// be visited twice with different required physical properties (e.g.,
+// different limit hints). We detect this case and return early to avoid
+// re-processing the group or panicking in SetBestProps.
 func (o *Optimizer) setLowestCostTree(parent opt.Expr, parentProps *physical.Required) opt.Expr {
 	var relParent memo.RelExpr
 	var relCost memo.Cost
@@ -795,6 +799,20 @@ func (o *Optimizer) setLowestCostTree(parent opt.Expr, parentProps *physical.Req
 		state := o.lookupOptState(t.FirstExpr(), parentProps)
 		relParent, relCost = state.best, state.cost
 		parent = relParent
+
+		// If this group was already processed with different physical
+		// properties, return the previously processed expression. This
+		// avoids re-processing children and panicking in SetBestProps.
+		if relParent.RequiredPhysical() != nil &&
+			relParent.RequiredPhysical() != parentProps {
+			prevState := o.lookupOptState(
+				t.FirstExpr(), relParent.RequiredPhysical(),
+			)
+			if prevState != nil && prevState.best != nil {
+				return prevState.best
+			}
+			return parent
+		}
 
 	case memo.ScalarPropsExpr:
 		// Short-circuit traversal of scalar expressions with no nested subquery,

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -678,3 +678,141 @@ project
  │    └── -1
  └── projections
       └── 0 [as="?column?":5]
+
+# --------------------------------------------------
+# Regression test for #116022, #166646. Exploration rules like
+# PushFilterIntoJoinLeftAndRight can duplicate scalar expressions
+# containing subqueries, causing the same memo group to be visited
+# twice with different required physical properties during
+# setLowestCostTree. Ensure this does not cause a panic in
+# SetBestProps.
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE limhint_a (
+  id INT PRIMARY KEY
+)
+----
+
+exec-ddl
+CREATE TABLE limhint_b (
+  id INT PRIMARY KEY,
+  x INT
+)
+----
+
+exec-ddl
+CREATE TABLE limhint_c (
+  id INT PRIMARY KEY,
+  x INT,
+  y INT
+)
+----
+
+exec-ddl
+CREATE TABLE limhint_d (
+  id INT PRIMARY KEY,
+  x INT,
+  y INT
+)
+----
+
+opt locality=(region=east)
+SELECT limhint_a.id
+FROM limhint_a
+INNER JOIN limhint_b ON limhint_b.x = limhint_a.id
+INNER JOIN limhint_c ON limhint_c.y = limhint_b.id
+LEFT JOIN LATERAL (
+  SELECT limhint_d.id
+  FROM limhint_d
+  WHERE limhint_d.x = limhint_c.x
+  ORDER BY limhint_d.y
+  LIMIT 1
+) ON true
+WHERE limhint_b.id = (SELECT id FROM limhint_b)
+----
+distribute
+ ├── columns: id:1!null
+ ├── fd: ()-->(1)
+ ├── distribution: east
+ ├── input distribution: 
+ └── project
+      ├── columns: limhint_a.id:1!null
+      ├── fd: ()-->(1)
+      └── distinct-on
+           ├── columns: limhint_a.id:1!null limhint_c.id:8!null
+           ├── grouping columns: limhint_c.id:8!null
+           ├── internal-ordering: +15 opt(1,4,5,10,18)
+           ├── key: (8)
+           ├── fd: ()-->(1)
+           ├── sort
+           │    ├── columns: limhint_a.id:1!null limhint_b.id:4!null limhint_b.x:5!null limhint_c.id:8!null limhint_c.x:9 limhint_c.y:10!null limhint_d.x:14 limhint_d.y:15 limhint_b.id:18!null
+           │    ├── fd: ()-->(1,4,5,10,18), (8)-->(9), (4)==(10,18), (10)==(4,18), (18)==(4,10), (1)==(5), (5)==(1)
+           │    ├── ordering: +15 opt(1,4,5,10,18) [actual: +15]
+           │    └── right-join (hash)
+           │         ├── columns: limhint_a.id:1!null limhint_b.id:4!null limhint_b.x:5!null limhint_c.id:8!null limhint_c.x:9 limhint_c.y:10!null limhint_d.x:14 limhint_d.y:15 limhint_b.id:18!null
+           │         ├── fd: ()-->(1,4,5,10,18), (8)-->(9), (4)==(10,18), (10)==(4,18), (18)==(4,10), (1)==(5), (5)==(1)
+           │         ├── scan limhint_d
+           │         │    └── columns: limhint_d.x:14 limhint_d.y:15
+           │         ├── inner-join (hash)
+           │         │    ├── columns: limhint_a.id:1!null limhint_b.id:4!null limhint_b.x:5!null limhint_c.id:8!null limhint_c.x:9 limhint_c.y:10!null limhint_b.id:18!null
+           │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │         │    ├── key: (8)
+           │         │    ├── fd: ()-->(1,4,5,10,18), (8)-->(9), (4)==(10,18), (10)==(4,18), (18)==(4,10), (1)==(5), (5)==(1)
+           │         │    ├── select
+           │         │    │    ├── columns: limhint_c.id:8!null limhint_c.x:9 limhint_c.y:10!null
+           │         │    │    ├── key: (8)
+           │         │    │    ├── fd: (8)-->(9,10)
+           │         │    │    ├── scan limhint_c
+           │         │    │    │    ├── columns: limhint_c.id:8!null limhint_c.x:9 limhint_c.y:10
+           │         │    │    │    ├── key: (8)
+           │         │    │    │    └── fd: (8)-->(9,10)
+           │         │    │    └── filters
+           │         │    │         └── eq [outer=(10), subquery]
+           │         │    │              ├── limhint_c.y:10
+           │         │    │              └── subquery
+           │         │    │                   └── max1-row
+           │         │    │                        ├── columns: limhint_b.id:18!null
+           │         │    │                        ├── error: "more than one row returned by a subquery used as an expression"
+           │         │    │                        ├── cardinality: [0 - 1]
+           │         │    │                        ├── key: ()
+           │         │    │                        ├── fd: ()-->(18)
+           │         │    │                        ├── distribution: east
+           │         │    │                        └── scan limhint_b
+           │         │    │                             ├── columns: limhint_b.id:18!null
+           │         │    │                             ├── key: (18)
+           │         │    │                             └── distribution: east
+           │         │    ├── inner-join (lookup limhint_a)
+           │         │    │    ├── columns: limhint_a.id:1!null limhint_b.id:4!null limhint_b.x:5!null limhint_b.id:18!null
+           │         │    │    ├── key columns: [5] = [1]
+           │         │    │    ├── lookup columns are key
+           │         │    │    ├── cardinality: [0 - 1]
+           │         │    │    ├── key: ()
+           │         │    │    ├── fd: ()-->(1,4,5,18), (4)==(18), (18)==(4), (1)==(5), (5)==(1)
+           │         │    │    ├── inner-join (lookup limhint_b)
+           │         │    │    │    ├── columns: limhint_b.id:4!null limhint_b.x:5 limhint_b.id:18!null
+           │         │    │    │    ├── key columns: [18] = [4]
+           │         │    │    │    ├── lookup columns are key
+           │         │    │    │    ├── cardinality: [0 - 1]
+           │         │    │    │    ├── key: ()
+           │         │    │    │    ├── fd: ()-->(4,5,18), (4)==(18), (18)==(4)
+           │         │    │    │    ├── max1-row
+           │         │    │    │    │    ├── columns: limhint_b.id:18!null
+           │         │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+           │         │    │    │    │    ├── cardinality: [0 - 1]
+           │         │    │    │    │    ├── key: ()
+           │         │    │    │    │    ├── fd: ()-->(18)
+           │         │    │    │    │    ├── distribution: east
+           │         │    │    │    │    └── scan limhint_b
+           │         │    │    │    │         ├── columns: limhint_b.id:18!null
+           │         │    │    │    │         ├── key: (18)
+           │         │    │    │    │         └── distribution: east
+           │         │    │    │    └── filters (true)
+           │         │    │    └── filters (true)
+           │         │    └── filters
+           │         │         └── limhint_c.y:10 = limhint_b.id:4 [outer=(4,10), fd=(4)==(10), (10)==(4)]
+           │         └── filters
+           │              └── limhint_d.x:14 = limhint_c.x:9 [outer=(9,14), fd=(9)==(14), (14)==(9)]
+           └── aggregations
+                └── const-agg [as=limhint_a.id:1, outer=(1)]
+                     └── limhint_a.id:1


### PR DESCRIPTION
## Summary

This fix was generated by Claude Code (Opus 4.6) — posting as a draft for discussion, not as a final solution.

- Exploration rules like `PushFilterIntoJoinLeftAndRight` can duplicate scalar expressions containing subqueries, causing two paths in the optimized tree to reference the same relational memo group.
- During `setLowestCostTree`, the group gets visited twice with different required physical properties (e.g., different limit hints or distributions), triggering a panic in `SetBestProps` ("cannot overwrite").
- The fix detects in `setLowestCostTree` when a relational group has already been processed with different physical properties and returns the previously processed expression instead of re-processing.

Fixes #166646
Fixes #116022

🤖 Generated with [Claude Code](https://claude.ai/code)