### PR TITLE
restore,kv: use LinkExternalSSTable reply to split filled ranges

### DIFF
--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -656,7 +656,7 @@ func (rd *restoreDataProcessor) linkFiles(
 		}
 
 		linkStart := timeutil.Now()
-		if err := kvDB.LinkExternalSSTable(ctx, restoringSubspan, loc, batchTimestamp); err != nil {
+		if _, _, err := kvDB.LinkExternalSSTable(ctx, restoringSubspan, loc, batchTimestamp); err != nil {
 			return summary, errors.Wrap(err, "linking external SSTable")
 		}
 		if elapsed := timeutil.Since(linkStart); elapsed > 5*time.Second {

--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -462,6 +463,7 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 			return errors.Wrap(err, "creating key rewriter from rekeys")
 		}
 
+		var lastRange lastLinkedRange
 		for {
 			done, err := func() (done bool, _ error) {
 				entry, ok := <-entries
@@ -502,7 +504,7 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 				if len(linkable) > 0 {
 					linkEntry := entry
 					linkEntry.Files = linkable
-					linkSummary, err := rd.linkFiles(ctx, kr, linkEntry)
+					linkSummary, err := rd.linkFiles(ctx, kr, linkEntry, &lastRange)
 					if err != nil {
 						return done, errors.Wrap(err, "linking files")
 					}
@@ -567,11 +569,22 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 	})
 }
 
+// lastLinkedRange tracks the range span and available capacity from the most
+// recent LinkExternalSSTable response. It is used to decide whether to split
+// before the next link to avoid overfilling a range.
+type lastLinkedRange struct {
+	span           roachpb.Span
+	availableBytes int64
+}
+
 // linkFiles links all files in the entry via LinkExternalSSTable instead of
 // downloading and ingesting them. This is used for online restore when the
 // UseLink flag is set on files.
 func (rd *restoreDataProcessor) linkFiles(
-	ctx context.Context, kr *KeyRewriter, entry execinfrapb.RestoreSpanEntry,
+	ctx context.Context,
+	kr *KeyRewriter,
+	entry execinfrapb.RestoreSpanEntry,
+	lastRange *lastLinkedRange,
 ) (kvpb.BulkOpSummary, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "restore.linkFiles")
 	defer sp.Finish()
@@ -613,6 +626,24 @@ func (rd *restoreDataProcessor) linkFiles(
 		}
 
 		log.VEventf(ctx, 2, "linking file %s (file span: %s) to span %s", file.Path, file.BackupFileEntrySpan, restoringSubspan)
+
+		// If the range we last linked into is nearly full and this file would
+		// land in the same range, split at this file's start key first so it
+		// goes to a new, empty range.
+		const splitThreshold = 64 << 20 // 64 MB
+		if lastRange.availableBytes < splitThreshold &&
+			lastRange.span.Valid() && lastRange.span.ContainsKey(restoringSubspan.Key) {
+			splitAt, splitErr := keys.EnsureSafeSplitKey(restoringSubspan.Key)
+			if splitErr == nil {
+				expire := hlc.Timestamp{WallTime: timeutil.Now().Add(10 * time.Minute).UnixNano()}
+				if splitErr = kvDB.AdminSplit(ctx, splitAt, expire); splitErr != nil {
+					log.Dev.Warningf(ctx, "pre-link split at %s failed: %v", splitAt, splitErr)
+				} else {
+					log.VEventf(ctx, 2, "split range at %s before link (available %d bytes)",
+						splitAt, lastRange.availableBytes)
+				}
+			}
+		}
 
 		counts := file.BackupFileEntryCounts
 		fileSize := file.ApproximatePhysicalSize
@@ -656,12 +687,16 @@ func (rd *restoreDataProcessor) linkFiles(
 		}
 
 		linkStart := timeutil.Now()
-		if _, _, err := kvDB.LinkExternalSSTable(ctx, restoringSubspan, loc, batchTimestamp); err != nil {
+		rangeSpan, availableBytes, err := kvDB.LinkExternalSSTable(ctx, restoringSubspan, loc, batchTimestamp)
+		if err != nil {
 			return summary, errors.Wrap(err, "linking external SSTable")
 		}
 		if elapsed := timeutil.Since(linkStart); elapsed > 5*time.Second {
 			log.Dev.Infof(ctx, "slow link of file %s span %s took %s", file.Path, restoringSubspan, elapsed)
 		}
+
+		lastRange.span = rangeSpan
+		lastRange.availableBytes = availableBytes
 
 		// Call testing knob after each file link, matching the old online restore path.
 		if restoreKnobs, ok := rd.FlowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -477,8 +477,9 @@ func sendRemoteAddSSTable(
 		MVCCStats:               fileStats,
 	}
 
-	return execCtx.ExecCfg().DB.LinkExternalSSTable(
+	_, _, err = execCtx.ExecCfg().DB.LinkExternalSSTable(
 		ctx, file.BackupFileEntrySpan, loc, batchTimestamp)
+	return err
 }
 
 // checkManifestsForOnlineCompat returns an error if the set of

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -853,13 +853,15 @@ func (db *DB) AddSSTable(
 	return resp.RangeSpan, resp.AvailableBytes, nil
 }
 
-// LinkExternalSSTable links an external sst into the Pebble log-structured merge-tree.
+// LinkExternalSSTable links an external sst into the Pebble log-structured
+// merge-tree. It returns the span of the range that the SSTable was linked into
+// and the approximate number of bytes available in that range.
 func (db *DB) LinkExternalSSTable(
 	ctx context.Context,
 	span roachpb.Span,
 	file kvpb.LinkExternalSSTableRequest_ExternalFile,
 	batchTimestamp hlc.Timestamp,
-) error {
+) (roachpb.Span, int64, error) {
 	b := &Batch{Header: kvpb.Header{Timestamp: batchTimestamp}}
 	b.linkExternalSSTable(span, file)
 	err := getOneErr(db.Run(ctx, b), b)
@@ -867,23 +869,24 @@ func (db *DB) LinkExternalSSTable(
 		if m := (*kvpb.RangeKeyMismatchError)(nil); errors.As(err, &m) {
 			r, err := m.MismatchedRange()
 			if err != nil {
-				return err
+				return roachpb.Span{}, 0, err
 			}
 			// TODO(dt): iterate over all of all of m.Ranges, not just first, but
 			// ensure we cover all of `span` when we do.
 			lhs := roachpb.Span{Key: span.Key, EndKey: r.Desc.EndKey.AsRawKey()}
 			rhs := roachpb.Span{Key: lhs.EndKey, EndKey: span.EndKey}
-			if err := db.LinkExternalSSTable(ctx, lhs, file, batchTimestamp); err != nil {
-				return err
+			if _, _, err := db.LinkExternalSSTable(ctx, lhs, file, batchTimestamp); err != nil {
+				return roachpb.Span{}, 0, err
 			}
 			return db.LinkExternalSSTable(ctx, rhs, file, batchTimestamp)
 		}
-		return err
+		return roachpb.Span{}, 0, err
 	}
 	if l := len(b.response.Responses); l != 1 {
-		return errors.AssertionFailedf("expected single response, got %d", l)
+		return roachpb.Span{}, 0, errors.AssertionFailedf("expected single response, got %d", l)
 	}
-	return nil
+	resp := b.response.Responses[0].GetLinkExternalSstable()
+	return resp.RangeSpan, resp.AvailableBytes, nil
 }
 
 // AddSSTableAtBatchTimestamp links a file into the Pebble log-structured

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2212,6 +2212,8 @@ message LinkExternalSSTableRequest {
 // LinkExternalSSTableResponse is the response to a LinkExternalSSTable() operation.
 message LinkExternalSSTableResponse {
     ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+    Span range_span = 2 [(gogoproto.nullable) = false];
+    int64 available_bytes = 3;
 }
 
 // RefreshRequest is arguments to the Refresh() method, which verifies that no

--- a/pkg/kv/kvserver/batcheval/cmd_link_external_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_link_external_sstable.go
@@ -59,6 +59,10 @@ func EvalLinkExternalSSTable(
 	s.ContainsEstimates++
 	ms.Add(s)
 
+	reply := resp.(*kvpb.LinkExternalSSTableResponse)
+	reply.RangeSpan = cArgs.EvalCtx.Desc().KeySpan().AsRawSpanWithNoLocals()
+	reply.AvailableBytes = cArgs.EvalCtx.GetMaxBytes(ctx) - cArgs.EvalCtx.GetMVCCStats().Total() - s.Total()
+
 	// Eval does not check for conflicts in the existing key space, as it assumes
 	// the client has sent the request at a timestamp above any requests in the
 	// key space.

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3173,7 +3173,7 @@ func TestMergeQueueWithExternalFiles(t *testing.T) {
 			size, err := extStore.Size(ctx, fileName)
 			require.NoError(t, err)
 
-			err = s.DB().LinkExternalSSTable(ctx, roachpb.Span{
+			_, _, err = s.DB().LinkExternalSSTable(ctx, roachpb.Span{
 				Key:    writeKey,
 				EndKey: writeKey.Next(),
 			}, kvpb.LinkExternalSSTableRequest_ExternalFile{

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -4436,7 +4436,7 @@ func TestSplitWithExternalFilesFastStats(t *testing.T) {
 			size, err := extStore.Size(ctx, fileName)
 			require.NoError(t, err)
 
-			err = s.DB().LinkExternalSSTable(ctx, roachpb.Span{
+			_, _, err = s.DB().LinkExternalSSTable(ctx, roachpb.Span{
 				Key:    roachpb.Key("a"),
 				EndKey: roachpb.Key("d"),
 			}, kvpb.LinkExternalSSTableRequest_ExternalFile{

--- a/pkg/kv/kvserver/deleted_external_sstable_test.go
+++ b/pkg/kv/kvserver/deleted_external_sstable_test.go
@@ -196,7 +196,7 @@ func (etc *externalSSTTestCluster) createExternalSSTableFile(
 func (etc *externalSSTTestCluster) linkExternalSSTableToFile(
 	ctx context.Context, startKey roachpb.Key, endKey roachpb.Key, URI string, fileName string,
 ) error {
-	errLink := etc.db.LinkExternalSSTable(ctx, roachpb.Span{
+	_, _, errLink := etc.db.LinkExternalSSTable(ctx, roachpb.Span{
 		Key:    startKey,
 		EndKey: endKey,
 	}, kvpb.LinkExternalSSTableRequest_ExternalFile{


### PR DESCRIPTION
AddSSTableResponse returns `RangeSpan` and `AvailableBytes`, enabling callers (notably sst_batcher) to make capacity-aware split decisions, like split-before-over-filling. LinkExternalSSTableResponse was missing these fields, preventing the restore path from making similar decisions during file linking.

Both fields are trivially computed from in-memory metadata already available during eval, requiring no disk IO.

This adds the fields to the proto, populates them during eval (matching the AddSSTable pattern), and updates DB.LinkExternalSSTable to return them. Existing callers, other than restore data processor, ignore them. Restore uses the returned capacity to split before overfilling.

Release note: None