### PR TITLE
release-24.1: build: adjust shard counts for tests

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 16,
+    shard_count = 24,
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -116,7 +116,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 16,
+    shard_count = 32,
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -38,7 +38,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 32,
+    shard_count = 48,
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "statement_diagnostics_test.go",
     ],
     embed = [":stmtdiagnostics"],
+    shard_count = 4,
     tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":metamorphic"],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 8,
     deps = [
         "//pkg/settings/cluster",
         "//pkg/testutils",


### PR DESCRIPTION
Backport 1/1 commits from #166859.

/cc @cockroachdb/release

---

These are long-running tests that could be sharded more, with the exception of pkg/storage/metamorphic which doesn't need to be sharded this much.

Release note: none
Epic: none

Release justification: CI/test-only changes
