### PR TITLE
crosscluster/physical: skip flaky TestStandbyReadTSPollerJob

### DIFF
--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgurlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -30,7 +29,6 @@ import (
 func TestStandbyReadTSPollerJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 166712)
 
 	beginTS := timeutil.Now()
 	ctx := context.Background()
@@ -125,14 +123,15 @@ func maybeOffsetReaderTenantSystemTables(
 	t *testing.T, c *replicationtestutils.TenantStreamingClusters,
 ) (int, func(sql *sqlutils.SQLRunner)) {
 	if c.Rng.Intn(2) == 0 {
-		// Use the default offset of 1 billion.
-		return 1_000_000_000, func(sql *sqlutils.SQLRunner) {}
+		c.DestSysSQL.Exec(t, `SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = 0`)
+		// Set on source to ensure failback works well too.
+		c.SrcSysSQL.Exec(t, `SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = 0`)
+		// Override to no offset.
+		return 0, func(sql *sqlutils.SQLRunner) {}
 	}
-	// Override the offset to 0 to test the no-offset path.
-	offset := 0
-	c.DestSysSQL.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = %d`, offset))
-	// Set on source to ensure failback works well too.
-	c.SrcSysSQL.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset = %d`, offset))
+
+	var offset int
+	c.DestSysSQL.QueryRow(t, `SHOW CLUSTER SETTING physical_cluster_replication.reader_system_table_id_offset`).Scan(&offset)
 
 	// swap a system table ID and a user table ID to simulate a cluster that has interleaving user and system table ids.
 	scaryTableIDRemapFunc := `

--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgurlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,6 +30,7 @@ import (
 func TestStandbyReadTSPollerJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 166712)
 
 	beginTS := timeutil.Now()
 	ctx := context.Background()


### PR DESCRIPTION
The TestStandbyReadTSPollerJob test has been observed to be flaky.
This commit temporarily skips the test to unblock CI while the root
cause is investigated and fixed.

Informs: #166712

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>