### PR TITLE
roachtest: disable disk-bandwidth-limiter on IBM/s390x

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -36,9 +36,10 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Owner:     registry.OwnerAdmissionControl,
 		Timeout:   3 * time.Hour,
 		Benchmark: true,
-		// Disabled on IBM only because the Azure test suite was used as a base
-		// for IBM tests, and this test was disabled on Azure as of 05/2025.
-		CompatibleClouds: registry.AllExceptAzure,
+		// Disabled on Azure and IBM due to inconsistent I/O performance
+		// causing the bandwidth lower-bound check to flake.
+		// See: https://github.com/cockroachdb/cockroach/issues/167455
+		CompatibleClouds: registry.AllExceptAzure.NoIBM(),
 		Suites:           registry.Suites(registry.Nightly),
 		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 		Cluster: r.MakeClusterSpec(


### PR DESCRIPTION
The admission-control/disk-bandwidth-limiter test asserts that total disk
bandwidth stays above 80% of the configured limit (51.2 MiB/s). On IBM/s390x
with 10iops-tier volumes, the observed mean was 51.17 — barely 0.03 MiB/s under
the threshold. Not worth chasing given the I/O variability on that platform.

The previous comment here said "Disabled on IBM only because the Azure test
suite was used as a base for IBM tests", but the `CompatibleClouds` line was
never actually updated to exclude IBM — 6d4fea5e499 added the comment without
changing the code. So the test has been running (and flaking) on IBM this whole
time.

Fixes #167455

Epic: none
Release note: None