### PR TITLE
roachtest: increase disk-bandwidth-limiter test threshold

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -171,8 +171,8 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 					panic("unreachable")
 				}
 
-				// Allow a 5% room for error.
-				const bandwidthThreshold = bandwidthLimit * 1.05
+				// Allow a 30% room for error.
+				const bandwidthThreshold = bandwidthLimit * 1.30
 				const collectionIntervalSeconds = 10.0
 				// Loop for ~20 minutes.
 				const numIterations = int(20 / (collectionIntervalSeconds / 60))


### PR DESCRIPTION
Widen the allowed overhead for the disk bandwidth limiter roachtest
from 5% to 30%. On older branches without the improved error
correction in >=26.2, the bandwidth limiter can overshoot by more
than 5%, causing flaky test failures.

Fixes: #167198