### PR TITLE
sql/inspect: bump shard count to address timeout

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -99,7 +99,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "large"},
         "//conditions:default": {"test.Pool": "default"},
     }),
-    shard_count = 4,
+    shard_count = 8,
     deps = [
         "//pkg/base",
         "//pkg/jobs",


### PR DESCRIPTION
Sharing the shard with the slow
`TestDetectIndexConsistencyErrors` leaves too
little time for other tests to complete.

Epic: none
Fixes: #166845

Release note: None
