### PR TITLE
roachtest: enable rangefuncs in pg_regress.

### DIFF
--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -362,7 +362,6 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"temp",
 		// TODO(#28296): Reenable copy2 when triggers and COPY [view] FROM are supported.
 		// "copy2",
-		"rangefuncs",
 		"sequence",
 		"truncate",
 		"alter_table",


### PR DESCRIPTION
Previously, rangefuncs in pg_regress was failing due to: #97822. This patch re-enables this test.

Fixes: #166495

Release note: None