### PR TITLE
ui: fix webpack 5 --display-error-details deprecation in cluster-ui

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
-    "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
+    "build:bundle": "NODE_ENV=production webpack --mode=production",
     "build:typescript": "tsc",
     "build:watch": "webpack --watch --mode=development --env WEBPACK_WATCH",
     "tsc:watch": "node build/typescript/watchWithMultipleDests.js --no-interactive",

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = (env, argv) => {
   env = env || {};
 
   return {
+    stats: {
+      errorDetails: true,
+    },
     context: __dirname,
     name: "cluster-ui",
     entry: path.resolve(__dirname, "./src/index.ts"),


### PR DESCRIPTION
## Summary
- Remove the deprecated `--display-error-details` CLI flag from the
  cluster-ui `build:bundle` script (removed in webpack 5).
- Add the equivalent `stats.errorDetails: true` option in
  `webpack.config.js`.

Epic: None
Release note: None