### PR TITLE
wag: rm unused count parameter from Seq.Next

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag/store.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store.go
@@ -51,10 +51,8 @@ func (s *Seq) Init(ctx context.Context, logEngine storage.Reader) error {
 	return nil
 }
 
-// Next allocates the given number of consecutive WAG nodes in the sequence, and
-// returns the index of the first allocated node. The caller can subsequently
-// use indices [Next, Next+count) for writing WAG nodes, and must not use
-// indices outside this span.
+// Next allocates the next WAG node sequence number. The caller can subsequently
+// use this index for writing a WAG node, and must not use any other index.
 //
 // The caller must make sure that conflicting writers call Next and do the
 // corresponding writes according to the topological ordering of these
@@ -62,8 +60,8 @@ func (s *Seq) Init(ctx context.Context, logEngine storage.Reader) error {
 // ordered. Independent / concurrent writers can call Next and perform the
 // corresponding writes in any order (e.g. different ranges can write their
 // events concurrently).
-func (s *Seq) Next(count uint64) uint64 {
-	return s.index.Add(count) - count + 1
+func (s *Seq) Next() uint64 {
+	return s.index.Add(1)
 }
 
 // Write puts the WAG node under the specific sequence number into the given

--- a/pkg/kv/kvserver/kvstorage/wag/store_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store_test.go
@@ -49,7 +49,7 @@ func TestWrite(t *testing.T) {
 	write("create", func(w storage.Writer) error { return createReplica(&s, w, id) })
 	// Intentionally introduce a gap in the sequence. We will later make sure that
 	// the iterator correctly skips over this gap.
-	s.seq.Next(1)
+	s.seq.Next()
 	write("init", func(w storage.Writer) error { return initReplica(&s, w, id, 10) })
 	write("split", func(w storage.Writer) error { return splitReplica(&s, w, id, rhsID, 200) })
 
@@ -125,7 +125,7 @@ func createReplica(s *store, w storage.Writer, id roachpb.FullReplicaID) error {
 	if err := writeStateMachine(b, "state-machine-key", "state"); err != nil {
 		return err
 	}
-	return Write(w, s.seq.Next(1), wagpb.Node{
+	return Write(w, s.seq.Next(), wagpb.Node{
 		Events: []wagpb.Event{
 			{Addr: wagpb.MakeAddr(id, 0), Type: wagpb.EventCreate},
 		},
@@ -134,7 +134,7 @@ func createReplica(s *store, w storage.Writer, id roachpb.FullReplicaID) error {
 }
 
 func initReplica(s *store, w storage.Writer, id roachpb.FullReplicaID, index uint64) error {
-	return Write(w, s.seq.Next(1), wagpb.Node{
+	return Write(w, s.seq.Next(), wagpb.Node{
 		Events: []wagpb.Event{
 			{Addr: wagpb.MakeAddr(id, kvpb.RaftIndex(index)), Type: wagpb.EventInit},
 		},
@@ -154,7 +154,7 @@ func splitReplica(
 	} else if err := writeStateMachine(b, "rhs-key", "rhs-state"); err != nil {
 		return err
 	}
-	return Write(w, s.seq.Next(1), wagpb.Node{
+	return Write(w, s.seq.Next(), wagpb.Node{
 		Events: []wagpb.Event{
 			{Addr: wagpb.MakeAddr(rhsID, 10), Type: wagpb.EventInit},
 			{Addr: wagpb.MakeAddr(lhsID, kvpb.RaftIndex(index)), Type: wagpb.EventSplit},
@@ -178,7 +178,7 @@ func TestSeqInit(t *testing.T) {
 
 		var seq Seq
 		require.NoError(t, seq.Init(ctx, eng))
-		require.Equal(t, uint64(1), seq.Next(1))
+		require.Equal(t, uint64(1), seq.Next())
 	})
 
 	t.Run("resumes after last node", func(t *testing.T) {
@@ -192,14 +192,14 @@ func TestSeqInit(t *testing.T) {
 		b := eng.NewWriteBatch()
 		require.NoError(t, createReplica(&s, b, id))
 		require.NoError(t, initReplica(&s, b, id, 10))
-		s.seq.Next(3) // skip indices 3-5
+		s.seq.Next() // skip index 3
 		require.NoError(t, splitReplica(&s, b, id, rhsID, 20))
 		require.NoError(t, b.Commit(false /* sync */))
 
 		// Init a fresh sequencer from the log engine.
 		var seq2 Seq
 		require.NoError(t, seq2.Init(ctx, eng))
-		// Next allocation should be after the last persisted index (6).
-		require.Equal(t, uint64(7), seq2.Next(1))
+		// Next allocation should be after the last persisted index (5).
+		require.Equal(t, uint64(5), seq2.Next())
 	})
 }

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -60,7 +60,7 @@ func (w *Writer) Flush(raftBatch storage.Writer, stateBatchRepr []byte) error {
 	if w.disabled() || len(w.events) == 0 {
 		return nil
 	}
-	return Write(raftBatch, w.seq.Next(1), wagpb.Node{
+	return Write(raftBatch, w.seq.Next(), wagpb.Node{
 		Events:   w.events,
 		Mutation: wagpb.Mutation{Batch: stateBatchRepr},
 	})

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -131,7 +131,7 @@ func syncAppliedState(r *Replica) error {
 		// node committing to its removal.
 		return nil
 	}
-	if err := wag.Write(b, s.wagSeq.Next(1), wagpb.Node{
+	if err := wag.Write(b, s.wagSeq.Next(), wagpb.Node{
 		Events: []wagpb.Event{{
 			Addr: wagpb.MakeAddr(r.ID(), r.shMu.state.RaftAppliedIndex),
 			Type: wagpb.EventApply,


### PR DESCRIPTION
Epic: none
Release note: None