### PR TITLE
dev: bump DEV_VERSION to 123

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=122
+DEV_VERSION=123
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
Bump DEV_VERSION to force a rebuild of the `dev` binary on all
machines. This picks up recent changes to `dev gen` that added
CODEOWNER metadata to metrics generation. Without this bump, CI
machines using a cached binary would not generate `metric_owners.yaml`
correctly, causing failures.

Epic: none

Release note: None