### PR TITLE
backup: add cloud tests to flaky storage tests

### DIFF
--- a/pkg/backup/backupinfo/manifest_handling.go
+++ b/pkg/backup/backupinfo/manifest_handling.go
@@ -1814,8 +1814,15 @@ func GetBackupManifestIterFactories(
 	backupManifests []backuppb.BackupManifest,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
-) (map[int]*IterFactory, error) {
+) (_ map[int]*IterFactory, err error) {
 	layerToFileIterFactory := make(map[int]*IterFactory)
+	defer func() {
+		if err != nil {
+			for _, f := range layerToFileIterFactory {
+				f.store.Close()
+			}
+		}
+	}()
 	for layer := range backupManifests {
 		es, err := storeFactory(ctx, backupManifests[layer].Dir)
 		if err != nil {

--- a/pkg/backup/flaky_storage_test.go
+++ b/pkg/backup/flaky_storage_test.go
@@ -8,26 +8,33 @@ package backup
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/amazon"
+	"github.com/cockroachdb/cockroach/pkg/cloud/azure"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	"github.com/cockroachdb/cockroach/pkg/util/fault"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
-// TestBackupRestore_FlakyStorage tests backup and restore operations with flaky storage enabled.
-// It creates a table with rows, performs backups with retries,
-// drops the table, performs restore with retries,
-// and verifies the restored data matches the original.
-func TestBackupRestore_FlakyStorage(t *testing.T) {
+// TestCloudBackupRestore_FlakyStorage tests backup and restore operations with
+// flaky storage enabled. It creates a table with rows, performs backups with
+// retries, drops the table, performs restore with retries, and verifies the
+// restored data matches the original.
+func TestCloudBackupRestore_FlakyStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -59,40 +66,201 @@ func TestBackupRestore_FlakyStorage(t *testing.T) {
 
 	sql := sqlutils.MakeSQLRunner(tc.Conns[0])
 
-	nextRow := 1
-	writeRows := func(t *testing.T, sql *sqlutils.SQLRunner) {
-		for i := 0; i < 10; i++ {
-			sql.Exec(t, fmt.Sprintf(`INSERT INTO testdb.test_table VALUES (%d, 'row_%d', %d)`, nextRow, nextRow, nextRow*10))
-			nextRow++
-		}
+	backupStores := []backupStoreURI{
+		nodelocalBackupStoreURI{},
+		gcpBackupStoreURI{},
+		s3BackupStoreURI{},
+		azureBackupStoreURI{},
 	}
 
-	sql.Exec(t, `CREATE DATABASE testdb`)
-	sql.Exec(t, `CREATE TABLE testdb.test_table (id INT PRIMARY KEY, name STRING, value INT)`)
+	for _, store := range backupStores {
+		t.Run(fmt.Sprintf("cloud=%s", store.Cloud()), func(t *testing.T) {
+			if !store.Available(t) {
+				skip.IgnoreLintf(
+					t, "backup store URI for cloud %s is not available, skipping tests with this store", store.Cloud(),
+				)
+			}
+			uri := store.URI(t, sql)
+			backupURI := uri.String()
+			t.Logf("using backup store URI: %s", backupURI)
 
-	writeRows(t, sql)
-	testutils.SucceedsSoon(t, func() error {
-		_, err := sqlDB.DB.ExecContext(ctx, `BACKUP TABLE testdb.test_table INTO 'nodelocal://1/backup'`)
-		return err
-	})
+			nextRow := 1
+			writeRows := func(t *testing.T, sql *sqlutils.SQLRunner) {
+				for i := 0; i < 10; i++ {
+					sql.Exec(t, fmt.Sprintf(`INSERT INTO testdb.test_table VALUES (%d, 'row_%d', %d)`, nextRow, nextRow, nextRow*10))
+					nextRow++
+				}
+			}
 
-	for i := 0; i < 10; i++ {
-		writeRows(t, sql)
-		testutils.SucceedsSoon(t, func() error {
-			_, err := sqlDB.DB.ExecContext(ctx, `BACKUP TABLE testdb.test_table INTO LATEST IN 'nodelocal://1/backup'`)
-			return err
+			sql.Exec(t, `CREATE DATABASE testdb`)
+			defer sql.Exec(t, `DROP DATABASE IF EXISTS testdb CASCADE`)
+			sql.Exec(t, `CREATE TABLE testdb.test_table (id INT PRIMARY KEY, name STRING, value INT)`)
+
+			writeRows(t, sql)
+			testutils.SucceedsSoon(t, func() error {
+				_, err := sqlDB.DB.ExecContext(ctx, `BACKUP TABLE testdb.test_table INTO $1`, backupURI)
+				return err
+			})
+
+			for i := 0; i < 10; i++ {
+				writeRows(t, sql)
+				testutils.SucceedsSoon(t, func() error {
+					_, err := sqlDB.DB.ExecContext(
+						ctx, `BACKUP TABLE testdb.test_table INTO LATEST IN $1`, backupURI,
+					)
+					return err
+				})
+			}
+
+			originalFingerprint := sql.QueryStr(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE testdb.test_table`)
+
+			sqlDB.Exec(t, `DROP TABLE testdb.test_table`)
+
+			testutils.SucceedsSoon(t, func() error {
+				_, err := sqlDB.DB.ExecContext(
+					ctx, `RESTORE TABLE testdb.test_table FROM LATEST IN $1`, backupURI,
+				)
+				return err
+			})
+
+			restoredFingerprint := sqlDB.QueryStr(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE testdb.test_table`)
+			require.Equal(t, originalFingerprint, restoredFingerprint, "fingerprints should match")
 		})
 	}
+}
 
-	originalFingerprint := sql.QueryStr(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE testdb.test_table`)
+type backupStoreURI interface {
+	// Cloud returns the cloud provider associated with this backup store URI.
+	Cloud() string
+	// Available returns true if the backup store URI is available for testing.
+	Available(t *testing.T) bool
+	// URI returns the backup store URI to be used in backup and restore operations.
+	URI(t *testing.T, db *sqlutils.SQLRunner) url.URL
+}
 
-	sqlDB.Exec(t, `DROP TABLE testdb.test_table`)
+type gcpBackupStoreURI struct{}
 
-	testutils.SucceedsSoon(t, func() error {
-		_, err := sqlDB.DB.ExecContext(ctx, `RESTORE TABLE testdb.test_table FROM LATEST IN 'nodelocal://1/backup'`)
-		return err
-	})
+func (g gcpBackupStoreURI) Cloud() string {
+	return "gcp"
+}
 
-	restoredFingerprint := sqlDB.QueryStr(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE testdb.test_table`)
-	require.Equal(t, originalFingerprint, restoredFingerprint, "Fingerprints should match")
+func (g gcpBackupStoreURI) Available(_ *testing.T) bool {
+	return os.Getenv("GOOGLE_BUCKET") != ""
+}
+
+func (g gcpBackupStoreURI) URI(t *testing.T, _ *sqlutils.SQLRunner) url.URL {
+	bucket := os.Getenv("GOOGLE_BUCKET")
+	require.NotEmpty(t, bucket, "GOOGLE_BUCKET environment variable must be set for GCP backup store URI")
+	uri := url.URL{Scheme: "gs", Host: bucket, Path: generateBucketPath(t)}
+	values := uri.Query()
+	values.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+	uri.RawQuery = values.Encode()
+	return uri
+}
+
+type s3BackupStoreURI struct{}
+
+func (s s3BackupStoreURI) Cloud() string {
+	return "aws"
+}
+
+func (s s3BackupStoreURI) Available(t *testing.T) bool {
+	t.Helper()
+	envConfig, err := config.NewEnvConfig()
+	require.NoError(t, err, "failed to load AWS credentials from environment")
+	if !envConfig.Credentials.HasKeys() {
+		return false
+	}
+	return os.Getenv("AWS_BUCKET") != ""
+}
+
+func (s s3BackupStoreURI) URI(t *testing.T, db *sqlutils.SQLRunner) url.URL {
+	t.Helper()
+	envConfig, err := config.NewEnvConfig()
+	require.NoError(t, err, "failed to load AWS credentials from environment")
+	require.True(t, envConfig.Credentials.HasKeys(), "AWS credentials must be set in environment for S3 backup store URI")
+	bucket := os.Getenv("AWS_BUCKET")
+	require.NotEmpty(t, bucket, "AWS_BUCKET environment variable must be set for S3 backup store URI")
+
+	endpoint := os.Getenv(amazon.NightlyEnvVarS3Params[amazon.AWSEndpointParam])
+	customCACert := os.Getenv("AWS_CUSTOM_CA_CERT")
+	region := os.Getenv(amazon.NightlyEnvVarS3Params[amazon.S3RegionParam])
+	if customCACert != "" {
+		db.Exec(t, fmt.Sprintf("SET CLUSTER SETTING cloudstorage.http.custom_ca='%s'", customCACert))
+	}
+
+	uri := url.URL{Scheme: "s3", Host: bucket, Path: generateBucketPath(t)}
+	values := uri.Query()
+	values.Add(amazon.AWSAccessKeyParam, envConfig.Credentials.AccessKeyID)
+	values.Add(amazon.AWSSecretParam, envConfig.Credentials.SecretAccessKey)
+	if endpoint != "" {
+		values.Add(amazon.AWSEndpointParam, endpoint)
+	}
+	if region != "" {
+		values.Add(amazon.S3RegionParam, region)
+	}
+	uri.RawQuery = values.Encode()
+	return uri
+}
+
+type azureBackupStoreURI struct{}
+
+func (a azureBackupStoreURI) Cloud() string {
+	return "azure"
+}
+
+func (a azureBackupStoreURI) Available(_ *testing.T) bool {
+	return os.Getenv("AZURE_ACCOUNT_NAME") != "" &&
+		os.Getenv("AZURE_CONTAINER") != "" &&
+		os.Getenv("AZURE_CLIENT_ID") != "" &&
+		os.Getenv("AZURE_CLIENT_SECRET") != "" &&
+		os.Getenv("AZURE_TENANT_ID") != "" &&
+		os.Getenv("AZURE_VAULT_NAME") != ""
+}
+
+func (a azureBackupStoreURI) URI(t *testing.T, _ *sqlutils.SQLRunner) url.URL {
+	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
+	container := os.Getenv("AZURE_CONTAINER")
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+
+	require.NotEmpty(t, accountName, "AZURE_ACCOUNT_NAME environment variable must be set for Azure backup store URI")
+	require.NotEmpty(t, container, "AZURE_CONTAINER environment variable must be set for Azure backup store URI")
+	require.NotEmpty(t, clientID, "AZURE_CLIENT_ID environment variable must be set for Azure backup store URI")
+	require.NotEmpty(t, clientSecret, "AZURE_CLIENT_SECRET environment variable must be set for Azure backup store URI")
+	require.NotEmpty(t, tenantID, "AZURE_TENANT_ID environment variable must be set for Azure backup store URI")
+
+	uri := url.URL{Scheme: "azure", Host: container, Path: generateBucketPath(t)}
+	values := uri.Query()
+	values.Add(azure.AzureAccountNameParam, accountName)
+	values.Add(azure.AzureClientIDParam, clientID)
+	values.Add(azure.AzureClientSecretParam, clientSecret)
+	values.Add(azure.AzureTenantIDParam, tenantID)
+	uri.RawQuery = values.Encode()
+	return uri
+}
+
+type nodelocalBackupStoreURI struct{}
+
+func (n nodelocalBackupStoreURI) Cloud() string {
+	return "nodelocal"
+}
+
+func (n nodelocalBackupStoreURI) Available(_ *testing.T) bool {
+	return true
+}
+
+func (n nodelocalBackupStoreURI) URI(t *testing.T, _ *sqlutils.SQLRunner) url.URL {
+	t.Helper()
+	uri := url.URL{Scheme: "nodelocal", Host: "1", Path: generateBucketPath(t)}
+	return uri
+}
+
+func generateBucketPath(t *testing.T) string {
+	return fmt.Sprintf(
+		"%s-%d",
+		url.PathEscape(t.Name()),
+		timeutil.Now().UnixNano(),
+	)
 }

--- a/pkg/backup/restore_span_covering.go
+++ b/pkg/backup/restore_span_covering.go
@@ -513,8 +513,13 @@ func newFileSpanStartKeyIterator(
 	ctx context.Context,
 	backups []backuppb.BackupManifest,
 	layerToBackupManifestFileIterFactory backupinfo.LayerToBackupManifestFileIterFactory,
-) (*fileSpanStartKeyIterator, error) {
+) (_ *fileSpanStartKeyIterator, err error) {
 	it := &fileSpanStartKeyIterator{}
+	defer func() {
+		if err != nil {
+			it.Close()
+		}
+	}()
 	for layer := range backups {
 		iter, err := layerToBackupManifestFileIterFactory[layer].NewFileIter(ctx)
 		if err != nil {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -673,6 +673,7 @@ func TestLint(t *testing.T) {
 					":!build/bazel",
 					":!ccl/acceptanceccl/backup_test.go",
 					":!backup/backup_cloud_test.go",
+					":!backup/flaky_storage_test.go",
 					// KMS requires AWS credentials from environment variables.
 					":!backup/backup_test.go",
 					":!ccl/changefeedccl/helpers_test.go",


### PR DESCRIPTION
This commit teaches our `TestBackupRestore_FlakyStorage` to also test failure injection on our Cloud stores. The test is renamed to `TestCloudBackupRestore_FlakyStorage` so that it is picked up by our cloud unit test suite.

Epic: None

Release note: None