### PR TITLE
sql: implement pg_get_statisticsobjdef builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3688,6 +3688,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_serial_sequence"></a><code>pg_get_serial_sequence(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the name of the sequence used by the given column_name in the table table_name.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_statisticsobjdef"></a><code>pg_get_statisticsobjdef(statobj_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE STATISTICS command for an extended statistics object.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_triggerdef"></a><code>pg_get_triggerdef(trigger_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE TRIGGER statement for the specified trigger.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_triggerdef"></a><code>pg_get_triggerdef(trigger_oid: oid, pretty_bool: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE TRIGGER statement for the specified trigger.</p>

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -1491,3 +1491,67 @@ statement ok
 DROP TABLE trig_test
 
 subtest end
+
+subtest pg_get_statisticsobjdef
+
+statement ok
+CREATE TABLE stxtest (a INT, b INT, c TEXT)
+
+statement ok
+CREATE STATISTICS stxtest_stat ON a, b FROM stxtest
+
+# pg_get_statisticsobjdef returns the CREATE STATISTICS command for a stat object.
+query T
+SELECT pg_get_statisticsobjdef(oid)
+FROM pg_catalog.pg_statistic_ext
+WHERE stxname = 'stxtest_stat'
+LIMIT 1
+----
+CREATE STATISTICS public.stxtest_stat ON a, b FROM public.stxtest
+
+# NULL input returns NULL.
+query T
+SELECT pg_get_statisticsobjdef(NULL)
+----
+NULL
+
+# Non-existent OID returns NULL.
+query T
+SELECT pg_get_statisticsobjdef(0)
+----
+NULL
+
+# Column names that are keywords should be quoted.
+statement ok
+CREATE TABLE stxtest_kw ("select" INT, "from" INT, normal INT)
+
+statement ok
+CREATE STATISTICS stxtest_kw_stat ON "select", "from" FROM stxtest_kw
+
+query T
+SELECT pg_get_statisticsobjdef(oid)
+FROM pg_catalog.pg_statistic_ext
+WHERE stxname = 'stxtest_kw_stat'
+LIMIT 1
+----
+CREATE STATISTICS public.stxtest_kw_stat ON "select", "from" FROM public.stxtest_kw
+
+# Mixed keyword and non-keyword columns.
+statement ok
+CREATE STATISTICS stxtest_kw_mixed ON "select", normal FROM stxtest_kw
+
+query T
+SELECT pg_get_statisticsobjdef(oid)
+FROM pg_catalog.pg_statistic_ext
+WHERE stxname = 'stxtest_kw_mixed'
+LIMIT 1
+----
+CREATE STATISTICS public.stxtest_kw_mixed ON "select", normal FROM public.stxtest_kw
+
+statement ok
+DROP TABLE stxtest_kw
+
+statement ok
+DROP TABLE stxtest
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2902,6 +2902,7 @@ var builtinOidsArray = []string{
 	2947: `information_schema.crdb_enable_statement_hints(enabled: bool, statement_fingerprint: string) -> int`,
 	2948: `information_schema.crdb_delete_statement_hints(statement_fingerprint: string, database: string) -> int`,
 	2949: `information_schema.crdb_enable_statement_hints(enabled: bool, statement_fingerprint: string, database: string) -> int`,
+	2950: `pg_get_statisticsobjdef(statobj_oid: oid) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -934,6 +934,31 @@ FROM defaults_parsed
 		},
 	),
 
+	// pg_get_statisticsobjdef returns the CREATE STATISTICS command for
+	// an extended statistics object.
+	"pg_get_statisticsobjdef": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo, DistsqlBlocklist: true},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "statobj_oid", Typ: types.Oid}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Body: `SELECT 'CREATE STATISTICS ' || quote_ident(n.nspname) || '.' || quote_ident(s.stxname) ||
+				' ON ' ||
+				(SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY ordinality)
+				 FROM unnest(s.stxkeys::INT2[]) WITH ORDINALITY AS u(attnum, ordinality)
+				 JOIN pg_catalog.pg_attribute a ON a.attrelid = s.stxrelid AND a.attnum = u.attnum::INT8) ||
+				' FROM ' || quote_ident(n2.nspname) || '.' || quote_ident(c.relname)
+			FROM pg_catalog.pg_statistic_ext s
+			JOIN pg_catalog.pg_namespace n ON n.oid = s.stxnamespace
+			JOIN pg_catalog.pg_class c ON c.oid = s.stxrelid
+			JOIN pg_catalog.pg_namespace n2 ON n2.oid = c.relnamespace
+			WHERE s.oid = $1`,
+			Info:              "Returns the CREATE STATISTICS command for an extended statistics object.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
+			Language:          tree.RoutineLangSQL,
+		},
+	),
+
 	// pg_get_viewdef functions like SHOW CREATE VIEW but returns the same format as
 	// PostgreSQL leaving out the actual 'CREATE VIEW table_name AS' portion of the statement.
 	"pg_get_viewdef": makeBuiltin(


### PR DESCRIPTION
Implement the pg_get_statisticsobjdef() builtin function, which returns
the CREATE STATISTICS command for an extended statistics object given
its OID. This is used by pg_dump when dumping extended statistics
objects from pg_statistic_ext.

Column names that are SQL keywords are properly quoted using
quote_ident, matching PostgreSQL's use of quote_identifier.

Informs: #20296

Release note (sql change): Added the pg_get_statisticsobjdef() builtin
function, which returns the CREATE STATISTICS DDL for a given statistics
object OID.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>