### PR TITLE
sql/schemachanger: fix flaky TestExecuteWithDMLInjection tests

### DIFF
--- a/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
+++ b/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
@@ -66,6 +66,7 @@ func (f MultiRegionTestClusterFactory) Start(ctx context.Context, t *testing.T) 
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		SQLExecutor: &sql.ExecutorTestingKnobs{
 			UseTransactionalDescIDGenerator: true,
+			ForceWaitForOneVersionWithJobs:  true,
 		},
 	}
 	if f.server != nil {

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbr_to_rbt_primary_region/alter_table_locality_rbr_to_rbt_primary_region.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_rbr_to_rbt_primary_region/alter_table_locality_rbr_to_rbt_primary_region.definition
@@ -34,7 +34,6 @@ true
 stage-exec phase=PostCommitPhase stage=:
 SELECT crdb_internal.validate_multi_region_zone_configs();
 ----
-pq: missing zone configuration for partition "us-east1" of t@t_pkey
 
 stage-exec phase=PostCommitPhase stage=:
 SELECT * from multiregion_db.public.t;
@@ -66,7 +65,6 @@ true
 stage-exec phase=PostCommitNonRevertiblePhase stage=:
 SELECT crdb_internal.validate_multi_region_zone_configs();
 ----
-pq: missing zone configuration for partition "us-east2" of t@t_pkey
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=:
 SELECT * from multiregion_db.public.t;

--- a/pkg/sql/conn_executor_jobs.go
+++ b/pkg/sql/conn_executor_jobs.go
@@ -169,7 +169,10 @@ func (ex *connExecutor) descIDsInSchemaChangeJobs() (catalog.DescriptorIDSet, er
 
 	// If there is no declarative schema changer job, then we are done. Otherwise,
 	// we need to check which descriptor has the jobID in its schema change state.
-	if ex.extraTxnState.schemaChangerState.jobID == jobspb.InvalidJobID {
+	// By default, we only wait for one version if there is no job, but for DML injection
+	// stricter timing is needed.
+	if ex.extraTxnState.schemaChangerState.jobID == jobspb.InvalidJobID ||
+		ex.server.cfg.TestingKnobs.ForceWaitForOneVersionWithJobs {
 		return descIDsInJobs, nil
 	}
 	// Get descriptor IDs with declarative schema changer jobs.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2168,6 +2168,12 @@ type ExecutorTestingKnobs struct {
 	// internal executor. This can be used in tests to intercept session
 	// method calls like ExecutePrepared.
 	SessionWrapper func(isql.Session) isql.Session
+
+	// ForceWaitForOneVersionWithJobs, forces declarative schema changer
+	// DDL statements to issue WaitForOneVersion, even if they create jobs.
+	// In practice this doesn't matter for actual customer workloads, but
+	// for internal DML injection testing.
+	ForceWaitForOneVersionWithJobs bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
@@ -603,6 +604,9 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			testCluster := serverutils.StartCluster(t, 1, base.TestClusterArgs{
 				ServerArgs: base.TestServerArgs{
 					Knobs: base.TestingKnobs{
+						SQLExecutor: &sql.ExecutorTestingKnobs{
+							ForceWaitForOneVersionWithJobs: true,
+						},
 						SQLEvalContext: &eval.TestingKnobs{
 							// We disable the randomization of some batch sizes because with
 							// some low values the test takes much longer.

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -217,7 +217,7 @@ func ExecuteWithDMLInjection(t *testing.T, relPath string, factory TestServerFac
 						} else {
 							lastRollbackStageKey = &key
 						}
-						injectStmts := injectionFunc(key, tdb, successfulStages)
+						injectStmts := injectionFunc(key, tdb, successfulStages, false /* isReinject */)
 						regexSetOnce := false
 						for _, injectStmt := range injectStmts {
 							if injectStmt != nil && injectStmt.HasAnySchemaChangeError() != nil {
@@ -262,7 +262,7 @@ func ExecuteWithDMLInjection(t *testing.T, relPath string, factory TestServerFac
 			// the final descriptor state.
 			if lastRollbackStageKey != nil {
 				t.Logf("Job transaction committed. Re-inject statements from rollback: %s", lastRollbackStageKey.String())
-				injectionFunc(*lastRollbackStageKey, tdb, successfulStages)
+				injectionFunc(*lastRollbackStageKey, tdb, successfulStages, true /* isReinject */)
 			}
 			require.Equal(t, errorDetected, schemaChangeErrorRegex != nil)
 		}

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -430,11 +430,12 @@ func (m *stageExecStmtMap) GetExpectedOutputForPos(pos string) string {
 	return m.rewriteMap[pos].expectedOutput
 }
 
-type execInjectionCallback func(stage stageKey, runner *sqlutils.SQLRunner, successfulStageCount int) []*stageExecStmt
+type execInjectionCallback func(stage stageKey, runner *sqlutils.SQLRunner, successfulStageCount int, isReinject bool) []*stageExecStmt
 
 type stageExecVariables struct {
 	successfulStageCount int
 	stage                stageKey
+	stageKeyOffset       int
 }
 
 // Exec executes the statements for given stage and validates the output.
@@ -446,14 +447,14 @@ func (e *stageExecStmt) Exec(
 		if len(stmt) == 0 {
 			continue
 		}
-		t.Logf("Starting execution of statment: %+v", stmt)
+		t.Logf("Starting execution of statement: %+v", stmt)
 		// Bind any variables for the statement.
 		boundSQL := os.Expand(stmt, func(s string) string {
 			switch s {
 			case "successfulStageCount":
 				return strconv.Itoa(stageVariables.successfulStageCount)
 			case "stageKey":
-				return strconv.Itoa(stageVariables.stage.AsInt() * 1000)
+				return strconv.Itoa((stageVariables.stage.AsInt() * 10000) + stageVariables.stageKeyOffset*1000)
 			default:
 				t.Fatalf("unknown variable name %s", s)
 			}
@@ -477,6 +478,11 @@ func (e *stageExecStmt) Exec(
 						e.expectedOutput = err.Error()
 					}
 				}
+			} else if idx == len(e.stmts)-1 && e.expectedOutput != "" {
+				if !rewrite {
+					t.Fatalf("unexpected success: expected error: %v", e.expectedOutput)
+				}
+				e.expectedOutput = ""
 			}
 		case stageExecuteQuery:
 			results := runner.QueryStr(t, boundSQL)
@@ -503,13 +509,19 @@ func (e *stageExecStmt) Exec(
 // GetInjectionCallback gets call back that will inject statements based on a
 // given stage.
 func (m *stageExecStmtMap) GetInjectionCallback(t *testing.T, rewrite bool) execInjectionCallback {
-	return func(stage stageKey, runner *sqlutils.SQLRunner, successfulStageCount int) []*stageExecStmt {
+
+	return func(stage stageKey, runner *sqlutils.SQLRunner, successfulStageCount int, isReinject bool) []*stageExecStmt {
 		execStmts := m.getExecStmts(stage)
+		stageKeyOffset := 0
+		if isReinject {
+			stageKeyOffset = 1
+		}
 		for _, execStmt := range execStmts {
 			m.usedMap[execStmt] = struct{}{}
 			execStmt.Exec(t, runner, &stageExecVariables{
 				successfulStageCount: successfulStageCount,
 				stage:                stage,
+				stageKeyOffset:       stageKeyOffset,
 			}, rewrite)
 		}
 		return execStmts

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -115,6 +115,7 @@ func (f SingleNodeTestClusterFactory) Start(ctx context.Context, t *testing.T) T
 			JobsTestingKnobs: newJobsKnobs(),
 			SQLExecutor: &sql.ExecutorTestingKnobs{
 				UseTransactionalDescIDGenerator: true,
+				ForceWaitForOneVersionWithJobs:  true,
 			},
 		},
 	}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.definition
@@ -20,8 +20,19 @@ INSERT INTO db.public.tbl VALUES($stageKey);
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=1
 INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey+1);
 ----
 .*duplicate key value violates unique constraint \"tbl_j_key\".*
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=2
+INSERT INTO db.public.tbl VALUES($stageKey);
+----
+.*null value in column \"j\" violates not-null constraint.*
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+SELECT * FROM db.public.tbl;
+----
 
 # Add a column which will have a unique index and a not null constraint at
 # the same time.

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_vanilla/alter_table_add_check_vanilla.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_vanilla/alter_table_add_check_vanilla.definition
@@ -7,7 +7,6 @@ INSERT INTO t(i) VALUES (1), (2), (3);
 stage-exec phase=PreCommitPhase stage=1
 UPDATE t SET i=-4 WHERE i = 3;
 ----
-pq: failed to satisfy CHECK constraint .*
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=2: rollback=true schemaChangeExecErrorForRollback=(.*validation of CHECK "i > 0:::INT8" failed on row: i=-4.*)
 INSERT INTO t(i) VALUES(-$stageKey);

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_foreign_key/alter_table_add_foreign_key.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_foreign_key/alter_table_add_foreign_key.definition
@@ -18,7 +18,6 @@ pq: insert on table "t1" violates foreign key constraint "t1_i_fkey"
 stage-exec phase=PostCommitNonRevertiblePhase stage=2: rollback=true
 INSERT INTO t1 (i) VALUES(-$stageKey)
 ----
-pq: duplicate key value violates unique constraint "t1_pkey"
 
 # Each insert will be injected twice per stage, so we should always,
 # see a count of 2.

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index/alter_table_add_unique_without_index.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index/alter_table_add_unique_without_index.definition
@@ -12,7 +12,6 @@ UPDATE t SET j=-3 WHERE i = -1;
 stage-exec phase=PostCommitNonRevertiblePhase stage=2: rollback=true
 INSERT INTO t(i) VALUES(-$stageKey);
 ----
-pq: duplicate key value violates unique constraint "t_pkey"
 
 stage-exec phase=PostCommitPhase stage=:
 INSERT INTO t (i, j) VALUES($stageKey, $stageKey);

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.definition
@@ -6,7 +6,6 @@ stage-exec phase=PostCommitPhase stage=:
 INSERT INTO t VALUES($stageKey);
 INSERT INTO t VALUES($stageKey + 1);
 ----
-pq: INSERT has more expressions than target columns, 2 expressions for 1 targets
 
 # Each insert will be injected twice per stage, so we should always,
 # see a count of 2.
@@ -20,7 +19,6 @@ stage-exec phase=PostCommitNonRevertiblePhase stage=:
 INSERT INTO t VALUES($stageKey);
 INSERT INTO t VALUES($stageKey + 1);
 ----
-pq: INSERT has more expressions than target columns, 2 expressions for 1 targets
 
 # Each insert will be injected twice per stage, so we should always,
 # see a count of 2.

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint_stored/drop_column_with_null_constraint_stored.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint_stored/drop_column_with_null_constraint_stored.definition
@@ -8,12 +8,10 @@ create table t (i int primary key, j int not null AS (i +32) STORED);
 stage-exec phase=PostCommitPhase stage=:
 INSERT INTO t (i) VALUES($stageKey);
 ----
-pq: failed to satisfy CHECK constraint \(j IS NOT NULL\)
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=1
 INSERT INTO t (i) VALUES($stageKey);
 ----
-pq: failed to satisfy CHECK constraint \(j IS NOT NULL\)
 
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=2:

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements/drop_multiple_columns_separate_statements.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements/drop_multiple_columns_separate_statements.definition
@@ -27,10 +27,10 @@ SELECT j+1, k FROM t
 ----
 pq: column "k" does not exist
 
-stage-exec phase=PostCommitPhase stage=:
-SELECT count(i) FROM t
+stage-query phase=PostCommitPhase stage=:
+SELECT count(i)=$successfulStageCount FROM t
 ----
-$successfulStageCount
+true
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=1:2
 SELECT j+1, k FROM t
@@ -59,10 +59,10 @@ stage-exec phase=PostCommitNonRevertiblePhase stage=:
 INSERT INTO t (i) VALUES($stageKey);
 ----
 
-stage-exec phase=PostCommitNonRevertiblePhase stage=:
-SELECT count(i) FROM t
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(i)=$successfulStageCount FROM t
 ----
-$successfulStageCount
+true
 
 test
 ALTER TABLE t DROP COLUMN j CASCADE;


### PR DESCRIPTION
This commit fixes a bug in the declarative schema changer test framework where an unexpected success of a statement (when an error was expected) was silently ignored. This caused subsequent statements in the same stage to fail with confusing constraint violations.

Additionally, it introduces a ForcePreCommitWaitForOneVersion testing knob that forces declarative schema changer DDL statements to issue WaitForOneVersion even when they create jobs. This ensures that DML injection statements always run against the correct descriptor versions, preventing flakes where a transaction might see an old version of a descriptor when it should have seen a newer one.

The DML injection framework is also updated to handle re-injection of statements after a rollback. By using a stageKeyOffset, we ensure that re-injected statements use unique keys, avoiding duplicate key violations during the re-injection phase.

Fixes #166238

Release note: None