### PR TITLE
release-26.2: teamcity, scripts: switch to release branches in Pebble scripts

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -39,10 +39,10 @@ cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
 # Pull in the version of Pebble from upstream. If none is specified, the
-# benchmarks run against the tip of the 'master' branch. We do this by `go
+# benchmarks run against the tip of the 'crl-release-26.2' branch. We do this by `go
 # get`ting the SHA of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-pebble_go_get_version="${PEBBLE_SHA:-master}"
+pebble_go_get_version="${PEBBLE_SHA:-crl-release-26.2}"
 echo "Benchmarking against: ${pebble_go_get_version}"
 
 bazel run @go_sdk//:bin/go get "github.com/cockroachdb/pebble@${pebble_go_get_version}"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -19,10 +19,10 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 mkdir -p artifacts
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-26.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-26.2
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
@@ -19,10 +19,10 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 mkdir -p artifacts
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-26.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-26.2
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
@@ -19,10 +19,10 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 mkdir -p artifacts
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-26.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-26.2
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -39,10 +39,10 @@ cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-26.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-26.2
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race -c opt

--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -11,8 +11,8 @@
 # branch name (e.g. crl-release-23.2, etc.). Also update pebble nightly scripts
 # in build/teamcity/cockroach/nightlies to use `@crl-release-xy.z` instead of
 # `@master`.
-BRANCH=master
-PEBBLE_BRANCH=master
+BRANCH=release-26.2
+PEBBLE_BRANCH=crl-release-26.2
 
 # This script may be used to produce a branch bumping the Pebble version. The
 # storage team bumps CockroachDB's Pebble dependency frequently, and this script


### PR DESCRIPTION
## Summary
- Switch Pebble nightly scripts to use `crl-release-26.2` branch instead of `master`
- Update `bump-pebble.sh` to use `release-26.2` / `crl-release-26.2`
- Mirrors the change from #144185 for the release-26.2 branch

Epic: none
Release note: None
Release justification: dev infra change only