### PR TITLE
release-26.2: backup: fix SHOW BACKUPS prepared statements

### DIFF
--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -747,7 +747,7 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 		// in time.
 		for _, coll := range []string{classicColl, rhColl} {
 			var ids []string
-			rows := sqlDB.Query(t, fmt.Sprintf("SHOW BACKUPS IN '%s'", coll))
+			rows := sqlDB.Query(t, "SHOW BACKUPS IN $1", coll)
 			for rows.Next() {
 				var id string
 				var unused any
@@ -761,7 +761,7 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 		sqlDB.Exec(t, "SET SESSION use_backups_with_ids = false")
 		for _, coll := range []string{classicColl, rhColl} {
 			var subdirs []string
-			rows := sqlDB.Query(t, fmt.Sprintf("SHOW BACKUPS IN '%s'", coll))
+			rows := sqlDB.Query(t, "SHOW BACKUPS IN $1", coll)
 			for rows.Next() {
 				var subdir string
 				require.NoError(t, rows.Scan(&subdir))

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -1379,6 +1379,10 @@ func showBackupsInCollectionTypeCheck(
 	); err != nil {
 		return false, nil, err
 	}
+
+	if p.SessionData().UseBackupsWithIDs {
+		return true, showBackupsWithIDsHeader, nil
+	}
 	return true, showBackupsInCollectionHeader, nil
 }
 

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -894,7 +894,7 @@ func TestShowBackupsWithIDs(t *testing.T) {
 
 	t.Run("backup times are in descending order", func(t *testing.T) {
 		shownTimes := sqlDB.QueryStr(
-			t, fmt.Sprintf(`SELECT backup_time FROM [SHOW BACKUPS IN '%s']`, collectionURI),
+			t, `SELECT backup_time FROM [SHOW BACKUPS IN $1]`, collectionURI,
 		)
 		require.Equal(t, len(times), len(shownTimes))
 		require.True(
@@ -921,10 +921,8 @@ func TestShowBackupsWithIDs(t *testing.T) {
 			var count int
 			sqlDB.QueryRow(
 				t,
-				fmt.Sprintf(
-					`SELECT count(*) FROM [SHOW BACKUPS IN '%s' OLDER THAN %d]`,
-					collectionURI, filterTime,
-				),
+				fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUPS IN $1 OLDER THAN %d]`, filterTime),
+				collectionURI,
 			).Scan(&count)
 
 			var expected int
@@ -946,10 +944,8 @@ func TestShowBackupsWithIDs(t *testing.T) {
 			var count int
 			sqlDB.QueryRow(
 				t,
-				fmt.Sprintf(
-					`SELECT count(*) FROM [SHOW BACKUPS IN '%s' NEWER THAN %d]`,
-					collectionURI, filterTime,
-				),
+				fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUPS IN $1 NEWER THAN %d]`, filterTime),
+				collectionURI,
 			).Scan(&count)
 
 			var expected int
@@ -980,10 +976,8 @@ func TestShowBackupsWithIDs(t *testing.T) {
 			var count int
 			sqlDB.QueryRow(
 				t,
-				fmt.Sprintf(
-					`SELECT count(*) FROM [SHOW BACKUPS IN '%s' OLDER THAN %d NEWER THAN %d]`,
-					collectionURI, newerTime, olderTime,
-				),
+				fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUPS IN $1 OLDER THAN %d NEWER THAN %d]`, newerTime, olderTime),
+				collectionURI,
 			).Scan(&count)
 
 			var expected int
@@ -1023,10 +1017,8 @@ func TestShowBackupsWithIDsAndRevisionHistory(t *testing.T) {
 	t.Run("WITH REVISION START TIME", func(t *testing.T) {
 		revStartTimes := sqlDB.QueryStr(
 			t,
-			fmt.Sprintf(
-				`SELECT backup_time, revision_start_time FROM [SHOW BACKUPS IN '%s' WITH REVISION START TIME]`,
-				collectionURI,
-			),
+			`SELECT backup_time, revision_start_time FROM [SHOW BACKUPS IN $1 WITH REVISION START TIME]`,
+			collectionURI,
 		)
 		require.Len(t, revStartTimes, 3, "expected 3 backups")
 		for idx, row := range revStartTimes {
@@ -1048,10 +1040,8 @@ func TestShowBackupsWithIDsAndRevisionHistory(t *testing.T) {
 	t.Run("WITHOUT REVISION START TIME", func(t *testing.T) {
 		revStartTimes := sqlDB.QueryStr(
 			t,
-			fmt.Sprintf(
-				`SELECT revision_start_time FROM [SHOW BACKUPS IN '%s']`,
-				collectionURI,
-			),
+			`SELECT revision_start_time FROM [SHOW BACKUPS IN $1]`,
+			collectionURI,
 		)
 		require.Len(t, revStartTimes, 3, "expected 3 backups")
 		for idx, row := range revStartTimes {
@@ -1112,7 +1102,7 @@ func TestShowBackupWithIDs(t *testing.T) {
 		sqlDB.Exec(t, "BACKUP DATABASE foo INTO LATEST IN $1 AS OF SYSTEM TIME $2::STRING", localFoo, t3.AsOfSystemTime())
 
 		sqlDB.QueryRow(
-			t, fmt.Sprintf(`SELECT path FROM [SHOW BACKUPS IN '%s']`, localFoo),
+			t, `SELECT path FROM [SHOW BACKUPS IN $1]`, localFoo,
 		).Scan(&fullSubdir)
 		require.NotEmpty(t, fullSubdir)
 
@@ -1150,7 +1140,7 @@ func TestShowBackupWithIDs(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, "SET SESSION use_backups_with_ids = true")
-	idRows := sqlDB.Query(t, fmt.Sprintf(`SHOW BACKUPS IN '%s'`, localFoo))
+	idRows := sqlDB.Query(t, `SHOW BACKUPS IN $1`, localFoo)
 	var ids []string // All ids in sorted chronological order
 	for idRows.Next() {
 		var id string

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -222,6 +222,7 @@ type Memo struct {
 	useImprovedRoutineDepsTriggersComputedCols bool
 	inlineAnyUnnestSubquery                    bool
 	useMinRowCountAntiJoinFix                  bool
+	useBackupsWithIDs                          bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -351,6 +352,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useMinRowCountAntiJoinFix:                  evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix,
 		skipUnderlyingViewPrivilegeChecks:          sqlclustersettings.SkipUnderlyingViewPrivilegeChecks.Get(&evalCtx.Settings.SV),
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
+		useBackupsWithIDs:                          evalCtx.SessionData().UseBackupsWithIDs,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(ctx, evalCtx, m)
@@ -536,7 +538,8 @@ func (m *Memo) IsStale(
 		m.inlineAnyUnnestSubquery != evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery ||
 		m.useMinRowCountAntiJoinFix != evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix ||
 		m.skipUnderlyingViewPrivilegeChecks != sqlclustersettings.SkipUnderlyingViewPrivilegeChecks.Get(&evalCtx.Settings.SV) ||
-		m.txnIsoLevel != evalCtx.TxnIsoLevel {
+		m.txnIsoLevel != evalCtx.TxnIsoLevel ||
+		m.useBackupsWithIDs != evalCtx.SessionData().UseBackupsWithIDs {
 		return true, nil
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #166713 on behalf of @kev-cao.

----

This fixes the bug that prevented using prepared statements with the new SHOW BACKUPS by properly setting the column types and invalidating the query plan cache when the `use_backups_with_ids` session variable is set.

Epic: None

Release note: None

----

Release justification: Prepared statements using `SHOW BACKUPS` were previously not working at all, this fixes that.