### PR TITLE
crosscluster/physical: skip flaky TestStandbyReadTSPollerJob

### DIFF
--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgurlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,6 +30,7 @@ import (
 func TestStandbyReadTSPollerJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 166712)
 
 	beginTS := timeutil.Now()
 	ctx := context.Background()


### PR DESCRIPTION
The TestStandbyReadTSPollerJob test has been observed to be flaky. This commit temporarily skips the test to unblock CI while the root cause is investigated and fixed.

Informs: #166712

Release note: None