### PR TITLE
gss: fix crlfmt lint for waitForSettingPropagation signature

### DIFF
--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -200,9 +200,7 @@ func TestGSS(t *testing.T) {
 	}
 }
 
-func waitForSettingPropagation(
-	t *testing.T, db *gosql.DB, nameValuePairs ...string,
-) {
+func waitForSettingPropagation(t *testing.T, db *gosql.DB, nameValuePairs ...string) {
 	t.Helper()
 	if len(nameValuePairs)%2 != 0 {
 		t.Fatal("nameValuePairs must be even")

--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -133,22 +133,31 @@ func TestGSS(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			if _, err := db.Exec(`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, tc.conf); !IsError(err, tc.hbaErr) {
+			_, err := db.Exec(
+				`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, tc.conf,
+			)
+			if !IsError(err, tc.hbaErr) {
 				t.Fatalf("expected err %v, got %v", tc.hbaErr, err)
 			}
 			if tc.hbaErr != "" {
 				return
 			}
-			if tc.identMap != "" {
-				if _, err := db.Exec(`SET CLUSTER SETTING server.identity_map.configuration = $1`, tc.identMap); err != nil {
-					t.Fatalf("bad identity_map: %v", err)
-				}
+			if _, err := db.Exec(
+				`SET CLUSTER SETTING server.identity_map.configuration = $1`, tc.identMap,
+			); err != nil {
+				t.Fatalf("bad identity_map: %v", err)
 			}
 			if _, err := db.Exec(fmt.Sprintf(`CREATE USER IF NOT EXISTS %s`, tc.user)); err != nil {
 				t.Fatal(err)
 			}
+			waitForSettingPropagation(t, db,
+				"server.host_based_authentication.configuration", tc.conf,
+				"server.identity_map.configuration", tc.identMap,
+			)
 			t.Run("libpq", func(t *testing.T) {
-				userConnector, err := pq.NewConnector(fmt.Sprintf("user=%s sslmode=require krbspn=postgres/gss_cockroach_1.gss_default", tc.user))
+				userConnector, err := pq.NewConnector(
+					fmt.Sprintf("user=%s sslmode=require krbspn=postgres/gss_cockroach_1.gss_default", tc.user),
+				)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -172,7 +181,10 @@ func TestGSS(t *testing.T) {
 					"--certs-dir", "/certs",
 					// TODO(mjibson): Teach the CLI to not ask for passwords during kerberos.
 					// See #51588.
-					"--url", fmt.Sprintf("postgresql://%s:nopassword@cockroach:26257/?sslmode=require&krbspn=postgres/gss_cockroach_1.gss_default", tc.user),
+					"--url", fmt.Sprintf(
+						"postgresql://%s:nopassword@cockroach:26257/?sslmode=require&krbspn=postgres/gss_cockroach_1.gss_default",
+						tc.user,
+					),
 				).CombinedOutput()
 				err = errors.Wrap(err, strings.TrimSpace(string(out)))
 				if !IsError(err, tc.gssErr) {
@@ -188,6 +200,37 @@ func TestGSS(t *testing.T) {
 	}
 }
 
+func waitForSettingPropagation(
+	t *testing.T, db *gosql.DB, nameValuePairs ...string,
+) {
+	t.Helper()
+	if len(nameValuePairs)%2 != 0 {
+		t.Fatal("nameValuePairs must be even")
+	}
+	for i := 0; i < len(nameValuePairs); i += 2 {
+		name := nameValuePairs[i]
+		expected := nameValuePairs[i+1]
+		var actual string
+		for attempt := 0; attempt < 50; attempt++ {
+			row := db.QueryRow(fmt.Sprintf("SHOW CLUSTER SETTING %s", name))
+			if err := row.Scan(&actual); err != nil {
+				t.Fatalf("error reading setting %s: %v", name, err)
+			}
+			if actual == expected {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if actual != expected {
+			t.Fatalf(
+				"setting %s did not propagate: expected %q, got %q",
+				name, expected, actual,
+			)
+		}
+	}
+	time.Sleep(200 * time.Millisecond)
+}
+
 func TestGSSFileDescriptorCount(t *testing.T) {
 	t.Skip("#110194")
 	rootConnector, err := pq.NewConnector("user=root password=rootpw sslmode=require")
@@ -197,7 +240,10 @@ func TestGSSFileDescriptorCount(t *testing.T) {
 	rootDB := gosql.OpenDB(rootConnector)
 	defer rootDB.Close()
 
-	if _, err := rootDB.Exec(`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, "host all all all gss include_realm=0"); err != nil {
+	if _, err := rootDB.Exec(
+		`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`,
+		"host all all all gss include_realm=0",
+	); err != nil {
 		t.Fatal(err)
 	}
 	const user = "tester"
@@ -243,7 +289,9 @@ func IsError(err error, re string) bool {
 // authentication a web session.
 func rootAuthCookie(t *testing.T) string {
 	t.Helper()
-	out, err := exec.Command("/cockroach/cockroach", "auth-session", "login", "root", "--only-cookie").CombinedOutput()
+	out, err := exec.Command(
+		"/cockroach/cockroach", "auth-session", "login", "root", "--only-cookie",
+	).CombinedOutput()
 	if err != nil {
 		t.Log(string(out))
 		t.Fatal(errors.Wrap(err, "auth-session failed"))

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3239,7 +3239,9 @@ func TestBackupRestoreIncremental(t *testing.T) {
 		getLatestBackupEndTime := func() string {
 			var endTime string
 			sqlDB.QueryRow(
-				t, `SELECT end_time FROM [SHOW BACKUP FROM LATEST IN $1] ORDER BY end_time DESC LIMIT 1`, backupDir,
+				t,
+				`SELECT end_time FROM [SHOW BACKUP FROM LATEST IN $1] ORDER BY end_time DESC LIMIT 1`,
+				backupDir,
 			).Scan(&endTime)
 			return endTime
 		}
@@ -4124,7 +4126,10 @@ func TestNonLinearChain(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO t VALUES (0)`)
 	sqlDB.Exec(t, `BACKUP TABLE defaultdb.t INTO $1`, localFoo)
-	require.Len(t, sqlDB.QueryStr(t, `SELECT DISTINCT end_time FROM [SHOW BACKUP FROM LATEST IN $1]`, localFoo), 1)
+	require.Len(t,
+		sqlDB.QueryStr(t, `SELECT DISTINCT end_time FROM [SHOW BACKUP FROM LATEST IN $1]`, localFoo),
+		1,
+	)
 
 	// Write a row and note the time that includes that row.
 	var ts1, ts2 string
@@ -4149,7 +4154,10 @@ func TestNonLinearChain(t *testing.T) {
 
 	// We should see two end times now in the shown backup -- the full and this
 	// (second) inc.
-	require.Len(t, sqlDB.QueryStr(t, `SELECT DISTINCT end_time FROM [SHOW BACKUP FROM LATEST IN $1]`, localFoo), 2)
+	require.Len(t,
+		sqlDB.QueryStr(t, `SELECT DISTINCT end_time FROM [SHOW BACKUP FROM LATEST IN $1]`, localFoo),
+		2,
+	)
 
 	// Now we have a full ending at t0, an incomplete inc from t0 to t1, and a
 	// complete inc also from t0 but to t2. We will move `t` out of our way and
@@ -4169,7 +4177,10 @@ func TestNonLinearChain(t *testing.T) {
 
 	// We should see three end times now in the shown backup -- the full, the 2nd
 	// inc we saw before, but now also this first inc as well.
-	require.Len(t, sqlDB.QueryStr(t, `SELECT DISTINCT end_time FROM [SHOW BACKUP FROM LATEST IN $1]`, localFoo), 3)
+	require.Len(t,
+		sqlDB.QueryStr(t, `SELECT DISTINCT end_time FROM [SHOW BACKUP FROM LATEST IN $1]`, localFoo),
+		3,
+	)
 
 	// Restore the same thing -- t2 -- we did before but now with the extra inc
 	// spur hanging out in the chain. This should produce the same result, and we
@@ -4415,7 +4426,10 @@ func TestEncryptedBackup(t *testing.T) {
 
 			sqlDB.Exec(t, `DROP DATABASE neverappears CASCADE`)
 
-			sqlDB.Exec(t, fmt.Sprintf(`SHOW BACKUP FROM LATEST IN ($1, $2) WITH %s`, encryptionOption), backupLoc1, backupLoc2)
+			sqlDB.Exec(t,
+				fmt.Sprintf(`SHOW BACKUP FROM LATEST IN ($1, $2) WITH %s`, encryptionOption),
+				backupLoc1, backupLoc2,
+			)
 
 			var expectedShowError string
 			if tc.useKMS {
@@ -10831,18 +10845,27 @@ CREATE TABLE child_pk (k INT8 PRIMARY KEY REFERENCES parent);
 	sqlDB.Exec(t, `CREATE DATABASE ts`)
 	sqlDB.Exec(t, `RESTORE TABLE test.rev_times FROM LATEST IN $1 WITH into_db = 'ts'`, localFoo)
 	for _, ts := range sqlDB.QueryStr(t, `SELECT logical_time FROM ts.rev_times`) {
-		sqlDB.Exec(t, fmt.Sprintf(`RESTORE DATABASE test FROM LATEST IN $1 AS OF SYSTEM TIME %s`, ts[0]), localFoo)
+		sqlDB.Exec(t,
+			fmt.Sprintf(`RESTORE DATABASE test FROM LATEST IN $1 AS OF SYSTEM TIME %s`, ts[0]),
+			localFoo,
+		)
 		// Just rendering the constraints loads and validates schema.
 		sqlDB.Exec(t, `SELECT * FROM pg_catalog.pg_constraint`)
 		sqlDB.Exec(t, `DROP DATABASE test`)
 
 		// Restore a couple tables, including parent but not child_pk.
 		sqlDB.Exec(t, `CREATE DATABASE test`)
-		sqlDB.Exec(t, fmt.Sprintf(`RESTORE TABLE test.circular FROM LATEST IN $1 AS OF SYSTEM TIME %s`, ts[0]), localFoo)
+		sqlDB.Exec(t,
+			fmt.Sprintf(`RESTORE TABLE test.circular FROM LATEST IN $1 AS OF SYSTEM TIME %s`, ts[0]),
+			localFoo,
+		)
 		require.Equal(t, [][]string{
 			{"test.public.circular", "CREATE TABLE public.circular (\n\tk INT8 NOT NULL,\n\tselfid INT8 NULL,\n\tCONSTRAINT circular_pkey PRIMARY KEY (k ASC),\n\tCONSTRAINT self_fk FOREIGN KEY (selfid) REFERENCES public.circular(selfid) NOT VALID,\n\tUNIQUE INDEX circular_selfid_key (selfid ASC)\n) WITH (schema_locked = true);"},
 		}, sqlDB.QueryStr(t, `SHOW CREATE TABLE test.circular`))
-		sqlDB.Exec(t, fmt.Sprintf(`RESTORE TABLE test.parent, test.child FROM LATEST IN $1 AS OF SYSTEM TIME %s `, ts[0]), localFoo)
+		sqlDB.Exec(t,
+			fmt.Sprintf(`RESTORE TABLE test.parent, test.child FROM LATEST IN $1 AS OF SYSTEM TIME %s `, ts[0]),
+			localFoo,
+		)
 		sqlDB.Exec(t, `SELECT * FROM pg_catalog.pg_constraint`)
 		sqlDB.Exec(t, `DROP DATABASE test`)
 
@@ -10850,9 +10873,18 @@ CREATE TABLE child_pk (k INT8 PRIMARY KEY REFERENCES parent);
 		sqlDB.Exec(t, `CREATE DATABASE test`)
 		for _, name := range []string{"child_pk", "child", "circular", "parent"} {
 			if name == "child" || name == "child_pk" {
-				sqlDB.ExpectErr(t, "cannot restore table.*without referenced table", fmt.Sprintf(`RESTORE TABLE test.%s FROM LATEST IN $1 AS OF SYSTEM TIME %s`, name, ts[0]), localFoo)
+				sqlDB.ExpectErr(t, "cannot restore table.*without referenced table",
+					fmt.Sprintf(`RESTORE TABLE test.%s FROM LATEST IN $1 AS OF SYSTEM TIME %s`, name, ts[0]),
+					localFoo,
+				)
 			}
-			sqlDB.Exec(t, fmt.Sprintf(`RESTORE TABLE test.%s FROM LATEST IN $1 AS OF SYSTEM TIME %s WITH skip_missing_foreign_keys`, name, ts[0]), localFoo)
+			sqlDB.Exec(t,
+				fmt.Sprintf(
+					`RESTORE TABLE test.%s FROM LATEST IN $1 AS OF SYSTEM TIME %s WITH skip_missing_foreign_keys`,
+					name, ts[0],
+				),
+				localFoo,
+			)
 		}
 		sqlDB.Exec(t, `SELECT * FROM pg_catalog.pg_constraint`)
 		sqlDB.Exec(t, `DROP DATABASE test`)

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -104,7 +104,9 @@ func TestBackupCompaction(t *testing.T) {
 			end := getTime()
 			db.Exec(t, incBackupQuery(fullCluster, collectionURI, end, noOpts))
 
-			compactionJobId := triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end)
+			compactionJobId := triggerCompaction(
+				t, db, backupStmt, getLatestFullDir(collectionURI), start, end,
+			)
 			compactionRedactedUri := getDescUri(t, db, compactionJobId)
 			require.Equal(t, fullRedactedUri, compactionRedactedUri)
 
@@ -116,8 +118,9 @@ func TestBackupCompaction(t *testing.T) {
 
 		// Ensure that additional backups were created.
 		var numBackups int
-		db.QueryRow(
-			t, fmt.Sprintf("SELECT count(DISTINCT (start_time, end_time)) FROM [%s]", showBackupQuery(collectionURI, noOpts)),
+		db.QueryRow(t,
+			fmt.Sprintf("SELECT count(DISTINCT (start_time, end_time)) FROM [%s]",
+				showBackupQuery(collectionURI, noOpts)),
 		).Scan(&numBackups)
 		require.Equal(t, 9, numBackups)
 	})
@@ -147,13 +150,17 @@ func TestBackupCompaction(t *testing.T) {
 		end := getTime()
 		db.Exec(t, incBackupQuery(fullCluster, collectionURI, end, noOpts))
 
-		jobutils.WaitForJobToSucceed(t, db, triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end))
+		jobutils.WaitForJobToSucceed(t, db,
+			triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end),
+		)
 		validateCompactedBackupForTables(t, db, collectionURI, []string{"foo", "bar", "baz"}, start, end, noOpts, noOpts, 2)
 
 		db.Exec(t, "DROP TABLE bar")
 		end = getTime()
 		db.Exec(t, incBackupQuery(fullCluster, collectionURI, end, noOpts))
-		jobutils.WaitForJobToSucceed(t, db, triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end))
+		jobutils.WaitForJobToSucceed(t, db,
+			triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end),
+		)
 
 		db.Exec(t, "DROP TABLE foo, baz")
 		db.Exec(t, restoreQuery(t, fullCluster, collectionURI, noAOST, noOpts))
@@ -183,7 +190,9 @@ func TestBackupCompaction(t *testing.T) {
 		end := getTime()
 		db.Exec(t, incBackupQuery(fullCluster, collectionURI, end, noOpts))
 
-		jobutils.WaitForJobToSucceed(t, db, triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end))
+		jobutils.WaitForJobToSucceed(t, db,
+			triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end),
+		)
 
 		var numIndexes, restoredNumIndexes int
 		db.QueryRow(t, "SELECT count(*) FROM [SHOW INDEXES FROM foo]").Scan(&numIndexes)
@@ -222,7 +231,9 @@ func TestBackupCompaction(t *testing.T) {
 		db.Exec(t, "INSERT INTO foo VALUES (6, 6)")
 		db.Exec(t, incBackupQuery(fullCluster, collectionURI, noAOST, noOpts))
 
-		jobutils.WaitForJobToSucceed(t, db, triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end))
+		jobutils.WaitForJobToSucceed(t, db,
+			triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end),
+		)
 		validateCompactedBackupForTables(t, db, collectionURI, []string{"foo"}, start, end, noOpts, noOpts, 4)
 	})
 
@@ -246,7 +257,9 @@ func TestBackupCompaction(t *testing.T) {
 		end := getTime()
 		db.Exec(t, incBackupQuery(fullCluster, collectionURI, end, noOpts))
 
-		jobutils.WaitForJobToSucceed(t, db, triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end))
+		jobutils.WaitForJobToSucceed(t, db,
+			triggerCompaction(t, db, backupStmt, getLatestFullDir(collectionURI), start, end),
+		)
 		validateCompactedBackupForTables(t, db, collectionURI, []string{"foo"}, start, end, noOpts, noOpts, 2)
 	})
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2401,7 +2401,9 @@ func indexDefFromDescriptor(
 	table catalog.TableDescriptor,
 	index catalog.Index,
 ) (string, error) {
-	tableName := tree.MakeTableNameWithSchema(tree.Name(db.GetName()), tree.Name(sc.GetName()), tree.Name(table.GetName()))
+	tableName := tree.MakeTableNameWithSchema(
+		tree.Name(db.GetName()), tree.Name(sc.GetName()), tree.Name(table.GetName()),
+	)
 	partitionStr := ""
 	fmtStr, err := catformat.IndexForDisplay(
 		ctx,

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -301,15 +301,18 @@ func cleanupTempSchemaObjects(
 					if _, ok := tblDescsByID[d.ID]; ok {
 						return nil
 					}
-					dTableDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, d.ID)
+					dTableDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).
+						WithoutNonPublic().Get().Table(ctx, d.ID)
 					if err != nil {
 						return err
 					}
-					db, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, dTableDesc.GetParentID())
+					db, err := descsCol.ByIDWithoutLeased(txn.KV()).
+						WithoutNonPublic().Get().Database(ctx, dTableDesc.GetParentID())
 					if err != nil {
 						return err
 					}
-					sc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Schema(ctx, dTableDesc.GetParentSchemaID())
+					sc, err := descsCol.ByIDWithoutLeased(txn.KV()).
+						WithoutNonPublic().Get().Schema(ctx, dTableDesc.GetParentSchemaID())
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Depends on #167200.

Collapse the `waitForSettingPropagation` function signature onto a
single line to satisfy `crlfmt`. The multi-line wrapping introduced
in #167200 is unnecessary since the signature fits within the column
limit.

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>