### PR TITLE
sql: skip dropping FK constraints in cascade/check setup

### DIFF
--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -390,6 +390,11 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 						}
 						tabOrd := fk.OriginColumnOrdinal(cb.childTable, idx)
 						col := mb.outScope.getColumnForTableOrdinal(tabOrd)
+						if col == nil {
+							panic(errors.AssertionFailedf(
+								"FK column (table ordinal %d) not found in child table scan scope", tabOrd,
+							))
+						}
 						return b.factory.ConstructVariable(col.id)
 					}
 					return b.factory.CopyAndReplaceDefault(e, replaceFn)
@@ -405,6 +410,11 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 			for i := range cb.origFKCols {
 				tabOrd := fk.OriginColumnOrdinal(cb.childTable, i)
 				col := mb.outScope.getColumnForTableOrdinal(tabOrd)
+				if col == nil {
+					panic(errors.AssertionFailedf(
+						"FK column (table ordinal %d) not found in child table scan scope", tabOrd,
+					))
+				}
 				if !notNullCols.Contains(col.id) {
 					filters = append(filters, b.factory.ConstructFiltersItem(
 						b.factory.ConstructIsNot(
@@ -673,6 +683,11 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	for i := range on {
 		tabOrd := fk.OriginColumnOrdinal(childTable, i)
 		col := outScope.getColumnForTableOrdinal(tabOrd)
+		if col == nil {
+			panic(errors.AssertionFailedf(
+				"FK column (table ordinal %d) not found in child table scan scope", tabOrd,
+			))
+		}
 		on[i] = b.factory.ConstructFiltersItem(b.factory.ConstructEq(
 			b.factory.ConstructVariable(col.id),
 			b.factory.ConstructVariable(outCols[i]),
@@ -1023,6 +1038,11 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 	for i := range on {
 		tabOrd := fk.OriginColumnOrdinal(childTable, i)
 		col := outScope.getColumnForTableOrdinal(tabOrd)
+		if col == nil {
+			panic(errors.AssertionFailedf(
+				"FK column (table ordinal %d) not found in child table scan scope", tabOrd,
+			))
+		}
 		on[i] = f.ConstructFiltersItem(f.ConstructEq(
 			f.ConstructVariable(col.id),
 			f.ConstructVariable(outColsOld[i]),

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -586,7 +586,7 @@ func (h *fkCheckHelper) initWithOutboundFK(mb *mutationBuilder, fkOrdinal int) b
 // initWithInboundFK initializes the helper with an inbound FK constraint.
 //
 // Returns false if the FK relation should be ignored (because the other table
-// is in the process of being created).
+// is in the process of being created, or the constraint is being dropped).
 func (h *fkCheckHelper) initWithInboundFK(mb *mutationBuilder, fkOrdinal int) (ok bool) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
@@ -595,6 +595,16 @@ func (h *fkCheckHelper) initWithInboundFK(mb *mutationBuilder, fkOrdinal int) (o
 		fk:         mb.tab.InboundForeignKey(fkOrdinal),
 		fkOrdinal:  fkOrdinal,
 		fkOutbound: false,
+	}
+
+	// Skip FK constraints that are being dropped. This can happen when a
+	// concurrent schema change is dropping the FK column on the child table:
+	// the column may already be in mutation state while the FK back-reference
+	// on the parent has not yet been fully removed. Building cascades or
+	// checks against a dropping FK would fail because the FK columns may not
+	// be in the child table's scan scope. See #166653.
+	if !h.fk.Validated() {
+		return false
 	}
 
 	originID := h.fk.OriginTableID()

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/backfill",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/execinfra",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -1458,4 +1459,125 @@ func TestTTLSchemaChangeFailuresRollsBackSchedule(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestFKCascadeDuringDropColumn is a regression test for #166653. It verifies
+// that a DELETE triggering an FK cascade (ON DELETE SET NULL) does not crash
+// when the child table's FK column is in WRITE_ONLY state due to a concurrent
+// DROP COLUMN.
+//
+// During a DROP COLUMN CASCADE on the child table, there is a window where:
+//   - The child's FK column is in WRITE_ONLY state (mutation).
+//   - The parent's inbound FK back-reference still exists with
+//     validity=Dropping (removed later in PostCommitNonRevertiblePhase).
+//
+// Without the fix, a DELETE on the parent during this window would set up an
+// FK cascade that dereferences a nil pointer because the WRITE_ONLY column is
+// excluded from the child table's scan scope.
+//
+// The fix skips FK constraints with validity != Validated in the optimizer's
+// initWithInboundFK, preventing cascades from being built for dropping
+// constraints.
+func TestFKCascadeDuringDropColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Channels to synchronize between the schema change goroutine and the
+	// main test goroutine.
+	schemaChangeReady := make(chan struct{})
+	schemaChangeProceed := make(chan struct{})
+	var signaled atomic.Bool
+
+	params := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
+				BeforeStage: func(p scplan.Plan, stageIdx int) error {
+					stage := p.Stages[stageIdx]
+					// Pause once at the first PostCommitPhase stage. At this
+					// point the FK column is WRITE_ONLY on the child table, but
+					// the parent's inbound FK back-reference has not been
+					// removed yet (it still has validity=Dropping).
+					if stage.Phase == scop.PostCommitPhase && !signaled.Swap(true) {
+						close(schemaChangeReady)
+						<-schemaChangeProceed
+					}
+					return nil
+				},
+			},
+		},
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create tables and insert data.
+	tdb.Exec(t, `CREATE TABLE parent (id INT PRIMARY KEY)`)
+	tdb.Exec(t, `CREATE TABLE child (
+		id INT PRIMARY KEY,
+		pid INT REFERENCES parent(id) ON DELETE SET NULL
+	)`)
+	tdb.Exec(t, `INSERT INTO parent VALUES (1)`)
+	tdb.Exec(t, `INSERT INTO child VALUES (1, 1)`)
+
+	// Start the schema change (DROP COLUMN pid CASCADE) in a background
+	// goroutine. CASCADE is required because the column has an FK constraint.
+	schemaChangeErr := make(chan error, 1)
+	go func() {
+		conn, err := sqlDB.Conn(ctx)
+		if err != nil {
+			schemaChangeErr <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, err = conn.ExecContext(ctx, `ALTER TABLE child DROP COLUMN pid CASCADE`)
+		schemaChangeErr <- err
+	}()
+
+	// Wait until the schema change is at PostCommitPhase (column is WRITE_ONLY,
+	// parent still has inbound FK with validity=Dropping).
+	<-schemaChangeReady
+
+	// Verify the intermediate state: the parent's inbound FK back-reference
+	// should still exist with validity=Dropping, and the child's FK column
+	// should be in mutation (WRITE_ONLY) state.
+	parentDesc := desctestutils.TestingGetPublicTableDescriptor(
+		s.DB(), s.ApplicationLayer().Codec(), "defaultdb", "parent",
+	)
+	childDesc := desctestutils.TestingGetPublicTableDescriptor(
+		s.DB(), s.ApplicationLayer().Codec(), "defaultdb", "child",
+	)
+	require.Equal(t, 1, len(parentDesc.InboundForeignKeys()),
+		"parent should still have inbound FK back-reference during PostCommitPhase")
+	require.Equal(t, descpb.ConstraintValidity_Dropping,
+		parentDesc.InboundForeignKeys()[0].GetConstraintValidity(),
+		"parent's inbound FK should have validity=Dropping")
+
+	// The FK column (pid) should be in WRITE_ONLY state.
+	var pidInMutation bool
+	for _, col := range childDesc.AllColumns() {
+		if col.WriteAndDeleteOnly() {
+			pidInMutation = true
+			break
+		}
+	}
+	require.True(t, pidInMutation, "child's FK column should be in mutation state")
+
+	// Run DELETE on the parent table. With the fix, the optimizer skips the
+	// dropping FK constraint, so no cascade is built and the DELETE succeeds.
+	// Without the fix (#166653), this would panic with nil pointer dereference.
+	conn2, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn2.Close() }()
+	_, err = conn2.ExecContext(ctx, `DELETE FROM parent WHERE id = 1`)
+	require.NoError(t, err)
+
+	// Let the schema change proceed.
+	close(schemaChangeProceed)
+
+	// Wait for the schema change to complete.
+	require.NoError(t, <-schemaChangeErr)
 }


### PR DESCRIPTION
Fixes #166653

During `DROP COLUMN CASCADE` on a child table with an FK constraint, the following sequence leads to a nil pointer dereference:

1. `ALTER TABLE child DROP COLUMN pid CASCADE` commits: the child's FK column enters WRITE_ONLY state and the FK constraint is marked `validity=Dropping` on both child and parent descriptors.
2. The schema change job enters `PostCommitPhase` (index backfill). The FK back-reference on the parent is not removed until `PostCommitNonRevertiblePhase`.
3. A concurrent `DELETE FROM parent` resolves the parent table, sees the inbound FK (still present, validity=Dropping), and sets up a cascade.
4. The cascade scans the child table with `includeMutations=false`, excluding the `WRITE_ONLY` column from the scan scope.
5. `getColumnForTableOrdinal` returns nil for the FK column's ordinal, and the nil is dereferenced.

Fix by skipping FK constraints with `validity != Validated` in `initWithInboundFK/initWithOutboundFK`. Also add defensive nil checks at all `getColumnForTableOrdinal` call sites in `fk_cascade.go`.

co-authored with Claude Code (Opus 4.6)

Release note (bug fix): Fixed a panic that could occur when a DELETE triggered a foreign key cascade (ON DELETE CASCADE/SET NULL/SET DEFAULT) while a concurrent schema change was dropping the referenced column on the child table.