### PR TITLE
release-26.2: security: add telemetry and metrics for SAN-based cert auth

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1024,6 +1024,26 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
+    - name: auth.cert.san.conn.success
+      exported_name: auth_cert_san_conn_success
+      description: Number of successful SQL connections using SAN-based certificate authentication
+      y_axis_label: Connections
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric tracks successful authentications when SAN-based certificate validation is enabled. Use this to monitor adoption and success rate of SAN authentication. Failure rate = auth.cert.san.conn.total - auth.cert.san.conn.success.
+      visibility: ESSENTIAL
+    - name: auth.cert.san.conn.total
+      exported_name: auth_cert_san_conn_total
+      description: Total number of SQL connection attempts using SAN-based certificate authentication
+      y_axis_label: Connections
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric tracks all authentication attempts when SAN-based certificate validation is enabled. Compare with auth.cert.san.conn.success to calculate failure rate.
+      visibility: ESSENTIAL
     - name: auth.gss.conn.latency
       exported_name: auth_gss_conn_latency
       description: Latency to establish and authenticate a SQL connection using GSS

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -641,13 +641,23 @@ func UserAuthCertHook(
 			}
 			return nil
 		}
-		return errors.WithDetailf(
-			errors.Errorf(
-				"certificate authentication failed for user %q (DN: %s)",
-				systemIdentity,
-				roleSubject,
-			),
-			"The client certificate (DN: %s) is valid for %s.", certSubject, FormatUserScopes(certUserScope))
+
+		// Build error message with SAN details when SAN authentication is enabled
+		baseErr := errors.Errorf(
+			"certificate authentication failed for user %q (DN: %s)",
+			systemIdentity,
+			roleSubject,
+		)
+
+		detailMsg := fmt.Sprintf("The client certificate (DN: %s) is valid for %s",
+			certSubject, FormatUserScopes(certUserScope))
+
+		if clientCertSANRequired {
+			detailMsg += fmt.Sprintf(" SAN authentication is enabled. Certificate SANs: [%s]. Expected user: %q",
+				strings.Join(certSANs, ", "), systemIdentity)
+		}
+
+		return errors.WithDetailf(baseErr, "%s", detailMsg)
 	}, nil
 }
 

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -123,6 +123,11 @@ func (c *conn) handleAuthentication(
 		return connClose, c.sendError(ctx, pgerror.WithCandidateCode(err, pgcode.InvalidAuthorizationSpecification))
 	}
 
+	// If SAN-based authentication is being used, increment the total attempt counter.
+	if behaviors.UsedCertSANAuth() {
+		c.metrics.AuthCertSANConnTotal.Inc(1)
+	}
+
 	// Choose the system identity that we'll use below for mapping
 	// externally-provisioned principals to database users. The system identity
 	// always is normalized to lower case.
