### PR TITLE
backup: retry download phase for 72h and pause on exhaustion

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -39,6 +39,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -46,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 )
 
@@ -80,8 +83,25 @@ var onlineRestoreUseDistFlow = settings.RegisterBoolSetting(
 	settings.WithVisibility(settings.Reserved),
 )
 
+var orDownloadRetryMaxDuration = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"backup.restore.online_download_retry_max_duration",
+	"maximum duration the online restore download phase will retry before pausing the job",
+	72*time.Hour,
+	settings.WithVisibility(settings.Reserved),
+	settings.PositiveDuration,
+)
+
+var orDownloadRetryLogRate = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"backup.restore.online_download_retry_log_rate",
+	"maximum rate at which retryable online restore download errors are logged to the job messages table",
+	5*time.Minute,
+	settings.WithVisibility(settings.Reserved),
+	settings.PositiveDuration,
+)
+
 const linkCompleteKey = "link_complete"
-const maxDownloadAttempts = 5
 
 // splitAndScatter runs through all entries produced by genSpans splitting and
 // scattering the key-space designated by the passed rewriter such that if all
@@ -849,28 +869,60 @@ func getRemainingExternalFileBytes(
 func (r *restoreResumer) doDownloadFilesWithRetry(
 	ctx context.Context, execCtx sql.JobExecContext,
 ) error {
+	maxDuration := orDownloadRetryMaxDuration.Get(&execCtx.ExecCfg().Settings.SV)
+	retryOpts := retry.Options{
+		InitialBackoff: time.Millisecond * 100,
+		MaxBackoff:     5 * time.Minute,
+		MaxDuration:    maxDuration,
+	}
+	if knobs := execCtx.ExecCfg().BackupRestoreTestingKnobs; knobs != nil &&
+		knobs.DownloadPhaseRetryPolicy != nil {
+		retryOpts = *knobs.DownloadPhaseRetryPolicy
+	}
+
+	logRate := orDownloadRetryLogRate.Get(&execCtx.ExecCfg().Settings.SV)
+	logThrottler := util.EveryMono(logRate)
+
 	var err error
 	var lastProgress float32
-	for rt := retry.StartWithCtx(ctx, retry.Options{
-		InitialBackoff: time.Millisecond * 100,
-		MaxBackoff:     time.Second,
-		MaxRetries:     maxDownloadAttempts - 1,
-	}); rt.Next(); {
+	for rt := retry.StartWithCtx(ctx, retryOpts); rt.Next(); {
 		err = r.doDownloadFiles(ctx, execCtx)
 		if err == nil {
 			return nil
 		}
+		log.Dev.Warningf(ctx, "failed attempt to download files: %v", err)
+
 		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
 			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
 		}
-		log.Dev.Warningf(ctx, "failed attempt to download files: %v", err)
+		if jobs.IsPauseSelfError(err) || jobs.IsPermanentJobError(err) {
+			return err
+		}
+
+		if logThrottler.ShouldProcess(crtime.NowMono()) {
+			besteffort.Warning(
+				ctx, "or-download-failed-log",
+				func(ctx context.Context) error {
+					return execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+						return r.job.Messages().Record(
+							ctx, txn, "error",
+							fmt.Sprintf("online restore download encountered error: %v", err),
+						)
+					})
+				},
+			)
+		}
+
 		if lastProgress != r.downloadJobProg {
 			lastProgress = r.downloadJobProg
 			rt.Reset()
 			log.Dev.Infof(ctx, "download progress has advanced since last retry, resetting retry counter")
 		}
 	}
-	return errors.Wrapf(err, "retries exhausted for downloading files")
+	if ctx.Err() != nil {
+		return errors.CombineErrors(ctx.Err(), err)
+	}
+	return jobs.MarkPauseRequestError(errors.Wrapf(err, "retries exhausted for downloading files"))
 }
 
 func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExecContext) error {

--- a/pkg/backup/restore_online_distflow_test.go
+++ b/pkg/backup/restore_online_distflow_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -171,6 +172,7 @@ func TestOnlineRestoreDistFlowSplitScatter(t *testing.T) {
 		runner.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
 		runner.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
 		runner.Exec(t, fmt.Sprintf("CANCEL JOB %d", downloadJobID))
+		jobutils.WaitForJobToCancel(t, runner, downloadJobID)
 		runner.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'")
 	}
 

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
@@ -54,6 +56,7 @@ func TestOnlineRestoreBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	ctx := context.Background()
@@ -104,7 +107,6 @@ func TestOnlineRestoreBasic(t *testing.T) {
 			rSQLDB.Exec(t, "DROP DATABASE data CASCADE")
 		})
 	})
