### PR TITLE
changefeedccl: deflake TestChangefeedOutdatedCursor

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7127,7 +7127,10 @@ func TestChangefeedOutdatedCursor(t *testing.T) {
 		expectErrCreatingFeed(t, f, createChangefeed, expectedErrorSubstring)
 	}
 
-	cdcTestWithSystem(t, testFn, feedTestNoTenants)
+	// Use root to avoid flakes. Non-root connections authenticate against
+	// descriptors that may already be GC'd, so auth fails before the expected
+	// cursor error. See #166880.
+	cdcTestWithSystem(t, testFn, feedTestNoTenants, feedTestUseRootUserConnection)
 }
 
 // TestChangefeedCursorWarning ensures that we show a warning if


### PR DESCRIPTION
We were seeing this test flake on authenticating a user before seeing the expected error. In order to test more directly, we use the root user connection so that auth doesn't take place and there's no longer a race. The test is validating cursor behavior, not user permissions so this makes sense.

Fixes: #166880

Release note: None