### PR TITLE
release-25.4: perturbation: rate-limit backfill pre-fill to avoid OOM on target node

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
+++ b/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
@@ -82,8 +82,8 @@ func (b backfill) startTargetNode(ctx context.Context, t test.Test, v variations
 	// want the fill to impact the test throughput. We use a larger block size
 	// to create a lot of SSTables and ranges in a short amount of time.
 	runCmd := fmt.Sprintf(
-		"./cockroach workload run kv --db backfill --duration=%s --max-block-bytes=%d --min-block-bytes=%d --concurrency=100 {pgurl%s}",
-		v.perturbationDuration, 10_000, 10_000, v.stableNodes())
+		"./cockroach workload run kv --db backfill --max-ops=11000000 --max-rate=8000 --max-block-bytes=10000 --min-block-bytes=10000 --concurrency=100 {pgurl%s}",
+		v.stableNodes())
 	v.Run(ctx, option.WithNodes(v.workloadNodes()), runCmd)
 
 	t.L().Printf("waiting for io overload to end")


### PR DESCRIPTION
Backport 1/1 commits from #166658 on behalf of @tbg.

----

## Summary

The backfill perturbation test pre-fills ~11M rows at 10KB each with no rate
limit, producing ~18K writes/sec. Because the backfill database is
zone-constrained to place one replica on n12 (the target node), n12's stores
receive 3-4x the follower write load of normal stores. This saturates both
disks, triggers WAL failover thrashing between the two stores, and causes
memtables to grow to ~20GB per store (OOM).

The IO overload score never triggers admission control (max 0.304 vs threshold
1.0) because it's based on L0 shape, not physical disk saturation. While WAL
failover is active (~always in the failing run), IO admission control ignores memtable
build-up. But we've seen failures in which replicas went unavailable due to overload
as well, so disabling WAL failover likely wouldn't stabilize this test either.

This change rate-limits the pre-fill to 8K ops/sec and uses `--max-ops=11000000`
to maintain the same total data volume. The fill will take ~23 minutes instead
of 10, but (hopefully) avoids saturating n12's disks.

See analysis: https://github.com/cockroachdb/cockroach/issues/166476#issuecomment-4125828130

Fixes-26.2: #166476
Fixes-25.2: https://github.com/cockroachdb/cockroach/issues/165780
Touches: #136848

## Test plan

- Run `perturbation/full/backfill` and verify n12 no longer OOMs during pre-fill.

----

Release justification: