### PR TITLE
sql/catalog/lease: clarify descriptor lease duration setting docs

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -54,16 +54,16 @@ const (
 	// See https://github.com/cockroachdb/cockroach/issues/20310.
 	DefaultMetricsSampleInterval = 10 * time.Second
 
-	// DefaultDescriptorLeaseDuration is the default mean duration a
-	// lease will be acquired for. The actual duration is jittered using
-	// the jitter fraction. Jittering is done to prevent multiple leases
-	// from being renewed simultaneously if they were all acquired
-	// simultaneously.
+	// DefaultDescriptorLeaseDuration is the default duration used as a
+	// grace period for old descriptor versions to expire after a new
+	// version is acquired. It also controls the background lease
+	// refresh/cleanup loop interval. The actual duration is jittered
+	// using the jitter fraction.
 	DefaultDescriptorLeaseDuration = 5 * time.Minute
 
 	// DefaultDescriptorLeaseJitterFraction is the default factor
-	// that we use to randomly jitter the lease duration when acquiring a
-	// new lease and the lease renewal timeout.
+	// that we use to randomly jitter the lease duration when computing
+	// the old version grace period and refresh interval.
 	DefaultDescriptorLeaseJitterFraction = 0.05
 
 	// DefaultDescriptorLeaseRenewalTimeout is the default time

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -112,8 +112,8 @@ func CheckTwoVersionInvariant(
 	// up schema changes there and potentially create a deadlock.
 	descsCol.ReleaseLeases(ctx)
 
-	// Increment the long wait gauge for two version invariant violations, if this
-	// function takes longer than the lease duration.
+	// Increment the long wait gauge if this function takes longer than the
+	// lease duration (the grace period for old versions to expire).
 	decAfterWait := descsCol.leased.lm.IncGaugeAfterLeaseDuration(lease.GaugeWaitForTwoVersionViolation)
 	defer decAfterWait()
 	// Wait until all older version leases have been released or expired.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -70,18 +70,22 @@ var errReadOlderVersion = errors.New("read older descriptor version from store")
 var errReadOlderVersionAtBase = errors.New("read older descriptor version from store at base timestamp")
 var errLeaseManagerIsDraining = errors.New("cannot acquire lease when draining")
 
-// LeaseDuration controls the duration of sql descriptor leases.
+// LeaseDuration controls the grace period for old descriptor versions to
+// expire after a new version is acquired. It also controls the background
+// lease refresh/cleanup loop interval. The actual duration is jittered using
+// the jitter fraction.
 var LeaseDuration = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"sql.catalog.descriptor_lease_duration",
-	"mean duration of sql descriptor leases, this actual duration is jitterred",
+	"grace period for old descriptor versions to expire after a schema change, "+
+		"also controls the background lease refresh interval; the actual duration is jittered",
 	base.DefaultDescriptorLeaseDuration)
 
-// LeaseJitterFraction controls the percent jitter around sql lease durations
+// LeaseJitterFraction controls the percent jitter around the lease duration.
 var LeaseJitterFraction = settings.RegisterFloatSetting(
 	settings.ApplicationLevel,
 	"sql.catalog.descriptor_lease_jitter_fraction",
-	"mean duration of sql descriptor leases, this actual duration is jitterred",
+	"jitter fraction applied to the descriptor lease duration",
 	base.DefaultDescriptorLeaseJitterFraction,
 	settings.Fraction)
 
@@ -161,8 +165,8 @@ func (m *Manager) WaitForNoVersion(
 			Version: 0, // Unused any version flag used below.
 		},
 	}
-	// Increment the long wait gauge for wait for no version, if this function
-	// takes longer than the lease duration.
+	// Increment the long wait gauge if this function takes longer than the
+	// lease duration (the grace period for old versions to expire).
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForNoVersion)
 	defer decAfterWait()
 	wsTracker := startWaitStatsTracker(ctx)
@@ -580,8 +584,8 @@ func (m *Manager) WaitForOneVersion(
 ) (catalog.Descriptor, error) {
 	ctx, span := tracing.ChildSpan(ctx, "wait-for-one-version")
 	defer span.Finish()
-	// Increment the long wait gauge for wait for one version, if this function
-	// takes longer than the lease duration.
+	// Increment the long wait gauge if this function takes longer than the
+	// lease duration (the grace period for old versions to expire).
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForOneVersion)
 	defer decAfterWait()
 	wsTracker := startWaitStatsTracker(ctx)
