### PR TITLE
release-26.1: sql: fix "rows written" metrics

### DIFF
--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -214,6 +215,7 @@ func TestStatementMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	rng, _ := randutil.NewTestRand()
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 	runner := sqlutils.MakeSQLRunner(sqlDB)
@@ -256,8 +258,14 @@ func TestStatementMetrics(t *testing.T) {
 		// Expect to write 5 rows - update primary index, delete and insert two
 		// rows in "y" secondary index.
 		{query: `UPDATE db.t SET y = 100 WHERE y >= 10 AND y <= 20`, rowsRead: 4, indexRowsWritten: 6},
+		// Same scenario as above but the UPDATE is executed in a CTE.
 		{
-			query:            `UPSERT INTO db.t VALUES (6, 60, ARRAY['date'], '[100, 110]')`,
+			query:            `WITH cte (c) AS (UPDATE db.t SET y = 100 WHERE y >= 50 AND y <= 60 RETURNING x) SELECT c FROM cte`,
+			rowsRead:         4,
+			indexRowsWritten: 6,
+		},
+		{
+			query:            `UPSERT INTO db.t VALUES (6, 100, ARRAY['date'], '[100, 110]')`,
 			rowsRead:         1,
 			indexRowsWritten: 3,
 		},
@@ -289,6 +297,13 @@ func TestStatementMetrics(t *testing.T) {
 			runner.Exec(t, `INSERT INTO db.t VALUES (1, 10, ARRAY['apple', 'orange'], '[1, 2]')`)
 			runner.Exec(t, `INSERT INTO db.t VALUES (2, 20, ARRAY['banana'], '[3, 4]')`)
 			runner.Exec(t, `INSERT INTO db.t VALUES (3, 30, ARRAY['apple', 'pear', 'mango'], '[5, 6]')`)
+
+			// Randomize whether we disable txn sampling or not (if it's
+			// disabled, then we don't collect execution stats, which could have
+			// an impact on the metrics' updates).
+			if rng.Float64() < 0.5 {
+				runner.Exec(t, `SET CLUSTER SETTING sql.txn_stats.sample_rate = 0`)
+			}
 
 			for _, tc := range testCases {
 				t.Run(tc.query, func(t *testing.T) {

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -253,19 +253,42 @@ func (p *planNodeToRowSource) forwardMetadata(metadata *execinfrapb.ProducerMeta
 }
 
 func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetadata {
+	if !p.InternalClose() {
+		return nil
+	}
 	var meta []execinfrapb.ProducerMetadata
-	if p.InternalClose() {
-		// Check if we're wrapping a mutation and emit the rows written metric
-		// if so.
-		if m, ok := p.node.(mutationPlanNode); ok {
-			metrics := execinfrapb.GetMetricsMeta()
-			metrics.RowsWritten = m.rowsWritten()
-			metrics.IndexRowsWritten = m.indexRowsWritten()
-			metrics.IndexBytesWritten = m.indexBytesWritten()
-			metrics.KVCPUTime = m.kvCPUTime()
-			meta = []execinfrapb.ProducerMetadata{{Metrics: metrics}}
+	// Check if we're wrapping a mutation and emit the rows written metric if
+	// so.
+	maybeEmitMeta := func(node planNode) {
+		m, ok := node.(mutationPlanNode)
+		if !ok {
+			return
+		}
+		metrics := execinfrapb.GetMetricsMeta()
+		metrics.RowsWritten = m.rowsWritten()
+		metrics.IndexRowsWritten = m.indexRowsWritten()
+		metrics.IndexBytesWritten = m.indexBytesWritten()
+		metrics.KVCPUTime = m.kvCPUTime()
+		meta = append(meta, execinfrapb.ProducerMetadata{Metrics: metrics})
+	}
+	// Note that we could be wrapping multiple planNodes at once, so we have to
+	// traverse the tree until we either reach the first DistSQL-plannable
+	// planNode or the leaf.
+	var visitNode func(node planNode)
+	visitNode = func(node planNode) {
+		if node == p.firstNotWrapped {
+			return
+		}
+		maybeEmitMeta(node)
+		for i, n := 0, node.InputCount(); i < n; i++ {
+			child, err := node.Input(i)
+			if err != nil {
+				continue
+			}
+			visitNode(child)
 		}
 	}
+	visitNode(p.node)
 	return meta
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #167360 on behalf of @yuzefovich.

----

This commit fixes a bug that was introduced long time ago in 03c09a32fa11f5927253669aaba678c7f7c11352. In particular, in that change we began tracking "rows written" for the purposes of the guardrails, and later this information was also added into statement statistics as well as extended to some metrics.

The bug was that we only check the first wrapped `planNode` for being a `mutationPlanNode`, but it's actually possible for a single `planNodeToRowSource` wrapper to wrap multiple `planNode`s at once. For example, if we have a mutation in the CTE, then we could have `bufferNode -> insertNode -> valuesNode`, all handled by a single wrapper. Previously, we would only check `bufferNode`, and since it's not a mutation planNode, we'd emit no "written" metrics.

This commit fixes the issue by traversing the planNode tree until we either reach the first not-wrapped planNode (i.e. it's handled by DistSQL separately) or reach the leaf nodes.

Note that this bug was further hidden by the fact that if we collect execution stats (which we do for stmt bundles and when the txn is sampled), then we wrap each planNode separately, so in those scenarios the behavior was correct.

Epic: None

Release note (bug fix): Previously, if a mutation was executed in a subquery (e.g. as a CTE), the "rows written" metrics like `sql.statements.index_rows_written.count` and
`sql.statements.index_bytes_written.count` might not be incremented correctly. This is now fixed.

----

Release justification: low-risk observability bug fix.