### PR TITLE
kvserver: stop treating split/merge trigger errors as replica corruption

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -96,7 +96,6 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//objstorage",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
 )
 
@@ -900,23 +899,18 @@ func RunCommitTrigger(
 			"commit wait. Was its timestamp bumped after acquiring latches?", txn, ct.Kind())
 	}
 
-	// Used by both splits and merges.
+	// Used by both splits and merges. Errors returned from here will fail
+	// the split or merge. Previously, errors were wrapped in
+	// ReplicaCorruptionError, which would crash the process. This was
+	// problematic because transient I/O errors (e.g. cloud storage
+	// timeouts) would be misidentified as corruption. See #165558.
+	//
+	// TODO(tbg): remove this wrapper, now that it's a no-op.
 	maybeWrapReplicaCorruptionError := func(ctx context.Context, err error) error {
 		if err == nil {
 			log.KvExec.Fatalf(ctx, "unexpected nil error")
 		}
-		if info := pebble.ExtractDataCorruptionInfo(err); info != nil {
-			// Data corruption errors due to external SSTable references getting
-			// deleted should not be wrapped in replica corruption errors. This
-			// ensures that we simply fail the split or merge and propagate the error,
-			// but don't crash the process. In such cases, an excise command should be
-			// used to get out of this data corruption situation.
-			return err
-		}
-		// Otherwise, fail the split or merge with a critical error that crashes the
-		// process. Reporting a replica corruption error ensures this. See
-		// setCorruptRaftMuLocked.
-		return kvpb.MaybeWrapReplicaCorruptionError(ctx, err)
+		return err
 	}
 
 	// Stage the commit trigger's side-effects so that they will go into effect on

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -4197,12 +4197,6 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var exitStatus exit.Code
-	log.SetExitFunc(true /* hideStack */, func(i exit.Code) {
-		exitStatus = i
-	})
-	defer log.ResetExitFunc()
-
 	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()
@@ -4237,13 +4231,9 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 	}
 
 	assignSeqNumsForReqs(txn, &args)
-	expErr := regexp.QuoteMeta("replica corruption (processed=true): range does not match splits")
+	expErr := "range does not match splits"
 	if _, pErr := tc.SendWrappedWith(h, &args); !testutils.IsPError(pErr, expErr) {
 		t.Errorf("unexpected error: %s", pErr)
-	}
-
-	if exitStatus != exit.FatalError() {
-		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }
 


### PR DESCRIPTION
Previously, `maybeWrapReplicaCorruptionError` in `RunCommitTrigger`
escalated any unrecognized error from split/merge trigger evaluation to
a `ReplicaCorruptionError`, which crashes the process via
`setCorruptRaftMuLocked`. This meant that transient I/O errors (e.g.
cloud storage network timeouts during `MVCCIsSpanEmpty`) would fatal
the node despite not indicating actual data corruption.

Remove the corruption wrapping so that these errors simply fail the
split or merge, which will be retried.

This is a minimal fix suitable for backporting. Follow-up work can
remove the now-no-op `maybeWrapReplicaCorruptionError` wrapper entirely.

Fixes-26.2: #165558
Epic: CRDB-61447

Release note (bug fix): Fixed a bug where transient I/O errors (such
as cloud storage network timeouts) during split or merge trigger
evaluation were misidentified as replica corruption, causing the node
to crash. These errors now correctly fail the operation, which is
retried automatically.