### PR TITLE
raft: ErrProposalDropped on rejected conf changes

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -266,9 +266,8 @@ func TestStoreMetrics(t *testing.T) {
 					StickyVFSRegistry: stickyVFSRegistry,
 				},
 				Store: &kvserver.StoreTestingKnobs{
-					DisableRaftLogQueue:                         true,
-					DisableRefreshReasonNewLeaderOrConfigChange: true, // see #166114
-					EngineKnobs: []storage.ConfigOption{storage.DisableAutomaticCompactions},
+					DisableRaftLogQueue: true,
+					EngineKnobs:         []storage.ConfigOption{storage.DisableAutomaticCompactions},
 				},
 			},
 		}

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -516,8 +516,11 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 				continue
 			}
 			sl := []raftpb.Entry{{Type: typ, Data: data}}
-			// Send config change in a single-element batch. We go through
-			// proposeBatch since there's observability in there.
+			// Config change entries must be proposed alone in a MsgProp, not
+			// batched with other entries. The raft leader relies on this
+			// invariant to reject invalid config changes via ErrProposalDropped
+			// (see stepLeader in pkg/raft/raft.go). We go through proposeBatch
+			// since there's observability in there.
 			if err := proposeBatch(
 				b.p, raftGroup, sl, []*ProposalData{p},
 			); err != nil && !errors.Is(err, raft.ErrProposalDropped) {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1842,6 +1842,10 @@ func stepLeader(r *raft, m pb.Message) error {
 			return ErrProposalDropped
 		}
 
+		// Scan entries for config changes. Config change entries must be proposed
+		// alone in a MsgProp (not batched with other entries), as ensured by
+		// confChangeToMsg. This allows the leader to reject the entire MsgProp
+		// if config change validation fails.
 		for i := range m.Entries {
 			e := &m.Entries[i]
 			var cc pb.ConfChangeI

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1863,6 +1863,14 @@ func stepLeader(r *raft, m pb.Message) error {
 				cc = ccc
 			}
 			if cc != nil {
+				// Config change entries must be proposed alone, not batched with
+				// other entries. See confChangeToMsg.
+				if len(m.Entries) != 1 {
+					r.logger.Panicf(
+						"%x conf change entry at index %d must be proposed alone, got %d entries",
+						r.id, i, len(m.Entries),
+					)
+				}
 				ccCtx := confchange.ValidationContext{
 					CurConfig:                         &r.config,
 					Applied:                           r.raftLog.applied,

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -989,11 +989,11 @@ func (r *raft) appliedTo(index uint64) {
 		if err != nil {
 			panic(err)
 		}
-		// NB: this proposal can't be dropped due to size, but can be
-		// dropped if a leadership transfer is in progress. We'll keep
-		// checking this condition on each applied entry, so either the
-		// leadership transfer will succeed and the new leader will leave
-		// the joint configuration, or the leadership transfer will fail,
+		// NB: this proposal can't be dropped due to size, but can be dropped if a
+		// leadership transfer is in progress or the config change is not allowed
+		// for another reason. We'll keep checking this condition on each applied
+		// entry, so either the leadership transfer will succeed and the new leader
+		// will leave the joint configuration, or the leadership transfer will fail,
 		// and we will propose the config change on the next advance.
 		if err := r.Step(m); err != nil {
 			r.logger.Debugf("not initiating automatic transition out of joint configuration %s: %v", r.config, err)
@@ -1880,10 +1880,9 @@ func stepLeader(r *raft, m pb.Message) error {
 				}
 				if err := confchange.ValidateProp(ccCtx, cc.AsV2()); err != nil {
 					r.logger.Infof("%x ignoring conf change %v at config %s: %s", r.id, cc, r.config, err)
-					m.Entries[i] = pb.Entry{Type: pb.EntryNormal}
-				} else {
-					r.pendingConfIndex = r.raftLog.lastIndex() + uint64(i) + 1
+					return ErrProposalDropped
 				}
+				r.pendingConfIndex = r.raftLog.lastIndex() + uint64(i) + 1
 			}
 		}
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -3306,21 +3306,26 @@ func TestStepConfig(t *testing.T) {
 }
 
 // TestStepIgnoreConfig tests that if raft step the second msgProp in
-// EntryConfChange type when the first one is uncommitted, the node will set
-// the proposal to noop and keep its original state.
+// EntryConfChange type when the first one is uncommitted, the proposal is
+// dropped with ErrProposalDropped and no entry is appended.
 func TestStepIgnoreConfig(t *testing.T) {
 	// a raft that cannot make progress
 	r := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
 	r.becomeCandidate()
 	r.becomeLeader()
-	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
+	require.NoError(t, r.Step(pb.Message{
+		From: 1, To: 1, Type: pb.MsgProp,
+		Entries: []pb.Entry{{Type: pb.EntryConfChange}},
+	}))
 	index := r.raftLog.lastIndex()
 	pendingConfIndex := r.pendingConfIndex
-	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
-	wents := []pb.Entry{{Type: pb.EntryNormal, Term: 1, Index: 3, Data: nil}}
-	ents, err := r.raftLog.entries(index, noLimit)
-	require.NoError(t, err)
-	assert.Equal(t, wents, ents)
+	err := r.Step(pb.Message{
+		From: 1, To: 1, Type: pb.MsgProp,
+		Entries: []pb.Entry{{Type: pb.EntryConfChange}},
+	})
+	assert.ErrorIs(t, err, ErrProposalDropped)
+	// No new entry was appended.
+	assert.Equal(t, index, r.raftLog.lastIndex())
 	assert.Equal(t, pendingConfIndex, r.pendingConfIndex)
 }
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -96,8 +96,13 @@ func (rn *RawNode) Propose(data []byte) error {
 
 // ProposeConfChange proposes a config change. Like any proposal, the config
 // change may be dropped with or without an error being returned (see the
-// Propose() method). In addition, config changes are dropped unless the leader
-// has certainty that there is no prior unapplied config change in its log.
+// Propose() method). In particular, ErrProposalDropped is returned if config
+// change validation fails, e.g. because there is a prior unapplied config
+// change in the leader's log.
+//
+// The config change is proposed as a single-entry MsgProp message (see
+// confChangeToMsg). This is a requirement: config change entries must not be
+// batched with other entries in a MsgProp.
 //
 // The method accepts either a pb.ConfChange (deprecated) or pb.ConfChangeV2
 // message. The latter allows arbitrary config changes via joint consensus,
@@ -112,6 +117,9 @@ func (rn *RawNode) ProposeConfChange(cc pb.ConfChangeI) error {
 	return rn.raft.Step(m)
 }
 
+// confChangeToMsg converts a config change to a MsgProp message with a single
+// entry. Config change entries must always be proposed alone in a MsgProp, not
+// batched with other entries. The raft leader relies on this invariant.
 func confChangeToMsg(c pb.ConfChangeI) (pb.Message, error) {
 	typ, data, err := pb.MarshalConfChange(c)
 	if err != nil {

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -480,30 +480,34 @@ func TestRawNodeProposeAddDuplicateNode(t *testing.T) {
 	rawNode.AckAppend(rd.Ack())
 
 	rawNode.Campaign()
-	for {
+	// Drain all Ready cycles until the leader's initial empty entry is committed
+	// and applied, so that applied index is >= pendingConfIndex and conf change
+	// proposals are not rejected.
+	for rawNode.HasReady() {
 		rd = rawNode.Ready()
 		s.Append(rd.Entries)
 		rawNode.AckAppend(rd.Ack())
 		rawNode.AckApplied(committedEntries(t, rawNode, rd))
-		if rd.HardState.Lead == rawNode.raft.id {
-			break
-		}
 	}
+	require.Equal(t, rawNode.raft.id, rawNode.raft.lead)
 
 	proposeConfChangeAndApply := func(cc pb.ConfChange) {
-		rawNode.ProposeConfChange(cc)
-		rd = rawNode.Ready()
-		s.Append(rd.Entries)
-		committed := committedEntries(t, rawNode, rd)
-		for _, entry := range committed {
-			if entry.Type == pb.EntryConfChange {
-				var cc pb.ConfChange
-				cc.Unmarshal(entry.Data)
-				rawNode.ApplyConfChange(cc)
+		require.NoError(t, rawNode.ProposeConfChange(cc))
+		// Drain all Ready cycles to ensure the conf change is committed and applied.
+		for rawNode.HasReady() {
+			rd = rawNode.Ready()
+			s.Append(rd.Entries)
+			committed := committedEntries(t, rawNode, rd)
+			for _, entry := range committed {
+				if entry.Type == pb.EntryConfChange {
+					var cc pb.ConfChange
+					cc.Unmarshal(entry.Data)
+					rawNode.ApplyConfChange(cc)
+				}
 			}
+			rawNode.AckAppend(rd.Ack())
+			rawNode.AckApplied(committed)
 		}
-		rawNode.AckAppend(rd.Ack())
-		rawNode.AckApplied(committed)
 	}
 
 	cc1 := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: 1}
@@ -511,7 +515,7 @@ func TestRawNodeProposeAddDuplicateNode(t *testing.T) {
 	require.NoError(t, err)
 	proposeConfChangeAndApply(cc1)
 
-	// try to add the same node again
+	// Try to add the same node again. This is a no-op but still gets committed.
 	proposeConfChangeAndApply(cc1)
 
 	// the new node join should be ok
@@ -526,6 +530,7 @@ func TestRawNodeProposeAddDuplicateNode(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 3)
 	assert.Equal(t, ccdata1, entries[0].Data)
+	assert.Equal(t, ccdata1, entries[1].Data)
 	assert.Equal(t, ccdata2, entries[2].Data)
 }
 

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -52,29 +52,22 @@ propose-conf-change 1
 l4
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeAddLearnerNode 4}] []} at config voters=(1): possible unapplied conf change at index 4 (applied to 3)
+raft proposal dropped
 
-# The new config change is appended to the log as an empty entry.
+# The rejected config change is not appended to the log.
 stabilize 1
 ----
 > 1 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
-  Entries:
-  1/5 EntryNormal ""
   Committed: (3,4]
-  OnSync:
-  1->1 MsgAppResp Term:1 Log:0/5 Commit:4
   Applying:
   1/4 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
-  Committed: (4,5]
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  Applying:
-  1/5 EntryNormal ""
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 l2 l3]
+  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 l2 l3]

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -139,19 +139,11 @@ propose-conf-change 1
 r2 l2
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeRemoveNode 2} {ConfChangeAddLearnerNode 2}] []} at config voters=(1 2 3 4): lead support has not caught up to previous configuration
+raft proposal dropped
 
 # Fortify v4 so that lead support catches up.
 stabilize 1 4
 ----
-> 1 handling Ready
-  Ready:
-  Entries:
-  1/5 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  OnSync:
-  1->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 4 receiving messages
   1->4 MsgFortifyLeader Term:1 Log:0/0
   INFO 4 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
@@ -176,13 +168,11 @@ stabilize 1 4
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
     1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
   ]
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
     1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
   ]
 > 4 handling Ready
   Ready:
