### PR TITLE
liveness: add liveness.uncached_scans metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -17686,6 +17686,15 @@ layers:
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
       owner: cockroachdb/kv
+    - name: liveness.uncached_scans
+      exported_name: liveness_uncached_scans
+      description: Number of non-cached scans of the node liveness range
+      y_axis_label: Scans
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      owner: cockroachdb/kv
     - name: lockbytes
       exported_name: lockbytes
       description: Number of bytes taken up by replicated lock key-values (shared and exclusive strength, not intent strength)

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -423,6 +423,7 @@ owners:
   liveness_heartbeatsinflight: cockroachdb/kv
   liveness_heartbeatsuccesses: cockroachdb/kv
   liveness_livenodes: cockroachdb/kv
+  liveness_uncached_scans: cockroachdb/kv
   lockbytes: cockroachdb/kv
   lockcount: cockroachdb/kv
   log_buffered_messages_dropped: cockroachdb/obs-prs

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -209,6 +209,12 @@ var (
 		Category:    metric.Metadata_REPLICATION,
 		HowToUse:    "If this metric exceeds 1 second, it is a sign of cluster instability.",
 	}
+	metaUncachedScans = metric.Metadata{
+		Name:        "liveness.uncached_scans",
+		Help:        "Number of non-cached scans of the node liveness range",
+		Measurement: "Scans",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // Metrics holds metrics for use with node liveness activity.
@@ -219,6 +225,7 @@ type Metrics struct {
 	HeartbeatFailures  telemetry.CounterWithMetric
 	EpochIncrements    telemetry.CounterWithMetric
 	HeartbeatLatency   metric.IHistogram
+	UncachedScans      *metric.Counter
 }
 
 // IsLiveCallback is invoked when a node's IsLive state changes to true.
@@ -366,6 +373,7 @@ func NewNodeLiveness(opts NodeLivenessOptions) *NodeLiveness {
 			Duration:     opts.HistogramWindowInterval,
 			BucketConfig: metric.IOLatencyBuckets,
 		}),
+		UncachedScans: metric.NewCounter(metaUncachedScans),
 	}
 	nl.cache.setLivenessChangedFn(nl.cacheUpdated)
 	nl.heartbeatToken <- struct{}{}
@@ -924,6 +932,7 @@ func (nl *NodeLiveness) ScanAllNodeVitalityFromCache() livenesspb.NodeVitalityMa
 func (nl *NodeLiveness) ScanNodeVitalityFromKV(
 	ctx context.Context,
 ) (livenesspb.NodeVitalityMap, error) {
+	nl.metrics.UncachedScans.Inc(1)
 	records, err := nl.storage.Scan(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/kv/kvserver/liveness/liveness_test.go
+++ b/pkg/kv/kvserver/liveness/liveness_test.go
@@ -450,6 +450,37 @@ func (s *mockStorage) Scan(ctx context.Context) ([]Record, error) {
 	return []Record{mockRecord(2), mockRecord(3)}, nil
 }
 
+func TestUncachedScansMetric(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	st := cluster.MakeTestingClusterSettings()
+	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(1, 0)))
+	nl := NewNodeLiveness(NodeLivenessOptions{
+		AmbientCtx:              log.MakeTestingAmbientCtxWithNewTracer(),
+		Stopper:                 stopper,
+		Cache:                   NewCache(&mockGossip{}, clock, st, nil),
+		Clock:                   clock,
+		Storage:                 &mockStorage{},
+		LivenessThreshold:       24 * time.Hour,
+		RenewalDuration:         23 * time.Hour,
+		HistogramWindowInterval: base.DefaultHistogramWindowInterval(),
+	})
+
+	require.Equal(t, int64(0), nl.Metrics().UncachedScans.Count())
+
+	_, err := nl.ScanNodeVitalityFromKV(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), nl.Metrics().UncachedScans.Count())
+
+	_, err = nl.ScanNodeVitalityFromKV(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), nl.Metrics().UncachedScans.Count())
+}
+
 func TestNodeLivenessIsLiveCallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1781,6 +1781,7 @@ liveness_heartbeatlatency_sum: liveness.heartbeatlatency.sum
 liveness_heartbeatsinflight: liveness.heartbeatsinflight
 liveness_heartbeatsuccesses: liveness.heartbeatsuccesses
 liveness_livenodes: liveness.livenodes
+liveness_uncached_scans: liveness.uncached_scans
 lockbytes: lockbytes
 lockcount: lockcount
 log_buffered_messages_dropped: log.buffered.messages.dropped


### PR DESCRIPTION
## Summary

Add a counter metric (`liveness.uncached_scans`) that tracks non-cached
scans of the node liveness range via `ScanNodeVitalityFromKV`.

Epic: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)