### PR TITLE
release-26.2: tochar: fix float8 to_char post-decimal digits; fix sign placement for FMS format

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/numeric_formatting
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_formatting
@@ -905,3 +905,11 @@ query T
 SELECT to_char('12345678901'::float8, 'FM9999999999D9999900000000000000000')
 ----
 ##########.####
+
+# Regression test: FMS with zero value should place the sign before the digit,
+# matching PostgreSQL's behavior. The sign-writing condition must check the
+# character at last_relevant, not at the current number position.
+query T
+SELECT to_char(0::numeric, 'FMS9999999999999999.999999999999999')
+----
++0.

--- a/pkg/sql/logictest/testdata/logic_test/numeric_formatting
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_formatting
@@ -897,3 +897,11 @@ query R
 SELECT to_number('   0', 'G99')
 ----
 0
+
+# Regression test: float8 to_char with FM mode and overflow should limit the
+# number of '#' characters in the decimal portion based on DBL_DIG (15),
+# matching PostgreSQL's float8_to_char behavior.
+query T
+SELECT to_char('12345678901'::float8, 'FM9999999999D9999900000000000000000')
+----
+##########.####

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2581,7 +2581,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				if _, err := d.SetFloat64(val); err != nil {
 					return nil, err
 				}
-				s, err := tochar.DecimalToChar(d, ctx.ToCharFormatCache, f)
+				s, err := tochar.Float8DecimalToChar(d, ctx.ToCharFormatCache, f)
 				return tree.NewDString(s), err
 			},
 			Info:       "Convert a float to a string using the given format.",

--- a/pkg/util/tochar/num_tochar.go
+++ b/pkg/util/tochar/num_tochar.go
@@ -419,9 +419,14 @@ func numProcessorToChar(
 			numIn = false
 
 			// Write sign before first digit when appropriate.
+			// The last condition matches PG's:
+			//   (IS_PREDEC_SPACE(Np) == false ||
+			//    (Np->last_relevant && *Np->last_relevant == '.'))
+			// Note: PG checks the character at last_relevant, not at the
+			// current number position.
 			if !signWrote &&
 				(numCurr >= outPreSpaces || (desc.isZero() && desc.zeroStart == numCurr)) &&
-				!(isPredecSpace(desc, number, numberIdx) && !(lastRelevant >= 0 && numberIdx < len(number) && number[numberIdx] == '.')) {
+				(!isPredecSpace(desc, number, numberIdx) || (lastRelevant >= 0 && lastRelevant < len(number) && number[lastRelevant] == '.')) {
 				sb.WriteString(writeSign(desc, sign))
 				signWrote = true
 			}

--- a/pkg/util/tochar/num_tochar.go
+++ b/pkg/util/tochar/num_tochar.go
@@ -17,9 +17,27 @@ import (
 )
 
 // DecimalToChar formats a decimal number using the given format string.
-// This is the main entry point for to_char(numeric, text),
-// to_char(int, text), and to_char(float8, text).
+// This is the main entry point for to_char(numeric, text) and
+// to_char(int, text).
 func DecimalToChar(d *apd.Decimal, c *FormatCache, format string) (string, error) {
+	return decimalToCharInternal(d, c, format, 0)
+}
+
+// Float8DecimalToChar formats a float8 (converted to decimal) using the given
+// format string. It adjusts the post-decimal digit count to fit within
+// DBL_DIG (15) significant digits, matching PostgreSQL's float8_to_char
+// behavior.
+func Float8DecimalToChar(d *apd.Decimal, c *FormatCache, format string) (string, error) {
+	return decimalToCharInternal(d, c, format, dblDig)
+}
+
+// dblDig is the maximum number of significant digits for a float8,
+// matching C's DBL_DIG (IEEE 754 double precision).
+const dblDig = 15
+
+func decimalToCharInternal(
+	d *apd.Decimal, c *FormatCache, format string, maxSigDigits int,
+) (string, error) {
 	nodes, desc, err := c.lookupNum(format)
 	if err != nil {
 		return "", err
@@ -27,6 +45,27 @@ func DecimalToChar(d *apd.Decimal, c *FormatCache, format string) (string, error
 
 	if len(format) == 0 {
 		return "", nil
+	}
+
+	// For float8, adjust post-decimal digits to fit within maxSigDigits,
+	// matching PostgreSQL's float8_to_char which limits Num.post based on
+	// DBL_DIG.
+	if maxSigDigits > 0 && !desc.isRoman() && !desc.isEEEE() {
+		abs := new(apd.Decimal).Abs(d)
+		// Compute the number of pre-decimal digits by formatting the integer
+		// part, matching PG's: orgnum = psprintf("%.0f", fabs(val)).
+		ctx := apd.BaseContext.WithPrecision(50)
+		intVal := new(apd.Decimal)
+		_, err := ctx.RoundToIntegralValue(intVal, abs)
+		if err != nil {
+			return "", err
+		}
+		preLen := len(intVal.Text('f'))
+		if preLen >= maxSigDigits {
+			desc.post = 0
+		} else if preLen+desc.post > maxSigDigits {
+			desc.post = maxSigDigits - preLen
+		}
 	}
 
 	return numToChar(d, nodes, &desc)


### PR DESCRIPTION
Backport 2/2 commits from #166714 on behalf of @rafiss.

----

### sql: limit float8 to_char post-decimal digits to DBL_DIG 

PostgreSQL's float8_to_char adjusts the post-decimal digit count
(Num.post) to fit within DBL_DIG (15) total significant digits
before generating the overflow '#' fill string. CockroachDB was
not performing this adjustment, causing overflow strings with too
many '#' characters in the decimal portion when the format had
many post-decimal digit specifiers.

Add Float8DecimalToChar which applies the DBL_DIG adjustment
before formatting, matching PostgreSQL's behavior.

Skipping a release note since this seems like a minor bug.

Resolves: #166635

### sql: fix to_char sign placement with FMS and predec space 

The sign-writing condition in numProcessorToChar was checking the
character at the current number position (numberIdx) instead of the
character at the last_relevant position. This caused the sign to be
placed after the digit instead of before it when using FMS format
with values like 0 that have a predecimal space.

For example, `to_char(0, 'FMS9999.999')` produced `0+.` instead of
the correct `+0.`.

Fix by matching PostgreSQL's condition which checks
`*Np->last_relevant == '.'` (the character at the last_relevant
pointer) rather than the character at the current number position.

No release note since this bug seems pretty minor.

fixes #166634

---

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

----

Release justification: bug fix in new 26.2 feature