### PR TITLE
backfill: skip distributed merge when nodelocal storage is unavailable

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1062,6 +1062,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		InternalRowMetrics:         &internalRowMetrics,
 		ProtectedTimestampProvider: cfg.protectedtsProvider,
 		ExternalIODirConfig:        cfg.ExternalIODirConfig,
+		ExternalIODir:              cfg.ExternalIODir,
 		GCJobNotifier:              gcJobNotifier,
 		RangeFeedFactory:           cfg.rangeFeedFactory,
 		CollectionFactory:          collectionFactory,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1829,6 +1829,10 @@ type ExecutorConfig struct {
 
 	ExternalIODirConfig base.ExternalIODirConfig
 
+	// ExternalIODir is the path to the directory used for nodelocal storage.
+	// An empty string indicates nodelocal storage is disabled.
+	ExternalIODir string
+
 	GCJobNotifier *gcjobnotifier.Notifier
 
 	RangeFeedFactory *rangefeed.Factory

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -135,7 +135,7 @@ func (ib *IndexBackfillPlanner) BackfillIndexes(
 		}
 		return tracker.SetBackfillProgress(ctx, progress)
 	}
-	useDistributedMerge, err := shouldUseDistributedMerge(ctx, mode, descriptor, progress)
+	useDistributedMerge, err := shouldUseDistributedMerge(ctx, mode, descriptor, progress, ib.execCfg.ExternalIODir)
 	if err != nil {
 		return err
 	}
@@ -371,17 +371,25 @@ func getIndexBackfillDistributedMergeMode(
 // shouldUseDistributedMerge decides whether the backfill should run through
 // the distributed merge pipeline. Force mode always enables it. Enabled mode
 // falls back to the regular path when every destination index shares leading
-// key columns with the source, since the SSTs are already non-overlapping.
+// key columns with the source, since the SSTs are already non-overlapping,
+// or when nodelocal storage is unavailable (ExternalIODir is not configured).
 func shouldUseDistributedMerge(
 	ctx context.Context,
 	mode jobspb.IndexBackfillDistributedMergeMode,
 	descriptor catalog.TableDescriptor,
 	progress scexec.BackfillProgress,
+	externalIODir string,
 ) (bool, error) {
 	if mode == jobspb.IndexBackfillDistributedMergeMode_Force {
 		return true, nil
 	}
 	if mode != jobspb.IndexBackfillDistributedMergeMode_Enabled {
+		return false, nil
+	}
+	// The distributed merge pipeline writes temporary SSTs to nodelocal
+	// storage, which requires ExternalIODir to be configured. When it is
+	// not available, fall back to the regular backfill path.
+	if externalIODir == "" {
 		return false, nil
 	}
 	// Mode is Enabled: check whether the backfill data is already sorted

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -2319,3 +2319,41 @@ func TestDistributedMergeRedoCleanupSSTs(t *testing.T) {
 	require.True(t, orphanCleanedBeforeJobEnd.Load(),
 		"expected orphan to be cleaned up before merge task, not by final job cleanup")
 }
+
+// TestDistributedMergeNoExternalIODir verifies behavior when ExternalIODir is
+// not configured and distributed merge is requested. Without ExternalIODir,
+// nodelocal storage is unavailable, so the distributed merge pipeline cannot
+// write temporary SSTs.
+func TestDistributedMergeNoExternalIODir(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// Intentionally omit ExternalIODir.
+		DefaultTestTenant: base.ExternalTestTenantAlwaysEnabled,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	// 'declarative' forces distributed merge unconditionally (Force mode),
+	// which should fail because nodelocal storage is unavailable.
+	t.Run("force-fails", func(t *testing.T) {
+		tdb.Exec(t, `SET CLUSTER SETTING bulkio.index_backfill.distributed_merge.mode = 'declarative'`)
+		tdb.Exec(t, `CREATE TABLE t_force (k INT PRIMARY KEY, v INT)`)
+		tdb.Exec(t, `INSERT INTO t_force SELECT i, i*10 FROM generate_series(1, 100) AS g(i)`)
+		_, err := db.ExecContext(ctx, `CREATE INDEX idx_force ON t_force (v)`)
+		require.Error(t, err)
+	})
+
+	// 'enabled' allows fallback when nodelocal is unavailable. The backfill
+	// should succeed via the non-distributed-merge code path.
+	t.Run("enabled-falls-back", func(t *testing.T) {
+		tdb.Exec(t, `SET CLUSTER SETTING bulkio.index_backfill.distributed_merge.mode = 'enabled'`)
+		tdb.Exec(t, `CREATE TABLE t_fallback (k INT PRIMARY KEY, v INT)`)
+		tdb.Exec(t, `INSERT INTO t_fallback SELECT i, i*10 FROM generate_series(1, 100) AS g(i)`)
+
+		tdb.Exec(t, `CREATE INDEX idx_fallback ON t_fallback (v)`)
+	})
+}


### PR DESCRIPTION
When distributed merge mode is "enabled" but ExternalIODir is not configured (e.g. external-process virtual clusters), fall back to the regular backfill path instead of failing with "local file access is disabled" errors.

Informs: #167407
Epic: CRDB-62563
Release note: None