### PR TITLE
sql: omit database prefix from pg_get_indexdef output

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -395,12 +395,12 @@ WHERE tablename = 't'
 ORDER BY 1, 2, 3
 ----
 tablename  indexname    indexdef
-t          new_idx      CREATE INDEX new_idx ON test.public.t USING btree (d ASC)
-t          t_a_b_c_idx  CREATE INDEX t_a_b_c_idx ON test.public.t USING btree (a ASC, b ASC, c ASC)
-t          t_b_idx      CREATE INDEX t_b_idx ON test.public.t USING btree (b ASC)
-t          t_c_key      CREATE UNIQUE INDEX t_c_key ON test.public.t USING btree (c ASC)
-t          t_j_idx      CREATE INDEX t_j_idx ON test.public.t USING gin (j)
-t          t_pkey       CREATE UNIQUE INDEX t_pkey ON test.public.t USING btree (pk ASC)
+t          new_idx      CREATE INDEX new_idx ON public.t USING btree (d ASC)
+t          t_a_b_c_idx  CREATE INDEX t_a_b_c_idx ON public.t USING btree (a ASC, b ASC, c ASC)
+t          t_b_idx      CREATE INDEX t_b_idx ON public.t USING btree (b ASC)
+t          t_c_key      CREATE UNIQUE INDEX t_c_key ON public.t USING btree (c ASC)
+t          t_j_idx      CREATE INDEX t_j_idx ON public.t USING gin (j)
+t          t_pkey       CREATE UNIQUE INDEX t_pkey ON public.t USING btree (pk ASC)
 
 statement error cannot ALTER INDEX PARTITION BY on an index which already has implicit column partitioning
 ALTER INDEX new_idx PARTITION BY LIST (a) (

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2352,17 +2352,17 @@ CREATE TABLE test.pg_indexdef_test (
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_idx'))
 ----
-CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test USING btree (a ASC)
+CREATE UNIQUE INDEX pg_indexdef_idx ON public.pg_indexdef_test USING btree (a ASC)
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_partial_idx'))
 ----
-CREATE INDEX pg_indexdef_partial_idx ON test.public.pg_indexdef_test USING btree (a ASC) WHERE (a > 0)
+CREATE INDEX pg_indexdef_partial_idx ON public.pg_indexdef_test USING btree (a ASC) WHERE (a > 0)
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_partial_enum_idx'))
 ----
-CREATE INDEX pg_indexdef_partial_enum_idx ON test.public.pg_indexdef_test USING btree (a ASC) WHERE (e IN ('foo'::public.testenum, 'bar'::public.testenum))
+CREATE INDEX pg_indexdef_partial_enum_idx ON public.pg_indexdef_test USING btree (a ASC) WHERE (e IN ('foo'::public.testenum, 'bar'::public.testenum))
 
 query T
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
@@ -2372,7 +2372,7 @@ NULL
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_idx'), 0, true)
 ----
-CREATE UNIQUE INDEX pg_indexdef_idx ON test.public.pg_indexdef_test USING btree (a ASC)
+CREATE UNIQUE INDEX pg_indexdef_idx ON public.pg_indexdef_test USING btree (a ASC)
 
 statement ok
 CREATE TABLE test.pg_indexdef_test_cols (a INT, b INT, UNIQUE INDEX pg_indexdef_cols_idx (a ASC, b DESC), INDEX other (a DESC))
@@ -2380,7 +2380,7 @@ CREATE TABLE test.pg_indexdef_test_cols (a INT, b INT, UNIQUE INDEX pg_indexdef_
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_cols_idx'), 0, true)
 ----
-CREATE UNIQUE INDEX pg_indexdef_cols_idx ON test.public.pg_indexdef_test_cols USING btree (a ASC, b DESC)
+CREATE UNIQUE INDEX pg_indexdef_cols_idx ON public.pg_indexdef_test_cols USING btree (a ASC, b DESC)
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_cols_idx'), 1, true)

--- a/pkg/sql/logictest/testdata/logic_test/hash_index_shard_columns
+++ b/pkg/sql/logictest/testdata/logic_test/hash_index_shard_columns
@@ -44,12 +44,12 @@ SELECT indexname, indexdef FROM pg_indexes
 WHERE tablename = 'shard_columns_test' AND indexname LIKE 'idx%'
 ORDER BY indexname
 ----
-idx1  CREATE INDEX idx1 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=4, shard_columns=(c1, c2))
-idx2  CREATE INDEX idx2 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=4, shard_columns=(c1, c2))
-idx3  CREATE INDEX idx3 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1, c2))
-idx4  CREATE INDEX idx4 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
-idx5  CREATE INDEX idx5 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
-idx6  CREATE INDEX idx6 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8)
+idx1  CREATE INDEX idx1 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=4, shard_columns=(c1, c2))
+idx2  CREATE INDEX idx2 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=4, shard_columns=(c1, c2))
+idx3  CREATE INDEX idx3 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1, c2))
+idx4  CREATE INDEX idx4 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
+idx5  CREATE INDEX idx5 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
+idx6  CREATE INDEX idx6 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8)
 
 statement ok
 DROP TABLE shard_columns_test
