### PR TITLE
Fix: docker-entrypoint-initdb.d scripts not running without COCKROACH_USER

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -158,9 +158,8 @@ setup_db() {
   if [[ -n "$COCKROACH_USER" ]]; then
     init_env_query+=( -e "GRANT ALL ON DATABASE "$COCKROACH_DATABASE" TO "$COCKROACH_USER"" \
                       -e "GRANT admin TO "$COCKROACH_USER" " )
+    run_sql_query "${init_env_query[@]}"
   fi
-
-  run_sql_query "${init_env_query[@]}"
 }
 
 # process_init_files run all the init scripts from /docker-entrypoint-initdb.d.


### PR DESCRIPTION
## Problem
When `COCKROACH_USER` environment variable is not set, Docker initialization scripts in `/docker-entrypoint-initdb.d/` fail to execute. The container hangs indefinitely waiting for user input instead of processing the initialization scripts.

## Root Cause
The `setup_db()` function in `build/deploy/cockroach.sh` calls `run_sql_query()` unconditionally, even when there are no SQL queries to execute. Without any `-e` flag providing a query, `cockroach sql` enters interactive mode and blocks, preventing initialization scripts from running.

## Solution
Move `run_sql_query()` inside the `if [[ -n "$COCKROACH_USER" ]]` block. This ensures SQL execution only happens when there are GRANT statements to execute (i.e., when a user is configured).

## Changes
- Moved `run_sql_query()` call from line 163 (outside if) to line 161 (inside if block)
- Now only executes when `COCKROACH_USER` is set

## Testing
- Without COCKROACH_USER: ✓ Init scripts now run without hanging
- With COCKROACH_USER: ✓ Still works as before (backward compatible)
- ShellCheck: ✓ No new warnings introduced

Fixes #110997