### PR TITLE
sql: increase memory slack in TestStreamerTightBudget

### DIFF
--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -195,8 +195,9 @@ func TestStreamerTightBudget(t *testing.T) {
 			// We expect that the maximum memory usage is about 2MiB (1MiB is
 			// accounted for by the Streamer, and another 1MiB is accounted for
 			// by the ColIndexJoin when the blob is copied into the columnar
-			// batch). We allow for 0.1MiB for other memory usage in the query.
-			maxAllowed := 2.1
+			// batch). We allow for 1MiB of slack for nondeterministic overhead
+			// (Go allocator, protobuf headers, memory accounting granularity).
+			maxAllowed := 3.0
 			require.GreaterOrEqualf(t, maxAllowed, usage, "unexpectedly high memory usage\n----\n%s", sb.String())
 			return
 		}


### PR DESCRIPTION
The test's 0.1 MiB slack above the expected 2 MiB memory usage was too tight, causing flaky failures when nondeterministic overhead (Go allocator, protobuf headers, memory accounting granularity) pushed observed usage to 2.3–2.4 MiB. Increase the allowed maximum from 2.1 to 3.0 MiB, providing 1 MiB of slack while still catching real regressions (e.g., the Streamer holding multiple results would push usage to 4+ MiB).

Fixes: #166373
Fixes: #166879
Release note: None