### PR TITLE
cli,tsdumpmeta: add node-to-region mapping in tsdump metadata

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1619,7 +1619,6 @@ func init() {
 	f.Var(&debugTimeSeriesDumpOpts.to, "to", "newest timestamp to include (inclusive)")
 	f.StringVar(&debugTimeSeriesDumpOpts.clusterLabel, "cluster-label",
 		"", "prometheus label for cluster name")
-	f.StringVar(&debugTimeSeriesDumpOpts.yaml, "yaml", debugTimeSeriesDumpOpts.yaml, "full path to create the tsdump.yaml with storeID: nodeID mappings (raw format only). This file is required when loading the raw tsdump for troubleshooting.")
 	f.StringVar(&debugTimeSeriesDumpOpts.targetURL, "target-url", "", "target URL to send openmetrics data over HTTP")
 	f.StringVar(&debugTimeSeriesDumpOpts.ddSite, "dd-site", getEnvOrDefault(datadogSiteEnvVar, defaultDDSite),
 		"Datadog site to use to send tsdump artifacts to datadog")

--- a/pkg/cli/testdata/tsdump_upload_embedded_metadata
+++ b/pkg/cli/testdata/tsdump_upload_embedded_metadata
@@ -51,3 +51,44 @@ cr.node.sql.query.count,2021-01-01T00:00:20Z,1,100.5
 [{"ddsource":"tsdump_upload","ddtags":"cluster_type:SELF_HOSTED,cluster_label:\"test-cluster\",cluster_id:test-cluster-id,zendesk_ticket:zd-test,org_name:test-org,user_name:test-user,upload_id:\"test-cluster\"-20241114000000,upload_timestamp:2024-11-14 00:00:00,upload_year:2024,upload_month:11,upload_day:14,series_uploaded:2","dry_run":"false","duration":"0","estimated_cost":"0.00012465753424657533","hostname":"hostname","message":"tsdump upload completed: uploaded 2 series overall","series_uploaded":"2","service":"tsdump_upload","success":"true"}]
 ----
 ----
+
+# Test case 5: both store-to-node and node-to-region mappings
+# Store metrics get node_id and region tags; node metrics get region tags.
+upload-datadog-with-regions
+cr.store.rocksdb.block.cache.usage,2021-01-01T00:00:00Z,1,75.2
+cr.node.sql.query.count,2021-01-01T00:00:20Z,2,100.5
+----
+----
+{"series":[{"interval":10,"metric":"cockroachdb.rocksdb.block.cache.usage","points":[{"timestamp":1609459200,"value":75.2}],"tags":["node_id:1","region:region-1","store:1","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":3},{"interval":10,"metric":"cockroachdb.sql.query.count","points":[{"timestamp":1604275220,"value":100.5}],"tags":["node_id:2","region:region-2","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":1}]}
+
+[{"ddsource":"tsdump_upload","ddtags":"cluster_type:SELF_HOSTED,cluster_label:\"test-cluster\",cluster_id:test-cluster-id,zendesk_ticket:zd-test,org_name:test-org,user_name:test-user,upload_id:\"test-cluster\"-20241114000000,upload_timestamp:2024-11-14 00:00:00,upload_year:2024,upload_month:11,upload_day:14,series_uploaded:2","dry_run":"false","duration":"0","estimated_cost":"0.00012465753424657533","hostname":"hostname","message":"tsdump upload completed: uploaded 2 series overall","series_uploaded":"2","service":"tsdump_upload","success":"true"}]
+----
+----
+
+# Test case 6: node-to-region mapping without store-to-node mapping
+# Node metrics still get region tags; store metrics cannot resolve node_id
+# so they get neither node_id nor region tags.
+upload-datadog-regions-no-store-map
+cr.store.rocksdb.block.cache.usage,2021-01-01T00:00:00Z,1,75.2
+cr.node.sql.query.count,2021-01-01T00:00:20Z,1,100.5
+----
+----
+{"series":[{"interval":10,"metric":"cockroachdb.rocksdb.block.cache.usage","points":[{"timestamp":1609459200,"value":75.2}],"tags":["store:1","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":3},{"interval":10,"metric":"cockroachdb.sql.query.count","points":[{"timestamp":1604275220,"value":100.5}],"tags":["node_id:1","region:region-1","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":1}]}
+
+[{"ddsource":"tsdump_upload","ddtags":"cluster_type:SELF_HOSTED,cluster_label:\"test-cluster\",cluster_id:test-cluster-id,zendesk_ticket:zd-test,org_name:test-org,user_name:test-user,upload_id:\"test-cluster\"-20241114000000,upload_timestamp:2024-11-14 00:00:00,upload_year:2024,upload_month:11,upload_day:14,series_uploaded:2","dry_run":"false","duration":"0","estimated_cost":"0.00012465753424657533","hostname":"hostname","message":"tsdump upload completed: uploaded 2 series overall","series_uploaded":"2","service":"tsdump_upload","success":"true"}]
+----
+----
+
+# Test case 7: partial region coverage
+# Node 1 has a region; node 2 does not. Only node 1 metrics get region tag.
+upload-datadog-partial-region-coverage
+cr.node.sql.query.count,2021-01-01T00:00:00Z,1,100.5
+cr.node.sql.query.count,2021-01-01T00:00:10Z,2,200.5
+cr.store.rocksdb.block.cache.usage,2021-01-01T00:00:20Z,3,42.0
+----
+----
+{"series":[{"interval":10,"metric":"cockroachdb.sql.query.count","points":[{"timestamp":1604275200,"value":100.5}],"tags":["node_id:1","region:region-1","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":1},{"interval":10,"metric":"cockroachdb.sql.query.count","points":[{"timestamp":1604275210,"value":200.5}],"tags":["node_id:2","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":1},{"interval":10,"metric":"cockroachdb.rocksdb.block.cache.usage","points":[{"timestamp":1609459220,"value":42}],"tags":["node_id:2","store:3","cluster_type:SELF_HOSTED","cluster_label:\"test-cluster\"","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:\"test-cluster\"-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":3}]}
+
+[{"ddsource":"tsdump_upload","ddtags":"cluster_type:SELF_HOSTED,cluster_label:\"test-cluster\",cluster_id:test-cluster-id,zendesk_ticket:zd-test,org_name:test-org,user_name:test-user,upload_id:\"test-cluster\"-20241114000000,upload_timestamp:2024-11-14 00:00:00,upload_year:2024,upload_month:11,upload_day:14,series_uploaded:3","dry_run":"false","duration":"0","estimated_cost":"0.000186986301369863","hostname":"hostname","message":"tsdump upload completed: uploaded 3 series overall","series_uploaded":"3","service":"tsdump_upload","success":"true"}]
+----
+----

--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -48,7 +49,6 @@ var debugTimeSeriesDumpOpts = struct {
 	format                 tsDumpFormat
 	from, to               timestampValue
 	clusterLabel           string
-	yaml                   string
 	targetURL              string
 	ddApiKey               string
 	ddSite                 string
@@ -72,7 +72,6 @@ var debugTimeSeriesDumpOpts = struct {
 	from:                   timestampValue{},
 	to:                     timestampValue(timeutil.Now().Add(24 * time.Hour)),
 	clusterLabel:           "",
-	yaml:                   "/tmp/tsdump.yaml",
 	retryFailedRequests:    false,
 	disableDeltaProcessing: false, // delta processing enabled by default
 	nonVerbose:             false, // dump all metrics by default
@@ -289,17 +288,18 @@ will then convert it to the --format requested in the current invocation.
 					return err
 				}
 
-				// Get store-to-node mapping for metadata
-				storeToNodeMap, err := getStoreToNodeMapping(ctx)
+				// Get store-to-node and node-to-region mappings for metadata.
+				storeToNodeMap, nodeToRegionMap, err := getTSDumpMappings(ctx)
 				if err != nil {
 					return err
 				}
 
 				// Create metadata header
 				metadata := tsdumpmeta.Metadata{
-					Version:        build.BinaryVersion(),
-					StoreToNodeMap: storeToNodeMap,
-					CreatedAt:      timeutil.Now(),
+					Version:         build.BinaryVersion(),
+					StoreToNodeMap:  storeToNodeMap,
+					NodeToRegionMap: nodeToRegionMap,
+					CreatedAt:       timeutil.Now(),
 				}
 
 				stream, err := tsClient.DumpRaw(context.Background(), req)
@@ -323,10 +323,6 @@ will then convert it to the --format requested in the current invocation.
 				}
 
 				if err := rawWriter.Close(); err != nil {
-					return err
-				}
-
-				if err = createYAML(ctx); err != nil {
 					return err
 				}
 
@@ -360,6 +356,9 @@ will then convert it to the --format requested in the current invocation.
 				dec = gob.NewDecoder(f) // Reset decoder to read from beginning
 			} else {
 				fmt.Printf("Found embedded store-to-node mapping with %d entries\n", len(embeddedMetadata.StoreToNodeMap))
+				if len(embeddedMetadata.NodeToRegionMap) > 0 {
+					fmt.Printf("Found embedded node-to-region mapping with %d entries\n", len(embeddedMetadata.NodeToRegionMap))
+				}
 			}
 
 			decodeOne := func() (*tspb.TimeSeriesData, error) {
@@ -594,35 +593,29 @@ type openMetricsWriter struct {
 	labels map[string]string
 }
 
-// createYAML generates and writes tsdump.yaml to default /tmp or to a specified path.
-// This file is used for staging the tsdump data into a local database for debugging
-func createYAML(ctx context.Context) (resErr error) {
-	// Write the YAML file for backward compatibility
-	file, err := os.OpenFile(debugTimeSeriesDumpOpts.yaml, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0666)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	mapping, err := getStoreToNodeMapping(ctx)
-	if err != nil {
-		return err
-	}
-
-	for storeID, nodeID := range mapping {
-		_, err := fmt.Fprintf(file, "%s: %s\n", storeID, nodeID)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+// queryRows runs the given query on the provided connection and returns the
+// result rows.
+func queryRows(ctx context.Context, sqlConn clisqlclient.Conn, query string) ([][]string, error) {
+	_, rows, err := sqlExecCtx.RunQuery(
+		ctx, sqlConn, clisqlclient.MakeQuery(query), false)
+	return rows, err
 }
 
-// getStoreToNodeMapping retrieves the store-to-node mapping from the database
-func getStoreToNodeMapping(ctx context.Context) (map[string]string, error) {
-	sqlConn, err := makeSQLClient(ctx, tsDumpAppName, useSystemDb)
+// makeTSDumpSQLConn opens a SQL connection for tsdump operations. The caller
+// is responsible for closing the returned connection.
+func makeTSDumpSQLConn(ctx context.Context) (clisqlclient.Conn, error) {
+	return makeSQLClient(ctx, tsDumpAppName, useSystemDb)
+}
+
+// getTSDumpMappings retrieves the store-to-node and node-to-region mappings
+// using a single SQL connection. Query failures for either mapping are
+// non-fatal; an empty map is returned with a warning so tsdump can proceed.
+func getTSDumpMappings(
+	ctx context.Context,
+) (storeToNode map[string]string, nodeToRegion map[string]string, _ error) {
+	sqlConn, err := makeTSDumpSQLConn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if closeErr := sqlConn.Close(); closeErr != nil {
@@ -630,11 +623,29 @@ func getStoreToNodeMapping(ctx context.Context) (map[string]string, error) {
 		}
 	}()
 
-	_, rows, err := sqlExecCtx.RunQuery(
-		ctx,
-		sqlConn,
-		clisqlclient.MakeQuery(`SELECT store_id, node_id FROM crdb_internal.kv_store_status`), false)
+	// Both mapping queries are non-fatal so tsdump still works when the
+	// underlying virtual tables are inaccessible.
+	storeToNode, err = getStoreToNodeMapping(ctx, sqlConn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to get store-to-node mapping: %v\n", err)
+		storeToNode = make(map[string]string)
+	}
 
+	nodeToRegion, err = getNodeToRegionMapping(ctx, sqlConn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to get node-to-region mapping: %v\n", err)
+		nodeToRegion = make(map[string]string)
+	}
+
+	return storeToNode, nodeToRegion, nil
+}
+
+// getStoreToNodeMapping retrieves the store-to-node mapping from the database.
+func getStoreToNodeMapping(
+	ctx context.Context, sqlConn clisqlclient.Conn,
+) (map[string]string, error) {
+	rows, err := queryRows(ctx, sqlConn,
+		`SELECT store_id, node_id FROM crdb_internal.kv_store_status`)
 	if err != nil {
 		return nil, err
 	}
@@ -648,6 +659,81 @@ func getStoreToNodeMapping(ctx context.Context) (map[string]string, error) {
 		}
 	}
 	return mapping, nil
+}
+
+// getNodeToRegionMapping retrieves the node-to-region mapping from the database
+// by querying gossip_nodes for each node's locality, then anonymizes region
+// names (e.g. "region-1", "region-2") to avoid leaking sensitive locality info.
+func getNodeToRegionMapping(
+	ctx context.Context, sqlConn clisqlclient.Conn,
+) (map[string]string, error) {
+	rows, err := queryRows(ctx, sqlConn,
+		`SELECT node_id, locality FROM crdb_internal.gossip_nodes`)
+	if err != nil {
+		return nil, err
+	}
+
+	return anonymizeNodeRegions(rows), nil
+}
+
+// anonymizeNodeRegions takes rows of [node_id, locality] and produces a mapping
+// from node ID to an anonymized region label. Unique region names are sorted
+// alphabetically and assigned labels "region-1", "region-2", etc. Nodes without
+// a region tier in their locality are omitted from the mapping.
+func anonymizeNodeRegions(rows [][]string) map[string]string {
+	// First pass: collect unique regions.
+	regionSet := make(map[string]struct{})
+	type nodeRegion struct {
+		nodeID string
+		region string
+	}
+	var nodeRegions []nodeRegion
+	for _, row := range rows {
+		if len(row) < 2 {
+			continue
+		}
+		nodeID := strings.TrimSpace(row[0])
+		locality := strings.TrimSpace(row[1])
+		region := extractRegionFromLocality(locality)
+		if region == "" {
+			continue
+		}
+		regionSet[region] = struct{}{}
+		nodeRegions = append(nodeRegions, nodeRegion{nodeID: nodeID, region: region})
+	}
+
+	// Sort unique regions alphabetically for deterministic assignment.
+	uniqueRegions := make([]string, 0, len(regionSet))
+	for r := range regionSet {
+		uniqueRegions = append(uniqueRegions, r)
+	}
+	sort.Strings(uniqueRegions)
+
+	// Build region-name to anonymized-label mapping.
+	regionToAnon := make(map[string]string, len(uniqueRegions))
+	for i, r := range uniqueRegions {
+		regionToAnon[r] = fmt.Sprintf("region-%d", i+1)
+	}
+
+	// Second pass: build node-to-anonymized-region mapping.
+	result := make(map[string]string, len(nodeRegions))
+	for _, nr := range nodeRegions {
+		result[nr.nodeID] = regionToAnon[nr.region]
+	}
+	return result
+}
+
+// extractRegionFromLocality parses a locality string like
+// "region=us-west-1,zone=us-west-1a" and returns the value of the "region"
+// tier, or "" if no region tier is found.
+func extractRegionFromLocality(locality string) string {
+	for _, tier := range strings.Split(locality, ",") {
+		parts := strings.SplitN(strings.TrimSpace(tier), "=", 2)
+		if len(parts) == 2 && parts[0] == "region" {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
 }
 
 func makeOpenMetricsWriter(out io.Writer) *openMetricsWriter {

--- a/pkg/cli/tsdump_test.go
+++ b/pkg/cli/tsdump_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -67,35 +66,6 @@ func TestDebugTimeSeriesDumpCmd(t *testing.T) {
 		require.NoError(t, err)
 		results = strings.Split(out, "\n")[1:]
 		require.Greater(t, len(results), 0, "expected output from tsdump with root user")
-	})
-
-	t.Run("debug tsdump --format=raw with custom SQL and gRPC ports", func(t *testing.T) {
-		//  The `NewCLITest` function we call above to setup the test, already uses custom
-		//  ports to avoid conflict between concurrently running tests.
-
-		// Make sure that the yamlFileName is unique for each concurrently running test
-		_, port, err := net.SplitHostPort(c.Server.SQLAddr())
-		require.NoError(t, err)
-		yamlFileName := fmt.Sprintf("/tmp/tsdump_test_%s.yaml", port)
-
-		// The `--host` flag is automatically added by the `RunWithCapture` function based on the assigned port.
-		out, err := c.RunWithCapture(
-			"debug tsdump --yaml=" + yamlFileName +
-				" --format=raw --cluster-name=test-cluster-1 --disable-cluster-name-verification",
-		)
-		require.NoError(t, err)
-		require.NotEmpty(t, out)
-
-		yaml, err := os.Open(yamlFileName)
-		require.NoError(t, err)
-		defer func() {
-			require.NoError(t, yaml.Close())
-			require.NoError(t, os.Remove(yamlFileName)) // cleanup
-		}()
-
-		yamlContents, err := io.ReadAll(yaml)
-		require.NoError(t, err)
-		require.NotEmpty(t, yamlContents)
 	})
 
 	t.Run("debug tsdump datadog upload with invalid upload workers", func(t *testing.T) {
@@ -400,6 +370,10 @@ func TestTSDumpConversionWithEmbeddedMetadata(t *testing.T) {
 			"1": "1",
 			"2": "2",
 		},
+		NodeToRegionMap: map[string]string{
+			"1": "region-1",
+			"2": "region-2",
+		},
 		CreatedAt: timeutil.Unix(1609459200, 0),
 	}
 	err = tsdumpmeta.Write(tmpFile, metadata)
@@ -426,6 +400,7 @@ func TestTSDumpConversionWithEmbeddedMetadata(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 
 	require.Contains(t, out, "Found embedded store-to-node mapping with 2 entries")
+	require.Contains(t, out, "Found embedded node-to-region mapping with 2 entries")
 
 	csvFound := false
 	for _, line := range lines {
@@ -881,4 +856,89 @@ distsender\.errors\..*
 			}
 		})
 	}
+}
+
+// TestExtractRegionFromLocality tests parsing region from locality strings.
+func TestExtractRegionFromLocality(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		locality string
+		expected string
+	}{
+		{"region=us-west-1,zone=us-west-1a", "us-west-1"},
+		{"region=eu-central-1", "eu-central-1"},
+		{"zone=us-east-1a,region=us-east-1", "us-east-1"},
+		{"zone=us-east-1a", ""},
+		{"", ""},
+		{"cloud=aws,region=ap-southeast-1,zone=ap-southeast-1a", "ap-southeast-1"},
+		{"region=", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.locality, func(t *testing.T) {
+			result := extractRegionFromLocality(tc.locality)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestAnonymizeNodeRegions tests the anonymization of node-to-region mappings.
+func TestAnonymizeNodeRegions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("basic anonymization", func(t *testing.T) {
+		rows := [][]string{
+			{"1", "region=us-west-1,zone=us-west-1a"},
+			{"2", "region=us-east-1,zone=us-east-1a"},
+			{"3", "region=us-west-1,zone=us-west-1b"},
+		}
+		result := anonymizeNodeRegions(rows)
+		require.Len(t, result, 3)
+		// us-east-1 sorts before us-west-1, so us-east-1 → region-1, us-west-1 → region-2
+		require.Equal(t, "region-2", result["1"]) // us-west-1
+		require.Equal(t, "region-1", result["2"]) // us-east-1
+		require.Equal(t, "region-2", result["3"]) // us-west-1
+	})
+
+	t.Run("no region tier", func(t *testing.T) {
+		rows := [][]string{
+			{"1", "zone=us-east-1a"},
+			{"2", "zone=us-west-1a"},
+		}
+		result := anonymizeNodeRegions(rows)
+		require.Empty(t, result)
+	})
+
+	t.Run("empty rows", func(t *testing.T) {
+		result := anonymizeNodeRegions(nil)
+		require.Empty(t, result)
+	})
+
+	t.Run("mixed nodes with and without region", func(t *testing.T) {
+		rows := [][]string{
+			{"1", "region=eu-west-1,zone=eu-west-1a"},
+			{"2", "zone=us-east-1a"},
+			{"3", "region=eu-west-1,zone=eu-west-1b"},
+		}
+		result := anonymizeNodeRegions(rows)
+		require.Len(t, result, 2)
+		require.Equal(t, "region-1", result["1"])
+		require.Equal(t, "region-1", result["3"])
+		_, exists := result["2"]
+		require.False(t, exists)
+	})
+
+	t.Run("single region", func(t *testing.T) {
+		rows := [][]string{
+			{"1", "region=us-west-1"},
+			{"2", "region=us-west-1"},
+		}
+		result := anonymizeNodeRegions(rows)
+		require.Len(t, result, 2)
+		require.Equal(t, "region-1", result["1"])
+		require.Equal(t, "region-1", result["2"])
+	})
 }

--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -44,6 +44,7 @@ const (
 	UploadStatusPartialSuccess = "Partial Success"
 	UploadStatusFailure        = "Failed"
 	nodeKey                    = "node_id"
+	regionKey                  = "region"
 )
 
 var (
@@ -212,6 +213,7 @@ type datadogWriter struct {
 	threshold         int
 	uploadTime        time.Time
 	storeToNodeMap    map[string]string
+	nodeToRegionMap   map[string]string
 	metricTypeMap     map[string]string
 	noOfUploadWorkers int
 	// isPartialUploadOfFailedRequests indicates whether are we retrying failed requests
@@ -305,6 +307,7 @@ func makeDatadogWriter(
 		threshold:                       threshold,
 		uploadTime:                      currentTime,
 		storeToNodeMap:                  make(map[string]string),
+		nodeToRegionMap:                 make(map[string]string),
 		metricTypeMap:                   metricTypeMap,
 		noOfUploadWorkers:               noOfUploadWorkers,
 		isPartialUploadOfFailedRequests: isPartialUploadOfFailedRequests,
@@ -447,22 +450,30 @@ func (d *datadogWriter) dump(kv *roachpb.KeyValue) (*datadogV2.MetricSeries, err
 		key := sl[1]
 		series.Metric = sl[2]
 
+		// Resolve the node ID and tag accordingly. For "node" metrics the
+		// source is the node ID itself; for "store" metrics it is looked up
+		// via the store-to-node mapping.
+		var nodeID string
 		switch key {
 		case "node":
-			if shouldAddTag(nodeKey) {
-				appendTag(series, nodeKey, source)
-			}
+			nodeID = source
 		case "store":
 			if shouldAddTag(key) {
 				appendTag(series, key, source)
 			}
-			// Add node_id from store-to-node mapping if available
-			if nodeID, ok := d.storeToNodeMap[source]; ok && shouldAddTag(nodeKey) {
-				appendTag(series, nodeKey, nodeID)
-			}
+			nodeID = d.storeToNodeMap[source]
 		default:
 			if shouldAddTag(key) {
 				appendTag(series, key, source)
+			}
+		}
+
+		if nodeID != "" {
+			if shouldAddTag(nodeKey) {
+				appendTag(series, nodeKey, nodeID)
+			}
+			if region, ok := d.nodeToRegionMap[nodeID]; ok && shouldAddTag(regionKey) {
+				appendTag(series, regionKey, region)
 			}
 		}
 	} else if shouldAddTag(nodeKey) {
@@ -859,6 +870,10 @@ func (d *datadogWriter) upload(fileName string) error {
 	if metadataErr == nil && embeddedMetadata != nil {
 		d.storeToNodeMap = embeddedMetadata.StoreToNodeMap
 		fmt.Printf("Using embedded store-to-node mapping with %d entries\n", len(d.storeToNodeMap))
+		if len(embeddedMetadata.NodeToRegionMap) > 0 {
+			d.nodeToRegionMap = embeddedMetadata.NodeToRegionMap
+			fmt.Printf("Using embedded node-to-region mapping with %d entries\n", len(d.nodeToRegionMap))
+		}
 	} else {
 		// Reset the reader since we tried to read metadata. Close the file and
 		// reopen a fresh reader.

--- a/pkg/cli/tsdump_upload_test.go
+++ b/pkg/cli/tsdump_upload_test.go
@@ -314,6 +314,25 @@ func TestTSDumpUploadWithEmbeddedMetadataDataDriven(t *testing.T) {
 			dumpFilePath = generateMockTSDumpFromCSV(t, d.Input)
 			// No extraFlag needed - this tests normal upload without any mapping
 
+		case "upload-datadog-with-regions":
+			// Both store-to-node and node-to-region mappings present.
+			regionMap := map[string]string{"1": "region-1", "2": "region-2"}
+			dumpFilePath = generateMockTSDumpFromCSV(t, d.Input,
+				withEmbeddedMetadata(), withNodeToRegionMap(regionMap))
+
+		case "upload-datadog-regions-no-store-map":
+			// Node-to-region mapping only, no store-to-node mapping.
+			// Store metrics cannot resolve a node ID so they get no region tag.
+			regionMap := map[string]string{"1": "region-1", "2": "region-2"}
+			dumpFilePath = generateMockTSDumpFromCSV(t, d.Input,
+				withNodeToRegionMap(regionMap))
+
+		case "upload-datadog-partial-region-coverage":
+			// Only some nodes have a region entry; others should be omitted.
+			partialRegionMap := map[string]string{"1": "region-1"}
+			dumpFilePath = generateMockTSDumpFromCSV(t, d.Input,
+				withEmbeddedMetadata(), withNodeToRegionMap(partialRegionMap))
+
 		default:
 			t.Fatalf("unknown command: %s", d.Cmd)
 			return ""
@@ -361,6 +380,20 @@ func withEmbeddedMetadata() mockTSDumpOption {
 			},
 			CreatedAt: timeutil.Unix(1609459200, 0),
 		}
+	}
+}
+
+// withNodeToRegionMap adds a node-to-region mapping to the embedded metadata.
+// Must be used after withEmbeddedMetadata so the metadata struct is initialized.
+func withNodeToRegionMap(m map[string]string) mockTSDumpOption {
+	return func(c *mockTSDumpConfig) {
+		if c.metadata == nil {
+			c.metadata = &tsdumpmeta.Metadata{
+				Version:   "v23.1.0",
+				CreatedAt: timeutil.Unix(1609459200, 0),
+			}
+		}
+		c.metadata.NodeToRegionMap = m
 	}
 }
 

--- a/pkg/cmd/tsdump2duck/main.go
+++ b/pkg/cmd/tsdump2duck/main.go
@@ -46,11 +46,13 @@ func main() {
 
 	// Try reading embedded metadata.
 	var storeToNode map[string]string
+	var nodeToRegion map[string]string
 	md, mdErr := tsdumpmeta.Read(dec)
 	if mdErr == nil {
 		storeToNode = md.StoreToNodeMap
-		fmt.Fprintf(os.Stderr, "read embedded metadata: version=%s, %d store-to-node entries\n",
-			md.Version, len(storeToNode))
+		nodeToRegion = md.NodeToRegionMap
+		fmt.Fprintf(os.Stderr, "read embedded metadata: version=%s, %d store-to-node entries, %d node-to-region entries\n",
+			md.Version, len(storeToNode), len(nodeToRegion))
 	} else {
 		// No embedded metadata; restart from beginning.
 		if _, err := f.Seek(0, io.SeekStart); err != nil {
@@ -89,6 +91,11 @@ func main() {
 	fmt.Fprintln(out, `CREATE TABLE store_node_map (
     store_id VARCHAR NOT NULL,
     node_id  VARCHAR NOT NULL
+);`)
+
+	fmt.Fprintln(out, `CREATE TABLE node_region_map (
+    node_id VARCHAR NOT NULL,
+    region  VARCHAR NOT NULL
 );`)
 
 	// Decode and emit timeseries data.
@@ -143,6 +150,16 @@ func main() {
 		var rows []string
 		for storeID, nodeID := range storeToNode {
 			rows = append(rows, fmt.Sprintf("  ('%s', '%s')", escapeSQLString(storeID), escapeSQLString(nodeID)))
+		}
+		fmt.Fprintln(out, strings.Join(rows, ",\n")+";")
+	}
+
+	// Emit node-to-region mapping.
+	if len(nodeToRegion) > 0 {
+		fmt.Fprintln(out, "INSERT INTO node_region_map VALUES")
+		var rows []string
+		for nodeID, region := range nodeToRegion {
+			rows = append(rows, fmt.Sprintf("  ('%s', '%s')", escapeSQLString(nodeID), escapeSQLString(region)))
 		}
 		fmt.Fprintln(out, strings.Join(rows, ",\n")+";")
 	}

--- a/pkg/ts/tsdumpmeta/metadata.go
+++ b/pkg/ts/tsdumpmeta/metadata.go
@@ -14,9 +14,10 @@ import (
 // Metadata contains metadata that can be embedded at the start of a raw tsdump
 // GOB stream. It includes a store-to-node mapping and auxiliary information.
 type Metadata struct {
-	Version        string            `json:"version"`
-	StoreToNodeMap map[string]string `json:"storeToNodeMap"`
-	CreatedAt      time.Time         `json:"createdAt"`
+	Version         string            `json:"version"`
+	StoreToNodeMap  map[string]string `json:"storeToNodeMap"`
+	NodeToRegionMap map[string]string `json:"nodeToRegionMap"`
+	CreatedAt       time.Time         `json:"createdAt"`
 }
 
 // Write encodes the provided metadata and writes it to w using gob.

--- a/pkg/ts/tsdumpmeta/metadata_test.go
+++ b/pkg/ts/tsdumpmeta/metadata_test.go
@@ -33,6 +33,10 @@ func TestMetadataReadWrite(t *testing.T) {
 				"3": "2",
 				"4": "2",
 			},
+			NodeToRegionMap: map[string]string{
+				"1": "region-1",
+				"2": "region-2",
+			},
 			CreatedAt: timeutil.Unix(1609459200, 0), // 2021-01-01 00:00:00 UTC
 		}
 
@@ -49,6 +53,11 @@ func TestMetadataReadWrite(t *testing.T) {
 				"2": "2",
 				"3": "3",
 			},
+			NodeToRegionMap: map[string]string{
+				"1": "region-1",
+				"2": "region-1",
+				"3": "region-2",
+			},
 			CreatedAt: timeutil.Unix(1640995200, 0), // 2022-01-01 00:00:00 UTC
 		}
 
@@ -63,6 +72,7 @@ func TestMetadataReadWrite(t *testing.T) {
 
 		require.Equal(t, originalMetadata.Version, readMetadata.Version)
 		require.Equal(t, originalMetadata.StoreToNodeMap, readMetadata.StoreToNodeMap)
+		require.Equal(t, originalMetadata.NodeToRegionMap, readMetadata.NodeToRegionMap)
 		require.Equal(t, originalMetadata.CreatedAt.Unix(), readMetadata.CreatedAt.Unix())
 	})
 


### PR DESCRIPTION
Previously, `cockroach debug tsdump` captured cluster metrics with
store-to-node mapping but lacked node-to-region mapping. This prevented
region-level metric visualization when uploading to Datadog.

This commit adds a `NodeToRegionMap` field to the tsdump metadata and
wires it through the dump and upload paths:

- During raw format generation, node localities are queried from
  `crdb_internal.gossip_nodes` and region names are anonymized
  (e.g. "region-1", "region-2") to avoid leaking sensitive locality
  info. Both mapping query failures are non-fatal.
- During Datadog upload, region tags are applied to both node metrics
  (directly from the mapping) and store metrics (chaining through the
  store-to-node mapping).
- GOB encoding is additive-field-safe, so old readers skip the new
  field and new readers default missing fields to nil.
- The `--yaml` flag and `createYAML` function have been removed, as
  the store-to-node mapping is now embedded directly in the tsdump
  metadata header, making the separate YAML file redundant.
- SQL connection boilerplate for metadata queries has been deduplicated
  into shared helpers (`queryRows`, `getTSDumpMappings`) that use a
  single connection for both mapping queries.
- `tsdump2duck` now creates a `node_region_map` table and populates it
  from the embedded metadata.

Resolves: https://github.com/cockroachdb/cockroach/issues/165282

Release note (cli change): The `--yaml` flag on `cockroach debug tsdump`
has been removed. The store-to-node mapping it produced is now embedded
in the tsdump metadata header alongside the new node-to-region mapping.