### PR TITLE
sql: rename zone_config_conformant to zone_config_needs_split

### DIFF
--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -429,7 +429,7 @@ all_span_stats AS (
 	// If zone config was requested, include it via the builtin.
 	if n.Options.Zone {
 		buf.WriteString(",\n  crdb_internal.zone_config_for_key(r.start_key) AS zone_config")
-		buf.WriteString(",\n  r.end_key <= crdb_internal.zone_config_span_end(r.start_key) AS zone_config_conformant")
+		buf.WriteString(",\n  r.end_key > crdb_internal.zone_config_span_end(r.start_key) AS zone_config_needs_split")
 	}
 	buf.WriteString("\nFROM named_ranges r)\n")
 
@@ -724,7 +724,7 @@ all_span_stats AS (
 	// If zone config was requested, propagate the columns.
 	if n.Options.Zone {
 		buf.WriteString(",\n  zone_config")
-		buf.WriteString(",\n  zone_config_conformant")
+		buf.WriteString(",\n  zone_config_needs_split")
 	}
 
 	// Complete this CTE. and add an order if needed.

--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -494,11 +494,11 @@ SELECT index_name FROM crdb_internal.ranges
 
 subtest show_ranges_with_zone
 
-# Assert the schema: WITH ZONE adds zone_config and zone_config_conformant.
+# Assert the schema: WITH ZONE adds zone_config and zone_config_needs_split.
 query TTITTTTTTTB colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH ZONE] LIMIT 0
 ----
-start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
+start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_needs_split
 
 # Verify zone_config column contains valid JSON with expected fields.
 query ITB
@@ -514,13 +514,13 @@ ORDER BY range_id LIMIT 1
 query TTITTTITTTTTTTTTB colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH TABLES, ZONE] LIMIT 0
 ----
-start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
+start_key  end_key  range_id  database_name  schema_name  table_name  table_id  table_start_key  table_end_key  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_needs_split
 
 # Combinable with KEYS.
 query TTTTITTTTTTTB colnames
 SELECT * FROM [SHOW CLUSTER RANGES WITH KEYS, ZONE] LIMIT 0
 ----
-start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
+start_key  end_key  raw_start_key  raw_end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_needs_split
 
 # WITH EXPLAIN + ZONE shows the generated SQL containing the builtins.
 query BB
@@ -534,7 +534,7 @@ true  true
 query TTITTTTTTTB colnames
 SELECT * FROM [SHOW RANGES FROM DATABASE test WITH ZONE] LIMIT 0
 ----
-start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_conformant
+start_key  end_key  range_id  replicas  replica_localities  voting_replicas  non_voting_replicas  learner_replicas  split_enforced_until  zone_config  zone_config_needs_split
 
 # Zone config changes are immediately reflected (no propagation delay).
 # Note: zone_config_for_key resolves based on the range start key, which


### PR DESCRIPTION
## Summary

Rename the `zone_config_conformant` column in `SHOW RANGES WITH ZONE` to
`zone_config_needs_split` with inverted boolean semantics. The old name
suggested the range conforms to its zone config (e.g. has enough replicas),
when it actually indicates whether the range straddles a zone config boundary
and needs a split.

Epic: none