### PR TITLE
sql: add validation for edge case values in array-to-vector cast

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/vector
+++ b/pkg/ccl/logictestccl/testdata/logic_test/vector
@@ -74,6 +74,22 @@ select '[3,Inf]'::vector
 query error pgcode 22000 infinite value not allowed in vector
 select '[3,-Inf]'::vector
 
+# Regression tests for edge case values in array-to-vector cast (#146606).
+query error pgcode 22000 vector must have at least 1 dimension
+SELECT '{}'::real[]::vector
+
+query error pgcode 22000 NaN not allowed in vector
+SELECT '{NaN}'::real[]::vector
+
+query error pgcode 22000 infinite value not allowed in vector
+SELECT '{Infinity}'::real[]::vector
+
+query error pgcode 22000 infinite value not allowed in vector
+SELECT '{-Infinity}'::real[]::vector
+
+query error pgcode 22000 infinite value not allowed in vector
+SELECT '{4e38,-4e38}'::double precision[]::vector
+
 statement ok
 CREATE TABLE x (a float[], b real[], c float4[])
 

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -638,6 +638,11 @@ func performCastWithoutPrecisionTruncation(
 		case *tree.DArray:
 			switch d.ParamTyp.Family() {
 			case types.FloatFamily, types.IntFamily, types.DecimalFamily:
+				if len(d.Array) == 0 {
+					return nil, pgerror.Newf(pgcode.DataException,
+						"vector must have at least 1 dimension")
+				}
+
 				if d.HasNulls() {
 					return nil, pgerror.Newf(pgcode.NullValueNotAllowed,
 						"array must not contain nulls")
@@ -648,7 +653,19 @@ func performCastWithoutPrecisionTruncation(
 					if err != nil {
 						return nil, err
 					}
-					v[i] = float32(*datum.(*tree.DFloat))
+
+					val := float32(*datum.(*tree.DFloat))
+					if math.IsInf(float64(val), 0) {
+						return nil, pgerror.Newf(pgcode.DataException,
+							"infinite value not allowed in vector")
+					}
+
+					if math.IsNaN(float64(val)) {
+						return nil, pgerror.Newf(pgcode.DataException,
+							"NaN not allowed in vector")
+					}
+
+					v[i] = val
 				}
 				return tree.NewDPGVector(v), nil
 			}


### PR DESCRIPTION
Previously, casting arrays containing NaN, Infinity, or empty arrays to the vector type was incorrectly allowed. While the string-to-vector parsing path already rejected these values, the array-to-vector cast path did not perform the same validation.

This patch adds checks in the array-to-vector cast path to reject:
- Empty arrays
- NaN values
- Infinite values (including float64 values that overflow to infinity when converted to float32)

Fixes: #146606

Release note (bug fix): Fixed a bug where casting arrays containing NaN, Infinity, or empty arrays to the vector type was incorrectly allowed, instead of returning an error matching PostgreSQL behavior.