### PR TITLE
backup: fast-fail on malformed localities

### DIFF
--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backupbase"
+	"github.com/cockroachdb/cockroach/pkg/backup/backupdest"
 	"github.com/cockroachdb/cockroach/pkg/backup/backupresolver"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
@@ -410,6 +411,13 @@ func backupPlanHook(
 	}
 
 	to, err := exprEval.StringArray(ctx, tree.Exprs(backupStmt.To))
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	// We call GetURIsByLocalityKV here to validate that COCKROACH_LOCALITY is
+	// well-formed in the backup destinations.
+	_, _, err = backupdest.GetURIsByLocalityKV(to, "")
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/backup/backup_planning_test.go
+++ b/pkg/backup/backup_planning_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +58,26 @@ func TestBackupResolveOptionsForJobDescription(t *testing.T) {
 	require.NoError(t, err)
 	ensureAllStructFieldsSet(output, "output")
 
+}
+
+func TestFastFailMalformedLocalities(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, sqlDB, cleanup := backupRestoreTestSetupEmpty(
+		t, singleNode, "", InitManualReplication, base.TestClusterArgs{},
+	)
+	defer cleanup()
+
+	sqlDB.ExpectErr(
+		t,
+		`no default URL provided for partitioned backup`,
+		`BACKUP INTO (
+			'nodelocal://1/backup?COCKROACH_LOCALITY=region%3Dus-east-1',
+			'nodelocal://2/backup?COCKROACH_LOCALITY=region%3Dus-west-1',
+			'nodelocal://3/backup?COCKROACH_LOCALITY=region%3Dus-central-1'
+		) WITH detached`,
+	)
 }
 
 func BenchmarkSpansForAllTableIndexes(b *testing.B) {


### PR DESCRIPTION
Previously, the localities in a locality-aware backup were not checked until job execution, which meant that a job record would be created and malformed localities would be retried. This added noticeable latency before the job would fail. This commit teaches backup to check locaities during backup planning and fast-fail if there is an issue.

Fixes: #167036

Release note: None