### PR TITLE
sql: use pretty-printing in SHOW CREATE FUNCTION/PROCEDURE

### DIFF
--- a/pkg/backup/testdata/backup-restore/plpgsql_procedures
+++ b/pkg/backup/testdata/backup-restore/plpgsql_procedures
@@ -96,14 +96,14 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-	END;
-$$
+		DECLARE
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			SELECT nextval('sc1.sq1'::REGCLASS);
+		END;
+	$$
 
 exec-sql
 CALL sc1.p1('Good'::sc1.enum1)
@@ -137,14 +137,14 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-	END;
-$$
+		DECLARE
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			SELECT nextval('sc1.sq1'::REGCLASS);
+		END;
+	$$
 
 # Make sure procedure signature is rewritten in schema descriptor so that
 # procedure can be resolved and executed.
@@ -302,14 +302,14 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-	END;
-$$
+		DECLARE
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			SELECT nextval('sc1.sq1'::REGCLASS);
+		END;
+	$$
 
 query-sql
 CALL sc1.p1('Good'::sc1.enum1)
@@ -344,14 +344,14 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-	END;
-$$
+		DECLARE
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			SELECT nextval('sc1.sq1'::REGCLASS);
+		END;
+	$$
 
 # Make sure procedure signature is rewritten in schema descriptor so that
 # procedure can be resolved and executed.

--- a/pkg/backup/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/backup/testdata/backup-restore/plpgsql_user_defined_functions
@@ -117,15 +117,15 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	x INT8 := 0;
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	RETURN nextval('sc1.sq1'::REGCLASS);
-	END;
-$$
+		DECLARE
+			x INT8 := 0;
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			RETURN nextval('sc1.sq1'::REGCLASS);
+		END;
+	$$
 
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
@@ -143,15 +143,15 @@ CREATE FUNCTION sc2.f2()
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	x INT8;
-	BEGIN
-	SELECT a FROM sc2.tbl2 LIMIT 1 INTO x;
-	SELECT sc1.f1('Good':::sc1.enum1);
-	CALL public.p_nested('Good':::sc1.enum1);
-	RETURN x;
-	END;
-$$
+		DECLARE
+			x INT8;
+		BEGIN
+			SELECT a FROM sc2.tbl2 LIMIT 1 INTO x;
+			SELECT sc1.f1('Good':::sc1.enum1);
+			CALL public.p_nested('Good':::sc1.enum1);
+			RETURN x;
+		END;
+	$$
 
 exec-sql
 DROP DATABASE db1
@@ -180,15 +180,15 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	x INT8 := 0;
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	RETURN nextval('sc1.sq1'::REGCLASS);
-	END;
-$$
+		DECLARE
+			x INT8 := 0;
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			RETURN nextval('sc1.sq1'::REGCLASS);
+		END;
+	$$
 
 query-sql
 SELECT create_statement FROM [SHOW CREATE FUNCTION sc2.f2]
@@ -201,15 +201,15 @@ CREATE FUNCTION sc2.f2()
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	x INT8;
-	BEGIN
-	SELECT a FROM sc2.tbl2 LIMIT 1 INTO x;
-	SELECT sc1.f1('Good':::sc1.enum1);
-	CALL public.p_nested('Good':::sc1.enum1);
-	RETURN x;
-	END;
-$$
+		DECLARE
+			x INT8;
+		BEGIN
+			SELECT a FROM sc2.tbl2 LIMIT 1 INTO x;
+			SELECT sc1.f1('Good':::sc1.enum1);
+			CALL public.p_nested('Good':::sc1.enum1);
+			RETURN x;
+		END;
+	$$
 
 # Make sure function signature is rewritten in schema descriptor so that
 # function can be resolved and executed.
@@ -372,16 +372,16 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	x INT8;
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
-	RETURN x;
-	END;
-$$
+		DECLARE
+			x INT8;
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
+			RETURN x;
+		END;
+	$$
 
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
@@ -416,16 +416,16 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE plpgsql
 	SECURITY INVOKER
 	AS $$
-	DECLARE
-	x INT8;
-	foobar sc1.enum1;
-	BEGIN
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
-	RETURN x;
-	END;
-$$
+		DECLARE
+			x INT8;
+			foobar sc1.enum1;
+		BEGIN
+			SELECT a FROM sc1.tbl1;
+			SELECT 'Good':::sc1.enum1;
+			SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
+			RETURN x;
+		END;
+	$$
 
 # Make sure function signature is rewritten in schema descriptor so that
 # function can be resolved and executed.

--- a/pkg/backup/testdata/backup-restore/procedures
+++ b/pkg/backup/testdata/backup-restore/procedures
@@ -90,10 +90,10 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 exec-sql
 CALL sc1.p1('Good'::sc1.enum1)
@@ -127,10 +127,10 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 # Make sure procedure signature is rewritten in schema descriptor so that
 # procedure can be resolved and executed.
@@ -282,10 +282,10 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 query-sql
 CALL sc1.p1('Good'::sc1.enum1)
@@ -320,10 +320,10 @@ CREATE PROCEDURE sc1.p1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 # Make sure procedure signature is rewritten in schema descriptor so that
 # procedure can be resolved and executed.

--- a/pkg/backup/testdata/backup-restore/user-defined-functions
+++ b/pkg/backup/testdata/backup-restore/user-defined-functions
@@ -93,10 +93,10 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
@@ -130,10 +130,10 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 # Make sure function signature is rewritten in schema descriptor so that
 # function can be resolved and executed.
@@ -279,10 +279,10 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
@@ -317,10 +317,10 @@ CREATE FUNCTION sc1.f1(a sc1.enum1)
 	LANGUAGE SQL
 	SECURITY INVOKER
 	AS $$
-	SELECT a FROM sc1.tbl1;
-	SELECT 'Good':::sc1.enum1;
-	SELECT nextval('sc1.sq1'::REGCLASS);
-$$
+		SELECT a FROM sc1.tbl1;
+		SELECT 'Good':::sc1.enum1;
+		SELECT nextval('sc1.sq1'::REGCLASS);
+	$$
 
 # Make sure function signature is rewritten in schema descriptor so that
 # function can be resolved and executed.

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
@@ -345,14 +345,19 @@ $$ LANGUAGE PLpgSQL;
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_param_types];
 ----
-CREATE PROCEDURE public.p_param_types(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, OUT p4 INT8)
+CREATE PROCEDURE public.p_param_types(
+  IN p1 INT8,
+  INOUT p2 INT8,
+  INOUT p3 INT8,
+  OUT p4 INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT p2, p3, p1;
-  END;
-$$
+    BEGIN
+      SELECT p2, p3, p1;
+    END;
+  $$
 
 statement ok
 DROP PROCEDURE p_param_types;
@@ -480,14 +485,19 @@ CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT column3 INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT column3 INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT 3 INTO column3;
-  END;
-$$
+    BEGIN
+      SELECT 3 INTO column3;
+    END;
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);
@@ -506,14 +516,19 @@ CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  param2 := 2;
-  END;
-$$
+    BEGIN
+      param2 := 2;
+    END;
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);
@@ -528,14 +543,19 @@ CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN in_param INT8, OUT INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN in_param INT8,
+  OUT INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT in_param INTO param2;
-  END;
-$$
+    BEGIN
+      SELECT in_param INTO param2;
+    END;
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_params
@@ -220,7 +220,12 @@ $$ LANGUAGE PLpgSQL;
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_param_types];
 ----
-CREATE FUNCTION public.f_param_types(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, OUT p4 INT8)
+CREATE FUNCTION public.f_param_types(
+  IN p1 INT8,
+  INOUT p2 INT8,
+  INOUT p3 INT8,
+  OUT p4 INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -228,10 +233,10 @@ CREATE FUNCTION public.f_param_types(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, O
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT p2, p3, p1;
-  END;
-$$
+    BEGIN
+      SELECT p2, p3, p1;
+    END;
+  $$
 
 statement ok
 DROP FUNCTION f_param_types;
@@ -408,7 +413,10 @@ CREATE OR REPLACE FUNCTION f_int(IN param INT, OUT param_out INT) AS $$ BEGIN SE
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_int];
 ----
-CREATE FUNCTION public.f_int(IN param INT8, OUT param_out INT8)
+CREATE FUNCTION public.f_int(
+  IN param INT8,
+  OUT param_out INT8
+)
   RETURNS INT8
   VOLATILE
   NOT LEAKPROOF
@@ -416,10 +424,10 @@ CREATE FUNCTION public.f_int(IN param INT8, OUT param_out INT8)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT param INTO param_out;
-  END;
-$$
+    BEGIN
+      SELECT param INTO param_out;
+    END;
+  $$
 
 query I colnames
 SELECT * FROM f_int(2);
@@ -433,7 +441,10 @@ CREATE OR REPLACE FUNCTION f_int(OUT param_out INT, IN param INT) AS $$ BEGIN SE
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_int];
 ----
-CREATE FUNCTION public.f_int(OUT param_out INT8, IN param INT8)
+CREATE FUNCTION public.f_int(
+  OUT param_out INT8,
+  IN param INT8
+)
   RETURNS INT8
   VOLATILE
   NOT LEAKPROOF
@@ -441,10 +452,10 @@ CREATE FUNCTION public.f_int(OUT param_out INT8, IN param INT8)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT param INTO param_out;
-  END;
-$$
+    BEGIN
+      SELECT param INTO param_out;
+    END;
+  $$
 
 query I colnames
 SELECT * FROM f_int(2);
@@ -491,7 +502,12 @@ CREATE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -499,10 +515,10 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT I
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  param2 := 2;
-  END;
-$$
+    BEGIN
+      param2 := 2;
+    END;
+  $$
 
 query T colnames
 SELECT f_default_names(0);
@@ -550,7 +566,12 @@ CREATE OR REPLACE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN INT, OUT 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT column3 INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT column3 INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -558,10 +579,10 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT c
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT 3 INTO column3;
-  END;
-$$
+    BEGIN
+      SELECT 3 INTO column3;
+    END;
+  $$
 
 query I colnames
 SELECT column3 FROM f_default_names(0);
@@ -580,7 +601,12 @@ CREATE OR REPLACE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN INT, OUT 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -588,10 +614,10 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT I
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  param2 := 2;
-  END;
-$$
+    BEGIN
+      param2 := 2;
+    END;
+  $$
 
 # Introducing the IN parameter name is ok.
 statement ok
@@ -600,7 +626,12 @@ CREATE OR REPLACE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN in_param 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN in_param INT8, OUT INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN in_param INT8,
+  OUT INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -608,10 +639,10 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN in_param IN
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  SELECT in_param INTO param2;
-  END;
-$$
+    BEGIN
+      SELECT in_param INTO param2;
+    END;
+  $$
 
 # But then the IN parameter name cannot be changed anymore.
 statement error cannot change name of input parameter "in_param"

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -98,50 +98,56 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             DECLARE
-             i INT8 := nextval('public.seq'::REGCLASS);
-             j INT8 := nextval('public.seq'::REGCLASS);
-             curs REFCURSOR := nextval('public.seq'::REGCLASS)::STRING;
-             curs2 CURSOR FOR SELECT nextval('public.seq'::REGCLASS);
-             BEGIN
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
-             RAISE NOTICE 'val1: %, val2: %', nextval('public.seq'::REGCLASS), nextval('public.seq'::REGCLASS);
-             DECLARE
-             k INT8 := nextval('public.seq'::REGCLASS);
-             BEGIN
-             RAISE NOTICE 'k: %, nextval: %', k, nextval('public.seq'::REGCLASS);
-             IF k > 0 THEN
-               SELECT nextval('public.seq'::REGCLASS);
-             END IF;
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
-             WHEN not_null_violation THEN
-             SELECT nextval('public.seq'::REGCLASS);
-             SELECT nextval('public.seq'::REGCLASS);
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
-             END;
-             WHILE nextval('public.seq'::REGCLASS) < 10:::INT8 LOOP
-             i := nextval('public.seq'::REGCLASS);
-             SELECT nextval('public.seq'::REGCLASS);
-             IF nextval('public.seq'::REGCLASS) = 1:::INT8 THEN
-               SELECT nextval('public.seq'::REGCLASS);
-               SELECT nextval('public.seq'::REGCLASS);
-               CONTINUE;
-             ELSIF nextval('public.seq'::REGCLASS) = 2:::INT8 THEN
-               SELECT v FROM ROWS FROM (nextval('public.seq'::REGCLASS)) AS v ("int") INTO i;
-             ELSIF nextval('public.seq'::REGCLASS) = 3:::INT8 THEN
-               SELECT nextval('public.seq'::REGCLASS);
-               SELECT nextval('public.seq'::REGCLASS);
-             END IF;
-             END LOOP;
-             OPEN curs FOR SELECT nextval('public.seq'::REGCLASS);
-             RETURN nextval('public.seq'::REGCLASS);
-             END;
-           $$
+               DECLARE
+                 i INT8 := nextval('public.seq'::REGCLASS);
+                 j INT8 := nextval('public.seq'::REGCLASS);
+                 curs REFCURSOR := nextval('public.seq'::REGCLASS)::STRING;
+                 curs2 CURSOR FOR SELECT nextval('public.seq'::REGCLASS);
+               BEGIN
+                 RAISE NOTICE
+                   USING
+                     MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
+                 RAISE NOTICE
+                   'val1: %, val2: %',
+                   nextval('public.seq'::REGCLASS),
+                   nextval('public.seq'::REGCLASS);
+                 DECLARE
+                   k INT8 := nextval('public.seq'::REGCLASS);
+                 BEGIN
+                   RAISE NOTICE 'k: %, nextval: %', k, nextval('public.seq'::REGCLASS);
+                   IF k > 0 THEN
+                     SELECT nextval('public.seq'::REGCLASS);
+                   END IF;
+                 EXCEPTION
+                   WHEN division_by_zero THEN
+                     RAISE NOTICE
+                       USING
+                         MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
+                   WHEN not_null_violation THEN
+                     SELECT nextval('public.seq'::REGCLASS);
+                     SELECT nextval('public.seq'::REGCLASS);
+                     RAISE NOTICE
+                       USING
+                         MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
+                 END;
+                 WHILE nextval('public.seq'::REGCLASS) < 10:::INT8 LOOP
+                   i := nextval('public.seq'::REGCLASS);
+                   SELECT nextval('public.seq'::REGCLASS);
+                   IF nextval('public.seq'::REGCLASS) = 1:::INT8 THEN
+                     SELECT nextval('public.seq'::REGCLASS);
+                     SELECT nextval('public.seq'::REGCLASS);
+                     CONTINUE;
+                   ELSIF nextval('public.seq'::REGCLASS) = 2:::INT8 THEN
+                     SELECT v FROM nextval('public.seq'::REGCLASS) AS v ("int") INTO i;
+                   ELSIF nextval('public.seq'::REGCLASS) = 3:::INT8 THEN
+                     SELECT nextval('public.seq'::REGCLASS);
+                     SELECT nextval('public.seq'::REGCLASS);
+                   END IF;
+                 END LOOP;
+                 OPEN curs FOR SELECT nextval('public.seq'::REGCLASS);
+                 RETURN nextval('public.seq'::REGCLASS);
+               END;
+             $$
 
 statement ok
 ALTER SEQUENCE seq RENAME TO renamed;
@@ -162,50 +168,56 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             DECLARE
-             i INT8 := nextval('public.renamed'::REGCLASS);
-             j INT8 := nextval('public.renamed'::REGCLASS);
-             curs REFCURSOR := nextval('public.renamed'::REGCLASS)::STRING;
-             curs2 CURSOR FOR SELECT nextval('public.renamed'::REGCLASS);
-             BEGIN
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
-             RAISE NOTICE 'val1: %, val2: %', nextval('public.renamed'::REGCLASS), nextval('public.renamed'::REGCLASS);
-             DECLARE
-             k INT8 := nextval('public.renamed'::REGCLASS);
-             BEGIN
-             RAISE NOTICE 'k: %, nextval: %', k, nextval('public.renamed'::REGCLASS);
-             IF k > 0 THEN
-               SELECT nextval('public.renamed'::REGCLASS);
-             END IF;
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
-             WHEN not_null_violation THEN
-             SELECT nextval('public.renamed'::REGCLASS);
-             SELECT nextval('public.renamed'::REGCLASS);
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
-             END;
-             WHILE nextval('public.renamed'::REGCLASS) < 10:::INT8 LOOP
-             i := nextval('public.renamed'::REGCLASS);
-             SELECT nextval('public.renamed'::REGCLASS);
-             IF nextval('public.renamed'::REGCLASS) = 1:::INT8 THEN
-               SELECT nextval('public.renamed'::REGCLASS);
-               SELECT nextval('public.renamed'::REGCLASS);
-               CONTINUE;
-             ELSIF nextval('public.renamed'::REGCLASS) = 2:::INT8 THEN
-               SELECT v FROM ROWS FROM (nextval('public.renamed'::REGCLASS)) AS v ("int") INTO i;
-             ELSIF nextval('public.renamed'::REGCLASS) = 3:::INT8 THEN
-               SELECT nextval('public.renamed'::REGCLASS);
-               SELECT nextval('public.renamed'::REGCLASS);
-             END IF;
-             END LOOP;
-             OPEN curs FOR SELECT nextval('public.renamed'::REGCLASS);
-             RETURN nextval('public.renamed'::REGCLASS);
-             END;
-           $$
+               DECLARE
+                 i INT8 := nextval('public.renamed'::REGCLASS);
+                 j INT8 := nextval('public.renamed'::REGCLASS);
+                 curs REFCURSOR := nextval('public.renamed'::REGCLASS)::STRING;
+                 curs2 CURSOR FOR SELECT nextval('public.renamed'::REGCLASS);
+               BEGIN
+                 RAISE NOTICE
+                   USING
+                     MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
+                 RAISE NOTICE
+                   'val1: %, val2: %',
+                   nextval('public.renamed'::REGCLASS),
+                   nextval('public.renamed'::REGCLASS);
+                 DECLARE
+                   k INT8 := nextval('public.renamed'::REGCLASS);
+                 BEGIN
+                   RAISE NOTICE 'k: %, nextval: %', k, nextval('public.renamed'::REGCLASS);
+                   IF k > 0 THEN
+                     SELECT nextval('public.renamed'::REGCLASS);
+                   END IF;
+                 EXCEPTION
+                   WHEN division_by_zero THEN
+                     RAISE NOTICE
+                       USING
+                         MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
+                   WHEN not_null_violation THEN
+                     SELECT nextval('public.renamed'::REGCLASS);
+                     SELECT nextval('public.renamed'::REGCLASS);
+                     RAISE NOTICE
+                       USING
+                         MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
+                 END;
+                 WHILE nextval('public.renamed'::REGCLASS) < 10:::INT8 LOOP
+                   i := nextval('public.renamed'::REGCLASS);
+                   SELECT nextval('public.renamed'::REGCLASS);
+                   IF nextval('public.renamed'::REGCLASS) = 1:::INT8 THEN
+                     SELECT nextval('public.renamed'::REGCLASS);
+                     SELECT nextval('public.renamed'::REGCLASS);
+                     CONTINUE;
+                   ELSIF nextval('public.renamed'::REGCLASS) = 2:::INT8 THEN
+                     SELECT v FROM nextval('public.renamed'::REGCLASS) AS v ("int") INTO i;
+                   ELSIF nextval('public.renamed'::REGCLASS) = 3:::INT8 THEN
+                     SELECT nextval('public.renamed'::REGCLASS);
+                     SELECT nextval('public.renamed'::REGCLASS);
+                   END IF;
+                 END LOOP;
+                 OPEN curs FOR SELECT nextval('public.renamed'::REGCLASS);
+                 RETURN nextval('public.renamed'::REGCLASS);
+               END;
+             $$
 
 # Reset sequence name for subtest.
 statement ok
