### PR TITLE
sql/stats: gate canary stats feature behind 26.2 cluster version

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -165,7 +166,12 @@ var detailedLatencyMetrics = settings.RegisterBoolSetting(
 //
 // The selection is atomic per query — all tables in the query use the same
 // rollout path. Only called for non-internal queries.
-func canaryRollDice(evalCtx *eval.Context, rng *rand.Rand) eval.StatsRolloutSelection {
+func canaryRollDice(
+	ctx context.Context, evalCtx *eval.Context, rng *rand.Rand,
+) eval.StatsRolloutSelection {
+	if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
+		return eval.StatsRolloutDefault
+	}
 	threshold := stats.CanaryFraction.Get(&evalCtx.Settings.SV)
 	if threshold == 0 {
 		return eval.StatsRolloutDefault

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3500,7 +3500,7 @@ func (ex *connExecutor) makeExecPlan(
 	//   - StatsRolloutStable:  experiment on, use stable (second-newest) stats
 	if !planner.SessionData().Internal {
 		planner.EvalContext().StatsRollout =
-			canaryRollDice(planner.EvalContext(), ex.rng.internal)
+			canaryRollDice(ctx, planner.EvalContext(), ex.rng.internal)
 	}
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/server/telemetry",
         "//pkg/sql/appstatspb",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -432,7 +433,8 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 					}
 				}
 			}
-			if tab.CanaryAndStableStatsDiffer() {
+			if tab.CanaryAndStableStatsDiffer() &&
+				b.evalCtx.Settings.Version.IsActive(b.ctx, clusterversion.V26_2) {
 				val.CanaryStatsActive = true
 				val.CanaryWindowSize = tab.StatsCanaryWindow()
 			}

--- a/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/storageparam/tablestorageparam",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -764,6 +765,10 @@ var tableParams = map[string]tableParam{
 	},
 	catpb.CanaryStatsWindowSettingName: {
 		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
+			if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V26_2) {
+				return "", pgerror.Newf(pgcode.FeatureNotSupported,
+					"%s cannot be used until the cluster upgrade to v26.2 is finalized", key)
+			}
 			d, err := paramparse.DatumAsDuration(ctx, evalCtx, key, datum)
 			if err != nil {
 				return "", err

--- a/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
+++ b/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
@@ -30,10 +30,9 @@ import (
 
 // TestTableStatisticsDelayDeleteColumnMigration verifies that the
 // V26_2_AddTableStatisticsDelayDeleteColumn migration correctly adds the
-// delayDelete column, and that SHOW STATISTICS and the stats cache work
-// correctly both before and after the migration. Before the migration,
-// GetTableStatisticsStmt uses `false AS "delayDelete"` as a fallback; after
-// the migration, it reads the real column.
+// delayDelete column to the system.table_statistics table.
+// End-to-end canary stats behavior is tested separately in
+// TestCanaryStatsDelayDelete.
 func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -87,67 +86,6 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	}
 	// Validate that the table_statistics table has the old schema.
 	validateSchemaExists(false)
-
-	// Create a test table with canary stats enabled (sql_stats_canary_window)
-	// and collect statistics before the migration. This exercises the
-	// pre-migration code path where GetTableStatisticsStmt uses
-	// `false AS "delayDelete"`.
-	_, err := sqlDB.Exec(
-		`CREATE TABLE t (k INT PRIMARY KEY, v STRING) WITH (sql_stats_canary_window = '15s')`,
-	)
-	require.NoError(t, err)
-	_, err = sqlDB.Exec(
-		`INSERT INTO t SELECT i, 'val' || i::STRING FROM generate_series(1, 100) AS g(i)`,
-	)
-	require.NoError(t, err)
-	_, err = sqlDB.Exec(`ANALYZE t`)
-	require.NoError(t, err)
-
-	// Verify SHOW STATISTICS works before migration.
-	var statsCount int
-	err = sqlDB.QueryRow(
-		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
-	).Scan(&statsCount)
-	require.NoError(t, err)
-	require.Greater(t, statsCount, 0)
-
-	// Insert more data and collect stats again. Even though the table has
-	// canary_window set, the version gate prevents MarkDelayDelete from
-	// running, so all stats should remain delay_delete=false.
-	_, err = sqlDB.Exec(
-		`INSERT INTO t SELECT i, 'more' || i::STRING FROM generate_series(101, 200) AS g(i)`,
-	)
-	require.NoError(t, err)
-	_, err = sqlDB.Exec(`ANALYZE t`)
-	require.NoError(t, err)
-
-	// Record the total stats count after the second ANALYZE. Before the
-	// migration, old stats are immediately deleted by
-	// DeleteOldStatsForColumns (keeping up to 4 per column set), so the
-	// total count here reflects the pre-gate deletion behavior.
-	var statsCountAfterSecondAnalyze int
-	err = sqlDB.QueryRow(
-		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
-	).Scan(&statsCountAfterSecondAnalyze)
-	require.NoError(t, err)
-	require.Greater(t, statsCountAfterSecondAnalyze, 0)
-
-	var delayDeleteTrueCount int
-	err = sqlDB.QueryRow(
-		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t] WHERE delay_delete = true`,
-	).Scan(&delayDeleteTrueCount)
-	require.NoError(t, err)
-	require.Equal(t, 0, delayDeleteTrueCount,
-		"before migration: delay_delete should stay false even with canary_window set")
-
-	// Verify SHOW STATISTICS USING JSON works before migration.
-	var jsonStats string
-	err = sqlDB.QueryRow(
-		`SELECT statistics::STRING FROM [SHOW STATISTICS USING JSON FOR TABLE t]`,
-	).Scan(&jsonStats)
-	require.NoError(t, err)
-	require.NotEmpty(t, jsonStats)
-
 	// Run the upgrade.
 	upgrades.Upgrade(
 		t,
@@ -158,8 +96,103 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	)
 	// Validate that the table has new schema.
 	validateSchemaExists(true)
+}
 
-	// Verify SHOW STATISTICS works after migration.
+// TestCanaryStatsDelayDelete verifies end-to-end canary stats behavior:
+// setting sql_stats_canary_window on a table, collecting stats with ANALYZE,
+// and checking that SHOW STATISTICS correctly reflects the delay_delete
+// marking.
+//
+// This test is separate from TestTableStatisticsDelayDeleteColumnMigration
+// because the sql_stats_canary_window storage parameter is gated behind
+// V26_2 (the final 26.2 version), while the migration test only upgrades
+// to V26_2_AddTableStatisticsDelayDeleteColumn (an intermediate version).
+// We upgrade all the way to V26_2 here to unlock the canary feature.
+func TestCanaryStatsDelayDelete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, clusterversion.V26_2)
+
+	clusterArgs := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					ClusterVersionOverride:         clusterversion.MinSupported.Version(),
+				},
+			},
+		},
+	}
+
+	var (
+		ctx   = context.Background()
+		tc    = testcluster.StartTestCluster(t, 1, clusterArgs)
+		sqlDB = tc.ServerConn(0)
+	)
+	defer tc.Stopper().Stop(ctx)
+
+	// Verify that sql_stats_canary_window is rejected before upgrading
+	// to V26_2.
+	_, err := sqlDB.Exec(
+		`CREATE TABLE t_canary (k INT PRIMARY KEY) WITH (sql_stats_canary_window = '15s')`,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(),
+		"sql_stats_canary_window cannot be used until the cluster upgrade to v26.2 is finalized")
+
+	// Create a table and collect statistics before the upgrade.
+	_, err = sqlDB.Exec(
+		`CREATE TABLE t (k INT PRIMARY KEY, v STRING)`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(
+		`INSERT INTO t SELECT i, 'val' || i::STRING FROM generate_series(1, 100) AS g(i)`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`ANALYZE t`)
+	require.NoError(t, err)
+
+	// Verify SHOW STATISTICS works before the upgrade.
+	var statsCount int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
+	).Scan(&statsCount)
+	require.NoError(t, err)
+	require.Greater(t, statsCount, 0)
+
+	// Insert more data and collect stats again. Without canary_window,
+	// all stats should have delay_delete=false.
+	_, err = sqlDB.Exec(
+		`INSERT INTO t SELECT i, 'more' || i::STRING FROM generate_series(101, 200) AS g(i)`,
+	)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`ANALYZE t`)
+	require.NoError(t, err)
+
+	var delayDeleteTrueCount int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t] WHERE delay_delete = true`,
+	).Scan(&delayDeleteTrueCount)
+	require.NoError(t, err)
+	require.Equal(t, 0, delayDeleteTrueCount,
+		"before upgrade: delay_delete should be false for all stats")
+
+	// Verify SHOW STATISTICS USING JSON works before the upgrade.
+	var jsonStats string
+	err = sqlDB.QueryRow(
+		`SELECT statistics::STRING FROM [SHOW STATISTICS USING JSON FOR TABLE t]`,
+	).Scan(&jsonStats)
+	require.NoError(t, err)
+	require.NotEmpty(t, jsonStats)
+
+	// Upgrade to V26_2 to unlock the canary stats feature.
+	upgrades.Upgrade(
+		t, sqlDB, clusterversion.V26_2,
+		nil /* done */, false, /* expectError */
+	)
+
+	// Verify SHOW STATISTICS still works after the upgrade.
 	var statsCountAfter int
 	err = sqlDB.QueryRow(
 		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
@@ -167,8 +200,14 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, statsCountAfter, 0)
 
-	// Now with the migration complete, the canary stats path is active.
-	// Collecting new stats should mark old ones with delay_delete=true.
+	// Now enable canary stats on the table.
+	_, err = sqlDB.Exec(
+		`ALTER TABLE t SET (sql_stats_canary_window = '15s')`,
+	)
+	require.NoError(t, err)
+
+	// Collect new stats. With canary_window set, old stats should be marked
+	// delay_delete=true while the freshest stats remain false.
 	_, err = sqlDB.Exec(
 		`INSERT INTO t SELECT i, 'post' || i::STRING FROM generate_series(201, 300) AS g(i)`,
 	)
@@ -176,27 +215,25 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	_, err = sqlDB.Exec(`ANALYZE t`)
 	require.NoError(t, err)
 
-	// After migration with canary_window set, old stats should be marked
-	// delay_delete=true while the freshest stats remain false. The total
-	// count includes both old (delay_delete=true) and new
-	// (delay_delete=false) stats, since old stats are now kept rather than
-	// immediately deleted.
-	var statsCountPostMigration int
-	err = sqlDB.QueryRow(
-		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
-	).Scan(&statsCountPostMigration)
-	require.NoError(t, err)
-
+	// Verify some stats are marked delay_delete=true.
 	err = sqlDB.QueryRow(
 		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t] WHERE delay_delete = true`,
 	).Scan(&delayDeleteTrueCount)
 	require.NoError(t, err)
 	require.Greater(t, delayDeleteTrueCount, 0,
-		"after migration: expected some stats with delay_delete=true when canary_window is set")
-	require.Greater(t, statsCountPostMigration, delayDeleteTrueCount,
+		"after upgrade: expected some stats with delay_delete=true when canary_window is set")
+
+	// Total stats should exceed delay_delete=true count because the freshest
+	// stats have delay_delete=false.
+	var totalCount int
+	err = sqlDB.QueryRow(
+		`SELECT count(*) FROM [SHOW STATISTICS FOR TABLE t]`,
+	).Scan(&totalCount)
+	require.NoError(t, err)
+	require.Greater(t, totalCount, delayDeleteTrueCount,
 		"total stats should exceed delay_delete=true count (freshest stats have delay_delete=false)")
 
-	// The freshest stats should still have delay_delete=false.
+	// The freshest stat should have delay_delete=false.
 	var latestDelayDelete bool
 	err = sqlDB.QueryRow(
 		`SELECT delay_delete FROM [SHOW STATISTICS FOR TABLE t] ORDER BY created DESC LIMIT 1`,
@@ -205,7 +242,7 @@ func TestTableStatisticsDelayDeleteColumnMigration(t *testing.T) {
 	require.False(t, latestDelayDelete,
 		"freshest stats should have delay_delete=false")
 
-	// Verify SHOW STATISTICS USING JSON works after migration and includes
+	// Verify SHOW STATISTICS USING JSON works after the upgrade and includes
 	// the delay_delete field.
 	var jsonStatsAfter string
 	err = sqlDB.QueryRow(


### PR DESCRIPTION
Gate the canary stats rollout feature behind `V26_2` version gate.
Fixes: #167366

Release note: None