### PR TITLE
release-26.1: stats: respect table-level params in auto stats refresher

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -406,17 +406,13 @@ func (r *Refresher) autoStatsEnabled(desc catalog.TableDescriptor) bool {
 
 // autoPartialStatsEnabled returns true if the
 // sql_stats_automatic_partial_collection_enabled setting of the table
-// descriptor set to true. If the table descriptor is nil or the table-level
-// setting is not set, the function returns true if the automatic partial stats
-// cluster setting is enabled.
-func (r *Refresher) autoPartialStatsEnabled(desc catalog.TableDescriptor) bool {
-	if desc == nil {
-		// If the descriptor could not be accessed, defer to the cluster setting.
+// descriptor set to true. If the table-level setting is not set, the function
+// returns true if the automatic partial stats cluster setting is enabled.
+func (r *Refresher) autoPartialStatsEnabled(explicitSettings *catpb.AutoStatsSettings) bool {
+	if explicitSettings == nil {
 		return AutomaticPartialStatisticsClusterMode.Get(&r.st.SV)
 	}
-	enabledForTable := desc.AutoPartialStatsCollectionEnabled()
-	// The table-level setting of sql_stats_automatic_partial_collection_enabled
-	// takes precedence over the cluster setting.
+	enabledForTable := explicitSettings.AutoPartialStatsCollectionEnabled()
 	if enabledForTable == catpb.AutoPartialStatsCollectionNotSet {
 		return AutomaticPartialStatisticsClusterMode.Get(&r.st.SV)
 	}
@@ -424,18 +420,14 @@ func (r *Refresher) autoPartialStatsEnabled(desc catalog.TableDescriptor) bool {
 }
 
 // autoFullStatsEnabled returns true if the
-// sql_stats_automatic_full_collection_enabled setting of the table
-// descriptor set to true. If the table descriptor is nil or the table-level
-// setting is not set, the function returns true if the automatic full stats
-// cluster setting is enabled.
-func (r *Refresher) autoFullStatsEnabled(desc catalog.TableDescriptor) bool {
-	if desc == nil {
-		// If the descriptor could not be accessed, defer to the cluster setting.
+// sql_stats_automatic_full_collection_enabled setting of the table descriptor
+// set to true. If the table-level setting is not set, the function returns true
+// if the automatic full stats cluster setting is enabled.
+func (r *Refresher) autoFullStatsEnabled(explicitSettings *catpb.AutoStatsSettings) bool {
+	if explicitSettings == nil {
 		return AutomaticFullStatisticsClusterMode.Get(&r.st.SV)
 	}
-	enabledForTable := desc.AutoFullStatsCollectionEnabled()
-	// The table-level setting of sql_stats_automatic_full_collection_enabled
-	// takes precedence over the cluster setting.
+	enabledForTable := explicitSettings.AutoFullStatsCollectionEnabled()
 	if enabledForTable == catpb.AutoFullStatsCollectionNotSet {
 		return AutomaticFullStatisticsClusterMode.Get(&r.st.SV)
 	}
@@ -672,8 +664,8 @@ func (r *Refresher) Start(
 								explicitSettings,
 								rowsAffected,
 								r.asOfTime,
-								r.autoPartialStatsEnabled(desc),
-								r.autoFullStatsEnabled(desc),
+								r.autoPartialStatsEnabled(explicitSettings),
+								r.autoFullStatsEnabled(explicitSettings),
 							)
 
 							select {

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -8,6 +8,7 @@ package stats_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,10 +20,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -951,4 +955,66 @@ func runAutoStatsJob(
 			t.Fatalf("auto stats job should have failed, but it didn't (beforeCount: %d, afterCount: %d)", beforeCount, afterCount)
 		}
 	}
+}
+
+// TestTableLevelStatsSettingsRespected ensures that table-level storage
+// parameters that control whether full or partial auto stats are enabled take
+// precedence over the cluster settings.
+func TestTableLevelStatsSettingsRespected(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	defer func(oldRefreshInterval, oldAsOf time.Duration) {
+		stats.DefaultRefreshInterval = oldRefreshInterval
+		stats.DefaultAsOfTime = oldAsOf
+	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
+	stats.DefaultRefreshInterval = time.Second
+	stats.DefaultAsOfTime = 100 * time.Millisecond
+
+	var params base.TestServerArgs
+	params.Knobs.TableStatsKnobs = &stats.TableStatsTestingKnobs{
+		DisableInitialTableCollection: true,
+	}
+	params.Settings = cluster.MakeTestingClusterSettings()
+	stats.AutomaticStatisticsClusterMode.Override(ctx, &params.Settings.SV, false)
+	stats.AutomaticStatisticsOnSystemTables.Override(ctx, &params.Settings.SV, false)
+
+	srv, sqlDB, _ := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	refresher := s.ExecutorConfig().(sql.ExecutorConfig).StatsRefresher
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// First test that table-level full stats enabled parameter is respected.
+	runner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_full_collection.enabled = false`)
+	runner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_partial_collection.enabled = false`)
+	runner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true`)
+
+	runner.Exec(t, `CREATE TABLE t (k INT PRIMARY KEY);`)
+	runner.Exec(t, `INSERT INTO t SELECT generate_series(1, 1000);`)
+	runner.Exec(t, `ALTER TABLE t SET (sql_stats_automatic_full_collection_enabled = true);`)
+	desc := desctestutils.TestingGetTableDescriptor(s.DB(), s.Codec(), "defaultdb", "public", "t")
+	refresher.NotifyMutation(ctx, desc, math.MaxInt32)
+
+	// There should be one full stat for table t.
+	runner.CheckQueryResultsRetry(t,
+		`SELECT statistics_name, column_names, row_count FROM [SHOW STATISTICS FOR TABLE t]`,
+		[][]string{
+			{"__auto__", "{k}", "1000"},
+		})
+
+	// Now test that table-level partial stats enabled parameter is respected.
+	runner.Exec(t, `ALTER TABLE t SET (sql_stats_automatic_full_collection_enabled = false, sql_stats_automatic_partial_collection_enabled = true);`)
+	// Get the updated table descriptor with new table-level storage params.
+	desc = desctestutils.TestingGetTableDescriptor(s.DB(), s.Codec(), "defaultdb", "public", "t")
+	refresher.NotifyMutation(ctx, desc, math.MaxInt32)
+
+	// There should be one full and one partial stat for table t.
+	runner.CheckQueryResultsRetry(t,
+		`SELECT statistics_name, column_names, row_count FROM [SHOW STATISTICS FOR TABLE t] ORDER BY 1`,
+		[][]string{
+			{"__auto__", "{k}", "1000"},
+			{"__auto_partial__", "{k}", "0"},
+		})
 }


### PR DESCRIPTION
Backport 1/1 commits from #167540 on behalf of @yuzefovich.

----

This commit fixes a bug where we could ignore `sql_stats_automatic_full_collection_enabled` and `sql_stats_automatic_partial_collection_enabled` table-level storage parameters in the auto stats refresher. In particular, we had a couple of helper methods that would take a TableDescriptor as an argument, and if that happens to be nil, then we'd default to the corresponding cluster setting. The thing is that we don't always fetch the TableDescriptor (we only do so only if the `maybeRefreshStats` goroutine has been running for at least 1 minute, meaning that there were previous long stats collections during the current refresh cycle). This commit fixes the bug by propagating the table-level parameters directly which side-steps the nil TableDescriptor issue (we do keep all overrides in the global map).

Note that we probably could have caught this bug in the logic tests, but we reduce DefaultRefreshInterval to 1ms in there, so we happened to fetch the TableDescriptor most (all?) of the time.

Epic: None

Release note (bug fix): Previously, CockroachDB might not have respected the table-level parameters `sql_stats_automatic_full_collection_enabled` and `sql_stats_automatic_partial_collection_enabled` and defaulted to using the corresponding cluster settings when deciding whether to perform automatic statistic collection on a table. This is now fixed.

----

Release justification: bug fix.