### PR TITLE
release-25.4: sqlstats: fix TestSQLStatsDiscardStatsOnFingerprintLimit flake

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -406,7 +406,7 @@ func waitForStatementStatsRows(
 		}
 
 		return nil
-	}, 5*time.Second)
+	}, testutils.SucceedsSoonDuration())
 }
 
 // WaitForStatementEntriesAtLeast waits for the count of statement stats entries to be >= expectedCount.
@@ -515,7 +515,7 @@ func waitForTransactionStatsRows(
 			return errors.Errorf("expected exec count of at least %d, got %d", filters[0].ExecCount, execCount)
 		}
 		return nil
-	}, 5*time.Second)
+	}, testutils.SucceedsSoonDuration())
 }
 
 // WaitForTransactionEntriesAtLeast waits for transaction fingerprint to be >= expectedCount.


### PR DESCRIPTION
Backport 1/1 commits from #166684 on behalf of @dhartunian.

----

Replace hardcoded 5s timeout in `waitForStatementStatsRows` and `waitForTransactionStatsRows` with `testutils.SucceedsSoonDuration()`, which scales to 225s under race builds.

Remove `skip.UnderRace` from `TestSQLStatsDiscardStatsOnFingerprintLimit` since the timeout fix makes it safe to run under race.

Fixes #166668

Release note: None

----

Release justification: test-only change