### PR TITLE
roachtest: remove redundant version prefix from index backfill snapshot names

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -66,15 +66,6 @@ var indexBackfillVariants = []indexBackfillVariant{
 	},
 }
 
-// versionedSnapshotPrefix returns a snapshot prefix that includes the major
-// version (e.g., "index-backfill-tpce-100k-bw-v26.2") so that each major
-// release uses its own snapshots. This is needed because snapshot data may
-// not be compatible across major versions.
-func versionedSnapshotPrefix(t test.Test) string {
-	v := t.BuildVersion()
-	return fmt.Sprintf("%s-v%s", t.SnapshotPrefix(), v.Major())
-}
-
 func registerIndexBackfill(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
@@ -118,18 +109,17 @@ func runIndexBackfill(
 	withCgroupLimiting bool,
 	withProvisionedBandwidth bool,
 ) {
-	snapshotPrefix := versionedSnapshotPrefix(t)
 	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 		// TODO(irfansharif): Search by taking in the other parts of the
 		// snapshot fingerprint, i.e. the node count, the version, etc.
-		NamePrefix: snapshotPrefix,
+		NamePrefix: t.SnapshotPrefix(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(snapshots) == 0 {
 		t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
-			t.Name(), snapshotPrefix)
+			t.Name(), t.SnapshotPrefix())
 
 		// Set up TPC-E with 100k customers. Do so using a published
 		// CRDB release, since we'll use this state to generate disk
@@ -176,7 +166,7 @@ func runIndexBackfill(
 		c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
 		// Create the aforementioned snapshots.
-		snapshots, err = c.CreateSnapshot(ctx, snapshotPrefix)
+		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				// Another concurrent run may have already created snapshots
@@ -187,11 +177,11 @@ func runIndexBackfill(
 			}
 		} else {
 			t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
-				len(snapshots), snapshotPrefix)
+				len(snapshots), t.SnapshotPrefix())
 		}
 	} else {
 		t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
-			len(snapshots), snapshotPrefix)
+			len(snapshots), t.SnapshotPrefix())
 
 		if !t.SkipInit() {
 			roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -466,9 +466,8 @@ func runSingleNodeIndexBackfill(
 
 func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Check for existing snapshots.
-	snapshotPrefix := versionedSnapshotPrefix(t)
 	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
-		NamePrefix: snapshotPrefix,
+		NamePrefix: t.SnapshotPrefix(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -478,7 +477,7 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		// No existing snapshots - need to initialize TPC-E and create snapshots.
 		// Use a published CRDB release so the snapshot has a well-defined internal
 		// version that can be upgraded to any newer version.
-		t.L().Printf("=== NO EXISTING SNAPSHOTS FOUND for prefix %q ===", snapshotPrefix)
+		t.L().Printf("=== NO EXISTING SNAPSHOTS FOUND for prefix %q ===", t.SnapshotPrefix())
 		t.L().Printf("=== WILL CREATE NEW SNAPSHOTS after TPC-E init ===")
 
 		// Get the latest predecessor release version.
@@ -547,8 +546,8 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
 		// Create snapshots.
-		t.Status(fmt.Sprintf("creating snapshots with prefix %q", snapshotPrefix))
-		snapshots, err = c.CreateSnapshot(ctx, snapshotPrefix)
+		t.Status(fmt.Sprintf("creating snapshots with prefix %q", t.SnapshotPrefix()))
+		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				// Another concurrent run may have already created snapshots
@@ -558,11 +557,11 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 				t.Fatal(err)
 			}
 		} else {
-			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), snapshotPrefix)
+			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), t.SnapshotPrefix())
 		}
 	} else {
 		t.L().Printf("found %d existing snapshot(s) with prefix %q",
-			len(snapshots), snapshotPrefix)
+			len(snapshots), t.SnapshotPrefix())
 		roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
 	}
 }


### PR DESCRIPTION
Previously, `versionedSnapshotPrefix` prepended the build's major version
(e.g., `v26.3`) to snapshot prefixes. This produced snapshot names like
`index-backfill-tpce-100k-bw-vv26.3-v26-1-0-n10-0002`, which contained
dots that violate GCE's naming regex and a double `v` since
`Major().String()` already includes the `v` prefix.

This was also redundant - `roachprod.snapshotName()` already embeds the
CRDB binary version into the snapshot name's infix, so snapshots are
naturally differentiated across releases.

This removes `versionedSnapshotPrefix` and goes back to using
`t.SnapshotPrefix()` directly.

Fixes: #167910
Fixes: #167908
Fixes: #167907
Fixes: #167906
Fixes: #167901
Epic: none
Release note: None
Release justification: test-only change