### PR TITLE
release-25.4: build: adjust shard counts for tests

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 16,
+    shard_count = 24,
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/crosscluster/physical/BUILD.bazel
+++ b/pkg/crosscluster/physical/BUILD.bazel
@@ -125,7 +125,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 16,
+    shard_count = 32,
     deps = [
         "//pkg/backup",
         "//pkg/base",

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -36,7 +36,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 32,
+    shard_count = 48,
     deps = [
         "//pkg/base",
         "//pkg/jobs",

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     ],
     embed = [":stmtdiagnostics"],
     exec_properties = {"test.Pool": "large"},
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/keys",

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":metamorphic"],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 8,
     deps = [
         "//pkg/settings/cluster",
         "//pkg/testutils",


### PR DESCRIPTION
Backport 1/1 commits from #166859 on behalf of @rickystewart.

----

These are long-running tests that could be sharded more, with the exception of pkg/storage/metamorphic which doesn't need to be sharded this much.

Release note: none
Epic: none

----

Release justification: Non-production code changes