### PR TITLE
log,cli,roachtest: add fatal exit hook for cluster preservation

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -456,22 +456,28 @@ func runStartInternal(
 	// making progress.
 	log.SetMakeProcessUnavailableFunc(closeAllSockets)
 
-	// Write a fatal exit marker file so that external tooling (e.g. roachtest)
-	// can detect exactly why the process exited without grepping logs.
-	log.SetFatalHook(func(format string, args ...interface{}) {
-		msg := fmt.Sprintf(format, args...)
-		for _, ss := range serverCfg.Stores.Specs {
-			if ss.InMemory {
-				continue
+	// When running under roachtest, write a fatal exit marker file so that
+	// roachtest can detect exactly why the process exited without grepping
+	// logs. This allows roachtest to preserve clusters that hit hard-to-
+	// reproduce failures (e.g. storage corruption, replica inconsistency)
+	// for further investigation. Gated on an env var set by roachtest to
+	// avoid writing unredacted fatal messages to disk on production clusters.
+	if envutil.EnvOrDefaultBool("COCKROACH_INTERNAL_WRITE_FATAL_EXIT_MARKER", false) {
+		log.SetFatalHook(func(format string, args ...interface{}) {
+			msg := fmt.Sprintf(format, args...)
+			for _, ss := range serverCfg.Stores.Specs {
+				if ss.InMemory {
+					continue
+				}
+				auxDir := filepath.Join(ss.Path, base.AuxiliaryDir)
+				_ = os.MkdirAll(auxDir, 0755)
+				_ = os.WriteFile(
+					filepath.Join(auxDir, "_FATAL_EXIT.txt"),
+					[]byte(msg), 0644,
+				)
 			}
-			auxDir := filepath.Join(ss.Path, base.AuxiliaryDir)
-			_ = os.MkdirAll(auxDir, 0755)
-			_ = os.WriteFile(
-				filepath.Join(auxDir, "_FATAL_EXIT.txt"),
-				[]byte(msg), 0644,
-			)
-		}
-	})
+		})
+	}
 
 	// The context annotation ensures that server identifiers show up
 	// in the logging metadata as soon as they are known.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -456,6 +456,23 @@ func runStartInternal(
 	// making progress.
 	log.SetMakeProcessUnavailableFunc(closeAllSockets)
 
+	// Write a fatal exit marker file so that external tooling (e.g. roachtest)
+	// can detect exactly why the process exited without grepping logs.
+	log.SetFatalHook(func(format string, args ...interface{}) {
+		msg := fmt.Sprintf(format, args...)
+		for _, ss := range serverCfg.Stores.Specs {
+			if ss.InMemory {
+				continue
+			}
+			auxDir := filepath.Join(ss.Path, base.AuxiliaryDir)
+			_ = os.MkdirAll(auxDir, 0755)
+			_ = os.WriteFile(
+				filepath.Join(auxDir, "_FATAL_EXIT.txt"),
+				[]byte(msg), 0644,
+			)
+		}
+	})
+
 	// The context annotation ensures that server identifiers show up
 	// in the logging metadata as soon as they are known.
 	ambientCtx := serverCfg.AmbientCtx

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2181,6 +2181,11 @@ func (c *clusterImpl) StartE(
 	if !envExists(settings.Env, "COCKROACH_INTERNAL_CHECK_CONSISTENCY_FATAL") {
 		settings.Env = append(settings.Env, "COCKROACH_INTERNAL_CHECK_CONSISTENCY_FATAL=true")
 	}
+	// Enable fatal exit marker files so maybeSaveClusterDueToInvariantProblems
+	// can detect why a node exited without grepping logs.
+	if !envExists(settings.Env, "COCKROACH_INTERNAL_WRITE_FATAL_EXIT_MARKER") {
+		settings.Env = append(settings.Env, "COCKROACH_INTERNAL_WRITE_FATAL_EXIT_MARKER=true")
+	}
 
 	if roachtestflags.ForceCpuProfile {
 		settings.ClusterSettings["server.cpu_profile.duration"] = "20s"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2006,18 +2006,79 @@ func gatherFatalNodeLogs(t *testImpl, testLogger *logger.Logger) (string, error)
 	return strings.Join(lines, "\n"), err
 }
 
-// maybeSaveClusterDueToInvariantProblems detects rare conditions (such as
-// storage durability crashes) on the cluster and if one is detected,
-// unconditionally preserves the cluster for future debugging. It also creates
-// volume snapshots so that the durable state close to the incident is
-// preserved.
+// fatalExitSkipPatterns lists fatal messages where cluster preservation
+// is not useful (e.g. disk stalls where the on-disk state is not
+// informative). Everything not in this list triggers preservation.
+var fatalExitSkipPatterns = []string{
+	"disk stall detected",
+}
+
+// maybeSaveClusterDueToInvariantProblems checks for fatal exit marker
+// files written by CockroachDB's fatal hook (see
+// log.SetFatalHook in pkg/cli/start.go). If a marker file is found
+// and its message is not in the skip list, the cluster is preserved
+// with volume snapshots for future debugging.
+//
+// It also checks the legacy log-grep detection for raft log corruption
+// to maintain backward compatibility with older binaries that do not
+// write marker files.
 func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 	ctx context.Context, t *testImpl, c *clusterImpl,
 ) {
 	if len(c.All()) == 0 {
 		return // test only
 	}
+
+	// Check for fatal exit marker files on all nodes.
 	dets, err := c.RunWithDetails(ctx, t.L(), option.WithNodes(c.All()),
+		"cat /mnt/data*/cockroach/auxiliary/_FATAL_EXIT.txt 2>/dev/null || true",
+	)
+	for _, det := range dets {
+		err = errors.CombineErrors(err, det.Err)
+	}
+	if err != nil {
+		t.L().Printf(
+			"failed to check for fatal exit markers: %s", err,
+		)
+		// Fall through to legacy detection below.
+	} else {
+		for _, det := range dets {
+			if det.Stdout == "" {
+				continue
+			}
+			msg := strings.TrimSpace(det.Stdout)
+
+			// Check if this fatal is in the skip list.
+			skip := false
+			for _, pattern := range fatalExitSkipPatterns {
+				if strings.Contains(msg, pattern) {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				t.L().Printf(
+					"fatal exit detected but skipping preservation: %s", msg,
+				)
+				continue
+			}
+
+			_ = c.Extend(ctx, 7*24*time.Hour, t.L())
+			timestamp := timeutil.Now().UnixMilli()
+			snapName := fmt.Sprintf("fatal-exit-%d", timestamp)
+			if _, err := c.CreateSnapshot(ctx, snapName); err != nil {
+				t.L().Printf("failed to create snapshot %q: %s", snapName, err)
+				snapName = "<failed>"
+			}
+			c.Save(ctx, "fatal exit - snap name "+snapName, t.L())
+			t.Error("fatal exit detected - snap name " + snapName + ":\n" + msg)
+			return
+		}
+	}
+
+	// Legacy detection: grep logs for raft log corruption. This covers
+	// older binaries that do not write _FATAL_EXIT.txt marker files.
+	dets, err = c.RunWithDetails(ctx, t.L(), option.WithNodes(c.All()),
 		"([ -d logs ] && grep -RE '^F.*Was the raft log corrupted' logs) || true",
 	)
 	for _, det := range dets {
@@ -2025,19 +2086,14 @@ func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 	}
 	if err != nil {
 		t.L().Printf(
-			"failed to check whether to save cluster due to invariant problems: %s",
-			err,
+			"failed to check logs for invariant problems: %s", err,
 		)
 		return
 	}
-
 	for _, det := range dets {
 		if det.Stdout != "" {
 			_ = c.Extend(ctx, 7*24*time.Hour, t.L())
 			timestamp := timeutil.Now().UnixMilli()
-			// We take the risk that two tests could attempt to create a snapshot
-			// at the same exact millisecond, as we have a 63 character limit on
-			// the name and the cluster name usually exceeds this by itself.
 			snapName := fmt.Sprintf("invariant-problem-%d", timestamp)
 			if _, err := c.CreateSnapshot(ctx, snapName); err != nil {
 				t.L().Printf("failed to create snapshot %q: %s", snapName, err)

--- a/pkg/cmd/roachtest/tests/invariant_check_detection.go
+++ b/pkg/cmd/roachtest/tests/invariant_check_detection.go
@@ -36,6 +36,50 @@ func registerInvariantCheckDetection(r registry.Registry) {
 			},
 		})
 	}
+
+	// End-to-end test: triggers a real log.Fatal and verifies the marker
+	// file is written.
+	r.Add(registry.TestSpec{
+		CompatibleClouds: registry.AllClouds,
+		Name:             "invariant-check-detection/fatal-exit/e2e",
+		Owner:            registry.OwnerTestEng,
+		Suites:           registry.ManualOnly,
+		Cluster:          r.MakeClusterSpec(1, spec.CPU(4), spec.ReuseNone(), spec.VolumeSize(100), spec.VolumeType("pd-ssd")),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runFatalExitE2E(ctx, t, c)
+		},
+	})
+
+	// Tests for fatal exit marker file detection.
+	for _, tc := range []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "local-corruption",
+			msg:  "local corruption detected: pebble: file 008647: block 35700474/12980: crc32c checksum mismatch 0 != f99fc415",
+		},
+		{
+			name: "replica-corruption",
+			msg:  "replica is corrupted: replica corruption (processed=true): unexpected inconsistency",
+		},
+		{
+			name: "disk-stall-skipped",
+			msg:  "disk stall detected: pebble: sync /mnt/data1/cockroach/000042.log: duration 25s",
+		},
+	} {
+		tc := tc
+		r.Add(registry.TestSpec{
+			CompatibleClouds: registry.AllClouds,
+			Name:             fmt.Sprintf("invariant-check-detection/fatal-exit/%s", tc.name),
+			Owner:            registry.OwnerTestEng,
+			Suites:           registry.ManualOnly,
+			Cluster:          r.MakeClusterSpec(1, spec.CPU(4), spec.ReuseNone(), spec.VolumeSize(100), spec.VolumeType("pd-ssd")),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runFatalExitMarkerDetection(ctx, t, c, tc.msg)
+			},
+		})
+	}
 }
 
 func runInvariantCheckDetection(ctx context.Context, t test.Test, c cluster.Cluster, failed bool) {
@@ -48,4 +92,36 @@ asdasds
 	if failed {
 		t.Error("boom")
 	}
+}
+
+// runFatalExitMarkerDetection plants a _FATAL_EXIT.txt marker file
+// and lets teardownTest -> maybeSaveClusterDueToInvariantProblems
+// detect it.
+func runFatalExitMarkerDetection(ctx context.Context, t test.Test, c cluster.Cluster, msg string) {
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
+	require.NoError(t, c.RunE(ctx, option.WithNodes(c.Node(1)),
+		"mkdir -p /mnt/data1/cockroach/auxiliary"))
+	require.NoError(t, c.PutString(ctx, msg,
+		"/mnt/data1/cockroach/auxiliary/_FATAL_EXIT.txt", 0644, c.Node(1)))
+}
+
+// runFatalExitE2E triggers a real log.Fatal via SQL and verifies that
+// the _FATAL_EXIT.txt marker file was written with the expected
+// message.
+func runFatalExitE2E(ctx context.Context, t test.Test, c cluster.Cluster) {
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
+
+	// Trigger a real log.Fatal via SQL. This will kill the node.
+	conn := c.Conn(ctx, t.L(), 1)
+	defer conn.Close()
+	_, _ = conn.ExecContext(ctx,
+		"SELECT crdb_internal.force_log_fatal('fatal-exit-e2e-test: simulated corruption')")
+
+	// The node should be dead now. Verify the marker file was written.
+	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)),
+		"cat /mnt/data1/cockroach/auxiliary/_FATAL_EXIT.txt 2>/dev/null")
+	require.NoError(t, err)
+	require.Contains(t, result.Stdout, "fatal-exit-e2e-test: simulated corruption",
+		"marker file should contain the fatal message")
+	t.L().Printf("marker file content: %s", result.Stdout)
 }

