### PR TITLE
admission: integrate SQL CPU admission with CTT WorkQueue 

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -606,7 +606,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	sqlCPUProvider := admission.NewSQLCPUProvider(
 		&st.SV,
 		func(tenantID roachpb.TenantID) *admission.WorkQueue {
-			return gcoords.RegularCPU.GetKVWorkQueue(tenantID.IsSystem())
+			return gcoords.RegularCPU.GetCTTWorkQueue(tenantID.IsSystem())
 		},
 	)
 	db.SQLCPUProvider = sqlCPUProvider

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -78,6 +78,15 @@ func (coord *CPUGrantCoordinators) GetKVWorkQueue(isSystemTenant bool) *WorkQueu
 	if !cpuTimeTokenACIsEnabled(&coord.st.SV) {
 		return coord.slotsCoord.GetWorkQueue(KVWork)
 	}
+	return coord.GetCTTWorkQueue(isSystemTenant)
+}
+
+// GetCTTWorkQueue returns the CPU time token WorkQueue unconditionally,
+// without checking whether CPU time token AC is enabled. The caller is
+// responsible for gating on the setting. This avoids a race in GetKVWorkQueue
+// where the setting can flip between the caller's check and the internal
+// re-check, returning a slot-based queue to a caller that expects a CTT queue.
+func (coord *CPUGrantCoordinators) GetCTTWorkQueue(isSystemTenant bool) *WorkQueue {
 	if isSystemTenant {
 		return coord.cpuTimeCoord.getWorkQueue(systemTenant)
 	}

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -61,7 +61,35 @@ var goroutineCPUHandlePool = sync.Pool{
 // SQLCPUHandle manages CPU accounting and admission for SQL work across
 // multiple goroutines.
 //
-// TODO(sumeer): fill in more details.
+// SQL CPU admission differs from KV admission in several important ways:
+//
+//   - Admission model: KV uses an estimate-then-correct model. WorkQueue.Admit
+//     is called before execution with an estimated RequestedCount (via
+//     cpuTimeTokenEstimator), and AdmittedWorkDone is called after execution to
+//     correct the estimate using the actual CPU time from grunning. SQL CPU
+//     admission uses a measure-then-admit model: measureAndAdmit is called
+//     periodically during execution (every ~1024 rows or every vectorized batch
+//     via the CancelChecker), and the exact CPU consumed since the last call is
+//     known from grunning. There is no estimation and no correction step.
+//
+//   - Lifetime: A KV request typically consumes microseconds to low
+//     milliseconds of on-CPU time (as measured by grunning), with a
+//     single Admit/AdmittedWorkDone pair. A SQLCPUHandle is created
+//     per-statement (in MakeCPUHandle) and lives until the statement
+//     completes. It spans the entire operator tree: each goroutine
+//     in the DistSQL flow registers via RegisterGoroutine and gets a
+//     GoroutineCPUHandle. For a simple query this may be a single goroutine
+//     lasting milliseconds; for a long-running OLAP query, IMPORT, or BACKUP,
+//     the handle can live for minutes or hours across many goroutines, with
+//     measureAndAdmit called thousands or millions of times.
+//
+//   - Why admit-after-consume is acceptable: The goroutine runs freely between
+//     measureAndAdmit calls — CPU is consumed without permission and then
+//     retroactively deducted from the shared token bucket. If the bucket is
+//     depleted, the goroutine blocks, preventing it from consuming more CPU.
+//     Each uncontrolled burst is bounded by the work between two CancelChecker
+//     calls (~1024 rows), so the amount of unpermitted CPU per check is limited.
+//     The throttling does not prevent past usage but gates future usage.
 type SQLCPUHandle struct {
 	workInfo  WorkInfo
 	atGateway bool
@@ -91,9 +119,12 @@ func newSQLCPUAdmissionHandle(
 	return h
 }
 
-// reportCPU atomically adds the CPU time difference to the appropriate
-// cumulative counter.
-func (h *SQLCPUHandle) reportCPU(ctx context.Context, diff time.Duration, noWait bool) error {
+// reportAndAcquireConsumedCPU updates cumulative CPU counters and, if a CTT
+// WorkQueue is attached, calls Admit to deduct the consumed CPU from the token
+// bucket. This may block until tokens are available unless noWait is true.
+func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
+	ctx context.Context, diff time.Duration, noWait bool,
+) error {
 	if h.atGateway {
 		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
 	} else {
@@ -120,9 +151,6 @@ func (h *SQLCPUHandle) reportCPU(ctx context.Context, diff time.Duration, noWait
 	workInfo := h.workInfo
 	workInfo.RequestedCount = diff.Nanoseconds()
 	workInfo.BypassAdmission = noWait
-	// AdmitResponse is intentionally discarded: its fields (Enabled,
-	// requestedCount) are only needed by AdmittedWorkDone, which is not
-	// called here (see comment above).
 	_, err := h.wq.Admit(ctx, workInfo)
 	return err
 }
@@ -260,39 +288,7 @@ func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
 // only measurement is desired (blocking is no longer productive). When noWait
 // is true, this function never returns an error.
 //
-// SQL CPU admission differs from KV admission in several important ways:
-//
-//   - Admission model: KV uses an estimate-then-correct model. WorkQueue.Admit
-//     is called before execution with an estimated RequestedCount (via
-//     cpuTimeTokenEstimator), and AdmittedWorkDone is called after execution to
-//     correct the estimate using the actual CPU time from grunning. SQL CPU
-//     admission uses a measure-then-admit model: measureAndAdmit is called
-//     periodically during execution (every 1024 rows or every vectorized batch
-//     via the CancelChecker), and the exact CPU consumed since the last call is
-//     known from grunning. There is no estimation and no correction step.
-//
-//   - Lifetime: A KV request is short-lived (microseconds to low milliseconds
-//     of CPU), with a single Admit/AdmittedWorkDone pair. A SQLCPUHandle is
-//     created per-statement (in MakeCPUHandle) and lives until the statement
-//     completes. It spans the entire operator tree: each goroutine in the
-//     DistSQL flow registers via RegisterGoroutine and gets a
-//     GoroutineCPUHandle. For a simple query this may be a single goroutine
-//     lasting milliseconds; for a long-running OLAP query, IMPORT, or BACKUP,
-//     the handle can live for minutes or hours across many goroutines, with
-//     measureAndAdmit called thousands or millions of times. Each invocation
-//     is self-contained: measure the CPU diff, deduct tokens, block if the
-//     budget is exhausted.
-//
-//   - Why admit-after-consume is acceptable: The goroutine runs freely
-//     between measureAndAdmit calls — CPU is consumed without permission and
-//     then retroactively deducted from the shared token bucket. If the bucket
-//     is depleted (because total CPU usage across all work has exhausted the
-//     budget), the goroutine blocks, preventing it from consuming more CPU.
-//     This is acceptable because each uncontrolled burst is small (bounded by
-//     the work between two CancelChecker calls, ~1024 rows), so the amount
-//     of unpermitted CPU per check is limited. The throttling does not prevent
-//     past usage but gates future usage: the goroutine cannot proceed to the
-//     next batch of rows until tokens become available.
+// See SQLCPUHandle for how SQL CPU admission differs from KV admission.
 func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) error {
 	if h.paused > 0 {
 		return nil
@@ -308,7 +304,7 @@ func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) e
 	// we would need an atomic here is that when SQLCPUHandle is closed, it
 	// needs to reach in and grab whatever CPU has not yet been reported.
 	h.cpuAccounted += diff
-	return h.h.reportCPU(ctx, diff, noWait)
+	return h.h.reportAndAcquireConsumedCPU(ctx, diff, noWait)
 }
 
 // PauseMeasuring is used to pause the CPU accounting for this goroutine. It
@@ -334,12 +330,12 @@ type sqlCPUProviderImpl struct {
 	// cumulativeGatewayCPUNanos tracks the cumulative CPU time in nanoseconds
 	// accounted for SQL work executed at gateway nodes. This value is
 	// monotonically increasing and is updated atomically as CPU time is
-	// reported via SQLCPUHandle.reportCPU.
+	// reported via SQLCPUHandle.reportAndAcquireConsumedCPU.
 	cumulativeGatewayCPUNanos atomic.Int64
 	// cumulativeDistSQLCPUNanos tracks the cumulative CPU time in nanoseconds
 	// accounted for distributed SQL work. This value is monotonically
 	// increasing and is updated atomically as CPU time is reported via
-	// SQLCPUHandle.reportCPU.
+	// SQLCPUHandle.reportAndAcquireConsumedCPU.
 	cumulativeDistSQLCPUNanos atomic.Int64
 	// sv is the settings values used to check if CTT AC is enabled.
 	sv *settings.Values

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -93,12 +93,38 @@ func newSQLCPUAdmissionHandle(
 
 // reportCPU atomically adds the CPU time difference to the appropriate
 // cumulative counter.
-func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
+func (h *SQLCPUHandle) reportCPU(ctx context.Context, diff time.Duration, noWait bool) error {
 	if h.atGateway {
 		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
 	} else {
 		h.p.cumulativeDistSQLCPUNanos.Add(diff.Nanoseconds())
 	}
+
+	if h.wq == nil {
+		return nil
+	}
+
+	// RequestedCount is set to the exact CPU consumed (from grunning), so the
+	// WorkQueue's CPU time token estimator is skipped (see Admit). Because the
+	// exact amount is deducted at Admit time, there is no estimate to correct,
+	// so AdmittedWorkDone is not called. This also avoids training the KV
+	// estimator with SQL CPU data, which would corrupt its estimates.
+	//
+	// TODO(wenyi): Currently we call Admit on every measureAndAdmit invocation,
+	// which happens every ~1024 rows. This means each SQL goroutine takes the
+	// WorkQueue mutex on every check. Consider reserving more tokens than the
+	// exact amount consumed (e.g., 2x the last diff, or a smoothed estimate of
+	// upcoming usage) and tracking remaining reservation locally. This would
+	// allow subsequent measureAndAdmit calls to deduct from the local
+	// reservation without calling Admit, reducing contention on the WorkQueue.
+	workInfo := h.workInfo
+	workInfo.RequestedCount = diff.Nanoseconds()
+	workInfo.BypassAdmission = noWait
+	// AdmitResponse is intentionally discarded: its fields (Enabled,
+	// requestedCount) are only needed by AdmittedWorkDone, which is not
+	// called here (see comment above).
+	_, err := h.wq.Admit(ctx, workInfo)
+	return err
 }
 
 // TODO(sumeer): see the comment
@@ -233,6 +259,40 @@ func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
 // noWait parameter should only be set to true when the work is finished, so
 // only measurement is desired (blocking is no longer productive). When noWait
 // is true, this function never returns an error.
+//
+// SQL CPU admission differs from KV admission in several important ways:
+//
+//   - Admission model: KV uses an estimate-then-correct model. WorkQueue.Admit
+//     is called before execution with an estimated RequestedCount (via
+//     cpuTimeTokenEstimator), and AdmittedWorkDone is called after execution to
+//     correct the estimate using the actual CPU time from grunning. SQL CPU
+//     admission uses a measure-then-admit model: measureAndAdmit is called
+//     periodically during execution (every 1024 rows or every vectorized batch
+//     via the CancelChecker), and the exact CPU consumed since the last call is
+//     known from grunning. There is no estimation and no correction step.
+//
+//   - Lifetime: A KV request is short-lived (microseconds to low milliseconds
+//     of CPU), with a single Admit/AdmittedWorkDone pair. A SQLCPUHandle is
+//     created per-statement (in MakeCPUHandle) and lives until the statement
+//     completes. It spans the entire operator tree: each goroutine in the
+//     DistSQL flow registers via RegisterGoroutine and gets a
+//     GoroutineCPUHandle. For a simple query this may be a single goroutine
+//     lasting milliseconds; for a long-running OLAP query, IMPORT, or BACKUP,
+//     the handle can live for minutes or hours across many goroutines, with
+//     measureAndAdmit called thousands or millions of times. Each invocation
+//     is self-contained: measure the CPU diff, deduct tokens, block if the
+//     budget is exhausted.
+//
+//   - Why admit-after-consume is acceptable: The goroutine runs freely
+//     between measureAndAdmit calls — CPU is consumed without permission and
+//     then retroactively deducted from the shared token bucket. If the bucket
+//     is depleted (because total CPU usage across all work has exhausted the
+//     budget), the goroutine blocks, preventing it from consuming more CPU.
+//     This is acceptable because each uncontrolled burst is small (bounded by
+//     the work between two CancelChecker calls, ~1024 rows), so the amount
+//     of unpermitted CPU per check is limited. The throttling does not prevent
+//     past usage but gates future usage: the goroutine cannot proceed to the
+//     next batch of rows until tokens become available.
 func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) error {
 	if h.paused > 0 {
 		return nil
@@ -248,8 +308,7 @@ func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) e
 	// we would need an atomic here is that when SQLCPUHandle is closed, it
 	// needs to reach in and grab whatever CPU has not yet been reported.
 	h.cpuAccounted += diff
-	h.h.reportCPU(diff)
-	return nil
+	return h.h.reportCPU(ctx, diff, noWait)
 }
 
 // PauseMeasuring is used to pause the CPU accounting for this goroutine. It

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -659,7 +659,11 @@ type AdmitResponse struct {
 // relevant when error=nil, and includes info on whether admission control
 // is enabled. AdmittedWorkDone must be called iff
 // AdmitResponse.Enabled=true && error==nil, and the WorkKind for this
-// queue is KVWork.
+// queue is KVWork, UNLESS the caller explicitly set RequestedCount (i.e.,
+// the exact resource usage is already known). In that case, the estimator
+// is skipped at Admit time and there is no estimate to correct, so
+// AdmittedWorkDone should not be called. See the callerSetRequestedCount
+// logic below for details.
 func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error) {
 	if fn := q.knobs.WorkQueueAdmitInterceptor; fn != nil {
 		fn(info)
@@ -677,6 +681,11 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// the memory overhead of enqueueing each raft command to see whether we
 	// need to do some coalescing at this level.
 
+	// Track whether the caller explicitly set RequestedCount. When true, the
+	// caller knows the exact resource usage (e.g., SQL CPU admission uses
+	// grunning to measure actual CPU consumed) and the CPU time token
+	// estimator should not override it.
+	callerSetRequestedCount := info.RequestedCount > 0
 	if info.RequestedCount == 0 {
 		// We treat unset RequestCounts as an implicit request of 1.
 		info.RequestedCount = 1
@@ -711,7 +720,15 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// a measurement of CPU time used servicing the request, courtesy of grunning.
 	// tenant.estimator uses past measurements from grunning to make estimates
 	// in this code path, that is, at admission time.
-	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation {
+	//
+	// The estimator is skipped when the caller explicitly set RequestedCount
+	// (callerSetRequestedCount == true). This is used by SQL CPU admission,
+	// where the exact CPU consumed is already known from grunning at the time
+	// of the call. In that case, AdmittedWorkDone is also not called, since
+	// the exact amount was deducted at Admit time (no estimate to correct)
+	// and training the estimator with SQL CPU data would corrupt KV estimates.
+	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation &&
+		!callerSetRequestedCount {
 		info.RequestedCount = tenant.cpuTimeTokenEstimator.estimateTokensToBeUsed()
 	}
 	admitResponse := AdmitResponse{
@@ -1002,7 +1019,12 @@ func recordAdmissionWorkQueueStats(
 }
 
 // AdmittedWorkDone is used to inform the WorkQueue that some admitted work is
-// finished. It must be called iff the WorkKind of this WorkQueue is for KVWork.
+// finished. It must be called iff the WorkKind of this WorkQueue is for KVWork
+// and the caller did not explicitly set RequestedCount at Admit time. When
+// RequestedCount is explicitly set (e.g., SQL CPU admission using grunning
+// measurements), the exact amount was already deducted at Admit time, so there
+// is no estimate to correct and AdmittedWorkDone should not be called.
+//
 // Note that cpuTime is an argument to AdmittedWorkDone. So, even though
 // WorkQueue supports various resources other than CPU, AdmittedWorkDone is
 // special-cased for CPU time admission control.

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -175,9 +175,30 @@ type WorkInfo struct {
 	// work within a (TenantID, Priority) pair -- earlier CreateTime is given
 	// preference.
 	CreateTime int64
-	// BypassAdmission allows the work to bypass admission control, but allows for
-	// it to be accounted for. It should be used for high-priority intra-KV work,
-	// and when KV work generates other KV work (to avoid deadlock).
+	// BypassAdmission allows the work to bypass admission control (it will
+	// never queue or block) while still being accounted for: the tokens are
+	// deducted via tookWithoutPermission so the token budget reflects the
+	// actual usage. This is used in three situations:
+	//
+	//  - High-priority intra-KV work whose source is OTHER (not FROM_SQL or
+	//    ROOT_KV). Blocking such work could cause deadlocks because it is
+	//    generated in the critical path of serving already-admitted requests
+	//    (e.g., Raft proposals, intent resolution, lease requests).
+	//
+	//  - Normal-and-above priority KV work when
+	//    KVBulkOnlyAdmissionControlEnabled is set. In this mode only bulk
+	//    (low-priority) work is subject to admission control; everything at
+	//    NormalPri or above bypasses.
+	//
+	//  - SQL CPU admission handles closing (noWait=true in reportCPU).
+	//    SQL CPU uses an admit-after-consume model: goroutines run
+	//    freely and retroactively deduct consumed CPU via Admit. During
+	//    execution, an exhausted token bucket blocks the goroutine until
+	//    tokens refill. At handle close (GoroutineCPUHandle.Close), a
+	//    final measureAndAdmit accounts for the last CPU burst, but
+	//    blocking serves no purpose — the work is done and there is
+	//    nothing left to throttle. BypassAdmission deducts the tokens
+	//    without blocking.
 	BypassAdmission bool
 	// RequestedCount is the requested number of tokens or slots. If unset:
 	// - For slot-based queues we treat it as an implicit request of 1;
@@ -684,7 +705,11 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// Track whether the caller explicitly set RequestedCount. When true, the
 	// caller knows the exact resource usage (e.g., SQL CPU admission uses
 	// grunning to measure actual CPU consumed) and the CPU time token
-	// estimator should not override it.
+	// estimator should not override it. Currently, only SQL CPU admission
+	// sets RequestedCount in usesCPUTimeTokens mode; above-raft KV leaves
+	// it at 0 and relies on the estimator. Below-raft KV does set
+	// RequestedCount (to the raft command byte size), but uses usesTokens
+	// mode, so it never reaches the estimator guard.
 	callerSetRequestedCount := info.RequestedCount > 0
 	if info.RequestedCount == 0 {
 		// We treat unset RequestCounts as an implicit request of 1.
@@ -721,12 +746,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// tenant.estimator uses past measurements from grunning to make estimates
 	// in this code path, that is, at admission time.
 	//
-	// The estimator is skipped when the caller explicitly set RequestedCount
-	// (callerSetRequestedCount == true). This is used by SQL CPU admission,
-	// where the exact CPU consumed is already known from grunning at the time
-	// of the call. In that case, AdmittedWorkDone is also not called, since
-	// the exact amount was deducted at Admit time (no estimate to correct)
-	// and training the estimator with SQL CPU data would corrupt KV estimates.
+	// Skip the estimator when callerSetRequestedCount is true (see above).
 	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation &&
 		!callerSetRequestedCount {
 		info.RequestedCount = tenant.cpuTimeTokenEstimator.estimateTokensToBeUsed()
@@ -1023,7 +1043,7 @@ func recordAdmissionWorkQueueStats(
 // and the caller did not explicitly set RequestedCount at Admit time. When
 // RequestedCount is explicitly set (e.g., SQL CPU admission using grunning
 // measurements), the exact amount was already deducted at Admit time, so there
-// is no estimate to correct and AdmittedWorkDone should not be called.
+// is no estimate to correct and AdmittedWorkDone must not be called.
 //
 // Note that cpuTime is an argument to AdmittedWorkDone. So, even though
 // WorkQueue supports various resources other than CPU, AdmittedWorkDone is

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -779,7 +779,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 
 		// Admit with an explicit RequestedCount — the estimator should be
 		// skipped and the exact value preserved. This is the path taken by
-		// SQL CPU admission via reportCPU.
+		// SQL CPU admission via reportAndAcquireConsumedCPU.
 		explicitCount := int64(12345)
 		resp, err = q.Admit(ctx, WorkInfo{
 			TenantID:       tenantID,
@@ -806,7 +806,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		// Gateway CPU.
 		h := newSQLCPUAdmissionHandle(
 			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
-		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false /* noWait */))
 		gw, dist := provider.GetCumulativeSQLCPUNanos()
 		require.Equal(t, int64(5*time.Millisecond), gw)
 		require.Equal(t, int64(0), dist)
@@ -814,7 +814,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		// DistSQL CPU.
 		h2 := newSQLCPUAdmissionHandle(
 			WorkInfo{TenantID: tenantID}, false /* atGateway */, provider, q)
-		require.NoError(t, h2.reportCPU(ctx, 10*time.Millisecond, false /* noWait */))
+		require.NoError(t, h2.reportAndAcquireConsumedCPU(ctx, 10*time.Millisecond, false /* noWait */))
 		gw, dist = provider.GetCumulativeSQLCPUNanos()
 		require.Equal(t, int64(5*time.Millisecond), gw)
 		require.Equal(t, int64(10*time.Millisecond), dist)
@@ -824,7 +824,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		provider := &sqlCPUProviderImpl{}
 		h := newSQLCPUAdmissionHandle(
 			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil /* wq */)
-		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false /* noWait */))
 		gw, _ := provider.GetCumulativeSQLCPUNanos()
 		require.Equal(t, int64(5*time.Millisecond), gw)
 	})
@@ -844,7 +844,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		err := h.reportCPU(cancelCtx, 1*time.Millisecond, false /* noWait */)
+		err := h.reportAndAcquireConsumedCPU(cancelCtx, 1*time.Millisecond, false /* noWait */)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -713,6 +713,142 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 	checkEstimation(resp3, 250*time.Millisecond)
 }
 
+// makeCPUTimeTokenWorkQueue creates a WorkQueue in CTT mode for testing. The
+// returned testGranter has tryGet returning true by default (all Admit calls
+// succeed immediately).
+func makeCPUTimeTokenWorkQueue(t *testing.T) (q *WorkQueue, tg *testGranter, cleanup func()) {
+	var buf builderWithMu
+	tg = &testGranter{buf: &buf}
+	tg.mu.returnValueFromTryGet = true
+
+	st := cluster.MakeTestingClusterSettings()
+	metrics := makeWorkQueueMetrics("", metric.NewRegistry())
+
+	initialTime := timeutil.FromUnixMicros(
+		int64(100) * int64(time.Millisecond/time.Microsecond))
+	opts := makeWorkQueueOptions(KVWork)
+	opts.mode = usesCPUTimeTokens
+	cpuMetrics := makeCPUTimeTokenMetrics()
+	opts.perTenantAggMetrics = &tenantAggMetrics{
+		admittedCount:  cpuMetrics.AdmittedCountPerTenant[systemTenant],
+		waitTimeNanos:  cpuMetrics.WaitTimeNanosPerTenant[systemTenant],
+		tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
+		tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
+	}
+	opts.timeSource = timeutil.NewManualTime(initialTime)
+	opts.disableEpochClosingGoroutine = true
+	opts.disableGCTenantsAndResetUsed = true
+
+	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
+		KVWork, tg, st, metrics, opts).(*WorkQueue)
+	tg.r = q
+	return q, tg, q.close
+}
+
+// TestSQLCPUAdmission verifies the SQL CPU admission integration with the CTT
+// WorkQueue. SQL CPU admission differs from KV admission: it sets
+// RequestedCount to the exact CPU consumed (from grunning), bypassing the
+// estimator, and does not call AdmittedWorkDone.
+func TestSQLCPUAdmission(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+
+	t.Run("explicit-requested-count-skips-estimator", func(t *testing.T) {
+		q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+		defer cleanup()
+
+		// Train the estimator so it returns something other than 1ns.
+		info := WorkInfo{TenantID: tenantID}
+		resp, err := q.Admit(ctx, info)
+		require.NoError(t, err)
+		for i := 0; i < 100; i++ {
+			q.AdmittedWorkDone(resp, 50*time.Millisecond)
+			if i%10 == 0 {
+				q.gcTenantsResetUsedAndUpdateEstimators()
+			}
+		}
+
+		// Verify the estimator is trained.
+		resp, err = q.Admit(ctx, info)
+		require.NoError(t, err)
+		require.Greater(t, resp.requestedCount, int64(time.Millisecond),
+			"estimator should return a value >> 1ns after training")
+
+		// Admit with an explicit RequestedCount — the estimator should be
+		// skipped and the exact value preserved. This is the path taken by
+		// SQL CPU admission via reportCPU.
+		explicitCount := int64(12345)
+		resp, err = q.Admit(ctx, WorkInfo{
+			TenantID:       tenantID,
+			RequestedCount: explicitCount,
+		})
+		require.NoError(t, err)
+		require.Equal(t, explicitCount, resp.requestedCount,
+			"explicit RequestedCount should not be overridden by estimator")
+
+		// A subsequent Admit without RequestedCount still uses the
+		// estimator (the explicit call didn't corrupt anything).
+		resp, err = q.Admit(ctx, info)
+		require.NoError(t, err)
+		require.Greater(t, resp.requestedCount, int64(time.Millisecond),
+			"estimator should still work for callers that don't set RequestedCount")
+	})
+
+	t.Run("report-cpu-updates-counters", func(t *testing.T) {
+		q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+		defer cleanup()
+
+		provider := &sqlCPUProviderImpl{}
+
+		// Gateway CPU.
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		gw, dist := provider.GetCumulativeSQLCPUNanos()
+		require.Equal(t, int64(5*time.Millisecond), gw)
+		require.Equal(t, int64(0), dist)
+
+		// DistSQL CPU.
+		h2 := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, false /* atGateway */, provider, q)
+		require.NoError(t, h2.reportCPU(ctx, 10*time.Millisecond, false /* noWait */))
+		gw, dist = provider.GetCumulativeSQLCPUNanos()
+		require.Equal(t, int64(5*time.Millisecond), gw)
+		require.Equal(t, int64(10*time.Millisecond), dist)
+	})
+
+	t.Run("nil-work-queue-skips-admit", func(t *testing.T) {
+		provider := &sqlCPUProviderImpl{}
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil /* wq */)
+		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		gw, _ := provider.GetCumulativeSQLCPUNanos()
+		require.Equal(t, int64(5*time.Millisecond), gw)
+	})
+
+	t.Run("context-canceled-propagates-error", func(t *testing.T) {
+		q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+		defer cleanup()
+
+		// Make tryGet return false so Admit blocks and observes the
+		// canceled context.
+		tg.mu.Lock()
+		tg.mu.returnValueFromTryGet = false
+		tg.mu.Unlock()
+
+		provider := &sqlCPUProviderImpl{}
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := h.reportCPU(cancelCtx, 1*time.Millisecond, false /* noWait */)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
 // TestWorkQueueTokenResetRace induces racing between tenantInfo.used
 // decrements and tenantInfo.used resets that used to fail until we eliminated
 // the code that decrements tenantInfo.used for tokens. It would also trigger


### PR DESCRIPTION
This change completes the SQL CPU admission integration with the CPU
Time Token (CTT) `WorkQueue`. `SQLCPUHandle.reportCPU` now calls
`WorkQueue.Admit` with the exact CPU consumed (measured via grunning),
and `GoroutineCPUHandle.measureAndAdmit` propagates errors from the
admission call back to the caller.

SQL CPU admission uses a measure-then-admit model that differs from KV
admission in three important ways:

1. `RequestedCount` is set to the exact CPU consumed. A new
   `callerSetRequestedCount` flag in `WorkQueue.Admit` detects when the
   caller has explicitly set `RequestedCount` (i.e., it is positive
   before the default-to-1 logic) and skips the `cpuTimeTokenEstimator`.
   This prevents the estimator from overriding the exact measurement.

2. `AdmittedWorkDone` is not called. The `AdmitResponse` is intentionally
   discarded because its fields (`Enabled`, `requestedCount`) exist
   solely to support `AdmittedWorkDone`. Since the exact amount is
   deducted at `Admit` time, there is no estimate to correct. Calling
   `AdmittedWorkDone` would also train the KV estimator with SQL CPU
   data, which would corrupt its estimates.

3. When `noWait` is true (handle closing via `GoroutineCPUHandle.Close`),
   `BypassAdmission` is set on the `WorkInfo` to avoid blocking a
   goroutine that has finished its work.

The admit-after-consume model is acceptable because each uncontrolled
burst is bounded by the work between two `CancelChecker` calls (~1024
rows or one vectorized batch). The throttling gates future usage: if the
shared token bucket is depleted, the goroutine blocks on the next
`measureAndAdmit` call until tokens become available.

Note that `Admit` is currently called on every `measureAndAdmit`
invocation, which means each SQL goroutine acquires the `WorkQueue`
mutex on every check. A future optimization will reserve more tokens
than the exact amount consumed and track the remaining reservation
locally, allowing subsequent calls to deduct from the local
reservation without entering `Admit`.

Part of: https://github.com/cockroachdb/cockroach/issues/166749
Epic: [CRDB-59016](https://cockroachlabs.atlassian.net/browse/CRDB-59016)
Release note: None