-
 }
 
 func TestOnlineRestoreRecovery(t *testing.T) {
@@ -117,6 +119,7 @@ func TestOnlineRestoreRecovery(t *testing.T) {
 
 	_, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
+	sqlDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '1s'")
 
 	trueExternalStorage := "nodelocal://1/backup"
 	externalStorage := backuptestutils.GetExternalStorageURI(t, trueExternalStorage, "backup", sqlDB)
@@ -164,7 +167,9 @@ func TestOnlineRestoreRecovery(t *testing.T) {
 		corruptBackup(t, sqlDB, tmpDir, trueExternalStorage)
 		sqlDB.ExpectErr(t, "no such file or directory", "SELECT count(*) FROM data_delete.bank")
 		sqlDB.Exec(t, fmt.Sprintf("RESUME JOB %d", downloadJobID))
-		jobutils.WaitForJobToFail(t, sqlDB, jobspb.JobID(downloadJobID))
+		jobutils.WaitForJobToPause(t, sqlDB, jobspb.JobID(downloadJobID))
+		sqlDB.Exec(t, fmt.Sprintf("CANCEL JOB %d", downloadJobID))
+		jobutils.WaitForJobToCancel(t, sqlDB, jobspb.JobID(downloadJobID))
 		checkRecovery(t, dbName)
 	})
 	t.Run("cancel link job", func(t *testing.T) {
@@ -195,7 +200,9 @@ func TestOnlineRestoreRecovery(t *testing.T) {
 		corruptBackup(t, sqlDB, tmpDir, trueExternalStorage)
 		sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
 		sqlDB.Exec(t, fmt.Sprintf("RESUME JOB %d", blockingJobID))
-		jobutils.WaitForJobToFail(t, sqlDB, jobspb.JobID(blockingJobID))
+		jobutils.WaitForJobToPause(t, sqlDB, jobspb.JobID(blockingJobID))
+		sqlDB.Exec(t, fmt.Sprintf("CANCEL JOB %d", blockingJobID))
+		jobutils.WaitForJobToCancel(t, sqlDB, jobspb.JobID(blockingJobID))
 		checkRecovery(t, dbName)
 	})
 }
@@ -216,6 +223,8 @@ func TestFullClusterOnlineRestoreRecovery(t *testing.T) {
 	trueExternalStorage := "nodelocal://1/backup"
 	externalStorage := backuptestutils.GetExternalStorageURI(t, trueExternalStorage, "backup", sqlDB)
 
+	// We are intentionally failing the download phase so lower retry duration.
+	sqlDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '1s'")
 	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'")
 	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
 
@@ -242,7 +251,7 @@ func TestFullClusterOnlineRestoreRecovery(t *testing.T) {
 	corruptBackup(t, sqlDB, tmpDir, trueExternalStorage)
 	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
 	sqlDB.Exec(t, fmt.Sprintf("RESUME JOB %d", downloadJobID))
-	jobutils.WaitForJobToFail(t, sqlDB, downloadJobID)
+	jobutils.WaitForJobToPause(t, sqlDB, downloadJobID)
 }
 
 func corruptBackup(t *testing.T, sqlDB *sqlutils.SQLRunner, ioDir string, uri string) {
@@ -300,6 +309,7 @@ func TestOnlineRestoreLinkCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	rng, _ := randutil.NewTestRand()
@@ -328,6 +338,7 @@ func TestOnlineRestoreStatementResult(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 2
@@ -421,6 +432,7 @@ func TestOnlineRestoreTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	params := base.TestClusterArgs{ServerArgs: base.TestServerArgs{
@@ -522,6 +534,7 @@ func TestOnlineRestoreErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, 2, InitManualReplication)
@@ -579,6 +592,13 @@ func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 	rng, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)
 
+	const maxDownloadAttempts = 5
+	downloadRetryPolicy := &retry.Options{
+		InitialBackoff: time.Millisecond * 100,
+		MaxBackoff:     time.Second,
+		MaxRetries:     maxDownloadAttempts - 1,
+	}
+
 	alwaysFail := rng.Intn(2) == 0
 	t.Logf("always fail download requests: %t", alwaysFail)
 	totalFailures := int32(rng.Intn(maxDownloadAttempts-1) + 1)
@@ -588,6 +608,7 @@ func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				BackupRestore: &sql.BackupRestoreTestingKnobs{
+					DownloadPhaseRetryPolicy: downloadRetryPolicy,
 					RunBeforeSendingDownloadSpan: func() error {
 						if alwaysFail {
 							return errors.Newf("always fail download request")
@@ -622,7 +643,7 @@ func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 	var downloadJobID jobspb.JobID
 	sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
 	if alwaysFail {
-		jobutils.WaitForJobToFail(t, sqlDB, downloadJobID)
+		jobutils.WaitForJobToPause(t, sqlDB, downloadJobID)
 	} else {
 		jobutils.WaitForJobToSucceed(t, sqlDB, downloadJobID)
 	}
@@ -634,11 +655,18 @@ func TestOnlineRestoreDownloadRetryReset(t *testing.T) {
 
 	backuptestutils.EnableFastRestoreForTest(t)
 
+	const maxDownloadAttempts = 5
+
 	var attemptCount int
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				BackupRestore: &sql.BackupRestoreTestingKnobs{
+					DownloadPhaseRetryPolicy: &retry.Options{
+						InitialBackoff: time.Millisecond * 100,
+						MaxBackoff:     time.Second,
+						MaxRetries:     maxDownloadAttempts - 1,
+					},
 					// We want the retry loop to fail until its final attempt, and then
 					// succeed on the last attempt. This will allow the download job to
 					// make progress, in which case the retry loop _should_ reset. Then
@@ -687,6 +715,7 @@ func TestOnlineRestoreFailScatterNonEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	// This test first runs online restore and waits for an external SST to be

--- a/pkg/backup/testdata/backup-restore/online-restore-cluster
+++ b/pkg/backup/testdata/backup-restore/online-restore-cluster
@@ -1,4 +1,4 @@
-# This test ensures that cluster online restore publishes only one download job. 
+# This test ensures that cluster online restore publishes only one download job.
 
 reset test-nodelocal
 ----
@@ -31,4 +31,10 @@ query-sql
 SELECT count(*) FROM [SHOW JOBS] WHERE description LIKE '%Background Data Download%';
 ----
 1
+
+# Wait for download job to complete
+query-sql retry
+SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' and status='succeeded';
+----
+2
 

--- a/pkg/backup/testdata/backup-restore/online-restore-in-progress-imports
+++ b/pkg/backup/testdata/backup-restore/online-restore-in-progress-imports
@@ -51,3 +51,9 @@ query-sql
 SELECT count(1) FROM d2.foo
 ----
 1
+
+# Wait for all download jobs to finish
+query-sql retry
+SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' and status='succeeded';
+----
+2

--- a/pkg/backup/testdata/backup-restore/online-restore-prefix-backups
+++ b/pkg/backup/testdata/backup-restore/online-restore-prefix-backups
@@ -36,6 +36,12 @@ SELECT count(*) FROM data.baz;
 ----
 3
 
-exec-sql 
+exec-sql
 RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY, new_db_name =d2;
 ----
+
+# Wait for all download jobs to finish
+query-sql retry
+SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' AND status != 'succeeded';
+----
+0

--- a/pkg/backup/utils_test.go
+++ b/pkg/backup/utils_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -590,4 +591,14 @@ func getFullBackupPaths(t *testing.T, sqlDB *sqlutils.SQLRunner, uri string) []s
 		fullBackupPaths = append(fullBackupPaths, path)
 	}
 	return fullBackupPaths
+}
+
+// AllowORDownloadBestEffortFailures marks the best-effort operations in the
+// online restore download retry loop as allowed to fail in test builds. Tests
+// that do not wait for the download phase to complete before tearing down the
+// cluster may encounter context cancellation in these operations, which would
+// otherwise panic in test builds.
+func AllowORDownloadBestEffortFailures(t *testing.T) {
+	t.Helper()
+	t.Cleanup(besteffort.TestAllowFailure("or-download-failed-log"))
 }

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -172,6 +172,11 @@ func executeNodeShutdown(
 
 type checkStatusFunc func(status jobs.State) (success bool, unexpected bool)
 
+// WaitForState waits for a job to reach a state that satisfies the provided
+// check function. The check function returns two booleans: the first indicates
+// whether the job is in a successful state, and the second indicates whether
+// the job is in an unexpected state that should fail fast. The two booleans
+// should never both be true.
 func WaitForState(
 	ctx context.Context,
 	db *gosql.DB,
@@ -289,6 +294,27 @@ func WaitForFailed(
 			case jobs.StateRunning:
 				return false, false
 			case jobs.StateReverting:
+				return false, false
+			default:
+				return false, true
+			}
+		}, maxWait)
+}
+
+// WaitForCanceled waits for a job to reach the canceled state.
+func WaitForCanceled(
+	ctx context.Context, db *gosql.DB, jobID jobspb.JobID, maxWait time.Duration,
+) error {
+	return WaitForState(ctx, db, jobID,
+		func(state jobs.State) (success bool, unexpected bool) {
+			switch state {
+			case jobs.StateCanceled:
+				return true, false
+			case jobs.StateCancelRequested:
+				return false, false
+			case jobs.StateReverting:
+				return false, false
+			case jobs.StateRunning:
 				return false, false
 			default:
 				return false, true

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -987,6 +987,14 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 			Execute: allNodes,
 		}
 
+		// Since we are intentionally failing the download job by deleting a file,
+		// we reduce the retry duration for the job to speed up the test.
+		if _, err := dbConn.ExecContext(
+			ctx, "SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '5s'",
+		); err != nil {
+			return errors.Wrap(err, "failed to set download phase retry duration")
+		}
+
 		// We set this pausepoint so that the download job is paused before it
 		// begins downloading external files. This allows us to guarantee that when
 		// we delete an SST file, it won't have already been downloaded by the
@@ -1074,9 +1082,19 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 				err, "waiting for download job %v to reach resumed state", downloadJobID,
 			)
 		}
-		if err := WaitForFailed(ctx, dbConn, jobspb.JobID(downloadJobID), 10*time.Minute); err != nil {
+		if err := WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
 			return errors.Wrapf(
-				err, "waiting for download job %v to reach failed state", downloadJobID,
+				err, "waiting for download job %v to reach paused state", downloadJobID,
+			)
+		}
+		if _, err := dbConn.ExecContext(ctx, "CANCEL JOB $1", downloadJobID); err != nil {
+			return errors.Wrapf(
+				err, "failed to cancel download job %v after it paused", downloadJobID,
+			)
+		}
+		if err := WaitForCanceled(ctx, dbConn, jobspb.JobID(downloadJobID), 10*time.Minute); err != nil {
+			return errors.Wrapf(
+				err, "waiting for download job %v to reach canceled state", downloadJobID,
 			)
 		}
 		return errors.Wrapf(

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -99,6 +99,10 @@ type BackupRestoreTestingKnobs struct {
 	// drops its descriptors.
 	AfterRevertRestoreDropDescriptors func() error
 
+	// DownloadPhaseRetryPolicy, if set, overrides the default retry policy
+	// used for the download phase of online restore.
+	DownloadPhaseRetryPolicy *retry.Options
+
 	RestoreSpanConfigConformanceRetryPolicy *retry.Options
 
 	OnCompactionFileAccess *func(processorLocality roachpb.Locality, fileLocality string) error


### PR DESCRIPTION
Previously, the download phase of online restore retried up to 5 times
before failing. Retry for up to 72 hours instead, and pause the job
when retries are exhausted. Pausing allows the user to either excise
the external SSTs or fix the underlying issue and resume the download.

Epic: None

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>