### PR TITLE
server: gate system log GC on meta1 leaseholder

### DIFF
--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -258,7 +258,18 @@ func startSystemLogsGC(ctx context.Context, sqlServer *SQLServer) error {
 		for ; ; timer.Reset(getPeriod()) {
 			select {
 			case <-timer.C:
-				// Do the work for all system tables.
+				if sqlServer.execCfg.Codec.ForSystemTenant() {
+					isMeta1LH, err := sqlServer.isMeta1Leaseholder(
+						ctx, sqlServer.execCfg.Clock.NowAsClockTimestamp(),
+					)
+					if err != nil {
+						log.Dev.Warningf(ctx, "failed to check meta1 leaseholder: %v", err)
+						continue
+					}
+					if !isMeta1LH {
+						continue // for loop
+					}
+				}
 				runSystemLogGC(ctx, sqlServer, st, systemLogsToGC)
 
 				// If we are in a test, coordinate with the test.


### PR DESCRIPTION
Previously, `startSystemLogsGC` launched a periodic background task on
every node in the cluster that garbage-collected old rows from
`system.rangelog`, `system.eventlog`, and `system.web_sessions`. Since
every node independently ran the same DELETE statements on the same
1-hour cadence, this caused N nodes to perform overlapping,
redundant work against the same tables, creating unnecessary load.

This commit gates the system log GC work on the meta1 leaseholder
check for system tenant nodes, following the same pattern used by
auto upgrade (`pkg/server/auto_upgrade.go`) and temporary object
cleanup (`pkg/sql/temporary_schema.go`). On each GC tick, the node
checks whether it holds the meta1 lease and skips the work if not.
Secondary tenants bypass the check and continue to run GC on all
SQL pods.

Resolves: #167021

Release note: None