@@ -295,50 +307,77 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             DECLARE
-             day public.weekday := 'wednesday':::public.weekday;
-             today public.weekday := 'thursday':::public.weekday;
-             curs REFCURSOR := 'monday':::public.weekday::STRING;
-             curs2 CURSOR FOR SELECT 'tuesday':::public.weekday;
-             BEGIN
-             RAISE NOTICE
-             USING MESSAGE = format('val: %d':::STRING, 'wednesday':::public.weekday);
-             RAISE NOTICE 'val1: %, val2: %', 'wednesday':::public.weekday, 'thursday':::public.weekday;
-             SELECT public.f_nested(1:::INT8, 'wednesday':::public.weekday);
-             CALL public.p_nested(1, 'wednesday':::public.weekday, day);
-             DECLARE
-             yesterday public.weekday := 'wednesday':::public.weekday;
-             BEGIN
-             RAISE NOTICE 'val3: %, val4: %', 'wednesday':::public.weekday, 'thursday':::public.weekday;
-             IF yesterday IS NOT NULL THEN
-               SELECT 'wednesday':::public.weekday;
-             END IF;
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('val: %d':::STRING, 'wednesday':::public.weekday);
-             WHEN not_null_violation THEN
-             SELECT 'wednesday':::public.weekday;
-             RAISE NOTICE 'val: %', 'wednesday':::public.weekday;
-             END;
-             WHILE day != 'wednesday':::public.weekday LOOP
-             day := 'friday':::public.weekday;
-             SELECT 'wednesday':::public.weekday;
-             IF day = 'wednesday':::public.weekday THEN
-               day := 'thursday':::public.weekday;
-               SELECT 'tuesday':::public.weekday;
-               CONTINUE;
-             ELSIF day = 'monday':::public.weekday THEN
-               SELECT 'tuesday':::public.weekday INTO day;
-             ELSIF day = 'tuesday':::public.weekday THEN
-               SELECT 'wednesday':::public.weekday INTO day;
-               SELECT 'wednesday':::public.weekday;
-             END IF;
-             END LOOP;
-             OPEN curs FOR SELECT 'wednesday':::public.weekday;
-             RETURN 'wednesday':::public.weekday;
-             END;
-           $$
+               DECLARE
+                 day public.weekday :=
+                   'wednesday':::public.weekday;
+                 today public.weekday :=
+                   'thursday':::public.weekday;
+                 curs REFCURSOR :=
+                   'monday':::public.weekday::STRING;
+                 curs2 CURSOR FOR
+                   SELECT 'tuesday':::public.weekday;
+               BEGIN
+                 RAISE NOTICE
+                   USING
+                     MESSAGE = format('val: %d':::STRING, 'wednesday':::public.weekday);
+                 RAISE NOTICE
+                   'val1: %, val2: %',
+                   'wednesday':::public.weekday,
+                   'thursday':::public.weekday;
+                 SELECT
+                   public.f_nested(
+                     1:::INT8,
+                     'wednesday':::public.weekday
+                   );
+                 CALL
+                   public.p_nested(
+                     1,
+                     'wednesday':::public.weekday,
+                     day
+                   );
+                 DECLARE
+                   yesterday public.weekday :=
+                     'wednesday':::public.weekday;
+                 BEGIN
+                   RAISE NOTICE
+                     'val3: %, val4: %',
+                     'wednesday':::public.weekday,
+                     'thursday':::public.weekday;
+                   IF yesterday IS NOT NULL THEN
+                     SELECT 'wednesday':::public.weekday;
+                   END IF;
+                 EXCEPTION
+                   WHEN division_by_zero THEN
+                     RAISE NOTICE
+                       USING
+                         MESSAGE = format('val: %d':::STRING, 'wednesday':::public.weekday);
+                   WHEN not_null_violation THEN
+                     SELECT 'wednesday':::public.weekday;
+                     RAISE NOTICE
+                       'val: %',
+                       'wednesday':::public.weekday;
+                 END;
+                 WHILE day != 'wednesday':::public.weekday LOOP
+                   day := 'friday':::public.weekday;
+                   SELECT 'wednesday':::public.weekday;
+                   IF day = 'wednesday':::public.weekday THEN
+                     day := 'thursday':::public.weekday;
+                     SELECT 'tuesday':::public.weekday;
+                     CONTINUE;
+                   ELSIF day = 'monday':::public.weekday THEN
+                     SELECT 'tuesday':::public.weekday
+                       INTO day;
+                   ELSIF day = 'tuesday':::public.weekday THEN
+                     SELECT 'wednesday':::public.weekday
+                       INTO day;
+                     SELECT 'wednesday':::public.weekday;
+                   END IF;
+                 END LOOP;
+                 OPEN curs FOR
+                   SELECT 'wednesday':::public.weekday;
+                 RETURN 'wednesday':::public.weekday;
+               END;
+             $$
 
 statement ok
 ALTER TYPE weekday RENAME VALUE 'wednesday' TO 'humpday';
