### PR TITLE
roachtest/pg_regress: some more cleanup

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
@@ -4449,8 +4449,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 -  3 | 13
 -  4 | 14
 -(4 rows)
-+  7 | 11
-+  8 | 12
++ 21 | 11
++ 22 | 12
 +(2 rows)
  
  select alter2.plus1(41);

--- a/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
@@ -511,131 +511,82 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ************************************************************
  -- * Describe the front of a patchfield slot
  -- ************************************************************
-@@ -953,54 +1156,83 @@
+@@ -953,6 +1156,35 @@
      return psrec.slotlink;
  end;
  ' language plpgsql;
---- ************************************************************
---- * Describe the front of a wall connector slot
---- ************************************************************
--create function wslot_slotlink_view(bpchar)
--returns text as '
 +ERROR:  at or near ";": at or near "from": syntax error
 +DETAIL:  source SQL:
 +SET ROW (comment from Hub H, HSlot HS
 +                 ^
 +--
 +source SQL:
- declare
--    rec		record;
++declare
 +    psrec	record;
-     sltype	char(2);
-     retval	text;
- begin
--    select into rec * from WSlot where slotname = $1;
++    sltype	char(2);
++    retval	text;
++begin
 +    select into psrec * from PSlot where slotname = $1;
-     if not found then
--        return '''';
++    if not found then
 +        return '';
-     end if;
--    if rec.slotlink = '''' then
--        return ''-'';
--    end if;
--    sltype := substr(rec.slotlink, 1, 2);
--    if sltype = ''PH'' then
--        select into rec * from PHone where slotname = rec.slotlink;
--	retval := ''Phone '' || trim(rec.slotname);
--	if rec.comment != '''' then
--	    retval := retval || '' ('';
--	    retval := retval || rec.comment;
--	    retval := retval || '')'';
--	end if;
--	return retval;
++    end if;
 +    if psrec.slotlink = '' then
 +        return '-';
-     end if;
--    if sltype = ''IF'' then
--	declare
--	    syrow	System%RowType;
--	    ifrow	IFace%ROWTYPE;
--        begin
--	    select into ifrow * from IFace where slotname = rec.slotlink;
--	    select into syrow * from System where name = ifrow.sysname;
--	    retval := syrow.name || '' IF '';
--	    retval := retval || ifrow.ifname;
--	    if syrow.comment != '''' then
--	        retval := retval || '' ('';
--		retval := retval || syrow.comment;
--		retval := retval || '')'';
--	    end if;
--	    return retval;
--	end;
++    end if;
 +    sltype := substr(psrec.slotlink, 1, 2);
 +    if sltype = 'PS' then
 +	retval := trim(psrec.slotlink) || ' -> ';
 +	return retval || pslot_backlink_view(psrec.slotlink);
-     end if;
--    return rec.slotlink;
--end;
--' language plpgsql;
++    end if;
 +    if sltype = 'HS' then
 +        retval := comment from Hub H, HSlot HS
 +			where HS.slotname = psrec.slotlink
 +			  and H.name = HS.hubname;
 +                            ^
 +HINT:  try \h SET SESSION
-+-- ************************************************************
-+-- * Describe the front of a wall connector slot
-+-- ************************************************************
-+-- create function wslot_slotlink_view(bpchar)
-+-- returns text as '
-+-- declare
-+--     rec		record;
-+--     sltype	char(2);
-+--     retval	text;
-+-- begin
-+--     select into rec * from WSlot where slotname = $1;
-+--     if not found then
-+--         return '''';
-+--     end if;
-+--     if rec.slotlink = '''' then
-+--         return ''-'';
-+--     end if;
-+--     sltype := substr(rec.slotlink, 1, 2);
-+--     if sltype = ''PH'' then
-+--         select into rec * from PHone where slotname = rec.slotlink;
-+-- 	retval := ''Phone '' || trim(rec.slotname);
-+-- 	if rec.comment != '''' then
-+-- 	    retval := retval || '' ('';
-+-- 	    retval := retval || rec.comment;
-+-- 	    retval := retval || '')'';
-+-- 	end if;
-+-- 	return retval;
-+--     end if;
-+--     if sltype = ''IF'' then
-+-- 	declare
-+-- 	    syrow	System%RowType;
-+-- 	    ifrow	IFace%ROWTYPE;
-+--         begin
-+-- 	    select into ifrow * from IFace where slotname = rec.slotlink;
-+-- 	    select into syrow * from System where name = ifrow.sysname;
-+-- 	    retval := syrow.name || '' IF '';
-+-- 	    retval := retval || ifrow.ifname;
-+-- 	    if syrow.comment != '''' then
-+-- 	        retval := retval || '' ('';
-+-- 		retval := retval || syrow.comment;
-+-- 		retval := retval || '')'';
-+-- 	    end if;
-+-- 	    return retval;
-+-- 	end;
-+--     end if;
-+--     return rec.slotlink;
-+-- end;
-+-- ' language plpgsql;
+ -- ************************************************************
+ -- * Describe the front of a wall connector slot
+ -- ************************************************************
+@@ -1001,6 +1233,38 @@
+     return rec.slotlink;
+ end;
+ ' language plpgsql;
++ERROR:  at or near "rowtype": syntax error: unable to parse type of variable declaration
++DETAIL:  source SQL:
++declare
++    rec		record;
++    sltype	char(2);
++    retval	text;
++begin
++    select into rec * from WSlot where slotname = $1;
++    if not found then
++        return '';
++    end if;
++    if rec.slotlink = '' then
++        return '-';
++    end if;
++    sltype := substr(rec.slotlink, 1, 2);
++    if sltype = 'PH' then
++        select into rec * from PHone where slotname = rec.slotlink;
++	retval := 'Phone ' || trim(rec.slotname);
++	if rec.comment != '' then
++	    retval := retval || ' (';
++	    retval := retval || rec.comment;
++	    retval := retval || ')';
++	end if;
++	return retval;
++    end if;
++    if sltype = 'IF' then
++	declare
++	    syrow	System%RowType;
++                  ^
++HINT:  you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
++--
++See: https://go.crdb.dev/issue-v/114676/_version_
  -- ************************************************************
  -- * View of a patchfield describing backside and patches
  -- ************************************************************
-@@ -1008,6 +1240,7 @@
+@@ -1008,6 +1272,7 @@
  	pslot_backlink_view(PF.slotname) as backside,
  	pslot_slotlink_view(PF.slotname) as patch
      from PSlot PF;
@@ -643,7 +594,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- First we build the house - so we create the rooms
  --
-@@ -1146,8 +1379,8 @@
+@@ -1146,8 +1411,8 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -654,7 +605,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2a            | 001      |                      |                     
   WS.001.2b            | 001      |                      |                     
   WS.001.3a            | 001      |                      |                     
-@@ -1169,9 +1402,9 @@
+@@ -1169,9 +1434,9 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -666,7 +617,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      |                     
   WS.001.3a            | 001      |                      |                     
   WS.001.3b            | 001      |                      |                     
-@@ -1192,9 +1425,9 @@
+@@ -1192,9 +1457,9 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -679,7 +630,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      |                     
   WS.001.3a            | 001      |                      |                     
   WS.001.3b            | 001      |                      |                     
-@@ -1221,9 +1454,9 @@
+@@ -1221,9 +1486,9 @@
  select * from WSlot where roomno = '001' order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -692,7 +643,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      | PS.base.a4          
   WS.001.3a            | 001      |                      | PS.base.a6          
   WS.001.3b            | 001      |                      |                     
-@@ -1235,20 +1468,20 @@
+@@ -1235,20 +1500,20 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -719,7 +670,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.3b            | 001      |                      | PS.base.a6          
  (6 rows)
  
-@@ -1258,18 +1491,18 @@
+@@ -1258,18 +1523,18 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -743,7 +694,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   WS.001.2b            | 001      |                      | PS.base.a4          
   WS.001.3a            | 001      |                      | PS.base.a5          
   WS.001.3b            | 001      |                      | PS.base.a6          
-@@ -1281,9 +1514,9 @@
+@@ -1281,9 +1546,9 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -756,7 +707,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (6 rows)
  
  insert into PField values ('PF1_2', 'Phonelines first floor');
-@@ -1309,9 +1542,9 @@
+@@ -1309,9 +1574,9 @@
   PS.base.a1           | PF0_1  |                      | WS.001.1a           
   PS.base.a2           | PF0_1  |                      | WS.001.1b           
   PS.base.a3           | PF0_1  |                      | WS.001.2a           
@@ -769,7 +720,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   PS.base.b1           | PF0_1  |                      | WS.002.1a           
   PS.base.b2           | PF0_1  |                      | WS.002.1b           
   PS.base.b3           | PF0_1  |                      | WS.002.2a           
-@@ -1324,18 +1557,18 @@
+@@ -1324,18 +1589,18 @@
   PS.base.c4           | PF0_1  |                      | WS.003.2b           
   PS.base.c5           | PF0_1  |                      | WS.003.3a           
   PS.base.c6           | PF0_1  |                      | WS.003.3b           
@@ -800,7 +751,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
   PS.first.a1          | PF1_1  |                      | WS.101.1a           
   PS.first.a2          | PF1_1  |                      | WS.101.1b           
   PS.first.a3          | PF1_1  |                      | WS.101.2a           
-@@ -1377,48 +1610,48 @@
+@@ -1377,48 +1642,48 @@
  select * from WSlot order by slotname;
         slotname       |  roomno  |       slotlink       |       backlink       
  ----------------------+----------+----------------------+----------------------
@@ -888,7 +839,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (42 rows)
  
  --
-@@ -1471,82 +1704,22 @@
+@@ -1471,82 +1736,22 @@
  -- Now we take a look at the patchfield
  --
  select * from PField_v1 where pfname = 'PF0_1' order by slotname;
@@ -973,7 +924,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- The following tests are unrelated to the scenario outlined above;
  -- they merely exercise specific parts of PL/pgSQL
-@@ -1564,12 +1737,9 @@
+@@ -1564,12 +1769,9 @@
      END IF;
      RETURN rslt;
  END;' LANGUAGE plpgsql;
@@ -988,7 +939,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test the FOUND magic variable
  --
-@@ -1609,22 +1779,13 @@
+@@ -1609,22 +1811,13 @@
    end if;
    return true;
    end;' language plpgsql;
@@ -1016,7 +967,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  --
  -- Test set-returning functions for PL/pgSQL
-@@ -1638,17 +1799,26 @@
+@@ -1638,17 +1831,26 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
@@ -1053,7 +1004,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_table_func_row() returns setof found_test_tbl as '
  DECLARE
  	row found_test_tbl%ROWTYPE;
-@@ -1658,17 +1828,16 @@
+@@ -1658,17 +1860,16 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
@@ -1080,7 +1031,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_set_scalar(int,int) returns setof int as '
  DECLARE
  	i int;
-@@ -1678,21 +1847,13 @@
+@@ -1678,21 +1879,13 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
@@ -1108,7 +1059,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_set_rec_dyn(int) returns setof record as '
  DECLARE
  	retval RECORD;
-@@ -1708,20 +1869,13 @@
+@@ -1708,20 +1901,13 @@
  	END IF;
  	RETURN;
  END;' language plpgsql;
@@ -1134,7 +1085,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_rec_dyn(int) returns record as '
  DECLARE
  	retval RECORD;
-@@ -1734,18 +1888,13 @@
+@@ -1734,18 +1920,13 @@
  		RETURN retval;
  	END IF;
  END;' language plpgsql;
@@ -1158,7 +1109,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test some simple polymorphism cases.
  --
-@@ -1753,31 +1902,37 @@
+@@ -1753,31 +1934,37 @@
  begin
    return x + 1;
  end$$ language plpgsql;
@@ -1212,7 +1163,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(x anyarray) returns anyelement as $$
  begin
    return x[1];
-@@ -1789,7 +1944,10 @@
+@@ -1789,7 +1976,10 @@
  (1 row)
  
  select f1(stavalues1) from pg_statistic;  -- fail, can't infer element type
@@ -1224,7 +1175,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function f1(x anyarray);
  create function f1(x anyarray) returns anyarray as $$
  begin
-@@ -1802,72 +1960,61 @@
+@@ -1802,72 +1992,61 @@
  (1 row)
  
  select f1(stavalues1) from pg_statistic;  -- fail, can't infer element type
@@ -1316,7 +1267,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(a anyelement, b anyarray,
                     c anycompatible, d anycompatible,
                     OUT x anyarray, OUT y anycompatiblearray)
-@@ -1876,35 +2023,30 @@
+@@ -1876,35 +2055,30 @@
    x := a || b;
    y := array[c, d];
  end$$ language plpgsql;
@@ -1366,7 +1317,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of OUT parameters, including polymorphic cases.
  -- Note that RETURN is optional with OUT params; we try both ways.
-@@ -1915,8 +2057,6 @@
+@@ -1915,8 +2089,6 @@
    return i+1;
  end$$ language plpgsql;
  ERROR:  RETURN cannot have a parameter in function with OUT parameters
@@ -1375,7 +1326,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(in i int, out j int) as $$
  begin
    j := i+1;
-@@ -2028,19 +2168,13 @@
+@@ -2028,19 +2200,13 @@
    k := array[lower(i),upper(i)];
    return;
  end$$ language plpgsql;
@@ -1399,7 +1350,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test PERFORM
  --
-@@ -2057,6 +2191,7 @@
+@@ -2057,6 +2223,7 @@
  		RETURN FALSE;
  	END IF;
  END;' language plpgsql;
@@ -1407,7 +1358,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function perform_test_func() returns void as '
  BEGIN
  	IF FOUND then
-@@ -2077,19 +2212,32 @@
+@@ -2077,19 +2244,32 @@
  
  	RETURN;
  END;' language plpgsql;
@@ -1422,7 +1373,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +	IF FOUND then
 +		INSERT INTO perform_test VALUES (100, 100);
 +	END IF;
-+
+ 
 +	PERFORM perform_simple_func(5);
 +                               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
@@ -1430,7 +1381,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -1451,7 +1402,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  drop table perform_test;
  --
-@@ -2103,19 +2251,12 @@
+@@ -2103,19 +2283,12 @@
    if found then return x; end if;
    return 0;
  end$$ language plpgsql stable;
@@ -1474,7 +1425,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function sp_add_user(a_login text) returns int as $$
  declare my_id_user int;
  begin
-@@ -2130,38 +2271,21 @@
+@@ -2130,38 +2303,21 @@
    END IF;
    RETURN my_id_user;
  end$$ language plpgsql;
@@ -1521,7 +1472,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- tests for refcursors
  --
-@@ -2185,12 +2309,13 @@
+@@ -2185,12 +2341,13 @@
      return x.a;
  end
  $$ language plpgsql;
@@ -1540,7 +1491,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function return_refcursor(rc refcursor) returns refcursor as $$
  begin
      open rc for select a from rc_test;
-@@ -2203,33 +2328,31 @@
+@@ -2203,33 +2360,31 @@
      return $1;
  end
  $$ language plpgsql;
@@ -1594,7 +1545,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  commit;
  -- should fail
  fetch next from test1;
-@@ -2249,13 +2372,25 @@
+@@ -2249,13 +2404,25 @@
      end if;
  end
  $$ language plpgsql;
@@ -1625,7 +1576,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- should fail
  create function constant_refcursor() returns refcursor as $$
  declare
-@@ -2266,8 +2401,11 @@
+@@ -2266,8 +2433,11 @@
  end
  $$ language plpgsql;
  select constant_refcursor();
@@ -1639,7 +1590,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- but it's okay like this
  create or replace function constant_refcursor() returns refcursor as $$
  declare
-@@ -2301,13 +2439,25 @@
+@@ -2301,13 +2471,25 @@
      end if;
  end
  $$ language plpgsql;
@@ -1670,7 +1621,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional argument notations
  create function namedparmcursor_test2(int, int) returns boolean as $$
  declare
-@@ -2324,12 +2474,24 @@
+@@ -2324,12 +2506,24 @@
      end if;
  end
  $$ language plpgsql;
@@ -1689,10 +1640,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select namedparmcursor_test2(20, 20);
@@ -1700,7 +1651,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional: param2 is given twice, once in named notation
  -- and second time in positional notation. Should throw an error at parse time
  create function namedparmcursor_test3() returns void as $$
-@@ -2339,9 +2501,22 @@
+@@ -2339,9 +2533,22 @@
      open c1(param2 := 20, 21);
  end
  $$ language plpgsql;
@@ -1726,7 +1677,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional: same as previous test, but param1 is duplicated
  create function namedparmcursor_test4() returns void as $$
  declare
-@@ -2350,9 +2525,22 @@
+@@ -2350,9 +2557,22 @@
      open c1(20, param1 := 21);
  end
  $$ language plpgsql;
@@ -1752,7 +1703,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- duplicate named parameter, should throw an error at parse time
  create function namedparmcursor_test5() returns void as $$
  declare
-@@ -2362,9 +2550,22 @@
+@@ -2362,9 +2582,22 @@
    open c1 (p2 := 77, p2 := 42);
  end
  $$ language plpgsql;
@@ -1778,7 +1729,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- not enough parameters, should throw an error at parse time
  create function namedparmcursor_test6() returns void as $$
  declare
-@@ -2374,9 +2575,22 @@
+@@ -2374,9 +2607,22 @@
    open c1 (p2 := 77);
  end
  $$ language plpgsql;
@@ -1804,7 +1755,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- division by zero runtime error, the context given in the error message
  -- should be sensible
  create function namedparmcursor_test7() returns void as $$
-@@ -2386,10 +2600,24 @@
+@@ -2386,10 +2632,24 @@
  begin
    open c1 (p2 := 77, p1 := 42/0);
  end $$ language plpgsql;
@@ -1832,7 +1783,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check that line comments work correctly within the argument list (there
  -- is some special handling of this case in the code: the newline after the
  -- comment must be preserved when the argument-evaluating query is
-@@ -2406,12 +2634,24 @@
+@@ -2406,12 +2666,24 @@
    fetch c1 into n;
    return n;
  end $$ language plpgsql;
@@ -1862,7 +1813,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- cursor parameter name can match plpgsql variable or unreserved keyword
  create function namedparmcursor_test9(p1 int) returns int4 as $$
  declare
-@@ -2425,12 +2665,24 @@
+@@ -2425,12 +2697,24 @@
    fetch c1 into n;
    return n;
  end $$ language plpgsql;
@@ -1892,7 +1843,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- tests for "raise" processing
  --
-@@ -2441,28 +2693,22 @@
+@@ -2441,28 +2725,22 @@
  end;
  $$ language plpgsql;
  ERROR:  too many parameters specified for RAISE
@@ -1924,7 +1875,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test re-RAISE inside a nested exception block.  This case is allowed
  -- by Oracle's PL/SQL but was handled differently by PG before 9.1.
  CREATE FUNCTION reraise_test() RETURNS void AS $$
-@@ -2484,14 +2730,30 @@
+@@ -2484,14 +2762,30 @@
         raise notice 'WRONG - exception % caught in outer block', sqlerrm;
  END;
  $$ LANGUAGE plpgsql;
@@ -1962,7 +1913,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- reject function definitions that contain malformed SQL queries at
  -- compile-time, where possible
-@@ -2504,9 +2766,17 @@
+@@ -2504,9 +2798,17 @@
      a := 10;
      return a;
  end$$ language plpgsql;
@@ -1983,7 +1934,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function bad_sql2() returns int as $$
  declare r record;
  begin
-@@ -2515,81 +2785,116 @@
+@@ -2515,46 +2817,85 @@
      end loop;
      return 5;
  end;$$ language plpgsql;
@@ -2040,7 +1991,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +    perform 2+2;
 +               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
- 
++
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -2049,7 +2000,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select void_return_expr();
 +ERROR:  unknown function: void_return_expr()
  -- but ordinary functions are not
@@ -2084,46 +2035,19 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- EXECUTE ... INTO test
  --
- create table eifoo (i integer, y integer);
- create type eitype as (i integer, y integer);
--create or replace function execute_into_test(varchar) returns record as $$
--declare
--    _r record;
--    _rt eifoo%rowtype;
--    _v eitype;
--    i int;
--    j int;
--    k int;
--begin
--    execute 'insert into '||$1||' values(10,15)';
--    execute 'select (row).* from (select row(10,1)::eifoo) s' into _r;
--    raise notice '% %', _r.i, _r.y;
--    execute 'select * from '||$1||' limit 1' into _rt;
--    raise notice '% %', _rt.i, _rt.y;
--    execute 'select *, 20 from '||$1||' limit 1' into i, j, k;
--    raise notice '% % %', i, j, k;
--    execute 'select 1,2' into _v;
--    return _v;
--end; $$ language plpgsql;
-+-- create or replace function execute_into_test(varchar) returns record as $$
-+-- declare
-+--     _r record;
-+--     _rt eifoo%rowtype;
-+--     _v eitype;
-+--     i int;
-+--     j int;
-+--     k int;
-+-- begin
-+--     execute 'insert into '||$1||' values(10,15)';
-+--     execute 'select (row).* from (select row(10,1)::eifoo) s' into _r;
-+--     raise notice '% %', _r.i, _r.y;
-+--     execute 'select * from '||$1||' limit 1' into _rt;
-+--     raise notice '% %', _rt.i, _rt.y;
-+--     execute 'select *, 20 from '||$1||' limit 1' into i, j, k;
-+--     raise notice '% % %', i, j, k;
-+--     execute 'select 1,2' into _v;
-+--     return _v;
-+-- end; $$ language plpgsql;
+@@ -2579,17 +2920,22 @@
+     execute 'select 1,2' into _v;
+     return _v;
+ end; $$ language plpgsql;
++ERROR:  at or near "rowtype": syntax error: unable to parse type of variable declaration
++DETAIL:  source SQL:
++declare
++    _r record;
++    _rt eifoo%rowtype;
++              ^
++HINT:  you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
++--
++See: https://go.crdb.dev/issue-v/114676/_version_
  select execute_into_test('eifoo');
 -NOTICE:  10 1
 -NOTICE:  10 15
@@ -2142,7 +2066,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- SQLSTATE and SQLERRM test
  --
-@@ -2597,14 +2902,11 @@
+@@ -2597,14 +2943,11 @@
  begin
      raise notice '% %', sqlstate, sqlerrm;
  end; $$ language plpgsql;
@@ -2159,7 +2083,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test2() returns void as $$
  begin
      begin
-@@ -2613,13 +2915,10 @@
+@@ -2613,13 +2956,10 @@
          end;
      end;
  end; $$ language plpgsql;
@@ -2175,7 +2099,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test3() returns void as $$
  begin
      begin
-@@ -2639,31 +2938,61 @@
+@@ -2639,31 +2979,61 @@
  	    raise notice '% %', sqlstate, sqlerrm;
      end;
  end; $$ language plpgsql;
@@ -2207,9 +2131,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select excpt_test3();
 +ERROR:  unknown function: excpt_test3()
  create function excpt_test4() returns text as $$
@@ -2235,9 +2159,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select excpt_test4();
 +ERROR:  unknown function: excpt_test4()
  drop function excpt_test1();
@@ -2251,7 +2175,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- parameters of raise stmt can be expressions
  create function raise_exprs() returns void as $$
  declare
-@@ -2714,13 +3043,11 @@
+@@ -2714,13 +3084,11 @@
    insert into foo values(5,6) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2269,7 +2193,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2728,10 +3055,11 @@
+@@ -2728,10 +3096,11 @@
    insert into foo values(7,8),(9,10) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2284,7 +2208,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2739,13 +3067,11 @@
+@@ -2739,13 +3108,11 @@
    execute 'insert into foo values(5,6) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2302,7 +2226,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2753,23 +3079,17 @@
+@@ -2753,23 +3120,17 @@
    execute 'insert into foo values(7,8),(9,10) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2331,7 +2255,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  create or replace function stricttest() returns void as $$
  declare x record;
-@@ -2778,13 +3098,11 @@
+@@ -2778,13 +3139,11 @@
    select * from foo where f1 = 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2349,7 +2273,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2792,9 +3110,11 @@
+@@ -2792,9 +3151,11 @@
    select * from foo where f1 = 0 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2363,7 +2287,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2802,10 +3122,11 @@
+@@ -2802,10 +3163,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2378,7 +2302,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2813,13 +3134,11 @@
+@@ -2813,13 +3175,11 @@
    execute 'select * from foo where f1 = 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2396,7 +2320,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2827,9 +3146,11 @@
+@@ -2827,9 +3187,11 @@
    execute 'select * from foo where f1 = 0' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2410,7 +2334,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2837,12 +3158,17 @@
+@@ -2837,12 +3199,17 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2430,7 +2354,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2853,10 +3179,11 @@
+@@ -2853,10 +3220,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2445,7 +2369,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2867,10 +3194,11 @@
+@@ -2867,10 +3235,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2460,7 +2384,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2881,11 +3209,11 @@
+@@ -2881,11 +3250,11 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2476,7 +2400,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2893,10 +3221,11 @@
+@@ -2893,10 +3262,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2491,7 +2415,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2904,10 +3233,11 @@
+@@ -2904,10 +3274,11 @@
    execute 'select * from foo where f1 = $1 or f1::text = $2' using 0, 'foo' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2506,7 +2430,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2915,10 +3245,11 @@
+@@ -2915,10 +3286,11 @@
    execute 'select * from foo where f1 > $1' using 1 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2521,7 +2445,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2926,9 +3257,11 @@
+@@ -2926,9 +3298,11 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2535,7 +2459,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  -- override the global
  #print_strict_params off
-@@ -2941,10 +3274,12 @@
+@@ -2941,10 +3315,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2551,7 +2475,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.print_strict_params;
  create or replace function stricttest() returns void as $$
  -- override the global
-@@ -2958,11 +3293,12 @@
+@@ -2958,11 +3334,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2568,7 +2492,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test warnings and errors
  set plpgsql.extra_warnings to 'all';
  set plpgsql.extra_warnings to 'none';
-@@ -2979,23 +3315,16 @@
+@@ -2979,23 +3356,16 @@
  begin
  end
  $$ language plpgsql;
@@ -2599,7 +2523,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function shadowtest(in1 int)
  	returns table (out1 int) as $$
  declare
-@@ -3004,18 +3333,15 @@
+@@ -3004,18 +3374,15 @@
  begin
  end
  $$ language plpgsql;
@@ -2625,7 +2549,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in a second DECLARE block
  create or replace function shadowtest()
  	returns void as $$
-@@ -3027,10 +3353,13 @@
+@@ -3027,10 +3394,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2642,7 +2566,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- several levels of shadowing
  create or replace function shadowtest(in1 int)
  	returns void as $$
-@@ -3042,13 +3371,13 @@
+@@ -3042,13 +3412,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2662,7 +2586,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in cursor definitions
  create or replace function shadowtest()
  	returns void as $$
-@@ -3057,34 +3386,49 @@
+@@ -3057,34 +3427,49 @@
  c1 cursor (f1 int) for select 1;
  begin
  end$$ language plpgsql;
@@ -2727,7 +2651,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- runtime extra checks
  set plpgsql.extra_warnings to 'too_many_rows';
  do $$
-@@ -3093,8 +3437,6 @@
+@@ -3093,8 +3478,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2736,7 +2660,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'too_many_rows';
  do $$
  declare x int;
-@@ -3102,9 +3444,6 @@
+@@ -3102,9 +3485,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2746,7 +2670,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
  set plpgsql.extra_warnings to 'strict_multi_assignment';
-@@ -3118,12 +3457,6 @@
+@@ -3118,12 +3498,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2759,7 +2683,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'strict_multi_assignment';
  do $$
  declare
-@@ -3135,10 +3468,6 @@
+@@ -3135,10 +3509,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2770,7 +2694,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create table test_01(a int, b int, c int);
  alter table test_01 drop column a;
  -- the check is active only when source table is not empty
-@@ -3154,10 +3483,6 @@
+@@ -3154,10 +3524,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2781,7 +2705,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3168,10 +3493,6 @@
+@@ -3168,10 +3534,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2792,7 +2716,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3179,10 +3500,6 @@
+@@ -3179,10 +3541,6 @@
    select 1 into t; -- should fail;
  end;
  $$;
@@ -2803,7 +2727,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table test_01;
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
-@@ -3201,16 +3518,9 @@
+@@ -3201,16 +3559,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2822,7 +2746,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c no scroll cursor for select f1 from int4_tbl;
-@@ -3225,10 +3535,9 @@
+@@ -3225,10 +3576,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2835,7 +2759,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3243,16 +3552,11 @@
+@@ -3243,16 +3593,11 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2856,7 +2780,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3267,14 +3571,27 @@
+@@ -3267,14 +3612,27 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2891,7 +2815,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3290,13 +3607,27 @@
+@@ -3290,13 +3648,27 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2925,7 +2849,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3316,14 +3647,9 @@
+@@ -3316,14 +3688,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2942,7 +2866,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3338,13 +3664,11 @@
+@@ -3338,13 +3705,11 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2959,7 +2883,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test qualified variable names
  create function pl_qual_names (param1 int) returns void as $$
  <<outerblock>>
-@@ -3362,17 +3686,15 @@
+@@ -3362,17 +3727,15 @@
    end;
  end;
  $$ language plpgsql;
@@ -2984,7 +2908,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- tests for RETURN QUERY
  create function ret_query1(out int, out int) returns setof record as $$
  begin
-@@ -3383,24 +3705,13 @@
+@@ -3383,24 +3746,13 @@
      return next;
  end;
  $$ language plpgsql;
@@ -3015,7 +2939,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type record_type as (x text, y int, z boolean);
  create or replace function ret_query2(lim int) returns setof record_type as $$
  begin
-@@ -3408,20 +3719,9 @@
+@@ -3408,20 +3760,9 @@
                   from generate_series(-8, lim) s (x) where s.x % 2 = 0;
  end;
  $$ language plpgsql;
@@ -3038,7 +2962,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test EXECUTE USING
  create function exc_using(int, text) returns int as $$
  declare i int;
-@@ -3433,19 +3733,27 @@
+@@ -3433,19 +3774,27 @@
    return i;
  end
  $$ language plpgsql;
@@ -3064,10 +2988,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select exc_using(5, 'foobar');
@@ -3077,7 +3001,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function exc_using(int) returns void as $$
  declare
    c refcursor;
-@@ -3461,19 +3769,29 @@
+@@ -3461,19 +3810,29 @@
    return;
  end;
  $$ language plpgsql;
@@ -3101,11 +3025,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  open c for execute 'select * from generate_series(1,$1)' using $1+1;
 +             ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
- 
++
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -3118,7 +3042,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test FOR-over-cursor
  create or replace function forc01() returns void as $$
  declare
-@@ -3513,32 +3831,28 @@
+@@ -3513,32 +3872,28 @@
    return;
  end;
  $$ language plpgsql;
@@ -3169,7 +3093,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function forc01() returns void as $$
  declare
    c cursor for select * from forc_test;
-@@ -3549,35 +3863,39 @@
+@@ -3549,35 +3904,39 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3196,7 +3120,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  for r in c loop
 +        ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -3205,7 +3129,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select forc01();
 +ERROR:  unknown function: forc01()
  select * from forc_test;
@@ -3236,7 +3160,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (10 rows)
  
  -- same, with a cursor whose portal name doesn't match variable name
-@@ -3595,38 +3913,42 @@
+@@ -3595,38 +3954,42 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3306,7 +3230,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- it's okay to re-use a cursor variable name, even when bound
  do $$
  declare cnt int := 0;
-@@ -3642,7 +3964,24 @@
+@@ -3642,7 +4005,24 @@
    end loop;
    raise notice 'cnt = %', cnt;
  end $$;
@@ -3332,7 +3256,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail because cursor has no query bound to it
  create or replace function forc_bad() returns void as $$
  declare
-@@ -3653,9 +3992,24 @@
+@@ -3653,9 +4033,24 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3360,7 +3284,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY EXECUTE
  create or replace function return_dquery()
  returns setof int as $$
-@@ -3664,16 +4018,26 @@
+@@ -3664,16 +4059,26 @@
    return query execute 'select * from (values($1),($2)) f' using 40,50;
  end;
  $$ language plpgsql;
@@ -3382,10 +3306,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select * from return_dquery();
@@ -3395,7 +3319,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY with dropped columns
  create table tabwithcols(a int, b int, c int, d int);
  insert into tabwithcols values(10,20,30,40),(50,60,70,80);
-@@ -3684,46 +4048,36 @@
+@@ -3684,46 +4089,36 @@
    return query execute 'select * from tabwithcols';
  end;
  $$ language plpgsql;
@@ -3418,10 +3342,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select * from returnqueryf();
@@ -3464,7 +3388,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table tabwithcols;
  --
  -- Tests for composite-type results
-@@ -3753,6 +4107,9 @@
+@@ -3753,6 +4148,9 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3474,7 +3398,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select compos();
    compos   
  -----------
-@@ -3778,9 +4135,11 @@
+@@ -3778,9 +4176,11 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3489,7 +3413,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ... but this does
  create or replace function compos() returns compostype as $$
  begin
-@@ -3803,12 +4162,11 @@
+@@ -3803,12 +4203,11 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3506,7 +3430,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: return row expr in return statement.
  create or replace function composrec() returns record as $$
  begin
-@@ -3850,9 +4208,9 @@
+@@ -3850,9 +4249,9 @@
    return 1 + 1;
  end;
  $$ language plpgsql;
@@ -3518,7 +3442,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- RETURN variable is a different code path ...
  create or replace function compos() returns compostype as $$
  declare x int := 42;
-@@ -3861,8 +4219,7 @@
+@@ -3861,8 +4260,7 @@
  end;
  $$ language plpgsql;
  select * from compos();
@@ -3528,7 +3452,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  -- test: invalid use of composite variable in scalar-returning function
  create or replace function compos() returns int as $$
-@@ -3874,8 +4231,7 @@
+@@ -3874,8 +4272,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3538,7 +3462,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: invalid use of composite expression in scalar-returning function
  create or replace function compos() returns int as $$
  begin
-@@ -3883,8 +4239,7 @@
+@@ -3883,8 +4280,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3548,7 +3472,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  drop type compostype;
  --
-@@ -3904,7 +4259,6 @@
+@@ -3904,7 +4300,6 @@
  HINT:  some hint
  ERROR:  1 2 3
  DETAIL:  some detail info
@@ -3556,7 +3480,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Since we can't actually see the thrown SQLSTATE in default psql output,
  -- test it like this; this also tests re-RAISE
  create or replace function raise_test() returns void as $$
-@@ -3917,11 +4271,33 @@
+@@ -3917,11 +4312,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3593,7 +3517,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise 'check me'
-@@ -3932,11 +4308,33 @@
+@@ -3932,11 +4349,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3630,7 +3554,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- SQLSTATE specification in WHEN
  create or replace function raise_test() returns void as $$
  begin
-@@ -3948,11 +4346,33 @@
+@@ -3948,11 +4387,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3667,7 +3591,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using detail = 'some detail info';
-@@ -3962,11 +4382,32 @@
+@@ -3962,11 +4423,32 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3703,7 +3627,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero;
-@@ -3974,7 +4415,6 @@
+@@ -3974,7 +4456,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  division_by_zero
@@ -3711,7 +3635,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise sqlstate '1234F';
-@@ -3982,7 +4422,6 @@
+@@ -3982,7 +4463,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  1234F
@@ -3719,7 +3643,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using message = 'custom' || ' message';
-@@ -3990,7 +4429,6 @@
+@@ -3990,7 +4470,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3727,7 +3651,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise using message = 'custom' || ' message', errcode = '22012';
-@@ -3998,34 +4436,48 @@
+@@ -3998,34 +4477,48 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3783,7 +3707,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test access to exception data
  create function zero_divide() returns int as $$
  declare v int := 0;
-@@ -4033,6 +4485,7 @@
+@@ -4033,6 +4526,7 @@
    return 10 / v;
  end;
  $$ language plpgsql;
@@ -3791,7 +3715,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise exception 'custom exception'
-@@ -4055,13 +4508,27 @@
+@@ -4055,13 +4549,27 @@
      _sqlstate, _message, replace(_context, E'\n', ' <- ');
  end;
  $$ language plpgsql;
@@ -3810,7 +3734,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  perform zero_divide();
 +                       ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -3819,13 +3743,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select stacked_diagnostics_test();
 +ERROR:  unknown function: stacked_diagnostics_test()
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
          _hint text;
-@@ -4076,13 +4543,27 @@
+@@ -4076,13 +4584,27 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3844,14 +3768,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  perform raise_test();
 +                      ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select stacked_diagnostics_test();
@@ -3859,7 +3783,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail, cannot use stacked diagnostics statement outside handler
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
-@@ -4096,11 +4577,25 @@
+@@ -4096,11 +4618,25 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3887,7 +3811,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check cases where implicit SQLSTATE variable could be confused with
  -- SQLSTATE as a keyword, cf bug #5524
  create or replace function raise_test() returns void as $$
-@@ -4112,10 +4607,26 @@
+@@ -4112,10 +4648,26 @@
      raise sqlstate '22012' using message = 'substitute message';
  end;
  $$ language plpgsql;
@@ -3917,7 +3841,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function raise_test();
  -- test passing column_name, constraint_name, datatype_name, table_name
  -- and schema_name error fields
-@@ -4143,14 +4654,23 @@
+@@ -4143,14 +4695,23 @@
      _column_name, _constraint_name, _datatype_name, _table_name, _schema_name;
  end;
  $$ language plpgsql;
@@ -3934,12 +3858,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select stacked_diagnostics_test();
 +ERROR:  unknown function: stacked_diagnostics_test()
  drop function stacked_diagnostics_test();
@@ -3947,7 +3871,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test variadic functions
  create or replace function vari(variadic int[])
  returns void as $$
-@@ -4159,36 +4679,34 @@
+@@ -4159,36 +4720,34 @@
      raise notice '%', $1[i];
    end loop; end;
  $$ language plpgsql;
@@ -4007,7 +3931,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- coercion test
  create or replace function pleast(variadic numeric[])
  returns numeric as $$
-@@ -4200,30 +4718,20 @@
+@@ -4200,30 +4759,20 @@
    return aux;
  end;
  $$ language plpgsql immutable strict;
@@ -4048,7 +3972,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- in case of conflict, non-variadic version is preferred
  create or replace function pleast(numeric)
  returns numeric as $$
-@@ -4232,15 +4740,13 @@
+@@ -4232,15 +4781,13 @@
    return $1;
  end;
  $$ language plpgsql immutable strict;
@@ -4068,7 +3992,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test table functions
  create function tftest(int) returns table(a int, b int) as $$
  begin
-@@ -4248,13 +4754,13 @@
+@@ -4248,13 +4795,13 @@
  end;
  $$ language plpgsql immutable strict;
  select * from tftest(10);
@@ -4089,7 +4013,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (5 rows)
  
  create or replace function tftest(a1 int) returns table(a int, b int) as $$
-@@ -4291,19 +4797,31 @@
+@@ -4291,19 +4838,31 @@
    raise notice '% %', found, rc;
  end;
  $$ language plpgsql;
@@ -4122,18 +4046,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select * from rttest();
 +ERROR:  unknown function: rttest()
  -- check some error cases, too
  create or replace function rttest()
  returns setof int as $$
-@@ -4311,25 +4829,45 @@
+@@ -4311,25 +4870,45 @@
    return query select 10 into no_such_table;
  end;
  $$ language plpgsql;
@@ -4187,7 +4111,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test for proper cleanup at subtransaction exit.  This example
  -- exposed a bug in PG 8.2.
  CREATE FUNCTION leaker_1(fail BOOL) RETURNS INTEGER AS $$
-@@ -4344,6 +4882,7 @@
+@@ -4344,6 +4923,7 @@
    RETURN 1;
  END;
  $$ LANGUAGE plpgsql;
@@ -4195,7 +4119,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION leaker_2(fail BOOL, OUT error_code INTEGER, OUT new_id INTEGER)
    RETURNS RECORD AS $$
  BEGIN
-@@ -4356,18 +4895,11 @@
+@@ -4356,18 +4936,11 @@
  END;
  $$ LANGUAGE plpgsql;
  SELECT * FROM leaker_1(false);
@@ -4217,7 +4141,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DROP FUNCTION leaker_2(bool);
  -- Test for appropriate cleanup of non-simple expression evaluations
  -- (bug in all versions prior to August 2010)
-@@ -4385,13 +4917,27 @@
+@@ -4385,13 +4958,27 @@
    RETURN arr;
  END;
  $$ LANGUAGE plpgsql;
@@ -4250,7 +4174,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION nonsimple_expr_test() RETURNS integer AS $$
  declare
     i integer NOT NULL := 0;
-@@ -4405,13 +4951,13 @@
+@@ -4405,13 +4992,13 @@
    return i;
  end;
  $$ LANGUAGE plpgsql;
@@ -4269,7 +4193,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test cases involving recursion and error recovery in simple expressions
  -- (bugs in all versions before October 2010).  The problems are most
-@@ -4427,15 +4973,13 @@
+@@ -4427,15 +5014,13 @@
    end if;
  end;
  $$ language plpgsql;
@@ -4288,7 +4212,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function error1(text) returns text language sql as
  $$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $$;
  create function error2(p_name_table text) returns text language plpgsql as $$
-@@ -4444,12 +4988,13 @@
+@@ -4444,12 +5029,13 @@
  end$$;
  BEGIN;
  create table public.stuffs (stuff text);
@@ -4305,7 +4229,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select error2('public.stuffs');
   error2 
  --------
-@@ -4457,70 +5002,72 @@
+@@ -4457,70 +5043,72 @@
  (1 row)
  
  rollback;
@@ -4417,7 +4341,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test handling of cast cache inside DO blocks
  -- (to check the original crash case, this must be a cast not previously
  -- used in this session)
-@@ -4534,45 +5081,29 @@
+@@ -4534,45 +5122,29 @@
    return 1/0;
  end
  $$;
@@ -4474,7 +4398,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  create or replace function strtest() returns text as $$
-@@ -4625,21 +5156,26 @@
+@@ -4625,21 +5197,26 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4514,7 +4438,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DO $$
  DECLARE r record;
  BEGIN
-@@ -4648,11 +5184,23 @@
+@@ -4648,11 +5225,23 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4543,7 +4467,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of errors thrown from/into anonymous code blocks.
  do $outer$
  begin
-@@ -4672,16 +5220,19 @@
+@@ -4672,16 +5261,19 @@
    end loop;
  end;
  $outer$;
@@ -4573,7 +4497,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check variable scoping -- a var is not available in its own or prior
  -- default expressions, but it is available in later ones.
  do $$
-@@ -4691,10 +5242,6 @@
+@@ -4691,10 +5283,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4584,7 +4508,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare y int := x + 1;  -- error
          x int := 42;
-@@ -4703,10 +5250,6 @@
+@@ -4703,10 +5291,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4595,7 +4519,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare x int := 42;
          y int := x + 1;
-@@ -4726,7 +5269,11 @@
+@@ -4726,7 +5310,11 @@
    end;
  end;
  $$;
@@ -4608,7 +4532,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of conflicts between plpgsql vars and table columns.
  set plpgsql.variable_conflict = error;
  create function conflict_test() returns setof int8_tbl as $$
-@@ -4738,13 +5285,26 @@
+@@ -4738,13 +5326,26 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4641,7 +4565,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_variable
  declare r record;
-@@ -4755,16 +5315,12 @@
+@@ -4755,16 +5356,12 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4663,7 +4587,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_column
  declare r record;
-@@ -4775,17 +5331,14 @@
+@@ -4775,17 +5372,14 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4687,7 +4611,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check that an unreserved keyword can be used as a variable name
  create function unreserved_test() returns int as $$
  declare
-@@ -4795,12 +5348,15 @@
+@@ -4795,12 +5389,15 @@
    return forward;
  end
  $$ language plpgsql;
@@ -4708,7 +4632,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    return int := 42;
-@@ -4809,12 +5365,20 @@
+@@ -4809,12 +5406,20 @@
    return return;
  end
  $$ language plpgsql;
@@ -4734,7 +4658,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    comment int := 21;
-@@ -4824,19 +5388,26 @@
+@@ -4824,19 +5429,26 @@
    return comment;
  end
  $$ language plpgsql;
@@ -4771,7 +4695,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test FOREACH over arrays
  --
-@@ -4850,26 +5421,27 @@
+@@ -4850,26 +5462,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4804,12 +4728,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4817,7 +4741,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int;
-@@ -4880,13 +5452,28 @@
+@@ -4880,13 +5493,28 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4850,7 +4774,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int[];
-@@ -4897,21 +5484,27 @@
+@@ -4897,21 +5525,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4881,9 +4805,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4891,7 +4815,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- higher level of slicing
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -4923,26 +5516,31 @@
+@@ -4923,26 +5557,31 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4938,7 +4862,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type xy_tuple AS (x int, y int);
  -- iteration over array of records
  create or replace function foreach_test(anyarray)
-@@ -4955,25 +5553,27 @@
+@@ -4955,25 +5594,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4973,9 +4897,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[(10,20),(40,69)],[(35,78),(88,76)]]::xy_tuple[]);
@@ -4983,7 +4907,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int; y int;
-@@ -4984,25 +5584,27 @@
+@@ -4984,25 +5625,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5015,10 +4939,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
@@ -5028,7 +4952,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- slicing over array of composite types
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -5014,22 +5616,29 @@
+@@ -5014,22 +5657,29 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5056,10 +4980,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
@@ -5071,7 +4995,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop type xy_tuple;
  --
  -- Assorted tests for array subscript assignment
