### PR TITLE
sql: support subscript access on the name type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -257,6 +257,40 @@ NULL
 query error cannot subscript type string because it is not an array
 SELECT '{a,b,c}'[0]
 
+# name type subscript access (0-based, matching PostgreSQL).
+# In PG, the name type has typsubscript => 'raw_array_subscript_handler',
+# treating it as a fixed-length array of chars. text does not support this.
+
+query T
+SELECT ('hello'::name)[0]
+----
+h
+
+query T
+SELECT ('hello'::name)[4]
+----
+o
+
+query T nosort
+SELECT ('hello'::name)[5]
+----
+NULL
+
+query T nosort
+SELECT ('hello'::name)[-1]
+----
+NULL
+
+# pg_dump compatibility: detect array types by checking first char of typname.
+query B
+SELECT (typname::name)[0] = '_' FROM pg_type WHERE typname = '_int4'
+----
+true
+
+# text/string subscripting is not supported (matches PG).
+statement error cannot subscript type string
+SELECT ('world'::STRING)[0]
+
 query T
 SELECT (ARRAY['a', 'b', 'c'])[2]
 ----

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_lib_pq//oid",
     ],
 )
 

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/lib/pq/oid"
 )
 
 // InferType derives the type of the given scalar expression. The result is
@@ -282,6 +283,11 @@ func typeIndirection(e opt.ScalarExpr) *types.T {
 		return t
 	case types.ArrayFamily:
 		return t.ArrayContents()
+	case types.StringFamily:
+		if t.Oid() == oid.T_name {
+			return types.String
+		}
+		panic(errors.AssertionFailedf("unknown type indirection type %s", t.SQLString()))
 	default:
 		panic(errors.AssertionFailedf("unknown type indirection type %s", t.SQLString()))
 	}

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -594,7 +594,7 @@ func (c *CustomFuncs) FoldIndirection(input, index opt.ScalarExpr) (_ opt.Scalar
 		return nil, false
 	}
 
-	// Case 2: The input is a constant DArray or DJSON.
+	// Case 2: The input is a constant DArray, DJSON, or Name.
 	if memo.CanExtractConstDatum(input) {
 		var resolvedType *types.T
 		switch input.DataType().Family() {
@@ -602,8 +602,14 @@ func (c *CustomFuncs) FoldIndirection(input, index opt.ScalarExpr) (_ opt.Scalar
 			resolvedType = input.DataType()
 		case types.ArrayFamily:
 			resolvedType = input.DataType().ArrayContents()
+		case types.StringFamily:
+			if input.DataType().Oid() == oid.T_name {
+				resolvedType = types.String
+			} else {
+				panic(errors.AssertionFailedf("expected array, json, or name; found %s", input.DataType().SQLString()))
+			}
 		default:
-			panic(errors.AssertionFailedf("expected array or json; found %s", input.DataType().SQLString()))
+			panic(errors.AssertionFailedf("expected array, json, or name; found %s", input.DataType().SQLString()))
 		}
 		inputD := memo.ExtractConstDatum(input)
 		texpr := tree.NewTypedIndirectionExpr(inputD, indexD, resolvedType)

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 // Expr evaluates a TypedExpr into a Datum.
@@ -381,6 +382,28 @@ func (e *evaluator) EvalIndirectionExpr(
 			}
 		}
 		return tree.NewDJSON(curr), nil
+	case types.StringFamily:
+		if d.ResolvedType().Oid() != oid.T_name {
+			return nil, errors.AssertionFailedf("unsupported feature should have been rejected during planning")
+		}
+		for i, t := range expr.Indirection {
+			if t.Slice || i > 0 {
+				return nil, errors.AssertionFailedf("unsupported feature should have been rejected during planning")
+			}
+			beginDatum, err := t.Begin.(tree.TypedExpr).Eval(ctx, e)
+			if err != nil {
+				return nil, err
+			}
+			if beginDatum == tree.DNull {
+				return tree.DNull, nil
+			}
+			subscriptIdx = int(tree.MustBeDInt(beginDatum))
+		}
+		str := string(tree.MustBeDString(d))
+		if subscriptIdx < 0 || subscriptIdx >= len(str) {
+			return tree.DNull, nil
+		}
+		return tree.NewDString(string(str[subscriptIdx])), nil
 	}
 	return nil, errors.AssertionFailedf("unsupported feature should have been rejected during planning")
 }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/lib/pq/oid"
 	"golang.org/x/text/language"
 )
 
@@ -778,6 +779,26 @@ func (expr *IndirectionExpr) TypeCheck(
 
 		if OnTypeCheckJSONBSubscript != nil {
 			OnTypeCheckJSONBSubscript()
+		}
+	case types.StringFamily:
+		// Only the name type supports subscripting, matching PostgreSQL where
+		// name has typsubscript => 'raw_array_subscript_handler'.
+		if typ.Oid() != oid.T_name {
+			return nil, pgerror.Newf(pgcode.DatatypeMismatch, "cannot subscript type %s because it is not an array, json, or name object", typ)
+		}
+		expr.typ = types.String
+		for i, t := range expr.Indirection {
+			if t.Slice {
+				return nil, pgerror.Newf(pgcode.DatatypeMismatch, "name subscript does not support slices")
+			}
+			if i > 0 {
+				return nil, pgerror.Newf(pgcode.DatatypeMismatch, "name subscript does not support multidimensional indexing")
+			}
+			beginExpr, err := typeCheckAndRequire(ctx, semaCtx, t.Begin, types.Int, "name subscript")
+			if err != nil {
+				return nil, err
+			}
+			t.Begin = beginExpr
 		}
 	default:
 		return nil, pgerror.Newf(pgcode.DatatypeMismatch, "cannot subscript type %s because it is not an array or json object", typ)


### PR DESCRIPTION
pg_dump uses `typname[0] = '_'` to detect array types. Previously,
CockroachDB would fail with "cannot subscript type name because it is
not an array or json object". In PostgreSQL, the `name` type has
`typsubscript => 'raw_array_subscript_handler'`, treating it as a
fixed-length array of chars with 0-based indexing.

This commit adds subscript support for the `name` type only (not
`text` or other string types, matching PostgreSQL behavior). The
implementation touches type checking, optimizer type inference,
constant folding, and runtime evaluation.

Informs: #20296

Release note (sql change): The `name` type now supports subscript
access with 0-based indexing, matching PostgreSQL behavior. For
example, `('hello'::name)[0]` returns `'h'`. Out-of-bounds access
returns NULL.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>