### PR TITLE
sql: add oid[] to string constant available types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -752,3 +752,63 @@ SELECT col1 FROM t123548_1 JOIN t123548_2 ON col1 = col2;
 statement ok
 RESET testing_optimizer_random_seed;
 RESET testing_optimizer_disable_rule_probability;
+
+# Regression test: string constants should be implicitly castable to oid[] in
+# comparisons, matching PostgreSQL behavior. This is needed for pg_dump
+# compatibility which compares oid[] columns against string literals like '{0}'.
+subtest oid_array_string_comparison
+
+statement ok
+CREATE TABLE t_oidarr (a OID[])
+
+statement ok
+INSERT INTO t_oidarr VALUES (ARRAY[0::oid])
+
+query B
+SELECT a = '{0}' FROM t_oidarr
+----
+true
+
+query B
+SELECT a = '{0}'::oid[] FROM t_oidarr
+----
+true
+
+statement ok
+DROP TABLE t_oidarr
+
+subtest end
+
+# Regression test: string constants should be resolvable as oid type, matching
+# PostgreSQL behavior. This is needed for pg_dump which uses EXECUTE with
+# string-literal OID arguments like: EXECUTE dumpEnumType('100108')
+subtest oid_string_constant
+
+# String constants should resolve to oid in EXECUTE parameter context.
+statement ok
+PREPARE test_oid_param(oid) AS SELECT $1
+
+query O
+EXECUTE test_oid_param('1234')
+----
+1234
+
+statement ok
+DEALLOCATE test_oid_param
+
+# String constants should be comparable to oid columns.
+statement ok
+CREATE TABLE t_oid_cmp (a OID)
+
+statement ok
+INSERT INTO t_oid_cmp VALUES (1234)
+
+query B
+SELECT a = '1234' FROM t_oid_cmp
+----
+true
+
+statement ok
+DROP TABLE t_oid_cmp
+
+subtest end

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -71,7 +71,16 @@ func typeCheckConstant(
 	if !desired.IsAmbiguous() {
 		for _, typ := range avail {
 			if desired.Equivalent(typ) {
-				return c.ResolveAsType(ctx, semaCtx, desired)
+				resolved, err := c.ResolveAsType(ctx, semaCtx, desired)
+				if desired.Family() == types.OidFamily &&
+					pgerror.GetPGCode(err) == pgcode.InvalidTextRepresentation {
+					// For OID family types, resolution can fail when a non-numeric
+					// string is used (e.g., 'pg_class'::regclass). In this case,
+					// fall through to resolve as the natural type (string) and let
+					// the cast handle name resolution at eval time.
+					break
+				}
+				return resolved, err
 			}
 		}
 	}
@@ -552,6 +561,8 @@ var (
 		types.AnyEnumArray,
 		types.INetArray,
 		types.VarBitArray,
+		types.Oid,
+		types.OidArray,
 		types.AnyTuple,
 		types.AnyTupleArray,
 		// TODO(#22513): Reevaluate conversions for jsonpath array.

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -447,6 +447,7 @@ var parseFuncs = map[*types.T]func(*testing.T, string) tree.Datum{
 	types.IntervalArray:    mustParseDArrayOfType(types.Interval),
 	types.INetArray:        mustParseDArrayOfType(types.INet),
 	types.VarBitArray:      mustParseDArrayOfType(types.VarBit),
+	types.OidArray:         mustParseDArrayOfType(types.Oid),
 }
 
 func typeSet(tys ...*types.T) map[*types.T]struct{} {
@@ -579,6 +580,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.FloatArray,
 				types.DecimalArray,
 				types.IntervalArray,
+				types.OidArray,
 				types.TSVector,
 				types.TSQuery,
 				types.RefCursor,
@@ -703,6 +705,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				types.FloatArray,
 				types.DecimalArray,
 				types.IntervalArray,
+				types.OidArray,
 				types.VarBitArray,
 				types.TSVector,
 				types.RefCursor,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -868,6 +868,10 @@ var (
 	VarBitArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: VarBit, Oid: oid.T__varbit, Locale: &emptyLocale}}
 
+	// OidArray is the type of an array value having Oid-typed elements.
+	OidArray = &T{InternalType: InternalType{
+		Family: ArrayFamily, ArrayContents: Oid, Oid: oid.T__oid, Locale: &emptyLocale}}
+
 	// AnyEnumArray is the type of an array value having AnyEnum-typed elements.
 	AnyEnumArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: AnyEnum, Oid: oid.T_anyarray, Locale: &emptyLocale}}


### PR DESCRIPTION
pg_dump compares oid[] columns against string literals like '{0}'
(e.g., `pol.polroles = '{0}'` in the pg_policy query). This failed
with "unsupported comparison operator: <oid[]> = <string>" because
oid[] was not in StrValAvailAllParsable, so the type checker could
not implicitly cast string constants to oid[].

Add an OidArray type constant and include it in the set of types
that string constants can become, matching PostgreSQL behavior.

Informs: cockroachdb#20296

Release note (bug fix): Fixed "unsupported comparison operator: <oid[]> = <string>"
error when comparing an oid[] column against
a string constant. This improves PostgreSQL compatibility.