@@ -362,50 +401,76 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             DECLARE
-             day public.workday := 'humpday':::public.workday;
-             today public.workday := 'thursday':::public.workday;
-             curs REFCURSOR := 'monday':::public.workday::STRING;
-             curs2 CURSOR FOR SELECT 'tuesday':::public.workday;
-             BEGIN
-             RAISE NOTICE
-             USING MESSAGE = format('val: %d':::STRING, 'humpday':::public.workday);
-             RAISE NOTICE 'val1: %, val2: %', 'humpday':::public.workday, 'thursday':::public.workday;
-             SELECT public.f_nested(1:::INT8, 'humpday':::public.workday);
-             CALL public.p_nested(1, 'humpday':::public.workday, day);
-             DECLARE
-             yesterday public.workday := 'humpday':::public.workday;
-             BEGIN
-             RAISE NOTICE 'val3: %, val4: %', 'humpday':::public.workday, 'thursday':::public.workday;
-             IF yesterday IS NOT NULL THEN
-               SELECT 'humpday':::public.workday;
-             END IF;
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('val: %d':::STRING, 'humpday':::public.workday);
-             WHEN not_null_violation THEN
-             SELECT 'humpday':::public.workday;
-             RAISE NOTICE 'val: %', 'humpday':::public.workday;
-             END;
-             WHILE day != 'humpday':::public.workday LOOP
-             day := 'friday':::public.workday;
-             SELECT 'humpday':::public.workday;
-             IF day = 'humpday':::public.workday THEN
-               day := 'thursday':::public.workday;
-               SELECT 'tuesday':::public.workday;
-               CONTINUE;
-             ELSIF day = 'monday':::public.workday THEN
-               SELECT 'tuesday':::public.workday INTO day;
-             ELSIF day = 'tuesday':::public.workday THEN
-               SELECT 'humpday':::public.workday INTO day;
-               SELECT 'humpday':::public.workday;
-             END IF;
-             END LOOP;
-             OPEN curs FOR SELECT 'humpday':::public.workday;
-             RETURN 'humpday':::public.workday;
-             END;
-           $$
+               DECLARE
+                 day public.workday :=
+                   'humpday':::public.workday;
+                 today public.workday :=
+                   'thursday':::public.workday;
+                 curs REFCURSOR :=
+                   'monday':::public.workday::STRING;
+                 curs2 CURSOR FOR
+                   SELECT 'tuesday':::public.workday;
+               BEGIN
+                 RAISE NOTICE
+                   USING
+                     MESSAGE = format('val: %d':::STRING, 'humpday':::public.workday);
+                 RAISE NOTICE
+                   'val1: %, val2: %',
+                   'humpday':::public.workday,
+                   'thursday':::public.workday;
+                 SELECT
+                   public.f_nested(
+                     1:::INT8,
+                     'humpday':::public.workday
+                   );
+                 CALL
+                   public.p_nested(
+                     1,
+                     'humpday':::public.workday,
+                     day
+                   );
+                 DECLARE
+                   yesterday public.workday :=
+                     'humpday':::public.workday;
+                 BEGIN
+                   RAISE NOTICE
+                     'val3: %, val4: %',
+                     'humpday':::public.workday,
+                     'thursday':::public.workday;
+                   IF yesterday IS NOT NULL THEN
+                     SELECT 'humpday':::public.workday;
+                   END IF;
+                 EXCEPTION
+                   WHEN division_by_zero THEN
+                     RAISE NOTICE
+                       USING
+                         MESSAGE = format('val: %d':::STRING, 'humpday':::public.workday);
+                   WHEN not_null_violation THEN
+                     SELECT 'humpday':::public.workday;
+                     RAISE NOTICE
+                       'val: %',
+                       'humpday':::public.workday;
+                 END;
+                 WHILE day != 'humpday':::public.workday LOOP
+                   day := 'friday':::public.workday;
+                   SELECT 'humpday':::public.workday;
+                   IF day = 'humpday':::public.workday THEN
+                     day := 'thursday':::public.workday;
+                     SELECT 'tuesday':::public.workday;
+                     CONTINUE;
+                   ELSIF day = 'monday':::public.workday THEN
+                     SELECT 'tuesday':::public.workday
+                       INTO day;
+                   ELSIF day = 'tuesday':::public.workday THEN
+                     SELECT 'humpday':::public.workday
+                       INTO day;
+                     SELECT 'humpday':::public.workday;
+                   END IF;
+                 END LOOP;
+                 OPEN curs FOR SELECT 'humpday':::public.workday;
+                 RETURN 'humpday':::public.workday;
+               END;
+             $$
 
 # Reset types for subtest.
 statement ok
@@ -434,7 +499,10 @@ SELECT get_body_str('f_rewrite');
 query TT
 SHOW CREATE FUNCTION f_rewrite;
 ----
-f_rewrite  CREATE FUNCTION public.f_rewrite(INOUT param1 public.weekday, OUT param2 public.weekday)
+f_rewrite  CREATE FUNCTION public.f_rewrite(
+             INOUT param1 public.weekday,
+             OUT param2 public.weekday
+           )
              RETURNS RECORD
              VOLATILE
              NOT LEAKPROOF
@@ -442,11 +510,11 @@ f_rewrite  CREATE FUNCTION public.f_rewrite(INOUT param1 public.weekday, OUT par
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             BEGIN
-             param2 := param1;
-             param1 := 'friday':::public.weekday;
-             END;
-           $$
+               BEGIN
+                 param2 := param1;
+                 param1 := 'friday':::public.weekday;
+               END;
+             $$
 
 statement ok
 ALTER TYPE weekday RENAME VALUE 'friday' TO 'humpday';
@@ -462,7 +530,10 @@ SELECT get_body_str('f_rewrite');
 query TT
 SHOW CREATE FUNCTION f_rewrite;
 ----
-f_rewrite  CREATE FUNCTION public.f_rewrite(INOUT param1 public.workday, OUT param2 public.workday)
+f_rewrite  CREATE FUNCTION public.f_rewrite(
+             INOUT param1 public.workday,
+             OUT param2 public.workday
+           )
              RETURNS RECORD
              VOLATILE
              NOT LEAKPROOF
@@ -470,11 +541,11 @@ f_rewrite  CREATE FUNCTION public.f_rewrite(INOUT param1 public.workday, OUT par
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             BEGIN
-             param2 := param1;
-             param1 := 'humpday':::public.workday;
-             END;
-           $$
+               BEGIN
+                 param2 := param1;
+                 param1 := 'humpday':::public.workday;
+               END;
+             $$
 
 # Reset types for subtest.
 statement ok
@@ -539,15 +610,18 @@ SELECT get_body_str('p_rewrite');
 query TT
 SHOW CREATE PROCEDURE p_rewrite;
 ----
-p_rewrite  CREATE PROCEDURE public.p_rewrite(INOUT param1 public.weekday, OUT param2 public.weekday)
+p_rewrite  CREATE PROCEDURE public.p_rewrite(
+             INOUT param1 public.weekday,
+             OUT param2 public.weekday
+           )
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             BEGIN
-             param2 := param1;
-             param1 := 'friday':::public.weekday;
-             END;
-           $$
+               BEGIN
+                 param2 := param1;
+                 param1 := 'friday':::public.weekday;
+               END;
+             $$
 
 statement ok
 ALTER TYPE weekday RENAME VALUE 'friday' TO 'humpday';
@@ -563,15 +637,18 @@ SELECT get_body_str('p_rewrite');
 query TT
 SHOW CREATE PROCEDURE p_rewrite;
 ----
-p_rewrite  CREATE PROCEDURE public.p_rewrite(INOUT param1 public.workday, OUT param2 public.workday)
+p_rewrite  CREATE PROCEDURE public.p_rewrite(
+             INOUT param1 public.workday,
+             OUT param2 public.workday
+           )
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $$
-             BEGIN
-             param2 := param1;
-             param1 := 'humpday':::public.workday;
-             END;
-           $$
+               BEGIN
+                 param2 := param1;
+                 param1 := 'humpday':::public.workday;
+               END;
+             $$
 
 # Reset types for subtest.
 statement ok
@@ -624,24 +701,28 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $funcbodyx$
-             BEGIN
-             DO $funcbody$
-             BEGIN
-             SELECT nextval('public.seq'::REGCLASS);
-             SELECT 'wednesday':::public.weekday;
-             RAISE NOTICE 'foo';
-             DO $$
-             BEGIN
-             RAISE NOTICE 'bar';
-             SELECT nextval('public.seq'::REGCLASS);
-             SELECT 'wednesday':::public.weekday;
-             END;
-             $$;
-             END;
-             $funcbody$;
-             RETURN 100;
-             END;
-           $funcbodyx$
+               BEGIN
+                 DO $funcbody$
+                   BEGIN
+                     SELECT nextval('public.seq'::REGCLASS);
+                     SELECT 'wednesday':::public.weekday;
+                     RAISE NOTICE 'foo';
+                     DO $$
+                       BEGIN
+                         RAISE NOTICE 'bar';
+                         SELECT
+                           nextval(
+                             'public.seq'::REGCLASS
+                           );
+                         SELECT
+                           'wednesday':::public.weekday;
+                       END;
+                     $$;
+                   END;
+                 $funcbody$;
+                 RETURN 100;
+               END;
+             $funcbodyx$
 
 statement ok
 ALTER TYPE weekday RENAME VALUE 'friday' TO 'humpday';
@@ -665,24 +746,28 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              LANGUAGE plpgsql
              SECURITY INVOKER
              AS $funcbodyx$
-             BEGIN
-             DO $funcbody$
-             BEGIN
-             SELECT nextval('public.seq'::REGCLASS);
-             SELECT 'wednesday':::public.workday;
-             RAISE NOTICE 'foo';
-             DO $$
-             BEGIN
-             RAISE NOTICE 'bar';
-             SELECT nextval('public.seq'::REGCLASS);
-             SELECT 'wednesday':::public.workday;
-             END;
-             $$;
-             END;
-             $funcbody$;
-             RETURN 100;
-             END;
-           $funcbodyx$
+               BEGIN
+                 DO $funcbody$
+                   BEGIN
+                     SELECT nextval('public.seq'::REGCLASS);
+                     SELECT 'wednesday':::public.workday;
+                     RAISE NOTICE 'foo';
+                     DO $$
+                       BEGIN
+                         RAISE NOTICE 'bar';
+                         SELECT
+                           nextval(
+                             'public.seq'::REGCLASS
+                           );
+                         SELECT
+                           'wednesday':::public.workday;
+                       END;
+                     $$;
+                   END;
+                 $funcbody$;
+                 RETURN 100;
+               END;
+             $funcbodyx$
 
 # Reset types for subtest.
 statement ok

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3417,33 +3417,11 @@ func createRoutinePopulate(
 			if err != nil {
 				return err
 			}
-			for i := range treeNode.Options {
-				if body, ok := treeNode.Options[i].(tree.RoutineBodyStr); ok {
-					bodyStr := string(body)
-					bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, bodyStr, fnDesc.GetLanguage())
-					if err != nil {
-						return err
-					}
-					bodyStr, err = formatQuerySequencesForDisplay(ctx, &p.semaCtx, bodyStr, true /* multiStmt */, fnDesc.GetLanguage())
-					if err != nil {
-						return err
-					}
-					bodyStr, err = formatUnqualifyTableNames(bodyStr, fnIDToDBName[fnDesc.GetID()], fnDesc.GetLanguage())
-					if err != nil {
-						return err
-					}
-
-					bodyStr = strings.TrimSpace(bodyStr)
-					stmtStrs := strings.Split(bodyStr, "\n")
-					for i := range stmtStrs {
-						if stmtStrs[i] != "" {
-							stmtStrs[i] = "\t" + stmtStrs[i]
-						}
-					}
-					p := &treeNode.Options[i]
-					// Add two new lines just for better formatting.
-					*p = tree.RoutineBodyStr("\n" + strings.Join(stmtStrs, "\n") + "\n")
-				}
+			createStatement, err := formatCreateRoutineForDisplay(
+				ctx, &p.semaCtx, treeNode, fnDesc.GetLanguage(), fnIDToDBName[fnDesc.GetID()],
+			)
+			if err != nil {
+				return err
 			}
 
 			err = addRow(
@@ -3453,7 +3431,7 @@ func createRoutinePopulate(
 				tree.NewDString(fnIDToScName[fnDesc.GetID()]),       // schema_name
 				tree.NewDInt(tree.DInt(fnDesc.GetID())),             // function_id
 				tree.NewDString(fnDesc.GetName()),                   // function_name
-				tree.NewDString(tree.AsString(treeNode)),            // create_statement
+				tree.NewDString(createStatement),                    // create_statement
 			)
 			if err != nil {
 				return err
@@ -3499,29 +3477,12 @@ func createRoutinePopulateByFnIndex(
 	if err != nil {
 		return false, err
 	}
-	for i := range treeNode.Options {
-		if body, ok := treeNode.Options[i].(tree.RoutineBodyStr); ok {
-			bodyStr := string(body)
-			bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, bodyStr, fnDesc.GetLanguage())
-			if err != nil {
-				return false, err
-			}
-			bodyStr, err = formatQuerySequencesForDisplay(ctx, &p.semaCtx, bodyStr, true /* multiStmt */, fnDesc.GetLanguage())
-			if err != nil {
-				return false, err
-			}
-			bodyStr = strings.TrimSpace(bodyStr)
-			stmtStrs := strings.Split(bodyStr, "\n")
-			for i := range stmtStrs {
-				if stmtStrs[i] != "" {
-					stmtStrs[i] = "\t" + stmtStrs[i]
-				}
-			}
-			p := &treeNode.Options[i]
-			*p = tree.RoutineBodyStr("\n" + strings.Join(stmtStrs, "\n") + "\n")
-		}
+	createStatement, err := formatCreateRoutineForDisplay(
+		ctx, &p.semaCtx, treeNode, fnDesc.GetLanguage(), dbName,
+	)
+	if err != nil {
+		return false, err
 	}
-	createStatement := tree.AsString(treeNode)
 	if err := addRow(
 		tree.NewDInt(tree.DInt(dbID)),           // database_id
 		tree.NewDString(dbName),                 // database_name
@@ -3534,6 +3495,41 @@ func createRoutinePopulateByFnIndex(
 		return false, err
 	}
 	return true, nil
+}
+
+// formatCreateRoutineForDisplay takes a tree.CreateRoutine and rewrites its
+// routine body (in place) to be more human-readable (e.g. by replacing OIDs
+// with names) and then generates a pretty-printed create statement.
+func formatCreateRoutineForDisplay(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	treeNode *tree.CreateRoutine,
+	lang catpb.Function_Language,
+	dbName string,
+) (string, error) {
+	for i := range treeNode.Options {
+		body, ok := treeNode.Options[i].(tree.RoutineBodyStr)
+		if !ok {
+			continue
+		}
+		bodyStr := string(body)
+		var err error
+		bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, semaCtx, bodyStr, lang)
+		if err != nil {
+			return "", err
+		}
+		bodyStr, err = formatQuerySequencesForDisplay(ctx, semaCtx, bodyStr, true /* multiStmt */, lang)
+		if err != nil {
+			return "", err
+		}
+		bodyStr, err = formatUnqualifyTableNames(bodyStr, dbName, lang)
+		if err != nil {
+			return "", err
+		}
+		treeNode.Options[i] = tree.RoutineBodyStr(strings.TrimSpace(bodyStr))
+	}
+	cfg := tree.DefaultPrettyCfg()
+	return cfg.Pretty(treeNode)
 }
 
 var crdbInternalCreateFunctionStmtsTable = virtualSchemaTable{

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -221,12 +221,17 @@ $$ LANGUAGE SQL;
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p];
 ----
-CREATE PROCEDURE public.p(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, OUT p4 INT8)
+CREATE PROCEDURE public.p(
+  IN p1 INT8,
+  INOUT p2 INT8,
+  INOUT p3 INT8,
+  OUT p4 INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT p2, p3, p1;
-$$
+    SELECT p2, p3, p1;
+  $$
 
 statement ok
 DROP PROCEDURE p;
@@ -368,12 +373,18 @@ CREATE OR REPLACE PROCEDURE p_3_in_2_out(IN param1 INT, OUT param1 INT, IN param
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_3_in_2_out];
 ----
-CREATE PROCEDURE public.p_3_in_2_out(IN param1 INT8, OUT param1 INT8, IN param2 INT8, IN param3 INT8, OUT param2 INT8)
+CREATE PROCEDURE public.p_3_in_2_out(
+  IN param1 INT8,
+  OUT param1 INT8,
+  IN param2 INT8,
+  IN param3 INT8,
+  OUT param2 INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (param1, param2 + param3);
-$$
+    SELECT (param1, param2 + param3);
+  $$
 
 query II colnames
 CALL p_3_in_2_out(2, NULL, 2, 2, NULL);
@@ -391,12 +402,16 @@ CREATE OR REPLACE PROCEDURE p_3_in_2_out(INOUT param1 INT, INOUT param2 INT, IN 
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_3_in_2_out];
 ----
-CREATE PROCEDURE public.p_3_in_2_out(INOUT param1 INT8, INOUT param2 INT8, IN param3 INT8)
+CREATE PROCEDURE public.p_3_in_2_out(
+  INOUT param1 INT8,
+  INOUT param2 INT8,
+  IN param3 INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (param1, param2 + param3);
-$$
+    SELECT (param1, param2 + param3);
+  $$
 
 query II colnames
 CALL p_3_in_2_out(2, 2, 2);
@@ -417,12 +432,17 @@ CREATE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
-$$
+    SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);
@@ -442,12 +462,17 @@ CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT column3 INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT column3 INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
-$$
+    SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);
@@ -462,12 +487,17 @@ CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
-$$
+    SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);
@@ -482,12 +512,17 @@ CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param
 query T
 SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
 ----
-CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN in_param INT8, OUT INT8)
+CREATE PROCEDURE public.p_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN in_param INT8,
+  OUT INT8
+)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (in_param, 2, 3);
-$$
+    SELECT (in_param, 2, 3);
+  $$
 
 query III colnames
 CALL p_default_names(NULL, NULL, 3, NULL);

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_routines
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_routines
@@ -51,17 +51,20 @@ CREATE FUNCTION public.add_one(x INT8)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT x + 1;
-$$;
-CREATE PROCEDURE public.double_triple(INOUT double INT8, OUT triple INT8)
+    SELECT x + 1;
+  $$;
+CREATE PROCEDURE public.double_triple(
+  INOUT double INT8,
+  OUT triple INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  double := double * 2;
-  triple := double * 3;
-  END;
-$$;
+    BEGIN
+      double := double * 2;
+      triple := double * 3;
+    END;
+  $$;
 
 statement ok
 CREATE FUNCTION add_one(x FLOAT) RETURNS FLOAT AS 'SELECT x + 1' LANGUAGE SQL;
@@ -78,8 +81,8 @@ CREATE FUNCTION public.add_one(x INT8)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT x + 1;
-$$;
+    SELECT x + 1;
+  $$;
 CREATE FUNCTION public.add_one(x FLOAT8)
   RETURNS FLOAT8
   VOLATILE
@@ -88,17 +91,20 @@ CREATE FUNCTION public.add_one(x FLOAT8)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT x + 1;
-$$;
-CREATE PROCEDURE public.double_triple(INOUT double INT8, OUT triple INT8)
+    SELECT x + 1;
+  $$;
+CREATE PROCEDURE public.double_triple(
+  INOUT double INT8,
+  OUT triple INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  double := double * 2;
-  triple := double * 3;
-  END;
-$$;
+    BEGIN
+      double := double * 2;
+      triple := double * 3;
+    END;
+  $$;
 
 
 #test dropping routines
@@ -112,15 +118,18 @@ query T colnames
 SHOW CREATE ALL ROUTINES;
 ----
 create_statement
-CREATE PROCEDURE public.double_triple(INOUT double INT8, OUT triple INT8)
+CREATE PROCEDURE public.double_triple(
+  INOUT double INT8,
+  OUT triple INT8
+)
   LANGUAGE plpgsql
   SECURITY INVOKER
   AS $$
-  BEGIN
-  double := double * 2;
-  triple := double * 3;
-  END;
-$$;
+    BEGIN
+      double := double * 2;
+      triple := double * 3;
+    END;
+  $$;
 
 statement ok
 DROP PROCEDURE double_triple;

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -678,8 +678,8 @@ CREATE FUNCTION public.single_quote(s STRING)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (e'\'' || s) || e'\'';
-$$
+    SELECT e'\'' || s || e'\'';
+  $$
 
 query T
 SELECT single_quote('hello')

--- a/pkg/sql/logictest/testdata/logic_test/udf_options
+++ b/pkg/sql/logictest/testdata/logic_test/udf_options
@@ -74,8 +74,8 @@ CREATE FUNCTION public.get_l(i INT8)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT v FROM test.public.kv WHERE k = i;
-$$
+    SELECT v FROM public.kv WHERE k = i;
+  $$
 
 query T
 SELECT pg_get_functiondef(NULL)

--- a/pkg/sql/logictest/testdata/logic_test/udf_params
+++ b/pkg/sql/logictest/testdata/logic_test/udf_params
@@ -92,7 +92,12 @@ $$ LANGUAGE SQL;
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_param_types];
 ----
-CREATE FUNCTION public.f_param_types(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, OUT p4 INT8)
+CREATE FUNCTION public.f_param_types(
+  IN p1 INT8,
+  INOUT p2 INT8,
+  INOUT p3 INT8,
+  OUT p4 INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -100,8 +105,8 @@ CREATE FUNCTION public.f_param_types(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, O
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT p2, p3, p1;
-$$
+    SELECT p2, p3, p1;
+  $$
 
 statement ok
 DROP FUNCTION f_param_types;
@@ -324,7 +329,10 @@ CREATE OR REPLACE FUNCTION f_int(IN param INT, OUT param_out INT) RETURNS INT AS
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_int];
 ----
-CREATE FUNCTION public.f_int(IN param INT8, OUT param_out INT8)
+CREATE FUNCTION public.f_int(
+  IN param INT8,
+  OUT param_out INT8
+)
   RETURNS INT8
   VOLATILE
   NOT LEAKPROOF
@@ -332,8 +340,8 @@ CREATE FUNCTION public.f_int(IN param INT8, OUT param_out INT8)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT param;
-$$
+    SELECT param;
+  $$
 
 query I colnames
 SELECT * FROM f_int(2);
@@ -347,7 +355,10 @@ CREATE OR REPLACE FUNCTION f_int(OUT param_out INT, IN param INT) RETURNS INT AS
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_int];
 ----
-CREATE FUNCTION public.f_int(OUT param_out INT8, IN param INT8)
+CREATE FUNCTION public.f_int(
+  OUT param_out INT8,
+  IN param INT8
+)
   RETURNS INT8
   VOLATILE
   NOT LEAKPROOF
@@ -355,8 +366,8 @@ CREATE FUNCTION public.f_int(OUT param_out INT8, IN param INT8)
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT param;
-$$
+    SELECT param;
+  $$
 
 query I colnames
 SELECT * FROM f_int(2);
@@ -410,7 +421,13 @@ CREATE OR REPLACE FUNCTION f_3_in_2_out(IN param1 INT, OUT param1 INT, IN param2
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_3_in_2_out];
 ----
-CREATE FUNCTION public.f_3_in_2_out(IN param1 INT8, OUT param1 INT8, IN param2 INT8, IN param3 INT8, OUT param2 INT8)
+CREATE FUNCTION public.f_3_in_2_out(
+  IN param1 INT8,
+  OUT param1 INT8,
+  IN param2 INT8,
+  IN param3 INT8,
+  OUT param2 INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -418,8 +435,8 @@ CREATE FUNCTION public.f_3_in_2_out(IN param1 INT8, OUT param1 INT8, IN param2 I
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (param1, param2 + param3);
-$$
+    SELECT (param1, param2 + param3);
+  $$
 
 query II colnames
 SELECT * FROM f_3_in_2_out(2, 2, 2);
@@ -437,7 +454,11 @@ CREATE OR REPLACE FUNCTION f_3_in_2_out(INOUT param1 INT, INOUT param2 INT, IN p
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_3_in_2_out];
 ----
-CREATE FUNCTION public.f_3_in_2_out(INOUT param1 INT8, INOUT param2 INT8, IN param3 INT8)
+CREATE FUNCTION public.f_3_in_2_out(
+  INOUT param1 INT8,
+  INOUT param2 INT8,
+  IN param3 INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -445,8 +466,8 @@ CREATE FUNCTION public.f_3_in_2_out(INOUT param1 INT8, INOUT param2 INT8, IN par
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (param1, param2 + param3);
-$$
+    SELECT (param1, param2 + param3);
+  $$
 
 query II colnames
 SELECT * FROM f_3_in_2_out(2, 2, 2);
@@ -468,7 +489,12 @@ CREATE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) RETURN
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -476,8 +502,8 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT I
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
-$$
+    SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+  $$
 
 query T colnames
 SELECT f_default_names(0);
@@ -527,7 +553,12 @@ CREATE OR REPLACE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN INT, OUT 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT column3 INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT column3 INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -535,8 +566,8 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT c
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
-$$
+    SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+  $$
 
 # Then we can omit the default OUT parameter name again.
 statement ok
@@ -545,7 +576,12 @@ CREATE OR REPLACE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN INT, OUT 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN INT8,
+  OUT INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -553,8 +589,8 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT I
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
-$$
+    SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+  $$
 
 # Introducing the IN parameter name is ok.
 statement ok
@@ -563,7 +599,12 @@ CREATE OR REPLACE FUNCTION f_default_names(OUT INT, OUT param2 INT, IN in_param 
 query T
 SELECT create_statement FROM [SHOW CREATE FUNCTION f_default_names];
 ----
-CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN in_param INT8, OUT INT8)
+CREATE FUNCTION public.f_default_names(
+  OUT INT8,
+  OUT param2 INT8,
+  IN in_param INT8,
+  OUT INT8
+)
   RETURNS RECORD
   VOLATILE
   NOT LEAKPROOF
@@ -571,8 +612,8 @@ CREATE FUNCTION public.f_default_names(OUT INT8, OUT param2 INT8, IN in_param IN
   LANGUAGE SQL
   SECURITY INVOKER
   AS $$
-  SELECT (in_param, 2, 3);
-$$
+    SELECT (in_param, 2, 3);
+  $$
 
 # But then the IN parameter name cannot be changed anymore.
 statement error cannot change name of input parameter "in_param"

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -113,8 +113,18 @@ f_subquery  CREATE FUNCTION public.f_subquery()
               LANGUAGE SQL
               SECURITY INVOKER
               AS $$
-              SELECT bar.a FROM (SELECT a FROM (SELECT t_onecol.a FROM public.t_onecol) AS foo) AS bar;
-            $$
+                SELECT
+                  bar.a
+                FROM
+                  (
+                    SELECT
+                      a
+                    FROM
+                      (SELECT t_onecol.a FROM public.t_onecol)
+                        AS foo
+                  )
+                    AS bar;
+              $$
 
 query TT
 SHOW CREATE FUNCTION f_allcolsel_alias


### PR DESCRIPTION
The populate functions for the virtual tables
`crdb_internal.create_{function,procedure}_statements`,
which back SHOW CREATE FUNCTION/PROCEDURE, have been
updated to use the pretty-printer to generate their
`create_statement` columns.

Fixes #166671

Release note (sql change): The `create_statement` column in
SHOW CREATE FUNCTION/PROCEDURE is now pretty-printed.