### PR TITLE
sql/inspect: add multiregion roachtest to test uniqueness check performance

### DIFF
--- a/pkg/cmd/roachtest/tests/inspect_throughput.go
+++ b/pkg/cmd/roachtest/tests/inspect_throughput.go
@@ -39,6 +39,18 @@ func registerInspectThoughput(r registry.Registry) {
 	// to be measured independently of elastic CPU control.
 	r.Add(makeInspectThroughputTest(r, 12, 8, 500_000_000, 3*time.Hour, 1, false))
 	r.Add(makeInspectThroughputTest(r, 12, 8, 1_000_000_000, 11*time.Hour, indexesForLongRun, false))
+
+	// Multi-region: 12 CRDB nodes (4 per region) × 8 CPUs, 500M rows, 1 index check.
+	// Measures INSPECT throughput on a geo-distributed cluster to establish a
+	// cross-region performance baseline.
+
+	// Non-complex key case: PK = (crdb_region, unique_val, filler_val)
+	// unique_val immediately follows crdb_region.
+	r.Add(makeInspectMultiRegionThroughputTest(r, 4, 8, 500_000_000, 5*time.Hour, true, false /* complexKey */))
+
+	// Complex key cases: PK = (crdb_region, filler_val, unique_val)
+	// unique_val does not immediately follow crdb_region.
+	r.Add(makeInspectMultiRegionThroughputTest(r, 4, 8, 500_000_000, 5*time.Hour, true, true /* complexKey */))
 }
 
 // initInspectHistograms creates a histogram registry with multiple named metrics.
@@ -141,7 +153,7 @@ func makeInspectThroughputTest(
 			cNum := 1000
 			aNum := numRows / (bNum * cNum)
 			if c.IsLocal() {
-				aNum = 100000
+				aNum = 100_000
 				bNum = 1
 				cNum = 1
 			}
@@ -252,37 +264,277 @@ func makeInspectThroughputTest(
 				duration := timeutil.Since(before)
 				t.L().Printf("INSPECT with %d check(s) took %v\n", checks, duration)
 
-				// Query the job progress to get the total check count. Since each span
-				// handles all indexes, we divide by the number of checks to get the
-				// actual span count. This is important for debugging because INSPECT
-				// concurrency is based on spans. So, knowing the number of spans vs
-				// CPUs helps understand how well INSPECT parallelized this job.
-				var jobTotalCheckCount int64
-				querySQL := `
-					SELECT coalesce(
-						(crdb_internal.pb_to_json(
-							'cockroach.sql.jobs.jobspb.Progress',
-							value
-						)->'inspect'->>'jobTotalCheckCount')::INT8,
-						0
-					)
-					FROM system.job_info
-					WHERE job_id = $1
-					AND info_key = 'legacy_progress'`
-				err := db.QueryRow(querySQL, jobID).Scan(&jobTotalCheckCount)
-				if err != nil {
-					t.L().Printf("Warning: failed to query job total check count: %v", err)
-				} else {
-					// Each span handles all indexes, so divide by number of checks to get span count
-					spanCount := int(jobTotalCheckCount) / checks
-					totalCPUs := numNodes * numCPUs
-					spansPerCPU := float64(spanCount) / float64(totalCPUs)
-					t.L().Printf("INSPECT completed %d checks across %d spans (%.2f spans/CPU with %d total CPUs)\n",
-						jobTotalCheckCount, spanCount, spansPerCPU, totalCPUs)
-				}
+				logInspectJobStats(t, db, jobID, checks, numNodes*numCPUs)
 			}
 		},
 	}
