### PR TITLE
release-26.1: roachtest: fix acceptance/cli/node-status quorum loss

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -59,7 +59,7 @@ func registerAcceptance(r registry.Registry) {
 				name: "many-splits", fn: runManySplits,
 				encryptionSupport: registry.EncryptionMetamorphic,
 			},
-			{name: "cli/node-status", fn: runCLINodeStatus},
+			{name: "cli/node-status", fn: runCLINodeStatus, numNodes: 5, timeout: 15 * time.Minute},
 			{name: "cluster-init", fn: runClusterInit},
 			{name: "rapid-restart", fn: runRapidRestart},
 		},

--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -22,13 +22,56 @@ import (
 )
 
 func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 3))
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 5))
 
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
 
 	err := roachtestutil.WaitFor3XReplication(ctx, t.L(), db)
 	require.NoError(t, err)
+
+	// Create user ranges at default 3x replication. With 5 nodes and 2 killed,
+	// some of these ranges will lose quorum — the test verifies that
+	// "node status" still works in that scenario.
+	_, err = db.ExecContext(ctx, `CREATE TABLE defaultdb.t (k INT PRIMARY KEY)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `ALTER TABLE defaultdb.t SPLIT AT SELECT generate_series(1, 100)`)
+	require.NoError(t, err)
+	err = roachtestutil.WaitFor3XReplication(ctx, t.L(), db)
+	require.NoError(t, err)
+
+	// System database ranges and meta ranges default to 5x replication
+	// (DefaultSystemZoneConfig). Wait for them to reach 5 replicas, since
+	// we're going to kill 2 nodes and need these ranges to retain quorum.
+	// Without this, SQL connections fail and `node status` (which uses SQL)
+	// won't work. We check database_name = 'system' (for system tables) and
+	// start_key LIKE '/Meta%' (for meta addressing ranges). Other pre-table
+	// system ranges (liveness, etc.) also replicate to 5 but upreplicate
+	// quickly. We must NOT include timeseries ranges (start_key LIKE
+	// '/System/tsd%') — those inherit num_replicas=3 from the default zone
+	// config and would never reach 5.
+	t.L().Printf("waiting for system/meta ranges to reach 5 replicas")
+	for i := 0; ; i++ {
+		var n int
+		if err := db.QueryRowContext(ctx, `
+			SELECT count(*) FROM [SHOW CLUSTER RANGES WITH TABLES]
+			WHERE (database_name = 'system' OR start_key LIKE '/Meta%')
+			AND array_length(replicas, 1) < 5`,
+		).Scan(&n); err != nil {
+			t.Fatalf("querying system range replication: %v", err)
+		}
+		if n == 0 {
+			t.L().Printf("all system/meta ranges at 5 replicas")
+			break
+		}
+		if i%10 == 0 {
+			t.L().Printf("waiting for %d system/meta ranges to reach 5 replicas", n)
+		}
+		if i > 300 {
+			t.Fatalf("timed out waiting for system/meta range replication (still %d ranges < 5 replicas)", n)
+		}
+		time.Sleep(time.Second)
+	}
 
 	lastWords := func(s string) []string {
 		var result []string
@@ -49,22 +92,6 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 			return "", nil, err
 		}
 		return result.Stdout, lastWords(result.Stdout), nil
-	}
-
-	{
-		expected := []string{
-			"is_available is_live",
-			"true true",
-			"true true",
-			"true true",
-		}
-		raw, actual, err := nodeStatus()
-		if err != nil {
-			t.Fatalf("node status failed: %v\n%s", err, raw)
-		}
-		if !reflect.DeepEqual(expected, actual) {
-			t.Fatalf("expected %s, but found %s:\nfrom:\n%s", expected, actual, raw)
-		}
 	}
 
 	waitUntil := func(expected []string) {
@@ -88,40 +115,63 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 		}
 	}
 
-	// Kill node 2 and wait for it to be marked as !is_available and !is_live.
-	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(2))
+	// Verify all 5 nodes are available and live.
+	{
+		expected := []string{
+			"is_available is_live",
+			"true true",
+			"true true",
+			"true true",
+			"true true",
+			"true true",
+		}
+		raw, actual, err := nodeStatus()
+		if err != nil {
+			t.Fatalf("node status failed: %v\n%s", err, raw)
+		}
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("expected %s, but found %s:\nfrom:\n%s", expected, actual, raw)
+		}
+	}
+
+	// Kill node 4 and wait for it to be marked as !is_available and !is_live.
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(4))
 	waitUntil([]string{
 		"is_available is_live",
+		"true true",
+		"true true",
 		"true true",
 		"false false",
 		"true true",
 	})
 
-	// Kill node 3 and wait for all of the nodes to be marked as
-	// !is_available. Node 1 is not available because the liveness check can no
-	// longer write to the liveness range due to lack of quorum. This test is
-	// verifying that "node status" still returns info in this situation since
-	// it only accesses gossip info.
-	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(3))
+	// Kill node 5. System ranges are 5x replicated and retain quorum with
+	// 3 of 5 nodes alive. Some user ranges (3x replicated) may lose quorum.
+	// This verifies that "node status" still works in this scenario.
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(5))
 	waitUntil([]string{
 		"is_available is_live",
-		"false false",
+		"true true",
+		"true true",
+		"true true",
 		"false false",
 		"false false",
 	})
 
-	// Stop the cluster and restart only 2 of the nodes. Verify that three nodes
+	// Stop the remaining nodes and restart them. Verify that all five nodes
 	// show up in the node status output.
-	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 2))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 2))
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 3))
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 3))
 
 	waitUntil([]string{
 		"is_available is_live",
 		"true true",
 		"true true",
+		"true true",
+		"false false",
 		"false false",
 	})
 
-	// Start node again to satisfy roachtest.
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(3))
+	// Start remaining nodes to satisfy roachtest.
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(4, 5))
 }


### PR DESCRIPTION
Backport 1/1 commits from #166418 on behalf of @tbg.

----

## Summary

The `acceptance/cli/node-status` test times out because it assumes `cockroach
node status` works after the cluster has lost quorum on the liveness range.

- Switch from a 3-node to a 5-node cluster. System ranges default to 5x
  replication (`DefaultSystemZoneConfig`), so killing 2 nodes still leaves
  quorum (3/5 alive).
- Create 100 user ranges at default 3x replication; some lose quorum when 2
  nodes die, verifying `node status` works despite partial user-range quorum
  loss.
- Wait for system database and meta ranges to finish upreplicating to 5x
  before killing nodes. Uses `SHOW CLUSTER RANGES` filtered to
  `database_name = 'system' OR start_key LIKE '/Meta%'`. Timeseries ranges
  are intentionally excluded — they inherit `num_replicas=3` from the
  default zone config (not the system zone config) and would never reach 5.

Fixes-25.4: #166351
Epic: none

Release note: None

----

Release justification: Non-production code change (roachtest fix only).
