### PR TITLE
kvserver: introduce stageDestroyReplica and pendingReplicaDestruction

### DIFF
--- a/pkg/kv/kvserver/client_replica_gc_test.go
+++ b/pkg/kv/kvserver/client_replica_gc_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -192,4 +193,113 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestReplicaGCQueueHandlesStagingError verifies that replica removal handles
+// errors from the staging phase (stageDestroyReplica) gracefully: the error
+// propagates without crashing, the replica survives intact, and a retry
+// succeeds once the error clears. Three removal paths are exercised:
+//
+//  1. Direct RemoveReplica call — observes the error return directly.
+//  2. Replica GC queue — the queue-based removal after voter removal.
+//  3. getOrCreateReplica — simulates a newer replica contacting the store.
+//
+// The eager self-removal path (ChangeReplicasTrigger) is not tested because it
+// fatals on error and uses DestroyData: false (so staging is not involved).
+// To prevent the eager path from firing, the target node is partitioned from
+// incoming raft messages before the voter removal, so the trigger never arrives.
+func TestReplicaGCQueueHandlesStagingError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numNodes = 3
+	const targetNode = numNodes - 1 // s3 (whose replica we test on)
+
+	errInjected := errors.New("injected staging error")
+	var shouldFail atomic.Bool
+	shouldFail.Store(true)
+	var failCount atomic.Int32
+
+	knobs := &kvserver.StoreTestingKnobs{
+		TestingReplicaDestroyErr: func() error {
+			if shouldFail.Load() {
+				failCount.Add(1)
+				return errInjected
+			}
+			return nil
+		},
+	}
+	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			targetNode: {Knobs: base.TestingKnobs{Store: knobs}},
+		},
+	})
+	defer tc.Stopper().Stop(context.Background())
+
+	// Create range, replicate to all nodes.
+	k := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, k, tc.Target(1), tc.Target(2))
+	require.NoError(t, tc.WaitForVoters(k, tc.Target(1), tc.Target(2)))
+
+	ts := tc.Servers[targetNode]
+	store, err := ts.GetStores().(*kvserver.Stores).GetStore(ts.GetFirstStoreID())
+	require.NoError(t, err)
+
+	// Partition the target node from incoming raft messages for this range
+	// before removing its voter, so it never receives the
+	// ChangeReplicasTrigger and doesn't fire the eager self-removal path.
+	// The voter removal still succeeds because the other two nodes form a
+	// quorum (2/3).
+	preRemovalDesc, err := tc.LookupRange(k)
+	require.NoError(t, err)
+	var fromReplicaIDs []roachpb.ReplicaID
+	for _, rd := range preRemovalDesc.Replicas().Descriptors() {
+		if rd.StoreID != store.StoreID() {
+			fromReplicaIDs = append(fromReplicaIDs, rd.ReplicaID)
+		}
+	}
+	dropRaftMessagesFrom(t, ts, preRemovalDesc, fromReplicaIDs, nil)
+
+	// Remove voter from targetNode.
+	desc := tc.RemoveVotersOrFatal(t, k, tc.Target(targetNode))
+
+	// Call RemoveReplica directly to observe the error.
+	repl, err := store.GetReplica(desc.RangeID)
+	require.NoError(t, err)
+	err = store.RemoveReplica(context.Background(), repl, desc.NextReplicaID, "test")
+	require.True(t, errors.Is(err, errInjected), "unexpected: %+v", err)
+	require.NotZero(t, failCount.Swap(0), "error injection was not hit")
+
+	// Exercise the GC queue's process method directly. A full scan via
+	// MustForceReplicaGCScanAndProcess is non-deterministic here because the
+	// partitioned replica's local descriptor still lists it as a member,
+	// causing shouldQueue's timing checks to gate enqueueing.
+	err = store.ProcessReplicaGC(context.Background(), repl)
+	require.True(t, errors.Is(err, errInjected), "unexpected: %+v", err)
+	require.NotZero(t, failCount.Swap(0), "error injection was not hit")
+
+	// Replica should still exist because removal failed.
+	_, err = store.GetReplica(desc.RangeID)
+	require.NoError(t, err, "replica should still exist after failed removal")
+
+	// Exercise the getOrCreateReplica path: simulate an incoming raft message
+	// from a newer incarnation of this replica. This triggers tryGetReplica to
+	// attempt removal of the current replica (since the incoming ReplicaID is
+	// higher), which hits the injected staging error.
+	_, _, err = store.GetOrCreateReplica(
+		context.Background(), desc.RangeID,
+		repl.ReplicaID()+1, /* pretend a newer replica is contacting us */
+	)
+	require.True(t, errors.Is(err, errInjected), "unexpected: %+v", err)
+	require.NotZero(t, failCount.Swap(0), "error injection was not hit")
+
+	// The replica should still exist — the failed removal left no side effects.
+	_, err = store.GetReplica(desc.RangeID)
+	require.NoError(t, err, "replica should survive failed getOrCreateReplica removal")
+
+	// Remove error injection. Processing via the GC queue should now succeed.
+	shouldFail.Store(false)
+	require.NoError(t, store.ProcessReplicaGC(context.Background(), repl))
+	require.Nil(t, store.GetReplicaIfExists(desc.RangeID), "replica should be removed")
 }

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -80,6 +80,29 @@ func (s *Store) FindTargetAndTransferLease(
 	return transferStatus == allocator.TransferOK, err
 }
 
