### PR TITLE
kvserver: release-25.4: deflake TestWriteLoadStatsAccounting

### DIFF
--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -304,6 +304,13 @@ func TestWriteLoadStatsAccounting(t *testing.T) {
 			lhRepl.Desc().Replicas().Descriptors(),
 			lhRepl.GetLeaseAppliedIndex(),
 		))
+		// Wait for raftMu on the followers to ensure that handleRaftReady has
+		// finished, including the load stats recording that happens after the
+		// applied index bump. See #161600.
+		followerRepl1.raftMu.Lock()
+		followerRepl1.raftMu.Unlock() //lint:ignore SA2001 empty critical section
+		followerRepl2.raftMu.Lock()
+		followerRepl2.raftMu.Unlock() //lint:ignore SA2001 empty critical section
 
 		requestsAfter := lhRepl.loadStats.TestingGetSum(load.Requests)
 		lhWritesAfter := lhRepl.loadStats.TestingGetSum(load.WriteKeys)

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -214,6 +215,11 @@ func assertGreaterThanInDelta(t *testing.T, expected float64, actual float64, de
 func TestWriteLoadStatsAccounting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// This test is known to flake. E.g. in #160265, a request raced in after
+	// clearing the load stats and before asserting they are 0.
+	skip.UnderDuress(t, "timing sensitive")
+
 	ctx := context.Background()
 
 	args := base.TestClusterArgs{


### PR DESCRIPTION
Backport 2/2 commits from #167075 (branch release-25.4).

/cc @cockroachdb/kv

---

Fixes #161600
Release justification: test deflake