### PR TITLE
drtprod: fix mixed_version.sh first-run and add day override

### DIFF
--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -17,11 +17,11 @@ CLOUD="${3:-}"
 
 if [ -z "${CLUSTER}" ] || [ -z "${WORKLOAD_CLUSTER}" ] || [ -z "${CLOUD}" ]; then
   echo "Usage: $0 <cluster> <workload_cluster> <cloud>"
-  echo "  cloud: aws or gcp"
+  echo "  cloud: aws or gce"
   echo ""
   echo "Examples:"
   echo "  $0 drt-chaos-aws workload-chaos-aws aws"
-  echo "  $0 drt-chaos workload-chaos gcp"
+  echo "  $0 drt-chaos workload-chaos gce"
   exit 1
 fi
 
@@ -29,7 +29,7 @@ cd /home/ubuntu
 
 export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
 export ROACHPROD_DNS="drt.crdb.io"
-./roachprod sync
+./drtprod sync
 sleep 20
 
 # Fetch secrets from cloud provider at runtime (not stored in any file)
@@ -52,7 +52,7 @@ fetch_secret() {
         exit 1
       fi
       ;;
-    gcp)
+    gce)
       if ! secret_value="$(gcloud --project=cockroach-drt secrets versions access latest \
         --secret "${secret_name}" 2>&1)"; then
         echo "Error: Failed to fetch secret '${secret_name}' from GCP Secret Manager" >&2

--- a/pkg/cmd/drtprod/configs/drt_upgrade.yaml
+++ b/pkg/cmd/drtprod/configs/drt_upgrade.yaml
@@ -9,7 +9,7 @@ environment:
   CLUSTER_NODES: 6
   WORKLOAD_CLUSTER: workload-upgrade-test
   WORKLOAD_NODES: 1
-  COCKROACH_VERSION: v24.3.8
+  COCKROACH_VERSION: v25.4.6
 
 targets:
   - target_name: $CLUSTER
@@ -100,12 +100,17 @@ targets:
       - command: put
         args:
           - $WORKLOAD_CLUSTER
+          - pkg/cmd/drt/scripts/roachtest_operations_run.sh
+          - roachtest_operations_run.sh
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
           - pkg/cmd/drtprod/scripts/mixed_version.sh
       - command: run
         args:
           - $WORKLOAD_CLUSTER
           - --
-          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; sudo systemctl start cron.service ; echo \"crontab -l ; echo '0 4 * * * /home/ubuntu/mixed_version.sh $CLUSTER >> /home/ubuntu/mixed_version.log' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
+          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; sudo systemctl start cron.service ; echo \"crontab -l ; echo '0 4 * * * /home/ubuntu/mixed_version.sh $CLUSTER $WORKLOAD_CLUSTER gce >> /home/ubuntu/mixed_version.log' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
   - target_name: post_tasks
     dependent_targets:
       - $CLUSTER

--- a/pkg/cmd/drtprod/scripts/mixed_version.sh
+++ b/pkg/cmd/drtprod/scripts/mixed_version.sh
@@ -7,7 +7,8 @@
 
 # This script schedules daily maintenance commands on a 2‐week cycle.
 # Optional parameters OLD_RELEASE and NEW_RELEASE can be provided.
-# Usage: ./mixed_version.sh <CLUSTER> [OLD_RELEASE=v24.3.8] [NEW_RELEASE=v25.2.0-alpha.2]
+# Usage: ./mixed_version.sh <CLUSTER> <WORKLOAD_CLUSTER> <CLOUD> [OLD_RELEASE] [NEW_RELEASE] [DAY_OVERRIDE]
+# DAY_OVERRIDE: optionally force a specific day's action (monday, tuesday, thursday, friday)
 
 # Schedule of commands:
 #
@@ -31,9 +32,13 @@
 #     - Reset cluster.preserve_downgrade_option
 #     - Upgrade node 6 to NEW_RELEASE (100% nodes as 1-5 were already upgraded)
 