+// GetOrCreateReplica exposes getOrCreateReplica for use in tests. On success,
+// the returned Replica's raftMu is unlocked before returning.
+func (s *Store) GetOrCreateReplica(
+	ctx context.Context, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
+) (*Replica, bool, error) {
+	repl, created, err := s.getOrCreateReplica(ctx, roachpb.FullReplicaID{
+		RangeID:   rangeID,
+		ReplicaID: replicaID,
+	}, nil /* creatingReplica */)
+	if repl != nil {
+		repl.raftMu.Unlock()
+	}
+	return repl, created, err
+}
+
+// ProcessReplicaGC directly invokes the replica GC queue's processing logic on
+// the given replica, bypassing the shouldQueue checks (lease activity,
+// inactivity threshold, etc.) that can make the full scan non-deterministic.
+func (s *Store) ProcessReplicaGC(ctx context.Context, repl *Replica) error {
+	_, err := s.replicaGCQueue.process(ctx, repl, nil /* confReader */, 0 /* priority */)
+	return err
+}
+
 // AddReplica adds the replica to the store's replica map and to the sorted
 // replicasByKey slice. To be used only by unittests.
 func (s *Store) AddReplica(repl *Replica) error {

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -698,9 +698,7 @@ func (r *Replica) handleChangeReplicasResult(
 	// NB: postDestroyRaftMuLocked requires that the batch which removed the data
 	// be durably synced to disk, which we have.
 	// See replicaAppBatch.ApplyToStateMachine().
-	if err := r.postDestroyRaftMuLocked(ctx); err != nil {
-		log.KvExec.Fatalf(ctx, "failed to run Replica postDestroy: %v", err)
-	}
+	r.postDestroyRaftMuLocked(ctx)
 
 	return true
 }

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -8,11 +8,14 @@ package kvserver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -86,51 +89,117 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context) {
 	}
 }
 
