### PR TITLE
release-25.4: workload/schemachanger: fix dependency detection for DROP COLUMN

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1715,7 +1715,7 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 	if err != nil {
 		return nil, err
 	}
-	columnIsDependedOn, err := og.columnIsDependedOn(ctx, tx, tableName, columnName)
+	columnIsDependedOn, err := og.columnIsDependedOn(ctx, tx, tableName, columnName, false /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}
@@ -2677,7 +2677,7 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 		return nil, err
 	}
 
-	columnHasDependencies, err := og.columnIsDependedOn(ctx, tx, tableName, columnForTypeChange.name)
+	columnHasDependencies, err := og.columnIsDependedOn(ctx, tx, tableName, columnForTypeChange.name, true /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #160659.

/cc @cockroachdb/release

---

Previously, the DROP COLUMN operation in the schema changer could fail, since it detected self referential foreign key dependencies as external ones. To address this, this patch excludes them from the detection.

Fixes: #160318
Fixes: #159952

Release note: None

Release justification: test only change
