### PR TITLE
release-26.2: schemachanger: validate region column placement in indexes for RBR tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -1658,3 +1658,35 @@ statement ok
 DROP TABLE t12
 
 subtest end
+
+# Validate that ALTER PRIMARY KEY blocks implicit partitioning columns at
+# non-leading positions, matching the CREATE INDEX behavior.
+
+subtest alter_primary_key_implicit_col_validation
+
+statement ok
+CREATE TABLE t_pab (
+  a INT PRIMARY KEY,
+  b STRING NOT NULL,
+  c INT
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+
+# CREATE INDEX with the implicit column at a non-leading position is blocked.
+statement error cannot explicitly include implicit partitioning columns from "PARTITION ALL BY" in index definition
+CREATE INDEX ON t_pab (a, b)
+
+# ALTER PRIMARY KEY with the implicit column at a non-leading position is blocked.
+statement error cannot explicitly include implicit partitioning columns from "PARTITION ALL BY" in index definition
+ALTER TABLE t_pab ALTER PRIMARY KEY USING COLUMNS (a, b)
+
+# Leading position is fine.
+statement ok
+ALTER TABLE t_pab ALTER PRIMARY KEY USING COLUMNS (b, a)
+
+statement ok
+DROP TABLE t_pab
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_index
@@ -15,14 +15,26 @@ CREATE TABLE t_regional (
 statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
 CREATE INDEX ON t_regional (crdb_region, b) USING HASH;
 
-statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+# Creating an index with crdb_region as the leading key column is allowed.
+statement ok
 CREATE INDEX ON t_regional USING btree(crdb_region, b);
 
 statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
 CREATE UNIQUE INDEX ON t_regional (crdb_region, b) USING HASH;
 
-statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+# Creating a unique index with crdb_region as the leading key column is allowed.
+statement ok
 CREATE UNIQUE INDEX ON t_regional USING btree(crdb_region, b);
+
+# Creating an index with crdb_region as a stored column is allowed;
+# the column is silently dropped from the STORING clause since it is
+# already part of the index key as an implicit partitioning column.
+statement ok
+CREATE INDEX ON t_regional (b) STORING (crdb_region);
+
+# crdb_region as a non-leading key column is still disallowed.
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+CREATE INDEX ON t_regional (b, crdb_region);
 
 statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
 ALTER TABLE t_regional ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk) USING HASH;
@@ -189,3 +201,164 @@ ALTER TABLE user_settings ADD FOREIGN KEY (crdb_internal_user_id_shard_16, user_
 statement ok
 ALTER TABLE user_settings ADD FOREIGN KEY (user_id, crdb_region)
   REFERENCES users (id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE
+
+# Validate that indexes on an existing table with the region column are checked
+# when converting to REGIONAL BY ROW.
+
+subtest validate_indexes_on_locality_change
+
+statement ok
+CREATE TABLE t_rbr (
+  pk INT PRIMARY KEY,
+  i INT,
+  j INT
+) LOCALITY REGIONAL BY ROW
+
+# On an RBR table, creating indexes with the region column as the leading key
+# column or as a stored column is allowed.
+statement ok
+CREATE INDEX dsc_idx_1 ON t_rbr (i) STORING (j, crdb_region)
+
+statement ok
+CREATE INDEX dsc_idx_2 ON t_rbr (crdb_region, i) STORING (j)
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+CREATE INDEX dsc_idx_3 ON t_rbr (i, crdb_region) STORING (j)
+
+statement ok
+CREATE INDEX dsc_idx_4 ON t_rbr (i) USING HASH STORING (j, crdb_region)
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+CREATE INDEX dsc_idx_5 ON t_rbr (crdb_region, i) USING HASH STORING (j)
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+CREATE INDEX dsc_idx_6 ON t_rbr (i, crdb_region) USING HASH STORING (j)
+
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+ALTER TABLE t_rbr ALTER PRIMARY KEY USING COLUMNS (pk, crdb_region);
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
+ALTER TABLE t_rbr ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk) USING HASH;
+
+statement ok
+ALTER TABLE t_rbr ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk);
+
+query TTBITTTBBBF colnames,rowsort
+SHOW INDEXES FROM t_rbr
+----
+table_name  index_name  non_unique  seq_in_index  column_name               definition                direction  storing  implicit  visible  visibility
+t_rbr       dsc_idx_1   true        1             crdb_region               crdb_region               ASC        false    true      true     1
+t_rbr       dsc_idx_1   true        2             i                         i                         ASC        false    false     true     1
+t_rbr       dsc_idx_1   true        3             j                         j                         N/A        true     false     true     1
+t_rbr       dsc_idx_1   true        4             pk                        pk                        ASC        false    true      true     1
+t_rbr       dsc_idx_2   true        1             crdb_region               crdb_region               ASC        false    false     true     1
+t_rbr       dsc_idx_2   true        2             i                         i                         ASC        false    false     true     1
+t_rbr       dsc_idx_2   true        3             j                         j                         N/A        true     false     true     1
+t_rbr       dsc_idx_2   true        4             pk                        pk                        ASC        false    true      true     1
+t_rbr       dsc_idx_4   true        1             crdb_region               crdb_region               ASC        false    true      true     1
+t_rbr       dsc_idx_4   true        2             crdb_internal_i_shard_16  crdb_internal_i_shard_16  ASC        false    true      true     1
+t_rbr       dsc_idx_4   true        3             i                         i                         ASC        false    false     true     1
+t_rbr       dsc_idx_4   true        4             j                         j                         N/A        true     false     true     1
+t_rbr       dsc_idx_4   true        5             pk                        pk                        ASC        false    true      true     1
+t_rbr       t_rbr_pkey  false       1             crdb_region               crdb_region               ASC        false    true      true     1
+t_rbr       t_rbr_pkey  false       2             pk                        pk                        ASC        false    false     true     1
+t_rbr       t_rbr_pkey  false       3             i                         i                         N/A        true     false     true     1
+t_rbr       t_rbr_pkey  false       4             j                         j                         N/A        true     false     true     1
+
+statement ok
+DROP INDEX dsc_idx_1, dsc_idx_2, dsc_idx_4
+
+# Ensure ALTER LOCALITY REGIONAL BY ROW is blocked when table has invalid indexes on crdb_region.
+statement ok
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY TABLE
+
+statement ok
+CREATE INDEX dsc_idx_1 ON t_rbr (i) STORING (j, crdb_region)
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW
+
+statement ok
+DROP INDEX dsc_idx_1
+
+statement ok
+CREATE INDEX dsc_idx_3 ON t_rbr (i, crdb_region) STORING (j);
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW
+
+statement ok
+DROP INDEX dsc_idx_3
+
+statement ok
+CREATE INDEX dsc_idx_5 ON t_rbr (crdb_region, i) USING HASH STORING (j)
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW
+
+statement ok
+DROP INDEX dsc_idx_5
+
+statement ok
+CREATE INDEX dsc_idx_6 ON t_rbr (i, crdb_region) USING HASH STORING (j)
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW
+
+statement ok
+DROP INDEX dsc_idx_6
+
+statement ok
+ALTER TABLE t_rbr ALTER PRIMARY KEY USING COLUMNS (pk, crdb_region);
+
+statement error cannot explicitly include implicit partitioning columns from "LOCALITY REGIONAL BY ROW" in index definition
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE t_rbr ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk) USING HASH;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "LOCALITY REGIONAL BY ROW"
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE t_rbr ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk);
+CREATE INDEX dsc_idx_2 ON t_rbr (crdb_region, i) STORING (j);
+
+query TTBITTTBBBF colnames,rowsort
+SHOW INDEXES FROM t_rbr
+----
+table_name  index_name                non_unique  seq_in_index  column_name  definition   direction  storing  implicit  visible  visibility
+t_rbr       dsc_idx_2                 true        1             crdb_region  crdb_region  ASC        false    false     true     1
+t_rbr       dsc_idx_2                 true        2             i            i            ASC        false    false     true     1
+t_rbr       dsc_idx_2                 true        3             j            j            N/A        true     false     true     1
+t_rbr       dsc_idx_2                 true        4             pk           pk           ASC        false    true      true     1
+t_rbr       t_rbr_pk_crdb_region_key  false       1             pk           pk           ASC        false    false     true     1
+t_rbr       t_rbr_pk_crdb_region_key  false       2             crdb_region  crdb_region  ASC        false    false     true     1
+t_rbr       t_rbr_pk_key              false       1             pk           pk           ASC        false    false     true     1
+t_rbr       t_rbr_pk_key              false       2             crdb_region  crdb_region  ASC        true     true      true     1
+t_rbr       t_rbr_pkey                false       1             crdb_region  crdb_region  ASC        false    false     true     1
+t_rbr       t_rbr_pkey                false       2             pk           pk           ASC        false    false     true     1
+t_rbr       t_rbr_pkey                false       3             i            i            N/A        true     false     true     1
+t_rbr       t_rbr_pkey                false       4             j            j            N/A        true     false     true     1
+
+
+# Drop problematic indexes.
+statement ok
+DROP INDEX t_rbr_pk_crdb_region_key, t_rbr_pk_key;
+
+statement ok
+ALTER TABLE t_rbr SET LOCALITY REGIONAL BY ROW;
+
+query TTBITTTBBBF colnames,rowsort
+SHOW INDEXES FROM t_rbr
+----
+table_name  index_name  non_unique  seq_in_index  column_name  definition   direction  storing  implicit  visible  visibility
+t_rbr       dsc_idx_2   true        1             crdb_region  crdb_region  ASC        false    false     true     1
+t_rbr       dsc_idx_2   true        2             i            i            ASC        false    false     true     1
+t_rbr       dsc_idx_2   true        3             j            j            N/A        true     false     true     1
+t_rbr       dsc_idx_2   true        4             pk           pk           ASC        false    true      true     1
+t_rbr       t_rbr_pkey  false       1             crdb_region  crdb_region  ASC        false    false     true     1
+t_rbr       t_rbr_pkey  false       2             pk           pk           ASC        false    false     true     1
+t_rbr       t_rbr_pkey  false       3             i            i            N/A        true     false     true     1
+t_rbr       t_rbr_pkey  false       4             j            j            N/A        true     false     true     1

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -927,9 +927,16 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 				// a PK column listed in StoreColumnNames, colIDs.Contains is true
 				// even though it wasn't explicitly added as a stored column. In
 				// that case we silently skip it rather than returning an error.
+				//
+				// Similarly, implicit partitioning columns (e.g. crdb_region on
+				// REGIONAL BY ROW tables) are prepended to the index key columns
+				// by UpdateIndexPartitioning. If the user also specified such a
+				// column in the STORING clause, silently skip it since the column
+				// is already present in the key.
 				if primaryColIDs.Contains(col.GetID()) &&
-					!idx.CollectKeyColumnIDs().Contains(col.GetID()) &&
-					idx.GetEncodingType() == catenumpb.SecondaryIndexEncoding {
+					idx.GetEncodingType() == catenumpb.SecondaryIndexEncoding &&
+					(!idx.CollectKeyColumnIDs().Contains(col.GetID()) ||
+						isImplicitPartitioningCol(idx, col.GetID())) {
 					continue
 				}
 				return sqlerrors.NewColumnAlreadyExistsInIndexError(idx.GetName(), col.GetName())
@@ -959,6 +966,19 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 		}
 	}
 	return nil
+}
+
+// isImplicitPartitioningCol returns true if colID is one of the implicit
+// partitioning key columns in the given index (i.e., within the leading
+// NumImplicitColumns prefix).
+func isImplicitPartitioningCol(idx catalog.Index, colID descpb.ColumnID) bool {
+	n := idx.ImplicitPartitioningColumnCount()
+	for i := 0; i < n && i < idx.NumKeyColumns(); i++ {
+		if idx.GetKeyColumnID(i) == colID {
+			return true
+		}
+	}
+	return false
 }
 
 func (desc *Mutable) allocateColumnFamilyIDs(columnNames map[string]descpb.ColumnID) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -447,16 +447,39 @@ func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
 		}
 	}
 
