### PR TITLE
ci: update cluster-ui publish workflows to pnpm 9 and Node 22

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -17,24 +17,24 @@ jobs:
         working-directory: pkg/ui/workspaces/cluster-ui
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Bazel Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
 
-    - uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
       with:
-        version: "8.6.10"
+        version: "9.15.5"
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
         cache: 'pnpm'

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -17,24 +17,24 @@ jobs:
         working-directory: pkg/ui/workspaces/cluster-ui
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Bazel Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
 
-    - uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
       with:
-        version: "8.6.10"
+        version: "9.15.5"
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
         always-auth: true
         cache: 'pnpm'


### PR DESCRIPTION
## Summary
- Update pnpm from 8.6.10 to 9.15.5 in both `cluster-ui-release.yml` and
  `cluster-ui-release-next.yml` to satisfy `pkg/ui/package.json` `engines.pnpm: >=9.15.5`
- Update Node from 16 to 22 (required by pnpm 9.x)
- Bump `actions/checkout`, `actions/cache`, `actions/setup-node` from v3 to v4
- Pin `pnpm/action-setup` to v4 commit SHA

Fixes https://github.com/cockroachdb/cockroach/actions/runs/23561786477/job/68603262841
Epic: None
Release note: None