### PR TITLE
release-24.3: kvserver: deflake TestRebalancingAndCrossRegionZoneSnapshotMetrics

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -2332,6 +2332,12 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 
 	defer tc.Stopper().Stop(ctx)
 
+	// Disable delegated snapshots as they can screw up the metric assertions
+	// this test makes.
+	kvserver.NumDelegateLimit.Override(
+		ctx, &tc.Server(0).ClusterSettings().SV, 0,
+	)
+
 	scratchStartKey := tc.ScratchRange(t)
 	// sendSnapshotFromServer is a testing helper that sends a learner snapshot
 	// from server[0] to server[serverIndex] and returns the expected size (in


### PR DESCRIPTION
Backport 1/1 commits from #167558 on behalf of @arulajmani.

----

Snapshot delegation is enabled by default, and `getSenderReplicas` can
pick server[1] as a delegate for the second snapshot if server[0] is
momentarily considered unhealthy by the store pool. When that happens,
the sent-bytes metrics land on the wrong server, failing the test's
assertions.

Disable delegation in this test, same as we already do in
`TestSnapshotsToDrainingOrDecommissioningNodes`.

Fixes-26.1 #167004

Epic: none
Release note: None

----

Release justification: