### PR TITLE
changefeedccl: check status history in TestChangefeedOrderingWithErrors

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9649,14 +9649,17 @@ func TestChangefeedOrderingWithErrors(t *testing.T) {
 		sqlDB.Exec(t, `UPSERT INTO foo VALUES (1, 'd')`)
 		feedJob := foo.(cdctest.EnterpriseTestFeed)
 
-		// check that running status correctly updates with retryable error
+		// Check that running status correctly updates with retryable error.
 		testutils.SucceedsSoon(t, func() error {
-			status, err := feedJob.FetchStatusMessage()
-			if err != nil {
-				return err
-			}
-			require.Regexp(t, "500 Internal Server Error", status)
-			return nil
+			var unused int
+			// If no rows are found by QueryRow, Scan will return an error (ErrNoRows)
+			return s.DB.QueryRow(`
+				SELECT 1 FROM system.job_message
+				WHERE job_id = $1
+				  AND kind = 'status'
+				  AND message LIKE '%500 Internal Server Error%'
+				LIMIT 1
+			`, feedJob.JobID()).Scan(&unused)
 		})
 
 		webhookFoo.mockSink.SetStatusCodes([]int{http.StatusOK})


### PR DESCRIPTION
Modified the test to check system.job_message history instead of current
status. This allows the test to verify that the error status was written
at some point, even if it gets overwritten by backfill status immediately.

Release note: None
Resolves: #167076