### PR TITLE
release-25.4: kvserver,server/status: handle disk stats counter wraps per-counter

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -4475,6 +4475,20 @@ func (sm *StoreMetrics) updateEnvStats(stats fs.EnvStats) {
 	sm.EncryptionAlgorithm.Update(int64(stats.EncryptionType))
 }
 
+// updateDiskCounter updates a disk stat counter with a cumulative value from
+// the OS. On s390x, /proc/diskstats counters are 32-bit unsigned and wrap
+// after ~2^32. If the new value is lower than the current counter value
+// (indicating a wrap), the counter is cleared before updating to avoid a
+// panic in test builds.
+func updateDiskCounter(ctx context.Context, counter *metric.Counter, val int64) {
+	if counter.Count() > val {
+		log.Ops.Infof(ctx,
+			"disk stats counter wrap detected for %s, resetting", counter.GetMetadata().Name)
+		counter.Clear()
+	}
+	counter.Update(val)
+}
+
 func (sm *StoreMetrics) updateDiskStats(
 	ctx context.Context,
 	rollingStats disk.StatsWindow,
@@ -4482,14 +4496,14 @@ func (sm *StoreMetrics) updateDiskStats(
 	cumulativeStatsErr error,
 ) {
 	if cumulativeStatsErr == nil {
-		sm.DiskReadCount.Update(int64(cumulativeStats.ReadsCount))
-		sm.DiskReadBytes.Update(int64(cumulativeStats.BytesRead()))
-		sm.DiskReadTime.Update(int64(cumulativeStats.ReadsDuration))
-		sm.DiskWriteCount.Update(int64(cumulativeStats.WritesCount))
-		sm.DiskWriteBytes.Update(int64(cumulativeStats.BytesWritten()))
-		sm.DiskWriteTime.Update(int64(cumulativeStats.WritesDuration))
-		sm.DiskIOTime.Update(int64(cumulativeStats.CumulativeDuration))
-		sm.DiskWeightedIOTime.Update(int64(cumulativeStats.WeightedIODuration))
+		updateDiskCounter(ctx, sm.DiskReadCount, int64(cumulativeStats.ReadsCount))
+		updateDiskCounter(ctx, sm.DiskReadBytes, int64(cumulativeStats.BytesRead()))
+		updateDiskCounter(ctx, sm.DiskReadTime, int64(cumulativeStats.ReadsDuration))
+		updateDiskCounter(ctx, sm.DiskWriteCount, int64(cumulativeStats.WritesCount))
+		updateDiskCounter(ctx, sm.DiskWriteBytes, int64(cumulativeStats.BytesWritten()))
+		updateDiskCounter(ctx, sm.DiskWriteTime, int64(cumulativeStats.WritesDuration))
+		updateDiskCounter(ctx, sm.DiskIOTime, int64(cumulativeStats.CumulativeDuration))
+		updateDiskCounter(ctx, sm.DiskWeightedIOTime, int64(cumulativeStats.WeightedIODuration))
 		sm.DiskIopsInProgress.Update(int64(cumulativeStats.InProgressCount))
 	} else {
 		// Don't update cumulative stats to the useless zero value.

--- a/pkg/kv/kvserver/metrics_test.go
+++ b/pkg/kv/kvserver/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,5 +124,54 @@ func TestPebbleDiskWriteMetrics(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestUpdateDiskCounter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name     string
+		initial  int64
+		newVal   int64
+		expected int64
+	}{{
+		name:     "fresh counter, first update",
+		initial:  0,
+		newVal:   100,
+		expected: 100,
+	}, {
+		name:     "normal increasing update",
+		initial:  100,
+		newVal:   200,
+		expected: 200,
+	}, {
+		name:     "same value (no change)",
+		initial:  100,
+		newVal:   100,
+		expected: 100,
+	}, {
+		name:     "counter wrap: new value lower than current",
+		initial:  4294720145000000,
+		newVal:   136286000000,
+		expected: 136286000000,
+	}, {
+		name:     "counter wrap to zero",
+		initial:  100,
+		newVal:   0,
+		expected: 0,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			counter := metric.NewCounter(metric.Metadata{Name: "test"})
+			if tt.initial > 0 {
+				counter.Update(tt.initial)
+			}
+			updateDiskCounter(ctx, counter, tt.newVal)
+			require.Equal(t, tt.expected, counter.Count())
+		})
 	}
 }

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -1443,38 +1443,49 @@ func sumAndFilterDiskCounters(disksStats []DiskStats) (DiskStats, error) {
 	return output, nil
 }
 
-// subtractDiskCounters subtracts the counters in `baseline` from the
-// counters in `stats`, saving the results in `stats`. If any counter
-// in `stats` is lower than the corresponding counter in `baseline`
-// (indicating a reset), the value for all metrics in `baseline`
-// is updated to the current value in `stats` to establish a new
-// baseline.
-func subtractDiskCounters(ctx context.Context, stats *DiskStats, baseline *DiskStats) {
-	if stats.WriteBytes < baseline.WriteBytes ||
-		stats.writeCount < baseline.writeCount ||
-		stats.writeTime < baseline.writeTime ||
-		stats.ReadBytes < baseline.ReadBytes ||
-		stats.readCount < baseline.readCount ||
-		stats.readTime < baseline.readTime ||
-		stats.ioTime < baseline.ioTime ||
-		stats.weightedIOTime < baseline.weightedIOTime {
-		*baseline = *stats
-		*stats = DiskStats{}
-		log.Ops.Info(ctx, "runtime: new baseline in disk stats from host. disk metric counters have been reset.")
-		return
+// subtractDiskStat subtracts base from stat. If stat < base (indicating a
+// counter wrap, e.g. on s390x where /proc/diskstats counters are 32-bit
+// unsigned), base is reset to stat and stat is zeroed.
+func subtractDiskStat(ctx context.Context, stat, base *int64, name string) {
+	if *stat < *base {
+		log.Ops.Infof(ctx,
+			"runtime: disk stats counter wrap detected for %s, resetting baseline", name)
+		*base = *stat
+		*stat = 0
+	} else {
+		*stat -= *base
 	}
+}
 
-	// Perform normal subtraction
-	stats.writeCount -= baseline.writeCount
-	stats.WriteBytes -= baseline.WriteBytes
-	stats.writeTime -= baseline.writeTime
+// subtractDiskStatDuration is like subtractDiskStat but for time.Duration
+// fields.
+func subtractDiskStatDuration(ctx context.Context, stat, base *time.Duration, name string) {
+	if *stat < *base {
+		log.Ops.Infof(ctx,
+			"runtime: disk stats counter wrap detected for %s, resetting baseline", name)
+		*base = *stat
+		*stat = 0
+	} else {
+		*stat -= *base
+	}
+}
 
-	stats.readCount -= baseline.readCount
-	stats.ReadBytes -= baseline.ReadBytes
-	stats.readTime -= baseline.readTime
-
-	stats.ioTime -= baseline.ioTime
-	stats.weightedIOTime -= baseline.weightedIOTime
+// subtractDiskCounters subtracts the counters in `baseline` from the
+// counters in `stats`, saving the results in `stats`. Each counter is
+// handled independently: if a counter in `stats` is lower than the
+// corresponding counter in `baseline` (indicating a wrap on s390x
+// where /proc/diskstats counters are 32-bit unsigned), that counter's
+// baseline is reset to the current value and the result for that
+// counter is zeroed. Counters that haven't wrapped subtract normally.
+func subtractDiskCounters(ctx context.Context, stats *DiskStats, baseline *DiskStats) {
+	subtractDiskStat(ctx, &stats.ReadBytes, &baseline.ReadBytes, "host-disk-read-bytes")
+	subtractDiskStat(ctx, &stats.readCount, &baseline.readCount, "host-disk-read-count")
+	subtractDiskStatDuration(ctx, &stats.readTime, &baseline.readTime, "host-disk-read-time")
+	subtractDiskStat(ctx, &stats.WriteBytes, &baseline.WriteBytes, "host-disk-write-bytes")
+	subtractDiskStat(ctx, &stats.writeCount, &baseline.writeCount, "host-disk-write-count")
+	subtractDiskStatDuration(ctx, &stats.writeTime, &baseline.writeTime, "host-disk-write-time")
+	subtractDiskStatDuration(ctx, &stats.ioTime, &baseline.ioTime, "host-disk-io-time")
+	subtractDiskStatDuration(ctx, &stats.weightedIOTime, &baseline.weightedIOTime, "host-disk-weighted-io-time")
 }
 
 // sumNetworkCounters returns a new net.IOCountersStat whose values are the sum of the

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -139,17 +139,18 @@ func TestSubtractDiskCounters(t *testing.T) {
 func TestSubtractDiskCountersReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Test case where current values are lower than baseline (indicating counter reset)
+	// Test per-counter wrap handling: only wrapped counters reset to zero,
+	// non-wrapped counters subtract normally.
 	stats := DiskStats{
-		ReadBytes:      2,                      // lower than sub (10)
-		readCount:      5,                      // higher than sub (3)
-		readTime:       time.Millisecond * 100, // lower than sub (200ms)
-		WriteBytes:     3,                      // lower than sub (8)
-		writeCount:     7,                      // higher than sub (4)
-		writeTime:      time.Millisecond * 150, // higher than sub (50ms)
-		ioTime:         time.Millisecond * 80,  // lower than sub (120ms)
-		weightedIOTime: time.Millisecond * 200, // higher than sub (180ms)
-		iopsInProgress: 5,                      // gauge - should not be affected
+		ReadBytes:      2,                      // wrapped: lower than baseline (10)
+		readCount:      5,                      // normal: higher than baseline (3)
+		readTime:       time.Millisecond * 100, // wrapped: lower than baseline (200ms)
+		WriteBytes:     3,                      // wrapped: lower than baseline (8)
+		writeCount:     7,                      // normal: higher than baseline (4)
+		writeTime:      time.Millisecond * 150, // normal: higher than baseline (50ms)
+		ioTime:         time.Millisecond * 80,  // wrapped: lower than baseline (120ms)
+		weightedIOTime: time.Millisecond * 200, // normal: higher than baseline (180ms)
+		iopsInProgress: 5,                      // gauge, not touched
 	}
 	baseline := DiskStats{
 		ReadBytes:      10,
@@ -163,18 +164,39 @@ func TestSubtractDiskCountersReset(t *testing.T) {
 		iopsInProgress: 2,
 	}
 
-	// Expected: all values should be reset
-	expected := DiskStats{}
+	// Wrapped counters get zeroed; non-wrapped counters subtract normally.
+	expected := DiskStats{
+		ReadBytes:      0,                      // wrapped -> 0
+		readCount:      2,                      // 5 - 3
+		readTime:       0,                      // wrapped -> 0
+		WriteBytes:     0,                      // wrapped -> 0
+		writeCount:     3,                      // 7 - 4
+		writeTime:      time.Millisecond * 100, // 150 - 50
+		ioTime:         0,                      // wrapped -> 0
+		weightedIOTime: time.Millisecond * 20,  // 200 - 180
+		iopsInProgress: 5,                      // gauge, untouched
+	}
 
-	// Verify that baselines were updated correctly for reset fields
-	expectedBaseline := stats
+	// Wrapped counters have their baseline reset to the current value;
+	// non-wrapped baselines are unchanged.
+	expectedBaseline := DiskStats{
+		ReadBytes:      2,                      // reset to current
+		readCount:      3,                      // unchanged
+		readTime:       time.Millisecond * 100, // reset to current
+		WriteBytes:     3,                      // reset to current
+		writeCount:     4,                      // unchanged
+		writeTime:      time.Millisecond * 50,  // unchanged
+		ioTime:         time.Millisecond * 80,  // reset to current
+		weightedIOTime: time.Millisecond * 180, // unchanged
+		iopsInProgress: 2,                      // unchanged
+	}
 
 	subtractDiskCounters(context.Background(), &stats, &baseline)
 	if !reflect.DeepEqual(stats, expected) {
 		t.Fatalf("expected %+v; got %+v", expected, stats)
 	}
 	if !reflect.DeepEqual(baseline, expectedBaseline) {
-		t.Fatalf("expected sub %+v; got %+v", expectedBaseline, baseline)
+		t.Fatalf("expected baseline %+v; got %+v", expectedBaseline, baseline)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #163315.

/cc @cockroachdb/release

Resolves: #162623

---

On s390x, /proc/diskstats counters are 32-bit unsigned and wrap after ~2^32 (~49.7 days of cumulative IO time). When this happens, the raw value drops to a small number, causing Counter.Update() to panic in test builds with "Counters should not decrease".

Store-level path (pkg/kv/kvserver/metrics.go):
Add an updateDiskCounter helper that detects per-counter wraps by comparing the new OS value against the current counter value. When a wrap is detected, the specific counter is cleared and the event is logged before updating.

Node-level path (pkg/server/status/runtime.go):
Refactor subtractDiskCounters to handle wraps per-counter instead of resetting all counters when any single one wraps. Each counter is now independently checked: wrapped counters have their baseline reset and result zeroed, while non-wrapped counters subtract normally.

Different counters accumulate at different rates and wrap independently, so per-counter handling preserves accuracy for counters that haven't wrapped.

Resolves: #162625
See also: #162624, #153048

Release note: None

----

Release justification: bug fix. only changes behavior during s390x counter wrap edge case, which currently causes panics in *test builds* (otherwise the only outcome is that on s390x, counters can go negative)