### PR TITLE
roachtest: add WaitForFullReplication helper

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/replication.go
+++ b/pkg/cmd/roachtest/roachtestutil/replication.go
@@ -8,6 +8,8 @@ package roachtestutil
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -19,6 +21,10 @@ import (
 
 // WaitFor3XReplication is like WaitForReplication but specifically requires
 // three as the minimum number of voters a range must be replicated on.
+//
+// TODO(tbg): consider replacing callers with WaitForFullReplication,
+// which checks each range against its own resolved zone config rather than
+// a hardcoded replication factor.
 func WaitFor3XReplication(ctx context.Context, l *logger.Logger, db *gosql.DB) error {
 	return WaitForReplication(ctx, l, db, 3 /* replicationFactor */, roachprod.AtLeastReplicationFactor)
 }
@@ -41,6 +47,67 @@ func WaitForReplication(
 		return errors.Wrap(err, "failed to wait for SQL to be ready")
 	}
 	return roachprod.WaitForReplication(ctx, db, l, replicationFactor, waitForReplicationType, install.RetryEveryDuration(time.Second))
+}
+
+// WaitForFullReplication polls until every range matching the optional
+// predicate has at least as many replicas as its resolved zone config demands.
+// It uses SHOW CLUSTER RANGES WITH ZONE to compare each range's actual replica
+// count against the numReplicas field from its (inheritance-resolved) zone
+// configuration.
+//
+// The predicate, if non-empty, is ANDed into the WHERE clause and may reference
+// any column from SHOW CLUSTER RANGES WITH TABLES, ZONE (e.g.
+// "database_name = 'system'"). Pass "" to check all ranges.
+func WaitForFullReplication(
+	ctx context.Context, l *logger.Logger, db *gosql.DB, predicate string,
+) error {
+	where := `WHERE array_length(replicas, 1) < (zone_config->>'numReplicas')::INT`
+	if predicate != "" {
+		where += "\nAND (" + predicate + ")"
+	}
+	q := `SELECT range_id, start_key,
+	array_length(replicas, 1) AS actual,
+	(zone_config->>'numReplicas')::INT AS desired,
+	count(*) OVER () AS total
+FROM [SHOW CLUSTER RANGES WITH TABLES, ZONE] ` + where + `
+ORDER BY range_id LIMIT 10`
+
+	const interval = 10 * time.Second
+	const logEvery = 6 // log every 6 iterations = 60s
+	for i := 0; ; i++ {
+		rows, err := db.QueryContext(ctx, q)
+		if err != nil {
+			return errors.Wrap(err, "querying replication status")
+		}
+		var total int
+		var buf strings.Builder
+		for rows.Next() {
+			var rangeID, actual, desired int
+			var startKey string
+			if err := rows.Scan(&rangeID, &startKey, &actual, &desired, &total); err != nil {
+				rows.Close()
+				return errors.Wrap(err, "scanning replication status")
+			}
+			fmt.Fprintf(&buf, "\n  r%d %s (%d/%d replicas)", rangeID, startKey, actual, desired)
+		}
+		if err := rows.Close(); err != nil {
+			return errors.Wrap(err, "querying replication status")
+		}
+		if total == 0 {
+			l.Printf("all ranges fully replicated")
+			return nil
+		}
+		if i > 0 && i%logEvery == 0 {
+			l.Printf("waiting for %d ranges to reach desired replication factor%s",
+				total, buf.String())
+		}
+		select {
+		case <-ctx.Done():
+			return errors.Wrapf(ctx.Err(),
+				"%d ranges still under-replicated%s", total, buf.String())
+		case <-time.After(interval):
+		}
+	}
 }
 
 // WaitForUpdatedReplicationReport waits for an updated replication report.

--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -27,51 +27,19 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
 
-	err := roachtestutil.WaitFor3XReplication(ctx, t.L(), db)
-	require.NoError(t, err)
-
 	// Create user ranges at default 3x replication. With 5 nodes and 2 killed,
 	// some of these ranges will lose quorum — the test verifies that
 	// "node status" still works in that scenario.
-	_, err = db.ExecContext(ctx, `CREATE TABLE defaultdb.t (k INT PRIMARY KEY)`)
+	_, err := db.ExecContext(ctx, `CREATE TABLE defaultdb.t (k INT PRIMARY KEY)`)
 	require.NoError(t, err)
 	_, err = db.ExecContext(ctx, `ALTER TABLE defaultdb.t SPLIT AT SELECT generate_series(1, 100)`)
 	require.NoError(t, err)
-	err = roachtestutil.WaitFor3XReplication(ctx, t.L(), db)
-	require.NoError(t, err)
 
-	// System database ranges and meta ranges default to 5x replication
-	// (DefaultSystemZoneConfig). Wait for them to reach 5 replicas, since
-	// we're going to kill 2 nodes and need these ranges to retain quorum.
-	// Without this, SQL connections fail and `node status` (which uses SQL)
-	// won't work. We check database_name = 'system' (for system tables) and
-	// start_key LIKE '/Meta%' (for meta addressing ranges). Other pre-table
-	// system ranges (liveness, etc.) also replicate to 5 but upreplicate
-	// quickly. We must NOT include timeseries ranges (start_key LIKE
-	// '/System/tsd%') — those inherit num_replicas=3 from the default zone
-	// config and would never reach 5.
-	t.L().Printf("waiting for system/meta ranges to reach 5 replicas")
-	for i := 0; ; i++ {
-		var n int
-		if err := db.QueryRowContext(ctx, `
-			SELECT count(*) FROM [SHOW CLUSTER RANGES WITH TABLES]
-			WHERE (database_name = 'system' OR start_key LIKE '/Meta%')
-			AND array_length(replicas, 1) < 5`,
-		).Scan(&n); err != nil {
-			t.Fatalf("querying system range replication: %v", err)
-		}
-		if n == 0 {
-			t.L().Printf("all system/meta ranges at 5 replicas")
-			break
-		}
-		if i%10 == 0 {
-			t.L().Printf("waiting for %d system/meta ranges to reach 5 replicas", n)
-		}
-		if i > 300 {
-			t.Fatalf("timed out waiting for system/meta range replication (still %d ranges < 5 replicas)", n)
-		}
-		time.Sleep(time.Second)
-	}
+	// Wait for all ranges to reach their configured replication factor.
+	// In particular, system/meta ranges need to reach 5x before we kill
+	// nodes, so SQL stays available.
+	err = roachtestutil.WaitForFullReplication(ctx, t.L(), db, "")
+	require.NoError(t, err)
 
 	lastWords := func(s string) []string {
 		var result []string


### PR DESCRIPTION
Add a reusable helper that polls `SHOW CLUSTER RANGES WITH TABLES, ZONE`
(from #166529) to wait until every range has at least as many replicas as
its resolved zone config demands. This replaces hand-rolled polling loops
that hardcode a target replication factor — the zone config is the source
of truth.

- Use the new helper in the `acceptance/cli/node-status` test, replacing
  a 20-line ad-hoc loop.
- Add a TODO on `WaitFor3XReplication` suggesting callers migrate.

Epic: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)