### PR TITLE
release-26.2: stats: fix rare flake in a new test

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -854,8 +854,6 @@ func TestReschedulingOnConcurrentCreateStatsError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "the test is too sensitive to overload")
-
 	defer func(oldRefreshInterval, oldAsOf time.Duration) {
 		stats.DefaultRefreshInterval = oldRefreshInterval
 		stats.DefaultAsOfTime = oldAsOf
@@ -901,17 +899,13 @@ func TestReschedulingOnConcurrentCreateStatsError(t *testing.T) {
 	// Lower the concurrency limit to allow at most one auto full stats job.
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_full_concurrency_limit = 1`)
 
-	// Create two tables. Notably auto stats are enabled on 't2'.
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
-	sqlDB.Exec(t, `CREATE TABLE d.t2 (x INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = true)`)
 	sqlDB.Exec(t, `INSERT INTO d.t SELECT generate_series(1,1000)`)
 
-	descT2 := desctestutils.TestingGetTableDescriptor(s.DB(), s.Codec(), "d", "public", "t2")
-
 	// Block the next stats collection on the table 't'.
-	var tID, t2ID descpb.ID
-	sqlDB.QueryRow(t, `SELECT 'd.t'::regclass::int, 'd.t2'::regclass::int`).Scan(&tID, &t2ID)
+	var tID descpb.ID
+	sqlDB.QueryRow(t, `SELECT 'd.t'::regclass::int`).Scan(&tID)
 	setTableID(tID)
 
 	// Start an auto full stat job and wait until it's done one scan. This will
@@ -926,11 +920,22 @@ func TestReschedulingOnConcurrentCreateStatsError(t *testing.T) {
 	select {
 	case allowRequest <- struct{}{}:
 	case err := <-backgroundAutoFullStatErrCh:
-		t.Fatal(err)
+		if err != nil {
+			t.Fatal(err)
+		} else {
+			t.Fatal("query unexpectedly finished")
+		}
 	}
 
-	// Don't block the other stats jobs.
+	// Don't block other stats jobs.
 	setTableID(descpb.InvalidID)
+
+	// Now create the second table on which we'll test the behavior of the auto
+	// stats refresher.
+	sqlDB.Exec(t, `CREATE TABLE d.t2 (x INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = true)`)
+	var t2ID descpb.ID
+	sqlDB.QueryRow(t, `SELECT 'd.t2'::regclass::int`).Scan(&t2ID)
+	descT2 := desctestutils.TestingGetTableDescriptor(s.DB(), s.Codec(), "d", "public", "t2")
 
 	// This should trigger a refresh on 't2' which should hit the
 	// ConcurrentCreateStatsError (due to global concurrency limit being


### PR DESCRIPTION
Backport 1/1 commits from #167448 on behalf of @yuzefovich.

----

In the recently added `TestReschedulingOnConcurrentCreateStatsError` we want to have manually-simulated auto stats job be blocked via the testing filter on table `t` while we test the behavior of auto stats refresher on table `t2`. Previously, we created two tables right away, before running the blocked auto stats on `t`, which made it possible for "true" auto stats on `t2` to be issued by the refresher. Given we reduced the concurrency limit to 1, our manually-issued auto stats on `t` would hit the ConcurrentCreateStatsError which would be swallowed, skipping the actual execution.

This commit prevents this flake by creating a single table at first, with auto stats disabled, so that we can guarantee to run our background stats job that will blocked.

Fixes: #167385.
Release note: None

----

Release justification: test-only change.