### PR TITLE
catalog/lease: use normal priority for descriptor version fetching

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -837,7 +837,10 @@ func getDescriptorsFromStoreForInterval(
 
 		// Export request returns descriptors in decreasing modification time.
 		res, pErr := kv.SendWrappedWithAdmission(ctx, db.NonTransactionalSender(), batchRequestHeader, kvpb.AdmissionHeader{
-			Priority:                 int32(admissionpb.BulkNormalPri),
+			// We are fetching descriptor versions for foreground traffic, so getting
+			// throttled delays foreground work. As a result, lease manager exports
+			// should execute with a normal priority.
+			Priority:                 int32(admissionpb.NormalPri),
 			CreateTime:               timeutil.Now().UnixNano(),
 			Source:                   kvpb.AdmissionHeader_FROM_SQL,
 			NoMemoryReservedAtSource: true,
@@ -1090,6 +1093,10 @@ func (m *Manager) getDescriptorsInTxnAtTimestamp(
 		}
 
 		res, pErr := kv.SendWrappedWithAdmission(ctx, m.storage.db.KV().NonTransactionalSender(), batchRequestHeader, kvpb.AdmissionHeader{
+			// We intentionally use a lower priority here because getting
+			// transaction information is background work. If we get throttled
+			// fetching this information, nothing bad happens, and the range feed
+			// checkpoint will cause us to public descriptors.
 			Priority:                 int32(admissionpb.BulkNormalPri),
 			CreateTime:               timeutil.Now().UnixNano(),
 			Source:                   kvpb.AdmissionHeader_FROM_SQL,

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1518,16 +1518,9 @@ func TestLeasedDescriptorByteSizeBaseline(t *testing.T) {
 	}
 }
 
-// TODO(adityamaru): We do not set SplitMidKey to true for ExportRequests sent
-// in getDescriptorsFromStoreForInterval. This disallows the elastic CPU limiter
-// from preempting the ExportRequest unless we are on a key boundary. In this
-// test we are only exporting revisions of the same key so we should never be
-// allowed to paginate because of exhausted CPU tokens. Once we do add support
-// for SplitMidKey, we should change the test to verify the correctness of our
-// pagination logic.
-//
-// For now, assert that all revisions are fetched in a single ExportRequest even
-// though we are always OverLimit according to the elastic CPU limiter.
+// TestGetDescriptorsFromStoreForIntervalCPULimiterPagination confirms that throttling
+// is not applied to getDescriptorsFromStoreForInterval. This function is invoked on behalf
+// of SQL work, and should not be subject to elastic CPU control.
 func TestGetDescriptorsFromStoreForIntervalCPULimiterPagination(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1543,12 +1536,9 @@ func TestGetDescriptorsFromStoreForIntervalCPULimiterPagination(t *testing.T) {
 						if export, ok := ru.GetInner().(*kvpb.ExportRequest); ok && TestIsLeasingTxnExportRequest(sqlCodec.Load(), request, export) {
 							numRequests++
 							h := admission.ElasticCPUWorkHandleFromContext(ctx)
-							if h == nil {
-								t.Fatalf("expected context to have CPU work handle")
+							if h != nil {
+								t.Fatalf("expected context to have not have CPU work handle")
 							}
-							h.TestingOverrideOverLimit(func() (bool, time.Duration) {
-								return true, 0
-							})
 						}
 					}
 					return nil


### PR DESCRIPTION
getDescriptorsFromStoreForInterval is used to fetch historical descriptor versions for foreground SQL traffic. Previously, it was using BulkNormalPri, which meant it could be throttled by the elastic CPU limiter. Throttling these requests delays foreground work, which can lead to query timeouts and test failures (like
backup-restore/small-ranges).

This change sets the priority to NormalPri, ensuring these requests are treated as foreground work and not subject to elastic CPU control.

Fixes: #166263

Release note (bug fix): Fixed a bug where descriptor version fetching could be incorrectly throttled by the elastic CPU limiter, potentially leading to increased query latency or timeouts under high CPU load.