### PR TITLE
sqlutils: dump goroutine stacks on ExpectErrWithTimeout timeout

### DIFF
--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -225,7 +225,8 @@ func (sr *SQLRunner) ExpectErrSucceedsSoon(
 	})
 }
 
-// ExpectErrWithTimeout wraps ExpectErr with a timeout.
+// ExpectErrWithTimeout wraps ExpectErr with a timeout. On timeout, a
+// goroutine dump is written to help debug.
 func (sr *SQLRunner) ExpectErrWithTimeout(
 	t Fataler, errRE string, query string, args ...interface{},
 ) {
@@ -236,13 +237,18 @@ func (sr *SQLRunner) ExpectErrWithTimeout(
 	}
 	err := timeutil.RunWithTimeout(context.Background(), "expect-err", d, func(ctx context.Context) error {
 		_, err := sr.DB.ExecContext(ctx, query, args...)
+		if ctx.Err() != nil {
+			// The context timed out; return the error so RunWithTimeout can
+			// wrap it as a TimeoutError and we can dump goroutine stacks.
+			return err
+		}
 		sr.expectErr(t, query, err, errRE)
 		return nil
 	})
 
-	// Fail the test on unexpected error message OR execution timeout
 	if err != nil {
-		t.Fatalf("failed assert error: %s", err)
+		dumpFile := testutils.WriteGoroutineDump()
+		t.Fatalf("failed assert error: %s\n\ngoroutine dump: %s", err, dumpFile)
 	}
 }
 

--- a/pkg/testutils/sqlutils/sql_runner_test.go
+++ b/pkg/testutils/sqlutils/sql_runner_test.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -82,4 +83,33 @@ type mockFataler struct {
 
 func (f *mockFataler) Fatalf(s string, args ...interface{}) {
 	f.err = fmt.Sprintf(s, args...)
+}
+
+func TestExpectErrWithTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	t.Run("matching error passes", func(t *testing.T) {
+		runner := sqlutils.MakeSQLRunner(db)
+		runner.ExpectErrWithTimeout(
+			t, `does not exist`,
+			`SELECT * FROM nonexistent_table`,
+		)
+	})
+
+	t.Run("timeout produces goroutine dump", func(t *testing.T) {
+		runner := sqlutils.MakeSQLRunner(db)
+		runner.SucceedsSoonDuration = 1 * time.Second
+
+		f := &mockFataler{}
+		runner.ExpectErrWithTimeout(
+			f, `will never match`,
+			`SELECT pg_sleep(30)`,
+		)
+		require.NotEmpty(t, f.err, "expected Fatalf to be called")
+		require.Contains(t, f.err, "goroutine dump")
+	})
 }


### PR DESCRIPTION
This commit adds dumping of goroutine stacks when we timeout
waiting for errors with ExpectErrWithTimeout. This should make
it easier to debug why we timed out (what we were doing instead)
when we see these test failures.

Fixes: https://github.com/cockroachdb/cockroach/issues/166774
Fixes: https://github.com/cockroachdb/cockroach/issues/166797

Release note: None