-@@ -5043,28 +5652,30 @@
+@@ -5043,28 +5693,30 @@
    r.ar[2] := 'replace';
    return r.ar;
  end$$;
@@ -5118,7 +5042,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function testoa(x1 int, x2 int, x3 int) returns orderedarray
  language plpgsql as $$
  declare res orderedarray;
-@@ -5073,26 +5684,19 @@
+@@ -5073,26 +5725,19 @@
    res[2] := x3;
    return res;
  end$$;
@@ -5152,7 +5076,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of expanded arrays
  --
-@@ -5101,72 +5705,48 @@
+@@ -5101,72 +5746,48 @@
    declare r int[];
    begin r := array[$1, $1]; return r; end;
  $$ stable;
@@ -5246,7 +5170,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare a int[] := array[1,2];
  begin
-@@ -5190,6 +5770,19 @@
+@@ -5190,6 +5811,19 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5266,7 +5190,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5201,6 +5794,7 @@
+@@ -5201,6 +5835,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5274,7 +5198,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5212,44 +5806,18 @@
+@@ -5212,44 +5847,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5325,7 +5249,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- access to call stack from exception
  create function inner_func(int)
  returns int as $$
-@@ -5272,6 +5840,26 @@
+@@ -5272,6 +5881,26 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5352,7 +5276,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5283,6 +5871,7 @@
+@@ -5283,6 +5912,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5360,7 +5284,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5294,44 +5883,18 @@
+@@ -5294,44 +5924,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5411,7 +5335,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test pg_routine_oid
  create function current_function(text)
  returns regprocedure as $$
-@@ -5342,13 +5905,17 @@
+@@ -5342,13 +5946,17 @@
    return fn_oid;
  end;
  $$ language plpgsql;
@@ -5434,7 +5358,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shouldn't fail in DO, even though there's no useful data
  do $$
  declare
-@@ -5358,7 +5925,13 @@
+@@ -5358,7 +5966,13 @@
    raise notice 'pg_routine_oid = %', fn_oid;
  end;
  $$;
@@ -5449,7 +5373,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test ASSERT
  --
-@@ -5367,20 +5940,55 @@
+@@ -5367,20 +5981,55 @@
    assert 1=1;  -- should succeed
  end;
  $$;
@@ -5509,7 +5433,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check controlling GUC
  set plpgsql.check_asserts = off;
  do $$
-@@ -5388,6 +5996,19 @@
+@@ -5388,6 +6037,19 @@
    assert 1=0;  -- won't be tested
  end;
  $$;
@@ -5529,7 +5453,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.check_asserts;
  -- test custom message
  do $$
-@@ -5396,8 +6017,19 @@
+@@ -5396,8 +6058,19 @@
    assert 1=0, format('assertion failed, var = "%s"', var);
  end;
  $$;
@@ -5551,7 +5475,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ensure assertions are not trapped by 'others'
  do $$
  begin
