### PR TITLE
release-25.2.16-rc: release-25.2: crosscluster: fix 24.3->25.2 compatibility bug

### DIFF
--- a/pkg/crosscluster/producer/BUILD.bazel
+++ b/pkg/crosscluster/producer/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/externalcatalog",
+        "//pkg/sql/catalog/externalcatalog/externalpb",
         "//pkg/sql/catalog/resolver",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/externalcatalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/externalcatalog/externalpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
@@ -156,7 +157,22 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 		SourceClusterID:      r.evalCtx.ClusterID,
 		ReplicationStartTime: replicationStartTime,
 		ExternalCatalog:      externalCatalog,
+		TableDescriptors:     tableDescriptorMapFromCatalog(externalCatalog, req.TableNames),
+		TypeDescriptors:      externalCatalog.Types,
 	}, nil
+}
+
+// tableDescriptorMapFromCatalog builds the deprecated map[string]TableDescriptor
+// (proto field 7) so that 24.3 consumers can read table descriptors. The map
+// key is the table name from the request, matching the 24.3 wire format.
+func tableDescriptorMapFromCatalog(
+	catalog externalpb.ExternalCatalog, tableNames []string,
+) map[string]descpb.TableDescriptor {
+	m := make(map[string]descpb.TableDescriptor, len(catalog.Tables))
+	for i, td := range catalog.Tables {
+		m[tableNames[i]] = td
+	}
+	return m
 }
 
 func maybeAuthorizeReverseStream(

--- a/pkg/crosscluster/streamclient/partitioned_stream_client.go
+++ b/pkg/crosscluster/streamclient/partitioned_stream_client.go
@@ -396,6 +396,16 @@ func (p *partitionedStreamClient) CreateForTables(
 	if err := protoutil.Unmarshal(specBytes, spec); err != nil {
 		return nil, err
 	}
+	// Backward compatibility: if receiving from a 24.3 source that only
+	// populates the deprecated map-typed field 7, construct ExternalCatalog
+	// from it. LDR jobs always have tables, so an empty ExternalCatalog.Tables
+	// means the source is a 24.3 node that doesn't know about ExternalCatalog.
+	if len(spec.ExternalCatalog.Tables) == 0 && len(spec.TableDescriptors) > 0 {
+		for _, name := range req.TableNames {
+			spec.ExternalCatalog.Tables = append(spec.ExternalCatalog.Tables, spec.TableDescriptors[name])
+		}
+		spec.ExternalCatalog.Types = spec.TypeDescriptors
+	}
 	return spec, nil
 }
 func (p *partitionedStreamClient) ExecStatement(

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -46,8 +46,11 @@ message ReplicationProducerSpec {
     (gogoproto.customname) = "SourceTenantID"
   ];
   
-  reserved 7;
-  reserved 8;
+  // Deprecated in favor of external_catalog (field 9). These fields exist only
+  // for backward compatibility with 24.3 nodes. Delete these fields in versions
+  // that do not support upgrades from 24.3.
+  map<string, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 7 [(gogoproto.nullable) = false];
+  repeated cockroach.sql.sqlbase.TypeDescriptor type_descriptors = 8 [(gogoproto.nullable) = false];
   sql.catalog.externalcatalog.externalpb.ExternalCatalog external_catalog = 9 [(gogoproto.nullable) = false];
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #167161.

/cc @cockroachdb/release

---

PR https://github.com/cockroachdb/cockroach/pull/136927 refactored the protobuf used when creating LDR jobs. In the
process, it broke mixed-version compatibility with 24.3.

Release note: fixes a compatibility bug introduced in 25.2 that causes
creating LDR jobs in mixed 24.3/25.2 deployments to fail.
Fixes: https://github.com/cockroachdb/cockroach/issues/167141
Fixes: ENGREQ-378

Release justification: This fixes a bug identified in a customer support issue. Creating LDR jobs in mixed 24.3/25.2 deployments fails with an error. There is no work around.