### PR TITLE
sql: show grant option markers for admin and root in ACL output

### DIFF
--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -48,8 +48,8 @@ Name,Owner,Encoding,Collate,Ctype,Access privileges
 defaultdb,root,UTF8,en_US.utf8,en_US.utf8,
 mydb,root,UTF8,en_US.utf8,en_US.utf8,
 postgres,root,UTF8,en_US.utf8,en_US.utf8,
-system,node,UTF8,en_US.utf8,en_US.utf8,"admin=c/node
-root=c/node"
+system,node,UTF8,en_US.utf8,en_US.utf8,"admin=c*/node
+root=c*/node"
 
 cli
 \l+
@@ -74,8 +74,8 @@ Name,Owner,Encoding,Collate,Ctype,Access privileges,Connections,Description
 defaultdb,root,UTF8,en_US.utf8,en_US.utf8,,Unlimited,
 mydb,root,UTF8,en_US.utf8,en_US.utf8,,Unlimited,my awesome db comment
 postgres,root,UTF8,en_US.utf8,en_US.utf8,,Unlimited,
-system,node,UTF8,en_US.utf8,en_US.utf8,"admin=c/node
-root=c/node",Unlimited,
+system,node,UTF8,en_US.utf8,en_US.utf8,"admin=c*/node
+root=c*/node",Unlimited,
 
 cli
 \l my%
@@ -145,9 +145,9 @@ List of schemas:
    AND n.nspname <> 'information_schema'
 ORDER BY 1
 Name,Owner,Access privileges,Description
-public,root,"admin=CU/root
+public,root,"admin=C*U*/root
 =CU/root
-root=CU/root",
+root=C*U*/root",
 
 cli
 \dn+ p%
@@ -164,9 +164,9 @@ ORDER BY 1
 Name,Owner,Access privileges,Description
 pg_catalog,node,,
 pg_extension,node,,
-public,root,"admin=CU/root
+public,root,"admin=C*U*/root
 =CU/root
-root=CU/root",
+root=C*U*/root",
 
 cli
 \dnS
@@ -202,9 +202,9 @@ crdb_internal,node,,
 information_schema,node,,
 pg_catalog,node,,
 pg_extension,node,,
-public,root,"admin=CU/root
+public,root,"admin=C*U*/root
 =CU/root
-root=CU/root",
+root=C*U*/root",
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -96,22 +96,22 @@ LEFT JOIN pg_roles e ON e.oid = a.grantee
 ORDER BY 1, 2, 3
 ----
 grantor  grantee  privilege_type  is_grantable
-root     admin    CREATE          false
-root     admin    DELETE          false
-root     admin    INSERT          false
-root     admin    MAINTAIN        false
-root     admin    SELECT          false
-root     admin    TRIGGER         false
-root     admin    TRUNCATE        false
-root     admin    UPDATE          false
-root     root     CREATE          false
-root     root     DELETE          false
-root     root     INSERT          false
-root     root     MAINTAIN        false
-root     root     SELECT          false
-root     root     TRIGGER         false
-root     root     TRUNCATE        false
-root     root     UPDATE          false
+root     admin    CREATE          true
+root     admin    DELETE          true
+root     admin    INSERT          true
+root     admin    MAINTAIN        true
+root     admin    SELECT          true
+root     admin    TRIGGER         true
+root     admin    TRUNCATE        true
+root     admin    UPDATE          true
+root     root     CREATE          true
+root     root     DELETE          true
+root     root     INSERT          true
+root     root     MAINTAIN        true
+root     root     SELECT          true
+root     root     TRIGGER         true
+root     root     TRUNCATE        true
+root     root     UPDATE          true
 
 subtest end
 
@@ -166,38 +166,38 @@ subtest acldefault
 query T
 SELECT acldefault('r'::"char", 'root'::regrole)
 ----
-{admin=CradwDtm/root,root=CradwDtm/root}
+{admin=C*r*a*d*w*D*t*m*/root,root=C*r*a*d*w*D*t*m*/root}
 
 # Database defaults: admin and root get CREATE, CONNECT, TEMPORARY.
 # PUBLIC gets CONNECT and TEMPORARY.
 query T
 SELECT acldefault('d'::"char", 'root'::regrole)
 ----
-{=cT/root,admin=CcT/root,root=CcT/root}
+{=cT/root,admin=C*c*T*/root,root=C*c*T*/root}
 
 # Function defaults: admin and root get EXECUTE, PUBLIC gets EXECUTE.
 query T
 SELECT acldefault('f'::"char", 'root'::regrole)
 ----
-{=X/root,admin=X/root,root=X/root}
+{=X/root,admin=X*/root,root=X*/root}
 
 # Type defaults: admin and root get USAGE, PUBLIC gets USAGE.
 query T
 SELECT acldefault('T'::"char", 'root'::regrole)
 ----
-{=U/root,admin=U/root,root=U/root}
+{=U/root,admin=U*/root,root=U*/root}
 
 # Schema defaults: admin and root get USAGE and CREATE, PUBLIC gets nothing.
 query T
 SELECT acldefault('n'::"char", 'root'::regrole)
 ----
-{admin=CU/root,root=CU/root}
+{admin=C*U*/root,root=C*U*/root}
 
 # Language defaults: admin, root, and PUBLIC get USAGE.
 query T
 SELECT acldefault('l'::"char", 'root'::regrole)
 ----
-{=U/root,admin=U/root,root=U/root}
+{=U/root,admin=U*/root,root=U*/root}
 
 # Column defaults: nobody gets anything.
 query T
@@ -209,7 +209,7 @@ SELECT acldefault('c'::"char", 'root'::regrole)
 query T
 SELECT acldefault('p'::"char", 'root'::regrole)
 ----
-{admin=sA/root,root=sA/root}
+{admin=s*A*/root,root=s*A*/root}
 
 # Error on invalid type char.
 statement error unrecognized object type abbreviation: "Z"
@@ -234,12 +234,29 @@ ORDER BY 1, 2, 3
 grantor  grantee  privilege_type  is_grantable
 root     PUBLIC   CONNECT         false
 root     PUBLIC   TEMPORARY       false
-root     admin    CONNECT         false
-root     admin    CREATE          false
-root     admin    TEMPORARY       false
-root     root     CONNECT         false
-root     root     CREATE          false
-root     root     TEMPORARY       false
+root     admin    CONNECT         true
+root     admin    CREATE          true
+root     admin    TEMPORARY       true
+root     root     CONNECT         true
+root     root     CREATE          true
+root     root     TEMPORARY       true
+
+# Round-trip for LANGUAGE type: admin and root should have grant options.
+query TTTB colnames
+SELECT
+  COALESCE(g.rolname, 'PUBLIC') AS grantor,
+  COALESCE(e.rolname, 'PUBLIC') AS grantee,
+  a.privilege_type,
+  a.is_grantable
+FROM aclexplode(acldefault('l'::"char", 'root'::regrole)) a
+LEFT JOIN pg_roles g ON g.oid = a.grantor
+LEFT JOIN pg_roles e ON e.oid = a.grantee
+ORDER BY 1, 2, 3
+----
+grantor  grantee  privilege_type  is_grantable
+root     PUBLIC   USAGE           false
+root     admin    USAGE           true
+root     root     USAGE           true
 
 # Round-trip for PARAMETER type: aclexplode(acldefault('p', ...)) should return
 # SET and ALTER SYSTEM privileges. This verifies no silent data loss occurs
@@ -257,10 +274,10 @@ LEFT JOIN pg_roles e ON e.oid = a.grantee
 ORDER BY 1, 2, 3
 ----
 grantor  grantee  privilege_type  is_grantable
-root     admin    ALTER SYSTEM    false
-root     admin    SET             false
-root     root     ALTER SYSTEM    false
-root     root     SET             false
+root     admin    ALTER SYSTEM    true
+root     admin    SET             true
+root     root     ALTER SYSTEM    true
+root     root     SET             true
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -430,7 +430,7 @@ crdb_internal       3233629770  NULL
 information_schema  3233629770  NULL
 pg_catalog          3233629770  NULL
 pg_extension        3233629770  NULL
-public              1546506610  {admin=CU/root,=CU/root,root=CU/root}
+public              1546506610  {admin=C*U*/root,=CU/root,root=C*U*/root}
 
 # Verify that we can still see the schemas even if we don't have any privilege
 # on the current database.
@@ -449,7 +449,7 @@ crdb_internal       3233629770  NULL
 information_schema  3233629770  NULL
 pg_catalog          3233629770  NULL
 pg_extension        3233629770  NULL
-public              1546506610  {admin=CU/root,=CU/root,root=CU/root}
+public              1546506610  {admin=C*U*/root,=CU/root,root=C*U*/root}
 
 user root
 
@@ -476,10 +476,10 @@ FROM pg_catalog.pg_database
 ORDER BY oid
 ----
 oid  datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
-1    system         -1            0              NULL          NULL        0              {admin=c/node,root=c/node}
+1    system         -1            0              NULL          NULL        0              {admin=c*/node,root=c*/node}
 100  defaultdb      -1            0              NULL          NULL        0              NULL
 102  postgres       -1            0              NULL          NULL        0              NULL
-104  test           -1            0              NULL          NULL        0              {admin=CcT/root,=c/root,root=CcT/root}
+104  test           -1            0              NULL          NULL        0              {admin=C*c*T*/root,=c/root,root=C*c*T*/root}
 108  constraint_db  -1            0              NULL          NULL        0              NULL
 
 user testuser
@@ -491,7 +491,7 @@ FROM pg_catalog.pg_database
 ORDER BY oid LIMIT 1
 ----
 oid  datname  datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
-1    system   -1            0              NULL          NULL        0              {admin=c/node,root=c/node}
+1    system   -1            0              NULL          NULL        0              {admin=c*/node,root=c*/node}
 
 user root
 
@@ -5807,7 +5807,7 @@ GRANT SELECT ON t1 TO testuser WITH GRANT OPTION
 query T
 SELECT relacl FROM pg_class WHERE relname = 't1'
 ----
-{admin=CradwDtm/root,root=CradwDtm/root,testuser=r*/root}
+{admin=C*r*a*d*w*D*t*m*/root,root=C*r*a*d*w*D*t*m*/root,testuser=r*/root}
 
 # relacl: returns to NULL after revoking back to defaults.
 statement ok
@@ -5823,7 +5823,7 @@ NULL
 query T
 SELECT nspacl FROM pg_namespace WHERE nspname = 'public'
 ----
-{admin=CU/root,=CU/root,root=CU/root}
+{admin=C*U*/root,=CU/root,root=C*U*/root}
 
 query T
 SELECT nspacl FROM pg_namespace WHERE nspname = 'pg_catalog'
@@ -5846,7 +5846,7 @@ GRANT USAGE ON SCHEMA acl_test_schema TO testuser
 query T
 SELECT nspacl FROM pg_namespace WHERE nspname = 'acl_test_schema'
 ----
-{admin=CU/root,root=CU/root,testuser=U/root}
+{admin=C*U*/root,root=C*U*/root,testuser=U/root}
 
 # nspacl: returns to NULL after revoking back to defaults.
 statement ok
@@ -5870,7 +5870,7 @@ GRANT CONNECT ON DATABASE defaultdb TO testuser
 query T
 SELECT datacl FROM pg_database WHERE datname = 'defaultdb'
 ----
-{admin=CcT/root,=cT/root,root=CcT/root,testuser=c/root}
+{admin=C*c*T*/root,=cT/root,root=C*c*T*/root,testuser=c/root}
 
 # datacl: returns to NULL after revoking back to defaults.
 statement ok
@@ -5898,7 +5898,7 @@ REVOKE EXECUTE ON FUNCTION acl_test_fn FROM public
 query T
 SELECT proacl FROM pg_proc WHERE proname = 'acl_test_fn'
 ----
-{admin=X/root,root=X/root}
+{admin=X*/root,root=X*/root}
 
 # proacl: returns to NULL after restoring defaults.
 statement ok
@@ -5935,7 +5935,7 @@ REVOKE USAGE ON TYPE acl_test_type FROM public
 query T
 SELECT typacl FROM pg_type WHERE typname = 'acl_test_type'
 ----
-{admin=U/root,root=U/root}
+{admin=U*/root,root=U*/root}
 
 # typacl: returns to NULL after restoring defaults.
 statement ok
@@ -5972,7 +5972,7 @@ GRANT SELECT ON testowner_table TO testuser
 query T
 SELECT relacl FROM pg_class WHERE relname = 'testowner_table'
 ----
-{admin=CradwDtm/testowner,root=CradwDtm/testowner,testuser=r/testowner,testowner=CradwDtm/testowner}
+{admin=C*r*a*d*w*D*t*m*/testowner,root=C*r*a*d*w*D*t*m*/testowner,testuser=r/testowner,testowner=CradwDtm/testowner}
 
 # relacl: returns to NULL after revoking back to defaults.
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1740,8 +1740,9 @@ func createDefACLItem(
 // included; CockroachDB-specific privileges (BACKUP, CHANGEFEED, etc.)
 // are silently skipped by ListToACL.
 //
-// Grant option markers ('*') are stripped for admin, root, and the owner,
-// since their grant options are implicit (matching PostgreSQL behavior).
+// Grant option markers ('*') are stripped for the owner, since the owner's
+// grant option is implicit in PostgreSQL (acldefault never includes '*' for
+// the owner).
 //
 // If the resulting ACL matches the default privileges for the object type,
 // NULL is returned (matching PostgreSQL behavior where NULL means defaults).
@@ -1769,10 +1770,12 @@ func privilegeDescriptorToACLArray(
 				return nil, err
 			}
 		}
-		// Strip grant options for admin, root, and owner — their grant
-		// options are implicit in PostgreSQL convention.
+		// Strip grant options for the owner — the owner's grant option is
+		// implicit in PostgreSQL (acldefault never includes '*' for the
+		// owner). However, root and admin always show explicit grant
+		// options since they appear in every ACL with grants.
 		var grantOptions privilege.List
-		if !grantee.IsAdminRole() && !grantee.IsRootUser() && grantee != owner {
+		if grantee != owner || grantee.IsRootUser() || grantee.IsAdminRole() {
 			grantOptions, err = privilege.ListFromBitField(
 				userPriv.WithGrantOption, objectType,
 			)

--- a/pkg/sql/privilege/aclitem.go
+++ b/pkg/sql/privilege/aclitem.go
@@ -153,7 +153,7 @@ var pgDefaultPublicPrivs = map[ObjectType]List{
 // default privileges and return NULL) and by the acldefault builtin.
 //
 // The returned items follow PostgreSQL conventions:
-//   - No '*' grant option markers for admin, root, or owner (implicit).
+//   - No '*' grant option markers for the owner (implicit in PostgreSQL).
 //   - Only privileges with a PG ACL character equivalent are included.
 //   - PUBLIC entries come first.
 func DefaultACLItems(objectType ObjectType, owner username.SQLUsername) ([]ACLItem, error) {
@@ -181,15 +181,16 @@ func DefaultACLItems(objectType ObjectType, owner username.SQLUsername) ([]ACLIt
 		))
 	}
 
-	// Admin and root entries.
+	// Admin and root entries (with explicit grant options).
 	items = append(items, NewACLItem(
-		username.AdminRoleName(), owner, filtered, nil,
+		username.AdminRoleName(), owner, filtered, filtered,
 	))
 	items = append(items, NewACLItem(
-		username.RootUserName(), owner, filtered, nil,
+		username.RootUserName(), owner, filtered, filtered,
 	))
 
-	// Owner entry (if different from admin and root).
+	// Owner entry (if different from admin and root). No grant option
+	// markers — the owner's grant option is implicit in PostgreSQL.
 	if !owner.IsAdminRole() && !owner.IsRootUser() {
 		items = append(items, NewACLItem(owner, owner, filtered, nil))
 	}

--- a/pkg/sql/privilege/aclitem_test.go
+++ b/pkg/sql/privilege/aclitem_test.go
@@ -220,42 +220,42 @@ func TestDefaultACLItems(t *testing.T) {
 		{
 			objectType: privilege.Table,
 			owner:      username.RootUserName(),
-			expected:   []string{"admin=CradwDtm/root", "root=CradwDtm/root"},
+			expected:   []string{"admin=C*r*a*d*w*D*t*m*/root", "root=C*r*a*d*w*D*t*m*/root"},
 		},
 		{
 			objectType: privilege.Table,
 			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
-			expected:   []string{"admin=CradwDtm/myuser", "root=CradwDtm/myuser", "myuser=CradwDtm/myuser"},
+			expected:   []string{"admin=C*r*a*d*w*D*t*m*/myuser", "root=C*r*a*d*w*D*t*m*/myuser", "myuser=CradwDtm/myuser"},
 		},
 		{
 			objectType: privilege.Sequence,
 			owner:      username.RootUserName(),
-			expected:   []string{"admin=CradwU/root", "root=CradwU/root"},
+			expected:   []string{"admin=C*r*a*d*w*U*/root", "root=C*r*a*d*w*U*/root"},
 		},
 		{
 			objectType: privilege.Database,
 			owner:      username.RootUserName(),
-			expected:   []string{"=cT/root", "admin=CcT/root", "root=CcT/root"},
+			expected:   []string{"=cT/root", "admin=C*c*T*/root", "root=C*c*T*/root"},
 		},
 		{
 			objectType: privilege.Schema,
 			owner:      username.RootUserName(),
-			expected:   []string{"admin=CU/root", "root=CU/root"},
+			expected:   []string{"admin=C*U*/root", "root=C*U*/root"},
 		},
 		{
 			objectType: privilege.Routine,
 			owner:      username.RootUserName(),
-			expected:   []string{"=X/root", "admin=X/root", "root=X/root"},
+			expected:   []string{"=X/root", "admin=X*/root", "root=X*/root"},
 		},
 		{
 			objectType: privilege.Type,
 			owner:      username.RootUserName(),
-			expected:   []string{"=U/root", "admin=U/root", "root=U/root"},
+			expected:   []string{"=U/root", "admin=U*/root", "root=U*/root"},
 		},
 		{
 			objectType: privilege.Database,
 			owner:      username.MakeSQLUsernameFromPreNormalizedString("myuser"),
-			expected:   []string{"=cT/myuser", "admin=CcT/myuser", "root=CcT/myuser", "myuser=CcT/myuser"},
+			expected:   []string{"=cT/myuser", "admin=C*c*T*/myuser", "root=C*c*T*/myuser", "myuser=CcT/myuser"},
 		},
 	}
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2652,7 +2652,7 @@ SELECT
 						username.RootUserName(),
 					} {
 						if err := appendItem(privilege.NewACLItem(
-							role, owner, def.ownerPrivs, nil,
+							role, owner, def.ownerPrivs, def.ownerPrivs,
 						)); err != nil {
 							return nil, err
 						}


### PR DESCRIPTION
Previously, grant option markers (`*`) were stripped from aclitem
strings for admin, root, and the object owner. In PostgreSQL, only
the owner's grant option is implicit — acldefault never includes `*`
for the owner. The admin and root roles in CockroachDB have explicit
grant options that should be visible.

Now only the owner's grant options are suppressed (unless the owner
is admin or root). This applies to pg_catalog ACL columns (relacl,
nspacl, etc.) and the acldefault builtin. The change also fixes
DefaultACLItems to include grant options for admin and root, so the
default ACL comparison in privilegeDescriptorToACLArray succeeds
and relacl returns NULL for tables with default privileges.

Informs: #20296

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>