### PR TITLE
kvstorage/wag: iterate over WAG nodes starting from a key

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/wag/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv/kvserver/kvstorage/wag/wagpb",
+        "//pkg/roachpb",
         "//pkg/storage",
     ],
 )
@@ -21,6 +22,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":wag"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvstorage/wag/wagpb",
         "//pkg/kv/kvserver/print",

--- a/pkg/kv/kvserver/kvstorage/wag/store.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 )
 
@@ -90,8 +91,6 @@ func Delete(w storage.Writer, index uint64) error {
 //	if err := iter.Error(); err != nil {
 //		return err
 //	}
-//
-// TODO(pav-kv): make it more flexible, e.g. iterate from a particular index.
 type Iterator struct {
 	// err is the last error encountered during the WAG iteration.
 	err error
@@ -100,6 +99,14 @@ type Iterator struct {
 // Iter returns an iterator that scans the WAG sequence. The iterator yields a
 // pair containing the WAG node index and the WAG node itself.
 func (it *Iterator) Iter(ctx context.Context, r storage.Reader) iter.Seq2[uint64, wagpb.Node] {
+	return it.IterFrom(ctx, r, keys.StoreWAGPrefix())
+}
+
+// IterFrom is similar to Iter, but allows specifying a starting point for the
+// iteration.
+func (it *Iterator) IterFrom(
+	ctx context.Context, r storage.Reader, seekKey roachpb.Key,
+) iter.Seq2[uint64, wagpb.Node] {
 	prefix := keys.StoreWAGPrefix()
 	mi, err := r.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
 		UpperBound: prefix.PrefixEnd(),
@@ -108,7 +115,7 @@ func (it *Iterator) Iter(ctx context.Context, r storage.Reader) iter.Seq2[uint64
 		it.err = err
 		return nil
 	}
-	mi.SeekGE(storage.MakeMVCCMetadataKey(prefix))
+	mi.SeekGE(storage.MakeMVCCMetadataKey(seekKey))
 
 	return func(yield func(uint64, wagpb.Node) bool) {
 		defer mi.Close()

--- a/pkg/kv/kvserver/kvstorage/wag/store_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
@@ -165,6 +166,43 @@ func splitReplica(
 
 func writeStateMachine(w storage.Writer, k, v string) error {
 	return w.PutUnversioned(roachpb.Key(k), []byte(v))
+}
+
+func TestIterFrom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	// Write 3 WAG nodes at indices 1, 5, 10.
+	id := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	node := wagpb.Node{
+		Events: []wagpb.Event{
+			{Addr: wagpb.MakeAddr(id, 10), Type: wagpb.EventApply},
+		},
+	}
+	require.NoError(t, Write(eng, 1, node))
+	require.NoError(t, Write(eng, 5, node))
+	require.NoError(t, Write(eng, 10, node))
+
+	readIndicesFrom := func(fromIndex uint64) []uint64 {
+		var it Iterator
+		var res []uint64
+		for index := range it.IterFrom(ctx, eng, keys.StoreWAGNodeKey(fromIndex)) {
+			res = append(res, index)
+		}
+		require.NoError(t, it.Error())
+		return res
+	}
+
+	require.Equal(t, []uint64{1, 5, 10}, readIndicesFrom(0))
+	require.Equal(t, []uint64{1, 5, 10}, readIndicesFrom(1))
+	require.Equal(t, []uint64{5, 10}, readIndicesFrom(4))
+	require.Equal(t, []uint64{10}, readIndicesFrom(6))
+	require.Equal(t, []uint64{10}, readIndicesFrom(10))
+	require.Empty(t, readIndicesFrom(11))
 }
 
 func TestSeqInit(t *testing.T) {


### PR DESCRIPTION
References: #167607

Release note: None