### PR TITLE
blob: removes race condition between ctx cancellation and stream close

### DIFF
--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -124,11 +124,15 @@ func (c *remoteClient) readFileWithFlowControl(
 }
 
 type streamWriter struct {
+	ctx context.Context
 	s   blobspb.RPCBlob_PutStreamClient
 	buf blobspb.StreamChunk
 }
 
 func (w *streamWriter) Write(p []byte) (int, error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
 	n := 0
 	for len(p) > 0 {
 		l := copy(w.buf.Payload[:cap(w.buf.Payload)], p)
@@ -145,6 +149,9 @@ func (w *streamWriter) Write(p []byte) (int, error) {
 }
 
 func (w *streamWriter) Close() error {
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
 	_, err := w.s.CloseAndRecv()
 	return err
 }
@@ -156,7 +163,7 @@ func (c *remoteClient) Writer(ctx context.Context, file string) (io.WriteCloser,
 		return nil, err
 	}
 	buf := make([]byte, 0, ChunkSize)
-	return &streamWriter{s: stream, buf: blobspb.StreamChunk{Payload: buf}}, nil
+	return &streamWriter{ctx: ctx, s: stream, buf: blobspb.StreamChunk{Payload: buf}}, nil
 }
 
 func (c *remoteClient) List(ctx context.Context, pattern string) ([]string, error) {


### PR DESCRIPTION
Previously, our remote local storage writer would always send a half-close and wait for a response when `Close` was called, even in the event of a context cancellation. This resulted in a race condition where either the context cancellation or `Close` could be surfaced to the RPC server first. If the former arrived first, the server would `Recv` a non-`EOF` error, indicating a failed write and would cleanup the file. If the latter arrived first, the server would see an `EOF` error, indicating a successful write and the file would be preserved.

As both a context cancellation and a `SendClose` will cleanup the connection, this commit teaches the remote writer to only `SendClose` if the context has not been canceled.

Fixes: #167121

Release note: None