### PR TITLE
sql/schemachanger: dispatch `ALTER DOMAIN` statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_domain
+++ b/pkg/sql/logictest/testdata/logic_test/alter_domain
@@ -1,0 +1,133 @@
+# LogicTest: local
+
+# Test ALTER DOMAIN syntax. All operations currently return unimplemented
+# errors, but the grammar should parse correctly and dispatch through the
+# declarative schema changer.
+
+statement ok
+CREATE DOMAIN d AS INT DEFAULT 0 NOT NULL CHECK (VALUE > 0)
+
+subtest set_default
+
+statement error pgcode 0A000 ALTER DOMAIN SET DEFAULT is not supported
+ALTER DOMAIN d SET DEFAULT 42
+
+statement error pgcode 0A000 ALTER DOMAIN SET DEFAULT is not supported
+ALTER DOMAIN d SET DEFAULT 1 + 2
+
+subtest end
+
+subtest drop_default
+
+statement error pgcode 0A000 ALTER DOMAIN DROP DEFAULT is not supported
+ALTER DOMAIN d DROP DEFAULT
+
+subtest end
+
+subtest set_not_null
+
+statement error pgcode 0A000 ALTER DOMAIN SET NOT NULL is not supported
+ALTER DOMAIN d SET NOT NULL
+
+subtest end
+
+subtest drop_not_null
+
+statement error pgcode 0A000 ALTER DOMAIN DROP NOT NULL is not supported
+ALTER DOMAIN d DROP NOT NULL
+
+subtest end
+
+subtest add_constraint
+
+statement error pgcode 0A000 ALTER DOMAIN ADD CHECK CONSTRAINT is not supported
+ALTER DOMAIN d ADD CHECK (VALUE < 100)
+
+statement error pgcode 0A000 ALTER DOMAIN ADD CHECK CONSTRAINT is not supported
+ALTER DOMAIN d ADD CONSTRAINT positive CHECK (VALUE > 0)
+
+statement error pgcode 0A000 ALTER DOMAIN ADD CHECK CONSTRAINT is not supported
+ALTER DOMAIN d ADD CONSTRAINT bounded CHECK (VALUE < 100) NOT VALID
+
+statement error pgcode 0A000 ALTER DOMAIN ADD NOT NULL CONSTRAINT is not supported
+ALTER DOMAIN d ADD NOT NULL
+
+statement error pgcode 0A000 ALTER DOMAIN ADD NOT NULL CONSTRAINT is not supported
+ALTER DOMAIN d ADD CONSTRAINT nn NOT NULL
+
+subtest end
+
+subtest drop_constraint
+
+statement error pgcode 0A000 ALTER DOMAIN DROP CONSTRAINT is not supported
+ALTER DOMAIN d DROP CONSTRAINT positive
+
+statement error pgcode 0A000 ALTER DOMAIN DROP CONSTRAINT is not supported
+ALTER DOMAIN d DROP CONSTRAINT IF EXISTS positive
+
+subtest end
+
+subtest rename_constraint
+
+statement error pgcode 0A000 ALTER DOMAIN RENAME CONSTRAINT is not supported
+ALTER DOMAIN d RENAME CONSTRAINT positive TO nonneg
+
+subtest end
+
+subtest validate_constraint
+
+statement error pgcode 0A000 ALTER DOMAIN VALIDATE CONSTRAINT is not supported
+ALTER DOMAIN d VALIDATE CONSTRAINT positive
+
+subtest end
+
+subtest owner_to
+
+statement error pgcode 0A000 ALTER DOMAIN OWNER TO is not supported
+ALTER DOMAIN d OWNER TO testuser
+
+subtest end
+
+subtest rename_to
+
+statement error pgcode 0A000 ALTER DOMAIN RENAME TO is not supported
+ALTER DOMAIN d RENAME TO d2
+
+subtest end
+
+subtest set_schema
+
+statement error pgcode 0A000 ALTER DOMAIN SET SCHEMA is not supported
+ALTER DOMAIN d SET SCHEMA public
+
+subtest end
+
+subtest nonexistent_domain
+
+statement error pgcode 42704 type "nonexistent" does not exist
+ALTER DOMAIN nonexistent SET DEFAULT 1
+
+subtest end
+
+subtest non_domain_type
+
+statement ok
+CREATE TYPE e AS ENUM ('a', 'b')
+
+statement error pgcode 42809 "e" is not a domain
+ALTER DOMAIN e SET DEFAULT 1
+
+subtest end
+
+subtest schema_qualified
+
+statement ok
+CREATE SCHEMA s
+
+statement ok
+CREATE DOMAIN s.d_qual AS INT
+
+statement error pgcode 0A000 ALTER DOMAIN SET DEFAULT is not supported
+ALTER DOMAIN s.d_qual SET DEFAULT 1
+
+subtest end

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -162,6 +162,13 @@ func TestLogic_alter_default_privileges_with_grant_option(
 	runLogicTest(t, "alter_default_privileges_with_grant_option")
 }
 
+func TestLogic_alter_domain(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "alter_domain")
+}
+
 func TestLogic_alter_external_connection(
 	t *testing.T,
 ) {

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -103,9 +103,7 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 	case *tree.AlterDefaultPrivileges:
 		return p.alterDefaultPrivileges(ctx, n)
 	case *tree.AlterDomain:
-		return nil, errors.WithHint(pgerror.New(pgcode.FeatureNotSupported,
-			"ALTER DOMAIN is not yet supported"),
-			"See: https://github.com/cockroachdb/cockroach/issues/27796")
+		return p.AlterDomain(ctx, n)
 	case *tree.AlterExternalConnection:
 		return p.AlterExternalConnection(ctx, n)
 	case *tree.AlterResourceGroup:

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -4,6 +4,7 @@ load("//pkg/testutils:buildutil/buildutil.bzl", "disallowed_imports_test")
 go_library(
     name = "scbuildstmt",
     srcs = [
+        "alter_domain.go",
         "alter_policy.go",
         "alter_sequence.go",
         "alter_table.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
@@ -1,0 +1,182 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/errors"
+)
+
+type supportedAlterDomainCommand = supportedStatement
+
+// supportedAlterDomainStatements tracks alter domain operations fully supported
+// by the declarative schema changer. Operations marked as non-fully supported
+// can only be used with the use_declarative_schema_changer session variable.
+var supportedAlterDomainStatements = map[reflect.Type]supportedAlterDomainCommand{
+	reflect.TypeOf((*tree.AlterDomainSetDefault)(nil)):           {fn: alterDomainSetDefault, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainDropDefault)(nil)):          {fn: alterDomainDropDefault, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainSetNotNull)(nil)):           {fn: alterDomainSetNotNull, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainDropNotNull)(nil)):          {fn: alterDomainDropNotNull, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainAddCheckConstraint)(nil)):   {fn: alterDomainAddCheckConstraint, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainAddNotNullConstraint)(nil)): {fn: alterDomainAddNotNullConstraint, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainDropConstraint)(nil)):       {fn: alterDomainDropConstraint, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainRenameConstraint)(nil)):     {fn: alterDomainRenameConstraint, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainValidateConstraint)(nil)):   {fn: alterDomainValidateConstraint, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainOwner)(nil)):                {fn: alterDomainOwner, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainRename)(nil)):               {fn: alterDomainRename, on: true, checks: isV263Active},
+	reflect.TypeOf((*tree.AlterDomainSetSchema)(nil)):            {fn: alterDomainSetSchema, on: true, checks: isV263Active},
+}
+
+func init() {
+	// Check function signatures inside the supportedAlterDomainStatements map.
+	for statementType, statementEntry := range supportedAlterDomainStatements {
+		callBackType := reflect.TypeOf(statementEntry.fn)
+		if callBackType.Kind() != reflect.Func {
+			panic(errors.AssertionFailedf("%v entry for statement is "+
+				"not a function", statementType))
+		}
+		if callBackType.NumIn() != 4 ||
+			!callBackType.In(0).Implements(reflect.TypeOf((*BuildCtx)(nil)).Elem()) ||
+			callBackType.In(1) != reflect.TypeOf((*tree.TypeName)(nil)) ||
+			callBackType.In(2) != reflect.TypeOf((*scpb.DomainType)(nil)) ||
+			callBackType.In(3) != statementType {
+			panic(errors.AssertionFailedf("%v entry for alter domain statement "+
+				"does not have a valid signature; got %v", statementType, callBackType))
+		}
+		if statementEntry.checks != nil {
+			if _, ok := statementEntry.checks.(isVersionActiveFunc); !ok {
+				panic(errors.AssertionFailedf(
+					"%v checks is not an isVersionActiveFunc; got %T",
+					statementType, statementEntry.checks))
+			}
+		}
+	}
+}
+
+// alterDomainChecks determines if the alter domain command is supported.
+func alterDomainChecks(
+	n *tree.AlterDomain,
+	mode sessiondatapb.NewSchemaChangerMode,
+	activeVersion clusterversion.ClusterVersion,
+) bool {
+	return isFullySupportedWithFalsePositiveInternal(
+		supportedAlterDomainStatements,
+		reflect.TypeOf(n.Cmd), reflect.ValueOf(n.Cmd), mode, activeVersion,
+	)
+}
+
+// AlterDomain implements ALTER DOMAIN.
+func AlterDomain(b BuildCtx, n *tree.AlterDomain) {
+	elts := b.ResolveUserDefinedTypeType(n.Domain, ResolveParams{})
+
+	domainTypeElts := elts.FilterDomainType()
+	if domainTypeElts.IsEmpty() {
+		panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not a domain", n.Domain.Object()))
+	}
+	domainType := domainTypeElts.MustGetOneElement()
+	domainTypeElts.ForEach(func(_ scpb.Status, target scpb.TargetStatus, _ *scpb.DomainType) {
+		if target != scpb.ToPublic {
+			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"domain %q is being dropped, try again later", n.Domain.Object()))
+		}
+	})
+
+	tn := n.Domain.ToTypeName()
+	tn.ObjectNamePrefix = b.NamePrefix(domainType)
+	b.SetUnresolvedNameAnnotation(n.Domain, &tn)
+	b.IncrementSchemaChangeAlterCounter("domain", n.Cmd.TelemetryName())
+
+	info := supportedAlterDomainStatements[reflect.TypeOf(n.Cmd)]
+	fn := reflect.ValueOf(info.fn)
+	fn.Call([]reflect.Value{
+		reflect.ValueOf(b),
+		reflect.ValueOf(&tn),
+		reflect.ValueOf(domainType),
+		reflect.ValueOf(n.Cmd),
+	})
+}
+
+func alterDomainSetDefault(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainSetDefault,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN SET DEFAULT is not supported"))
+}
+
+func alterDomainDropDefault(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainDropDefault,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN DROP DEFAULT is not supported"))
+}
+
+func alterDomainSetNotNull(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainSetNotNull,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN SET NOT NULL is not supported"))
+}
+
+func alterDomainDropNotNull(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainDropNotNull,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN DROP NOT NULL is not supported"))
+}
+
+func alterDomainAddCheckConstraint(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainAddCheckConstraint,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN ADD CHECK CONSTRAINT is not supported"))
+}
+
+func alterDomainAddNotNullConstraint(
+	b BuildCtx,
+	tn *tree.TypeName,
+	domainType *scpb.DomainType,
+	t *tree.AlterDomainAddNotNullConstraint,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN ADD NOT NULL CONSTRAINT is not supported"))
+}
+
+func alterDomainDropConstraint(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainDropConstraint,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN DROP CONSTRAINT is not supported"))
+}
+
+func alterDomainRenameConstraint(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainRenameConstraint,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN RENAME CONSTRAINT is not supported"))
+}
+
+func alterDomainValidateConstraint(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainValidateConstraint,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN VALIDATE CONSTRAINT is not supported"))
+}
+
+func alterDomainOwner(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainOwner,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN OWNER TO is not supported"))
+}
+
+func alterDomainRename(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainRename,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN RENAME TO is not supported"))
+}
+
+func alterDomainSetSchema(
+	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainSetSchema,
+) {
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN SET SCHEMA is not supported"))
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -40,6 +40,7 @@ type supportedStatement struct {
 //
 // Please keep this list alphabetized for easier navigation.
 var supportedStatements = map[reflect.Type]supportedStatement{
+	reflect.TypeOf((*tree.AlterDomain)(nil)): {fn: AlterDomain, statementTags: []string{tree.AlterDomainTag}, on: true, checks: alterDomainChecks},
 	// Alter table will have commands individually whitelisted via the
 	// supportedAlterTableStatements list, so we will consider it fully supported
 	// here.

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_domain
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_domain
@@ -1,0 +1,3 @@
+setup
+CREATE DOMAIN defaultdb.d AS INT DEFAULT 0 NOT NULL CHECK (VALUE > 0);
+----

--- a/pkg/sql/unimplemented.go
+++ b/pkg/sql/unimplemented.go
@@ -20,6 +20,10 @@ import (
 // The below methods are ordered in alphabetical order. They represent statements
 // which are UNIMPLEMENTED for the legacy schema changer.
 
+func (p *planner) AlterDomain(ctx context.Context, n *tree.AlterDomain) (planNode, error) {
+	return nil, makeUnimplementedLegacyError("ALTER DOMAIN")
+}
+
 func (p *planner) AlterPolicy(ctx context.Context, n *tree.AlterPolicy) (planNode, error) {
 	return nil, makeUnimplementedLegacyError("ALTER POLICY")
 }


### PR DESCRIPTION
As they're implemented, the delegator wires the `ALTER DOMAIN`
subcommands to the schema changer.

Epic: CRDB-62146
Closes: #166934
Part of: #27796

Release note: None