### PR TITLE
release-25.4: roachtest: don't run c2c/BulkOps with runtime assertions

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -519,6 +519,12 @@ type replicationSpec struct {
 
 	clouds registry.CloudSet
 	suites registry.SuiteSet
+
+	// cockroachBinary specifies the type of cockroach binary to use for this test.
+	// If not set (zero value), defaults to RandomizedCockroach.
+	// Set to registry.StandardCockroach to disable runtime assertions for
+	// performance-sensitive tests.
+	cockroachBinary registry.ClusterCockroachBinary
 }
 
 type multiRegionSpecs struct {
@@ -1312,6 +1318,7 @@ func c2cRegisterWrapper(
 		CompatibleClouds:          sp.clouds,
 		Suites:                    sp.suites,
 		TestSelectionOptOutSuites: sp.suites,
+		CockroachBinary:           sp.cockroachBinary,
 		Run:                       run,
 		// Read from standby tests also spin up the schema change workload which
 		// uses the workload binary.
@@ -1556,8 +1563,11 @@ func registerClusterToCluster(r registry.Registry) {
 			// Skipping node distribution check because there is little data on the
 			// source when the replication stream begins.
 			skipNodeDistributionCheck: true,
-			clouds:                    registry.OnlyGCE,
-			suites:                    registry.Suites(registry.Nightly),
+			// Never run with runtime assertions as import rollback with tombstones
+			// gets much slower.
+			cockroachBinary: registry.StandardCockroach,
+			clouds:          registry.OnlyGCE,
+			suites:          registry.Suites(registry.Nightly),
 		},
 		{
 			name:               "c2c/BulkOps/singleImport",


### PR DESCRIPTION
Backport 1/1 commits from #167598 on behalf of @msbutler.

----

Over the past couple months, c2c/BulkOps tests have occasionally timed out on 26.1 and newer because import rollback seems slower, but only when RuntimeAssertions have been enabled. This is likely due to a combination of factors:
- as of 26.1, we roll back with point tombstones
- as of #160983, rollbacks could be subject to elastic cpu AC
- runtime assertions add a bunch of extra work to the delete hotpath (e.g. mvcc value encoding validation)

Fixes: #161366

Release note: none

----

Release justification: