### PR TITLE
release-26.2: sqlstats: fix TestSQLStatsDiscardStatsOnFingerprintLimit flake

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -408,7 +408,7 @@ func waitForStatementStatsRows(
 		}
 
 		return nil
-	}, 5*time.Second)
+	}, testutils.SucceedsSoonDuration())
 }
 
 // WaitForStatementEntriesAtLeast waits for the count of statement stats entries to be >= expectedCount.
@@ -517,7 +517,7 @@ func waitForTransactionStatsRows(
 			return errors.Errorf("expected exec count of at least %d, got %d", filters[0].ExecCount, execCount)
 		}
 		return nil
-	}, 5*time.Second)
+	}, testutils.SucceedsSoonDuration())
 }
 
 // WaitForTransactionEntriesAtLeast waits for transaction fingerprint to be >= expectedCount.

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -74,7 +74,6 @@ go_test(
         "//pkg/sql/sqlstats/ssmemstorage",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -1641,7 +1640,6 @@ FROM crdb_internal.statement_statistics WHERE app_name = $1`, appName)
 func TestSQLStatsDiscardStatsOnFingerprintLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t)
 
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})


### PR DESCRIPTION
Backport 1/1 commits from #166684 on behalf of @dhartunian.

----

Replace hardcoded 5s timeout in `waitForStatementStatsRows` and `waitForTransactionStatsRows` with `testutils.SucceedsSoonDuration()`, which scales to 225s under race builds.

Remove `skip.UnderRace` from `TestSQLStatsDiscardStatsOnFingerprintLimit` since the timeout fix makes it safe to run under race.

Fixes #166668

Release note: None

----

Release justification: test-only change