-// destroyRaftMuLocked deletes data associated with a replica, leaving a
-// tombstone. The Replica may not be initialized in which case only the
-// range ID local data is removed.
-func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb.ReplicaID) error {
-	startTime := timeutil.Now()
+// pendingReplicaDestruction holds a staged but uncommitted replica destruction.
+// The engine batch has been populated with all writes needed to destroy the
+// replica's on-disk state and install a tombstone. Call MustCommit to durably
+// apply the destruction.
+type pendingReplicaDestruction struct {
+	batch       kvstorage.Batch[storage.WriteBatch]
+	ms          enginepb.MVCCStats
+	initialized bool
+	stageTime   time.Time
+	clearTime   time.Time
+}
 
-	ms := r.GetMVCCStats()
-	batch := r.store.batchFactory.NewWriteBatch()
-	defer batch.Close()
+// MustCommit sync-commits the staged destruction batch and logs the result.
+//
+// A batch commit is expected to be infallible (the data is already in memory
+// and just needs to be written to the WAL). Callers rely on this by performing
+// irreversible in-memory state changes (e.g. setting destroyStatus) between
+// staging and committing. Making commit fallible would force callers to handle
+// rollback of those in-memory changes, adding significant complexity. If a
+// commit does fail, we are in an unrecoverable situation and must terminate.
+//
+// We sync here because we are potentially deleting sideloaded proposals from
+// the file system next, and don't want a crash in the middle to leave a log
+// entry with a missing sideloaded file.
+func (p *pendingReplicaDestruction) MustCommit(ctx context.Context) {
+	if err := p.batch.Commit(true /* sync */); err != nil {
+		log.KvDistribution.Fatalf(ctx, "unable to commit replica destruction batch: %v", err)
+	}
+	commitTime := timeutil.Now()
+	if p.initialized {
+		log.KvDistribution.Infof(ctx,
+			"removed %d (%d+%d) keys in %0.0fms [clear=%0.0fms commit=%0.0fms]",
+			p.ms.KeyCount+p.ms.SysCount, p.ms.KeyCount, p.ms.SysCount,
+			commitTime.Sub(p.stageTime).Seconds()*1000,
+			p.clearTime.Sub(p.stageTime).Seconds()*1000,
+			commitTime.Sub(p.clearTime).Seconds()*1000,
+		)
+	} else {
+		log.KvDistribution.Infof(ctx,
+			"removed uninitialized range in %0.0fms [clear=%0.0fms commit=%0.0fms]",
+			commitTime.Sub(p.stageTime).Seconds()*1000,
+			p.clearTime.Sub(p.stageTime).Seconds()*1000,
+			commitTime.Sub(p.clearTime).Seconds()*1000,
+		)
+	}
+}
 
+// Close must be the last call made on this type.
+func (p *pendingReplicaDestruction) Close() {
+	p.batch.Close()
+}
+
+// stageDestroyReplica builds a batch that, when committed, will destroy the
+// replica's on-disk state and install a tombstone. The returned
+// pendingReplicaDestruction must have Close called when it is no longer needed.
+//
+// This function performs engine reads (to validate replica ID and tombstone
+// state) and stages engine writes into a batch, but does not commit. If any
+// engine read fails (e.g. due to context cancellation or I/O error), the error
+// is returned and the caller can abort with no side effects.
+func stageDestroyReplica(
+	ctx context.Context,
+	bf *kvstorage.BatchFactory,
+	stateRO kvstorage.StateRO,
+	raftRO kvstorage.RaftRO,
+	info kvstorage.DestroyReplicaInfo,
+	nextReplicaID roachpb.ReplicaID,
+	ms enginepb.MVCCStats,
+) (pendingReplicaDestruction, error) {
+	stageTime := timeutil.Now()
+	batch := bf.NewWriteBatch()
 	stateWO, raftWO := kvstorage.StateWO(batch.State()), batch.Raft()
 	if err := kvstorage.DestroyReplica(
 		ctx, kvstorage.ReadWriter{
-			State: kvstorage.State{RO: r.store.StateEngine(), WO: stateWO},
-			Raft:  kvstorage.Raft{RO: r.store.LogEngine(), WO: raftWO},
+			State: kvstorage.State{RO: stateRO, WO: stateWO},
+			Raft:  kvstorage.Raft{RO: raftRO, WO: raftWO},
 		},
-		r.destroyInfoRaftMuLocked(), nextReplicaID,
+		info, nextReplicaID,
 	); err != nil {
+		batch.Close()
+		return pendingReplicaDestruction{}, err
+	}
+	return pendingReplicaDestruction{
+		batch:       batch,
+		ms:          ms,
+		initialized: len(info.Keys.EndKey) > 0,
+		stageTime:   stageTime,
+		clearTime:   timeutil.Now(),
+	}, nil
+}
+
+// destroyRaftMuLocked deletes data associated with a replica, leaving a
+// tombstone. The Replica may not be initialized in which case only the
+// range ID local data is removed.
+//
+// If an error is returned from this method, the removal failed but no
+// side effects have occurred, i.e. the caller may be able to handle the
+// error cleanly.
+func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb.ReplicaID) error {
+	pending, err := stageDestroyReplica(
+		ctx, &r.store.batchFactory,
+		r.store.StateEngine(), r.store.LogEngine(),
+		r.destroyInfoRaftMuLocked(), nextReplicaID,
+		r.GetMVCCStats(),
+	)
+	if err != nil {
 		return err
 	}
-	preTime := timeutil.Now()
-
-	// We need to sync here because we are potentially deleting sideloaded
-	// proposals from the file system next. We could write the tombstone only in
-	// a synchronous batch first and then delete the data alternatively, but
-	// then need to handle the case in which there is both the tombstone and
-	// leftover replica data.
-	if err := batch.Commit(true /* sync */); err != nil {
-		return err
-	}
-	commitTime := timeutil.Now()
-
+	defer pending.Close()
+	pending.MustCommit(ctx)
 	r.postDestroyRaftMuLocked(ctx)
-	if r.IsInitialized() {
-		log.KvDistribution.Infof(ctx, "removed %d (%d+%d) keys in %0.0fms [clear=%0.0fms commit=%0.0fms]",
-			ms.KeyCount+ms.SysCount, ms.KeyCount, ms.SysCount,
-			commitTime.Sub(startTime).Seconds()*1000,
-			preTime.Sub(startTime).Seconds()*1000,
-			commitTime.Sub(preTime).Seconds()*1000)
-	} else {
-		log.KvDistribution.Infof(ctx, "removed uninitialized range in %0.0fms [clear=%0.0fms commit=%0.0fms]",
-			commitTime.Sub(startTime).Seconds()*1000,
-			preTime.Sub(startTime).Seconds()*1000,
-			commitTime.Sub(preTime).Seconds()*1000)
-	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -58,6 +58,20 @@ func (s destroyStatus) Removed() bool {
 	return s.reason == destroyReasonRemoved
 }
 
+// setDestroyStatusRemovedRaftMuLocked marks the replica as removed. The caller
+// must hold raftMu; readOnlyCmdMu and mu are acquired internally.
+func (r *Replica) setDestroyStatusRemovedRaftMuLocked() {
+	r.raftMu.AssertHeld()
+	r.readOnlyCmdMu.Lock()
+	defer r.readOnlyCmdMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.shMu.destroyStatus.Set(
+		kvpb.NewRangeNotFoundError(r.RangeID, r.StoreID()),
+		destroyReasonRemoved,
+	)
+}
+
 // postDestroyRaftMuLocked is called after the replica destruction is durably
 // written to Pebble.
 func (r *Replica) postDestroyRaftMuLocked(ctx context.Context) {

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -194,29 +194,6 @@ func stageDestroyReplica(
 	}, nil
 }
 
-// destroyRaftMuLocked deletes data associated with a replica, leaving a
-// tombstone. The Replica may not be initialized in which case only the
-// range ID local data is removed.
-//
-// If an error is returned from this method, the removal failed but no
-// side effects have occurred, i.e. the caller may be able to handle the
-// error cleanly.
-func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb.ReplicaID) error {
-	pending, err := stageDestroyReplica(
-		ctx, &r.store.batchFactory,
-		r.store.StateEngine(), r.store.LogEngine(),
-		r.destroyInfoRaftMuLocked(), nextReplicaID,
-		r.GetMVCCStats(),
-	)
-	if err != nil {
-		return err
-	}
-	defer pending.Close()
-	pending.MustCommit(ctx)
-	r.postDestroyRaftMuLocked(ctx)
-	return nil
-}
-
 // disconnectReplicationRaftMuLocked is called when a Replica is being removed.
 // It cancels all outstanding proposals, closes the proposalQuota if there
 // is one, releases all held flow tokens, and removes the in-memory raft state.

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -57,12 +57,21 @@ func (s destroyStatus) Removed() bool {
 
 // postDestroyRaftMuLocked is called after the replica destruction is durably
 // written to Pebble.
-func (r *Replica) postDestroyRaftMuLocked(ctx context.Context) error {
-	// TODO(#136416): at node startup, we should remove all on-disk directories
+func (r *Replica) postDestroyRaftMuLocked(ctx context.Context) {
+	// Clearing sideloaded storage may fail (e.g. due to I/O errors), but we log
+	// and continue. We've already committed the replica removal, and any future
+	// replica instantiation will go through a snapshot path which clears the
+	// sideloaded storage.
+	// Leaking the files is preferable to crashing or having to recover from a
+	// partially-destroyed replica state.
+	//
+	// TODO(#136416): at node startup, we could remove all on-disk directories
 	// belonging to replicas which aren't present. A crash before a call to
-	// postDestroyRaftMuLocked will currently leave the files around forever.
+	// postDestroyRaftMuLocked or hitting an error below will currently leave the
+	// files around forever.
 	if err := r.logStorage.ls.Sideload.Clear(ctx); err != nil {
-		return err
+		log.KvDistribution.Warningf(ctx, "failed to clear sideloaded storage: %v", err)
+		err = nil // ignore intentionally
 	}
 
 	// Release the reference to this tenant in metrics, we know the tenant ID is
@@ -75,8 +84,6 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context) error {
 	if r.tenantLimiter != nil {
 		r.store.tenantRateLimiters.Release(r.tenantLimiter)
 	}
-
-	return nil
 }
 
 // destroyRaftMuLocked deletes data associated with a replica, leaving a
@@ -111,9 +118,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	}
 	commitTime := timeutil.Now()
 
-	if err := r.postDestroyRaftMuLocked(ctx); err != nil {
-		return err
-	}
+	r.postDestroyRaftMuLocked(ctx)
 	if r.IsInitialized() {
 		log.KvDistribution.Infof(ctx, "removed %d (%d+%d) keys in %0.0fms [clear=%0.0fms commit=%0.0fms]",
 			ms.KeyCount+ms.SysCount, ms.KeyCount, ms.SysCount,

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 )
@@ -362,9 +361,6 @@ func (rgcq *replicaGCQueue) process(
 		// above and deciding to remove the replica, it could have been removed
 		// concurrently. RemoveReplica gracefully returns nil in this case.
 		if err := repl.store.RemoveReplica(ctx, repl, nextReplicaID, "replica GC queue"); err != nil {
-			// Should never get an error from RemoveReplica.
-			const format = "error during replicaGC: %v"
-			logcrash.ReportOrPanic(ctx, &repl.store.ClusterSettings().SV, format, err)
 			return false, err
 		}
 	} else {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -829,9 +829,7 @@ func (r *Replica) clearSubsumedReplicaInMemoryData(
 		phs = append(phs, ph)
 		// We removed sr's data when we committed the batch. Finish subsumption by
 		// updating the in-memory bookkeping.
-		if err := sr.postDestroyRaftMuLocked(ctx); err != nil {
-			return nil, err
-		}
+		sr.postDestroyRaftMuLocked(ctx)
 	}
 	return phs, nil
 }

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -114,6 +114,8 @@ func (s *Store) tryGetReplica(
 		if err := s.removeReplicaRaftMuLocked(
 			ctx, repl, id.ReplicaID, "superseded by newer Replica",
 		); err != nil {
+			// TODO(in this PR): we should be able to recover from this now, and
+			// propagate the error up.
 			log.KvExec.Fatalf(ctx, "failed to remove replica: %v", err)
 		}
 		repl.raftMu.Unlock()

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -114,9 +114,8 @@ func (s *Store) tryGetReplica(
 		if err := s.removeReplicaRaftMuLocked(
 			ctx, repl, id.ReplicaID, "superseded by newer Replica",
 		); err != nil {
-			// TODO(in this PR): we should be able to recover from this now, and
-			// propagate the error up.
-			log.KvExec.Fatalf(ctx, "failed to remove replica: %v", err)
+			repl.raftMu.Unlock()
+			return nil, err
 		}
 		repl.raftMu.Unlock()
 		return nil, errRetry

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -138,9 +138,7 @@ func (s *Store) MergeRange(
 		return errors.Wrap(err, "cannot remove range")
 	}
 
-	if err := rightRepl.postDestroyRaftMuLocked(ctx); err != nil {
-		return err
-	}
+	rightRepl.postDestroyRaftMuLocked(ctx)
 
 	leftRepl.loadStats.Merge(rightRepl.loadStats)
 

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -640,6 +640,9 @@ func (s *Store) HandleRaftResponse(
 
 				repl.mu.Unlock()
 				nextReplicaID := tErr.ReplicaID + 1
+				// TODO(in this PR): we can log this error now (behind a log.Every)
+				// and return nil. No reason to break down the stream due to an error
+				// affecting possibly only a single local replica. Log and move on.
 				return s.removeReplicaRaftMuLocked(ctx, repl, nextReplicaID, "received ReplicaTooOldError")
 			case *kvpb.RaftGroupDeletedError:
 				if replErr != nil {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -33,8 +33,9 @@ import (
 )
 
 var (
-	logRaftRecvQueueFullEvery = log.Every(1 * time.Second)
-	logRaftSendQueueFullEvery = log.Every(1 * time.Second)
+	logRaftRecvQueueFullEvery    = log.Every(1 * time.Second)
+	logRaftSendQueueFullEvery    = log.Every(1 * time.Second)
+	logReplicaRemovalFailedEvery = log.Every(1 * time.Second)
 )
 
 type raftRequestInfo struct {
@@ -640,10 +641,12 @@ func (s *Store) HandleRaftResponse(
 
 				repl.mu.Unlock()
 				nextReplicaID := tErr.ReplicaID + 1
-				// TODO(in this PR): we can log this error now (behind a log.Every)
-				// and return nil. No reason to break down the stream due to an error
-				// affecting possibly only a single local replica. Log and move on.
-				return s.removeReplicaRaftMuLocked(ctx, repl, nextReplicaID, "received ReplicaTooOldError")
+				if err := s.removeReplicaRaftMuLocked(ctx, repl, nextReplicaID, "received ReplicaTooOldError"); err != nil {
+					if logReplicaRemovalFailedEvery.ShouldLog() {
+						log.KvExec.Warningf(ctx, "failed to remove replica %v: %v", repl, err)
+					}
+				}
+				return nil
 			case *kvpb.RaftGroupDeletedError:
 				if replErr != nil {
 					// RangeNotFoundErrors are expected here; nothing else is.

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -81,67 +81,74 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 		return nil, errors.AssertionFailedf("cannot specify both InsertPlaceholder and DestroyData")
 	}
 
-	// Run sanity checks and on success commit to the removal by setting the
-	// destroy status. If (nil, nil) is returned, there's nothing to do.
-	desc, err := func() (*roachpb.RangeDescriptor, error) {
-		rep.readOnlyCmdMu.Lock()
-		defer rep.readOnlyCmdMu.Unlock()
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		rep.mu.Lock()
-		defer rep.mu.Unlock()
-
-		if opts.DestroyData {
-			// Detect if we were already removed.
-			if rep.shMu.destroyStatus.Removed() {
-				return nil, nil // already removed, noop
-			}
-		} else {
-			// If the caller doesn't want to destroy the data because it already
-			// has done so, then it must have already also set the destroyStatus.
-			if !rep.shMu.destroyStatus.Removed() {
-				return nil, errors.AssertionFailedf("replica not marked as destroyed but data already destroyed: %v", rep)
-			}
+	// Run sanity checks.
+	//
+	// All checks below access shMu fields (destroyStatus, state.Desc) or the
+	// sync-map replicasByRangeID, both of which are safe to read under raftMu
+	// without additional locks. Holding raftMu is sufficient to guarantee that
+	// the replica's store membership does not change: removal from the store
+	// also requires raftMu (later in this method), and a new Replica for the
+	// same range cannot be inserted while the current one is still present.
+	if opts.DestroyData {
+		// Detect if we were already removed.
+		if rep.shMu.destroyStatus.Removed() {
+			return nil, nil // already removed, noop
 		}
-
-		// Check if Replica is in the Store.
-		//
-		// There is a certain amount of idempotency in this method (repeat attempts
-		// to destroy an already destroyed replica are allowed when DestroyData is
-		// set, see the early return above), but if we get here then the Replica
-		// better be in the Store (since the Store enforces ownership over the
-		// keyspace, so deleting data for a Replica that's not in the Store can
-		// delete random active data). Note that if the caller has !DestroyData,
-		// this means it needs to already know that the Replica is still in the
-		// Store.
-		if existing, ok := s.mu.replicasByRangeID.Load(rep.RangeID); !ok {
-			return nil, errors.AssertionFailedf("cannot remove replica which does not exist in Store")
-		} else if existing != rep {
-			return nil, errors.AssertionFailedf("replica %v replaced by %v before being removed",
-				rep, existing)
+	} else {
+		// If the caller doesn't want to destroy the data because it already
+		// has done so, then it must have already also set the destroyStatus.
+		if !rep.shMu.destroyStatus.Removed() {
+			return nil, errors.AssertionFailedf("replica not marked as destroyed but data already destroyed: %v", rep)
 		}
-
-		// Now we know that the Store's Replica is identical to the passed-in
-		// Replica.
-		desc := rep.shMu.state.Desc
-		if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= nextReplicaID {
-			// The ReplicaID of a Replica is immutable.
-			return nil, errors.AssertionFailedf("replica descriptor's ID has changed (%s >= %s)",
-				repDesc.ReplicaID, nextReplicaID)
-		}
-
-		// Sanity checks passed. Mark the replica as removed before deleting data.
-		rep.shMu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
-			destroyReasonRemoved)
-		return desc, nil
-	}()
-	if err != nil {
-		return nil, err
 	}
-	if desc == nil {
-		// Already removed/removing, no-op.
-		return nil, nil
+
+	// Check if Replica is in the Store.
+	//
+	// There is a certain amount of idempotency in this method (repeat attempts
+	// to destroy an already destroyed replica are allowed when DestroyData is
+	// set, see the early return above), but if we get here then the Replica
+	// better be in the Store (since the Store enforces ownership over the
+	// keyspace, so deleting data for a Replica that's not in the Store can
+	// delete random active data). Note that if the caller has !DestroyData,
+	// this means it needs to already know that the Replica is still in the
+	// Store.
+	if existing, ok := s.mu.replicasByRangeID.Load(rep.RangeID); !ok {
+		return nil, errors.AssertionFailedf("cannot remove replica which does not exist in Store")
+	} else if existing != rep {
+		return nil, errors.AssertionFailedf("replica %v replaced by %v before being removed",
+			rep, existing)
 	}
+
+	// Now we know that the Store's Replica is identical to the passed-in
+	// Replica.
+	desc := rep.shMu.state.Desc
+	if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= nextReplicaID {
+		// The ReplicaID of a Replica is immutable.
+		return nil, errors.AssertionFailedf("replica descriptor's ID has changed (%s >= %s)",
+			repDesc.ReplicaID, nextReplicaID)
+	}
+
+	// Stage the engine destruction batch before any in-memory state changes.
+	// If staging fails, we return the error with no side effects.
+	var pending pendingReplicaDestruction
+	if opts.DestroyData {
+		var err error
+		pending, err = stageDestroyReplica(
+			ctx, &s.batchFactory,
+			s.StateEngine(), s.LogEngine(),
+			rep.destroyInfoRaftMuLocked(), nextReplicaID,
+			rep.GetMVCCStats(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer pending.Close()
+	}
+
+	// Mark the replica as removed. This is done after staging (which is
+	// fallible) but before committing (which is infallible), so that a staging
+	// failure leaves the replica in a clean state.
+	rep.setDestroyStatusRemovedRaftMuLocked()
 
 	// Proceed with the removal, all errors encountered from here down are fatal.
 
@@ -176,9 +183,8 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	// (preventing any concurrent access to the replica's key range).
 	rep.disconnectReplicationRaftMuLocked(ctx)
 	if opts.DestroyData {
-		if err := rep.destroyRaftMuLocked(ctx, nextReplicaID); err != nil {
-			return nil, err
-		}
+		pending.MustCommit(ctx)
+		rep.postDestroyRaftMuLocked(ctx)
 	}
 
 	ph := func() *ReplicaPlaceholder {
@@ -242,23 +248,15 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 	rep.raftMu.AssertHeld()
 
 	// Sanity check this removal.
-	func() {
-		rep.readOnlyCmdMu.Lock()
-		defer rep.readOnlyCmdMu.Unlock()
-		rep.mu.Lock()
-		defer rep.mu.Unlock()
-
-		// Detect if we were already removed, this is a fatal error
-		// because we should have already checked this under the raftMu
-		// before calling this method.
-		if rep.shMu.destroyStatus.Removed() {
-			log.KvDistribution.Fatalf(ctx, "uninitialized replica unexpectedly already removed")
-		}
-
-		if rep.IsInitialized() {
-			log.KvDistribution.Fatalf(ctx, "cannot remove initialized replica in removeUninitializedReplica: %v", rep)
-		}
-	}()
+	//
+	// These checks only access shMu fields (safe to read under raftMu) and
+	// IsInitialized (atomic), so no additional locks are needed.
+	if rep.shMu.destroyStatus.Removed() {
+		log.KvDistribution.Fatalf(ctx, "uninitialized replica unexpectedly already removed")
+	}
+	if rep.IsInitialized() {
+		log.KvDistribution.Fatalf(ctx, "cannot remove initialized replica in removeUninitializedReplica: %v", rep)
+	}
 
 	// Stage the engine work before any in-memory state changes. If the engine
 	// work fails (e.g. context cancellation, I/O error), we can return the error
@@ -277,16 +275,7 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 	// Mark the replica as removed. This is done after staging (which is
 	// fallible) but before committing (which is infallible), so that a staging
 	// failure leaves the replica in a clean state.
-	func() {
-		rep.readOnlyCmdMu.Lock()
-		defer rep.readOnlyCmdMu.Unlock()
-		rep.mu.Lock()
-		defer rep.mu.Unlock()
-		// NB: we hold raftMu throughout and destroyStatus is in shMu, so the
-		// destroyStatus did not change between the earlier sanity checks and here.
-		rep.shMu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
-			destroyReasonRemoved)
-	}()
+	rep.setDestroyStatusRemovedRaftMuLocked()
 
 	// Proceed with the removal.
 

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -65,7 +65,7 @@ func (s *Store) removeReplicaRaftMuLocked(
 // which is sometimes called directly when the necessary lock is already held.
 // It requires that Replica.raftMu is held and that s.mu is not held.
 //
-// If opts.DestroyData is false, replica.destroyRaftMuLocked is not called.
+// If opts.DestroyData is false, the on-disk replica data is not destroyed.
 func (s *Store) removeInitializedReplicaRaftMuLocked(
 	ctx context.Context,
 	rep *Replica,

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -55,7 +55,9 @@ func (s *Store) removeReplicaRaftMuLocked(
 			ctx, rep, nextReplicaID, reason, RemoveOptions{DestroyData: true})
 		return errors.Wrap(err, "failed to remove replica")
 	}
-	s.removeUninitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID)
+	if err := s.removeUninitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID); err != nil {
+		return errors.Wrap(err, "failed to remove replica")
+	}
 	return nil
 }
 
@@ -229,45 +231,68 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 // All paths which call this code held the raftMu before calling this method
 // and ensured that the removal was sane given the current replicaID and
 // initialization status (which only changes under the raftMu).
+//
+// The replica must not have been previously destroyed. Unlike
+// removeInitializedReplicaRaftMuLocked, this method does not handle the
+// idempotent "already removed" case and will fatal if called on a replica
+// whose destroyStatus is already set.
 func (s *Store) removeUninitializedReplicaRaftMuLocked(
 	ctx context.Context, rep *Replica, nextReplicaID roachpb.ReplicaID,
-) {
+) error {
 	rep.raftMu.AssertHeld()
 
-	// Sanity check this removal and set the destroyStatus.
-	{
+	// Sanity check this removal.
+	func() {
 		rep.readOnlyCmdMu.Lock()
+		defer rep.readOnlyCmdMu.Unlock()
 		rep.mu.Lock()
+		defer rep.mu.Unlock()
 
 		// Detect if we were already removed, this is a fatal error
 		// because we should have already checked this under the raftMu
 		// before calling this method.
 		if rep.shMu.destroyStatus.Removed() {
-			rep.mu.Unlock()
-			rep.readOnlyCmdMu.Unlock()
 			log.KvDistribution.Fatalf(ctx, "uninitialized replica unexpectedly already removed")
 		}
 
 		if rep.IsInitialized() {
-			rep.mu.Unlock()
-			rep.readOnlyCmdMu.Unlock()
 			log.KvDistribution.Fatalf(ctx, "cannot remove initialized replica in removeUninitializedReplica: %v", rep)
 		}
+	}()
 
-		// Mark the replica as removed before deleting data.
+	// Stage the engine work before any in-memory state changes. If the engine
+	// work fails (e.g. context cancellation, I/O error), we can return the error
+	// cleanly without leaving the replica in a half-destroyed state.
+	pending, err := stageDestroyReplica(
+		ctx, &s.batchFactory,
+		s.StateEngine(), s.LogEngine(),
+		rep.destroyInfoRaftMuLocked(), nextReplicaID,
+		rep.GetMVCCStats(),
+	)
+	if err != nil {
+		return err
+	}
+	defer pending.Close()
+
+	// Mark the replica as removed. This is done after staging (which is
+	// fallible) but before committing (which is infallible), so that a staging
+	// failure leaves the replica in a clean state.
+	func() {
+		rep.readOnlyCmdMu.Lock()
+		defer rep.readOnlyCmdMu.Unlock()
+		rep.mu.Lock()
+		defer rep.mu.Unlock()
+		// NB: we hold raftMu throughout and destroyStatus is in shMu, so the
+		// destroyStatus did not change between the earlier sanity checks and here.
 		rep.shMu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
 			destroyReasonRemoved)
-
-		rep.mu.Unlock()
-		rep.readOnlyCmdMu.Unlock()
-	}
+	}()
 
 	// Proceed with the removal.
 
 	rep.disconnectReplicationRaftMuLocked(ctx)
-	if err := rep.destroyRaftMuLocked(ctx, nextReplicaID); err != nil {
-		log.KvDistribution.Fatalf(ctx, "failed to remove uninitialized replica %v: %v", rep, err)
-	}
+	pending.MustCommit(ctx)
+	rep.postDestroyRaftMuLocked(ctx)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -284,6 +309,7 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 	}
 
 	s.unlinkReplicaByRangeIDLocked(ctx, rep.RangeID)
+	return nil
 }
 
 // unlinkReplicaByRangeIDLocked removes all of the store's references to the

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -132,6 +132,11 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	// If staging fails, we return the error with no side effects.
 	var pending pendingReplicaDestruction
 	if opts.DestroyData {
+		if fn := s.TestingKnobs().TestingReplicaDestroyErr; fn != nil {
+			if err := fn(); err != nil {
+				return nil, err
+			}
+		}
 		var err error
 		pending, err = stageDestroyReplica(
 			ctx, &s.batchFactory,
@@ -261,6 +266,11 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 	// Stage the engine work before any in-memory state changes. If the engine
 	// work fails (e.g. context cancellation, I/O error), we can return the error
 	// cleanly without leaving the replica in a half-destroyed state.
+	if fn := s.TestingKnobs().TestingReplicaDestroyErr; fn != nil {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
 	pending, err := stageDestroyReplica(
 		ctx, &s.batchFactory,
 		s.StateEngine(), s.LogEngine(),

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -286,6 +286,13 @@ type StoreTestingKnobs struct {
 	// spin attempting to acquire a split or merge lock on a RHS which will
 	// always fail and is generally not safe but is useful for testing.
 	DisableEagerReplicaRemoval bool
+	// TestingReplicaDestroyErr, if set, is called before staging a replica
+	// destruction batch in removal paths that set DestroyData (i.e. GC queue,
+	// direct RemoveReplica, and getOrCreateReplica — but NOT the eager
+	// self-removal via ChangeReplicasTrigger, which uses DestroyData: false).
+	// If it returns a non-nil error, the staging is short-circuited and the
+	// error is returned to the caller.
+	TestingReplicaDestroyErr func() error
 	// DisableReplicaGCQueueAddOnRaftGroupDeleted, when set, prevents
 	// HandleRaftResponse from adding replicas to the GC queue when a
 	// RaftGroupDeletedError is received. This is useful for testing the


### PR DESCRIPTION
This PR makes replica destruction resilient to engine errors by separating
fallible engine I/O from irreversible in-memory state changes.

Today, `destroyRaftMuLocked` builds an engine batch and commits it in one
shot. If the batch-building fails (e.g. due to I/O errors), the replica
may be left in a half-destroyed state, causing crashes or stuck replicas
(#155121, #162534).

The fix introduces a staging pattern: `stageDestroyReplica` builds the
engine batch without committing it. Callers perform sanity checks, then
stage, then (only on success) mark the replica as removed and commit via
the infallible `MustCommit`. If staging fails, the replica is untouched
and callers can return the error cleanly.

The early commits make `postDestroyRaftMuLocked` infallible (log-and-ignore
sideload cleanup errors) and introduce the staging API. The middle commits
wire it into both removal paths (initialized and uninitialized) and update
the three callers that previously crashed on removal errors (GC queue,
raft transport, `tryGetOrCreateReplica`) to handle them gracefully. The
final commit adds an integration test exercising error injection across
all three removal paths.

Part of: #162534
Fixes: #155121
Informs: #164944, #165558
Epic: none