### PR TITLE
importer: fix race between descriptor and job record updates on pause

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -742,13 +742,18 @@ func importCancellationRunner(
 		// remove the files that succeeded so we don't try to import them again.
 		// If this was the last attempt, this should remove all the remaining
 		// files and `filesToImport` should be empty.
-		if status == "succeeded" {
+		switch status {
+		case "succeeded":
 			t.L().PrintfCtx(ctx, "Removing files [%s] from consideration; completed", strings.Join(urls, ", "))
 			urlsToImport = slices.DeleteFunc(urlsToImport, func(url string) bool {
 				return slices.Contains(urls, url)
 			})
-		} else if status == "failed" {
+		case "canceled":
+			// Expected outcome of cancellation.
+		case "failed":
 			return errors.Newf("Job %s failed with error: %s\n", jobID, errorMsg)
+		default:
+			return errors.Newf("job %s in unexpected state %q after completion", jobID, status)
 		}
 	}
 	if len(urlsToImport) != 0 {
@@ -804,15 +809,21 @@ func importPauseRunner(
 			return ctx.Err()
 		}
 
-		// Check if job already completed (might finish before all pauses)
+		// Check if job is still running before attempting to pause.
 		var status string
 		err = conn.QueryRowContext(ctx, `SELECT status FROM [SHOW JOB $1]`, jobID).Scan(&status)
 		if err != nil {
 			return errors.Wrapf(err, "checking job status before pause %d", i+1)
 		}
-		if status == "succeeded" {
+		switch status {
+		case "running":
+			// Expected — proceed to pause.
+		case "succeeded":
 			t.WorkerStatus(fmt.Sprintf("job %d completed before pause %d/%d", jobID, i+1, numPauses))
 			return nil
+		default:
+			return errors.Newf("job %d in unexpected state %q before pause %d/%d",
+				jobID, status, i+1, numPauses)
 		}
 
 		// Pause the job

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -333,11 +333,28 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		details.Table.Desc.ImportStartWallTime = details.Walltime
 		details.Tables[0].Desc.ImportStartWallTime = details.Walltime
 
-		if err := bindTableDescImportProperties(ctx, p, table.Desc.ID, details.Walltime); err != nil {
-			return err
-		}
-
-		if err := r.job.NoTxn().SetDetails(ctx, details); err != nil {
+		// Write the import start walltime to both the table descriptor and the job
+		// record atomically. If these writes are not atomic, a pause between them
+		// can leave the descriptor with ImportStartWallTime set while the job record
+		// still has Walltime == 0. On resume, InitializeImport would then fire an
+		// assertion because ImportStartWallTime is already non-zero.
+		if err := sql.DescsTxn(ctx, p.ExecCfg(), func(
+			ctx context.Context, txn isql.Txn, descsCol *descs.Collection,
+		) error {
+			mutableDesc, err := descsCol.MutableByID(txn.KV()).Table(ctx, table.Desc.ID)
+			if err != nil {
+				return err
+			}
+			if err := mutableDesc.InitializeImport(details.Walltime); err != nil {
+				return err
+			}
+			if err := descsCol.WriteDesc(
+				ctx, false /* kvTrace */, mutableDesc, txn.KV(),
+			); err != nil {
+				return err
+			}
+			return r.job.WithTxn(txn).SetDetails(ctx, details)
+		}); err != nil {
 			return err
 		}
 	}
@@ -615,33 +632,6 @@ func (r *importResumer) prepareTableForIngestion(
 	// choosing our Walltime.
 	importDetails.Walltime = 0
 	return importDetails, nil
-}
-
-// bindTableDescImportProperties updates the table descriptor at the start of an
-// import for a table that existed before the import.
-func bindTableDescImportProperties(
-	ctx context.Context, p sql.JobExecContext, id catid.DescID, startWallTime int64,
-) error {
-	if err := sql.DescsTxn(ctx, p.ExecCfg(), func(
-		ctx context.Context, txn isql.Txn, descsCol *descs.Collection,
-	) error {
-		mutableDesc, err := descsCol.MutableByID(txn.KV()).Table(ctx, id)
-		if err != nil {
-			return err
-		}
-		if err := mutableDesc.InitializeImport(startWallTime); err != nil {
-			return err
-		}
-		if err := descsCol.WriteDesc(
-			ctx, false /* kvTrace */, mutableDesc, txn.KV(),
-		); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	return nil
 }
 
 // publishTable updates the status of the imported table from OFFLINE to PUBLIC.


### PR DESCRIPTION
Previously, the IMPORT INTO resume path wrote the import start walltime
to the table descriptor (via `InitializeImport`) and the job record
(via `SetDetails`) in separate transactions. If the job was paused
between these two writes, the descriptor retained `ImportStartWallTime`
while the job record still had `Walltime == 0`. On resume, the code
re-entered the `Walltime == 0` branch and `InitializeImport` fired an
assertion because `ImportStartWallTime` was already non-zero, causing
the job to fail.

Fix this by wrapping both writes in a single `DescsTxn` so they commit
atomically. Also harden the import/pause roachtest to fail early with a
clear message if the job enters an unexpected state before a pause
attempt.

Fixes: #167549
Epic: CRDB-48845

Release note: None