### PR TITLE
kvcoord: disable leaseholder randomization on context errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -457,9 +457,13 @@ var NonTransactionalWritesNotIdempotent = settings.RegisterBoolSetting(
 // randomizeLeaseholderOnContextErrorDuration controls the timeout after which
 // we deliberately randomize the leaseholder in a cached range descriptor after
 // seeing context errors (deadline exceeded, context canceled, etc.) to force
-// us to contact a healthy replica.
-var randomizeLeaseholderOnContextErrorDuration = max(500*time.Millisecond,
-	envutil.EnvOrDefaultDuration("COCKROACH_RANDOMIZE_LEASEHOLDER_ON_CONTEXT_ERROR_DURATION", 2*time.Second))
+// us to contact a healthy replica. A zero value disables this behavior.
+//
+// TODO(arul): re-enable this (default 2s, with a 500ms floor) once the
+// RACv2 test flakes caused by leaseholder randomization have been addressed.
+var randomizeLeaseholderOnContextErrorDuration = envutil.EnvOrDefaultDuration(
+	"COCKROACH_RANDOMIZE_LEASEHOLDER_ON_CONTEXT_ERROR_DURATION", 0,
+)
 
 // DistSenderMetrics is the set of metrics for a given distributed sender.
 type DistSenderMetrics struct {
@@ -2430,6 +2434,7 @@ func (ds *DistSender) sendPartialBatch(
 	// See the documentation for the function
 	// (*EvictionToken).RandomizeLeaseholder() for an explanation.
 	if ctx.Err() != nil && routingTok.Valid() &&
+		randomizeLeaseholderOnContextErrorDuration > 0 &&
 		routingTok.SinceLeaseholderContacted() >= randomizeLeaseholderOnContextErrorDuration {
 
 		ds.metrics.LeaseholderRandomizedOnContextErrorCount.Inc(1)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -1870,6 +1870,12 @@ func TestEventuallyRecoverFromLeaseholderContextError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Enable leaseholder randomization on context errors, which is disabled by
+	// default (see the TODO on randomizeLeaseholderOnContextErrorDuration).
+	old := randomizeLeaseholderOnContextErrorDuration
+	randomizeLeaseholderOnContextErrorDuration = 2 * time.Second
+	defer func() { randomizeLeaseholderOnContextErrorDuration = old }()
+
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)


### PR DESCRIPTION
The leaseholder randomization behaviour introduced in #166760 has been causing a
bunch of RACv2 tests to flake. While those are investigated, let's turn this off
by defaulting the env var to 0 (disabled). The zero value is now explicitly
treated as "off" at the usage site.

Epic: none
Release note: None