@@ -190,16 +180,15 @@ stabilize 1 4
   Entries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v4
-  1/5 EntryNormal ""
   Committed: (2,4]
   OnSync:
-  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
   Applying:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v4
   INFO 4 switched to configuration voters=(1 2 3 4)
 > 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
 
 store-liveness
 ----
@@ -227,197 +216,173 @@ stabilize
 > 1 handling Ready
   Ready:
   Entries:
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
-  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
-  1->4 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
+  1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
   OnSync:
-  1->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  1->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 2 handling Ready
   Ready:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   OnSync:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 3 handling Ready
   Ready:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   OnSync:
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 4 handling Ready
   Ready:
   Entries:
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   OnSync:
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
-  Committed: (4,6]
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  Committed: (4,5]
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
-  1->4 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-  1->3 MsgApp Term:1 Log:1/6 Commit:6
-  1->4 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->3 MsgApp Term:1 Log:1/5 Commit:5
+  1->4 MsgApp Term:1 Log:1/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   INFO 1 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
   INFO initiating automatic transition out of joint configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:6
+  1->3 MsgApp Term:1 Log:1/5 Commit:5
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/6 Commit:5
-  1->4 MsgApp Term:1 Log:1/6 Commit:6
+  1->4 MsgApp Term:1 Log:1/5 Commit:5
 > 1 handling Ready
   Ready:
   Entries:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-  1->4 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+  1->4 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
   OnSync:
-  1->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  1->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 2 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
-  Committed: (4,6]
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  Committed: (4,5]
   OnSync:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   INFO 2 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
 > 3 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
-  Committed: (4,6]
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  Committed: (4,5]
   OnSync:
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   INFO 3 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
 > 4 handling Ready
   Ready:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
-  Committed: (4,6]
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
+  Committed: (4,5]
   OnSync:
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   INFO 4 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:5
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+  1->4 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
 > 2 handling Ready
   Ready:
   Entries:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   OnSync:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 3 handling Ready
   Ready:
   Entries:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   OnSync:
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 4 handling Ready
   Ready:
   Entries:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   OnSync:
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (6,7]
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  Committed: (5,6]
   Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-  1->3 MsgApp Term:1 Log:1/7 Commit:7
-  1->4 MsgApp Term:1 Log:1/7 Commit:7
+  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->3 MsgApp Term:1 Log:1/6 Commit:6
+  1->4 MsgApp Term:1 Log:1/6 Commit:6
   Applying:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   INFO 1 switched to configuration voters=(1 3 4) learners=(2)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
+  1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/7 Commit:7
+  1->3 MsgApp Term:1 Log:1/6 Commit:6
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/7 Commit:7
+  1->4 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (6,7]
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  Committed: (5,6]
   OnSync:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
   Applying:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   INFO 2 switched to configuration voters=(1 3 4) learners=(2)
 > 3 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (6,7]
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  Committed: (5,6]
   OnSync:
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
   Applying:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   INFO 3 switched to configuration voters=(1 3 4) learners=(2)
 > 4 handling Ready
   Ready:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (6,7]
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
+  Committed: (5,6]
   OnSync:
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:6
   Applying:
-  1/7 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   INFO 4 switched to configuration voters=(1 3 4) learners=(2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:6

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -38,6 +38,7 @@ propose-conf-change 1 v1=true
 r1
 ----
 INFO 1 ignoring conf change {ConfChangeRemoveNode 1 [] 0} at config voters=(1 2 3): voters must be demoted to learners before being removed
+raft proposal dropped
 
 # Instead, demote n1 to a learner in a joint config.
 propose-conf-change 1 v1=false transition=explicit
@@ -70,43 +71,43 @@ process-ready 1
 ----
 Ready:
 Entries:
-1/6 EntryConfChangeV2
-1/7 EntryNormal "foo"
+1/5 EntryConfChangeV2
+1/6 EntryNormal "foo"
 Messages:
-1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
+1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
 OnSync:
-1->1 MsgAppResp Term:1 Log:0/6 Commit:5
-1->1 MsgAppResp Term:1 Log:0/7 Commit:5
+1->1 MsgAppResp Term:1 Log:0/5 Commit:4
+1->1 MsgAppResp Term:1 Log:0/6 Commit:4
 
 # Send response from n2 and n3 (which is enough to commit the entries so far
 # next time n1 runs).
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
 > 2 handling Ready
   Ready:
   Entries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   OnSync:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 3 handling Ready
   Ready:
   Entries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   OnSync:
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -120,29 +121,29 @@ stabilize 1
 > 1 handling Ready
   Ready:
   Entries:
-  1/8 EntryNormal "bar"
+  1/7 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
   OnSync:
-  1->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  1->1 MsgAppResp Term:1 Log:0/7 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (5,7]
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  Committed: (4,6]
   Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  1->2 MsgApp Term:1 Log:1/8 Commit:7
-  1->3 MsgApp Term:1 Log:1/8 Commit:7
+  1->2 MsgApp Term:1 Log:1/7 Commit:5
+  1->3 MsgApp Term:1 Log:1/7 Commit:5
+  1->2 MsgApp Term:1 Log:1/7 Commit:6
+  1->3 MsgApp Term:1 Log:1/7 Commit:6
   Applying:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   INFO 1 switched to configuration voters=(2 3) learners=(1)
   DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 became follower at term 1
@@ -150,7 +151,7 @@ stabilize 1
 > 1 handling Ready
   Ready:
   State:StateFollower
-  HardState Term:1 Vote:1 Commit:7 Lead:0 LeadEpoch:0
+  HardState Term:1 Vote:1 Commit:6 Lead:0 LeadEpoch:0
 
 raft-state
 ----
@@ -162,57 +163,57 @@ raft-state
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->2 MsgApp Term:1 Log:1/8 Commit:7
+  1->2 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/7 Commit:5
+  1->2 MsgApp Term:1 Log:1/7 Commit:6
 > 2 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   Entries:
-  1/8 EntryNormal "bar"
-  Committed: (5,7]
+  1/7 EntryNormal "bar"
+  Committed: (4,6]
   OnSync:
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
   Applying:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   INFO 2 switched to configuration voters=(2 3) learners=(1)
 
 # ...because the old leader n1 ignores the append responses.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:7
+  1->3 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/7 Commit:5
+  1->3 MsgApp Term:1 Log:1/7 Commit:6
 > 3 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   Entries:
-  1/8 EntryNormal "bar"
-  Committed: (5,7]
+  1/7 EntryNormal "bar"
+  Committed: (4,6]
   OnSync:
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
   Applying:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   INFO 3 switched to configuration voters=(2 3) learners=(1)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
 
 # n1 can no longer propose.
 propose 1 baz

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -71,7 +71,18 @@ Applying:
 1/4 EntryConfChangeV2 v2 v3
 INFO 1 switched to configuration voters=(1 2 3)&&(1) autoleave
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2 3)&&(1) autoleave: lead support has not caught up to previous configuration
-INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
+DEBUG not initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave: raft proposal dropped
+
+# The automatic transition was rejected because lead support hasn't caught up
+# (n2 and n3 haven't fortified yet). Propose some entry so that, once lead
+# support catches up and the entry is applied, the auto-leave is retried.
+#
+# TODO(pav-kv): the autoleave mechanism is not entirely reliable because it is
+# only triggered by applied commands. It must also happen when all the blocking
+# conditions are cleared. We could also remove it since CRDB doesn't use it.
+propose 1 abc
+----
+ok
 
 # n1 immediately probes n2 and n3.
 stabilize 1