--- a/pkg/util/log/channels.go
+++ b/pkg/util/log/channels.go
@@ -75,6 +75,7 @@ func logfDepthInternal(
 			err := errors.NewWithDepthf(depth+1, "log.Dev.Fatal: "+format, args...)
 			MaybeSendCrashReport(ctx, err)
 		}
+		invokeFatalHook(format, args...)
 		if ch != channel.OPS {
 			// Tell the OPS channel about this termination.
 			logfDepth(ctx, depth+1, severity.INFO, channel.OPS,

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -700,6 +700,31 @@ func TestExitOnFullDisk(t *testing.T) {
 	exited.Wait()
 }
 
+func TestFatalHook(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer ScopeWithoutShowLogs(t).Close(t)
+
+	// Prevent actual process exit.
+	SetExitFunc(true /* hideStack */, func(exit.Code) {})
+	defer ResetExitFunc()
+
+	var hookCalled sync.WaitGroup
+	hookCalled.Add(1)
+	var capturedMsg string
+	SetFatalHook(func(format string, args ...interface{}) {
+		capturedMsg = fmt.Sprintf(format, args...)
+		hookCalled.Done()
+	})
+	defer SetFatalHook(nil)
+
+	Dev.Fatalf(context.Background(),
+		"local corruption detected: %s", "pebble: checksum mismatch")
+
+	hookCalled.Wait()
+	require.Contains(t, capturedMsg, "local corruption detected")
+	require.Contains(t, capturedMsg, "pebble: checksum mismatch")
+}
+
 func BenchmarkHeader(b *testing.B) {
 	entry := logpb.Entry{
 		Severity:  severity.INFO,

--- a/pkg/util/log/exit_override.go
+++ b/pkg/util/log/exit_override.go
@@ -41,6 +41,34 @@ func SetMakeProcessUnavailableFunc(fn func()) {
 	makeProcessUnavailableFunc.Unlock()
 }
 
+var fatalHook struct {
+	syncutil.Mutex
+	fn func(format string, args ...interface{})
+}
+
+// SetFatalHook registers a function that is called with the fatal log
+// message before the process exits. The hook receives the raw format
+// string and args (same as passed to Fatalf). The hook must return
+// quickly — it runs in a dying process with an exit timeout.
+//
+// This is used by the server to write a marker file capturing the
+// fatal message for post-mortem analysis (e.g. by roachtest).
+func SetFatalHook(fn func(format string, args ...interface{})) {
+	fatalHook.Lock()
+	fatalHook.fn = fn
+	fatalHook.Unlock()
+}
+
+// invokeFatalHook calls the registered fatal hook, if any.
+func invokeFatalHook(format string, args ...interface{}) {
+	fatalHook.Lock()
+	fn := fatalHook.fn
+	fatalHook.Unlock()
+	if fn != nil {
+		fn(format, args...)
+	}
+}
+
 // SetExitFunc allows setting a function that will be called to exit
 // the process when a Fatal message is generated. The supplied bool,
 // if true, suppresses the stack trace, which is useful for test


### PR DESCRIPTION
Add a `SetFatalHook` API to the logging package that allows registering a callback invoked with the fatal message before the process exits. The server startup code uses this hook to write a `_FATAL_EXIT.txt` marker file to each store's auxiliary directory, capturing the exact fatal message.

On the roachtest side, `maybeSaveClusterDueToInvariantProblems` now checks for these marker files instead of grepping logs. This is more reliable (no log truncation/rotation issues) and uses denylist logic (preserve by default, skip known un-actionable patterns like disk stalls) rather than allowlist logic.

The legacy log-grep detection for raft log corruption is preserved for backward compatibility with older binaries.