### PR TITLE
sql/udf: Defer Routine Body Building to Execution Time

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1143,13 +1143,9 @@ SET ROLE bob;
 statement error pgcode 42501 pq: user bob does not have EXECUTE privilege on function f_scalar
 SELECT f_scalar();
 
-# Note: Postgres fails with a different error message: "user bob does not have EXECUTE privilege on function f_scalar".
-# This is because psql will first validate access to f_scalar, but crdb first validates access to xy.
-skipif config local-mixed-25.4 local-mixed-26.1
-statement error pgcode 42501 pq: user bob does not have SELECT privilege on relation xy
-SELECT * FROM v;
-
-onlyif config local-mixed-25.4 local-mixed-26.1
+# With deferred body building, CockroachDB now checks EXECUTE privilege on the
+# function before checking SELECT on the table referenced in the body. This
+# matches PostgreSQL behavior.
 statement error pgcode 42501 pq: user bob does not have EXECUTE privilege on function f_scalar
 SELECT * FROM v;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_fk
+++ b/pkg/sql/logictest/testdata/logic_test/udf_fk
@@ -11,7 +11,6 @@ CREATE TABLE parent (p INT PRIMARY KEY);
 statement ok
 CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p));
 
-
 subtest insert
 
 statement ok
@@ -125,7 +124,6 @@ SELECT currval('s');
 subtest end
 
 subtest delete
-
 
 statement ok
 ALTER TABLE parent SET (schema_locked=false)
@@ -636,7 +634,6 @@ SELECT * FROM selfref;
 
 subtest end
 
-
 subtest corruption_check
 
 statement ok
@@ -704,7 +701,6 @@ SELECT i, j FROM child@child_j_idx;
 statement ok
 DROP TABLE IF EXISTS child CASCADE;
 
-
 statement ok
 ALTER TABLE parent SET (schema_locked=false)
 
@@ -759,5 +755,158 @@ SELECT i, j FROM child@child_j_idx;
 ----
 0  2
 
+subtest end
+
+subtest deferred_build_mutation_conflicts
+
+# Tests for cross-query mutation conflict detection with deferred-build UDFs.
+# These UDFs have their bodies built at execution time, so the statement tree
+# must be initialized with outer-query mutations captured at plan time.
+
+statement ok
+DROP TABLE IF EXISTS child CASCADE;
+
+statement ok
+DROP TABLE IF EXISTS parent CASCADE;
+
+statement ok
+CREATE TABLE parent (j INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE child (i INT PRIMARY KEY, j INT REFERENCES parent (j) ON UPDATE CASCADE ON DELETE CASCADE, INDEX (j));
+
+statement ok
+INSERT INTO parent VALUES (0), (1), (2), (3), (4);
+
+statement ok
+INSERT INTO child VALUES (0, 0), (1, 1), (2, 2);
+
+# UDF that updates parent, which cascades to child.
+statement ok
+CREATE OR REPLACE FUNCTION f_update_parent(k INT) RETURNS INT AS $$
+  UPDATE parent SET j = j + 10 WHERE j = k RETURNING j
+$$ LANGUAGE SQL;
+
+# UDF that directly updates child.
+statement ok
+CREATE OR REPLACE FUNCTION f_update_child(k INT, v INT) RETURNS INT AS $$
+  UPDATE child SET j = v WHERE i = k RETURNING j
+$$ LANGUAGE SQL;
+
+# UDF that does a simple INSERT into child.
+statement ok
+CREATE OR REPLACE FUNCTION f_insert_child(k INT, v INT) RETURNS INT AS $$
+  INSERT INTO child VALUES (k, v) RETURNING j
+$$ LANGUAGE SQL;
+
+# UDF that uses a CTE with a mutation inside.
+statement ok
+CREATE OR REPLACE FUNCTION f_cte_update_child(k INT, v INT) RETURNS INT AS $$
+  WITH x AS (UPDATE child SET j = v WHERE i = k RETURNING j) SELECT j FROM x
+$$ LANGUAGE SQL;
+
+# --- Conflict cases (should error) ---
+
+# A deferred UDF that cascades to child + a sibling CTE that directly mutates child.
+statement error pgcode 0A000 pq: multiple mutations of the same table "child"
+WITH x AS (SELECT f_update_parent(0) AS j), y AS (UPDATE child SET j = 4 WHERE i = 1 RETURNING j) SELECT * FROM x;
+
+# Verify no corruption occurred.
+query II rowsort
+SELECT i, j FROM child@primary;
+----
+0  0
+1  1
+2  2
+
+query II rowsort
+SELECT i, j FROM child@child_j_idx;
+----
+0  0
+1  1
+2  2
+
+# A deferred UDF that directly mutates child + a sibling CTE that also mutates child.
+statement error pgcode 0A000 pq: multiple mutations of the same table "child"
+WITH x AS (SELECT f_update_child(0, 4) AS j), y AS (UPDATE child SET j = 3 WHERE i = 1 RETURNING j) SELECT * FROM x;
+
+# Verify no corruption.
+query II rowsort
+SELECT i, j FROM child@primary;
+----
+0  0
+1  1
+2  2
+
+# A deferred UDF with an internal CTE mutation of child + a sibling CTE that mutates child.
+statement error pgcode 0A000 pq: multiple mutations of the same table "child"
+WITH x AS (SELECT f_cte_update_child(0, 4) AS j), y AS (UPDATE child SET j = 3 WHERE i = 1 RETURNING j) SELECT * FROM x;
+
+# Verify no corruption.
+query II rowsort
+SELECT i, j FROM child@primary;
+----
+0  0
+1  1
+2  2
+
+# --- Allowed cases (should succeed) ---
+
+# Two sibling deferred UDFs mutating child independently. This is allowed because
+# neither UDF's mutations are in the other's captured state (they are siblings).
+query II
+SELECT f_update_child(0, 3), f_update_child(1, 4);
+----
+3  4
+
+# Verify correctness.
+query II rowsort
+SELECT i, j FROM child@primary;
+----
+0  3
+1  4
+2  2
+
+query II rowsort
+SELECT i, j FROM child@child_j_idx;
+----
+0  3
+1  4
+2  2
+
+# Reset.
+statement ok
+UPDATE child SET j = i WHERE true;
+
+# Two sibling deferred UDFs doing simple INSERTs to the same table. Allowed.
+query II
+SELECT f_insert_child(10, 3), f_insert_child(11, 4);
+----
+3  4
+
+statement ok
+DELETE FROM child WHERE i >= 10;
+
+# A deferred UDF that mutates parent + a sibling CTE that mutates a DIFFERENT table (child).
+# Allowed because they target different tables.
+query I
+WITH x AS (UPDATE child SET j = 3 WHERE i = 0 RETURNING j) SELECT f_update_parent(4) FROM x;
+----
+14
+
+# Verify correctness across both tables.
+query II rowsort
+SELECT i, j FROM child@primary;
+----
+0  3
+1  1
+2  2
+
+query II rowsort
+SELECT i, j FROM child@child_j_idx;
+----
+0  3
+1  1
+2  2
 
 subtest end

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/sql/opt/exec/explain",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",
+        "//pkg/sql/opt/optbuilder",
         "//pkg/sql/opt/ordering",
         "//pkg/sql/opt/props",
         "//pkg/sql/opt/props/physical",

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1473,3 +1473,23 @@ func (b *Builder) setMutationFlags(e memo.RelExpr) {
 		b.flags.Set(exec.PlanFlagContainsUpsert)
 	}
 }
