### PR TITLE
kvserver: deflake TestReplicaCircuitBreaker_Follower_QuorumLoss

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -1063,6 +1063,10 @@ func setupCircuitBreakerTest(t *testing.T, leaseType roachpb.LeaseType) *circuit
 		kvserver.OverrideDefaultLeaseType(ctx, &st.SV, leaseType)
 	}
 
+	// Disable the leaderless watcher; it is tested separately and can
+	// interfere with circuit breaker assertions. See #163999.
+	kvserver.ReplicaLeaderlessUnavailableThreshold.Override(ctx, &st.SV, 0)
+
 	storeKnobs := &kvserver.StoreTestingKnobs{
 		SlowReplicationThresholdOverride: func(ba *kvpb.BatchRequest) time.Duration {
 			t.Helper()


### PR DESCRIPTION
On slow CI machines, circuit breaker tests can exceed the default 60s leaderless threshold, causing the watcher to return a `ReplicaUnavailableError` that the test helpers don't expect. Disable it since these tests exercise the circuit breaker specifically and the leaderless watcher has its own dedicated tests.

Fixes #163999