### PR TITLE
kvcoord,kvserver: deflake flow control tests affected by leaseholder randomization

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -458,12 +458,10 @@ var NonTransactionalWritesNotIdempotent = settings.RegisterBoolSetting(
 // we deliberately randomize the leaseholder in a cached range descriptor after
 // seeing context errors (deadline exceeded, context canceled, etc.) to force
 // us to contact a healthy replica. A zero value disables this behavior.
-//
-// TODO(arul): re-enable this (default 2s, with a 500ms floor) once the
-// RACv2 test flakes caused by leaseholder randomization have been addressed.
 var randomizeLeaseholderOnContextErrorDuration = envutil.EnvOrDefaultDuration(
-	"COCKROACH_RANDOMIZE_LEASEHOLDER_ON_CONTEXT_ERROR_DURATION", 0,
-)
+	"COCKROACH_RANDOMIZE_LEASEHOLDER_ON_CONTEXT_ERROR_DURATION", 2*time.Second)
+
+const minRandomizeLeaseholderOnContextErrorDuration = 500 * time.Millisecond
 
 // DistSenderMetrics is the set of metrics for a given distributed sender.
 type DistSenderMetrics struct {
@@ -795,6 +793,15 @@ type DistSender struct {
 
 	routeToLeaseholderFirst bool
 
+	// randomizeLeaseholderOnCtxErrDuration, if set to a non-zero value,
+	// controls the time after which we randomize the leaseholder stored in the
+	// DistSender's RangeCache for a range in response to a context error. Doing
+	// so ensures the next request to the range tries a different replica, to
+	// prevent cases where a (what turns out to be) a bad leaseholder cache
+	// entry is never evicted, even when the lease has moved to a different
+	// node.
+	randomizeLeaseholderOnCtxErrDuration time.Duration
+
 	// dontConsiderConnHealth, if set, makes the GRPCTransport not take into
 	// consideration the connection health when deciding the ordering for
 	// replicas. When not set, replicas on nodes with unhealthy connections are
@@ -875,7 +882,7 @@ type DistSenderConfig struct {
 // Cockroach cluster via the supplied gossip instance. Supplying a
 // DistSenderContext or the fields within is optional. For omitted values, sane
 // defaults will be used.
-func NewDistSender(cfg DistSenderConfig) *DistSender {
+func NewDistSender(ctx context.Context, cfg DistSenderConfig) *DistSender {
 	nodeIDGetter := cfg.NodeIDGetter
 	if nodeIDGetter == nil {
 		// Fallback to gossip-based implementation if other is not provided.
@@ -991,6 +998,16 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 		}
 	}
 
+	// Clamp the randomizedLeaseholderOnCtxErrDuration, if enabled, to a floor
+	// value of minRandomizeLeaseholderOnContextErrorDuration.
+	dur := randomizeLeaseholderOnContextErrorDuration
+	if dur > 0 && dur < minRandomizeLeaseholderOnContextErrorDuration {
+		log.Dev.Warningf(ctx,
+			"randomizeLeaseholderOnContextErrorDuration is %s, clamping to %s",
+			dur, minRandomizeLeaseholderOnContextErrorDuration)
+		dur = minRandomizeLeaseholderOnContextErrorDuration
+	}
+	ds.randomizeLeaseholderOnCtxErrDuration = dur
 	return ds
 }
 
@@ -2438,10 +2455,8 @@ func (ds *DistSender) sendPartialBatch(
 	//
 	// See the documentation for the function
 	// (*EvictionToken).RandomizeLeaseholder() for an explanation.
-	if ctx.Err() != nil && routingTok.Valid() &&
-		randomizeLeaseholderOnContextErrorDuration > 0 &&
-		routingTok.SinceLeaseholderContacted() >= randomizeLeaseholderOnContextErrorDuration &&
-		!ds.dontRandomizeLeaseholderOnCtxError {
+	if ctx.Err() != nil && routingTok.Valid() && ds.randomizeLeaseholderOnCtxErrEnabled() &&
+		routingTok.SinceLeaseholderContacted() >= ds.randomizeLeaseholderOnCtxErrDuration {
 
 		ds.metrics.LeaseholderRandomizedOnContextErrorCount.Inc(1)
 		log.VEventf(ctx, 1,
@@ -3366,6 +3381,13 @@ func (ds *DistSender) AllRangeSpans(
 	}
 
 	return ranges, replicas.Len(), nil
+}
+
+// randomizeLeaseholderOnCtxErrEnabled returns whether the DistSender is
+// configured to randomize the leaseholder for the next retry upon receiving a
+// context cancelled error.
+func (ds *DistSender) randomizeLeaseholderOnCtxErrEnabled() bool {
+	return ds.randomizeLeaseholderOnCtxErrDuration > 0 && !ds.dontRandomizeLeaseholderOnCtxError
 }
 
 // skipStaleReplicas advances the transport until it's positioned on a replica

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -801,6 +801,10 @@ type DistSender struct {
 	// deprioritized.
 	dontConsiderConnHealth bool
 
+	// dontRandomizeLeaseholderOnCtxError, if set, disables randomization of the
+	// cached leaseholder when a context error is encountered.
+	dontRandomizeLeaseholderOnCtxError bool
+
 	// Currently executing range feeds.
 	activeRangeFeeds syncutil.Set[*rangeFeedRegistry]
 }
@@ -929,6 +933,7 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 	ds.dontReorderReplicas = cfg.TestingKnobs.DontReorderReplicas
 	ds.routeToLeaseholderFirst = cfg.TestingKnobs.RouteToLeaseholderFirst || metamorphicRouteToLeaseholderFirst
 	ds.dontConsiderConnHealth = cfg.TestingKnobs.DontConsiderConnHealth
+	ds.dontRandomizeLeaseholderOnCtxError = cfg.TestingKnobs.DontRandomizeLeaseholderOnCtxError
 	ds.rpcRetryOptions = base.DefaultRetryOptions()
 	// TODO(arul): The rpcRetryOptions passed in here from server/tenant don't
 	// set a max retries limit. Should they?
@@ -2435,7 +2440,8 @@ func (ds *DistSender) sendPartialBatch(
 	// (*EvictionToken).RandomizeLeaseholder() for an explanation.
 	if ctx.Err() != nil && routingTok.Valid() &&
 		randomizeLeaseholderOnContextErrorDuration > 0 &&
-		routingTok.SinceLeaseholderContacted() >= randomizeLeaseholderOnContextErrorDuration {
+		routingTok.SinceLeaseholderContacted() >= randomizeLeaseholderOnContextErrorDuration &&
+		!ds.dontRandomizeLeaseholderOnCtxError {
 
 		ds.metrics.LeaseholderRandomizedOnContextErrorCount.Inc(1)
 		log.VEventf(ctx, 1,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -129,7 +129,7 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 					transport.EXPECT().Release().AnyTimes()
 				}
 
-				ds := NewDistSender(DistSenderConfig{
+				ds := NewDistSender(ctx, DistSenderConfig{
 					AmbientCtx:      log.MakeTestingAmbientCtxWithNewTracer(),
 					Clock:           clock,
 					NodeDescs:       g,
@@ -275,7 +275,7 @@ func TestMuxRangeFeedTransportRace(t *testing.T) {
 		Replica:  desc.InternalReplicas[0],
 		Sequence: 1,
 	}
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:      log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:           clock,
 		NodeDescs:       g,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -93,7 +93,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	// to not hit in the range descriptor cache forcing a RangeLookup operation.
 	ambient := s.AmbientCtx()
 	gs := s.GossipI().(*gossip.Gossip)
-	ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
+	ds := kvcoord.NewDistSender(context.Background(), kvcoord.DistSenderConfig{
 		AmbientCtx:         ambient,
 		Settings:           cluster.MakeTestingClusterSettings(),
 		Clock:              s.Clock(),
@@ -925,7 +925,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 				gs := s.GossipI().(*gossip.Gossip)
 				testutils.SucceedsSoon(t, func() error {
 					clock := hlc.NewClockForTesting(timeutil.NewManualTime(ts.GoTime().Add(1)))
-					ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
+					ds := kvcoord.NewDistSender(ctx, kvcoord.DistSenderConfig{
 						AmbientCtx:         s.AmbientCtx(),
 						Settings:           s.ClusterSettings(),
 						Clock:              clock,
@@ -1447,7 +1447,7 @@ func TestBatchPutWithConcurrentSplit(t *testing.T) {
 	// Now, split further at the given keys, but use a new dist sender so
 	// we don't update the caches on the default dist sender-backed client.
 	gs := s.GossipI().(*gossip.Gossip)
-	ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
+	ds := kvcoord.NewDistSender(context.Background(), kvcoord.DistSenderConfig{
 		AmbientCtx:         s.AmbientCtx(),
 		Clock:              s.Clock(),
 		NodeDescs:          gs,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -460,7 +460,7 @@ func TestSendRPCOrder(t *testing.T) {
 			cfg.Locality = roachpb.Locality{
 				Tiers: tc.tiers,
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 
 			ds.rangeCache.Clear()
 			var lease roachpb.Lease
@@ -595,7 +595,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	txn := roachpb.MakeTransaction(
 		"test", nil /* baseKey */, isolation.Serializable, roachpb.NormalUserPriority,
@@ -718,7 +718,7 @@ func TestErrorWithCancellationExit(t *testing.T) {
 				RangeDescriptorDB: defaultMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			// Start a request that runs through distSender.
 			put := kvpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
 			_, pErr := kv.SendWrapped(ctx, ds, put)
@@ -839,7 +839,7 @@ func TestRetryOnNotLeaseHolderError(t *testing.T) {
 				RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			v := roachpb.MakeValueFromString("value")
 			put := kvpb.NewPut(roachpb.Key("a"), v)
 			if _, pErr := kv.SendWrapped(ctx, ds, put); !testutils.IsPError(pErr, "boom") {
@@ -941,7 +941,7 @@ func TestBackoffOnNotLeaseHolderErrorDuringTransfer(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			sequences = c.leaseSequences
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			v := roachpb.MakeValueFromString("value")
 			put := kvpb.NewPut(roachpb.Key("a"), v)
 			if _, pErr := kv.SendWrapped(ctx, ds, put); !testutils.IsPError(pErr, "boom") {
@@ -1013,7 +1013,7 @@ func TestNoBackoffOnNotLeaseHolderErrorFromFollowerRead(t *testing.T) {
 			return true
 		},
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 		Desc:  testUserRangeDescriptor3Replicas,
 		Lease: lease,
@@ -1080,7 +1080,7 @@ func TestNoBackoffOnNotLeaseHolderErrorWithoutLease(t *testing.T) {
 		RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 		Desc:  rangeDesc,
 		Lease: lease,
@@ -1183,7 +1183,7 @@ func TestDistSenderMovesOnFromReplicaWithStaleLease(t *testing.T) {
 		// the leaseholder first to avoid spurious calls.
 		TestingKnobs: ClientTestingKnobs{RouteToLeaseholderFirst: true},
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 		Desc:  desc,
@@ -1305,7 +1305,7 @@ func TestDistSenderIgnoresNLHEBasedOnOldRangeGeneration(t *testing.T) {
 				// has to route to the leaseholder first.
 				TestingKnobs: ClientTestingKnobs{RouteToLeaseholderFirst: true},
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 
 			ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 				Desc:  desc,
@@ -1410,7 +1410,7 @@ func TestDistSenderRetryOnTransportErrors(t *testing.T) {
 				RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 
 			ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 				Desc:  desc,
@@ -1506,7 +1506,7 @@ func TestDistSenderLeaseholderDown(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 		Desc:                  desc,
 		Lease:                 lease1,
@@ -1571,7 +1571,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 		}),
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	put := kvpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
 	// Error on descriptor lookup, second attempt successful.
 	if _, pErr := kv.SendWrapped(context.Background(), ds, put); pErr != nil {
@@ -1641,7 +1641,7 @@ func TestEvictOnFirstRangeGossip(t *testing.T) {
 		Settings:           cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg).withMetaRecursion()
+	ds := NewDistSender(ctx, cfg).withMetaRecursion()
 
 	anyKey := roachpb.Key("anything")
 	rAnyKey := keys.MustAddr(anyKey)
@@ -1777,7 +1777,7 @@ func TestEvictCacheOnError(t *testing.T) {
 				RangeDescriptorDB: defaultMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 
 			var lease roachpb.Lease
 			lease.Replica = leaseHolder
@@ -1850,7 +1850,7 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 		RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	key := roachpb.Key("a")
 	put := kvpb.NewPut(key, roachpb.MakeValueFromString("value"))
 
@@ -1869,12 +1869,6 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 func TestEventuallyRecoverFromLeaseholderContextError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	// Enable leaseholder randomization on context errors, which is disabled by
-	// default (see the TODO on randomizeLeaseholderOnContextErrorDuration).
-	old := randomizeLeaseholderOnContextErrorDuration
-	randomizeLeaseholderOnContextErrorDuration = 2 * time.Second
-	defer func() { randomizeLeaseholderOnContextErrorDuration = old }()
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -1921,7 +1915,7 @@ func TestEventuallyRecoverFromLeaseholderContextError(t *testing.T) {
 			RouteToLeaseholderFirst: true,
 		},
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	// Set the clock for the range cache to be manual.
 	manualClock := hlc.NewHybridManualClock()
@@ -2059,7 +2053,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 		FirstRangeProvider: g,
 		Settings:           cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	if _, err := kv.SendWrapped(context.Background(), ds, scan); err != nil {
 		t.Errorf("scan encountered error: %s", err)
@@ -2160,7 +2154,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 		// lookups. However if our sender returns an error, this test wants to fail.
 		RPCRetryOptions: &retry.Options{MaxRetries: 1},
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	if _, err := kv.SendWrapped(context.Background(), ds, scan); err != nil {
 		t.Errorf("scan encountered error: %s", err)
@@ -2170,9 +2164,10 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 	tr := tracing.NewTracer()
 	stopper := stop.NewStopper(stop.WithTracer(tr))
-	defer stopper.Stop(context.Background())
+	defer stopper.Stop(ctx)
 
 	n := simulation.NewNetwork(stopper, 3, true)
 	for _, node := range n.Nodes {
@@ -2185,7 +2180,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	<-n.Nodes[0].Gossip.Connected
 	<-n.Nodes[1].Gossip.Connected
 
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:         log.MakeTestingAmbientContext(stopper.Tracer()),
 		NodeDescs:          n.Nodes[0].Gossip,
 		Stopper:            stopper,
@@ -2283,7 +2278,7 @@ func TestSendRPCRetry(t *testing.T) {
 		RangeDescriptorDB: descDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	sr, err := kv.SendWrappedWith(ctx, ds, kvpb.Header{MaxSpanRequestKeys: 1}, scan)
 	if err != nil {
@@ -2404,7 +2399,7 @@ func TestDistSenderDescriptorUpdatesOnSuccessfulRPCs(t *testing.T) {
 				RangeDescriptorDB: descDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 
 			// Send a request that's going to receive a response with a RangeInfo.
 			k := roachpb.Key("a")
@@ -2511,7 +2506,7 @@ func TestSendRPCRangeNotFoundError(t *testing.T) {
 		RangeDescriptorDB: descDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds = NewDistSender(cfg)
+	ds = NewDistSender(ctx, cfg)
 	get := kvpb.NewGet(roachpb.Key("b"))
 	_, err := kv.SendWrapped(ctx, ds, get)
 	if err != nil {
@@ -2591,7 +2586,7 @@ func TestMultiRangeGapReverse(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	txn := roachpb.MakeTransaction(
 		"foo",
@@ -2706,7 +2701,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		}),
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
 	// Set the Txn info to avoid an OpRequiresTxnError.
 	reply, err := kv.SendWrappedWith(ctx, ds, kvpb.Header{
@@ -2751,7 +2746,7 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 		}),
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	rScan := &kvpb.ReverseScanRequest{
 		RequestHeader: kvpb.RequestHeader{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
 	}
@@ -2781,7 +2776,7 @@ func TestClockUpdateOnResponse(t *testing.T) {
 		TransportFactory:  GRPCTransportFactory(nodedialer.New(rpcContext, gossip.AddressResolver(g))),
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	expectedErr := kvpb.NewError(errors.New("boom"))
 
@@ -2915,7 +2910,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 		RangeDescriptorDB: descDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	// Send a batch request containing two puts. In the first
 	// attempt, the span of the descriptor found in the cache is
@@ -3040,7 +3035,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 		RangeDescriptorDB: descDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	// Send a batch request contains two scans. In the first
 	// attempt, the range of the descriptor found in the cache is
@@ -3229,7 +3224,7 @@ func TestMultiRangeWithEndTxn(t *testing.T) {
 			RangeDescriptorDB: descDB,
 			Settings:          cluster.MakeTestingClusterSettings(),
 		}
-		ds := NewDistSender(cfg)
+		ds := NewDistSender(ctx, cfg)
 		ds.DisableParallelBatches()
 
 		// Send a batch request containing two puts.
@@ -3360,7 +3355,7 @@ func TestParallelCommitSplitFromQueryIntents(t *testing.T) {
 				RangeDescriptorDB: defaultMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			ds.DisableParallelBatches()
 
 			// Send a batch request containing the requests.
@@ -3487,7 +3482,7 @@ func TestParallelCommitsDetectIntentMissingCause(t *testing.T) {
 				RangeDescriptorDB: defaultMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 
 			// Send a parallel commit batch request.
 			ba := &kvpb.BatchRequest{}
@@ -3571,7 +3566,7 @@ func TestCountRanges(t *testing.T) {
 		RangeDescriptorDB: descDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	// Verify counted ranges.
 	keyIn := func(desc roachpb.RangeDescriptor) roachpb.RKey {
@@ -3653,7 +3648,7 @@ func TestPProfLabelsAppliedToBatchRequestHeader(t *testing.T) {
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ba := &kvpb.BatchRequest{}
 	ba.Add(kvpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value")))
 	expectedLabels := map[string]string{"key": "value", "key2": "value2"}
@@ -3705,7 +3700,7 @@ func TestGatewayNodeID(t *testing.T) {
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ba := &kvpb.BatchRequest{}
 	ba.Add(kvpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value")))
 	if _, err := ds.Send(context.Background(), ba); err != nil {
@@ -3947,7 +3942,7 @@ func TestReplicaErrorsMerged(t *testing.T) {
 					TransportFactory: adaptSimpleTransport(transportFn),
 					Settings:         st,
 				}
-				ds := NewDistSender(cfg)
+				ds := NewDistSender(ctx, cfg)
 
 				ba := &kvpb.BatchRequest{}
 				ba.Add(kvpb.NewGet(roachpb.Key("a")))
@@ -4165,7 +4160,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 					Settings:          cluster.MakeTestingClusterSettings(),
 					RPCRetryOptions:   &retry.Options{MaxRetries: 1},
 				}
-				ds := NewDistSender(cfg)
+				ds := NewDistSender(ctx, cfg)
 
 				ba := &kvpb.BatchRequest{}
 				ba.Txn = txn.Clone()
@@ -4321,7 +4316,7 @@ func TestErrorIndexAlignment(t *testing.T) {
 				RangeDescriptorDB: descDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			ds.DisableParallelBatches()
 
 			ba := &kvpb.BatchRequest{}
@@ -4443,7 +4438,7 @@ func TestCanSendToFollower(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			sentTo = roachpb.ReplicaDescriptor{}
 			canSend = c.canSendToFollower
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			// Make store 2 the leaseholder.
 			lease := roachpb.Lease{
 				Replica:  testUserRangeDescriptor3Replicas.InternalReplicas[1],
@@ -4621,7 +4616,7 @@ func TestEvictMetaRange(t *testing.T) {
 			FirstRangeProvider: g,
 			Settings:           cluster.MakeTestingClusterSettings(),
 		}
-		ds := NewDistSender(cfg)
+		ds := NewDistSender(ctx, cfg)
 
 		scan := kvpb.NewScan(roachpb.Key("a"), roachpb.Key("b"))
 		if _, pErr := kv.SendWrapped(ctx, ds, scan); pErr != nil {
@@ -4740,7 +4735,7 @@ func TestConnectionClass(t *testing.T) {
 		RangeDescriptorDB: rDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	for _, pair := range []struct {
 		key       roachpb.Key
@@ -4898,7 +4893,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 		FirstRangeProvider: g,
 		Settings:           cluster.MakeTestingClusterSettings(),
 	}
-	ds = NewDistSender(cfg)
+	ds = NewDistSender(ctx, cfg)
 
 	var batchWaitGroup sync.WaitGroup
 	putFn := func(key, value string) {
@@ -5102,7 +5097,7 @@ func TestErrorIndexOnRangeSplit(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	rc = ds.rangeCache
 
 	ba := &kvpb.BatchRequest{}
@@ -5236,7 +5231,7 @@ func TestRequestSubdivisionAfterDescriptorChange(t *testing.T) {
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
 
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			rc = ds.rangeCache
 
 			// We're going to send a batch with two reqs, on different sides of the split.
@@ -5327,7 +5322,7 @@ func TestRequestSubdivisionAfterDescriptorChangeWithUnavailableReplicasTerminate
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	ba := &kvpb.BatchRequest{}
 	ba.Add(get(keyA), get(keyC))
@@ -5492,7 +5487,7 @@ func TestDescriptorChangeAfterRequestSubdivision(t *testing.T) {
 				Settings:          cluster.MakeTestingClusterSettings(),
 			}
 
-			ds := NewDistSender(cfg)
+			ds := NewDistSender(ctx, cfg)
 			rc = ds.rangeCache
 
 			// We're going to send a batch with two reqs, on different sides of the split.
@@ -5721,7 +5716,7 @@ func TestSendToReplicasSkipsStaleReplicas(t *testing.T) {
 					Settings:         cluster.MakeTestingClusterSettings(),
 				}
 
-				ds := NewDistSender(cfg)
+				ds := NewDistSender(ctx, cfg)
 
 				ba := &kvpb.BatchRequest{}
 				get := &kvpb.GetRequest{}
@@ -5858,7 +5853,7 @@ func TestDistSenderDescEvictionAfterLeaseUpdate(t *testing.T) {
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ba := &kvpb.BatchRequest{}
 	get := &kvpb.GetRequest{}
 	get.Key = roachpb.Key("a")
@@ -5922,7 +5917,7 @@ func TestDistSenderRPCMetrics(t *testing.T) {
 		Settings:         cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ds.rangeCache.Insert(ctx, roachpb.RangeInfo{
 		Desc: desc,
 		Lease: roachpb.Lease{
@@ -6120,7 +6115,7 @@ func TestDistSenderNLHEFromUninitializedReplicaDoesNotCauseUnboundedBackoff(t *t
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
 
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 	ba := &kvpb.BatchRequest{}
 	get := &kvpb.GetRequest{}
 	get.Key = roachpb.Key("a")
@@ -6157,6 +6152,7 @@ func TestOptimisticRangeDescriptorLookups(t *testing.T) {
 		}),
 	)
 	setup := func() (chan batchRequest, *DistSender, *stop.Stopper) {
+		ctx := context.Background()
 		stopper := stop.NewStopper()
 		manualC := timeutil.NewManualTime(timeutil.Unix(0, 1))
 		clock := hlc.NewClockForTesting(manualC)
@@ -6199,7 +6195,7 @@ func TestOptimisticRangeDescriptorLookups(t *testing.T) {
 			},
 			Settings: cluster.MakeTestingClusterSettings(),
 		}
-		ds := NewDistSender(cfg)
+		ds := NewDistSender(ctx, cfg)
 		return sendCh, ds, stopper
 	}
 
@@ -6476,7 +6472,7 @@ func TestProxyRequestDoesNotSplit(t *testing.T) {
 		TransportFactory:  adaptSimpleTransport(transportFn),
 		Settings:          cluster.MakeTestingClusterSettings(),
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	// Send without the proxy header. This request will be split into two and
 	// sent through the transport twice, once to each store.
@@ -6680,7 +6676,7 @@ func benchDistSender(b *testing.B, rf int, numRange int, conc bool) {
 		},
 		Settings: st,
 	}
-	ds := NewDistSender(cfg)
+	ds := NewDistSender(ctx, cfg)
 
 	// Run through all the ranges once to pre-populate the cache. This allows the
 	// runs to be stable fairly quickly.

--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -77,7 +77,7 @@ func NewDistSenderForLocalTestCluster(
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldQuiesce()
 	senderTransportFactory := SenderTransportFactory(tracer, stores)
-	return NewDistSender(DistSenderConfig{
+	return NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:         log.MakeTestingAmbientContext(tracer),
 		Settings:           st,
 		Clock:              clock,

--- a/pkg/kv/kvclient/kvcoord/range_iter_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter_test.go
@@ -58,7 +58,7 @@ func TestRangeIterForward(t *testing.T) {
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:             clock,
 		NodeDescs:         g,
@@ -95,7 +95,7 @@ func TestRangeIterSeekForward(t *testing.T) {
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:             clock,
 		NodeDescs:         g,
@@ -135,7 +135,7 @@ func TestRangeIterReverse(t *testing.T) {
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:             clock,
 		NodeDescs:         g,
@@ -172,7 +172,7 @@ func TestRangeIterSeekReverse(t *testing.T) {
 	clock := hlc.NewClockForTesting(nil)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:             clock,
 		NodeDescs:         g,

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -244,7 +244,7 @@ func sendBatch(
 			})
 	}
 
-	ds := NewDistSender(DistSenderConfig{
+	ds := NewDistSender(ctx, DistSenderConfig{
 		AmbientCtx:         log.MakeTestingAmbientCtxWithNewTracer(),
 		Settings:           cluster.MakeTestingClusterSettings(),
 		NodeDescs:          g,

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -71,6 +71,10 @@ type ClientTestingKnobs struct {
 	// picking a transaction's anchor key; instead, the transaction is anchored at
 	// the first key it locks.
 	DisableTxnAnchorKeyRandomization bool
+
+	// DontRandomizeLeaseholderOnCtxError, if set, disables randomization of the
+	// cached leaseholder when a context error is encountered.
+	DontRandomizeLeaseholderOnCtxError bool
 }
 
 var _ base.ModuleTestingKnobs = &ClientTestingKnobs{}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_client_test.go
@@ -103,7 +103,7 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 		return resp, nil
 	}
 	ambient := log.MakeTestingAmbientCtxWithNewTracer()
-	ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
+	ds := kvcoord.NewDistSender(ctx, kvcoord.DistSenderConfig{
 		AmbientCtx:        ambient,
 		Clock:             s.Clock,
 		NodeDescs:         s.Gossip,

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -2663,6 +2663,9 @@ func TestFlowControlRangeSplitMergeMixedVersion(t *testing.T) {
 						return disableWorkQueueGrantingServers[idx].Load()
 					},
 				},
+				KVClient: &kvcoord.ClientTestingKnobs{
+					DontRandomizeLeaseholderOnCtxError: true,
+				},
 			},
 		}
 	}

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1089,6 +1089,9 @@ func TestFlowControlRaftMembershipRemoveSelfV2(t *testing.T) {
 								return disableWorkQueueGranting.Load()
 							},
 						},
+						KVClient: &kvcoord.ClientTestingKnobs{
+							DontRandomizeLeaseholderOnCtxError: true,
+						},
 					},
 				},
 			})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1662,6 +1662,9 @@ func TestFlowControlGranterAdmitOneByOneV2(t *testing.T) {
 						},
 						AlwaysTryGrantWhenAdmitted: true,
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1456,6 +1456,9 @@ func TestFlowControlTransferLeaseV2(t *testing.T) {
 							return disableWorkQueueGranting.Load()
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -2248,6 +2248,9 @@ func TestFlowControlSendQueueManyInflight(t *testing.T) {
 						return disableWorkQueueGranting.Load()
 					},
 				},
+				KVClient: &kvcoord.ClientTestingKnobs{
+					DontRandomizeLeaseholderOnCtxError: true,
+				},
 			},
 		},
 	})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1830,6 +1830,9 @@ func TestFlowControlSendQueue(t *testing.T) {
 						return disableWorkQueueGrantingServers[idx].Load()
 					},
 				},
+				KVClient: &kvcoord.ClientTestingKnobs{
+					DontRandomizeLeaseholderOnCtxError: true,
+				},
 			},
 		}
 	}

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -432,6 +432,9 @@ func TestFlowControlAdmissionPostSplitMergeV2(t *testing.T) {
 							return disableWorkQueueGranting.Load()
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1228,6 +1228,9 @@ func TestFlowControlClassPrioritizationV2(t *testing.T) {
 							return disableWorkQueueGranting.Load()
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1545,6 +1545,9 @@ func TestFlowControlLeaderNotLeaseholderV2(t *testing.T) {
 							return disableWorkQueueGranting.Load()
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -2422,6 +2422,9 @@ func TestFlowControlSendQueueRangeRelocate(t *testing.T) {
 								return disableWorkQueueGrantingServers[idx].Load()
 							},
 						},
+						KVClient: &kvcoord.ClientTestingKnobs{
+							DontRandomizeLeaseholderOnCtxError: true,
+						},
 					},
 				}
 			}

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -319,6 +319,9 @@ func TestFlowControlBlockedAdmissionV2(t *testing.T) {
 							return disableWorkQueueGranting.Load()
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -587,6 +587,9 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 							return true
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 				},
 			},
 		})

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -267,7 +267,7 @@ func createTestStoreWithoutStart(
 
 	rangeProv := &dummyFirstRangeProvider{}
 	var storeSender struct{ kv.Sender }
-	ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
+	ds := kvcoord.NewDistSender(ctx, kvcoord.DistSenderConfig{
 		AmbientCtx:         cfg.AmbientCtx,
 		Settings:           cfg.Settings,
 		Clock:              cfg.Clock,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -510,7 +510,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			return livenessCache.GetNodeVitality(id).IsLive(livenesspb.DistSender)
 		},
 	}
-	distSender := kvcoord.NewDistSender(distSenderCfg)
+	distSender := kvcoord.NewDistSender(ctx, distSenderCfg)
 	appRegistry.AddMetricStruct(distSender.Metrics())
 
 	txnMetrics := kvcoord.MakeTxnMetrics(cfg.HistogramWindowInterval())

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1314,7 +1314,7 @@ func makeTenantSQLServerArgs(
 		TestingKnobs:      dsKnobs,
 		CanSendToFollower: followerreads.CanSendToFollower,
 	}
-	ds := kvcoord.NewDistSender(dsCfg)
+	ds := kvcoord.NewDistSender(startupCtx, dsCfg)
 	registry.AddMetricStruct(ds.Metrics())
 
 	var clientKnobs kvcoord.ClientTestingKnobs


### PR DESCRIPTION
The leaseholder randomization introduced in #166760 can cause flow
control tests to stall indefinitely. These tests deliberately disable
admission control on specific nodes; if leaseholder randomization
kicks in during a slow config change (e.g., `AddVotersOrFatal` with
joint consensus), the cached leaseholder can be set to an AC-disabled
node, causing `h.put()` to block forever.

See https://github.com/cockroachdb/cockroach/issues/167371#issuecomment-4195466951
for the full root cause analysis.

The first commit introduces a `DontRandomizeLeaseholderOnCtxError`
testing knob. The middle commits are mechanical — each sets the knob on
one affected test. The last commit re-enables the 2s default (reverting
the temporary disable from #167646) and adds a 500ms floor with a
warning if someone sets the env var too low.

Fixes: #167371
Fixes: #167383
Fixes: #167396
Fixes: #167406
Fixes: #167415
Fixes: #167416
Fixes: #167421
Fixes: #167422
Fixes: #167443
Fixes: #167451
Fixes: #167486
Fixes: #167496
Fixes: #167372
Epic: none
Release note: None