### PR TITLE
tracing: unify SHOW TRACE span start format with Recording.String()

### DIFF
--- a/pkg/cli/clisqlshell/sql_test.go
+++ b/pkg/cli/clisqlshell/sql_test.go
@@ -487,7 +487,7 @@ func TestAutoTraceInAutoRunStatements(t *testing.T) {
 	if !strings.HasPrefix(out, strings.Join(stmt, " ")+"\n?column?\nhello") {
 		t.Errorf("output does not start with statement result")
 	}
-	if !strings.Contains(out, "SPAN START") {
+	if !strings.Contains(out, "=== operation:") {
 		t.Errorf("output does not contain trace")
 	}
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3477,7 +3477,7 @@ func getMessagesForSubtrace(
 		allLogs,
 		logRecordRow{
 			timestamp: span.StartTime,
-			msg:       fmt.Sprintf("=== SPAN START: %s ===", span.Operation),
+			msg:       tracingpb.FormatSpanStartMessage(span.RecordedSpan).StripMarkers(),
 			span:      span,
 			index:     0,
 		},

--- a/pkg/sql/logictest/testdata/logic_test/udf_observability
+++ b/pkg/sql/logictest/testdata/logic_test/udf_observability
@@ -136,13 +136,18 @@ statement ok
 SET tracing = off
 
 query T rowsort
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message ~ '^=== SPAN START: routine-stmt-trace_fn'
+SELECT regexp_replace(
+    message,
+    ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+    '', 'g')
+FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '=== operation:routine-stmt-trace_fn%'
 ----
-=== SPAN START: routine-stmt-trace_fn-1 ===
-=== SPAN START: routine-stmt-trace_fn-2 ===
-=== SPAN START: routine-stmt-trace_fn-1 ===
-=== SPAN START: routine-stmt-trace_fn-2 ===
-=== SPAN START: routine-stmt-trace_fn-1 ===
-=== SPAN START: routine-stmt-trace_fn-2 ===
+=== operation:routine-stmt-trace_fn-1 _verbose:1
+=== operation:routine-stmt-trace_fn-2 _verbose:1
+=== operation:routine-stmt-trace_fn-1 _verbose:1
+=== operation:routine-stmt-trace_fn-2 _verbose:1
+=== operation:routine-stmt-trace_fn-1 _verbose:1
+=== operation:routine-stmt-trace_fn-2 _verbose:1
 
 subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -21,36 +21,44 @@ SET tracing = off; RESET vectorize
 # how many commands we ran in the session.
 query ITT
 SELECT
-  span, regexp_replace(message, 'pos:[0-9]*', 'pos:?'), operation
+  span,
+  CASE WHEN message LIKE '=== operation:%'
+    THEN regexp_replace(
+      regexp_replace(message, ' statement:.*?( _| $)', '\1'),
+      ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+      '', 'g')
+    ELSE regexp_replace(message, 'pos:[0-9]*', 'pos:?')
+  END,
+  operation
 FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
+WHERE message LIKE '%=== operation:%' OR message LIKE '%pos%executing%';
 ----
-0   === SPAN START: session recording ===                session recording
-1   === SPAN START: session tracing ===                  session tracing
-1   [Open pos:?] executing Sync                          session tracing
-2   === SPAN START: commit sql txn ===                   commit sql txn
-0   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
-3   === SPAN START: sql txn ===                          sql txn
-3   [Open pos:?] executing ExecStmt: SELECT 1            sql txn
-4   === SPAN START: sql query ===                        sql query
-5   === SPAN START: optimizer ===                        optimizer
-6   === SPAN START: consuming rows ===                   consuming rows
-7   === SPAN START: flow ===                             flow
-8   === SPAN START: values ===                           values
-3   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
-9   === SPAN START: sql query ===                        sql query
-10  === SPAN START: commit sql txn ===                   commit sql txn
-0   [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
-11  === SPAN START: sql txn ===                          sql txn
-11  [Open pos:?] executing ExecStmt: SELECT 2            sql txn
-12  === SPAN START: sql query ===                        sql query
-13  === SPAN START: optimizer ===                        optimizer
-14  === SPAN START: consuming rows ===                   consuming rows
-15  === SPAN START: flow ===                             flow
-16  === SPAN START: values ===                           values
-17  === SPAN START: commit sql txn ===                   commit sql txn
-0   [NoTxn pos:?] executing Sync                         session recording
-0   [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
+0   === operation:session recording _unfinished:1 _verbose:1  session recording
+1   === operation:session tracing _verbose:1                  session tracing
+1   [Open pos:?] executing Sync                               session tracing
+2   === operation:commit sql txn _verbose:1                   commit sql txn
+0   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION       session recording
+3   === operation:sql txn _verbose:1                          sql txn
+3   [Open pos:?] executing ExecStmt: SELECT 1                 sql txn
+4   === operation:sql query _verbose:1 statement:SELECT 1     sql query
+5   === operation:optimizer _verbose:1                        optimizer
+6   === operation:consuming rows _verbose:1                   consuming rows
+7   === operation:flow _verbose:1                             flow
+8   === operation:values _verbose:1                           values
+3   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION       sql txn
+9   === operation:sql query _verbose:1 statement:COMMIT       sql query
+10  === operation:commit sql txn _verbose:1                   commit sql txn
+0   [NoTxn pos:?] executing ExecStmt: SELECT 2                session recording
+11  === operation:sql txn _verbose:1                          sql txn
+11  [Open pos:?] executing ExecStmt: SELECT 2                 sql txn
+12  === operation:sql query _verbose:1 statement:SELECT 2     sql query
+13  === operation:optimizer _verbose:1                        optimizer
+14  === operation:consuming rows _verbose:1                   consuming rows
+15  === operation:flow _verbose:1                             flow
+16  === operation:values _verbose:1                           values
+17  === operation:commit sql txn _verbose:1                   commit sql txn
+0   [NoTxn pos:?] executing Sync                              session recording
+0   [NoTxn pos:?] executing ExecStmt: SET TRACING = off       session recording
 
 statement ok
 CREATE TABLE num_ref (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))
@@ -1940,16 +1948,23 @@ SELECT id FROM system.namespace WHERE name='a'
 # was improperly configured to add a limit to the ScanRequest batch.
 # See #30943 for more details.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION]
+SELECT CASE WHEN message LIKE '=== operation:%'
+    THEN regexp_replace(
+      message,
+      ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+      '', 'g')
+    ELSE message
+  END
+FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE 'querying next range at /Table/$t_id3/1%' OR
-      message = '=== SPAN START: kv.DistSender: sending partial batch ==='
+      message LIKE '=== operation:kv.DistSender: sending partial batch%'
 ----
 querying next range at /Table/127/1/0/0
 querying next range at /Table/127/1/10/0
 querying next range at /Table/127/1/0/0
 querying next range at /Table/127/1/10/0
 querying next range at /Table/127/1/0/0
-=== SPAN START: kv.DistSender: sending partial batch ===
+=== operation:kv.DistSender: sending partial batch _verbose:1
 querying next range at /Table/127/1/10/0
 
 # Test for 42202 -- ensure filters can get pushed down through project-set.

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -255,12 +255,19 @@ SET tracing = off
 # "querying next range at /Table/109/1/0/0". It's not clear why that happens, so
 # we deduplicate the messages to make the test non-flaky.
 query T rowsort
-SELECT DISTINCT message FROM [SHOW TRACE FOR SESSION]
+SELECT DISTINCT CASE WHEN message LIKE '=== operation:%'
+    THEN regexp_replace(
+      message,
+      ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+      '', 'g')
+    ELSE message
+  END
+FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE 'querying next range at %' OR
-      message = '=== SPAN START: kv.DistSender: sending partial batch ==='
+      message LIKE '=== operation:kv.DistSender: sending partial batch%'
 ----
 querying next range at /Table/109/1/0/0
-=== SPAN START: kv.DistSender: sending partial batch ===
+=== operation:kv.DistSender: sending partial batch _verbose:1
 querying next range at /Table/109/1/10/0
 
 # Used to be a regression test for #46123 (rowexec.TableReader not implementing

--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -205,7 +205,7 @@ func writeEntry(w redact.SafeWriter, entry traceLogData, start time.Time, mode f
 // was generated after the child Span started (or even after the child
 // finished).
 //
-// TODO(andrei): this should be unified with
+// The span start format is shared with
 // SessionTracing.generateSessionTraceVTable().
 func (r Recording) String() string {
 	return redact.Sprint(r).StripMarkers()
@@ -316,6 +316,33 @@ type OperationAndMetadata struct {
 	Metadata  OperationMetadata
 }
 
+// FormatSpanStartMessage formats the operation line for a recorded span,
+// including the goroutine ID and all tags. The format is:
+//
+//	=== operation:<name> [gid:<N>] [<tag-key>:<value>]...
+//
+// Tag values are treated as unsafe for redaction; everything else is safe.
+// This is the canonical format used by both Recording.String() and SHOW TRACE
+// FOR SESSION.
+func FormatSpanStartMessage(sp *RecordedSpan) redact.RedactableString {
+	var sb redact.StringBuilder
+	sb.SafeString("=== operation:")
+	sb.SafeString(redact.SafeString(sp.Operation))
+	if sp.GoroutineID != 0 {
+		sb.Printf(" gid:%d", sp.GoroutineID)
+	}
+	for _, tg := range sp.TagGroups {
+		var prefix redact.RedactableString
+		if tg.Name != AnonymousTagGroupName {
+			prefix = redact.Sprintf("%s-", redact.SafeString(tg.Name))
+		}
+		for _, tag := range tg.Tags {
+			sb.Printf(" %s%s:%s", prefix, redact.SafeString(tag.Key), tag.Value)
+		}
+	}
+	return sb.RedactableString()
+}
+
 // visitSpan returns the log messages for sp, and all of sp's children.
 //
 // All messages from a Span are kept together. Sibling spans are ordered within
@@ -345,24 +372,7 @@ func (r Recording) visitSpanWithWriter(
 
 	// Build operation line only in full mode.
 	if mode == formatFull {
-		var sb redact.StringBuilder
-		sb.SafeString("=== operation:")
-		sb.SafeString(redact.SafeString(sp.Operation))
-
-		if sp.GoroutineID != 0 {
-			sb.Printf(" gid:%d", sp.GoroutineID)
-		}
-
-		for _, tg := range sp.TagGroups {
-			var prefix redact.RedactableString
-			if tg.Name != AnonymousTagGroupName {
-				prefix = redact.Sprintf("%s-", redact.SafeString(tg.Name))
-			}
-			for _, tag := range tg.Tags {
-				sb.Printf(" %s%s:%s", prefix, redact.SafeString(tag.Key), tag.Value)
-			}
-		}
-		ownLogs = append(ownLogs, conv(sb.RedactableString(), sp.StartTime, time.Time{}))
+		ownLogs = append(ownLogs, conv(FormatSpanStartMessage(&sp), sp.StartTime, time.Time{}))
 	}
 
 	// Sort the OperationMetadata of s' children in descending order of duration.


### PR DESCRIPTION
SHOW TRACE FOR SESSION previously rendered span starts as `=== SPAN START: <op> ===`, while Recording.String() (used in trace files, Jaeger export, debug endpoints) rendered them as `=== operation:<op> <tags>`. This meant span-level tags like `_dropped_logs`, `_dropped_children`, and `_verbose` were invisible in SHOW TRACE output, giving users no indication when trace data had been dropped due to size limits.

This addresses a longstanding TODO in recording.go about unifying these two rendering paths.

Epic: None

Release note (sql change): SHOW TRACE FOR SESSION now displays span start messages using the `=== operation:<name> <tags>` format instead of `=== SPAN START: <name> ===`. The new format includes span tags such as `_verbose`, `_dropped_logs`, and `_dropped_children`, making it easier to identify when trace data has been truncated.