### PR TITLE
sql: append trailing semicolon to view definitions in pg_views and pg_matviews

### DIFF
--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -1545,7 +1545,7 @@ Column,Type,Collation,Nullable,Default,Description
 mycolumn,bigint,,,,
 > SELECT pg_catalog.pg_get_viewdef(108::pg_catalog.oid, true) AS "View definition"
 View definition
-SELECT mycolumn FROM defaultdb.public.mytable
+SELECT mycolumn FROM defaultdb.public.mytable;
 
 subtest end
 
@@ -1641,7 +1641,7 @@ Indexes
 "mymview_pkey PRIMARY KEY, btree (rowid ASC)"
 > SELECT pg_catalog.pg_get_viewdef(107::pg_catalog.oid, true) AS "View definition"
 View definition
-SELECT mycolumn FROM defaultdb.public.mytable
+SELECT mycolumn FROM defaultdb.public.mytable;
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2424,7 +2424,7 @@ CREATE VIEW test.pg_viewdef_view AS SELECT a, b FROM test.pg_viewdef_test
 query T
 SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid)
 ----
-SELECT a, b FROM test.public.pg_viewdef_test
+SELECT a, b FROM test.public.pg_viewdef_test;
 
 query T
 SELECT pg_catalog.pg_get_viewdef(0, true)
@@ -2439,12 +2439,12 @@ NULL
 query T
 SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid, true)
 ----
-SELECT a, b FROM test.public.pg_viewdef_test
+SELECT a, b FROM test.public.pg_viewdef_test;
 
 query T
 SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid, false)
 ----
-SELECT a, b FROM test.public.pg_viewdef_test
+SELECT a, b FROM test.public.pg_viewdef_test;
 
 statement ok
 CREATE MATERIALIZED VIEW test.pg_viewdef_mview AS SELECT b, a FROM test.pg_viewdef_test
@@ -2452,7 +2452,7 @@ CREATE MATERIALIZED VIEW test.pg_viewdef_mview AS SELECT b, a FROM test.pg_viewd
 query T
 SELECT pg_catalog.pg_get_viewdef('pg_viewdef_mview'::regclass::oid)
 ----
-SELECT b, a FROM test.public.pg_viewdef_test
+SELECT b, a FROM test.public.pg_viewdef_test;
 
 statement ok
 CREATE TABLE test.pg_constraintdef_test (

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -542,7 +542,7 @@ query TTTT colnames
 SELECT * FROM pg_catalog.pg_views
 ----
 schemaname  viewname  viewowner  definition
-public      v1        root       SELECT p, a, b, c FROM constraint_db.public.t1
+public      v1        root       SELECT p, a, b, c FROM constraint_db.public.t1;
 
 ## pg_catalog.pg_matviews
 
@@ -553,7 +553,7 @@ query TTTTBBT colnames
 SELECT * FROM pg_catalog.pg_matviews
 ----
 schemaname  matviewname  matviewowner  tablespace  hasindexes  ispopulated  definition
-public      mv1          root          NULL        false       true         SELECT 1
+public      mv1          root          NULL        false       true         SELECT 1;
 
 ## pg_catalog.pg_class
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2511,8 +2511,8 @@ https://www.postgresql.org/docs/9.6/view-pg-matviews.html`,
 					owner,                         // matviewowner
 					tree.DNull,                    // tablespace
 					tree.MakeDBool(len(desc.PublicNonPrimaryIndexes()) > 0), // hasindexes
-					tree.DBoolTrue,                       // ispopulated,
-					tree.NewDString(desc.GetViewQuery()), // definition
+					tree.DBoolTrue, // ispopulated,
+					tree.NewDString(desc.GetViewQuery()+";"), // definition
 				)
 			})
 	},
@@ -5504,10 +5504,10 @@ https://www.postgresql.org/docs/9.5/view-pg-views.html`,
 				// TODO(SQL Features): Insert column aliases into view query once we
 				// have a semantic query representation to work with (#10083).
 				return addRow(
-					tree.NewDName(sc.GetName()),          // schemaname
-					tree.NewDName(desc.GetName()),        // viewname
-					owner,                                // viewowner
-					tree.NewDString(desc.GetViewQuery()), // definition
+					tree.NewDName(sc.GetName()),   // schemaname
+					tree.NewDName(desc.GetName()), // viewname
+					owner,                         // viewowner
+					tree.NewDString(desc.GetViewQuery()+";"), // definition
 				)
 			})
 	},


### PR DESCRIPTION
PostgreSQL's pg_views.definition and pg_matviews.definition columns
include a trailing semicolon in the view query text. CockroachDB was
omitting it. This caused pg_dump to produce truncated view definitions,
since pg_dump assumes the last character is a semicolon and strips it
(see createViewAsClause in pg_dump.c). For example, a view with
`WHERE is_active = true` would be dumped as `WHERE is_active = tru`.

This also affects pg_get_viewdef(), which reads from pg_views/pg_matviews
and is used by pg_dump and psql's \d command.

Informs: #20296

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>