### PR TITLE
sql: gate PREPARE TRANSACTION behind a cluster setting

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -92,6 +93,7 @@ func TestDataDriven(t *testing.T) {
 		require.NoError(t, err)
 
 		tenantSQLDB := testTenantInterface.SQLConn(t)
+		sql.PreparedTransactionsEnabled.Override(ctx, &testTenantInterface.ClusterSettings().SV, true)
 
 		lastUpdateTS := tc.Server(0).Clock().Now() // ensure watcher isn't starting out empty
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1514,6 +1514,11 @@ func (t *logicTest) newCluster(
 		// disable stats collection on system tables in order to have
 		// deterministic tests.
 		stats.AutomaticStatisticsOnSystemTables.Override(context.Background(), &st.SV, false)
+		for _, opt := range clusterOpts {
+			if so, ok := opt.(settingsOpt); ok {
+				so.applySettings(st)
+			}
+		}
 		if t.cfg.UseFakeSpanResolver {
 			// We will need to update the DistSQL span resolver with the fake
 			// resolver, but this can only be done while DistSQL is disabled.
@@ -2139,6 +2144,14 @@ type clusterOpt interface {
 	apply(args *base.TestServerArgs)
 }
 
+// settingsOpt is an optional interface that clusterOpts can implement to
+// apply settings overrides to the cluster settings object. This is useful for
+// overriding unsafe settings that cannot be set via SET CLUSTER SETTING
+// without the interlock.
+type settingsOpt interface {
+	applySettings(st *cluster.Settings)
+}
+
 // clusterOptTracingOff corresponds to the tracing-off directive.
 type clusterOptTracingOff struct{}
 
@@ -2210,6 +2223,19 @@ func (c clusterOptDisableUseMVCCRangeTombstonesForPointDeletes) apply(args *base
 		args.Knobs.Store = &kvserver.StoreTestingKnobs{}
 	}
 	args.Knobs.Store.(*kvserver.StoreTestingKnobs).EvalKnobs.UseRangeTombstonesForPointDeletes = false
+}
+
+// clusterOptEnablePreparedTransactions enables the unsafe prepared transactions
+// cluster setting via Override, bypassing the unsafe setting interlock.
+type clusterOptEnablePreparedTransactions struct{}
+
+var _ clusterOpt = clusterOptEnablePreparedTransactions{}
+var _ settingsOpt = clusterOptEnablePreparedTransactions{}
+
+func (c clusterOptEnablePreparedTransactions) apply(args *base.TestServerArgs) {}
+
+func (c clusterOptEnablePreparedTransactions) applySettings(st *cluster.Settings) {
+	sql.PreparedTransactionsEnabled.Override(context.Background(), &st.SV, true)
 }
 
 // knobOptDisableCorpusGeneration disables corpus generation for declarative
@@ -2360,6 +2386,8 @@ func readClusterOptions(t *testing.T, path string) []clusterOpt {
 			res = append(res, clusterOptIgnoreStrictGCForTenants{})
 		case "disable-mvcc-range-tombstones-for-point-deletes":
 			res = append(res, clusterOptDisableUseMVCCRangeTombstonesForPointDeletes{})
+		case "enable-prepared-transactions-unsafe":
+			res = append(res, clusterOptEnablePreparedTransactions{})
 		default:
 			t.Fatalf("unrecognized cluster option: %s", opt)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -1,3 +1,5 @@
+# cluster-opt: enable-prepared-transactions-unsafe
+
 statement ok
 SET autocommit_before_ddl = false
 

--- a/pkg/sql/logictest/testdata/logic_test/two_phase_commit
+++ b/pkg/sql/logictest/testdata/logic_test/two_phase_commit
@@ -1,4 +1,9 @@
 # LogicTest: !3node-tenant-default-configs !local-prepared
+# cluster-opt: enable-prepared-transactions-unsafe
+
+# This test uses the enable-prepared-transactions-unsafe cluster-opt to bypass
+# the unsafe setting interlock, since the setting cannot be changed via SET
+# CLUSTER SETTING without the interlock dance.
 
 query T
 SHOW max_prepared_transactions

--- a/pkg/sql/logictest/testdata/logic_test/two_phase_commit_disabled
+++ b/pkg/sql/logictest/testdata/logic_test/two_phase_commit_disabled
@@ -1,0 +1,11 @@
+# LogicTest: local
+
+# Verify that prepared transactions are disabled by default. BEGIN is required
+# because PREPARE TRANSACTION is only valid inside an explicit transaction. The
+# failed PREPARE TRANSACTION rolls back the transaction and transitions to
+# stateNoTxn, so no explicit ROLLBACK is needed.
+statement ok
+BEGIN
+
+statement error pgcode 0A000 prepared transactions are disabled because the feature is not yet GA
+PREPARE TRANSACTION 'disabled'

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2617,6 +2617,13 @@ func TestLogic_two_phase_commit(
 	runLogicTest(t, "two_phase_commit")
 }
 
+func TestLogic_two_phase_commit_disabled(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "two_phase_commit_disabled")
+}
+
 func TestLogic_txn(
 	t *testing.T,
 ) {

--- a/pkg/sql/two_phase_commit.go
+++ b/pkg/sql/two_phase_commit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -24,6 +25,18 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var PreparedTransactionsEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.prepared_transactions.unsafe.enabled",
+	"enables PREPARE TRANSACTION statements (two-phase commit). "+
+		"When a transaction is prepared, it holds its locks indefinitely and "+
+		"cannot be pushed. If the coordinator that initiated the prepare fails "+
+		"to follow up with COMMIT PREPARED or ROLLBACK PREPARED, those locks "+
+		"will be held potentially forever, even across restarts, until the "+
+		"transaction is manually resolved. Use with caution.",
+	false,
+	settings.WithUnsafe)
+
 // maxPreparedTxnGlobalIDLen is the maximum length of a prepared transaction's
 // global ID. Taken from Postgres, see GIDSIZE.
 const maxPreparedTxnGlobalIDLen = 200
@@ -35,6 +48,20 @@ func (ex *connExecutor) execPrepareTransactionInOpenState(
 ) (fsm.Event, fsm.EventPayload) {
 	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "prepare sql txn")
 	defer sp.Finish()
+
+	if !PreparedTransactionsEnabled.Get(&ex.server.cfg.Settings.SV) {
+		if rbErr := ex.state.mu.txn.Rollback(ctx); rbErr != nil {
+			log.Dev.Warningf(ctx, "txn rollback failed: err=%s", rbErr)
+		}
+		return eventTxnFinishPrepared{}, eventTxnFinishPreparedErrPayload{
+			err: errors.WithHint(
+				pgerror.Newf(pgcode.FeatureNotSupported,
+					"prepared transactions are disabled because the feature is not yet GA"),
+				"Set the cluster setting sql.prepared_transactions.unsafe.enabled "+
+					"to true to enable prepared transactions.",
+			),
+		}
+	}
 
 	// Insert into the system table and prepare the transaction in the KV layer.
 	prepareErr := ex.execPrepareTransactionInOpenStateInternal(ctx, s)


### PR DESCRIPTION
## Summary

- Adds `sql.prepared_transactions.enabled` cluster setting (default `false`) that gates `PREPARE TRANSACTION`
- When disabled, `PREPARE TRANSACTION` returns `pgcode.FeatureNotSupported` with a hint to enable the setting
- `COMMIT PREPARED` and `ROLLBACK PREPARED` are intentionally not gated so users can clean up existing prepared transactions if the setting is later disabled

Resolves: #166765

Release note (sql change): Added a new cluster setting
`sql.prepared_transactions.enabled` (default false) that controls whether
PREPARE TRANSACTION statements are accepted. When disabled, attempting
to prepare a transaction returns an error. COMMIT PREPARED and ROLLBACK
PREPARED remain available regardless of this setting to allow cleanup of
existing prepared transactions.