### PR TITLE
release: preserve unreleased series in cockroach_releases.yaml

### DIFF
--- a/pkg/cmd/release/update_releases.go
+++ b/pkg/cmd/release/update_releases.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,9 +79,21 @@ func updateReleasesFiles(_ *cobra.Command, _ []string) (retErr error) {
 	result := processReleaseData(data)
 	fmt.Printf("generated data for %d release series\n", len(result))
 
+	// Validate before preserveUnreleasedSeries/addCurrentRelease, which
+	// intentionally add entries with empty Latest that would fail validation.
 	if err := validateReleaseData(result); err != nil {
 		return fmt.Errorf("failed to validate downloaded data: %w", err)
 	}
+
+	// Preserve unreleased series from the existing file before adding
+	// the current release. This prevents losing entries for development
+	// series that have been branched but don't have GA releases yet.
+	existing, err := loadExistingReleaseData()
+	if err != nil {
+		return err
+	}
+	preserveUnreleasedSeries(result, existing)
+
 	currentVersion := version.MustParse(build.BinaryVersion())
 	addCurrentRelease(result, &currentVersion)
 
@@ -89,11 +102,12 @@ func updateReleasesFiles(_ *cobra.Command, _ []string) (retErr error) {
 		return err
 	}
 	currentSeries := currentVersion.Format("%X.%Y")
-	predecessor := result[result[currentSeries].Predecessor].Latest
+	predecessor := findLatestReleasedPredecessor(result, currentSeries)
 	if predecessor == "" {
 		return fmt.Errorf("could not determine predecessor version for version %+v", currentVersion)
 	}
-	prePredecessor := result[result[result[currentSeries].Predecessor].Predecessor].Latest
+	predecessorSeries := version.MustParse("v" + predecessor).Format("%X.%Y")
+	prePredecessor := findLatestReleasedPredecessor(result, predecessorSeries)
 	if prePredecessor == "" {
 		return fmt.Errorf("could not determine predecessor's predecessor version for version %+v", currentVersion)
 	}
@@ -132,11 +146,6 @@ func processReleaseData(data []Release) map[string]release.Series {
 		if v.IsPrerelease() && !strings.HasPrefix(v.Format("%P"), "rc") {
 			continue
 		}
-		// Skip cloud-only releases, because the binaries are not yet publicly available.
-		if r.CloudOnly {
-			continue
-		}
-
 		filtered = append(filtered, r)
 	}
 
@@ -179,32 +188,122 @@ func processReleaseData(data []Release) map[string]release.Series {
 	return result
 }
 
-// addCurrentRelease adds an entry to the `data` map corresponding to
-// the binary version of the current build, if one does not exist. The
-// new entry will have no `Latest` information as, in that case, the
-// current release series is still in development.
+// addCurrentRelease adds or updates an entry in the `data` map for the
+// current binary version's release series. If the series already has
+// actual releases (non-empty Latest), it is left unchanged. Otherwise,
+// the predecessor is (re)calculated from the highest series below the
+// current version, which corrects stale predecessors from previous runs
+// and handles newly added entries.
 func addCurrentRelease(data map[string]release.Series, currentVersion *version.Version) {
 	name := currentVersion.Format("%X.%Y")
-	if _, ok := data[name]; ok {
+	if s, ok := data[name]; ok && s.Latest != "" {
+		// Series already exists with actual releases; nothing to do.
 		return
 	}
 
-	var latestVersion version.Version
-	for _, d := range data {
-		v := version.MustParse("v" + d.Latest)
-		if latestVersion.Empty() {
-			latestVersion = v
-		}
+	currentParsed := version.MustParse("v" + name + ".0")
 
-		if v.AtLeast(latestVersion) {
-			latestVersion = v
+	// Find the highest series below the current version to use as
+	// predecessor. This considers both released and unreleased series,
+	// so that intermediate unreleased series are correctly chained.
+	var predecessorName string
+	for seriesName := range data {
+		v, err := version.Parse("v" + seriesName + ".0")
+		if err != nil {
+			continue
+		}
+		if v.Compare(currentParsed) >= 0 {
+			continue
+		}
+		if predecessorName == "" {
+			predecessorName = seriesName
+			continue
+		}
+		prev := version.MustParse("v" + predecessorName + ".0")
+		if v.Compare(prev) > 0 {
+			predecessorName = seriesName
 		}
 	}
 
-	// Assume that the predecessor of the current version is the latest
-	// released series.
 	data[name] = release.Series{
-		Predecessor: latestVersion.Format("%X.%Y"),
+		Predecessor: predecessorName,
+	}
+}
+
+// findLatestReleasedPredecessor walks the predecessor chain of the
+// given series, returning the Latest version of the first released
+// predecessor found. Unreleased series (those with no Latest) are
+// skipped. Returns empty string if none is found.
+func findLatestReleasedPredecessor(data map[string]release.Series, series string) string {
+	visited := map[string]bool{}
+	for cur := series; cur != "" && !visited[cur]; {
+		visited[cur] = true
+		s, ok := data[cur]
+		if !ok {
+			return ""
+		}
+		if cur != series && s.Latest != "" {
+			return s.Latest
+		}
+		cur = s.Predecessor
+	}
+	return ""
+}
+
+// loadExistingReleaseData reads the current cockroach_releases.yaml
+// file and returns the parsed release data. Returns nil if the file
+// does not exist.
+func loadExistingReleaseData() (map[string]release.Series, error) {
+	return loadReleaseDataFromPath(releaseDataFile)
+}
+
+// loadReleaseDataFromPath reads release data from the given file path.
+// Returns nil, nil if the file does not exist.
+func loadReleaseDataFromPath(path string) (map[string]release.Series, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("could not read existing release data: %w", err)
+	}
+
+	var result map[string]release.Series
+	if err := yaml.Unmarshal(data, &result); err != nil { //nolint:yaml
+		return nil, fmt.Errorf("could not parse existing release data: %w", err)
+	}
+	return result, nil
+}
+
+// preserveUnreleasedSeries merges unreleased series entries from the
+// existing release data file into the newly generated data. This
+// prevents losing entries for development series that have been
+// branched but don't have GA releases yet.
+func preserveUnreleasedSeries(data map[string]release.Series, existing map[string]release.Series) {
+	// Iterate until no new entries are added, so that chains of
+	// unreleased series (e.g. 26.2 → 26.3 where neither has releases)
+	// are fully resolved regardless of map iteration order.
+	for changed := true; changed; {
+		changed = false
+		for name, series := range existing {
+			if _, ok := data[name]; ok {
+				continue
+			}
+			if series.Latest != "" {
+				// Has releases; should come from downloaded data.
+				continue
+			}
+			if series.Predecessor == "" {
+				continue
+			}
+			if _, ok := data[series.Predecessor]; !ok {
+				// Predecessor not yet in data; may be added in a
+				// subsequent iteration.
+				continue
+			}
+			data[name] = series
+			changed = true
+		}
 	}
 }
 

--- a/pkg/cmd/release/update_releases_test.go
+++ b/pkg/cmd/release/update_releases_test.go
@@ -7,9 +7,11 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
+	"github.com/cockroachdb/version"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -41,6 +43,334 @@ func Test_processReleaseData(t *testing.T) {
 		},
 	}
 	require.Equal(t, expectedReleaseData, processReleaseData(data))
+}
+
+func Test_loadReleaseDataFromPath(t *testing.T) {
+	t.Run("file does not exist", func(t *testing.T) {
+		result, err := loadReleaseDataFromPath(filepath.Join(t.TempDir(), "nonexistent.yaml"))
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("valid file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "releases.yaml")
+		content := `"26.1":
+  latest: 26.1.0
+  predecessor: "25.4"
+`
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+		result, err := loadReleaseDataFromPath(path)
+		require.NoError(t, err)
+		require.Equal(t, map[string]release.Series{
+			"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+		}, result)
+	})
+
+	t.Run("corrupt YAML", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "releases.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("not: [valid: yaml"), 0644))
+		_, err := loadReleaseDataFromPath(path)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not parse existing release data")
+	})
+}
+
+func Test_preserveUnreleasedSeries(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     map[string]release.Series
+		existing map[string]release.Series
+		expected map[string]release.Series
+	}{
+		{
+			name: "preserves unreleased series",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"25.4": {Latest: "25.4.5", Predecessor: "25.3"},
+			},
+			existing: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+			},
+			expected: map[string]release.Series{
+				"25.4": {Latest: "25.4.5", Predecessor: "25.3"},
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+			},
+		},
+		{
+			name: "preserves chain of unreleased series",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+			existing: map[string]release.Series{
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.2"},
+			},
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.2"},
+			},
+		},
+		{
+			name: "does not preserve entries with Latest",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+			existing: map[string]release.Series{
+				"25.4": {Latest: "25.4.3", Predecessor: "25.3"},
+			},
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+		},
+		{
+			name:     "nil existing data",
+			data:     map[string]release.Series{"26.1": {Latest: "26.1.0"}},
+			existing: nil,
+			expected: map[string]release.Series{"26.1": {Latest: "26.1.0"}},
+		},
+		{
+			name: "downloaded data wins over stale existing entries",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.2", Predecessor: "25.4"},
+			},
+			existing: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.2", Predecessor: "25.4"},
+			},
+		},
+		{
+			name: "does not preserve orphaned entries",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+			existing: map[string]release.Series{
+				"99.1": {Predecessor: "99.0"},
+			},
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			preserveUnreleasedSeries(tc.data, tc.existing)
+			require.Equal(t, tc.expected, tc.data)
+		})
+	}
+}
+
+func Test_addCurrentRelease(t *testing.T) {
+	testCases := []struct {
+		name           string
+		data           map[string]release.Series
+		currentVersion string
+		expected       map[string]release.Series
+	}{
+		{
+			name: "adds current release with correct predecessor",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+			currentVersion: "v26.2.0",
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+			},
+		},
+		{
+			name: "uses unreleased series as predecessor",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+			},
+			currentVersion: "v26.3.0",
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.2"},
+			},
+		},
+		{
+			name: "no-op if series already exists with releases",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+			currentVersion: "v26.1.0",
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+			},
+		},
+		{
+			name: "ignores series higher than current version",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"27.1": {Predecessor: "26.2"},
+			},
+			currentVersion: "v26.3.0",
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.2"},
+				"27.1": {Predecessor: "26.2"},
+			},
+		},
+		{
+			name: "overwrites unreleased entry with correct predecessor",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.1"}, // stale
+			},
+			currentVersion: "v26.3.0",
+			expected: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.2"}, // corrected
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := version.MustParse(tc.currentVersion)
+			addCurrentRelease(tc.data, &v)
+			require.Equal(t, tc.expected, tc.data)
+		})
+	}
+}
+
+func Test_findLatestReleasedPredecessor(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     map[string]release.Series
+		series   string
+		expected string
+	}{
+		{
+			name: "direct predecessor has releases",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+			},
+			series:   "26.2",
+			expected: "26.1.0",
+		},
+		{
+			name: "skips unreleased intermediate series",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+				"26.2": {Predecessor: "26.1"},
+				"26.3": {Predecessor: "26.2"},
+			},
+			series:   "26.3",
+			expected: "26.1.0",
+		},
+		{
+			name: "no released predecessor",
+			data: map[string]release.Series{
+				"26.2": {Predecessor: "26.1"},
+			},
+			series:   "26.2",
+			expected: "",
+		},
+		{
+			name: "series not in data",
+			data: map[string]release.Series{
+				"26.1": {Latest: "26.1.0"},
+			},
+			series:   "99.9",
+			expected: "",
+		},
+		{
+			name: "handles cycle in predecessor chain",
+			data: map[string]release.Series{
+				"26.1": {Predecessor: "26.2"},
+				"26.2": {Predecessor: "26.1"},
+			},
+			series:   "26.2",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := findLatestReleasedPredecessor(tc.data, tc.series)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// Test_simulatePR167081 reproduces the exact scenario from PR #167081.
+// On master (binary version 26.3), the docs YAML has no 26.2 releases.
+// The existing cockroach_releases.yaml has a 26.2 entry (added when
+// master was at 26.2). The tool should preserve 26.2, chain
+// 26.3 → 26.2 → 26.1, and find the correct released versions for
+// the REPOSITORIES.bzl file.
+func Test_simulatePR167081(t *testing.T) {
+	// Step 1: Simulate processReleaseData output — the docs YAML has
+	// releases up to 26.1 but nothing for 26.2.
+	downloaded := map[string]release.Series{
+		"21.2": {Latest: "21.2.17"},
+		"22.1": {Latest: "22.1.22", Predecessor: "21.2"},
+		"22.2": {Latest: "22.2.19", Predecessor: "22.1"},
+		"23.1": {Latest: "23.1.30", Predecessor: "22.2"},
+		"23.2": {Latest: "23.2.29", Predecessor: "23.1"},
+		"24.1": {Latest: "24.1.26", Predecessor: "23.2"},
+		"24.2": {Latest: "24.2.10", Predecessor: "24.1"},
+		"24.3": {Latest: "24.3.28", Predecessor: "24.2"},
+		"25.1": {Latest: "25.1.10", Predecessor: "24.3"},
+		"25.2": {Latest: "25.2.14", Predecessor: "25.1"},
+		"25.3": {Latest: "25.3.7", Predecessor: "25.2"},
+		"25.4": {Latest: "25.4.5", Predecessor: "25.3"},
+		"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+	}
+
+	// Validate the downloaded data (same as production flow).
+	require.NoError(t, validateReleaseData(downloaded))
+
+	// Step 2: Simulate the existing file — it has 26.2 and 26.3 from
+	// a previous run.
+	existing := map[string]release.Series{
+		"26.1": {Latest: "26.1.0", Predecessor: "25.4"},
+		"26.2": {Predecessor: "26.1"},
+		"26.3": {Predecessor: "26.1"}, // bug: was set to 26.1 before our fix
+	}
+
+	// Step 3: Preserve unreleased series.
+	preserveUnreleasedSeries(downloaded, existing)
+
+	// 26.2 should be preserved.
+	require.Contains(t, downloaded, "26.2", "26.2 entry should be preserved")
+	require.Equal(t, "26.1", downloaded["26.2"].Predecessor)
+
+	// Step 4: Add current release (master is at 26.3).
+	currentVersion := version.MustParse("v26.3.0")
+	addCurrentRelease(downloaded, &currentVersion)
+
+	// 26.3 should exist with predecessor 26.2 (not 26.1).
+	require.Contains(t, downloaded, "26.3")
+	require.Equal(t, "26.2", downloaded["26.3"].Predecessor,
+		"26.3's predecessor should be 26.2, not 26.1")
+
+	// Step 5: Verify findLatestReleasedPredecessor walks past
+	// unreleased 26.2 to find 26.1.
+	predecessor := findLatestReleasedPredecessor(downloaded, "26.3")
+	require.Equal(t, "26.1.0", predecessor,
+		"should walk past unreleased 26.2 to find 26.1.0")
+
+	predecessorSeries := version.MustParse("v" + predecessor).Format("%X.%Y")
+	prePredecessor := findLatestReleasedPredecessor(downloaded, predecessorSeries)
+	require.Equal(t, "25.4.5", prePredecessor,
+		"pre-predecessor should be 25.4.5")
 }
 
 func Test_validateReleaseData(t *testing.T) {

--- a/pkg/testutils/release/releases.go
+++ b/pkg/testutils/release/releases.go
@@ -81,10 +81,11 @@ func IsWithdrawn(v *version.Version) (bool, error) {
 	return false, nil
 }
 
-// MajorReleasesBetween returns the number of major releases between
-// any two versions passed. Returns an error when there is no
-// predecessor information for a release in the chain (which should
-// only happen if one of the versions passed is very old).
+// MajorReleasesBetween returns the number of released major versions
+// between any two versions passed, skipping unreleased series (those
+// with empty Latest). Returns an error when there is no predecessor
+// information for a release in the chain (which should only happen if
+// one of the versions passed is very old).
 func MajorReleasesBetween(v1, v2 *version.Version) (int, error) {
 	older, newer := v1, v2
 	if v1.AtLeast(*v2) {
@@ -93,12 +94,23 @@ func MajorReleasesBetween(v1, v2 *version.Version) (int, error) {
 
 	var count int
 	currentSeries := VersionSeries(newer)
+	olderSeries := VersionSeries(older)
+	visited := map[string]bool{}
 
-	for currentSeries != VersionSeries(older) {
-		count++
+	for currentSeries != olderSeries {
+		if visited[currentSeries] {
+			return -1, fmt.Errorf("cycle in predecessor chain at series: %s", currentSeries)
+		}
+		visited[currentSeries] = true
+
 		seriesData, ok := releaseData[currentSeries]
 		if !ok {
 			return -1, fmt.Errorf("no release data for release series: %s", currentSeries)
+		}
+
+		// Only count series that have actual releases.
+		if seriesData.Latest != "" {
+			count++
 		}
 
 		currentSeries = seriesData.Predecessor
@@ -114,6 +126,9 @@ func LatestPatch(seriesStr string) (string, error) {
 	series, ok := releaseData[seriesStr]
 	if !ok {
 		return "", fmt.Errorf("no release information for %q series", seriesStr)
+	}
+	if series.Latest == "" {
+		return "", fmt.Errorf("no releases available for %q series", seriesStr)
 	}
 	activeReleases := activePatchReleases(series)
 	return activeReleases[len(activeReleases)-1], nil
@@ -251,7 +266,9 @@ func activePatchReleases(releaseSeries Series) []string {
 }
 
 // predecessorSeries retrieves the corresponding `Series` data for the
-// version passed. Returns an error if the data is not available.
+// predecessor of the version passed, skipping unreleased series
+// (those with empty Latest). Returns an error if no released
+// predecessor is found.
 func predecessorSeries(v *version.Version) (Series, error) {
 	var empty Series
 	seriesStr := VersionSeries(v)
@@ -260,16 +277,25 @@ func predecessorSeries(v *version.Version) (Series, error) {
 		return empty, fmt.Errorf("no release information for %q (%q series)", v, seriesStr)
 	}
 
+	// Walk the predecessor chain, skipping unreleased series.
+	visited := map[string]bool{seriesStr: true}
+	cur := series.Predecessor
+	for cur != "" && !visited[cur] {
+		visited[cur] = true
+		predSeries, ok := releaseData[cur]
+		if !ok {
+			return empty, fmt.Errorf("no release information for %q (predecessor of %q)", cur, v)
+		}
+		if predSeries.Latest != "" {
+			return predSeries, nil
+		}
+		cur = predSeries.Predecessor
+	}
+
 	if series.Predecessor == "" {
 		return empty, fmt.Errorf("no known predecessor for %q (%q series)", v, seriesStr)
 	}
-
-	predSeries, ok := releaseData[series.Predecessor]
-	if !ok {
-		return empty, fmt.Errorf("no release information for %q (predecessor of %q)", series.Predecessor, v)
-	}
-
-	return predSeries, nil
+	return empty, fmt.Errorf("no released predecessor for %q (%q series)", v, seriesStr)
 }
 
 func mustParseVersion(str string) *version.Version {

--- a/pkg/testutils/release/releases_test.go
+++ b/pkg/testutils/release/releases_test.go
@@ -40,6 +40,9 @@ var (
 		"24.1": {
 			Predecessor: "23.2",
 		},
+		"24.2": {
+			Predecessor: "24.1", // unreleased predecessor
+		},
 	}
 
 	// Results rely on this constant seed.
@@ -86,6 +89,12 @@ func TestLatestAndRandomPredecessor(t *testing.T) {
 		{
 			name:           "latest is pre-release",
 			v:              "v24.1.0",
+			expectedLatest: "23.2.0-beta.1",
+			expectedRandom: "23.2.0-beta.1",
+		},
+		{
+			name:           "skips unreleased predecessor",
+			v:              "v24.2.0",
 			expectedLatest: "23.2.0-beta.1",
 			expectedRandom: "23.2.0-beta.1",
 		},
@@ -179,6 +188,30 @@ func TestLatestPredecessorHistory(t *testing.T) {
 	}
 }
 
+func TestLatestPatch(t *testing.T) {
+	oldReleaseData := releaseData
+	releaseData = testReleaseData
+	defer func() { releaseData = oldReleaseData }()
+
+	t.Run("released series", func(t *testing.T) {
+		patch, err := LatestPatch("22.2")
+		require.NoError(t, err)
+		require.Equal(t, "22.2.8", patch)
+	})
+
+	t.Run("unreleased series returns error", func(t *testing.T) {
+		_, err := LatestPatch("24.1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no releases available")
+	})
+
+	t.Run("unknown series returns error", func(t *testing.T) {
+		_, err := LatestPatch("99.9")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no release information")
+	})
+}
+
 func TestMajorReleasesBetween(t *testing.T) {
 	oldReleaseData := releaseData
 	releaseData = testReleaseData
@@ -212,7 +245,13 @@ func TestMajorReleasesBetween(t *testing.T) {
 			name:     "v1 and v2 are multiple major releases apart",
 			v1:       "19.2.3",
 			v2:       "24.1.10",
-			expected: 5,
+			expected: 4, // 24.1 is unreleased and not counted
+		},
+		{
+			name:     "skips unreleased series in count",
+			v1:       "23.2.0",
+			v2:       "24.2.0",
+			expected: 0,
 		},
 	}
 


### PR DESCRIPTION
Previously, when master's binary version advanced (e.g., from 26.2 to 26.3 after a release branch cut), the update-releases-file command would drop entries for intermediate unreleased series. This happened because processReleaseData only produces entries for series with actual releases in the docs YAML, and addCurrentRelease only added the current binary version's series.

Fix this by:
- Reading the existing cockroach_releases.yaml before regenerating
- Preserving unreleased series entries (those with no Latest) whose predecessor chain connects to a known series
- Finding the predecessor by comparing series names as versions instead of by highest Latest version, so unreleased intermediate series are correctly chained
- Walking past unreleased series when finding versions for the logictest REPOSITORIES.bzl file
- Recalculating predecessors for unreleased entries to fix stale values from previous runs

Also removes a duplicate CloudOnly check in processReleaseData and uses errors.Is for os.ErrNotExist per modern Go idiom.

See also: #167081
Epic: None
Release note: None