### PR TITLE
release-26.1: pcr: set reader_system_table_id_offset default to 1 billion

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -2143,7 +2143,8 @@ func destClusterSettings(
 	}
 
 	if rng.Intn(2) == 0 {
-		db.Exec(t, `SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = 100000`)
+		// Override the default offset to 0 to test the no-offset path.
+		db.Exec(t, `SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = 0`)
 	}
 }
 

--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -123,14 +123,15 @@ func maybeOffsetReaderTenantSystemTables(
 	t *testing.T, c *replicationtestutils.TenantStreamingClusters,
 ) (int, func(sql *sqlutils.SQLRunner)) {
 	if c.Rng.Intn(2) == 0 {
-		// Use the default offset of 1 billion.
-		return 1_000_000_000, func(sql *sqlutils.SQLRunner) {}
+		c.DestSysSQL.Exec(t, `SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = 0`)
+		// Set on source to ensure failback works well too.
+		c.SrcSysSQL.Exec(t, `SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = 0`)
+		// Override to no offset.
+		return 0, func(sql *sqlutils.SQLRunner) {}
 	}
-	// Override the offset to 0 to test the no-offset path.
-	offset := 0
-	c.DestSysSQL.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = %d`, offset))
-	// Set on source to ensure failback works well too.
-	c.SrcSysSQL.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = %d`, offset))
+
+	var offset int
+	c.DestSysSQL.QueryRow(t, `SHOW CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset`).Scan(&offset)
 
 	// swap a system table ID and a user table ID to simulate a cluster that has interleaving user and system table ids.
 	scaryTableIDRemapFunc := `

--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -123,9 +123,11 @@ func maybeOffsetReaderTenantSystemTables(
 	t *testing.T, c *replicationtestutils.TenantStreamingClusters,
 ) (int, func(sql *sqlutils.SQLRunner)) {
 	if c.Rng.Intn(2) == 0 {
-		return 0, func(sql *sqlutils.SQLRunner) {}
+		// Use the default offset of 1 billion.
+		return 1_000_000_000, func(sql *sqlutils.SQLRunner) {}
 	}
-	offset := 100000
+	// Override the offset to 0 to test the no-offset path.
+	offset := 0
 	c.DestSysSQL.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = %d`, offset))
 	// Set on source to ensure failback works well too.
 	c.SrcSysSQL.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = %d`, offset))

--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -40,7 +40,7 @@ var readerTenantSystemTableIDOffset = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"physical_cluster_replication.reader_system_table_id_offset",
 	"the offset added to dynamically allocated system table IDs in the reader tenant",
-	0,
+	1_000_000_000,
 	// Max offset is 1000 less than MaxUint32 to leave room 1000 dynamically
 	// allocated system table ids. Hope that never happens.
 	settings.NonNegativeIntWithMaximum(math.MaxUint32-1000),


### PR DESCRIPTION
Backport 1/1 commits from #166383 on behalf of @msbutler.

----

Set the default for `physical_cluster_replication.reader_system_table_id_offset` to 1 billion as it reduces the chance of standby cluster start up failures and appears to have little risk.

Epic: none

Release note: none

----

Release justification: Low-risk bug fix that reduces the chance of standby cluster start up failures in physical cluster replication by adjusting a configuration default.