### PR TITLE
sql/export,util/parquet: use shared ValidateDatum in parquet export test

### DIFF
--- a/pkg/sql/export/exportparquet_test.go
+++ b/pkg/sql/export/exportparquet_test.go
@@ -114,59 +114,11 @@ func validateParquetFile(
 			return fmt.Errorf("reading record failed: %w", err)
 		}
 		for j := 0; j < len(test.cols); j++ {
-			// If we're encoding a DOidWrapper, then we want to cast the wrapped
-			// datum. Note that we don't use eval.UnwrapDatum since we're not
-			// interested in evaluating the placeholders.
-			// TODO(#104278): use ValidateDatum from util/parquet.
-			validateDatum(t, tree.UnwrapDOidWrapper(test.datums[i][j]), tree.UnwrapDOidWrapper(row[j]), test.cols[j].Typ)
+			parquet.ValidateDatum(t, test.datums[i][j], row[j])
 		}
 		i++
 	}
 	return nil
-}
-
-func validateDatum(t *testing.T, expected tree.Datum, actual tree.Datum, typ *types.T) {
-	switch expected.ResolvedType().Family() {
-	case types.ArrayFamily:
-		eArr := expected.(*tree.DArray)
-		aArr := actual.(*tree.DArray)
-		for i := 0; i < eArr.Len(); i++ {
-			validateDatum(t, tree.UnwrapDOidWrapper(eArr.Array[i]),
-				tree.UnwrapDOidWrapper(aArr.Array[i]), typ.ArrayContents())
-		}
-	case types.DateFamily:
-		// pgDate.orig property doesn't matter and can cause the test to fail
-		require.Equal(t, expected.(*tree.DDate).Date.UnixEpochDays(),
-			actual.(*tree.DDate).Date.UnixEpochDays())
-	case types.JsonFamily:
-		// Only the value of the json object matters, not that additional properties
-		require.Equal(t, expected.(*tree.DJSON).JSON.String(),
-			actual.(*tree.DJSON).JSON.String())
-	case types.EnumFamily:
-		// Only the value of the enum string matters, not that additional properties
-		require.Equal(t, expected.(*tree.DEnum).LogicalRep,
-			actual.(*tree.DEnum).LogicalRep)
-	case types.CollatedStringFamily:
-		// Only the value of the collated string matters, not that additional properties
-		require.Equal(t, expected.(*tree.DCollatedString).Contents,
-			actual.(*tree.DCollatedString).Contents)
-	case types.FloatFamily:
-		if typ.Equal(types.Float4) && expected.(*tree.DFloat).String() != "NaN" {
-			// CRDB currently doesn't truncate non NAN float4's correctly, so this
-			// test does it manually :(
-			// https://github.com/cockroachdb/cockroach/issues/73743
-			e := float32(*expected.(*tree.DFloat))
-			a := float32(*expected.(*tree.DFloat))
-			require.Equal(t, e, a)
-		} else {
-			require.Equal(t, expected.String(), actual.String())
-		}
-	case types.DecimalFamily:
-		require.Equal(t, expected.String(), actual.String())
-
-	default:
-		require.Equal(t, expected, actual)
-	}
 }
 
 func TestRandomParquetExports(t *testing.T) {

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -393,7 +393,7 @@ func ValidateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 			// test does it manually :(
 			// https://github.com/cockroachdb/cockroach/issues/73743
 			e := float32(*expected.(*tree.DFloat))
-			a := float32(*expected.(*tree.DFloat))
+			a := float32(*actual.(*tree.DFloat))
 			require.Equal(t, e, a)
 		} else {
 			require.Equal(t, expected.String(), actual.String())
@@ -427,6 +427,8 @@ func ValidateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 		require.Equal(t, expected.String(), actual.String())
 	case types.OidFamily:
 		require.Equal(t, expected.(*tree.DOid).Oid, actual.(*tree.DOid).Oid)
+	case types.DecimalFamily:
+		require.Equal(t, expected.String(), actual.String())
 	default:
 		require.Equal(t, expected, actual)
 	}


### PR DESCRIPTION
Replace the local `validateDatum` function in `exportparquet_test.go` with the shared `parquet.ValidateDatum` from `util/parquet/testutils.go`. The local copy was missing a `types.BitFamily` case, causing `TestRandomParquetExports` to fail on `BIT(0)` columns due to a nil vs empty slice mismatch in `bitarray.BitArray.words`. PR #164308 fixed the shared function but never updated the local copy.

Also add a `types.DecimalFamily` case to the shared `ValidateDatum`. The local function had this case (comparing via `.String()`) but the shared function did not, causing deep equality failures on `DDecimal` values due to internal `big.Int` pointer differences.

Resolves: #167507

Release note: None