@@ -283,6 +288,11 @@ func (c *conn) handleAuthentication(
 	// If user has PROVISIONSRC set, increment the login success counter
 	if provisioningSource != nil {
 		telemetry.Inc(provisioning.ProvisionedUserLoginSuccessCounter)
+	}
+
+	// If SAN-based authentication was successful, increment the SAN success counter
+	if behaviors.UsedCertSANAuth() {
+		c.metrics.AuthCertSANConnSuccess.Inc(1)
 	}
 
 	// Compute the authentication latency needed to serve a SQL query.

--- a/pkg/sql/pgwire/auth_behaviors.go
+++ b/pkg/sql/pgwire/auth_behaviors.go
@@ -40,6 +40,7 @@ type AuthBehaviors struct {
 	provisioner      Provisioner
 	externalAuthTime time.Duration
 	sanIdentities    []string
+	usedCertSANAuth  bool
 }
 
 // Ensure that an AuthBehaviors is easily composable with itself.
@@ -230,4 +231,14 @@ func (b *AuthBehaviors) SetSANIdentities(sans []string) {
 // GetSANIdentities returns the SAN identities extracted from the client certificate.
 func (b *AuthBehaviors) GetSANIdentities() []string {
 	return b.sanIdentities
+}
+
+// MarkUsedCertSANAuth marks that SAN-based authentication was used for this connection.
+func (b *AuthBehaviors) MarkUsedCertSANAuth() {
+	b.usedCertSANAuth = true
+}
+
+// UsedCertSANAuth returns whether SAN-based authentication was used for this connection.
+func (b *AuthBehaviors) UsedCertSANAuth() bool {
+	return b.usedCertSANAuth
 }

--- a/pkg/sql/pgwire/auth_internal_test.go
+++ b/pkg/sql/pgwire/auth_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -28,6 +29,7 @@ type mockAuthConn struct {
 	setDbUserCalled   bool
 	dbUserSet         username.SQLUsername
 	systemIdentitySet string
+	metrics           *tenantSpecificMetrics
 }
 
 var _ AuthConn = (*mockAuthConn)(nil)
@@ -52,7 +54,7 @@ func (m *mockAuthConn) LogAuthFailed(
 func (m *mockAuthConn) LogAuthOK(ctx context.Context)                        {}
 func (m *mockAuthConn) LogSessionEnd(ctx context.Context, endTime time.Time) {}
 func (m *mockAuthConn) GetTenantSpecificMetrics() *tenantSpecificMetrics {
-	return nil
+	return m.metrics
 }
 
 // TestCheckClientUsernameMatchesMapping tests the checkClientUsernameMatchesMapping
@@ -289,8 +291,11 @@ func TestCheckClientUsernameMatchesMapping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create mock AuthConn
-			mockAC := &mockAuthConn{}
+			// Create mock AuthConn with real metrics
+			sqlMetrics := sql.MakeMemMetrics("test", metric.TestSampleInterval)
+			mockAC := &mockAuthConn{
+				metrics: newTenantSpecificMetrics(sqlMetrics, metric.TestSampleInterval),
+			}
 
 			// Create AuthBehaviors with appropriate mapper
 			behaviors := &AuthBehaviors{}
@@ -331,4 +336,32 @@ func TestCheckClientUsernameMatchesMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthCertSANMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Verify MarkUsedCertSANAuth / UsedCertSANAuth tracking.
+	b := &AuthBehaviors{}
+	require.False(t, b.UsedCertSANAuth())
+	b.MarkUsedCertSANAuth()
+	require.True(t, b.UsedCertSANAuth())
+
+	// Verify metric counters are properly initialized and incrementable.
+	sqlMetrics := sql.MakeMemMetrics("test", metric.TestSampleInterval)
+	metrics := newTenantSpecificMetrics(sqlMetrics, metric.TestSampleInterval)
+	require.NotNil(t, metrics.AuthCertSANConnTotal)
+	require.NotNil(t, metrics.AuthCertSANConnSuccess)
+
+	metrics.AuthCertSANConnTotal.Inc(1)
+	require.Equal(t, int64(1), metrics.AuthCertSANConnTotal.Count())
+
+	metrics.AuthCertSANConnSuccess.Inc(1)
+	require.Equal(t, int64(1), metrics.AuthCertSANConnSuccess.Count())
+
+	// Verify failure count = total - success.
+	metrics.AuthCertSANConnTotal.Inc(1)
+	failures := metrics.AuthCertSANConnTotal.Count() - metrics.AuthCertSANConnSuccess.Count()
+	require.Equal(t, int64(1), failures)
 }

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -439,6 +439,12 @@ func authCert(
 		// Use regular mapper for non-SAN authentication.
 		b.SetRoleMapper(HbaMapper(hbaEntry, identMap))
 	}
+
+	// Mark that SAN authentication will be used if SAN is required.
+	if clientCertSANRequired {
+		b.MarkUsedCertSANAuth()
+	}
+
 	b.SetAuthenticator(func(
 		ctx context.Context,
 		systemIdentity string,
@@ -478,7 +484,7 @@ func authCert(
 		if clientCertSANRequired {
 			identityList := security.ExtractSANsFromCertificate(tlsState.PeerCertificates[0])
 			if len(identityList) == 0 {
-				return nil, errors.New("client certificate SAN is required, but no SAN found in the certificate")
+				return b, errors.New("client certificate SAN is required, but no SAN found in the certificate")
 			}
 			b.SetSANIdentities(identityList)
 		} else {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -260,6 +261,24 @@ var (
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `See Description.`,
 	}
+	AuthCertSANConnTotal = metric.Metadata{
+		Name:        "auth.cert.san.conn.total",
+		Help:        "Total number of SQL connection attempts using SAN-based certificate authentication",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_SQL,
+		HowToUse:    "This metric tracks all authentication attempts when SAN-based certificate validation is enabled. Compare with auth.cert.san.conn.success to calculate failure rate.",
+	}
+	AuthCertSANConnSuccess = metric.Metadata{
+		Name:        "auth.cert.san.conn.success",
+		Help:        "Number of successful SQL connections using SAN-based certificate authentication",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_SQL,
+		HowToUse:    "This metric tracks successful authentications when SAN-based certificate validation is enabled. Use this to monitor adoption and success rate of SAN authentication. Failure rate = auth.cert.san.conn.total - auth.cert.san.conn.success.",
+	}
 )
 
 const (
@@ -420,6 +439,8 @@ type tenantSpecificMetrics struct {
 	AuthGSSConnLatency          metric.IHistogram
 	AuthScramConnLatency        metric.IHistogram
 	AuthLDAPConnLatencyInternal metric.IHistogram
+	AuthCertSANConnTotal        *metric.Counter
+	AuthCertSANConnSuccess      *metric.Counter
 }
 
 func newTenantSpecificMetrics(
@@ -456,6 +477,8 @@ func newTenantSpecificMetrics(
 			getHistogramOptionsForIOLatency(AuthScramConnLatency, histogramWindow)),
 		AuthLDAPConnLatencyInternal: metric.NewHistogram(
 			getHistogramOptionsForIOLatency(AuthLDAPConnLatencyInternal, histogramWindow)),
+		AuthCertSANConnTotal:   metric.NewCounter(AuthCertSANConnTotal),
+		AuthCertSANConnSuccess: metric.NewCounter(AuthCertSANConnSuccess),
 	}
 }
 
@@ -534,6 +557,16 @@ func MakeServer(
 	})
 	ConnIdentityMapConf.SetOnChange(&st.SV, func(ctx context.Context) {
 		loadLocalIdentityMapUponRemoteSettingChange(ctx, server, st)
+	})
+
+	// Track SAN authentication feature enablement.
+	security.ClientCertSANRequired.SetOnChange(&st.SV, func(ctx context.Context) {
+		if security.ClientCertSANRequired.Get(&st.SV) {
+			telemetry.Inc(sqltelemetry.CertSANEnableCounter)
+			log.Ops.Infof(ctx, "SAN-based certificate authentication has been enabled")
+		} else {
+			log.Ops.Infof(ctx, "SAN-based certificate authentication has been disabled")
+		}
 	})
 
 	return server

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -81,3 +81,7 @@ var NotReadOnlyStmtsTriedWithPausablePortals = telemetry.GetCounterOnce("pgwire.
 // pgwire portal and the session variable multiple_active_portals_enabled has
 // been set to true. In this case the execution cannot be paused.
 var SubOrPostQueryStmtsTriedWithPausablePortals = telemetry.GetCounterOnce("pgwire.pausable_portal_stmts_with_sub_or_post_queries")
+
+// CertSANEnableCounter is to be incremented every time the
+// security.client_cert.san_required.enabled cluster setting is toggled on.
+var CertSANEnableCounter = telemetry.GetCounterOnce("auth.cert.san.enable")


### PR DESCRIPTION
Backport 1/1 commits from #164277.

---

* Add telemetry counter to track when the SAN authentication cluster setting is enabled, with ops-level logging on setting toggle.
* Add tenant-specific Prometheus counters for total and successful SAN-based certificate authentication attempts.
* Enhance certificate authentication failure errors with SAN details when SAN authentication is enabled

Epic: [CRDB-58866](https://cockroachlabs.atlassian.net/browse/CRDB-58866)

Resolves: #164137
    
Release note (ops change): Added two new metrics, auth.cert.san.conn.total and auth.cert.san.conn.success, to track SAN-based certificate authentication attempts and successes.

Release justification: SAN feature is releasing in 26.2 and these metrics are important to track connection success and customer usage
