### PR TITLE
changefeedccl: re-enable periodic aggregator frontier flushing 

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -103,8 +103,10 @@ type changeAggregator struct {
 	// eventConsumer consumes the event.
 	eventConsumer eventConsumer
 
-	flushFrequency time.Duration // how often high watermark can be checkpointed.
-	lastSpanFlush  time.Time     // last time expensive, span based checkpoint was written.
+	flushFrequency       time.Duration // how often high watermark can be checkpointed.
+	lastSpanFlush        time.Time     // last time expensive, span based checkpoint was written.
+	periodicFlushEnabled bool          // if true, flush periodically even without frontier advancement.
+	unflushedSpans       bool          // indicates if there is any span that has advanced since we last flushed.
 
 	// frontierFlushLimiter is a rate limiter for flushing the span frontier
 	// to the coordinator because of frontier advancement.
@@ -445,6 +447,11 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	ca.eventConsumer = consumer
 	// Reassign sink, since s may be a wrapped version of the original sink.
 	ca.sink = s
+
+	// Enable periodic flushing unless the sink is cloud storage, which
+	// has ordering violations under partial checkpoints (#155174).
+	ca.periodicFlushEnabled = changefeedbase.PeriodicAggregatorFlush.Get(
+		&ca.FlowCtx.Cfg.Settings.SV) && ca.sink.getConcreteType() != sinkTypeCloudstorage
 
 	// Generate expensive checkpoint only after we ran for a while.
 	ca.lastSpanFlush = timeutil.Now()
@@ -821,15 +828,16 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 	if err != nil {
 		return err
 	}
-	advanced := result.FrontierForwarded()
+	frontierAdvanced := result.FrontierForwarded()
+	ca.unflushedSpans = ca.unflushedSpans || result.SpanForwarded()
 	sv := &ca.FlowCtx.Cfg.Settings.SV
 
 	defer func(ctx context.Context) {
-		maybeLogBehindSpan(ctx, "aggregator", ca.frontier, advanced, sv)
+		maybeLogBehindSpan(ctx, "aggregator", ca.frontier, frontierAdvanced, sv)
 	}(ctx)
 
 	// The resolved sliMetric data backs the aggregator_progress metric
-	if advanced {
+	if frontierAdvanced {
 		ca.sliMetrics.setResolved(ca.sliMetricsID, ca.frontier.Frontier())
 	}
 
@@ -837,12 +845,14 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 		return ca.flushFrontier(ctx)
 	}
 
-	forceFlush := resolved.BoundaryType != jobspb.ResolvedSpan_NONE
+	// Always flush at schema change boundaries.
+	forceFlush := frontierAdvanced && resolved.BoundaryType != jobspb.ResolvedSpan_NONE
+	// Flush if the frontier advanced or if we have periodic flushing enabled
+	// and any span in the frontier advanced. This flush is rate limited.
+	shouldFlush := (frontierAdvanced || (ca.periodicFlushEnabled && ca.unflushedSpans)) &&
+		ca.frontierFlushLimiter.canSave(ctx)
 
-	// TODO(#155015): Re-enable periodic frontier flushing.
-	checkpointFrontier := advanced && (forceFlush || ca.frontierFlushLimiter.canSave(ctx))
-
-	if checkpointFrontier {
+	if forceFlush || shouldFlush {
 		now := crtime.NowMono()
 		if err := ca.flushFrontier(ctx); err != nil {
 			return err
@@ -851,9 +861,10 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 		return nil
 	}
 
-	// At a lower frequency, we checkpoint specific spans in the job progress
-	// either in backfills or if the highwater mark is excessively lagging behind.
-	checkpointSpans := (ca.frontier.InBackfill(resolved) || ca.frontier.HasLaggingSpans(sv)) &&
+	// If periodic flushing is not enabled, we (at a lower frequency) checkpoint specific
+	// spans in the job progress either in backfills or if the highwater mark is excessively
+	// lagging behind.
+	checkpointSpans := !ca.periodicFlushEnabled && (ca.frontier.InBackfill(resolved) || ca.frontier.HasLaggingSpans(sv)) &&
 		canCheckpointSpans(sv, ca.lastSpanFlush)
 
 	if checkpointSpans {
@@ -877,6 +888,7 @@ func (ca *changeAggregator) flushFrontier(ctx context.Context) error {
 	if err := ca.flushBufferedEvents(ctx); err != nil {
 		return err
 	}
+	ca.unflushedSpans = false
 
 	// Iterate frontier spans and build a list of spans to emit.
 	batch := slices.Collect(ca.frontier.All())

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -817,10 +817,11 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error
 		return nil
 	}
 
-	advanced, err := ca.frontier.ForwardResolvedSpan(resolved)
+	result, err := ca.frontier.ForwardResolvedSpan(resolved)
 	if err != nil {
 		return err
 	}
+	advanced := result.FrontierForwarded()
 	sv := &ca.FlowCtx.Cfg.Settings.SV
 
 	defer func(ctx context.Context) {
@@ -1710,11 +1711,11 @@ func (cf *changeFrontier) forwardFrontier(
 			continue
 		}
 
-		changed, err := cf.frontier.ForwardResolvedSpan(resolved)
+		result, err := cf.frontier.ForwardResolvedSpan(resolved)
 		if err != nil {
 			return false, err
 		}
-		frontierChanged = frontierChanged || changed
+		frontierChanged = frontierChanged || result.FrontierForwarded()
 	}
 	return frontierChanged, nil
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -482,6 +482,19 @@ var TrackPerTableProgress = settings.RegisterBoolSetting(
 	metamorphic.ConstantWithTestBool("changefeed.progress.per_table_tracking.enabled", true),
 )
 
+// PeriodicAggregatorFlush controls whether aggregators periodically flush
+// their frontier to the coordinator, even when the frontier has not advanced.
+// This is disabled for cloud storage sinks due to #155174.
+var PeriodicAggregatorFlush = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.aggregator.periodic_flushing.enabled",
+	"if true, aggregators periodically flush their frontier to the "+
+		"coordinator even when the frontier has not advanced; this "+
+		"improves checkpoint freshness. Ignored and disabled for cloud "+
+		"storage sinks which are incompatible.",
+	true,
+)
+
 // FrontierPersistenceInterval configures the minimum amount of time that must
 // elapse before a changefeed will persist its entire span frontier again.
 var FrontierPersistenceInterval = settings.RegisterDurationSettingWithExplicitUnit(

--- a/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
+        "//pkg/util/span",
         "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 )
@@ -71,7 +72,7 @@ func Make(
 
 // SpanForwarder is an interface for forwarding spans to a changefeed.
 type SpanForwarder interface {
-	Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error)
+	Forward(span roachpb.Span, ts hlc.Timestamp) (span.ForwardResult, error)
 }
 
 // Restore restores the saved progress from a checkpoint to the given SpanForwarder.

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -48,7 +48,7 @@ func NewAggregatorFrontier(
 // some boundary validation.
 func (f *AggregatorFrontier) ForwardResolvedSpan(
 	r jobspb.ResolvedSpan,
-) (forwarded bool, err error) {
+) (span.ForwardResult, error) {
 	switch boundaryType := r.BoundaryType; boundaryType {
 	case jobspb.ResolvedSpan_NONE:
 	case jobspb.ResolvedSpan_BACKFILL, jobspb.ResolvedSpan_EXIT, jobspb.ResolvedSpan_RESTART:
@@ -56,10 +56,10 @@ func (f *AggregatorFrontier) ForwardResolvedSpan(
 		// serially, where the changefeed won't ever observe a new schema change
 		// boundary until it has progressed past the current boundary.
 		if err := f.assertBoundaryNotEarlierOrDifferent(r); err != nil {
-			return false, err
+			return span.ForwardNoChange, err
 		}
 	default:
-		return false, errors.AssertionFailedf("unknown boundary type: %v", boundaryType)
+		return span.ForwardNoChange, errors.AssertionFailedf("unknown boundary type: %v", boundaryType)
 	}
 	return f.resolvedSpanFrontier.ForwardResolvedSpan(r)
 }
@@ -97,7 +97,7 @@ func NewCoordinatorFrontier(
 // some boundary validation.
 func (f *CoordinatorFrontier) ForwardResolvedSpan(
 	r jobspb.ResolvedSpan,
-) (forwarded bool, err error) {
+) (span.ForwardResult, error) {
 	switch boundaryType := r.BoundaryType; boundaryType {
 	case jobspb.ResolvedSpan_NONE:
 	case jobspb.ResolvedSpan_BACKFILL:
@@ -118,7 +118,7 @@ func (f *CoordinatorFrontier) ForwardResolvedSpan(
 			break
 		}
 		if err := f.assertBoundaryNotEarlierOrDifferent(r); err != nil {
-			return false, err
+			return span.ForwardNoChange, err
 		}
 		f.backfills = append(f.backfills, boundaryTS)
 	case jobspb.ResolvedSpan_EXIT, jobspb.ResolvedSpan_RESTART:
@@ -126,17 +126,17 @@ func (f *CoordinatorFrontier) ForwardResolvedSpan(
 		// processors to all move to draining and so should not be followed
 		// by any other boundaries.
 		if err := f.assertBoundaryNotEarlierOrDifferent(r); err != nil {
-			return false, err
+			return span.ForwardNoChange, err
 		}
 	default:
-		return false, errors.AssertionFailedf("unknown boundary type: %v", boundaryType)
+		return span.ForwardNoChange, errors.AssertionFailedf("unknown boundary type: %v", boundaryType)
 	}
-	frontierChanged, err := f.resolvedSpanFrontier.ForwardResolvedSpan(r)
+	result, err := f.resolvedSpanFrontier.ForwardResolvedSpan(r)
 	if err != nil {
-		return false, err
+		return span.ForwardNoChange, err
 	}
 	// If the frontier changed, we check if the frontier has advanced past any known backfills.
-	if frontierChanged {
+	if result.FrontierForwarded() {
 		frontier := f.Frontier()
 		i, _ := slices.BinarySearchFunc(f.backfills, frontier,
 			func(elem hlc.Timestamp, ts hlc.Timestamp) int {
@@ -144,7 +144,7 @@ func (f *CoordinatorFrontier) ForwardResolvedSpan(
 			})
 		f.backfills = f.backfills[i:]
 	}
-	return frontierChanged, nil
+	return result, nil
 }
 
 // InBackfill returns whether a resolved span is part of an ongoing backfill
@@ -249,20 +249,22 @@ func newResolvedSpanFrontier(
 // and all the spans are at the boundary timestamp already.
 func (f *resolvedSpanFrontier) ForwardResolvedSpan(
 	r jobspb.ResolvedSpan,
-) (forwarded bool, err error) {
-	forwarded, err = f.Forward(r.Span, r.Timestamp)
+) (span.ForwardResult, error) {
+	result, err := f.Forward(r.Span, r.Timestamp)
 	if err != nil {
-		return false, err
+		return span.ForwardNoChange, err
 	}
 	f.latestTS.Forward(r.Timestamp)
 	boundaryForwarded := f.boundary.Forward(r.Timestamp, r.BoundaryType)
-	if boundaryForwarded && !forwarded {
+	if boundaryForwarded && !result.FrontierForwarded() {
 		// The frontier is considered forwarded if the boundary type
 		// changes to non-NONE and all the spans are at the boundary
 		// timestamp already.
-		forwarded, _, _ = f.AtBoundary()
+		if atBoundary, _, _ := f.AtBoundary(); atBoundary {
+			result = span.ForwardResolvedTime
+		}
 	}
-	return forwarded, nil
+	return result, nil
 }
 
 // AtBoundary returns true at the single moment when all watched spans

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier_test.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier_test.go
@@ -181,8 +181,8 @@ func TestCoordinatorFrontier(t *testing.T) {
 type frontier interface {
 	AddSpansAt(hlc.Timestamp, ...roachpb.Span) error
 	Frontier() hlc.Timestamp
-	Forward(roachpb.Span, hlc.Timestamp) (bool, error)
-	ForwardResolvedSpan(jobspb.ResolvedSpan) (bool, error)
+	Forward(roachpb.Span, hlc.Timestamp) (span.ForwardResult, error)
+	ForwardResolvedSpan(jobspb.ResolvedSpan) (span.ForwardResult, error)
 	InBackfill(jobspb.ResolvedSpan) bool
 	AtBoundary() (bool, jobspb.ResolvedSpan_BoundaryType, hlc.Timestamp)
 	All() iter.Seq[jobspb.ResolvedSpan]
@@ -315,17 +315,17 @@ func TestAggregatorFrontier_ForwardResolvedSpan(t *testing.T) {
 
 	t.Run("advance frontier with no boundary", func(t *testing.T) {
 		// Forwarding part of the span space to 10 should not advance the frontier.
-		forwarded, err := f.ForwardResolvedSpan(
+		result, err := f.ForwardResolvedSpan(
 			makeResolvedSpan("a", "b", makeTS(10), jobspb.ResolvedSpan_NONE))
 		require.NoError(t, err)
-		require.False(t, forwarded)
+		require.False(t, result.FrontierForwarded())
 		require.Zero(t, f.Frontier())
 
 		// Forwarding the rest of the span space to 10 should advance the frontier.
-		forwarded, err = f.ForwardResolvedSpan(
+		result, err = f.ForwardResolvedSpan(
 			makeResolvedSpan("b", "f", makeTS(10), jobspb.ResolvedSpan_NONE))
 		require.NoError(t, err)
-		require.True(t, forwarded)
+		require.True(t, result.FrontierForwarded())
 		require.Equal(t, makeTS(10), f.Frontier())
 	})
 
@@ -333,19 +333,19 @@ func TestAggregatorFrontier_ForwardResolvedSpan(t *testing.T) {
 		// Forwarding part of the span space to 10 again with a non-NONE boundary
 		// should be considered forwarding the frontier because we're learning
 		// about a new boundary.
-		forwarded, err := f.ForwardResolvedSpan(
+		result, err := f.ForwardResolvedSpan(
 			makeResolvedSpan("c", "f", makeTS(10), jobspb.ResolvedSpan_RESTART))
 		require.NoError(t, err)
-		require.True(t, forwarded)
+		require.True(t, result.FrontierForwarded())
 		require.Equal(t, makeTS(10), f.Frontier())
 
 		// Forwarding the rest of the span space to 10 again with a non-NONE boundary
 		// should not be considered forwarding the frontier because we already
 		// know about the new boundary.
-		forwarded, err = f.ForwardResolvedSpan(
+		result, err = f.ForwardResolvedSpan(
 			makeResolvedSpan("a", "c", makeTS(10), jobspb.ResolvedSpan_RESTART))
 		require.NoError(t, err)
-		require.False(t, forwarded)
+		require.False(t, result.FrontierForwarded())
 		require.Equal(t, makeTS(10), f.Frontier())
 	})
 }

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -228,9 +228,9 @@ func TestCloudStorageSink(t *testing.T) {
 	})
 
 	forwardFrontier := func(f span.Frontier, s roachpb.Span, wall int64) bool {
-		forwarded, err := f.Forward(s, ts(wall))
+		result, err := f.Forward(s, ts(wall))
 		require.NoError(t, err)
-		return forwarded
+		return result.FrontierForwarded()
 	}
 
 	stringOrDefault := func(s, ifEmpty string) string {

--- a/pkg/cmd/roachtest/roachtestutil/cdcutil/metamorphic.go
+++ b/pkg/cmd/roachtest/roachtestutil/cdcutil/metamorphic.go
@@ -58,6 +58,15 @@ var (
 			return vals[rng.Intn(len(vals))], true
 		},
 	}
+	PeriodicAggregatorFlushing = MetamorphicSetting{
+		Name: "changefeed.aggregator.periodic_flushing.enabled",
+		Resolve: func(rng *rand.Rand) (string, bool) {
+			if rng.Float64() < 0.1 {
+				return "false", true
+			}
+			return "true", true
+		},
+	}
 )
 
 // resolvedSetting represents a metamorphic setting that has been

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -783,6 +783,9 @@ func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster, opts ...o
 	if v, ok := tester.metamorphic.Get(cdcutil.PerTableTrackingEnabled); ok {
 		settings.ClusterSettings["changefeed.progress.per_table_tracking.enabled"] = v
 	}
+	if v, ok := tester.metamorphic.Get(cdcutil.PeriodicAggregatorFlushing); ok {
+		settings.ClusterSettings["changefeed.aggregator.periodic_flushing.enabled"] = v
+	}
 
 	settings.Env = append(settings.Env, envVars...)
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -551,11 +551,11 @@ func TestMuxRangeFeedMetricsManagement(t *testing.T) {
 							return false, nil
 						}
 
-						advanced, err := frontier.Forward(checkpoint.Span, checkpoint.ResolvedTS)
+						result, err := frontier.Forward(checkpoint.Span, checkpoint.ResolvedTS)
 						if err != nil {
 							return false, err
 						}
-						if advanced {
+						if result.FrontierForwarded() {
 							defer frontierHasAdvanced()
 						}
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -457,18 +457,18 @@ func (f *RangeFeed) processEvent(
 			ts.Logical = 0
 			ts.WallTime -= ts.WallTime % int64(f.frontierQuantize)
 		}
-		advanced, err := frontier.Forward(ev.Checkpoint.Span, ts)
+		result, err := frontier.Forward(ev.Checkpoint.Span, ts)
 		if err != nil {
 			return err
 		}
 		if f.onCheckpoint != nil {
 			f.onCheckpoint(ctx, ev.Checkpoint)
 		}
-		if advanced && f.onFrontierAdvance != nil {
+		if result.FrontierForwarded() && f.onFrontierAdvance != nil {
 			f.onFrontierAdvance(ctx, frontier.Frontier())
 		}
 		if f.frontierVisitor != nil {
-			f.frontierVisitor(ctx, advanced, frontier)
+			f.frontierVisitor(ctx, result.FrontierForwarded(), frontier)
 		}
 	case ev.SST != nil:
 		if f.onSSTable == nil {

--- a/pkg/kv/kvclient/rangefeed/scanner.go
+++ b/pkg/kv/kvclient/rangefeed/scanner.go
@@ -73,12 +73,12 @@ func (f *RangeFeed) runInitialScan(
 				return err
 			}
 		}
-		advanced, err := frontier.Forward(sp, f.initialTimestamp)
+		result, err := frontier.Forward(sp, f.initialTimestamp)
 		if err != nil {
 			return err
 		}
 		if f.frontierVisitor != nil {
-			f.frontierVisitor(ctx, advanced, frontier)
+			f.frontierVisitor(ctx, result.FrontierForwarded(), frontier)
 		}
 		return nil
 	}

--- a/pkg/kv/kvnemesis/watcher.go
+++ b/pkg/kv/kvnemesis/watcher.go
@@ -297,11 +297,11 @@ func (w *Watcher) handleCheckpoint(
 		}
 	}()
 
-	frontierAdvanced, err := w.mu.frontier.Forward(span, resolvedTS)
+	result, err := w.mu.frontier.Forward(span, resolvedTS)
 	if err != nil {
 		return errors.Wrapf(err, "unexpected frontier error advancing to %s@%s", span, resolvedTS)
 	}
-	if frontierAdvanced {
+	if result.FrontierForwarded() {
 		frontier = w.mu.frontier.Frontier()
 		log.Dev.Infof(ctx, `watcher reached frontier %s lagging by %s`,
 			frontier, timeutil.Since(frontier.GoTime()))

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -23,6 +23,27 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// ForwardResult describes what changed as a result of a Forward call.
+// The values are ordered such that ForwardResolvedTime > ForwardSpan
+// implies that a span was also forwarded.
+type ForwardResult int
+
+const (
+	// ForwardNoChange indicates no span was forwarded, i.e. a no-op.
+	ForwardNoChange ForwardResult = iota
+	// ForwardSpan indicates that a sub span of the frontier was forwarded
+	// but not the frontier.
+	ForwardSpan
+	// ForwardResolvedTime indicates the frontier was forwarded.
+	ForwardResolvedTime
+)
+
+// FrontierForwarded returns true if the overall frontier timestamp advanced.
+func (r ForwardResult) FrontierForwarded() bool { return r == ForwardResolvedTime }
+
+// SpanForwarded returns true if at least one span's timestamp was forwarded.
+func (r ForwardResult) SpanForwarded() bool { return r >= ForwardSpan }
+
 // Frontier tracks the minimum timestamp of a set of spans.
 // Frontier is not safe for concurrent modification, but MakeConcurrentFrontier
 // can be used to make thread safe frontier.
@@ -35,10 +56,9 @@ type Frontier interface {
 	// timestamp.
 	AddSpansAt(startAt hlc.Timestamp, spans ...roachpb.Span) error
 
-	// Forward advances the timestamp for a span. Any part of the span that doesn't
-	// overlap the tracked span set will be ignored. True is returned if the
-	// frontier advanced as a result.
-	Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error)
+	// Forward advances the timestamp for a span. Any part of the span that
+	// doesn't overlap the tracked span set will be ignored.
+	Forward(span roachpb.Span, ts hlc.Timestamp) (ForwardResult, error)
 
 	// Release removes all items from the frontier. In doing so, it allows memory
 	// held by the frontier to be recycled. Failure to call this method before
@@ -211,7 +231,7 @@ func (f *btreeFrontier) AddSpansAt(startAt hlc.Timestamp, spans ...roachpb.Span)
 				return err
 			}
 		}
-		if err := f.forward(toAdd, startAt); err != nil {
+		if _, err := f.forward(toAdd, startAt); err != nil {
 			return err
 		}
 	}
@@ -247,8 +267,7 @@ func (f *btreeFrontier) PeekFrontierSpan() roachpb.Span {
 }
 
 // Forward advances the timestamp for a span. Any part of the span that doesn't
-// overlap the tracked span set will be ignored. True is returned if the
-// frontier advanced as a result.
+// overlap the tracked span set will be ignored.
 //
 // Note that internally, it may be necessary to use multiple entries to
 // represent this timestamped span (e.g. if it overlaps with the tracked span
@@ -259,14 +278,14 @@ func (f *btreeFrontier) PeekFrontierSpan() roachpb.Span {
 // call returns.
 func (f *btreeFrontier) Forward(
 	span roachpb.Span, ts hlc.Timestamp,
-) (forwarded bool, retErr error) {
+) (result ForwardResult, retErr error) {
 	if err := f.checkDisallowedMutation(); err != nil {
-		return false, err
+		return ForwardNoChange, err
 	}
 
 	// Validate caller provided span.
 	if err := checkSpan(span); err != nil {
-		return false, err
+		return ForwardNoChange, err
 	}
 
 	if expensiveChecksEnabled() {
@@ -278,10 +297,17 @@ func (f *btreeFrontier) Forward(
 	}
 
 	prevFrontier := f.Frontier()
-	if err := f.forward(span, ts); err != nil {
-		return false, err
+	spanForwarded, err := f.forward(span, ts)
+	if err != nil {
+		return ForwardNoChange, err
 	}
-	return prevFrontier.Less(f.Frontier()), nil
+	if prevFrontier.Less(f.Frontier()) {
+		return ForwardResolvedTime, nil
+	}
+	if spanForwarded {
+		return ForwardSpan, nil
+	}
+	return ForwardNoChange, nil
 }
 
 // clone augments generated iterStack code to support cloning.
@@ -438,7 +464,10 @@ func (f *btreeFrontier) setEndKey(e *btreeFrontierEntry, endKey roachpb.Key) {
 
 // forward is the work horse of the btreeFrontier.  It forwards the timestamp
 // for the specified span, splitting, and merging btreeFrontierEntries as needed.
-func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error {
+// Returns true if any span's timestamp was actually forwarded.
+func (f *btreeFrontier) forward(
+	span roachpb.Span, insertTS hlc.Timestamp,
+) (spanForwarded bool, _ error) {
 	todoEntry := newSearchKey(span.Key, span.EndKey)
 	defer putFrontierEntry(todoEntry)
 
@@ -447,6 +476,7 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 	// NB: passed in entry and any existing iterators should be considered invalid
 	// after this call.
 	forwardEntryTimestamp := func(e *btreeFrontierEntry) (*btreeFrontierEntry, error) {
+		spanForwarded = true
 		e.ts = insertTS
 		heap.Fix(&f.minHeap, e.heapIdx)
 		return f.mergeEntries(e)
@@ -455,7 +485,7 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 	for !todoEntry.isEmptyRange() { // Keep going as long as there is work to be done.
 		if expensiveChecksEnabled() {
 			if err := checkSpan(todoEntry.span()); err != nil {
-				return err
+				return false, err
 			}
 		}
 
@@ -490,7 +520,7 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		// update overlap timestamp and be done.
 		if overlap.span().Equal(todoEntry.span()) {
 			if _, err := forwardEntryTimestamp(overlap); err != nil {
-				return err
+				return false, err
 			}
 			break
 		}
@@ -508,14 +538,14 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 			// part starts at todoEntry.Start.
 			_, _, err := f.splitEntryAt(overlap, todoEntry.Start)
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
 
 		// NB: overlap.Start must be equal to todoEntry.Start (established by Invariant (a) and (b) above).
 		if expensiveChecksEnabled() && !overlap.Start.Equal(todoEntry.Start) {
-			return errors.AssertionFailedf("expected overlap %s to start at %s", overlap, todoEntry)
+			return false, errors.AssertionFailedf("expected overlap %s to start at %s", overlap, todoEntry)
 		}
 
 		switch cmp := todoEntry.End.Compare(overlap.End); {
@@ -526,24 +556,24 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 			// Left entry can reuse overlap with insertTS.
 			left, right, err := f.splitEntryAt(overlap, todoEntry.End)
 			if err != nil {
-				return err
+				return false, err
 			}
 			todoEntry.Start = right.End
 			// The left part advances its timestamp.
 			if _, err := forwardEntryTimestamp(left); err != nil {
-				return err
+				return false, err
 			}
 		case cmp >= 0:
 			// todoEntry ends at or beyond overlap.  Regardless, we can simply update overlap
 			// and if needed, continue matching remaining todoEntry (if any).
 			fwd, err := forwardEntryTimestamp(overlap)
 			if err != nil {
-				return err
+				return false, err
 			}
 			todoEntry.Start = fwd.End
 		}
 	}
-	return nil
+	return spanForwarded, nil
 }
 
 func (f *btreeFrontier) disallowMutations() func() {
@@ -842,7 +872,7 @@ func (f *concurrentFrontier) PeekFrontierSpan() roachpb.Span {
 }
 
 // Forward implements Frontier.
-func (f *concurrentFrontier) Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error) {
+func (f *concurrentFrontier) Forward(span roachpb.Span, ts hlc.Timestamp) (ForwardResult, error) {
 	f.Lock()
 	defer f.Unlock()
 	return f.f.Forward(span, ts)

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -33,13 +33,17 @@ func entriesStr(f Frontier) string {
 }
 
 type frontierForwarder struct {
-	t        *testing.T
-	f        Frontier
-	advanced bool
+	t      *testing.T
+	f      Frontier
+	result ForwardResult
 }
 
 func (f frontierForwarder) expectAdvanced(expected bool) frontierForwarder {
-	require.Equal(f.t, expected, f.advanced, entriesStr(f.f))
+	require.Equal(f.t, expected, f.result.FrontierForwarded(), entriesStr(f.f))
+	return f
+}
+func (f frontierForwarder) expectSpanAdvanced(expected bool) frontierForwarder {
+	require.Equal(f.t, expected, f.result.SpanForwarded(), entriesStr(f.f))
 	return f
 }
 func (f frontierForwarder) expectFrontier(wall int64) frontierForwarder {
@@ -57,12 +61,12 @@ func makeFrontierForwarded(
 ) func(s roachpb.Span, wall int64) frontierForwarder {
 	t.Helper()
 	return func(s roachpb.Span, wall int64) frontierForwarder {
-		advanced, err := f.Forward(s, hlc.Timestamp{WallTime: wall})
+		result, err := f.Forward(s, hlc.Timestamp{WallTime: wall})
 		require.NoError(t, err)
 		return frontierForwarder{
-			t:        t,
-			f:        f,
-			advanced: advanced,
+			t:      t,
+			f:      f,
+			result: result,
 		}
 	}
 }
@@ -89,42 +93,49 @@ func TestSpanFrontier(t *testing.T) {
 	// Untracked spans are ignored
 	forwardFrontier(roachpb.Span{Key: []byte("d"), EndKey: []byte("e")}, 1).
 		expectAdvanced(false).
+		expectSpanAdvanced(false).
 		expectFrontier(0).
 		expectEntries(`{a-d}@0`)
 
 	// Forward the entire tracked spanspace.
 	forwardFrontier(spAD, 1).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(1).
 		expectEntries(`{a-d}@1`)
 
 	// Forward it again.
 	forwardFrontier(spAD, 2).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(2).
 		expectEntries(`{a-d}@2`)
 
 	// Forward to the previous frontier.
 	forwardFrontier(spAD, 2).
 		expectAdvanced(false).
+		expectSpanAdvanced(false).
 		expectFrontier(2).
 		expectEntries(`{a-d}@2`)
 
 	// Forward into the past is ignored.
 	forwardFrontier(spAD, 1).
 		expectAdvanced(false).
+		expectSpanAdvanced(false).
 		expectFrontier(2).
 		expectEntries(`{a-d}@2`)
 
 	// Forward a subset.
 	forwardFrontier(spBC, 3).
 		expectAdvanced(false).
+		expectSpanAdvanced(true).
 		expectFrontier(2).
 		expectEntries(`{a-b}@2 {b-c}@3 {c-d}@2`)
 
 	// Forward it more.
 	forwardFrontier(spBC, 4).
 		expectAdvanced(false).
+		expectSpanAdvanced(true).
 		expectFrontier(2).
 		expectEntries(`{a-b}@2 {b-c}@4 {c-d}@2`)
 
@@ -133,55 +144,65 @@ func TestSpanFrontier(t *testing.T) {
 	// forwarded span to be split into two spans, one on each side of BC.
 	forwardFrontier(spAD, 3).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(3).
 		expectEntries(`{a-b}@3 {b-c}@4 {c-d}@3`)
 
 	// Forward everything but BC, advances to the min of tracked spans.
 	forwardFrontier(spAB, 5).
 		expectAdvanced(false).
+		expectSpanAdvanced(true).
 		expectFrontier(3)
 
 	forwardFrontier(spCD, 5).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(4).
 		expectEntries(`{a-b}@5 {b-c}@4 {c-d}@5`)
 
 	// Catch BC up: spans collapse.
 	forwardFrontier(spBC, 5).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(5).
 		expectEntries(`{a-d}@5`)
 
 	// Forward them all at once.
 	forwardFrontier(spAD, 6).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(6).
 		expectEntries(`{a-d}@6`)
 
 	// Split AC with BD.
 	forwardFrontier(spCD, 7).
 		expectAdvanced(false).
+		expectSpanAdvanced(true).
 		expectFrontier(6).
 		expectEntries(`{a-c}@6 {c-d}@7`)
 
 	forwardFrontier(spBD, 8).
 		expectAdvanced(false).
+		expectSpanAdvanced(true).
 		expectFrontier(6).
 		expectEntries(`{a-b}@6 {b-d}@8`)
 
 	forwardFrontier(spAB, 8).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(8).
 		expectEntries(`{a-d}@8`)
 
 	// Split BD with AC.
 	forwardFrontier(spAC, 9).
 		expectAdvanced(false).
+		expectSpanAdvanced(true).
 		expectFrontier(8).
 		expectEntries(`{a-c}@9 {c-d}@8`)
 
 	forwardFrontier(spCD, 9).
 		expectAdvanced(true).
+		expectSpanAdvanced(true).
 		expectFrontier(9).
 		expectEntries(`{a-d}@9`)
 }

--- a/pkg/util/span/multi_frontier.go
+++ b/pkg/util/span/multi_frontier.go
@@ -137,41 +137,44 @@ func (f *MultiFrontier[P]) PeekFrontierSpan() roachpb.Span {
 }
 
 // Forward implements Frontier.
-func (f *MultiFrontier[P]) Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error) {
+func (f *MultiFrontier[P]) Forward(span roachpb.Span, ts hlc.Timestamp) (ForwardResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	partition, err := f.partitioner(span)
 	if err != nil {
-		return false, errors.Wrapf(err, "got partitioner error when attempting to forward")
+		return ForwardNoChange, errors.Wrapf(err, "got partitioner error when attempting to forward")
 	}
 
 	frontier := f.mu.frontiers.get(partition)
 	if frontier == nil {
-		return false, nil
+		return ForwardNoChange, nil
 	}
 
 	prevMinFrontier := f.mu.frontiers.min().Frontier()
-	forwarded, err := frontier.Forward(span, ts)
+	result, err := frontier.Forward(span, ts)
 	if err != nil {
-		return false, err
+		return ForwardNoChange, err
 	}
-	if forwarded {
+	if result.FrontierForwarded() {
 		if err := f.mu.frontiers.fixup(partition); err != nil {
-			return false, err
+			return ForwardNoChange, err
 		}
 	}
 
 	if buildutil.CrdbTestBuild && !f.mu.frontiers.valid() {
-		return false, errors.AssertionFailedf(
+		return ForwardNoChange, errors.AssertionFailedf(
 			"Forward: heap invariant violated after forwarding span: %v", span)
 	}
 
 	newMinFrontier := f.mu.frontiers.min().Frontier()
 	if prevMinFrontier.Less(newMinFrontier) {
-		return true, nil
+		return ForwardResolvedTime, nil
 	}
-	return false, nil
+	if result.SpanForwarded() {
+		return ForwardSpan, nil
+	}
+	return ForwardNoChange, nil
 }
 
 // Release implements Frontier.

--- a/pkg/util/span/multi_frontier_test.go
+++ b/pkg/util/span/multi_frontier_test.go
@@ -83,15 +83,15 @@ func TestMultiFrontier_Frontier(t *testing.T) {
 		require.Equal(t, ts(3), f.Frontier())
 		require.Equal(t, `1: {{a-b}@3} 2: {{d-e}@3}`, multiFrontierStr(f))
 
-		forwarded, err := f.Forward(sp('a', 'b'), ts(5))
+		result, err := f.Forward(sp('a', 'b'), ts(5))
 		require.NoError(t, err)
-		require.False(t, forwarded)
+		require.False(t, result.FrontierForwarded())
 		require.Equal(t, ts(3), f.Frontier())
 		require.Equal(t, `1: {{a-b}@5} 2: {{d-e}@3}`, multiFrontierStr(f))
 
-		forwarded, err = f.Forward(sp('d', 'e'), ts(5))
+		result, err = f.Forward(sp('d', 'e'), ts(5))
 		require.NoError(t, err)
-		require.True(t, forwarded)
+		require.True(t, result.FrontierForwarded())
 		require.Equal(t, ts(5), f.Frontier())
 		require.Equal(t, `1: {{a-b}@5} 2: {{d-e}@5}`, multiFrontierStr(f))
 	})
@@ -119,9 +119,9 @@ func TestMultiFrontier_Forward(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, `1: {{a-d}@0} 2: {{d-f}@0} 3: {{f-k}@0}`, multiFrontierStr(f))
 
-	forwarded, err := f.Forward(sp('a', 'b'), ts(2))
+	result, err := f.Forward(sp('a', 'b'), ts(2))
 	require.NoError(t, err)
-	require.False(t, forwarded)
+	require.False(t, result.FrontierForwarded())
 	require.Equal(t, ts(0), f.Frontier())
 	require.Equal(t, `1: {{a-b}@2 {b-d}@0} 2: {{d-f}@0} 3: {{f-k}@0}`, multiFrontierStr(f))
 
@@ -129,21 +129,21 @@ func TestMultiFrontier_Forward(t *testing.T) {
 	require.ErrorContains(t, err,
 		"got partitioner error when attempting to forward: invalid range")
 
-	forwarded, err = f.Forward(sp('b', 'd'), ts(2))
+	result, err = f.Forward(sp('b', 'd'), ts(2))
 	require.NoError(t, err)
-	require.False(t, forwarded)
+	require.False(t, result.FrontierForwarded())
 	require.Equal(t, ts(0), f.Frontier())
 	require.Equal(t, `1: {{a-d}@2} 2: {{d-f}@0} 3: {{f-k}@0}`, multiFrontierStr(f))
 
-	forwarded, err = f.Forward(sp('f', 'k'), ts(2))
+	result, err = f.Forward(sp('f', 'k'), ts(2))
 	require.NoError(t, err)
-	require.False(t, forwarded)
+	require.False(t, result.FrontierForwarded())
 	require.Equal(t, ts(0), f.Frontier())
 	require.Equal(t, `1: {{a-d}@2} 2: {{d-f}@0} 3: {{f-k}@2}`, multiFrontierStr(f))
 
-	forwarded, err = f.Forward(sp('d', 'f'), ts(2))
+	result, err = f.Forward(sp('d', 'f'), ts(2))
 	require.NoError(t, err)
-	require.True(t, forwarded)
+	require.True(t, result.FrontierForwarded())
 	require.Equal(t, ts(2), f.Frontier())
 	require.Equal(t, `1: {{a-d}@2} 2: {{d-f}@2} 3: {{f-k}@2}`, multiFrontierStr(f))
 }

--- a/pkg/util/span/test_helper.go
+++ b/pkg/util/span/test_helper.go
@@ -163,7 +163,9 @@ type captureHistoryFrontier struct {
 	history []string
 }
 
-func (f *captureHistoryFrontier) Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error) {
+func (f *captureHistoryFrontier) Forward(
+	span roachpb.Span, ts hlc.Timestamp,
+) (ForwardResult, error) {
 	f.history = append(f.history,
 		fmt.Sprintf(`advanceFrontier(t, f, makeSpan(%q, %q), %d)`, span.Key, span.EndKey, ts.WallTime))
 	if len(f.history) > maxHistory {


### PR DESCRIPTION
Periodic frontier flushing for aggregators was disabled and removed in https://github.com/cockroachdb/cockroach/pull/154982 due to ordering violations in the cloud storage sink, see: (https://github.com/cockroachdb/cockroach/issues/155174).

This change re-enables periodic flushing but disables it for cloud storage sinks. It can also be disabled for all sinks with the cluster setting `changefeed.aggregator.periodic_flushing.enabled"`. We also avoid flushing if there were no changes to any span in the frontier.

Fixes: #155015
Epic: none
Release note: none