### PR TITLE
storage: override Pebble's ExitFunc to route through fatal logging

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1209,6 +1209,17 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	}
 	// Else, already have a LoggerAndTracer. This only occurs in unit tests.
 
+	// Override Pebble's exit function so that invariant violation exits
+	// route through CockroachDB's fatal logging. Without this, Pebble's
+	// direct os.Exit(1) calls (cache invariant checks, memtable
+	// assertions, etc.) bypass all logging, crash reporting, and marker
+	// file writing — the process just vanishes with no indication of why.
+	//
+	// Requires cockroachdb/pebble#5865.
+	cfg.opts.ExitFunc = func(code int) {
+		log.Storage.Fatalf(logCtx, "pebble: invariant violation (exit code %d)", code)
+	}
+
 	// Establish the emergency ballast if we can. If there's not sufficient
 	// disk space, the ballast will be reestablished from Capacity when the
 	// store's capacity is queried periodically.


### PR DESCRIPTION
## Summary

Set `pebble.Options.ExitFunc` so that Pebble invariant violation exits (cache assertions, memtable checks, sstable reader checks) route through CockroachDB's `log.Fatal` path instead of calling `os.Exit(1)` directly.

Without this, Pebble's 18 direct `os.Exit(1)` calls bypass all logging, crash reporting (Sentry), and marker file writing — the process just vanishes with exit code 1 and no indication of why.

**Depends on**: cockroachdb/pebble#5865 (adds `Options.ExitFunc` to Pebble)

## Note

This PR will not compile until the Pebble dependency is updated to include cockroachdb/pebble#5865.