### PR TITLE
security: add certificate rotation timestamp and expiry days metrics

### DIFF
--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -889,6 +889,24 @@ owners:
   security_certificate_expiration_node_client: cockroachdb/security-engineering
   security_certificate_expiration_ui: cockroachdb/security-engineering
   security_certificate_expiration_ui_ca: cockroachdb/security-engineering
+  security_certificate_expiry_days: cockroachdb/security-engineering
+  security_certificate_expiry_days_ca: cockroachdb/security-engineering
+  security_certificate_expiry_days_ca_client_tenant: cockroachdb/security-engineering
+  security_certificate_expiry_days_client_ca: cockroachdb/security-engineering
+  security_certificate_expiry_days_client_tenant: cockroachdb/security-engineering
+  security_certificate_expiry_days_node: cockroachdb/security-engineering
+  security_certificate_expiry_days_node_client: cockroachdb/security-engineering
+  security_certificate_expiry_days_ui: cockroachdb/security-engineering
+  security_certificate_expiry_days_ui_ca: cockroachdb/security-engineering
+  security_certificate_last_rotation: cockroachdb/security-engineering
+  security_certificate_last_rotation_ca: cockroachdb/security-engineering
+  security_certificate_last_rotation_ca_client_tenant: cockroachdb/security-engineering
+  security_certificate_last_rotation_client_ca: cockroachdb/security-engineering
+  security_certificate_last_rotation_client_tenant: cockroachdb/security-engineering
+  security_certificate_last_rotation_node: cockroachdb/security-engineering
+  security_certificate_last_rotation_node_client: cockroachdb/security-engineering
+  security_certificate_last_rotation_ui: cockroachdb/security-engineering
+  security_certificate_last_rotation_ui_ca: cockroachdb/security-engineering
   security_certificate_ttl: cockroachdb/security-engineering
   security_certificate_ttl_ca: cockroachdb/security-engineering
   security_certificate_ttl_ca_client_tenant: cockroachdb/security-engineering

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -6,6 +6,7 @@
 package security
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -430,6 +432,19 @@ func (cm *CertificateManager) LoadCertificates() error {
 		if nodeCert.Error != nil {
 			return makeErrorf(nodeCert.Error, "validating node cert")
 		}
+	}
+
+	// Detect actual certificate content changes and record rotation timestamps.
+	if cm.initialized {
+		now := cm.rotationNow()
+		cm.maybeRecordRotation(cm.caCert, caCert, cm.certMetrics.CALastRotation, now)
+		cm.maybeRecordRotation(cm.clientCACert, clientCACert, cm.certMetrics.ClientCALastRotation, now)
+		cm.maybeRecordRotation(cm.uiCACert, uiCACert, cm.certMetrics.UICALastRotation, now)
+		cm.maybeRecordRotation(cm.tenantCACert, tenantCACert, cm.certMetrics.TenantCALastRotation, now)
+		cm.maybeRecordRotation(cm.nodeCert, nodeCert, cm.certMetrics.NodeLastRotation, now)
+		cm.maybeRecordRotation(cm.nodeClientCert, nodeClientCert, cm.certMetrics.NodeClientLastRotation, now)
+		cm.maybeRecordRotation(cm.uiCert, uiCert, cm.certMetrics.UILastRotation, now)
+		cm.maybeRecordRotation(cm.tenantCert, tenantCert, cm.certMetrics.TenantLastRotation, now)
 	}
 
 	// Swap everything.
@@ -906,4 +921,37 @@ func (cm *CertificateManager) ListCertificates() ([]*CertInfo, error) {
 	}
 
 	return ret, nil
+}
+
+// rotationNow returns the current Unix timestamp using the manager's time
+// source. Used by LoadCertificates to stamp rotation metrics.
+func (cm *CertificateManager) rotationNow() int64 {
+	ts := cm.timeSource
+	if ts == nil {
+		ts = defaultTimeSource
+	}
+	return ts.Now().Unix()
+}
+
+// maybeRecordRotation compares old and new certificate file contents. If the
+// certificate content changed (including going from nil to non-nil or vice
+// versa), the rotation gauge is updated to the provided timestamp.
+// cm.mu must be held.
+func (cm *CertificateManager) maybeRecordRotation(
+	oldCert, newCert *CertInfo, gauge *metric.Gauge, nowUnix int64,
+) {
+	oldContents := certFileContents(oldCert)
+	newContents := certFileContents(newCert)
+	if !bytes.Equal(oldContents, newContents) {
+		gauge.Update(nowUnix)
+	}
+}
+
+// certFileContents returns the raw file contents for a CertInfo, or nil if
+// the cert is nil or has an error.
+func certFileContents(ci *CertInfo) []byte {
+	if ci == nil || ci.Error != nil {
+		return nil
+	}
+	return ci.FileContents
 }

