### PR TITLE
release-26.2: roachtest: bump user_login.timeout in follower-reads insufficient-quorum

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -252,6 +252,15 @@ func runFollowerReadsTest(
 		return err
 	}())
 
+	// Bump the login timeout to 60s (from the default 10s) to avoid
+	// authentication timeouts when new SQL connections are opened after possibly
+	// causing failover for system ranges. See #166376.
+	{
+		_, err := systemConnectFunc(1).ExecContext(ctx,
+			"SET CLUSTER SETTING server.user_login.timeout = '60s'")
+		require.NoError(t, err)
+	}
+
 	var conns []*gosql.DB
 	for i := 0; i < c.Spec().NodeCount; i++ {
 		isoLevel := isoLevels[rng.Intn(len(isoLevels))]


### PR DESCRIPTION
Backport 1/1 commits from #166422 on behalf of @tbg.

----

Bump `server.user_login.timeout` from the default 10s to 60s in the
follower-reads insufficient-quorum test variants. After killing the
entire primary region, lease acquisition on system ranges can take ~10s,
racing with the authentication timeout on newly opened SQL connections.

Fixes-24.3 #166376

Release note: None
Epic: none 

----

Release justification: