### PR TITLE
ui: bump cluster-ui to 26.2.0

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "26.2.0-prerelease.0",
+  "version": "26.2.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump cluster-ui package version to 26.2.0 for the release branch.

Epic: REL-4280
Release note: None

Release justification: version bump that's part of release flow. no production code changed.