### PR TITLE
roachtest: add LDR hot key benchmarks

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -3155,6 +3155,7 @@ GO_TARGETS = [
     "//pkg/workload/tpch:tpch_test",
     "//pkg/workload/ttlbench:ttlbench",
     "//pkg/workload/ttllogger:ttllogger",
+    "//pkg/workload/uniqueindex:uniqueindex",
     "//pkg/workload/vecann:vecann",
     "//pkg/workload/vecann:vecann_test",
     "//pkg/workload/workload_generator:workload_generator",

--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/workload/tpch",
         "//pkg/workload/ttlbench",
         "//pkg/workload/ttllogger",
+        "//pkg/workload/uniqueindex",
         "//pkg/workload/vecann",
         "//pkg/workload/workload_generator",
         "//pkg/workload/ycsb",

--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ttlbench"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ttllogger"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/uniqueindex"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/vecann"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/workload_generator"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ycsb"

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -277,6 +277,7 @@ go_library(
         "//pkg/workload/tpch",
         "//pkg/workload/ttlbench",
         "//pkg/workload/ttllogger",
+        "//pkg/workload/uniqueindex",
         "//pkg/workload/workload_generator",
         "//pkg/workload/workloadsql",
         "//pkg/workload/ycsb",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"               // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ttlbench"           // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ttllogger"          // registers workloads
+	_ "github.com/cockroachdb/cockroach/pkg/workload/uniqueindex"        // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/workload_generator" //registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ycsb"               // registers workloads
 	"github.com/cockroachdb/errors"

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -395,6 +395,39 @@ WHERE
 	require.False(t, strings.Contains(locality, kv.antiRegion), "region %s is in locality %s", kv.antiRegion, locality)
 }
 
+type replicateUniqueIndex struct {
+	rows       int
+	dataSize   int
+	splitEvery int // splitEvery specifies the interval at which to split the unique index.
+	scatter    bool
+	duration   time.Duration
+}
+
+func (w replicateUniqueIndex) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
+	cmd := roachtestutil.NewCommand(`./cockroach workload init uniqueindex`).
+		MaybeFlag(w.rows > 0, "rows", w.rows).
+		MaybeFlag(w.dataSize > 0, "data-size", w.dataSize).
+		MaybeFlag(w.splitEvery > 0, "split-every", w.splitEvery).
+		MaybeOption(w.scatter, "scatter").
+		Arg("{pgurl%s:%s}", nodes, tenantName).
+		WithEqualsSyntax()
+	return cmd.String()
+}
+
+func (w replicateUniqueIndex) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
+	cmd := roachtestutil.NewCommand(`./cockroach workload run uniqueindex`).
+		MaybeFlag(w.duration > 0, "duration", w.duration).
+		Arg("{pgurl%s:%s}", nodes, tenantName).
+		WithEqualsSyntax()
+	return cmd.String()
+}
+
+func (w replicateUniqueIndex) runDriver(
+	workloadCtx context.Context, c cluster.Cluster, t test.Test, setup *c2cSetup,
+) error {
+	return defaultWorkloadDriver(workloadCtx, setup, c, w)
+}
+
 type replicateBulkOps struct {
 	// short uses less data during the import and rollback steps. Also only runs one rollback.
 	short bool

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -20,11 +20,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -258,6 +260,48 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 			requiresDeprecatedWorkload: true,
 			run:                        TestLDRConflict,
 		},
+		{
+			name: "ldr/kv0/workload=source/single_key_update_benchmark",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{
+				createTables: true,
+			},
+			// PR #158351 added --always-inc-key-seq to the kv workload
+			// in v26.2; predecessors can't parse this flag via IMPORT.
+			mixedVersionMinimum: clusterversion.V26_2,
+			run:                 TestLDRHotKeyUpdate,
+			monitor:             true,
+		},
+		{
+			name: "ldr/unique_constraint/workload=source/update_benchmark",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{
+				createTables: true,
+			},
+			// PR #158351 added --always-inc-key-seq to the kv workload
+			// in v26.2; predecessors can't parse this flag via IMPORT.
+			mixedVersionMinimum: clusterversion.V26_2,
+			run:                 TestLDRUniqueConstraintUpdate,
+			monitor:             true,
+		},
 	}
 
 	for _, sp := range specs {
@@ -270,6 +314,7 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 			Cluster:                    sp.clusterSpec.ToSpec(r),
 			Leases:                     registry.MetamorphicLeases,
 			RequiresDeprecatedWorkload: sp.requiresDeprecatedWorkload,
+			Monitor:                    sp.monitor,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				rng, seed := randutil.NewPseudoRand()
 				t.L().Printf("random seed is %d", seed)
@@ -835,6 +880,94 @@ func TestLDROnNetworkPartition(
 	VerifyCorrectness(ctx, c, t, setup, leftJobID, rightJobID, 5*time.Minute, ldrWorkload)
 }
 
+// Unidirectional hot key update workload.
+func TestLDRHotKeyUpdate(
+	ctx context.Context, t test.Test, c cluster.Cluster, setup multiClusterSetup, ldrConfig ldrConfig,
+) {
+	duration := 10 * time.Minute
+	if c.IsLocal() {
+		duration = 3 * time.Minute
+	}
+
+	ldrWorkload := LDRWorkload{
+		workload: replicateKV{
+			readPercent:             0,
+			debugRunDuration:        duration,
+			maxBlockBytes:           1024,
+			initRows:                1,
+			tolerateErrors:          true,
+			initWithSplitAndScatter: false,
+			uniform:                 true,
+		},
+		manualSchemaSetup: true,
+		dbName:            "kv",
+		tableNames:        []string{"kv"},
+	}
+
+	setup.right.sysSQL.Exec(t, "CREATE DATABASE kv")
+	c.Run(ctx,
+		option.WithNodes(setup.workloadNode),
+		ldrWorkload.workload.sourceInitCmd("system", setup.left.nodes))
+
+	_, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+
+	workloadDoneCh := make(chan struct{})
+	maxExpectedLatency := 10 * time.Minute
+	group := t.NewGroup()
+	validateLatency := setupLatencyVerifiersWithGroup(t, c, group, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+
+	group.Go(func(ctx context.Context, _ *logger.Logger) error {
+		defer close(workloadDoneCh)
+		return c.RunE(ctx, option.WithNodes(setup.workloadNode), ldrWorkload.workload.sourceRunCmd("system", setup.left.nodes))
+	})
+
+	group.Wait()
+	validateLatency()
+}
+
+// Unidirectional unique constraint update workload.
+func TestLDRUniqueConstraintUpdate(
+	ctx context.Context, t test.Test, c cluster.Cluster, setup multiClusterSetup, ldrConfig ldrConfig,
+) {
+	duration := 10 * time.Minute
+	if c.IsLocal() {
+		duration = 3 * time.Minute
+	}
+
+	ldrWorkload := LDRWorkload{
+		workload: replicateUniqueIndex{
+			rows:       600,
+			dataSize:   1024,
+			splitEvery: 1000,
+			scatter:    true,
+			duration:   duration,
+		},
+		manualSchemaSetup: true,
+		dbName:            "uniqueindex",
+		tableNames:        []string{"uniqueindex"},
+	}
+
+	setup.right.sysSQL.Exec(t, "CREATE DATABASE uniqueindex")
+	c.Run(ctx,
+		option.WithNodes(setup.workloadNode),
+		ldrWorkload.workload.sourceInitCmd("system", setup.left.nodes))
+
+	_, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+
+	workloadDoneCh := make(chan struct{})
+	maxExpectedLatency := 10 * time.Minute
+	group := t.NewGroup()
+	validateLatency := setupLatencyVerifiersWithGroup(t, c, group, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+
+	group.Go(func(ctx context.Context, _ *logger.Logger) error {
+		defer close(workloadDoneCh)
+		return c.RunE(ctx, option.WithNodes(setup.workloadNode), ldrWorkload.workload.sourceRunCmd("system", setup.left.nodes))
+	})
+
+	group.Wait()
+	validateLatency()
+}
+
 type ldrJobInfo struct {
 	*jobRecord
 }
@@ -869,6 +1002,7 @@ type ldrTestSpec struct {
 	// required for mixed version testing. If no supported predecessor
 	// meets this minimum, mixed version testing is skipped.
 	mixedVersionMinimum clusterversion.Key
+	monitor             bool
 }
 
 type mode int
@@ -1189,6 +1323,58 @@ func setupLatencyVerifiers(
 		return nil
 	})
 	return func() {
+		rlv.assertValid(t)
+		if leftJobID != 0 {
+			llv.assertValid(t)
+		}
+	}
+}
+
+// setupLatencyVerifiersWithGroup is like setupLatencyVerifiers but uses a
+// task.Group for goroutine management instead of the deprecated cluster.Monitor.
+func setupLatencyVerifiersWithGroup(
+	t test.Test,
+	c cluster.Cluster,
+	group task.Group,
+	leftJobID, rightJobID int,
+	setup multiClusterSetup,
+	workloadDoneCh chan struct{},
+	maxExpectedLatency time.Duration,
+) func() {
+	var llv *latencyVerifier
+	if leftJobID != 0 {
+		llv = makeLatencyVerifier("ldr-left", 0, maxExpectedLatency, t.L(),
+			getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
+	}
+
+	rlv := makeLatencyVerifier("ldr-right", 0, maxExpectedLatency, t.L(),
+		getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
+
+	debugZipFetcher := &sync.Once{}
+
+	group.Go(func(ctx context.Context, _ *logger.Logger) error {
+		if leftJobID == 0 {
+			t.L().Printf("No left job created")
+			return nil
+		}
+		if err := llv.pollLatencyUntilJobSucceeds(ctx, setup.left.db, leftJobID, time.Second, workloadDoneCh); err != nil {
+			debugZipFetcher.Do(func() { getDebugZips(ctx, t, c, setup) })
+			return err
+		}
+		return nil
+	})
+	group.Go(func(ctx context.Context, _ *logger.Logger) error {
+		if err := rlv.pollLatencyUntilJobSucceeds(ctx, setup.right.db, rightJobID, time.Second, workloadDoneCh); err != nil {
+			debugZipFetcher.Do(func() { getDebugZips(ctx, t, c, setup) })
+			return err
+		}
+		return nil
+	})
+	return func() {
+		rlv.maybeLogLatencyHist()
+		if leftJobID != 0 {
+			llv.maybeLogLatencyHist()
+		}
 		rlv.assertValid(t)
 		if leftJobID != 0 {
 			llv.assertValid(t)

--- a/pkg/workload/uniqueindex/BUILD.bazel
+++ b/pkg/workload/uniqueindex/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "uniqueindex",
+    srcs = ["uniqueindex.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/workload/uniqueindex",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/col/coldata",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/types",
+        "//pkg/util/bufalloc",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
+        "//pkg/workload",
+        "//pkg/workload/histogram",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_lib_pq//:pq",
+        "@com_github_spf13_pflag//:pflag",
+    ],
+)

--- a/pkg/workload/uniqueindex/uniqueindex.go
+++ b/pkg/workload/uniqueindex/uniqueindex.go
@@ -1,0 +1,233 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package uniqueindex
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
+	"github.com/spf13/pflag"
+)
+
+const (
+	uniqueIndexSchema = `(
+		id INT PRIMARY KEY,
+		unique_val INT UNIQUE,
+		data BYTES
+	)`
+)
+
+var RandomSeed = workload.NewUint64RandomSeed()
+
+type uniqueIndex struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	rows       int
+	dataSize   int
+	splitEvery int
+	scatter    bool
+}
+
+func init() {
+	workload.Register(uniqueIndexMeta)
+}
+
+var uniqueIndexMeta = workload.Meta{
+	Name: `uniqueindex`,
+	Description: `UniqueIndex stresses unique constraint updates across range splits.
+
+	This workload creates a table with a unique constraint on a non-primary-key
+	column, then continuously updates that column with random values that span
+	multiple range splits. This pattern stresses cross-range delete+insert
+	operations that occur when updating unique indexes.`,
+	Version:    `1.0.0`,
+	RandomSeed: RandomSeed,
+	New: func() workload.Generator {
+		g := &uniqueIndex{}
+		g.flags.FlagSet = pflag.NewFlagSet(`uniqueindex`, pflag.ContinueOnError)
+		g.flags.IntVar(&g.rows, `rows`, 600,
+			`Number of rows to insert initially.`)
+		g.flags.IntVar(&g.dataSize, `data-size`, 1024,
+			`Size of data column in bytes.`)
+		g.flags.IntVar(&g.splitEvery, `split-every`, 0,
+			`Split the unique index at regular intervals of this value.`)
+		g.flags.BoolVar(&g.scatter, `scatter`, false,
+			`Scatter the unique index after splits.`)
+		RandomSeed.AddFlag(&g.flags)
+		g.connFlags = workload.NewConnFlags(&g.flags)
+		return g
+	},
+}
+
+// Meta implements the Generator interface.
+func (*uniqueIndex) Meta() workload.Meta { return uniqueIndexMeta }
+
+// Flags implements the Flagser interface.
+func (u *uniqueIndex) Flags() workload.Flags { return u.flags }
+
+// ConnFlags implements the ConnFlagser interface.
+func (u *uniqueIndex) ConnFlags() *workload.ConnFlags { return u.connFlags }
+
+// Hooks implements the Hookser interface.
+func (u *uniqueIndex) Hooks() workload.Hooks {
+	return workload.Hooks{
+		PostLoad: func(_ context.Context, db *gosql.DB) error {
+			if u.splitEvery > 0 {
+				var splitPoints []string
+				maxUniqueVal := u.rows * 10
+				for i := u.splitEvery; i < maxUniqueVal; i += u.splitEvery {
+					splitPoints = append(splitPoints, fmt.Sprintf("%d", i))
+				}
+
+				if len(splitPoints) > 0 {
+					splitValues := make([]string, len(splitPoints))
+					for i, point := range splitPoints {
+						splitValues[i] = fmt.Sprintf("(%s)", strings.TrimSpace(point))
+					}
+					splitSQL := fmt.Sprintf(
+						"ALTER INDEX uniqueindex@uniqueindex_unique_val_key SPLIT AT VALUES %s",
+						strings.Join(splitValues, ", "),
+					)
+					if _, err := db.Exec(splitSQL); err != nil {
+						return errors.Wrap(err, "splitting unique index")
+					}
+				}
+			}
+
+			if u.scatter {
+				if _, err := db.Exec("ALTER INDEX uniqueindex@uniqueindex_unique_val_key SCATTER"); err != nil {
+					return errors.Wrap(err, "scattering unique index")
+				}
+			}
+
+			return nil
+		},
+		Validate: func() error {
+			if u.rows < 1 {
+				return errors.Errorf("rows must be at least 1; was %d", u.rows)
+			}
+			if u.dataSize < 0 {
+				return errors.Errorf("data-size must be non-negative; was %d", u.dataSize)
+			}
+			if u.splitEvery < 0 {
+				return errors.Errorf("split-every must be non-negative; was %d", u.splitEvery)
+			}
+			return nil
+		},
+	}
+}
+
+var uniqueIndexTypes = []*types.T{
+	types.Int,
+	types.Int,
+	types.Bytes,
+}
+
+// Tables implements the Generator interface.
+func (u *uniqueIndex) Tables() []workload.Table {
+	table := workload.Table{
+		Name:   `uniqueindex`,
+		Schema: uniqueIndexSchema,
+		InitialRows: workload.BatchedTuples{
+			NumBatches: 1,
+			FillBatch: func(batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
+				cb.Reset(uniqueIndexTypes, u.rows, coldata.StandardColumnFactory)
+				idCol := cb.ColVec(0).Int64()
+				uniqueValCol := cb.ColVec(1).Int64()
+				dataCol := cb.ColVec(2).Bytes()
+				dataCol.Reset()
+
+				for rowIdx := range u.rows {
+					idCol[rowIdx] = int64(rowIdx)
+					// Multiples of 10 leave gaps for the workload to land on
+					// non-colliding values.
+					uniqueValCol[rowIdx] = int64(rowIdx * 10)
+					var data []byte
+					*a, data = a.Alloc(u.dataSize)
+					for i := range data {
+						data[i] = 'x'
+					}
+					dataCol.Set(rowIdx, data)
+				}
+			},
+		},
+	}
+	return []workload.Table{table}
+}
+
+// Ops implements the Opser interface.
+func (u *uniqueIndex) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
+	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	db.SetMaxOpenConns(u.connFlags.Concurrency + 1)
+	db.SetMaxIdleConns(u.connFlags.Concurrency + 1)
+
+	updateStmt, err := db.Prepare(`UPDATE uniqueindex SET unique_val = $1 WHERE id = $2`)
+	if err != nil {
+		return workload.QueryLoad{}, errors.CombineErrors(err, db.Close())
+	}
+
+	ql := workload.QueryLoad{
+		Close: func(_ context.Context) error {
+			return db.Close()
+		},
+	}
+
+	numWorkers := min(u.connFlags.Concurrency, u.rows)
+	if numWorkers < u.connFlags.Concurrency {
+		log.Dev.Warningf(ctx, "warning: concurrency %d exceeds number of rows %d, capping workers to %d",
+			u.connFlags.Concurrency, u.rows, numWorkers)
+	}
+	for i := range numWorkers {
+		rng := rand.New(rand.NewPCG(RandomSeed.Seed(), uint64(i)))
+		hists := reg.GetHandle()
+		rowID := i
+
+		workerFn := func(ctx context.Context) error {
+			// Offset by +1..+9 to avoid colliding with the pre-populated
+			// multiples of 10.
+			randomVal := rng.IntN(u.rows)*10 + rng.IntN(9) + 1
+
+			start := timeutil.Now()
+			_, err := updateStmt.ExecContext(ctx, randomVal, rowID)
+			elapsed := timeutil.Since(start)
+			hists.Get(`update`).Record(elapsed)
+
+			if err != nil && !isUniqueViolation(err) {
+				return err
+			}
+			return nil
+		}
+		ql.WorkerFns = append(ql.WorkerFns, workerFn)
+	}
+	return ql, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pq.Error
+	if errors.As(err, &pgErr) {
+		return pgcode.MakeCode(string(pgErr.Code)) == pgcode.UniqueViolation
+	}
+	return false
+}


### PR DESCRIPTION
Add benchmarks to determine if hot key updates will be a significant 
bottleneck for LDR.

One test updates one row over and over again.

The other test updates the unique constraint column of a row with 
random values, where it is likely to land on a different range each time. 
The unique index is also scattered to test the worst case scenario.

Release note: None
Resolves: CRDB-61284

Result for `TestLDRHotKeyUpdate`: https://grafana.testeng.crdb.io/goto/bhne41hDg?orgId=1
Result for `TestLDRUniqueConstraintUpdate`: https://grafana.testeng.crdb.io/goto/RdoeV1hvg?orgId=1