### PR TITLE
roachtest: bump max backfill duration for single-node-index-backfill

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -433,7 +433,7 @@ func runSingleNodeIndexBackfill(
 	// tolerate run-to-run variance while catching severe regressions (e.g.,
 	// AC over-throttling the backfill or starving the disk).
 	const (
-		maxBackfillDuration = 90 * time.Minute
+		maxBackfillDuration = 150 * time.Minute
 		minAvgTotalBW       = 50.0 // MiB/s
 	)
 	if backfillDuration > maxBackfillDuration {


### PR DESCRIPTION
## Summary

The test's 90-minute assertion on index backfill duration is too tight.
We've seen the backfill take ~2h4m in CI -- the average disk bandwidth
was ~113 MiB/s against a provisioned 128 MB/s, so things weren't wildly
off. Looking at the logs, there are ~100 instances of
`RangeKeyMismatchError` retries during SST ingestion, and since we wait
in admission control before each retry, that's likely enough to push us
past the threshold.

Bump the assertion to 150 minutes (2.5 hours).

Closes: https://github.com/cockroachdb/cockroach/issues/167108
Epic: none
Release note: None