### PR TITLE
ci: scope unit tests to affected files in PRs

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -274,17 +274,26 @@ jobs:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 120
     steps:
+      - name: calculate commit depth
+        if: github.event.pull_request.commits
+        run: echo COMMIT_DEPTH=$(echo '${{ github.event.pull_request.commits }} + 1' | bc) >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
         with:
           # By default, checkout merges the PR into the current master.
           # Instead, we want to check out the PR as is.
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: ${{ env.COMMIT_DEPTH || 1 }}
+      - name: Fetch the base commit
+        if: github.event.pull_request.base.sha
+        run: git fetch origin ${{ github.event.pull_request.base.sha }} --depth 100
       - name: compute metadata
         run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
       - run: ./build/github/get-engflow-keys.sh
       - run: ./build/github/prepare-summarize-build.sh
       - name: run tests
         run: ./build/github/unit-tests.sh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
       - name: generate code
         if: failure()
         # NB: To correctly report test owners, we'll have to make sure all Go

--- a/build/github/affected-targets.sh
+++ b/build/github/affected-targets.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Computes the Bazel test targets affected by changes between a base SHA and
+# HEAD. Outputs one target label per line. If the change is too broad (non-Go
+# file changes, bulk edits) or no testable files changed, the script prints a
+# fallback marker or nothing so callers can decide what to do.
+#
+# Usage: affected-targets.sh BASE_SHA
+#
+# Exit behaviour:
+#   - Prints affected test target labels (one per line) on stdout.
+#   - Prints "FULL" if a full test run is required (non-Go changes, bulk edits).
+#   - Prints nothing if no test-relevant files changed.
+
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: affected-targets.sh BASE_SHA" >&2
+  exit 1
+fi
+
+BASE_SHA="$1"
+
+MERGE_BASE=$(git merge-base "$BASE_SHA" HEAD)
+
+# Check for non-Go/non-testdata changes that require a full run.
+NON_GO_CHANGES=$(git diff --no-ext-diff --name-only "$MERGE_BASE" -- \
+  '*.proto' '*.bzl' 'BUILD.bazel' '*/BUILD.bazel' 'WORKSPACE' 'DEPS.bzl' \
+  '.bazelrc' '.bazelrc.user' 'go.mod' 'go.sum' \
+  '.github/*' 'build/github/*' | head -1)
+
+if [ -n "$NON_GO_CHANGES" ]; then
+  echo "FULL"
+  exit 0
+fi
+
+# If only inert files changed (docs, markdown, config that doesn't affect
+# build/test), skip tests entirely rather than running the full suite.
+ALL_CHANGES=$(git diff --no-ext-diff --name-only "$MERGE_BASE")
+if [ -n "$ALL_CHANGES" ]; then
+  NON_INERT=$(echo "$ALL_CHANGES" | grep -v \
+    -e '\.md$' \
+    -e '^docs/' \
+    -e '^\.claude/' \
+    -e '^LICENSE$' \
+    -e '^\.gitignore$' \
+    -e '^\.gitattributes$' \
+    -e '^\.editorconfig$' \
+    || true)
+  if [ -z "$NON_INERT" ]; then
+    # Only inert files changed, no tests needed.
+    exit 0
+  fi
+fi
+
+# Generate all possible Bazel labels for each changed file by splitting the
+# path at every directory boundary. Bazel itself validates which are real
+# source file targets, so no shell heuristics about package structure are needed.
+CANDIDATES=""
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  dir=$(dirname "$file")
+  rest=$(basename "$file")
+  while [ "$dir" != "." ]; do
+    CANDIDATES="${CANDIDATES} //${dir}:${rest}"
+    rest="$(basename "$dir")/${rest}"
+    dir=$(dirname "$dir")
+  done
+done <<< "$ALL_CHANGES"
+
+if [ -z "$CANDIDATES" ]; then
+  exit 0
+fi
+
+# Let Bazel resolve which candidates are real source file targets, find the
+# build rules that own them, then find all go_test targets that transitively
+# depend on those rules. One query, fully authoritative.
+QUERY="kind('go_test', rdeps(//pkg/..., same_pkg_direct_rdeps(set(${CANDIDATES}))))"
+
+# Temporarily disable errexit so we can inspect the query exit code.
+set +e
+AFFECTED=$(bazel query --keep_going "$QUERY" --output=label 2>/dev/null)
+QUERY_EXIT=$?
+set -e
+# Exit 0 = success, exit 3 = partial (some invalid labels skipped by --keep_going).
+# Any other exit code means the query itself failed; fall back to full suite.
+if [ $QUERY_EXIT -ne 0 ] && [ $QUERY_EXIT -ne 3 ]; then
+  echo "FULL"
+  exit 0
+fi
+
+if [ -z "$AFFECTED" ]; then
+  exit 0
+fi
+
+# If too many targets are affected, fall back to full suite.
+TARGET_COUNT=$(echo "$AFFECTED" | wc -l | tr -d ' ')
+if [ "$TARGET_COUNT" -gt 1000 ]; then
+  echo "FULL"
+  exit 0
+fi
+
+echo "$AFFECTED"

