### PR TITLE
release-26.1: singleflight,stop: fix trace.StartRegion crash with oversized strings

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -331,6 +331,13 @@ func (s *Stopper) startRegion(ctx context.Context, taskName string) region {
 	if !trace.IsEnabled() {
 		return noopRegion{}
 	}
+	// Truncate the task name to avoid hitting a Go runtime bug where
+	// trace.StartRegion crashes with strings longer than ~64KB. See
+	// https://github.com/golang/go/pull/78348.
+	const maxRegionNameLen = 256
+	if len(taskName) > maxRegionNameLen {
+		taskName = taskName[:maxRegionNameLen]
+	}
 	return trace.StartRegion(ctx, taskName)
 }
 

--- a/pkg/util/syncutil/singleflight/singleflight.go
+++ b/pkg/util/syncutil/singleflight/singleflight.go
@@ -380,7 +380,7 @@ func (g *Group) doCall(
 		ctx, cancel = opts.Stop.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		if err := opts.Stop.RunTask(ctx, g.opName+":"+key, func(ctx context.Context) {
+		if err := opts.Stop.RunTask(ctx, g.opName, func(ctx context.Context) {
 			c.val, c.err = fn(ctx)
 		}); err != nil {
 			c.err = err


### PR DESCRIPTION
Backport 2/2 commits from #166669 on behalf of @tbg.

----

## Summary

Go's `runtime/trace` crashes with `traceRegion: alloc too large` when
`trace.StartRegion` receives a string longer than ~64KB. This is an upstream
Go bug (missing truncation in `traceStringTable.put`; fix at
https://github.com/golang/go/pull/78348), triggered by CockroachDB's
`singleflight.doCall` which constructs a task name by concatenating
`g.opName + ":" + key`. For range cache lookups, `key` is built from raw
`roachpb.RKey` bytes via `makeLookupRequestKey` and can be hundreds of KB.

Three production crashes were observed on v25.4.5 with string lengths of
96KB, 387KB, and 444KB.

### Commit 1: `singleflight: don't include key in RunTask name`

Drops the key from the task name passed to `RunTask`. The task name is only
used for `trace.StartRegion`; the key is already recorded in the tracing
span via `sp.SetTag`.

### Commit 2: `stop: truncate trace region names to 256 bytes`

Defense in depth: truncates the task name to 256 bytes in `startRegion`
before passing it to `trace.StartRegion`, protecting against any future
caller passing an oversized string.

Epic: none



----

Release justification: fixes a bug that can crash the process when execution tracing is enabled