### PR TITLE
release-26.1: roachtest: limit schemachange/bulkingest to GCE only

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -342,7 +342,9 @@ func makeSchemaChangeBulkIngestTest(
 		Benchmark: true,
 		Cluster:   r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.Disks(4)),
 		// Skip s390x, see https://github.com/cockroachdb/cockroach/issues/161453.
-		CompatibleClouds: registry.AllExceptAWS.NoIBM(),
+		// Limit to GCE only to avoid disk stall issues on Azure, see
+		// https://github.com/cockroachdb/cockroach/issues/166667.
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.LeaderLeases,
 		Timeout:          length * 2,


### PR DESCRIPTION
Backport 1/1 commits from #166764 on behalf of @rafiss.

----

This test was previously running on all clouds except AWS and IBM. Limit it to GCE only to avoid disk stall issues observed on Azure.

Resolves: #166667
Resolves: https://github.com/cockroachdb/cockroach/issues/166808

Release note: None

----

Release justification: test only change