### PR TITLE
sql: propagate lock_timeout to insert fast path FK checks

### DIFF
--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -383,6 +383,11 @@ func (n *insertFastPathNode) runFKUniqChecks(params runParams) error {
 
 	// Run the combined uniqueness and FK checks batch.
 	ba := n.run.uniqBatch.ShallowCopy()
+	// Copy the locking-related header fields from the FK batch so that the
+	// combined batch honors lock_timeout and deadlock_timeout for FK checks.
+	ba.Header.WaitPolicy = n.run.fkBatch.Header.WaitPolicy
+	ba.Header.LockTimeout = n.run.fkBatch.Header.LockTimeout
+	ba.Header.DeadlockTimeout = n.run.fkBatch.Header.DeadlockTimeout
 	log.VEventf(params.ctx, 2, "fk / uniqueness check: sending a batch with %d requests", len(ba.Requests))
 	br, err := params.p.txn.Send(params.ctx, ba)
 	if err != nil {
@@ -436,6 +441,8 @@ func (n *insertFastPathNode) startExec(params runParams) error {
 		maxSpans := len(n.run.fkChecks) * len(n.input)
 		// Any FK checks using locking should have lock wait policy BLOCK.
 		n.run.fkBatch.Header.WaitPolicy = lock.WaitPolicy_Block
+		n.run.fkBatch.Header.LockTimeout = params.SessionData().LockTimeout
+		n.run.fkBatch.Header.DeadlockTimeout = params.SessionData().DeadlockTimeout
 		n.run.fkBatch.Requests = make([]kvpb.RequestUnion, 0, maxSpans)
 		n.run.fkSpanInfo = make([]insertFastPathFKUniqSpanInfo, 0, maxSpans)
 		if len(n.input) > 1 {

--- a/pkg/sql/logictest/testdata/logic_test/lock_timeout
+++ b/pkg/sql/logictest/testdata/logic_test/lock_timeout
@@ -134,3 +134,52 @@ DELETE FROM t WHERE v = 9
 onlyif config weak-iso-level-configs
 statement count 0
 DELETE FROM t WHERE v = 9
+
+# Verify that lock_timeout is honored by insert fast path FK checks. The insert
+# fast path performs FK existence checks in a separate KV batch that previously
+# did not propagate lock_timeout from the session, causing indefinite blocking.
+
+user root
+
+statement ok
+COMMIT
+
+statement ok
+CREATE TABLE parent_lt (p INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE child_lt (c INT PRIMARY KEY, p INT REFERENCES parent_lt (p))
+
+statement ok
+GRANT ALL ON TABLE parent_lt TO testuser
+
+statement ok
+GRANT ALL ON TABLE child_lt TO testuser
+
+statement ok
+INSERT INTO parent_lt VALUES (1)
+
+statement ok
+BEGIN; UPDATE parent_lt SET p = 1 WHERE p = 1
+
+user testuser
+
+statement ok
+SET lock_timeout = '1ms';
+SET enable_implicit_fk_locking_for_serializable = on;
+SET enable_shared_locking_for_serializable = on;
+SET enable_durable_locking_for_serializable = on
+
+statement error conflicting locks.*reason=lock_timeout
+INSERT INTO child_lt VALUES (1, 1)
+
+statement ok
+RESET lock_timeout;
+RESET enable_implicit_fk_locking_for_serializable;
+RESET enable_shared_locking_for_serializable;
+RESET enable_durable_locking_for_serializable
+
+user root
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Previously, the insert fast path did not propagate `lock_timeout` or
`deadlock_timeout` from the session to the FK check batch header. This
meant that when FK checks using locking (e.g. with
`enable_implicit_fk_locking_for_serializable`) encountered a conflicting
lock, they would block indefinitely regardless of the session's
`lock_timeout` setting.

Every other code path that sends locking KV requests (`tableWriterBase`,
`delete_range`, `row.Fetcher`, rowexec joiners) properly propagates these
timeouts. The insert fast path was the only outlier.

This was the root cause of flaky test timeouts in
`TestCCLLogic_fk_read_committed/fk_cascade_race_150282`, where the
INSERT's FK check would race with a DELETE, lose, and then wait
indefinitely on the DELETE's locks despite `lock_timeout = '10s'` being
set on the session.

Fixes: #165853
Fixes: #153453
Epic: none

Release note (bug fix): Fixed a bug where the `lock_timeout` and
`deadlock_timeout` session settings were not honored by FK existence
checks performed during insert fast path execution. This could cause
inserts to block indefinitely on conflicting locks instead of
returning a timeout error.