### PR TITLE
opt: allow `ST_AsMVT` to be used as a window function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -6440,6 +6440,22 @@ false
 statement ok
 DROP TABLE mvt_test
 
+# Regression test: st_asmvt with NULL args alongside an ordered aggregate
+# should not cause an internal error. When a non-commutative aggregate (like
+# array_agg with ORDER BY) is present, all aggregates are built as window
+# functions. st_asmvt's optional args must be properly projected into columns
+# rather than remaining as raw NullExprs.
+statement ok
+CREATE TABLE mvt_null_test (a INT)
+
+query TI
+SELECT st_asmvt(NULL, NULL), array_agg(a ORDER BY a) FROM mvt_null_test
+----
+NULL  NULL
+
+statement ok
+DROP TABLE mvt_null_test
+
 # Test ST_AsMVT with empty geometries and edge cases
 subtest st_asmvt_edge_cases
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -7612,3 +7612,76 @@ FI9.2  Gi8KBHRlc3QSDhIEAAABARgBIgQJMt4/GgJjMhoCYzEiBgoEYWJjZCICKBQogCB4Ag==
 
 
 subtest end
+
+subtest st_asmvt_window
+
+statement ok
+CREATE TABLE mvt_win_test (
+  id INT PRIMARY KEY,
+  geom GEOMETRY,
+  name STRING
+)
+
+statement ok
+INSERT INTO mvt_win_test VALUES
+  (1, 'POINT(100 200)', 'a'),
+  (2, 'POINT(300 400)', 'b'),
+  (3, 'POINT(500 600)', 'c')
+
+# st_asmvt can be used as a window function.
+query IB rowsort
+SELECT id, st_asmvt(mvt_win_test.*) OVER () IS NOT NULL FROM mvt_win_test
+----
+1  true
+2  true
+3  true
+
+# st_asmvt as a window function with a custom layer name.
+query IB rowsort
+SELECT id, st_asmvt(mvt_win_test.*, 'layer1') OVER () IS NOT NULL FROM mvt_win_test
+----
+1  true
+2  true
+3  true
+
+# st_asmvt as a window function with custom layer name and extent.
+query IB rowsort
+SELECT id, st_asmvt(mvt_win_test.*, 'layer1', 2048) OVER () IS NOT NULL FROM mvt_win_test
+----
+1  true
+2  true
+3  true
+
+# st_asmvt as a window function with PARTITION BY.
+query IB rowsort
+SELECT id, st_asmvt(mvt_win_test.*) OVER (PARTITION BY id) IS NOT NULL FROM mvt_win_test
+----
+1  true
+2  true
+3  true
+
+# st_asmvt as a window function with ORDER BY.
+query IB rowsort
+SELECT id, st_asmvt(mvt_win_test.*) OVER (ORDER BY id) IS NOT NULL FROM mvt_win_test
+----
+1  true
+2  true
+3  true
+
+# Regression test for #165687: st_asmvt with NULL arguments alongside an
+# ordered aggregate should not panic.
+statement ok
+SET testing_optimizer_disable_rule_probability = 0.5
+
+query TT
+SELECT array_agg(id ORDER BY id)::STRING, st_asmvt(NULL, NULL)::STRING FROM mvt_win_test
+----
+{1,2,3}  \x
+
+statement ok
+RESET testing_optimizer_disable_rule_probability
+
+statement ok
+DROP TABLE mvt_win_test
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4397,11 +4397,3 @@ NULL  4  4
 
 statement ok
 RESET null_ordered_last
-
-# Regression test for #165754 - st_asmvt cannot be used as a window function
-# (which matches postgres).
-statement ok
-CREATE TABLE t165754 (geom GEOMETRY)
-
-query error pgcode 0A000 aggregate function st_asmvt does not support use as a window function
-SELECT st_asmvt(t165754) OVER () FROM t165754

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -711,6 +711,17 @@ func (b *Builder) buildAggregateFunction(
 		info.args[i] = b.buildAggArg(pexpr.(tree.TypedExpr), &info, tempScope, fromScope)
 	}
 
+	// Pad st_asmvt optional args with typed NULLs so that columns for the
+	// default values are added to the scope before the projection is built.
+	if def.Name == "st_asmvt" {
+		padded := padSTAsMVTArgs(getTypedExprs(f.Exprs))
+		for j := len(f.Exprs); j < len(padded); j++ {
+			info.args = append(
+				info.args, b.buildAggArg(padded[j], &info, tempScope, fromScope),
+			)
+		}
+	}
+
 	// If we have a filter, add it to tempScope after all the arguments. We'll
 	// later extract the column that gets added here in buildAggregation.
 	if f.Filter != nil {
@@ -873,23 +884,7 @@ func (b *Builder) constructAggregate(name string, args []opt.ScalarExpr) opt.Sca
 	case "st_union", "st_memunion":
 		return b.factory.ConstructSTUnion(args[0])
 	case "st_asmvt":
-		layerName := b.factory.ConstructNull(types.String)
-		if len(args) >= 2 {
-			layerName = args[1]
-		}
-		extent := b.factory.ConstructNull(types.Int)
-		if len(args) >= 3 {
-			extent = args[2]
-		}
-		geomColumn := b.factory.ConstructNull(types.String)
-		if len(args) >= 4 {
-			geomColumn = args[3]
-		}
-		featureIDColumn := b.factory.ConstructNull(types.String)
-		if len(args) >= 5 {
-			featureIDColumn = args[4]
-		}
-		return b.factory.ConstructSTAsMVT(args[0], layerName, extent, geomColumn, featureIDColumn)
+		return b.factory.ConstructSTAsMVT(args[0], args[1], args[2], args[3], args[4])
 	case "xor_agg":
 		return b.factory.ConstructXorAgg(args[0])
 	case "json_agg":
@@ -921,6 +916,24 @@ func (b *Builder) constructAggregate(name string, args []opt.ScalarExpr) opt.Sca
 
 func isAggregate(def *tree.ResolvedFunctionDefinition) bool {
 	return isClass(def, tree.AggregateClass)
+}
+
+// padSTAsMVTArgs pads the argument list for st_asmvt with typed NULL defaults
+// for any missing optional arguments, ensuring all 5 arguments are present.
+func padSTAsMVTArgs(argExprs []tree.TypedExpr) []tree.TypedExpr {
+	if len(argExprs) < 2 {
+		argExprs = append(argExprs, reType(tree.DNull, types.String)) // layerName
+	}
+	if len(argExprs) < 3 {
+		argExprs = append(argExprs, reType(tree.DNull, types.Int)) // extent
+	}
+	if len(argExprs) < 4 {
+		argExprs = append(argExprs, reType(tree.DNull, types.String)) // geomColumn
+	}
+	if len(argExprs) < 5 {
+		argExprs = append(argExprs, reType(tree.DNull, types.String)) // featureIDColumn
+	}
+	return argExprs
 }
 
 func isGenerator(def *tree.ResolvedFunctionDefinition) bool {

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -771,10 +771,6 @@ func (b *Builder) buildAggregateFunction(
 	return &info
 }
 
-var stAsMVTWindowFunctionErr = pgerror.New(
-	pgcode.FeatureNotSupported, "aggregate function st_asmvt does not support use as a window function",
-)
-
 func (b *Builder) constructWindowFn(name string, args []opt.ScalarExpr) opt.ScalarExpr {
 	switch name {
 	case "rank":
@@ -799,8 +795,6 @@ func (b *Builder) constructWindowFn(name string, args []opt.ScalarExpr) opt.Scal
 		return b.factory.ConstructLastValue(args[0])
 	case "nth_value":
 		return b.factory.ConstructNthValue(args[0], args[1])
-	case "st_asmvt":
-		panic(stAsMVTWindowFunctionErr)
 	default:
 		return b.constructAggregate(name, args)
 	}

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -258,6 +258,15 @@ func (b *Builder) buildAggregationAsWindow(
 	for i, agg := range g.aggs {
 		argExprs := getTypedExprs(agg.Exprs)
 
+		// st_asmvt has optional arguments that must be padded with defaults
+		// before buildWindowArgs, so they get projected into columns
+		// (VariableExprs) rather than remaining as NullExprs. This is necessary
+		// because buildWindow in the execbuilder requires all window function
+		// children to be VariableExprs.
+		if agg.def.Name == "st_asmvt" {
+			argExprs = padSTAsMVTArgs(argExprs)
+		}
+
 		// Build the appropriate arguments.
 		argLists[i] = b.buildWindowArgs(argExprs, i, agg.def.Name, fromScope, g.aggInScope)
 
@@ -345,6 +354,8 @@ func (b *Builder) getTypedWindowArgs(w *windowInfo) []tree.TypedExpr {
 			null := reType(tree.DNull, argExprs[0].ResolvedType())
 			argExprs = append(argExprs, null)
 		}
+	case "st_asmvt":
+		argExprs = padSTAsMVTArgs(argExprs)
 	}
 
 	return argExprs


### PR DESCRIPTION
### Revert "optbuilder: prohibit usage of st_asmvt as a window function"

This reverts #165757. The next commit in this branch fixes the
underlying panic that motivated PR #165757, so the prohibition is no
longer needed.

Regarding PG compatibility, It's true that in PostGIS / PostgreSQL,
`ST_AsMVT` cannot be used as a window function. But this restriction is
due to the implementation of `ST_AsMVT` in PostGIS, not some fundamental
logical problem with using it as a window function. PostGIS has other
aggregation functions that cannot be used as window functions in
PostgreSQL which can be used as window functions in CockroachDB
(e.g. `ST_Union`, `ST_Collect`, `ST_MakeLine`) so I don't think we need
to match this limitation of PostGIS for `ST_AsMVT`.

Furthermore, the Cockroach optimizer assumes that all aggregation
functions can work as window functions, and occasionally transforms them
into window functions, so I don't think we should introduce a
prohibition on this usage if we can help it.

Informs: #165687
Informs: #166382

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### opt: allow `ST_AsMVT` to be used as a window function

The only reason we couldn't use `ST_AsMVT` as a window function was
because the NULL-padding in `constructAggregate` was breaking
`buildWindow`, which expected VariableExpr for all columns.

Fix this by padding `ST_AsMVT`'s optional arguments with typed NULL
defaults in `buildAggregateFunction`, so the default value columns are
added to the scope before the projection is built. In the
`buildAggregationAsWindow` path, the arguments are also padded before
`buildWindowArgs` so they get projected into columns and become
VariableExpr nodes in the memo.

Informs: #57829
Informs: #165687
Fixes: #166382

Release note (sql change): Aggregation function `ST_AsMVT` can now also
be used as a window function.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql: add logic tests for `ST_AsMVT` as a window function

Add tests for using `ST_AsMVT` as a window function with various
configurations (OVER (), PARTITION BY, ORDER BY, custom layer/extent).
Also add a regression test for the panic that occurred when `ST_AsMVT`
with NULL arguments was combined with ordered aggregates.

Informs: #57829
Informs: #166382

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>