### PR TITLE
release-26.2: sql/multiregion: add telemetry counters for super region usage

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_db
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_db
@@ -86,3 +86,28 @@ feature-usage
 ALTER DATABASE d SURVIVE ZONE FAILURE
 ----
 sql.multiregion.alter_database.survival_goal.survive_zone_failure
+
+# Super region telemetry counters.
+
+exec
+ALTER DATABASE d ADD REGION "us-east-1"
+----
+
+exec
+ALTER DATABASE d ADD REGION "ap-southeast-2"
+----
+
+feature-usage
+ALTER DATABASE d ADD SUPER REGION "sr1" VALUES "us-east-1", "ap-southeast-2"
+----
+sql.multiregion.add_super_region
+
+feature-usage
+ALTER DATABASE d ALTER SUPER REGION "sr1" VALUES "us-east-1", "ca-central-1"
+----
+sql.multiregion.alter_super_region
+
+feature-usage
+ALTER DATABASE d DROP SUPER REGION "sr1"
+----
+sql.multiregion.drop_super_region

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1641,6 +1641,8 @@ func (n *alterDatabaseAddSuperRegion) startExec(params runParams) error {
 		)
 	}
 
+	telemetry.Inc(sqltelemetry.AlterDatabaseAddSuperRegionCounter)
+
 	// Check if the primary and secondary regions are members of this super region.
 	regionConfig, err := SynthesizeRegionConfig(
 		params.ctx, params.p.txn, n.desc.ID, params.p.Descriptors(),
@@ -1731,6 +1733,8 @@ func (n *alterDatabaseDropSuperRegion) startExec(params runParams) error {
 			n.n.DatabaseName.String(),
 		)
 	}
+
+	telemetry.Inc(sqltelemetry.AlterDatabaseDropSuperRegionCounter)
 
 	typeID, err := n.desc.MultiRegionEnumID()
 	if err != nil {
@@ -1840,6 +1844,8 @@ func (n *alterDatabaseAlterSuperRegion) startExec(params runParams) error {
 			n.n.DatabaseName.String(),
 		)
 	}
+
+	telemetry.Inc(sqltelemetry.AlterDatabaseAlterSuperRegionCounter)
 
 	typeID, err := n.desc.MultiRegionEnumID()
 	if err != nil {

--- a/pkg/sql/sqltelemetry/multiregion.go
+++ b/pkg/sql/sqltelemetry/multiregion.go
@@ -71,6 +71,24 @@ var (
 	OverrideMultiRegionTableZoneConfigurationSystem = telemetry.GetCounterOnce(
 		"sql.multiregion.zone_configuration.override.system.table",
 	)
+
+	// AlterDatabaseAddSuperRegionCounter is to be incremented when a super
+	// region is added to a database.
+	AlterDatabaseAddSuperRegionCounter = telemetry.GetCounterOnce(
+		"sql.multiregion.add_super_region",
+	)
+
+	// AlterDatabaseDropSuperRegionCounter is to be incremented when a super
+	// region is dropped from a database.
+	AlterDatabaseDropSuperRegionCounter = telemetry.GetCounterOnce(
+		"sql.multiregion.drop_super_region",
+	)
+
+	// AlterDatabaseAlterSuperRegionCounter is to be incremented when a super
+	// region's regions are altered.
+	AlterDatabaseAlterSuperRegionCounter = telemetry.GetCounterOnce(
+		"sql.multiregion.alter_super_region",
+	)
 )
 
 // CreateDatabaseSurvivalGoalCounter is to be incremented when the survival goal


### PR DESCRIPTION
Backport 1/1 commits from #167427.

/cc @cockroachdb/release

---

Add telemetry counters to track super region operations:
- ALTER DATABASE ADD SUPER REGION
- ALTER DATABASE DROP SUPER REGION
- ALTER DATABASE ALTER SUPER REGION

The experimental flag for super regions is being removed in 26.2, so we expect increased usage and should have visibility into adoption.

Resolves: #167412
Epic: CRDB-58694

Release note: None

Release justification: address a GA-blocker