-	if t.Partitioning != nil {
-		newImplicitCols := t.Partitioning.NewImplicitColumns
-		for i := 0; i < min(len(t.Columns), len(newImplicitCols)); i++ {
-			partCol := tree.Name(newImplicitCols[i].Name)
-			if partCol != t.Columns[i].Column && usedColumns[partCol] {
-				panic(errors.WithHint(
-					pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-						"cannot add column %q as an implicit partitioning column", partCol),
-					"partitioning columns should already exist in the index or they must be a suffix of the keys",
-				))
+	// Determine implicit partitioning columns from the table's locality (RBR)
+	// or PARTITION ALL BY configuration. Note that RBR and PARTITION ALL BY
+	// cases are mutually exclusive.
+	var implicitColNames map[tree.Name]struct{}
+	isRegionalByRow := false
+	tableElts := b.QueryByID(tbl.TableID).Filter(publicTargetFilter)
+	if rbrElem := tableElts.FilterTableLocalityRegionalByRow().MustGetZeroOrOneElement(); rbrElem != nil {
+		isRegionalByRow = true
+		regionColName := explicitRegionColName(tree.Name(rbrElem.As))
+		implicitColNames = map[tree.Name]struct{}{regionColName: {}}
+	} else if tableElts.FilterTablePartitioning().MustGetZeroOrOneElement() != nil {
+		// PARTITION ALL BY: the implicit columns are the leading implicit key
+		// columns of the current primary index.
+		primaryIdx := mustRetrieveCurrentPrimaryIndexElement(b, tbl.TableID)
+		implicitColNames = make(map[tree.Name]struct{})
+		for _, col := range mustRetrieveKeyIndexColumns(b, tbl.TableID, primaryIdx.IndexID) {
+			if !col.Implicit {
+				break
+			}
+			colName := mustRetrieveColumnName(b, tbl.TableID, col.ColumnID)
+			implicitColNames[tree.Name(colName.Name)] = struct{}{}
+		}
+	}
+
+	// Block implicit partitioning columns that appear as non-leading key
+	// columns, since the implicit column will be prepended and the explicit
+	// reference would create a duplicate.
+	for i, col := range t.Columns {
+		if _, ok := implicitColNames[col.Column]; ok && i != 0 {
+			if isRegionalByRow {
+				panic(sqlerrors.NewIndexIncludesImplicitPartitionColFromRBR)
+			} else {
+				panic(sqlerrors.NewIndexIncludeImplicitPartitionColFromPartitionAllBy)
 			}
 		}
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -208,6 +209,52 @@ func checkPrivilegesForMultiRegionOp(b BuildCtx, tbl *scpb.Table, tableName stri
 	}
 }
 
+// validateIndexesForRegionalByRow checks that existing indexes (both primary
+// and secondary) are compatible with the region column that will be implicitly
+// partitioned into each index when the table becomes REGIONAL BY ROW.
+// Specifically:
+//   - The region column may only appear as a KEY column if it is the first key
+//     column and the index is not hash-sharded.
+//   - The region column may not appear as a STORED column.
+func validateIndexesForRegionalByRow(
+	b BuildCtx, tableID catid.DescID, targetLocality *tree.Locality,
+) {
+	if !isLocalityRegionalByRow(targetLocality) {
+		return
+	}
+
+	regionColName := explicitRegionColName(targetLocality.RegionalByRowColumn)
+	regionColID := getColumnIDFromColumnName(b, tableID, regionColName, true /* required */)
+
+	validateIndex := func(idx *scpb.Index, checkStored bool) {
+		idxCols := mustRetrieveIndexColumnElements(b, tableID, idx.IndexID)
+		for _, col := range idxCols {
+			if col.ColumnID != regionColID {
+				continue
+			}
+			if checkStored && col.Kind == scpb.IndexColumn_STORED {
+				panic(sqlerrors.NewIndexIncludesImplicitPartitionColFromRBR)
+			}
+			if col.Kind == scpb.IndexColumn_KEY {
+				if idx.Sharding != nil {
+					panic(sqlerrors.HashIndexIncludesImplicitPartitionColFromRBR)
+				}
+				if col.OrdinalInKind != 0 {
+					panic(sqlerrors.NewIndexIncludesImplicitPartitionColFromRBR)
+				}
+			}
+		}
+	}
+
+	tblElems := b.QueryByID(tableID).Filter(publicTargetFilter)
+	tblElems.FilterPrimaryIndex().ForEach(func(_ scpb.Status, _ scpb.TargetStatus, idx *scpb.PrimaryIndex) {
+		validateIndex(&idx.Index, false /* checkStored */)
+	})
+	tblElems.FilterSecondaryIndex().ForEach(func(_ scpb.Status, _ scpb.TargetStatus, idx *scpb.SecondaryIndex) {
+		validateIndex(&idx.Index, true /* checkStored */)
+	})
+}
+
 // alterPrimaryKeyForRegionalByRowTable handles the index changes when transitioning
 // to or from REGIONAL BY ROW.
 func alterPrimaryKeyForRegionalByRowTable(
@@ -226,19 +273,20 @@ func alterPrimaryKeyForRegionalByRowTable(
 		return
 	}
 
-	// Step 1: Get current primary key columns
-	primaryIndexElem := mustRetrieveCurrentPrimaryIndexElement(b, tableID)
+	// Step 1: Validate indexes
+	validateIndexesForRegionalByRow(b, tableID, targetLocality)
 
-	// Step 2: Build columns list with an empty slot for a new region column prepended
+	// Step 2: Get current primary key columns
+	primaryIndexElem := mustRetrieveCurrentPrimaryIndexElement(b, tableID)
 	cols := retrieveNonImplicitIndexColumns(b, tableID, primaryIndexElem.IndexID)
 
 	// Step 3: Get current PK name and sharding
 	currentPKName := mustRetrieveIndexNameElem(b, tableID, primaryIndexElem.IndexID)
 	var sharded *tree.ShardedIndexDef
 	if primaryIndexElem.Sharding != nil {
-		// remove shard column for the keys
+		// Remove shard column for the keys.
 		cols = cols[1:]
-		// pass non nil sharding definition to alter primary key to recreate the sharding
+		// Pass non nil sharding definition to alter primary key to recreate the sharding.
 		sharded = &tree.ShardedIndexDef{
 			ShardBuckets: tree.NewDInt(tree.DInt(primaryIndexElem.Sharding.ShardBuckets)),
 		}
@@ -254,8 +302,8 @@ func alterPrimaryKeyForRegionalByRowTable(
 		Partitioning: &partSpec,
 	}
 
-	// Step 5: Call alterPrimaryKey
-	// This will trigger recreation of all secondary indexes with new partitioning
+	// Step 5: Call alterPrimaryKey.
+	// This will trigger recreation of all secondary indexes with new partitioning.
 	alterPrimaryKey(b, nil, tbl, nil, spec)
 	b.EvalCtx().ClientNoticeSender.BufferClientNotice(
 		b,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -510,6 +510,15 @@ func maybeAddPartitionDescriptorForIndex(b BuildCtx, n *tree.CreateIndex, idxSpe
 			for _, col := range idxSpec.columns {
 				if _, ok := implicitColumns[col.ColumnID]; !col.Implicit && ok {
 					if isRegionalByRow {
+						// Allow the implicit partitioning column when it is the
+						// leading KEY column of the index without sharding. This
+						// matches the legacy schema changer behavior where the
+						// column is recognized as the explicit partitioning prefix
+						// and no implicit column is prepended.
+						if idxSpec.secondary.Sharding == nil &&
+							col.Kind == scpb.IndexColumn_KEY && col.OrdinalInKind == 0 {
+							continue
+						}
 						panic(sqlerrors.NewIndexIncludesImplicitPartitionColFromRBR)
 					} else {
 						panic(sqlerrors.NewIndexIncludeImplicitPartitionColFromPartitionAllBy)


### PR DESCRIPTION
Backport 1/1 commits from #167608 on behalf of @shghasemi.

----

Previously, the declarative schema changer did not validate the primary and secondary indexes of a table before converting to REGIONAL BY ROW. This commit fixes these issues and adds a logic test to verify the behavior. Changes include:
- Fix ALTER LOCALITY to validate secondary indexes not have crdb_region as a non-leading key column or a stored column
- Fix CREATE INDEX on RBR tables to allow the region column as the leading key column (matching legacy behavior) and as a stored column (silently dropped since it's already an implicit key column).
- Fix the legacy schema changer blocking region column as a stored column.
- Fix ALTER PRIMARY KEY to block the region column at non-leading positions.

Fixes: #167452

Release note: None

----

Release justification: Bug fix. ALTER LOCALITY is running with the declarative schema changer in 26.2.