### PR TITLE
sql: check role membership in CREATE SCHEMA AUTHORIZATION

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -869,17 +869,39 @@ func (p *planner) checkCanAlterToNewOwner(
 
 	// To alter the owner, you must also be a direct or indirect member of the new
 	// owning role.
-	if p.User() == newOwner {
+	return p.checkMemberOfRole(ctx, newOwner)
+}
+
+// checkMemberOfRole checks that the current user is a member of the given role,
+// either directly or indirectly. Being the role itself counts as membership.
+func (p *planner) checkMemberOfRole(ctx context.Context, role username.SQLUsername) error {
+	if p.User() == role {
 		return nil
 	}
 	memberOf, err := p.MemberOfWithAdminOption(ctx, p.User())
 	if err != nil {
 		return err
 	}
-	if _, ok := memberOf[newOwner]; ok {
+	if _, ok := memberOf[role]; ok {
 		return nil
 	}
-	return pgerror.Newf(pgcode.InsufficientPrivilege, "must be member of role %q", newOwner)
+	return pgerror.Newf(pgcode.InsufficientPrivilege, "must be member of role %q", role)
+}
+
+// checkAdminOrMemberOfRole checks that the given role exists and that the
+// current user is either an admin or a member of the given role.
+func (p *planner) checkAdminOrMemberOfRole(ctx context.Context, role username.SQLUsername) error {
+	if err := p.CheckRoleExists(ctx, role); err != nil {
+		return err
+	}
+	hasAdmin, err := p.HasAdminRole(ctx)
+	if err != nil {
+		return err
+	}
+	if hasAdmin {
+		return nil
+	}
+	return p.checkMemberOfRole(ctx, role)
 }
 
 // HasOwnershipOnSchema checks if the current user has ownership on the schema.

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/decodeusername"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -38,16 +37,18 @@ func (n *createSchemaNode) startExec(params runParams) error {
 	return params.p.createUserDefinedSchema(params, n.n)
 }
 
-// CreateUserDefinedSchemaDescriptor constructs a mutable schema descriptor.
-func CreateUserDefinedSchemaDescriptor(
+// createUserDefinedSchemaDescriptor constructs a mutable schema descriptor.
+// Also validates the schema authorization role if specified. The current user
+// must be an admin or a member of the authorization role.
+func (p *planner) createUserDefinedSchemaDescriptor(
 	ctx context.Context,
 	sessionData *sessiondata.SessionData,
 	n *tree.CreateSchema,
-	txn descs.Txn,
-	descIDGenerator eval.DescIDGenerator,
 	db catalog.DatabaseDescriptor,
 	allocateID bool,
 ) (*schemadesc.Mutable, *catpb.PrivilegeDescriptor, error) {
+	txn := p.InternalSQLTxn()
+	descIDGenerator := p.extendedEvalCtx.DescIDGenerator
 	authRole, err := decodeusername.FromRoleSpec(
 		sessionData, username.PurposeValidation, n.AuthRole,
 	)
@@ -96,12 +97,8 @@ func CreateUserDefinedSchemaDescriptor(
 
 	owner := user
 	if !n.AuthRole.Undefined() {
-		exists, err := RoleExists(ctx, txn, authRole)
-		if err != nil {
+		if err := p.checkAdminOrMemberOfRole(ctx, authRole); err != nil {
 			return nil, nil, err
-		}
-		if !exists {
-			return nil, nil, sqlerrors.NewUndefinedUserError(authRole)
 		}
 		owner = authRole
 	}
@@ -196,9 +193,8 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 		return err
 	}
 
-	desc, privs, err := CreateUserDefinedSchemaDescriptor(
-		params.ctx, params.SessionData(), n, p.InternalSQLTxn(),
-		p.extendedEvalCtx.DescIDGenerator, db, true, /* allocateID */
+	desc, privs, err := p.createUserDefinedSchemaDescriptor(
+		params.ctx, params.SessionData(), n, db, true, /* allocateID */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -121,6 +121,9 @@ func (p *planner) createDatabase(
 		if err != nil {
 			return nil, true, err
 		}
+		if err := p.checkAdminOrMemberOfRole(ctx, owner); err != nil {
+			return nil, true, err
+		}
 	}
 
 	db := dbdesc.NewInitial(
@@ -138,10 +141,6 @@ func (p *planner) createDatabase(
 		Privileges: catpb.NewPublicSchemaPrivilegeDescriptor(owner, includeCreatePriv),
 		Version:    1,
 	}).BuildCreatedMutableSchema()
-
-	if err := p.checkCanAlterToNewOwner(ctx, db, owner); err != nil {
-		return nil, true, err
-	}
 
 	if err := p.createDescriptor(ctx, db, jobDesc); err != nil {
 		return nil, true, err

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -344,6 +344,71 @@ CREATE DATABASE d WITH OWNER testuser2
 
 user root
 
+# Regression test for #122901: with CREATEDB privilege, non-admins must
+# still be a member of the owning role.
+subtest create_database_owner_membership_check
+
+statement ok
+CREATE ROLE db_owner_role;
+
+statement ok
+ALTER USER testuser CREATEDB
+
+user testuser
+
+statement error pq: role/user "db_owner_role2" does not exist
+CREATE DATABASE d_owned WITH OWNER db_owner_role2
+
+statement error pq: must be member of role "db_owner_role"
+CREATE DATABASE d_owned WITH OWNER db_owner_role
+
+user root
+
+statement ok
+GRANT db_owner_role TO testuser
+
+user testuser
+
+statement ok
+CREATE DATABASE d_owned WITH OWNER db_owner_role
+
+user root
+
+statement ok
+ALTER USER testuser NOCREATEDB
+
+statement ok
+REVOKE db_owner_role FROM testuser
+
+# Admin role must bypass role membership.
+statement ok
+CREATE USER db_admin_role;
+ALTER USER db_admin_role CREATEDB;
+
+statement ok
+SET ROLE db_admin_role
+
+statement error pq: must be member of role "db_owner_role"
+CREATE DATABASE d_admin WITH OWNER db_owner_role
+
+statement ok
+RESET ROLE;
+ALTER USER db_admin_role NOCREATEDB;
+GRANT ADMIN TO db_admin_role;
+SET ROLE db_admin_role
+
+statement ok
+CREATE DATABASE db_admin WITH OWNER db_owner_role
+
+statement ok
+CREATE DATABASE db_root WITH OWNER root
+
+statement ok
+RESET ROLE;
+DROP USER db_admin_role
+
+subtest end
+
 # Fix for https://github.com/cockroachdb/cockroach/issues/97938.
 subtest if_not_exists_with_owner
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/drop_owned_by
@@ -395,6 +395,54 @@ DROP OWNED BY root
 statement error pq: cannot drop objects owned by role "admin" because they are required by the database system
 DROP OWNED BY admin
 
+# Regression test for #122901: granting testuser membership IN testuser2's
+# child role should not allow testuser to drop testuser2's objects. Only being
+# a member OF testuser2 (or a parent role of testuser2) should grant that.
+user root
+
+statement ok
+CREATE ROLE child_role;
+
+statement ok
+GRANT child_role TO testuser2
+
+statement ok
+GRANT child_role TO testuser
+
+user testuser
+
+statement error pq: permission denied to drop objects
+DROP OWNED BY testuser2
+
+user root
+
+statement ok
+REVOKE child_role FROM testuser
+
+statement ok
+REVOKE child_role FROM testuser2
+
+statement ok
+DROP ROLE child_role
+
+statement ok
+GRANT ADMIN TO testuser
+
+user testuser 
+
+statement ok
+DROP OWNED BY testuser2
+
+statement error pq: cannot drop objects owned by role "root" because they are required by the database system
+DROP OWNED BY root
+
+user root
+
+statement ok
+REVOKE ADMIN FROM testuser
+
+subtest end
+
 # KITCHEN-SINK: Test DROP OWNED BY when there are multiple databases/schemas.
 # Only objects/privileges in the current database should be dropped.
 subtest kitchen-sink

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -613,6 +613,90 @@ WHERE
 user1         user1
 user1_schema  user1
 
+# Non-admins must be a member of the role specified in AUTHORIZATION.
+subtest authorization_membership_check
+
+user root
+
+statement ok
+CREATE ROLE auth_check_role;
+
+statement ok
+CREATE DATABASE auth_check_db;
+
+statement ok
+GRANT CREATE ON DATABASE auth_check_db TO testuser;
+
+user testuser
+
+statement ok
+USE auth_check_db
+
+statement error pq: role/user "auth_check_role2" does not exist
+CREATE SCHEMA AUTHORIZATION auth_check_role2
+
+statement error pq: must be member of role "auth_check_role"
+CREATE SCHEMA AUTHORIZATION auth_check_role
+
+statement error pq: must be member of role "auth_check_role"
+CREATE SCHEMA s_auth AUTHORIZATION auth_check_role
+
+# After granting auth_check_role to testuser, the CREATE SCHEMA should succeed.
+user root
+
+statement ok
+GRANT auth_check_role TO testuser
+
+user testuser
+
+statement ok
+USE auth_check_db
+
+statement ok
+CREATE SCHEMA AUTHORIZATION auth_check_role
+
+statement ok
+CREATE SCHEMA s_auth AUTHORIZATION auth_check_role
+
+# A user can always create a schema with authorization as themselves.
+statement ok
+CREATE SCHEMA s_testuser AUTHORIZATION testuser
+
+user root
+
+# Admin role must bypass role membership.
+statement ok
+CREATE USER db_admin_role;
+GRANT CREATE ON DATABASE auth_check_db TO db_admin_role;
+
+statement ok
+SET ROLE db_admin_role;
+USE auth_check_db
+
+statement error pq: must be member of role "auth_check_role"
+CREATE SCHEMA s_admin AUTHORIZATION auth_check_role
+
+statement ok
+RESET ROLE;
+REVOKE CREATE ON DATABASE auth_check_db FROM db_admin_role;
+GRANT ADMIN TO db_admin_role;
+SET ROLE db_admin_role
+
+statement ok
+CREATE SCHEMA s_admin AUTHORIZATION auth_check_role
+
+statement ok
+CREATE SCHEMA s_admin_root AUTHORIZATION root
+
+statement ok
+RESET ROLE;
+DROP USER db_admin_role
+
+statement ok
+USE defaultdb
+
+subtest end
+
 # Ensure that we need CREATE on a database to create a schema.
 statement ok
 CREATE DATABASE perms

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -463,11 +463,11 @@ func (b *builderState) CurrentUserHasAdminOrIsMemberOf(role username.SQLUsername
 	if b.evalCtx.SessionData().User() == role {
 		return true
 	}
-	memberships, err := b.auth.MemberOfWithAdminOption(b.ctx, role)
+	memberships, err := b.auth.MemberOfWithAdminOption(b.ctx, b.evalCtx.SessionData().User())
 	if err != nil {
 		panic(err)
 	}
-	_, ok := memberships[b.evalCtx.SessionData().User()]
+	_, ok := memberships[role]
 	return ok
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_schema.go
@@ -84,6 +84,10 @@ func CreateSchema(b BuildCtx, n *tree.CreateSchema) {
 		if err = b.CheckRoleExists(b, authRole); err != nil {
 			panic(sqlerrors.NewUndefinedUserError(authRole))
 		}
+		if !b.CurrentUserHasAdminOrIsMemberOf(authRole) {
+			panic(pgerror.Newf(pgcode.InsufficientPrivilege,
+				"must be member of role %q", authRole))
+		}
 		owner = authRole
 	}
 


### PR DESCRIPTION
Previously, `CREATE SCHEMA ... AUTHORIZATION <role>` did not verify that the current user is a member of the specified authorization role, allowing any user with CREATE privilege on the database to create schemas owned by arbitrary roles. PostgreSQL requires the current user to be a direct or indirect member of the authorization role (or a superuser).

This commit adds the missing membership check to `CREATE SCHEMA ... AUTHORIZATION`. It also fixes a bug in
`CurrentUserHasAdminOrIsMemberOf` where the membership lookup direction was reversed — it was checking whether the target role is a member of the current user, rather than whether the current user is a member of the target role.

Resolves: #122901

Release note (bug fix): `CREATE SCHEMA ... AUTHORIZATION <role>` now correctly requires the executing user to be a member of the specified role, matching PostgreSQL behavior. Previously, any user with CREATE privilege on the database could create schemas owned by arbitrary roles.

Generated by Claude Code Auto-Solver