### PR TITLE
workflows: default to trunk merge for backport auto-merge

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -83,8 +83,9 @@ jobs:
               const baseRef = pr.baseRefName;
               console.log(`Processing PR #${pr.number}, Created at: ${pr.createdAt}, Approved: ${approved}, Target: ${baseRef}, Labels: ${labels}`);
 
-              const trunkBranches = ['release-24.3', 'release-25.2'];
-              if (trunkBranches.includes(baseRef)) {
+              const nonTrunkBranches = ['release-24.1', 'release-25.1', 'release-25.3'];
+              const useTrunk = !nonTrunkBranches.includes(baseRef);
+              if (useTrunk) {
                 // Use comment to trigger trunk merge for trunk-enabled branches
                 console.log(`Adding /trunk merge comment for PR #${pr.number} (target: ${baseRef})`);
                 try {


### PR DESCRIPTION
Previously, the auto-merge workflow maintained an allowlist of
trunk-enabled branches, which required updating every time a new
release branch was cut. This caused auto-merge failures on newer
branches like release-25.4, release-26.1, and release-26.2 because
the `GITHUB_TOKEN` lacks permission to push directly to protected
branches.

Invert the logic to use a blocklist of known non-trunk branches
instead, so new release branches default to using `/trunk merge`.

Epic: none
Release note: None