### PR TITLE
release-25.4: roachtest: add index backfill admission control tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "roachtestutil",
     srcs = [
         "commandbuilder.go",
+        "disk_snapshot.go",
         "disk_stall.go",
         "disk_usage.go",
         "httpclient.go",
@@ -31,6 +32,7 @@ go_library(
         "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/vm",
         "//pkg/testutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util",

--- a/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+)
+
+// CopySnapshotDataToNodes copies CockroachDB data from GCE disk snapshots to
+// each CRDB node's primary disk, replacing any existing data in
+// /mnt/data1/cockroach. This avoids using cluster.ApplySnapshots directly
+// because GCE snapshot-backed disks have a hydration problem: reads are very
+// slow (~50 MB/s with 250ms latency) until the disk is fully hydrated in the
+// background.
+//
+// For each CRDB node, the function:
+//  1. Finds the matching snapshot by node number suffix
+//  2. Creates a temporary pd-ssd disk from the snapshot
+//  3. Attaches and mounts it read-only
+//  4. Removes existing data at /mnt/data1/cockroach and copies snapshot
+//     data in its place via rsync
+//  5. Cleans up (unmount, detach, delete the temporary disk)
+//
+// All nodes are processed in parallel.
+func CopySnapshotDataToNodes(
+	ctx context.Context, t test.Test, c cluster.Cluster, snapshots []vm.VolumeSnapshot,
+) {
+	t.Status("copying snapshot data to CRDB nodes (avoiding GCE hydration problem)")
+
+	g := t.NewGroup(task.WithContext(ctx))
+	for _, nodeID := range c.CRDBNodes() {
+		nodeID := nodeID
+		g.Go(func(ctx context.Context, l *logger.Logger) error {
+			return copySnapshotDataToNode(ctx, l, c, snapshots, nodeID)
+		}, task.Name(fmt.Sprintf("copy-snapshot-n%d", nodeID)))
+	}
+	g.Wait()
+
+	t.L().Printf("snapshot data successfully copied to all %d CRDB nodes",
+		len(c.CRDBNodes()))
+}
+
+func copySnapshotDataToNode(
+	ctx context.Context,
+	l *logger.Logger,
+	c cluster.Cluster,
+	snapshots []vm.VolumeSnapshot,
+	nodeID int,
+) error {
+	node := option.NodeListOption{nodeID}
+
+	// Find the snapshot for this node. Snapshot names end with a zero-padded
+	// node number, e.g. "index-backfill-tpce-100k-v24.3.0-n10-0003".
+	suffix := fmt.Sprintf("-%04d", nodeID)
+	var snap vm.VolumeSnapshot
+	for _, s := range snapshots {
+		if strings.HasSuffix(s.Name, suffix) {
+			snap = s
+			break
+		}
+	}
+	if snap.ID == "" {
+		return fmt.Errorf("no snapshot found for node %d (suffix %s)", nodeID, suffix)
+	}
+	l.Printf("n%d: using snapshot %s (ID: %s)", nodeID, snap.Name, snap.ID)
+
+	// Query the GCE zone from instance metadata rather than hardcoding it.
+	getZoneCmd := `curl -sf -H "Metadata-Flavor: Google" ` +
+		`http://metadata.google.internal/computeMetadata/v1/instance/zone`
+	zoneOutput, err := c.RunWithDetailsSingleNode(
+		ctx, l, option.WithNodes(node), getZoneCmd,
+	)
+	if err != nil {
+		return fmt.Errorf("n%d: failed to get zone from GCE metadata: %w", nodeID, err)
+	}
+	// Zone format: projects/PROJECT_NUMBER/zones/ZONE_NAME
+	zoneParts := strings.Split(strings.TrimSpace(zoneOutput.Stdout), "/")
+	if len(zoneParts) < 4 || zoneParts[len(zoneParts)-2] != "zones" {
+		return fmt.Errorf(
+			"n%d: unexpected zone format from metadata: %q", nodeID, zoneOutput.Stdout,
+		)
+	}
+	zone := zoneParts[len(zoneParts)-1]
+
+	// Use a per-node temp disk name to avoid collisions when running in
+	// parallel across nodes.
+	tempDiskName := fmt.Sprintf("%s-temp-snapshot-%04d", c.Name(), nodeID)
+	deviceName := fmt.Sprintf("snapshot-disk-%04d", nodeID)
+
+	// Create a temporary disk from the snapshot.
+	l.Printf("n%d: creating temp disk %s from snapshot in zone %s",
+		nodeID, tempDiskName, zone)
+	createDiskCmd := fmt.Sprintf(
+		`gcloud compute disks create %s --source-snapshot=%s --zone=%s --type=pd-ssd --quiet`,
+		tempDiskName, snap.ID, zone,
+	)
+	if err := c.RunE(ctx, option.WithNodes(node), createDiskCmd); err != nil {
+		return fmt.Errorf("n%d: failed to create disk from snapshot: %w", nodeID, err)
+	}
+
+	// Clean up the temp disk when we're done, regardless of success or
+	// failure. Use a fresh context since the original may be cancelled
+	// on test timeout, and we don't want to leave orphaned GCE disks.
+	unmountCmd := `sudo umount /mnt/snapshot && sudo rmdir /mnt/snapshot`
+	mounted := false
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		if mounted {
+			if err := c.RunE(cleanupCtx, option.WithNodes(node), unmountCmd); err != nil {
+				l.Printf("n%d: warning: failed to unmount snapshot disk: %v", nodeID, err)
+			}
+		}
+
+		l.Printf("n%d: cleaning up temp disk %s", nodeID, tempDiskName)
+		detachCmd := fmt.Sprintf(
+			`gcloud compute instances detach-disk $(hostname) --disk=%s --zone=%s --quiet`,
+			tempDiskName, zone,
+		)
+		_ = c.RunE(cleanupCtx, option.WithNodes(node), detachCmd)
+		deleteCmd := fmt.Sprintf(
+			`gcloud compute disks delete %s --zone=%s --quiet`,
+			tempDiskName, zone,
+		)
+		_ = c.RunE(cleanupCtx, option.WithNodes(node), deleteCmd)
+	}()
+
+	// Attach the temporary disk.
+	l.Printf("n%d: attaching temp disk", nodeID)
+	attachCmd := fmt.Sprintf(
+		`gcloud compute instances attach-disk $(hostname) --disk=%s --zone=%s --device-name=%s --quiet`,
+		tempDiskName, zone, deviceName,
+	)
+	if err := c.RunE(ctx, option.WithNodes(node), attachCmd); err != nil {
+		return fmt.Errorf("n%d: failed to attach snapshot disk: %w", nodeID, err)
+	}
+
+	// Mount the temporary disk read-only.
+	l.Printf("n%d: mounting snapshot disk", nodeID)
+	mountCmd := fmt.Sprintf(
+		`sudo mkdir -p /mnt/snapshot && sudo mount -o ro /dev/disk/by-id/google-%s /mnt/snapshot`,
+		deviceName,
+	)
+	if err := c.RunE(ctx, option.WithNodes(node), mountCmd); err != nil {
+		return fmt.Errorf("n%d: failed to mount snapshot disk: %w", nodeID, err)
+	}
+	mounted = true
+
+	// Remove existing data and copy snapshot data to the primary disk.
+	l.Printf("n%d: wiping /mnt/data1/cockroach and copying snapshot data", nodeID)
+	copyCmd := `sudo rm -rf /mnt/data1/cockroach && ` +
+		`sudo rsync -ah --info=progress2 /mnt/snapshot/cockroach /mnt/data1/`
+	if err := c.RunE(ctx, option.WithNodes(node), copyCmd); err != nil {
+		return fmt.Errorf("n%d: failed to copy data from snapshot: %w", nodeID, err)
+	}
+	l.Printf("n%d: data copy complete", nodeID)
+
+	return nil
+}

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "admission_control_multi_store_overload.go",
         "admission_control_multitenant_fairness.go",
         "admission_control_row_level_ttl.go",
+        "admission_control_single_node_index_backfill.go",
         "admission_control_snapshot_overload.go",
         "admission_control_snapshot_overload_io.go",
         "admission_control_tpcc_overload.go",

--- a/pkg/cmd/roachtest/tests/admission_control.go
+++ b/pkg/cmd/roachtest/tests/admission_control.go
@@ -35,6 +35,7 @@ func registerAdmission(r registry.Registry) {
 	registerTPCCSevereOverload(r)
 	registerIndexOverload(r)
 	registerIndexBackfill(r)
+	registerSingleNodeIndexBackfill(r)
 	registerMultiStoreIndexBackfill(r)
 	registerDatabaseDrop(r)
 	registerIntentResolutionOverload(r)

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -8,21 +8,72 @@ package tests
 import (
 	"context"
 	"fmt"
+	"math"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
+
+var indexBackfillQPS = clusterstats.ClusterStat{
+	LabelName: "node",
+	Query:     "rate(sql_query_count[2m])",
+}
+
+var indexBackfillQPSAgg = clusterstats.AggQuery{
+	Stat:  indexBackfillQPS,
+	Query: "sum(rate(sql_query_count[2m]))",
+	Tag:   "Total QPS",
+}
+
+type indexBackfillVariant struct {
+	nameSuffix               string
+	snapshotPrefix           string
+	withCgroupLimiting       bool
+	withProvisionedBandwidth bool
+}
+
+var indexBackfillVariants = []indexBackfillVariant{
+	{
+		nameSuffix:     "/no-disk-limit",
+		snapshotPrefix: "index-backfill-tpce-100k-nodisklimit",
+	},
+	{
+		nameSuffix:         "/provisioned-bandwidth=false",
+		snapshotPrefix:     "index-backfill-tpce-100k-nobw",
+		withCgroupLimiting: true,
+	},
+	{
+		nameSuffix:               "/provisioned-bandwidth=true",
+		snapshotPrefix:           "index-backfill-tpce-100k-bw",
+		withCgroupLimiting:       true,
+		withProvisionedBandwidth: true,
+	},
+}
+
+// versionedSnapshotPrefix returns a snapshot prefix that includes the major
+// version (e.g., "index-backfill-tpce-100k-bw-v26.2") so that each major
+// release uses its own snapshots. This is needed because snapshot data may
+// not be compatible across major versions.
+func versionedSnapshotPrefix(t test.Test) string {
+	v := t.BuildVersion()
+	return fmt.Sprintf("%s-v%s", t.SnapshotPrefix(), v.Major())
+}
 
 func registerIndexBackfill(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
@@ -34,185 +85,454 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
+		spec.ReuseNone(),
 	)
 
-	r.Add(registry.TestSpec{
-		Name:             "admission-control/index-backfill",
-		Timeout:          6 * time.Hour,
-		Owner:            registry.OwnerAdmissionControl,
-		Benchmark:        true,
-		CompatibleClouds: registry.OnlyGCE,
-		Suites:           registry.ManualOnly,
-		// TODO(aaditya): Revisit this as part of #111614.
-		//Suites:           registry.Suites(registry.Weekly),
-		//Tags:             registry.Tags(`weekly`),
-		Cluster:        clusterSpec,
-		SnapshotPrefix: "index-backfill-tpce-100k",
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
-				// TODO(irfansharif): Search by taking in the other parts of the
-				// snapshot fingerprint, i.e. the node count, the version, etc.
-				NamePrefix: t.SnapshotPrefix(),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(snapshots) == 0 {
-				t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
-					t.Name(), t.SnapshotPrefix())
+	for _, v := range indexBackfillVariants {
+		r.Add(registry.TestSpec{
+			Name:             "admission-control/index-backfill" + v.nameSuffix,
+			Timeout:          12 * time.Hour,
+			Owner:            registry.OwnerAdmissionControl,
+			Benchmark:        true,
+			CompatibleClouds: registry.OnlyGCE,
+			Suites:           registry.Suites(registry.Nightly),
+			Cluster:          clusterSpec,
+			SnapshotPrefix:   v.snapshotPrefix,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runIndexBackfill(ctx, t, c, clusterSpec, v.withCgroupLimiting, v.withProvisionedBandwidth)
+			},
+		})
+	}
+}
 
-				// Set up TPC-E with 100k customers. Do so using a published
-				// CRDB release, since we'll use this state to generate disk
-				// snapshots.
-				runTPCE(ctx, t, c, tpceOptions{
-					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						pred, err := release.LatestPredecessor(t.BuildVersion())
-						if err != nil {
-							t.Fatal(err)
-						}
+const indexBackfillDiskBandwidth = 128 << 20 // 128 MiB/s
 
-						path, err := clusterupgrade.UploadCockroach(
-							ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
-						)
-						if err != nil {
-							t.Fatal(err)
-						}
+func runIndexBackfill(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	clusterSpec spec.ClusterSpec,
+	withCgroupLimiting bool,
+	withProvisionedBandwidth bool,
+) {
+	snapshotPrefix := versionedSnapshotPrefix(t)
+	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
+		// TODO(irfansharif): Search by taking in the other parts of the
+		// snapshot fingerprint, i.e. the node count, the version, etc.
+		NamePrefix: snapshotPrefix,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) == 0 {
+		t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
+			t.Name(), snapshotPrefix)
 
-						// Copy over the binary to ./cockroach and run it from
-						// there. This test captures disk snapshots, which are
-						// fingerprinted using the binary version found in this
-						// path. The reason it can't just poke at the running
-						// CRDB process is because when grabbing snapshots, CRDB
-						// is not running.
-						c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
-						settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
-						startOpts := option.NewStartOpts(option.NoBackupSchedule)
-						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-						if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
-							t.Fatal(err)
-						}
-					},
-					customers:          100_000,
-					disablePrometheus:  true,
-					setupType:          usingTPCEInit,
-					estimatedSetupTime: 4 * time.Hour,
-					nodes:              len(c.CRDBNodes()),
-					cpus:               clusterSpec.CPUs,
-					ssds:               1,
-					onlySetup:          true,
-				})
-
-				// Stop all nodes before capturing cluster snapshots.
-				c.Stop(ctx, t.L(), option.DefaultStopOpts())
-
-				// Create the aforementioned snapshots.
-				snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
+		// Set up TPC-E with 100k customers. Do so using a published
+		// CRDB release, since we'll use this state to generate disk
+		// snapshots.
+		runTPCE(ctx, t, c, tpceOptions{
+			start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				pred, err := release.LatestPredecessor(t.BuildVersion())
 				if err != nil {
 					t.Fatal(err)
 				}
-				t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
-					len(snapshots), t.SnapshotPrefix())
-			} else {
-				t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
-					len(snapshots), t.SnapshotPrefix())
 
