### PR TITLE
jobs: enable probabilistic multi-tenant testing

### DIFF
--- a/pkg/jobs/ash_integration_test.go
+++ b/pkg/jobs/ash_integration_test.go
@@ -108,6 +108,10 @@ func TestJobKVWorkloadIDPropagation(t *testing.T) {
 	defer cleanup()
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		// This test uses kvserver.StoreTestingKnobs.TestingRequestFilter to
+		// intercept KV-level BatchRequests, which only fires on the storage
+		// layer and is not propagated to secondary tenants.
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			KeyVisualizer:    &keyvisualizer.TestingKnobs{SkipJobBootstrap: true},

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2316,7 +2316,11 @@ func TestStartableJobMixedVersion(t *testing.T) {
 		false, /* initializeVersion */
 	)
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Settings: st,
+		// This test manipulates cluster version via SET CLUSTER SETTING, which
+		// does not work under a secondary tenant because tenants cannot upgrade
+		// ahead of the storage cluster.
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(167929),
+		Settings:          st,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				ClusterVersionOverride:         clusterversion.MinSupported.Version(),

--- a/pkg/jobs/main_test.go
+++ b/pkg/jobs/main_test.go
@@ -21,8 +21,7 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory,
-		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly),
-		serverutils.WithTenantOption(base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(156331)))
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -81,9 +81,15 @@ func TestExpiringSessionsAndClaimJobsDoesNotTouchTerminalJobs(t *testing.T) {
 	// Don't adopt, cancel rapidly.
 	adopt := 10 * time.Hour
 	cancel := 10 * time.Millisecond
-	args := base.TestServerArgs{Knobs: base.TestingKnobs{
-		JobsTestingKnobs: jobs.NewTestingKnobsWithIntervals(adopt, cancel, adopt, adopt),
-	}}
+	args := base.TestServerArgs{
+		// Under a secondary tenant, s.SQLLivenessProvider() may return a
+		// different session than the one used by the tenant's job registry to
+		// claim jobs, causing the claim_session_id check to fail.
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(167929),
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithIntervals(adopt, cancel, adopt, adopt),
+		},
+	}
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, args)
@@ -287,8 +293,12 @@ func TestRegistrySettingUpdate(t *testing.T) {
 			// the job interval to a short duration.
 			cs := clusterSettings(ctx, test.toOverride)
 			args := base.TestServerArgs{
-				Settings: cs,
-				Knobs:    base.TestingKnobs{SQLExecutor: &sql.ExecutorTestingKnobs{StatementFilter: stmtFilter}},
+				// Under a secondary tenant, the cancel loop runs extra times
+				// during initialization, causing the exact initCount checks
+				// to fail.
+				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(167929),
+				Settings:          cs,
+				Knobs:             base.TestingKnobs{SQLExecutor: &sql.ExecutorTestingKnobs{StatementFilter: stmtFilter}},
 			}
 			s, sdb, _ := serverutils.StartServer(t, args)
 			defer s.Stopper().Stop(ctx)

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -108,6 +108,10 @@ func TestRegistryGC(t *testing.T) {
 
 	ctx := context.Background()
 	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// This test directly manipulates table descriptors at the KV layer
+		// using keys.SystemSQLCodec, which is incompatible with secondary
+		// tenants.
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		Knobs: base.TestingKnobs{
 			SpanConfig: &spanconfig.TestingKnobs{
 				// This test directly modifies `system.jobs` and makes over its contents


### PR DESCRIPTION
Remove the package-level disablement of randomized secondary tenant testing for pkg/jobs. Most tests operate at the SQL/registry layer and work correctly under a secondary tenant without changes. A handful of tests that require storage-layer access or have behavioral assumptions incompatible with multi-tenant mode are given per-test opt-outs.

Fixes #156331

Release note: None