### PR TITLE
sql: replace TestingDisableTableLeases with AcquireFreshestFromStore

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -209,18 +209,8 @@ func TestOldBitColumnMetadata(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -268,10 +258,19 @@ CREATE TABLE t.test (k INT);
 	tableDesc.PrimaryIndex.StoreColumnIDs = append(tableDesc.PrimaryIndex.StoreColumnIDs, col.ID)
 	tableDesc.PrimaryIndex.StoreColumnNames = append(tableDesc.PrimaryIndex.StoreColumnNames, col.Name)
 
-	// Write the modified descriptor.
+	// Write the modified descriptor. Bump the version so the lease manager
+	// recognizes the change.
+	tableDesc.Version++
 	if err := kvDB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 		return txn.Put(ctx, catalogkeys.MakeDescMetadataKey(s.Codec(), tableDesc.ID), tableDesc.DescriptorProto())
 	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force the lease manager to acquire a fresh descriptor from the store,
+	// since we wrote it directly via KV above.
+	lm := s.LeaseManager().(*lease.Manager)
+	if err := lm.AcquireFreshestFromStore(ctx, tableDesc.GetID()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -431,13 +430,7 @@ func TestInvalidObjects(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	params := base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	}
+	params := base.TestServerArgs{}
 	params.Knobs = base.TestingKnobs{
 		Store: &kvserver.StoreTestingKnobs{
 			DisableMergeQueue: true,
@@ -445,10 +438,6 @@ func TestInvalidObjects(t *testing.T) {
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
-
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
 
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -247,18 +247,9 @@ func TestDeletePreservingIndexEncodingUsesNormalDeletesInDeleteOnly(t *testing.T
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(context.Background())
-
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
+	lm := server.LeaseManager().(*lease.Manager)
 
 	setupSQL := `
 CREATE DATABASE t;
@@ -275,7 +266,7 @@ CREATE UNIQUE INDEX test_index_to_mutate ON t.test (b);
 	err = mutateIndexByName(kvDB, codec, tableDesc, "test_index_to_mutate", func(idx *descpb.IndexDescriptor) error {
 		idx.UseDeletePreservingEncoding = true
 		return nil
-	}, descpb.DescriptorMutation_DELETE_ONLY)
+	}, descpb.DescriptorMutation_DELETE_ONLY, lm)
 	require.NoError(t, err)
 
 	_, err = sqlDB.Exec(`INSERT INTO t.test VALUES (1, 1)`)
@@ -286,7 +277,7 @@ CREATE UNIQUE INDEX test_index_to_mutate ON t.test (b);
 
 	// Move index to WRITE_ONLY. The following inserts
 	// are seen by the index and deletes should be preserved.
-	err = mutateIndexByName(kvDB, codec, tableDesc, "test_index_to_mutate", nil, descpb.DescriptorMutation_WRITE_ONLY)
+	err = mutateIndexByName(kvDB, codec, tableDesc, "test_index_to_mutate", nil, descpb.DescriptorMutation_WRITE_ONLY, lm)
 	require.NoError(t, err)
 
 	_, err = sqlDB.Exec(`INSERT INTO t.test VALUES (2, 2), (3, 3)`)
@@ -317,18 +308,9 @@ func TestDeletePreservingIndexEncodingWithEmptyValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(context.Background())
-
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
+	lm := server.LeaseManager().(*lease.Manager)
 
 	setupSQL := `
 CREATE DATABASE t;
@@ -352,7 +334,7 @@ CREATE UNIQUE INDEX test_index_to_mutate ON t.test (y) STORING (z, a);
 		idx.StoreColumnIDs = []catid.ColumnID{0x1, 0x3, 0x4}
 		idx.KeySuffixColumnIDs = nil
 		return nil
-	}, descpb.DescriptorMutation_WRITE_ONLY)
+	}, descpb.DescriptorMutation_WRITE_ONLY, lm)
 	require.NoError(t, err)
 	_, err = sqlDB.Exec(`INSERT INTO t.test VALUES (1, 1, 1, 1); DELETE FROM t.test WHERE x = 1;`)
 	require.NoError(t, err)
@@ -365,6 +347,7 @@ func mutateIndexByName(
 	index string,
 	fn func(*descpb.IndexDescriptor) error,
 	state descpb.DescriptorMutation_State,
+	leaseManager *lease.Manager,
 ) error {
 	idx, err := catalog.MustFindIndexByName(tableDesc, index)
 	if err != nil {
@@ -395,11 +378,16 @@ func mutateIndexByName(
 		tableDesc.Mutations[ord] = m
 	}
 	tableDesc.Version++
-	return kvDB.Put(
+	if err := kvDB.Put(
 		context.Background(),
 		catalogkeys.MakeDescMetadataKey(codec, tableDesc.ID),
 		tableDesc.DescriptorProto(),
-	)
+	); err != nil {
+		return err
+	}
+	// Force the lease manager to acquire a fresh descriptor from the store,
+	// since we wrote it directly via KV above.
+	return leaseManager.AcquireFreshestFromStore(context.Background(), tableDesc.GetID())
 }
 
 type WrappedVersionedValues struct {
@@ -620,15 +608,9 @@ func TestMergeProcessor(t *testing.T) {
 	}
 
 	run := func(t *testing.T, test TestCase) {
-		server, tdb, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-			// This test directly manipulates descriptors via KV and relies on
-			// TestingDisableTableLeases to make those changes immediately visible.
-			// This is incompatible with external process virtual clusters where
-			// the lease disable doesn't take effect.
-			DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-		})
+		server, tdb, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 		defer server.Stopper().Stop(context.Background())
-		defer lease.TestingDisableTableLeases()()
+		lm := server.LeaseManager().(*lease.Manager)
 
 		// Run the initial setupSQL.
 		if _, err := tdb.Exec(test.setupSQL); err != nil {
@@ -664,27 +646,27 @@ func TestMergeProcessor(t *testing.T) {
 			}
 		}
 
-		err := mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_WRITE_ONLY)
+		err := mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_WRITE_ONLY, lm)
 		require.NoError(t, err)
-		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, setUseDeletePreservingEncoding(true), descpb.DescriptorMutation_DELETE_ONLY)
+		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, setUseDeletePreservingEncoding(true), descpb.DescriptorMutation_DELETE_ONLY, lm)
 		require.NoError(t, err)
 
 		if _, err := tdb.Exec(test.dstDataSQL); err != nil {
 			t.Fatal(err)
 		}
 
