### PR TITLE
admission: plumb SQL CPU time token admission through SQLCPUProvider

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -1973,7 +1973,7 @@ type cpuHandleAssertingSession struct {
 func (s *cpuHandleAssertingSession) assertHandle(ctx context.Context) {
 	h := admission.SQLCPUHandleFromContext(ctx)
 	if h != nil {
-		require.False(s.t, h.WorkInfo().AtGateway,
+		require.False(s.t, h.AtGateway(),
 			"LDR CPU handle should have AtGateway=false")
 		require.True(s.t, h.IsGoroutineRegistered(),
 			"goroutine handle should be registered before internal SQL execution")

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -855,12 +855,11 @@ func (lrw *logicalReplicationWriterProcessor) flushBuffer(
 	// the multi metric allocator assumes non-gateway sql cpu usage will
 	// follow the leaseholder when the leaseholder moves. LDR work is
 	// not collocated with leaseholders in the destination cluster.
-	handle := lrw.FlowCtx.Cfg.SQLCPUProvider.GetHandle(admission.SQLWorkInfo{
-		AtGateway:  false,
+	handle := lrw.FlowCtx.Cfg.SQLCPUProvider.GetHandle(admission.WorkInfo{
 		TenantID:   lrw.FlowCtx.Codec().TenantID,
 		Priority:   admissionpb.LowPri,
 		CreateTime: timeutil.Now().UnixNano(),
-	})
+	}, false /*atGateway*/)
 	defer handle.Close()
 
 	ctx = admission.ContextWithSQLCPUHandle(ctx, handle)

--- a/pkg/kv/kvserver/load/BUILD.bazel
+++ b/pkg/kv/kvserver/load/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     srcs = ["node_capacity_provider_test.go"],
     deps = [
         ":load",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/util/admission",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/load/node_capacity_provider_test.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -41,7 +42,8 @@ func TestNodeCapacityProvider(t *testing.T) {
 		storeCount: 3,
 	}
 
-	provider := load.NewNodeCapacityProvider(stopper, mockStores, admission.NewSQLCPUProvider(), load.NodeCapacityProviderConfig{
+	st := cluster.MakeTestingClusterSettings()
+	provider := load.NewNodeCapacityProvider(stopper, mockStores, admission.NewSQLCPUProvider(&st.SV, nil), load.NodeCapacityProviderConfig{
 		CPUUsageRefreshInterval:    1 * time.Millisecond,
 		CPUCapacityRefreshInterval: 1 * time.Millisecond,
 		CPUUsageMovingAverageAge:   20,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -603,7 +603,12 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	)
 	db.SQLKVResponseAdmissionQ = gcoords.RegularCPU.GetSQLWorkQueue(admission.SQLKVResponseWork)
 	db.AdmissionPacerFactory = gcoords.ElasticCPU
-	sqlCPUProvider := admission.NewSQLCPUProvider()
+	sqlCPUProvider := admission.NewSQLCPUProvider(
+		&st.SV,
+		func(tenantID roachpb.TenantID) *admission.WorkQueue {
+			return gcoords.RegularCPU.GetKVWorkQueue(tenantID.IsSystem())
+		},
+	)
 	db.SQLCPUProvider = sqlCPUProvider
 	goschedstats.RegisterSettings(st)
 	if goschedstats.Supported {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -226,7 +226,7 @@ func NewSeparateProcessTenantServer(
 	var noopElasticCPUGrantCoord *admission.ElasticCPUGrantCoordinator = nil
 	return newTenantServer(
 		ctx, stopper, baseCfg, sqlCfg, tenantNameContainer, deps, mtinfopb.ServiceModeExternal,
-		noopElasticCPUGrantCoord, admission.NewSQLCPUProvider())
+		noopElasticCPUGrantCoord, admission.NewSQLCPUProvider(&baseCfg.Settings.SV, nil))
 }
 
 // newSharedProcessTenantServer creates a tenant-specific, SQL-only

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -226,7 +226,10 @@ func NewSeparateProcessTenantServer(
 	var noopElasticCPUGrantCoord *admission.ElasticCPUGrantCoordinator = nil
 	return newTenantServer(
 		ctx, stopper, baseCfg, sqlCfg, tenantNameContainer, deps, mtinfopb.ServiceModeExternal,
-		noopElasticCPUGrantCoord, admission.NewSQLCPUProvider(&baseCfg.Settings.SV, nil))
+		noopElasticCPUGrantCoord,
+		// nil getWorkQueue: separate-process tenants don't have access to the
+		// in-process KV CTT WorkQueue, so SQL CPU time token AC is unavailable.
+		admission.NewSQLCPUProvider(&baseCfg.Settings.SV, nil /*getWorkQueue*/))
 }
 
 // newSharedProcessTenantServer creates a tenant-specific, SQL-only

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2945,7 +2945,11 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		var mainGoroutineCPUHandle *admission.GoroutineCPUHandle
 		var err error
 		ctx, cpuHandle, mainGoroutineCPUHandle, err = flowinfra.MakeCPUHandle(
-			ctx, cpuProvider, planner.extendedEvalCtx.Codec.TenantID, planner.txn, true /* atGateway */)
+			ctx, cpuProvider, planner.extendedEvalCtx.Codec.TenantID, planner.txn, true, /* atGateway */
+			planner.extendedEvalCtx.WorkloadID,
+			planner.extendedEvalCtx.AppNameID,
+			roachpb.NodeID(planner.extendedEvalCtx.NodeID.SQLInstanceID()),
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -411,8 +411,16 @@ func (ds *ServerImpl) setupFlow(
 			var mainGoroutineCPUHandle *admission.GoroutineCPUHandle
 			var err error
 			// Remote flow (for flows at the gateway, the initialization happens in connExecutor).
+			// TODO(wenyi): this passes the local node ID as GatewayNodeID, matching
+			// the existing pattern in flow.go:337. Consider using
+			// roachpb.NodeID(req.Flow.Gateway) instead to reflect the actual
+			// gateway node for ASH attribution.
 			ctx, cpuHandle, mainGoroutineCPUHandle, err = flowinfra.MakeCPUHandle(
-				ctx, ds.SQLCPUProvider, evalCtx.Codec.TenantID, evalCtx.Txn, false /* atGateway */)
+				ctx, ds.SQLCPUProvider, evalCtx.Codec.TenantID, evalCtx.Txn, false, /* atGateway */
+				evalCtx.WorkloadID,
+				evalCtx.AppNameID,
+				roachpb.NodeID(ds.ServerConfig.NodeID.SQLInstanceID()),
+			)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -784,15 +784,14 @@ func MakeCPUHandle(
 		priority = admissionpb.WorkPriority(h.Priority)
 		createTime = h.CreateTime
 	}
-	cpuHandle := provider.GetHandle(admission.SQLWorkInfo{
-		AtGateway:     atGateway,
+	cpuHandle := provider.GetHandle(admission.WorkInfo{
 		TenantID:      tenantID,
 		Priority:      priority,
 		CreateTime:    createTime,
 		WorkloadID:    workloadID,
 		AppNameID:     appNameID,
 		GatewayNodeID: gatewayNodeID,
-	})
+	}, atGateway)
 	newCtx := admission.ContextWithSQLCPUHandle(ctx, cpuHandle)
 	gh := cpuHandle.RegisterGoroutine()
 	err := gh.MeasureAndAdmit(ctx)

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -770,6 +770,9 @@ func MakeCPUHandle(
 	tenantID roachpb.TenantID,
 	txn *kv.Txn,
 	atGateway bool,
+	workloadID uint64,
+	appNameID uint64,
+	gatewayNodeID roachpb.NodeID,
 ) (context.Context, *admission.SQLCPUHandle, *admission.GoroutineCPUHandle, error) {
 	var priority admissionpb.WorkPriority
 	var createTime int64
@@ -782,10 +785,13 @@ func MakeCPUHandle(
 		createTime = h.CreateTime
 	}
 	cpuHandle := provider.GetHandle(admission.SQLWorkInfo{
-		AtGateway:  atGateway,
-		TenantID:   tenantID,
-		Priority:   priority,
-		CreateTime: createTime,
+		AtGateway:     atGateway,
+		TenantID:      tenantID,
+		Priority:      priority,
+		CreateTime:    createTime,
+		WorkloadID:    workloadID,
+		AppNameID:     appNameID,
+		GatewayNodeID: gatewayNodeID,
 	})
 	newCtx := admission.ContextWithSQLCPUHandle(ctx, cpuHandle)
 	gh := cpuHandle.RegisterGoroutine()

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
 )
 
 var cpuTimeTokenACEnabled = settings.RegisterBoolSetting(
@@ -47,18 +46,7 @@ var sqlCPUTimeTokenACEnabled = settings.RegisterBoolSetting(
 		"budget as KV work; has no effect unless admission.cpu_time_tokens.enabled "+
 		"is also true",
 	false,
-	settings.WithValidateBool(func(sv *settings.Values, val bool) error {
-		// Note: disabling cpuTimeTokenACEnabled with sqlCPUTimeTokenACEnabled
-		// is allowed and harmless (SQL CPU admission path is effectively
-		// disabled).
-		if val && !cpuTimeTokenACIsEnabled(sv) {
-			return errors.New(
-				"admission.sql_cpu_time_tokens.enabled requires " +
-					"admission.cpu_time_tokens.enabled to also be true",
-			)
-		}
-		return nil
-	}))
+)
 
 // sqlCPUTimeTokenACIsEnabled returns true if SQL CPU usage is admitted through
 // the same CPU time token AC as KV work. It has no effect unless

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 var cpuTimeTokenACEnabled = settings.RegisterBoolSetting(
@@ -37,6 +38,33 @@ var cpuTimeTokenACKillSwitch = envutil.EnvOrDefaultBool(
 // takes precedence over the cluster setting.
 func cpuTimeTokenACIsEnabled(sv *settings.Values) bool {
 	return !cpuTimeTokenACKillSwitch && cpuTimeTokenACEnabled.Get(sv)
+}
+
+var sqlCPUTimeTokenACEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"admission.sql_cpu_time_tokens.enabled",
+	"when true, SQL CPU usage is admitted through the same CPU time token "+
+		"budget as KV work; has no effect unless admission.cpu_time_tokens.enabled "+
+		"is also true",
+	false,
+	settings.WithValidateBool(func(sv *settings.Values, val bool) error {
+		// Note: disabling cpuTimeTokenACEnabled with sqlCPUTimeTokenACEnabled
+		// is allowed and harmless (SQL CPU admission path is effectively
+		// disabled).
+		if val && !cpuTimeTokenACIsEnabled(sv) {
+			return errors.New(
+				"admission.sql_cpu_time_tokens.enabled requires " +
+					"admission.cpu_time_tokens.enabled to also be true",
+			)
+		}
+		return nil
+	}))
+
+// sqlCPUTimeTokenACIsEnabled returns true if SQL CPU usage is admitted through
+// the same CPU time token AC as KV work. It has no effect unless
+// admission.cpu_time_tokens.enabled is also true.
+func sqlCPUTimeTokenACIsEnabled(sv *settings.Values) bool {
+	return cpuTimeTokenACIsEnabled(sv) && sqlCPUTimeTokenACEnabled.Get(sv)
 }
 
 // CPUGrantCoordinators's main purpose is to act as a shim. Depending on

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -36,6 +36,13 @@ type SQLWorkInfo struct {
 	// work within a (WorkloadID, Priority) pair -- earlier CreateTime is given
 	// preference.
 	CreateTime int64
+	// WorkloadID is the statement fingerprint ID, used for ASH sampling.
+	WorkloadID uint64
+	// AppNameID is the hash of the application name, used for ASH sampling.
+	AppNameID uint64
+	// GatewayNodeID is the node that initiated the workload, used for ASH
+	// sampling.
+	GatewayNodeID roachpb.NodeID
 }
 
 // SQLCPUProvider is used to get a SQLCPUHandle that is used for CPU

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
@@ -80,6 +81,7 @@ var goroutineCPUHandlePool = sync.Pool{
 type SQLCPUHandle struct {
 	workInfo SQLWorkInfo
 	p        *sqlCPUProviderImpl
+	wq       *WorkQueue
 
 	mu struct {
 		syncutil.Mutex
@@ -91,10 +93,13 @@ type SQLCPUHandle struct {
 	}
 }
 
-func newSQLCPUAdmissionHandle(workInfo SQLWorkInfo, p *sqlCPUProviderImpl) *SQLCPUHandle {
+func newSQLCPUAdmissionHandle(
+	workInfo SQLWorkInfo, p *sqlCPUProviderImpl, wq *WorkQueue,
+) *SQLCPUHandle {
 	h := &SQLCPUHandle{
 		workInfo: workInfo,
 		p:        p,
+		wq:       wq,
 	}
 	h.mu.gHandles = h.mu.handlesBacking[:0]
 	return h
@@ -290,6 +295,12 @@ type sqlCPUProviderImpl struct {
 	// increasing and is updated atomically as CPU time is reported via
 	// SQLCPUHandle.reportCPU.
 	cumulativeDistSQLCPUNanos atomic.Int64
+	// sv is the settings values used to check if CTT AC is enabled.
+	sv *settings.Values
+	// getWorkQueue returns the CTT WorkQueue for the given tenant. This
+	// allows SQL to share the KV CTT WorkQueue, using the appropriate
+	// tier (system vs app) based on tenant ID. Can be nil in testing.
+	getWorkQueue func(roachpb.TenantID) *WorkQueue
 }
 
 func (p *sqlCPUProviderImpl) GetCumulativeSQLCPUNanos() (gatewayCPUNanos, distCPUNanos int64) {
@@ -297,13 +308,23 @@ func (p *sqlCPUProviderImpl) GetCumulativeSQLCPUNanos() (gatewayCPUNanos, distCP
 }
 
 func (p *sqlCPUProviderImpl) GetHandle(workInfo SQLWorkInfo) *SQLCPUHandle {
-	// TODO(sumeer): implement.
-	return newSQLCPUAdmissionHandle(workInfo, p)
+	var wq *WorkQueue
+	if p.getWorkQueue != nil && sqlCPUTimeTokenACIsEnabled(p.sv) {
+		wq = p.getWorkQueue(workInfo.TenantID)
+	}
+	return newSQLCPUAdmissionHandle(workInfo, p, wq)
 }
 
-// NewSQLCPUProvider creates a new SQLCPUProvider.
-//
-// TODO(sumeer): real implementation.
-func NewSQLCPUProvider() SQLCPUProvider {
-	return &sqlCPUProviderImpl{}
+// NewSQLCPUProvider creates a new SQLCPUProvider. The sv parameter is required
+// and provides access to cluster settings for checking if SQL CPU time token
+// AC is enabled. The getWorkQueue function returns the CTT WorkQueue for a
+// given tenant, allowing SQL to share the KV CTT WorkQueue; it may be nil when
+// CTT AC is not available (e.g. separate-process tenants).
+func NewSQLCPUProvider(
+	sv *settings.Values, getWorkQueue func(roachpb.TenantID) *WorkQueue,
+) SQLCPUProvider {
+	return &sqlCPUProviderImpl{
+		sv:           sv,
+		getWorkQueue: getWorkQueue,
+	}
 }

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -13,43 +13,20 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/petermattis/goid"
 )
 
-// SQLWorkInfo captures identifying information about SQL work for CPU
-// accounting and admission.
-type SQLWorkInfo struct {
-	// AtGateway is true if the work is being executed at a gateway node.
-	AtGateway bool
-	// TenantID is the id of the tenant. For single-tenant clusters, this will
-	// always be the SystemTenantID.
-	TenantID roachpb.TenantID
-	// Priority is utilized within a tenant.
-	Priority admissionpb.WorkPriority
-	// CreateTime is equivalent to Time.UnixNano() at the creation time of this
-	// work or a parent work (e.g. could be the start time of the transaction,
-	// if this work was created as part of a transaction). It is used to order
-	// work within a (WorkloadID, Priority) pair -- earlier CreateTime is given
-	// preference.
-	CreateTime int64
-	// WorkloadID is the statement fingerprint ID, used for ASH sampling.
-	WorkloadID uint64
-	// AppNameID is the hash of the application name, used for ASH sampling.
-	AppNameID uint64
-	// GatewayNodeID is the node that initiated the workload, used for ASH
-	// sampling.
-	GatewayNodeID roachpb.NodeID
-}
-
 // SQLCPUProvider is used to get a SQLCPUHandle that is used for CPU
 // accounting and admission.
 type SQLCPUProvider interface {
 	// GetHandle returns a SQLCPUHandle for the supplied work info.
-	GetHandle(work SQLWorkInfo) *SQLCPUHandle
+	// atGateway indicates whether the work is being executed at the
+	// gateway node, used for CPU accounting to distinguish gateway
+	// vs DistSQL CPU usage.
+	GetHandle(work WorkInfo, atGateway bool) *SQLCPUHandle
 	GetCumulativeSQLCPUNanos() (gatewayCPUNanos, distCPUNanos int64)
 }
 
@@ -86,9 +63,10 @@ var goroutineCPUHandlePool = sync.Pool{
 //
 // TODO(sumeer): fill in more details.
 type SQLCPUHandle struct {
-	workInfo SQLWorkInfo
-	p        *sqlCPUProviderImpl
-	wq       *WorkQueue
+	workInfo  WorkInfo
+	atGateway bool
+	p         *sqlCPUProviderImpl
+	wq        *WorkQueue
 
 	mu struct {
 		syncutil.Mutex
@@ -101,12 +79,13 @@ type SQLCPUHandle struct {
 }
 
 func newSQLCPUAdmissionHandle(
-	workInfo SQLWorkInfo, p *sqlCPUProviderImpl, wq *WorkQueue,
+	workInfo WorkInfo, atGateway bool, p *sqlCPUProviderImpl, wq *WorkQueue,
 ) *SQLCPUHandle {
 	h := &SQLCPUHandle{
-		workInfo: workInfo,
-		p:        p,
-		wq:       wq,
+		workInfo:  workInfo,
+		atGateway: atGateway,
+		p:         p,
+		wq:        wq,
 	}
 	h.mu.gHandles = h.mu.handlesBacking[:0]
 	return h
@@ -115,7 +94,7 @@ func newSQLCPUAdmissionHandle(
 // reportCPU atomically adds the CPU time difference to the appropriate
 // cumulative counter.
 func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
-	if h.workInfo.AtGateway {
+	if h.atGateway {
 		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
 	} else {
 		h.p.cumulativeDistSQLCPUNanos.Add(diff.Nanoseconds())
@@ -126,9 +105,10 @@ func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
 // https://github.com/cockroachdb/cockroach/pull/161952#pullrequestreview-3741525716
 // on additional integrations that may need to call RegisterGoroutine.
 
-// WorkInfo returns the SQLWorkInfo that was used to create this handle.
-func (h *SQLCPUHandle) WorkInfo() SQLWorkInfo {
-	return h.workInfo
+// AtGateway returns true if this handle is for work executing at the gateway
+// node, as opposed to DistSQL work on a remote node.
+func (h *SQLCPUHandle) AtGateway() bool {
+	return h.atGateway
 }
 
 // IsGoroutineRegistered returns true if the calling goroutine already has a
@@ -314,12 +294,12 @@ func (p *sqlCPUProviderImpl) GetCumulativeSQLCPUNanos() (gatewayCPUNanos, distCP
 	return p.cumulativeGatewayCPUNanos.Load(), p.cumulativeDistSQLCPUNanos.Load()
 }
 
-func (p *sqlCPUProviderImpl) GetHandle(workInfo SQLWorkInfo) *SQLCPUHandle {
+func (p *sqlCPUProviderImpl) GetHandle(workInfo WorkInfo, atGateway bool) *SQLCPUHandle {
 	var wq *WorkQueue
 	if p.getWorkQueue != nil && sqlCPUTimeTokenACIsEnabled(p.sv) {
 		wq = p.getWorkQueue(workInfo.TenantID)
 	}
-	return newSQLCPUAdmissionHandle(workInfo, p, wq)
+	return newSQLCPUAdmissionHandle(workInfo, atGateway, p, wq)
 }
 
 // NewSQLCPUProvider creates a new SQLCPUProvider. The sv parameter is required


### PR DESCRIPTION
## Summary

This PR wires the SQL CPU time token admission control setting through
`SQLCPUProvider` and prepares the plumbing for SQL CPU work to be
admitted through the same CTT `WorkQueue` as KV work.

- **Commit 1**: Introduces `admission.sql_cpu_time_tokens.enabled` cluster
  setting with a validation guard requiring `admission.cpu_time_tokens.enabled`.
- **Commit 2**: Wires the setting into `SQLCPUProvider`. When enabled,
  `GetHandle` returns a handle with a reference to the CTT `WorkQueue`.
  `NewSQLCPUProvider` now requires `*settings.Values` and accepts an optional
  `getWorkQueue` callback, wired in `server.go` to
  `CPUGrantCoordinators.GetKVWorkQueue`.
- **Commit 3**: Plumbs `WorkloadID`, `AppNameID`, and `GatewayNodeID` through
  `MakeCPUHandle` so ASH can attribute admission waits to specific SQL
  statements.
- **Commit 4**: Replaces `SQLWorkInfo` with `WorkInfo` directly, eliminating a
  duplicate type. `AtGateway` becomes a separate bool parameter on `GetHandle`.

Part of: https://github.com/cockroachdb/cockroach/issues/166749
Epic: none
Release note: None