### PR TITLE
sql: fast path pg_roles lookup for system roles

### DIFF
--- a/pkg/sql/builtin_test.go
+++ b/pkg/sql/builtin_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -109,5 +110,78 @@ func TestFuncNull(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// TestRoleNameFromOID validates that builtin roles can correctly
+// have their OID resolved inside: RoleNameFromOID.
+func TestRoleNameFromOID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	p := &planner{}
+	ctx := context.Background()
+
+	// Use the same OID hashing logic as the server.
+	h := makeOidHasher()
+
+	testCases := []struct {
+		name     username.SQLUsername
+		expected string
+	}{
+		{username.NodeUserName(), username.NodeUser},
+		{username.RootUserName(), username.RootUser},
+		{username.AdminRoleName(), username.AdminRole},
+		{username.PublicRoleName(), username.PublicRole},
+	}
+
+	for _, tc := range testCases {
+		oidVal := h.UserOid(tc.name).Oid
+		name, ok := p.MaybeResolveSystemRoleOID(ctx, oidVal)
+		if !ok {
+			t.Errorf("expected fast-path match for %s (OID %d)", tc.name, oidVal)
+			continue
+		}
+		if name != tc.expected {
+			t.Errorf("expected %s, got %s", tc.expected, name)
+		}
+	}
+
+	// Test unknown OID
+	if _, ok := p.MaybeResolveSystemRoleOID(ctx, 123456); ok {
+		t.Error("expected no match for unknown OID")
+	}
+}
+
+// TestSystemRoleOIDResolution validates that pg_has_role does not
+// read to read system tables to resolve builtin roles.
+func TestSystemRoleOIDResolution(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	// Verify that pg_has_role (which uses getNameForArg) works correctly for
+	// system roles. These roles have OIDs that are deterministic hashes of
+	// their names.
+	systemRoles := []string{"node", "root", "admin"}
+
+	for _, role := range systemRoles {
+		t.Run(role, func(t *testing.T) {
+			var oid int64
+			query := fmt.Sprintf("SELECT oid FROM pg_catalog.pg_roles WHERE rolname = '%s'", role)
+			err := db.QueryRowContext(ctx, query).Scan(&oid)
+			if err != nil {
+				t.Fatalf("failed to get OID for %s: %v", role, err)
+			}
+
+			// Test pg_has_role. This triggers the getNameForArg code path.
+			// Explicitly cast to OID to ensure we hit the DOid case in getNameForArg.
+			var hasRole bool
+			err = db.QueryRowContext(ctx, "SELECT pg_catalog.pg_has_role($1::OID, 'USAGE')", oid).Scan(&hasRole)
+			if err != nil {
+				t.Errorf("pg_has_role failed for %s (OID %d): %v", role, oid, err)
+			}
+		})
 	}
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -238,7 +238,14 @@ func (ep *DummyEvalPlanner) ResetLeaseTimestamp(ctx context.Context) {
 	panic(errors.WithStack(errEvalPlanner))
 }
 
-// UserHasAdminRole is part of the Planner interface.
+// MaybeResolveSystemRoleOID is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) MaybeResolveSystemRoleOID(
+	ctx context.Context, roleOID oid.Oid,
+) (string, bool) {
+	return "", false
+}
+
+// UserHasAdminRole is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) UserHasAdminRole(
 	ctx context.Context, user username.SQLUsername,
 ) (bool, error) {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -661,6 +661,25 @@ func (p *planner) ExecMon() *mon.BytesMonitor {
 	return p.execMon
 }
 
+// MaybeResolveSystemRoleOID is part of the eval.Planner interface.
+func (p *planner) MaybeResolveSystemRoleOID(ctx context.Context, roleOID oid.Oid) (string, bool) {
+	h := makeOidHasher()
+	// Fast-path for the most common built-in role owners to minimize virtual table scans.
+	if roleOID == h.UserOid(username.NodeUserName()).Oid {
+		return username.NodeUser, true
+	}
+	if roleOID == h.UserOid(username.RootUserName()).Oid {
+		return username.RootUser, true
+	}
+	if roleOID == h.UserOid(username.AdminRoleName()).Oid {
+		return username.AdminRole, true
+	}
+	if roleOID == h.UserOid(username.PublicRoleName()).Oid {
+		return username.PublicRole, true
+	}
+	return "", false
+}
+
 // ExecCfg implements the PlanHookState interface.
 func (p *planner) ExecCfg() *ExecutorConfig {
 	return p.extendedEvalCtx.ExecCfg

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -515,11 +515,21 @@ func getNameForArg(
 		if u == username.PublicRoleName() {
 			return username.PublicRole, nil
 		}
+		if pgTable == "pg_roles" {
+			if u == username.NodeUserName() || u == username.RootUserName() || u == username.AdminRoleName() {
+				return u.Normalized(), nil
+			}
+		}
 		arg = tree.NewDString(u.Normalized())
 		query = fmt.Sprintf("SELECT %s FROM pg_catalog.%s WHERE %s = $1 LIMIT 1", pgCol, pgTable, pgCol)
 	case *tree.DOid:
 		if t.Oid == username.PublicRoleID {
 			return username.PublicRole, nil
+		}
+		if pgTable == "pg_roles" {
+			if name, ok := evalCtx.Planner.MaybeResolveSystemRoleOID(ctx, t.Oid); ok {
+				return name, nil
+			}
 		}
 		query = fmt.Sprintf("SELECT %s FROM pg_catalog.%s WHERE oid = $1 LIMIT 1", pgCol, pgTable)
 	default:

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -316,6 +316,11 @@ type Planner interface {
 	// UnsafeDeleteComment is used to delete comments for a non-existent object.
 	UnsafeDeleteComment(ctx context.Context, objectID int64) error
 
+	// MaybeResolveSystemRoleOID returns the role name for the given OID, if it is a
+	// known system role. It returns a boolean indicating if the resolution was
+	// successful. This is an optimization to avoid expensive virtual table joins.
+	MaybeResolveSystemRoleOID(ctx context.Context, roleOID oid.Oid) (string, bool)
+
 	// UserHasAdminRole returns tuple of bool and error:
 	// (true, nil) means that the user has an admin role (i.e. root or node)
 	// (false, nil) means that the user has NO admin role


### PR DESCRIPTION
This commit adds a fast path for resolving the names of well-known system roles (node, root, admin, public) from their OIDs.

When querying views like information_schema.routines, CockroachDB evaluates pg_has_role() for every builtin function. Because built-in functions are owned by 'node', this triggered thousands of internal queries to the pg_catalog.pg_roles virtual table, causing severe RPC stalls and watchdog timeouts on larger clusters. By resolving these common system OIDs in memory without a query, we eliminate this N+1 query explosion.

Fixes: #167516
Fixes: #167379

Release note (performance improvement): Improve performance of information_schema.routines when querying role information for builtins.