### PR TITLE
roachprod: idempotent dns delete during gc

### DIFF
--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -246,7 +246,14 @@ func (n *dnsProvider) deleteRecords(
 			// have been partially deleted.
 			n.clearCacheEntry(name)
 			if err != nil {
-				return rperrors.TransientFailure(errors.Wrapf(err, "output: %s", out), dnsProblemLabel)
+				outStr := string(out)
+				// Be idempotent: gcloud returns a non-zero exit code when the
+				// record does not exist, with an error message like:
+				//   The 'parameters.name' resource named 'xxxx-0001.roachprod.crdb.io.' does not exist.
+				if strings.Contains(outStr, "does not exist") {
+					return nil
+				}
+				return rperrors.TransientFailure(errors.Wrapf(err, "output: %s", outStr), dnsProblemLabel)
 			}
 			return nil
 		})


### PR DESCRIPTION
Previously, all errors during DNS records deletions were being returned. This could lead to race conditions in which normal clusters operations were racing with the GC process and were trying to delete records that were already deleted.

This patch makes the DNS records deletion idempotent by not throwing an error if the record is already deleted.

Epic: none
Release note: None