### PR TITLE
sql/catalog: fix hydration of objects referencing temporary schemas

### DIFF
--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -135,7 +135,7 @@ func makeMutableTypeLookupFunc(
 		}
 		f := getterFlags{
 			contextFlags: contextFlags{
-				isMutable: true,
+				isMutable: !skipHydration, // Immutable descriptors are fine for non-hydrated cases.
 			},
 			layerFilters: layerFilters{
 				withoutSynthetic: true,
@@ -172,7 +172,11 @@ func makeMutableTypeLookupFunc(
 		}
 		return desc, nil
 	}
-	return makeTypeLookupFuncForHydration(mc, mutableLookupFunc)
+	resolveTempSchemas := func(ctx context.Context, dbDesc catalog.DatabaseDescriptor) error {
+		_, err := tc.cr.ScanNamespaceForDatabaseSchemas(ctx, txn, dbDesc)
+		return err
+	}
+	return makeTypeLookupFuncForHydration(mc, mutableLookupFunc, resolveTempSchemas)
 }
 
 func makeImmutableTypeLookupFunc(
@@ -189,9 +193,9 @@ func makeImmutableTypeLookupFunc(
 		mc.UpsertDescriptor(desc)
 	}
 	immutableLookupFunc := func(ctx context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error) {
-		witoutDropped := true
+		withoutDropped := true
 		if !flags.layerFilters.withoutLeased {
-			witoutDropped = false
+			withoutDropped = false
 		}
 		f := getterFlags{
 			layerFilters: layerFilters{
@@ -200,7 +204,7 @@ func makeImmutableTypeLookupFunc(
 				withoutHydration: skipHydration,
 			},
 			descFilters: descFilters{
-				withoutDropped: witoutDropped,
+				withoutDropped: withoutDropped,
 				// For hydration, we will allow offline descriptors for lookups
 				// of type descriptors. A descriptor can be offline either due to:
 				// 1) IMPORT in which case we are looking at an implicit record type
@@ -222,7 +226,7 @@ func makeImmutableTypeLookupFunc(
 		// Note: This is a special case because type hydration cannot tolerate
 		// dropped descriptors. This already could occur by leasing any schema
 		// with type references that are being dropped.
-		if !witoutDropped && !flags.layerFilters.withoutLeased && desc.Dropped() {
+		if !withoutDropped && !flags.layerFilters.withoutLeased && desc.Dropped() {
 			if tc.leased.leaseTimestampSet &&
 				tc.leased.leaseTimestamp.GetTimestamp().Less(desc.GetModificationTime()) {
 				return nil, &retryOnModifiedDescriptor{
@@ -251,7 +255,11 @@ func makeImmutableTypeLookupFunc(
 		}
 		return desc, nil
 	}
-	return makeTypeLookupFuncForHydration(mc, immutableLookupFunc)
+	resolveTempSchemas := func(ctx context.Context, dbDesc catalog.DatabaseDescriptor) error {
+		_, err := tc.cr.ScanNamespaceForDatabaseSchemas(ctx, txn, dbDesc)
+		return err
+	}
+	return makeTypeLookupFuncForHydration(mc, immutableLookupFunc, resolveTempSchemas)
 }
 
 // HydrateCatalog installs type metadata in the type.T objects present for all
@@ -263,7 +271,10 @@ func HydrateCatalog(ctx context.Context, c nstree.MutableCatalog) error {
 	fakeLookupFunc := func(_ context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error) {
 		return nil, catalog.NewDescriptorNotFoundError(id)
 	}
-	typeLookupFunc := makeTypeLookupFuncForHydration(c, fakeLookupFunc)
+	fakeResolveTempSchema := func(_ context.Context, dbDesc catalog.DatabaseDescriptor) error {
+		return nil
+	}
+	typeLookupFunc := makeTypeLookupFuncForHydration(c, fakeLookupFunc, fakeResolveTempSchema)
 	var hydratable []catalog.Descriptor
 	_ = c.ForEachDescriptor(func(desc catalog.Descriptor) error {
 		if isHydratable(desc) {
@@ -295,6 +306,10 @@ func (tc *Collection) canUseHydratedDescriptorCache(id descpb.ID) bool {
 // descriptors and their parent schemas and databases when hydrating an object.
 type hydrationLookupFunc func(ctx context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error)
 
+// hydrationResolveTemporarySchemas is used to prime any temporary schemas for future calls to
+// the lookup function.
+type hydrationResolveTemporarySchemas func(ctx context.Context, dbDesc catalog.DatabaseDescriptor) error
+
 // isHydratable returns false iff the descriptor definitely does not require
 // hydration
 func isHydratable(desc catalog.Descriptor) bool {
@@ -322,7 +337,9 @@ func hydrate(
 // looked up in the nstree.Catalog object before being looked up via the
 // hydrationLookupFunc.
 func makeTypeLookupFuncForHydration(
-	c nstree.MutableCatalog, lookupFn hydrationLookupFunc,
+	c nstree.MutableCatalog,
+	lookupFn hydrationLookupFunc,
+	resolveTempSchemas hydrationResolveTemporarySchemas,
 ) typedesc.TypeLookupFunc {
 	var typeLookupFunc func(ctx context.Context, id descpb.ID) (tn tree.TypeName, typ catalog.TypeDescriptor, err error)
 
@@ -368,18 +385,31 @@ func makeTypeLookupFuncForHydration(
 			}
 			c.UpsertDescriptor(dbDesc)
 		}
-		if _, err = catalog.AsDatabaseDescriptor(dbDesc); err != nil {
+		var resolvedDbDesc catalog.DatabaseDescriptor
+		if resolvedDbDesc, err = catalog.AsDatabaseDescriptor(dbDesc); err != nil {
 			return tree.TypeName{}, nil, err
 		}
 		scDesc := c.LookupDescriptor(typ.GetParentSchemaID())
 		if scDesc == nil {
 			scDesc, err = lookupFn(ctx, typ.GetParentSchemaID(), true /* skipHydration */)
-			if err != nil {
-				if errors.Is(err, catalog.ErrDescriptorNotFound) {
-					n := fmt.Sprintf("[%d]", typ.GetParentSchemaID())
-					return tree.TypeName{}, nil, sqlerrors.NewUndefinedSchemaError(n)
-				}
+			if err != nil && !errors.Is(err, catalog.ErrDescriptorNotFound) {
 				return tree.TypeName{}, nil, err
+			}
+			// Attempt to resolve temporary schemas via the database as a last resort.
+			if scDesc == nil {
+				err := resolveTempSchemas(ctx, resolvedDbDesc)
+				if err != nil {
+					return tree.TypeName{}, nil, err
+				}
+				// If name resolution fails, then the schema isn't a temporary one either.
+				scDesc, err = lookupFn(ctx, typ.GetParentSchemaID(), true /* skipHydration */)
+				if err != nil {
+					if errors.Is(err, catalog.ErrDescriptorNotFound) {
+						n := fmt.Sprintf("[%d]", typ.GetParentSchemaID())
+						return tree.TypeName{}, nil, sqlerrors.NewUndefinedSchemaError(n)
+					}
+					return tree.TypeName{}, nil, err
+				}
 			}
 			c.UpsertDescriptor(scDesc)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -762,7 +762,46 @@ USE defaultdb
 statement ok
 DROP DATABASE temp_priv_db CASCADE
 
+subtest end
+
+# Tests that UDFs referencing temp tables in a differnt schema will leave the
+# schema accessible to the user (see #166495).
+subtest temp_schema_udf_regression
+
+user root
+
+statement ok
+CREATE DATABASE tmpdb
+
+user testuser
+
+statement ok
+USE tmpdb
+
+statement ok
+CREATE TEMP TABLE users (userid INT PRIMARY KEY)
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE OR REPLACE FUNCTION tmpdb.public.get_users() RETURNS SETOF users AS
+$$ SELECT * FROM users ORDER BY userid; $$
+LANGUAGE SQL STABLE
+
+user root
+
+statement ok
+USE tmpdb
+
+statement ok
+SELECT * FROM [SHOW TABLES]
+
+statement ok
+DROP DATABASE tmpdb CASCADE
+
+subtest end
+
 statement ok
 DROP USER temp_test_user
 
-subtest end
+statement ok
+USE test;


### PR DESCRIPTION
Hydration of descriptors (e.g., UDFs) that reference objects in temporary schemas was failing if the temporary schema was not already present in the nstree.Catalog. This occurred because temporary schemas are session-specific and not necessarily persisted in a way that the standard hydration lookup could find them without extra context.

This change introduces a mechanism to resolve temporary schemas during hydration. When a schema descriptor is not found, the lookup function now attempts to scan the database's namespace for temporary schemas as a last resort. This ensures that descriptors referencing temporary objects can be fully hydrated even if the temporary schema hasn't been explicitly added to the catalog yet.

A regression test is added to verify that UDFs referencing temporary tables in different schemas work correctly.

Fixes: #166495

Release note: None