### PR TITLE
sql/catalog: address panic inside maybeReleaseReadTimestamp

### DIFF
--- a/pkg/sql/catalog/descs/leased_descriptors.go
+++ b/pkg/sql/catalog/descs/leased_descriptors.go
@@ -297,14 +297,17 @@ func (ld *leasedDescriptors) maybeInitReadTimestamp(ctx context.Context, txn dea
 		return ld.maybeAdvanceReadTimestamp(ctx, txn)
 	}
 	readTimestamp := txn.ReadTimestamp()
-	ld.leaseTimestampSet = true
+	setTimestamp := func(ts lease.ReadTimestamp) {
+		ld.leaseTimestamp = ts
+		ld.leaseTimestampSet = true
+	}
 	// Fixed timestamp queries will use descriptors at the user-selected timestamp.
 	if txn.ReadTimestampFixed() {
-		ld.leaseTimestamp = lease.TimestampToReadTimestamp(readTimestamp)
+		setTimestamp(lease.TimestampToReadTimestamp(readTimestamp))
 		return nil
 	}
 	// Otherwise, get a safe read timestamp from the lease manager.
-	ld.leaseTimestamp = ld.lm.GetReadTimestamp(ctx, readTimestamp)
+	setTimestamp(ld.lm.GetReadTimestamp(ctx, readTimestamp))
 	return nil
 }
 


### PR DESCRIPTION
This prevents a nil pointer dereference in maybeReleaseReadTimestamp if a panic occurs during maybeInitReadTimestamp before the timestamp is successfully retrieved and assigned.

Fixes: #167895
Release note: None