### PR TITLE
release-26.2: restore: clean up fast restore job status updates

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2361,6 +2361,15 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	// has already complete. This ensures we skip the link phase if we resume an
 	// online restore job that blocks on the download job.
 
+	// Set status message for Phase 1 if this is a two-phase ExperimentalCopy restore.
+	if details.ExperimentalCopy {
+		if err := r.execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return r.job.StatusStorage().Set(ctx, txn, "Phase 1 of 2: Link External Data")
+		}); err != nil {
+			return errors.Wrap(err, "updating status message for link phase")
+		}
+	}
+
 	if !preData.isEmpty() {
 		res, err := restoreWithRetry(
 			ctx,

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -210,10 +210,6 @@ func sendAddRemoteSSTs(
 		return 0, 0, err
 	}
 
-	if err := job.NoTxn().UpdateStatusMessage(ctx, "Splitting and distributing spans"); err != nil {
-		return 0, 0, err
-	}
-
 	if err := splitAndScatter(ctx, execCtx, genSpan, *kr, fromSystemTenant, targetRangeSize); err != nil {
 		return 0, 0, errors.Wrap(err, "failed to split and scatter spans")
 	}
@@ -228,10 +224,6 @@ func sendAddRemoteSSTs(
 		}
 	}
 	if err := execCtx.ExecCfg().JobRegistry.CheckPausepoint("restore.before_link"); err != nil {
-		return 0, 0, err
-	}
-
-	if err := job.NoTxn().UpdateStatusMessage(ctx, ""); err != nil {
 		return 0, 0, err
 	}
 
@@ -562,8 +554,14 @@ func (r *restoreResumer) maybeCalculateTotalDownloadSpans(
 	// amount we expect to download and persist it so that we can indicate our
 	// progress as that number goes down later.
 	log.Dev.Infof(ctx, "calculating total download size (across all stores) to complete restore")
-	if err := r.job.NoTxn().UpdateStatusMessage(ctx, "Calculating total download size..."); err != nil {
-		return 0, errors.Wrapf(err, "failed to update running status of job %d", r.job.ID())
+
+	// Set the Phase 2 status message before calculating the total download size.
+	// This ensures users always see the download phase status, even if there's
+	// nothing to download.
+	if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return r.job.StatusStorage().Set(ctx, txn, "Phase 2 of 2: Downloading restored data")
+	}); err != nil {
+		return 0, errors.Wrap(err, "updating status message for download phase")
 	}
 
 	total, err := getExternalBytesOverSpans(ctx, execCtx.ExecCfg(), details.DownloadSpans)
@@ -579,7 +577,6 @@ func (r *restoreResumer) maybeCalculateTotalDownloadSpans(
 
 	if err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 		md.Progress.GetRestore().TotalDownloadRequired = total
-		md.Progress.StatusMessage = fmt.Sprintf("Downloading %s of restored data...", sz(total))
 		ju.UpdateProgress(md.Progress)
 		return nil
 	}); err != nil {

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -1496,3 +1496,59 @@ func TestOnlineRestoreURIRedaction(t *testing.T) {
 		require.Equal(t, numAccounts, rowCount)
 	})
 }
+
+// TestOnlineRestoreStatusMessages verifies that the correct status messages are
+// written to system.job_message during an online restore with EXPERIMENTAL COPY.
+func TestOnlineRestoreStatusMessages(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	backuptestutils.EnableFastRestoreForTest(t)
+
+	rng, seed := randutil.NewPseudoRand()
+	t.Logf("random seed: %d", seed)
+
+	const numAccounts = 100
+
+	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	_, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, base.TestClusterArgs{})
+	defer cleanupFnRestored()
+
+	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB, rSQLDB)
+
+	// Randomly toggle dist flow setting to test both code paths
+	useDistFlow := rng.Intn(2) == 0
+	t.Logf("using dist flow: %t", useDistFlow)
+	rSQLDB.Exec(t, fmt.Sprintf("SET CLUSTER SETTING backup.restore.online_use_dist_flow.enabled = %t", useDistFlow))
+
+	// Create backup
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE data INTO '%s'", externalStorage))
+
+	// Create database on restore cluster
+	rSQLDB.Exec(t, "CREATE DATABASE data")
+
+	// Execute EXPERIMENTAL COPY restore in detached mode
+	var jobID int
+	rSQLDB.QueryRow(t,
+		fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL COPY, detached", externalStorage),
+	).Scan(&jobID)
+
+	// Wait for job to complete
+	jobutils.WaitForJobToSucceed(t, rSQLDB, jobspb.JobID(jobID))
+
+	// Verify exactly the expected status messages were written to system.job_message
+	rSQLDB.CheckQueryResults(t,
+		fmt.Sprintf(`SELECT message FROM system.job_message WHERE job_id = %d AND kind = 'status' ORDER BY written ASC`, jobID),
+		[][]string{
+			{"Phase 1 of 2: Link External Data"},
+			{"Phase 2 of 2: Downloading restored data"},
+		},
+	)
+
+	// Sanity check: verify restored data is accessible
+	var restoreRowCount int
+	rSQLDB.QueryRow(t, "SELECT count(*) FROM data.bank").Scan(&restoreRowCount)
+	require.Equal(t, numAccounts, restoreRowCount)
+}


### PR DESCRIPTION
Backport 1/1 commits from #167147 on behalf of @msbutler.

----

Previously the job statuses for fast restore was inconsistent during the link phase, depending on whether the distsql powered link phase is used. This patch cleans up the status updates such that only 2 statuses could occur during the running fast restore:

- Phase 1/2: link phase
- Phase 2/2: download phase

Epic: none

Release note: none

----

Release justification: