### PR TITLE
drt: add operation duration metric and dashboard widget

### DIFF
--- a/pkg/cmd/drtprod/configs/datadog_operations_dashboard.json
+++ b/pkg/cmd/drtprod/configs/datadog_operations_dashboard.json
@@ -348,7 +348,39 @@
             "layout": {
               "x": 0,
               "y": 3,
-              "width": 12,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "id": 5918230571639843,
+            "definition": {
+              "title": "Top 5 Longest Operations (Last Run)",
+              "type": "toplist",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "top(last:roachtest_operation_last_run_duration_seconds{cluster:$cluster.value} by {operation}, 5, 'last', 'desc')",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "duration (s)"
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": {
+              "x": 6,
+              "y": 3,
+              "width": 6,
               "height": 3
             }
           }

--- a/pkg/cmd/roachtest/operation_metrics.go
+++ b/pkg/cmd/roachtest/operation_metrics.go
@@ -53,6 +53,10 @@ type operationMetrics struct {
 
 	// pendingCleanups tracks cleanups waiting to execute.
 	pendingCleanups *prometheus.GaugeVec
+
+	// lastRunDuration records the wall-clock duration (in seconds) of
+	// the most recent run phase for each operation. Excludes cleanup.
+	lastRunDuration *prometheus.GaugeVec
 }
 
 func newOperationMetrics(factory promauto.Factory) *operationMetrics {
@@ -76,6 +80,13 @@ func newOperationMetrics(factory promauto.Factory) *operationMetrics {
 			Subsystem: "operation",
 			Name:      "pending_cleanups",
 			Help:      "Number of cleanups waiting to execute.",
+		}, []string{"operation"}),
+
+		lastRunDuration: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "roachtest",
+			Subsystem: "operation",
+			Name:      "last_run_duration_seconds",
+			Help:      "Duration of the most recent run phase for each operation, in seconds.",
 		}, []string{"operation"}),
 	}
 }

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -426,12 +426,15 @@ func (r *opsRunner) runOperation(
 	// Run phase.
 	emitter.EmitStarted()
 	op.Status(fmt.Sprintf("running operation %s with run id %d", op.spec.Name, operationRunID))
+	runStart := timeutil.Now()
 	func() {
 		ctx, cancel := context.WithTimeout(ctx, opSpec.Timeout)
 		defer cancel()
 
 		cleanup = opSpec.Run(ctx, op, c)
 	}()
+	r.metrics.lastRunDuration.WithLabelValues(opName).
+		Set(timeutil.Since(runStart).Seconds())
 
 	opFailed := op.Failed()
 	if opFailed {


### PR DESCRIPTION
## Summary

- Add a Prometheus gauge `roachtest_operation_last_run_duration_seconds` that
  records the wall-clock duration of the most recent run phase for each
  operation (excluding cleanup wait time).
- Add a "Top 5 Longest Operations (Last Run)" toplist widget to the DRT
  operations Datadog dashboard.
- Narrow the "Executions Count Per Operation" table to half-width to
  accommodate the new widget side-by-side.

The existing OpenTelemetry scrape config already matches
`roachtest_operation_.*`, so no scrape config changes are needed.

Epic: none

Release note: None