### PR TITLE
liveness: use transactional reads for Get and Scan, add contention benchmark

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -234,8 +234,15 @@ func DecodeStoreUnsafeReplicaRecoveryKey(key roachpb.Key) (uuid.UUID, error) {
 
 // NodeLivenessKey returns the key for the node liveness record.
 func NodeLivenessKey(nodeID roachpb.NodeID) roachpb.Key {
-	key := make(roachpb.Key, 0, len(NodeLivenessPrefix)+9)
-	key = append(key, NodeLivenessPrefix...)
+	return NodeLivenessKeyWithPrefix(NodeLivenessPrefix, nodeID)
+}
+
+// NodeLivenessKeyWithPrefix returns the key for a node liveness record under
+// the given prefix. This is used by tests that operate on a synthetic liveness
+// keyspace.
+func NodeLivenessKeyWithPrefix(prefix roachpb.Key, nodeID roachpb.NodeID) roachpb.Key {
+	key := make(roachpb.Key, 0, len(prefix)+9)
+	key = append(key, prefix...)
 	key = encoding.EncodeUvarintAscending(key, uint64(nodeID))
 	return key
 }

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     name = "liveness_test",
     size = "medium",
     srcs = [
+        "client_benchmark_test.go",
         "client_test.go",
         "liveness_test.go",
         "main_test.go",
@@ -57,10 +58,12 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/gossip",
+        "//pkg/kv",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/plan",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
@@ -68,6 +71,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/serverutils/regionlatency",
         "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/liveness/client_benchmark_test.go
+++ b/pkg/kv/kvserver/liveness/client_benchmark_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package liveness_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils/regionlatency"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
+)
+
+// benchRunCounter is used to generate unique keyspace prefixes across
+// benchmark runs. Each invocation of the benchmark function gets a unique
+// prefix so that Create calls don't collide with keys from prior runs.
+var benchRunCounter atomic.Int64
+
+// benchNodeState tracks the latest liveness record for a simulated node,
+// protected by a mutex to allow concurrent heartbeat writers.
+type benchNodeState struct {
+	mu    syncutil.Mutex
+	rec   liveness.Record
+	store liveness.Storage
+}
+
+// BenchmarkLivenessContention measures heartbeat write latency under concurrent
+// full-range scan load on a multi-node cluster with injected inter-node
+// latency. It uses a synthetic keyspace via NewTestKVStorage so that N
+// simulated nodes can write heartbeats against the cluster without requiring N
+// actual nodes.
+//
+// Each simulated node's heartbeat writes and scans are distributed across the
+// cluster's server DB handles, so that most operations cross the network (with
+// injected latency).
+//
+// The benchmark reports ns/op for a single heartbeat write. The "scans/sec"
+// custom metric shows the achieved scan throughput during the benchmark.
+func BenchmarkLivenessContention(b *testing.B) {
+	skip.UnderShort(b)
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	ctx := context.Background()
+
+	const numServers = 3
+
+	// Set up latency injection knobs for each server.
+	latencyEnabled := &atomic.Bool{}
+	addrMaps := make([]regionlatency.AddrMap, numServers)
+	perServerArgs := make(map[int]base.TestServerArgs, numServers)
+	for i := 0; i < numServers; i++ {
+		addrMaps[i] = regionlatency.MakeAddrMap()
+		perServerArgs[i] = base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					ContextTestingKnobs: rpc.ContextTestingKnobs{
+						InjectedLatencyOracle:  addrMaps[i],
+						InjectedLatencyEnabled: latencyEnabled.Load,
+					},
+				},
+			},
+		}
+	}
+
+	tc := testcluster.StartTestCluster(b, numServers, base.TestClusterArgs{
+		ServerArgsPerNode: perServerArgs,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Collect server addresses and DB handles.
+	serverAddrs := make([]string, numServers)
+	dbs := make([]*kv.DB, numServers)
+	for i := 0; i < numServers; i++ {
+		serverAddrs[i] = tc.Server(i).AdvRPCAddr()
+		dbs[i] = tc.Server(i).DB()
+	}
+
+	// setLatency updates the injected one-way latency between all server
+	// pairs and enables (or disables for zero) latency injection.
+	setLatency := func(oneWay time.Duration) {
+		for i := 0; i < numServers; i++ {
+			for j := 0; j < numServers; j++ {
+				if i != j {
+					addrMaps[i].SetLatency(serverAddrs[j], oneWay)
+				}
+			}
+		}
+		latencyEnabled.Store(oneWay > 0)
+	}
+
+	for _, oneWayLatency := range []time.Duration{
+		0,
+		2 * time.Millisecond,  // cross-AZ
+		10 * time.Millisecond, // cross-region (nearby)
+	} {
+		setLatency(oneWayLatency)
+		for _, numNodes := range []int{10, 100} {
+			for _, numScanners := range []int{0, 1, 5} {
+				name := fmt.Sprintf("latency=%s/nodes=%d/scanners=%d",
+					oneWayLatency, numNodes, numScanners)
+				b.Run(name, func(b *testing.B) {
+					benchmarkLivenessContention(ctx, b, dbs, numNodes, numScanners)
+				})
+			}
+		}
+	}
+}
+
+func benchmarkLivenessContention(
+	ctx context.Context, b *testing.B, dbs []*kv.DB, numNodes int, numScanners int,
+) {
+	numServers := len(dbs)
+
+	// Each sub-benchmark invocation gets its own keyspace to avoid
+	// interference between the framework's calibration runs and count repeats.
+	run := benchRunCounter.Add(1)
+	prefix := roachpb.Key(fmt.Sprintf("/test-liveness/%d/%d/%d/",
+		numNodes, numScanners, run))
+
+	// Use the first server's DB to create all records. The keyspace will
+	// land on a range whose leaseholder is on some node; operations from
+	// other nodes' DBs will cross the network.
+	setupStore := liveness.NewTestKVStorage(dbs[0], prefix)
+	for i := 1; i <= numNodes; i++ {
+		require.NoError(b, setupStore.Create(ctx, roachpb.NodeID(i)))
+	}
+
+	// Read back all records to get the raw bytes needed for CPut.
+	records, err := setupStore.Scan(ctx)
+	require.NoError(b, err)
+	require.Len(b, records, numNodes)
+
+	// Assign each simulated node a store backed by a different server's DB
+	// (round-robin), so heartbeat writes are distributed across servers.
+	nodes := make([]benchNodeState, numNodes+1) // 1-indexed
+	for _, rec := range records {
+		serverIdx := int(rec.NodeID) % numServers
+		nodes[rec.NodeID] = benchNodeState{
+			rec:   rec,
+			store: liveness.NewTestKVStorage(dbs[serverIdx], prefix),
+		}
+	}
+
+	// Prime each node with epoch=1, simulating its first heartbeat.
+	for i := 1; i <= numNodes; i++ {
+		nodeID := roachpb.NodeID(i)
+		old := nodes[i].rec
+		nl := old.Liveness
+		nl.Epoch = 1
+		nl.Expiration = hlc.LegacyTimestamp{
+			WallTime: time.Now().Add(time.Minute).UnixNano(),
+		}
+		update := liveness.MakeTestLivenessUpdate(nl, old)
+		written, err := nodes[i].store.Update(ctx, update, func(actual liveness.Record) error {
+			return fmt.Errorf("unexpected condition failure for n%d", nodeID)
+		})
+		require.NoError(b, err)
+		nodes[i].rec = written
+	}
+
+	// Create scanner stores distributed across servers.
+	scanStores := make([]liveness.Storage, numScanners)
+	for i := 0; i < numScanners; i++ {
+		serverIdx := i % numServers
+		scanStores[i] = liveness.NewTestKVStorage(dbs[serverIdx], prefix)
+	}
+
+	// Start background scanners that continuously scan the full keyspace.
+	var scanCount atomic.Int64
+	scanCtx, scanCancel := context.WithCancel(ctx)
+	var scanWg sync.WaitGroup
+	for i := 0; i < numScanners; i++ {
+		scanWg.Add(1)
+		store := scanStores[i]
+		go func() {
+			defer scanWg.Done()
+			for scanCtx.Err() == nil {
+				_, _ = store.Scan(scanCtx)
+				scanCount.Add(1)
+			}
+		}()
+	}
+
+	// Benchmark: b.N counts individual heartbeat writes.
+	// Each iteration picks a node round-robin and writes a heartbeat.
+	b.ResetTimer()
+	start := time.Now()
+	for i := 0; i < b.N; i++ {
+		n := (i % numNodes) + 1
+		doHeartbeat(ctx, &nodes[n])
+	}
+	elapsed := time.Since(start)
+	b.StopTimer()
+
+	scanCancel()
+	scanWg.Wait()
+
+	scans := scanCount.Load()
+	if numScanners > 0 && elapsed > 0 {
+		b.ReportMetric(float64(scans)/elapsed.Seconds(), "scans/sec")
+	}
+}
+
+// doHeartbeat simulates a single heartbeat write for a node, updating the
+// expiration. On contention it retries once with the fresh record.
+func doHeartbeat(ctx context.Context, ns *benchNodeState) {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+
+	old := ns.rec
+	nl := old.Liveness
+	nl.Expiration = hlc.LegacyTimestamp{
+		WallTime: time.Now().Add(time.Minute).UnixNano(),
+	}
+	update := liveness.MakeTestLivenessUpdate(nl, old)
+	written, err := ns.store.Update(ctx, update, func(actual liveness.Record) error {
+		ns.rec = actual
+		return fmt.Errorf("contention on n%d", nl.NodeID)
+	})
+	if err != nil {
+		// Retry once with the fresh record from the condition failure.
+		old = ns.rec
+		nl = old.Liveness
+		nl.Expiration = hlc.LegacyTimestamp{
+			WallTime: time.Now().Add(time.Minute).UnixNano(),
+		}
+		update = liveness.MakeTestLivenessUpdate(nl, old)
+		written, err = ns.store.Update(ctx, update, func(actual liveness.Record) error {
+			ns.rec = actual
+			return fmt.Errorf("repeated contention on n%d", nl.NodeID)
+		})
+		if err != nil {
+			return
+		}
+	}
+	ns.rec = written
+}

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -217,27 +217,34 @@ func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error 
 	return errors.AssertionFailedf("unexpected problem while creating liveness record for node %d", nodeID)
 }
 
