### PR TITLE
release-26.2: logictest: set the session variable on a new connection

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
@@ -64,6 +64,11 @@ SET kv_transaction_buffered_writes_enabled = true;
 statement async writeReq count 1
 UPDATE t SET a = 2 WHERE a = 1
 
+# Since we executed the stmt above asynchronously, we're likely to get a new
+# connection here, so we must set the session variable on it too.
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
 onlyif config local-read-committed
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks


### PR DESCRIPTION
Backport 1/1 commits from #167804 on behalf of @yuzefovich.

----

Whenever we execute the async statement, we're holding the SQL connection, so the connection pool is likely to open a new one if we need to run any more queries under the same user. The fresh connection doesn't inherit the session variables that were set on the connection that is held, which could lead to flakes. This commit ensures that we enabled the write buffering on the fresh connection in a test.

Fixes: #167466.
Release note: None

----

Release justification: test-only change.