### PR TITLE
release-25.4: ccl/sqlproxyccl/acl: fix race condition in test

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/file_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/file_test.go
@@ -574,9 +574,7 @@ func TestParsingErrorHandling(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			select {
 			case <-next:
-				t.Fatal("should not have gotten a new controller")
-				// We need to return something to make the compiler happy, but t.Fatal will end execution.
-				return nil
+				return fmt.Errorf("Received new controller; discarding")
 			default:
 				errorCount := errorCountMetric.Value()
 				// If error count isn't one, then it hasn't happened yet.


### PR DESCRIPTION
Backport 1/1 commits from #161197 on behalf of @davidwding.

----

TestParsingErrorHandling was written in such a way that it was possible for the test to fail due to receiving a new valid controller, if the timing of the polling didn't play nice with writing the new invalid YAML.

To fix this, we just discard the new controller that may sporadically be generated during this test. The point of the test is to eventually receive an error after writing the initial YAML, which we are still testing.

Fixes https://github.com/cockroachdb/cockroach/issues/160971

----

Release justification: update to test-only code