-@@ -5406,32 +6038,55 @@
+@@ -5406,32 +6079,55 @@
    null; -- do nothing
  end;
  $$;
@@ -5611,7 +5535,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare v_test plpgsql_arr_domain;
  begin
-@@ -5439,14 +6094,14 @@
+@@ -5439,14 +6135,14 @@
    v_test := v_test || 2;
  end;
  $$;
@@ -5628,7 +5552,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test usage of transition tables in AFTER triggers
  --
-@@ -5472,25 +6127,40 @@
+@@ -5472,25 +6168,40 @@
    RETURN new;
  END;
  $$;
@@ -5676,7 +5600,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION transition_table_base_upd_func()
    RETURNS trigger
    LANGUAGE plpgsql
-@@ -5512,30 +6182,42 @@
+@@ -5512,30 +6223,42 @@
    RETURN new;
  END;
  $$;
@@ -5729,7 +5653,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_level2
  (
        level2_no serial NOT NULL ,
-@@ -5543,6 +6225,7 @@
+@@ -5543,6 +6266,7 @@
        level1_node_name varchar(255),
         PRIMARY KEY (level2_no)
  ) WITHOUT OIDS;
@@ -5737,7 +5661,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_status
  (
        level int NOT NULL,
-@@ -5563,11 +6246,29 @@
+@@ -5563,11 +6287,29 @@
      RETURN NULL;
    END;
  $$;
@@ -5767,7 +5691,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level1_ri_parent_upd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5595,6 +6296,9 @@
+@@ -5595,6 +6337,9 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level1_ri_parent_upd_func();
@@ -5777,7 +5701,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level2_ri_child_insupd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5610,16 +6314,37 @@
+@@ -5610,16 +6355,37 @@
      RETURN NULL;
    END;
  $$;
@@ -5815,7 +5739,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- create initial test data
  INSERT INTO transition_table_level1 (level1_no)
    SELECT generate_series(1,200);
-@@ -5627,6 +6352,7 @@
+@@ -5627,6 +6393,7 @@
  INSERT INTO transition_table_level2 (level2_no, parent_no)
    SELECT level2_no, level2_no / 50 + 1 AS parent_no
      FROM generate_series(1,9999) level2_no;
@@ -5823,7 +5747,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  ANALYZE transition_table_level2;
  INSERT INTO transition_table_status (level, node_no, status)
    SELECT 1, level1_no, 0 FROM transition_table_level1;
-@@ -5651,30 +6377,23 @@
+@@ -5651,30 +6418,23 @@
    REFERENCING OLD TABLE AS dx
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level2_bad_usage_func();
@@ -5858,7 +5782,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- attempt modifications which would not break RI (should all succeed)
  DELETE FROM transition_table_level1
    WHERE level1_no BETWEEN 201 AND 1000;
-@@ -5683,7 +6402,7 @@
+@@ -5683,7 +6443,7 @@
  SELECT count(*) FROM transition_table_level1;
   count 
  -------
@@ -5867,7 +5791,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  DELETE FROM transition_table_level2
-@@ -5691,7 +6410,7 @@
+@@ -5691,7 +6451,7 @@
  SELECT count(*) FROM transition_table_level2;
   count 
  -------
@@ -5876,7 +5800,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  CREATE TABLE alter_table_under_transition_tables
-@@ -5717,36 +6436,30 @@
+@@ -5717,36 +6477,30 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      alter_table_under_transition_tables_upd_func();
@@ -5917,7 +5841,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test multiple reference to a transition table
  --
-@@ -5764,19 +6477,37 @@
+@@ -5764,19 +6518,37 @@
  CREATE TRIGGER my_trigger AFTER UPDATE ON multi_test
    REFERENCING NEW TABLE AS new_test OLD TABLE as old_test
    FOR EACH STATEMENT EXECUTE PROCEDURE multi_test_trig();
@@ -5957,7 +5881,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION get_from_partitioned_table(partitioned_table.a%type)
  RETURNS partitioned_table AS $$
  DECLARE
-@@ -5787,13 +6518,13 @@
+@@ -5787,13 +6559,13 @@
      SELECT * INTO result FROM partitioned_table WHERE a = a_val;
      RETURN result;
  END; $$ LANGUAGE plpgsql;
@@ -5977,7 +5901,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION list_partitioned_table()
  RETURNS SETOF partitioned_table.a%TYPE AS $$
  DECLARE
-@@ -5806,14 +6537,13 @@
+@@ -5806,14 +6578,13 @@
      END LOOP;
      RETURN;
  END; $$ LANGUAGE plpgsql;
@@ -5998,7 +5922,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Check argument name is used instead of $n in error message
  --
-@@ -5822,6 +6552,16 @@
+@@ -5822,6 +6593,16 @@
    GET DIAGNOSTICS x = ROW_COUNT;
    RETURN;
  END; $$ LANGUAGE plpgsql;

--- a/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
@@ -1846,64 +1846,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- Check some cases involving added/dropped columns in a rowtype result
  --
-@@ -2193,64 +1737,29 @@
- create or replace function get_users() returns setof users as
- $$ SELECT * FROM users ORDER BY userid; $$
- language sql stable;
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
- SELECT get_users();
--      get_users      
-----------------------
-- (id,1,email,11,t)
-- (id2,2,email2,12,t)
--(2 rows)
--
-+ERROR:  unknown function: get_users()
- SELECT * FROM get_users();
-- userid | seq | email  | moredrop | enabled 
----------+-----+--------+----------+---------
-- id     |   1 | email  |       11 | t
-- id2    |   2 | email2 |       12 | t
--(2 rows)
--
-+ERROR:  unknown function: get_users()
- SELECT * FROM get_users() WITH ORDINALITY;   -- make sure ordinality copes
-- userid | seq | email  | moredrop | enabled | ordinality 
----------+-----+--------+----------+---------+------------
-- id     |   1 | email  |       11 | t       |          1
-- id2    |   2 | email2 |       12 | t       |          2
--(2 rows)
--
-+ERROR:  unknown function: get_users()
- -- multiple functions vs. dropped columns
- SELECT * FROM ROWS FROM(generate_series(10,11), get_users()) WITH ORDINALITY;
-- generate_series | userid | seq | email  | moredrop | enabled | ordinality 
-------------------+--------+-----+--------+----------+---------+------------
--              10 | id     |   1 | email  |       11 | t       |          1
--              11 | id2    |   2 | email2 |       12 | t       |          2
--(2 rows)
--
-+ERROR:  unknown function: get_users()
- SELECT * FROM ROWS FROM(get_users(), generate_series(10,11)) WITH ORDINALITY;
-- userid | seq | email  | moredrop | enabled | generate_series | ordinality 
----------+-----+--------+----------+---------+-----------------+------------
-- id     |   1 | email  |       11 | t       |              10 |          1
-- id2    |   2 | email2 |       12 | t       |              11 |          2
--(2 rows)
--
-+ERROR:  unknown function: get_users()
- -- check that we can cope with post-parsing changes in rowtypes
- create temp view usersview as
- SELECT * FROM ROWS FROM(get_users(), generate_series(10,11)) WITH ORDINALITY;
-+ERROR:  unknown function: get_users()
- select * from usersview;
-- userid | seq | email  | moredrop | enabled | generate_series | ordinality 
----------+-----+--------+----------+---------+-----------------+------------
-- id     |   1 | email  |       11 | t       |              10 |          1
-- id2    |   2 | email2 |       12 | t       |              11 |          2
--(2 rows)
--
-+ERROR:  relation "usersview" does not exist
+@@ -2241,16 +1785,10 @@
+ 
  alter table users add column junk text;
  select * from usersview;
 - userid | seq | email  | moredrop | enabled | generate_series | ordinality 
@@ -1912,16 +1856,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 - id2    |   2 | email2 |       12 | t       |              11 |          2
 -(2 rows)
 -
-+ERROR:  relation "usersview" does not exist
++ERROR:  return type mismatch in function declared to return users
  alter table users drop column moredrop;  -- fail, view has reference
 -ERROR:  cannot drop column moredrop of table users because other objects depend on it
 -DETAIL:  view usersview depends on column moredrop of table users
 -HINT:  Use DROP ... CASCADE to drop the dependent objects too.
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
++ERROR:  cannot drop column "moredrop" because function "get_first_user" depends on it
++HINT:  consider dropping "get_first_user" first.
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -2264,18 +1773,15 @@
+@@ -2264,18 +1802,15 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -1945,7 +1890,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- likewise, check we don't crash if the dependency goes wrong
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -2286,173 +1792,128 @@
+@@ -2286,15 +1821,11 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -1963,34 +1908,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +ERROR:  current transaction is aborted, commands ignored until end of transaction block
  rollback;
  drop view usersview;
-+ERROR:  relation "usersview" does not exist
  drop function get_first_user();
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
- drop function get_users();
-+ERROR:  unknown function: get_users()
- drop table users;
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
- -- check behavior with type coercion required for a set-op
- create or replace function rngfuncbar() returns setof text as
- $$ select 'foo'::varchar union all select 'bar'::varchar ; $$
- language sql stable;
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
- select rngfuncbar();
-- rngfuncbar 
--------------
-- foo
-- bar
--(2 rows)
--
-+ERROR:  unknown function: rngfuncbar()
- select * from rngfuncbar();
-- rngfuncbar 
--------------
-- foo
-- bar
--(2 rows)
--
-+ERROR:  unknown function: rngfuncbar()
+@@ -2320,17 +1851,11 @@
+ 
  -- this function is now inlinable, too:
  explain (verbose, costs off) select * from rngfuncbar();
 -                   QUERY PLAN                   
@@ -2010,25 +1930,19 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +                        ^
 +HINT:  try \h <SELECTCLAUSE>
  drop function rngfuncbar();
-+ERROR:  unknown function: rngfuncbar()
  -- check handling of a SQL function with multiple OUT params (bug #5777)
  create or replace function rngfuncbar(out integer, out numeric) as
- $$ select (1, 2.1) $$ language sql;
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
- select * from rngfuncbar();
-- column1 | column2 
-----------+---------
--       1 |     2.1
--(1 row)
--
-+ERROR:  unknown function: rngfuncbar()
+@@ -2344,115 +1869,93 @@
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2) $$ language sql;
-+ERROR:  pg_temp_1774460983107663167_1 is a temporary schema and cannot be modified
  select * from rngfuncbar();  -- fail
 -ERROR:  function return row and query-specified return row do not match
 -DETAIL:  Returned type integer at ordinal position 2, but query expects numeric.
-+ERROR:  unknown function: rngfuncbar()
++ column1 | column2 
++---------+---------
++       1 |       2
++(1 row)
++
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2.1, 3) $$ language sql;
 +ERROR:  return type mismatch in function declared to return record
@@ -2036,9 +1950,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from rngfuncbar();  -- fail
 -ERROR:  function return row and query-specified return row do not match
 -DETAIL:  Returned row contains 3 attributes, but query expects 2.
-+ERROR:  unknown function: rngfuncbar()
++ column1 | column2 
++---------+---------
++       1 |       2
++(1 row)
++
  drop function rngfuncbar();
-+ERROR:  unknown function: rngfuncbar()
  -- check whole-row-Var handling in nested lateral functions (bug #11703)
  create function extractq2(t int8_tbl) returns int8 as $$
    select t.q2
@@ -2182,7 +2099,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (0 rows)
  
  drop type rngfunc2;
-@@ -2463,18 +1924,11 @@
+@@ -2463,18 +1966,11 @@
     from unnest(array['{"lectures": [{"id": "1"}]}'::jsonb])
          as unnested_modules(module)) as ss,
    jsonb_to_recordset(ss.lecture) as j (id text);

--- a/pkg/cmd/roachtest/testdata/pg_regress/union.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/union.diffs
@@ -797,19 +797,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  -- But this should work:
  SELECT q1 FROM int8_tbl EXCEPT (((SELECT q2 FROM int8_tbl ORDER BY q2 LIMIT 1))) ORDER BY 1;
          q1        
