### PR TITLE
admission: add reservation to SQLCPUHandle

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -606,7 +606,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	sqlCPUProvider := admission.NewSQLCPUProvider(
 		&st.SV,
 		func(tenantID roachpb.TenantID) *admission.WorkQueue {
-			return gcoords.RegularCPU.GetKVWorkQueue(tenantID.IsSystem())
+			return gcoords.RegularCPU.GetCTTWorkQueue(tenantID.IsSystem())
 		},
 	)
 	db.SQLCPUProvider = sqlCPUProvider

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "scheduler_latency_listener_test.go",
         "sequencer_test.go",
         "snapshot_queue_test.go",
+        "sql_cpu_handle_test.go",
         "store_token_estimation_test.go",
         "tokens_linear_model_test.go",
         "work_queue_test.go",

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -78,6 +78,15 @@ func (coord *CPUGrantCoordinators) GetKVWorkQueue(isSystemTenant bool) *WorkQueu
 	if !cpuTimeTokenACIsEnabled(&coord.st.SV) {
 		return coord.slotsCoord.GetWorkQueue(KVWork)
 	}
+	return coord.GetCTTWorkQueue(isSystemTenant)
+}
+
+// GetCTTWorkQueue returns the CPU time token WorkQueue unconditionally,
+// without checking whether CPU time token AC is enabled. The caller is
+// responsible for gating on the setting. This avoids a race in GetKVWorkQueue
+// where the setting can flip between the caller's check and the internal
+// re-check, returning a slot-based queue to a caller that expects a CTT queue.
+func (coord *CPUGrantCoordinators) GetCTTWorkQueue(isSystemTenant bool) *WorkQueue {
 	if isSystemTenant {
 		return coord.cpuTimeCoord.getWorkQueue(systemTenant)
 	}

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/petermattis/goid"
 )
 
@@ -98,14 +99,22 @@ type SQLCPUHandle struct {
 
 	refillMu struct {
 		syncutil.Mutex
-		// reservation and closed are accessed atomically without the lock
-		// on the fast path (CAS deduction, closed check). This is safe
-		// because the fast path only deducts from reservation (self-
-		// protecting via CAS) and reads closed (monotonic false→true).
-		// The lock serializes the slow path (Admit + Add) with Close
-		// (set closed + Swap reservation).
+		// reservation is accessed atomically without the lock on the
+		// fast path (CAS deduction) and the noWait path. This is safe
+		// because CAS is self-protecting (never drives negative).
+		// closed is read under refillMu in the slow path; the noWait
+		// path skips the closed check since BypassAdmission is safe
+		// after Close. The lock serializes the slow path (Admit + Add)
+		// with Close (set closed + Swap reservation).
 		reservation atomic.Int64
 		closed      atomic.Bool
+		// lastRefillTime is the wall-clock time of the last Admit call,
+		// used to compute the interval for adaptive sizing.
+		lastRefillTime time.Time
+		// lastHeuristic is the adaptive buffer size (in nanoseconds)
+		// to request beyond the consumed CPU on the next Admit call.
+		// The total RequestedCount is diffNanos + lastHeuristic.
+		lastHeuristic int64
 	}
 
 	mu struct {
@@ -155,26 +164,50 @@ func (h *SQLCPUHandle) tryDeductReservation(diffNanos int64) bool {
 	}
 }
 
-// maxRefillBuffer caps the reservation buffer requested per Admit call.
-// Without a cap, a large checkpoint (e.g. 100ms of CPU between two
-// CancelChecker calls) would hold 100ms of tokens idle in the reservation,
-// reducing availability for other statements until Close returns them.
-const maxRefillBuffer = int64(10 * time.Millisecond)
+const (
+	// refillGrowThreshold is the wall-clock duration below which we
+	// consider refills too frequent and double the heuristic. Below this
+	// threshold, contention on the WorkQueue mutex is the primary concern.
+	refillGrowThreshold = time.Millisecond
+	// refillDecayThreshold is the wall-clock duration above which we
+	// consider the heuristic too large and halve it. Above this threshold,
+	// overcounting in tenant.used is the primary concern. Between
+	// refillGrowThreshold and refillDecayThreshold is the acceptable
+	// deadband where the heuristic is stable.
+	refillDecayThreshold = 5 * time.Millisecond
+	// maxRefillHeuristic caps the buffer portion of the heuristic to
+	// bound overcounting. 10ms of CPU buffer per handle.
+	maxRefillHeuristic = int64(10 * time.Millisecond)
+)
 
-// refillHeuristic returns the total RequestedCount to pass to Admit: the
-// consumed CPU (diffNanos) plus a buffer for future fast-path CAS deductions.
-// The buffer is min(diffNanos, maxRefillBuffer), so the reservation portion
-// (resp.requestedCount - diffNanos) is always non-negative and bounded.
-//
-// TODO(wenyihu6): replace this simple 2x heuristic with an adaptive scheme
-// that adjusts the buffer size based on the interval between Admit calls:
-// grow the buffer when calls are too frequent (interval < 1ms), shrink it
-// when calls are infrequent (interval > 5ms), and keep it stable otherwise.
-// This would reduce Admit call overhead for steady workloads while avoiding
-// over-reservation for bursty ones.
-func (h *SQLCPUHandle) refillHeuristic(diffNanos int64) int64 {
-	buffer := min(diffNanos, maxRefillBuffer)
-	return diffNanos + buffer
+// refillHeuristicLocked returns the total RequestedCount to pass to Admit:
+// the consumed CPU (diffNanos) plus an adaptive buffer for future fast-path
+// CAS deductions. The buffer (lastHeuristic) is adjusted based on the
+// interval between Admit calls: doubled when calls are too frequent
+// (< 1ms), halved when too infrequent (> 5ms), and stable otherwise.
+// The buffer is capped at maxRefillHeuristic. The return value is always
+// >= diffNanos, so (resp.requestedCount - diffNanos) is non-negative.
+func (h *SQLCPUHandle) refillHeuristicLocked(diffNanos int64) int64 {
+	h.refillMu.AssertHeld()
+	now := timeutil.Now()
+	if h.refillMu.lastHeuristic == 0 {
+		// Bootstrap: seed buffer equal to consumed.
+		h.refillMu.lastHeuristic = diffNanos
+	} else {
+		elapsed := now.Sub(h.refillMu.lastRefillTime)
+		if elapsed < refillGrowThreshold {
+			// Came back too soon — double to reduce call frequency.
+			h.refillMu.lastHeuristic *= 2
+		} else if elapsed > refillDecayThreshold {
+			// Buffer lasted too long — halve to reduce overcounting.
+			h.refillMu.lastHeuristic /= 2
+		}
+		// else: in [1ms, 5ms] deadband — no change.
+	}
+	// Cap buffer at maxRefillHeuristic.
+	h.refillMu.lastHeuristic = min(h.refillMu.lastHeuristic, maxRefillHeuristic)
+	h.refillMu.lastRefillTime = now
+	return diffNanos + h.refillMu.lastHeuristic
 }
 
 // constructWorkInfo returns a copy of the handle's WorkInfo with the given
@@ -245,7 +278,7 @@ func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
 	// portion goes into reservation for future fast-path CAS deductions.
 	// Because the exact amount is deducted at Admit time, there is no
 	// estimate to correct, so AdmittedWorkDone is not called.
-	resp, err := h.wq.Admit(ctx, h.constructWorkInfo(h.refillHeuristic(diffNanos), false))
+	resp, err := h.wq.Admit(ctx, h.constructWorkInfo(h.refillHeuristicLocked(diffNanos), false))
 	if err != nil {
 		return err
 	}
@@ -395,8 +428,6 @@ func (h *GoroutineCPUHandle) Close(ctx context.Context) {
 // CPU time spent in the goroutine and decide whether more CPU needs to be
 // allocated. If more CPU is needed, it can block in acquiring CPU tokens.
 // Returns a non-nil error iff the context is canceled while waiting.
-//
-// TODO(sumeer): implement the measurement and admission logic.
 func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
 	return h.measureAndAdmit(ctx, false /* noWait */)
 }

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -119,17 +119,23 @@ func newSQLCPUAdmissionHandle(
 	return h
 }
 
+// reportCPU atomically adds the CPU time difference to the appropriate
+// cumulative counter.
+func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
+	if h.atGateway {
+		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
+	} else {
+		h.p.cumulativeDistSQLCPUNanos.Add(diff.Nanoseconds())
+	}
+}
+
 // reportAndAcquireConsumedCPU updates cumulative CPU counters and, if a CTT
 // WorkQueue is attached, calls Admit to deduct the consumed CPU from the token
 // bucket. This may block until tokens are available unless noWait is true.
 func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
 	ctx context.Context, diff time.Duration, noWait bool,
 ) error {
-	if h.atGateway {
-		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
-	} else {
-		h.p.cumulativeDistSQLCPUNanos.Add(diff.Nanoseconds())
-	}
+	h.reportCPU(diff)
 
 	if h.wq == nil {
 		return nil

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -61,7 +61,35 @@ var goroutineCPUHandlePool = sync.Pool{
 // SQLCPUHandle manages CPU accounting and admission for SQL work across
 // multiple goroutines.
 //
-// TODO(sumeer): fill in more details.
+// SQL CPU admission differs from KV admission in several important ways:
+//
+//   - Admission model: KV uses an estimate-then-correct model. WorkQueue.Admit
+//     is called before execution with an estimated RequestedCount (via
+//     cpuTimeTokenEstimator), and AdmittedWorkDone is called after execution to
+//     correct the estimate using the actual CPU time from grunning. SQL CPU
+//     admission uses a measure-then-admit model: measureAndAdmit is called
+//     periodically during execution (every ~1024 rows or every vectorized batch
+//     via the CancelChecker), and the exact CPU consumed since the last call is
+//     known from grunning. There is no estimation and no correction step.
+//
+//   - Lifetime: A KV request typically consumes microseconds to low
+//     milliseconds of on-CPU time (as measured by grunning), with a
+//     single Admit/AdmittedWorkDone pair. A SQLCPUHandle is created
+//     per-statement (in MakeCPUHandle) and lives until the statement
+//     completes. It spans the entire operator tree: each goroutine
+//     in the DistSQL flow registers via RegisterGoroutine and gets a
+//     GoroutineCPUHandle. For a simple query this may be a single goroutine
+//     lasting milliseconds; for a long-running OLAP query, IMPORT, or BACKUP,
+//     the handle can live for minutes or hours across many goroutines, with
+//     measureAndAdmit called thousands or millions of times.
+//
+//   - Why admit-after-consume is acceptable: The goroutine runs freely between
+//     measureAndAdmit calls — CPU is consumed without permission and then
+//     retroactively deducted from the shared token bucket. If the bucket is
+//     depleted, the goroutine blocks, preventing it from consuming more CPU.
+//     Each uncontrolled burst is bounded by the work between two CancelChecker
+//     calls (~1024 rows), so the amount of unpermitted CPU per check is limited.
+//     The throttling does not prevent past usage but gates future usage.
 type SQLCPUHandle struct {
 	workInfo  WorkInfo
 	atGateway bool
@@ -91,9 +119,12 @@ func newSQLCPUAdmissionHandle(
 	return h
 }
 
-// reportCPU atomically adds the CPU time difference to the appropriate
-// cumulative counter.
-func (h *SQLCPUHandle) reportCPU(ctx context.Context, diff time.Duration, noWait bool) error {
+// reportAndAcquireConsumedCPU updates cumulative CPU counters and, if a CTT
+// WorkQueue is attached, calls Admit to deduct the consumed CPU from the token
+// bucket. This may block until tokens are available unless noWait is true.
+func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
+	ctx context.Context, diff time.Duration, noWait bool,
+) error {
 	if h.atGateway {
 		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
 	} else {
@@ -120,9 +151,6 @@ func (h *SQLCPUHandle) reportCPU(ctx context.Context, diff time.Duration, noWait
 	workInfo := h.workInfo
 	workInfo.RequestedCount = diff.Nanoseconds()
 	workInfo.BypassAdmission = noWait
-	// AdmitResponse is intentionally discarded: its fields (Enabled,
-	// requestedCount) are only needed by AdmittedWorkDone, which is not
-	// called here (see comment above).
 	_, err := h.wq.Admit(ctx, workInfo)
 	return err
 }
@@ -260,39 +288,7 @@ func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
 // only measurement is desired (blocking is no longer productive). When noWait
 // is true, this function never returns an error.
 //
-// SQL CPU admission differs from KV admission in several important ways:
-//
-//   - Admission model: KV uses an estimate-then-correct model. WorkQueue.Admit
-//     is called before execution with an estimated RequestedCount (via
-//     cpuTimeTokenEstimator), and AdmittedWorkDone is called after execution to
-//     correct the estimate using the actual CPU time from grunning. SQL CPU
-//     admission uses a measure-then-admit model: measureAndAdmit is called
-//     periodically during execution (every 1024 rows or every vectorized batch
-//     via the CancelChecker), and the exact CPU consumed since the last call is
-//     known from grunning. There is no estimation and no correction step.
-//
-//   - Lifetime: A KV request is short-lived (microseconds to low milliseconds
-//     of CPU), with a single Admit/AdmittedWorkDone pair. A SQLCPUHandle is
-//     created per-statement (in MakeCPUHandle) and lives until the statement
-//     completes. It spans the entire operator tree: each goroutine in the
-//     DistSQL flow registers via RegisterGoroutine and gets a
-//     GoroutineCPUHandle. For a simple query this may be a single goroutine
-//     lasting milliseconds; for a long-running OLAP query, IMPORT, or BACKUP,
-//     the handle can live for minutes or hours across many goroutines, with
-//     measureAndAdmit called thousands or millions of times. Each invocation
-//     is self-contained: measure the CPU diff, deduct tokens, block if the
-//     budget is exhausted.
-//
-//   - Why admit-after-consume is acceptable: The goroutine runs freely
-//     between measureAndAdmit calls — CPU is consumed without permission and
-//     then retroactively deducted from the shared token bucket. If the bucket
-//     is depleted (because total CPU usage across all work has exhausted the
-//     budget), the goroutine blocks, preventing it from consuming more CPU.
-//     This is acceptable because each uncontrolled burst is small (bounded by
-//     the work between two CancelChecker calls, ~1024 rows), so the amount
-//     of unpermitted CPU per check is limited. The throttling does not prevent
-//     past usage but gates future usage: the goroutine cannot proceed to the
-//     next batch of rows until tokens become available.
+// See SQLCPUHandle for how SQL CPU admission differs from KV admission.
 func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) error {
 	if h.paused > 0 {
 		return nil
@@ -308,7 +304,7 @@ func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) e
 	// we would need an atomic here is that when SQLCPUHandle is closed, it
 	// needs to reach in and grab whatever CPU has not yet been reported.
 	h.cpuAccounted += diff
-	return h.h.reportCPU(ctx, diff, noWait)
+	return h.h.reportAndAcquireConsumedCPU(ctx, diff, noWait)
 }
 
 // PauseMeasuring is used to pause the CPU accounting for this goroutine. It
@@ -334,12 +330,12 @@ type sqlCPUProviderImpl struct {
 	// cumulativeGatewayCPUNanos tracks the cumulative CPU time in nanoseconds
 	// accounted for SQL work executed at gateway nodes. This value is
 	// monotonically increasing and is updated atomically as CPU time is
-	// reported via SQLCPUHandle.reportCPU.
+	// reported via SQLCPUHandle.reportAndAcquireConsumedCPU.
 	cumulativeGatewayCPUNanos atomic.Int64
 	// cumulativeDistSQLCPUNanos tracks the cumulative CPU time in nanoseconds
 	// accounted for distributed SQL work. This value is monotonically
 	// increasing and is updated atomically as CPU time is reported via
-	// SQLCPUHandle.reportCPU.
+	// SQLCPUHandle.reportAndAcquireConsumedCPU.
 	cumulativeDistSQLCPUNanos atomic.Int64
 	// sv is the settings values used to check if CTT AC is enabled.
 	sv *settings.Values

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -96,9 +96,20 @@ type SQLCPUHandle struct {
 	p         *sqlCPUProviderImpl
 	wq        *WorkQueue
 
+	refillMu struct {
+		syncutil.Mutex
+		// reservation and closed are accessed atomically without the lock
+		// on the fast path (CAS deduction, closed check). This is safe
+		// because the fast path only deducts from reservation (self-
+		// protecting via CAS) and reads closed (monotonic false→true).
+		// The lock serializes the slow path (Admit + Add) with Close
+		// (set closed + Swap reservation).
+		reservation atomic.Int64
+		closed      atomic.Bool
+	}
+
 	mu struct {
 		syncutil.Mutex
-		closed   bool
 		gHandles []*GoroutineCPUHandle
 		// Backing for up to 2 goroutine handles, to avoid allocations in
 		// gHandles when there are 2 or fewer goroutines.
@@ -129,9 +140,61 @@ func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
 	}
 }
 
+// tryDeductReservation attempts to deduct diffNanos from the reservation
+// via CAS. Returns true if successful (reservation had enough tokens).
+// Never drives the reservation negative.
+func (h *SQLCPUHandle) tryDeductReservation(diffNanos int64) bool {
+	for {
+		current := h.refillMu.reservation.Load()
+		if current < diffNanos {
+			return false
+		}
+		if h.refillMu.reservation.CompareAndSwap(current, current-diffNanos) {
+			return true
+		}
+	}
+}
+
+// maxRefillBuffer caps the reservation buffer requested per Admit call.
+// Without a cap, a large checkpoint (e.g. 100ms of CPU between two
+// CancelChecker calls) would hold 100ms of tokens idle in the reservation,
+// reducing availability for other statements until Close returns them.
+const maxRefillBuffer = int64(10 * time.Millisecond)
+
+// refillHeuristic returns the total RequestedCount to pass to Admit: the
+// consumed CPU (diffNanos) plus a buffer for future fast-path CAS deductions.
+// The buffer is min(diffNanos, maxRefillBuffer), so the reservation portion
+// (resp.requestedCount - diffNanos) is always non-negative and bounded.
+//
+// TODO(wenyihu6): replace this simple 2x heuristic with an adaptive scheme
+// that adjusts the buffer size based on the interval between Admit calls:
+// grow the buffer when calls are too frequent (interval < 1ms), shrink it
+// when calls are infrequent (interval > 5ms), and keep it stable otherwise.
+// This would reduce Admit call overhead for steady workloads while avoiding
+// over-reservation for bursty ones.
+func (h *SQLCPUHandle) refillHeuristic(diffNanos int64) int64 {
+	buffer := min(diffNanos, maxRefillBuffer)
+	return diffNanos + buffer
+}
+
+// constructWorkInfo returns a copy of the handle's WorkInfo with the given
+// RequestedCount and BypassAdmission values set.
+func (h *SQLCPUHandle) constructWorkInfo(reqCount int64, noWait bool) WorkInfo {
+	workInfo := h.workInfo
+	workInfo.RequestedCount = reqCount
+	workInfo.BypassAdmission = noWait
+	return workInfo
+}
+
 // reportAndAcquireConsumedCPU updates cumulative CPU counters and, if a CTT
-// WorkQueue is attached, calls Admit to deduct the consumed CPU from the token
-// bucket. This may block until tokens are available unless noWait is true.
+// WorkQueue is attached, deducts the consumed CPU from the token bucket. Three
+// paths are tried in order:
+//
+//  1. Fast path — CAS deduction from the local reservation (no lock, no Admit).
+//  2. noWait path — BypassAdmission Admit (non-blocking accounting only, used
+//     by GoroutineCPUHandle.Close).
+//  3. Slow path — acquire refillMu, call Admit to replenish the reservation.
+//     May block until tokens are available.
 func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
 	ctx context.Context, diff time.Duration, noWait bool,
 ) error {
@@ -141,24 +204,59 @@ func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
 		return nil
 	}
 
-	// RequestedCount is set to the exact CPU consumed (from grunning), so the
-	// WorkQueue's CPU time token estimator is skipped (see Admit). Because the
-	// exact amount is deducted at Admit time, there is no estimate to correct,
-	// so AdmittedWorkDone is not called. This also avoids training the KV
-	// estimator with SQL CPU data, which would corrupt its estimates.
-	//
-	// TODO(wenyi): Currently we call Admit on every measureAndAdmit invocation,
-	// which happens every ~1024 rows. This means each SQL goroutine takes the
-	// WorkQueue mutex on every check. Consider reserving more tokens than the
-	// exact amount consumed (e.g., 2x the last diff, or a smoothed estimate of
-	// upcoming usage) and tracking remaining reservation locally. This would
-	// allow subsequent measureAndAdmit calls to deduct from the local
-	// reservation without calling Admit, reducing contention on the WorkQueue.
-	workInfo := h.workInfo
-	workInfo.RequestedCount = diff.Nanoseconds()
-	workInfo.BypassAdmission = noWait
-	_, err := h.wq.Admit(ctx, workInfo)
-	return err
+	diffNanos := diff.Nanoseconds()
+
+	// Fast path: deduct from reservation via CAS. No lock needed.
+	// After Close, reservation is 0 (Swap'd), so CAS fails immediately.
+	if h.tryDeductReservation(diffNanos) {
+		return nil
+	}
+
+	if noWait {
+		// Account the CPU via BypassAdmission (non-blocking). This
+		// updates tenant.used and tells the granter tokens were taken,
+		// but never blocks. We do not deduct from reservation here
+		// because driving it negative would break the CAS invariant
+		// for other goroutines. This path is safe after Close because
+		// BypassAdmission never blocks and keeps tenant.used accurate
+		// for CPU consumed by goroutines that haven't closed yet.
+		_, _ = h.wq.Admit(ctx, h.constructWorkInfo(diffNanos, true))
+		return nil
+	}
+
+	// Slow path: serialize refills under refillMu so only one goroutine
+	// calls Admit at a time.
+	h.refillMu.Lock()
+	defer h.refillMu.Unlock()
+
+	// Re-check after acquiring the lock: Close may have run, or another
+	// goroutine's refill may have replenished the reservation.
+	if h.refillMu.closed.Load() {
+		return nil
+	}
+	if h.tryDeductReservation(diffNanos) {
+		return nil
+	}
+
+	// Request the consumed CPU plus a buffer (see refillHeuristic). Setting
+	// RequestedCount > 0 skips the WorkQueue's CPU time token estimator
+	// (see callerSetRequestedCount in Admit), which is designed for KV
+	// requests and should not be trained with SQL CPU data. The buffer
+	// portion goes into reservation for future fast-path CAS deductions.
+	// Because the exact amount is deducted at Admit time, there is no
+	// estimate to correct, so AdmittedWorkDone is not called.
+	resp, err := h.wq.Admit(ctx, h.constructWorkInfo(h.refillHeuristic(diffNanos), false))
+	if err != nil {
+		return err
+	}
+
+	if resp.Enabled {
+		// Add the buffer portion (requestedCount - diffNanos) to the
+		// reservation. Close cannot race here because we hold refillMu;
+		// it will return these tokens when it acquires the lock.
+		h.refillMu.reservation.Add(resp.requestedCount - diffNanos)
+	}
+	return nil
 }
 
 // TODO(sumeer): see the comment
@@ -210,13 +308,27 @@ func (h *SQLCPUHandle) RegisterGoroutine() *GoroutineCPUHandle {
 	return gh
 }
 
+// setClosed marks the handle as closed and returns any remaining reservation
+// tokens to the granter. Holding refillMu ensures no concurrent slow-path
+// refill is in progress — any in-flight Admit must complete and release the
+// lock before we proceed, so Swap(0) captures all outstanding tokens.
+func (h *SQLCPUHandle) setClosed() {
+	h.refillMu.Lock()
+	defer h.refillMu.Unlock()
+	h.refillMu.closed.Store(true)
+	if h.wq != nil {
+		remaining := h.refillMu.reservation.Swap(0)
+		h.wq.AdmittedSQLWorkDone(h.workInfo.TenantID, remaining)
+	}
+}
+
 // Close is called when no more reporting is needed. It pools
 // GoroutineCPUHandles that have been closed. GoroutineCPUHandles that are not
 // yet closed are left for GC.
 func (h *SQLCPUHandle) Close() {
+	h.setClosed()
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.mu.closed = true
 	for i, gh := range h.mu.gHandles {
 		if gh.closed.Load() {
 			gh.reset()

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -93,12 +93,38 @@ func newSQLCPUAdmissionHandle(
 
 // reportCPU atomically adds the CPU time difference to the appropriate
 // cumulative counter.
-func (h *SQLCPUHandle) reportCPU(diff time.Duration) {
+func (h *SQLCPUHandle) reportCPU(ctx context.Context, diff time.Duration, noWait bool) error {
 	if h.atGateway {
 		h.p.cumulativeGatewayCPUNanos.Add(diff.Nanoseconds())
 	} else {
 		h.p.cumulativeDistSQLCPUNanos.Add(diff.Nanoseconds())
 	}
+
+	if h.wq == nil {
+		return nil
+	}
+
+	// RequestedCount is set to the exact CPU consumed (from grunning), so the
+	// WorkQueue's CPU time token estimator is skipped (see Admit). Because the
+	// exact amount is deducted at Admit time, there is no estimate to correct,
+	// so AdmittedWorkDone is not called. This also avoids training the KV
+	// estimator with SQL CPU data, which would corrupt its estimates.
+	//
+	// TODO(wenyi): Currently we call Admit on every measureAndAdmit invocation,
+	// which happens every ~1024 rows. This means each SQL goroutine takes the
+	// WorkQueue mutex on every check. Consider reserving more tokens than the
+	// exact amount consumed (e.g., 2x the last diff, or a smoothed estimate of
+	// upcoming usage) and tracking remaining reservation locally. This would
+	// allow subsequent measureAndAdmit calls to deduct from the local
+	// reservation without calling Admit, reducing contention on the WorkQueue.
+	workInfo := h.workInfo
+	workInfo.RequestedCount = diff.Nanoseconds()
+	workInfo.BypassAdmission = noWait
+	// AdmitResponse is intentionally discarded: its fields (Enabled,
+	// requestedCount) are only needed by AdmittedWorkDone, which is not
+	// called here (see comment above).
+	_, err := h.wq.Admit(ctx, workInfo)
+	return err
 }
 
 // TODO(sumeer): see the comment
@@ -233,6 +259,40 @@ func (h *GoroutineCPUHandle) MeasureAndAdmit(ctx context.Context) error {
 // noWait parameter should only be set to true when the work is finished, so
 // only measurement is desired (blocking is no longer productive). When noWait
 // is true, this function never returns an error.
+//
+// SQL CPU admission differs from KV admission in several important ways:
+//
+//   - Admission model: KV uses an estimate-then-correct model. WorkQueue.Admit
+//     is called before execution with an estimated RequestedCount (via
+//     cpuTimeTokenEstimator), and AdmittedWorkDone is called after execution to
+//     correct the estimate using the actual CPU time from grunning. SQL CPU
+//     admission uses a measure-then-admit model: measureAndAdmit is called
+//     periodically during execution (every 1024 rows or every vectorized batch
+//     via the CancelChecker), and the exact CPU consumed since the last call is
+//     known from grunning. There is no estimation and no correction step.
+//
+//   - Lifetime: A KV request is short-lived (microseconds to low milliseconds
+//     of CPU), with a single Admit/AdmittedWorkDone pair. A SQLCPUHandle is
+//     created per-statement (in MakeCPUHandle) and lives until the statement
+//     completes. It spans the entire operator tree: each goroutine in the
+//     DistSQL flow registers via RegisterGoroutine and gets a
+//     GoroutineCPUHandle. For a simple query this may be a single goroutine
+//     lasting milliseconds; for a long-running OLAP query, IMPORT, or BACKUP,
+//     the handle can live for minutes or hours across many goroutines, with
+//     measureAndAdmit called thousands or millions of times. Each invocation
+//     is self-contained: measure the CPU diff, deduct tokens, block if the
+//     budget is exhausted.
+//
+//   - Why admit-after-consume is acceptable: The goroutine runs freely
+//     between measureAndAdmit calls — CPU is consumed without permission and
+//     then retroactively deducted from the shared token bucket. If the bucket
+//     is depleted (because total CPU usage across all work has exhausted the
+//     budget), the goroutine blocks, preventing it from consuming more CPU.
+//     This is acceptable because each uncontrolled burst is small (bounded by
+//     the work between two CancelChecker calls, ~1024 rows), so the amount
+//     of unpermitted CPU per check is limited. The throttling does not prevent
+//     past usage but gates future usage: the goroutine cannot proceed to the
+//     next batch of rows until tokens become available.
 func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) error {
 	if h.paused > 0 {
 		return nil
@@ -248,8 +308,7 @@ func (h *GoroutineCPUHandle) measureAndAdmit(ctx context.Context, noWait bool) e
 	// we would need an atomic here is that when SQLCPUHandle is closed, it
 	// needs to reach in and grab whatever CPU has not yet been reported.
 	h.cpuAccounted += diff
-	h.h.reportCPU(diff)
-	return nil
+	return h.h.reportCPU(ctx, diff, noWait)
 }
 
 // PauseMeasuring is used to pause the CPU accounting for this goroutine. It

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -15,11 +15,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,11 +98,9 @@ func TestSQLCPUHandleSlowPath(t *testing.T) {
 	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false))
 
 	// 5ms > 2ms reservation, so slow path runs again.
-	// heuristic = 2 * 5ms = 10ms requested. Reservation gets
-	// existing(2ms) + (10ms - 5ms) = 7ms, because the Add is on top
-	// of the existing reservation (only the CAS on fast path failed,
-	// the leftover stays).
-	require.Equal(t, int64(7*time.Millisecond), h.refillMu.reservation.Load())
+	// Elapsed < 1ms (grow): buffer = 2ms * 2 = 4ms. Total = 5ms + 4ms = 9ms.
+	// Reservation += 9ms - 5ms = 4ms, total = existing(2ms) + 4ms = 6ms.
+	require.Equal(t, int64(6*time.Millisecond), h.refillMu.reservation.Load())
 }
 
 // TestSQLCPUHandleCloseReturnsTokens verifies that Close returns unused
@@ -281,9 +281,9 @@ func TestSQLCPUHandleConcurrentFastPath(t *testing.T) {
 	h := newSQLCPUAdmissionHandle(
 		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
 
-	// Seed the reservation by calling the slow path. With 50ms diff, the
-	// buffer portion is capped at maxRefillBuffer (10ms), so
-	// reservation = heuristic(60ms) - 50ms = 10ms.
+	// Seed the reservation by calling the slow path. With 50ms diff,
+	// buffer = min(50ms, maxRefillHeuristic=10ms) = 10ms. Total =
+	// 50ms + 10ms = 60ms. Reservation = 60ms - 50ms = 10ms.
 	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 50*time.Millisecond, false))
 	require.Equal(t, int64(10*time.Millisecond), h.refillMu.reservation.Load())
 
@@ -644,6 +644,55 @@ func TestSQLCPUHandlePauseMeasuring(t *testing.T) {
 
 	gh.Close(ctx)
 	h.Close()
+}
+
+// TestRefillHeuristic exercises the adaptive buffer sizing in
+// refillHeuristicLocked using datadriven testdata.
+func TestRefillHeuristic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	h := &SQLCPUHandle{}
+	callHeuristic := func(diffNanos int64) (buffer, total int64) {
+		h.refillMu.Lock()
+		defer h.refillMu.Unlock()
+		total = h.refillHeuristicLocked(diffNanos)
+		buffer = h.refillMu.lastHeuristic
+		return buffer, total
+	}
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "refill_heuristic"),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "refill":
+				var diffStr string
+				d.ScanArgs(t, "diff", &diffStr)
+				diff, err := time.ParseDuration(diffStr)
+				require.NoError(t, err)
+				buffer, total := callHeuristic(diff.Nanoseconds())
+				return fmt.Sprintf("buffer: %s, total: %s\n",
+					time.Duration(buffer), time.Duration(total))
+
+			case "set-age":
+				var ageStr string
+				d.ScanArgs(t, "age", &ageStr)
+				age, err := time.ParseDuration(ageStr)
+				require.NoError(t, err)
+				h.refillMu.lastRefillTime = timeutil.Now().Add(-age)
+				return "ok\n"
+
+			case "set-buffer":
+				var valStr string
+				d.ScanArgs(t, "val", &valStr)
+				val, err := time.ParseDuration(valStr)
+				require.NoError(t, err)
+				h.refillMu.lastHeuristic = val.Nanoseconds()
+				return "ok\n"
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
 }
 
 // makeBenchWorkQueue creates a WorkQueue in CTT mode for benchmarks.

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -1,0 +1,739 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLCPUHandleFastPath verifies that the CAS-based fast path deducts
+// from reservation without acquiring refillMu or calling Admit.
+func TestSQLCPUHandleFastPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	// First call exhausts reservation (0) and goes through slow path,
+	// which calls Admit and refills reservation with heuristic buffer.
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+
+	// Reservation should now be diffNanos (heuristic=2*diff, minus diff consumed).
+	reservationBefore := h.refillMu.reservation.Load()
+	require.Equal(t, int64(1*time.Millisecond), reservationBefore,
+		"reservation should be heuristic(2*diff) - diff = diff")
+
+	// Second call should deduct via fast path CAS without calling Admit.
+	// Clear the testGranter buffer to verify no new Admit call is made.
+	_ = tg.buf.stringAndReset()
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 500*time.Microsecond, false))
+
+	reservationAfter := h.refillMu.reservation.Load()
+	require.Equal(t, reservationBefore-int64(500*time.Microsecond), reservationAfter)
+
+	// Verify no Admit call was made (no tryGet in the buffer).
+	output := tg.buf.stringAndReset()
+	require.Empty(t, output, "fast path should not call Admit")
+
+	// CPU should still be reported.
+	gw, _ := provider.GetCumulativeSQLCPUNanos()
+	require.Equal(t, int64(1*time.Millisecond+500*time.Microsecond), gw)
+}
+
+// TestSQLCPUHandleSlowPath verifies that when reservation is exhausted,
+// the slow path acquires refillMu, calls Admit, and refills reservation.
+func TestSQLCPUHandleSlowPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	// First call: reservation is 0, so slow path is taken.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 2*time.Millisecond, false))
+
+	// heuristic = 2 * 2ms = 4ms requested. 2ms consumed, so reservation = 2ms.
+	require.Equal(t, int64(2*time.Millisecond), h.refillMu.reservation.Load())
+
+	// Exhaust the reservation with a large request.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false))
+
+	// 5ms > 2ms reservation, so slow path runs again.
+	// heuristic = 2 * 5ms = 10ms requested. Reservation gets
+	// existing(2ms) + (10ms - 5ms) = 7ms, because the Add is on top
+	// of the existing reservation (only the CAS on fast path failed,
+	// the leftover stays).
+	require.Equal(t, int64(7*time.Millisecond), h.refillMu.reservation.Load())
+}
+
+// TestSQLCPUHandleCloseReturnsTokens verifies that Close returns unused
+// reservation tokens via AdmittedSQLWorkDone.
+func TestSQLCPUHandleCloseReturnsTokens(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	// Acquire tokens so reservation has a buffer.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+	remaining := h.refillMu.reservation.Load()
+	require.Equal(t, int64(1*time.Millisecond), remaining)
+
+	// Clear buffer and close.
+	_ = tg.buf.stringAndReset()
+	h.Close()
+
+	// Verify returnGrant was called with the remaining reservation.
+	output := tg.buf.String()
+	require.Contains(t, output, "returnGrant")
+
+	// Reservation should be zeroed.
+	require.Equal(t, int64(0), h.refillMu.reservation.Load())
+	require.True(t, h.refillMu.closed.Load())
+}
+
+// TestSQLCPUHandleCloseZeroReservation verifies that Close calls
+// AdmittedSQLWorkDone even when reservation is 0 (defensive).
+func TestSQLCPUHandleCloseZeroReservation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	// No CPU consumed, reservation is 0. Close should still work.
+	_ = tg.buf.stringAndReset()
+	h.Close()
+
+	require.True(t, h.refillMu.closed.Load())
+	// No returnGrant or tookWithoutPermission since remaining is 0.
+	output := tg.buf.String()
+	require.NotContains(t, output, "returnGrant")
+	require.NotContains(t, output, "tookWithoutPermission")
+}
+
+// TestSQLCPUHandleClosedSkipsAdmission verifies that after Close,
+// reportAndAcquireConsumedCPU still reports CPU but skips Admit.
+func TestSQLCPUHandleClosedSkipsAdmission(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	h.Close()
+	require.True(t, h.refillMu.closed.Load())
+
+	// Post-close reportAndAcquireConsumedCPU should still report CPU.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 3*time.Millisecond, false))
+	gw, _ := provider.GetCumulativeSQLCPUNanos()
+	require.Equal(t, int64(3*time.Millisecond), gw)
+}
+
+// TestSQLCPUHandleNoWaitBypassAdmission verifies that the noWait path
+// uses BypassAdmission=true and does not block or deduct from reservation.
+func TestSQLCPUHandleNoWaitBypassAdmission(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	// Make tryGet return false — a blocking Admit would hang, but noWait
+	// should bypass admission entirely.
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = false
+	tg.mu.Unlock()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	// noWait=true should not block even when tryGet returns false,
+	// because BypassAdmission=true skips the granter entirely.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, true))
+
+	gw, _ := provider.GetCumulativeSQLCPUNanos()
+	require.Equal(t, int64(1*time.Millisecond), gw)
+}
+
+// TestSQLCPUHandleRegisterGoroutineIdempotent verifies that registering the
+// same goroutine ID twice returns the existing handle.
+func TestSQLCPUHandleRegisterGoroutineIdempotent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tenantID := roachpb.MustMakeTenantID(1)
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil)
+
+	gh1 := h.RegisterGoroutine()
+	gh2 := h.RegisterGoroutine()
+	require.Same(t, gh1, gh2, "same goroutine should get the same handle")
+
+	h.mu.Lock()
+	require.Len(t, h.mu.gHandles, 1)
+	h.mu.Unlock()
+}
+
+// TestSQLCPUHandleClosePoolsHandles verifies that Close pools
+// GoroutineCPUHandles that have been closed, and nils out unclosed ones.
+func TestSQLCPUHandleClosePoolsHandles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil)
+
+	gh := h.RegisterGoroutine()
+	gh.Close(ctx)
+	require.True(t, gh.closed.Load())
+
+	h.Close()
+	h.mu.Lock()
+	require.Nil(t, h.mu.gHandles, "gHandles should be nil after Close")
+	h.mu.Unlock()
+}
+
+// TestSQLCPUHandleConcurrentFastPath exercises the CAS-based fast path
+// under contention from multiple goroutines. All goroutines deduct from the
+// same reservation via CompareAndSwap. The total deducted must equal the sum
+// of individual deductions, and reservation must never go negative.
+func TestSQLCPUHandleConcurrentFastPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	// Seed the reservation by calling the slow path. With 50ms diff, the
+	// buffer portion is capped at maxRefillBuffer (10ms), so
+	// reservation = heuristic(60ms) - 50ms = 10ms.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 50*time.Millisecond, false))
+	require.Equal(t, int64(10*time.Millisecond), h.refillMu.reservation.Load())
+
+	// Clear the buffer so we can check if any slow-path Admit calls happen.
+	_ = tg.buf.stringAndReset()
+
+	// Launch N goroutines that each deduct a small amount via fast path.
+	const numGoroutines = 20
+	const perGoroutine = 100 * time.Microsecond // 100us each = 2ms total
+	var wg sync.WaitGroup
+	var errors atomic.Int64
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := h.reportAndAcquireConsumedCPU(ctx, perGoroutine, false); err != nil {
+				errors.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int64(0), errors.Load())
+
+	// Verify reservation was correctly deducted.
+	expected := int64(10*time.Millisecond) - int64(numGoroutines)*int64(perGoroutine)
+	require.Equal(t, expected, h.refillMu.reservation.Load(),
+		"CAS deductions should be exact under contention")
+
+	// Verify no Admit calls were made (all satisfied via fast path).
+	output := tg.buf.stringAndReset()
+	require.Empty(t, output, "all deductions should use CAS fast path")
+}
+
+// TestSQLCPUHandleConcurrentSlowPath exercises the slow path under
+// contention. When reservation is exhausted, goroutines serialize on
+// refillMu and only one calls Admit while others may find reservation
+// refilled by the winner.
+func TestSQLCPUHandleConcurrentSlowPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	// Don't seed reservation — all goroutines must go through the slow
+	// path (or find reservation refilled by another goroutine).
+	const numGoroutines = 10
+	const perGoroutine = 1 * time.Millisecond
+	var wg sync.WaitGroup
+	var errors atomic.Int64
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := h.reportAndAcquireConsumedCPU(ctx, perGoroutine, false); err != nil {
+				errors.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(0), errors.Load())
+	// Reservation should be non-negative.
+	require.GreaterOrEqual(t, h.refillMu.reservation.Load(), int64(0),
+		"reservation must never be negative")
+
+	// All CPU should be reported.
+	gw, _ := provider.GetCumulativeSQLCPUNanos()
+	require.Equal(t, int64(numGoroutines)*int64(perGoroutine), gw)
+}
+
+// TestSQLCPUHandleConcurrentCloseAndAdmit verifies that Close and
+// reportAndAcquireConsumedCPU (both blocking and noWait) can run
+// concurrently without races or panics. After Close, ongoing calls
+// should see the closed flag and skip admission.
+func TestSQLCPUHandleConcurrentCloseAndAdmit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	// Seed reservation.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false))
+
+	var wg sync.WaitGroup
+
+	// Start goroutines that repeatedly call reportAndAcquireConsumedCPU
+	// via the blocking path (simulating MeasureAndAdmit).
+	const numBlocking = 10
+	wg.Add(numBlocking)
+	for i := 0; i < numBlocking; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = h.reportAndAcquireConsumedCPU(ctx, 10*time.Microsecond, false)
+			}
+		}()
+	}
+
+	// Start goroutines that call the noWait path (simulating
+	// GoroutineCPUHandle.Close).
+	const numNoWait = 10
+	wg.Add(numNoWait)
+	for i := 0; i < numNoWait; i++ {
+		go func() {
+			defer wg.Done()
+			_ = h.reportAndAcquireConsumedCPU(ctx, 100*time.Microsecond, true /* noWait */)
+		}()
+	}
+
+	// Close concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		h.Close()
+	}()
+
+	wg.Wait()
+
+	require.True(t, h.refillMu.closed.Load())
+	require.Equal(t, int64(0), h.refillMu.reservation.Load(),
+		"Close should have swapped reservation to 0")
+}
+
+// TestSQLCPUHandleConcurrentCASAndSwap verifies that the fast-path CAS
+// and Close's Swap(0) don't lose tokens. After Close, the reservation is
+// 0 and Close has returned whatever was left.
+func TestSQLCPUHandleConcurrentCASAndSwap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	provider := &sqlCPUProviderImpl{}
+
+	// Run many iterations to exercise the race window.
+	for iter := 0; iter < 100; iter++ {
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+		// Seed a large reservation.
+		require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 10*time.Millisecond, false))
+
+		var wg sync.WaitGroup
+		var casDeducted atomic.Int64
+
+		// Goroutines try CAS deductions concurrently.
+		const numGoroutines = 5
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				amount := int64(500 * time.Microsecond)
+				if h.tryDeductReservation(amount) {
+					casDeducted.Add(amount)
+				}
+			}()
+		}
+
+		// Close concurrently (Swap(0)).
+		wg.Add(1)
+		var swapped int64
+		go func() {
+			defer wg.Done()
+			h.refillMu.Lock()
+			h.refillMu.closed.Store(true)
+			swapped = h.refillMu.reservation.Swap(0)
+			h.refillMu.Unlock()
+		}()
+
+		wg.Wait()
+
+		// The initial reservation (10ms) should be fully accounted for:
+		// either deducted via CAS or returned via Swap.
+		initialReservation := int64(10 * time.Millisecond)
+		totalAccountedFor := casDeducted.Load() + swapped
+		require.Equal(t, initialReservation, totalAccountedFor,
+			"iter %d: CAS(%d) + Swap(%d) should equal initial reservation(%d)",
+			iter, casDeducted.Load(), swapped, initialReservation)
+	}
+}
+
+// TestSQLCPUHandleConcurrentRegisterGoroutine verifies that concurrent
+// calls to RegisterGoroutine from different goroutines are safe and each
+// goroutine gets its own handle.
+func TestSQLCPUHandleConcurrentRegisterGoroutine(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tenantID := roachpb.MustMakeTenantID(1)
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil)
+
+	const numGoroutines = 20
+	handles := make([]*GoroutineCPUHandle, numGoroutines)
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			handles[i] = h.RegisterGoroutine()
+		}()
+	}
+	wg.Wait()
+
+	// Each goroutine should have a unique handle.
+	seen := make(map[*GoroutineCPUHandle]bool)
+	for _, gh := range handles {
+		require.NotNil(t, gh)
+		require.False(t, seen[gh], "each goroutine should get a unique handle")
+		seen[gh] = true
+	}
+
+	h.mu.Lock()
+	require.Equal(t, numGoroutines, len(h.mu.gHandles))
+	h.mu.Unlock()
+}
+
+// TestSQLCPUHandleConcurrentMeasureAndClose exercises the real
+// GoroutineCPUHandle.MeasureAndAdmit and Close paths under concurrency,
+// simulating the actual DistSQL flow pattern.
+func TestSQLCPUHandleConcurrentMeasureAndClose(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	tg.mu.Lock()
+	tg.mu.returnValueFromTryGet = true
+	tg.mu.Unlock()
+
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+
+	const numGoroutines = 5
+	var wg sync.WaitGroup
+
+	// Each goroutine registers, calls MeasureAndAdmit several times,
+	// then closes its handle — mimicking a DistSQL flow.
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			gh := h.RegisterGoroutine()
+			for j := 0; j < 10; j++ {
+				_ = gh.MeasureAndAdmit(ctx)
+			}
+			gh.Close(ctx)
+		}()
+	}
+	wg.Wait()
+
+	// All goroutine handles should be closed.
+	h.mu.Lock()
+	for _, gh := range h.mu.gHandles {
+		require.True(t, gh.closed.Load())
+	}
+	h.mu.Unlock()
+
+	// SQLCPUHandle close should pool all the closed handles.
+	h.Close()
+	require.True(t, h.refillMu.closed.Load())
+	h.mu.Lock()
+	require.Nil(t, h.mu.gHandles)
+	h.mu.Unlock()
+}
+
+// TestSQLCPUHandleNoWorkQueue verifies that when no WorkQueue is
+// attached (CTT AC disabled), reportAndAcquireConsumedCPU still reports
+// CPU but skips all admission logic.
+func TestSQLCPUHandleNoWorkQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil)
+
+	// Both blocking and noWait paths should succeed without a WorkQueue.
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 2*time.Millisecond, true))
+
+	// CPU should still be reported.
+	gw, _ := provider.GetCumulativeSQLCPUNanos()
+	require.Equal(t, int64(3*time.Millisecond), gw)
+
+	// Reservation stays at 0 (no refills without a WorkQueue).
+	require.Equal(t, int64(0), h.refillMu.reservation.Load())
+
+	// Close should work cleanly.
+	h.Close()
+	require.True(t, h.refillMu.closed.Load())
+}
+
+// TestSQLCPUHandlePauseMeasuring verifies that pausing and unpausing
+// measurement works correctly with concurrent MeasureAndAdmit calls.
+func TestSQLCPUHandlePauseMeasuring(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tenantID := roachpb.MustMakeTenantID(1)
+	provider := &sqlCPUProviderImpl{}
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil)
+
+	gh := h.RegisterGoroutine()
+
+	// Nested pause/unpause.
+	gh.PauseMeasuring()
+	require.Equal(t, 1, gh.paused)
+	gh.PauseMeasuring()
+	require.Equal(t, 2, gh.paused)
+
+	// MeasureAndAdmit while paused should be a no-op.
+	ctx := context.Background()
+	require.NoError(t, gh.MeasureAndAdmit(ctx))
+
+	gh.UnpauseMeasuring()
+	require.Equal(t, 1, gh.paused)
+	gh.UnpauseMeasuring()
+	require.Equal(t, 0, gh.paused)
+
+	gh.Close(ctx)
+	h.Close()
+}
+
+// makeBenchWorkQueue creates a WorkQueue in CTT mode for benchmarks.
+func makeBenchWorkQueue(b *testing.B) (q *WorkQueue, tg *testGranter) {
+	var buf builderWithMu
+	tg = &testGranter{buf: &buf}
+	tg.mu.returnValueFromTryGet = true
+
+	st := cluster.MakeTestingClusterSettings()
+	metrics := makeWorkQueueMetrics("", metric.NewRegistry())
+	initialTime := timeutil.FromUnixMicros(
+		int64(100) * int64(time.Millisecond/time.Microsecond))
+	opts := makeWorkQueueOptions(KVWork)
+	opts.mode = usesCPUTimeTokens
+	cpuMetrics := makeCPUTimeTokenMetrics()
+	opts.perTenantAggMetrics = &tenantAggMetrics{
+		admittedCount:  cpuMetrics.AdmittedCountPerTenant[systemTenant],
+		waitTimeNanos:  cpuMetrics.WaitTimeNanosPerTenant[systemTenant],
+		tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
+		tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
+	}
+	opts.timeSource = timeutil.NewManualTime(initialTime)
+	opts.disableEpochClosingGoroutine = true
+	opts.disableGCTenantsAndResetUsed = true
+	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
+		KVWork, tg, st, metrics, opts).(*WorkQueue)
+	tg.r = q
+	b.Cleanup(q.close)
+	return q, tg
+}
+
+// BenchmarkSQLCPUHandleReservation measures the throughput benefit of the
+// reservation under concurrent goroutine contention.
+//
+// "with-reservation" uses the normal flow: the heuristic buffer lets ~half
+// the checkpoints deduct via lock-free CAS (fast path), avoiding Admit
+// entirely.
+//
+// "without-reservation" drains the reservation before each checkpoint,
+// forcing every call through the slow path (refillMu lock + Admit).
+//
+// The ns/op difference shows the real cost saved by the reservation: under
+// contention the fast path avoids both the refillMu lock and the WorkQueue
+// internal lock, so throughput scales with goroutine count.
+func BenchmarkSQLCPUHandleReservation(b *testing.B) {
+	const cpuPerCheckpoint = 100 * time.Microsecond
+
+	for _, numGoroutines := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("goroutines=%d", numGoroutines), func(b *testing.B) {
+			for _, useReservation := range []bool{true, false} {
+				label := "with-reservation"
+				if !useReservation {
+					label = "without-reservation"
+				}
+				b.Run(label, func(b *testing.B) {
+					ctx := context.Background()
+					tenantID := roachpb.MustMakeTenantID(1)
+					q, _ := makeBenchWorkQueue(b)
+
+					provider := &sqlCPUProviderImpl{}
+					h := newSQLCPUAdmissionHandle(
+						WorkInfo{TenantID: tenantID}, true, provider, q)
+
+					// Pre-seed reservation so the first iteration isn't
+					// a cold start.
+					_ = h.reportAndAcquireConsumedCPU(ctx, cpuPerCheckpoint, false)
+
+					b.ResetTimer()
+					var wg sync.WaitGroup
+					wg.Add(numGoroutines)
+					opsPerGoroutine := b.N / numGoroutines
+					for g := 0; g < numGoroutines; g++ {
+						go func() {
+							defer wg.Done()
+							for i := 0; i < opsPerGoroutine; i++ {
+								if !useReservation {
+									// Drain reservation to force every call
+									// through the slow path (Admit).
+									h.refillMu.reservation.Store(0)
+								}
+								_ = h.reportAndAcquireConsumedCPU(
+									ctx, cpuPerCheckpoint, false)
+							}
+						}()
+					}
+					wg.Wait()
+					b.StopTimer()
+					h.Close()
+				})
+			}
+		})
+	}
+}

--- a/pkg/util/admission/testdata/refill_heuristic
+++ b/pkg/util/admission/testdata/refill_heuristic
@@ -1,0 +1,104 @@
+# Bootstrap: first call seeds buffer equal to consumed.
+refill diff=100µs
+----
+buffer: 100µs, total: 200µs
+
+# Grow: elapsed < 1ms (immediate successive call) → double buffer.
+refill diff=100µs
+----
+buffer: 200µs, total: 300µs
+
+# Grow again.
+refill diff=100µs
+----
+buffer: 400µs, total: 500µs
+
+# Decay: set age > 5ms → halve buffer.
+set-age age=10ms
+----
+ok
+
+refill diff=100µs
+----
+buffer: 200µs, total: 300µs
+
+# Deadband: set age in [1ms, 5ms] → no change.
+set-age age=3ms
+----
+ok
+
+refill diff=100µs
+----
+buffer: 200µs, total: 300µs
+
+# Ceiling: grow from 8ms → 16ms, capped at 10ms.
+set-buffer val=8ms
+----
+ok
+
+refill diff=100µs
+----
+buffer: 10ms, total: 10.1ms
+
+# Large diff: buffer capped at maxRefillHeuristic, total still >= diff.
+set-buffer val=0
+----
+ok
+
+refill diff=50ms
+----
+buffer: 10ms, total: 60ms
+
+# Decay to zero re-bootstraps: buffer=1ns halved to 0, next call bootstraps.
+set-buffer val=1ns
+----
+ok
+
+set-age age=10ms
+----
+ok
+
+refill diff=200µs
+----
+buffer: 0s, total: 200µs
+
+refill diff=200µs
+----
+buffer: 200µs, total: 400µs
+
+# Repeated grow converges to cap.
+set-buffer val=100µs
+----
+ok
+
+refill diff=50µs
+----
+buffer: 200µs, total: 250µs
+
+refill diff=50µs
+----
+buffer: 400µs, total: 450µs
+
+refill diff=50µs
+----
+buffer: 800µs, total: 850µs
+
+refill diff=50µs
+----
+buffer: 1.6ms, total: 1.65ms
+
+refill diff=50µs
+----
+buffer: 3.2ms, total: 3.25ms
+
+refill diff=50µs
+----
+buffer: 6.4ms, total: 6.45ms
+
+refill diff=50µs
+----
+buffer: 10ms, total: 10.05ms
+
+refill diff=50µs
+----
+buffer: 10ms, total: 10.05ms

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -659,7 +659,11 @@ type AdmitResponse struct {
 // relevant when error=nil, and includes info on whether admission control
 // is enabled. AdmittedWorkDone must be called iff
 // AdmitResponse.Enabled=true && error==nil, and the WorkKind for this
-// queue is KVWork.
+// queue is KVWork, UNLESS the caller explicitly set RequestedCount (i.e.,
+// the exact resource usage is already known). In that case, the estimator
+// is skipped at Admit time and there is no estimate to correct, so
+// AdmittedWorkDone should not be called. See the callerSetRequestedCount
+// logic below for details.
 func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error) {
 	if fn := q.knobs.WorkQueueAdmitInterceptor; fn != nil {
 		fn(info)
@@ -677,6 +681,11 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// the memory overhead of enqueueing each raft command to see whether we
 	// need to do some coalescing at this level.
 
+	// Track whether the caller explicitly set RequestedCount. When true, the
+	// caller knows the exact resource usage (e.g., SQL CPU admission uses
+	// grunning to measure actual CPU consumed) and the CPU time token
+	// estimator should not override it.
+	callerSetRequestedCount := info.RequestedCount > 0
 	if info.RequestedCount == 0 {
 		// We treat unset RequestCounts as an implicit request of 1.
 		info.RequestedCount = 1
@@ -711,7 +720,15 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// a measurement of CPU time used servicing the request, courtesy of grunning.
 	// tenant.estimator uses past measurements from grunning to make estimates
 	// in this code path, that is, at admission time.
-	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation {
+	//
+	// The estimator is skipped when the caller explicitly set RequestedCount
+	// (callerSetRequestedCount == true). This is used by SQL CPU admission,
+	// where the exact CPU consumed is already known from grunning at the time
+	// of the call. In that case, AdmittedWorkDone is also not called, since
+	// the exact amount was deducted at Admit time (no estimate to correct)
+	// and training the estimator with SQL CPU data would corrupt KV estimates.
+	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation &&
+		!callerSetRequestedCount {
 		info.RequestedCount = tenant.cpuTimeTokenEstimator.estimateTokensToBeUsed()
 	}
 	admitResponse := AdmitResponse{
@@ -1002,7 +1019,12 @@ func recordAdmissionWorkQueueStats(
 }
 
 // AdmittedWorkDone is used to inform the WorkQueue that some admitted work is
-// finished. It must be called iff the WorkKind of this WorkQueue is for KVWork.
+// finished. It must be called iff the WorkKind of this WorkQueue is for KVWork
+// and the caller did not explicitly set RequestedCount at Admit time. When
+// RequestedCount is explicitly set (e.g., SQL CPU admission using grunning
+// measurements), the exact amount was already deducted at Admit time, so there
+// is no estimate to correct and AdmittedWorkDone should not be called.
+//
 // Note that cpuTime is an argument to AdmittedWorkDone. So, even though
 // WorkQueue supports various resources other than CPU, AdmittedWorkDone is
 // special-cased for CPU time admission control.

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1130,6 +1130,22 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 	}
 }
 
+// AdmittedSQLWorkDone adjusts token accounting when a SQL statement closes.
+// remaining is the leftover reservation (always non-negative, since the
+// CAS-based deduction in SQLCPUHandle never drives the reservation below
+// zero). Positive remaining means unused tokens are returned to the granter.
+func (q *WorkQueue) AdmittedSQLWorkDone(tenantID roachpb.TenantID, remaining int64) {
+	if remaining == 0 {
+		return
+	}
+	q.adjustTenantUsed(tenantID, -remaining)
+	if remaining < 0 {
+		q.granter.tookWithoutPermission(-remaining)
+	} else if remaining > 0 {
+		q.granter.returnGrant(remaining)
+	}
+}
+
 func (q *WorkQueue) hasWaitingRequests() (bool, burstQualification) {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -175,9 +175,30 @@ type WorkInfo struct {
 	// work within a (TenantID, Priority) pair -- earlier CreateTime is given
 	// preference.
 	CreateTime int64
-	// BypassAdmission allows the work to bypass admission control, but allows for
-	// it to be accounted for. It should be used for high-priority intra-KV work,
-	// and when KV work generates other KV work (to avoid deadlock).
+	// BypassAdmission allows the work to bypass admission control (it will
+	// never queue or block) while still being accounted for: the tokens are
+	// deducted via tookWithoutPermission so the token budget reflects the
+	// actual usage. This is used in three situations:
+	//
+	//  - High-priority intra-KV work whose source is OTHER (not FROM_SQL or
+	//    ROOT_KV). Blocking such work could cause deadlocks because it is
+	//    generated in the critical path of serving already-admitted requests
+	//    (e.g., Raft proposals, intent resolution, lease requests).
+	//
+	//  - Normal-and-above priority KV work when
+	//    KVBulkOnlyAdmissionControlEnabled is set. In this mode only bulk
+	//    (low-priority) work is subject to admission control; everything at
+	//    NormalPri or above bypasses.
+	//
+	//  - SQL CPU admission handles closing (noWait=true in reportCPU).
+	//    SQL CPU uses an admit-after-consume model: goroutines run
+	//    freely and retroactively deduct consumed CPU via Admit. During
+	//    execution, an exhausted token bucket blocks the goroutine until
+	//    tokens refill. At handle close (GoroutineCPUHandle.Close), a
+	//    final measureAndAdmit accounts for the last CPU burst, but
+	//    blocking serves no purpose — the work is done and there is
+	//    nothing left to throttle. BypassAdmission deducts the tokens
+	//    without blocking.
 	BypassAdmission bool
 	// RequestedCount is the requested number of tokens or slots. If unset:
 	// - For slot-based queues we treat it as an implicit request of 1;
@@ -684,7 +705,11 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// Track whether the caller explicitly set RequestedCount. When true, the
 	// caller knows the exact resource usage (e.g., SQL CPU admission uses
 	// grunning to measure actual CPU consumed) and the CPU time token
-	// estimator should not override it.
+	// estimator should not override it. Currently, only SQL CPU admission
+	// sets RequestedCount in usesCPUTimeTokens mode; above-raft KV leaves
+	// it at 0 and relies on the estimator. Below-raft KV does set
+	// RequestedCount (to the raft command byte size), but uses usesTokens
+	// mode, so it never reaches the estimator guard.
 	callerSetRequestedCount := info.RequestedCount > 0
 	if info.RequestedCount == 0 {
 		// We treat unset RequestCounts as an implicit request of 1.
@@ -721,12 +746,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// tenant.estimator uses past measurements from grunning to make estimates
 	// in this code path, that is, at admission time.
 	//
-	// The estimator is skipped when the caller explicitly set RequestedCount
-	// (callerSetRequestedCount == true). This is used by SQL CPU admission,
-	// where the exact CPU consumed is already known from grunning at the time
-	// of the call. In that case, AdmittedWorkDone is also not called, since
-	// the exact amount was deducted at Admit time (no estimate to correct)
-	// and training the estimator with SQL CPU data would corrupt KV estimates.
+	// Skip the estimator when callerSetRequestedCount is true (see above).
 	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation &&
 		!callerSetRequestedCount {
 		info.RequestedCount = tenant.cpuTimeTokenEstimator.estimateTokensToBeUsed()
@@ -1023,7 +1043,7 @@ func recordAdmissionWorkQueueStats(
 // and the caller did not explicitly set RequestedCount at Admit time. When
 // RequestedCount is explicitly set (e.g., SQL CPU admission using grunning
 // measurements), the exact amount was already deducted at Admit time, so there
-// is no estimate to correct and AdmittedWorkDone should not be called.
+// is no estimate to correct and AdmittedWorkDone must not be called.
 //
 // Note that cpuTime is an argument to AdmittedWorkDone. So, even though
 // WorkQueue supports various resources other than CPU, AdmittedWorkDone is

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -779,7 +779,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 
 		// Admit with an explicit RequestedCount — the estimator should be
 		// skipped and the exact value preserved. This is the path taken by
-		// SQL CPU admission via reportCPU.
+		// SQL CPU admission via reportAndAcquireConsumedCPU.
 		explicitCount := int64(12345)
 		resp, err = q.Admit(ctx, WorkInfo{
 			TenantID:       tenantID,
@@ -806,7 +806,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		// Gateway CPU.
 		h := newSQLCPUAdmissionHandle(
 			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
-		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false /* noWait */))
 		gw, dist := provider.GetCumulativeSQLCPUNanos()
 		require.Equal(t, int64(5*time.Millisecond), gw)
 		require.Equal(t, int64(0), dist)
@@ -814,7 +814,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		// DistSQL CPU.
 		h2 := newSQLCPUAdmissionHandle(
 			WorkInfo{TenantID: tenantID}, false /* atGateway */, provider, q)
-		require.NoError(t, h2.reportCPU(ctx, 10*time.Millisecond, false /* noWait */))
+		require.NoError(t, h2.reportAndAcquireConsumedCPU(ctx, 10*time.Millisecond, false /* noWait */))
 		gw, dist = provider.GetCumulativeSQLCPUNanos()
 		require.Equal(t, int64(5*time.Millisecond), gw)
 		require.Equal(t, int64(10*time.Millisecond), dist)
@@ -824,7 +824,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		provider := &sqlCPUProviderImpl{}
 		h := newSQLCPUAdmissionHandle(
 			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil /* wq */)
-		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 5*time.Millisecond, false /* noWait */))
 		gw, _ := provider.GetCumulativeSQLCPUNanos()
 		require.Equal(t, int64(5*time.Millisecond), gw)
 	})
@@ -844,7 +844,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		err := h.reportCPU(cancelCtx, 1*time.Millisecond, false /* noWait */)
+		err := h.reportAndAcquireConsumedCPU(cancelCtx, 1*time.Millisecond, false /* noWait */)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -713,6 +713,142 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 	checkEstimation(resp3, 250*time.Millisecond)
 }
 
+// makeCPUTimeTokenWorkQueue creates a WorkQueue in CTT mode for testing. The
+// returned testGranter has tryGet returning true by default (all Admit calls
+// succeed immediately).
+func makeCPUTimeTokenWorkQueue(t *testing.T) (q *WorkQueue, tg *testGranter, cleanup func()) {
+	var buf builderWithMu
+	tg = &testGranter{buf: &buf}
+	tg.mu.returnValueFromTryGet = true
+
+	st := cluster.MakeTestingClusterSettings()
+	metrics := makeWorkQueueMetrics("", metric.NewRegistry())
+
+	initialTime := timeutil.FromUnixMicros(
+		int64(100) * int64(time.Millisecond/time.Microsecond))
+	opts := makeWorkQueueOptions(KVWork)
+	opts.mode = usesCPUTimeTokens
+	cpuMetrics := makeCPUTimeTokenMetrics()
+	opts.perTenantAggMetrics = &tenantAggMetrics{
+		admittedCount:  cpuMetrics.AdmittedCountPerTenant[systemTenant],
+		waitTimeNanos:  cpuMetrics.WaitTimeNanosPerTenant[systemTenant],
+		tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
+		tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
+	}
+	opts.timeSource = timeutil.NewManualTime(initialTime)
+	opts.disableEpochClosingGoroutine = true
+	opts.disableGCTenantsAndResetUsed = true
+
+	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
+		KVWork, tg, st, metrics, opts).(*WorkQueue)
+	tg.r = q
+	return q, tg, q.close
+}
+
+// TestSQLCPUAdmission verifies the SQL CPU admission integration with the CTT
+// WorkQueue. SQL CPU admission differs from KV admission: it sets
+// RequestedCount to the exact CPU consumed (from grunning), bypassing the
+// estimator, and does not call AdmittedWorkDone.
+func TestSQLCPUAdmission(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tenantID := roachpb.MustMakeTenantID(1)
+
+	t.Run("explicit-requested-count-skips-estimator", func(t *testing.T) {
+		q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+		defer cleanup()
+
+		// Train the estimator so it returns something other than 1ns.
+		info := WorkInfo{TenantID: tenantID}
+		resp, err := q.Admit(ctx, info)
+		require.NoError(t, err)
+		for i := 0; i < 100; i++ {
+			q.AdmittedWorkDone(resp, 50*time.Millisecond)
+			if i%10 == 0 {
+				q.gcTenantsResetUsedAndUpdateEstimators()
+			}
+		}
+
+		// Verify the estimator is trained.
+		resp, err = q.Admit(ctx, info)
+		require.NoError(t, err)
+		require.Greater(t, resp.requestedCount, int64(time.Millisecond),
+			"estimator should return a value >> 1ns after training")
+
+		// Admit with an explicit RequestedCount — the estimator should be
+		// skipped and the exact value preserved. This is the path taken by
+		// SQL CPU admission via reportCPU.
+		explicitCount := int64(12345)
+		resp, err = q.Admit(ctx, WorkInfo{
+			TenantID:       tenantID,
+			RequestedCount: explicitCount,
+		})
+		require.NoError(t, err)
+		require.Equal(t, explicitCount, resp.requestedCount,
+			"explicit RequestedCount should not be overridden by estimator")
+
+		// A subsequent Admit without RequestedCount still uses the
+		// estimator (the explicit call didn't corrupt anything).
+		resp, err = q.Admit(ctx, info)
+		require.NoError(t, err)
+		require.Greater(t, resp.requestedCount, int64(time.Millisecond),
+			"estimator should still work for callers that don't set RequestedCount")
+	})
+
+	t.Run("report-cpu-updates-counters", func(t *testing.T) {
+		q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+		defer cleanup()
+
+		provider := &sqlCPUProviderImpl{}
+
+		// Gateway CPU.
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		gw, dist := provider.GetCumulativeSQLCPUNanos()
+		require.Equal(t, int64(5*time.Millisecond), gw)
+		require.Equal(t, int64(0), dist)
+
+		// DistSQL CPU.
+		h2 := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, false /* atGateway */, provider, q)
+		require.NoError(t, h2.reportCPU(ctx, 10*time.Millisecond, false /* noWait */))
+		gw, dist = provider.GetCumulativeSQLCPUNanos()
+		require.Equal(t, int64(5*time.Millisecond), gw)
+		require.Equal(t, int64(10*time.Millisecond), dist)
+	})
+
+	t.Run("nil-work-queue-skips-admit", func(t *testing.T) {
+		provider := &sqlCPUProviderImpl{}
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, nil /* wq */)
+		require.NoError(t, h.reportCPU(ctx, 5*time.Millisecond, false /* noWait */))
+		gw, _ := provider.GetCumulativeSQLCPUNanos()
+		require.Equal(t, int64(5*time.Millisecond), gw)
+	})
+
+	t.Run("context-canceled-propagates-error", func(t *testing.T) {
+		q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+		defer cleanup()
+
+		// Make tryGet return false so Admit blocks and observes the
+		// canceled context.
+		tg.mu.Lock()
+		tg.mu.returnValueFromTryGet = false
+		tg.mu.Unlock()
+
+		provider := &sqlCPUProviderImpl{}
+		h := newSQLCPUAdmissionHandle(
+			WorkInfo{TenantID: tenantID}, true /* atGateway */, provider, q)
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := h.reportCPU(cancelCtx, 1*time.Millisecond, false /* noWait */)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
 // TestWorkQueueTokenResetRace induces racing between tenantInfo.used
 // decrements and tenantInfo.used resets that used to fail until we eliminated
 // the code that decrements tenantInfo.used for tokens. It would also trigger


### PR DESCRIPTION
On top of https://github.com/cockroachdb/cockroach/pull/166792. 
Resolves: https://github.com/cockroachdb/cockroach/issues/166749
Epic: none
Release note: None

---
**admission: extract reportCPU helper**

This commit extracts the cumulative CPU counter update into a
standalone `reportCPU` helper on `SQLCPUHandle`.
`reportAndAcquireConsumedCPU` now delegates to `reportCPU` for the
counter update before proceeding with CTT `WorkQueue` admission.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: add reservation to SQLCPUHandle**

This change introduces a local token reservation in `SQLCPUHandle` that
allows most `measureAndAdmit` calls to deduct via a lock-free CAS,
falling back to `WorkQueue.Admit` only when the reservation is
exhausted.

The slow path serializes under `refillMu`, requests
`diffNanos + min(diffNanos, 10ms)` from Admit, and adds the buffer
portion to the reservation. The `noWait` path uses `BypassAdmission`
for non-blocking accounting. `setClosed` acquires `refillMu`, swaps
the reservation to zero, and returns remaining tokens via
`AdmittedSQLWorkDone` (which calls `adjustTenantUsed` to decrement
`tenant.used` before returning tokens to the granter).

Note that `RequestedCount > 0` causes the WorkQueue's CPU time token
estimator to be skipped (via `callerSetRequestedCount` in `Admit`),
which is correct because SQL CPU uses exact grunning measurements.

Benchmark results confirm ~2x throughput improvement:

  goroutines=1:  with=113ns  without=214ns  (1.9x)
  goroutines=2:  with=117ns  without=230ns  (2.0x)
  goroutines=4:  with=120ns  without=231ns  (1.9x)
  goroutines=8:  with=132ns  without=286ns  (2.2x)

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: replace fixed refill heuristic with adaptive buffer sizing**

This change replaces the fixed `min(diffNanos, maxRefillBuffer)` buffer
heuristic with an adaptive scheme that adjusts based on the interval
between Admit calls: double the buffer when refills are < 1ms apart,
halve it when > 5ms apart, and hold steady in the deadband. The buffer
is capped at `maxRefillHeuristic` (10ms). The return value is always
`diffNanos + lastHeuristic`, ensuring the reservation receives a
non-negative addition.

This change also removes the early `closed` check before the fast path.
The `noWait` path now accounts CPU via `BypassAdmission` after close,
keeping `tenant.used` accurate for goroutines that outlive the handle.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

