### PR TITLE
release-24.3: roachtest: deflake bad stats issues in tpcc PCR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -679,6 +679,39 @@ func (rd *replicationDriver) preStreamingWorkload(ctx context.Context) {
 		rd.c.Run(ctx, option.WithNodes(rd.setup.workloadNode), initCmd)
 		rd.t.L().Printf("src cluster workload initialization took %s",
 			timeutil.Since(initStart))
+
+		if _, ok := rd.rs.workload.(replicateTPCC); ok {
+			// Ensure all imported tables have stats before starting the
+			// replication stream. Without this, serialized auto-stats collection
+			// can leave some tables without stats for 15+ minutes after import,
+			// causing bad query plans and CPU saturation on the reader tenant
+			// workload. See #164639.
+			rd.t.Status("collecting table statistics on source tenant")
+			analyzeStart := timeutil.Now()
+			srcTenantConn := rd.c.Conn(
+				ctx, rd.t.L(), rd.setup.src.nodes[0],
+				option.VirtualClusterName(rd.setup.src.name),
+				option.DBName("tpcc"),
+				option.User("root"),
+				option.AuthMode(install.AuthRootCert),
+			)
+			defer srcTenantConn.Close()
+			srcTenantSQL := sqlutils.MakeSQLRunner(srcTenantConn)
+
+			rows := srcTenantSQL.QueryStr(
+				rd.t, `SELECT table_name FROM [SHOW TABLES]`,
+			)
+			for _, row := range rows {
+				tableName := row[0]
+				rd.t.L().Printf("running ANALYZE on %q", tableName)
+				srcTenantSQL.Exec(
+					rd.t, fmt.Sprintf(`ANALYZE "%s"`, tableName),
+				)
+			}
+			rd.t.L().Printf(
+				"table statistics collection took %s", timeutil.Since(analyzeStart),
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #167321 on behalf of @andrew-r-thomas.

----

This patch avoids an issue identified in #164639 where asynchronous table statistic collection would fail to collect stats prior to the reader tenant workload starting, causing bad query plans which lead to our 2m latency SLA being violated. The fix is to run `ANALYZE` queries on relevant tables prior to starting the replication stream, ensuring the destination cluster has proper table statistics for its query plans.

Epic: None

Release note: None

----

Release justification: Test only change to reduce flakes.