-@@ -935,10 +943,7 @@
- --
- -- Check behavior with empty select list (allowed since 9.4)
- --
--select union select;
----
--(1 row)
--
-+-- select union select;
- select intersect select;
- --
- (1 row)
-@@ -949,104 +954,142 @@
+@@ -949,29 +957,45 @@
  
  -- check hashed implementation
  set enable_hashagg = true;
@@ -865,37 +853,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
 -               ->  Function Scan on generate_series generate_series_1
 -(6 rows)
 -
--select from generate_series(1,5) union select from generate_series(1,3);
----
--(1 row)
--
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
 +explain (costs off)
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+-- select from generate_series(1,5) union select from generate_series(1,3);
- select from generate_series(1,5) union all select from generate_series(1,3);
+ select from generate_series(1,5) union select from generate_series(1,3);
  --
- (8 rows)
- 
--select from generate_series(1,5) intersect select from generate_series(1,3);
----
--(1 row)
--
-+-- select from generate_series(1,5) intersect select from generate_series(1,3);
- select from generate_series(1,5) intersect all select from generate_series(1,3);
- --
- (3 rows)
- 
--select from generate_series(1,5) except select from generate_series(1,3);
----
--(0 rows)
--
-+-- select from generate_series(1,5) except select from generate_series(1,3);
- select from generate_series(1,5) except all select from generate_series(1,3);
- --
- (2 rows)
+ (1 row)
+@@ -998,29 +1022,45 @@
  
  -- check sorted implementation
  set enable_hashagg = false;
