### PR TITLE
util/metric: add benchmark comparing classic vs native histograms

### DIFF
--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -1059,6 +1059,153 @@ func BenchmarkHistogramRecordValue(b *testing.B) {
 	})
 }
 
+// BenchmarkClassicVsNativeHistogram compares the performance of classic
+// Prometheus histograms against native (exponential) histograms for both
+// observation recording and quantile computation.
+func BenchmarkClassicVsNativeHistogram(b *testing.B) {
+	bucketConfigs := []struct {
+		name   string
+		config staticBucketConfig
+	}{
+		{"IOLatency", IOLatencyBuckets},
+		{"Count1K", Count1KBuckets},
+	}
+
+	for _, bc := range bucketConfigs {
+		b.Run(bc.name, func(b *testing.B) {
+			makeClassic := func() IHistogram {
+				return NewHistogram(HistogramOptions{
+					Metadata:     Metadata{Name: "classic"},
+					Duration:     0,
+					BucketConfig: bc.config,
+					Mode:         HistogramModePrometheus,
+				})
+			}
+			makeNative := func(bucketFactor float64) IHistogram {
+				prevEnabled := nativeHistogramsEnabled
+				prevFactor := nativeHistogramsBucketFactor
+				nativeHistogramsEnabled = true
+				nativeHistogramsBucketFactor = bucketFactor
+				defer func() {
+					nativeHistogramsEnabled = prevEnabled
+					nativeHistogramsBucketFactor = prevFactor
+				}()
+				return NewHistogram(HistogramOptions{
+					Metadata:     Metadata{Name: "native"},
+					Duration:     0,
+					BucketConfig: bc.config,
+					Mode:         HistogramModePrometheus,
+				})
+			}
+			// Compute the classic growth factor so we can match it for the
+			// "native-matched" variant.
+			classicGrowthFactor := math.Pow(
+				bc.config.max/bc.config.min, 1.0/float64(bc.config.count-1),
+			)
+
+			// Benchmark Observe: sequential
+			b.Run("Observe/classic", func(b *testing.B) {
+				h := makeClassic()
+				r, _ := randutil.NewTestRand()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+				}
+			})
+			b.Run("Observe/native-fine", func(b *testing.B) {
+				h := makeNative(1.1)
+				r, _ := randutil.NewTestRand()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+				}
+			})
+			b.Run("Observe/native-matched", func(b *testing.B) {
+				h := makeNative(classicGrowthFactor)
+				r, _ := randutil.NewTestRand()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+				}
+			})
+
+			// Benchmark Observe: parallel (contended)
+			b.Run("ObserveParallel/classic", func(b *testing.B) {
+				h := makeClassic()
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					r, _ := randutil.NewTestRand()
+					for pb.Next() {
+						h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+					}
+				})
+			})
+			b.Run("ObserveParallel/native-fine", func(b *testing.B) {
+				h := makeNative(1.1)
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					r, _ := randutil.NewTestRand()
+					for pb.Next() {
+						h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+					}
+				})
+			})
+			b.Run("ObserveParallel/native-matched", func(b *testing.B) {
+				h := makeNative(classicGrowthFactor)
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					r, _ := randutil.NewTestRand()
+					for pb.Next() {
+						h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+					}
+				})
+			})
+
+			// Benchmark quantile computation (snapshot + ValueAtQuantile).
+			// Pre-populate with 10k observations to simulate realistic state.
+			seedHistogram := func(h IHistogram) {
+				r, _ := randutil.NewTestRand()
+				for i := 0; i < 10000; i++ {
+					h.RecordValue(int64(randutil.RandIntInRange(r, int(bc.config.min), int(bc.config.max))))
+				}
+			}
+			b.Run("Quantile/classic", func(b *testing.B) {
+				h := makeClassic()
+				seedHistogram(h)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					snap := MakeHistogramSnapshot(h.ToPrometheusMetric().Histogram)
+					snap.ValueAtQuantile(50)
+					snap.ValueAtQuantile(99)
+					snap.ValueAtQuantile(99.9)
+				}
+			})
+			b.Run("Quantile/native-fine", func(b *testing.B) {
+				h := makeNative(1.1)
+				seedHistogram(h)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					snap := MakeHistogramSnapshot(h.ToPrometheusMetric().Histogram)
+					snap.ValueAtQuantile(50)
+					snap.ValueAtQuantile(99)
+					snap.ValueAtQuantile(99.9)
+				}
+			})
+			b.Run("Quantile/native-matched", func(b *testing.B) {
+				h := makeNative(classicGrowthFactor)
+				seedHistogram(h)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					snap := MakeHistogramSnapshot(h.ToPrometheusMetric().Histogram)
+					snap.ValueAtQuantile(50)
+					snap.ValueAtQuantile(99)
+					snap.ValueAtQuantile(99.9)
+				}
+			})
+		})
+	}
+}
+
 func TestMetadataGetLabels(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Summary

- Adds `BenchmarkClassicVsNativeHistogram` comparing classic Prometheus histograms against native (exponential) histograms across sequential observation, parallel observation, and quantile computation.
- Tests two bucket configs (IOLatency, Count1K) with three variants: classic, native-fine (factor=1.1), and native-matched (factor matching classic growth factor) to isolate whether the ~2x overhead is from bucket count or the underlying `sync.Map` data structure.
- Results show the overhead is a fixed cost of `sync.Map` vs `[]uint64` — matching the growth factor does not close the gap.

### Benchmark Results (Apple M3 Pro, arm64)

| Scenario | Classic | Native-fine (1.1) | Native-matched |
|----------|---------|-------------------|----------------|
| **Observe (sequential)** | ~31 ns/op | ~65 ns/op (2.1x) | ~64 ns/op (2.1x) |
| **Observe (parallel, 11 goroutines)** | ~315 ns/op | ~284 ns/op (0.9x) | ~289 ns/op (0.9x) |
| **Quantile (p50/p99/p99.9)** | ~2.3 us/op | ~4.5 us/op (2.0x) | ~4.7 us/op (2.0x) |

Epic: none