### PR TITLE
release-26.2: kvserver: disable assertions for legacy writes

### DIFF
--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -315,6 +316,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					ctx, rec, batch, enginepb.MVCCStats{}, &split, in, hlc.Timestamp{})
 				require.NoError(t, err)
 				if legacy {
+					batch := spanset.DisableForbiddenSpanAssertions(batch)
 					writeLegacySplitTriggerKeys(ctx, t, batch, rightDesc.RangeID)
 				}
 


### PR DESCRIPTION
Backport 1/6 commits from #165796.

/cc @cockroachdb/release

---

Epic: none
Release note: none
Release justification: test deflake
