### PR TITLE
release-26.2: roachtest: tolerate "already exists" on snapshot creation in index-backfill

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -8,6 +8,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -155,10 +156,17 @@ func runIndexBackfill(
 		// Create the aforementioned snapshots.
 		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
 		if err != nil {
-			t.Fatal(err)
+			if strings.Contains(err.Error(), "already exists") {
+				// Another concurrent run may have already created snapshots
+				// with the same name.
+				t.L().Printf("snapshot creation hit 'already exists' error, proceeding: %v", err)
+			} else {
+				t.Fatal(err)
+			}
+		} else {
+			t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
+				len(snapshots), t.SnapshotPrefix())
 		}
-		t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
-			len(snapshots), t.SnapshotPrefix())
 	} else {
 		t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
 			len(snapshots), t.SnapshotPrefix())

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -8,6 +8,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -532,9 +533,16 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		t.Status(fmt.Sprintf("creating snapshots with prefix %q", t.SnapshotPrefix()))
 		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
 		if err != nil {
-			t.Fatal(err)
+			if strings.Contains(err.Error(), "already exists") {
+				// Another concurrent run may have already created snapshots
+				// with the same name.
+				t.L().Printf("snapshot creation hit 'already exists' error, proceeding: %v", err)
+			} else {
+				t.Fatal(err)
+			}
+		} else {
+			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), t.SnapshotPrefix())
 		}
-		t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), t.SnapshotPrefix())
 	} else {
 		t.L().Printf("found %d existing snapshot(s) with prefix %q",
 			len(snapshots), t.SnapshotPrefix())


### PR DESCRIPTION
Backport 1/1 commits from #167024 on behalf of @angeladietz.

----

When two concurrent nightly builds (e.g. master and release-26.2) run
the index-backfill test for the first time, they race to create GCE
snapshots with the same name. The loser gets an HTTP 409 "already
exists" error and the test fails.

The snapshot is only needed by future runs (via ListSnapshots). The
current run already has the TPC-E data on disk from the init it just
completed. So when we hit "already exists", log it and move on.

Fixes #166155
Fixes #167206

----

Release justification: