### PR TITLE
roachtest/operations: fix common operation failures

### DIFF
--- a/pkg/cmd/roachtest/operations/add_index.go
+++ b/pkg/cmd/roachtest/operations/add_index.go
@@ -100,8 +100,7 @@ WHERE
 		if typ.Family() == types.ArrayFamily ||
 			typ.Family() == types.JsonFamily ||
 			typ.Family() == types.GeographyFamily ||
-			typ.Family() == types.GeometryFamily ||
-			typ.Family() == types.StringFamily {
+			typ.Family() == types.GeometryFamily {
 			if rng.Intn(2) == 0 {
 				indexUsingClause = "INVERTED"
 			}

--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -98,7 +98,7 @@ func registerClusterSettings(r registry.Registry) {
 		{
 			Name: "storage.wal_failover.unhealthy_op_threshold",
 			Generator: timeBasedRandomValue(timeutil.Now, 20*time.Minute, func(rng *rand.Rand) string {
-				return fmt.Sprintf("%d", rng.Intn(246)+5)
+				return fmt.Sprintf("%dms", rng.Intn(151)+100)
 			}),
 			Owner: registry.OwnerStorage,
 		},

--- a/pkg/cmd/roachtest/operations/debug_zip.go
+++ b/pkg/cmd/roachtest/operations/debug_zip.go
@@ -37,9 +37,12 @@ func runDebugZip(
 
 	// NOTE(seanc@): we don't actually want the payload from the debug zip, we
 	// just want to run the debug zip command to observe its impact. We write to
-	// a temporary file because /dev/null causes a "zip: not a valid zip file"
-	// error when the command validates the output.
-	zipFile := fmt.Sprintf("/tmp/debug-zip-%d.zip", rng.Uint32())
+	// the parent of the store directory because /tmp was running out of disk
+	// space on DRT clusters. We avoid writing directly inside the store
+	// directory to prevent interfering with CockroachDB's data. /dev/null
+	// causes a "zip: not a valid zip file" error when the command validates
+	// the output.
+	zipFile := fmt.Sprintf("$(dirname {store-dir})/debug-zip-%d.zip", rng.Uint32())
 	debugZipCmd := roachtestutil.NewCommand("./%s debug zip %s", o.ClusterCockroach(), zipFile).
 		WithEqualsSyntax().
 		Flag("host", addr[0]).
@@ -49,7 +52,7 @@ func runDebugZip(
 
 	o.Status(fmt.Sprintf("running %q on node %s", debugZipCmd.String(), node.NodeIDsString()))
 	err = c.RunE(ctx, option.WithNodes(node), debugZipCmd.String())
-	// Clean up the temporary zip file regardless of success or failure.
+	// Clean up the zip file regardless of success or failure.
 	_ = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf("rm -f %s", zipFile))
 	if err != nil {
 		o.Fatal(err)


### PR DESCRIPTION
Three fixes for DRT operation failures:

1. add-index: remove StringFamily from inverted index eligibility. Text columns require the gin_trgm_ops operator class for GIN indexes, which the operation doesn't specify, causing: "data type text has no default operator class for access method gin"

2. cluster-settings: fix wal_failover.unhealthy_op_threshold range. The value was generated without a unit suffix, so bare integers were interpreted as nanoseconds instead of milliseconds. Also narrowed the range from 5-250 to 100-250ms.

3. debug-zip: write zip to store directory parent instead of /tmp to avoid running out of disk space on DRT clusters.

Epic: none

Release note: None