--- a/pkg/security/certificate_metrics.go
+++ b/pkg/security/certificate_metrics.go
@@ -6,6 +6,8 @@
 package security
 
 import (
+	"math"
+
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -45,6 +47,29 @@ type Metrics struct {
 	NodeTTL       *metric.FunctionalGauge
 	NodeClientTTL *metric.FunctionalGauge
 	ClientTTL     *aggmetric.AggFunctionalGauge
+
+	// Rotation timestamp metrics. Each records the unix timestamp (seconds)
+	// of the last successful certificate reload where the certificate content
+	// actually changed. 0 means never rotated since process start.
+	CALastRotation         *metric.Gauge
+	ClientCALastRotation   *metric.Gauge
+	UICALastRotation       *metric.Gauge
+	TenantCALastRotation   *metric.Gauge
+	NodeLastRotation       *metric.Gauge
+	NodeClientLastRotation *metric.Gauge
+	UILastRotation         *metric.Gauge
+	TenantLastRotation     *metric.Gauge
+
+	// Days-until-expiry metrics. Each reports the number of days remaining
+	// until the certificate expires. 0 means expired, missing, or error.
+	CAExpiryDays         *metric.FunctionalGauge
+	ClientCAExpiryDays   *metric.FunctionalGauge
+	UICAExpiryDays       *metric.FunctionalGauge
+	TenantCAExpiryDays   *metric.FunctionalGauge
+	NodeExpiryDays       *metric.FunctionalGauge
+	NodeClientExpiryDays *metric.FunctionalGauge
+	UIExpiryDays         *metric.FunctionalGauge
+	TenantExpiryDays     *metric.FunctionalGauge
 }
 
 var _ metric.Struct = (*Metrics)(nil)
@@ -217,6 +242,138 @@ var (
 		LabeledName:  "security.certificate.ttl",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
 	}
+
+	// Rotation timestamp metadata.
+	metaCALastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.ca",
+		Help:         "Unix timestamp of the last CA certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca"),
+	}
+	metaClientCALastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.client-ca",
+		Help:         "Unix timestamp of the last client CA certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-ca"),
+	}
+	metaUICALastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.ui-ca",
+		Help:         "Unix timestamp of the last UI CA certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui-ca"),
+	}
+	metaTenantCALastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.ca-client-tenant",
+		Help:         "Unix timestamp of the last tenant client CA certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca-client-tenant"),
+	}
+	metaNodeLastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.node",
+		Help:         "Unix timestamp of the last node certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node"),
+	}
+	metaNodeClientLastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.node-client",
+		Help:         "Unix timestamp of the last node client certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node-client"),
+	}
+	metaUILastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.ui",
+		Help:         "Unix timestamp of the last UI certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui"),
+	}
+	metaTenantLastRotation = metric.Metadata{
+		Name:         "security.certificate.last_rotation.client-tenant",
+		Help:         "Unix timestamp of the last tenant client certificate rotation. 0 means no rotation since process start.",
+		Measurement:  "Certificate Last Rotation",
+		Unit:         metric.Unit_TIMESTAMP_SEC,
+		LabeledName:  "security.certificate.last_rotation",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
+	}
+
+	// Days-until-expiry metadata.
+	metaCAExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.ca",
+		Help:         "Days until expiration for the CA certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca"),
+	}
+	metaClientCAExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.client-ca",
+		Help:         "Days until expiration for the client CA certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-ca"),
+	}
+	metaUICAExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.ui-ca",
+		Help:         "Days until expiration for the UI CA certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui-ca"),
+	}
+	metaTenantCAExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.ca-client-tenant",
+		Help:         "Days until expiration for the tenant client CA certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca-client-tenant"),
+	}
+	metaNodeExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.node",
+		Help:         "Days until expiration for the node certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node"),
+	}
+	metaNodeClientExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.node-client",
+		Help:         "Days until expiration for the node client certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node-client"),
+	}
+	metaUIExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.ui",
+		Help:         "Days until expiration for the UI certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui"),
+	}
+	metaTenantExpiryDays = metric.Metadata{
+		Name:         "security.certificate.expiry_days.client-tenant",
+		Help:         "Days until expiration for the tenant client certificate. 0 means expired, no certificate or error.",
+		Measurement:  "Certificate Expiry Days",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "security.certificate.expiry_days",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
+	}
 )
 
 // certClosure defines a way to expose a certificate to the below metric types.
@@ -254,6 +411,24 @@ func ttlGauge(
 	})
 }
 
