### PR TITLE
kvserver: improve store.capacity allocations 

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -359,6 +359,7 @@ go_test(
         "replica_learner_test.go",
         "replica_lease_renewal_test.go",
         "replica_lifecycle_datadriven_test.go",
+        "replica_load_bench_test.go",
         "replica_metrics_test.go",
         "replica_probe_test.go",
         "replica_proposal_bench_test.go",

--- a/pkg/kv/kvserver/allocator/range_usage_info.go
+++ b/pkg/kv/kvserver/allocator/range_usage_info.go
@@ -39,9 +39,23 @@ type RangeRequestLocalityInfo struct {
 // Load returns a load dimension representation of the range usage.
 func (r RangeUsageInfo) Load() load.Load {
 	dims := load.Vector{}
-	dims[load.Queries] = r.QueriesPerSecond
-	dims[load.CPU] = r.RequestCPUNanosPerSecond + r.RaftCPUNanosPerSecond
+	dims[load.Queries] = r.LoadDim(load.Queries)
+	dims[load.CPU] = r.LoadDim(load.CPU)
 	return dims
+}
+
+// LoadDim returns the value of a single load dimension without allocating.
+// Unlike Load().Dim(), this avoids constructing a load.Vector and boxing it
+// into the load.Load interface.
+func (r RangeUsageInfo) LoadDim(dim load.Dimension) float64 {
+	switch dim {
+	case load.Queries:
+		return r.QueriesPerSecond
+	case load.CPU:
+		return r.RequestCPUNanosPerSecond + r.RaftCPUNanosPerSecond
+	default:
+		return 0
+	}
 }
 
 // TransferImpact returns the impact of transferring the lease for the range,

--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -168,11 +168,12 @@ func (rl *ReplicaLoad) Merge(other *ReplicaLoad) {
 
 // Reset will clear all recorded history.
 func (rl *ReplicaLoad) Reset() {
+	now := timeutil.Unix(0, rl.clock.PhysicalNow())
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
 	for i := range rl.mu.stats {
-		rl.mu.stats[i].ResetRequestCounts(timeutil.Unix(0, rl.clock.PhysicalNow()))
+		rl.mu.stats[i].ResetRequestCounts(now)
 	}
 }
 
@@ -206,9 +207,10 @@ func (rl *ReplicaLoad) statsLockedWithNow(now time.Time) ReplicaLoadStats {
 
 // Stats returns a current stat summary of replica load.
 func (rl *ReplicaLoad) Stats() ReplicaLoadStats {
+	now := timeutil.Unix(0, rl.clock.PhysicalNow())
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
-	return rl.statsLockedWithNow(timeutil.Unix(0, rl.clock.PhysicalNow()))
+	return rl.statsLockedWithNow(now)
 }
 
 // StatsWithLocalityInfo returns load stats and the Queries dimension's
@@ -217,9 +219,9 @@ func (rl *ReplicaLoad) Stats() ReplicaLoadStats {
 // which matters when called per-replica during Store.Capacity scans
 // (30k+ replicas).
 func (rl *ReplicaLoad) StatsWithLocalityInfo() (ReplicaLoadStats, replicastats.RatedSummary) {
+	now := timeutil.Unix(0, rl.clock.PhysicalNow())
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
-	now := timeutil.Unix(0, rl.clock.PhysicalNow())
 
 	return rl.statsLockedWithNow(now), rl.mu.stats[Queries].SnapshotRatedSummary(now)
 }
@@ -227,10 +229,11 @@ func (rl *ReplicaLoad) StatsWithLocalityInfo() (ReplicaLoadStats, replicastats.R
 // RequestLocalityInfo returns the summary of client localities for requests
 // made to this replica.
 func (rl *ReplicaLoad) RequestLocalityInfo() replicastats.RatedSummary {
+	now := timeutil.Unix(0, rl.clock.PhysicalNow())
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	return rl.mu.stats[Queries].SnapshotRatedSummary(timeutil.Unix(0, rl.clock.PhysicalNow()))
+	return rl.mu.stats[Queries].SnapshotRatedSummary(now)
 }
 
 // TestingGetSum returns the sum of recorded values for the LoadStat with

--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -213,7 +213,7 @@ func (rl *ReplicaLoad) Stats() ReplicaLoadStats {
 
 // RequestLocalityInfo returns the summary of client localities for requests
 // made to this replica.
-func (rl *ReplicaLoad) RequestLocalityInfo() *replicastats.RatedSummary {
+func (rl *ReplicaLoad) RequestLocalityInfo() replicastats.RatedSummary {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 

--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -6,6 +6,8 @@
 package load
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/replicastats"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -174,33 +176,39 @@ func (rl *ReplicaLoad) Reset() {
 	}
 }
 
-// getLocked returns the current value for the LoadStat with ordinal stat. It
-// requires holding a lock.
-func (rl *ReplicaLoad) getLocked(stat LoadStat) float64 {
+// getLockedWithNow returns the current value for the LoadStat with ordinal
+// stat using the provided time. It requires rl.mu to be held.
+func (rl *ReplicaLoad) getLockedWithNow(stat LoadStat, now time.Time) float64 {
+	rl.mu.AssertHeld()
 	var ret float64
 	// Only return the value if the statistics have been gathered for longer
 	// than the minimum duration.
-	if val, dur := rl.mu.stats[stat].AverageRatePerSecond(timeutil.Unix(0, rl.clock.PhysicalNow())); dur >= replicastats.MinStatsDuration {
+	if val, dur := rl.mu.stats[stat].AverageRatePerSecond(now); dur >= replicastats.MinStatsDuration {
 		ret = val
 	}
 	return ret
+}
+
+// statsLockedWithNow returns a ReplicaLoadStats populated using the provided
+// time. It requires rl.mu to be held.
+func (rl *ReplicaLoad) statsLockedWithNow(now time.Time) ReplicaLoadStats {
+	return ReplicaLoadStats{
+		QueriesPerSecond:         rl.getLockedWithNow(Queries, now),
+		RequestsPerSecond:        rl.getLockedWithNow(Requests, now),
+		WriteKeysPerSecond:       rl.getLockedWithNow(WriteKeys, now),
+		ReadKeysPerSecond:        rl.getLockedWithNow(ReadKeys, now),
+		WriteBytesPerSecond:      rl.getLockedWithNow(WriteBytes, now),
+		ReadBytesPerSecond:       rl.getLockedWithNow(ReadBytes, now),
+		RequestCPUNanosPerSecond: rl.getLockedWithNow(ReqCPUNanos, now),
+		RaftCPUNanosPerSecond:    rl.getLockedWithNow(RaftCPUNanos, now),
+	}
 }
 
 // Stats returns a current stat summary of replica load.
 func (rl *ReplicaLoad) Stats() ReplicaLoadStats {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
-
-	return ReplicaLoadStats{
-		QueriesPerSecond:         rl.getLocked(Queries),
-		RequestsPerSecond:        rl.getLocked(Requests),
-		WriteKeysPerSecond:       rl.getLocked(WriteKeys),
-		ReadKeysPerSecond:        rl.getLocked(ReadKeys),
-		WriteBytesPerSecond:      rl.getLocked(WriteBytes),
-		ReadBytesPerSecond:       rl.getLocked(ReadBytes),
-		RequestCPUNanosPerSecond: rl.getLocked(ReqCPUNanos),
-		RaftCPUNanosPerSecond:    rl.getLocked(RaftCPUNanos),
-	}
+	return rl.statsLockedWithNow(timeutil.Unix(0, rl.clock.PhysicalNow()))
 }
 
 // RequestLocalityInfo returns the summary of client localities for requests

--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -211,6 +211,19 @@ func (rl *ReplicaLoad) Stats() ReplicaLoadStats {
 	return rl.statsLockedWithNow(timeutil.Unix(0, rl.clock.PhysicalNow()))
 }
 
+// StatsWithLocalityInfo returns load stats and the Queries dimension's
+// locality info in a single locked operation. This avoids the overhead of
+// acquiring the mutex twice and computing the current time repeatedly,
+// which matters when called per-replica during Store.Capacity scans
+// (30k+ replicas).
+func (rl *ReplicaLoad) StatsWithLocalityInfo() (ReplicaLoadStats, replicastats.RatedSummary) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := timeutil.Unix(0, rl.clock.PhysicalNow())
+
+	return rl.statsLockedWithNow(now), rl.mu.stats[Queries].SnapshotRatedSummary(now)
+}
+
 // RequestLocalityInfo returns the summary of client localities for requests
 // made to this replica.
 func (rl *ReplicaLoad) RequestLocalityInfo() replicastats.RatedSummary {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2843,8 +2843,7 @@ func (r *Replica) MeasureRaftCPUNanos(start time.Duration) {
 // usage information matches. Which is dubious in some cases but often
 // reasonable when we only consider the leaseholder.
 func (r *Replica) RangeUsageInfo() allocator.RangeUsageInfo {
-	loadStats := r.LoadStats()
-	localityInfo := r.loadStats.RequestLocalityInfo()
+	loadStats, localityInfo := r.loadStats.StatsWithLocalityInfo()
 	return allocator.RangeUsageInfo{
 		LogicalBytes:             r.GetMVCCStats().Total(),
 		QueriesPerSecond:         loadStats.QueriesPerSecond,

--- a/pkg/kv/kvserver/replica_load_bench_test.go
+++ b/pkg/kv/kvserver/replica_load_bench_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// BenchmarkReplicaRangeUsageInfo benchmarks Replica.RangeUsageInfo() which is
+// called per-replica during Store.Capacity scans.
+func BenchmarkReplicaRangeUsageInfo(b *testing.B) {
+	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Now()))
+	locality := func(_ roachpb.NodeID) string { return "us-east-1" }
+
+	r := &Replica{}
+	r.loadStats = load.NewReplicaLoad(clock, locality)
+	r.shMu.state.Stats = &enginepb.MVCCStats{
+		LiveBytes: 1024 * 1024,
+		KeyBytes:  512 * 1024,
+		ValBytes:  512 * 1024,
+	}
+
+	// Record some load so stats are non-zero.
+	for i := 0; i < 100; i++ {
+		r.loadStats.RecordBatchRequests(1, 1)
+		r.loadStats.RecordRequests(5)
+		r.loadStats.RecordWriteKeys(3)
+		r.loadStats.RecordReadKeys(10)
+		r.loadStats.RecordWriteBytes(1024)
+		r.loadStats.RecordReadBytes(4096)
+		r.loadStats.RecordReqCPUNanos(5000)
+		r.loadStats.RecordRaftCPUNanos(2000)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.RangeUsageInfo()
+	}
+}

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -113,7 +113,7 @@ func NewReplicaAccumulator(dims ...load.Dimension) *RRAccumulator {
 		dim := dim
 		res.dims[dim] = &rrPriorityQueue{}
 		res.dims[dim].val = func(r CandidateReplica) float64 {
-			return r.RangeUsageInfo().Load().Dim(dim)
+			return r.RangeUsageInfo().LoadDim(dim)
 		}
 	}
 	return res

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -88,9 +88,9 @@ func TestReplicaRankings(t *testing.T) {
 				continue
 			}
 			for i := range want {
-				if repls[i].RangeUsageInfo().Load().Dim(dimension) != want[i] {
+				if repls[i].RangeUsageInfo().LoadDim(dimension) != want[i] {
 					t.Errorf("got %f for %d'th element; want %f (input: %v)",
-						repls[i].RangeUsageInfo().Load().Dim(dimension), i, want, rLoad)
+						repls[i].RangeUsageInfo().LoadDim(dimension), i, want, rLoad)
 					break
 				}
 			}

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -656,3 +656,30 @@ func TestNewReplicaRankingsMap(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkReplicaAccumulator(b *testing.B) {
+	for _, numReplicas := range []int{128, 1000, 10000, 30000} {
+		b.Run(fmt.Sprintf("replicas=%d", numReplicas), func(b *testing.B) {
+			// Pre-build the candidate replicas.
+			candidates := make([]candidateReplica, numReplicas)
+			for i := range candidates {
+				candidates[i] = candidateReplica{
+					Replica: &Replica{RangeID: roachpb.RangeID(i)},
+					usage: allocator.RangeUsageInfo{
+						QueriesPerSecond:         rand.Float64() * 1000,
+						RequestCPUNanosPerSecond: rand.Float64() * 1e9,
+						RaftCPUNanosPerSecond:    rand.Float64() * 1e8,
+					},
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				acc := NewReplicaAccumulator(aload.CPU, aload.Queries)
+				for i := range candidates {
+					acc.AddReplica(candidates[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/kv/kvserver/replicastats/replica_stats.go
+++ b/pkg/kv/kvserver/replicastats/replica_stats.go
@@ -368,10 +368,10 @@ func (rs *ReplicaStats) ResetRequestCounts(now time.Time) {
 // SnapshotRatedSummary returns a RatedSummary representing a snapshot of the
 // current replica stats state, summarized by arithmetic mean count,
 // per-locality count and duration recorded over.
-func (rs *ReplicaStats) SnapshotRatedSummary(now time.Time) *RatedSummary {
+func (rs *ReplicaStats) SnapshotRatedSummary(now time.Time) RatedSummary {
 	qps, duration := rs.AverageRatePerSecond(now)
 	localityCounts := rs.PerLocalityDecayingRate(now)
-	return &RatedSummary{
+	return RatedSummary{
 		QPS:            qps,
 		LocalityCounts: localityCounts,
 		Duration:       duration,


### PR DESCRIPTION
Epic: none 
Release note: none
Informs: #158288
Fixes: https://github.com/cockroachdb/cockroach/issues/167775

---
**kvserver: add BenchmarkReplicaAccumulator**

This commit adds a benchmark for ReplicaAccumulator.AddReplica to
measure the cost of replica ranking during Store.Capacity scans.
This exercises the heap insertion path that is called for every
replica on the store.

---
**kvserver: avoid interface boxing in replica ranking comparisons**

The replica accumulator's `val()` closure calls `RangeUsageInfo().Load().Dim(dim)`
on every heap comparison. `Load()` returns a `load.Vector` as the `load.Load`
interface, which boxes the `[2]float64` array on the heap each time. With 30k
replicas and 2 dimensions, the heap operations invoke `val()` ~180k+ times per
`Store.Capacity` scan.

This change adds `RangeUsageInfo.LoadDim()` which returns a single dimension
value directly as `float64`, bypassing the interface. The accumulator's `val()`
closure is updated to use it.

```
benchdiff --new=581804e8b667be04e648fb75b6730ab1d1f6a1e9 --old=68eb5349dfa28054c133309fe9ee2821aa2ec014  --post-checkout='bash post-checkout.sh' --run=BenchmarkReplicaAccumulator  --count=10 ./pkg/kv/kvserver

name                                  old time/op    new time/op    delta
ReplicaAccumulator/replicas=1000-12      544µs ±10%     337µs ± 6%  -38.07%  (p=0.000 n=10+9)
ReplicaAccumulator/replicas=30000-12    5.38ms ± 6%    3.46ms ± 1%  -35.68%  (p=0.000 n=9+9)
ReplicaAccumulator/replicas=10000-12    2.28ms ± 5%    1.48ms ± 3%  -35.17%  (p=0.000 n=10+9)
ReplicaAccumulator/replicas=128-12      40.9µs ± 8%    27.7µs ± 7%  -32.31%  (p=0.000 n=10+9)

name                                  old alloc/op   new alloc/op   delta
ReplicaAccumulator/replicas=1000-12      405kB ± 3%     105kB ± 0%  -74.08%  (p=0.000 n=10+10)
ReplicaAccumulator/replicas=10000-12    2.10MB ± 1%    0.97MB ± 0%  -53.87%  (p=0.000 n=10+10)
ReplicaAccumulator/replicas=30000-12    5.43MB ± 1%    2.89MB ± 0%  -46.79%  (p=0.000 n=10+9)
ReplicaAccumulator/replicas=128-12      38.5kB ± 3%    21.3kB ± 0%  -44.63%  (p=0.000 n=10+10)

name                                  old allocs/op  new allocs/op  delta
ReplicaAccumulator/replicas=1000-12      19.8k ± 3%      1.0k ± 0%  -94.84%  (p=0.000 n=10+10)
ReplicaAccumulator/replicas=128-12       1.22k ± 6%     0.15k ± 0%  -87.89%  (p=0.000 n=10+10)
ReplicaAccumulator/replicas=10000-12     80.7k ± 2%     10.0k ± 0%  -87.59%  (p=0.000 n=10+10)
ReplicaAccumulator/replicas=30000-12      189k ± 1%       30k ± 0%  -84.10%  (p=0.000 n=10+10)
```

---
**kvserver: add `BenchmarkReplicaRangeUsageInfo`**

This commit adds a benchmark for `Replica.RangeUsageInfo()`, which is
called per-replica during `Store.Capacity` scans. The benchmark
establishes a baseline for measuring the preceding optimizations
to the load stats retrieval path.

---
**kvserver: extract `getLockedWithNow` and `statsLockedWithNow`**

The `getLocked` method recomputes `timeutil.Unix(0, rl.clock.PhysicalNow())`
on every call. `Stats()` calls it 8 times under a single mutex hold,
producing 8 independent timestamps where one would suffice.

This change replaces `getLocked` with `getLockedWithNow`, which accepts
a pre-computed `time.Time`, and adds `statsLockedWithNow` to populate a
`ReplicaLoadStats` from a single timestamp. `Stats()` is updated to use
the new helper.

---
**kvserver: return `RatedSummary` by value**

`SnapshotRatedSummary` returns `*RatedSummary`, forcing a heap allocation
on every call. The method is not inlineable (its callers hold a mutex),
so the escape is unavoidable. `RatedSummary` is small enough to return
by value without concern.

This change switches `SnapshotRatedSummary` to return `RatedSummary` and
updates `RequestLocalityInfo` accordingly, eliminating one allocation per
replica during `Store.Capacity` scans.

---
**kvserver: combine mutex acquisitions in `RangeUsageInfo`**

`Replica.RangeUsageInfo()` acquires the `ReplicaLoad` mutex twice: once
via `LoadStats()` and once via `RequestLocalityInfo()`. During
`Store.Capacity` scans with 30k+ replicas, this doubles the lock
overhead per replica.

This change adds `StatsWithLocalityInfo()`, which acquires the mutex
once, computes the current time once, and returns both the load stats
and the locality summary. `Replica.RangeUsageInfo()` is updated to
use it.

Execution traces from kv/splits roachtest failures (#167775) show
the `ReplicaLoad` path as the most frequently recurring contributor
to scheduling latency spikes (6 of 10 worst). The longest-running
entries blocking other goroutines:

  `RequestLocalityInfo` -> `PerLocalityDecayingRate`   18-20ms
  `getLocked` -> `AverageRatePerSecond`                15ms
  `Capacity.func1` -> `LoadStats` -> `Stats`           16ms

```
benchdiff --new=2a7001d22023034ffefb124b8751c59270bc7934 --old= 14f968ea1532de3b73e4e668230803492b015cb8 --post-checkout='bash post-checkout.sh' --run=BenchmarkReplicaRangeUsageInfo --count=10 ./pkg/kv/kvserver

building benchmark binaries for 83e4584: kvserver: combine mutex acquisitions in `RangeUsag [bazel=false] 1/1 |
name                      old time/op    new time/op    delta
ReplicaRangeUsageInfo-12     549ns ±10%     471ns ± 4%  -14.26%  (p=0.000 n=9+9)

name                      old alloc/op   new alloc/op   delta
ReplicaRangeUsageInfo-12      296B ± 0%      272B ± 0%   -8.11%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
ReplicaRangeUsageInfo-12      4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.000 n=10+10)
```
