### PR TITLE
logictest: deflake select_for_share SKIP LOCKED test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_share
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share
@@ -214,6 +214,14 @@ CREATE TABLE t(a INT PRIMARY KEY);
 INSERT INTO t VALUES(1), (2);
 GRANT ALL ON t TO testuser;
 
+# Read both keys to ensure the INSERT's intents are resolved before any SKIP
+# LOCKED scan, which would skip unresolved intents (see #167582).
+query I rowsort
+SELECT * FROM t
+----
+1
+2
+
 user testuser
 
 statement ok


### PR DESCRIPTION
The select_for_share logic test was flaking because SKIP LOCKED
unconditionally skips keys with intents from other transactions,
including committed ones whose intents haven't been resolved yet. The
metamorphic constant max-intents-in-flight-per-caller (introduced in
59446e8af66) can serialize intent resolution when set to 1, widening
this window enough for the INSERT's intents to still be present when
the SKIP LOCKED scan runs.

Add a SELECT * FROM t after the INSERT to force intent resolution on
both keys before the SKIP LOCKED scan.

Fixes: #167458
See also: #167582
Epic: none

Release note: None