+const secondsPerDay = 86400
+
+func expiryDaysGauge(
+	metadata metric.Metadata, certFunc certClosure, ts timeutil.TimeSource,
+) *metric.FunctionalGauge {
+	return metric.NewFunctionalGauge(metadata, func() int64 {
+		ci := certFunc()
+		if ci != nil && ci.Error == nil {
+			sec := ci.ExpirationTime.Sub(ts.Now()).Seconds()
+			if sec < 0 {
+				return 0
+			}
+			return int64(math.Ceil(sec / secondsPerDay))
+		}
+		return 0
+	})
+}
+
 var defaultTimeSource = timeutil.DefaultTimeSource{}
 
 // createMetrics makes metrics using the certificate values on the manager.
@@ -286,5 +461,23 @@ func createMetrics(cm *CertificateManager) *Metrics {
 		ClientCATTL:   ttlGauge(metaClientCATTL, cm.ClientCACert, ts),
 		NodeTTL:       ttlGauge(metaNodeTTL, cm.NodeCert, ts),
 		NodeClientTTL: ttlGauge(metaNodeClientTTL, cm.NodeClientCert, ts),
+
+		CALastRotation:         metric.NewGauge(metaCALastRotation),
+		ClientCALastRotation:   metric.NewGauge(metaClientCALastRotation),
+		UICALastRotation:       metric.NewGauge(metaUICALastRotation),
+		TenantCALastRotation:   metric.NewGauge(metaTenantCALastRotation),
+		NodeLastRotation:       metric.NewGauge(metaNodeLastRotation),
+		NodeClientLastRotation: metric.NewGauge(metaNodeClientLastRotation),
+		UILastRotation:         metric.NewGauge(metaUILastRotation),
+		TenantLastRotation:     metric.NewGauge(metaTenantLastRotation),
+
+		CAExpiryDays:         expiryDaysGauge(metaCAExpiryDays, cm.CACert, ts),
+		ClientCAExpiryDays:   expiryDaysGauge(metaClientCAExpiryDays, cm.ClientCACert, ts),
+		UICAExpiryDays:       expiryDaysGauge(metaUICAExpiryDays, cm.UICACert, ts),
+		TenantCAExpiryDays:   expiryDaysGauge(metaTenantCAExpiryDays, cm.TenantCACert, ts),
+		NodeExpiryDays:       expiryDaysGauge(metaNodeExpiryDays, cm.NodeCert, ts),
+		NodeClientExpiryDays: expiryDaysGauge(metaNodeClientExpiryDays, cm.NodeClientCert, ts),
+		UIExpiryDays:         expiryDaysGauge(metaUIExpiryDays, cm.UICert, ts),
+		TenantExpiryDays:     expiryDaysGauge(metaTenantExpiryDays, cm.TenantCert, ts),
 	}
 }

--- a/pkg/security/certificate_metrics.go
+++ b/pkg/security/certificate_metrics.go
@@ -251,6 +251,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that CA certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca"),
 	}
@@ -261,6 +262,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that client CA certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-ca"),
 	}
@@ -271,6 +273,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that UI CA certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui-ca"),
 	}
@@ -281,6 +284,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that tenant client CA certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca-client-tenant"),
 	}
@@ -291,6 +295,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that node certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node"),
 	}
@@ -301,6 +306,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that node client certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node-client"),
 	}
@@ -311,6 +317,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that UI certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui"),
 	}
@@ -321,6 +328,7 @@ var (
 		Unit:         metric.Unit_TIMESTAMP_SEC,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Use this metric to verify that tenant client certificate rotations are occurring as expected. A value of 0 indicates no rotation has happened since the process started. Compare with the corresponding expiry metric to ensure rotations happen well before expiration.",
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
 	}
@@ -333,6 +341,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the CA certificate and reload it before expiration to avoid cluster-wide TLS failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca"),
 	}
@@ -343,6 +352,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the client CA certificate and reload it before expiration to avoid client authentication failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-ca"),
 	}
@@ -353,6 +363,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the UI CA certificate and reload it before expiration to avoid DB Console access failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui-ca"),
 	}
@@ -363,6 +374,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the tenant client CA certificate and reload it before expiration to avoid tenant authentication failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca-client-tenant"),
 	}
@@ -373,6 +385,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the node certificate and reload it before expiration to avoid inter-node communication failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node"),
 	}
@@ -383,6 +396,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the node client certificate and reload it before expiration to avoid node-to-node RPC failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node-client"),
 	}
@@ -393,6 +407,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the UI certificate and reload it before expiration to avoid DB Console HTTPS failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui"),
 	}
@@ -403,6 +418,7 @@ var (
 		Unit:         metric.Unit_COUNT,
 		Visibility:   metric.Metadata_ESSENTIAL,
 		Category:     metric.Metadata_EXPIRATIONS,
+		HowToUse:     "Alert when this value drops below your organization's rotation threshold (e.g. 30 days). A value of 0 means the certificate is expired, missing, or has an error. Renew the tenant client certificate and reload it before expiration to avoid tenant-to-KV communication failures.",
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
 	}

