### PR TITLE
sql: skip redundant cast when replacing subquery results in render expressions

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -440,6 +440,18 @@ func (ex *connExecutor) execStmtInOpenState(
 	if err != nil {
 		return makeErrEvent(err)
 	}
+
+	// Set up an OID name resolver so that reg* type values (e.g. REGCLASS)
+	// display as resolved names rather than numeric OIDs in query results.
+	if ex.executorType != executorTypeInternal {
+		res.SetOidNameResolver(
+			MakeOidNameResolver(
+				ctx, ex.server.cfg.InternalDB.Executor(), ex.state.mu.txn,
+				ex.sessionData().Database,
+			),
+		)
+	}
+
 	os := ex.machine.CurState().(stateOpen)
 
 	isExtendedProtocol := prepared != nil

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/ring"
@@ -922,6 +923,11 @@ type RestrictedCommandResult interface {
 	// IMPORT, BACKUP or RESTORE.
 	GetBulkJobId() uint64
 
+	// SetOidNameResolver sets a function that resolves OID values to their
+	// display names. This is used by pgwire to format reg* type values as
+	// names rather than numeric OIDs when sending results to the client.
+	SetOidNameResolver(func(oid.Oid, *types.T) string)
+
 	// ErrAllowReleased returns the error without asserting the result is not
 	// released yet. It should be used only in clean-up stages of a pausable
 	// portal.
@@ -1212,6 +1218,10 @@ func (r *streamingCommandResult) SetError(err error) {
 // GetBulkJobId is part of the sql.RestrictedCommandResult interface.
 func (r *streamingCommandResult) GetBulkJobId() uint64 {
 	return 0
+}
+
+// SetOidNameResolver is part of the RestrictedCommandResult interface.
+func (r *streamingCommandResult) SetOidNameResolver(func(oid.Oid, *types.T) string) {
 }
 
 // Err is part of the RestrictedCommandResult interface.

--- a/pkg/sql/isession/command_result.go
+++ b/pkg/sql/isession/command_result.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -140,6 +141,9 @@ func (i *internalCommandResult) ErrAllowReleased() error {
 
 func (i *internalCommandResult) RevokePortalPausability() error {
 	return errors.AssertionFailedf("RevokePortalPausability is for limitedCommandResult only")
+}
+
+func (i *internalCommandResult) SetOidNameResolver(func(oid.Oid, *types.T) string) {
 }
 
 func (i *internalCommandResult) SendCopyData(ctx context.Context, data []byte, flush bool) error {

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -752,3 +752,28 @@ SELECT col1 FROM t123548_1 JOIN t123548_2 ON col1 = col2;
 statement ok
 RESET testing_optimizer_random_seed;
 RESET testing_optimizer_disable_rule_probability;
+
+# Regression test for incorrect REGCLASS rendering in scalar subqueries
+# (#166802).
+subtest regression_166802
+
+statement ok
+CREATE TABLE t166802 (a REGCLASS);
+INSERT INTO t166802 VALUES ('t166802'::REGCLASS)
+
+statement ok
+SET testing_optimizer_disable_rule_probability = 1.0
+
+# The result should be the same with and without optimizer rules disabled.
+query T
+SELECT (SELECT a FROM t166802)
+----
+132
+
+statement ok
+RESET testing_optimizer_disable_rule_probability
+
+query T
+SELECT (SELECT a FROM t166802)
+----
+132

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -765,10 +765,11 @@ statement ok
 SET testing_optimizer_disable_rule_probability = 1.0
 
 # The result should be the same with and without optimizer rules disabled.
+# Both paths should display the resolved table name, not a numeric OID.
 query T
 SELECT (SELECT a FROM t166802)
 ----
-132
+t166802
 
 statement ok
 RESET testing_optimizer_disable_rule_probability
@@ -776,4 +777,4 @@ RESET testing_optimizer_disable_rule_probability
 query T
 SELECT (SELECT a FROM t166802)
 ----
-132
+t166802

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -88,6 +88,10 @@ type commandResult struct {
 	// (except types must always be set).
 	types []*types.T
 
+	// oidNameResolver, if set, resolves OID values to display names when
+	// formatting reg* type result values.
+	oidNameResolver func(oid.Oid, *types.T) string
+
 	// bufferingDisabled is conditionally set during planning of certain
 	// statements.
 	bufferingDisabled bool
@@ -435,6 +439,11 @@ func (r *commandResult) ResetStmtType(stmt tree.Statement) {
 	r.assertNotReleased()
 	r.stmtType = stmt.StatementReturnType()
 	r.cmdCompleteTag = stmt.StatementTag()
+}
+
+// SetOidNameResolver is part of the sql.RestrictedCommandResult interface.
+func (r *commandResult) SetOidNameResolver(fn func(oid.Oid, *types.T) string) {
+	r.oidNameResolver = fn
 }
 
 // GetBulkJobId is part of the sql.RestrictedCommandResult interface.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -906,6 +906,8 @@ func cookTag(
 func (c *conn) bufferRow(ctx context.Context, row tree.Datums, r *commandResult) error {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgDataRow)
 	c.msgBuilder.putInt16(int16(len(row)))
+	old := c.msgBuilder.textFormatter.SetOidNameResolver(r.oidNameResolver)
+	defer c.msgBuilder.textFormatter.SetOidNameResolver(old)
 	for i, col := range row {
 		fmtCode, err := r.GetFormatCode(i)
 		if err != nil {
@@ -937,6 +939,8 @@ func (c *conn) bufferBatch(ctx context.Context, batch coldata.Batch, r *commandR
 	sel := batch.Selection()
 	n := batch.Length()
 	if n > 0 {
+		old := c.msgBuilder.textFormatter.SetOidNameResolver(r.oidNameResolver)
+		defer c.msgBuilder.textFormatter.SetOidNameResolver(old)
 		c.vecsScratch.SetBatch(batch)
 		// Make sure that c doesn't hold on to the memory of the batch.
 		defer c.vecsScratch.Reset()

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -203,7 +203,13 @@ func (r *iVarAndSubqueryReplacer) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 		newExpr := tree.Expr(val)
 		typ := t.ResolvedType()
 		if _, isTuple := val.(*tree.DTuple); !isTuple && typ.Family() != types.UnknownFamily && typ.Family() != types.TupleFamily {
-			newExpr = tree.NewTypedCastExpr(val, typ)
+			// Skip the cast if the datum's type already matches the
+			// subquery's resolved type. Adding a redundant cast can cause
+			// undesirable side effects like OID name resolution for
+			// REGCLASS values. See #166802.
+			if !val.ResolvedType().Identical(typ) {
+				newExpr = tree.NewTypedCastExpr(val, typ)
+			}
 		}
 		return false, newExpr
 

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -89,6 +89,43 @@ func resolveOID(
 	), true, nil
 }
 
+// MakeOidNameResolver creates a function that resolves OID values to their
+// display names by querying pg_catalog. Results are cached for the lifetime
+// of the returned function. This is used to populate DOid names during result
+// formatting so that reg* types display as names rather than numeric OIDs.
+func MakeOidNameResolver(
+	ctx context.Context, ie isql.Executor, txn *kv.Txn, database string,
+) func(oid.Oid, *types.T) string {
+	cache := make(map[oid.Oid]string)
+	override := sessiondata.InternalExecutorOverride{
+		Database: database,
+	}
+	return func(o oid.Oid, t *types.T) string {
+		if name, ok := cache[o]; ok {
+			return name
+		}
+		info, ok := regTypeInfos[t.Oid()]
+		if !ok {
+			return ""
+		}
+		q := fmt.Sprintf(
+			"SELECT %s FROM pg_catalog.%s WHERE oid = $1",
+			info.nameCol, info.tableName,
+		)
+		results, err := ie.QueryRowEx(
+			ctx, "resolveOidName", txn,
+			override, q, tree.NewDOid(o),
+		)
+		if err != nil || results == nil {
+			cache[o] = ""
+			return ""
+		}
+		name := string(tree.MustBeDString(results[0]))
+		cache[o] = name
+		return name
+	}
+}
+
 // regTypeInfo contains details on a pg_catalog table that has a reg* type.
 type regTypeInfo struct {
 	tableName string

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5578,6 +5578,12 @@ func (d *DOid) Format(ctx *FmtCtx) {
 		// Special case for the "unknown" oid.
 		ctx.WriteString(UnknownOidName)
 	} else if d.semanticType.Oid() == oid.T_oid || d.name == "" {
+		if d.name == "" && d.semanticType.Oid() != oid.T_oid && ctx.oidNameResolver != nil {
+			if name := ctx.oidNameResolver(d.Oid, d.semanticType); name != "" {
+				lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, name, lexbase.EncBareStrings)
+				return
+			}
+		}
 		ctx.Write(strconv.AppendUint(ctx.scratch[:0], uint64(d.Oid), 10))
 	} else if ctx.HasFlags(fmtDisambiguateDatumTypes) {
 		ctx.WriteString("crdb_internal.create_")

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/lib/pq/oid"
 )
 
 // FmtFlags carries options for the pretty-printer.
@@ -348,6 +349,10 @@ type FmtCtx struct {
 	// indexedTypeFormatter is an optional interceptor for formatting
 	// IDTypeReferences differently than normal.
 	indexedTypeFormatter func(*FmtCtx, *OIDTypeReference)
+	// oidNameResolver is an optional callback for resolving OID values to
+	// their display names. When set, DOid.Format will use it to look up
+	// names for OIDs that were loaded from storage without a name.
+	oidNameResolver func(oid.Oid, *types.T) string
 
 	// inPLpgSQL, if set, indicates that we're formatting a node within PLpgSQL
 	// context.
@@ -414,6 +419,14 @@ func FmtLocation(loc *time.Location) FmtCtxOption {
 	}
 }
 
+// FmtOidNameResolver modifies FmtCtx to use the provided function for
+// resolving OID values to display names.
+func FmtOidNameResolver(fn func(oid.Oid, *types.T) string) FmtCtxOption {
+	return func(ctx *FmtCtx) {
+		ctx.oidNameResolver = fn
+	}
+}
+
 // FmtInPLpgSQL modifies FmtCtx to indicate whether we're in the PLpgSQL
 // context.
 func FmtInPLpgSQL(inPLpgSQL bool) FmtCtxOption {
@@ -449,6 +462,7 @@ func (ctx *FmtCtx) Clone() *FmtCtx {
 	newCtx.placeholderFormat = ctx.placeholderFormat
 	newCtx.tableNameFormatter = ctx.tableNameFormatter
 	newCtx.indexedTypeFormatter = ctx.indexedTypeFormatter
+	newCtx.oidNameResolver = ctx.oidNameResolver
 	newCtx.inPLpgSQL = ctx.inPLpgSQL
 	return newCtx
 }
@@ -467,6 +481,15 @@ func (ctx *FmtCtx) SetDataConversionConfig(
 func (ctx *FmtCtx) SetLocation(loc *time.Location) *time.Location {
 	old := ctx.location
 	ctx.location = loc
+	return old
+}
+
+// SetOidNameResolver sets the OID name resolver on ctx and returns the old one.
+func (ctx *FmtCtx) SetOidNameResolver(
+	fn func(oid.Oid, *types.T) string,
+) func(oid.Oid, *types.T) string {
+	old := ctx.oidNameResolver
+	ctx.oidNameResolver = fn
 	return old
 }
 


### PR DESCRIPTION
When DistSQL serializes render expressions containing subquery results, the iVarAndSubqueryReplacer wraps the result datum in a TypedCastExpr to preserve type information through the serialization round-trip. However, when the datum's type already matches the subquery's resolved type, this cast is redundant and can cause undesirable side effects.

For OID-family types like REGCLASS, the redundant cast triggers OID name resolution: the DOid value (with an empty name field from KV storage) serializes as just the numeric OID, and the cast deserializes it back with the resolved name. This causes the render/project execution path to return the table name (e.g. "t") while the values/tuple path returns the numeric OID (e.g. "104"), producing inconsistent results depending on which optimizer rules are active.

Skip the cast when the datum's resolved type is identical to the target type.

Fixes: #166802

Release note (bug fix): Fixed a bug where scalar subqueries returning REGCLASS column values could produce different results depending on the query plan chosen by the optimizer. In some plans, the REGCLASS value would incorrectly render as the table name instead of the numeric OID.