### PR TITLE
backup: deflake `TestOnlineRestoreLinkingNonexistentFiles`

### DIFF
--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -1210,6 +1210,8 @@ func TestOnlineRestoreLinkingNonexistentFiles(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
+
 	backuptestutils.EnableFastRestoreForTest(t)
 
 	const numAccounts = 1000


### PR DESCRIPTION
This patch adds the `AllowORDownloadBestEffortFailures` helper to `TestOnlineRestoreLinkingNonexistentFiles`. This test specifically creates conditions where the download phase will fail, but is not testing the download phase itself. As such, besteffort operations within the download phase can fail due to context cancelation, and potentially throw a panic before the test completes, causing false failures.

Fixes: #167404

Release note: None