### PR TITLE
release-26.2: sql: fix race condition with statement_timeout for schema changes

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4384,8 +4384,10 @@ func (ex *connExecutor) runWithStatementTimeout(
 			var cancelFn context.CancelFunc
 			waitCtx, cancelFn = context.WithCancel(waitCtx)
 			queryTimeTicker := time.AfterFunc(ex.sessionData().StmtTimeout-timePassed, func() {
-				cancelFn()
+				// Before the cancellation make sure that the query
+				// is marked as timed out.
 				queryTimedout.Store(true)
+				cancelFn()
 			})
 			defer cancelFn()
 			defer queryTimeTicker.Stop()


### PR DESCRIPTION
Backport 1/1 commits from #167063 on behalf of @fqazi.

----

Previously, we added logic to apply statement_timeout to schema change related waits. This logic had a bug, where the context for the timeout was cancelled before, the query timeout flag was flipped. This would cause us to incorrectly surface context cancellation errors instead of statement timeout errors.

Fixes: #165974

Release note (bug fix): Context cancellation is surfaced if a statement_timeout occurs while waiting for a schema change.

----

Release justification: low risk fix to address a race condition when enforcing statement_timeouts for schema changes