### PR TITLE
cli: strip license NOTICE before collapsing SQL data retrieval lines

### DIFF
--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -364,14 +364,19 @@ func captureOutput(f func()) (out string, err error) {
 		if x := recover(); x != nil {
 			err = errors.Errorf("panic: %v", x)
 		}
+		// Strip license-related NOTICE messages that the SQL driver may inject
+		// into output. These appear nondeterministically and can split retrieval
+		// lines across multiple lines, breaking the <dumping SQL tables> collapsing
+		// below. Strip them early so retrieval lines remain intact.
+		out = regexp.MustCompile(`NOTICE: No license is installed[^\n]*\n?`).
+			ReplaceAllString(out, "")
 		// Replace any series of 'retrieving SQL data for ...' messages with a
 		// single '<dumping SQL tables>' message so that these tests are agnostic to
 		// both specific names and total number of system and internal tables that
 		// are exported. The regex matches the rest of the line after the prefix
 		// unless the line contains an uppercase E to avoid trimming "ERROR" message
-		// lines (but not NOTICE which is informational), which are expected
-		// (and tested) for certain tables.
-		out = regexp.MustCompile(`(.*retrieving SQL data for (([^E\n])*|.*NOTICE.*)\n)+`).
+		// lines, which are expected (and tested) for certain tables.
+		out = regexp.MustCompile(`(.*retrieving SQL data for ([^E\n])*\n)+`).
 			ReplaceAllString(out, "<dumping SQL tables>\n")
 	}()
 

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -724,7 +724,9 @@ func eraseNonDeterministicZipOutput(out string) string {
 	out = re.ReplaceAllString(out, `[node ?] ? execution traces found`)
 
 	// Remove license-related NOTICE messages that may appear intermittently.
-	re = regexp.MustCompile(`(?m)^NOTICE: No license is installed.*\n?`)
+	// Most NOTICE messages are stripped earlier in RunWithCapture, but this
+	// catches any that appear outside of SQL data retrieval lines.
+	re = regexp.MustCompile(`(?m)NOTICE: No license is installed[^\n]*\n?`)
 	out = re.ReplaceAllString(out, ``)
 
 	return out


### PR DESCRIPTION
Strip `NOTICE: No license is installed...` messages in `RunWithCapture` **before** the `<dumping SQL tables>` collapsing regex runs

Previously, NOTICE messages injected by the SQL driver could split `retrieving SQL data for ...` lines across multiple lines, breaking the collapsing and leaving orphaned fragments in test output

Also broadens the safety-net NOTICE regex in `eraseNonDeterministicZipOutput` to catch inline occurrences (not just line-start)

Simplifies the `<dumping SQL tables>` regex by removing the now-unnecessary `|.*NOTICE.*` alternative

This fixes `TestPartialZip` failures on release-25.2 where the NOTICE stripping didn't exist, and hardens master/26.x against the same issue when NOTICE appears inline.

Resolves: #165776
Resolves: #166149

Release note: None