### PR TITLE
sql/builtins: add type check gate for makeSpanStatsGenerator

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -4146,8 +4146,20 @@ func makeSpanStatsGenerator(
 		if len(s.D) != 2 || s.D[0] == tree.DNull || s.D[1] == tree.DNull {
 			continue
 		}
-		startKey := roachpb.Key(tree.MustBeDBytes(s.D[0]))
-		endKey := roachpb.Key(tree.MustBeDBytes(s.D[1]))
+		startKeyBytes, ok := s.D[0].(*tree.DBytes)
+		if !ok {
+			return nil, errors.Newf(
+				"start key of span stats generator must be of *DBytes type",
+			)
+		}
+		endKeyBytes, ok := s.D[1].(*tree.DBytes)
+		if !ok {
+			return nil, errors.Newf(
+				"end key of span stats generator must be of *DBytes type",
+			)
+		}
+		startKey := roachpb.Key(*startKeyBytes)
+		endKey := roachpb.Key(*endKeyBytes)
 		spans = append(spans, roachpb.Span{
 			Key:    startKey,
 			EndKey: endKey,


### PR DESCRIPTION
Fixes #166791

Previously, `makeSpanStatsGenerator` used `Must*` type assertions which panic on type mismatch. This caused crashes on live clusters when datums with unexpected types (e.g. `*DString` instead of `*DBytes`) were passed in.

This patch replaces the panicking `Must*` calls with comma-ok type assertions. In test builds, a type mismatch still panics to surface bugs early; in production builds, it returns an assertion-failure error instead.

Release note: None