-				if !t.SkipInit() {
-					// Creating and attaching volumes takes some time. This test
-					// is written to be re-entrant. Assume the user passing in
-					// --skip-init knows this particular test behavior.
-					if err := c.ApplySnapshots(ctx, snapshots); err != nil {
-						t.Fatal(err)
-					}
-				}
-			}
-
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
-				WithNodeExporter(c.CRDBNodes().InstallNodes()).
-				WithCluster(c.CRDBNodes().InstallNodes()).
-				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
-				WithScrapeConfigs(
-					prometheus.MakeWorkloadScrapeConfig("workload", "/",
-						makeWorkloadScrapeNodes(
-							c.WorkloadNode().InstallNodes()[0],
-							[]workloadInstance{{nodes: c.WorkloadNode()}},
-						),
-					),
+				path, err := clusterupgrade.UploadCockroach(
+					ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
 				)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			// Run the foreground TPC-E workload for 20k customers for 1hr. Run
-			// large index backfills while it's running.
-			runTPCE(ctx, t, c, tpceOptions{
-				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					startOpts := option.NewStartOpts(option.NoBackupSchedule)
-					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-					settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
-					if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
-						t.Fatal(err)
-					}
-				},
-				customers:        100_000,
-				activeCustomers:  20_000,
-				threads:          400,
-				skipCleanup:      true,
-				ssds:             1,
-				setupType:        usingExistingTPCEData,
-				nodes:            clusterSpec.NodeCount - 1,
-				cpus:             clusterSpec.CPUs,
-				prometheusConfig: promCfg,
-				workloadDuration: time.Hour + 30*time.Minute,
-				during: func(ctx context.Context) error {
-					db := c.Conn(ctx, t.L(), 1)
-					defer db.Close()
+				// Copy over the binary to ./cockroach and run it from
+				// there. This test captures disk snapshots, which are
+				// fingerprinted using the binary version found in this
+				// path. The reason it can't just poke at the running
+				// CRDB process is because when grabbing snapshots, CRDB
+				// is not running.
+				c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
+				settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
+				roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+				if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+					t.Fatal(err)
+				}
+			},
+			customers:          100_000,
+			disablePrometheus:  true,
+			setupType:          usingTPCEInit,
+			estimatedSetupTime: 4 * time.Hour,
+			nodes:              len(c.CRDBNodes()),
+			cpus:               clusterSpec.CPUs,
+			ssds:               1,
+			onlySetup:          true,
+		})
 
-					// Defeat https://github.com/cockroachdb/cockroach/issues/98311.
-					if _, err := db.ExecContext(ctx,
-						"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false;",
-					); err != nil {
-						t.Fatal(err)
-					}
+		// Stop all nodes before capturing cluster snapshots.
+		c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
-					t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
-					time.Sleep(5 * time.Minute)
+		// Create the aforementioned snapshots.
+		snapshots, err = c.CreateSnapshot(ctx, snapshotPrefix)
+		if err != nil {
+			if strings.Contains(err.Error(), "already exists") {
+				// Another concurrent run may have already created snapshots
+				// with the same name.
+				t.L().Printf("snapshot creation hit 'already exists' error, proceeding: %v", err)
+			} else {
+				t.Fatal(err)
+			}
+		} else {
+			t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
+				len(snapshots), snapshotPrefix)
+		}
+	} else {
+		t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
+			len(snapshots), snapshotPrefix)
 
-					// Choose index creations and primary key changes that would
-					// take ~30 minutes each. Offset them by 5 minutes.
-					//
-					// TODO(irfansharif): These now take closer to an hour after
-					// https://github.com/cockroachdb/cockroach/pull/109085. Do
-					// something about it if customers complain.
-					m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-					m.Go(func(ctx context.Context) error {
-						t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
-						_, err := db.ExecContext(ctx,
-							fmt.Sprintf("CREATE INDEX index_%s ON tpce.cash_transaction (ct_dts)",
-								timeutil.Now().Format("20060102_T150405"),
-							),
-						)
-						t.Status("finished index creation")
-						return err
-					})
-					m.Go(func(ctx context.Context) error {
-						// TODO(irfansharif): Is the re-entrant? As in,
-						// effective when re-running the roachtest against the
-						// same cluster that's already run the test once? Useful
-						// to make it so if possible, to run things more
-						// iteratively.
-						time.Sleep(5 * time.Minute)
-						t.Status(fmt.Sprintf("starting primary key change (<%s)", 30*time.Minute))
-						_, err := db.ExecContext(ctx,
-							"ALTER TABLE tpce.holding_history ALTER PRIMARY KEY USING COLUMNS (hh_h_t_id ASC, hh_t_id ASC, hh_before_qty ASC)",
-						)
-						t.Status("finished primary key change")
-						return err
-					})
-					m.Wait()
+		if !t.SkipInit() {
+			roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
+		}
+	}
 