@@ -72,9 +72,9 @@ SELECT indexname, indexdef FROM pg_indexes
 WHERE tablename = 'shard_columns_test' AND indexname LIKE 'idx%'
 ORDER BY indexname
 ----
-idx1  CREATE UNIQUE INDEX idx1 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
-idx2  CREATE UNIQUE INDEX idx2 ON test.public.shard_columns_test USING btree (c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c2))
-idx3  CREATE INDEX idx3 ON test.public.shard_columns_test USING btree (c3 ASC, c4 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c3))
+idx1  CREATE UNIQUE INDEX idx1 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
+idx2  CREATE UNIQUE INDEX idx2 ON public.shard_columns_test USING btree (c2 ASC, c3 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c2))
+idx3  CREATE INDEX idx3 ON public.shard_columns_test USING btree (c3 ASC, c4 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c3))
 
 statement ok
 DROP TABLE shard_columns_test
@@ -97,7 +97,7 @@ SELECT indexname, indexdef FROM pg_indexes
 WHERE tablename = 'shard_columns_test' AND indexname LIKE 'idx%'
 ORDER BY indexname
 ----
-idx1  CREATE UNIQUE INDEX idx1 ON test.public.shard_columns_test USING btree (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
+idx1  CREATE UNIQUE INDEX idx1 ON public.shard_columns_test USING btree (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
 
 statement ok
 DROP TABLE shard_columns_test
@@ -114,7 +114,7 @@ query TT
 SELECT tablename, indexdef FROM pg_indexes
 WHERE tablename = 'MixedCase' AND indexname = 'IdX'
 ----
-MixedCase  CREATE INDEX "IdX" ON test.public."MixedCase" USING btree ("Col1" ASC, "Col2" ASC, "Col3" ASC) USING HASH WITH (bucket_count=4, shard_columns=("Col1", "Col2"))
+MixedCase  CREATE INDEX "IdX" ON public."MixedCase" USING btree ("Col1" ASC, "Col2" ASC, "Col3" ASC) USING HASH WITH (bucket_count=4, shard_columns=("Col1", "Col2"))
 
 statement ok
 DROP TABLE "MixedCase"
@@ -195,8 +195,8 @@ CREATE INDEX idx2 ON legacy_test (c2, c3, c4) USING HASH WITH (shard_columns=(c2
 query TT
 SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'legacy_test' AND indexname LIKE 'idx%' ORDER BY indexname
 ----
-idx1  CREATE UNIQUE INDEX idx1 ON test.public.legacy_test USING btree (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
-idx2  CREATE INDEX idx2 ON test.public.legacy_test USING btree (c2 ASC, c3 ASC, c4 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c2, c3))
+idx1  CREATE UNIQUE INDEX idx1 ON public.legacy_test USING btree (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c1))
+idx2  CREATE INDEX idx2 ON public.legacy_test USING btree (c2 ASC, c3 ASC, c4 ASC) USING HASH WITH (bucket_count=8, shard_columns=(c2, c3))
 
 statement ok
 DROP TABLE legacy_test

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -76,7 +76,7 @@ WHERE tablename = 'sharded_primary'
 ORDER BY 1, 2, 3
 ----
 tablename        indexname  indexdef
-sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC) USING HASH WITH (bucket_count=10)
+sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON public.sharded_primary USING btree (a ASC) USING HASH WITH (bucket_count=10)
 
 # Test that the indexdef output from pg_indexes is round-trippable. This is a
 # regression test for #161516.
@@ -92,7 +92,7 @@ FROM pg_indexes
 WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
 ----
 tablename           indexname  indexdef
-store_columns_test  idx1       CREATE INDEX idx1 ON test.public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
+store_columns_test  idx1       CREATE INDEX idx1 ON public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
 
 # Verify that the CREATE INDEX statement from pg_indexes can be executed.
 # First, save the index definition.
@@ -112,7 +112,7 @@ FROM pg_indexes
 WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
 ----
 tablename           indexname  indexdef
-store_columns_test  idx1       CREATE INDEX idx1 ON test.public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
+store_columns_test  idx1       CREATE INDEX idx1 ON public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
 
 statement ok
 DROP TABLE store_columns_test

--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -720,7 +720,7 @@ FROM pg_indexes
 WHERE tablename = 'intervalstyle_in_index'
 AND indexname = 'idx'
 ----
-idx  CREATE INDEX idx ON test.public.intervalstyle_in_index USING btree (b ASC) WHERE (b > '3-0'::INTERVAL)
+idx  CREATE INDEX idx ON public.intervalstyle_in_index USING btree (b ASC) WHERE (b > '3-0'::INTERVAL)
 
 statement ok
 SET intervalstyle = 'iso_8601'
@@ -731,7 +731,7 @@ FROM pg_indexes
 WHERE tablename = 'intervalstyle_in_index'
 AND indexname = 'idx'
 ----
-idx  CREATE INDEX idx ON test.public.intervalstyle_in_index USING btree (b ASC) WHERE (b > 'P3Y'::INTERVAL)
+idx  CREATE INDEX idx ON public.intervalstyle_in_index USING btree (b ASC) WHERE (b > 'P3Y'::INTERVAL)
 
 # date_trunc
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -72,8 +72,8 @@ GROUP BY i.relname,
 ORDER BY i.relname
 ----
 name              primary  unique  indkey  column_indexes  column_names  definition
-customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.public.customers USING btree (id ASC)
-customers_pkey    true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX customers_pkey ON test.public.customers USING btree (name ASC)
+customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON public.customers USING btree (id ASC)
+customers_pkey    true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX customers_pkey ON public.customers USING btree (name ASC)
 
 
 query TT colnames

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -1253,12 +1253,12 @@ CREATE INDEX expr_idx ON expr_idx_tbl (id, (json->>'bar'), (length(id)))
 query T
 SELECT pg_get_indexdef('expr_idx'::regclass::oid)
 ----
-CREATE INDEX expr_idx ON test.public.expr_idx_tbl USING btree (id ASC, (json->>'bar'::STRING) ASC, length(id) ASC)
+CREATE INDEX expr_idx ON public.expr_idx_tbl USING btree (id ASC, (json->>'bar'::STRING) ASC, length(id) ASC)
 
 query IT
 SELECT k, pg_get_indexdef('expr_idx'::regclass::oid, k, true) FROM generate_series(0,4) k ORDER BY k
 ----
-0  CREATE INDEX expr_idx ON test.public.expr_idx_tbl USING btree (id ASC, (json->>'bar'::STRING) ASC, length(id) ASC)
+0  CREATE INDEX expr_idx ON public.expr_idx_tbl USING btree (id ASC, (json->>'bar'::STRING) ASC, length(id) ASC)
 1  id
 2  (json->>'bar'::STRING)
 3  (length(id))

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1067,23 +1067,23 @@ WHERE schemaname = 'public'
 ORDER BY tablename, indexname
 ----
 crdb_oid    tablename  indexname          indexdef
-784389845   mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON constraint_db.public.mv1 USING btree (rowid ASC)
-3687884464  t1         index_key          CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 USING btree (b ASC, c ASC)
-3687884465  t1         t1_a_key           CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 USING btree (a ASC)
-3687884466  t1         t1_pkey            CREATE UNIQUE INDEX t1_pkey ON constraint_db.public.t1 USING btree (p ASC)
-2342807459  t1_m_seq   primary            CREATE INDEX "primary" ON constraint_db.public.t1_m_seq USING btree (value ASC)
-5181036     t1_n_seq   primary            CREATE INDEX "primary" ON constraint_db.public.t1_n_seq USING btree (value ASC)
-2955071325  t2         t2_pkey            CREATE UNIQUE INDEX t2_pkey ON constraint_db.public.t2 USING btree (rowid ASC)
-2955071326  t2         t2_t1_id_idx       CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 USING btree (t1_id ASC)
-2695335053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 USING btree (a ASC, b DESC) STORING (c)
-2695335054  t3         t3_pkey            CREATE UNIQUE INDEX t3_pkey ON constraint_db.public.t3 USING btree (rowid ASC)
-3214807592  t4         t4_pkey            CREATE UNIQUE INDEX t4_pkey ON constraint_db.public.t4 USING btree (rowid ASC)
-1869730585  t5         t5_pkey            CREATE UNIQUE INDEX t5_pkey ON constraint_db.public.t5 USING btree (rowid ASC)
-2129466854  t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON constraint_db.public.t6 USING btree (lower(c) ASC, (a + b) ASC)
-2129466855  t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON constraint_db.public.t6 USING btree ((a + b) ASC)
-2129466850  t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree ((m = 'foo'::public.mytype) ASC) WHERE (m = 'foo'::public.mytype)
-2129466848  t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON constraint_db.public.t6 USING btree (lower(c) ASC)
-2129466852  t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON constraint_db.public.t6 USING btree (rowid ASC)
+784389845   mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON public.mv1 USING btree (rowid ASC)
+3687884464  t1         index_key          CREATE UNIQUE INDEX index_key ON public.t1 USING btree (b ASC, c ASC)
+3687884465  t1         t1_a_key           CREATE UNIQUE INDEX t1_a_key ON public.t1 USING btree (a ASC)
+3687884466  t1         t1_pkey            CREATE UNIQUE INDEX t1_pkey ON public.t1 USING btree (p ASC)
+2342807459  t1_m_seq   primary            CREATE INDEX "primary" ON public.t1_m_seq USING btree (value ASC)
+5181036     t1_n_seq   primary            CREATE INDEX "primary" ON public.t1_n_seq USING btree (value ASC)
+2955071325  t2         t2_pkey            CREATE UNIQUE INDEX t2_pkey ON public.t2 USING btree (rowid ASC)
+2955071326  t2         t2_t1_id_idx       CREATE INDEX t2_t1_id_idx ON public.t2 USING btree (t1_id ASC)
+2695335053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON public.t3 USING btree (a ASC, b DESC) STORING (c)
+2695335054  t3         t3_pkey            CREATE UNIQUE INDEX t3_pkey ON public.t3 USING btree (rowid ASC)
+3214807592  t4         t4_pkey            CREATE UNIQUE INDEX t4_pkey ON public.t4 USING btree (rowid ASC)
+1869730585  t5         t5_pkey            CREATE UNIQUE INDEX t5_pkey ON public.t5 USING btree (rowid ASC)
+2129466854  t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON public.t6 USING btree (lower(c) ASC, (a + b) ASC)
+2129466855  t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON public.t6 USING btree ((a + b) ASC)
+2129466850  t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON public.t6 USING btree ((m = 'foo'::public.mytype) ASC) WHERE (m = 'foo'::public.mytype)
+2129466848  t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON public.t6 USING btree (lower(c) ASC)
+2129466852  t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON public.t6 USING btree (rowid ASC)
 
 ## pg_catalog.pg_index
 
@@ -4359,7 +4359,7 @@ CREATE INDEX regression_46450_idx ON regression_46450 USING gin(json)
 query T
 select indexdef from pg_indexes where indexname = 'regression_46450_idx'
 ----
-CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json)
+CREATE INDEX regression_46450_idx ON public.regression_46450 USING gin (json)
 
 # Make sure indexdef uses user-defined schemas.
 
@@ -4377,8 +4377,8 @@ FROM pg_indexes WHERE schemaname='test_schema' and tablename='test'
 ORDER BY indexname
 ----
 schemaname   tablename  indexname   indexdef
-test_schema  test       test_b_idx  CREATE INDEX test_b_idx ON test.test_schema.test USING btree (b ASC)
-test_schema  test       test_pkey   CREATE UNIQUE INDEX test_pkey ON test.test_schema.test USING btree (a ASC)
+test_schema  test       test_b_idx  CREATE INDEX test_b_idx ON test_schema.test USING btree (b ASC)
+test_schema  test       test_pkey   CREATE UNIQUE INDEX test_pkey ON test_schema.test USING btree (a ASC)
 
 # Make sure that selecting from vtables with indexes in other dbs properly
 # hides descriptors that should be hidden.
@@ -4419,9 +4419,9 @@ WHERE tablename = 'geospatial_table'
 ORDER BY indexname
 ----
 indexname              indexdef
-geospatial_table_pkey  CREATE UNIQUE INDEX geospatial_table_pkey ON test.public.geospatial_table USING btree (id ASC)
-idxa                   CREATE INDEX idxa ON test.public.geospatial_table USING gin (a)
-idxb                   CREATE INDEX idxb ON test.public.geospatial_table USING gin (b)
+geospatial_table_pkey  CREATE UNIQUE INDEX geospatial_table_pkey ON public.geospatial_table USING btree (id ASC)
+idxa                   CREATE INDEX idxa ON public.geospatial_table USING gin (a)
+idxb                   CREATE INDEX idxb ON public.geospatial_table USING gin (b)
 
 subtest vector
 
@@ -4445,9 +4445,9 @@ WHERE tablename = 'vector_table'
 ORDER BY indexname
 ----
 indexname          indexdef
-idxa               CREATE INDEX idxa ON test.public.vector_table USING cspann (a vector_l2_ops)
-idxb               CREATE INDEX idxb ON test.public.vector_table USING cspann (a vector_l2_ops)
-vector_table_pkey  CREATE UNIQUE INDEX vector_table_pkey ON test.public.vector_table USING btree (id ASC)
+idxa               CREATE INDEX idxa ON public.vector_table USING cspann (a vector_l2_ops)
+idxb               CREATE INDEX idxb ON public.vector_table USING cspann (a vector_l2_ops)
+vector_table_pkey  CREATE UNIQUE INDEX vector_table_pkey ON public.vector_table USING btree (id ASC)
 
 subtest partial_index
 
@@ -4474,9 +4474,9 @@ WHERE tablename = 'partial_index_table'
 ORDER BY indexname
 ----
 indexname                   indexdef
-partial_index_table_a_key   CREATE UNIQUE INDEX partial_index_table_a_key ON test.public.partial_index_table USING btree (a ASC) WHERE (a > 0)
-partial_index_table_a_key1  CREATE UNIQUE INDEX partial_index_table_a_key1 ON test.public.partial_index_table USING btree (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
-partial_index_table_pkey    CREATE UNIQUE INDEX partial_index_table_pkey ON test.public.partial_index_table USING btree (rowid ASC)
+partial_index_table_a_key   CREATE UNIQUE INDEX partial_index_table_a_key ON public.partial_index_table USING btree (a ASC) WHERE (a > 0)
+partial_index_table_a_key1  CREATE UNIQUE INDEX partial_index_table_a_key1 ON public.partial_index_table USING btree (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
+partial_index_table_pkey    CREATE UNIQUE INDEX partial_index_table_pkey ON public.partial_index_table USING btree (rowid ASC)
 
 query TT colnames
 SELECT conname, condef

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2369,11 +2369,11 @@ https://www.postgresql.org/docs/9.5/view-pg-indexes.html`,
 		opts := forEachTableDescOptions{virtualOpts: hideVirtual} /* virtual tables do not have indexes */
 		return forEachTableDesc(ctx, p, dbContext, opts,
 			func(ctx context.Context, descCtx tableDescContext) error {
-				db, sc, table := descCtx.database, descCtx.schema, descCtx.table
+				sc, table := descCtx.schema, descCtx.table
 				scNameName := tree.NewDName(sc.GetName())
 				tblName := tree.NewDName(table.GetName())
 				return catalog.ForEachIndex(table, catalog.IndexOpts{}, func(index catalog.Index) error {
-					def, err := indexDefFromDescriptor(ctx, p, db, sc, table, index)
+					def, err := indexDefFromDescriptor(ctx, p, sc, table, index)
 					if err != nil {
 						return err
 					}
@@ -2391,17 +2391,19 @@ https://www.postgresql.org/docs/9.5/view-pg-indexes.html`,
 }
 
 // indexDefFromDescriptor creates an index definition (`CREATE INDEX ... ON (...)`) from
-// and index descriptor by reconstructing a CreateIndex parser node and calling its
-// String method.
+// an index descriptor by reconstructing a CreateIndex parser node and calling its
+// String method. The table name is schema-qualified only (no database prefix),
+// matching PostgreSQL's format. Cross-database index references are not possible
+// in either PostgreSQL or CockroachDB.
 func indexDefFromDescriptor(
 	ctx context.Context,
 	p *planner,
-	db catalog.DatabaseDescriptor,
 	sc catalog.SchemaDescriptor,
 	table catalog.TableDescriptor,
 	index catalog.Index,
 ) (string, error) {
-	tableName := tree.MakeTableNameWithSchema(tree.Name(db.GetName()), tree.Name(sc.GetName()), tree.Name(table.GetName()))
+	tableName := tree.MakeTableNameWithSchema("", tree.Name(sc.GetName()), tree.Name(table.GetName()))
+	tableName.ExplicitCatalog = false
 	partitionStr := ""
 	fmtStr, err := catformat.IndexForDisplay(
 		ctx,


### PR DESCRIPTION
Previously, `pg_get_indexdef` and `pg_indexes.indexdef` included the
database name in the table reference (e.g., `ON defaultdb.public.t`).
PostgreSQL only uses schema-qualified names (e.g., `ON public.t`)
since there is no cross-database reference concept. The extra prefix
caused pg_dump to emit invalid index definitions that would fail on
restore.

Remove the database catalog prefix from index definitions in
`indexDefFromDescriptor` to match PostgreSQL's format.

Informs: #20296

Release note (bug fix): Fixed a bug where `pg_get_indexdef` and
`pg_indexes.indexdef` included a database name prefix in the table
reference (e.g., `CREATE INDEX idx ON mydb.public.t ...`), which
does not match PostgreSQL's format and could cause issues with
tools that use this table. The output now uses only the schema-qualified
table name (e.g., `CREATE INDEX idx ON public.t ...`).

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>