### PR TITLE
staging-v24.1.27: release-24.1: restore: add missing logging and telemetry

### DIFF
--- a/pkg/ccl/backupccl/backup_telemetry.go
+++ b/pkg/ccl/backupccl/backup_telemetry.go
@@ -326,10 +326,10 @@ func logRestoreTelemetry(
 		requestedTargets = append(requestedTargets, *desc.DescriptorProto())
 	}
 
-	largestScope := getLargestScope(details.DescriptorCoverage == tree.AllDescriptors, requestedTargets)
+	largestScope := getLargestScope(details.DescriptorCoverage != tree.RequestedDescriptors, requestedTargets)
 
 	targetCount := 1
-	if details.DescriptorCoverage != tree.AllDescriptors {
+	if details.DescriptorCoverage == tree.RequestedDescriptors {
 		targetCount = len(requestedTargets)
 	}
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1513,7 +1513,7 @@ func checkPrivilegesForRestore(
 	{
 		// Cluster and tenant restores require the `RESTORE` system privilege for
 		// non-admin users.
-		requiresRestoreSystemPrivilege := restoreStmt.DescriptorCoverage == tree.AllDescriptors ||
+		requiresRestoreSystemPrivilege := restoreStmt.DescriptorCoverage != tree.RequestedDescriptors ||
 			restoreStmt.Targets.TenantID.IsSet()
 
 		if requiresRestoreSystemPrivilege {
@@ -2265,6 +2265,9 @@ func collectRestoreTelemetry(
 	telemetry.Count("restore.total.started")
 	if restoreStmt.DescriptorCoverage == tree.AllDescriptors {
 		telemetry.Count("restore.full-cluster")
+	}
+	if restoreStmt.DescriptorCoverage == tree.SystemUsers {
+		telemetry.Count("restore.system-users")
 	}
 	if restoreStmt.Subdir == nil {
 		telemetry.Count("restore.deprecated-subdir-syntax")

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -133,7 +133,8 @@ func (e *scheduledBackupExecutor) executeBackup(
 		return nil
 	}
 
-	log.Infof(ctx, "Starting scheduled backup %d", sj.ScheduleID())
+	log.Infof(ctx, "starting scheduled backup %d (%s)",
+		sj.ScheduleID(), sj.ScheduleLabel())
 
 	if knobs, ok := cfg.TestingKnobs.(*jobs.TestingKnobs); ok {
 		if knobs.OverrideAsOfClause != nil {
@@ -202,15 +203,16 @@ func (e *scheduledBackupExecutor) NotifyJobTermination(
 ) error {
 	if jobStatus == jobs.StatusSucceeded {
 		e.metrics.NumSucceeded.Inc(1)
-		log.Infof(ctx, "backup job %d scheduled by %d succeeded", jobID, schedule.ScheduleID())
+		log.Infof(ctx, "backup job %d scheduled by %d (%s) succeeded",
+			jobID, schedule.ScheduleID(), schedule.ScheduleLabel())
 		return e.backupSucceeded(ctx, jobs.ScheduledJobTxn(txn), schedule, details, env)
 	}
 
 	e.metrics.NumFailed.Inc(1)
 	err := errors.Errorf(
-		"backup job %d scheduled by %d failed with status %s",
-		jobID, schedule.ScheduleID(), jobStatus)
-	log.Errorf(ctx, "backup error: %v	", err)
+		"backup job %d scheduled by %d (%s) failed with status %s",
+		jobID, schedule.ScheduleID(), schedule.ScheduleLabel(), jobStatus)
+	log.Errorf(ctx, "backup error: %v", err)
 	jobs.DefaultHandleFailedRun(schedule, "backup job %d failed with err=%v", jobID, err)
 	return nil
 }
@@ -441,7 +443,7 @@ func extractBackupStatement(sj *jobs.ScheduledJob) (*annotatedBackupStatement, e
 		}, nil
 	}
 
-	return nil, errors.Newf("unexpect node type %T", node)
+	return nil, errors.Newf("unexpected node type %T", node)
 }
 
 var _ jobs.ScheduledJobController = &scheduledBackupExecutor{}

--- a/pkg/scheduledjobs/schedulebase/util.go
+++ b/pkg/scheduledjobs/schedulebase/util.go
@@ -70,15 +70,17 @@ func ComputeScheduleRecurrence(now time.Time, rec *string) (*ScheduleRecurrence,
 func CheckScheduleAlreadyExists(
 	ctx context.Context, p sql.PlanHookState, scheduleLabel string,
 ) (bool, error) {
+	// IF NOT EXISTS usually is used when it already exists (to noop) so use limit
+	// 1 to stop scanning as soon as we see a match.
 	row, err := p.InternalSQLTxn().QueryRowEx(ctx, "check-sched",
 		p.Txn(), sessiondata.NodeUserSessionDataOverride,
-		fmt.Sprintf("SELECT count(schedule_name) FROM %s WHERE schedule_name = '%s'",
-			scheduledjobs.ProdJobSchedulerEnv.ScheduledJobsTableName(), scheduleLabel))
-
+		fmt.Sprintf("SELECT 1 FROM %s WHERE schedule_name = $1 LIMIT 1",
+			scheduledjobs.ProdJobSchedulerEnv.ScheduledJobsTableName()), scheduleLabel,
+	)
 	if err != nil {
 		return false, err
 	}
-	return int64(tree.MustBeDInt(row[0])) != 0, nil
+	return row != nil, nil
 }
 
 // ParseOnError parses schedule option optOnExecFailure into


### PR DESCRIPTION
Backport 2/2 commits from #167664 on behalf of @dt.

----

Backport 2/2 commits from #167602.

/cc @cockroachdb/release

---

Previously RESTORE SYSTEM USERS was being mis-reported in telemetry as a tables restore rather than as a cluster restore. Also add schedule names to logging to make it easier to tie specific backup failures to their owning schedules.

Release note: none.
Epic: none.

Release justification: low risk change


----

Release justification: