### PR TITLE
*: reduce frequency of auto stats refresh in some tests

### DIFF
--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -184,8 +184,8 @@ func TestImportFixture(t *testing.T) {
 		stats.DefaultRefreshInterval = oldRefreshInterval
 		stats.DefaultAsOfTime = oldAsOf
 	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
-	stats.DefaultRefreshInterval = time.Millisecond
-	stats.DefaultAsOfTime = 10 * time.Millisecond
+	stats.DefaultRefreshInterval = time.Second
+	stats.DefaultAsOfTime = 100 * time.Millisecond
 
 	// Disable auto stats collection on all tables. This is needed because we
 	// run only one auto stats job at a time, and collecting auto stats on

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5379,8 +5379,8 @@ func TestCreateStatsAfterImport(t *testing.T) {
 		stats.DefaultRefreshInterval = oldRefreshInterval
 		stats.DefaultAsOfTime = oldAsOf
 	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
-	stats.DefaultRefreshInterval = time.Millisecond
-	stats.DefaultAsOfTime = time.Microsecond
+	stats.DefaultRefreshInterval = time.Second
+	stats.DefaultAsOfTime = 100 * time.Millisecond
 
 	const nodes = 1
 	numFiles := nodes

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1662,9 +1662,8 @@ func (t *logicTest) newCluster(
 	// Update the defaults for automatic statistics to avoid delays in testing.
 	// Avoid making the DefaultAsOfTime too small to avoid interacting with
 	// schema changes and causing transaction retries.
-	// TODO(radu): replace these with testing knobs.
-	stats.DefaultAsOfTime = 10 * time.Millisecond
-	stats.DefaultRefreshInterval = time.Millisecond
+	stats.DefaultRefreshInterval = time.Second
+	stats.DefaultAsOfTime = 100 * time.Millisecond
 
 	t.cluster = serverutils.StartCluster(t.rootT, cfg.NumNodes, params)
 	t.purgeZoneConfig()

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
@@ -71,14 +71,14 @@ __auto_partial__  {a}           0          0               0           (a IS NUL
 __auto_partial__  {c}           0          0               0           (c IS NULL) OR ((c < 1.0:::FLOAT8) OR (c > 10.0:::FLOAT8))
 __auto_partial__  {d}           100        1               0           (d IS NULL) OR ((d < 1:::DECIMAL) OR (d > 1:::DECIMAL))
 
-# Enable full stat collections with the cluster setting.
-statement ok
-SET CLUSTER SETTING sql.stats.automatic_full_collection.enabled = true
-
 # Disable automatic partial and full stats with the table settings.
 statement ok
 ALTER TABLE data SET (sql_stats_automatic_partial_collection_enabled = false);
 ALTER TABLE data SET (sql_stats_automatic_full_collection_enabled = false)
+
+# Enable full stat collections with the cluster setting.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_full_collection.enabled = true
 
 # Change 20% of the table, no new partial or full stats should be collected.
 statement ok

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5057,8 +5057,8 @@ func TestCreateStatsAfterSchemaChange(t *testing.T) {
 		stats.DefaultRefreshInterval = oldRefreshInterval
 		stats.DefaultAsOfTime = oldAsOf
 	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
-	stats.DefaultRefreshInterval = time.Millisecond
-	stats.DefaultAsOfTime = time.Microsecond
+	stats.DefaultRefreshInterval = time.Second
+	stats.DefaultAsOfTime = 100 * time.Millisecond
 
 	server, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(context.Background())


### PR DESCRIPTION
**logictest: fix an unlikely flake in distsql_automatic_partial_stats**

Previously, the test enabled the cluster setting for auto full stats collections before disabling the table-level parameter, so it was possible for an auto full stats collection to be kicked off in-between those two events, which would lead to a rare flake. Now the order is reversed, so the flake shouldn't be possible.

***: reduce frequency of auto stats refresh in some tests**

Previously, several tests (including the logic test setup) used very aggressive DefaultRefreshInterval and DefaultAsOfTime overrides, which meant that the auto stats refresher goroutine could be spinning based on the timer firing without doing any useful work. The most wasteful setup was in the logic tests where these knobs were set to 1ms and 10ms, respectively, and since we subtract the latter from the former to get the actual refresh interval, we'd end up with 0ms. This commit dials down the aggressiveness to 1s and 100ms, respectively, which should be quick enough to not slow down the actual test runtime. (In the logic tests only a handful of test files actually have the auto stats enabled, so perhaps this is an actual speedup of the overall runtime of all tests.)

Epic: None
Release note: None