### PR TITLE
release-26.2: sql: remove DisableUnsafeInternalCheck bypass for user-defined views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inflight_trace_spans
+++ b/pkg/sql/logictest/testdata/logic_test/inflight_trace_spans
@@ -5,6 +5,7 @@
 # picks up more spans than it wants.
 # TODO(andrei): Figure out a replacement for this test that is more robust.
 # cluster-opt: tracing-off
+# knob-opt: allow-unsafe
 
 statement ok
 GRANT ADMIN TO testuser

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -1,6 +1,7 @@
 # Disable SQL Stats flush to prevents stats from being cleared from the
 # in-memory store.
 # LogicTest: local 3node-tenant
+# knob-opt: allow-unsafe
 
 statement ok
 SET CLUSTER SETTING sql.stats.flush.enabled = false;

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -353,13 +353,13 @@ func (b *Builder) buildView(
 	// the invoker on the underlying tables. Checking the invoker would defeat
 	// the purpose of having separate SELECT privileges on the view, which is
 	// intended to allow exposing some subset of a restricted table's data to
-	// less privileged users. We also DisableUnsafeInternalCheck to allow
-	// reading system tables through user-defined views.
+	// less privileged users.
 	//
 	// For user-created views, we check the SELECT privilege of the view owner
 	// (definer) on the underlying tables to ensure the view owner still has
 	// access. This also means that the definer's RLS policies are enforced
-	// rather than the invoker's.
+	// rather than the invoker's. Additionaly, we check for indirect unsafe
+	// access to crdb_internals through the view.
 	//
 	// For system views (e.g. pg_catalog.pg_description,
 	// crdb_internal.transaction_statistics), we skip SELECT privilege checks
@@ -380,7 +380,6 @@ func (b *Builder) buildView(
 			}(b.dataSourcePrivilegeUserOverride)
 			b.dataSourcePrivilegeUserOverride = view.Owner()
 		}
-		defer b.DisableUnsafeInternalCheck()()
 		if b.skipSelectPrivilegeChecks {
 			b.skipSelectPrivilegeChecks = false
 			defer func() { b.skipSelectPrivilegeChecks = true }()

--- a/pkg/sql/unsafesql/unsafesql_test.go
+++ b/pkg/sql/unsafesql/unsafesql_test.go
@@ -314,6 +314,83 @@ func TestIntegration(t *testing.T) {
 	})
 }
 
+func TestViewOverSystemTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLEvalContext: &eval.TestingKnobs{
+				UnsafeOverride: func() *bool { return nil },
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	rootDB := sqlutils.MakeSQLRunner(s.SQLConn(t))
+
+	// Creating a view over pg_catalog succeeds without allow_unsafe_internals.
+	rootDB.Exec(t, "CREATE VIEW v_pg_desc AS SELECT objoid, description FROM pg_catalog.pg_description LIMIT 5")
+
+	// Creating a view over crdb_internal fails without allow_unsafe_internals.
+	_, err := rootDB.DB.ExecContext(ctx,
+		"CREATE VIEW v_should_fail AS SELECT * FROM crdb_internal.kv_catalog_comments LIMIT 5")
+	checkUnsafeErr(t, err)
+
+	// Enable unsafe access to create the view, then disable it.
+	rootDB.Exec(t, "SET allow_unsafe_internals = true")
+	rootDB.Exec(t, "CREATE VIEW v_kv_comments AS SELECT objoid, description FROM crdb_internal.kv_catalog_comments LIMIT 5")
+	rootDB.Exec(t, "SET allow_unsafe_internals = false")
+
+	// Create a non-admin test user and grant SELECT on both views.
+	rootDB.Exec(t, "CREATE USER testuser")
+	rootDB.Exec(t, "GRANT SELECT ON v_pg_desc TO testuser")
+	rootDB.Exec(t, "GRANT SELECT ON v_kv_comments TO testuser")
+
+	testUserDB := sqlutils.MakeSQLRunner(
+		s.ApplicationLayer().SQLConn(t, serverutils.User("testuser")),
+	)
+
+	// Run the same sequence for both root and a non-admin user.
+	for _, tc := range []struct {
+		name string
+		r    *sqlutils.SQLRunner
+	}{
+		{name: "root", r: rootDB},
+		{name: "testuser", r: testUserDB},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Safe view works without any override.
+			tc.r.Exec(t, "SELECT * FROM pg_catalog.pg_description LIMIT 1")
+			tc.r.Exec(t, "SELECT * FROM v_pg_desc")
+
+			// Unsafe view is blocked.
+			_, err := tc.r.DB.ExecContext(ctx, "SELECT * FROM v_kv_comments")
+			checkUnsafeErr(t, err)
+			_, err = tc.r.DB.ExecContext(ctx, "SELECT * FROM crdb_internal.kv_catalog_comments LIMIT 1")
+			checkUnsafeErr(t, err)
+
+			// Session variable unblocks the unsafe view.
+			r := sqlutils.MakeSQLRunner(s.SQLConn(t))
+			r.Exec(t, "SET allow_unsafe_internals = true")
+			r.Exec(t, "SELECT * FROM v_pg_desc")
+			r.Exec(t, "SELECT * FROM v_kv_comments")
+			r.Exec(t, "SELECT * FROM pg_catalog.pg_description LIMIT 1")
+			r.Exec(t, "SELECT * FROM crdb_internal.kv_catalog_comments LIMIT 1")
+			r.Exec(t, "SET allow_unsafe_internals = false")
+
+			// Cluster setting override unblocks the unsafe view.
+			rootDB.Exec(t, "SET CLUSTER SETTING sql.override.allow_unsafe_internals.enabled = true")
+			tc.r.Exec(t, "SELECT * FROM v_pg_desc")
+			tc.r.Exec(t, "SELECT * FROM v_kv_comments")
+			r.Exec(t, "SELECT * FROM pg_catalog.pg_description LIMIT 1")
+			r.Exec(t, "SELECT * FROM crdb_internal.kv_catalog_comments LIMIT 1")
+			rootDB.Exec(t, "SET CLUSTER SETTING sql.override.allow_unsafe_internals.enabled = false")
+		})
+	}
+}
+
 // panickingStatement is a mock Statement that panics during formatting
 type panickingStatement struct{}
 


### PR DESCRIPTION
Backport 1/1 commits from #166817 on behalf of @shghasemi.

----

Previously, building a view would unconditionally disable the unsafe internal check, allowing any user-defined view to access crdb_internal tables without restriction. This removes that bypass so that indirect unsafe access to crdb_internal through user-defined views is properly checked.

The logic tests that rely on unsafe internal access are updated to use the `allow-unsafe` knob-opt directive.

Fixes: #166816

Release note (backward-incompatible change): User-defined views that reference crdb_internal virtual tables now enforce unsafe access checks. set the cluster setting `sql.override.allow_unsafe_internals.enabled` to `true` to restore the previous behavior.

----

Release justification: Important bug fix.