### PR TITLE
sql: add parser grammar for DROP PROVISIONED ROLES

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -144,6 +144,7 @@ FILES = [
     "drop_func_stmt",
     "drop_policy_stmt",
     "drop_proc",
+    "drop_provisioned_roles_stmt",
     "drop_index",
     "drop_owned_by_stmt",
     "drop_role_stmt",

--- a/docs/generated/sql/bnf/drop_provisioned_roles_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_provisioned_roles_stmt.bnf
@@ -1,0 +1,2 @@
+drop_provisioned_roles_stmt ::=
+	'DROP' 'PROVISIONED' 'ROLES' opt_with_drop_provisioned_roles_options opt_limit_clause

--- a/docs/generated/sql/bnf/drop_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_stmt.bnf
@@ -11,5 +11,6 @@ drop_stmt ::=
 	| drop_trigger_stmt
 	| drop_policy_stmt
 	| drop_role_stmt
+	| drop_provisioned_roles_stmt
 	| drop_schedule_stmt
 	| drop_external_connection_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -229,6 +229,7 @@ delete_stmt ::=
 drop_stmt ::=
 	drop_ddl_stmt
 	| drop_role_stmt
+	| drop_provisioned_roles_stmt
 	| drop_schedule_stmt
 	| drop_external_connection_stmt
 
@@ -727,6 +728,9 @@ drop_ddl_stmt ::=
 drop_role_stmt ::=
 	'DROP' role_or_group_or_user role_spec_list
 	| 'DROP' role_or_group_or_user 'IF' 'EXISTS' role_spec_list
+
+drop_provisioned_roles_stmt ::=
+	'DROP' 'PROVISIONED' 'ROLES' opt_with_drop_provisioned_roles_options opt_limit_clause
 
 drop_schedule_stmt ::=
 	'DROP' 'SCHEDULE' a_expr
@@ -1444,6 +1448,7 @@ unreserved_keyword ::=
 	| 'PUSH'
 	| 'PROCEDURE'
 	| 'PROCEDURES'
+	| 'PROVISIONED'
 	| 'PROVISIONSRC'
 	| 'PUBLIC'
 	| 'PUBLICATION'
@@ -2083,6 +2088,10 @@ drop_trigger_stmt ::=
 drop_policy_stmt ::=
 	'DROP' 'POLICY' name 'ON' table_name opt_drop_behavior
 	| 'DROP' 'POLICY' 'IF' 'EXISTS' name 'ON' table_name opt_drop_behavior
+
+opt_with_drop_provisioned_roles_options ::=
+	'WITH' drop_provisioned_roles_options_list
+	| 
 
 explain_option_name ::=
 	non_reserved_word
@@ -3034,6 +3043,9 @@ view_name_list ::=
 sequence_name_list ::=
 	db_object_name_list
 
+drop_provisioned_roles_options_list ::=
+	( drop_provisioned_roles_option ) ( ( ',' drop_provisioned_roles_option ) )*
+
 non_reserved_word ::=
 	'identifier'
 	| unreserved_keyword
@@ -3699,6 +3711,10 @@ only_signed_fconst ::=
 
 db_object_name_list ::=
 	( db_object_name ) ( ( ',' db_object_name ) )*
+
+drop_provisioned_roles_option ::=
+	'SOURCE' '=' a_expr
+	| 'LAST' 'LOGIN' 'BEFORE' a_expr
 
 array_subscript ::=
 	'[' a_expr ']'
@@ -4473,6 +4489,7 @@ bare_label_keywords ::=
 	| 'PUSH'
 	| 'PROCEDURE'
 	| 'PROCEDURES'
+	| 'PROVISIONED'
 	| 'PROVISIONSRC'
 	| 'PUBLIC'
 	| 'PUBLICATION'

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -146,6 +146,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:drop_owned_by_stmt.bnf",
     "//docs/generated/sql/bnf:drop_policy_stmt.bnf",
     "//docs/generated/sql/bnf:drop_proc.bnf",
+    "//docs/generated/sql/bnf:drop_provisioned_roles_stmt.bnf",
     "//docs/generated/sql/bnf:drop_role_stmt.bnf",
     "//docs/generated/sql/bnf:drop_schedule_stmt.bnf",
     "//docs/generated/sql/bnf:drop_schema.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -147,6 +147,7 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:drop_owned_by.html",
     "//docs/generated/sql/bnf:drop_policy.html",
     "//docs/generated/sql/bnf:drop_proc.html",
+    "//docs/generated/sql/bnf:drop_provisioned_roles.html",
     "//docs/generated/sql/bnf:drop_role.html",
     "//docs/generated/sql/bnf:drop_schedule.html",
     "//docs/generated/sql/bnf:drop_schema.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -156,6 +156,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:drop_owned_by_stmt.bnf",
     "//docs/generated/sql/bnf:drop_policy_stmt.bnf",
     "//docs/generated/sql/bnf:drop_proc.bnf",
+    "//docs/generated/sql/bnf:drop_provisioned_roles_stmt.bnf",
     "//docs/generated/sql/bnf:drop_role_stmt.bnf",
     "//docs/generated/sql/bnf:drop_schedule_stmt.bnf",
     "//docs/generated/sql/bnf:drop_schema.bnf",

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -244,6 +244,8 @@ func TestContextualHelp(t *testing.T) {
 		{`DROP ROLE IF ??`, `DROP ROLE`},
 		{`DROP ROLE IF EXISTS bluh ??`, `DROP ROLE`},
 
+		{`DROP PROVISIONED ROLES ??`, `DROP PROVISIONED ROLES`},
+
 		{`DROP SEQUENCE blah ??`, `DROP SEQUENCE`},
 		{`DROP SEQUENCE IF ??`, `DROP SEQUENCE`},
 		{`DROP SEQUENCE IF EXISTS blih, bloh ??`, `DROP SEQUENCE`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -754,6 +754,9 @@ func (u *sqlSymUnion) showBackupDetails() tree.ShowBackupDetails {
 func (u *sqlSymUnion) showBackupOptions() *tree.ShowBackupOptions {
   return u.val.(*tree.ShowBackupOptions)
 }
+func (u *sqlSymUnion) dropProvisionedRolesOptions() *tree.DropProvisionedRolesOptions {
+  return u.val.(*tree.DropProvisionedRolesOptions)
+}
 func (u *sqlSymUnion) showBackupTimeFilter() *tree.ShowBackupTimeFilter {
   return u.val.(*tree.ShowBackupTimeFilter)
 }
@@ -1073,7 +1076,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %token <str> PARALLEL PARENT PARTIAL PARTITION PARTITIONS PASSWORD PAUSE PAUSED PER PERMISSIVE PHYSICAL PLACEMENT PLACING
 %token <str> PLAN PLANS POINT POINTM POINTZ POINTZM POLICIES POLICY POLYGON POLYGONM POLYGONZ POLYGONZM
 %token <str> POSITION PRECEDING PRECISION PREPARE PREPARED PRESERVE PRIMARY PRIOR PRIORITY PRIVILEGES PUSH
-%token <str> PROCEDURAL PROCEDURE PROCEDURES PROVISIONSRC PUBLIC PUBLICATION
+%token <str> PROCEDURAL PROCEDURE PROCEDURES PROVISIONED PROVISIONSRC PUBLIC PUBLICATION
 
 %token <str> QUERIES QUERY QUOTE
 
@@ -1338,6 +1341,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %type <tree.Statement> drop_external_connection_stmt
 %type <tree.Statement> drop_index_stmt
 %type <tree.Statement> drop_role_stmt
+%type <tree.Statement> drop_provisioned_roles_stmt
 %type <tree.Statement> drop_schema_stmt
 %type <tree.Statement> drop_table_stmt
 %type <tree.Statement> drop_type_stmt
@@ -1490,6 +1494,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %type <tree.ShowBackupDetails> show_backup_details
 %type <*tree.ShowJobOptions> show_job_options show_job_options_list
 %type <*tree.ShowBackupOptions> opt_with_show_backup_options show_backup_options show_backup_options_list opt_with_show_backups_options show_backups_options
+%type <*tree.DropProvisionedRolesOptions> opt_with_drop_provisioned_roles_options drop_provisioned_roles_option drop_provisioned_roles_options_list
 %type <*tree.ShowBackupTimeFilter> opt_show_backups_time_filter_clause
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list copy_generic_options copy_generic_options_list
 %type <str> import_format
@@ -6628,11 +6633,12 @@ discard_stmt:
 // %Category: Group
 // %Text:
 // DROP DATABASE, DROP INDEX, DROP TABLE, DROP VIEW, DROP SEQUENCE,
-// DROP USER, DROP ROLE, DROP TYPE
+// DROP USER, DROP ROLE, DROP TYPE, DROP PROVISIONED ROLES,
 drop_stmt:
-  drop_ddl_stmt                 // help texts in sub-rule
-| drop_role_stmt                // EXTEND WITH HELP: DROP ROLE
-| drop_schedule_stmt            // EXTEND WITH HELP: DROP SCHEDULES
+  drop_ddl_stmt                    // help texts in sub-rule
+| drop_role_stmt                   // EXTEND WITH HELP: DROP ROLE
+| drop_provisioned_roles_stmt      // EXTEND WITH HELP: DROP PROVISIONED ROLES
+| drop_schedule_stmt               // EXTEND WITH HELP: DROP SCHEDULES
 | drop_external_connection_stmt // EXTEND WITH HELP: DROP EXTERNAL CONNECTION
 | drop_virtual_cluster_stmt     // EXTEND WITH HELP: DROP VIRTUAL CLUSTER
 | drop_unsupported   {}
@@ -6866,6 +6872,57 @@ drop_role_stmt:
     $$.val = &tree.DropRole{Names: $5.roleSpecList(), IfExists: true, IsRole: $2.bool()}
   }
 | DROP role_or_group_or_user error // SHOW HELP: DROP ROLE
+
+// %Help: DROP PROVISIONED ROLES - bulk-drop provisioned users
+// %Category: Priv
+// %Text:
+// DROP PROVISIONED ROLES [WITH <options>] [LIMIT <n>]
+//
+// Options:
+//   SOURCE = <string>
+//   LAST LOGIN BEFORE <expr>
+// %SeeAlso: SHOW USERS, DROP ROLE
+drop_provisioned_roles_stmt:
+  DROP PROVISIONED ROLES opt_with_drop_provisioned_roles_options opt_limit_clause
+  {
+    $$.val = &tree.DropProvisionedRoles{
+      Options: $4.dropProvisionedRolesOptions(),
+      Limit:   $5.limit(),
+    }
+  }
+| DROP PROVISIONED ROLES error // SHOW HELP: DROP PROVISIONED ROLES
+
+opt_with_drop_provisioned_roles_options:
+  WITH drop_provisioned_roles_options_list
+  {
+    $$.val = $2.dropProvisionedRolesOptions()
+  }
+| /* EMPTY */
+  {
+    $$.val = (*tree.DropProvisionedRolesOptions)(nil)
+  }
+
+drop_provisioned_roles_options_list:
+  drop_provisioned_roles_option
+  {
+    $$.val = $1.dropProvisionedRolesOptions()
+  }
+| drop_provisioned_roles_options_list ',' drop_provisioned_roles_option
+  {
+    if err := $1.dropProvisionedRolesOptions().CombineWith($3.dropProvisionedRolesOptions()); err != nil {
+      return setErr(sqllex, err)
+    }
+  }
+
+drop_provisioned_roles_option:
+  SOURCE '=' a_expr
+  {
+    $$.val = &tree.DropProvisionedRolesOptions{Source: $3.expr()}
+  }
+| LAST LOGIN BEFORE a_expr
+  {
+    $$.val = &tree.DropProvisionedRolesOptions{LastLoginBefore: $4.expr()}
+  }
 
 db_object_name_list:
   db_object_name
@@ -19112,6 +19169,7 @@ unreserved_keyword:
 | PUSH
 | PROCEDURE
 | PROCEDURES
+| PROVISIONED
 | PROVISIONSRC
 | PUBLIC
 | PUBLICATION
@@ -19704,6 +19762,7 @@ bare_label_keywords:
 | PUSH
 | PROCEDURE
 | PROCEDURES
+| PROVISIONED
 | PROVISIONSRC
 | PUBLIC
 | PUBLICATION

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6633,7 +6633,7 @@ discard_stmt:
 // %Category: Group
 // %Text:
 // DROP DATABASE, DROP INDEX, DROP TABLE, DROP VIEW, DROP SEQUENCE,
-// DROP USER, DROP ROLE, DROP TYPE, DROP PROVISIONED ROLES,
+// DROP USER, DROP ROLE, DROP TYPE, DROP PROVISIONED ROLES
 drop_stmt:
   drop_ddl_stmt                    // help texts in sub-rule
 | drop_role_stmt                   // EXTEND WITH HELP: DROP ROLE

--- a/pkg/sql/parser/testdata/drop_user
+++ b/pkg/sql/parser/testdata/drop_user
@@ -63,6 +63,14 @@ DROP PROVISIONED ROLES WITH SOURCE = '_', LAST LOGIN BEFORE '_' -- literals remo
 DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' -- identifiers removed
 
 parse
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01', SOURCE = 'ldap:ldap.example.com'
+----
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01'
+DROP PROVISIONED ROLES WITH SOURCE = ('ldap:ldap.example.com'), LAST LOGIN BEFORE ('2025-01-01') -- fully parenthesized
+DROP PROVISIONED ROLES WITH SOURCE = '_', LAST LOGIN BEFORE '_' -- literals removed
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' -- identifiers removed
+
+parse
 DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
 ----
 DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10

--- a/pkg/sql/parser/testdata/drop_user
+++ b/pkg/sql/parser/testdata/drop_user
@@ -29,3 +29,75 @@ DROP ROLE IF EXISTS foo, bar
 DROP ROLE IF EXISTS foo, bar -- fully parenthesized
 DROP ROLE IF EXISTS foo, bar -- literals removed
 DROP ROLE IF EXISTS _, _ -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES
+----
+DROP PROVISIONED ROLES
+DROP PROVISIONED ROLES -- fully parenthesized
+DROP PROVISIONED ROLES -- literals removed
+DROP PROVISIONED ROLES -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com'
+----
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com'
+DROP PROVISIONED ROLES WITH SOURCE = ('ldap:ldap.example.com') -- fully parenthesized
+DROP PROVISIONED ROLES WITH SOURCE = '_' -- literals removed
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01'
+----
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01'
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE ('2025-01-01') -- fully parenthesized
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '_' -- literals removed
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01' -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01'
+----
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01'
+DROP PROVISIONED ROLES WITH SOURCE = ('ldap:ldap.example.com'), LAST LOGIN BEFORE ('2025-01-01') -- fully parenthesized
+DROP PROVISIONED ROLES WITH SOURCE = '_', LAST LOGIN BEFORE '_' -- literals removed
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
+----
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
+DROP PROVISIONED ROLES WITH SOURCE = ('ldap:ldap.example.com') LIMIT (10) -- fully parenthesized
+DROP PROVISIONED ROLES WITH SOURCE = '_' LIMIT _ -- literals removed
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10 -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' LIMIT 100
+----
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' LIMIT 100
+DROP PROVISIONED ROLES WITH SOURCE = ('ldap:ldap.example.com'), LAST LOGIN BEFORE ('2025-01-01') LIMIT (100) -- fully parenthesized
+DROP PROVISIONED ROLES WITH SOURCE = '_', LAST LOGIN BEFORE '_' LIMIT _ -- literals removed
+DROP PROVISIONED ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' LIMIT 100 -- identifiers removed
+
+parse
+DROP PROVISIONED ROLES LIMIT 5
+----
+DROP PROVISIONED ROLES LIMIT 5
+DROP PROVISIONED ROLES LIMIT (5) -- fully parenthesized
+DROP PROVISIONED ROLES LIMIT _ -- literals removed
+DROP PROVISIONED ROLES LIMIT 5 -- identifiers removed
+
+error
+DROP PROVISIONED ROLES WITH SOURCE = 'a', SOURCE = 'b'
+----
+at or near "EOF": syntax error: SOURCE option specified multiple times
+DETAIL: source SQL:
+DROP PROVISIONED ROLES WITH SOURCE = 'a', SOURCE = 'b'
+                                                      ^
+
+error
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01', LAST LOGIN BEFORE '2025-06-01'
+----
+at or near "EOF": syntax error: LAST LOGIN BEFORE option specified multiple times
+DETAIL: source SQL:
+DROP PROVISIONED ROLES WITH LAST LOGIN BEFORE '2025-01-01', LAST LOGIN BEFORE '2025-06-01'
+                                                                                          ^

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -285,7 +285,7 @@ func combineBools(v1 bool, v2 bool, label string) (bool, error) {
 func combineExpr(v1 Expr, v2 Expr, label string) (Expr, error) {
 	if v1 != nil {
 		if v2 != nil {
-			return v1, errors.Newf("% option specified multiple times", label)
+			return v1, errors.Newf("%s option specified multiple times", label)
 		}
 		return v1, nil
 	}
@@ -296,7 +296,7 @@ func combineStringOrPlaceholderOptList(
 ) (StringOrPlaceholderOptList, error) {
 	if v1 != nil {
 		if v2 != nil {
-			return v1, errors.Newf("% option specified multiple times", label)
+			return v1, errors.Newf("%s option specified multiple times", label)
 		}
 		return v1, nil
 	}


### PR DESCRIPTION
Extend the SQL parser grammar to support the DROP PROVISIONED ROLES
statement with optional WITH clauses and LIMIT:

DROP PROVISIONED ROLES [WITH <options>] [LIMIT <n>]

Options (comma-separated):
  SOURCE = <string>
  LAST LOGIN BEFORE <expr>

Add `PROVISIONED` as an unreserved keyword. Define dedicated grammar
rules (`opt_with_drop_provisioned_roles_options`,
`drop_provisioned_roles_options_list`, `drop_provisioned_roles_option`)
and wire the new `drop_provisioned_roles_stmt` production into `drop_stmt`.

Add parse roundtrip tests covering all option combinations, including
error tests for duplicate option detection.

Fix a pre-existing format string bug in `combineExpr` and
`combineStringOrPlaceholderOptList` where `%` was used instead of `%s`,
producing garbled error messages for duplicate options.

Epic [CRDB-52460](https://cockroachlabs.atlassian.net/browse/CRDB-52460)

fixes: [CRDB-52797](https://cockroachlabs.atlassian.net/browse/CRDB-52797)

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>