### PR TITLE
release-25.4: roachtest: tolerate missing elastic_control setting on predecessor binary

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -514,11 +514,13 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		}
 
 		// Disable elastic CPU control for import so it is not throttled.
+		// This setting may not exist on predecessor versions (e.g. 25.3),
+		// where the default is already false.
 		if _, err := db.ExecContext(
 			ctx, "SET CLUSTER SETTING bulkio.import.elastic_control.enabled = false",
 		); err != nil {
-			db.Close()
-			t.Fatal(err)
+			t.L().Printf("ignoring error setting bulkio.import.elastic_control.enabled "+
+				"(may not exist on predecessor): %v", err)
 		}
 		db.Close()
 


### PR DESCRIPTION
Previously, the single-node index backfill test would fatal when setting
`bulkio.import.elastic_control.enabled = false` on the predecessor binary
used for snapshot creation. On release-25.4, the predecessor is 25.3.x
which doesn't have this setting.

Now, the error is logged and ignored since the default value is already
false on versions that don't have the setting.

Fixes: #167894
Fixes: #167893
Epic: none
Release note: None
Release justification: test-only change