### PR TITLE
testcluster: use race-aware timeout in WaitForSplitAndInitialization

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1631,7 +1631,7 @@ func (tc *TestCluster) ScratchRangeWithExpirationLease(t serverutils.TestFataler
 // NB: This doesn't actually wait for full upreplication to whatever the zone
 // config specifies.
 func (tc *TestCluster) WaitForSplitAndInitialization(startKey roachpb.Key) error {
-	return retry.ForDuration(testutils.DefaultSucceedsSoonDuration, func() error {
+	return retry.ForDuration(testutils.SucceedsSoonDuration(), func() error {
 		desc, err := tc.LookupRange(startKey)
 		if err != nil {
 			return errors.Wrapf(err, "unable to lookup range for %s", startKey)


### PR DESCRIPTION
Use `testutils.SucceedsSoonDuration()` instead of the hardcoded `testutils.DefaultSucceedsSoonDuration` (45s) so that the timeout extends to 225s under the race detector. This fixes a flake in TestAmbiguousCommit where the automatic range split for a new table does not complete within 45s under race.

Fixes #166670

Release note: None