### PR TITLE
ui: migrate Top Ranges database filter from Redux to SWR

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -43,6 +43,7 @@ export * from "./text";
 export * from "./tracez";
 export { util, api };
 export { useCluster, useClusterLabel } from "./api/clusterApi";
+export { useDatabasesList } from "./api/databasesApi";
 export { useNodes } from "./api/nodesApi";
 export { useNodesSummary } from "./api/nodesSummaryApi";
 export { useHealth } from "./api/healthApi";

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
@@ -11,13 +11,11 @@ import {
   FilterCheckboxOptionItem,
   NodeSelector,
   NodeID,
+  useDatabasesList,
 } from "@cockroachlabs/cluster-ui";
 import { Row, Col } from "antd";
 import classNames from "classnames/bind";
 import React, { useMemo } from "react";
-import { useSelector } from "react-redux";
-
-import { selectDatabases } from "../statements/statementsPage";
 
 import styles from "./hotRanges.module.scss";
 import { Filters } from "./useFilters";
@@ -59,7 +57,7 @@ export const HotRangesFilter = (props: HotRangesFilterProps) => {
   const setIndex = (index: string) => mergeFilters({ index });
 
   // Setup the options and selected values for the database filter.
-  const databaseNames = useSelector(selectDatabases);
+  const { databases: databaseNames } = useDatabasesList();
   const databaseOptions = databaseNames.map((db: string) => ({
     label: db,
     value: db,

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
@@ -17,11 +17,10 @@ import {
 import classNames from "classnames/bind";
 import React, { useRef, useMemo, useEffect, useContext, useState } from "react";
 import { Helmet } from "react-helmet";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import { useHotRanges } from "src/hooks/useHotRanges";
 import { analytics } from "src/redux/analytics";
-import { refreshDatabases } from "src/redux/apiReducers";
 import { selectNodeLocalities } from "src/redux/localities";
 import { performanceBestPracticesHotSpots } from "src/util/docs";
 import { HotRangesFilter } from "src/views/hotRanges/hotRangesFilter";
@@ -48,7 +47,6 @@ const emptyMessages = {
 };
 
 const HotRangesPage = () => {
-  const dispatch = useDispatch();
   const nodeIdToLocalityMap = useSelector(selectNodeLocalities);
   const timezone = useContext(TimezoneContext);
 
@@ -83,11 +81,6 @@ const HotRangesPage = () => {
     // when the contents haven't changed, but the references have.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [analyticsKey]);
-
-  // load the databases if possible.
-  useEffect(() => {
-    dispatch(refreshDatabases());
-  }, [dispatch]);
 
   const clearButtonRef = useRef<HTMLSpanElement>();
   const filteredRanges = useMemo(() => {

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -15,7 +15,6 @@ import {
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { bindActionCreators } from "redux";
-import { createSelector } from "reselect";
 
 import {
   trackApplySearchCriteriaAction,
@@ -31,20 +30,6 @@ import {
   trackActivateDiagnostics,
   trackDiagnosticsModalOpen,
 } from "src/util/analytics";
-
-// selectDatabases returns the array of all databases in the cluster.
-export const selectDatabases = createSelector(
-  (state: AdminUIState) => state.cachedData.databases,
-  state => {
-    if (!state?.data) {
-      return [];
-    }
-
-    return state.data.databases
-      .filter((dbName: string) => dbName !== null && dbName.length > 0)
-      .sort();
-  },
-);
 
 export const statementColumnsLocalSetting = new LocalSetting(
   "create_statement_columns",


### PR DESCRIPTION
The Top Ranges page fetches the database list through a Redux dispatch (refreshDatabases) on mount, and reads it via a Redux selector (selectDatabases) in the filter component. This was identified during review of #166563 as a missed Redux pattern that should use the SWR hook created in that PR.

Replace the Redux refreshDatabases dispatch and selectDatabases selector with the useDatabasesList SWR hook. Export the hook from cluster-ui's barrel file so db-console can import it. Remove the now-unused selectDatabases selector and its createSelector import.

Epic: CRDB-58145
Release note: None