### PR TITLE
release-25.4: storeliveness: skip flaky multi-store tests under duress

### DIFF
--- a/pkg/kv/kvserver/storeliveness/multi_store_test.go
+++ b/pkg/kv/kvserver/storeliveness/multi_store_test.go
@@ -165,6 +165,7 @@ func makeMultiStoreArgs(storeKnobs *kvserver.StoreTestingKnobs) base.TestCluster
 func TestStoreLivenessAllToAllSupport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuressWithIssue(t, 167469)
 
 	ctx := context.Background()
 	args := makeMultiStoreArgs(nil)
@@ -232,6 +233,7 @@ func TestStoreLivenessRestart(t *testing.T) {
 func TestStoreLivenessDiskStall(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuressWithIssue(t, 167469)
 
 	ctx := context.Background()
 	stalledStore := slpb.StoreIdent{NodeID: roachpb.NodeID(2), StoreID: roachpb.StoreID(3)}


### PR DESCRIPTION
Backport 1/1 commits from #167655 on behalf of @arulajmani.

----

Skip `TestStoreLivenessAllToAllSupport` and `TestStoreLivenessDiskStall`
under duress (race). These tests spin up a 3-node, 2-store-per-node
cluster and sequentially check all 36 store pairs using `SucceedsSoon`.
Under the race detector, this gets proper slow --
`TestStoreLivenessAllToAllSupport` has been observed taking 7+ minutes on
its own, starving subsequent tests in the same shard of their time
budget.

Same treatment as `TestStoreLivenessRestart` in #148566.

Fixes: #167469
Epic: none

----

Release justification: