### PR TITLE
githubpost: strip refs/heads/ prefix from TC_BUILD_BRANCH

### DIFF
--- a/pkg/cmd/bazci/githubpost/issues/issues.go
+++ b/pkg/cmd/bazci/githubpost/issues/issues.go
@@ -187,6 +187,7 @@ func DefaultOptionsFromEnv() *Options {
 		goFlagsEnv             = "GOFLAGS"
 	)
 
+	branch := strings.TrimPrefix(maybeEnv(teamcityBuildBranchEnv, "branch-not-found-in-env"), "refs/heads/")
 	return &Options{
 		Token: maybeEnv(githubAPITokenEnv, ""),
 		Org:   maybeEnv(githubOrgEnv, "cockroachdb"),
@@ -196,7 +197,7 @@ func DefaultOptionsFromEnv() *Options {
 		// at least it'll be obvious that something went wrong (as an
 		// issue will be posted pointing at that SHA).
 		SHA:              maybeEnv(teamcityVCSNumberEnv, "8548987813ff9e1b8a9878023d3abfc6911c16db"),
-		Branch:           maybeEnv(teamcityBuildBranchEnv, "branch-not-found-in-env"),
+		Branch:           branch,
 		GetBinaryVersion: build.BinaryVersion,
 		TeamCityOptions: &TeamCityOptions{
 			BuildTypeID: maybeEnv(teamcityBuildTypeIDEnv, "BUILDTYPE_ID-not-found-in-env"),

--- a/pkg/cmd/bazci/githubpost/issues/issues_test.go
+++ b/pkg/cmd/bazci/githubpost/issues/issues_test.go
@@ -552,3 +552,99 @@ func TestDataDriven(t *testing.T) {
 	})
 
 }
+
+func TestDefaultOptionsFromEnv_StripsBranchPrefix(t *testing.T) {
+	testCases := []struct {
+		name           string
+		envValue       string
+		expectedBranch string
+	}{
+		{
+			name:           "strips refs/heads/ prefix from master",
+			envValue:       "refs/heads/master",
+			expectedBranch: "master",
+		},
+		{
+			name:           "strips refs/heads/ from release branch",
+			envValue:       "refs/heads/release-24.3",
+			expectedBranch: "release-24.3",
+		},
+		{
+			name:           "strips refs/heads/ from provisional branch",
+			envValue:       "refs/heads/provisional_24_3_0_rc1",
+			expectedBranch: "provisional_24_3_0_rc1",
+		},
+		{
+			name:           "handles branch without prefix",
+			envValue:       "master",
+			expectedBranch: "master",
+		},
+		{
+			name:           "handles release branch without prefix",
+			envValue:       "release-19.2",
+			expectedBranch: "release-19.2",
+		},
+		{
+			name:           "handles branch-not-found-in-env fallback",
+			envValue:       "",
+			expectedBranch: "branch-not-found-in-env",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := map[string]string{}
+			if tc.envValue != "" {
+				env["TC_BUILD_BRANCH"] = tc.envValue
+			}
+			unset := setEnv(env)
+			defer unset()
+
+			opts := DefaultOptionsFromEnv()
+			require.Equal(t, tc.expectedBranch, opts.Branch)
+		})
+	}
+}
+
+func TestOptions_IsReleaseBranch(t *testing.T) {
+	testCases := []struct {
+		branch   string
+		expected bool
+	}{
+		{"master", true},
+		{"release-24.3", true},
+		{"release-19.2", true},
+		{"provisional_24_3_0_rc1", true},
+		{"provisional_19_2_0", true},
+		{"feature-branch", false},
+		{"my-branch", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.branch, func(t *testing.T) {
+			opts := &Options{Branch: tc.branch}
+			result := opts.IsReleaseBranch()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestReleaseLabel(t *testing.T) {
+	testCases := []struct {
+		branch   string
+		expected string
+	}{
+		{"master", "branch-master"},
+		{"release-24.3", "branch-release-24.3"},
+		{"provisional_24_3", "branch-provisional_24_3"},
+		{"my-feature", "branch-my-feature"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.branch, func(t *testing.T) {
+			result := releaseLabel(tc.branch)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
When TeamCity sets `TC_BUILD_BRANCH` to `refs/heads/master`, multiple
consumers of `Options.Branch` break: `branchTitlePrefix` doesn't
recognize it as master (adding a `refs/heads/master:` prefix to issue
titles), `IsReleaseBranch` returns false, and `releaseLabel` produces
an incorrect label. For example:
https://github.com/cockroachdb/cockroach/issues/167186

Strip the `refs/heads/` prefix in `DefaultOptionsFromEnv` so that all
downstream consumers see the short branch name they expect.

Epic: none

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>