+USAGE="Usage: $0 <CLUSTER> <WORKLOAD_CLUSTER> <CLOUD> [OLD_RELEASE] [NEW_RELEASE] [DAY_OVERRIDE]"
+
 CLUSTER="$1"
-if [ -z "$CLUSTER" ]; then
-    echo "Usage: $0 <CLUSTER> [OLD_RELEASE] [NEW_RELEASE]"
+WORKLOAD_CLUSTER="$2"
+CLOUD="$3"
+if [ -z "$CLUSTER" ] || [ -z "$WORKLOAD_CLUSTER" ] || [ -z "$CLOUD" ]; then
+    echo "$USAGE"
     exit 1
 fi
 
@@ -42,24 +47,39 @@ export ROACHPROD_DISABLED_PROVIDERS=IBM
 /home/ubuntu/drtprod sync
 
 # Set optional release versions
-OLD_RELEASE="${2:-v24.3.8}"
-NEW_RELEASE="${3:-v25.2.0-alpha.2}"
+OLD_RELEASE="${4:-v25.4.6}"
+NEW_RELEASE="${5:-v26.2.0-beta.1}"
 
 # Get today's day of week (1 for Monday, ... 7 for Sunday) and date
-day_of_week=$(date +%u)
+# An optional 6th argument overrides the day for manual triggering.
+DAY_OVERRIDE="${6:-}"
+case "$DAY_OVERRIDE" in
+    monday)    day_of_week=1 ;;
+    tuesday)   day_of_week=2 ;;
+    wednesday) day_of_week=3 ;;
+    thursday)  day_of_week=4 ;;
+    friday)    day_of_week=5 ;;
+    "")        day_of_week=$(date +%u) ;;
+    *)         echo "Invalid day override: $DAY_OVERRIDE (use monday, tuesday, thursday, or friday)"; exit 1 ;;
+esac
 today=$(date +%F)
 cycle_file="/home/ubuntu/.cycle_info.txt"
 
+first_run=false
 if [ -f "$cycle_file" ]; then
     read saved_cycle saved_day < "$cycle_file"
 else
     # Initialize cycle_week to 0 if no previous info exists
     saved_cycle=0
     saved_day=$today
+    first_run=true
 fi
 
-# On Monday, if this is the first run of today, flip the cycle week
-if [ "$day_of_week" -eq 1 ] && [ "$saved_day" != "$today" ]; then
+# On Monday, if this is the first run of today, flip the cycle week.
+# Use the real day of week here so that a day override doesn't accidentally
+# flip the cycle.
+actual_day_of_week=$(date +%u)
+if [ "$actual_day_of_week" -eq 1 ] && [ "$saved_day" != "$today" ]; then
     cycle_week=$((1 - saved_cycle))
 else
     cycle_week=$saved_cycle
@@ -71,13 +91,13 @@ echo "$cycle_week $today" > "$cycle_file"
 # Use an array to store multiple commands
 cmds=()
 
