### PR TITLE
release-26.2: sql,workload: fix aclitem usage in mixed-version schemachange workload

### DIFF
--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
-	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -322,7 +321,7 @@ func ColVecToDatumAndDeselect(
 					}
 					goto vecToDatum_true_true_true_return_0
 				}
-				if ct.Oid() == oidext.T_aclitem {
+				if ct.Oid() == oid.T_aclitem {
 					for idx = 0; idx < length; idx++ {
 						{
 							destIdx = idx
@@ -815,7 +814,7 @@ func ColVecToDatumAndDeselect(
 					}
 					goto vecToDatum_false_true_true_return_1
 				}
-				if ct.Oid() == oidext.T_aclitem {
+				if ct.Oid() == oid.T_aclitem {
 					for idx = 0; idx < length; idx++ {
 						{
 							destIdx = idx
@@ -1240,7 +1239,7 @@ func ColVecToDatum(
 						}
 						goto vecToDatum_true_true_false_return_2
 					}
-					if ct.Oid() == oidext.T_aclitem {
+					if ct.Oid() == oid.T_aclitem {
 						for idx = 0; idx < length; idx++ {
 							{
 								//gcassert:bce
@@ -1718,7 +1717,7 @@ func ColVecToDatum(
 						}
 						goto vecToDatum_true_false_false_return_3
 					}
-					if ct.Oid() == oidext.T_aclitem {
+					if ct.Oid() == oid.T_aclitem {
 						for idx = 0; idx < length; idx++ {
 							{
 								destIdx = idx
@@ -2214,7 +2213,7 @@ func ColVecToDatum(
 						}
 						goto vecToDatum_false_true_false_return_4
 					}
-					if ct.Oid() == oidext.T_aclitem {
+					if ct.Oid() == oid.T_aclitem {
 						for idx = 0; idx < length; idx++ {
 							{
 								//gcassert:bce
@@ -2615,7 +2614,7 @@ func ColVecToDatum(
 						}
 						goto vecToDatum_false_false_false_return_5
 					}
-					if ct.Oid() == oidext.T_aclitem {
+					if ct.Oid() == oid.T_aclitem {
 						for idx = 0; idx < length; idx++ {
 							{
 								destIdx = idx

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
-	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -423,7 +422,7 @@ func vecToDatum(
 			}
 			return
 		}
-		if ct.Oid() == oidext.T_aclitem {
+		if ct.Oid() == oid.T_aclitem {
 			for idx = 0; idx < length; idx++ {
 				setDestIdx(destIdx, idx, sel, hasSel, deselect)
 				setSrcIdx(srcIdx, idx, sel, hasSel)

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/sql/colmem",  # keep
         "//pkg/sql/execinfrapb",
         "//pkg/sql/lex",  # keep
-        "//pkg/sql/oidext",  # keep
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc",  # keep

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
-	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -49,7 +48,6 @@ var (
 	_ = lex.DecodeRawBytesToByteArrayAuto
 	_ = uuid.FromBytes
 	_ = oid.T_name
-	_ = oidext.T_aclitem
 	_ = util.TruncateString
 	_ = pgcode.Syntax
 	_ = pgdate.ParseTimestamp
@@ -2134,7 +2132,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2180,7 +2178,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2226,7 +2224,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2272,7 +2270,7 @@ func (c *castBoolStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							var r []byte
 
 							r = []byte(strconv.FormatBool(v))
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2355,7 +2353,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2401,7 +2399,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2449,7 +2447,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -2495,7 +2493,7 @@ func (c *castBytesStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							_format := evalCtx.SessionData().DataConversionConfig.BytesEncodeFormat
 							r = []byte(lex.EncodeByteArrayToRawBytes(string(v), _format, false /* skipHexPrefix */))
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3462,7 +3460,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3512,7 +3510,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3562,7 +3560,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -3612,7 +3610,7 @@ func (c *castDateStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							_date.Format(buf)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4735,7 +4733,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4781,7 +4779,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4827,7 +4825,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4873,7 +4871,7 @@ func (c *castDecimalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetada
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -4960,7 +4958,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5009,7 +5007,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5060,7 +5058,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5109,7 +5107,7 @@ func (c *castEnumStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(logical)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5947,7 +5945,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -5995,7 +5993,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6043,7 +6041,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6091,7 +6089,7 @@ func (c *castFloatStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							dcc := evalCtx.SessionData().DataConversionConfig
 							r = tree.PgwireFormatFloat(nil /* buf */, v, dcc, types.Float)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6880,7 +6878,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6939,7 +6937,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -6998,7 +6996,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7057,7 +7055,7 @@ func (c *castInt2StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7870,7 +7868,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7929,7 +7927,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -7988,7 +7986,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -8047,7 +8045,7 @@ func (c *castInt4StringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -8884,7 +8882,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -8943,7 +8941,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9002,7 +9000,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9061,7 +9059,7 @@ func (c *castIntStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) 
 								r = []byte(strconv.FormatInt(int64(v), 10))
 							}
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9146,7 +9144,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9196,7 +9194,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9246,7 +9244,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9296,7 +9294,7 @@ func (c *castIntervalStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 							v.FormatWithStyle(buf, dcc.IntervalStyle)
 							r = []byte(buf.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9377,7 +9375,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9421,7 +9419,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9467,7 +9465,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -9511,7 +9509,7 @@ func (c *castJsonbStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata
 							var r []byte
 
 							r = []byte(v.String())
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11421,7 +11419,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11465,7 +11463,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11511,7 +11509,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -11555,7 +11553,7 @@ func (c *castStringStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var r []byte
 
 							r = v
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12149,7 +12147,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12195,7 +12193,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12241,7 +12239,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12287,7 +12285,7 @@ func (c *castTimestampStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMeta
 							var r []byte
 
 							r = tree.PGWireFormatTimestamp(v, nil, r)
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12377,7 +12375,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12432,7 +12430,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12487,7 +12485,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12542,7 +12540,7 @@ func (c *castTimestamptzStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 
 							r = tree.PGWireFormatTimestamp(_t, evalCtx.GetLocation(), r)
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12628,7 +12626,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12677,7 +12675,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12728,7 +12726,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")
@@ -12777,7 +12775,7 @@ func (c *castUuidStringOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata)
 							}
 							r = []byte(_uuid.String())
 
-							if toType.Oid() != oid.T_name && toType.Oid() != oidext.T_aclitem {
+							if toType.Oid() != oid.T_name && toType.Oid() != oid.T_aclitem {
 								// bpchar types truncate trailing whitespace.
 								if toType.Oid() == oid.T_bpchar {
 									r = bytes.TrimRight(r, " ")

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
-	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -54,7 +53,6 @@ var (
 	_ = lex.DecodeRawBytesToByteArrayAuto
 	_ = uuid.FromBytes
 	_ = oid.T_name
-	_ = oidext.T_aclitem
 	_ = util.TruncateString
 	_ = pgcode.Syntax
 	_ = pgdate.ParseTimestamp

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -529,7 +529,7 @@ func toString(conv, to, toType string) string {
 	// tree.AdjustValueToType.
 	convStr := `
 		%[1]s
-		if %[3]s.Oid() != oid.T_name && %[3]s.Oid() != oidext.T_aclitem {
+		if %[3]s.Oid() != oid.T_name && %[3]s.Oid() != oid.T_aclitem {
 			// bpchar types truncate trailing whitespace.
 			if %[3]s.Oid() == oid.T_bpchar {
 				%[2]s = bytes.TrimRight(%[2]s, " ")

--- a/pkg/sql/oidext/oidext.go
+++ b/pkg/sql/oidext/oidext.go
@@ -41,7 +41,6 @@ const (
 // github.com/lib/pq/oid. See postgres/src/include/catalog/pg_type.dat for oids.
 const (
 	T_aclitem   = oid.Oid(1033)
-	T__aclitem  = oid.Oid(1034)
 	T_jsonpath  = oid.Oid(4072)
 	T__jsonpath = oid.Oid(4073)
 )
@@ -57,8 +56,6 @@ var ExtensionTypeName = map[oid.Oid]string{
 	T__box2d:     "_BOX2D",
 	T_pgvector:   "VECTOR",
 	T__pgvector:  "_VECTOR",
-	T_aclitem:    "ACLITEM",
-	T__aclitem:   "_ACLITEM",
 	T_jsonpath:   "JSONPATH",
 	T__jsonpath:  "_JSONPATH",
 	T_citext:     "CITEXT",

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -976,7 +976,7 @@ func DecodeDatum(
 			return nil, err
 		}
 		return da.NewDName(tree.DString(bs)), nil
-	case oidext.T_aclitem:
+	case oid.T_aclitem:
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -274,7 +274,7 @@ func RandDatumWithNullChance(
 		if typ.Oid() == oid.T_bpchar {
 			return tree.NewDString(strings.TrimRight(string(p), " "))
 		}
-		if typ.Oid() == oidext.T_aclitem {
+		if typ.Oid() == oid.T_aclitem {
 			// Generate a valid aclitem string: grantee=privchars/grantor.
 			// Use only alphanumeric chars for the grantee to avoid special
 			// characters (=, /, ") that break the aclitem format.
@@ -471,7 +471,7 @@ func adjustDatum(datum tree.Datum, typ *types.T) tree.Datum {
 	case types.StringFamily:
 		if typ.Oid() == oid.T_name {
 			datum = tree.NewDName(string(*datum.(*tree.DString)))
-		} else if typ.Oid() == oidext.T_aclitem {
+		} else if typ.Oid() == oid.T_aclitem {
 			// Return a fixed valid aclitem rather than trying to adapt
 			// the generic string datum, since special characters like
 			// quotes break the aclitem parser.

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -187,7 +187,7 @@ func IsLegalColumnType(typ *types.T) bool {
 		// unlikely to use these types of columns, so disabling their generation
 		// is low risk.
 		return false
-	case oidext.T_aclitem, oidext.T__aclitem:
+	case oid.T_aclitem, oid.T__aclitem:
 		// aclitem has strict format requirements (grantee=privchars/grantor) that
 		// make random generation unreliable for workloads like schemachange.
 		return false

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -119,7 +119,7 @@ func Decode(
 		switch valType.Oid() {
 		case oid.T_name:
 			return a.NewDName(tree.DString(r)), rkey, err
-		case oidext.T_aclitem:
+		case oid.T_aclitem:
 			d, aclErr := a.NewDACLItem(tree.DString(r))
 			if aclErr != nil {
 				return nil, rkey, aclErr

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -68,7 +68,7 @@ func DecodeUntaggedDatum(
 		switch t.Oid() {
 		case oid.T_name:
 			return a.NewDName(tree.DString(data)), b, nil
-		case oidext.T_aclitem:
+		case oid.T_aclitem:
 			d, err := a.NewDACLItem(tree.DString(data))
 			if err != nil {
 				return nil, b, err

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -291,7 +291,7 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		if typ.Oid() == oid.T_name {
 			return a.NewDName(tree.DString(v)), nil
 		}
-		if typ.Oid() == oidext.T_aclitem {
+		if typ.Oid() == oid.T_aclitem {
 			return a.NewDACLItem(tree.DString(v))
 		}
 		return a.NewDString(tree.DString(v)), nil

--- a/pkg/sql/sem/cast/cast_map.go
+++ b/pkg/sql/sem/cast/cast_map.go
@@ -38,7 +38,7 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_varchar:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 	},
-	oidext.T_aclitem: {
+	oid.T_aclitem: {
 		oid.T_bpchar:    {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_name:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -88,13 +88,13 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 	},
 	oid.T_bpchar: {
-		oid.T_bpchar:     {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_name:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_text:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_varchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bpchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_name:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_text:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_varchar:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_aclitem:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from bpchar to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -184,17 +184,17 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_text:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		oid.T_varchar: {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from citext to other types.
-		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_name:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_bool:       {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_inet:       {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_regrole:    {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
-		oid.T_pg_lsn:     {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_regclass:   {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
-		oidext.T_box2d:   {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_bit:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oid.T_bytea:      {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_char:     {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_name:     {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_aclitem:  {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bool:     {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_inet:     {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_regrole:  {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
+		oid.T_pg_lsn:   {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_regclass: {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Stable},
+		oidext.T_box2d: {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bit:      {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bytea:    {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_date: {
 			MaxContext:     ContextExplicit,
 			origin:         ContextOriginAutomaticIOConversion,
@@ -262,9 +262,9 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_text:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		oid.T_varchar: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		// Automatic I/O conversions to string types.
-		oid.T_name:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_name:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_aclitem:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from "char" to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -627,9 +627,9 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oid.T_text:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Leakproof},
 		oid.T_varchar: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
 		// Automatic I/O conversions to string types.
-		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
-		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_aclitem:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from NAME to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -888,10 +888,10 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		//
 		// TODO(#72980): If we use the VARCHAR OID for STRING(n) types rather
 		// then the TEXT OID, and we can remove this entry.
-		oid.T_text:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_varchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_text:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_varchar:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_aclitem:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from TEXT to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -1142,14 +1142,14 @@ var castMap = map[oid.Oid]map[oid.Oid]Cast{
 		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 	},
 	oid.T_varchar: {
-		oid.T_bpchar:     {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_char:       {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_name:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_regclass:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Stable},
-		oid.T_text:       {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oid.T_varchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_citext:  {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
-		oidext.T_aclitem: {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
+		oid.T_bpchar:    {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_char:      {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_name:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_regclass:  {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Stable},
+		oid.T_text:      {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_varchar:   {MaxContext: ContextImplicit, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oidext.T_citext: {MaxContext: ContextAssignment, origin: ContextOriginPgCast, Volatility: volatility.Immutable},
+		oid.T_aclitem:   {MaxContext: ContextAssignment, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		// Automatic I/O conversions from VARCHAR to other types.
 		oid.T_bit:         {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
 		oid.T_bool:        {MaxContext: ContextExplicit, origin: ContextOriginAutomaticIOConversion, Volatility: volatility.Immutable},
@@ -1303,7 +1303,7 @@ func init() {
 			// implicit casts for these types so that INSERT and assignment
 			// contexts work.
 			ioConversionExemptTypes := map[oid.Oid]bool{
-				oidext.T_aclitem: true,
+				oid.T_aclitem: true,
 			}
 
 			// Automatic I/O conversions to string types are assignment casts.

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -515,7 +515,7 @@ func performCastWithoutPrecisionTruncation(
 			if t.Oid() == oid.T_name {
 				return tree.NewDName(s), nil
 			}
-			if t.Oid() == oidext.T_aclitem {
+			if t.Oid() == oid.T_aclitem {
 				return tree.NewDACLItem(s)
 			}
 

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -635,7 +634,7 @@ func (expr *StrVal) ResolveAsType(
 		fallthrough
 	case types.StringFamily:
 		switch typ.Oid() {
-		case oidext.T_aclitem:
+		case oid.T_aclitem:
 			return NewDACLItem(expr.s)
 		case oid.T_name:
 			expr.resString = DString(expr.s)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5656,7 +5656,7 @@ func (d *DOid) Name() string {
 // Types that currently benefit from DOidWrapper are:
 // - DName => DOidWrapper(*DString, oid.T_name)
 // - DRefCursor => DOidWrapper(*DString, oid.T_refcursor)
-// - DACLItem => DOidWrapper(*DString, oidext.T_aclitem)
+// - DACLItem => DOidWrapper(*DString, oid.T_aclitem)
 // - DCIText => DOidWrapper(*DCollatedString, oidext.T_citext)
 type DOidWrapper struct {
 	Wrapped Datum
@@ -5846,7 +5846,7 @@ func NewDACLItemFromDString(d *DString) (Datum, error) {
 	if err := privilege.ValidateACLItemString(string(*d)); err != nil {
 		return nil, err
 	}
-	return wrapWithOid(d, oidext.T_aclitem), nil
+	return wrapWithOid(d, oid.T_aclitem), nil
 }
 
 // NewDACLItem is a helper routine to create a *DOidWrapper with aclitem OID,

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -54,6 +54,7 @@ var (
 // instead of a method so that other packages can iterate over the map directly.
 // Note that additional elements for the array Oid types are added in init().
 var OidToType = map[oid.Oid]*T{
+	oid.T_aclitem:    AclItem,
 	oid.T_anyelement: AnyElement,
 	oid.T_any:        Any,
 	oid.T_bit:        typeBit,
@@ -102,7 +103,6 @@ var OidToType = map[oid.Oid]*T{
 	oid.T_varchar:      VarChar,
 	oid.T_void:         Void,
 
-	oidext.T_aclitem:   AclItem,
 	oidext.T_geometry:  Geometry,
 	oidext.T_geography: Geography,
 	oidext.T_box2d:     Box2D,
@@ -114,6 +114,7 @@ var OidToType = map[oid.Oid]*T{
 
 // oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
 var oidToArrayOid = map[oid.Oid]oid.Oid{
+	oid.T_aclitem:      oid.T__aclitem,
 	oid.T_anyelement:   oid.T_anyarray,
 	oid.T_bit:          oid.T__bit,
 	oid.T_bool:         oid.T__bool,
@@ -154,7 +155,6 @@ var oidToArrayOid = map[oid.Oid]oid.Oid{
 	oid.T_varbit:       oid.T__varbit,
 	oid.T_varchar:      oid.T__varchar,
 
-	oidext.T_aclitem:   oidext.T__aclitem,
 	oidext.T_geometry:  oidext.T__geometry,
 	oidext.T_geography: oidext.T__geography,
 	oidext.T_box2d:     oidext.T__box2d,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -237,7 +237,7 @@ func (t *T) Canonical() *T {
 			// Name uses StringFamily and DOidWrapper.
 			return Name
 		}
-		if t.Oid() == oidext.T_aclitem {
+		if t.Oid() == oid.T_aclitem {
 			// AclItem uses StringFamily and DOidWrapper.
 			return AclItem
 		}
@@ -463,7 +463,7 @@ var (
 	// It represents a PostgreSQL access control list item in the format
 	// "grantee=privchars/grantor".
 	AclItem = &T{InternalType: InternalType{
-		Family: StringFamily, Oid: oidext.T_aclitem, Locale: &emptyLocale}}
+		Family: StringFamily, Oid: oid.T_aclitem, Locale: &emptyLocale}}
 
 	// Bytes is the type of a list of raw byte values.
 	Bytes = &T{InternalType: InternalType{
@@ -1773,7 +1773,7 @@ func (t *T) Name() string {
 			return "name"
 		case oidext.T_citext:
 			return "citext"
-		case oidext.T_aclitem:
+		case oid.T_aclitem:
 			return "aclitem"
 		}
 		panic(errors.AssertionFailedf("unexpected OID: %d", t.Oid()))
@@ -1992,7 +1992,7 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 			return "name"
 		case oidext.T_citext:
 			return "citext"
-		case oidext.T_aclitem:
+		case oid.T_aclitem:
 			return "aclitem"
 		default:
 			panic(errors.AssertionFailedf("unexpected OID: %d", t.Oid()))
@@ -3034,7 +3034,7 @@ func (t *T) stringTypeSQL() string {
 		typName = `"char"`
 	case oid.T_name:
 		typName = "NAME"
-	case oidext.T_aclitem:
+	case oid.T_aclitem:
 		typName = "ACLITEM"
 	}
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4363,9 +4363,9 @@ func (og *operationGenerator) randType(
 		return nil, nil, err
 	}
 
-	typ := randgen.RandSortingType(og.params.rng)
+	typ := randgen.RandColumnType(og.params.rng)
 	for ltreeNotSupported && (typ.Oid() == oidext.T_ltree || typ.Oid() == oidext.T__ltree) {
-		typ = randgen.RandSortingType(og.params.rng)
+		typ = randgen.RandColumnType(og.params.rng)
 	}
 
 	typeName := tree.MakeUnqualifiedTypeName(typ.SQLString())


### PR DESCRIPTION
Backport 1/1 commits from #166750.

/cc @cockroachdb/release

---

The schemachange workload used RandSortingType to pick random column types, which could select aclitem even in mixed-version clusters where older nodes don't know about it. This caused "function does not exist" errors when resolving function signatures via pg_catalog.pg_type on nodes that lack the aclitem type entry.

Fix this by switching the workload to use RandColumnType, which respects IsLegalColumnType (which already excludes aclitem).

Additionally, remove redundant oidext.T_aclitem and oidext.T__aclitem constants in favor of the upstream oid.T_aclitem and oid.T__aclitem that are now available in lib/pq.

Resolves: #166032
Resolves: #166220

Release note: None

Release justification: bug fix for mixed-version schemachange workload errors
