### PR TITLE
release-26.2: workflows: remove EngFlow from stress canary GHA Essential CI job

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -262,26 +262,14 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   race_canary:
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_big_2404]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: compute metadata
-        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
-      - run: ./build/github/get-engflow-keys.sh
-      - run: ./build/github/prepare-summarize-build.sh
       - name: run race canary test
         run: ./build/github/race-canary.sh
-      - name: upload build results
-        run: ./build/github/summarize-build.sh bes.bin
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: clean up
-        run: ./build/github/cleanup-engflow-keys.sh
-        if: always()
   unit_tests:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 120

--- a/build/github/race-canary.sh
+++ b/build/github/race-canary.sh
@@ -15,9 +15,7 @@ set -euxo pipefail
 bazel test //pkg/server:server_test \
     --config crosslinux --config race \
     --test_filter=TestSpanStatsFanOut \
-    --jobs 100 $(./build/github/engflow-args.sh) \
-    --remote_download_minimal \
+    --jobs 100 \
     --test_timeout=300 \
     --runs_per_test=10 \
-    --bes_keywords ci-race-canary \
-    --build_event_binary_file=bes.bin
+    --bes_keywords ci-race-canary


### PR DESCRIPTION
Backport 1/1 commits from #166706 on behalf of @rickystewart.

----

This might be introducing too much load on the EngFlow cluster. Remove EngFlow support from the job. Also move the machine to a larger runner to give it more headroom to run the build.

Part of: DEVINF-1698

Release note: none
Epic: none

----

Release justification: Non-production code changes