@@ -951,36 +917,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
 -               ->  Function Scan on generate_series generate_series_1
 -(6 rows)
 -
--select from generate_series(1,5) union select from generate_series(1,3);
----
--(1 row)
--
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
 +explain (costs off)
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+-- select from generate_series(1,5) union select from generate_series(1,3);
- select from generate_series(1,5) union all select from generate_series(1,3);
+ select from generate_series(1,5) union select from generate_series(1,3);
  --
- (8 rows)
- 
--select from generate_series(1,5) intersect select from generate_series(1,3);
----
--(1 row)
--
-+-- select from generate_series(1,5) intersect select from generate_series(1,3);
- select from generate_series(1,5) intersect all select from generate_series(1,3);
- --
- (3 rows)
- 
--select from generate_series(1,5) except select from generate_series(1,3);
----
--(0 rows)
--
-+-- select from generate_series(1,5) except select from generate_series(1,3);
- select from generate_series(1,5) except all select from generate_series(1,3);
- --
+ (1 row)
+@@ -1046,7 +1086,31 @@
  (2 rows)
  
  reset enable_hashagg;
@@ -1012,7 +957,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  --
  -- Check handling of a case with unknown constants.  We don't guarantee
  -- an undecorated constant will work in all cases, but historically this
-@@ -1066,9 +1109,7 @@
+@@ -1066,9 +1130,7 @@
  
  -- This should fail, but it should produce an error cursor
  SELECT '3.4'::numeric UNION SELECT 'foo';
@@ -1023,7 +968,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  --
  -- Test that expression-index constraints can be pushed down through
  -- UNION or UNION ALL
-@@ -1079,69 +1120,103 @@
+@@ -1079,69 +1141,103 @@
  INSERT INTO t1 VALUES ('a', 'b'), ('x', 'y');
  INSERT INTO t2 VALUES ('ab'), ('xy');
  set enable_seqscan = off;
@@ -1158,7 +1103,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
    SELECT * FROM
    (SELECT a || b AS ab FROM t1
     UNION ALL
-@@ -1151,40 +1226,74 @@
+@@ -1151,40 +1247,74 @@
  ----
   ab
   ab
@@ -1251,7 +1196,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  -- Test constraint exclusion of UNION ALL subqueries
  explain (costs off)
   SELECT * FROM
-@@ -1192,11 +1301,11 @@
+@@ -1192,11 +1322,11 @@
     UNION ALL
     SELECT 2 AS t, * FROM tenk1 b) c
   WHERE t = 2;
@@ -1268,7 +1213,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  -- Test that we push quals into UNION sub-selects only when it's safe
  explain (costs off)
  SELECT * FROM
-@@ -1205,19 +1314,11 @@
+@@ -1205,19 +1335,11 @@
     SELECT 2 AS t, 4 AS x) ss
  WHERE x < 4
  ORDER BY x;
@@ -1293,7 +1238,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  SELECT * FROM
    (SELECT 1 AS t, 2 AS x
     UNION
-@@ -1236,20 +1337,11 @@
+@@ -1236,20 +1358,11 @@
     SELECT 2 AS t, 4 AS x) ss
  WHERE x < 4
  ORDER BY x;
@@ -1319,7 +1264,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  SELECT * FROM
    (SELECT 1 AS t, generate_series(1,10) AS x
     UNION
-@@ -1270,20 +1362,11 @@
+@@ -1270,20 +1383,11 @@
     SELECT 2 AS t, 4 AS x) ss
  WHERE x > 3
  ORDER BY x;
@@ -1345,7 +1290,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  SELECT * FROM
    (SELECT 1 AS t, (random()*3)::int AS x
     UNION
-@@ -1303,25 +1386,11 @@
+@@ -1303,25 +1407,11 @@
     union all
     select distinct * from int8_tbl i82) ss
  where q2 = q2;
@@ -1376,7 +1321,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  select distinct q1 from
    (select distinct * from int8_tbl i81
     union all
-@@ -1339,25 +1408,11 @@
+@@ -1339,25 +1429,11 @@
     union all
     select distinct * from int8_tbl i82) ss
  where -q1 = q2;
@@ -1407,7 +1352,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  select distinct q1 from
    (select distinct * from int8_tbl i81
     union all
-@@ -1373,35 +1428,43 @@
+@@ -1373,35 +1449,43 @@
  create function expensivefunc(int) returns int
  language plpgsql immutable strict cost 10000
  as $$begin return $1; end$$;
@@ -1468,7 +1413,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/union.out --label
  -- Test handling of appendrel quals that const-simplify into an AND
  explain (costs off)
  select * from
-@@ -1409,14 +1472,11 @@
+@@ -1409,14 +1493,11 @@
     union all
     select *, 1 as x from int8_tbl b) ss
  where (x = 0) or (q1 >= q2 and q1 <= q2);

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -221,8 +221,6 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"comments",
 		"geometry",
 		"xid",
-		// TODO(yuzefovich): add a patch to explicitly set the time zone in the
-		// 'horology' so that time zone handling is unified between two DBs.
 		"horology",
 		"type_sanity",
 		"expressions",
@@ -364,8 +362,7 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"temp",
 		// TODO(#28296): Reenable copy2 when triggers and COPY [view] FROM are supported.
 		// "copy2",
-		// TODO(#166495): uncomment when fixed.
-		// "rangefuncs",
+		"rangefuncs",
 		"sequence",
 		"truncate",
 		"alter_table",
