### PR TITLE
security: switch join token generation to crypto/rand

### DIFF
--- a/pkg/security/join_token.go
+++ b/pkg/security/join_token.go
@@ -8,16 +8,14 @@ package security
 import (
 	"bytes"
 	"crypto/hmac"
+	crypto_rand "crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"hash/crc32"
 	"io"
-	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -56,8 +54,10 @@ func GenerateJoinToken(cm *CertificateManager) (JoinToken, error) {
 	var jt JoinToken
 
 	jt.TokenID = uuid.MakeV4()
-	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
-	jt.SharedSecret = randutil.RandBytes(r, joinTokenSecretLen)
+	jt.SharedSecret = make([]byte, joinTokenSecretLen)
+	if _, err := crypto_rand.Read(jt.SharedSecret); err != nil {
+		return jt, err
+	}
 	jt.sign(cm.CACert().FileContents)
 	return jt, nil
 }

--- a/pkg/security/join_token_test.go
+++ b/pkg/security/join_token_test.go
@@ -88,3 +88,19 @@ func TestJoinTokenVersion(t *testing.T) {
 		require.EqualValues(t, err, errInvalidJoinToken)
 	})
 }
+
+func TestGenerateJoinTokenUniqueness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cm, err := NewCertificateManager(certnames.EmbeddedCertsDir, CommandTLSSettings{})
+	require.NoError(t, err)
+
+	token1, err := GenerateJoinToken(cm)
+	require.NoError(t, err)
+
+	token2, err := GenerateJoinToken(cm)
+	require.NoError(t, err)
+
+	require.NotEqual(t, token1.SharedSecret, token2.SharedSecret, "subsequent tokens should not have identical shared secrets")
+}


### PR DESCRIPTION
The previous implementation used math/rand with a time-based seed to generate the shared secret for cluster join tokens. This approach is predictable and not suitable for security-sensitive use cases, making the tokens vulnerable to brute-force attacks.

This change replaces math/rand with crypto/rand to ensure the shared secret is generated using a cryptographically secure random source. While this introduces a minor dependency on OS entropy, the impact is negligible since join tokens are created infrequently.

Release note (security update): Improve the security of cluster join tokens by generating shared secrets using a cryptographically secure random number generator.