### PR TITLE
sql: emit NOTICE when a statement hint overrides existing hints

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -621,8 +621,8 @@ func (ep *DummyEvalPlanner) InsertStatementHint(
 	statementFingerprint string,
 	hint hintpb.StatementHintUnion,
 	optDatabase string,
-) (int64, error) {
-	return 0, nil
+) (int64, int64, error) {
+	return 0, 0, nil
 }
 
 // DeleteStatementHint is part of the eval.Planner interface.

--- a/pkg/sql/hintpb/statement_hint.go
+++ b/pkg/sql/hintpb/statement_hint.go
@@ -104,6 +104,24 @@ func (h StatementHintUnion) RecreateStmt(stmt string, database tree.Datum) (stri
 	}
 }
 
+// Conflicts reports whether this hint conflicts with another hint. Two hints
+// conflict when only the newer one will be applied at execution time (the older
+// is skipped by deduplication logic). InjectHints always conflict with other
+// InjectHints. SessionVariableHints conflict only when they set the same
+// variable. Hints of different types never conflict.
+func (h *StatementHintUnion) Conflicts(other *StatementHintUnion) bool {
+	switch t := h.GetValue().(type) {
+	case *InjectHints:
+		_, ok := other.GetValue().(*InjectHints)
+		return ok
+	case *SessionVariableHint:
+		o, ok := other.GetValue().(*SessionVariableHint)
+		return ok && t.VariableName == o.VariableName
+	default:
+		return false
+	}
+}
+
 // Details returns a JSON representation of the hint details. This is used for
 // displaying hint information in SHOW STATEMENT HINTS WITH DETAILS.
 func (h *StatementHintUnion) Details() (json.JSON, error) {

--- a/pkg/sql/hints/hint_table.go
+++ b/pkg/sql/hints/hint_table.go
@@ -271,6 +271,45 @@ func InsertHintIntoDB(
 	return int64(tree.MustBeDInt(row[0])), nil
 }
 
+// CountConflictingHintsInDB counts existing enabled hints for the given
+// fingerprint that conflict with the provided hint, excluding the row with
+// excludeRowID. Two hints conflict when only the newer one will be applied at
+// execution time (the older is skipped by deduplication logic).
+func CountConflictingHintsInDB(
+	ctx context.Context,
+	settings *cluster.Settings,
+	txn isql.Txn,
+	fingerprint string,
+	hint hintpb.StatementHintUnion,
+	excludeRowID int64,
+) (int64, error) {
+	const opName = "count-conflicting-hints"
+	if !settings.Version.IsActive(ctx, clusterversion.V26_2_StatementHintsTypeNameEnabledColumnsAdded) {
+		return 0, nil
+	}
+	const selectStmt = `SELECT hint FROM system.statement_hints
+WHERE fingerprint = $1 AND hint_type = $2 AND enabled = true AND row_id != $3`
+	rows, err := txn.QueryBufferedEx(
+		ctx, opName, txn.KV(), sessiondata.NodeUserSessionDataOverride,
+		selectStmt, fingerprint, hint.HintType(), excludeRowID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	var count int64
+	for _, row := range rows {
+		otherBytes := []byte(tree.MustBeDBytes(row[0]))
+		other, err := hintpb.ParseHintProto(otherBytes)
+		if err != nil {
+			continue
+		}
+		if hint.Conflicts(&other) {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // DeleteHintFromDB deletes statement hints from system.statement_hints,
 // filtered by row ID or fingerprint. If the provided rowID is zero, we don't
 // filter on row ID. If the fingerprint is empty string, we don't filter on

--- a/pkg/sql/hints/hint_table_test.go
+++ b/pkg/sql/hints/hint_table_test.go
@@ -219,3 +219,40 @@ func TestHintTableOperations(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must specify at least one of row_id or fingerprint")
 }
+
+// TestStatementHintConflicts tests the Conflicts method on StatementHintUnion.
+func TestStatementHintConflicts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	inject1 := &hintpb.StatementHintUnion{}
+	inject1.SetValue(&hintpb.InjectHints{DonorSQL: "SELECT a FROM t@idx1"})
+
+	inject2 := &hintpb.StatementHintUnion{}
+	inject2.SetValue(&hintpb.InjectHints{DonorSQL: "SELECT a FROM t@idx2"})
+
+	varHintA := &hintpb.StatementHintUnion{}
+	varHintA.SetValue(&hintpb.SessionVariableHint{VariableName: "distsql", VariableValue: "off"})
+
+	varHintA2 := &hintpb.StatementHintUnion{}
+	varHintA2.SetValue(&hintpb.SessionVariableHint{VariableName: "distsql", VariableValue: "on"})
+
+	varHintB := &hintpb.StatementHintUnion{}
+	varHintB.SetValue(&hintpb.SessionVariableHint{VariableName: "reorder_joins_limit", VariableValue: "0"})
+
+	// InjectHints vs InjectHints → true.
+	require.True(t, inject1.Conflicts(inject2))
+	require.True(t, inject2.Conflicts(inject1))
+
+	// SessionVariableHint vs SessionVariableHint (same var) → true.
+	require.True(t, varHintA.Conflicts(varHintA2))
+	require.True(t, varHintA2.Conflicts(varHintA))
+
+	// SessionVariableHint vs SessionVariableHint (different var) → false.
+	require.False(t, varHintA.Conflicts(varHintB))
+	require.False(t, varHintB.Conflicts(varHintA))
+
+	// InjectHints vs SessionVariableHint → false.
+	require.False(t, inject1.Conflicts(varHintA))
+	require.False(t, varHintA.Conflicts(inject1))
+}

--- a/pkg/sql/logictest/testdata/logic_test/show_statement_hints
+++ b/pkg/sql/logictest/testdata/logic_test/show_statement_hints
@@ -311,3 +311,46 @@ statement error pgcode 42601 pq: at or near "\|": syntax error
 SELECT fingerprint, hint_type
 FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM ' || 'ab WHERE a = 1']
 ORDER BY created_at DESC, row_id DESC;
+
+# Test that conflicting hints are visible via SHOW STATEMENT HINTS WITH DETAILS.
+subtest show_conflicting_hints
+
+# Clean up any hints for this fingerprint first.
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM ab WHERE b = _');
+
+# Create two inline hints for the same fingerprint with different donors.
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM ab WHERE b = _',
+  'SELECT * FROM ab@primary WHERE b = _'
+);
+
+statement ok
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM ab WHERE b = _',
+  'SELECT * FROM ab@ab_b_idx WHERE b = _'
+);
+
+# Both hints should be visible via SHOW STATEMENT HINTS WITH DETAILS.
+query I
+SELECT count(*)
+FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM ab WHERE b = 1' WITH DETAILS]
+WHERE hint_type = 'REWRITE INLINE HINTS';
+----
+2
+
+# The user can distinguish them via the details column (different donor SQL).
+query TT
+SELECT hint_type, details
+FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM ab WHERE b = 1' WITH DETAILS]
+ORDER BY created_at DESC, row_id DESC;
+----
+REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM ab@ab_b_idx WHERE b = _"}
+REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM ab@primary WHERE b = _"}
+
+# Clean up.
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM ab WHERE b = _');
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -923,3 +923,85 @@ statement ok
 SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM ab WHERE b = _', 'mydb');
 
 subtest end
+
+# Test that NOTICE is emitted when a hint overrides an existing one.
+subtest hint_overwrite_notice
+
+# Clean up any existing hints for the fingerprints used below.
+skipif config local-mixed-25.4 local-mixed-26.1
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE y = _');
+
+# Use pre-fingerprinted inputs to avoid fingerprint normalization notices.
+
+# First inline hint for a fingerprint: no overwrite notice.
+skipif config local-mixed-25.4 local-mixed-26.1
+query I noticetrace
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = _',
+  'SELECT * FROM xy@primary WHERE y = _'
+);
+----
+
+# Second inline hint for same fingerprint: overwrite notice mentioning 1
+# existing hint.
+skipif config local-mixed-25.4 local-mixed-26.1
+query I noticetrace
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = _',
+  'SELECT * FROM xy@xy_y_idx WHERE y = _'
+);
+----
+NOTICE: this hint overrides 1 existing inline hint(s) for the same statement fingerprint; the older hint(s) will be skipped. Use SHOW STATEMENT HINTS to identify stale hints.
+
+# Third inline hint for same fingerprint: overwrite notice mentioning 2
+# existing hints.
+skipif config local-mixed-25.4 local-mixed-26.1
+query I noticetrace
+SELECT information_schema.crdb_rewrite_inline_hints(
+  'SELECT * FROM xy WHERE y = _',
+  'SELECT * FROM xy@primary WHERE y = _'
+);
+----
+NOTICE: this hint overrides 2 existing inline hint(s) for the same statement fingerprint; the older hint(s) will be skipped. Use SHOW STATEMENT HINTS to identify stale hints.
+
+# Clean up inline hints.
+skipif config local-mixed-25.4 local-mixed-26.1
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE y = _');
+
+# First session variable hint: no overwrite notice.
+skipif config local-mixed-25.4 local-mixed-26.1
+query I noticetrace
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE y = _',
+  'distsql', 'off'
+);
+----
+
+# Second session variable hint for same variable: overwrite notice.
+skipif config local-mixed-25.4 local-mixed-26.1
+query I noticetrace
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE y = _',
+  'distsql', 'on'
+);
+----
+NOTICE: this hint overrides 1 existing session variable hint(s) for "distsql" on the same statement fingerprint; the older hint(s) will be skipped. Use SHOW STATEMENT HINTS to identify stale hints.
+
+# Session variable hint for different variable on same fingerprint: no
+# overwrite notice.
+skipif config local-mixed-25.4 local-mixed-26.1
+query I noticetrace
+SELECT information_schema.crdb_set_session_variable_hint(
+  'SELECT * FROM xy WHERE y = _',
+  'reorder_joins_limit', '0'
+);
+----
+
+# Clean up session variable hints.
+skipif config local-mixed-25.4 local-mixed-26.1
+statement ok
+SELECT information_schema.crdb_delete_statement_hints('SELECT * FROM xy WHERE y = _');
+
+subtest end

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -1226,10 +1226,21 @@ func (p *planner) InsertStatementHint(
 	statementFingerprint string,
 	hint hintpb.StatementHintUnion,
 	optDatabase string,
-) (int64, error) {
-	return hints.InsertHintIntoDB(
-		ctx, p.execCfg.Settings, p.InternalSQLTxn(), statementFingerprint, hint, optDatabase,
+) (int64, int64, error) {
+	txn := p.InternalSQLTxn()
+	hintID, err := hints.InsertHintIntoDB(
+		ctx, p.execCfg.Settings, txn, statementFingerprint, hint, optDatabase,
 	)
+	if err != nil {
+		return 0, 0, err
+	}
+	numOverridden, err := hints.CountConflictingHintsInDB(
+		ctx, p.execCfg.Settings, txn, statementFingerprint, hint, hintID,
+	)
+	if err != nil {
+		return 0, 0, err
+	}
+	return hintID, numOverridden, nil
 }
 
 // DeleteStatementHint is part of the eval.Planner interface.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -13354,9 +13354,16 @@ func rewriteInlineHintsImpl(
 	// Now that we've passed some basic validation, insert into statement_hints.
 	var hint hintpb.StatementHintUnion
 	hint.SetValue(&hintpb.InjectHints{DonorSQL: donorSQL})
-	hintID, err := evalCtx.Planner.InsertStatementHint(ctx, targetSQL, hint, optDatabase)
+	hintID, numOverridden, err := evalCtx.Planner.InsertStatementHint(ctx, targetSQL, hint, optDatabase)
 	if err != nil {
 		return nil, err
+	}
+	if numOverridden > 0 {
+		evalCtx.ClientNoticeSender.BufferClientNotice(ctx, pgnotice.Newf(
+			"this hint overrides %d existing inline hint(s) for the same statement fingerprint; "+
+				"the older hint(s) will be skipped. Use SHOW STATEMENT HINTS to identify stale hints.",
+			numOverridden,
+		))
 	}
 
 	// Log the statement hint injection event.
@@ -13635,9 +13642,17 @@ func sessionVariableHintImpl(
 		VariableName:  varName,
 		VariableValue: varValue,
 	})
