### PR TITLE
release-26.2: cli: strip ash_report files from zip test output comparison

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -1521,6 +1521,9 @@ func trimNonDeterministicZipOutputFiles(out string) string {
 	out = re.ReplaceAllString(out, ``)
 	re = regexp.MustCompile(`(?m).*goroutine_dump.*\.pb\.gz$` + "\n")
 	out = re.ReplaceAllString(out, ``)
+	// ASH report files have timestamps in filenames, making them non-deterministic.
+	re = regexp.MustCompile(`(?m).*ash_report.*\.(json|txt)$` + "\n")
+	out = re.ReplaceAllString(out, ``)
 	// CPU profiles are non-deterministic: stored profiles have timestamps in
 	// filenames, and live profile collection may fail producing error files.
 	re = regexp.MustCompile(`(?m).*cpuprof/cpuprof\..*\.pprof$` + "\n")


### PR DESCRIPTION
Backport 1/1 commits from #166831 on behalf of @dhartunian.

----

Strip nondeterministic ASH report files from `trimNonDeterministicZipOutputFiles` in zip tests

The ASH report profiler generates timestamped files (`ash_report.<ts>.goroutine_dump.json/txt`) in the heapprof directory that cause `TestZipIncludeAndExcludeFilesDataDriven` to fail when comparing against static testdata

Follows the same pattern already used for goroutine_dump, memprof, and cpuprof files

Resolves: #166244
Resolves: #166292

Release note: None

----

Release justification: test-only change