### PR TITLE
release-26.1: roachprod: address ibm quota and image deprecation, and optimize clusters list

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1635,15 +1635,44 @@ func (e *ClusterAlreadyExistsError) Error() string {
 	return fmt.Sprintf("cluster %s already exists", e.name)
 }
 
-func cleanupFailedCreate(l *logger.Logger, clusterName string) error {
+func cleanupFailedCreate(l *logger.Logger, clusterName string, providers []string) error {
 	c, err := getClusterFromCloud(l, clusterName)
 	if err != nil {
-		// If the cluster doesn't exist, we didn't manage to create any VMs
-		// before failing. Not an error.
-		//nolint:returnerrcheck
-		return nil
+		// We failed to list the cluster (e.g., due to API rate limiting),
+		// but VMs may still have been created. Fall back to asking the
+		// providers that were involved in creation to delete by name.
+		l.Printf(
+			"failed to list cluster %s for cleanup, trying DeleteCluster: %v",
+			clusterName, err,
+		)
+		return deleteClusterByName(l, clusterName, providers)
 	}
 	return cloud.DestroyCluster(l, c)
+}
+
+// deleteClusterByName asks the specified providers to delete any resources
+// matching the given cluster name. Providers that support DeleteCluster can
+// find instances by name pattern even when tag queries fail.
+func deleteClusterByName(l *logger.Logger, clusterName string, providers []string) error {
+	var errs []error
+	for _, name := range providers {
+		p, ok := vm.Providers[name]
+		if !ok || !p.Active() {
+			continue
+		}
+		dc, ok := p.(vm.DeleteCluster)
+		if !ok {
+			continue
+		}
+		if err := dc.DeleteCluster(l, clusterName); err != nil {
+			l.Printf(
+				"failed to delete cluster %s via provider %s: %v",
+				clusterName, name, err,
+			)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // AddLabels adds (or updates) the given labels to the VMs corresponding to the given cluster.
@@ -1747,7 +1776,7 @@ func Create(
 				return
 			}
 			l.Errorf("Cleaning up partially-created cluster (prev err: %s)", retErr)
-			if err := cleanupFailedCreate(l, clusterName); err != nil {
+			if err := cleanupFailedCreate(l, clusterName, includeProviders); err != nil {
 				l.Errorf("Error while cleaning up partially-created cluster: %s", err)
 			} else {
 				l.Printf("Cleaning up OK")

--- a/pkg/roachprod/vm/ibm/account_config.go
+++ b/pkg/roachprod/vm/ibm/account_config.go
@@ -43,16 +43,26 @@ const (
 
 var (
 	// supportedRegions is the list of regions used by roachprod resources.
-	// These regions have been contractually agreed upon with IBM.
+	// br-sao and ca-tor are historic regions contractually agreed upon with IBM,
+	// while the others have been added after s390x deprecation to load balance
+	// across more regions and mitigate capacity issues.
 	supportedRegions = []string{
 		"br-sao",
 		"ca-tor",
+		"us-east",
+		"us-south",
+		"eu-de",
+		"eu-gb",
 	}
 )
 
 // ibmCloudConfig contains the configuration for the IBM Cloud provider
 // for roachprod including the account ID, resource group ID, and regions info.
 type ibmCloudConfig struct {
+	// mu serializes calls to configureCloudAccountFull so that concurrent
+	// Create calls don't all run the full account setup in parallel.
+	mu syncutil.Mutex
+
 	accountID                string
 	roachprodResourceGroupID string
 	regions                  map[string]regionDetails
@@ -110,12 +120,18 @@ func (p *Provider) configureCloudAccountInitial() (*ibmCloudConfig, error) {
 // within a region.
 func (p *Provider) configureCloudAccountFull(cc *ibmCloudConfig) error {
 
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
 	// Check if the account is already configured.
 	if cc.loaded {
 		return nil
 	}
 
 	var g errgroup.Group
+	// Limit the number of concurrent region configurations to avoid
+	// overwhelming the IBM API with too many parallel requests.
+	g.SetLimit(maxConcurrentRequests)
 	var regionMutex syncutil.Mutex
 
 	// Create a transit gateway for the account in the first region.
@@ -214,6 +230,7 @@ func (p *Provider) configureCloudAccountFull(cc *ibmCloudConfig) error {
 		return errors.Wrap(err, "failed to configure IBM Cloud account")
 	}
 
+	cc.loaded = true
 	return nil
 }
 

--- a/pkg/roachprod/vm/ibm/helpers.go
+++ b/pkg/roachprod/vm/ibm/helpers.go
@@ -6,6 +6,7 @@
 package ibm
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
@@ -26,18 +27,82 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
 	maxFloatingIPAttempts   = 5
 	ErrUnsupportedLocalSSDs = "WARN: local SSDs are not supported by IBM Cloud; using network volumes instead"
 )
+
+// throttledTransport wraps an http.RoundTripper with a semaphore to limit
+// the number of concurrent in-flight HTTP requests. This is used to enforce
+// a global request concurrency limit across all IBM SDK services within a
+// single Provider instance, regardless of how many goroutines are active.
+type throttledTransport struct {
+	sem   chan struct{}
+	inner http.RoundTripper
+}
+
+func (t *throttledTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.sem <- struct{}{}
+	defer func() { <-t.sem }()
+	return t.inner.RoundTrip(req)
+}
+
+// newThrottledHTTPClient returns an http.Client that limits concurrent
+// requests to maxConcurrent using a shared semaphore channel.
+func newThrottledHTTPClient(sem chan struct{}) *http.Client {
+	return &http.Client{
+		Transport: &throttledTransport{
+			sem:   sem,
+			inner: http.DefaultTransport,
+		},
+	}
+}
+
+// isRateLimitError checks if an IBM API error is a rate-limiting response.
+// IBM Cloud APIs return 429 for standard rate limiting, but the Global Tagging
+// service is known to return 403 (Forbidden) when rate-limited.
+func isRateLimitError(resp *core.DetailedResponse) bool {
+	if resp == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusTooManyRequests ||
+		resp.StatusCode == http.StatusForbidden
+}
+
+// retryOnRateLimit retries the given function on rate-limit errors (429 and
+// 403). The function must return a *core.DetailedResponse and an error, which
+// is the standard signature for IBM SDK API calls.
+func retryOnRateLimit[T any](fn func() (T, *core.DetailedResponse, error)) (T, error) {
+	var result T
+	var lastErr error
+	for r := retry.StartWithCtx(
+		context.Background(), retry.Options{
+			InitialBackoff: 2 * time.Second,
+			MaxBackoff:     retryMaxInterval,
+			Multiplier:     2,
+			MaxRetries:     retryMaxAttempts,
+		},
+	); r.Next(); {
+		var resp *core.DetailedResponse
+		result, resp, lastErr = fn()
+		if lastErr == nil {
+			return result, nil
+		}
+		if !isRateLimitError(resp) {
+			return result, lastErr
+		}
+	}
+	return result, lastErr
+}
 
 // getVpcService returns the VPC service for a given region.
 func (p *Provider) getVpcService(region string) (*vpcv1.VpcV1, error) {
@@ -236,7 +301,11 @@ func (p *Provider) createInstance(
 	// Add tags to the instance before doing anything else.
 	// This is to ensure that if the floating IP address creation fails,
 	// the instance is still tagged and we can destroy the cluster during cleanup.
-	_, _, err = p.tagService.AttachTag(opts.tags.toAttachTagOptions(*instanceResp.CRN))
+	_, err = retryOnRateLimit(func() (*globaltaggingv1.TagResults, *core.DetailedResponse, error) {
+		return p.tagService.AttachTag(
+			opts.tags.toAttachTagOptions(*instanceResp.CRN),
+		)
+	})
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
@@ -247,34 +316,33 @@ func (p *Provider) createInstance(
 	}
 
 	// Wait for the instance to be in a valid state to get all the information.
+	// Use exponential backoff to reduce API call frequency during instance startup.
+	// Instances typically take 30-60 seconds to become ready.
 	instanceReady := false
-	stableState := struct {
-		InstanceStatus  string
-		NetworkAttached bool
-	}{}
-	waitForRunningState := retry.Start(retry.Options{
-		InitialBackoff: 1 * time.Second,
-		MaxBackoff:     1 * time.Second,
-		MaxRetries:     int(maxWaitForReadyState.Seconds()),
-	})
-	for waitForRunningState.Next() {
+	lastKnownStatus := ""
+	networkAttached := false
+	for r := retry.Start(retry.Options{
+		InitialBackoff: 2 * time.Second,
+		MaxBackoff:     10 * time.Second,
+		Multiplier:     1.5,
+		MaxDuration:    maxWaitForReadyState,
+	}); r.Next(); {
 		instanceResp, _, err = vpcService.GetInstance(&vpcv1.GetInstanceOptions{
 			ID: instanceResp.ID,
 		})
 		if err != nil {
 			return nil, err
 		}
-		lastKnownStatus := core.StringNilMapper(instanceResp.Status)
+		lastKnownStatus = core.StringNilMapper(instanceResp.Status)
 		if lastKnownStatus == "failed" {
 			return nil, fmt.Errorf(
 				"instance %s in zone %s failed to start; [instance state: %s | network attached: %t]",
 				opts.vmName,
 				opts.zone,
 				lastKnownStatus,
-				stableState.NetworkAttached,
+				networkAttached,
 			)
 		} else if lastKnownStatus != "running" {
-			stableState.InstanceStatus = lastKnownStatus
 			continue
 		}
 
@@ -282,7 +350,7 @@ func (p *Provider) createInstance(
 			instanceResp.PrimaryNetworkAttachment.VirtualNetworkInterface == nil {
 			continue
 		}
-		stableState.NetworkAttached = true
+		networkAttached = true
 
 		// Fill missing boot volume information.
 		if instanceResp.BootVolumeAttachment != nil && instanceResp.BootVolumeAttachment.Volume != nil {
@@ -331,11 +399,11 @@ func (p *Provider) createInstance(
 
 	if !instanceReady {
 		return nil, fmt.Errorf(
-			`instance %s didn't reach stable state in %s; [instance state: %s|network attached: %t]`,
+			"instance %s didn't reach stable state in %s; [instance state: %s|network attached: %t]",
 			opts.vmName,
 			maxWaitForReadyState.String(),
-			stableState.InstanceStatus,
-			stableState.NetworkAttached,
+			lastKnownStatus,
+			networkAttached,
 		)
 	}
 
@@ -753,14 +821,18 @@ func (p *Provider) getSshKeyID(l *logger.Logger, keyName, region string) (string
 	return "", ErrKeyNotFound
 }
 
-// listRegion queries the IBM Cloud API to get all Roachprod VMs in a single region.
-func (p *Provider) listRegion(l *logger.Logger, r string, opts vm.ListOptions) (vm.List, error) {
+// listRegion queries the IBM Cloud API to get all Roachprod VMs in a single
+// region. concurrencyLimit controls how many parallel API calls (e.g. toVM)
+// this region is allowed to make, so that the caller can keep the total
+// across all regions within bounds.
+func (p *Provider) listRegion(
+	ctx context.Context, l *logger.Logger, r string, opts vm.ListOptions, concurrencyLimit int,
+) (vm.List, error) {
 
 	// We have to force the IncludeVolumes flag to get basic volume information
 	// like size and type.
 	opts.IncludeVolumes = true
 
-	var g errgroup.Group
 	var volumes map[string]*vpcV1Volume
 	var instances map[string]*instance
 
@@ -769,8 +841,11 @@ func (p *Provider) listRegion(l *logger.Logger, r string, opts vm.ListOptions) (
 		return nil, err
 	}
 
+	g := ctxgroup.WithContext(ctx)
+	g.SetLimit(concurrencyLimit)
+
 	// Fetch instances
-	g.Go(func() error {
+	g.GoCtx(func(ctx context.Context) error {
 		var err error
 		instances, err = p.listRegionInstances(l, r, vpcService)
 		if err != nil {
@@ -797,6 +872,9 @@ func (p *Provider) listRegion(l *logger.Logger, r string, opts vm.ListOptions) (
 	}
 
 	var vms vm.List
+	var vmListMutex syncutil.Mutex
+	g = ctxgroup.WithContext(ctx)
+	g.SetLimit(concurrencyLimit)
 	for _, i := range instances {
 
 		if opts.IncludeVolumes {
@@ -848,7 +926,24 @@ func (p *Provider) listRegion(l *logger.Logger, r string, opts vm.ListOptions) (
 			continue
 		}
 
-		vms = append(vms, i.toVM())
+		// toVM will query additional information like floating IPs, so we parallelize it.
+		g.GoCtx(func(ctx context.Context) error {
+
+			// Load the instance information and convert it to a VM.
+			vm := i.toVM()
+
+			// Add it to the list of VMs.
+			vmListMutex.Lock()
+			defer vmListMutex.Unlock()
+			vms = append(vms, vm)
+
+			return nil
+		})
+	}
+
+	err = g.Wait()
+	if err != nil {
+		return nil, err
 	}
 
 	return vms, nil

--- a/pkg/roachprod/vm/ibm/ibm_extended_types.go
+++ b/pkg/roachprod/vm/ibm/ibm_extended_types.go
@@ -386,9 +386,13 @@ func (i *instance) getTagsAsMap() (map[string]string, error) {
 		SetOffset(0)
 
 	for {
-		tagResp, _, err := tagService.ListTags(options)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to query instance tags")
+		tagResp, listTagsErr := retryOnRateLimit(
+			func() (*globaltaggingv1.TagList, *core.DetailedResponse, error) {
+				return tagService.ListTags(options)
+			},
+		)
+		if listTagsErr != nil {
+			return nil, errors.Wrap(listTagsErr, "failed to query instance tags")
 		}
 
 		nbItems := int64(len(tagResp.Items))
@@ -522,22 +526,34 @@ func (i *instance) load() error {
 		}
 	}
 
-	vpcService, err := i.provider.getVpcServiceFromZone(*i.instance.Zone.Name)
-	if err != nil {
-		return errors.Wrap(err, "failed to get VPC service from zone")
+	// Only fetch full instance details if we have a partial object (e.g., only CRN was provided).
+	// Check if CreatedAt is present - it's always populated by List/Get/Create APIs but not when
+	// constructing minimal instance objects manually.
+	if i.instance.CreatedAt == nil {
+		vpcService, err := i.provider.getVpcServiceFromZone(*i.instance.Zone.Name)
+		if err != nil {
+			return errors.Wrap(err, "failed to get VPC service from zone")
+		}
+
+		instanceResp, _, err := vpcService.GetInstance(
+			vpcService.NewGetInstanceOptions(*i.instance.ID),
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to query instance")
+		}
+
+		i.instance = instanceResp
 	}
 
-	instanceResp, _, err := vpcService.GetInstance(
-		vpcService.NewGetInstanceOptions(*i.instance.ID),
-	)
-	if err != nil {
-		return errors.Wrap(err, "failed to query instance")
-	}
-
-	i.instance = instanceResp
-	i.networkInterface, err = i.getPrimaryNetworkInterface()
-	if err != nil {
-		return errors.Wrap(err, "failed to get primary network interface")
+	// Only fetch network interface details if not already present.
+	// When instances come from List API, they already have complete instance data,
+	// so we skip the expensive GetInstance call and only fetch network interface if needed.
+	if i.networkInterface == nil {
+		var err error
+		i.networkInterface, err = i.getPrimaryNetworkInterface()
+		if err != nil {
+			return errors.Wrap(err, "failed to get primary network interface")
+		}
 	}
 
 	return nil

--- a/pkg/roachprod/vm/ibm/provider.go
+++ b/pkg/roachprod/vm/ibm/provider.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -42,7 +41,7 @@ const (
 	defaultCPUArch     = vm.ArchS390x
 	defaultCPUFamily   = "IBM zSystem"
 	defaultRemoteUser  = "ubuntu"
-	defaultImageAMI    = "ibm-ubuntu-22-04-5-minimal-s390x-5"
+	defaultImageAMI    = "ibm-ubuntu-22-04-5-minimal-s390x-7"
 	defaultNTPServer   = "time.adn.networklayer.com"
 
 	// Default values for volumes
@@ -57,6 +56,18 @@ const (
 	InstanceNotRochprod    = "not-roachprod"
 
 	expectedEnvVarIBMAPIKey = defaultAPIKeyEnvVarPrefix + "_" + core.PROPNAME_APIKEY
+
+	// This limits the number of concurrent requests made to the IBM API.
+	// This is not an absolute requests limit, but this is used to limit the number
+	// of goroutines making requests to avoid overwhelming the API.
+	maxConcurrentRequests = 30
+
+	// retryMaxAttempts is the maximum number of retries for IBM API calls
+	// when encountering 429 (Too Many Requests) or 503 (Service Unavailable).
+	retryMaxAttempts = 5
+
+	// retryMaxInterval is the maximum interval between retries.
+	retryMaxInterval = 30 * time.Second
 )
 
 var (
@@ -83,15 +94,38 @@ var (
 	// the zones to use for the cluster, as the supported regions are defined in
 	// the each provider's instance.
 	defaultZones = map[string][]string{
+		// South America
+		"br-sao": {
+			"br-sao-1",
+			"br-sao-2",
+			"br-sao-3",
+		},
+		// North America
 		"ca-tor": {
 			"ca-tor-1",
 			"ca-tor-2",
 			"ca-tor-3",
 		},
-		"br-sao": {
-			"br-sao-1",
-			"br-sao-2",
-			"br-sao-3",
+		"us-east": {
+			"us-east-1",
+			"us-east-2",
+			"us-east-3",
+		},
+		"us-south": {
+			"us-south-1",
+			"us-south-2",
+			"us-south-3",
+		},
+		// Europe
+		"eu-de": {
+			"eu-de-1",
+			"eu-de-2",
+			"eu-de-3",
+		},
+		"eu-gb": {
+			"eu-gb-1",
+			"eu-gb-2",
+			"eu-gb-3",
 		},
 	}
 )
@@ -244,6 +278,11 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 		}
 	}
 
+	// Create a shared semaphore and HTTP client to enforce a global limit on
+	// the number of concurrent API requests across all services.
+	apiSem := make(chan struct{}, maxConcurrentRequests)
+	throttledClient := newThrottledHTTPClient(apiSem)
+
 	// Build the list of supported regions if none are provided.
 	if len(p.regions) == 0 {
 		for _, region := range supportedRegions {
@@ -270,6 +309,8 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create VPC service for region %s", region)
 		}
+		p.vpcServices[region].Service.SetHTTPClient(throttledClient)
+		p.vpcServices[region].EnableRetries(retryMaxAttempts, retryMaxInterval)
 	}
 
 	// Create Global Tagging service.
@@ -279,6 +320,8 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Global Tagging service")
 	}
+	p.tagService.Service.SetHTTPClient(throttledClient)
+	p.tagService.EnableRetries(retryMaxAttempts, retryMaxInterval)
 
 	// Resource Controller service is used to get resource details like preemption events.
 	p.resourceControllerService, err = resourcecontrollerv2.NewResourceControllerV2(
@@ -289,6 +332,8 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Resource Controller service")
 	}
+	p.resourceControllerService.Service.SetHTTPClient(throttledClient)
+	p.resourceControllerService.EnableRetries(retryMaxAttempts, retryMaxInterval)
 
 	// Resource Manager service is used to get/create the resource group
 	p.resourceManagerService, err = resourcemanagerv2.NewResourceManagerV2(
@@ -299,6 +344,8 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Resource Manager service")
 	}
+	p.resourceManagerService.Service.SetHTTPClient(throttledClient)
+	p.resourceManagerService.EnableRetries(retryMaxAttempts, retryMaxInterval)
 
 	// Global Search service is used to search for resources across all regions.
 	p.globalSearchService, err = globalsearchv2.NewGlobalSearchV2(&globalsearchv2.GlobalSearchV2Options{
@@ -307,6 +354,8 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Global Search service")
 	}
+	p.globalSearchService.Service.SetHTTPClient(throttledClient)
+	p.globalSearchService.EnableRetries(retryMaxAttempts, retryMaxInterval)
 
 	// Create the Transit Gateway service.
 	p.transitgatewayService, err = transitgatewayapisv1.NewTransitGatewayApisV1(
@@ -318,6 +367,8 @@ func NewProvider(options ...Option) (p *Provider, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create Transit Gateway service")
 	}
+	p.transitgatewayService.Service.SetHTTPClient(throttledClient)
+	p.transitgatewayService.EnableRetries(retryMaxAttempts, retryMaxInterval)
 
 	// Configure the IBM Cloud account and get the required resource IDs.
 	p.config, err = p.configureCloudAccountInitial()
@@ -344,11 +395,20 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 
 	var ret vm.List
 	var mux syncutil.Mutex
-	var g errgroup.Group
+	g := ctxgroup.WithContext(context.Background())
+	numRegions := len(p.vpcServices)
+	g.SetLimit(numRegions)
+
+	// Compute a per-region concurrency limit so that the total number of
+	// concurrent API requests across all regions stays within bounds.
+	perRegionLimit := maxConcurrentRequests / numRegions
+	if perRegionLimit < 1 {
+		perRegionLimit = 1
+	}
 
 	for r := range p.vpcServices {
-		g.Go(func() error {
-			vms, err := p.listRegion(l, r, opts)
+		g.GoCtx(func(ctx context.Context) error {
+			vms, err := p.listRegion(ctx, l, r, opts, perRegionLimit)
 			if err != nil {
 				// Failing to list VMs in a region is not fatal.
 				l.Printf("failed to list IBM VMs in region: %s\n%v\n", r, err)
@@ -426,15 +486,14 @@ func (p *Provider) Create(
 		waitTime = 900
 	}
 
-	// We will create all VMs in parallel. We don't use an errgroup here
-	// because we don't want goroutines to be cancelled if one of them fails.
-	// This is because we create the instance and tag it in two different
-	// API calls, and we want to make sure that all instances are tagged
-	// even if an error occurs during the creation of one instance.
+	// We will create all VMs in parallel with a concurrency limit.
+	// ctxgroup does not cancel sibling goroutines on error, so all
+	// instances will be tagged even if one creation fails.
 	var mutex syncutil.Mutex
-	var g sync.WaitGroup
 	createErrors := make([]error, 0)
 	vms := make(vm.List, len(names))
+	g := ctxgroup.WithContext(context.TODO())
+	g.SetLimit(maxConcurrentRequests)
 
 	for i, vmName := range names {
 
@@ -457,10 +516,7 @@ func (p *Provider) Create(
 			return nil, errors.Wrapf(err, "unable to get SSH key ID for region %s", region)
 		}
 
-		g.Add(1)
-
-		go func() {
-			defer g.Done()
+		g.GoCtx(func(ctx context.Context) error {
 
 			vm, err := p.createInstance(l, instanceOptions{
 				vmName: vmName,
@@ -490,13 +546,14 @@ func (p *Provider) Create(
 			} else {
 				vms[i] = *vm
 			}
-		}()
+
+			return nil
+		})
 	}
 
-	g.Wait()
-
-	if len(createErrors) > 0 {
-		return nil, errors.Join(createErrors...)
+	err = g.Wait()
+	if err != nil || len(createErrors) > 0 {
+		return nil, errors.CombineErrors(err, errors.Join(createErrors...))
 	}
 
 	return vms, nil
@@ -743,10 +800,12 @@ func (p *Provider) AddLabels(l *logger.Logger, vms vm.List, labels map[string]st
 		})
 	}
 
-	_, _, err := p.tagService.AttachTag(&globaltaggingv1.AttachTagOptions{
-		Resources: resources,
-		TagNames:  tags,
-		Update:    core.BoolPtr(true),
+	_, err := retryOnRateLimit(func() (*globaltaggingv1.TagResults, *core.DetailedResponse, error) {
+		return p.tagService.AttachTag(&globaltaggingv1.AttachTagOptions{
+			Resources: resources,
+			TagNames:  tags,
+			Update:    core.BoolPtr(true),
+		})
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to attach tags to resources")
@@ -801,9 +860,11 @@ func (p *Provider) RemoveLabels(l *logger.Logger, vms vm.List, labels []string) 
 			ResourceID: &vm.ProviderID,
 		})
 	}
-	_, _, err = p.tagService.DetachTag(&globaltaggingv1.DetachTagOptions{
-		Resources: resources,
-		TagNames:  labelsToRemove,
+	_, err = retryOnRateLimit(func() (*globaltaggingv1.TagResults, *core.DetailedResponse, error) {
+		return p.tagService.DetachTag(&globaltaggingv1.DetachTagOptions{
+			Resources: resources,
+			TagNames:  labelsToRemove,
+		})
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to detach tags from instances")
@@ -901,6 +962,9 @@ func (p *Provider) GetVMSpecsWithContext(
 	vmSpecs := make(map[string]map[string]interface{})
 	var mu syncutil.Mutex
 	g := ctxgroup.WithContext(ctx)
+	// Not using the maxConcurrentRequests constant as specs fetching can be slower
+	// and we don't want to overload the API with too many requests at once.
+	// 5 seems like a reasonable limit here.
 	g.SetLimit(5)
 
 	for _, vmInstance := range vms {


### PR DESCRIPTION
Backport 1/1 commits from #166415.

/cc @cockroachdb/release

---

This PR contains four changes for IBM cloud in roachprod:

1. roachprod: use more ibm AZs to reduce capa issues
  In order to avoid impacting IBM customers, roachprod was only using two IBM Cloud regions per our agreement with IBM.
  With the deprecation of s390x in IBM Cloud, we can no longer request for quota increases in these two regions, and as the number of customers decrease, we now can scale the number of regions roachprod uses.
  This patch grows from two regions to six in order to load balance the cluster creations during roachtest operations and reduce quota issues.

2. roachprod: use latest ubuntu 22.04 image in ibm
  Previously, roachprod was using the s390x  Ubuntu 22.04 rev. 5 image in IBM Cloud.
  As this image was deprecated a few months ago and replaced by rev. 7, this patch switches to the latest image.

3. roachprod: fix ibm clusters list
  Previously, listing clusters in IBM was creating two many requests in parallel, leading to very long list/create operations and, sometimes, the API returning HTTP error code 429.
  This patch adds a ctxgroup with a limit fixed to 30 concurrent requests to avoid spamming the IBM API when listing clusters.
  Also, some code path were leading to querying each instance details multiple times. This patch fixes this by only loading instance data when the creation date is unknown. This will reduce the total number of queries per instance from two to one.

4. roachprod: improve clusters cleanup for ibm
  Previously, after a failed cluster creation, roachtest was attempting to destroy the partially created cluster. This process relied on listing the cluster and destroy it via `provider.DestroyCluster()`.
  In IBM, this is subject to failures because of implicit rate limitings, so this patch attempts to call `provider.DeleteCluster()` (by name) in case no clusters were returned during listing.
  This should reduce the number of dangling resources cleaned by the garbage collector.


Epic: none
Release note: none

Release justification: Test only change