-		err = mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_DELETE_ONLY)
+		err = mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_DELETE_ONLY, lm)
 		require.NoError(t, err)
-		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, nil, descpb.DescriptorMutation_WRITE_ONLY)
+		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, nil, descpb.DescriptorMutation_WRITE_ONLY, lm)
 		require.NoError(t, err)
 
 		if _, err := tdb.Exec(test.srcDataSQL); err != nil {
 			t.Fatal(err)
 		}
 
-		err = mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_WRITE_ONLY)
+		err = mutateIndexByName(kvDB, codec, tableDesc, test.dstIndex, nil, descpb.DescriptorMutation_WRITE_ONLY, lm)
 		require.NoError(t, err)
-		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, nil, descpb.DescriptorMutation_DELETE_ONLY)
+		err = mutateIndexByName(kvDB, codec, tableDesc, test.srcIndex, nil, descpb.DescriptorMutation_DELETE_ONLY, lm)
 		require.NoError(t, err)
 
 		if _, err := tdb.Exec(test.dstDataSQL2); err != nil {

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -33,20 +33,27 @@ type mutationTest struct {
 	// SQLRunner embeds testing.TB
 	testing.TB
 	*sqlutils.SQLRunner
-	kvDB      *kv.DB
-	tableDesc *tabledesc.Mutable
-	codec     keys.SQLCodec
+	kvDB         *kv.DB
+	tableDesc    *tabledesc.Mutable
+	codec        keys.SQLCodec
+	leaseManager *lease.Manager
 }
 
 func makeMutationTest(
-	t *testing.T, kvDB *kv.DB, db *gosql.DB, codec keys.SQLCodec, tableDesc *tabledesc.Mutable,
+	t *testing.T,
+	s serverutils.TestServerInterface,
+	kvDB *kv.DB,
+	db *gosql.DB,
+	codec keys.SQLCodec,
+	tableDesc *tabledesc.Mutable,
 ) mutationTest {
 	return mutationTest{
-		TB:        t,
-		SQLRunner: sqlutils.MakeSQLRunner(db),
-		kvDB:      kvDB,
-		tableDesc: tableDesc,
-		codec:     codec,
+		TB:           t,
+		SQLRunner:    sqlutils.MakeSQLRunner(db),
+		kvDB:         kvDB,
+		tableDesc:    tableDesc,
+		codec:        codec,
+		leaseManager: s.LeaseManager().(*lease.Manager),
 	}
 }
 
@@ -89,6 +96,11 @@ func (mt mutationTest) makeMutationsActive(ctx context.Context) {
 		catalogkeys.MakeDescMetadataKey(mt.codec, mt.tableDesc.ID),
 		mt.tableDesc.DescriptorProto(),
 	); err != nil {
+		mt.Fatal(err)
+	}
+	// Force the lease manager to acquire a fresh descriptor from the store,
+	// since we wrote it directly via KV above.
+	if err := mt.leaseManager.AcquireFreshestFromStore(ctx, mt.tableDesc.GetID()); err != nil {
 		mt.Fatal(err)
 	}
 }
@@ -151,6 +163,11 @@ func (mt mutationTest) writeMutation(ctx context.Context, m descpb.DescriptorMut
 	); err != nil {
 		mt.Fatal(err)
 	}
+	// Force the lease manager to acquire a fresh descriptor from the store,
+	// since we wrote it directly via KV above.
+	if err := mt.leaseManager.AcquireFreshestFromStore(ctx, mt.tableDesc.GetID()); err != nil {
+		mt.Fatal(err)
+	}
 }
 
 // Test that UPSERT with a column mutation that has a default value with a
@@ -165,18 +182,9 @@ func TestUpsertWithColumnMutationAndNotNullDefault(t *testing.T) {
 	// no job associated with the added mutations, those mutations stay on the
 	// table descriptor but don't do anything, which is what we want.
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer server.Stopper().Stop(ctx)
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -191,7 +199,7 @@ ALTER TABLE t.test ADD COLUMN i VARCHAR NOT NULL DEFAULT 'i';
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		kvDB, server.Codec(), "t", "test")
 
-	mTest := makeMutationTest(t, kvDB, sqlDB, server.Codec(), tableDesc)
+	mTest := makeMutationTest(t, server, kvDB, sqlDB, server.Codec(), tableDesc)
 	// Add column "i" as a mutation in delete/write.
 	mTest.writeColumnMutation(ctx, "i", descpb.DescriptorMutation{State: descpb.DescriptorMutation_WRITE_ONLY})
 
@@ -231,19 +239,9 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 
 	// Disable external processing of mutations.
 	ctx := context.Background()
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(ctx)
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
-
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
 
 	// Fix the column families so the key counts below don't change if the
 	// family heuristics are updated.
@@ -256,7 +254,7 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		kvDB, server.Codec(), "t", "test")
 
-	mTest := makeMutationTest(t, kvDB, sqlDB, server.Codec(), tableDesc)
+	mTest := makeMutationTest(t, server, kvDB, sqlDB, server.Codec(), tableDesc)
 
 	starQuery := `SELECT * FROM t.test`
 	for _, useUpsert := range []bool{true, false} {
@@ -503,17 +501,9 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	// no job associated with the added mutations, those mutations stay on the
 	// table descriptor but don't do anything, which is what we want.
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(context.Background())
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
-	// The descriptor changes made must have an immediate effect.
-	defer lease.TestingDisableTableLeases()()
 
 	sqlRunner.Exec(t, `CREATE DATABASE t;`)
 	sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v)) WITH (schema_locked=false);`)
@@ -522,7 +512,7 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		kvDB, server.Codec(), "t", "test")
 
-	mTest := makeMutationTest(t, kvDB, sqlDB, server.Codec(), tableDesc)
+	mTest := makeMutationTest(t, server, kvDB, sqlDB, server.Codec(), tableDesc)
 
 	starQuery := `SELECT * FROM t.test`
 	indexQuery := `SELECT v FROM t.test@foo`
@@ -674,19 +664,10 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 	// no job associated with the added mutations, those mutations stay on the
 	// table descriptor but don't do anything, which is what we want.
 
-	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	})
+	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer server.Stopper().Stop(ctx)
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
 
 	// Create a table with column i and an index on v and i. Fix the column
 	// families so the key counts below don't change if the family heuristics
@@ -700,7 +681,7 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		kvDB, server.Codec(), "t", "test")
 
-	mTest := makeMutationTest(t, kvDB, sqlDB, server.Codec(), tableDesc)
+	mTest := makeMutationTest(t, server, kvDB, sqlDB, server.Codec(), tableDesc)
 
 	starQuery := `SELECT * FROM t.test`
 	indexQuery := `SELECT i FROM t.test@foo`
@@ -896,13 +877,7 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Disable external processing of mutations.
-	params := base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	}
+	params := base.TestServerArgs{}
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			SchemaChangeJobNoOp: func() bool {
@@ -913,9 +888,6 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	ctx := context.Background()
 	defer server.Stopper().Stop(ctx)
-	// The descriptor changes made must have an immediate effect
-	// so disable leases on tables.
-	defer lease.TestingDisableTableLeases()()
 
 	if _, err := sqlDB.Exec(`
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
@@ -935,7 +907,7 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		kvDB, server.Codec(), "t", "test")
 
-	mt := makeMutationTest(t, kvDB, sqlDB, server.Codec(), tableDesc)
+	mt := makeMutationTest(t, server, kvDB, sqlDB, server.Codec(), tableDesc)
 
 	// Test CREATE INDEX in the presence of mutations.
 

--- a/pkg/sql/index_mutation_test.go
+++ b/pkg/sql/index_mutation_test.go
@@ -35,13 +35,7 @@ func TestIndexMutationKVOps(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	params := base.TestServerArgs{
-		// This test directly manipulates descriptors via KV and relies on
-		// TestingDisableTableLeases to make those changes immediately visible.
-		// This is incompatible with external process virtual clusters where
-		// the lease disable doesn't take effect.
-		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(166311),
-	}
+	params := base.TestServerArgs{}
 	// Decrease the adopt loop interval so that retries happen quickly.
 	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.Knobs.SQLEvalContext = &eval.TestingKnobs{
@@ -51,7 +45,7 @@ func TestIndexMutationKVOps(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "index_mutations"), func(t *testing.T, path string) {
 		srv, sqlDB, kvDB := serverutils.StartServer(t, params)
 		defer srv.Stopper().Stop(ctx)
-		defer lease.TestingDisableTableLeases()()
+		lm := srv.LeaseManager().(*lease.Manager)
 		s := srv.ApplicationLayer()
 		_, err := sqlDB.Exec("CREATE DATABASE t; USE t")
 		require.NoError(t, err)
@@ -85,7 +79,7 @@ func TestIndexMutationKVOps(t *testing.T) {
 					return nil
 				}
 				tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(kvDB, s.Codec(), "t", tableName)
-				err = mutateIndexByName(kvDB, s.Codec(), tableDesc, name, mutFn, state)
+				err = mutateIndexByName(kvDB, s.Codec(), tableDesc, name, mutFn, state, lm)
 				require.NoError(t, err)
 			case "statement":
 				_, err := sqlDB.Exec(td.Input)

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -268,7 +268,7 @@ CREATE INDEX foo ON t.test (v)
 	}
 
 	// Ensure that the indexes have been created.
-	mTest := makeMutationTest(t, kvDB, sqlDB, s.Codec(), tableDesc)
+	mTest := makeMutationTest(t, s, kvDB, sqlDB, s.Codec(), tableDesc)
 	indexQuery := `SELECT v FROM t.test@foo`
 	mTest.CheckQueryResults(t, indexQuery, [][]string{{"b"}, {"d"}})
 


### PR DESCRIPTION
Tests that directly manipulate descriptors via KV and rely on lease.TestingDisableTableLeases() to make changes immediately visible are incompatible with external-process virtual clusters, because the process-global atomic bool doesn't propagate across process boundaries.

Replace the lease disable pattern with explicit lease refresh via AcquireFreshestFromStore after each direct KV descriptor write. The descriptor version bump (already present in most helpers) causes the lease manager to recognize the change, and AcquireFreshestFromStore forces a synchronous refresh. This works across process boundaries because the lease manager reads from KV, which is shared.

For TestInvalidObjects, the lease disable was unnecessary since it uses crdb_internal.unsafe_upsert_descriptor() which goes through the normal SQL descriptor write path that handles leases internally.

Resolves: #166311

Release note: None