### PR TITLE
release-26.1: kvserver: deflake TestRebalancingAndCrossRegionZoneSnapshotMetrics

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -2340,6 +2340,12 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 
 	defer tc.Stopper().Stop(ctx)
 
+	// Disable delegated snapshots as they can screw up the metric assertions
+	// this test makes.
+	kvserver.NumDelegateLimit.Override(
+		ctx, &tc.Server(0).ClusterSettings().SV, 0,
+	)
+
 	scratchStartKey := tc.ScratchRange(t)
 	desc := tc.LookupRangeOrFatal(t, scratchStartKey)
 	// Wait for the expiration lease to upgrade to an epoch or leader lease.


### PR DESCRIPTION
Backport 1/1 commits from #167558 on behalf of @arulajmani.

----

Snapshot delegation is enabled by default, and `getSenderReplicas` can
pick server[1] as a delegate for the second snapshot if server[0] is
momentarily considered unhealthy by the store pool. When that happens,
the sent-bytes metrics land on the wrong server, failing the test's
assertions.

Disable delegation in this test, same as we already do in
`TestSnapshotsToDrainingOrDecommissioningNodes`.

Fixes #167004

Epic: none
Release note: None

----

Release justification: