### PR TITLE
release-26.2: sql: add mixed-version upgrade tests for new privileges and aclitem type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_aclitem
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_aclitem
@@ -1,0 +1,108 @@
+# LogicTest: cockroach-go-testserver-25.4 cockroach-go-testserver-26.1
+
+# This test verifies that the aclitem type and related functions introduced in
+# 26.2 work correctly before, during, and after upgrade from an older version.
+
+# Lower the capacity check threshold to avoid failures on low-disk-space
+# machines.
+statement ok
+SET CLUSTER SETTING kv.bulk_io_write.min_capacity_remaining_fraction = 0.04
+
+subtest pre_upgrade
+
+# Before upgrade, aclitem type should not be recognized.
+statement error type "aclitem" does not exist
+SELECT 'testuser=r/root'::aclitem
+
+# Before upgrade, makeaclitem should not exist.
+statement error unknown function: makeaclitem
+SELECT makeaclitem(0, 0, 'SELECT', false)
+
+subtest end
+
+subtest mid_upgrade
+
+# Upgrade node 0 only. Nodes 1 and 2 remain on the old binary.
+upgrade 0
+
+# On the upgraded node, aclitem type should be available.
+user root nodeidx=0
+
+query T
+SELECT pg_typeof('testuser=r/root'::aclitem)
+----
+aclitem
+
+# On the upgraded node, makeaclitem should work.
+query T
+SELECT makeaclitem(0, 0, 'SELECT', false)
+----
+=r/0
+
+# On the upgraded node, acldefault should return aclitem[].
+query T
+SELECT pg_typeof(acldefault('r', 0::oid))
+----
+aclitem[]
+
+# On an old node, aclitem type should still not be recognized.
+user root nodeidx=2
+
+statement error type "aclitem" does not exist
+SELECT 'testuser=r/root'::aclitem
+
+# On an old node, makeaclitem should still not exist.
+statement error unknown function: makeaclitem
+SELECT makeaclitem(0, 0, 'SELECT', false)
+
+subtest end
+
+subtest post_upgrade
+
+# Upgrade remaining nodes and finalize.
+upgrade 1
+
+upgrade 2
+
+user root nodeidx=0
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+# After full upgrade, aclitem type should be available on all nodes.
+query T
+SELECT pg_typeof('testuser=r/root'::aclitem)
+----
+aclitem
+
+# Verify acldefault returns aclitem[] after upgrade.
+query T
+SELECT pg_typeof(acldefault('r', 0::oid))
+----
+aclitem[]
+
+# Verify makeaclitem works.
+query T
+SELECT makeaclitem(0, 0, 'SELECT', false)
+----
+=r/0
+
+# Verify aclitem can be used in table columns.
+statement ok
+CREATE TABLE acl_test (id INT PRIMARY KEY, acl aclitem)
+
+statement ok
+INSERT INTO acl_test VALUES (1, 'testuser=arwdDxt/root')
+
+query IT
+SELECT * FROM acl_test
+----
+1  testuser=arwdDxt/root
+
+# Verify aclitem array operations work.
+query T
+SELECT ARRAY['testuser=r/root'::aclitem, '=r/root'::aclitem]
+----
+{testuser=r/root,=r/root}
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_aclitem
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_aclitem
@@ -45,6 +45,26 @@ SELECT pg_typeof(acldefault('r', 0::oid))
 ----
 aclitem[]
 
+# On the upgraded node, creating a table with an aclitem column should work.
+statement ok
+CREATE TABLE acl_mid_upgrade (id INT PRIMARY KEY, acl aclitem)
+
+statement ok
+INSERT INTO acl_mid_upgrade VALUES (1, 'testuser=r/root')
+
+query IT
+SELECT * FROM acl_mid_upgrade
+----
+1  testuser=r/root
+
+# On an old node, reading from a table with an aclitem column should still work.
+user root nodeidx=2
+
+query IT
+SELECT * FROM acl_mid_upgrade
+----
+1  testuser=r/root
+
 # On an old node, aclitem type should still not be recognized.
 user root nodeidx=2
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_new_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_new_privileges
@@ -1,0 +1,121 @@
+# LogicTest: cockroach-go-testserver-25.4 cockroach-go-testserver-26.1
+
+# This test verifies that the MAINTAIN privilege introduced in
+# 26.2 works correctly before, during, and after upgrade from an older version.
+# This privilege has no version gate because it uses backward-compatible
+# bitmasks; unknown bits are silently ignored by older nodes.
+
+# Disable the capacity check to avoid failures on low-disk-space machines.
+statement ok
+SET CLUSTER SETTING kv.bulk_io_write.min_capacity_remaining_fraction = 0.04
+
+# Set up tables before upgrade.
+statement ok
+CREATE TABLE mat_view_source (id INT PRIMARY KEY, val INT)
+
+statement ok
+INSERT INTO mat_view_source VALUES (1, 10), (2, 20)
+
+statement ok
+CREATE MATERIALIZED VIEW mat_view AS SELECT id, val FROM mat_view_source
+
+subtest pre_upgrade
+
+# Before upgrade, GRANT MAINTAIN should not be recognized
+# because the old binary does not have this privilege kind in its lookup map.
+statement error not a valid privilege: "maintain"
+GRANT MAINTAIN ON TABLE mat_view TO testuser
+
+subtest end
+
+subtest mid_upgrade
+
+# Upgrade node 0 only. Nodes 1 and 2 remain on the old binary.
+upgrade 0
+
+# On the upgraded node, GRANT MAINTAIN should work even though
+# the cluster version has not been finalized. This privilege has no version
+# gate.
+user root nodeidx=0
+
+statement ok
+GRANT MAINTAIN ON TABLE mat_view TO testuser
+
+# testuser also needs SELECT on the source table to refresh the materialized
+# view.
+statement ok
+GRANT SELECT ON TABLE mat_view_source TO testuser
+
+# Verify the privileges are visible from the upgraded node.
+query TTTB colnames,nodeidx=0
+SELECT table_name, grantee, privilege_type, is_grantable
+FROM [SHOW GRANTS ON TABLE mat_view] WHERE grantee = 'testuser'
+----
+table_name  grantee   privilege_type  is_grantable
+mat_view    testuser  MAINTAIN        false
+
+# On an old node, the privileges are stored as bitmask bits. The old node
+# silently ignores unknown bits, so SHOW GRANTS will not show the new privilege
+# names. However, the table should still be fully usable.
+user root nodeidx=2
+
+query TTTB colnames,nodeidx=2
+SELECT table_name, grantee, privilege_type, is_grantable
+FROM [SHOW GRANTS ON TABLE mat_view] WHERE grantee = 'testuser'
+----
+table_name  grantee  privilege_type  is_grantable
+
+# Verify MAINTAIN privilege allows REFRESH MATERIALIZED VIEW on the upgraded
+# node.
+user testuser nodeidx=0
+
+statement ok
+REFRESH MATERIALIZED VIEW mat_view
+
+subtest end
+
+subtest post_upgrade
+
+# Upgrade remaining nodes and finalize.
+upgrade 1
+
+upgrade 2
+
+user root nodeidx=0
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+# After full upgrade, all nodes should see the privileges.
+query TTTB colnames
+SELECT table_name, grantee, privilege_type, is_grantable
+FROM [SHOW GRANTS ON TABLE mat_view] WHERE grantee = 'testuser'
+----
+table_name  grantee   privilege_type  is_grantable
+mat_view    testuser  MAINTAIN        false
+
+# Verify MAINTAIN privilege allows REFRESH MATERIALIZED VIEW.
+user testuser
+
+statement ok
+REFRESH MATERIALIZED VIEW mat_view
+
+user root
+
+# Verify revoking works.
+statement ok
+REVOKE MAINTAIN ON TABLE mat_view FROM testuser
+
+query TTTB colnames
+SELECT table_name, grantee, privilege_type, is_grantable
+FROM [SHOW GRANTS ON TABLE mat_view] WHERE grantee = 'testuser'
+----
+table_name  grantee  privilege_type  is_grantable
+
+# Verify the user can no longer perform the privileged operation.
+user testuser
+
+statement error pq: user testuser does not have MAINTAIN privilege on relation mat_view
+REFRESH MATERIALIZED VIEW mat_view
+
+subtest end

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.4/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.4/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 9,
+    shard_count = 11,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.4/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.4/generated_test.go
@@ -76,6 +76,13 @@ func TestLogic_cross_version_tenant_backup(
 	runLogicTest(t, "cross_version_tenant_backup")
 }
 
+func TestLogic_mixed_version_aclitem(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_aclitem")
+}
+
 func TestLogic_mixed_version_bootstrap_tenant(
 	t *testing.T,
 ) {
@@ -88,6 +95,13 @@ func TestLogic_mixed_version_can_login(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "mixed_version_can_login")
+}
+
+func TestLogic_mixed_version_new_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_new_privileges")
 }
 
 func TestLogic_mixed_version_statement_hints_session_settings(

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-26.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-26.1/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 8,
+    shard_count = 10,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-26.1/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-26.1/generated_test.go
@@ -76,6 +76,13 @@ func TestLogic_cross_version_tenant_backup(
 	runLogicTest(t, "cross_version_tenant_backup")
 }
 
+func TestLogic_mixed_version_aclitem(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_aclitem")
+}
+
 func TestLogic_mixed_version_bootstrap_tenant(
 	t *testing.T,
 ) {
@@ -88,6 +95,13 @@ func TestLogic_mixed_version_can_login(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "mixed_version_can_login")
+}
+
+func TestLogic_mixed_version_new_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_new_privileges")
 }
 
 func TestLogic_mixed_version_statement_hints_session_settings(


### PR DESCRIPTION
Backport 2/2 commits from #166876 on behalf of @rafiss.

----

Add cockroach-go-testserver logic tests to verify upgrade compatibility for MAINTAIN privileges and the aclitem type introduced in 26.2. These features have no version gate because they use backward-compatible mechanisms (privilege bitmask bits are silently ignored by old nodes, and the aclitem type simply becomes available after upgrade). The tests verify that the features are correctly unavailable before upgrade and functional after upgrade from both 25.4 and 26.1.

resolves: #165475
Release note: None

----

Release justification: test only change