### PR TITLE
cli/demo: add --background flag to run without interactive shell

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1639,6 +1639,15 @@ Disable the creation of a default dataset in the demo shell.
 This makes 'cockroach demo' faster to start.`,
 	}
 
+	DemoBackground = FlagInfo{
+		Name: "background",
+		Description: `
+Start the demo cluster in the background without opening an interactive SQL
+shell. The cluster runs until the process receives a SIGINT or SIGTERM signal.
+Use --listening-url-file to write the connection URL to a file for use by
+other tools.`,
+	}
+
 	GeoLibsDir = FlagInfo{
 		Name: "spatial-libs",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -720,6 +720,7 @@ var demoCtx = struct {
 	democluster.Context
 	disableEnterpriseFeatures bool
 	pidFile                   string
+	background                bool
 
 	demoNodeCacheSizeValue  bytesOrPercentageValue
 	demoNodeSQLMemSizeValue bytesOrPercentageValue
@@ -753,6 +754,7 @@ func setDemoContextDefaults() {
 	demoCtx.DefaultEnableRangefeeds = true
 
 	demoCtx.pidFile = ""
+	demoCtx.background = false
 	demoCtx.disableEnterpriseFeatures = false
 
 	demoCtx.demoNodeCacheSizeValue = makeBytesOrPercentageValue(

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clienturl"
@@ -332,6 +333,20 @@ func runDemoInternal(
 				certsDir,
 			)
 		}
+	} else if demoCtx.background {
+		// In non-interactive background mode, print connection info since
+		// the interactive block above was skipped.
+		var nodeList strings.Builder
+		c.ListDemoNodes(&nodeList, stderr, false /* justOne */, true /* verbose */)
+		fmt.Fprintf(stderr, "#\n# Connection parameters:\n#\n#   %s",
+			strings.ReplaceAll(
+				strings.TrimSuffix(nodeList.String(), "\n"), "\n", "\n#   "))
+		if !demoCtx.Insecure {
+			adminUser, adminPassword, certsDir := c.GetSQLCredentials()
+			fmt.Fprintf(stderr, "\n#\n#   Username: %q, password: %q\n", adminUser, adminPassword)
+			fmt.Fprintf(stderr, "#   Certificate directory: %s\n", certsDir)
+		}
+		fmt.Fprintln(stderr)
 	}
 
 	conn, err := sqlCtx.MakeConn(c.GetConnURL())
@@ -364,6 +379,20 @@ func runDemoInternal(
 
 	// Ensure the last few entries in the log files are flushed at the end.
 	defer log.FlushFiles()
+
+	if demoCtx.background {
+		// In background mode, skip the interactive SQL shell and block
+		// until signaled. Connection info was already printed above.
+		fmt.Fprintf(stderr, "# Demo cluster running in background.\n")
+		fmt.Fprintf(stderr, "# To shut down, send SIGINT or SIGTERM (Ctrl+C).\n#\n")
+
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, DrainSignals...)
+		<-ch
+
+		fmt.Fprintf(stderr, "\n# Shutting down demo cluster...\n")
+		return nil
+	}
 
 	return sqlCtx.Run(ctx, conn)
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1008,6 +1008,7 @@ func init() {
 		cliflagcfg.IntFlag(f, &demoCtx.HTTPPort, cliflags.DemoHTTPPort)
 		cliflagcfg.StringFlag(f, &demoCtx.ListeningURLFile, cliflags.ListeningURLFile)
 		cliflagcfg.StringFlag(f, &demoCtx.pidFile, cliflags.PIDFile)
+		cliflagcfg.BoolFlag(f, &demoCtx.background, cliflags.DemoBackground)
 	}
 
 	{


### PR DESCRIPTION
Add a `--background` flag to `cockroach demo` that starts the cluster
and blocks on SIGINT/SIGTERM instead of entering the interactive SQL
shell. This makes it easy to script demo clusters for tooling,
automated testing, and CI workflows.

When `--background` is set, the process prints connection parameters
(SQL URLs, CLI commands, Web UI URL) and credentials (in secure mode)
to stderr, then waits for a signal to shut down cleanly.

Example usage:

```
  cockroach demo movr --nodes=9 --insecure --background --with-load &
  # ... use the cluster ...
  kill %1
```

Epic: None
Release note (cli change): `cockroach demo` now accepts a `--background`
flag that starts the demo cluster without opening an interactive SQL
shell. The process prints connection information and blocks until it
receives SIGINT or SIGTERM.