-// Scan will iterate over the KV liveness names and generate liveness records from them.
+// Scan will iterate over the KV liveness names and generate liveness records
+// from them. The scan runs inside a transaction so that the read timestamp is
+// assigned at the coordinator (not at the leaseholder), reducing false
+// serialization conflicts with concurrent heartbeat writes.
 func (ls *storageImpl) Scan(ctx context.Context) ([]Record, error) {
-	kvs, err := ls.db.Scan(ctx, ls.keyPrefix, ls.keyMax, 0)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get liveness")
-	}
 	var results []Record
-	for _, kv := range kvs {
-		if kv.Value == nil {
-			return nil, errors.AssertionFailedf("missing liveness record")
+	if err := ls.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		results = nil
+		kvs, err := txn.Scan(ctx, ls.keyPrefix, ls.keyMax, 0)
+		if err != nil {
+			return errors.Wrap(err, "unable to get liveness")
 		}
-		var liveness livenesspb.Liveness
-		if err := kv.Value.GetProto(&liveness); err != nil {
-			return nil, errors.Wrap(err, "invalid liveness record")
+		for _, kv := range kvs {
+			if kv.Value == nil {
+				return errors.AssertionFailedf("missing liveness record")
+			}
+			var liveness livenesspb.Liveness
+			if err := kv.Value.GetProto(&liveness); err != nil {
+				return errors.Wrap(err, "invalid liveness record")
+			}
+			results = append(results, Record{
+				Liveness: liveness,
+				raw:      kv.Value.TagAndDataBytes(),
+			})
 		}
-
-		results = append(results, Record{
-			Liveness: liveness,
-			raw:      kv.Value.TagAndDataBytes(),
-		})
+		return nil
+	}); err != nil {
+		return nil, err
 	}
-
 	return results, nil
 }

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -83,22 +83,28 @@ type LivenessUpdate struct {
 // call get, since the handleCondFailed after a CPut will notify you of the
 // previous data.
 func (ls *storageImpl) Get(ctx context.Context, nodeID roachpb.NodeID) (Record, error) {
-	var oldLiveness livenesspb.Liveness
-	record, err := ls.db.Get(ctx, ls.nodeKey(nodeID))
-	if err != nil {
-		return Record{}, errors.Wrap(err, "unable to get liveness")
+	var result Record
+	if err := ls.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		record, err := txn.Get(ctx, ls.nodeKey(nodeID))
+		if err != nil {
+			return errors.Wrap(err, "unable to get liveness")
+		}
+		if record.Value == nil {
+			return ErrMissingRecord
+		}
+		var oldLiveness livenesspb.Liveness
+		if err := record.Value.GetProto(&oldLiveness); err != nil {
+			return errors.Wrap(err, "invalid liveness record")
+		}
+		result = Record{
+			Liveness: oldLiveness,
+			raw:      record.Value.TagAndDataBytes(),
+		}
+		return nil
+	}); err != nil {
+		return Record{}, err
 	}
-	if record.Value == nil {
-		return Record{}, ErrMissingRecord
-	}
-	if err := record.Value.GetProto(&oldLiveness); err != nil {
-		return Record{}, errors.Wrap(err, "invalid liveness record")
-	}
-
-	return Record{
-		Liveness: oldLiveness,
-		raw:      record.Value.TagAndDataBytes(),
-	}, nil
+	return result, nil
 }
 
 // Update will attempt to update the liveness record using a CPut with the

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -31,16 +31,34 @@ type Storage interface {
 	Scan(ctx context.Context) ([]Record, error)
 }
 
