### PR TITLE
[release-26.1] build: add Trunk merge queue configuration

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -30,6 +30,7 @@ on:
       - "release-*"
       - "staging-*"
       - "staging"
+      - "trunk-merge/**"
       - "trying"
       - "!release-1.0*"
       - "!release-1.1*"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -19,7 +19,6 @@ merge:
     - "check_generated_code"
     - "docker_image_amd64"
     - "examples_orms"
-    - "label_validation"
     - "lint"
     - "linux_amd64_build"
     - "linux_amd64_fips_build"

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -1,0 +1,49 @@
+# Trunk configuration file
+# This configuration replicates the bors.toml settings for merge queue functionality
+
+version: 0.1
+
+# CLI configuration
+cli:
+  version: 1.22.2
+
+# Merge queue configuration (equivalent to bors.toml)
+merge:
+  # Use Trunk's merge queue service
+  service: queue
+  
+  # Required status checks that must pass before merging
+  # These correspond to the job names in github-actions-essential-ci.yml
+  required_statuses:
+    - "acceptance"
+    - "check_generated_code"
+    - "docker_image_amd64"
+    - "examples_orms"
+    - "label_validation"
+    - "lint"
+    - "linux_amd64_build"
+    - "linux_amd64_fips_build"
+    - "local_roachtest"
+    - "local_roachtest_fips"
+    - "unit_tests"
+  
+# Actions configuration
+actions:
+  enabled:
+    - merge-queue
+
+  # Disable for other branches to avoid conflicts
+  disabled: []
+
+# Plugins configuration (if needed for additional functionality)
+plugins:
+  sources: []
+
+# Lint configuration (keeping minimal for merge queue focus)
+lint:
+  enabled: []
+
+# Runtimes (if needed)
+runtimes:
+  enabled: []
+


### PR DESCRIPTION
Backport 2/2 commits from #161230 and 1/1 commits from #161281.

/cc @cockroachdb/release

---

build: add Trunk merge queue configuration

Add trunk.yaml configuration to enable Trunk's merge queue service
as a replacement for the existing bors.toml workflow. The configuration
includes all essential CI checks required for safe merging and enables
merge queue functionality.

Also includes:
- Add trunk-merge/** CI trigger to github-actions-essential-ci.yml (critical for CI to run on trunk branches)
- Move trunk.yaml to .trunk/ directory

Release note (build change): Replaces bors with Trunk merge queue for better performance and reliability. Configuration-only change with no runtime impact - maintains same safety checks while improving CI workflow.

Release justification: Build and CI configuration only - no functional changes.