### PR TITLE
release-25.4: server: fix TestPlainHTTPServer flake by retrying HTTP GET

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -213,16 +213,15 @@ func TestPlainHTTPServer(t *testing.T) {
 	if !strings.HasPrefix(url, "http://") {
 		t.Fatalf("expected insecure admin url to start with http://, but got %s", url)
 	}
-	if resp, err := httputil.Get(context.Background(), url); err != nil {
-		t.Error(err)
-	} else {
-		func() {
-			defer resp.Body.Close()
-			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-				t.Error(err)
-			}
-		}()
-	}
+	testutils.SucceedsSoon(t, func() error {
+		resp, err := httputil.Get(context.Background(), url)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		_, err = io.Copy(io.Discard, resp.Body)
+		return err
+	})
 
 	// Attempting to connect to the insecure server with HTTPS doesn't work.
 	secureURL := strings.Replace(url, "http://", "https://", 1)


### PR DESCRIPTION
Backport 1/1 commits from #165573 on behalf of @dhartunian.

----

`TestPlainHTTPServer` was using `httputil.Get` with the default 3-second
`StandardHTTPTimeout` to fetch the admin URL. Under CI resource
pressure, the request to `/` (which goes through the full
`authenticatedUIHandler` chain) can exceed this timeout, causing
intermittent failures across multiple branches since December 2025.

Wrap the HTTP GET in `testutils.SucceedsSoon` to retry on transient
timeouts, matching the pattern already used in the same test for the
health check request.

Resolves: #165366

Release note: None

----

Release justification: Test only change to fix flaky tests