### PR TITLE
kvserver: fix TestVirtualizedIntentResolution flake

### DIFF
--- a/pkg/kv/kvserver/replica_read_test.go
+++ b/pkg/kv/kvserver/replica_read_test.go
@@ -7,6 +7,7 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -34,6 +35,11 @@ func TestVirtualizedIntentResolution(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	tsc := TestStoreConfig(hlc.NewClockForTesting(tc.manualClock))
+	// Disable the optimization that acks transactional writes before the engine
+	// batch is applied. This is a fast store-level test that can race with
+	// application; without this, the transactional Put that writes the intent
+	// may return before the intent is visible to subsequent reads.
+	tsc.TestingKnobs.DisableCanAckBeforeApplication = true
 	tc.StartWithStoreConfig(ctx, t, stopper, tsc)
 
 	// The manual clock starts at time 123.
@@ -68,99 +74,106 @@ func TestVirtualizedIntentResolution(t *testing.T) {
 		obsNode    int
 	}
 	testCases := []struct {
+		name      string
 		readTs    hlc.Timestamp
 		readGUL   hlc.Timestamp
 		toResolve *toResolve
 		exp       res
 	}{
 		// Reading below the intent's ts results in seeing the original value.
-		{readTs: ts200, exp: res{value: "original"}},
+		{name: "no-vir-read-below-intent", readTs: ts200, exp: res{value: "original"}},
 		// Reading at or above the intent's ts results in a lock conflict error.
-		{readTs: ts300, exp: res{error: "conflicting locks"}},
-		{readTs: ts400, exp: res{error: "conflicting locks"}},
+		{name: "no-vir-read-at-intent", readTs: ts300, exp: res{error: "conflicting locks"}},
+		{name: "no-vir-read-above-intent", readTs: ts400, exp: res{error: "conflicting locks"}},
 		// Next, we look at cases where we have intents to resolve virtually.
 		// Reading below the pushed writeTxn's ts results in the original value
 		// since these reads have no uncertainty interval.
-		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{value: "original"}},
-		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{value: "original"}},
-		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{value: "original"}},
-		{readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{name: "pending-read-below", readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{name: "staging-read-below", readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{name: "committed-read-below", readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{name: "aborted-read-below", readTs: ts300, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
 		// Reading at or above the pushed writeTxn's ts results in a lock conflict
 		// error if the txn is not finalized. Otherwise, the intent value is
 		// expected if the txn is committed, and the original value is expected if
 		// the txn is aborted.
-		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{error: "conflicting lock"}},
-		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{error: "conflicting lock"}},
-		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{value: "intent"}},
-		{readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{name: "pending-read-at", readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{error: "conflicting lock"}},
+		{name: "staging-read-at", readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{error: "conflicting lock"}},
+		{name: "committed-read-at", readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{value: "intent"}},
+		{name: "aborted-read-at", readTs: ts400, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
 		// Next, we look at more subtle cases with uncertainty intervals. To do so,
 		// the read is now a transactional read with a global uncertainty limit.
 		// Reading below the pushed txn's write ts is no longer enough to avoid
 		// conflict because the read GUL is above that ts.
-		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
-		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
-		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
-		{readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
+		{name: "pending-uncertainty", readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
+		{name: "staging-uncertainty", readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.STAGING, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
+		{name: "committed-uncertainty", readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.COMMITTED, txnWriteTs: ts400}, exp: res{error: "uncertainty interval"}},
+		{name: "aborted-uncertainty", readTs: ts300, readGUL: ts500, toResolve: &toResolve{txnStatus: roachpb.ABORTED, txnWriteTs: ts400}, exp: res{value: "original"}},
 		// To circumvent the uncertainty restart, we can pass in a clock observation
 		// via the intents to resolve. Using a clock observation to set the intent's
 		// local timestamp for non-pending transactions is not safe. See the comment
 		// in pushLockTxn in lock_table_waiter.go.
-		{readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 1}, exp: res{value: "original"}},
+		{name: "pending-obs-local", readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 1}, exp: res{value: "original"}},
 		// A clock observation from a different node doesn't help.
-		{readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 2}, exp: res{error: "uncertainty interval"}},
+		{name: "pending-obs-remote", readTs: ts300, readGUL: ts600, toResolve: &toResolve{txnStatus: roachpb.PENDING, txnWriteTs: ts500, obsTs: ts400, obsNode: 2}, exp: res{error: "uncertainty interval"}},
 	}
 
 	for _, resolveRange := range []bool{true, false} {
+		resolveType := "point"
+		if resolveRange {
+			resolveType = "range"
+		}
 		for _, c := range testCases {
-			// Build a mock guard, injecting any intents to resolve virtually.
-			var intents []roachpb.LockUpdate
-			if c.toResolve != nil {
-				writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
-				status := c.toResolve.txnStatus
-				obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
-				var span roachpb.Span
-				if resolveRange {
-					span = roachpb.Span{Key: k, EndKey: k.Next()}
-				} else {
-					span = roachpb.Span{Key: k}
+			t.Run(fmt.Sprintf("%s/resolve=%s", c.name, resolveType), func(t *testing.T) {
+				// Build a mock guard, injecting any intents to resolve virtually.
+				var intents []roachpb.LockUpdate
+				if c.toResolve != nil {
+					writeTxn.TxnMeta.WriteTimestamp = c.toResolve.txnWriteTs
+					status := c.toResolve.txnStatus
+					obs := roachpb.ObservedTimestamp{Timestamp: hlc.ClockTimestamp(c.toResolve.obsTs), NodeID: roachpb.NodeID(c.toResolve.obsNode)}
+					var span roachpb.Span
+					if resolveRange {
+						span = roachpb.Span{Key: k, EndKey: k.Next()}
+					} else {
+						span = roachpb.Span{Key: k}
+					}
+					intents = []roachpb.LockUpdate{{Span: span, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
 				}
-				intents = []roachpb.LockUpdate{{Span: span, Status: status, Txn: writeTxn.TxnMeta, ClockWhilePending: obs}}
-			}
-			g := mockGuard{
-				req: concurrency.Request{
-					LatchSpans: allSpans(),
-					LockSpans:  lockspanset.New(),
-				},
-				intentsToResolveVirtually: intents,
-			}
-			// Construct the read-only request.
-			ba := &kvpb.BatchRequest{}
-			ba.Timestamp = c.readTs
-			// If the read wants to set a GUL, use a transactional read.
-			if !c.readGUL.IsEmpty() {
-				readTxn := newTransaction("readTxn", k, 1, nil)
-				readTxn.ReadTimestamp = c.readTs
-				readTxn.GlobalUncertaintyLimit = c.readGUL
-				// We need a fairly old observation here to make sure the read's local
-				// uncertainty limit lets it read under the intent with a clock
-				// observation while pending. This observation needs to be lower than the
-				// local timestamp set on the intent (set using ClockWhilePending).
-				// The txn's observed timestamp is usually set when the request is first
-				// received by the store, so here we'll record it as the read's ts.
-				readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
-				ba.Txn = readTxn
-			}
-			gArgs := getArgs(k)
-			ba.Add(&gArgs)
-			br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, g, kvadmission.AdmissionInfo{})
+				g := mockGuard{
+					req: concurrency.Request{
+						LatchSpans: allSpans(),
+						LockSpans:  lockspanset.New(),
+					},
+					intentsToResolveVirtually: intents,
+				}
+				// Construct the read-only request.
+				ba := &kvpb.BatchRequest{}
+				ba.Timestamp = c.readTs
+				// If the read wants to set a GUL, use a transactional read.
+				if !c.readGUL.IsEmpty() {
+					readTxn := newTransaction("readTxn", k, 1, nil)
+					readTxn.ReadTimestamp = c.readTs
+					readTxn.GlobalUncertaintyLimit = c.readGUL
+					// We need a fairly old observation here to make sure the read's local
+					// uncertainty limit lets it read under the intent with a clock
+					// observation while pending. This observation needs to be lower than the
+					// local timestamp set on the intent (set using ClockWhilePending).
+					// The txn's observed timestamp is usually set when the request is first
+					// received by the store, so here we'll record it as the read's ts.
+					readTxn.UpdateObservedTimestamp(roachpb.NodeID(1), c.readTs.UnsafeToClockTimestamp())
+					ba.Txn = readTxn
+				}
+				gArgs := getArgs(k)
+				ba.Add(&gArgs)
+				br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, g, kvadmission.AdmissionInfo{})
 
-			if c.exp.error == "" {
-				require.NoError(t, pErr.GoError())
-				require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
-			} else {
-				require.Nil(t, br)
-				require.Regexp(t, c.exp.error, pErr.GoError())
-			}
+				if c.exp.error == "" {
+					require.NoError(t, pErr.GoError())
+					require.Regexp(t, c.exp.value, string(br.Responses[0].GetGet().Value.RawBytes))
+				} else {
+					require.Nil(t, br)
+					require.Regexp(t, c.exp.error, pErr.GoError())
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
The test writes a transactional intent via `SendWrappedWith` and then immediately calls `executeReadOnlyBatch` to read it. `CanAckBeforeApplication` returns true for transactional intent writes, so the proposal can be ack'd
before the engine batch is applied. This means the read can open a snapshot that doesn't yet contain the intent, causing it to return the original value instead of a `LockConflictError`.

Fix by setting `DisableCanAckBeforeApplication` on the test's store config.
Also add named subtests for easier debugging.

Fixes: https://github.com/cockroachdb/cockroach/issues/166600

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>