### PR TITLE
teamcity: bump extra stress test timeout from 300s to 600s

### DIFF
--- a/build/teamcity/cockroach/nightlies/cockroach_nightly_extra_stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cockroach_nightly_extra_stress_impl.sh
@@ -47,7 +47,7 @@ done
 test_filter="${test_filter})\$"
 
 export RUNS_PER_TEST=1000
-export TEST_ARGS="--test_timeout=300 --runs_per_test $RUNS_PER_TEST"
+export TEST_ARGS="--test_timeout=600 --runs_per_test $RUNS_PER_TEST"
 
 mkdir -p $ARTIFACTS_DIR
 


### PR DESCRIPTION
The extra stress pipeline runs `TestKVNemesisMultiNode` and
`TestKVNemesisMultiNode_BufferedWritesLockDurabilityUpgrades` in the
same Go test binary via `--test_filter`. Since `--test_timeout` sets
the Go binary's `-test.timeout`, both tests share a single timeout
budget. 300s is not enough time in case of slower tests (e.g. due to
some infra issue).

Bump to 600s to give both tests room. This is consistent with the
regular EngFlow nightly stress, which uses Bazel's default 900s
timeout for `large` tests.

Fixes: #167561

Epic: none