### PR TITLE
roachtest: log compaction failures in backupFixture tests rather than returning an error

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -326,7 +326,7 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) error {
 			} else if bd.sp.fixture.CompactionThreshold > 0 {
 				bd.t.L().Printf("%d compaction jobs succeeded, %d running", len(compSuccess), len(compRunning))
 				if len(compFailed) > 0 {
-					return errors.Newf("compaction jobs failed while running incrementals: %v", compFailed)
+					bd.t.L().Errorf("compaction jobs failed while running incrementals: %v", compFailed)
 				}
 			}
 
@@ -345,7 +345,7 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) error {
 			if len(backupFailed) > 0 {
 				return errors.Newf("backup jobs failed while waiting completion: %v", backupFailed)
 			} else if len(compFailed) > 0 {
-				return errors.Newf("compaction jobs failed while waiting completion: %v", compFailed)
+				bd.t.L().Errorf("compaction jobs failed while waiting completion: %v", compFailed)
 			} else if len(backupRunning) > 0 {
 				bd.t.L().Printf("waiting for %d backup jobs to finish", len(backupRunning))
 			} else if len(compRunning) > 0 {
@@ -354,6 +354,18 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) error {
 				state = Done
 			}
 		}
+	}
+
+	// Do a final accounting of compactions to determine if the test as a whole should fail.
+	compSuccess, _, compFailed, err := bd.compactionJobStates(sql)
+	if err != nil {
+		return err
+	}
+	if len(compSuccess) < len(compFailed) {
+		return errors.Newf(
+			"more compaction jobs failed than succeeded (%d failed, %d succeeded), failures: %v",
+			len(compFailed), len(compSuccess), compFailed,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
This patch adjusts the backupFixture roachtests to log compaction failures rather than failing the test. Backup compaction needs a new retry loop that better handles spurious errors. This patch is a quick fix to make these tests less flaky in the meantime.

Fixes: #166264

Release note: None