-	hintID, err := evalCtx.Planner.InsertStatementHint(ctx, fingerprint, hint, optDatabase)
+	hintID, numOverridden, err := evalCtx.Planner.InsertStatementHint(ctx, fingerprint, hint, optDatabase)
 	if err != nil {
 		return nil, err
+	}
+	if numOverridden > 0 {
+		evalCtx.ClientNoticeSender.BufferClientNotice(ctx, pgnotice.Newf(
+			"this hint overrides %d existing session variable hint(s) for %q "+
+				"on the same statement fingerprint; the older hint(s) will be skipped. "+
+				"Use SHOW STATEMENT HINTS to identify stale hints.",
+			numOverridden, varName,
+		))
 	}
 
 	// Log the session variable hint event.

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -506,9 +506,10 @@ type Planner interface {
 
 	// InsertStatementHint adds a new hint for the given statement fingerprint to
 	// the system.statement_hints table. It returns the hint ID of the newly
-	// created hint. If optDatabase is non-empty, the hint is scoped to the
+	// created hint and a count of existing enabled hints that the new hint
+	// conflicts with. If optDatabase is non-empty, the hint is scoped to the
 	// given database.
-	InsertStatementHint(ctx context.Context, statementFingerprint string, hint hintpb.StatementHintUnion, optDatabase string) (int64, error)
+	InsertStatementHint(ctx context.Context, statementFingerprint string, hint hintpb.StatementHintUnion, optDatabase string) (hintID int64, numOverridden int64, retErr error)
 
 	// DeleteStatementHint deletes statement hints from
 	// system.statement_hints, filtered by the row ID, fingerprint, and/or


### PR DESCRIPTION
When a user creates a new statement hint that conflicts with an existing one (same fingerprint for inline hints, same fingerprint+variable for session variable hints), the older hint is silently disabled at read time by dedup logic. This change raises a NOTICE so the user is aware:

- Add a `Conflicts` method on `StatementHintUnion` that centralizes conflict detection logic.
- Add `CountConflictingHintsInDB` in the `hints` package to count existing enabled hints that conflict with a newly inserted one.
- Update the `InsertStatementHint` planner method to return both the hint ID and a count of overridden hints.
- Emit a NOTICE in `rewriteInlineHintsImpl` and `sessionVariableHintImpl` when the count is greater than zero.
- Add a `SHOW STATEMENT HINTS` test covering conflicting hints.

Fixes: #167324

Release note (sql change): Creating a statement hint that conflicts with an existing one now emits a NOTICE informing the user that older hints will be skipped. Use SHOW STATEMENT HINTS to identify stale hints.