@@ -1727,12 +1731,12 @@ func (m *Manager) purgeOldVersions(
 				defer m.mu.Unlock()
 				leaseToExpire.mu.Lock()
 				defer leaseToExpire.mu.Unlock()
-				// Expire any active old versions into the future based on the lease
-				// duration. If the session lifetime had been longer then use
-				// that. We will only expire later into the future, then what
-				// was previously observed, since transactions may have already
-				// picked this time. If the lease duration is zero, then we are
-				// looking at instant expiration for testing.
+				// Set an expiration on old versions so they don't persist
+				// indefinitely under session-based leasing. The expiration is
+				// now + leaseDuration, or the session expiry if that is later.
+				// We never move the expiration earlier than a previously set
+				// value, since transactions may have already observed it. A
+				// lease duration of zero means instant expiration (for testing).
 				leaseDuration := LeaseDuration.Get(&m.storage.settings.SV)
 				expiration := m.storage.db.KV().Clock().Now().AddDuration(leaseDuration)
 				if sessionExpiry := (*leaseToExpire.session.Load()).Expiration(); leaseDuration > 0 && expiration.Less(sessionExpiry) {
@@ -3599,7 +3603,8 @@ func (m *Manager) VisitLeases(
 	}
 }
 
-// AfterLeaseDurationGauge metric to increment after a long wait.
+// AfterLeaseDurationGauge identifies which long-wait gauge to increment when a
+// wait operation exceeds the lease duration.
 type AfterLeaseDurationGauge int
 
 const (
@@ -3614,8 +3619,10 @@ const (
 	GaugeWaitForInitialVersion
 )
 
-// IncGaugeAfterLeaseDuration increments a wait metric after the lease duration
-// has passed. A function is returned to decrement the same metric after.
+// IncGaugeAfterLeaseDuration increments a wait metric if the caller's operation
+// takes longer than the lease duration (the grace period for old descriptor
+// versions to expire). The returned function must be deferred to decrement the
+// metric when the operation completes.
 func (m *Manager) IncGaugeAfterLeaseDuration(
 	gaugeType AfterLeaseDurationGauge,
 ) (decrAfterWait func()) {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3538,11 +3538,11 @@ func TestLeaseTableWriteFailure(t *testing.T) {
 	require.Truef(t, firstBlock, "did not block any lease writes")
 }
 
-// TestLongLeaseWaitMetrics validates metrics that can be used to detect if
-// the lease manager is stuck waiting for old versions to expire. These are added
-// to help us diagnose if the session based leasing migration runs into issues.
-// These work by detecting active routines in any of the wait functions past
-// the lease duration (intentionally set to 0 for these tests).
+// TestLongLeaseWaitMetrics validates the long-wait gauges that detect when the
+// lease manager is stuck waiting for old descriptor versions to drain. The
+// gauges fire when a wait operation exceeds the lease duration (the grace period
+// for old versions). This test sets the lease duration to 0 so the gauges
+// trigger immediately.
 func TestLongLeaseWaitMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -108,7 +108,8 @@ var LeaseRenewalCrossValidate = settings.RegisterBoolSetting(
 	base.DefaultLeaseRenewalCrossValidate)
 
 // jitteredLeaseDuration returns a randomly jittered duration from the interval
-// [(1-leaseJitterFraction) * leaseDuration, (1+leaseJitterFraction) * leaseDuration].
+// [(1-jitterFraction) * leaseDuration, (1+jitterFraction) * leaseDuration].
+// This is used for the old-version grace period and background refresh interval.
 func (s storage) jitteredLeaseDuration() time.Duration {
 	leaseDuration := LeaseDuration.Get(&s.settings.SV)
 	jitterFraction := LeaseJitterFraction.Get(&s.settings.SV)


### PR DESCRIPTION
The `sql.catalog.descriptor_lease_duration` setting description and surrounding comments referred to "mean duration of sql descriptor leases," which is misleading with session-based leasing. The setting actually controls two things: the grace period for old descriptor versions to expire after a schema change, and the background lease refresh/cleanup loop interval. Update all comments and the setting description to reflect this.

Also fix the `sql.catalog.descriptor_lease_jitter_fraction` description, which was a copy-paste of the lease duration description.

Epic: None
Release note: None