@@ -1426,155 +1423,6 @@ index 2c0f87a651..26bd75bbf0 100644
  
  -- **************** pg_class ****************
 `},
-	// TODO(yuzefovich): this no longer hits an internal error so no need to
-	// comment it out.
-	{"plpgsql.sql", `diff --git a/src/test/regress/sql/plpgsql.sql b/src/test/regress/sql/plpgsql.sql
-index 924d524094..eb7bc0cf87 100644
---- a/src/test/regress/sql/plpgsql.sql
-+++ b/src/test/regress/sql/plpgsql.sql
-@@ -1087,51 +1087,51 @@ end;
- -- ************************************************************
- -- * Describe the front of a wall connector slot
- -- ************************************************************
--create function wslot_slotlink_view(bpchar)
--returns text as '"'"'
--declare
--    rec		record;
--    sltype	char(2);
--    retval	text;
--begin
--    select into rec * from WSlot where slotname = $1;
--    if not found then
--        return '"'"''"'"''"'"''"'"';
--    end if;
--    if rec.slotlink = '"'"''"'"''"'"''"'"' then
--        return '"'"''"'"'-'"'"''"'"';
--    end if;
--    sltype := substr(rec.slotlink, 1, 2);
--    if sltype = '"'"''"'"'PH'"'"''"'"' then
--        select into rec * from PHone where slotname = rec.slotlink;
--	retval := '"'"''"'"'Phone '"'"''"'"' || trim(rec.slotname);
--	if rec.comment != '"'"''"'"''"'"''"'"' then
--	    retval := retval || '"'"''"'"' ('"'"''"'"';
--	    retval := retval || rec.comment;
--	    retval := retval || '"'"''"'"')'"'"''"'"';
--	end if;
--	return retval;
--    end if;
--    if sltype = '"'"''"'"'IF'"'"''"'"' then
--	declare
--	    syrow	System%RowType;
--	    ifrow	IFace%ROWTYPE;
--        begin
--	    select into ifrow * from IFace where slotname = rec.slotlink;
--	    select into syrow * from System where name = ifrow.sysname;
--	    retval := syrow.name || '"'"''"'"' IF '"'"''"'"';
--	    retval := retval || ifrow.ifname;
--	    if syrow.comment != '"'"''"'"''"'"''"'"' then
--	        retval := retval || '"'"''"'"' ('"'"''"'"';
--		retval := retval || syrow.comment;
--		retval := retval || '"'"''"'"')'"'"''"'"';
--	    end if;
--	    return retval;
--	end;
--    end if;
--    return rec.slotlink;
--end;
--'"'"' language plpgsql;
-+-- create function wslot_slotlink_view(bpchar)
-+-- returns text as '"'"'
-+-- declare
-+--     rec		record;
-+--     sltype	char(2);
-+--     retval	text;
-+-- begin
-+--     select into rec * from WSlot where slotname = $1;
-+--     if not found then
-+--         return '"'"''"'"''"'"''"'"';
-+--     end if;
-+--     if rec.slotlink = '"'"''"'"''"'"''"'"' then
-+--         return '"'"''"'"'-'"'"''"'"';
-+--     end if;
-+--     sltype := substr(rec.slotlink, 1, 2);
-+--     if sltype = '"'"''"'"'PH'"'"''"'"' then
-+--         select into rec * from PHone where slotname = rec.slotlink;
-+-- 	retval := '"'"''"'"'Phone '"'"''"'"' || trim(rec.slotname);
-+-- 	if rec.comment != '"'"''"'"''"'"''"'"' then
-+-- 	    retval := retval || '"'"''"'"' ('"'"''"'"';
-+-- 	    retval := retval || rec.comment;
-+-- 	    retval := retval || '"'"''"'"')'"'"''"'"';
-+-- 	end if;
-+-- 	return retval;
-+--     end if;
-+--     if sltype = '"'"''"'"'IF'"'"''"'"' then
-+-- 	declare
-+-- 	    syrow	System%RowType;
-+-- 	    ifrow	IFace%ROWTYPE;
-+--         begin
-+-- 	    select into ifrow * from IFace where slotname = rec.slotlink;
-+-- 	    select into syrow * from System where name = ifrow.sysname;
-+-- 	    retval := syrow.name || '"'"''"'"' IF '"'"''"'"';
-+-- 	    retval := retval || ifrow.ifname;
-+-- 	    if syrow.comment != '"'"''"'"''"'"''"'"' then
-+-- 	        retval := retval || '"'"''"'"' ('"'"''"'"';
-+-- 		retval := retval || syrow.comment;
-+-- 		retval := retval || '"'"''"'"')'"'"''"'"';
-+-- 	    end if;
-+-- 	    return retval;
-+-- 	end;
-+--     end if;
-+--     return rec.slotlink;
-+-- end;
-+-- '"'"' language plpgsql;
- 
- 
- 
-@@ -2191,25 +2191,25 @@ drop function missing_return_expr();
- create table eifoo (i integer, y integer);
- create type eitype as (i integer, y integer);
- 
--create or replace function execute_into_test(varchar) returns record as $$
--declare
--    _r record;
--    _rt eifoo%rowtype;
--    _v eitype;
--    i int;
--    j int;
--    k int;
--begin
--    execute '"'"'insert into '"'"'||$1||'"'"' values(10,15)'"'"';
--    execute '"'"'select (row).* from (select row(10,1)::eifoo) s'"'"' into _r;
--    raise notice '"'"'% %'"'"', _r.i, _r.y;
--    execute '"'"'select * from '"'"'||$1||'"'"' limit 1'"'"' into _rt;
--    raise notice '"'"'% %'"'"', _rt.i, _rt.y;
--    execute '"'"'select *, 20 from '"'"'||$1||'"'"' limit 1'"'"' into i, j, k;
--    raise notice '"'"'% % %'"'"', i, j, k;
--    execute '"'"'select 1,2'"'"' into _v;
--    return _v;
--end; $$ language plpgsql;
-+-- create or replace function execute_into_test(varchar) returns record as $$
-+-- declare
-+--     _r record;
-+--     _rt eifoo%rowtype;
-+--     _v eitype;
-+--     i int;
-+--     j int;
-+--     k int;
-+-- begin
-+--     execute '"'"'insert into '"'"'||$1||'"'"' values(10,15)'"'"';
-+--     execute '"'"'select (row).* from (select row(10,1)::eifoo) s'"'"' into _r;
-+--     raise notice '"'"'% %'"'"', _r.i, _r.y;
-+--     execute '"'"'select * from '"'"'||$1||'"'"' limit 1'"'"' into _rt;
-+--     raise notice '"'"'% %'"'"', _rt.i, _rt.y;
-+--     execute '"'"'select *, 20 from '"'"'||$1||'"'"' limit 1'"'"' into i, j, k;
-+--     raise notice '"'"'% % %'"'"', i, j, k;
-+--     execute '"'"'select 1,2'"'"' into _v;
-+--     return _v;
-+-- end; $$ language plpgsql;
- 
- select execute_into_test('"'"'eifoo'"'"');
-
-`},
 	// TODO(#114847): Remove this patch when the internal error is fixed.
 	{"rowtypes.sql", `diff --git a/src/test/regress/sql/rowtypes.sql b/src/test/regress/sql/rowtypes.sql
 index 565e6249d5..f36ce2844b 100644
@@ -1592,51 +1440,6 @@ index 565e6249d5..f36ce2844b 100644
  -- non-comparable types
  create type testtype6 as (a int, b point);
 
-`},
-	// TODO(#118698): Remove patch when internal error is fixed.
-	{"union.sql", `diff --git a/src/test/regress/sql/union.sql b/src/test/regress/sql/union.sql
-index ca8c9b4d12..7b8aaf2df2 100644
---- a/src/test/regress/sql/union.sql
-+++ b/src/test/regress/sql/union.sql
-@@ -294,7 +294,7 @@ SELECT q1 FROM int8_tbl EXCEPT (((SELECT q2 FROM int8_tbl ORDER BY q2 LIMIT 1)))
- -- Check behavior with empty select list (allowed since 9.4)
- --
- 
--select union select;
-+-- select union select;
- select intersect select;
- select except select;
- 
-@@ -307,11 +307,11 @@ select from generate_series(1,5) union select from generate_series(1,3);
- explain (costs off)
- select from generate_series(1,5) intersect select from generate_series(1,3);
- 
--select from generate_series(1,5) union select from generate_series(1,3);
-+-- select from generate_series(1,5) union select from generate_series(1,3);
- select from generate_series(1,5) union all select from generate_series(1,3);
--select from generate_series(1,5) intersect select from generate_series(1,3);
-+-- select from generate_series(1,5) intersect select from generate_series(1,3);
- select from generate_series(1,5) intersect all select from generate_series(1,3);
--select from generate_series(1,5) except select from generate_series(1,3);
-+-- select from generate_series(1,5) except select from generate_series(1,3);
- select from generate_series(1,5) except all select from generate_series(1,3);
- 
- -- check sorted implementation
-@@ -323,11 +323,11 @@ select from generate_series(1,5) union select from generate_series(1,3);
- explain (costs off)
- select from generate_series(1,5) intersect select from generate_series(1,3);
- 
--select from generate_series(1,5) union select from generate_series(1,3);
-+-- select from generate_series(1,5) union select from generate_series(1,3);
- select from generate_series(1,5) union all select from generate_series(1,3);
--select from generate_series(1,5) intersect select from generate_series(1,3);
-+-- select from generate_series(1,5) intersect select from generate_series(1,3);
- select from generate_series(1,5) intersect all select from generate_series(1,3);
--select from generate_series(1,5) except select from generate_series(1,3);
-+-- select from generate_series(1,5) except select from generate_series(1,3);
- select from generate_series(1,5) except all select from generate_series(1,3);
- 
- reset enable_hashagg;
 `},
 	// Use SET ROLE instead of SET SESSION AUTHORIZATION. Adjust SQL to allow
 	// creation of a function (f_leak), which is used throughout the test.


### PR DESCRIPTION
Remove patches for `plpgsql` and `union` since they commented out functionality that used to cause internal errors but not any more.

Unskip `rangefuncs` - the issue that it was skipped for has just been fixed.

Remove the TODO around `horology` given that I don't think it makes sense. (It talks about setting the time zone explicitly at the beginning of the test run, but that wouldn't affect the expected output since it comes from the PG repo.)

Fixes: #118698.
Release note: None