--- a/pkg/security/certificate_metrics.go
+++ b/pkg/security/certificate_metrics.go
@@ -249,6 +249,8 @@ var (
 		Help:         "Unix timestamp of the last CA certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca"),
 	}
@@ -257,6 +259,8 @@ var (
 		Help:         "Unix timestamp of the last client CA certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-ca"),
 	}
@@ -265,6 +269,8 @@ var (
 		Help:         "Unix timestamp of the last UI CA certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui-ca"),
 	}
@@ -273,6 +279,8 @@ var (
 		Help:         "Unix timestamp of the last tenant client CA certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca-client-tenant"),
 	}
@@ -281,6 +289,8 @@ var (
 		Help:         "Unix timestamp of the last node certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node"),
 	}
@@ -289,6 +299,8 @@ var (
 		Help:         "Unix timestamp of the last node client certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node-client"),
 	}
@@ -297,6 +309,8 @@ var (
 		Help:         "Unix timestamp of the last UI certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui"),
 	}
@@ -305,6 +319,8 @@ var (
 		Help:         "Unix timestamp of the last tenant client certificate rotation. 0 means no rotation since process start.",
 		Measurement:  "Certificate Last Rotation",
 		Unit:         metric.Unit_TIMESTAMP_SEC,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.last_rotation",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
 	}
@@ -315,6 +331,8 @@ var (
 		Help:         "Days until expiration for the CA certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca"),
 	}
@@ -323,6 +341,8 @@ var (
 		Help:         "Days until expiration for the client CA certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-ca"),
 	}
@@ -331,6 +351,8 @@ var (
 		Help:         "Days until expiration for the UI CA certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui-ca"),
 	}
@@ -339,6 +361,8 @@ var (
 		Help:         "Days until expiration for the tenant client CA certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ca-client-tenant"),
 	}
@@ -347,6 +371,8 @@ var (
 		Help:         "Days until expiration for the node certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node"),
 	}
@@ -355,6 +381,8 @@ var (
 		Help:         "Days until expiration for the node client certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "node-client"),
 	}
@@ -363,6 +391,8 @@ var (
 		Help:         "Days until expiration for the UI certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "ui"),
 	}
@@ -371,6 +401,8 @@ var (
 		Help:         "Days until expiration for the tenant client certificate. 0 means expired, no certificate or error.",
 		Measurement:  "Certificate Expiry Days",
 		Unit:         metric.Unit_COUNT,
+		Visibility:   metric.Metadata_ESSENTIAL,
+		Category:     metric.Metadata_EXPIRATIONS,
 		LabeledName:  "security.certificate.expiry_days",
 		StaticLabels: metric.MakeLabelPairs(metric.LabelCertificateType, "client-tenant"),
 	}
