### PR TITLE
release-26.1: ccl/sqlproxyccl/acl: fix flaky TestAllowlistLogic test

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/file_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/file_test.go
@@ -493,15 +493,31 @@ allowlist:
 	for _, tc := range testCases {
 		require.NoError(t, os.WriteFile(filename, []byte(tc.input), 0777))
 
-		controller := <-channel
-		for _, ioPairs := range tc.specs {
-			err := controller.CheckConnection(ctx, ioPairs.connection)
-			if ioPairs.outcome == "" {
-				require.Nil(t, err)
-			} else {
-				require.EqualError(t, err, ioPairs.outcome)
+		// Keep polling until we get the controller we expect. It's possible
+		// that occasionally things run too slowly, and a stale controller
+		// without the most recent data gets pushed because the polling
+		// interval passes. However, we do know that eventually we expect to
+		// read our desired controller.
+		testutils.SucceedsSoon(t, func() error {
+			select {
+			case controller := <-channel:
+				for _, ioPairs := range tc.specs {
+					err := controller.CheckConnection(ctx, ioPairs.connection)
+					if ioPairs.outcome == "" {
+						if err != nil {
+							return errors.Newf("expected no error, but got %v", err) // nolint:errwrap
+						}
+					} else {
+						if err == nil || err.Error() != ioPairs.outcome {
+							return errors.Newf("expected %v, but got %v", ioPairs.outcome, err) // nolint:errwrap
+						}
+					}
+				}
+				return nil
+			default:
+				return errors.New("no data")
 			}
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #161295 on behalf of @davidwding.

----

TestAllowlistLogic was written in such a way that it was possible for the test to fail due to receiving a stale controller, if the timing of the polling didn't play nice with writing the new data.

To fix this, we read controllers until we receive the one that we expect, flushing out the stale ones.

Fixes https://github.com/cockroachdb/cockroach/issues/157975

----

Release justification: update to test-only code