### PR TITLE
roachtest: enable revision history backups in OR roundtrip

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -1607,9 +1607,8 @@ func (rh revisionHistory) String() string {
 // creating a new backup. Each backup option has a 50% chance of being
 // included.
 func newBackupOptions(rng *rand.Rand, onlineRestoreExpected bool) []backupOption {
-	possibleOpts := []backupOption{}
+	possibleOpts := []backupOption{revisionHistory{}}
 	if !onlineRestoreExpected {
-		possibleOpts = append(possibleOpts, revisionHistory{})
 		possibleOpts = append(possibleOpts, newEncryptionPassphrase(rng))
 	}
 


### PR DESCRIPTION
This commit enables revision history backups in our OR roundtrip tests.

Resolves: #163240

Release note: None