@@ -413,6 +445,10 @@ func ttlGauge(
 
 const secondsPerDay = 86400
 
+// expiryDaysGauge returns a FunctionalGauge that reports the number of whole
+// days remaining until the certificate expires. math.Ceil is used so that any
+// partial day is rounded up: a certificate with 1 second remaining reports 1
+// (not 0), matching operator expectations that 0 means "already expired".
 func expiryDaysGauge(
 	metadata metric.Metadata, certFunc certClosure, ts timeutil.TimeSource,
 ) *metric.FunctionalGauge {

--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -330,6 +330,129 @@ func TestRotationTimestampsAllCertTypes(t *testing.T) {
 	}
 }
 
+// TestExpiryDaysExpiredCert verifies that the expiry-days gauge returns 0
+// when the certificate is already expired (exercises the sec < 0 branch
+// in expiryDaysGauge).
+func TestExpiryDaysExpiredCert(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	certsDir := t.TempDir()
+
+	// Write certs that expired at Unix time 100.
+	expiration := timeutil.Unix(100, 0)
+	for _, certName := range []string{"ca", "node", "client.node"} {
+		_, certBytes := makeTestCert(t, "", 0, nil, expiration)
+		require.NoError(t, os.WriteFile(filepath.Join(certsDir, certName+".crt"), certBytes, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(certsDir, certName+".key"), []byte("key"), 0700))
+	}
+
+	// Set "now" well past the expiration so sec < 0.
+	now := timeutil.NewManualTime(timeutil.Unix(99999, 0))
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(now),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+	require.Equal(t, int64(0), metrics.CAExpiryDays.Value(), "expired CA should report 0 days")
+	require.Equal(t, int64(0), metrics.NodeExpiryDays.Value(), "expired node should report 0 days")
+	require.Equal(t, int64(0), metrics.NodeClientExpiryDays.Value(), "expired node-client should report 0 days")
+}
+
+// TestExpiryDaysErroredCert verifies that the expiry-days gauge returns 0
+// when a certificate file contains garbage and CertInfo.Error is set.
+func TestExpiryDaysErroredCert(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	certsDir := t.TempDir()
+	now := timeutil.NewManualTime(timeutil.Unix(0, 0))
+
+	// Write a valid CA cert (required) and node cert, but write garbage to
+	// the UI cert file so its CertInfo.Error is set.
+	_, caCert := makeTestCert(t, "", 0, nil, timeutil.Unix(86400, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.crt"), caCert, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.key"), []byte("key"), 0700))
+
+	_, nodeCert := makeTestCert(t, "", 0, nil, timeutil.Unix(86400, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.crt"), nodeCert, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.key"), []byte("key"), 0700))
+
+	_, nodeClientCert := makeTestCert(t, "", 0, nil, timeutil.Unix(86400, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "client.node.crt"), nodeClientCert, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "client.node.key"), []byte("key"), 0700))
+
+	// Write garbage to ui.crt — the cert loader will set CertInfo.Error.
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ui.crt"), []byte("not a cert"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ui.key"), []byte("key"), 0700))
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(now),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+	// Valid certs should report > 0 days.
+	require.Greater(t, metrics.CAExpiryDays.Value(), int64(0), "valid CA should report > 0 days")
+	require.Greater(t, metrics.NodeExpiryDays.Value(), int64(0), "valid node should report > 0 days")
+	// Errored UI cert should report 0.
+	require.Equal(t, int64(0), metrics.UIExpiryDays.Value(), "errored UI cert should report 0 days")
+}
+
+// TestExpiryDaysMissingCert verifies that the expiry-days gauge returns 0
+// for optional certificates that are not present on disk (CertInfo is nil).
+func TestExpiryDaysMissingCert(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	certsDir := t.TempDir()
+	now := timeutil.NewManualTime(timeutil.Unix(0, 0))
+
+	// Write only the required certs: CA + node + client.node.
+	// All optional certs (UI CA, client CA, tenant CA, UI, tenant) are absent.
+	_, caCert := makeTestCert(t, "", 0, nil, timeutil.Unix(86400, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.crt"), caCert, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.key"), []byte("key"), 0700))
+
+	_, nodeCert := makeTestCert(t, "", 0, nil, timeutil.Unix(86400, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.crt"), nodeCert, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.key"), []byte("key"), 0700))
+
+	_, nodeClientCert := makeTestCert(t, "", 0, nil, timeutil.Unix(86400, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "client.node.crt"), nodeClientCert, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "client.node.key"), []byte("key"), 0700))
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(now),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+	// Present certs should report > 0 days.
+	require.Greater(t, metrics.CAExpiryDays.Value(), int64(0), "CA should report > 0 days")
+	require.Greater(t, metrics.NodeExpiryDays.Value(), int64(0), "node should report > 0 days")
+	require.Greater(t, metrics.NodeClientExpiryDays.Value(), int64(0), "node-client should report > 0 days")
+	// Missing optional certs should report 0.
+	require.Equal(t, int64(0), metrics.UICAExpiryDays.Value(), "missing UI CA should report 0 days")
+	require.Equal(t, int64(0), metrics.ClientCAExpiryDays.Value(), "missing client CA should report 0 days")
+	require.Equal(t, int64(0), metrics.TenantCAExpiryDays.Value(), "missing tenant CA should report 0 days")
+	require.Equal(t, int64(0), metrics.UIExpiryDays.Value(), "missing UI cert should report 0 days")
+	require.Equal(t, int64(0), metrics.TenantExpiryDays.Value(), "missing tenant cert should report 0 days")
+}
+
 // TestCertificateReload verifies that when the certificate manager's
 // underlying ceritificates change, the original metrics references (which are
 // the ones registered) also reflect the TTLs on the new certificates.
@@ -445,6 +568,28 @@ func TestCertificateMetricsReloadRace(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(certsDir, c.certFile), certBytes, 0700))
 	}
 
+	// Collect ExpiryDays and LastRotation gauges to include in the race loop.
+	expiryDaysGauges := []*metric.FunctionalGauge{
+		metrics.CAExpiryDays,
+		metrics.ClientCAExpiryDays,
+		metrics.TenantCAExpiryDays,
+		metrics.UICAExpiryDays,
+		metrics.NodeExpiryDays,
+		metrics.UIExpiryDays,
+		metrics.TenantExpiryDays,
+		metrics.NodeClientExpiryDays,
+	}
+	rotationGauges := []*metric.Gauge{
+		metrics.CALastRotation,
+		metrics.ClientCALastRotation,
+		metrics.TenantCALastRotation,
+		metrics.UICALastRotation,
+		metrics.NodeLastRotation,
+		metrics.UILastRotation,
+		metrics.TenantLastRotation,
+		metrics.NodeClientLastRotation,
+	}
+
 	// Read all metrics concurrently with LoadCertificates to trigger the
 	// race detector on any unsynchronized field access. The stop channel
 	// ensures the reader goroutine stays active throughout the entire
@@ -462,6 +607,12 @@ func TestCertificateMetricsReloadRace(t *testing.T) {
 				for i := range checks {
 					checks[i].expiration.Value()
 					checks[i].ttl.Value()
+				}
+				for _, g := range expiryDaysGauges {
+					g.Value()
+				}
+				for _, g := range rotationGauges {
+					g.Value()
 				}
 			}
 		}

--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
@@ -104,6 +105,199 @@ func TestMetricsValues(t *testing.T) {
 		}
 	}
 
+}
+
+// TestExpiryDaysValues verifies that the days-until-expiry metrics report
+// the correct number of days for each certificate type.
+func TestExpiryDaysValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	// Set now to unix 1. Certificates expire at offsets 2..9
+	// (see writeTestCerts). The TTL in seconds for each cert is
+	// (expiration - 1). Days = ceil(ttlSeconds / 86400).
+	// With these tiny TTLs (1-8 seconds), all should be 1 day.
+	now := timeutil.Unix(1, 0)
+	certsDir := t.TempDir()
+	writeTestCerts(t, certsDir)
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(timeutil.NewManualTime(now)),
+		security.ForTenant(1),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+	checks := []struct {
+		name     string
+		expected int64
+		actual   int64
+	}{
+		{"CA Expiry Days", 1, metrics.CAExpiryDays.Value()},
+		{"Client CA Expiry Days", 1, metrics.ClientCAExpiryDays.Value()},
+		{"Tenant CA Expiry Days", 1, metrics.TenantCAExpiryDays.Value()},
+		{"UI CA Expiry Days", 1, metrics.UICAExpiryDays.Value()},
+		{"Node Expiry Days", 1, metrics.NodeExpiryDays.Value()},
+		{"UI Expiry Days", 1, metrics.UIExpiryDays.Value()},
+		{"Tenant Expiry Days", 1, metrics.TenantExpiryDays.Value()},
+		{"Node Client Expiry Days", 1, metrics.NodeClientExpiryDays.Value()},
+	}
+	for _, check := range checks {
+		require.Equal(t, check.expected, check.actual, check.name)
+	}
+}
+
+// TestExpiryDaysLargerValues verifies days-until-expiry with multi-day
+// expirations to ensure the calculation is correct beyond trivial values.
+func TestExpiryDaysLargerValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	now := timeutil.Unix(0, 0)
+	certsDir := t.TempDir()
+
+	// Write a CA cert expiring in exactly 10 days (864000 seconds).
+	_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(864000, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.crt"), certBytes, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.key"), []byte("key"), 0700))
+
+	// Write a node cert expiring in 2.5 days (216000 seconds) -> ceil = 3 days.
+	_, nodeBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(216000, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.crt"), nodeBytes, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.key"), []byte("key"), 0700))
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(timeutil.NewManualTime(now)),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+	require.Equal(t, int64(10), metrics.CAExpiryDays.Value(), "CA expiry days")
+	require.Equal(t, int64(3), metrics.NodeExpiryDays.Value(), "Node expiry days")
+}
+
+// TestRotationTimestamps verifies that rotation timestamp metrics are zero
+// after initial load and are updated when certificates actually change.
+func TestRotationTimestamps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	now := timeutil.NewManualTime(timeutil.Unix(1000, 0))
+	certsDir := t.TempDir()
+	writeTestCerts(t, certsDir)
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(now),
+		security.ForTenant(1),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+
+	// After initial load, all rotation timestamps should be 0
+	// (no rotation has happened yet, only the first load).
+	require.Equal(t, int64(0), metrics.CALastRotation.Value(), "CA rotation before reload")
+	require.Equal(t, int64(0), metrics.NodeLastRotation.Value(), "Node rotation before reload")
+	require.Equal(t, int64(0), metrics.UILastRotation.Value(), "UI rotation before reload")
+	require.Equal(t, int64(0), metrics.TenantLastRotation.Value(), "Tenant rotation before reload")
+
+	// Reload without changing any certificates. Rotation timestamps should
+	// remain 0 because no certificate content changed.
+	now.Advance(100 * time.Second)
+	require.NoError(t, cm.LoadCertificates())
+
+	require.Equal(t, int64(0), metrics.CALastRotation.Value(), "CA rotation after no-op reload")
+	require.Equal(t, int64(0), metrics.NodeLastRotation.Value(), "Node rotation after no-op reload")
+
+	// Change the CA certificate and reload. Only the CA rotation timestamp
+	// should be updated.
+	now.Advance(100 * time.Second)
+	_, newCACert := makeTestCert(t, "", 0, nil, timeutil.Unix(5000, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "ca.crt"), newCACert, 0700))
+	require.NoError(t, cm.LoadCertificates())
+
+	require.Equal(t, int64(1200), metrics.CALastRotation.Value(), "CA rotation after CA change")
+	require.Equal(t, int64(0), metrics.NodeLastRotation.Value(), "Node rotation unchanged after CA change")
+	require.Equal(t, int64(0), metrics.UILastRotation.Value(), "UI rotation unchanged after CA change")
+
+	// Now change the node cert and reload.
+	now.Advance(50 * time.Second)
+	_, newNodeCert := makeTestCert(t, "", 0, nil, timeutil.Unix(6000, 0))
+	require.NoError(t, os.WriteFile(filepath.Join(certsDir, "node.crt"), newNodeCert, 0700))
+	require.NoError(t, cm.LoadCertificates())
+
+	// CA rotation timestamp should not change; node should be updated.
+	require.Equal(t, int64(1200), metrics.CALastRotation.Value(), "CA rotation stays from previous")
+	require.Equal(t, int64(1250), metrics.NodeLastRotation.Value(), "Node rotation after node change")
+}
+
+// TestRotationTimestampsAllCertTypes verifies rotation timestamps for all
+// certificate types after a full cert rotation.
+func TestRotationTimestampsAllCertTypes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	now := timeutil.NewManualTime(timeutil.Unix(1000, 0))
+	certsDir := t.TempDir()
+	writeTestCerts(t, certsDir)
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(now),
+		security.ForTenant(1),
+	)
+	require.NoError(t, err)
+
+	metrics := cm.Metrics()
+
+	type rotationCheck struct {
+		name     string
+		certFile string
+		gauge    *metric.Gauge
+	}
+	checks := []rotationCheck{
+		{"CA", "ca.crt", metrics.CALastRotation},
+		{"ClientCA", "ca-client.crt", metrics.ClientCALastRotation},
+		{"TenantCA", "ca-client-tenant.crt", metrics.TenantCALastRotation},
+		{"UICA", "ca-ui.crt", metrics.UICALastRotation},
+		{"Node", "node.crt", metrics.NodeLastRotation},
+		{"UI", "ui.crt", metrics.UILastRotation},
+		{"Tenant", "client-tenant.1.crt", metrics.TenantLastRotation},
+		{"NodeClient", "client.node.crt", metrics.NodeClientLastRotation},
+	}
+
+	// All should be 0 after initial load.
+	for _, c := range checks {
+		require.Equal(t, int64(0), c.gauge.Value(), "%s rotation before reload", c.name)
+	}
+
+	// Rotate all certificates at once.
+	now.Advance(500 * time.Second)
+	for _, c := range checks {
+		_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(9999, 0))
+		require.NoError(t, os.WriteFile(filepath.Join(certsDir, c.certFile), certBytes, 0700))
+	}
+	require.NoError(t, cm.LoadCertificates())
+
+	// All should now reflect the rotation timestamp.
+	for _, c := range checks {
+		require.Equal(t, int64(1500), c.gauge.Value(), "%s rotation after reload", c.name)
+	}
 }
 
 // TestCertificateReload verifies that when the certificate manager's

