### PR TITLE
changefeedccl: fix cloud storage sink file ordering bug

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -140,6 +140,32 @@ type changeAggregatorLowerBoundOracle struct {
 	initialInclusiveLowerBound hlc.Timestamp
 }
 
+func newChangeAggregatorLowerBoundOracle(
+	sf frontier, scanTime hlc.Timestamp, maxSpanTSAtStart hlc.Timestamp, boundOnMaxSpanTSAtStart bool,
+) *changeAggregatorLowerBoundOracle {
+	initialLowerBound := scanTime
+	if boundOnMaxSpanTSAtStart {
+		// cloudStorageSink files are timestamped with the high watermark
+		// of the local aggregator frontier. On restart, the high watermark
+		// may rollback to an older timestamp and re-emit rows. With partial
+		// checkpoints, we skip rows already covered by the checkpoint. Those
+		// rows exist only in the previous session's higher-timestamped files
+		// which may break lexicographical ordering.
+		//
+		// We floor the initial lower bound on the initial max span timestamp,
+		// so new rows sort after any files created in the previous session.
+		//
+		// N.B. we must call `Next()` here on maxSpanTSAtStart for the
+		// same reason we call `Next()` on the frontier timestamp in
+		// `inclusiveLowerBoundTS()`.
+		initialLowerBound.Forward(maxSpanTSAtStart.Next())
+	}
+	return &changeAggregatorLowerBoundOracle{
+		sf:                         sf,
+		initialInclusiveLowerBound: initialLowerBound,
+	}
+}
+
 // inclusiveLowerBoundTs is used to generate a representative timestamp to name
 // cloudStorageSink files. This timestamp is either the statement time (in case this
 // changefeed job hasn't yet seen any resolved timestamps) or the successor timestamp to
@@ -153,7 +179,9 @@ func (o *changeAggregatorLowerBoundOracle) inclusiveLowerBoundTS() hlc.Timestamp
 		// Files being created at the point this method is called are guaranteed
 		// to contain row updates with timestamps strictly greater than the local
 		// span frontier timestamp.
-		return frontier.Next()
+		ts := frontier.Next()
+		ts.Forward(o.initialInclusiveLowerBound)
+		return ts
 	}
 	// This should only be returned in the case where the changefeed job hasn't yet
 	// seen a resolved timestamp.
@@ -344,10 +372,10 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	}
 	opts := feed.Opts
 
-	timestampOracle := &changeAggregatorLowerBoundOracle{
-		sf:                         ca.frontier,
-		initialInclusiveLowerBound: feed.ScanTime,
-	}
+	timestampOracle := newChangeAggregatorLowerBoundOracle(
+		ca.frontier, feed.ScanTime, ca.frontier.MaxSpanTS(),
+		changefeedbase.CloudStorageSinkInitialLowerBoundOnMaxSpanTS.Get(&ca.FlowCtx.Cfg.Settings.SV),
+	)
 
 	if cfKnobs, ok := ca.FlowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
 		ca.knobs = *cfKnobs
@@ -638,10 +666,8 @@ func (ca *changeAggregator) setupSpansAndFrontier() (spans []roachpb.Span, err e
 		return nil, errors.Wrapf(err, "failed to restore span-level checkpoint")
 	}
 
-	for _, rs := range ca.spec.ResolvedSpans {
-		if _, err := ca.frontier.Forward(rs.Span, rs.Timestamp); err != nil {
-			return nil, errors.Wrapf(err, "failed to restore frontier")
-		}
+	if err := ca.frontier.RestoreCheckpoint(ca.spec.ResolvedSpans); err != nil {
+		return nil, errors.Wrapf(err, "failed to restore frontier")
 	}
 
 	return spans, nil
@@ -1014,6 +1040,9 @@ type changeFrontier struct {
 	// CHANGEFEED statement was run at. It's used in an assertion that we never
 	// regress the job high-water.
 	highWaterAtStart hlc.Timestamp
+	// maxSpanTSAtStart is the max span timestamp after restoring a
+	// checkpoint.
+	maxSpanTSAtStart hlc.Timestamp
 	// passthroughBuf, in some but not all flows, contains changed row data to
 	// pass through unchanged to the gateway node.
 	passthroughBuf encDatumRowBuffer
@@ -1444,14 +1473,13 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 		return
 	}
 
-	for _, rs := range cf.spec.ResolvedSpans {
-		if _, err := cf.frontier.Forward(rs.Span, rs.Timestamp); err != nil {
-			log.Changefeed.Warningf(cf.Ctx(),
-				"moving to draining due to error restoring frontier: %v", err)
-			cf.MoveToDraining(err)
-			return
-		}
+	if err := cf.frontier.RestoreCheckpoint(cf.spec.ResolvedSpans); err != nil {
+		log.Changefeed.Warningf(cf.Ctx(),
+			"moving to draining due to error restoring frontier: %v", err)
+		cf.MoveToDraining(err)
+		return
 	}
+	cf.maxSpanTSAtStart = cf.frontier.MaxSpanTS()
 
 	if cf.knobs.AfterCoordinatorFrontierRestore != nil {
 		cf.knobs.AfterCoordinatorFrontierRestore(cf.frontier)
@@ -2274,6 +2302,13 @@ func (cf *changeFrontier) remakeSystemTablesPTSRecord(
 
 func (cf *changeFrontier) maybeEmitResolved(ctx context.Context, newResolved hlc.Timestamp) error {
 	if cf.freqEmitResolved == emitNoResolved || newResolved.IsEmpty() {
+		return nil
+	}
+	// On restart, the cloud storage sink may write rows to files timestamped
+	// with the max span timestamp. We can't emit a resolved timestamp until the
+	// frontier is at least the initial maxSpanTS. We gate unconditionally
+	// regardless of the sink as the expected delay should be minimal.
+	if newResolved.Less(cf.maxSpanTSAtStart) {
 		return nil
 	}
 	sinceEmitted := newResolved.GoTime().Sub(cf.lastEmitResolved)

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -373,7 +373,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	opts := feed.Opts
 
 	timestampOracle := newChangeAggregatorLowerBoundOracle(
-		ca.frontier, feed.ScanTime, ca.frontier.MaxSpanTS(),
+		ca.frontier, feed.ScanTime, ca.frontier.LatestTS(),
 		changefeedbase.CloudStorageSinkInitialLowerBoundOnMaxSpanTS.Get(&ca.FlowCtx.Cfg.Settings.SV),
 	)
 
@@ -1479,7 +1479,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 		cf.MoveToDraining(err)
 		return
 	}
-	cf.maxSpanTSAtStart = cf.frontier.MaxSpanTS()
+	cf.maxSpanTSAtStart = cf.frontier.LatestTS()
 
 	if cf.knobs.AfterCoordinatorFrontierRestore != nil {
 		cf.knobs.AfterCoordinatorFrontierRestore(cf.frontier)

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -482,6 +482,26 @@ var TrackPerTableProgress = settings.RegisterBoolSetting(
 	metamorphic.ConstantWithTestBool("changefeed.progress.per_table_tracking.enabled", true),
 )
 
+// CloudStorageSinkInitialLowerBoundOnMaxSpanTS controls whether the cloud storage
+// sink bounds its initial file timestamp lower bound on the max span timestamp
+// from a restored checkpoint. This prevents file ordering violations after
+// restart with a partial checkpoint. See #155015.
+//
+// When enabled, file timestamps may be higher than the timestamps of
+// the rows they contain. This setting exists as a precaution in case any
+// existing users depend on that ordering.
+//
+// TODO(darrylwong): Remove this setting once we are confident no users
+// depend on file timestamps being lower than row timestamps.
+var CloudStorageSinkInitialLowerBoundOnMaxSpanTS = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.cloud_storage.initial_lower_bound_on_max_span_timestamp.enabled",
+	"if true, the cloud storage sink bounds its initial file timestamp lower "+
+		"bound on the max span timestamp from a restored checkpoint, preventing "+
+		"file ordering violations after restart with a partial checkpoint",
+	true,
+)
+
 // FrontierPersistenceInterval configures the minimum amount of time that must
 // elapse before a changefeed will persist its entire span frontier again.
 var FrontierPersistenceInterval = settings.RegisterDurationSettingWithExplicitUnit(

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -348,9 +348,38 @@ func (f *resolvedSpanFrontier) HasLaggingSpans(sv *settings.Values) bool {
 	return frontier.Add(lagThresholdNanos, 0).Less(f.latestTS)
 }
 
-// LatestTS returns the latest timestamp in the frontier.
+// LatestTS returns the most recent timestamp that any span in the frontier
+// has ever been forwarded to.
 func (f *resolvedSpanFrontier) LatestTS() hlc.Timestamp {
 	return f.latestTS
+}
+
+// MaxSpanTS returns the maximum timestamp of any span in the frontier.
+//
+// N.B. This diverges from LatestTS after restarting from a checkpoint,
+// where the latestTS will be empty until new resolved spans are forwarded,
+// while the MaxSpanTS will take into account the restored spans. We need
+// this distinction for schema change boundaries, since latestTS is used to
+// determine whether we've reached a boundary. i.e. if we just forwarded the
+// latestTS to the MaxSpanTS after restoring, we would take the latestTS as
+// having passed the boundary.
+func (f *resolvedSpanFrontier) MaxSpanTS() hlc.Timestamp {
+	maxTS := hlc.Timestamp{}
+	for _, ts := range f.Entries() {
+		maxTS.Forward(ts)
+	}
+	return maxTS
+}
+
+// RestoreCheckpoint restores the frontier from a checkpoint.
+func (f *resolvedSpanFrontier) RestoreCheckpoint(spans []jobspb.ResolvedSpan) error {
+	for _, rs := range spans {
+		if _, err := f.Forward(rs.Span, rs.Timestamp); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // All returns an iterator over the resolved spans in the frontier.

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -212,6 +212,8 @@ type resolvedSpanFrontier struct {
 
 	// boundary stores the latest-known non-NONE resolved span boundary.
 	boundary resolvedSpanBoundary
+	// boundaryPassed is true if any span has been forwarded past boundary.
+	boundaryPassed bool
 }
 
 // newResolvedSpanFrontier returns a new resolvedSpanFrontier.
@@ -256,6 +258,13 @@ func (f *resolvedSpanFrontier) ForwardResolvedSpan(
 	}
 	f.latestTS.Forward(r.Timestamp)
 	boundaryForwarded := f.boundary.Forward(r.Timestamp, r.BoundaryType)
+	if boundaryForwarded {
+		// We received a new boundary, reset boundaryPassed.
+		f.boundaryPassed = false
+	}
+	if !f.boundaryPassed && f.boundary.IsSet() {
+		f.boundaryPassed = r.Timestamp.After(f.boundary.ts)
+	}
 	if boundaryForwarded && !forwarded {
 		// The frontier is considered forwarded if the boundary type
 		// changes to non-NONE and all the spans are at the boundary
@@ -266,7 +275,8 @@ func (f *resolvedSpanFrontier) ForwardResolvedSpan(
 }
 
 // AtBoundary returns true at the single moment when all watched spans
-// have reached a boundary and no spans after the boundary have been received.
+// have reached a boundary and no spans after the boundary have been received
+// in the _current_ session.
 func (f *resolvedSpanFrontier) AtBoundary() (
 	bool,
 	jobspb.ResolvedSpan_BoundaryType,
@@ -277,8 +287,7 @@ func (f *resolvedSpanFrontier) AtBoundary() (
 	if !frontierAtBoundary {
 		return false, 0, hlc.Timestamp{}
 	}
-	latestAtBoundary, _ := f.boundary.At(f.latestTS)
-	if !latestAtBoundary {
+	if f.boundaryPassed {
 		return false, 0, hlc.Timestamp{}
 	}
 	return true, boundaryType, frontier
@@ -354,31 +363,14 @@ func (f *resolvedSpanFrontier) LatestTS() hlc.Timestamp {
 	return f.latestTS
 }
 
-// MaxSpanTS returns the maximum timestamp of any span in the frontier.
-//
-// N.B. This diverges from LatestTS after restarting from a checkpoint,
-// where the latestTS will be empty until new resolved spans are forwarded,
-// while the MaxSpanTS will take into account the restored spans. We need
-// this distinction for schema change boundaries, since latestTS is used to
-// determine whether we've reached a boundary. i.e. if we just forwarded the
-// latestTS to the MaxSpanTS after restoring, we would take the latestTS as
-// having passed the boundary.
-func (f *resolvedSpanFrontier) MaxSpanTS() hlc.Timestamp {
-	maxTS := hlc.Timestamp{}
-	for _, ts := range f.Entries() {
-		maxTS.Forward(ts)
-	}
-	return maxTS
-}
-
 // RestoreCheckpoint restores the frontier from a checkpoint.
 func (f *resolvedSpanFrontier) RestoreCheckpoint(spans []jobspb.ResolvedSpan) error {
 	for _, rs := range spans {
 		if _, err := f.Forward(rs.Span, rs.Timestamp); err != nil {
 			return err
 		}
+		f.latestTS.Forward(rs.Timestamp)
 	}
-
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -1068,7 +1068,7 @@ func TestCloudStorageSinkOrderingWithPartialCheckpoint(t *testing.T) {
 			hlc.Timestamp{}, hlc.Timestamp{}, nil /* codec */, false /* perTableTracking */, span1, span2,
 		)
 		require.NoError(t, err)
-		oracle := newChangeAggregatorLowerBoundOracle(sf, hlc.Timestamp{}, sf.MaxSpanTS(), boundOnMaxSpanTSAtStart)
+		oracle := newChangeAggregatorLowerBoundOracle(sf, hlc.Timestamp{}, sf.LatestTS(), boundOnMaxSpanTSAtStart)
 		sink, err := makeCloudStorageSink(
 			ctx, sinkURL, 1, settings, opts, oracle, externalStorageFromURI, user, nil, nil,
 		)
@@ -1109,7 +1109,7 @@ func TestCloudStorageSinkOrderingWithPartialCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, sf.RestoreCheckpoint(checkpoint))
 		// sf.Frontier() = min(span1@t=10, span2@t=10, span3@t=0) = t=0.
-		oracle = newChangeAggregatorLowerBoundOracle(sf, hlc.Timestamp{}, sf.MaxSpanTS(), boundOnMaxSpanTSAtStart)
+		oracle = newChangeAggregatorLowerBoundOracle(sf, hlc.Timestamp{}, sf.LatestTS(), boundOnMaxSpanTSAtStart)
 		sink, err = makeCloudStorageSink(
 			ctx, sinkURL, 1, settings, opts, oracle, externalStorageFromURI, user, nil, nil,
 		)

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/resolvedspan"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
@@ -1009,4 +1010,145 @@ func (n *mockSinkStorage) Delete(_ context.Context, _ string) error {
 
 func (n *mockSinkStorage) Size(_ context.Context, _ string) (int64, error) {
 	return 0, nil
+}
+
+// TestCloudStorageSinkOrderingWithPartialCheckpoint is a regression test for
+// #155015. Partial (frontier) checkpoints violate the cloud storage sink's
+// ordering guarantee because the catch-up scan after restart skips rows
+// covered by the checkpoint, breaking invariant 1 in the sink's proof of
+// correctness.
+//
+// Consider the following timeline:
+//  1. Frontier advances to t=10.
+//  2. Emit foo@t=20.
+//  3. Checkpoint records foo@t=20.
+//  4. Job restarts; low watermark is t=0. Catch-up scan skips foo@t=20.
+//  5. Emit foo@t=30.
+//  6. Client reads files in order.
+//
+// In the behavior before the fix for #155015, (2) and (5) write to files at t=10 and t=0, respectively.
+// This gives us the invalid ordering: file_t=0:[foo@t=30], file_t=10:[foo@t=20]
+func TestCloudStorageSinkOrderingWithPartialCheckpoint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "boundOnMaxSpanTSAtStart", func(t *testing.T, boundOnMaxSpanTSAtStart bool) {
+		ctx := context.Background()
+
+		externalIODir, dirCleanupFn := testutils.TempDir(t)
+		defer dirCleanupFn()
+
+		settings := cluster.MakeTestingClusterSettings()
+		enableAsyncFlush.Override(ctx, &settings.SV, false)
+		opts := changefeedbase.EncodingOptions{
+			Format:     changefeedbase.OptFormatJSON,
+			Envelope:   changefeedbase.OptEnvelopeWrapped,
+			KeyInValue: true,
+		}
+		ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
+		var noKey []byte
+
+		clientFactory := blobs.TestBlobServiceClient(externalIODir)
+		externalStorageFromURI := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
+			return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, settings,
+				clientFactory, user, nil, nil, cloud.NilMetrics, opts...)
+		}
+		user := username.RootUserName()
+
+		sinkURL := sinkURI(t, unlimitedFileSize)
+		topic := makeTopic(`foo`)
+
+		// Use non-contiguous spans so the frontier doesn't merge them into one entry.
+		// span3 simulates a span from a different aggregator that hasn't advanced.
+		span1 := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		span2 := roachpb.Span{Key: []byte("c"), EndKey: []byte("d")}
+		span3 := roachpb.Span{Key: []byte("e"), EndKey: []byte("f")}
+
+		sf, err := resolvedspan.NewAggregatorFrontier(
+			hlc.Timestamp{}, hlc.Timestamp{}, nil /* codec */, false /* perTableTracking */, span1, span2,
+		)
+		require.NoError(t, err)
+		oracle := newChangeAggregatorLowerBoundOracle(sf, hlc.Timestamp{}, sf.MaxSpanTS(), boundOnMaxSpanTSAtStart)
+		sink, err := makeCloudStorageSink(
+			ctx, sinkURL, 1, settings, opts, oracle, externalStorageFromURI, user, nil, nil,
+		)
+		require.NoError(t, err)
+		sink.(*cloudStorageSink).sinkID = 0
+		sink.(*cloudStorageSink).jobSessionID = "session-a"
+
+		// (1) Local frontier advances to t=10.
+		_, err = sf.Forward(span1, ts(10))
+		require.NoError(t, err)
+		_, err = sf.Forward(span2, ts(10))
+		require.NoError(t, err)
+		require.NoError(t, sink.Flush(ctx))
+
+		// (2) Emit foo@t=20 in a file named at t=10.
+		require.NoError(t, sink.EmitRow(ctx, topic, noKey, []byte(`{"k":"foo","v":"bar_t20"}`), ts(20), ts(20), zeroAlloc, nil))
+
+		// (3) Checkpoint records foo@t=20.
+		require.NoError(t, sink.Flush(ctx))
+
+		// (4) Job restarts; low watermark is t=0. Catch-up scan skips foo@t=20.
+		// We mimic restarting by creating a new frontier and sink based off of
+		// the checkpointed frontier state. span3 is at t=0 to simulate a span
+		// from another aggregator that hasn't advanced.
+		var checkpoint []jobspb.ResolvedSpan
+		for sp, spTS := range sf.Entries() {
+			checkpoint = append(checkpoint, jobspb.ResolvedSpan{
+				Span:      sp,
+				Timestamp: spTS,
+			})
+		}
+		checkpoint = append(checkpoint, jobspb.ResolvedSpan{Span: span3})
+
+		require.NoError(t, sink.Close())
+		sf, err = resolvedspan.NewAggregatorFrontier(
+			hlc.Timestamp{}, hlc.Timestamp{}, nil /* codec */, false /* perTableTracking */, span1, span2, span3,
+		)
+		require.NoError(t, err)
+		require.NoError(t, sf.RestoreCheckpoint(checkpoint))
+		// sf.Frontier() = min(span1@t=10, span2@t=10, span3@t=0) = t=0.
+		oracle = newChangeAggregatorLowerBoundOracle(sf, hlc.Timestamp{}, sf.MaxSpanTS(), boundOnMaxSpanTSAtStart)
+		sink, err = makeCloudStorageSink(
+			ctx, sinkURL, 1, settings, opts, oracle, externalStorageFromURI, user, nil, nil,
+		)
+		require.NoError(t, err)
+		sink.(*cloudStorageSink).sinkID = 0
+		sink.(*cloudStorageSink).jobSessionID = "session-b"
+
+		// (5) Emit foo@t=30. Without the fix, this file would be named at t=0,
+		// violating ordering. With the fix, the oracle floors the timestamp.
+		require.NoError(t, sink.EmitRow(ctx, topic, noKey, []byte(`{"k":"foo","v":"bar_t30"}`), ts(30), ts(30), zeroAlloc, nil))
+		require.NoError(t, sink.Flush(ctx))
+		require.NoError(t, sink.Close())
+
+		// (6) Check that our sink emitted files in order.
+		var files []string
+		absRoot := filepath.Join(externalIODir, testDir(t))
+		require.NoError(t, filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() || strings.HasSuffix(d.Name(), ".RESOLVED") {
+				return walkErr
+			}
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+			t.Logf("%s, rows: %s", d.Name(), content)
+			files = append(files, string(content))
+			return nil
+		}))
+		require.Len(t, files, 2)
+		if boundOnMaxSpanTSAtStart {
+			// With the fix, files are ordered correctly.
+			require.Contains(t, files[0], "bar_t20",
+				"first file (lexically) should contain the t=20 row")
+			require.Contains(t, files[1], "bar_t30",
+				"second file (lexically) should contain the t=30 row")
+		} else {
+			// Without the fix, files are out of order.
+			require.Contains(t, files[0], "bar_t30",
+				"first file (lexically) should contain the t=30 row (buggy ordering)")
+			require.Contains(t, files[1], "bar_t20",
+				"second file (lexically) should contain the t=20 row (buggy ordering)")
+		}
+	})
 }


### PR DESCRIPTION
Cloud storage sink files are timestamped with the high watermark of the lcoal aggregator frontier. On restart, the high watermark may rollback to an older timestamp.

With the new partial checkpoints, we skip rows covered by the checkpoint. If we emit later rows, they will be timestamped with the older rolledback timestamp, breaking lexicographical ordering.

This change floors the initial lower bound on the initial max span timestamp, as well as blocks emitting resolved timestamps until the frontier is at least the max span ts.

Fixes: https://github.com/cockroachdb/cockroach/issues/155174
Release note (bug fix): Fixed a bug where the cloud storage sink could produce out-of-order files restoring from a partial checkpoint. This change can also cause file timestamps to be higher than the timestamps of the rows they contain.