@@ -79,7 +90,7 @@ stabilize 1
 > 1 handling Ready
   Ready:
   Entries:
-  1/5 EntryNormal ""
+  1/5 EntryNormal "abc"
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -90,9 +101,9 @@ stabilize 1
 
 # First, play out the whole interaction between n1 and n2. We see n1's probe to
 # n2 get rejected (since n2 needs a snapshot); the snapshot is delivered at which
-# point n2 switches to the correct config, and n1 catches it up. This notably
-# includes the empty conf change which gets committed and applied by both and
-# which transitions them out of their joint configuration into the final one (1 2 3).
+# point n2 switches to the joint config. Once n2 catches up, n1 commits and
+# applies the entry proposed above, which triggers the auto-leave out of the
+# joint configuration into the final one (1 2 3).
 stabilize 1 2
 ----
 > 2 receiving messages
@@ -139,13 +150,13 @@ stabilize 1 2
 > 1 handling Ready
   Ready:
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal "abc"]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal "abc"]
 > 2 handling Ready
   Ready:
   Entries:
-  1/5 EntryNormal ""
+  1/5 EntryNormal "abc"
   OnSync:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
@@ -157,7 +168,7 @@ stabilize 1 2
   Messages:
   1->2 MsgApp Term:1 Log:1/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
+  1/5 EntryNormal "abc"
   INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
@@ -176,7 +187,7 @@ stabilize 1 2
   OnSync:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
+  1/5 EntryNormal "abc"
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
 > 2 receiving messages

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -117,6 +117,7 @@ propose-conf-change 1
 v3 v4 v5
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeAddNode 3} {ConfChangeAddNode 4} {ConfChangeAddNode 5}] []} at config voters=(1 2)&&(1): must transition out of joint config first
+raft proposal dropped
 
 # Propose a transition out of the joint config. We'll see this at index 6 below.
 propose-conf-change 1
@@ -129,100 +130,51 @@ stabilize
 > 1 handling Ready
   Ready:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
   OnSync:
   1->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  1->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 2 handling Ready
   Ready:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   OnSync:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
   Ready:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
-  Committed: (4,6]
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  Committed: (4,5]
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   INFO 1 switched to configuration voters=(1 2)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
   Ready:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
-  Committed: (4,6]
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
+  Committed: (4,5]
   OnSync:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   Applying:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   INFO 2 switched to configuration voters=(1 2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
 
 # Check that trying to transition out again won't do anything.
 propose-conf-change 1
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2): not in joint state; refusing empty conf change
+raft proposal dropped
 
-# Finishes work for the empty entry we just proposed.
+# No remaining work to do.
 stabilize
 ----
-> 1 handling Ready
-  Ready:
-  Entries:
-  1/7 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
-  OnSync:
-  1->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
-> 2 handling Ready
-  Ready:
-  Entries:
-  1/7 EntryNormal ""
-  OnSync:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 handling Ready
-  Ready:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (6,7]
-  Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-  Applying:
-  1/7 EntryNormal ""
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-> 2 handling Ready
-  Ready:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
-  Committed: (6,7]
-  OnSync:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  Applying:
-  1/7 EntryNormal ""
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
+ok


### PR DESCRIPTION
This PR documents and enforces the existing invariant when proposing config changes: the `MsgProp` with a config change must contain exactly one entry.

This allows changing the behaviour for rejected config changes: instead of emptying the entry and appending it to the log, return `ErrProposalDropped`. This avoids wasting space in the raft log and replicating the no-op entry, and gives the `Step` caller a clear immediate signal that the proposal has been voided.

In some cases like one described in #166424, this avoids self-reproducing reproposal loops with many empty entries.

The change is also a step in the right direction of clearer separation between regular proposals and config changes. A forward-looking aspiration is to have a separate message type like in #141936. The present PR, however, does a backwards-compatible change for now.

Fixes #166424