### PR TITLE
sql: fix TestTrace flake with DRPC-enabled tenants

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -76,6 +76,7 @@ func TestTrace(t *testing.T) {
 	drpcOptionalSpans := []string{
 		"/cockroach.roachpb.KVBatch/Batch",
 		"/cockroach.roachpb.KVBatch/BatchStream",
+		"/cockroach.roachpb.TenantService/RangeLookup",
 	}
 	commonExpSpans := []string{
 		"session recording",


### PR DESCRIPTION
Add `/cockroach.roachpb.TenantService/RangeLookup` to the DRPC optional spans list. Since e0582ec started propagating the DRPC setting to external tenants, RangeLookup spans use the `TenantService` service name instead of `Internal`, which wasn't being filtered.

Fixes #167119
Epic: none
Release note: None