### PR TITLE
kvstorage/wag: initialize WAG sequencer on store restart

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag/store.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store.go
@@ -19,8 +19,36 @@ import (
 // assist the writes of the WAG nodes in a topologically sorted order.
 type Seq struct {
 	// index is the last allocated index into the WAG nodes sequence.
-	// TODO(pav-kv): initialize it on store restarts.
 	index atomic.Uint64
+}
+
+// Init initializes the sequencer from the last WAG node index persisted in the
+// log engine, ensuring that subsequent calls to Next return indices above all
+// existing WAG nodes. Must be called before any calls to Next, typically during
+// store startup.
+func (s *Seq) Init(ctx context.Context, logEngine storage.Reader) error {
+	prefix := keys.StoreWAGPrefix()
+	prefixEnd := prefix.PrefixEnd()
+	mi, err := logEngine.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
+		LowerBound: prefix,
+		UpperBound: prefixEnd,
+	})
+	if err != nil {
+		return err
+	}
+	defer mi.Close()
+	mi.SeekLT(storage.MakeMVCCMetadataKey(prefixEnd))
+	if ok, err := mi.Valid(); err != nil {
+		return err
+	} else if !ok {
+		return nil // no WAG nodes; index stays at 0
+	}
+	index, err := keys.DecodeWAGNodeKey(mi.UnsafeKey().Key)
+	if err != nil {
+		return err
+	}
+	s.index.Store(index)
+	return nil
 }
 
 // Next allocates the given number of consecutive WAG nodes in the sequence, and

--- a/pkg/kv/kvserver/kvstorage/wag/store_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store_test.go
@@ -119,3 +119,40 @@ func splitReplica(
 func writeStateMachine(w storage.Writer, k, v string) error {
 	return w.PutUnversioned(roachpb.Key(k), []byte(v))
 }
+
+func TestSeqInit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	t.Run("empty log engine", func(t *testing.T) {
+		eng := storage.NewDefaultInMemForTesting()
+		defer eng.Close()
+
+		var seq Seq
+		require.NoError(t, seq.Init(ctx, eng))
+		require.Equal(t, uint64(1), seq.Next(1))
+	})
+
+	t.Run("resumes after last node", func(t *testing.T) {
+		eng := storage.NewDefaultInMemForTesting()
+		defer eng.Close()
+
+		// Write 3 WAG nodes with a gap in the sequence.
+		id := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+		rhsID := roachpb.FullReplicaID{RangeID: 2, ReplicaID: 1}
+		s := store{eng: eng}
+		b := eng.NewWriteBatch()
+		require.NoError(t, createReplica(&s, b, id))
+		require.NoError(t, initReplica(&s, b, id, 10))
+		s.seq.Next(3) // skip indices 3-5
+		require.NoError(t, splitReplica(&s, b, id, rhsID, 20))
+		require.NoError(t, b.Commit(false /* sync */))
+
+		// Init a fresh sequencer from the log engine.
+		var seq2 Seq
+		require.NoError(t, seq2.Init(ctx, eng))
+		// Next allocation should be after the last persisted index (6).
+		require.Equal(t, uint64(7), seq2.Next(1))
+	})
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2293,6 +2293,14 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	now := s.cfg.Clock.Now()
 	s.startedAt = now.WallTime
 
+	// Initialize the WAG sequencer from the last persisted node index so that
+	// new WAG nodes are written after existing ones.
+	if s.EnginesSeparated() {
+		if err := s.wagSeq.Init(ctx, s.LogEngine()); err != nil {
+			return err
+		}
+	}
+
 	// Iterate over all range descriptors, ignoring uncommitted versions
 	// (consistent=false). Uncommitted intents which have been abandoned
 	// due to a split crashing halfway will simply be resolved on the


### PR DESCRIPTION
The WAG sequencer allocates consecutive indices for writing WAG nodes.
Previously it started at 0 on every store restart, which means new WAG
nodes could overwrite existing ones in the log engine.

Add Seq.Init which seeks to the last persisted WAG node index in the log
engine and seeds the sequencer, so that new nodes are written after
existing ones. Call it in Store.Start before LoadAndReconcileReplicas.

Resolves: #167291
Epic: CRDB-55218

Release note: None