### PR TITLE
CLAUDE.md: improve PR description guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,11 @@ the `slices`, `maps`, and `cmp` packages) where appropriate.
 
 Use the `/commit-helper` skill when creating commits and PRs.
 
-- For multi-commit PRs, summarize each commit in the PR record.
+- For multi-commit PRs, describe the overall goal and the approach taken.
+  Reference individual commits only when needed for orientation (e.g.
+  "early commits are mechanical refactors; the last two hook everything up").
+  Don't repeat commit messages — they're visible in the commit list and
+  go stale as the PR evolves.
 - Do not include a test plan unless explicitly asked by the user.
 
 ### Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,8 @@ Use the `/commit-helper` skill when creating commits and PRs.
   Don't repeat commit messages — they're visible in the commit list and
   go stale as the PR evolves.
 - Do not include a test plan unless explicitly asked by the user.
+- Always include an `Epic:` footer in PR descriptions. Use the epic from
+  prior context or attached issues if available, otherwise `Epic: none`.
 
 ### Skills
 


### PR DESCRIPTION
Two small improvements to CLAUDE.md PR guidance:

1. For multi-commit PRs, describe the overall goal and approach rather than
   enumerating individual commit messages. Per-commit summaries go stale as
   the PR evolves through review, making them actively misleading.

2. Always include an `Epic:` footer in PR descriptions.

Inspired by review feedback on #166698.

Release note: None
Epic: none