### PR TITLE
roachtest/operations: support deferred cleanup to avoid blocking workers

### DIFF
--- a/pkg/cmd/roachtest/operations/add_rls_policy.go
+++ b/pkg/cmd/roachtest/operations/add_rls_policy.go
@@ -24,66 +24,44 @@ type cleanupRLSPolicy struct {
 	db, table       string
 	policies        []string
 	originalRLSStmt string
-	waitDuration    time.Duration
 }
 
 func (cl *cleanupRLSPolicy) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
-	o.Status(fmt.Sprintf("Scheduling cleanup to happen after %s", cl.waitDuration))
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
 
-	// Start a goroutine to handle the wait and cleanup. Since this runs in the
-	// background, we also create a new context so that the background goroutine
-	// isn't aborted by the parent context.
-	go func() {
-		newCtx := context.Background()
+	// Switch to the database where the table is located.
+	o.Status(fmt.Sprintf("switching to database %s for cleanup", cl.db))
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", cl.db)); err != nil {
+		o.Error(err)
+		return
+	}
 
-		if deadline, ok := ctx.Deadline(); ok {
-			var cancel context.CancelFunc
-			newCtx, cancel = context.WithDeadline(newCtx, deadline.Add(cl.waitDuration))
-			defer cancel()
-		}
-		ctx = newCtx
-
-		// Wait for the specified duration before performing cleanup.
-		time.Sleep(cl.waitDuration)
-
-		conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
-		defer conn.Close()
-
-		// Switch to the database where the table is located
-		o.Status(fmt.Sprintf("switching to database %s for cleanup", cl.db))
-		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", cl.db)); err != nil {
+	// Drop all policies that were created.
+	for _, policy := range cl.policies {
+		o.Status(fmt.Sprintf("dropping policy %s on table %s.%s", policy, cl.db, cl.table))
+		_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP POLICY IF EXISTS %s ON %s.%s", policy, cl.db, cl.table))
+		if err != nil {
 			o.Error(err)
 			return
 		}
+	}
 
-		// Drop all policies that were created
-		for _, policy := range cl.policies {
-			o.Status(fmt.Sprintf("dropping policy %s on table %s.%s", policy, cl.db, cl.table))
-			_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP POLICY IF EXISTS %s ON %s.%s", policy, cl.db, cl.table))
-			if err != nil {
-				o.Error(err)
-				return
-			}
+	// Restore original RLS state or disable it if it wasn't enabled before.
+	if cl.originalRLSStmt != "" {
+		o.Status(fmt.Sprintf("restoring original row level security state for %s.%s", cl.db, cl.table))
+		if _, err := conn.ExecContext(ctx, cl.originalRLSStmt); err != nil {
+			o.Error(err)
+			return
 		}
-
-		// Restore original RLS state or disable it if it wasn't enabled before
-		if cl.originalRLSStmt != "" {
-			// Restore the original RLS state
-			o.Status(fmt.Sprintf("restoring original row level security state for %s.%s", cl.db, cl.table))
-			if _, err := conn.ExecContext(ctx, cl.originalRLSStmt); err != nil {
-				o.Error(err)
-				return
-			}
-		} else {
-			// If the table didn't have RLS before, disable it
-			o.Status(fmt.Sprintf("disabling row level security for %s.%s", cl.db, cl.table))
-			_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DISABLE ROW LEVEL SECURITY, NO FORCE ROW LEVEL SECURITY", cl.db, cl.table))
-			if err != nil {
-				o.Error(err)
-				return
-			}
+	} else {
+		o.Status(fmt.Sprintf("disabling row level security for %s.%s", cl.db, cl.table))
+		_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DISABLE ROW LEVEL SECURITY, NO FORCE ROW LEVEL SECURITY", cl.db, cl.table))
+		if err != nil {
+			o.Error(err)
+			return
 		}
-	}()
+	}
 }
 
 func runAddRLSPolicy(
@@ -196,14 +174,11 @@ func runAddRLSPolicy(
 
 	o.Status(fmt.Sprintf("created %d RLS policies on table %s.%s", numPolicies, dbName, tableName))
 
-	// Return the cleanup struct with wait duration.
-	waitTime := time.Hour
 	return &cleanupRLSPolicy{
 		db:              dbName,
 		table:           tableName,
 		policies:        policies,
 		originalRLSStmt: originalRLSStmt,
-		waitDuration:    waitTime,
 	}
 }
 
@@ -216,5 +191,7 @@ func registerAddRLSPolicy(r registry.Registry) {
 		CanRunConcurrently: registry.OperationCanRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
 		Run:                runAddRLSPolicy,
+		WaitBeforeCleanup:  1 * time.Hour,
+		DeferCleanup:       true,
 	})
 }

--- a/pkg/cmd/roachtest/operations/grant_role.go
+++ b/pkg/cmd/roachtest/operations/grant_role.go
@@ -99,5 +99,6 @@ func registerGrantRole(r registry.Registry) {
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresNodes},
 		Run:                runGrantRole,
 		WaitBeforeCleanup:  1 * time.Hour,
+		DeferCleanup:       true,
 	})
 }

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -90,6 +90,13 @@ type OperationSpec struct {
 	// --wait-before-cleanup.
 	WaitBeforeCleanup time.Duration
 
+	// DeferCleanup, when true, causes the worker to enqueue cleanup for
+	// later execution and immediately become available for the next
+	// operation. The cleanup executes after WaitBeforeCleanup elapses.
+	// Only set this for non-destructive operations whose Run phase does
+	// not degrade cluster state during the wait.
+	DeferCleanup bool
+
 	// Run is the operation function. It returns an OperationCleanup if this
 	// operation requires additional cleanup steps afterwards (eg. dropping an
 	// extra column that was created). A nil return value indicates no cleanup

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -11,6 +11,8 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"slices"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -37,6 +39,18 @@ import (
 
 const baseSleepTime = 15
 
+// deferredCleanup holds everything needed to run a cleanup that was
+// deferred by a DeferCleanup operation. It is enqueued with a future
+// executeAt time and processed by the cleanup processor goroutine.
+type deferredCleanup struct {
+	executeAt time.Time
+	op        *operationImpl
+	c         *dynamicClusterImpl
+	cleanup   registry.OperationCleanup
+	emitter   *operationEventEmitter
+	opSpec    *registry.OperationSpec
+}
+
 type opsRunner struct {
 	clusterName string
 	nodeCount   int
@@ -53,6 +67,14 @@ type opsRunner struct {
 	datadogTags        []string
 
 	waitBeforeNextExecution time.Duration
+	runForever              bool
+
+	// cleanupMu protects cleanupQueue.
+	cleanupMu syncutil.Mutex
+	// cleanupQueue holds deferred cleanups sorted by executeAt (ascending).
+	cleanupQueue []deferredCleanup
+	// cleanupDone is closed when the cleanup processor goroutine exits.
+	cleanupDone chan struct{}
 
 	status struct {
 		syncutil.Mutex
@@ -63,6 +85,9 @@ type opsRunner struct {
 		operationRunCompleted sync.Cond
 		running               map[string]struct{}
 		lastRun               map[string]time.Time
+		// pendingCleanup tracks operations with deferred cleanup waiting
+		// to execute. Prevents re-selection until cleanup completes.
+		pendingCleanup map[string]struct{}
 	}
 }
 
@@ -89,22 +114,7 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = newDatadogContext(ctx)
-	CtrlC(ctx, l, cancel, nil)
-
 	metrics := newOperationMetrics(r.PromFactory())
-
-	go func() {
-		if err := http.ListenAndServe(
-			fmt.Sprintf(":%d", roachtestflags.PromPort),
-			promhttp.HandlerFor(r.promRegistry, promhttp.HandlerOpts{}),
-		); err != nil {
-			l.Errorf("error serving prometheus: %v", err)
-		}
-	}()
-
 	or := opsRunner{
 		clusterName:             clusterName,
 		nodeCount:               cluster.VMs.Len(),
@@ -115,10 +125,32 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 		datadogEventClient:      datadogV1.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
 		datadogTags:             getDatadogTags(),
 		waitBeforeNextExecution: roachtestflags.WaitBeforeNextExecution,
+		runForever:              roachtestflags.RunForever,
 	}
 	or.status.running = make(map[string]struct{})
 	or.status.lastRun = make(map[string]time.Time)
+	or.status.pendingCleanup = make(map[string]struct{})
 	or.status.operationRunCompleted.L = &or.status
+	or.cleanupDone = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		<-or.cleanupDone
+	}()
+
+	ctx = newDatadogContext(ctx)
+	CtrlC(ctx, l, cancel, nil)
+	go or.runCleanupProcessor(ctx)
+
+	go func() {
+		if err := http.ListenAndServe(
+			fmt.Sprintf(":%d", roachtestflags.PromPort),
+			promhttp.HandlerFor(r.promRegistry, promhttp.HandlerOpts{}),
+		); err != nil {
+			l.Errorf("error serving prometheus: %v", err)
+		}
+	}()
 
 	if roachtestflags.WorkloadCluster != "" {
 		workloadCluster, err := getCachedCluster(roachtestflags.WorkloadCluster)
@@ -139,7 +171,11 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 			return nil
 		})
 	}
-	return wg.Wait()
+	wgErr := wg.Wait()
+	// All workers have exited. Process any cleanups that were enqueued
+	// after the processor's last poll or drain, ensuring nothing is lost.
+	or.processCleanups(or.dequeueAll())
+	return wgErr
 }
 
 // setWorkerState updates the workerCurrentOperation gauge for a worker,
@@ -174,12 +210,16 @@ func (r *opsRunner) runWorker(ctx context.Context, workerIdx int, runForever boo
 			// Already idle, stay idle.
 			sleepDuration := time.Duration(baseSleepTime+rng.Intn(baseSleepTime)) * time.Second
 			r.logger.Printf("[%d] couldn't find candidate operation to run, sleeping for %s", workerIdx, sleepDuration)
-			time.Sleep(sleepDuration)
+			select {
+			case <-time.After(sleepDuration):
+			case <-ctx.Done():
+				return
+			}
 			continue
 		}
 
 		r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, opSpec.NamePrefix(), workerStateExecuting)
-		_ = r.runOperation(ctx, opSpec, rng, workerIdx)
+		_, deferred := r.runOperation(ctx, opSpec, rng, workerIdx)
 		func() {
 			r.status.Lock()
 			defer r.status.Unlock()
@@ -189,6 +229,9 @@ func (r *opsRunner) runWorker(ctx context.Context, workerIdx int, runForever boo
 			}
 			delete(r.status.running, opSpec.NamePrefix())
 			r.status.lastRun[opSpec.NamePrefix()] = timeutil.Now()
+			if deferred {
+				r.status.pendingCleanup[opSpec.NamePrefix()] = struct{}{}
+			}
 		}()
 
 		r.setWorkerState(workerLabel, opSpec.NamePrefix(), workerStateExecuting, workerOperationIdle, workerStateIdle)
@@ -199,7 +242,11 @@ func (r *opsRunner) runWorker(ctx context.Context, workerIdx int, runForever boo
 		}
 		sleepDuration := time.Duration(1+rng.Intn(2)) * time.Minute
 		r.logger.Printf("[%d] going idle for %s", workerIdx, sleepDuration)
-		time.Sleep(sleepDuration)
+		select {
+		case <-time.After(sleepDuration):
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 
@@ -229,6 +276,11 @@ func (r *opsRunner) selectOperationToRun(
 		return nil
 	}
 
+	// Operation has a deferred cleanup pending; choose another one.
+	if _, ok := r.status.pendingCleanup[opSpec.NamePrefix()]; ok {
+		return nil
+	}
+
 	// If the time since the last run of the operation has not exceeded its
 	// cadence, choose another operation.
 	if lastRun, ok := r.status.lastRun[opSpec.NamePrefix()]; ok {
@@ -241,7 +293,7 @@ func (r *opsRunner) selectOperationToRun(
 	if opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
 		r.status.lockOperationSelection = true
 		// selected operation cannot run concurrently with other operations —
-		// wait for other running operation completion.
+		// wait for other running operations to finish.
 		workerLabel := strconv.Itoa(workerID)
 		for {
 			if len(r.status.running) == 0 {
@@ -309,10 +361,95 @@ func (r *opsRunner) executeCleanup(
 	cleanup.Cleanup(cleanupCtx, op, c)
 }
 
-// runOperation runs a single operation passed in as opSpec parameter within a single operation worker.
+// enqueueCleanup adds a deferred cleanup to the queue, maintaining
+// ascending executeAt order.
+func (r *opsRunner) enqueueCleanup(dc deferredCleanup) {
+	r.cleanupMu.Lock()
+	defer r.cleanupMu.Unlock()
+	i := sort.Search(len(r.cleanupQueue), func(i int) bool {
+		return r.cleanupQueue[i].executeAt.After(dc.executeAt)
+	})
+	r.cleanupQueue = slices.Insert(r.cleanupQueue, i, dc)
+	r.metrics.pendingCleanups.WithLabelValues(dc.opSpec.NamePrefix()).Inc()
+}
+
+// dequeueReady removes and returns all cleanups whose executeAt <= now.
+func (r *opsRunner) dequeueReady() []deferredCleanup {
+	r.cleanupMu.Lock()
+	defer r.cleanupMu.Unlock()
+	now := timeutil.Now()
+	i := sort.Search(len(r.cleanupQueue), func(i int) bool {
+		return r.cleanupQueue[i].executeAt.After(now)
+	})
+	if i == 0 {
+		return nil
+	}
+	ready := make([]deferredCleanup, i)
+	copy(ready, r.cleanupQueue[:i])
+	r.cleanupQueue = r.cleanupQueue[i:]
+	return ready
+}
+
+// dequeueAll removes and returns all queued cleanups regardless of
+// executeAt time. Used during shutdown to drain the queue.
+func (r *opsRunner) dequeueAll() []deferredCleanup {
+	r.cleanupMu.Lock()
+	defer r.cleanupMu.Unlock()
+	all := r.cleanupQueue
+	r.cleanupQueue = nil
+	return all
+}
+
+// runCleanupProcessor polls the cleanup queue and executes ready
+// cleanups. On context cancellation (shutdown), it drains all remaining
+// cleanups immediately.
+func (r *opsRunner) runCleanupProcessor(ctx context.Context) {
+	defer close(r.cleanupDone)
+
+	const pollInterval = 30 * time.Second
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.processCleanups(r.dequeueReady())
+		case <-ctx.Done():
+			r.processCleanups(r.dequeueAll())
+			return
+		}
+	}
+}
+
+// processCleanups executes a batch of deferred cleanups, updating
+// metrics and concurrency tracking after each one.
+func (r *opsRunner) processCleanups(cleanups []deferredCleanup) {
+	for _, dc := range cleanups {
+		opName := dc.opSpec.NamePrefix()
+		r.logger.Printf(
+			"executing deferred cleanup for %s (scheduled at %s)",
+			opName, dc.executeAt.Format(time.RFC3339),
+		)
+		r.executeCleanup(dc.op, dc.c, dc.cleanup, dc.emitter, dc.opSpec)
+		r.metrics.pendingCleanups.WithLabelValues(opName).Dec()
+
+		func() {
+			r.status.Lock()
+			defer r.status.Unlock()
+			delete(r.status.pendingCleanup, opName)
+			r.status.operationRunCompleted.Broadcast()
+		}()
+	}
+}
+
+// runOperation runs a single operation passed in as opSpec parameter
+// within a single operation worker. When DeferCleanup is set on the
+// spec and the operation succeeds, cleanup is enqueued for later
+// execution and cleanupDeferred is returned as true. The caller must
+// add the operation to pendingCleanup under the status lock.
 func (r *opsRunner) runOperation(
 	ctx context.Context, opSpec *registry.OperationSpec, rng *rand.Rand, workerIdx int,
-) error {
+) (error, bool) {
 	// operationRunID is used for datadog event aggregation and logging.
 	operationRunID := rng.Uint64()
 	opName := opSpec.NamePrefix()
@@ -341,10 +478,10 @@ func (r *opsRunner) runOperation(
 		r.logger.Printf("Loading operation configuration from: %s", roachtestflags.ConfigPath)
 		configFileData, err := os.ReadFile(roachtestflags.ConfigPath)
 		if err != nil {
-			return errors.Wrap(err, "failed to read config")
+			return errors.Wrap(err, "failed to read config"), false
 		}
 		if err = yaml.UnmarshalStrict(configFileData, &config); err != nil {
-			return errors.Wrapf(err, "failed to unmarshal config: %s", roachtestflags.ConfigPath)
+			return errors.Wrapf(err, "failed to unmarshal config: %s", roachtestflags.ConfigPath), false
 		}
 	}
 
@@ -387,6 +524,10 @@ func (r *opsRunner) runOperation(
 
 	var cleanup registry.OperationCleanup
 	var pendingCleanupIncremented bool
+	// cleanupDeferred is set to true when the cleanup is enqueued for
+	// later execution. When true, the defer skips running cleanup and
+	// decrementing pendingCleanups (the processor handles both).
+	var cleanupDeferred bool
 
 	defer func() {
 		// Handle panic if it occurred during operation execution.
@@ -397,6 +538,9 @@ func (r *opsRunner) runOperation(
 			failures := append(op.Failures(), fmt.Errorf("panic: %v\n\n%s", rc, stack))
 			emitter.EmitCompleted(resultPanicked, failures)
 			r.logger.Printf("recovered from panic: %v\n%s", rc, stack)
+		}
+		if cleanupDeferred {
+			return
 		}
 		if pendingCleanupIncremented {
 			r.metrics.pendingCleanups.WithLabelValues(opName).Dec()
@@ -411,7 +555,7 @@ func (r *opsRunner) runOperation(
 		if err != nil {
 			emitter.EmitDepCheckFailed(depCheckError, []error{err})
 			op.Errorf("error checking dependencies: %s", err)
-			return errors.Wrap(err, "checking dependencies")
+			return errors.Wrap(err, "checking dependencies"), false
 		}
 		if !ok {
 			emitter.EmitDepCheckFailed(depCheckFailed, nil)
@@ -419,7 +563,7 @@ func (r *opsRunner) runOperation(
 			// "ran successfully" / cleanupResultSkipped event.
 			op.Errorf("operation dependencies not met")
 			op.Status("operation dependencies not met. Use --skip-dependency-check to skip this check.")
-			return nil
+			return nil, false
 		}
 	}
 
@@ -443,19 +587,39 @@ func (r *opsRunner) runOperation(
 		emitter.EmitCompleted(resultFailed, failures)
 		// Don't return early — defer will run cleanup if a cleanup handler
 		// was returned by the operation.
-		return failures[0]
+		return failures[0], false
 	}
 	emitter.EmitCompleted(resultSuccess, nil)
 
 	if cleanup == nil {
 		// No cleanup needed; the defer will emit cleanupResultSkipped.
-		return nil
+		return nil, false
 	}
 
 	// Wait before cleanup if operation succeeded.
 	waitBeforeCleanup := roachtestflags.WaitBeforeCleanup
 	if opSpec.WaitBeforeCleanup != 0 {
 		waitBeforeCleanup = opSpec.WaitBeforeCleanup
+	}
+
+	// If DeferCleanup is set and we're running in forever mode,
+	// enqueue cleanup for later execution and free the worker.
+	// In single-run mode, deferring has no benefit since the
+	// process exits after the operation completes.
+	if opSpec.DeferCleanup && r.runForever {
+		op.Status(fmt.Sprintf(
+			"operation ran successfully; cleanup deferred for %s", waitBeforeCleanup,
+		))
+		r.enqueueCleanup(deferredCleanup{
+			executeAt: timeutil.Now().Add(waitBeforeCleanup),
+			op:        op,
+			c:         c,
+			cleanup:   cleanup,
+			emitter:   emitter,
+			opSpec:    opSpec,
+		})
+		cleanupDeferred = true
+		return nil, true
 	}
 
 	r.metrics.pendingCleanups.WithLabelValues(opName).Inc()
@@ -468,5 +632,5 @@ func (r *opsRunner) runOperation(
 	}
 
 	// Function ends, defer runs and executes cleanup.
-	return nil
+	return nil, false
 }


### PR DESCRIPTION
Previously, operations with WaitBeforeCleanup (e.g. grant_role, add_rls_policy) blocked their worker goroutine for the entire wait duration before executing cleanup. This tied up workers and reduced runner throughput.

Add a DeferCleanup field to OperationSpec. When set, the worker enqueues cleanup into a sorted queue and immediately becomes available for the next operation. A dedicated cleanup processor goroutine polls the queue every 30s and executes cleanups whose wait time has elapsed. On shutdown, all remaining cleanups are drained immediately.

Operations with pending deferred cleanup are excluded from re-selection.

Also removes the ad-hoc background goroutine cleanup from add_rls_policy, replacing it with the new DeferCleanup mechanism.

Fixes #166409

Release note: None

Epic: none