--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -108,20 +108,39 @@ func TestMetricsValues(t *testing.T) {
 }
 
 // TestExpiryDaysValues verifies that the days-until-expiry metrics report
-// the correct number of days for each certificate type.
+// the correct number of days for each certificate type, with distinct
+// day counts per cert to ensure each metric is wired correctly.
 func TestExpiryDaysValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	securityassets.ResetLoader()
 	defer ResetTest()
 
-	// Set now to unix 1. Certificates expire at offsets 2..9
-	// (see writeTestCerts). The TTL in seconds for each cert is
-	// (expiration - 1). Days = ceil(ttlSeconds / 86400).
-	// With these tiny TTLs (1-8 seconds), all should be 1 day.
-	now := timeutil.Unix(1, 0)
+	const day = int64(86400)
+	now := timeutil.Unix(0, 0)
 	certsDir := t.TempDir()
-	writeTestCerts(t, certsDir)
+
+	// Write each certificate with a distinct multi-day expiration.
+	// Cert order matches writeTestCerts file names.
+	certs := []struct {
+		certFile string
+		keyFile  string
+		days     int64
+	}{
+		{"ca.crt", "ca.key", 1},
+		{"ca-client.crt", "ca-client.key", 2},
+		{"ca-client-tenant.crt", "ca-client-tenant.key", 3},
+		{"ca-ui.crt", "ca-ui.key", 4},
+		{"node.crt", "node.key", 5},
+		{"ui.crt", "ui.key", 6},
+		{"client-tenant.1.crt", "client-tenant.1.key", 7},
+		{"client.node.crt", "client.node.key", 8},
+	}
+	for _, c := range certs {
+		_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(c.days*day, 0))
+		require.NoError(t, os.WriteFile(filepath.Join(certsDir, c.certFile), certBytes, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(certsDir, c.keyFile), []byte("key"), 0700))
+	}
 
 	cm, err := security.NewCertificateManager(
 		certsDir,
@@ -138,13 +157,13 @@ func TestExpiryDaysValues(t *testing.T) {
 		actual   int64
 	}{
 		{"CA Expiry Days", 1, metrics.CAExpiryDays.Value()},
-		{"Client CA Expiry Days", 1, metrics.ClientCAExpiryDays.Value()},
-		{"Tenant CA Expiry Days", 1, metrics.TenantCAExpiryDays.Value()},
-		{"UI CA Expiry Days", 1, metrics.UICAExpiryDays.Value()},
-		{"Node Expiry Days", 1, metrics.NodeExpiryDays.Value()},
-		{"UI Expiry Days", 1, metrics.UIExpiryDays.Value()},
-		{"Tenant Expiry Days", 1, metrics.TenantExpiryDays.Value()},
-		{"Node Client Expiry Days", 1, metrics.NodeClientExpiryDays.Value()},
+		{"Client CA Expiry Days", 2, metrics.ClientCAExpiryDays.Value()},
+		{"Tenant CA Expiry Days", 3, metrics.TenantCAExpiryDays.Value()},
+		{"UI CA Expiry Days", 4, metrics.UICAExpiryDays.Value()},
+		{"Node Expiry Days", 5, metrics.NodeExpiryDays.Value()},
+		{"UI Expiry Days", 6, metrics.UIExpiryDays.Value()},
+		{"Tenant Expiry Days", 7, metrics.TenantExpiryDays.Value()},
+		{"Node Client Expiry Days", 8, metrics.NodeClientExpiryDays.Value()},
 	}
 	for _, check := range checks {
 		require.Equal(t, check.expected, check.actual, check.name)
@@ -286,17 +305,28 @@ func TestRotationTimestampsAllCertTypes(t *testing.T) {
 		require.Equal(t, int64(0), c.gauge.Value(), "%s rotation before reload", c.name)
 	}
 
-	// Rotate all certificates at once.
-	now.Advance(500 * time.Second)
-	for _, c := range checks {
+	// Rotate each certificate at a distinct time so each gets a unique
+	// rotation timestamp, verifying that each metric is wired correctly.
+	for i, c := range checks {
+		now.Advance(time.Duration(100*(i+1)) * time.Second)
 		_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(9999, 0))
 		require.NoError(t, os.WriteFile(filepath.Join(certsDir, c.certFile), certBytes, 0700))
+		require.NoError(t, cm.LoadCertificates())
 	}
-	require.NoError(t, cm.LoadCertificates())
 
-	// All should now reflect the rotation timestamp.
-	for _, c := range checks {
-		require.Equal(t, int64(1500), c.gauge.Value(), "%s rotation after reload", c.name)
+	// Compute expected timestamps. Starting at 1000, each cert i advances
+	// by 100*(i+1) seconds cumulatively.
+	// i=0: 1000 + 100 = 1100
+	// i=1: 1100 + 200 = 1300
+	// i=2: 1300 + 300 = 1600
+	// i=3: 1600 + 400 = 2000
+	// i=4: 2000 + 500 = 2500
+	// i=5: 2500 + 600 = 3100
+	// i=6: 3100 + 700 = 3800
+	// i=7: 3800 + 800 = 4600
+	expectedTimestamps := []int64{1100, 1300, 1600, 2000, 2500, 3100, 3800, 4600}
+	for i, c := range checks {
+		require.Equal(t, expectedTimestamps[i], c.gauge.Value(), "%s rotation after reload", c.name)
 	}
 }
 


### PR DESCRIPTION
Operators lacked visibility into certificate lifecycle events — there was no easy way to monitor when certificates were last rotated or how many days remain until they expire. This made it difficult to set up proactive alerting.

Add two new families of certificate metrics:

1. Rotation timestamps (`security.certificate.last_rotation.*`): Gauge recording the Unix timestamp of the last cert reload where the certificate content actually changed. Remains 0 until the first rotation after process start. Covers ca, client-ca, ui-ca, ca-client-tenant, node, node-client, ui, and client-tenant.

2. Days until expiry (`security.certificate.expiry_days.*`): FunctionalGauge reporting ceil(ttl_seconds / 86400). Returns 0 when the certificate is expired, missing, or has an error. Covers the same set of certificate types.

Rotation detection works by comparing old vs new FileContents in LoadCertificates before the swap, so a no-op reload (same cert on disk) does not update the timestamp.

Resolves: #167380
Epic: CRDB-59291

Release note (ops change): Added new certificate lifecycle metrics: `security.certificate.last_rotation.*` reports the Unix timestamp of the most recent certificate rotation, and
`security.certificate.expiry_days.*` reports the number of days remaining until each certificate expires. These enable operators to set up monitoring alerts for certificate health.