### PR TITLE
util/pretty: improve handling of hard line breaks

### DIFF
--- a/pkg/sql/plpgsql/parser/testdata/combo
+++ b/pkg/sql/plpgsql/parser/testdata/combo
@@ -124,15 +124,13 @@ DECLARE
 BEGIN
 	i := 0;
 	LOOP
-		IF i
-		= idx THEN
+		IF i = idx THEN
 			res := res || val;
 		ELSE
 			res := res || arr[i + 1];
 		END IF;
 		i := i + 1;
-		IF i
-		>= n THEN
+		IF i >= n THEN
 			EXIT;
 		END IF;
 	END LOOP;

--- a/pkg/sql/plpgsql/parser/testdata/stmt_while
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_while
@@ -148,8 +148,7 @@ DECLARE
 BEGIN
 	x := 10;
 	WHILE x > 0
-	AND x
-		< 100 LOOP
+	AND x < 100 LOOP
 		x := x - 1;
 		x := x - 2;
 	END LOOP;

--- a/pkg/util/pretty/document.go
+++ b/pkg/util/pretty/document.go
@@ -37,6 +37,7 @@ func (text) isDoc()      {}
 func (line) isDoc()      {}
 func (softbreak) isDoc() {}
 func (hardline) isDoc()  {}
+func (failDoc) isDoc()   {}
 func (nilDoc) isDoc()    {}
 func (*concat) isDoc()   {}
 func (nestt) isDoc()     {}
@@ -94,6 +95,11 @@ type hardline struct{}
 // HardLine is a newline and cannot be flattened.
 var HardLine Doc = hardline{}
 
+type failDoc struct{}
+
+// fail signals that a document cannot be flattened (laid out on a single line).
+var fail Doc = failDoc{}
+
 // concat represents (DOC <> DOC) :: DOC -- the concatenation of two docs.
 type concat struct {
 	a, b Doc
@@ -145,9 +151,14 @@ type union struct {
 	x, y Doc
 }
 
-// Group will format d on one line if possible.
+// Group will format d on one line if possible. If d cannot be flattened,
+// d is returned unchanged.
 func Group(d Doc) Doc {
-	return &union{flatten(d), d}
+	f := flatten(d)
+	if f == fail {
+		return d
+	}
+	return &union{f, d}
 }
 
 var textSpace = Text(" ")
@@ -156,14 +167,34 @@ func flatten(d Doc) Doc {
 	switch t := d.(type) {
 	case nilDoc:
 		return Nil
+	case failDoc:
+		return fail
 	case *concat:
-		return Concat(flatten(t.a), flatten(t.b))
+		a := flatten(t.a)
+		if a == fail {
+			return fail
+		}
+		b := flatten(t.b)
+		if b == fail {
+			return fail
+		}
+		return Concat(a, b)
 	case nestt:
-		return NestT(flatten(t.d))
+		inner := flatten(t.d)
+		if inner == fail {
+			return fail
+		}
+		return NestT(inner)
 	case nests:
-		return NestS(t.n, flatten(t.d))
-	case text, keyword, hardline:
+		inner := flatten(t.d)
+		if inner == fail {
+			return fail
+		}
+		return NestS(t.n, inner)
+	case text, keyword:
 		return d
+	case hardline:
+		return fail
 	case line:
 		return textSpace
 	case softbreak:

--- a/pkg/util/pretty/pretty.go
+++ b/pkg/util/pretty/pretty.go
@@ -36,6 +36,7 @@ const (
 	hardlineB
 	spacesB
 	keywordB
+	failB
 )
 
 // Pretty returns a pretty-printed string for the Doc d at line length
@@ -148,6 +149,8 @@ func (b *beExec) be(k docPos, xlist *iDoc) *docBest {
 	switch t := d.d.(type) {
 	case nilDoc:
 		res = b.be(k, z)
+	case failDoc:
+		res = b.newDocBest(docBest{tag: failB})
 	case *concat:
 		res = b.be(k, b.iDoc(d.i, t.a, b.iDoc(d.i, t.b, z)))
 	case nests:
@@ -273,12 +276,12 @@ func fits(w int16, x *docBest) bool {
 	switch x.tag {
 	case textB, keywordB:
 		return fits(w-int16(len(x.s)), x.d)
-	case lineB:
+	case lineB, hardlineB:
 		return true
-	case hardlineB:
-		return false
 	case spacesB:
 		return fits(w-x.i.spaces, x.d)
+	case failB:
+		return false
 	default:
 		panic(fmt.Errorf("unknown type: %d", x.tag))
 	}
@@ -314,6 +317,8 @@ func (b *beExec) layout(sb *strings.Builder, useTabs bool, d *docBest) {
 			for i := int16(0); i < d.i.spaces; i++ {
 				sb.WriteByte(' ')
 			}
+		case failB:
+			panic(errors.AssertionFailedf("failB should never reach layout"))
 		default:
 			panic(fmt.Errorf("unknown type: %d", d.tag))
 		}


### PR DESCRIPTION
Previously, a `pretty.HardLine` could lead to unnecessary line-breaking
in other parts of the doc by the pretty-printer. This has been fixed by
making sure we can distinguish between documents that can't be flattened
(because they contain a hard line break) and documents that are too long
to be rendered on one line.

Informs #112136

Release note: None