-if [ "$day_of_week" -eq 1 ] && [ "$cycle_week" -eq 1 ]; then
-        # Week 2 - Monday
-        cmds+=("/home/ubuntu/drtprod deploy $CLUSTER:3-5 release $NEW_RELEASE")
-elif [ "$day_of_week" -eq 2 ] && [ "$cycle_week" -eq 0 ]; then
-        # Tuesday in Week 1 only
-        cmds+=("sudo systemctl stop tpcc_run_cct_tpcc")
-        cmds+=("sudo systemctl stop roachtest_ops")
+# Appends the cluster initialization commands (wipe, stage, start, upgrade, workloads).
+# Used on Week 1 Tuesday and also on first-ever run regardless of day.
+append_init_cmds() {
+        cmds+=("sudo systemctl stop tpcc_run_cct_tpcc || true")
+        cmds+=("sudo systemctl reset-failed tpcc_run_cct_tpcc || true")
+        cmds+=("sudo systemctl stop roachtest_ops || true")
+        cmds+=("sudo systemctl reset-failed roachtest_ops || true")
         cmds+=("/home/ubuntu/drtprod stop $CLUSTER")
         cmds+=("/home/ubuntu/drtprod wipe $CLUSTER")
         cmds+=("/home/ubuntu/drtprod stage $CLUSTER release $OLD_RELEASE")
@@ -91,8 +111,20 @@ elif [ "$day_of_week" -eq 2 ] && [ "$cycle_week" -eq 0 ]; then
         cmds+=("/home/ubuntu/tpcc_init_cct_tpcc.sh")
         cmds+=("sudo systemd-run --unit tpcc_run_cct_tpcc --same-dir --uid $(id -u) --gid $(id -g) bash /home/ubuntu/tpcc_run_cct_tpcc.sh")
         cmds+=("sleep 30")
-        # Note that roachtest_operations_run.sh needs to be setup manually for the first time.
-        cmds+=("sudo systemd-run --unit roachtest_ops --same-dir --uid $(id -u) --gid $(id -g) bash /home/ubuntu/roachtest_operations_run.sh")
+        # TODO: parameterize
+        cmds+=("sudo systemd-run --unit roachtest_ops --same-dir --uid $(id -u) --gid $(id -g) bash /home/ubuntu/roachtest_operations_run.sh $CLUSTER $WORKLOAD_CLUSTER $CLOUD")
+}
+
+if [ "$first_run" = true ]; then
+        # First run ever: initialize the cluster regardless of day of week
+        echo "First run detected; running cluster initialization."
+        append_init_cmds
+elif [ "$day_of_week" -eq 1 ] && [ "$cycle_week" -eq 1 ]; then
+        # Week 2 - Monday
+        cmds+=("/home/ubuntu/drtprod deploy $CLUSTER:3-5 release $NEW_RELEASE")
+elif [ "$day_of_week" -eq 2 ] && [ "$cycle_week" -eq 0 ]; then
+        # Tuesday in Week 1 only
+        append_init_cmds
 elif [ "$day_of_week" -eq 4 ] && [ "$cycle_week" -eq 0 ]; then
     # Thursday in Week 1 only
     cmds+=("/home/ubuntu/drtprod deploy $CLUSTER:4-6 release $NEW_RELEASE")
@@ -112,14 +144,10 @@ fi
 # Always check the status of the cluster
 cmds+=("/home/ubuntu/drtprod status $CLUSTER")
 
-if [ ${#cmds[@]} -gt 0 ]; then
-    for cmd in "${cmds[@]}"; do
-        echo "Executing: $cmd"
-        if ! eval "$cmd"; then
-            echo "Error executing: $cmd" >&2
-            exit 1
-        fi
-    done
-else
-    echo "No scheduled command for today."
-fi
+for cmd in "${cmds[@]}"; do
+    echo "Executing: $cmd"
+    if ! eval "$cmd"; then
+        echo "Error executing: $cmd" >&2
+        exit 1
+    fi
+done


### PR DESCRIPTION
Previously, the script assumed its first-ever run would happen on or before Tuesday of Week 1. If the first run occurred on Wednesday or later, the critical Tuesday initialization (wipe, stage, start, set preserve_downgrade_option, upgrade nodes 1-3, start workloads) was skipped, leaving subsequent days operating on an uninitialized cluster.

This commit:
- Detects first-ever runs (no cycle file) and runs the initialization commands regardless of day of week.
- Extracts initialization commands into an `append_init_cmds` function to avoid duplication between the first-run and Tuesday paths.
- Allows `systemctl stop` of workload units to fail gracefully on first run when the units don't exist yet.
- Adds an optional 4th argument (`DAY_OVERRIDE`) to manually trigger any day's action, e.g. `./mixed_version.sh <CLUSTER> "" "" tuesday`.
- Updates default release versions.

Epic: none
Release note: None