### PR TITLE
c-deps: configure jemalloc with 64KB page size for ppc64le

### DIFF
--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -28,7 +28,10 @@ configure_make(
             "--host=aarch64-unknown-linux-gnu",
             "--with-lg-page=16",
         ],
-        "@io_bazel_rules_go//go/platform:linux_ppc64le": ["--host=powerpc64le-unknown-linux-gnu"],
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": [
+            "--host=powerpc64le-unknown-linux-gnu",
+            "--with-lg-page=16",
+        ],
         "@io_bazel_rules_go//go/platform:linux_s390x": ["--host=s390x-unknown-linux-gnu"],
         # NB: Normally host detection is handled by configure, but the version
         # of jemalloc we have vendored is pretty ancient and can't handle some


### PR DESCRIPTION
POWER (ppc64le) systems commonly use 64KB pages. Without `--with-lg-page=16`, jemalloc aborts at startup with "Unsupported system page size", crashing the cockroach binary before it can initialize.

The same flag is already passed for aarch64 (linux_arm64) which also supports large pages. This commit applies it to linux_ppc64le as well.

Epic: none

Release note (bug fix): Fixed a build configuration issue that caused CockroachDB binaries cross-compiled for ppc64le (POWER) to crash at startup with "Unsupported system page size" on systems using 64KB pages, by configuring jemalloc with `--with-lg-page=16`.