### PR TITLE
roachprod: pin docker image to bookworm

### DIFF
--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN cp $(bazel info bazel-bin --config=crosslinux)/pkg/cmd/roachprod/roachprod_/
 
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/golang:1.25
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/golang:1.25-bookworm
 COPY entrypoint.sh build.sh /build/
 RUN ["/build/build.sh"]
 COPY --from=builder /build/roachprod /usr/local/bin/roachprod

--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:c3e379f7f51
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:da76d9d091d
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
Previously, the roachprod docker build script used `golang:1.25` as its base image, which defaulted to Debian trixie (Debian 13).

This was inadequate because trixie removed `apt-key` and the Azure CLI apt repository does not yet have a Release file for trixie, causing the docker image build to fail.

This patch fixes this by pinning the base image to `golang:1.25-bookworm` (Debian 12), which supports both `apt-key` and the Azure CLI repository.

Epic: none
Release note: None