### PR TITLE
release-26.2: backup: deflake TestBackupJobRetryReset

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1686,6 +1686,9 @@ func TestBackupJobRetryReset(t *testing.T) {
 	}
 	params.ServerArgs = base.TestServerArgs{Knobs: knobs}
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 10, InitManualReplication, params)
+	// We disable range-sized spans for this test to avoid 0-span progress
+	// updates. The conditions in which this can occur are outlined in #166401.
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.presplit_request_spans.enabled = false")
 	// This creates 4 additional backup chunks.
 	for i := 0; i < 4; i++ {
 		sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s AS (SELECT * FROM bank)`, "bank"+strconv.Itoa(i)))


### PR DESCRIPTION
Backport 1/1 commits from #167504 on behalf of @kev-cao.

----

See the analysis in #166401 for details on this flake.

Fixes: #166401

Release note: None

----

Release justification: Test-only change.