### PR TITLE
CODEOWNERS: assign `pg_regress` test to SQL Foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -502,7 +502,7 @@
 /pkg/cmd/roachtest/spec/              @cockroachdb/test-eng
 /pkg/cmd/roachtest/test/              @cockroachdb/test-eng
 /pkg/cmd/roachtest/testdata/          @cockroachdb/test-eng
-/pkg/cmd/roachtest/testdata/pg_regress @cockroachdb/sql-queries-prs
+/pkg/cmd/roachtest/testdata/pg_regress @cockroachdb/sql-foundations
 /pkg/cmd/roachtest/testselector/      @cockroachdb/test-eng
 # This isn't quite right, each file should ideally be owned
 # by a team (or at least most of them), namely the team that

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -509,7 +509,7 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 func registerPGRegress(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:      "pg_regress",
-		Owner:     registry.OwnerSQLQueries,
+		Owner:     registry.OwnerSQLFoundations,
 		Benchmark: false,
 		Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
 		// At the moment, we have a very large deviation from postgres, also


### PR DESCRIPTION
Given that most new changes are related to PG compatibility and / or new features that SQL Foundations team owns, it makes more sense to re-assign the ownership.

Epic: None
Release note: None