-					t.Status(fmt.Sprintf("waiting for workload to finish (<%s)", 50*time.Minute))
+	// Set up prometheus for metrics collection.
+	promCfg := &prometheus.Config{}
+	promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+		WithNodeExporter(c.CRDBNodes().InstallNodes()).
+		WithCluster(c.CRDBNodes().InstallNodes()).
+		WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
+		WithScrapeConfigs(
+			prometheus.MakeWorkloadScrapeConfig("workload", "/",
+				makeWorkloadScrapeNodes(
+					c.WorkloadNode().InstallNodes()[0],
+					[]workloadInstance{{nodes: c.WorkloadNode()}},
+				),
+			),
+		)
+	if err := c.StartGrafana(ctx, t.L(), promCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up prometheus client and stat collector for roachperf export.
+	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+	require.NoError(t, err)
+	statCollector := clusterstats.NewStatsCollector(ctx, promClient)
+
+	// Start the cluster.
+	t.Status("starting cluster for workload")
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
+	roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+	roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+	settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+	if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure cluster settings before workload begins.
+	db := c.Conn(ctx, t.L(), 1)
+	defer db.Close()
+
+	// Work around https://github.com/cockroachdb/cockroach/issues/98311.
+	// TPC-E tables use a 300s GC TTL. When admission control delays
+	// AddSSTable requests beyond this TTL, the GC threshold advances
+	// past the batch timestamp and the request fails.
+	if _, err := db.ExecContext(ctx,
+		"SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if withCgroupLimiting {
+		// Optionally tell admission control the disk's provisioned
+		// bandwidth so it can manage elastic vs. foreground work.
+		if withProvisionedBandwidth {
+			if _, err := db.ExecContext(ctx,
+				"SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
+			); err != nil {
+				t.Fatal(err)
+			}
+			// Allow elastic work to fully utilize the provisioned
+			// bandwidth.
+			if _, err := db.ExecContext(ctx,
+				"SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Limit disk bandwidth to 128 MiB/s via cgroups so that disk I/O
+		// becomes the bottleneck. Without this, pd-ssd disks are fast enough
+		// that admission control has nothing meaningful to manage. This must
+		// run after c.StartE, since the cgroup path for the cockroach systemd
+		// service only exists after the service has been created.
+		t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups",
+			indexBackfillDiskBandwidth))
+		staller := roachtestutil.MakeCgroupDiskStaller(t, c,
+			true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
+		staller.Setup(ctx)
+		staller.Slow(ctx, c.CRDBNodes(), indexBackfillDiskBandwidth)
+	}
+
+	// Initialize TPC-E spec for running workload commands.
+	tpceSpec, err := initTPCESpec(ctx, t.L(), c)
+	require.NoError(t, err)
+
+	// Run TPC-E workload and schema changes concurrently, collecting
+	// disk bandwidth metrics during the schema changes.
+	const (
+		workloadDuration = 90 * time.Minute
+		baselineWait     = 5 * time.Minute
+	)
+	var backfillDuration time.Duration
+	var pkChangeDuration time.Duration
+	var totalBWSamples []float64
+	var metricsStart, metricsEnd time.Time
+
+	g := t.NewGroup(task.WithContext(ctx))
+
+	// Goroutine 1: Run TPC-E workload.
+	g.Go(func(ctx context.Context, l *logger.Logger) error {
+		t.Status(fmt.Sprintf("starting TPC-E workload with 20000 active customers (<%s)",
+			workloadDuration))
+		runOptions := tpceCmdOptions{
+			customers:       100_000,
+			activeCustomers: 20_000,
+			racks:           len(c.CRDBNodes()),
+			duration:        workloadDuration,
+			threads:         400,
+			skipCleanup:     true,
+			connectionOpts:  defaultTPCEConnectionOpts(),
+		}
+		result, err := tpceSpec.run(ctx, t, c, runOptions)
+		if err != nil {
+			l.Printf("TPC-E workload error: %v", err)
+			return err
+		}
+		l.Printf("TPC-E workload output:\n%s\n", result.Stdout)
+		return nil
+	}, task.Name("tpce-workload"))
+
+	// Goroutine 2: Run index creation after baseline period.
+	g.Go(func(ctx context.Context, l *logger.Logger) error {
+		t.Status(fmt.Sprintf("recording baseline performance (<%s)", baselineWait))
+		time.Sleep(baselineWait)
+
+		t.Status("starting index creation on tpce.cash_transaction")
+		indexName := fmt.Sprintf("index_%s", timeutil.Now().Format("20060102_T150405"))
+
+		backfillStart := timeutil.Now()
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf("CREATE INDEX %s ON tpce.cash_transaction (ct_dts)", indexName),
+		)
+		backfillDuration = timeutil.Since(backfillStart)
+		if err != nil {
+			l.Printf("index creation error: %v", err)
+			return err
+		}
+		l.Printf("index backfill completed in %s", backfillDuration)
+		t.Status("finished index creation")
+		return nil
+	}, task.Name("index-backfill"))
+
+	// Goroutine 3: Run primary key change, starting 10 minutes after
+	// test start (5 minutes after the index backfill starts).
+	g.Go(func(ctx context.Context, l *logger.Logger) error {
+		time.Sleep(baselineWait + 5*time.Minute)
+
+		t.Status("starting primary key change on tpce.holding_history")
+		pkChangeStart := timeutil.Now()
+		_, err := db.ExecContext(ctx,
+			"ALTER TABLE tpce.holding_history ALTER PRIMARY KEY USING COLUMNS (hh_h_t_id ASC, hh_t_id ASC, hh_before_qty ASC)",
+		)
+		pkChangeDuration = timeutil.Since(pkChangeStart)
+		if err != nil {
+			l.Printf("primary key change error: %v", err)
+			return err
+		}
+		l.Printf("primary key change completed in %s", pkChangeDuration)
+		t.Status("finished primary key change")
+		return nil
+	}, task.Name("pk-change"))
+
+	// Collect disk bandwidth metrics in a separate goroutine outside the
+	// group, so g.Wait() only blocks on the workload and schema changes.
+	stopMetrics := make(chan struct{})
+	metricsDone := make(chan struct{})
+	t.Go(func(ctx context.Context, l *logger.Logger) error {
+		defer close(metricsDone)
+
+		// Wait for baseline period before starting collection.
+		time.Sleep(baselineWait)
+
+		metricsStart = timeutil.Now()
+		defer func() { metricsEnd = timeutil.Now() }()
+
+		// Use avg() across nodes to get per-node average bandwidth,
+		// which is comparable to the 128 MiB/s cgroup limit.
+		writeBWQuery := divQuery("avg(rate(sys_host_disk_write_bytes[1m]))", 1<<20)
+		readBWQuery := divQuery("avg(rate(sys_host_disk_read_bytes[1m]))", 1<<20)
+
+		getMetricVal := func(query string) (float64, error) {
+			point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
+			if err != nil {
+				return 0, err
+			}
+			for _, v := range point[""] {
+				return v.Value, nil
+			}
+			return 0, fmt.Errorf("no data for query %s", query)
+		}
+
+		l.Printf("=== DISK BANDWIDTH METRICS COLLECTION STARTED (1m interval) ===")
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
+		iteration := 0
+		for {
+			select {
+			case <-ticker.C:
+				iteration++
+				writeBW, writeErr := getMetricVal(writeBWQuery)
+				readBW, readErr := getMetricVal(readBWQuery)
+				if writeErr != nil || readErr != nil {
+					l.Printf("[metrics %d] error collecting: write=%v, read=%v",
+						iteration, writeErr, readErr)
+					continue
+				}
+				totalBW := writeBW + readBW
+				totalBWSamples = append(totalBWSamples, totalBW)
+				l.Printf("[metrics %d] disk bandwidth: read=%.2f MiB/s, write=%.2f MiB/s, total=%.2f MiB/s",
+					iteration, readBW, writeBW, totalBW)
+			case <-stopMetrics:
+				l.Printf("=== DISK BANDWIDTH METRICS COLLECTION STOPPED ===")
+				return nil
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}, task.Name("metrics-collector"))
+
+	// Wait for workload and schema changes, then stop metrics collection.
+	g.Wait()
+	close(stopMetrics)
+	<-metricsDone
+
+	t.L().Printf("index backfill duration: %s", backfillDuration)
+	t.L().Printf("primary key change duration: %s", pkChangeDuration)
+
+	// Compute mean total bandwidth from the samples collected during
+	// schema changes.
+	var avgTotalBW float64
+	if len(totalBWSamples) > 0 {
+		var sum float64
+		for _, s := range totalBWSamples {
+			sum += s
+		}
+		avgTotalBW = sum / float64(len(totalBWSamples))
+		t.L().Printf("average total disk bandwidth during schema changes: %.2f MiB/s (%d samples)",
+			avgTotalBW, len(totalBWSamples))
+	}
+
+	// Export metrics to roachperf.
+	if !metricsStart.IsZero() && !metricsEnd.IsZero() {
+		exportingStats, err := statCollector.Exporter().Export(
+			ctx, c, t, true, /* dryRun */
+			metricsStart, metricsEnd,
+			[]clusterstats.AggQuery{sqlServiceLatencyAgg, indexBackfillQPSAgg},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return &roachtestutil.AggregatedMetric{
+					Name:           "index_backfill_duration",
+					Value:          roachtestutil.MetricPoint(backfillDuration.Seconds()),
+					Unit:           "s",
+					IsHigherBetter: false,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return &roachtestutil.AggregatedMetric{
+					Name:           "primary_key_change_duration",
+					Value:          roachtestutil.MetricPoint(pkChangeDuration.Seconds()),
+					Unit:           "s",
+					IsHigherBetter: false,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				if avgTotalBW == 0 {
 					return nil
-				},
-			})
-		},
-	})
+				}
+				return &roachtestutil.AggregatedMetric{
+					Name:           "mean_total_bandwidth",
+					Value:          roachtestutil.MetricPoint(avgTotalBW),
+					Unit:           "MiB/s",
+					IsHigherBetter: true,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return meanNonNaN(stats, sqlServiceLatency.Query, "mean_p99_latency", "ms", false)
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return meanNonNaN(stats, indexBackfillQPS.Query, "mean_qps", "queries/s", true)
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Replace NaN values to avoid JSON serialization errors.
+		// histogram_quantile returns NaN when there are no queries
+		// in the rate window.
+		cleanNaN(exportingStats, sqlServiceLatency.Query)
+		cleanNaN(exportingStats, indexBackfillQPS.Query)
+
+		if err := exportingStats.SerializeOutRun(
+			ctx, t, c, t.ExportOpenmetrics(),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Status("test completed successfully")
+}
+
+// meanNonNaN computes the mean of non-NaN values in a StatSummary's
+// Value timeseries and returns it as an AggregatedMetric. Returns nil
+// if no valid data points exist.
+func meanNonNaN(
+	stats map[string]clusterstats.StatSummary, key, name, unit string, isHigherBetter bool,
+) *roachtestutil.AggregatedMetric {
+	summary, ok := stats[key]
+	if !ok || len(summary.Value) == 0 {
+		return nil
+	}
+	var sum float64
+	var count int
+	for _, v := range summary.Value {
+		if !math.IsNaN(v) {
+			sum += v
+			count++
+		}
+	}
+	if count == 0 {
+		return nil
+	}
+	return &roachtestutil.AggregatedMetric{
+		Name:           name,
+		Value:          roachtestutil.MetricPoint(sum / float64(count)),
+		Unit:           unit,
+		IsHigherBetter: isHigherBetter,
+	}
+}
+
+// cleanNaN replaces NaN values with 0 in a StatSummary's Value array
+// to avoid JSON serialization errors.
+func cleanNaN(stats *clusterstats.ClusterStatRun, key string) {
+	summary, ok := stats.Stats[key]
+	if !ok {
+		return
+	}
+	for i, val := range summary.Value {
+		if math.IsNaN(val) {
+			summary.Value[i] = 0
+		}
+	}
+	stats.Stats[key] = summary
 }

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -1,0 +1,599 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/grafana"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/testutils/release"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	singleNodeIndexBackfillCustomers       = 25_000
+	singleNodeIndexBackfillActiveCustomers = 5_000
+)
+
+// registerSingleNodeIndexBackfill registers tests that run an index backfill on
+// a single node cluster with disk bandwidth limited via cgroups. The test
+// imports TPC-E data (without disk limiting for speed), then applies disk
+// bandwidth limits before running the workload and index backfill concurrently.
+//
+// The test uses disk snapshots to speed up repeated runs - on first run it
+// creates a snapshot after TPC-E init using a published CRDB release (so the
+// snapshot has a well-defined internal version), and subsequent runs reuse that
+// snapshot.
+//
+// Two variants are registered:
+// - One without AC provisioned bandwidth setting (just cgroup limiting)
+// - One with AC provisioned bandwidth set to match the cgroup limit
+func registerSingleNodeIndexBackfill(r registry.Registry) {
+	for _, withProvisionedBandwidth := range []bool{false, true} {
+		withProvisionedBandwidth := withProvisionedBandwidth // capture loop variable
+
+		nameSuffix := fmt.Sprintf("/provisioned-bandwidth=%t", withProvisionedBandwidth)
+		// Keep prefix short to fit GCE's 63 character limit for snapshot names.
+		snapshotPrefix := "snibf-tpce"
+		if withProvisionedBandwidth {
+			snapshotPrefix += "-bw"
+		}
+
+		// Snapshot prefix includes customer count so we can scale up later
+		// without conflicting with existing snapshots.
+		snapshotPrefix = fmt.Sprintf("%s-%d", snapshotPrefix, singleNodeIndexBackfillCustomers)
+
+		r.Add(registry.TestSpec{
+			Name:             "admission-control/single-node-index-backfill" + nameSuffix,
+			Owner:            registry.OwnerAdmissionControl,
+			Timeout:          12 * time.Hour,
+			Benchmark:        true,
+			CompatibleClouds: registry.OnlyGCE,
+			Suites:           registry.Suites(registry.Nightly),
+			Cluster: r.MakeClusterSpec(
+				2, // 1 CRDB node + 1 workload node
+				// 16vCPUs so that CPU is not the bottleneck.
+				spec.CPU(16),
+				spec.WorkloadNode(),
+				spec.WorkloadNodeCPU(16),
+				spec.VolumeSize(500),
+				spec.ReuseNone(),
+				spec.Arch(spec.AllExceptFIPS),
+			),
+			SnapshotPrefix: snapshotPrefix,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runSingleNodeIndexBackfill(ctx, t, c, withProvisionedBandwidth)
+			},
+		})
+	}
+}
+
+const customers = singleNodeIndexBackfillCustomers
+
+func runSingleNodeIndexBackfill(
+	ctx context.Context, t test.Test, c cluster.Cluster, withProvisionedBandwidth bool,
+) {
+	const (
+		activeCustomers      = singleNodeIndexBackfillActiveCustomers
+		provisionedBandwidth = 128 << 20 // 128 MiB/s
+	)
+
+	if c.Spec().NodeCount != 2 {
+		t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
+	}
+
+	if !t.SkipInit() {
+		doInitSingleNodeIndexBackfill(ctx, t, c)
+	}
+
+	// Set up Prometheus for metrics collection.
+	promCfg := &prometheus.Config{}
+	promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+		WithNodeExporter(c.CRDBNodes().InstallNodes()).
+		WithCluster(c.CRDBNodes().InstallNodes()).
+		WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
+	if err := c.StartGrafana(ctx, t.L(), promCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the cluster (or restart after snapshot creation) with the current
+	// version. This will upgrade the data if the snapshot was created with an
+	// older version.
+	t.Status("starting cluster for workload")
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
+	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+		"--vmodule=io_load_listener=2")
+	roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+	roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+	settings := install.MakeClusterSettings(install.NumRacksOption(1))
+	if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up Prometheus client for metrics collection during index backfill.
+	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+	require.NoError(t, err)
+	statCollector := clusterstats.NewStatsCollector(ctx, promClient)
+
+	// Initialize TPC-E spec for running workload commands.
+	tpceSpec, err := initTPCESpec(ctx, t.L(), c)
+	require.NoError(t, err)
+
+	// Configure cluster settings for workload phase.
+	db := c.Conn(ctx, t.L(), 1)
+	defer db.Close()
+
+	// Enable admission control first since we may override some settings below.
+	roachtestutil.SetAdmissionControl(ctx, t, c, true)
+
+	// Disable elastic CPU control for index backfill so it is not throttled.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING bulkio.index_backfill.elastic_control.enabled = false",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Increase index backfill parallelism to utilize more vCPUs.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING bulkio.index_backfill.ingest_concurrency = 8",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disable elastic CPU control completely, so that this test can focus
+	// on the disk bandwidth bottleneck. NB: this makes the other elastic
+	// CPU settings irrelevant, but we leave them there for future reference,
+	// in case we revisit this decision.
+	//
+	// TODO(sumeer): revisit.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING admission.elastic_cpu.enabled = false",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure elastic CPU settings so that all unknown elastic work can also
+	// proceed fast in this context.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING admission.elastic_cpu.adjustment_delta_per_second = 0.01",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING admission.elastic_cpu.inactive_point = 0.2",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING admission.elastic_cpu.multiplicative_factor_on_inactive_decrease = 0.1",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up cgroup disk staller to limit disk bandwidth to 128 MiB/s.
+	t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s via cgroups", provisionedBandwidth))
+	staller := roachtestutil.MakeCgroupDiskStaller(t, c,
+		true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
+	staller.Setup(ctx)
+	staller.Slow(ctx, c.CRDBNodes(), provisionedBandwidth /* bytesPerSecond */)
+
+	// Optionally set the AC provisioned bandwidth cluster setting.
+	if withProvisionedBandwidth {
+		t.Status("setting kvadmission.store.provisioned_bandwidth = '128MiB'")
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '128MiB'",
+		); err != nil {
+			t.Fatal(err)
+		}
+		t.Status("setting kvadmission.store.elastic_disk_bandwidth_max_util = 1.0, to attempt to fully utilize the disk bandwidth")
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = 1.0",
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Increase compaction concurrency to better utilize 16 vCPUs. This
+	// also ensures compaction concurrency does not become a bottleneck for
+	// writes to the store.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING storage.compaction_concurrency = 4",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING storage.max_compaction_concurrency = 6",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Work around https://github.com/cockroachdb/cockroach/issues/98311.
+	// TPC-E tables use a 300s GC TTL. When admission control delays
+	// AddSSTable requests beyond this TTL, the GC threshold advances past
+	// the batch timestamp and the request fails. Disabling strict
+	// enforcement avoids this.
+	if _, err := db.ExecContext(
+		ctx, "SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false;",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run TPC-E workload, KV0 workload, and index backfill concurrently.
+	workloadDuration := 120 * time.Minute
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+	var backfillDuration time.Duration
+	var totalBWSamples []float64
+	var metricsStart, metricsEnd time.Time
+
+	// Goroutine 1: Run TPC-E workload.
+	m.Go(func(ctx context.Context) error {
+		t.Status(fmt.Sprintf("starting TPC-E workload with %d active customers (<%s)",
+			activeCustomers, workloadDuration))
+		runOptions := tpceCmdOptions{
+			customers:       customers,
+			activeCustomers: activeCustomers,
+			racks:           1,
+			duration:        workloadDuration,
+			threads:         256,
+			skipCleanup:     true,
+			connectionOpts:  defaultTPCEConnectionOpts(),
+		}
+		result, err := tpceSpec.run(ctx, t, c, runOptions)
+		if err != nil {
+			t.L().Printf("TPC-E workload error: %v", err)
+			return err
+		}
+		t.L().Printf("TPC-E workload output:\n%s\n", result.Stdout)
+		return nil
+	})
+
+	// Goroutine 2: Run KV0 (all writes) workload to add additional write load.
+	// This generates ~5 MiB/s of writes (5000 ops/s × 1024 bytes). This adds
+	// some background write load to the cluster, which TPC-E lacks.
+	m.Go(func(ctx context.Context) error {
+		t.Status("starting KV0 workload (all writes, ~5 MiB/s)")
+		const (
+			kvBlockSize   = 1024
+			kvConcurrency = 20
+			kvSplits      = 100
+			kvMaxRate     = 5000
+		)
+		cmd := fmt.Sprintf(
+			"./cockroach workload run kv --init --read-percent=0 "+
+				"--min-block-bytes=%d --max-block-bytes=%d "+
+				"--concurrency=%d --splits=%d --max-rate=%d "+
+				"--duration=%s "+
+				"--tolerate-errors "+
+				"{pgurl:1}",
+			kvBlockSize, kvBlockSize,
+			kvConcurrency, kvSplits, kvMaxRate,
+			workloadDuration,
+		)
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
+		if err != nil {
+			t.L().Printf("KV0 workload error: %v", err)
+			return err
+		}
+		t.L().Printf("KV0 workload completed")
+		return nil
+	})
+
+	// Goroutine 3: Run index backfill after a short baseline period, with
+	// metrics collection.
+	m.Go(func(ctx context.Context) error {
+		// Wait for workload to stabilize before starting index backfill.
+		t.Status(fmt.Sprintf("recording baseline performance (<%s)", 5*time.Minute))
+		time.Sleep(5 * time.Minute)
+
+		t.Status("starting index creation on tpce.cash_transaction")
+		indexName := fmt.Sprintf("index_%s", timeutil.Now().Format("20060102_T150405"))
+
+		// Start metrics collection goroutine that runs during index backfill.
+		stopMetrics := make(chan struct{})
+		metricsDone := make(chan struct{})
+		t.Go(func(context.Context, *logger.Logger) error {
+			defer close(metricsDone)
+			metricsStart = timeutil.Now()
+			defer func() { metricsEnd = timeutil.Now() }()
+			writeBWQuery := divQuery("rate(sys_host_disk_write_bytes[1m])", 1<<20)
+			readBWQuery := divQuery("rate(sys_host_disk_read_bytes[1m])", 1<<20)
+
+			getMetricVal := func(query string) (float64, error) {
+				point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
+				if err != nil {
+					return 0, err
+				}
+				for _, v := range point["node"] {
+					return v.Value, nil
+				}
+				return 0, fmt.Errorf("no data for query %s", query)
+			}
+
+			t.L().Printf("=== INDEX BACKFILL METRICS COLLECTION STARTED (1m interval) ===")
+			ticker := time.NewTicker(1 * time.Minute)
+			defer ticker.Stop()
+
+			iteration := 0
+			for {
+				select {
+				case <-ticker.C:
+					iteration++
+					writeBW, writeErr := getMetricVal(writeBWQuery)
+					readBW, readErr := getMetricVal(readBWQuery)
+					if writeErr != nil || readErr != nil {
+						t.L().Printf("[metrics %d] error collecting: write=%v, read=%v",
+							iteration, writeErr, readErr)
+						continue
+					}
+					totalBW := writeBW + readBW
+					totalBWSamples = append(totalBWSamples, totalBW)
+					t.L().Printf("[metrics %d] disk bandwidth: read=%.2f MiB/s, write=%.2f MiB/s, total=%.2f MiB/s",
+						iteration, readBW, writeBW, totalBW)
+				case <-stopMetrics:
+					t.L().Printf("=== INDEX BACKFILL METRICS COLLECTION STOPPED ===")
+					return nil
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		}, task.Name("metrics-collector"))
+
+		// Run the actual index creation.
+		backfillStart := timeutil.Now()
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf("CREATE INDEX %s ON tpce.cash_transaction (ct_dts)", indexName),
+		)
+		backfillDuration = timeutil.Since(backfillStart)
+
+		// Stop metrics collection.
+		close(stopMetrics)
+		<-metricsDone
+
+		if err != nil {
+			t.L().Printf("index creation error: %v", err)
+			return err
+		}
+		t.L().Printf("index backfill completed in %s", backfillDuration)
+		t.Status("finished index creation")
+		return nil
+	})
+
+	m.Wait()
+
+	t.L().Printf("index backfill duration: %s", backfillDuration)
+
+	// Compute mean total bandwidth from the samples collected during
+	// index backfill.
+	var avgTotalBW float64
+	if len(totalBWSamples) > 0 {
+		var sum float64
+		for _, s := range totalBWSamples {
+			sum += s
+		}
+		avgTotalBW = sum / float64(len(totalBWSamples))
+		t.L().Printf("average total disk bandwidth during backfill: %.2f MiB/s (%d samples)",
+			avgTotalBW, len(totalBWSamples))
+	}
+
+	// Export backfill duration and mean total bandwidth as scalar metrics
+	// for roachperf.
+	if !metricsStart.IsZero() && !metricsEnd.IsZero() {
+		exportingStats, err := statCollector.Exporter().Export(
+			ctx, c, t, true, /* dryRun */
+			metricsStart, metricsEnd,
+			[]clusterstats.AggQuery{sqlServiceLatencyAgg, indexBackfillQPSAgg},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return &roachtestutil.AggregatedMetric{
+					Name:           "index_backfill_duration",
+					Value:          roachtestutil.MetricPoint(backfillDuration.Seconds()),
+					Unit:           "s",
+					IsHigherBetter: false,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				if avgTotalBW == 0 {
+					return nil
+				}
+				return &roachtestutil.AggregatedMetric{
+					Name:           "mean_total_bandwidth",
+					Value:          roachtestutil.MetricPoint(avgTotalBW),
+					Unit:           "MiB/s",
+					IsHigherBetter: true,
+				}
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return meanNonNaN(stats, sqlServiceLatency.Query, "mean_p99_latency", "ms", false)
+			},
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+				return meanNonNaN(stats, indexBackfillQPS.Query, "mean_qps", "queries/s", true)
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Replace NaN values to avoid JSON serialization errors.
+		// histogram_quantile returns NaN when there are no queries
+		// in the rate window.
+		cleanNaN(exportingStats, sqlServiceLatency.Query)
+		cleanNaN(exportingStats, indexBackfillQPS.Query)
+
+		if err := exportingStats.SerializeOutRun(
+			ctx, t, c, t.ExportOpenmetrics(),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Performance assertions are disabled on this release branch because disk
+	// bandwidth admission control does not work reliably on versions < 26.2.
+	// Metrics are still collected and exported to roachperf for tracking.
+
+	t.Status("test completed successfully")
+}
+
+func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.Cluster) {
+	// Check for existing snapshots.
+	snapshotPrefix := versionedSnapshotPrefix(t)
+	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
+		NamePrefix: snapshotPrefix,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(snapshots) == 0 {
+		// No existing snapshots - need to initialize TPC-E and create snapshots.
+		// Use a published CRDB release so the snapshot has a well-defined internal
+		// version that can be upgraded to any newer version.
+		t.L().Printf("=== NO EXISTING SNAPSHOTS FOUND for prefix %q ===", snapshotPrefix)
+		t.L().Printf("=== WILL CREATE NEW SNAPSHOTS after TPC-E init ===")
+
+		// Get the latest predecessor release version.
+		pred, err := release.LatestPredecessor(t.BuildVersion())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.L().Printf("Using predecessor release %s for snapshot creation", pred)
+
+		// Upload the predecessor binary to all nodes.
+		path, err := clusterupgrade.UploadCockroach(
+			ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Copy over the binary to ./cockroach and run it from there. This test
+		// captures disk snapshots, which are fingerprinted using the binary
+		// version found in this path.
+		c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
+
+		// Start the cluster with rack locality configured (required by TPC-E init).
+		t.Status(fmt.Sprintf("starting cluster with %s for snapshot creation", pred))
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
+		roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+		settings := install.MakeClusterSettings(install.NumRacksOption(1))
+		if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initialize TPC-E spec for running workload commands.
+		tpceSpec, err := initTPCESpec(ctx, t.L(), c)
+		require.NoError(t, err)
+
+		// Configure cluster settings before import.
+		db := c.Conn(ctx, t.L(), 1)
+
+		// Disable automatic stats collection to speed up import.
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
+		); err != nil {
+			db.Close()
+			t.Fatal(err)
+		}
+
+		// Disable elastic CPU control for import so it is not throttled.
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING bulkio.import.elastic_control.enabled = false",
+		); err != nil {
+			db.Close()
+			t.Fatal(err)
+		}
+		db.Close()
+
+		// Import TPC-E data.
+		t.Status(fmt.Sprintf("initializing TPC-E with %d customers for snapshot creation", customers))
+		tpceSpec.init(ctx, t, c, tpceCmdOptions{
+			customers:      customers,
+			racks:          1, // single node
+			connectionOpts: defaultTPCEConnectionOpts(),
+		})
+
+		// Stop all nodes before capturing cluster snapshots.
+		t.Status("stopping cluster to create snapshots")
+		c.Stop(ctx, t.L(), option.DefaultStopOpts())
+
+		// Create snapshots.
+		t.Status(fmt.Sprintf("creating snapshots with prefix %q", snapshotPrefix))
+		snapshots, err = c.CreateSnapshot(ctx, snapshotPrefix)
+		if err != nil {
+			if strings.Contains(err.Error(), "already exists") {
+				// Another concurrent run may have already created snapshots
+				// with the same name.
+				t.L().Printf("snapshot creation hit 'already exists' error, proceeding: %v", err)
+			} else {
+				t.Fatal(err)
+			}
+		} else {
+			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), snapshotPrefix)
+		}
+	} else {
+		t.L().Printf("found %d existing snapshot(s) with prefix %q",
+			len(snapshots), snapshotPrefix)
+		roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
+	}
+}
+
+// Index backfill results on master as of Feb 1, 2026:
+
+// Without the provisioned bandwidth set, the backfill
+// took ~38min.
+//
+// The cgroup limiting to 128MiB/s is not very effective, since we
+// see the 1min rates exceed 128MiB/s (without the provisioned bandwidth set):
+// [metrics 11] disk bandwidth: read=27.26 MiB/s, write=111.12 MiB/s, total=138.38 MiB/s
+// [metrics 12] disk bandwidth: read=34.36 MiB/s, write=108.92 MiB/s, total=143.28 MiB/s
+// [metrics 13] disk bandwidth: read=44.72 MiB/s, write=130.52 MiB/s, total=175.24 MiB/s
+// [metrics 14] disk bandwidth: read=40.98 MiB/s, write=130.78 MiB/s, total=171.77 MiB/s
+// [metrics 15] disk bandwidth: read=47.38 MiB/s, write=129.66 MiB/s, total=177.04 MiB/s
+// [metrics 16] disk bandwidth: read=36.05 MiB/s, write=88.03 MiB/s, total=124.08 MiB/s
+// [metrics 17] disk bandwidth: read=33.54 MiB/s, write=109.46 MiB/s, total=143.00 MiB/s
+// [metrics 18] disk bandwidth: read=26.79 MiB/s, write=58.79 MiB/s, total=85.58 MiB/s
+// [metrics 19] disk bandwidth: read=48.01 MiB/s, write=118.73 MiB/s, total=166.75 MiB/s
+// [metrics 20] disk bandwidth: read=45.58 MiB/s, write=128.43 MiB/s, total=174.01 MiB/s
+// [metrics 21] disk bandwidth: read=39.16 MiB/s, write=89.80 MiB/s, total=128.95 MiB/s
+// [metrics 22] disk bandwidth: read=26.91 MiB/s, write=124.97 MiB/s, total=151.89 MiB/s
+// [metrics 23] disk bandwidth: read=74.38 MiB/s, write=129.95 MiB/s, total=204.33 MiB/s
+// [metrics 24] disk bandwidth: read=56.46 MiB/s, write=56.99 MiB/s, total=113.46 MiB/s
+// [metrics 25] disk bandwidth: read=58.86 MiB/s, write=89.39 MiB/s, total=148.25 MiB/s
+// [metrics 26] disk bandwidth: read=53.40 MiB/s, write=58.13 MiB/s, total=111.53 MiB/s
+// [metrics 27] disk bandwidth: read=56.57 MiB/s, write=89.15 MiB/s, total=145.72 MiB/s
+//
+// With the provisioned bandwidth set, the backfill took 57min, even though
+// it was set to fully utilize the disk bandwidth. We see disk bandwidth
+// sequences like:
+// [metrics 15] disk bandwidth: read=19.19 MiB/s, write=79.17 MiB/s, total=98.36 MiB/s
+// [metrics 16] disk bandwidth: read=29.32 MiB/s, write=112.51 MiB/s, total=141.83 MiB/s
+// [metrics 17] disk bandwidth: read=15.61 MiB/s, write=83.52 MiB/s, total=99.13 MiB/s
+// [metrics 18] disk bandwidth: read=26.57 MiB/s, write=109.58 MiB/s, total=136.15 MiB/s
+// [metrics 19] disk bandwidth: read=15.96 MiB/s, write=84.80 MiB/s, total=100.76 MiB/s
+// [metrics 20] disk bandwidth: read=33.39 MiB/s, write=123.29 MiB/s, total=156.68 MiB/s
+// [metrics 21] disk bandwidth: read=12.52 MiB/s, write=93.12 MiB/s, total=105.65 MiB/s
+// [metrics 22] disk bandwidth: read=35.68 MiB/s, write=114.89 MiB/s, total=150.57 MiB/s
+// [metrics 23] disk bandwidth: read=19.50 MiB/s, write=93.59 MiB/s, total=113.09 MiB/s
+// [metrics 24] disk bandwidth: read=21.38 MiB/s, write=71.85 MiB/s, total=93.23 MiB/s
+//
+// One of the causes of underutilization of bandwidth is write-amp model
+// fluctuation, noted in
+// https://github.com/cockroachdb/cockroach/issues/146223#issuecomment-3786601809.


### PR DESCRIPTION
Provisioned bandwidth admission control has been significantly
improved on v26.2. This backports and enables the index backfill
admission control roachtests on this branch so we can validate
those performance gains by comparing results across versions.

The tests run TPC-E with concurrent index backfill and primary key
change operations, with disk bandwidth limited via cgroups. Three
multi-node variants are registered (no disk limit, cgroup-limited
without provisioned bandwidth, and cgroup-limited with provisioned
bandwidth) along with two single-node variants. Snapshot names
include the major version so each release uses its own snapshots.

Performance assertions are disabled on this branch because disk
bandwidth AC does not work reliably on older versions. Metrics are
still collected and exported to roachperf for cross-version
comparison.

Backports parts of #161656, #165576, #163865, #167428, and #167609.
Informs: CRDB-58716
Release note: None
Release justification: test-only change.