### PR TITLE
roachprod: fix C4 machine type support for microbenchmarks

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -82,6 +82,7 @@ done
 # Set up credentials
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
+
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity
 export ROACHPROD_CLUSTER=teamcity-microbench-${TC_BUILD_ID}
@@ -127,8 +128,19 @@ BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GOOGLE_EPHEMERAL_CREDENTIALS -e SANITIZED_BE
 # Log into gcloud again (credentials are removed by teamcity-support in the build script)
 log_into_gcloud
 
+# Check if machine type starts with c4
+# For this machine type we need to specify additional flags
+additional_roachprod_args=""
+if [[ "$GCE_MACHINE_TYPE" == c4* ]]; then
+  additional_roachprod_args="--gce-boot-disk-type=hyperdisk-balanced \
+    --gce-pd-volume-type=hyperdisk-balanced \
+    --gce-turbo-mode=ALL_CORE_MAX \
+    --gce-threads-per-core=1"
+fi
+
 # Create roachprod cluster
 ./bin/roachprod create "$ROACHPROD_CLUSTER" -n "$GCE_NODE_COUNT" \
+  ${additional_roachprod_args:+$additional_roachprod_args} \
   --lifetime "$CLUSTER_LIFETIME" \
   --clouds gce \
   --gce-machine-type "$GCE_MACHINE_TYPE" \

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1436,6 +1436,9 @@ func (p *ProviderOpts) minCPUPlatform() string {
 	case "best":
 		// By default, we choose the latest CPU platform available for the machine
 		// type. This ensures run-to-run consistency.
+		if !supportsMinCPUPlatform(p.MachineType) {
+			return ""
+		}
 		info, err := gcedb.GetMachineInfo(p.MachineType)
 		if err != nil || len(info.CPUPlatforms) < 2 {
 			return ""
@@ -1444,6 +1447,25 @@ func (p *ProviderOpts) minCPUPlatform() string {
 
 	default:
 		return p.MinCPUPlatform
+	}
+}
+
+// supportsMinCPUPlatform returns whether the given machine type supports the
+// --min-cpu-platform flag. C4 family VMs reject this flag with the error
+// "C4 VM does not support minCpuPlatform" when instances are created via
+// managed instance groups. This is not documented in the GCE docs but is
+// enforced by the API.
+func supportsMinCPUPlatform(machineType string) bool {
+	parts := strings.Split(machineType, "-")
+	if len(parts) < 2 {
+		return false
+	}
+	family := parts[0]
+	switch family {
+	case "c4", "c4a", "c4d":
+		return false
+	default:
+		return true
 	}
 }
 


### PR DESCRIPTION
This PR fixes roachprod cluster creation for C4 machine families and
adds C4 support to the weekly microbenchmark runs.

The first commit skips the `--min-cpu-platform` flag for C4/C4A/C4D VMs,
which reject it with "C4 VM does not support minCpuPlatform". The second
commit passes the required additional flags (hyperdisk-balanced storage,
turbo mode, single-threaded cores) when running weekly microbenchmarks
on C4 machine types.

Release note: None
Epic: None