### PR TITLE
sql: emit notice on manual full stats collection with canary window

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
@@ -170,6 +172,10 @@ type createStatsNode struct {
 
 	// whereIndexID is the index to use to collect statistics with a WHERE clause.
 	whereIndexID descpb.IndexID
+
+	// statsCanaryWindow is set during makeJobRecord to the table's canary
+	// window duration so that runJob can emit a notice for manual collections.
+	statsCanaryWindow time.Duration
 }
 
 func (n *createStatsNode) startExec(params runParams) error {
@@ -236,6 +242,15 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 		}
 	} else {
 		telemetry.Inc(sqltelemetry.CreateStatisticsUseCounter)
+		if n.statsCanaryWindow > 0 &&
+			stats.CanaryFraction.Get(n.p.ExecCfg().SV()) > 0 &&
+			!n.Options.UsingExtremes && n.Options.Where == nil {
+			n.p.BufferClientNotice(ctx, pgnotice.Newf(
+				"this table has a canary window of %s; newly collected statistics "+
+					"will not take effect for all queries until the canary window passes",
+				n.statsCanaryWindow,
+			))
+		}
 	}
 
 	var job *jobs.StartableJob
@@ -515,6 +530,8 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 			return nil, maintainErr
 		}
 	}
+
+	n.statsCanaryWindow = tableDesc.TableDesc().StatsCanaryWindow
 
 	var colStats []jobspb.CreateStatsDetails_ColStat
 	var deleteOtherStats bool

--- a/pkg/sql/logictest/testdata/logic_test/canary_stats_deletion
+++ b/pkg/sql/logictest/testdata/logic_test/canary_stats_deletion
@@ -1,5 +1,114 @@
 # LogicTest: !local-mixed-25.4 !local-mixed-26.1
 
+subtest canary_window_notice
+
+# Test that manually collecting statistics on a table with a canary window
+# emits a notice when the canary fraction cluster setting is positive.
+
+statement ok
+CREATE TABLE t_notice (a INT PRIMARY KEY) WITH (sql_stats_canary_window = '15s')
+
+# No notice when canary_fraction is 0 (default).
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+ANALYZE t_notice
+----
+
+# Under weaker isolation levels, ANALYZE upgrades to SERIALIZABLE and emits a notice.
+onlyif config local-read-committed local-repeatable-read
+query T noticetrace
+ANALYZE t_notice
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = 0.2
+
+# Notice should appear when both canary_window and canary_fraction are set.
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+ANALYZE t_notice
+----
+NOTICE: this table has a canary window of 15s; newly collected statistics will not take effect for all queries until the canary window passes
+
+onlyif config local-read-committed local-repeatable-read
+query T noticetrace
+ANALYZE t_notice
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: this table has a canary window of 15s; newly collected statistics will not take effect for all queries until the canary window passes
+
+# CREATE STATISTICS should also show the notice.
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE STATISTICS s FROM t_notice
+----
+NOTICE: this table has a canary window of 15s; newly collected statistics will not take effect for all queries until the canary window passes
+
+onlyif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE STATISTICS s FROM t_notice
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: this table has a canary window of 15s; newly collected statistics will not take effect for all queries until the canary window passes
+
+# No notice for a table without canary window.
+statement ok
+CREATE TABLE t_no_canary (a INT PRIMARY KEY)
+
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+ANALYZE t_no_canary
+----
+
+onlyif config local-read-committed local-repeatable-read
+query T noticetrace
+ANALYZE t_no_canary
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+# Partial stats (USING EXTREMES and WHERE) are not canaried, so no notice.
+statement ok
+SET enable_create_stats_using_extremes = true
+
+statement ok
+INSERT INTO t_notice VALUES (1), (2), (3)
+
+statement ok
+ANALYZE t_notice
+
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE STATISTICS s_extremes ON a FROM t_notice USING EXTREMES
+----
+
+onlyif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE STATISTICS s_extremes ON a FROM t_notice USING EXTREMES
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE STATISTICS s_where ON a FROM t_notice WHERE a > 1
+----
+
+onlyif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE STATISTICS s_where ON a FROM t_notice WHERE a > 1
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+# Reset cluster setting.
+statement ok
+SET CLUSTER SETTING sql.stats.canary_fraction = 0
+
+statement ok
+DROP TABLE t_notice;
+DROP TABLE t_no_canary
+
+subtest end
+
 subtest delay_delete_with_manual_stats
 # We test that for a table with canary stats rollout enabled (i.e. with
 # a non-zero stats_canary_window), when a new stats is created, the


### PR DESCRIPTION
sql: emit notice on manual stats collection with canary window
When a user manually collects full statistics (ANALYZE or CREATE
STATISTICS) on a table with a non-zero canary window and the
sql.stats.canary_fraction cluster setting is positive, emit a client
notice informing the user that the newly collected stats will not take
effect for all queries until the canary window passes.

The notice is intentionally suppressed for partial stats collection
(USING EXTREMES or WHERE clause) since partial stats are not subject
to canary rollout and take effect immediately.

Epic: None
Release note: None