### PR TITLE
sql: add AST node for DROP PROVISIONED ROLES

### DIFF
--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -211,6 +211,7 @@ go_test(
         "datum_invariants_test.go",
         "datum_prev_next_test.go",
         "datum_test.go",
+        "drop_provisioned_roles_test.go",
         "expr_test.go",
         "format_test.go",
         "function_definition_test.go",

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -164,6 +164,88 @@ func (node *DropRole) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Names)
 }
 
+// DropProvisionedRolesOptions describes filter options for the
+// DROP PROVISIONED ROLES statement.
+type DropProvisionedRolesOptions struct {
+	// Source filters users by their PROVISIONSRC role option value.
+	Source Expr
+	// LastLoginBefore filters users whose estimated last login
+	// is before this timestamp.
+	LastLoginBefore Expr
+}
+
+// Format implements the NodeFormatter interface.
+func (o *DropProvisionedRolesOptions) Format(ctx *FmtCtx) {
+	var addSep bool
+	maybeAddSep := func() {
+		if addSep {
+			ctx.WriteString(", ")
+		}
+		addSep = true
+	}
+
+	if o.Source != nil {
+		maybeAddSep()
+		ctx.WriteString("SOURCE = ")
+		ctx.FormatNode(o.Source)
+	}
+	if o.LastLoginBefore != nil {
+		maybeAddSep()
+		ctx.WriteString("LAST LOGIN BEFORE ")
+		ctx.FormatNode(o.LastLoginBefore)
+	}
+}
+
+// CombineWith merges other DropProvisionedRolesOptions into this
+// struct. An error is returned if the same option is specified
+// multiple times.
+func (o *DropProvisionedRolesOptions) CombineWith(other *DropProvisionedRolesOptions) error {
+	var err error
+	o.Source, err = combineExpr(o.Source, other.Source, "SOURCE")
+	if err != nil {
+		return err
+	}
+	o.LastLoginBefore, err = combineExpr(
+		o.LastLoginBefore, other.LastLoginBefore,
+		"LAST LOGIN BEFORE",
+	)
+	return err
+}
+
+// IsDefault returns true if no options are set.
+func (o DropProvisionedRolesOptions) IsDefault() bool {
+	return o.Source == nil && o.LastLoginBefore == nil
+}
+
+var _ NodeFormatter = &DropProvisionedRolesOptions{}
+
+// DropProvisionedRoles represents a DROP PROVISIONED ROLES statement that
+// bulk-drops provisioned users matching filter criteria.
+//
+//	DROP PROVISIONED ROLES
+//	  WITH SOURCE = 'ldap:ldap.example.com',
+//	       LAST LOGIN BEFORE '2025-01-01'
+//	  LIMIT 10
+type DropProvisionedRoles struct {
+	Options *DropProvisionedRolesOptions
+	Limit   *Limit
+}
+
+var _ Statement = &DropProvisionedRoles{}
+
+// Format implements the NodeFormatter interface.
+func (node *DropProvisionedRoles) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP PROVISIONED ROLES")
+	if node.Options != nil && !node.Options.IsDefault() {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(node.Options)
+	}
+	if node.Limit != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(node.Limit)
+	}
+}
+
 // DropType represents a DROP TYPE command.
 type DropType struct {
 	Names        []*UnresolvedObjectName

--- a/pkg/sql/sem/tree/drop_provisioned_roles_test.go
+++ b/pkg/sql/sem/tree/drop_provisioned_roles_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tree_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropProvisionedRolesFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name     string
+		node     *tree.DropProvisionedRoles
+		expected string
+	}{
+		{
+			name:     "no options",
+			node:     &tree.DropProvisionedRoles{},
+			expected: "DROP PROVISIONED ROLES",
+		},
+		{
+			name: "source only",
+			node: &tree.DropProvisionedRoles{
+				Options: &tree.DropProvisionedRolesOptions{
+					Source: tree.NewStrVal("ldap:ldap.example.com"),
+				},
+			},
+			expected: "DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com'",
+		},
+		{
+			name: "last login before only",
+			node: &tree.DropProvisionedRoles{
+				Options: &tree.DropProvisionedRolesOptions{
+					LastLoginBefore: tree.NewStrVal("2025-01-01"),
+				},
+			},
+			expected: "DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01'",
+		},
+		{
+			name: "both options",
+			node: &tree.DropProvisionedRoles{
+				Options: &tree.DropProvisionedRolesOptions{
+					Source:          tree.NewStrVal("ldap:ldap.example.com"),
+					LastLoginBefore: tree.NewStrVal("2025-01-01"),
+				},
+			},
+			expected: "DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01'",
+		},
+		{
+			name: "source with limit",
+			node: &tree.DropProvisionedRoles{
+				Options: &tree.DropProvisionedRolesOptions{
+					Source: tree.NewStrVal("ldap:ldap.example.com"),
+				},
+				Limit: &tree.Limit{Count: tree.NewDInt(10)},
+			},
+			expected: "DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10",
+		},
+		{
+			name: "limit only",
+			node: &tree.DropProvisionedRoles{
+				Limit: &tree.Limit{Count: tree.NewDInt(5)},
+			},
+			expected: "DROP PROVISIONED ROLES LIMIT 5",
+		},
+		{
+			name: "all options with limit",
+			node: &tree.DropProvisionedRoles{
+				Options: &tree.DropProvisionedRolesOptions{
+					Source:          tree.NewStrVal("ldap:ldap.example.com"),
+					LastLoginBefore: tree.NewStrVal("2025-01-01"),
+				},
+				Limit: &tree.Limit{Count: tree.NewDInt(10)},
+			},
+			expected: "DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' LIMIT 10",
+		},
+		{
+			name: "nil options pointer",
+			node: &tree.DropProvisionedRoles{
+				Options: nil,
+			},
+			expected: "DROP PROVISIONED ROLES",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tree.AsString(tc.node)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestDropProvisionedRolesOptionsCombineWith(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("merge disjoint options", func(t *testing.T) {
+		a := &tree.DropProvisionedRolesOptions{Source: tree.NewStrVal("ldap:x")}
+		b := &tree.DropProvisionedRolesOptions{
+			LastLoginBefore: tree.NewStrVal("2025-01-01"),
+		}
+		err := a.CombineWith(b)
+		require.NoError(t, err)
+		require.NotNil(t, a.Source)
+		require.NotNil(t, a.LastLoginBefore)
+	})
+
+	t.Run("duplicate source", func(t *testing.T) {
+		a := &tree.DropProvisionedRolesOptions{Source: tree.NewStrVal("ldap:x")}
+		b := &tree.DropProvisionedRolesOptions{Source: tree.NewStrVal("ldap:y")}
+		err := a.CombineWith(b)
+		require.ErrorContains(t, err, "SOURCE")
+		require.ErrorContains(t, err, "specified multiple times")
+	})
+
+	t.Run("duplicate last login before", func(t *testing.T) {
+		a := &tree.DropProvisionedRolesOptions{
+			LastLoginBefore: tree.NewStrVal("2025-01-01"),
+		}
+		b := &tree.DropProvisionedRolesOptions{
+			LastLoginBefore: tree.NewStrVal("2025-06-01"),
+		}
+		err := a.CombineWith(b)
+		require.ErrorContains(t, err, "LAST LOGIN BEFORE")
+		require.ErrorContains(t, err, "specified multiple times")
+	})
+}
+
+func TestDropProvisionedRolesOptionsIsDefault(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	require.True(t, tree.DropProvisionedRolesOptions{}.IsDefault())
+	require.False(t,
+		tree.DropProvisionedRolesOptions{Source: tree.NewStrVal("x")}.IsDefault())
+	require.False(t,
+		tree.DropProvisionedRolesOptions{
+			LastLoginBefore: tree.NewStrVal("2025-01-01"),
+		}.IsDefault())
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1303,6 +1303,17 @@ func (*DropRole) StatementTag() string { return "DROP ROLE" }
 func (*DropRole) hiddenFromShowQueries() {}
 
 // StatementReturnType implements the Statement interface.
+func (*DropProvisionedRoles) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*DropProvisionedRoles) StatementType() StatementType { return TypeDCL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropProvisionedRoles) StatementTag() string { return "DROP PROVISIONED ROLES" }
+
+func (*DropProvisionedRoles) hiddenFromShowQueries() {}
+
+// StatementReturnType implements the Statement interface.
 func (*DropType) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
@@ -2689,6 +2700,7 @@ func (n *DropSequence) String() string                        { return AsString(
 func (n *DropTable) String() string                           { return AsString(n) }
 func (n *DropType) String() string                            { return AsString(n) }
 func (n *DropView) String() string                            { return AsString(n) }
+func (n *DropProvisionedRoles) String() string                { return AsString(n) }
 func (n *DropRole) String() string                            { return AsString(n) }
 func (n *DropTenant) String() string                          { return AsString(n) }
 func (n *Execute) String() string                             { return AsString(n) }


### PR DESCRIPTION
Add the `DropProvisionedRoles` AST struct and `DropProvisionedRolesOptions` to `pkg/sql/sem/tree/drop.go`, along with statement metadata methods in `stmt.go`.

The new statement supports optional filter clauses:

  DROP PROVISIONED ROLES
    WITH SOURCE = 'ldap:ldap.example.com',
         LAST LOGIN BEFORE '2025-01-01'
    LIMIT 10

`DropProvisionedRolesOptions` has its own `Format`, `CombineWith`, and `IsDefault` methods, mirroring the pattern used by `ShowUsersOptions`.

SQL parsing tests for the `pkg/sql/parser` package will be added in a subsequent PR.

Epic: CRDB-52460
informs #150605

Release note: None