### PR TITLE
schemachanger: fix skip_unique_checks not cleared on PK for RBR→GLOBAL

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_skip_unique_checks
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_skip_unique_checks
@@ -275,6 +275,12 @@ FROM [EXPLAIN INSERT INTO t VALUES (19, 190, 1900, 5, 5), (20, 200, 2000, 6, 6)]
 WHERE info ~ 'table:';
 ----
 
+# Verify that skip_unique_checks is cleared on the primary key as well.
+query T
+SELECT show_index(create_statement, 't_pkey') FROM [SHOW CREATE TABLE t]
+----
+t_pkey PRIMARY KEY (e ASC),
+
 # Verify that skip_unique_checks is no longer shown in SHOW CREATE TABLE.
 query T
 SELECT show_index(create_statement, 't_a_key') FROM [SHOW CREATE TABLE t]

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -55,11 +55,6 @@ type alterPrimaryKeySpec struct {
 	Name          tree.Name
 	StorageParams tree.StorageParams
 	Partitioning  *partitioningSpec
-	// IsLocalitySwap is true when the ALTER PRIMARY KEY is triggered by an ALTER
-	// TABLE SET LOCALITY that changes between RBR variants. When true,
-	// skip_unique_checks is preserved from old indexes if the new indexes retain
-	// implicit partitioning.
-	IsLocalitySwap bool
 }
 
 // partitioningSpec specifies partitioning to apply during ALTER PRIMARY KEY.
@@ -248,9 +243,11 @@ func setupStorageParams(
 ) {
 	// Reset to defaults first, since the new PK should not inherit storage
 	// params from the old PK unless explicitly specified in the WITH clause.
-	// For RBR-to-RBR locality swaps, preserve skip_unique_checks from the old
-	// PK since the index remains implicitly partitioned.
-	if t.IsLocalitySwap && partitioning != nil && partitioning.NumImplicitColumns > 0 {
+	// For locality swaps where the new index retains implicit partitioning
+	// (e.g. RBR-to-RBR), preserve skip_unique_checks from the old PK.
+	// For transitions that remove implicit partitioning (e.g. RBR-to-GLOBAL),
+	// clear it since it's only valid on implicitly partitioned indexes.
+	if t.Partitioning != nil && len(t.Partitioning.NewImplicitColumns) > 0 {
 		final.SkipUniqueChecks = old.SkipUniqueChecks
 	} else {
 		final.SkipUniqueChecks = false

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
@@ -247,12 +247,11 @@ func alterPrimaryKeyForRegionalByRowTable(
 	// Step 4: Build the alterPrimaryKeySpec
 	partSpec := getTablePartitioningSpec(b, tableID, targetLocality)
 	spec := alterPrimaryKeySpec{
-		n:              t,
-		Columns:        cols,
-		Sharded:        sharded,
-		Name:           tree.Name(currentPKName.Name),
-		Partitioning:   &partSpec,
-		IsLocalitySwap: true,
+		n:            t,
+		Columns:      cols,
+		Sharded:      sharded,
+		Name:         tree.Name(currentPKName.Name),
+		Partitioning: &partSpec,
 	}
 
 	// Step 5: Call alterPrimaryKey


### PR DESCRIPTION
When converting a table from REGIONAL BY ROW to GLOBAL, the declarative schema changer preserved `skip_unique_checks` on the primary key because `setupStorageParams` checked a stale `IndexPartitioning` element (already dropped from builder state) rather than the target partitioning spec.

Fix by checking `t.Partitioning.NewImplicitColumns` instead, matching the pattern already used in `maybeAddUniqueIndexForOldPrimaryKey`.

Fixes: #167123

Release note (bug fix): Fixed a bug where converting a table from REGIONAL BY ROW to GLOBAL would not clear the `skip_unique_checks` storage parameter on the primary key, even though implicit partitioning was removed.