+}
+
+// makeInspectMultiRegionThroughputTest creates a benchmark that measures INSPECT
+// throughput on a three-region cluster.
+func makeInspectMultiRegionThroughputTest(
+	r registry.Registry,
+	nodesPerRegion, numCPUs, numRows int,
+	length time.Duration,
+	admissionControl bool,
+	complexKey bool,
+) registry.TestSpec {
+	type regionSpec struct {
+		name string
+		zone string
+	}
+	regions := []regionSpec{
+		{name: "us-east1", zone: "us-east1-b"},
+		{name: "us-west1", zone: "us-west1-b"},
+		{name: "europe-west2", zone: "europe-west2-b"},
+	}
+	numRegions := len(regions)
+	numCRDBNodes := nodesPerRegion * numRegions
+
+	var zones []string
+	for _, reg := range regions {
+		for j := 0; j < nodesPerRegion; j++ {
+			zones = append(zones, reg.zone)
+		}
+	}
+	zones = append(zones, regions[0].zone) // workload node in primary region
+
+	name := fmt.Sprintf(
+		"inspect/throughput/bulkingest/nodes=%d/cpu=%d/rows=%d/checks=1/unique/complex=%t",
+		numCRDBNodes, numCPUs, numRows, complexKey,
+	)
+	if !admissionControl {
+		name += "/elastic=false"
+	}
+
+	return registry.TestSpec{
+		Name:      name,
+		Owner:     registry.OwnerSQLFoundations,
+		Benchmark: true,
+		Cluster: r.MakeClusterSpec(
+			numCRDBNodes+1, // +1 for workload node
+			spec.CPU(numCPUs),
+			spec.WorkloadNode(),
+			spec.Geo(),
+			spec.GCEZones(strings.Join(zones, ",")),
+		),
+		CompatibleClouds:    registry.OnlyGCE,
+		Suites:              registry.Suites(registry.Nightly),
+		Leases:              registry.LeaderLeases,
+		Timeout:             length,
+		SkipPostValidations: registry.PostValidationInspect,
+		PostProcessPerfMetrics: func(
+			test string, histogram *roachtestutil.HistogramMetric,
+		) (roachtestutil.AggregatedPerfMetrics, error) {
+			metrics := roachtestutil.AggregatedPerfMetrics{}
+
+			for _, summary := range histogram.Summaries {
+				totalElapsed := summary.TotalElapsed
+				if totalElapsed == 0 {
+					continue
+				}
+
+				inspectDuration := totalElapsed / 1000
+				if inspectDuration == 0 {
+					inspectDuration = 1
+				}
+				totalCPUs := int64(numCRDBNodes * numCPUs)
+				throughput := roachtestutil.MetricPoint(
+					float64(numRows) / float64(totalCPUs*inspectDuration),
+				)
+
+				metrics = append(metrics, &roachtestutil.AggregatedMetric{
+					Name:           fmt.Sprintf("%s_%s_throughput", test, summary.Name),
+					Value:          throughput,
+					Unit:           "rows/s/cpu",
+					IsHigherBetter: true,
+				})
+			}
+
+			return metrics, nil
+		},
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			bNum := 1000
+			cNum := 1000
+			aNum := numRows / (bNum * cNum)
+			if c.IsLocal() {
+				aNum = 100_000
+				bNum = 1
+				cNum = 1
+			}
+			payloadBytes := 40
+
+			settings := install.MakeClusterSettings()
+
+			for i, reg := range regions {
+				startNode := i*nodesPerRegion + 1
+				endNode := startNode + nodesPerRegion - 1
+				nodes := c.Range(startNode, endNode)
+				startOpts := option.DefaultStartOpts()
+				startOpts.RoachprodOpts.ExtraArgs = append(
+					startOpts.RoachprodOpts.ExtraArgs,
+					fmt.Sprintf("--locality=region=%s,zone=%s", reg.name, reg.zone),
+				)
+				c.Start(ctx, t.L(), startOpts, settings, nodes)
+			}
+
+			db := c.Conn(ctx, t.L(), 1)
+			defer db.Close()
+
+			disableRowCountValidation(t, db)
+
+			if !admissionControl {
+				t.L().Printf("Disabling admission control for INSPECT")
+				if _, err := db.ExecContext(ctx,
+					"SET CLUSTER SETTING sql.inspect.admission_control.enabled = false",
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Set up the MR database.
+			t.L().Printf("Creating a MR bulkingest database")
+			if _, err := db.ExecContext(ctx, "CREATE DATABASE bulkingest"); err != nil {
+				t.Fatal(err)
+			}
+
+			primaryRegion := regions[0].name
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`ALTER DATABASE bulkingest SET PRIMARY REGION '%s'`, primaryRegion,
+			)); err != nil {
+				t.Fatal(err)
+			}
+			for _, reg := range regions[1:] {
+				t.L().Printf("Adding region %s", reg.name)
+				if _, err := db.ExecContext(ctx, fmt.Sprintf(
+					`ALTER DATABASE bulkingest ADD REGION '%s'`, reg.name,
+				)); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Create the MR table with a bulkingest friendly schema.
+			//
+			// Complex: PK becomes (crdb_region, a, unique_val) where unique_val
+			//          does not immediately follow crdb_region.
+			// Non-complex: PK becomes (crdb_region, unique_val, a) where unique_val
+			//              immediately follows crdb_region.
+			t.L().Printf("Creating REGIONAL BY ROW table with final schema (complexKey=%t)", complexKey)
+			var createTableSQL string
+			if complexKey {
+				createTableSQL = `CREATE TABLE IF NOT EXISTS bulkingest.bulkingest (
+					a INT,
+					b INT,
+					c INT,
+					payload STRING,
+					unique_val INT NOT VISIBLE DEFAULT unique_rowid(),
+					PRIMARY KEY (a, unique_val)
+				) LOCALITY REGIONAL BY ROW`
+			} else {
+				createTableSQL = `CREATE TABLE IF NOT EXISTS bulkingest.bulkingest (
+					a INT,
+					b INT,
+					c INT,
+					payload STRING,
+					unique_val INT NOT VISIBLE DEFAULT unique_rowid(),
+					PRIMARY KEY (unique_val, a)
+				) LOCALITY REGIONAL BY ROW`
+			}
+			if _, err := db.ExecContext(ctx, createTableSQL); err != nil {
+				t.Fatal(err)
+			}
+
+			// Import will use the existing table and distribute the data.
+			cmdImport := fmt.Sprintf(
+				"./cockroach workload fixtures import bulkingest"+
+					" {pgurl:1} --a %d --b %d --c %d --payload-bytes %d --index-b-c-a=false",
+				aNum, bNum, cNum, payloadBytes,
+			)
+			t.L().Printf("Importing bulkingest data (will be distributed across %d regions)", numRegions)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdImport)
+
+			bulkDB := c.Conn(ctx, t.L(), 1, option.DBName("bulkingest"))
+			defer bulkDB.Close()
+
+			t.L().Printf("Computing table statistics")
+			if _, err := bulkDB.Exec("CREATE STATISTICS stats FROM bulkingest"); err != nil {
+				t.Fatal(err)
+			}
+
+			if complexKey {
+				enableComplexKeyUniquenessValidation(t, bulkDB)
+			}
+
+			metricName := "inspect"
+			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
+			reg, perfBuf := initInspectHistograms(
+				length*2, t, exporter, []string{metricName},
+			)
+			defer roachtestutil.CloseExporter(
+				ctx, exporter, t, c, perfBuf, c.Node(1), "",
+			)
+
+			tickHistogram := func(name string) {
+				reg.Tick(func(tick histogram.Tick) {
+					if tick.Name == name {
+						_ = tick.Exporter.SnapshotAndWrite(
+							tick.Hist, tick.Now, tick.Elapsed, &tick.Name,
+						)
+					}
+				})
+			}
+
+			inspectSQL := "INSPECT TABLE bulkingest WITH OPTIONS DETACHED"
+
+			t.L().Printf("Running INSPECT on multi-region cluster")
+			tickHistogram(metricName)
+			before := timeutil.Now()
+
+			jobID := runInspectInBackground(ctx, t, bulkDB, inspectSQL)
+
+			tickHistogram(metricName)
+			duration := timeutil.Since(before)
+			t.L().Printf("INSPECT on multi-region cluster took %v\n", duration)
+
+			logInspectJobStats(t, bulkDB, jobID, 0 /* numChecks */, numCRDBNodes*numCPUs)
+		},
+	}
+}
+
+// logInspectJobStats queries and logs the span count and parallelism metrics
+// for a completed INSPECT job.
+func logInspectJobStats(t test.Test, db *gosql.DB, jobID int64, numChecks int, totalCPUs int) {
+	t.Helper()
+	var jobTotalCheckCount int64
+	querySQL := `
+		SELECT coalesce(
+			(crdb_internal.pb_to_json(
+				'cockroach.sql.jobs.jobspb.Progress',
+				value
+			)->'inspect'->>'jobTotalCheckCount')::INT8,
+			0
+		)
+		FROM system.job_info
+		WHERE job_id = $1
+		AND info_key = 'legacy_progress'`
+	err := db.QueryRow(querySQL, jobID).Scan(&jobTotalCheckCount)
+	if err != nil {
+		t.L().Printf("Warning: failed to query job total check count: %v", err)
+		return
+	}
+
+	var spanCount int
+	if numChecks > 0 {
+		// Each span handles all indexes, so divide by number of checks to get span count.
+		spanCount = int(jobTotalCheckCount) / numChecks
+	} else {
+		spanCount = int(jobTotalCheckCount)
+	}
+	spansPerCPU := float64(spanCount) / float64(totalCPUs)
+	t.L().Printf(
+		"INSPECT completed %d checks across %d spans (%.2f spans/CPU with %d total CPUs)\n",
+		jobTotalCheckCount, spanCount, spansPerCPU, totalCPUs,
+	)
 }
 
 // disableRowCountValidation disables automatic row count validation during import.
@@ -292,6 +544,18 @@ func disableRowCountValidation(t test.Test, db *gosql.DB) {
 	t.Helper()
 	t.L().Printf("Disabling automatic row count validation")
 	_, err := db.Exec("SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'off'")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// enableComplexKeyUniquenessValidation enables validation of complex keys (i.e.
+// the unique column does not immediately follow the region column) during the
+// uniqueness check.
+func enableComplexKeyUniquenessValidation(t test.Test, db *gosql.DB) {
+	t.Helper()
+	t.L().Printf("Enabling complex key uniqueness validation")
+	_, err := db.Exec("SET CLUSTER SETTING sql.inspect.uniqueness_check.complex_keys.enabled = true;")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The roachtest for inspect was run in a single region which precluded
testing the uniqueness check. This change adds a multiregion roachtest
which measures the performance implications of a uniqueness check on
tables with a complex key.

Closes: CRDB-61451

Epic: CRDB-58692

Release note: None
