### PR TITLE
release-26.1: catalog/lease: use normal priority for descriptor version fetching

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/storage",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	kvstorage "github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -792,7 +793,16 @@ func getDescriptorsFromStoreForInterval(
 		}
 
 		// Export request returns descriptors in decreasing modification time.
-		res, pErr := kv.SendWrappedWith(ctx, db.NonTransactionalSender(), batchRequestHeader, req)
+		res, pErr := kv.SendWrappedWithAdmission(ctx, db.NonTransactionalSender(), batchRequestHeader, kvpb.AdmissionHeader{
+			// We are fetching descriptor versions for foreground traffic, so getting
+			// throttled delays foreground work. As a result, lease manager exports
+			// should execute with a normal priority.
+			Priority:                 int32(admissionpb.NormalPri),
+			CreateTime:               timeutil.Now().UnixNano(),
+			Source:                   kvpb.AdmissionHeader_FROM_SQL,
+			NoMemoryReservedAtSource: true,
+		},
+			req)
 		if pErr != nil {
 			return nil, errors.Wrapf(pErr.GoError(), "error in retrieving descs between %s, %s",
 				lowerBound, upperBound)


### PR DESCRIPTION
Backport 1/1 commits from #166746.

/cc @cockroachdb/release

---

getDescriptorsFromStoreForInterval is used to fetch historical descriptor versions for foreground SQL traffic. Previously, it was using BulkNormalPri, which meant it could be throttled by the elastic CPU limiter. Throttling these requests delays foreground work, which can lead to query timeouts and test failures (like
backup-restore/small-ranges).

This change sets the priority to NormalPri, ensuring these requests are treated as foreground work and not subject to elastic CPU control.

Fixes: #166263

Release note (bug fix): Fixed a bug where descriptor version fetching could be incorrectly throttled by the elastic CPU limiter, potentially leading to increased query latency or timeouts under high CPU load.

Release justification: bug fix
