### PR TITLE
release-25.2: roachtest: preserve cluster on Pebble storage corruption

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1577,6 +1577,11 @@ func (r *testRunner) teardownTest(
 		t.taskManager.Terminate(t.L())
 	}()
 
+	// Check for rare conditions (such as storage durability crashes) at this
+	// point. This may still mark the test as failed (so that we enter artifacts
+	// collection below).
+	r.maybeSaveClusterDueToInvariantProblems(ctx, t, c)
+
 	if timedOut || t.Failed() || roachtestflags.AlwaysCollectArtifacts {
 		err := r.collectArtifacts(ctx, t, c, timedOut, time.Hour)
 		if err != nil {
@@ -1626,6 +1631,50 @@ func (r *testRunner) teardownTest(
 		getCpuProfileArtifacts(ctx, c, t)
 	}
 	return nil
+}
+
+// maybeSaveClusterDueToInvariantProblems detects rare conditions (such as
+// storage durability crashes) on the cluster and if one is detected,
+// unconditionally preserves the cluster for future debugging. It also creates
+// volume snapshots so that the durable state close to the incident is
+// preserved.
+func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
+	ctx context.Context, t *testImpl, c *clusterImpl,
+) {
+	if len(c.All()) == 0 {
+		return // test only
+	}
+	dets, err := c.RunWithDetails(ctx, t.L(), option.WithNodes(c.All()),
+		"([ -d logs ] && grep -RE 'F[0-9]{6}.*(Was the raft log corrupted|local corruption detected)' logs) || true",
+	)
+	for _, det := range dets {
+		err = errors.CombineErrors(err, det.Err)
+	}
+	if err != nil {
+		t.L().Printf(
+			"failed to check whether to save cluster due to invariant problems: %s",
+			err,
+		)
+		return
+	}
+
+	for _, det := range dets {
+		if det.Stdout != "" {
+			_ = c.Extend(ctx, 7*24*time.Hour, t.L())
+			timestamp := timeutil.Now().UnixMilli()
+			// We take the risk that two tests could attempt to create a snapshot
+			// at the same exact millisecond, as we have a 63 character limit on
+			// the name and the cluster name usually exceeds this by itself.
+			snapName := fmt.Sprintf("invariant-problem-%d", timestamp)
+			if _, err := c.CreateSnapshot(ctx, snapName); err != nil {
+				t.L().Printf("failed to create snapshot %q: %s", snapName, err)
+				snapName = "<failed>"
+			}
+			c.Save(ctx, "invariant problem - snap name "+snapName, t.L())
+			t.Error("invariant problem - snap name " + snapName + ":\n" + det.Stdout)
+			return
+		}
+	}
 }
 
 func (r *testRunner) collectArtifacts(

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "import_cancellation.go",
         "inconsistency.go",
         "indexes.go",
+        "invariant_check_detection.go",
         "inverted_index.go",
         "jasyncsql.go",
         "jasyncsql_blocklist.go",

--- a/pkg/cmd/roachtest/tests/invariant_check_detection.go
+++ b/pkg/cmd/roachtest/tests/invariant_check_detection.go
@@ -1,0 +1,73 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
+)
+
+func registerInvariantCheckDetection(r registry.Registry) {
+	// Tests for maybeSaveClusterDueToInvariantProblems. These don't verify
+	// that everything works as it should, but they can be run to verify
+	// manually that the cluster is saved correctly and the log output is
+	// helpful.
+
+	for _, failed := range []bool{false, true} {
+		r.Add(registry.TestSpec{
+			CompatibleClouds: registry.AllClouds,
+			Name:             fmt.Sprintf("invariant-check-detection/failed=%t", failed),
+			Owner:            registry.OwnerTestEng,
+			Suites:           registry.ManualOnly,
+			Cluster:          r.MakeClusterSpec(1),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runInvariantCheckDetection(ctx, t, c, failed)
+			},
+		})
+	}
+
+	// Test that local corruption (checksum mismatch) is also detected.
+	r.Add(registry.TestSpec{
+		CompatibleClouds: registry.AllClouds,
+		Name:             "invariant-check-detection/local-corruption",
+		Owner:            registry.OwnerTestEng,
+		Suites:           registry.ManualOnly,
+		Cluster:          r.MakeClusterSpec(1),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runLocalCorruptionDetection(ctx, t, c)
+		},
+	})
+}
+
+func runInvariantCheckDetection(ctx context.Context, t test.Test, c cluster.Cluster, failed bool) {
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
+	require.NoError(t, c.PutString(ctx, `
+foo br baz
+F250502 11:37:20.387424 1036 raft/raft.go:2411 ⋮ [T1,Vsystem,n1,s1,r155/1:‹/Table/113/1/{43/578…-51/201…}›] 80 match(30115) is out of range [lastIndex(30114)]. Was the raft log corrupted, truncated, or lost?
+asdasds
+`, "logs/foo.log", 0644, c.Node(1)))
+	if failed {
+		t.Error("boom")
+	}
+}
+
+// runLocalCorruptionDetection plants a fake "local corruption detected"
+// fatal log line and lets teardownTest -> maybeSaveClusterDueToInvariantProblems
+// detect it. The test is expected to fail — maybeSaveClusterDueToInvariantProblems
+// calls t.Error when it preserves the cluster, which marks the test as failed.
+func runLocalCorruptionDetection(ctx context.Context, t test.Test, c cluster.Cluster) {
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
+	require.NoError(t, c.PutString(ctx, `
+F260402 03:11:00.515510 2215881 storage/pebble.go:1436 ⋮ [n3,s3,pebble] 2364  local corruption detected: pebble: file 039091: block 8375813/30902: ‹crc32c› checksum mismatch b136961c != ed105766
+`, "logs/cockroach.log", 0644, c.Node(1)))
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -74,6 +74,7 @@ func RegisterTests(r registry.Registry) {
 	registerImportTPCC(r)
 	registerImportTPCH(r)
 	registerInconsistency(r)
+	registerInvariantCheckDetection(r)
 	registerIndexes(r)
 	registerJasyncSQL(r)
 	registerJepsen(r)


### PR DESCRIPTION
Backport 1/1 commits from #167584 on behalf of @williamchoe3.

/cc @cockroachdb/test-eng

Expand maybeSaveClusterDueToInvariantProblems to also detect "local
corruption detected" fatal messages, which indicate on-disk Pebble
corruption (SST checksum mismatches, etc.).

Since `maybeSaveClusterDueToInvariantProblems` did not exist on this
branch, this backport patches the entire function and test file directly
rather than cherry-picking.

Informs #167367
Epic: none
Release note: None

Release justification: test only change