### PR TITLE
roachprod: clean up prom conf on vm preemption

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1607,6 +1607,13 @@ func destroyCluster(
 ) error {
 	c, ok := cld.Clusters[clusterName]
 	if !ok {
+		// Best-effort: try to clean up Prometheus config even if the
+		// cluster no longer exists (e.g. VMs were preempted).
+		if cl, err := promhelperclient.NewPromClient(); err == nil {
+			if err := cl.DeleteClusterConfig(ctx, clusterName, l); err != nil {
+				l.Printf("WARNING: failed to delete prometheus config for %s: %s", clusterName, err)
+			}
+		}
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
 	if c.IsEmptyCluster() {


### PR DESCRIPTION
Previously, Prometheus target cleanup was only performed inside `cloud.DestroyCluster`, which is called by `destroyCluster` after looking up the cluster in the cloud listing.

This was inadequate because when VMs are preempted by the cloud provider, the cluster no longer appears in the cloud listing. `destroyCluster` returns a "cluster does not exist" error and never reaches `cloud.DestroyCluster`, leaving stale Prometheus targets registered indefinitely.

This patch fixes this by performing a best-effort Prometheus config cleanup in the error path of `Destroy`, ensuring targets are unregistered even when the cluster can no longer be found in the cloud provider.

Epic: none
Release note: None