+
+// setMutationFlagsFromTag sets mutation plan flags based on a statement tag
+// string. This is used for SQL routines with deferred body building, where the
+// body RelExprs are not yet available but the statement tags are known.
+func (b *Builder) setMutationFlagsFromTag(tag string) {
+	switch tag {
+	case "INSERT":
+		b.flags.Set(exec.PlanFlagContainsMutation)
+		b.flags.Set(exec.PlanFlagContainsInsert)
+	case "DELETE":
+		b.flags.Set(exec.PlanFlagContainsMutation)
+		b.flags.Set(exec.PlanFlagContainsDelete)
+	case "UPDATE":
+		b.flags.Set(exec.PlanFlagContainsMutation)
+		b.flags.Set(exec.PlanFlagContainsUpdate)
+	case "UPSERT":
+		b.flags.Set(exec.PlanFlagContainsMutation)
+		b.flags.Set(exec.PlanFlagContainsUpsert)
+	}
+}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3709,13 +3709,27 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		}
 	}
 
-	for _, s := range udf.Def.Body {
-		if s.Relational().CanMutate {
-			b.setMutationFlags(s)
+	if udf.Def.Body != nil {
+		for _, s := range udf.Def.Body {
+			if s.Relational().CanMutate {
+				b.setMutationFlags(s)
+			}
+		}
+	} else {
+		// Body is nil for SQL routines with deferred build. Infer mutation
+		// flags from body statement tags.
+		for _, tag := range udf.Def.BodyTags {
+			b.setMutationFlagsFromTag(tag)
 		}
 	}
 
 	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
+	// For SQL routines with deferred body building (nil Body), pass the
+	// definition so the planGen closure can build from ASTs at execution time.
+	var deferredDef *memo.UDFDefinition
+	if udf.Def.Body == nil {
+		deferredDef = udf.Def
+	}
 	planGen := b.buildRoutinePlanGenerator(
 		udf.Def.Params,
 		udf.Def.Body,
@@ -3726,6 +3740,7 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		false, /* allowOuterWithRefs */
 		nil,   /* wrapRootExpr */
 		0,     /* resultBufferID */
+		deferredDef,
 	)
 
 	r := tree.NewTypedRoutineExpr(

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
@@ -701,7 +702,8 @@ func (b *Builder) buildExistsSubquery(
 			nil,  /* stmtASTs */
 			true, /* allowOuterWithRefs */
 			wrapRootExpr,
-			0, /* resultBufferID */
+			0,   /* resultBufferID */
+			nil, /* def */
 		)
 		return tree.NewTypedCoalesceExpr(tree.TypedExprs{
 			tree.NewTypedRoutineExpr(
@@ -830,6 +832,7 @@ func (b *Builder) buildSubquery(
 			true, /* allowOuterWithRefs */
 			nil,  /* wrapRootExpr */
 			0,    /* resultBufferID */
+			nil,  /* def */
 		)
 		_, tailCall := b.tailCalls[subquery]
 		return tree.NewTypedRoutineExpr(
@@ -986,9 +989,17 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		return nil, err
 	}
 
-	for _, s := range udf.Def.Body {
-		if s.Relational().CanMutate {
-			b.setMutationFlags(s)
+	if udf.Def.Body != nil {
+		for _, s := range udf.Def.Body {
+			if s.Relational().CanMutate {
+				b.setMutationFlags(s)
+			}
+		}
+	} else {
+		// Body is nil for SQL routines with deferred build. Infer mutation
+		// flags from body statement tags.
+		for _, tag := range udf.Def.BodyTags {
+			b.setMutationFlagsFromTag(tag)
 		}
 	}
 
@@ -1000,8 +1011,10 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 
 	// Execution expects there to be more than one body statement if a cursor is
 	// opened or the result of the first statement is directed to a buffer.
+	// This check is skipped for deferred-build routines (nil Body) since cursor
+	// declarations and target buffers are PL/pgSQL features only.
 	firstStmtOut := udf.Def.FirstStmtOutput
-	if len(udf.Def.Body) <= 1 &&
+	if udf.Def.Body != nil && len(udf.Def.Body) <= 1 &&
 		(firstStmtOut.CursorDeclaration != nil || firstStmtOut.TargetBufferID != 0) {
 		panic(errors.AssertionFailedf(
 			"expected more than one body statement for a routine that " +
@@ -1016,6 +1029,12 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	}
 
 	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
+	// For SQL routines with deferred body building (nil Body), pass the
+	// definition so the planGen closure can build from ASTs at execution time.
+	var deferredDef *memo.UDFDefinition
+	if udf.Def.Body == nil {
+		deferredDef = udf.Def
+	}
 	planGen := b.buildRoutinePlanGenerator(
 		udf.Def.Params,
 		udf.Def.Body,
@@ -1026,6 +1045,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		false, /* allowOuterWithRefs */
 		nil,   /* wrapRootExpr */
 		udf.Def.ResultBufferID,
+		deferredDef,
 	)
 
 	// Enable stepping for volatile functions so that statements within the UDF
@@ -1101,6 +1121,7 @@ func (b *Builder) initRoutineExceptionHandler(
 			false, /* allowOuterWithRefs */
 			nil,   /* wrapRootExpr */
 			0,     /* resultBufferID */
+			nil,   /* def */
 		)
 		// Build a routine with no arguments for the exception handler. The actual
 		// arguments will be supplied when (if) the handler is invoked.
@@ -1152,6 +1173,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 	allowOuterWithRefs bool,
 	wrapRootExpr wrapRootExprFn,
 	resultBufferID memo.RoutineResultBufferID,
+	def *memo.UDFDefinition, // non-nil for SQL routines with deferred build
 ) tree.RoutinePlanGenerator {
 	// argOrd returns the ordinal of the argument within the arguments list that
 	// can be substituted for each reference to the given function parameter
@@ -1198,6 +1220,43 @@ func (b *Builder) buildRoutinePlanGenerator(
 		defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
 			log.VEventf(ctx, 1, "%v", caughtErr)
 		})
+
+		// Shadow closure variables so that the deferred-build path can
+		// override them without affecting future invocations.
+		stmts := stmts
+		stmtProps := stmtProps
+		originalMemo := originalMemo
+		argOrd := argOrd
+		if def != nil {
+			// Deferred-build path: build body RelExprs from ASTs now, at
+			// execution time. This enables a future hint-injection fallback
+			// (retry without hints if optimization fails) because we have the
+			// original ASTs available.
+			var tmpO xform.Optimizer
+			tmpO.Init(ctx, b.evalCtx, b.catalog)
+			// The stmt parameter is nil because we don't call bld.Build() (which
+			// uses it). Instead, we call BuildSQLRoutineBodyFromASTs directly.
+			bld := optbuilder.New(
+				ctx, b.semaCtx, b.evalCtx, b.catalog, tmpO.Factory(), nil, /* stmt */
+			)
+
+			body, bodyProps, newParams := bld.BuildSQLRoutineBodyFromASTs(
+				def.BodyASTs, def.ParamTypes, def.ParamNames,
+				def.Typ, def.SetReturning, def.InsideDataSource,
+				def.DefinerUser,
+			)
+			stmts = body
+			stmtProps = bodyProps
+			originalMemo = tmpO.Factory().Memo()
+			argOrd = func(col opt.ColumnID) (ord int, ok bool) {
+				for i, p := range newParams {
+					if col == p {
+						return i, true
+					}
+				}
+				return 0, false
+			}
+		}
 
 		dbName := b.evalCtx.SessionData().Database
 		appName := b.evalCtx.SessionData().ApplicationName

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1243,7 +1243,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 			body, bodyProps, newParams := bld.BuildSQLRoutineBodyFromASTs(
 				def.BodyASTs, def.ParamTypes, def.ParamNames,
 				def.Typ, def.SetReturning, def.InsideDataSource,
-				def.DefinerUser,
+				def.DefinerUser, def.RoutineType, def.StmtTreeInitFn,
 			)
 			stmts = body
 			stmtProps = bodyProps

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -733,9 +733,14 @@ type UDFDefinition struct {
 	// of the function invocation.
 	Params opt.ColList
 
-	// ParamTypes stores the declared parameter types. Needed for deferred body
-	// building at execution time where the original Overload is not available.
+	// ParamTypes stores the declared parameter types (after polymorphic
+	// resolution). Needed for deferred body building at execution time where
+	// the original Overload is not available.
 	ParamTypes []*types.T
+
+	// ParamNames stores the declared parameter names. Needed so that the
+	// deferred body build can resolve named parameter references.
+	ParamNames []string
 
 	// BodyText is the raw SQL body text from the routine definition. Used for
 	// deferred body building at execution time.
@@ -745,6 +750,13 @@ type UDFDefinition struct {
 	// (e.g., SELECT * FROM my_udf()). Needed for return-type finalization
 	// during deferred build.
 	InsideDataSource bool
+
+	// DefinerUser is set for SECURITY DEFINER routines to the routine owner's
+	// username. When the deferred body build runs at execution time, it sets
+	// privilege overrides on the optbuilder so that table and function access
+	// within the body uses the definer's privileges. Empty for SECURITY
+	// INVOKER (the default).
+	DefinerUser string
 
 	// Body contains a relational expression for each statement in the function
 	// body. It is unset during construction of a recursive UDF.

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -733,6 +733,19 @@ type UDFDefinition struct {
 	// of the function invocation.
 	Params opt.ColList
 
+	// ParamTypes stores the declared parameter types. Needed for deferred body
+	// building at execution time where the original Overload is not available.
+	ParamTypes []*types.T
+
+	// BodyText is the raw SQL body text from the routine definition. Used for
+	// deferred body building at execution time.
+	BodyText string
+
+	// InsideDataSource is true if the routine is used as a data source
+	// (e.g., SELECT * FROM my_udf()). Needed for return-type finalization
+	// during deferred build.
+	InsideDataSource bool
+
 	// Body contains a relational expression for each statement in the function
 	// body. It is unset during construction of a recursive UDF.
 	Body []RelExpr

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -758,6 +758,12 @@ type UDFDefinition struct {
 	// INVOKER (the default).
 	DefinerUser string
 
+	// StmtTreeInitFn, when non-nil, returns an optbuilder statementTree
+	// initialized with mutations from the outer query. Used for deferred-build
+	// routines to detect cross-query mutation conflicts at execution time.
+	// Typed as any to avoid an import cycle (actual type: func() statementTree).
+	StmtTreeInitFn any
+
 	// Body contains a relational expression for each statement in the function
 	// body. It is unset during construction of a recursive UDF.
 	Body []RelExpr

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1080,29 +1080,39 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 				f.formatColList(tp, "params:", def.Params, opt.ColSet{} /* notNullCols */)
 			}
 			n := tp.Child("body")
-			for i := range def.Body {
-				stmtNode := n
-				if i == 0 {
-					if def.FirstStmtOutput.CursorDeclaration != nil {
-						// The first statement is opening a cursor.
-						stmtNode = n.Child("open-cursor")
-					} else if def.FirstStmtOutput.TargetBufferID != 0 {
-						// The first statement is writing to a target buffer.
-						stmtNode = n.Child("add-to-srf-result")
+			if def.Body != nil {
+				for i := range def.Body {
+					stmtNode := n
+					if i == 0 {
+						if def.FirstStmtOutput.CursorDeclaration != nil {
+							// The first statement is opening a cursor.
+							stmtNode = n.Child("open-cursor")
+						} else if def.FirstStmtOutput.TargetBufferID != 0 {
+							// The first statement is writing to a target buffer.
+							stmtNode = n.Child("add-to-srf-result")
+						}
+					}
+					prevTailCalls := f.tailCalls
+
+					// Routine calls in the last body statement may be tail calls if
+					// ResultBufferID is unset. If it is set, the result of the last body
+					// statement is not directly used as the result of the UDF call, so it
+					// cannot contain tail calls.
+					if i == len(def.Body)-1 && def.ResultBufferID == 0 {
+						f.tailCalls = make(map[opt.ScalarExpr]struct{})
+						ExtractTailCalls(def.Body[i], f.tailCalls)
+					}
+					f.formatExpr(def.Body[i], stmtNode)
+					f.tailCalls = prevTailCalls
+				}
+			} else {
+				// Body is nil for SQL routines with deferred body building.
+				// Show the body AST text instead.
+				for i, ast := range def.BodyASTs {
+					if ast != nil {
+						n.Childf("stmt%d: %s", i+1, ast.String())
 					}
 				}
-				prevTailCalls := f.tailCalls
-
-				// Routine calls in the last body statement may be tail calls if
-				// ResultBufferID is unset. If it is set, the result of the last body
-				// statement is not directly used as the result of the UDF call, so it
-				// cannot contain tail calls.
-				if i == len(def.Body)-1 && def.ResultBufferID == 0 {
-					f.tailCalls = make(map[opt.ScalarExpr]struct{})
-					ExtractTailCalls(def.Body[i], f.tailCalls)
-				}
-				f.formatExpr(def.Body[i], stmtNode)
-				f.tailCalls = prevTailCalls
 			}
 			delete(f.withinUDFs, def)
 		} else if _, recursive := f.withinUDFs[def]; recursive {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1110,7 +1110,13 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 				// Show the body AST text instead.
 				for i, ast := range def.BodyASTs {
 					if ast != nil {
-						n.Childf("stmt%d: %s", i+1, ast.String())
+						var s string
+						if f.RedactableValues {
+							s = tree.AsStringWithFlags(ast, tree.FmtMarkRedactionNode|tree.FmtOmitNameRedaction)
+						} else {
+							s = ast.String()
+						}
+						n.Childf("stmt%d: %s", i+1, s)
 					}
 				}
 			}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -1387,10 +1387,7 @@ func (h *hasher) IsUDFDefinitionEqual(l, r *UDFDefinition) bool {
 			return false
 		}
 	}
-	if l.DefinerUser != r.DefinerUser {
-		return false
-	}
-	return true
+	return l.DefinerUser == r.DefinerUser
 }
 
 func (h *hasher) IsStoredProcTxnOpEqual(l, r tree.StoredProcTxnOp) bool {

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -1362,7 +1362,24 @@ func (h *hasher) IsUDFDefinitionEqual(l, r *UDFDefinition) bool {
 	if l.FirstStmtOutput.TargetBufferID != r.FirstStmtOutput.TargetBufferID {
 		return false
 	}
-	return h.IsColListEqual(l.Params, r.Params) && l.IsRecursive == r.IsRecursive
+	if !h.IsColListEqual(l.Params, r.Params) || l.IsRecursive != r.IsRecursive {
+		return false
+	}
+	if l.InsideDataSource != r.InsideDataSource {
+		return false
+	}
+	if l.BodyText != r.BodyText {
+		return false
+	}
+	if len(l.ParamTypes) != len(r.ParamTypes) {
+		return false
+	}
+	for i := range l.ParamTypes {
+		if !l.ParamTypes[i].Identical(r.ParamTypes[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *hasher) IsStoredProcTxnOpEqual(l, r tree.StoredProcTxnOp) bool {

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -1379,6 +1379,17 @@ func (h *hasher) IsUDFDefinitionEqual(l, r *UDFDefinition) bool {
 			return false
 		}
 	}
+	if len(l.ParamNames) != len(r.ParamNames) {
+		return false
+	}
+	for i := range l.ParamNames {
+		if l.ParamNames[i] != r.ParamNames[i] {
+			return false
+		}
+	}
+	if l.DefinerUser != r.DefinerUser {
+		return false
+	}
 	return true
 }
 

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -379,10 +379,13 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (retErr error) {
 				newDef = &defCopy
 				newRoutineDefs[t.Def] = newDef
 				// Make sure to copy the slice that stores the body statements, rather
-				// than mutating the original.
-				newDef.Body = make([]memo.RelExpr, len(t.Def.Body))
-				for i := range t.Def.Body {
-					newDef.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
+				// than mutating the original. Body may be nil for SQL routines with
+				// deferred body building.
+				if t.Def.Body != nil {
+					newDef.Body = make([]memo.RelExpr, len(t.Def.Body))
+					for i := range t.Def.Body {
+						newDef.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
+					}
 				}
 			}
 			return f.ConstructUDFCall(newArgs, &memo.UDFCallPrivate{Def: newDef})

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -223,6 +223,12 @@ type Builder struct {
 	// skipUnsafeInternalsCheck is used to skip the check that the
 	// planner is not used for unsafe internal statements.
 	skipUnsafeInternalsCheck bool
+
+	// DisableDeferredRoutineBuild, when true, prevents deferred body building
+	// for SQL routines. This is set when building inside EXPLAIN or EXPLAIN
+	// ANALYZE so that all table references within routine bodies are tracked
+	// in the metadata (needed for explain bundles and plan formatting).
+	DisableDeferredRoutineBuild bool
 }
 
 // New creates a new Builder structure initialized with the given

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -35,6 +35,11 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 		emptyValues := &tree.LiteralValuesClause{Rows: tree.RawRows{}}
 		stmtScope = b.buildLiteralValuesClause(emptyValues, nil /* desiredTypes */, inScope)
 	} else {
+		// Disable deferred routine body building inside EXPLAIN so that all
+		// table references are tracked in the metadata (needed for explain
+		// bundles and plan formatting with redaction).
+		defer func(old bool) { b.DisableDeferredRoutineBuild = old }(b.DisableDeferredRoutineBuild)
+		b.DisableDeferredRoutineBuild = true
 		stmtScope = b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */)
 	}
 

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -283,6 +283,7 @@ func (b *Builder) buildRoutine(
 	bodyScope := b.allocScope()
 	var params opt.ColList
 	var resolvedParamTypes []*types.T
+	var resolvedParamNames []string
 	var polyArgTyp *types.T
 	if o.Types.Length() > 0 {
 		// If necessary, add DEFAULT arguments.
@@ -325,6 +326,7 @@ func (b *Builder) buildRoutine(
 		// correctly typed column to the bodyScope for each parameter.
 		params = make(opt.ColList, len(paramTypes))
 		resolvedParamTypes = make([]*types.T, len(paramTypes))
+		resolvedParamNames = make([]string, len(paramTypes))
 		for i := range paramTypes {
 			argTyp := argTypes[i]
 			desiredTyp := maybeReplacePolymorphicType(paramTypes[i].Typ, polyArgTyp)
@@ -344,6 +346,7 @@ func (b *Builder) buildRoutine(
 				args[i] = b.factory.ConstructCast(args[i], desiredTyp)
 			}
 			resolvedParamTypes[i] = desiredTyp
+			resolvedParamNames[i] = paramTypes[i].Name
 			argColName := funcParamColName(tree.Name(paramTypes[i].Name), i)
 			col := b.synthesizeColumn(bodyScope, argColName, desiredTyp, nil /* expr */, nil /* scalar */)
 			col.setParamOrd(i)
@@ -379,6 +382,7 @@ func (b *Builder) buildRoutine(
 	b.insideUDF = true
 	b.insideSQLRoutine = o.Language == tree.RoutineLangSQL
 	isSetReturning := o.Class == tree.GeneratorClass
+	var definerUser string
 	if o.Type != tree.BuiltinRoutine {
 		if o.SecurityMode == tree.RoutineDefiner {
 			// SECURITY DEFINER: override both privilege users to the routine
@@ -390,6 +394,7 @@ func (b *Builder) buildRoutine(
 			}
 			b.dataSourcePrivilegeUserOverride = checkPrivUser
 			b.executePrivilegeUserOverride = checkPrivUser
+			definerUser = checkPrivUser.Normalized()
 		} else {
 			// SECURITY INVOKER (default): set dataSourcePrivilegeUserOverride to
 			// the invoker. This is necessary because a view may have overridden
@@ -466,10 +471,33 @@ func (b *Builder) buildRoutine(
 			})
 			appendedNullForVoidReturn = true
 		}
-		body, bodyProps, bodyTags, bodyASTs = b.buildSQLRoutineBodyStmts(
-			stmts, bodyScope, f, inScope,
-			isSetReturning, oldInsideDataSource, appendedNullForVoidReturn,
-		)
+
+		// For routines whose return type needs to be inferred from the body
+		// (RETURNS RECORD without OUT params), we must build eagerly. Otherwise,
+		// defer body building to execution time.
+		if f.ResolvedType().Identical(types.AnyTuple) {
+			body, bodyProps, bodyTags, bodyASTs = b.buildSQLRoutineBodyStmts(
+				stmts, bodyScope, f, inScope,
+				isSetReturning, oldInsideDataSource, appendedNullForVoidReturn,
+			)
+		} else {
+			// Defer body building to execution time. Populate bodyASTs and
+			// bodyTags now; body and bodyProps remain nil.
+			bodyTags = make([]string, len(stmts))
+			bodyASTs = make([]tree.Statement, len(stmts))
+			for i := range stmts {
+				bodyASTs[i] = stmts[i].AST
+				if appendedNullForVoidReturn && i == len(stmts)-1 {
+					bodyTags[i] = ""
+				} else {
+					bodyTags[i] = stmts[i].AST.StatementTag()
+				}
+				// Register mutation targets from the AST in the
+				// statementTree so that the multiple-mutation safety
+				// check works even though we skip full body building.
+				b.checkMultipleMutationsFromAST(stmts[i].AST)
+			}
+		}
 
 		if b.verboseTracing {
 			bodyStmts = make([]string, len(stmts))
@@ -544,8 +572,10 @@ func (b *Builder) buildRoutine(
 				BodyASTs:           bodyASTs,
 				Params:             params,
 				ParamTypes:         resolvedParamTypes,
+				ParamNames:         resolvedParamNames,
 				BodyText:           o.Body,
 				InsideDataSource:   oldInsideDataSource,
+				DefinerUser:        definerUser,
 				ResultBufferID:     resultBufferID,
 			},
 		},
@@ -595,6 +625,80 @@ func (b *Builder) buildSQLRoutineBodyStmts(
 		}
 	}
 	return body, bodyProps, bodyTags, bodyASTs
+}
+
+// BuildSQLRoutineBodyFromASTs builds RelExprs from statement ASTs for a
+// SQL-language routine body. It creates a body scope with parameter columns,
+// builds each statement, and applies finishRoutineReturnStmt on the last
+// statement. This is used at execution time for deferred body building.
+//
+// definerUser, when non-empty, indicates that the routine is SECURITY DEFINER
+// and privilege checks within the body should use the definer's credentials.
+func (b *Builder) BuildSQLRoutineBodyFromASTs(
+	stmtASTs []tree.Statement,
+	paramTypes []*types.T,
+	paramNames []string,
+	rTyp *types.T,
+	isSetReturning bool,
+	insideDataSource bool,
+	definerUser string,
+) (body []memo.RelExpr, bodyProps []*physical.Required, params opt.ColList) {
+	// Set up builder state for building inside a SQL routine.
+	defer func(
+		origUDF, origSQLRoutine, origDS, origTrackDeps bool,
+		origDSPriv, origExecPriv username.SQLUsername,
+	) {
+		b.insideUDF = origUDF
+		b.insideSQLRoutine = origSQLRoutine
+		b.insideDataSource = origDS
+		b.trackSchemaDeps = origTrackDeps
+		b.dataSourcePrivilegeUserOverride = origDSPriv
+		b.executePrivilegeUserOverride = origExecPriv
+	}(
+		b.insideUDF, b.insideSQLRoutine, b.insideDataSource, b.trackSchemaDeps,
+		b.dataSourcePrivilegeUserOverride, b.executePrivilegeUserOverride,
+	)
+	b.insideUDF = true
+	b.insideSQLRoutine = true
+	b.insideDataSource = false
+	b.trackSchemaDeps = false
+
+	// For SECURITY DEFINER routines, override privilege checks to use the
+	// definer's credentials.
+	if definerUser != "" {
+		user := username.MakeSQLUsernameFromPreNormalizedString(definerUser)
+		b.dataSourcePrivilegeUserOverride = user
+		b.executePrivilegeUserOverride = user
+	}
+
+	// Create body scope with parameter columns.
+	bodyScope := b.allocScope()
+	params = make(opt.ColList, len(paramTypes))
+	for i, typ := range paramTypes {
+		var name tree.Name
+		if i < len(paramNames) {
+			name = tree.Name(paramNames[i])
+		}
+		argColName := funcParamColName(name, i)
+		col := b.synthesizeColumn(bodyScope, argColName, typ, nil /* expr */, nil /* scalar */)
+		col.setParamOrd(i)
+		params[i] = col.id
+	}
+
+	// Build each statement.
+	body = make([]memo.RelExpr, len(stmtASTs))
+	bodyProps = make([]*physical.Required, len(stmtASTs))
+	for i, ast := range stmtASTs {
+		stmtScope := b.buildStmtAtRootWithScope(ast, nil /* desiredTypes */, bodyScope)
+		if i == len(stmtASTs)-1 {
+			stmtScope = b.finishRoutineReturnStmt(
+				stmtScope, isSetReturning, insideDataSource, rTyp,
+			)
+		}
+		body[i] = stmtScope.expr
+		bodyProps[i] = stmtScope.makePhysicalProps()
+	}
+	return body, bodyProps, params
 }
 
 // finishRoutineReturnStmt manages the output columns for a statement that will

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -466,32 +466,10 @@ func (b *Builder) buildRoutine(
 			})
 			appendedNullForVoidReturn = true
 		}
-		body = make([]memo.RelExpr, len(stmts))
-		bodyProps = make([]*physical.Required, len(stmts))
-		bodyTags = make([]string, len(stmts))
-		bodyASTs = make([]tree.Statement, len(stmts))
-		for i := range stmts {
-			// TODO(michae2): We should be checking the statement hints cache here to
-			// find any external statement hints that could apply to this statement.
-			stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
-
-			// The last statement produces the output of the UDF.
-			if i == len(stmts)-1 {
-				rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
-				stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, oldInsideDataSource, rTyp)
-			}
-			body[i] = stmtScope.expr
-			bodyProps[i] = stmtScope.makePhysicalProps()
-			bodyASTs[i] = stmts[i].AST
-			// We don't need a statement tag for the artificial appended `SELECT NULL`
-			// statement.
-			if appendedNullForVoidReturn && i == len(stmts)-1 {
-				bodyTags[i] = ""
-			} else {
-				bodyTags[i] = stmts[i].AST.StatementTag()
-			}
-
-		}
+		body, bodyProps, bodyTags, bodyASTs = b.buildSQLRoutineBodyStmts(
+			stmts, bodyScope, f, inScope,
+			isSetReturning, oldInsideDataSource, appendedNullForVoidReturn,
+		)
 
 		if b.verboseTracing {
 			bodyStmts = make([]string, len(stmts))
@@ -573,6 +551,50 @@ func (b *Builder) buildRoutine(
 		},
 	)
 	return routine
+}
+
+// buildSQLRoutineBodyStmts builds RelExprs for each statement in a SQL-language
+// routine body. bodyScope must already have parameter columns set up. For the
+// last statement, it calls finalizeRoutineReturnType and finishRoutineReturnStmt
+// to handle return-type resolution and output column shaping.
+func (b *Builder) buildSQLRoutineBodyStmts(
+	stmts statements.Statements,
+	bodyScope *scope,
+	f *tree.FuncExpr,
+	inScope *scope,
+	isSetReturning bool,
+	insideDataSource bool,
+	appendedNullForVoidReturn bool,
+) (
+	body []memo.RelExpr,
+	bodyProps []*physical.Required,
+	bodyTags []string,
+	bodyASTs []tree.Statement,
+) {
+	body = make([]memo.RelExpr, len(stmts))
+	bodyProps = make([]*physical.Required, len(stmts))
+	bodyTags = make([]string, len(stmts))
+	bodyASTs = make([]tree.Statement, len(stmts))
+	for i := range stmts {
+		stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+
+		// The last statement produces the output of the UDF.
+		if i == len(stmts)-1 {
+			rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, insideDataSource)
+			stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, insideDataSource, rTyp)
+		}
+		body[i] = stmtScope.expr
+		bodyProps[i] = stmtScope.makePhysicalProps()
+		bodyASTs[i] = stmts[i].AST
+		// We don't need a statement tag for the artificial appended
+		// `SELECT NULL` statement.
+		if appendedNullForVoidReturn && i == len(stmts)-1 {
+			bodyTags[i] = ""
+		} else {
+			bodyTags[i] = stmts[i].AST.StatementTag()
+		}
+	}
+	return body, bodyProps, bodyTags, bodyASTs
 }
 
 // finishRoutineReturnStmt manages the output columns for a statement that will

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -492,10 +492,6 @@ func (b *Builder) buildRoutine(
 				} else {
 					bodyTags[i] = stmts[i].AST.StatementTag()
 				}
-				// Register mutation targets from the AST in the
-				// statementTree so that the multiple-mutation safety
-				// check works even though we skip full body building.
-				b.checkMultipleMutationsFromAST(stmts[i].AST)
 			}
 		}
 
@@ -565,6 +561,7 @@ func (b *Builder) buildRoutine(
 				MultiColDataSource: multiColDataSource,
 				RoutineType:        o.Type,
 				RoutineLang:        o.Language,
+				StmtTreeInitFn:     b.stmtTree.GetInitFnForDeferredRoutine(),
 				Body:               body,
 				BodyProps:          bodyProps,
 				BodyStmts:          bodyStmts,
@@ -642,7 +639,14 @@ func (b *Builder) BuildSQLRoutineBodyFromASTs(
 	isSetReturning bool,
 	insideDataSource bool,
 	definerUser string,
+	routineType tree.RoutineType,
+	stmtTreeInitFn any,
 ) (body []memo.RelExpr, bodyProps []*physical.Required, params opt.ColList) {
+	// Builtins should have access to unsafe internals (e.g. system tables).
+	if routineType == tree.BuiltinRoutine {
+		defer b.DisableUnsafeInternalCheck()()
+	}
+
 	// Set up builder state for building inside a SQL routine.
 	defer func(
 		origUDF, origSQLRoutine, origDS, origTrackDeps bool,
@@ -671,6 +675,13 @@ func (b *Builder) BuildSQLRoutineBodyFromASTs(
 		b.executePrivilegeUserOverride = user
 	}
 
+	// Initialize the statement tree with mutations from the outer query. This
+	// allows the normal checkMultipleMutations calls during body building to
+	// detect cross-query mutation conflicts.
+	if stmtTreeInitFn != nil {
+		b.stmtTree = stmtTreeInitFn.(func() statementTree)()
+	}
+
 	// Create body scope with parameter columns.
 	bodyScope := b.allocScope()
 	params = make(opt.ColList, len(paramTypes))
@@ -691,6 +702,14 @@ func (b *Builder) BuildSQLRoutineBodyFromASTs(
 	for i, ast := range stmtASTs {
 		stmtScope := b.buildStmtAtRootWithScope(ast, nil /* desiredTypes */, bodyScope)
 		if i == len(stmtASTs)-1 {
+			// Validate that the body's result type is compatible with the declared
+			// return type. In the eager build path this is done inside
+			// finalizeRoutineReturnType; we replicate it here for the deferred
+			// path so that incompatible types produce a user-facing error rather
+			// than an internal assertion in maybeAddRoutineAssignmentCasts.
+			if err := validateReturnType(b.ctx, b.semaCtx, rTyp, stmtScope.cols); err != nil {
+				panic(err)
+			}
 			stmtScope = b.finishRoutineReturnStmt(
 				stmtScope, isSetReturning, insideDataSource, rTyp,
 			)

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -472,10 +472,23 @@ func (b *Builder) buildRoutine(
 			appendedNullForVoidReturn = true
 		}
 
+		// Validate the column definition list (if any) against the return type
+		// at plan time. This doesn't depend on the body being built, so it runs
+		// before the eager/deferred branch. We skip AnyTuple (RETURNS RECORD
+		// without OUT params) because those always take the eager path below,
+		// where the validation happens inside finalizeRoutineReturnType after the
+		// concrete return type has been inferred from the body.
+		if oldInsideDataSource && !f.ResolvedType().Identical(types.AnyTuple) {
+			b.validateGeneratorFunctionReturnType(f.ResolvedOverload(), f.ResolvedType(), inScope)
+		}
+
 		// For routines whose return type needs to be inferred from the body
-		// (RETURNS RECORD without OUT params), we must build eagerly. Otherwise,
-		// defer body building to execution time.
-		if f.ResolvedType().Identical(types.AnyTuple) {
+		// (RETURNS RECORD without OUT params), we must build eagerly. We also
+		// build eagerly when DisableDeferredRoutineBuild is set (e.g. inside
+		// EXPLAIN or EXPLAIN ANALYZE) so that all table references within the
+		// body are tracked in the metadata (needed for explain bundles and plan
+		// formatting). Otherwise, defer body building to execution time.
+		if f.ResolvedType().Identical(types.AnyTuple) || b.DisableDeferredRoutineBuild {
 			body, bodyProps, bodyTags, bodyASTs = b.buildSQLRoutineBodyStmts(
 				stmts, bodyScope, f, inScope,
 				isSetReturning, oldInsideDataSource, appendedNullForVoidReturn,

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -282,6 +282,7 @@ func (b *Builder) buildRoutine(
 	// CTEs that mutate and are not at the top-level.
 	bodyScope := b.allocScope()
 	var params opt.ColList
+	var resolvedParamTypes []*types.T
 	var polyArgTyp *types.T
 	if o.Types.Length() > 0 {
 		// If necessary, add DEFAULT arguments.
@@ -323,6 +324,7 @@ func (b *Builder) buildRoutine(
 		// Add any needed casts from argument type to parameter type, and add a
 		// correctly typed column to the bodyScope for each parameter.
 		params = make(opt.ColList, len(paramTypes))
+		resolvedParamTypes = make([]*types.T, len(paramTypes))
 		for i := range paramTypes {
 			argTyp := argTypes[i]
 			desiredTyp := maybeReplacePolymorphicType(paramTypes[i].Typ, polyArgTyp)
@@ -341,6 +343,7 @@ func (b *Builder) buildRoutine(
 				}
 				args[i] = b.factory.ConstructCast(args[i], desiredTyp)
 			}
+			resolvedParamTypes[i] = desiredTyp
 			argColName := funcParamColName(tree.Name(paramTypes[i].Name), i)
 			col := b.synthesizeColumn(bodyScope, argColName, desiredTyp, nil /* expr */, nil /* scalar */)
 			col.setParamOrd(i)
@@ -562,6 +565,9 @@ func (b *Builder) buildRoutine(
 				BodyTags:           bodyTags,
 				BodyASTs:           bodyASTs,
 				Params:             params,
+				ParamTypes:         resolvedParamTypes,
+				BodyText:           o.Body,
+				InsideDataSource:   oldInsideDataSource,
 				ResultBufferID:     resultBufferID,
 			},
 		},

--- a/pkg/sql/opt/optbuilder/statement_tree.go
+++ b/pkg/sql/opt/optbuilder/statement_tree.go
@@ -209,6 +209,38 @@ func (st *statementTree) CanMutateTable(
 	return true
 }
 
+// GetInitFnForDeferredRoutine returns a function that can be used to initialize
+// the statement tree for a deferred-build SQL routine body. Unlike
+// GetInitFnForPostQuery, this captures ALL statements on the stack (including
+// the current one), because CTE mutations are registered at the current level
+// via buildCTE → buildStmt (without Push/Pop).
+//
+// The returned function creates a synthesized ancestor node containing the
+// union of direct mutations from all captured nodes. Children mutations are
+// intentionally omitted because including them would cause false positives for
+// intra-routine sibling body statements (which are allowed to mutate the same
+// table independently).
+func (st *statementTree) GetInitFnForDeferredRoutine() func() statementTree {
+	if len(st.stmts) == 0 {
+		return nil
+	}
+	// Save references to all ancestor statementTreeNodes, including the current
+	// one. Modifications to them after this point will be reflected via the
+	// pointers, ensuring that mutations registered later (e.g., by sibling
+	// CTEs) are visible by the time the deferred body is built at execution
+	// time.
+	ancestors := make([]*statementTreeNode, len(st.stmts))
+	copy(ancestors, st.stmts)
+	return func() statementTree {
+		var node statementTreeNode
+		for i := range ancestors {
+			node.simpleInsertTables.UnionWith(ancestors[i].simpleInsertTables)
+			node.generalMutationTables.UnionWith(ancestors[i].generalMutationTables)
+		}
+		return statementTree{stmts: []*statementTreeNode{&node}}
+	}
+}
+
 // GetInitFnForPostQuery returns a function that can be used to initialize the
 // statement tree for a post-query that is a child of the current statement.
 // This is necessary because the post-query is not built until after the main

--- a/pkg/sql/opt/optbuilder/statement_tree_test.go
+++ b/pkg/sql/opt/optbuilder/statement_tree_test.go
@@ -21,6 +21,8 @@ func TestStatementTree(t *testing.T) {
 		post
 		getInit
 		init
+		getInitDeferred
+		initDeferred
 		t1
 		t2
 		fail
@@ -587,11 +589,245 @@ func TestStatementTree(t *testing.T) {
 				mut | t1 | fail,
 			},
 		},
+		// 29.
+		// Deferred routine: capture when no mutations exist, then add a
+		// mutation to the current node after capture. The deferred init
+		// should see the mutation via the captured pointer.
+		//
+		// Original:
+		// Push
+		//     GetInitFnForDeferredRoutine()  -- captures rootStmt (no mutations yet)
+		//     CanMutateTable(t1, default)    -- adds t1 to rootStmt
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL  -- t1 visible from captured rootStmt
+		{
+			cmds: []cmd{
+				push,
+				getInitDeferred,
+				mut | t1,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 30.
+		// Deferred routine: capture includes the current node. Mutation at
+		// the current level (simulating a CTE mutation) is visible.
+		//
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 31.
+		// Deferred routine: no conflict when mutating a different table.
+		//
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t2, default)
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t2,
+				pop,
+			},
+		},
+		// 32.
+		// Deferred routine: captures nested ancestors. Parent mutation
+		// is visible through the deferred init.
+		//
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     Push
+		//         GetInitFnForDeferredRoutine()
+		//     Pop
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				push,
+				getInitDeferred,
+				pop,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 33.
+		// Deferred routine with sibling mutations: mutations added after
+		// capture at the same level are visible (CTE sibling scenario).
+		//
+		// Original:
+		// Push
+		//     GetInitFnForDeferredRoutine()  -- captures rootStmt
+		//     CanMutateTable(t1, default)    -- sibling CTE adds mutation
+		//     CanMutateTable(t2, default)    -- another sibling
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL  -- conflict with sibling
+		{
+			cmds: []cmd{
+				push,
+				getInitDeferred,
+				mut | t1,
+				mut | t2,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 34.
+		// Deferred routine: simpleInsert on same table as ancestor
+		// simpleInsert is OK.
+		//
+		// Original:
+		// Push
+		//     CanMutateTable(t1, simpleInsert)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t1, simpleInsert)
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				mut | t1 | simple,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | simple,
+				pop,
+			},
+		},
+		// 35.
+		// Deferred routine: generalMutation on same table as ancestor
+		// simpleInsert FAILs.
+		//
+		// Original:
+		// Push
+		//     CanMutateTable(t1, simpleInsert)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				mut | t1 | simple,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 36.
+		// Deferred routine: empty stack returns nil initFn.
+		//
+		// Deferred (no original):
+		// initDeferredFn() -- nil, creates empty tree
+		// Push
+		//     CanMutateTable(t1, default) -- OK, no ancestors
+		// Pop
+		{
+			cmds: []cmd{
+				initDeferred,
+				push,
+				mut | t1,
+				pop,
+			},
+		},
+		// 37.
+		// Deferred routine with multiple body statements: sibling body
+		// mutations within the deferred routine do NOT conflict with each
+		// other (children mutations are not copied).
+		//
+		// Original:
+		// Push
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred:
+		// initDeferredFn()
+		// Push                              -- body stmt 1
+		//     CanMutateTable(t1, default)
+		// Pop
+		// Push                              -- body stmt 2
+		//     CanMutateTable(t1, default)   -- allowed: sibling, not ancestor
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1,
+				pop,
+				push,
+				mut | t1,
+				pop,
+			},
+		},
 	}
 
 	for i, tc := range testCases {
 		var mt statementTree
 		var pqTreeFn func() statementTree
+		var deferredTreeFn func() statementTree
 		for j, c := range tc.cmds {
 			switch {
 			case c&push == push:
@@ -599,6 +835,19 @@ func TestStatementTree(t *testing.T) {
 
 			case c&pop == pop:
 				mt.Pop()
+
+			case c&getInitDeferred == getInitDeferred:
+				if deferredTreeFn != nil {
+					t.Fatalf("test case %d: GetInitFnForDeferredRoutine called twice", i)
+				}
+				deferredTreeFn = mt.GetInitFnForDeferredRoutine()
+
+			case c&initDeferred == initDeferred:
+				if deferredTreeFn == nil {
+					mt = statementTree{}
+				} else {
+					mt = deferredTreeFn()
+				}
 
 			case c&getInit == getInit:
 				if pqTreeFn != nil {

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -580,64 +580,6 @@ func (b *Builder) checkMultipleMutationsCascade(
 	}
 }
 
-// checkMultipleMutationsFromAST extracts the mutation target table from a
-// statement AST and registers it in the statementTree. This is used for
-// deferred-build SQL routine bodies where we skip full body building at plan
-// time but still need to detect multiple mutations of the same table across
-// the outer query and the routine body.
-//
-// Each body statement is wrapped in a Push/Pop to mirror the nesting that
-// buildStmtAtRootWithScope would create during eager building.
-func (b *Builder) checkMultipleMutationsFromAST(ast tree.Statement) {
-	var tableExpr tree.TableExpr
-	var typ mutationType
-	switch stmt := ast.(type) {
-	case *tree.Update:
-		tableExpr = stmt.Table
-		typ = generalMutation
-	case *tree.Delete:
-		tableExpr = stmt.Table
-		typ = generalMutation
-	case *tree.Insert:
-		tableExpr = stmt.Table
-		if stmt.OnConflict == nil {
-			typ = simpleInsert
-		} else {
-			typ = generalMutation
-		}
-	default:
-		return
-	}
-
-	// Extract the table name from the TableExpr.
-	if ate, ok := tableExpr.(*tree.AliasedTableExpr); ok {
-		tableExpr = ate.Expr
-	}
-	tn, ok := tableExpr.(*tree.TableName)
-	if !ok {
-		// TableRef or other forms — skip. The check will run at execution
-		// time during deferred body building.
-		return
-	}
-
-	// Resolve the table without privilege checks. Privileges will be
-	// checked at execution time when the body is actually built.
-	ds, _, err := b.catalog.ResolveDataSource(b.ctx, cat.Flags{}, tn)
-	if err != nil {
-		// If resolution fails, skip the check. The error will surface at
-		// execution time during deferred body building.
-		return
-	}
-	tab, ok := ds.(cat.Table)
-	if !ok {
-		return
-	}
-
-	b.stmtTree.Push()
-	defer b.stmtTree.Pop()
-	b.checkMultipleMutations(tab, typ)
-}
-
 // resolveTableForMutation is a helper method for building mutations. It returns
 // the table in the catalog that matches the given TableExpr, along with the
 // table's MDDepName and alias, and the IDs of any columns explicitly specified

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -580,6 +580,64 @@ func (b *Builder) checkMultipleMutationsCascade(
 	}
 }
 
+// checkMultipleMutationsFromAST extracts the mutation target table from a
+// statement AST and registers it in the statementTree. This is used for
+// deferred-build SQL routine bodies where we skip full body building at plan
+// time but still need to detect multiple mutations of the same table across
+// the outer query and the routine body.
+//
+// Each body statement is wrapped in a Push/Pop to mirror the nesting that
+// buildStmtAtRootWithScope would create during eager building.
+func (b *Builder) checkMultipleMutationsFromAST(ast tree.Statement) {
+	var tableExpr tree.TableExpr
+	var typ mutationType
+	switch stmt := ast.(type) {
+	case *tree.Update:
+		tableExpr = stmt.Table
+		typ = generalMutation
+	case *tree.Delete:
+		tableExpr = stmt.Table
+		typ = generalMutation
+	case *tree.Insert:
+		tableExpr = stmt.Table
+		if stmt.OnConflict == nil {
+			typ = simpleInsert
+		} else {
+			typ = generalMutation
+		}
+	default:
+		return
+	}
+
+	// Extract the table name from the TableExpr.
+	if ate, ok := tableExpr.(*tree.AliasedTableExpr); ok {
+		tableExpr = ate.Expr
+	}
+	tn, ok := tableExpr.(*tree.TableName)
+	if !ok {
+		// TableRef or other forms — skip. The check will run at execution
+		// time during deferred body building.
+		return
+	}
+
+	// Resolve the table without privilege checks. Privileges will be
+	// checked at execution time when the body is actually built.
+	ds, _, err := b.catalog.ResolveDataSource(b.ctx, cat.Flags{}, tn)
+	if err != nil {
+		// If resolution fails, skip the check. The error will surface at
+		// execution time during deferred body building.
+		return
+	}
+	tab, ok := ds.(cat.Table)
+	if !ok {
+		return
+	}
+
+	b.stmtTree.Push()
+	defer b.stmtTree.Pop()
+	b.checkMultipleMutations(tab, typ)
+}
+
 // resolveTableForMutation is a helper method for building mutations. It returns
 // the table in the catalog that matches the given TableExpr, along with the
 // table's MDDepName and alias, and the IDs of any columns explicitly specified

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -600,6 +600,9 @@ func (opc *optPlanningCtx) buildReusableMemo(
 	if opc.flags.IsSet(planFlagSessionMigration) {
 		bld.SkipAOST = true
 	}
+	if p.instrumentation.collectBundle {
+		bld.DisableDeferredRoutineBuild = true
+	}
 	if err := bld.Build(); err != nil {
 		return nil, memoTypeUnknown, err
 	}
@@ -1000,6 +1003,9 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 	}
 	f.Metadata().SetHintIDs(opc.p.GetHintIDs())
 	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), opc.catalog, f, ast)
+	if p.instrumentation.collectBundle {
+		bld.DisableDeferredRoutineBuild = true
+	}
 	if err := bld.Build(); err != nil {
 		return nil, err
 	}

--- a/udf-failure.txt
+++ b/udf-failure.txt
@@ -1,0 +1,136 @@
+Test Failure Analysis: Unconditional Deferral of SQL Routine Body Building
+===========================================================================
+
+6 test failures caused by deferring the optbuilder phase (AST → RelExpr)
+for SQL-language routine body statements from plan time to execution time.
+
+
+1. udf_fk/corruption_check (udf_fk:670)
+----------------------------------------
+
+Expected: Error "multiple mutations of the same table "child" are not
+  supported unless they all use INSERT without ON CONFLICT"
+Got: No error
+
+Root cause: The "multiple mutations" safety check works by inspecting the
+top-level memo for mutation operators. With eager build, the UDF's body
+RelExprs are embedded in the memo, so the checker sees both the outer
+mutation and the inner (UDF body) mutation of the same table. With deferred
+build, Body is nil — the top-level optimizer never sees the UDF's internal
+mutations, so the safety check is bypassed entirely.
+
+Fix approach: Either (a) infer mutation targets from ASTs at plan time and
+store them in UDFDefinition for the safety checker, or (b) keep eager build
+for UDFs whose body contains mutations targeting the same table as the outer
+statement.
+
+
+2. udf_in_index (udf_in_index:157)
+-----------------------------------
+
+Expected: Success
+Got: (42809) index "t_idx2" is a partial index that does not contain all the
+  rows needed
+
+Root cause: The deferred build creates a fresh temporary optimizer/optbuilder.
+When the UDF body references a table with partial indexes, the partial index
+predicate evaluation needs the same planning context (e.g., stable function
+folding context) as the outer query. The fresh optimizer may evaluate partial
+index predicates differently, causing the optimizer to select a partial index
+that doesn't cover all needed rows.
+
+Fix approach: Ensure the temporary optimizer inherits the same evalCtx and
+catalog state. This may already be happening, so the issue could be more
+subtle — likely related to how the exec builder's scan constraints interact
+with partial indexes when the UDF is used in an index expression context.
+
+
+3. udf_options/volatility (udf_options:67)
+-------------------------------------------
+
+Expected: Success (for SELECT pg_get_functiondef(...))
+Got: (42501) Access to crdb_internal and system is restricted
+
+Root cause: At plan time, the session may have appropriate internal executor
+privileges to access crdb_internal tables. When the body is built at execution
+time via a fresh optbuilder, the privilege check for restricted virtual tables
+runs in a context that doesn't carry the same internal access permissions.
+
+Fix approach: Propagate the "allow restricted table access" flag from the
+session/evalCtx into the temporary optbuilder created during deferred build.
+
+
+4. udf_polymorphic/poly_in (udf_polymorphic:362)
+-------------------------------------------------
+
+Expected: "return type mismatch in function declared to return int"
+Got: "internal error: invalid cast from STRING to INT8 should have been caught
+  earlier"
+
+Root cause: Polymorphic type validation at plan time produces a clean
+user-facing error when the body's return type doesn't match the resolved
+polymorphic return type. With deferred build, the body isn't built at plan
+time so the mismatch isn't caught. At execution time,
+finishRoutineReturnStmt → maybeAddRoutineAssignmentCasts encounters the type
+mismatch and hits an internal assertion rather than producing a proper user
+error.
+
+Fix approach: Either (a) add explicit return-type validation in
+BuildSQLRoutineBodyFromASTs that produces the same user-facing error, or
+(b) keep eager build for polymorphic functions where type validation is
+critical at plan time.
+
+
+5. udf_record/column_definition_errors (udf_record:624)
+--------------------------------------------------------
+
+Expected: "a column definition list is only allowed for functions returning
+  "record""
+Got: No error
+
+Root cause: The column definition list validation happens during buildRoutine
+at plan time when the optbuilder processes the function call with a column
+definition list. With deferred build, the body build is skipped, and this
+validation (which checks the relationship between the column definition list
+and the function's return type) doesn't run.
+
+Fix approach: Move or duplicate this validation check to occur at plan time
+independent of body building — it only depends on the function signature
+metadata, not the body RelExprs.
+
+
+6. udf_security/nested_udfs (udf_security:224)
+-----------------------------------------------
+
+Expected: "user owner1 does not have SELECT privilege on relation t"
+Got: "user invoker does not have SELECT privilege on relation t"
+
+Root cause: Nested SECURITY DEFINER. When outer UDF A (SECURITY DEFINER,
+owner=owner1) calls inner UDF B, A's body is built at execution time with
+DefinerUser = "owner1". However, when building A's body, the optbuilder
+encounters a call to B. In the eager path, the nested buildRoutine for B
+would inherit the privilege context showing that the current effective user
+is owner1. In the deferred path, the fresh optbuilder's
+BuildSQLRoutineBodyFromASTs for A correctly sets
+dataSourcePrivilegeUserOverride = "owner1", but when it encounters the
+nested call to B and builds B's definition, B's DefinerUser is set based on
+the catalog owner lookup, not the effective invoker context. The privilege
+check at B's call site sees "invoker" instead of "owner1".
+
+Fix approach: When building A's body at execution time and encountering a
+nested routine call to B, the effective user for privilege checking at B's
+call site should be the definer user of A (owner1), not the original
+invoker. This requires the deferred-build optbuilder to propagate the
+SECURITY DEFINER context through nested routine resolution.
+
+
+Summary Table
+=============
+
+  #  Test                              Category                 Severity
+  1  udf_fk/corruption_check           Safety check bypassed    HIGH — could allow data corruption
+  2  udf_in_index                      Partial index evaluation MEDIUM — runtime error, not silent
+  3  udf_options/volatility            Privilege propagation    MEDIUM — blocks valid queries
+  4  udf_polymorphic/poly_in           Error quality regression LOW — still errors, just worse message
+  5  udf_record/column_definition_errors  Validation bypassed   LOW — cosmetic, query still runs
+  6  udf_security/nested_udfs          Nested SECURITY DEFINER  MEDIUM — wrong privilege context


### PR DESCRIPTION
Commit 1: Add ParamTypes, BodyText, InsideDataSource fields to UDFDefinition
Commit 2: Extract body-building loop into buildSQLRoutineBodyStmts 


Fixes: #167687

Informs: https://github.com/cockroachdb/cockroach/issues/162627
Reference: https://github.com/cockroachdb/cockroach/pull/162057

Release note: None