--- a/build/github/unit-tests.sh
+++ b/build/github/unit-tests.sh
@@ -15,8 +15,20 @@ if [[ "$GITHUB_ACTIONS_BRANCH" == "staging" || "$GITHUB_ACTIONS_BRANCH" == trunk
   EXTRA_PARAMS=" --flaky_test_attempts=2"
 fi
 
+# Determine test targets: use affected targets if a base SHA is provided,
+# otherwise fall back to the full test suite.
+TEST_TARGETS="//pkg:all_tests"
+if [ -n "${BASE_SHA:-}" ]; then
+  AFFECTED=$(./build/github/affected-targets.sh "$BASE_SHA")
+  if [ -z "$AFFECTED" ]; then
+    echo "No test-relevant files changed, skipping unit tests."
+    exit 0
+  elif [ "$AFFECTED" != "FULL" ]; then
+    TEST_TARGETS="$AFFECTED"
+  fi
+fi
 
-bazel test //pkg:all_tests //pkg/ui:lint //pkg/ui:test \
+bazel test $TEST_TARGETS //pkg/ui:lint //pkg/ui:test \
     --config crosslinux --jobs 200 --remote_download_minimal \
     --bes_keywords ci-unit-test --config=use_ci_timeouts \
     --build_event_binary_file=bes.bin $(./build/github/engflow-args.sh) \


### PR DESCRIPTION
## Summary

Currently, every PR runs all ~3,163 test targets (`//pkg:all_tests`) regardless of what files changed. This change adds affected-target detection to scope the `unit_tests` CI job to only the targets that transitively depend on changed files.

- New `build/github/affected-targets.sh` script computes affected test targets from a git diff using Bazel's reverse dependency graph
- `unit-tests.sh` uses affected targets instead of `//pkg:all_tests` when a `BASE_SHA` is provided
- The GHA workflow passes the PR base SHA to the unit-tests script

The script uses Bazel as the sole authority on file-to-target mapping: changed file paths are split at every directory boundary to generate candidate labels, then `same_pkg_direct_rdeps` resolves owning build rules and `rdeps` finds all affected `go_test` targets. This approach avoids shell heuristics about package structure — Bazel validates everything.

**Fallbacks to full suite for:**
- Build-affecting file changes (`.proto`, `.bzl`, `BUILD.bazel`, `go.mod`, `.github/*`, `build/github/*`)
- Bulk changes (>1000 affected targets)
- Bazel query failures (non-trivial exit codes)

**Skips tests entirely for:** documentation-only changes (`.md`, `docs/`, `.claude/`, `LICENSE`)

Expected reduction: ~85-90% fewer test targets for typical PRs.

### Testing

Tested by copying the script into git worktrees at real historical commits and running `./build/github/affected-targets.sh <parent-sha>` end-to-end:

| Scenario | Commit | Changed files | Expected | Result |
|---|---|---|---|---|
| Go-only (1 pkg) | `c697963913e` | `pkg/spanconfig/.../job.go` | Scoped | **317 targets** (90% reduction) |
| Go+testdata (5 pkgs) | `e61a44ce562` | 8 `.go` + 1 testdata across `pkg/sql/*` | Scoped | **452 targets** (86% reduction) |
| Docs-only | `cd06503a6b5` | `pkg/cmd/roachtest/CLAUDE.md` | Skip | **No output** (tests skipped) |
| CI files | `899d1e6ab14` | `.github/workflows/auto-merge-backports.yml` | Full | **FULL** |
| Proto+Go | `04fd4373c61` | `.proto` + `.go` + testdata | Full | **FULL** |
| BUILD.bazel+Go | `a5fd29cd92c` | 10 `.go` + `BUILD.bazel` across 7 pkgs | Full | **FULL** |
| Invalid bazel labels | (manual) | Mixed valid + `//pkg/NONEXISTENT:fake.go` | Graceful skip | **Valid targets only** (`--keep_going`) |
| All-invalid labels | (manual) | `//pkg/NONEXISTENT:fake.go` only | No targets | **Exit code 3 → empty** |

Epic: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)