### PR TITLE
sql: fix session variable hints for non-string variable types

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4839,17 +4839,12 @@ func (ex *connExecutor) applySessionVariableHint(
 		return errors.New("unknown session variable")
 	}
 
-	// Normalize the value via GetStringVal if available (e.g. for booleans,
-	// this canonicalizes "TRUE"/"1" to "on").
-	if v.GetStringVal != nil {
-		values := []tree.TypedExpr{tree.NewDString(varValue)}
-		normalized, err := v.GetStringVal(ctx, &p.extendedEvalCtx, values, p.Txn())
-		if err != nil {
-			return err
-		}
-		varValue = normalized
-	}
-
+	// Skip GetStringVal normalization for hints. GetStringVal is designed for
+	// the SET var = <expr> path where the SQL parser produces typed datums
+	// (e.g. DInt for integers, DBool for booleans). Hint values are always
+	// strings, and wrapping them as DString breaks GetStringVal functions that
+	// expect non-string datum types (e.g. makeIntGetStringValFn expects DInt).
+	// The Set method already accepts a plain string and handles its own parsing.
 	if v.Set != nil {
 		return ex.dataMutatorIterator.ApplyOnStmtScopedMutator(
 			func(m sessionmutator.SessionDataMutator) error {

--- a/pkg/sql/opt/exec/execbuilder/testdata/statement_hint_builtins
+++ b/pkg/sql/opt/exec/execbuilder/testdata/statement_hint_builtins
@@ -1911,3 +1911,60 @@ statement ok
 SELECT information_schema.crdb_delete_statement_hints(
   'SELECT * FROM abc WHERE b = _'
 )
+
+# Regression test: session variable hints must be applied for all variable
+# types. Previously, the hint value was wrapped as a DString and passed to
+# GetStringVal, which expected type-specific datums (DInt, DFloat, etc.),
+# causing hints to be silently skipped for non-string variable types.
+statement ok
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE x = 10',
+  'reorder_joins_limit', '0'
+)
+
+statement ok
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE x = 10',
+  'testing_optimizer_cost_perturbation', '0.5'
+)
+
+statement ok
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE x = 10',
+  'enable_zigzag_join', 'false'
+)
+
+statement ok
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE x = 10',
+  'statement_timeout', '30s'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+statement ok
+SET tracing = on
+
+query II
+SELECT * FROM xy WHERE x = 10
+----
+10  10
+
+statement ok
+SET tracing = off
+
+query T rowsort
+SELECT message FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%session variable hint%'
+----
+applied session variable hint: enable_zigzag_join = false
+applied session variable hint: reorder_joins_limit = 0
+applied session variable hint: statement_timeout = 30s
+applied session variable hint: testing_optimizer_cost_perturbation = 0.5
+
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE x = _')
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()


### PR DESCRIPTION
Session variable hints for integer, float, and timeout variables were silently skipped at application time. The hint value (always a string) was wrapped as a DString and passed to GetStringVal, which expected type-specific datums (DInt for integers, DFloat for floats, etc.), causing a type assertion failure. The error was caught and the hint was silently skipped.

Fix by bypassing GetStringVal entirely when applying hints. It exists to normalize typed SQL expressions (from SET var = <expr>) into strings, which is unnecessary for hints since the value is already a string and the Set method handles its own string parsing.

Fixes: #167175

Release note (bug fix): Fixed a bug where statement hints that set session variables with integer, float, or timeout types (e.g. reorder_joins_limit, testing_optimizer_cost_perturbation, statement_timeout) were silently ignored at execution time despite being accepted at creation time.