### PR TITLE
release-26.2: roachtest: default to best CPU platform for all machine types

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -395,11 +395,14 @@ func getGCEOpts(
 	bootDiskOnly bool,
 ) vm.ProviderOpts {
 	opts := gce.DefaultProviderOpts()
-	hasDifferentMachineType := machineType != "" && machineType != opts.MachineType
 	opts.MachineType = machineType
-	// Use the default CPU platform if the user has not
-	// overriden it or specified a different machine type.
-	if minCPUPlatform != "" || hasDifferentMachineType {
+	// Default to "best" so that minCPUPlatform() resolves to the latest
+	// platform available for the machine type, ensuring run-to-run
+	// consistency regardless of machine family. Tests that explicitly
+	// set GCE.MinCPUPlatform can still override this.
+	if minCPUPlatform == "" {
+		opts.MinCPUPlatform = "best"
+	} else {
 		opts.MinCPUPlatform = minCPUPlatform
 	}
 	if volumeSize != 0 {


### PR DESCRIPTION
Backport 1/1 commits from #167275 on behalf of @rafiss.

----

Previously, getGCEOpts would clear the MinCPUPlatform default from DefaultProviderOpts ("Intel Ice Lake") whenever a test used a non-default machine type (e.g. n2-standard-8 instead of n2-standard-4). This meant tests like sysbench/oltp_read_only/nodes=3/cpu=8 lost the Ice Lake floor and GCE could schedule on Cascade Lake, causing a bimodal ~30% QPS regression on roughly half of nightly runs.

The partial fix in #163362 restored the guard for the default machine type but still cleared MinCPUPlatform for any other type.

Default to "best" when the test doesn't explicitly set GCE.MinCPUPlatform, so that minCPUPlatform() resolves to the latest platform available for the machine family. This ensures run-to-run consistency regardless of machine type.

Informs: cockroachdb/pebble#5775

Release note: None

----

Release justification: test only change