-// storageImpl implements Storage by storing entries in the replicated KV liveness range.
+// storageImpl implements Storage by storing entries in the replicated KV
+// liveness range. The key prefix is configurable to allow contention testing
+// against a synthetic keyspace without requiring N actual nodes.
 type storageImpl struct {
-	db *kv.DB
+	db        *kv.DB
+	keyPrefix roachpb.Key
+	keyMax    roachpb.Key
+	// gossipOnUpdate is true when operating on the real liveness keyspace. It
+	// controls whether Update includes an InternalCommitTrigger to gossip the
+	// changed record. Set once at construction; the branch is essentially free.
+	gossipOnUpdate bool
 }
 
 var _ Storage = (*storageImpl)(nil)
 
 // NewKVStorage returns a Storage backed by the node liveness range.
 func NewKVStorage(db *kv.DB) Storage {
-	return &storageImpl{db}
+	return &storageImpl{
+		db:             db,
+		keyPrefix:      keys.NodeLivenessPrefix,
+		keyMax:         keys.NodeLivenessKeyMax,
+		gossipOnUpdate: true,
+	}
+}
+
+// nodeKey returns the KV key for the given node's liveness record.
+func (ls *storageImpl) nodeKey(nodeID roachpb.NodeID) roachpb.Key {
+	return keys.NodeLivenessKeyWithPrefix(ls.keyPrefix, nodeID)
 }
 
 // LivenessUpdate contains the information for CPutting a new version of a
@@ -66,7 +84,7 @@ type LivenessUpdate struct {
 // previous data.
 func (ls *storageImpl) Get(ctx context.Context, nodeID roachpb.NodeID) (Record, error) {
 	var oldLiveness livenesspb.Liveness
-	record, err := ls.db.Get(ctx, keys.NodeLivenessKey(nodeID))
+	record, err := ls.db.Get(ctx, ls.nodeKey(nodeID))
 	if err != nil {
 		return Record{}, errors.Wrap(err, "unable to get liveness")
 	}
@@ -100,26 +118,31 @@ func (ls *storageImpl) Update(
 		v = new(roachpb.Value)
 
 		b := txn.NewBatch()
-		key := keys.NodeLivenessKey(update.newLiveness.NodeID)
+		key := ls.nodeKey(update.newLiveness.NodeID)
 		if err := v.SetProto(&update.newLiveness); err != nil {
 			log.KvExec.Fatalf(ctx, "failed to marshall proto: %s", err)
 		}
 		b.CPut(key, v, update.oldRaw)
-		// Use a trigger on EndTxn to indicate that node liveness should be
-		// re-gossiped. Further, require that this transaction complete as a one
-		// phase commit to eliminate the possibility of leaving write intents.
-		b.AddRawRequest(&kvpb.EndTxnRequest{
+		// Require that this transaction complete as a one phase commit to
+		// eliminate the possibility of leaving write intents.
+		endTxn := &kvpb.EndTxnRequest{
 			Commit:     true,
 			Require1PC: true,
-			InternalCommitTrigger: &roachpb.InternalCommitTrigger{
+		}
+		// Use a trigger on EndTxn to indicate that node liveness should be
+		// re-gossiped. This is only valid on the real liveness range, not on
+		// synthetic keyspaces used for testing.
+		if ls.gossipOnUpdate {
+			endTxn.InternalCommitTrigger = &roachpb.InternalCommitTrigger{
 				ModifiedSpanTrigger: &roachpb.ModifiedSpanTrigger{
 					NodeLivenessSpan: &roachpb.Span{
 						Key:    key,
 						EndKey: key.Next(),
 					},
 				},
-			},
-		})
+			}
+		}
+		b.AddRawRequest(endTxn)
 		return txn.Run(ctx, b)
 	}); err != nil {
 		if tErr := (*kvpb.ConditionFailedError)(nil); errors.As(err, &tErr) {
@@ -159,7 +182,7 @@ func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error 
 		err := ls.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			txn.SetWorkloadInfo(uint64(workloadid.WORKLOAD_ID_NODE_LIVENESS), 0 /* appNameID */, workloadid.WorkloadTypeSystem)
 			b := txn.NewBatch()
-			key := keys.NodeLivenessKey(nodeID)
+			key := ls.nodeKey(nodeID)
 			if err := v.SetProto(&liveness); err != nil {
 				log.KvExec.Fatalf(ctx, "failed to marshall proto: %s", err)
 			}
@@ -196,7 +219,7 @@ func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error 
 
 // Scan will iterate over the KV liveness names and generate liveness records from them.
 func (ls *storageImpl) Scan(ctx context.Context) ([]Record, error) {
-	kvs, err := ls.db.Scan(ctx, keys.NodeLivenessPrefix, keys.NodeLivenessKeyMax, 0)
+	kvs, err := ls.db.Scan(ctx, ls.keyPrefix, ls.keyMax, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get liveness")
 	}

--- a/pkg/kv/kvserver/liveness/test_helpers.go
+++ b/pkg/kv/kvserver/liveness/test_helpers.go
@@ -10,7 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
 const (
@@ -91,4 +93,29 @@ func (nl *NodeLiveness) TestingMaybeUpdate(ctx context.Context, newRec Record) {
 // before a node is considered not-live.
 func (nl *NodeLiveness) TestingGetLivenessThreshold() time.Duration {
 	return nl.livenessThreshold
+}
+
+// NewTestKVStorage returns a Storage that uses the given key prefix instead of
+// the real node liveness keyspace. This allows contention benchmarks to
+// simulate many nodes' heartbeats and scans against a single-node test cluster
+// without requiring N actual nodes. The gossip trigger on Update is disabled
+// since it is only valid on the real liveness range.
+func NewTestKVStorage(db *kv.DB, keyPrefix roachpb.Key) Storage {
+	return &storageImpl{
+		db:             db,
+		keyPrefix:      keyPrefix,
+		keyMax:         keyPrefix.PrefixEnd(),
+		gossipOnUpdate: false,
+	}
+}
+
+// MakeTestLivenessUpdate constructs a LivenessUpdate for use in tests. It
+// pairs the new liveness value with the old record's raw bytes for the CPut
+// condition.
+func MakeTestLivenessUpdate(newLiveness livenesspb.Liveness, old Record) LivenessUpdate {
+	return LivenessUpdate{
+		newLiveness: newLiveness,
+		oldLiveness: old.Liveness,
+		oldRaw:      old.raw,
+	}
 }


### PR DESCRIPTION
- Add a configurable key prefix to the liveness storage layer and a BenchmarkLivenessContention that measures heartbeat write latency under concurrent full-range scan load with injected inter-node latency.

- Switch storageImpl.Scan and storageImpl.Get from non-transactional db.Scan/db.Get to db.Txn + txn.Scan/txn.Get.

Non-transactional reads get their read timestamp assigned at the leaseholder on arrival, maximizing the conflict window with concurrent heartbeat CPut writes. Transactional reads assign their timestamp at the coordinator (before the network hop), so this may reduce contention a bit.

However, this also allows us to potentially use historical reads for some use cases and admission control headers in the future.

Part of #165109

Release note: None