### PR TITLE
sctest: reuse a single cluster per top-level backup test

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -47,15 +47,11 @@ func BackupSuccess(t *testing.T, path string, factory TestServerFactory) {
 	// Disable schema_locked in backup and restore tests, since the userfiles table
 	// cannot be created with schema_locked by default yet.
 	cumulativeTestForEachPostCommitStage(t, path, factory,
-		func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+		func(t *testing.T, spec CumulativeTestSpec) PrepResult[backupSuccessTestArgs] {
 			result := backupSuccessPrepare(t, factory, spec)
-			var ok bool
-			backupArgs, ok = result.PrepData.(backupSuccessTestArgs)
-			if !ok {
-				t.Fatalf("PrepData has wrong type: got %T, want backupSuccessTestArgs", result.PrepData)
-			}
+			backupArgs = result.PrepData
 			return result
-		}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+		}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData backupSuccessTestArgs) {
 			backupSuccess(t, backupArgs, cs)
 		},
 		nil /*samplingFn */)
@@ -81,20 +77,12 @@ func BackupRollbacks(t *testing.T, path string, factory TestServerFactory) {
 		}
 	}()
 	cumulativeTestForEachPostCommitStage(t, path, factory,
-		func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+		func(t *testing.T, spec CumulativeTestSpec) PrepResult[backupRollbacksTestArgs] {
 			result := backupRollbacksPrepare(t, factory, spec)
-			var ok bool
-			rollbackArgs, ok = result.PrepData.(backupRollbacksTestArgs)
-			if !ok {
-				t.Fatalf("PrepData has wrong type: got %T, want backupRollbacksTestArgs", result.PrepData)
-			}
+			rollbackArgs = result.PrepData
 			return result
-		}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
-			args, ok := prepData.(backupRollbacksTestArgs)
-			if !ok {
-				t.Fatalf("prepData has wrong type: got %T, want backupRollbacksTestArgs", prepData)
-			}
-			backupRollbacks(t, args, cs, false /*isMixedVersion*/)
+		}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData backupRollbacksTestArgs) {
+			backupRollbacks(t, prepData, cs, false /*isMixedVersion*/)
 		},
 		nil /* samplingFn */)
 }
@@ -118,20 +106,16 @@ func BackupSuccessMixedVersion(t *testing.T, path string, factory TestServerFact
 	}()
 	// Disable schema_locked in backup and restore tests, since the userfiles table
 	// cannot be created with schema_locked by default yet.
-	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult[backupSuccessTestArgs] {
 		result := backupSuccessPrepare(t, factory, spec)
-		var ok bool
-		backupArgs, ok = result.PrepData.(backupSuccessTestArgs)
-		if !ok {
-			t.Fatalf("PrepData has wrong type: got %T, want backupSuccessTestArgs", result.PrepData)
-		}
+		backupArgs = result.PrepData
 		if backupArgs.isMultiRegion {
 			// Speed up the mixed version multiregion cases by excluding restores of individual
 			// tables in the mixed version state.
 			backupArgs.excludeAllTablesInDatabaseFlavor = true
 		}
 		return result
-	}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+	}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData backupSuccessTestArgs) {
 		backupSuccess(t, backupArgs, cs)
 	},
 		nil /* samplingFn */)
@@ -158,20 +142,12 @@ func BackupRollbacksMixedVersion(t *testing.T, path string, factory TestServerFa
 			rollbackArgs.server.Stopper(t)
 		}
 	}()
-	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult[backupRollbacksTestArgs] {
 		result := backupRollbacksPrepare(t, factory, spec)
-		var ok bool
-		rollbackArgs, ok = result.PrepData.(backupRollbacksTestArgs)
-		if !ok {
-			t.Fatalf("PrepData has wrong type: got %T, want backupRollbacksTestArgs", result.PrepData)
-		}
+		rollbackArgs = result.PrepData
 		return result
-	}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
-		args, ok := prepData.(backupRollbacksTestArgs)
-		if !ok {
-			t.Fatalf("prepData has wrong type: got %T, want backupRollbacksTestArgs", prepData)
-		}
-		backupRollbacks(t, args, cs, true /*isMixedVersion*/)
+	}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData backupRollbacksTestArgs) {
+		backupRollbacks(t, prepData, cs, true /*isMixedVersion*/)
 	}, nil /* samplingFn */)
 }
 
@@ -253,7 +229,7 @@ type backupRollbacksTestArgs struct {
 // count stages before running tests.
 func backupSuccessPrepare(
 	t *testing.T, factory TestServerFactory, spec CumulativeTestSpec,
-) PrepResult {
+) PrepResult[backupSuccessTestArgs] {
 	ctx := context.Background()
 
 	backupArgs := backupSuccessTestArgs{
@@ -447,7 +423,7 @@ func backupSuccessPrepare(
 		postCommitNonRevertibleCount = mu.postCommitNonRevertibleCount
 	}()
 
-	return PrepResult{
+	return PrepResult[backupSuccessTestArgs]{
 		PostCommitCount:              postCommitCount,
 		PostCommitNonRevertibleCount: postCommitNonRevertibleCount,
 		After:                        backupArgs.after,
@@ -462,7 +438,7 @@ func backupSuccessPrepare(
 // recreating the test database for each rollback scenario.
 func backupRollbacksPrepare(
 	t *testing.T, factory TestServerFactory, spec CumulativeTestSpec,
-) PrepResult {
+) PrepResult[backupRollbacksTestArgs] {
 	ctx := context.Background()
 	args := backupRollbacksTestArgs{
 		scenarios: make(map[backupKey]rollbackScenario),
@@ -707,7 +683,7 @@ func backupRollbacksPrepare(
 		postCommitNonRevertibleCount = discovery.postCommitNonRevertibleCount
 	}()
 
-	return PrepResult{
+	return PrepResult[backupRollbacksTestArgs]{
 		PostCommitCount:              postCommitCount,
 		PostCommitNonRevertibleCount: postCommitNonRevertibleCount,
 		DatabaseName:                 dbName,

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -47,11 +46,18 @@ func BackupSuccess(t *testing.T, path string, factory TestServerFactory) {
 	}()
 	// Disable schema_locked in backup and restore tests, since the userfiles table
 	// cannot be created with schema_locked by default yet.
-	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec, dbName string) {
-		backupArgs = backupSuccessPrepare(t, factory, spec, dbName)
-	}, func(t *testing.T, cs CumulativeTestCaseSpec) {
-		backupSuccess(t, backupArgs, cs)
-	},
+	cumulativeTestForEachPostCommitStage(t, path, factory,
+		func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+			result := backupSuccessPrepare(t, factory, spec)
+			var ok bool
+			backupArgs, ok = result.PrepData.(backupSuccessTestArgs)
+			if !ok {
+				t.Fatalf("PrepData has wrong type: got %T, want backupSuccessTestArgs", result.PrepData)
+			}
+			return result
+		}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+			backupSuccess(t, backupArgs, cs)
+		},
 		nil /*samplingFn */)
 }
 
@@ -68,9 +74,28 @@ func BackupRollbacks(t *testing.T, path string, factory TestServerFactory) {
 	// Disable schema_locked in backup and restore tests, since the userfiles table
 	// cannot be created with schema_locked by default yet.
 	factory = factory.WithSchemaLockDisabled()
-	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
-		backupRollbacks(t, factory, cs, false /*isMixedVersion*/)
-	},
+	var rollbackArgs backupRollbacksTestArgs
+	defer func() {
+		if rollbackArgs.server.Stopper != nil {
+			rollbackArgs.server.Stopper(t)
+		}
+	}()
+	cumulativeTestForEachPostCommitStage(t, path, factory,
+		func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+			result := backupRollbacksPrepare(t, factory, spec)
+			var ok bool
+			rollbackArgs, ok = result.PrepData.(backupRollbacksTestArgs)
+			if !ok {
+				t.Fatalf("PrepData has wrong type: got %T, want backupRollbacksTestArgs", result.PrepData)
+			}
+			return result
+		}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+			args, ok := prepData.(backupRollbacksTestArgs)
+			if !ok {
+				t.Fatalf("prepData has wrong type: got %T, want backupRollbacksTestArgs", prepData)
+			}
+			backupRollbacks(t, args, cs, false /*isMixedVersion*/)
+		},
 		nil /* samplingFn */)
 }
 
@@ -93,14 +118,20 @@ func BackupSuccessMixedVersion(t *testing.T, path string, factory TestServerFact
 	}()
 	// Disable schema_locked in backup and restore tests, since the userfiles table
 	// cannot be created with schema_locked by default yet.
-	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec, dbName string) {
-		backupArgs = backupSuccessPrepare(t, factory, spec, dbName)
-	}, func(t *testing.T, cs CumulativeTestCaseSpec) {
+	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+		result := backupSuccessPrepare(t, factory, spec)
+		var ok bool
+		backupArgs, ok = result.PrepData.(backupSuccessTestArgs)
+		if !ok {
+			t.Fatalf("PrepData has wrong type: got %T, want backupSuccessTestArgs", result.PrepData)
+		}
 		if backupArgs.isMultiRegion {
 			// Speed up the mixed version multiregion cases by excluding restores of individual
 			// tables in the mixed version state.
 			backupArgs.excludeAllTablesInDatabaseFlavor = true
 		}
+		return result
+	}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
 		backupSuccess(t, backupArgs, cs)
 	},
 		nil /* samplingFn */)
@@ -121,8 +152,26 @@ func BackupRollbacksMixedVersion(t *testing.T, path string, factory TestServerFa
 	// Disable schema_locked in mixed version tests, since we do not support
 	// disabling schema_locked in a mixed version state yet.
 	factory = factory.WithSchemaLockDisabled()
-	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
-		backupRollbacks(t, factory, cs, true /*isMixedVersion*/)
+	var rollbackArgs backupRollbacksTestArgs
+	defer func() {
+		if rollbackArgs.server.Stopper != nil {
+			rollbackArgs.server.Stopper(t)
+		}
+	}()
+	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult {
+		result := backupRollbacksPrepare(t, factory, spec)
+		var ok bool
+		rollbackArgs, ok = result.PrepData.(backupRollbacksTestArgs)
+		if !ok {
+			t.Fatalf("PrepData has wrong type: got %T, want backupRollbacksTestArgs", result.PrepData)
+		}
+		return result
+	}, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+		args, ok := prepData.(backupRollbacksTestArgs)
+		if !ok {
+			t.Fatalf("prepData has wrong type: got %T, want backupRollbacksTestArgs", prepData)
+		}
+		backupRollbacks(t, args, cs, true /*isMixedVersion*/)
 	}, nil /* samplingFn */)
 }
 
@@ -185,26 +234,51 @@ type backupSuccessTestArgs struct {
 	excludeAllTablesInDatabaseFlavor bool
 }
 
-// backupSuccessPrepare setups a server and takes all required backups for
-// the backupSuccess test.
+// rollbackScenario contains all data for testing one rollback scenario
+type rollbackScenario struct {
+	databaseName string     // Unique database for this scenario
+	urls         []string   // Backup URLs taken during rollback
+	expected     [][]string // Expected descriptor state after rollback
+}
+
+// backupRollbacksTestArgs are arguments generated by backupRollbacksPrepare
+type backupRollbacksTestArgs struct {
+	server    TestServer
+	scenarios map[backupKey]rollbackScenario
+}
+
+// backupSuccessPrepare sets up a server, executes the schema change, and
+// collects backups at each stage. It returns a PrepResult containing stage
+// counts and test data, eliminating the need for a throwaway cluster to
+// count stages before running tests.
 func backupSuccessPrepare(
-	t *testing.T, factory TestServerFactory, spec CumulativeTestSpec, dbName string,
-) backupSuccessTestArgs {
+	t *testing.T, factory TestServerFactory, spec CumulativeTestSpec,
+) PrepResult {
 	ctx := context.Background()
 
 	backupArgs := backupSuccessTestArgs{
 		backups: make(map[backupKey]backupInfo),
 	}
-	var mu syncutil.Mutex
-	hasBackfill := false
-	mutationAfterBackfill := false
+	var mu struct {
+		syncutil.Mutex
+		postCommitCount              int
+		postCommitNonRevertibleCount int
+		stageCounted                 bool
+		hasBackfill                  bool
+		mutationAfterBackfill        bool
+	}
 	backupsToTake := make(map[backupKey]string)
 	var dbForBackup atomic.Pointer[gosql.DB]
 	var knobEnabled atomic.Bool
+	var dbName string
+	var createDatabaseStmt string
 	backupArgs.pe = MakePlanExplainer()
 	knobs := &scexec.TestingKnobs{
-		// Back up the database exactly once when reaching the stage prescribed
-		// by the test case specification.
+		// BeforeStage serves two purposes:
+		// 1. Count stages during the first plan encounter to populate PrepResult.
+		// 2. Collect backups at each stage during the main schema change execution.
+		// The hook fires for both the original schema change and post-RESTORE
+		// schema changes, so guards are necessary to avoid duplicate work.
 		BeforeStage: func(p scplan.Plan, stageIdx int) error {
 			// Only enabled after setup.
 			if !knobEnabled.Load() {
@@ -212,13 +286,34 @@ func backupSuccessPrepare(
 			}
 			// Collect EXPLAIN (DDL) diagram for debug purposes.
 			if err := backupArgs.pe.MaybeUpdateWithPlan(p); err != nil {
-				return err
+				return errors.Wrapf(err, "updating plan explainer (stage=%d, phase=%s)",
+					stageIdx, p.Stages[stageIdx].Phase)
 			}
 			// Since this callback is also active during post-RESTORE
 			// schema changes, we have to be careful to exit early in those cases.
 			if dbForBackup.Load() == nil {
 				return nil
 			}
+
+			// Count stages and collect backup info (all under single lock)
+			mu.Lock()
+			defer mu.Unlock()
+
+			// Count stages on first plan encounter only.
+			// The BeforeStage hook fires for both the original schema change and
+			// post-RESTORE schema changes, so we guard against double-counting.
+			if !mu.stageCounted {
+				mu.stageCounted = true
+				for _, s := range p.Stages {
+					switch s.Phase {
+					case scop.PostCommitPhase:
+						mu.postCommitCount++
+					case scop.PostCommitNonRevertiblePhase:
+						mu.postCommitNonRevertibleCount++
+					}
+				}
+			}
+
 			key := backupKey{
 				Phase:   p.Stages[stageIdx].Phase,
 				Ordinal: p.Stages[stageIdx].Ordinal,
@@ -230,19 +325,18 @@ func backupSuccessPrepare(
 				dbName,
 				url,
 				backupArgs.server.Server.Clock().Now().AsOfSystemTime())
-			mu.Lock()
-			defer mu.Unlock()
+
 			// Before backing up, check whether the plan executed so far includes
 			// backfill operations which are not going to be replayed post-RESTORE.
 			// Backing up at this point may lead the post-RESTORE schema change to fail.
 			if p.Stages[stageIdx].Type() == scop.BackfillType {
-				hasBackfill = true
-			} else if p.Stages[stageIdx].Type() == scop.MutationType && hasBackfill {
-				mutationAfterBackfill = true
+				mu.hasBackfill = true
+			} else if p.Stages[stageIdx].Type() == scop.MutationType && mu.hasBackfill {
+				mu.mutationAfterBackfill = true
 			}
 			backupArgs.backups[key] = backupInfo{
 				url:            url,
-				isPostBackfill: mutationAfterBackfill,
+				isPostBackfill: mu.mutationAfterBackfill,
 			}
 			backupsToTake[key] = backupStmt
 			return nil
@@ -250,12 +344,35 @@ func backupSuccessPrepare(
 	}
 	// Setup a server for the backup test cases.
 	backupArgs.server = factory.WithSchemaChangerKnobs(knobs).Start(ctx, t)
+	t.Cleanup(func() {
+		if backupArgs.server.Stopper != nil {
+			backupArgs.server.Stopper(t)
+		}
+	})
 	db := backupArgs.server.DB
 	dbForBackup.Store(db)
 	tdb := sqlutils.MakeSQLRunner(db)
 	// Setup the test cluster.
 	tdb.Exec(t, "CREATE DATABASE backups")
 	require.NoError(t, setupSchemaChange(ctx, t, spec, db))
+
+	// Skip test if it requires system tenant operations and we're running under a secondary tenant.
+	maybeSkipUnderSecondaryTenant(t, spec, backupArgs.server.Server)
+
+	// Determine which database contains the schema change before enabling knobs.
+	// Some tests create a separate database (e.g. "db"), others use defaultdb.
+	rows := tdb.QueryStr(t, "SELECT database_name FROM [SHOW DATABASES] WHERE database_name NOT IN ('system', 'postgres', 'defaultdb', 'backups')")
+	if len(rows) > 0 {
+		dbName = rows[0][0]
+	} else {
+		dbName = "defaultdb"
+	}
+	res := tdb.QueryStr(t, fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE DATABASE %q]", dbName))
+	if len(res) > 0 {
+		createDatabaseStmt = res[0][0]
+	}
+
+	// Enable knobs - this will capture stage counts and plan when schema change runs.
 	knobEnabled.Swap(true)
 
 	// Fetch the state of the cluster before the schema change kicks off.
@@ -263,12 +380,30 @@ func backupSuccessPrepare(
 	backupArgs.before = parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
 
 	// Kick off the schema change and perform the backup via the BeforeStage hook.
+	// The knob will count stages and collect backup information.
 	require.NoError(t, executeSchemaChangeTxn(ctx, t, spec, db))
+
+	// Check if we dropped the database, and switch to system database if so.
+	// For DROP DATABASE, the database no longer exists, so we can't fetch its state.
+	droppedDatabase := false
+	for _, stmt := range spec.Stmts {
+		if stmt.AST.StatementTag() == "DROP DATABASE" {
+			droppedDatabase = true
+			tdb.Exec(t, "USE system")
+			break
+		}
+	}
+
 	require.True(t, hasLatestSchemaChangeSucceeded(t, tdb))
 
 	// Fetch the state of the cluster after the schema change succeeds.
-	tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
-	backupArgs.after = parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
+	if !droppedDatabase {
+		tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
+		backupArgs.after = parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
+	} else {
+		// For DROP DATABASE, "after" state is empty since the database is gone.
+		backupArgs.after = [][]string{}
+	}
 
 	knobEnabled.Store(false)
 	dbForBackup.Store(nil)
@@ -291,11 +426,294 @@ func backupSuccessPrepare(
 			backupArgs.backups[key] = backupInfo{}
 			continue
 		}
-		tdb.Exec(t, backupsToTake[key])
+		// For DROP DATABASE, the database might not exist at this stage, so we need
+		// to check and skip the backup if it fails.
+		_, err := tdb.DB.ExecContext(ctx, backupsToTake[key])
+		if err != nil && droppedDatabase {
+			// Database doesn't exist, skip this backup.
+			t.Logf("Skipping backup for dropped database (key=%v): %v", key, err)
+			backupArgs.backups[key] = backupInfo{}
+			continue
+		}
+		require.NoError(t, err, "failed to take backup: %s", backupsToTake[key])
 		numStagesIncluded += 1
 	}
 
-	return backupArgs
+	var postCommitCount, postCommitNonRevertibleCount int
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		postCommitCount = mu.postCommitCount
+		postCommitNonRevertibleCount = mu.postCommitNonRevertibleCount
+	}()
+
+	return PrepResult{
+		PostCommitCount:              postCommitCount,
+		PostCommitNonRevertibleCount: postCommitNonRevertibleCount,
+		After:                        backupArgs.after,
+		DatabaseName:                 dbName,
+		CreateDatabaseStmt:           createDatabaseStmt,
+		PrepData:                     backupArgs,
+	}
+}
+
+// backupRollbacksPrepare sets up a server and runs all rollback scenarios,
+// collecting backups for each. It reuses a single cluster by dropping and
+// recreating the test database for each rollback scenario.
+func backupRollbacksPrepare(
+	t *testing.T, factory TestServerFactory, spec CumulativeTestSpec,
+) PrepResult {
+	ctx := context.Background()
+	args := backupRollbacksTestArgs{
+		scenarios: make(map[backupKey]rollbackScenario),
+	}
+
+	// discovery is populated once during the discovery run (phase 1) and
+	// read-only thereafter. It records stage counts and which stages to test.
+	var discovery struct {
+		syncutil.Mutex
+		counted                      bool
+		postCommitCount              int
+		postCommitNonRevertibleCount int
+		stagesToTest                 []backupKey
+	}
+
+	// scenario tracks the currently-executing rollback scenario (phase 2).
+	// It is reset before each iteration and read by the BeforeStage hook.
+	var scenario struct {
+		syncutil.Mutex
+		active      bool
+		key         backupKey
+		dbName      string
+		urls        []string
+		urlsSamples map[string]struct{}
+	}
+
+	// Create knobs that handle both discovery and rollback phases.
+	knobs := &scexec.TestingKnobs{
+		BeforeStage: func(p scplan.Plan, stageIdx int) error {
+			// Count stages on first plan encounter (discovery phase).
+			func() {
+				discovery.Lock()
+				defer discovery.Unlock()
+				if !discovery.counted {
+					discovery.counted = true
+					for _, s := range p.Stages {
+						switch s.Phase {
+						case scop.PostCommitPhase:
+							discovery.postCommitCount++
+							discovery.stagesToTest = append(discovery.stagesToTest, backupKey{
+								Phase:   s.Phase,
+								Ordinal: s.Ordinal,
+							})
+						case scop.PostCommitNonRevertiblePhase:
+							discovery.postCommitNonRevertibleCount++
+						}
+					}
+				}
+			}()
+
+			// Check if a rollback scenario is active and determine
+			// what action to take.
+			var shouldBackup bool
+			var backupStmt string
+			var shouldFail bool
+			var failOrdinal int
+			var activeKey backupKey
+
+			func() {
+				scenario.Lock()
+				defer scenario.Unlock()
+
+				if !scenario.active {
+					return
+				}
+				activeKey = scenario.key
+
+				// Inject failure at target stage.
+				if s := p.Stages[stageIdx]; s.Phase == activeKey.Phase && s.Ordinal == activeKey.Ordinal {
+					shouldFail = true
+					failOrdinal = activeKey.Ordinal
+					return
+				}
+
+				// Collect backups during rollback.
+				// Skip stage 0 (first rollback stage) because the schema changer state
+				// is identical to pre-rollback state due to how rollback initialization works.
+				// Restoring this backup wouldn't test anything meaningful.
+				if p.InRollback && stageIdx > 0 {
+					url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d_%d",
+						activeKey.Phase, activeKey.Ordinal, stageIdx)
+					if _, ok := scenario.urlsSamples[url]; !ok {
+						scenario.urlsSamples[url] = struct{}{}
+						scenario.urls = append(scenario.urls, url)
+						backupStmt = fmt.Sprintf("BACKUP DATABASE %s INTO '%s'", scenario.dbName, url)
+						shouldBackup = true
+					}
+				}
+			}()
+
+			if shouldFail {
+				return errors.Newf("boom %d", failOrdinal)
+			}
+			if shouldBackup {
+				_, err := args.server.DB.ExecContext(ctx, backupStmt)
+				if err != nil {
+					return errors.Wrapf(err, "backup during rollback (phase=%s, ordinal=%d, stage=%d)",
+						activeKey.Phase, activeKey.Ordinal, stageIdx)
+				}
+			}
+			return nil
+		},
+	}
+
+	// Create one long-lived cluster for discovery + all rollback scenarios.
+	args.server = factory.WithSchemaChangerKnobs(knobs).Start(ctx, t)
+	t.Cleanup(func() {
+		if args.server.Stopper != nil {
+			args.server.Stopper(t)
+		}
+	})
+	db := args.server.DB
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	// Create backups database for userfile before discovery.
+	tdb.Exec(t, "CREATE DATABASE backups")
+
+	// Phase 1: Discovery — run the schema change to completion to discover stages.
+	require.NoError(t, setupSchemaChange(ctx, t, spec, db))
+
+	// Skip test if it requires system tenant operations and we're running under a secondary tenant.
+	maybeSkipUnderSecondaryTenant(t, spec, args.server.Server)
+
+	require.NoError(t, executeSchemaChangeTxn(ctx, t, spec, db))
+
+	// Switch to system database before waiting for jobs if we might have dropped
+	// the current database. This prevents "database does not exist" errors.
+	for _, stmt := range spec.Stmts {
+		if stmt.AST.StatementTag() == "DROP DATABASE" {
+			tdb.Exec(t, "USE system")
+			break
+		}
+	}
+
+	waitForSchemaChangesToFinish(t, tdb)
+
+	// Discover the database name and CREATE DATABASE statement.
+	// Some tests create a separate database (e.g. "db"), others use defaultdb.
+	rows := tdb.QueryStr(t, "SELECT database_name FROM [SHOW DATABASES] WHERE database_name NOT IN ('system', 'postgres', 'defaultdb', 'backups')")
+	dbName := "defaultdb"
+	var createDatabaseStmt string
+	if len(rows) > 0 {
+		dbName = rows[0][0]
+	}
+	res := tdb.QueryStr(t, fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE DATABASE %q]", dbName))
+	if len(res) > 0 {
+		createDatabaseStmt = res[0][0]
+	}
+
+	// Phase 2: Run each rollback scenario by dropping and recreating the database.
+	// Discovery is complete, so stagesToTest is read-only from here on.
+	var stagesToTest []backupKey
+	func() {
+		discovery.Lock()
+		defer discovery.Unlock()
+		stagesToTest = append([]backupKey{}, discovery.stagesToTest...)
+	}()
+
+	for _, key := range stagesToTest {
+		// Switch to system database before dropping the test database.
+		tdb.Exec(t, "USE system")
+
+		// Reset use_declarative_schema_changer on all pool connections.
+		// executeSchemaChangeTxn sets 'unsafe_always' which persists on returned
+		// pool connections and breaks setupSchemaChange's CREATE TABLE.
+		tdb.Exec(t, "SET use_declarative_schema_changer = 'on'")
+
+		// Drop the database from the previous iteration and let setupSchemaChange recreate it.
+		tdb.Exec(t, fmt.Sprintf("DROP DATABASE IF EXISTS %q CASCADE", dbName))
+
+		// Re-run setup from scratch.
+		require.NoError(t, setupSchemaChange(ctx, t, spec, db))
+
+		tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
+
+		// Capture expected state before schema change.
+		expected := parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
+
+		// Store the highest job ID to track relevant jobs.
+		var maxJobID int64
+		tdb.QueryRow(t, "SELECT COALESCE(max(job_id), 0) FROM [SHOW JOBS]").Scan(&maxJobID)
+
+		// Activate this scenario in the knobs.
+		func() {
+			scenario.Lock()
+			defer scenario.Unlock()
+			scenario.key = key
+			scenario.dbName = dbName
+			scenario.urls = nil
+			scenario.urlsSamples = make(map[string]struct{})
+			scenario.active = true
+		}()
+
+		// Execute schema change with failure injection.
+		require.Regexp(t, fmt.Sprintf("boom %d", key.Ordinal),
+			executeSchemaChangeTxn(ctx, t, spec, db))
+
+		// Switch to system database before waiting for rollback if we might have
+		// dropped the current database. This prevents "database does not exist" errors.
+		for _, stmt := range spec.Stmts {
+			if stmt.AST.StatementTag() == "DROP DATABASE" {
+				tdb.Exec(t, "USE system")
+				break
+			}
+		}
+
+		// Wait for rollback to complete.
+		waitForSchemaChangesToFinish(t, tdb)
+
+		// Deactivate scenario and collect URLs.
+		var urls []string
+		func() {
+			scenario.Lock()
+			defer scenario.Unlock()
+			scenario.active = false
+			urls = append([]string{}, scenario.urls...)
+		}()
+
+		// Verify rollback was successful.
+		succeeded, jobExists := hasLatestSchemaChangeSucceededWithMaxJobID(t, tdb, maxJobID)
+		require.False(t, succeeded && jobExists)
+
+		// Fetch state after rollback and verify it matches expected.
+		tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
+		postRollback := parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
+		require.Equal(t, expected, postRollback, "rolled back schema change should be no-op")
+
+		// Store scenario for later test execution.
+		args.scenarios[key] = rollbackScenario{
+			databaseName: dbName,
+			urls:         urls,
+			expected:     postRollback,
+		}
+	}
+
+	// Discovery is complete; extract final counts.
+	var postCommitCount, postCommitNonRevertibleCount int
+	func() {
+		discovery.Lock()
+		defer discovery.Unlock()
+		postCommitCount = discovery.postCommitCount
+		postCommitNonRevertibleCount = discovery.postCommitNonRevertibleCount
+	}()
+
+	return PrepResult{
+		PostCommitCount:              postCommitCount,
+		PostCommitNonRevertibleCount: postCommitNonRevertibleCount,
+		DatabaseName:                 dbName,
+		CreateDatabaseStmt:           createDatabaseStmt,
+		PrepData:                     args,
+	}
 }
 
 // backupSuccess executes cumulative tests against an existing server containing
@@ -375,133 +793,59 @@ func backupSuccess(t *testing.T, args backupSuccessTestArgs, cs CumulativeTestCa
 }
 
 func backupRollbacks(
-	t *testing.T, factory TestServerFactory, cs CumulativeTestCaseSpec, isMixedVersion bool,
+	t *testing.T, args backupRollbacksTestArgs, cs CumulativeTestCaseSpec, isMixedVersion bool,
 ) {
 	if cs.Phase != scop.PostCommitPhase {
 		return
 	}
+
+	// TODO(msbutler): perhaps we can remove this, now that we're not creating a
+	// cluster for every rollback.
 	maybeRandomlySkip(t)
-	ctx := context.Background()
-	var mu struct {
-		syncutil.Mutex
-		urls        []string
-		urlsSamples map[string]struct{}
+
+	key := backupKey{Phase: cs.Phase, Ordinal: cs.StageOrdinal}
+	scenario, ok := args.scenarios[key]
+	if !ok {
+		skip.IgnoreLintf(t, "no rollback scenario for %v", key)
 	}
-	mu.urlsSamples = make(map[string]struct{})
-	var dbForBackup atomic.Pointer[gosql.DB]
-	pe := MakePlanExplainer()
-	var knobEnabled atomic.Bool
-	knobs := &scexec.TestingKnobs{
-		// Inject an error when reaching the stage prescribed by the test case
-		// specification. This will trigger a rollback.
-		// Before each stage during the rollback, back up the database.
-		BeforeStage: func(p scplan.Plan, stageIdx int) error {
-			// Only enabled after setup.
-			if !knobEnabled.Load() {
-				return nil
-			}
-			// Collect EXPLAIN (DDL) diagram for debug purposes.
-			if err := pe.MaybeUpdateWithPlan(p); err != nil {
-				return err
-			}
-			// Since this callback is also active during post-RESTORE
-			// schema changes, we have to be careful to exit early in those cases.
-			if dbForBackup.Load() == nil {
-				return nil
-			}
-			if p.InRollback {
-				// Discard the first backup, which is going to be the backup taken
-				// right at the very beginning of the rollback. Due to various quirks,
-				// the declarative schema changer state in that backup is going to be
-				// exactly the same as the state pre-rollback.
-				//
-				// This doesn't matter in production, as whichever error triggered the
-				// rollback in the first place will simply manifest itself again during
-				// the post-RESTORE schema change and roll it back.
-				if stageIdx == 0 {
-					return nil
-				}
-				url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d_%d",
-					cs.Phase, cs.StageOrdinal, stageIdx)
-				mu.Lock()
-				defer mu.Unlock()
-				// De-duplicated URLs that occur due to retries.
-				if _, ok := mu.urlsSamples[url]; ok {
-					return nil
-				}
-				mu.urlsSamples[url] = struct{}{}
-				mu.urls = append(mu.urls, url)
-				backupStmt := fmt.Sprintf("BACKUP DATABASE %s INTO '%s'", cs.DatabaseName, url)
-				_, err := dbForBackup.Load().ExecContext(ctx, backupStmt)
-				return err
-			}
-			if s := p.Stages[stageIdx]; s.Phase == cs.Phase && s.Ordinal == cs.StageOrdinal {
-				return errors.Newf("boom %d", cs.StageOrdinal)
-			}
-			return nil
-		},
-	}
-	runfn := func(s serverutils.TestServerInterface, db *gosql.DB) {
-		_, err := db.Exec("SET create_table_with_schema_locked = 'off'")
-		require.NoError(t, err)
-		dbForBackup.Store(db)
-		tdb := sqlutils.MakeSQLRunner(db)
-		// Setup the test cluster.
-		tdb.Exec(t, "CREATE DATABASE backups")
-		require.NoError(t, setupSchemaChange(ctx, t, cs.CumulativeTestSpec, db))
-		knobEnabled.Swap(true)
 
-		// Fetch the state of the cluster before the schema change kicks off.
-		tdb.Exec(t, fmt.Sprintf("USE %q", cs.DatabaseName))
-		expected := parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
-		// Store the highest job ID, so we know which jobs are relevant.
-		jobID := tdb.QueryRow(t, "SELECT COALESCE(max(job_id), 0) FROM [SHOW JOBS]")
-		var maxJobID int64
-		jobID.Scan(&maxJobID)
-		// Kick off the schema change, fail it at the prescribed stage,
-		// and perform the backups during the rollback via the BeforeStage hook.
-		require.Regexp(t, fmt.Sprintf("boom %d", cs.StageOrdinal),
-			executeSchemaChangeTxn(ctx, t, cs.CumulativeTestSpec, db))
-		waitForSchemaChangesToFinish(t, tdb)
-		dbForBackup.Store(nil)
+	tdb := sqlutils.MakeSQLRunner(args.server.DB)
 
-		// Fetch the state of the cluster after the schema change rolls back.
-		// Note: Depending on the state of the schema objects, no job may be created
-		// to finalize the rollback, since dependent objects were never backed
-		// up.
-		succeeded, jobExists := hasLatestSchemaChangeSucceededWithMaxJobID(t, tdb, maxJobID)
-		require.False(t, succeeded && jobExists)
-		tdb.Exec(t, fmt.Sprintf("USE %q", cs.DatabaseName))
-		postRollback := parserRoundTrip(t, tdb.QueryStr(t, fetchDescriptorStateQuery))
-
-		// Check that it's the same as before the schema change was attempted.
-		require.Equal(t, expected, postRollback, "rolled back schema change should be no-op")
-		isMultiRegion := false
-		tdb.QueryRow(t, "SELECT count(*) >1  FROM [SHOW REGIONS]").Scan(&isMultiRegion)
-
-		// Restore the backups of the database taken mid-rolled-back-schema-change
-		// in various ways, check that they end up in the same state as present.
-		urls := func() []string {
-			mu.Lock()
-			defer mu.Unlock()
-			return append([]string{}, mu.urls...)
-		}()
-		for i, url := range urls {
-			b := backupRestoreOutcome{
-				url:                url,
-				mayRollback:        true,
-				expectedOnRollback: postRollback,
-				// Speed up multi-region or mixed version variants by excluding
-				// individual table restores, due to the slower speed due to multiple nodes.
-				excludeAllTablesInDatabaseFlavor: isMultiRegion || isMixedVersion,
-			}
-			name := fmt.Sprintf("post_%d_rollback_stages_exec", i+1)
-			t.Run(name, func(t *testing.T) {
-				exerciseBackupRestore(t, tdb, cs, b, pe)
-			})
+	// Upgrade cluster if mixed version.
+	if isMixedVersion {
+		if args.server.Server.StartedDefaultTestTenant() {
+			sysDB := args.server.Server.SystemLayer().SQLConn(t)
+			_, err := sysDB.Exec("SET CLUSTER SETTING VERSION = $1", clusterversion.Latest.String())
+			require.NoError(t, err)
 		}
+		tdb.Exec(t, "SET CLUSTER SETTING VERSION = $1", clusterversion.Latest.String())
 	}
-	factory.WithSchemaChangerKnobs(knobs).Run(ctx, t, runfn)
+
+	// Switch to system database which always exists (prior restore tests may
+	// have dropped the test database).
+	tdb.Exec(t, "USE system")
+
+	// Check if multi-region for test optimization.
+	isMultiRegion := false
+	tdb.QueryRow(t, "SELECT count(*) >1 FROM [SHOW REGIONS]").Scan(&isMultiRegion)
+
+	pe := MakePlanExplainer()
+
+	// Test each backup from this rollback scenario.
+	for i, url := range scenario.urls {
+		b := backupRestoreOutcome{
+			url:                url,
+			mayRollback:        true,
+			expectedOnRollback: scenario.expected,
+			// Speed up multi-region or mixed version variants by excluding
+			// individual table restores, due to the slower speed due to multiple nodes.
+			excludeAllTablesInDatabaseFlavor: isMultiRegion || isMixedVersion,
+		}
+		name := fmt.Sprintf("post_%d_rollback_stages_exec", i+1)
+		t.Run(name, func(t *testing.T) {
+			exerciseBackupRestore(t, tdb, cs, b, pe)
+		})
+	}
 }
 
 type backupRestoreOutcome struct {
@@ -602,7 +946,6 @@ func exerciseBackupRestore(
 			tdb.Exec(t, "SET use_declarative_schema_changer = 'off'")
 			tdb.Exec(t, fmt.Sprintf("DROP DATABASE IF EXISTS %q CASCADE", cs.DatabaseName))
 			if rc.restoreFlavor == restoreAllTablesInDatabase {
-				// Database must be created explicitly pre-RESTORE in this case.
 				tdb.Exec(t, cs.CreateDatabaseStmt)
 			}
 

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -118,7 +118,7 @@ func Rollback(t *testing.T, relPath string, factory TestServerFactory) {
 		}
 		factory.WithSchemaChangerKnobs(knobs).Run(ctx, t, runfn)
 	}
-	cumulativeTestForEachPostCommitStage(t, relPath, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+	cumulativeTestForEachPostCommitStage[struct{}](t, relPath, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, _ struct{}) {
 		testRollbackCase(t, cs)
 	}, sampleAllPostCommitRevertible /* enableSampling */)
 }
@@ -338,7 +338,7 @@ func Pause(t *testing.T, path string, factory TestServerFactory) {
 	skip.UnderRace(t)
 	skip.UnderDeadlock(t)
 
-	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+	cumulativeTestForEachPostCommitStage[struct{}](t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, _ struct{}) {
 		pause(t, factory, cs)
 	},
 		sampleAllPostCommitStages /* enableSampling */)
@@ -353,7 +353,7 @@ func PauseMixedVersion(t *testing.T, path string, factory TestServerFactory) {
 	skip.UnderDeadlock(t)
 
 	factory.WithMixedVersion()
-	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+	cumulativeTestForEachPostCommitStage[struct{}](t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, _ struct{}) {
 		pause(t, factory, cs)
 	},
 		sampleAllPostCommitStages /* enableSampling */)

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -118,7 +118,9 @@ func Rollback(t *testing.T, relPath string, factory TestServerFactory) {
 		}
 		factory.WithSchemaChangerKnobs(knobs).Run(ctx, t, runfn)
 	}
-	cumulativeTestForEachPostCommitStage(t, relPath, factory, nil, testRollbackCase, sampleAllPostCommitRevertible /* enableSampling */)
+	cumulativeTestForEachPostCommitStage(t, relPath, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
+		testRollbackCase(t, cs)
+	}, sampleAllPostCommitRevertible /* enableSampling */)
 }
 
 // ExecuteWithDMLInjection tests that the schema changer behaviour is sane
@@ -336,7 +338,7 @@ func Pause(t *testing.T, path string, factory TestServerFactory) {
 	skip.UnderRace(t)
 	skip.UnderDeadlock(t)
 
-	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
+	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
 		pause(t, factory, cs)
 	},
 		sampleAllPostCommitStages /* enableSampling */)
@@ -351,7 +353,7 @@ func PauseMixedVersion(t *testing.T, path string, factory TestServerFactory) {
 	skip.UnderDeadlock(t)
 
 	factory.WithMixedVersion()
-	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
+	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec, prepData interface{}) {
 		pause(t, factory, cs)
 	},
 		sampleAllPostCommitStages /* enableSampling */)

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -687,7 +687,7 @@ var runAllCumulative = flag.Bool(
 // PrepResult contains the results from the prepare phase of backup tests.
 // It provides stage counts and metadata needed to build test cases, along with
 // variant-specific data to be passed to each test case.
-type PrepResult struct {
+type PrepResult[T any] struct {
 	// PostCommitCount is the number of PostCommit stages.
 	PostCommitCount int
 	// PostCommitNonRevertibleCount is the number of PostCommitNonRevertible stages.
@@ -699,22 +699,17 @@ type PrepResult struct {
 	// CreateDatabaseStmt is the CREATE DATABASE statement for this database.
 	CreateDatabaseStmt string
 	// PrepData is variant-specific data to pass to test cases.
-	// Type depends on the prepare function:
-	//   - backupSuccessPrepare: backupSuccessTestArgs
-	//   - backupRollbacksPrepare: backupRollbacksTestArgs
-	// Test functions must type-assert to the expected type. The use of interface{}
-	// provides flexibility for different test variants without requiring generics.
-	PrepData interface{}
+	PrepData T
 }
 
 // CumulativeTestPrepareFunc prepares the test environment and returns metadata
 // needed for cumulative tests. It is called once per test spec to determine
 // the number of post-commit stages and collect variant-specific test data.
-type CumulativeTestPrepareFunc func(t *testing.T, spec CumulativeTestSpec) PrepResult
+type CumulativeTestPrepareFunc[T any] func(t *testing.T, spec CumulativeTestSpec) PrepResult[T]
 
 // CumulativeTestStageFunc is the test function executed for each post-commit
 // stage.
-type CumulativeTestStageFunc func(t *testing.T, spec CumulativeTestCaseSpec, prepData interface{})
+type CumulativeTestStageFunc[T any] func(t *testing.T, spec CumulativeTestCaseSpec, prepData T)
 
 // CumulativeTestSamplingFunc optionally filters or samples the generated test
 // cases to reduce the number of stages executed.
@@ -722,12 +717,12 @@ type CumulativeTestSamplingFunc func([]CumulativeTestCaseSpec) []CumulativeTestC
 
 // cumulativeTestForEachPostCommitStage invokes `tf` once for each stage in the
 // PostCommitPhase.
-func cumulativeTestForEachPostCommitStage(
+func cumulativeTestForEachPostCommitStage[T any](
 	t *testing.T,
 	relTestCaseDir string,
 	factory TestServerFactory,
-	prepFn CumulativeTestPrepareFunc,
-	tf CumulativeTestStageFunc,
+	prepFn CumulativeTestPrepareFunc[T],
+	tf CumulativeTestStageFunc[T],
 	samplingFn CumulativeTestSamplingFunc,
 ) {
 	testFunc := func(t *testing.T, spec CumulativeTestSpec) {
@@ -738,12 +733,12 @@ func cumulativeTestForEachPostCommitStage(
 
 		// Call prepare function to get stage counts and test data.
 		// This eliminates the need for a throwaway cluster.
-		var result PrepResult
+		var result PrepResult[T]
 		if prepFn != nil {
 			result = prepFn(t, spec)
 		} else {
 			// If no prepFn provided, fall back to old behavior of creating throwaway cluster.
-			result = legacyPrepareWithThrowawayCluster(t, spec, factory)
+			result = legacyPrepareWithThrowawayCluster[T](t, spec, factory)
 		}
 
 		if result.PostCommitCount+result.PostCommitNonRevertibleCount == 0 {
@@ -814,10 +809,10 @@ func cumulativeTestForEachPostCommitStage(
 // These should be migrated to provide their own prepare functions that reuse
 // a single cluster, similar to how backup tests (BackupSuccess*, BackupRollbacks*)
 // have been migrated.
-func legacyPrepareWithThrowawayCluster(
+func legacyPrepareWithThrowawayCluster[T any](
 	t *testing.T, spec CumulativeTestSpec, factory TestServerFactory,
-) PrepResult {
-	var result PrepResult
+) PrepResult[T] {
+	var result PrepResult[T]
 	prepfn := func(db *gosql.DB, p scplan.Plan) {
 		for _, s := range p.Stages {
 			switch s.Phase {

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -850,10 +850,10 @@ SELECT
 		ELSE create_statement
 	END AS create_statement
 FROM
-	( 
+	(
 		SELECT descriptor_id, create_statement, false AS needs_split FROM crdb_internal.create_schema_statements
 		UNION ALL SELECT descriptor_id, create_statement, true AS needs_split FROM crdb_internal.create_statements
-		UNION ALL SELECT descriptor_id, create_statement, false AS needs_split FROM crdb_internal.create_type_statements
+		UNION ALL SELECT descriptor_id, create_statement, true AS needs_split FROM crdb_internal.create_type_statements
     UNION ALL SELECT function_id as descriptor_id, create_statement, false AS needs_split FROM crdb_internal.create_function_statements
 	)
 WHERE descriptor_id IN (

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -684,87 +684,110 @@ var runAllCumulative = flag.Bool(
 	"if true, run all cumulative instead of a random subset",
 )
 
+// PrepResult contains the results from the prepare phase of backup tests.
+// It provides stage counts and metadata needed to build test cases, along with
+// variant-specific data to be passed to each test case.
+type PrepResult struct {
+	// PostCommitCount is the number of PostCommit stages.
+	PostCommitCount int
+	// PostCommitNonRevertibleCount is the number of PostCommitNonRevertible stages.
+	PostCommitNonRevertibleCount int
+	// After is the expected descriptor state after schema change completion.
+	After [][]string
+	// DatabaseName is the database containing the schema change.
+	DatabaseName string
+	// CreateDatabaseStmt is the CREATE DATABASE statement for this database.
+	CreateDatabaseStmt string
+	// PrepData is variant-specific data to pass to test cases.
+	// Type depends on the prepare function:
+	//   - backupSuccessPrepare: backupSuccessTestArgs
+	//   - backupRollbacksPrepare: backupRollbacksTestArgs
+	// Test functions must type-assert to the expected type. The use of interface{}
+	// provides flexibility for different test variants without requiring generics.
+	PrepData interface{}
+}
+
+// CumulativeTestPrepareFunc prepares the test environment and returns metadata
+// needed for cumulative tests. It is called once per test spec to determine
+// the number of post-commit stages and collect variant-specific test data.
+type CumulativeTestPrepareFunc func(t *testing.T, spec CumulativeTestSpec) PrepResult
+
+// CumulativeTestStageFunc is the test function executed for each post-commit
+// stage.
+type CumulativeTestStageFunc func(t *testing.T, spec CumulativeTestCaseSpec, prepData interface{})
+
+// CumulativeTestSamplingFunc optionally filters or samples the generated test
+// cases to reduce the number of stages executed.
+type CumulativeTestSamplingFunc func([]CumulativeTestCaseSpec) []CumulativeTestCaseSpec
+
 // cumulativeTestForEachPostCommitStage invokes `tf` once for each stage in the
 // PostCommitPhase.
 func cumulativeTestForEachPostCommitStage(
 	t *testing.T,
 	relTestCaseDir string,
 	factory TestServerFactory,
-	prepFn func(t *testing.T, spec CumulativeTestSpec, dbName string),
-	tf func(t *testing.T, spec CumulativeTestCaseSpec),
-	samplingFn func([]CumulativeTestCaseSpec) []CumulativeTestCaseSpec,
+	prepFn CumulativeTestPrepareFunc,
+	tf CumulativeTestStageFunc,
+	samplingFn CumulativeTestSamplingFunc,
 ) {
 	testFunc := func(t *testing.T, spec CumulativeTestSpec) {
 		// Skip this test if any of the stmts is not fully supported.
 		if err := areStmtsFullySupportedAtClusterVersion(t, spec, factory); err != nil {
 			skip.IgnoreLint(t, "test is skipped because", err.Error())
 		}
-		var postCommitCount, postCommitNonRevertibleCount int
-		var after [][]string
-		var dbName string
-		var createDatabaseStmt string
-		prepfn := func(db *gosql.DB, p scplan.Plan) {
-			for _, s := range p.Stages {
-				switch s.Phase {
-				case scop.PostCommitPhase:
-					postCommitCount++
-				case scop.PostCommitNonRevertiblePhase:
-					postCommitNonRevertibleCount++
-				}
-			}
-			tdb := sqlutils.MakeSQLRunner(db)
-			var ok bool
-			dbName, ok = maybeGetDatabaseForIDs(t, tdb, screl.AllTargetStateDescIDs(p.TargetState))
-			if ok {
-				tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
-				res := tdb.QueryStr(t, fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE DATABASE %q]", dbName))
-				createDatabaseStmt = res[0][0]
-			}
-			after = tdb.QueryStr(t, fetchDescriptorStateQuery)
+
+		// Call prepare function to get stage counts and test data.
+		// This eliminates the need for a throwaway cluster.
+		var result PrepResult
+		if prepFn != nil {
+			result = prepFn(t, spec)
+		} else {
+			// If no prepFn provided, fall back to old behavior of creating throwaway cluster.
+			result = legacyPrepareWithThrowawayCluster(t, spec, factory)
 		}
-		withPostCommitPlanAfterSchemaChange(t, spec, factory, prepfn)
-		if postCommitCount+postCommitNonRevertibleCount == 0 {
+
+		if result.PostCommitCount+result.PostCommitNonRevertibleCount == 0 {
 			skip.IgnoreLint(t, "test case has no post-commit stages")
 			return
 		}
-		if dbName == "" {
+		if result.DatabaseName == "" {
 			skip.IgnoreLint(t, "test case has no usable database")
 			return
 		}
+
+		// Build test cases from prepare result.
 		var testCases []CumulativeTestCaseSpec
-		for stageOrdinal := 1; stageOrdinal <= postCommitCount; stageOrdinal++ {
+		for stageOrdinal := 1; stageOrdinal <= result.PostCommitCount; stageOrdinal++ {
 			testCases = append(testCases, CumulativeTestCaseSpec{
 				CumulativeTestSpec: spec,
 				Phase:              scop.PostCommitPhase,
 				StageOrdinal:       stageOrdinal,
-				StagesCount:        postCommitCount,
-				After:              after,
-				DatabaseName:       dbName,
-				CreateDatabaseStmt: createDatabaseStmt,
+				StagesCount:        result.PostCommitCount,
+				After:              result.After,
+				DatabaseName:       result.DatabaseName,
+				CreateDatabaseStmt: result.CreateDatabaseStmt,
 			})
 		}
-		for stageOrdinal := 1; stageOrdinal <= postCommitNonRevertibleCount; stageOrdinal++ {
+		for stageOrdinal := 1; stageOrdinal <= result.PostCommitNonRevertibleCount; stageOrdinal++ {
 			testCases = append(testCases, CumulativeTestCaseSpec{
 				CumulativeTestSpec: spec,
 				Phase:              scop.PostCommitNonRevertiblePhase,
 				StageOrdinal:       stageOrdinal,
-				StagesCount:        postCommitNonRevertibleCount,
-				After:              after,
-				DatabaseName:       dbName,
-				CreateDatabaseStmt: createDatabaseStmt,
+				StagesCount:        result.PostCommitNonRevertibleCount,
+				After:              result.After,
+				DatabaseName:       result.DatabaseName,
+				CreateDatabaseStmt: result.CreateDatabaseStmt,
 			})
-		}
-		var hasFailed bool
-		if prepFn != nil {
-			prepFn(t, spec, dbName)
 		}
 		// If sampling is enabled limit the number of stages executed.
 		if samplingFn != nil {
 			testCases = samplingFn(testCases)
 		}
+
+		var hasFailed bool
 		for _, tc := range testCases {
 			fn := func(t *testing.T) {
-				tf(t, tc)
+				tf(t, tc, result.PrepData)
 			}
 			if hasFailed {
 				fn = func(t *testing.T) {
@@ -777,6 +800,45 @@ func cumulativeTestForEachPostCommitStage(
 		}
 	}
 	cumulativeTest(t, relTestCaseDir, testFunc)
+}
+
+// legacyPrepareWithThrowawayCluster is a fallback for tests that haven't been
+// migrated to the new PrepResult pattern. It creates a throwaway cluster just
+// to count stages, matching the old behavior.
+//
+// Tests still using this legacy path (passing nil prepFn):
+//   - Rollback
+//   - Pause
+//   - PauseMixedVersion
+//
+// These should be migrated to provide their own prepare functions that reuse
+// a single cluster, similar to how backup tests (BackupSuccess*, BackupRollbacks*)
+// have been migrated.
+func legacyPrepareWithThrowawayCluster(
+	t *testing.T, spec CumulativeTestSpec, factory TestServerFactory,
+) PrepResult {
+	var result PrepResult
+	prepfn := func(db *gosql.DB, p scplan.Plan) {
+		for _, s := range p.Stages {
+			switch s.Phase {
+			case scop.PostCommitPhase:
+				result.PostCommitCount++
+			case scop.PostCommitNonRevertiblePhase:
+				result.PostCommitNonRevertibleCount++
+			}
+		}
+		tdb := sqlutils.MakeSQLRunner(db)
+		var ok bool
+		result.DatabaseName, ok = maybeGetDatabaseForIDs(t, tdb, screl.AllTargetStateDescIDs(p.TargetState))
+		if ok {
+			tdb.Exec(t, fmt.Sprintf("USE %q", result.DatabaseName))
+			res := tdb.QueryStr(t, fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE DATABASE %q]", result.DatabaseName))
+			result.CreateDatabaseStmt = res[0][0]
+		}
+		result.After = tdb.QueryStr(t, fetchDescriptorStateQuery)
+	}
+	withPostCommitPlanAfterSchemaChange(t, spec, factory, prepfn)
+	return result
 }
 
 // fetchDescriptorStateQuery returns the CREATE statements for all descriptors


### PR DESCRIPTION
Previously, the schema changer backup tests created multiple
clusters per test spec file:
- BackupSuccess/BackupSuccessMixedVersion: 2 clusters each
- BackupRollbacks/BackupRollbacksMixedVersion: ~N+1 clusters each
  (where N = number of post-commit stages)

This was expensive and dominated test runtime for schema changes with
many post-commit stages.

This commit refactors all four backup test variants to use a single
cluster per test spec file. BackupSuccess variants eliminate the
throwaway cluster by counting stages on the real test cluster.
BackupRollbacks variants run all rollback scenarios sequentially on
one cluster by dropping and recreating the test database between
scenarios.

For the 121 test specs with typical schema changes (~9 post-commit
stages), this reduces total cluster creation from ~2,904 to 484:
- Before: 2,904 clusters (242 + 242 + 1,210 + 1,210)
- After:  484 clusters (121 + 121 + 121 + 121)
- Reduction: 83%

NB: this analysis assumes every rollback test is run, but in reality some
follback tests are skipped if the schema change as no post commit phase.

Potential next steps:
- skip initial cluster creation all together on rollback tests that have no
  post commit phase.
- apply this logic to Rollback, Pause, and PauseMixedVersion drivers.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>