### PR TITLE
release-26.1: crosscluster/physical: noop cutover cmd if same timestamp passed

### DIFF
--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -627,6 +627,11 @@ func applyCutoverTime(
 		progress := md.Progress.GetStreamIngest()
 		details := md.Payload.GetStreamIngestion()
 		if progress.ReplicationStatus == jobspb.ReplicationFailingOver {
+			// If already failing over to the same timestamp, this is a noop.
+			if cutoverTimestamp.Equal(progress.CutoverTime) {
+				return nil
+			}
+			// Error if trying to change to a different timestamp.
 			return errors.Newf("job %d already started cutting over to timestamp %s",
 				job.ID(), progress.CutoverTime)
 		}

--- a/pkg/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/crosscluster/physical/alter_replication_job_test.go
@@ -315,9 +315,12 @@ func TestAlterTenantFailUpdatingCutoverTime(t *testing.T) {
 	// Wait for cutover to start.
 	<-cutoverStartedCh
 
-	// Another cutover should fail, verify the error.
+	// Attempting to cutover to the same timestamp (LATEST) should succeed (noop).
+	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO LATEST`, args.DestTenantName)
+
+	// Attempting to cutover to a different timestamp should fail.
 	c.DestSysSQL.ExpectErr(t, "already started cutting over to timestamp",
-		fmt.Sprintf("ALTER TENANT %s COMPLETE REPLICATION TO LATEST", args.DestTenantName))
+		fmt.Sprintf("ALTER TENANT %s COMPLETE REPLICATION TO SYSTEM TIME '-1us'", args.DestTenantName))
 
 	// Done, the tenant is cutting over, unblock the job.
 	unblockJob()


### PR DESCRIPTION
Backport 1/1 commits from #166584 on behalf of @msbutler.

----

Previously ALTER TENANT ... COMPLETE REPLICATION would error if the the cutover had already began, regardless of timestamp. Now this command noops if the time passed is the same as the already set cutover time.

Epic: none

Release note: none

----

Release justification: