### PR TITLE
workload: filter illegal column types from createFunction parameters

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4565,6 +4565,13 @@ FROM
 			continue
 		}
 
+		// Skip types that are not legal column types (e.g. aclitem, int2vector,
+		// oidvector, regproc, jsonpath) since they have strict format requirements
+		// or edge cases that make random generation unreliable.
+		if !randgen.IsLegalColumnType(typeVal) {
+			continue
+		}
+
 		if ltreeNotSupported &&
 			(typeVal.Oid() == oidext.T_ltree || typeVal.Oid() == oidext.T__ltree) {
 			continue


### PR DESCRIPTION
The `createFunction` method in the schemachange workload iterates over `randgen.SeedTypes` to build a pool of candidate parameter types for generated `CREATE FUNCTION` statements. Unlike `randType()`, which was fixed in #166750 to use `RandColumnType` (excluding types like `aclitem`), this code path had no such filtering. This caused `aclitem` parameters to appear in generated functions, which fail on v26.1 nodes during mixed-version testing since `aclitem` was introduced in v26.2.

Add an `IsLegalColumnType` check to the loop, filtering out `aclitem`, `int2vector`, `oidvector`, `regproc`, `regprocedure`, and `jsonpath` — all of which have strict format requirements or edge cases that make random generation unreliable.

Resolves: #166886

Release note: None