### PR TITLE
optbuilder: fix schema-qualified REGCLASS cast failing in UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -794,3 +794,75 @@ statement ok
 EXPLAIN ANALYZE (DEBUG) SELECT f161993('{}')
 
 subtest end
+
+subtest regression_62227
+
+# Regression test for #62227. Creating a PL/pgSQL UDF that references a
+# schema-qualified sequence via a REGCLASS cast should not fail with
+# "relation does not exist" at CREATE FUNCTION time.
+statement ok
+CREATE SCHEMA sc_62227;
+CREATE SEQUENCE sc_62227.myseq;
+
+statement ok
+CREATE FUNCTION sc_62227.next_id()
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v INT;
+BEGIN
+  SELECT nextval('sc_62227.myseq'::REGCLASS) INTO v;
+  RETURN v;
+END;
+$$;
+
+query I
+SELECT sc_62227.next_id()
+----
+1
+
+# The same bug affected SQL UDFs, not only PL/pgSQL.
+statement ok
+CREATE FUNCTION sc_62227.next_id_sql()
+RETURNS INT
+LANGUAGE sql
+AS $$
+  SELECT nextval('sc_62227.myseq'::REGCLASS);
+$$;
+
+query I
+SELECT sc_62227.next_id_sql()
+----
+2
+
+# Also test using an OID integer as the source of a ::REGCLASS cast. The OID
+# may change across test runs, so we capture it in a variable first.
+let $seqoid
+SELECT 'sc_62227.myseq'::REGCLASS::OID;
+
+statement ok
+CREATE OR REPLACE FUNCTION sc_62227.next_id()
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v INT;
+BEGIN
+  SELECT nextval($seqoid::REGCLASS) INTO v;
+  RETURN v;
+END;
+$$;
+
+query I
+SELECT sc_62227.next_id()
+----
+3
+
+statement ok
+DROP FUNCTION sc_62227.next_id;
+DROP FUNCTION sc_62227.next_id_sql;
+DROP SEQUENCE sc_62227.myseq;
+DROP SCHEMA sc_62227;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -7,7 +7,6 @@ package optbuilder
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -21,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -572,37 +570,38 @@ func (b *Builder) trackReferencedColumnForViews(col *scopeColumn) {
 }
 
 func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
-	if b.trackSchemaDeps {
-		if texpr != nil && texpr.ResolvedType().Identical(types.RegClass) {
-			// We do not add a dependency if the RegClass Expr contains variables,
-			// we cannot resolve the variables in this context. This matches Postgres
-			// behavior.
-			if !tree.ContainsVars(texpr) {
-				regclass, err := eval.Expr(b.ctx, b.evalCtx, texpr)
-				if err != nil {
-					panic(err)
-				}
-
-				var ds cat.DataSource
-				// Regclass can contain an ID or a string.
-				// Ex. nextval('s'::regclass) and nextval(59::regclass) are both valid.
-				id, err := strconv.Atoi(regclass.String())
-				if err == nil {
-					ds, _, err = b.catalog.ResolveDataSourceByID(b.ctx, cat.Flags{}, cat.StableID(id))
-					if err != nil {
-						panic(err)
-					}
-				} else {
-					tn := tree.MakeUnqualifiedTableName(tree.Name(regclass.String()))
-					ds, _, _ = b.resolveDataSource(&tn, privilege.SELECT)
-				}
-
-				b.schemaDeps = append(b.schemaDeps, opt.SchemaDep{
-					DataSource: ds,
-				})
-			}
-		}
+	if !b.trackSchemaDeps {
+		return
 	}
+	if texpr == nil || !texpr.ResolvedType().Identical(types.RegClass) {
+		return
+	}
+	// We do not add a dependency if the RegClass Expr contains variables,
+	// we cannot resolve the variables in this context. This matches Postgres
+	// behavior.
+	if tree.ContainsVars(texpr) {
+		return
+	}
+	regclass, err := eval.Expr(b.ctx, b.evalCtx, texpr)
+	if err != nil {
+		panic(err)
+	}
+	// eval.Expr on a REGCLASS expression returns a *tree.DOid.
+	// Use the OID directly for resolution rather than DOid.String(), which
+	// returns only the object name and drops the schema prefix (e.g. returns
+	// "myseq" instead of "sc.myseq"), causing unqualified lookups to fail
+	// when the schema is not in the search path.
+	dOid, ok := regclass.(*tree.DOid)
+	if !ok {
+		panic(errors.AssertionFailedf(
+			"expected *tree.DOid from eval.Expr on REGCLASS expression, got %T", regclass,
+		))
+	}
+	ds, _, err := b.catalog.ResolveDataSourceByID(b.ctx, cat.Flags{}, cat.StableID(dOid.Oid))
+	if err != nil {
+		panic(err)
+	}
+	b.schemaDeps = append(b.schemaDeps, opt.SchemaDep{DataSource: ds})
 }
 
 func (b *Builder) maybeTrackUserDefinedTypeDepsForViews(texpr tree.TypedExpr) {


### PR DESCRIPTION
When building a UDF or view, `maybeTrackRegclassDependenciesForViews` evaluates any constant `REGCLASS` expression to record the referenced data source as a schema dependency. The previous implementation resolved the data source by converting the evaluated datum to a string via `DOid.String()`, then constructing an unqualified table name from it.

The root cause is that `ParseDOid` stores only the bare object name in `DOid.name` (`pkg/sql/sem/eval/parse_doid.go:189-206`) when creating the datum (e.g. "myseq" instead of "sc.myseq"). The schema is used to resolve the `OID` correctly, but is then discarded from the name field. `DOid.String()` therefore returns only the bare object name, and constructing an unqualified table name from it fails when the object's schema is not in the search path - at `CREATE FUNCTION` time, not at call time.

The fix bypasses the lossy name entirely by asserting the evaluated datum to `*tree.DOid` and calling `ResolveDataSourceByID` with the numeric `OID` directly, which is always correct regardless of schema. This bug affects both `PL/pgSQL` and `SQL` UDFs since both languages go through `finishBuildScalar`, which calls this function.

The function is also refactored to use early returns instead of nested `if` blocks, reducing indentation depth.

Resolves: #167057
Epic: CRDB-62227

Release note (bug fix): Fixed a bug where creating a PL/pgSQL or SQL user-defined function that references a schema-qualified sequence or table via a REGCLASS cast (e.g.
nextval('sc.myseq'::REGCLASS)) would fail with "relation does not exist" at CREATE FUNCTION time when the object's schema was not in the search path.