### PR TITLE
sql/sem/tree: quote reserved keywords in index names after '@'

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -527,9 +527,9 @@ func TestTenantStartupWithMultiRegionEnum(t *testing.T) {
 
 	// Validate that the zone configuration contains the appropriate constraints.q
 	tenSQLDB.CheckQueryResults(t, "SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE target LIKE 'PARTITION %lease%' ORDER BY target;", [][]string{
-		{"ALTER PARTITION \"us-east1\" OF INDEX system.public.lease@primary CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east1]',\n\tlease_preferences = '[[+region=us-east1]]'"},
-		{"ALTER PARTITION \"us-east2\" OF INDEX system.public.lease@primary CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east2]',\n\tlease_preferences = '[[+region=us-east2]]'"},
-		{"ALTER PARTITION \"us-east3\" OF INDEX system.public.lease@primary CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east3]',\n\tlease_preferences = '[[+region=us-east3]]'"},
+		{"ALTER PARTITION \"us-east1\" OF INDEX system.public.lease@\"primary\" CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east1]',\n\tlease_preferences = '[[+region=us-east1]]'"},
+		{"ALTER PARTITION \"us-east2\" OF INDEX system.public.lease@\"primary\" CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east2]',\n\tlease_preferences = '[[+region=us-east2]]'"},
+		{"ALTER PARTITION \"us-east3\" OF INDEX system.public.lease@\"primary\" CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east3]',\n\tlease_preferences = '[[+region=us-east3]]'"},
 	})
 }
 
@@ -601,9 +601,9 @@ func TestMrSystemDatabaseUpgrade(t *testing.T) {
 		{"CREATE DATABASE system PRIMARY REGION \"us-east1\" REGIONS = \"us-east1\", \"us-east2\", \"us-east3\" SURVIVE REGION FAILURE"},
 	})
 	tDB.CheckQueryResults(t, "SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATIONS] WHERE target LIKE 'PARTITION %lease%' ORDER BY target;", [][]string{
-		{"ALTER PARTITION \"us-east1\" OF INDEX system.public.lease@primary CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east1]',\n\tlease_preferences = '[[+region=us-east1]]'"},
-		{"ALTER PARTITION \"us-east2\" OF INDEX system.public.lease@primary CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east2]',\n\tlease_preferences = '[[+region=us-east2]]'"},
-		{"ALTER PARTITION \"us-east3\" OF INDEX system.public.lease@primary CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east3]',\n\tlease_preferences = '[[+region=us-east3]]'"},
+		{"ALTER PARTITION \"us-east1\" OF INDEX system.public.lease@\"primary\" CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east1]',\n\tlease_preferences = '[[+region=us-east1]]'"},
+		{"ALTER PARTITION \"us-east2\" OF INDEX system.public.lease@\"primary\" CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east2]',\n\tlease_preferences = '[[+region=us-east2]]'"},
+		{"ALTER PARTITION \"us-east3\" OF INDEX system.public.lease@\"primary\" CONFIGURE ZONE USING\n\tnum_voters = 3,\n\tvoter_constraints = '[+region=us-east3]',\n\tlease_preferences = '[[+region=us-east3]]'"},
 	})
 }
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -1245,7 +1245,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		checkBundle(
 			t, fmt.Sprint(rows), "table161829", func(name, contents string) error {
 				if name == "schema.sql" {
-					reg := regexp.MustCompile(`crdb_rewrite_inline_hints\(.*\@primary.*\n.*crdb_rewrite_inline_hints.*\@xy161829.*\n.*crdb_rewrite_inline_hints.*\@y161829`)
+					reg := regexp.MustCompile(`crdb_rewrite_inline_hints\(.*\@"primary".*\n.*crdb_rewrite_inline_hints.*\@xy161829.*\n.*crdb_rewrite_inline_hints.*\@y161829`)
 					if reg.FindString(contents) == "" {
 						return errors.Errorf("could not find full crdb_rewrite_inline_hints in schema.sql")
 					}
@@ -1260,7 +1260,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		checkBundle(
 			t, fmt.Sprint(rows), "table161829", func(name, contents string) error {
 				if name == "schema.sql" {
-					reg := regexp.MustCompile(`crdb_rewrite_inline_hints\(.*\@primary.*\n.*crdb_rewrite_inline_hints.*\@xy161829.*\n.*crdb_rewrite_inline_hints.*\@y161829`)
+					reg := regexp.MustCompile(`crdb_rewrite_inline_hints\(.*\@"primary".*\n.*crdb_rewrite_inline_hints.*\@xy161829.*\n.*crdb_rewrite_inline_hints.*\@y161829`)
 					if reg.FindString(contents) == "" {
 						return errors.Errorf("could not find full crdb_rewrite_inline_hints in schema.sql")
 					}

--- a/pkg/sql/logictest/testdata/logic_test/show_statement_hints
+++ b/pkg/sql/logictest/testdata/logic_test/show_statement_hints
@@ -142,7 +142,7 @@ FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10' WITH DETAILS]
 ORDER BY created_at DESC, row_id DESC;
 ----
 fingerprint                   hint_type             details
-SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM xy@primary WHERE y = _"}
+SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM xy@\"primary\" WHERE y = _"}
 SELECT * FROM xy WHERE y = _  REWRITE INLINE HINTS  {"donorSql": "SELECT * FROM xy@xy_y_idx WHERE y = _"}
 
 # Test that SHOW STATEMENT HINTS works inside a SELECT

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -108,7 +108,7 @@ FROM system.eventlog
 WHERE "eventType" = 'rewrite_inline_hints'
 ORDER BY "timestamp"
 ----
-1  SELECT * FROM xy WHERE y = _                   SELECT * FROM xy@primary WHERE y = _
+1  SELECT * FROM xy WHERE y = _                   SELECT * FROM xy@"primary" WHERE y = _
 1  SELECT * FROM xy WHERE y = _                   SELECT * FROM xy@xy_y_idx WHERE y = _
 1  SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b  SELECT * FROM xy INNER JOIN ab ON xy.x = ab.b
 
@@ -399,7 +399,7 @@ SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', h
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
-SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@"primary" WHERE y = _
 SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_yx WHERE y = _
 SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_y WHERE y = _
 
@@ -409,7 +409,6 @@ SELECT information_schema.crdb_delete_statement_hints(row_id)
 FROM [SHOW STATEMENT HINTS FOR 'SELECT * FROM xy WHERE y = 10' WITH DETAILS]
 WHERE details->>'donorSql' LIKE '%xy@primary%';
 ----
-1
 
 query TTT
 SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', hint)->'injectHints'->>'donorSql' AS donor_sql FROM system.statement_hints ORDER BY "created_at";
@@ -417,6 +416,7 @@ SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', h
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@"primary" WHERE y = _
 SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_yx WHERE y = _
 SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_y WHERE y = _
 
@@ -459,7 +459,7 @@ SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', h
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
-SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@"primary" WHERE y = _
 SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_yx WHERE y = _
 SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@xy_y WHERE y = _
 
@@ -507,8 +507,8 @@ SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', h
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
-SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
-SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@primary WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@"primary" WHERE y = _
+SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@"primary" WHERE y = _
 
 statement ok
 SAVEPOINT s1
@@ -522,7 +522,7 @@ SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', h
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
-SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@primary WHERE y = _
+SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@"primary" WHERE y = _
 
 statement ok
 ROLLBACK TO s1
@@ -533,8 +533,8 @@ SELECT fingerprint, '|', crdb_internal.pb_to_json('hintpb.StatementHintUnion', h
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT a FROM ab WHERE b = _  |  SELECT a FROM ab WHERE b = _
 SELECT b FROM ab WHERE a = _  |  SELECT b FROM ab WHERE a = _
-SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@primary WHERE y = _
-SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@primary WHERE y = _
+SELECT * FROM xy WHERE y = _  |  SELECT * FROM xy@"primary" WHERE y = _
+SELECT x FROM xy WHERE y = _  |  SELECT x FROM xy@"primary" WHERE y = _
 
 statement ok
 ROLLBACK

--- a/pkg/sql/parser/testdata/alter_index
+++ b/pkg/sql/parser/testdata/alter_index
@@ -25,9 +25,9 @@ ALTER INDEX _@_ RENAME TO _ -- identifiers removed
 parse
 ALTER INDEX a@primary RENAME TO like
 ----
-ALTER INDEX a@primary RENAME TO like
-ALTER INDEX a@primary RENAME TO like -- fully parenthesized
-ALTER INDEX a@primary RENAME TO like -- literals removed
+ALTER INDEX a@"primary" RENAME TO like -- normalized!
+ALTER INDEX a@"primary" RENAME TO like -- fully parenthesized
+ALTER INDEX a@"primary" RENAME TO like -- literals removed
 ALTER INDEX _@_ RENAME TO _ -- identifiers removed
 
 parse
@@ -49,9 +49,9 @@ ALTER INDEX IF EXISTS _@_ RENAME TO _ -- identifiers removed
 parse
 ALTER INDEX IF EXISTS a@primary RENAME TO like
 ----
-ALTER INDEX IF EXISTS a@primary RENAME TO like
-ALTER INDEX IF EXISTS a@primary RENAME TO like -- fully parenthesized
-ALTER INDEX IF EXISTS a@primary RENAME TO like -- literals removed
+ALTER INDEX IF EXISTS a@"primary" RENAME TO like -- normalized!
+ALTER INDEX IF EXISTS a@"primary" RENAME TO like -- fully parenthesized
+ALTER INDEX IF EXISTS a@"primary" RENAME TO like -- literals removed
 ALTER INDEX IF EXISTS _@_ RENAME TO _ -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/hints
+++ b/pkg/sql/parser/testdata/hints
@@ -9,17 +9,83 @@ SELECT 'a' FROM _@_ -- identifiers removed
 parse
 SELECT 'a' FROM t@primary
 ----
-SELECT 'a' FROM t@primary
-SELECT ('a') FROM t@primary -- fully parenthesized
-SELECT '_' FROM t@primary -- literals removed
+SELECT 'a' FROM t@"primary" -- normalized!
+SELECT ('a') FROM t@"primary" -- fully parenthesized
+SELECT '_' FROM t@"primary" -- literals removed
 SELECT 'a' FROM _@_ -- identifiers removed
 
 parse
 SELECT 'a' FROM t@like
 ----
-SELECT 'a' FROM t@like
-SELECT ('a') FROM t@like -- fully parenthesized
-SELECT '_' FROM t@like -- literals removed
+SELECT 'a' FROM t@"like" -- normalized!
+SELECT ('a') FROM t@"like" -- fully parenthesized
+SELECT '_' FROM t@"like" -- literals removed
+SELECT 'a' FROM _@_ -- identifiers removed
+
+# Regression tests for #165400: reserved keywords used as index names after '@'
+# must be quoted to ensure parse-format-reparse roundtrips succeed.
+#
+# The original failure was a COPY wrapping an UPSERT with an index hint whose
+# name was the reserved keyword FOR:
+#
+#   COPY ( UPSERT INTO ident @ FOR * TABLE error ORDER BY ... ) TO STDOUT ...
+#
+# The parser accepted this because opt_descendant ('*') separated FOR from the
+# next token TABLE. But the formatter dropped '*' (parsed but not stored in the
+# AST) and output the index name unquoted as '@for'. On re-parse, without the
+# '*' separator, the LALR parser hit a conflict at 'FOR TABLE' and failed.
+#
+# The fix quotes reserved keywords used as index names after '@', making the
+# formatted output safe to re-parse regardless of surrounding context.
+
+# Reduced reproducer from #165400: the original failing statement.
+parse
+COPY ( UPSERT INTO ident @ FOR * TABLE error ORDER BY INDEX_AFTER_ORDER_BY_BEFORE_AT INDEX_AFTER_ORDER_BY_BEFORE_AT @ INTERVAL DESC RETURNING NOTHING_AFTER_RETURNING ) TO STDOUT WITH ( ESCAPE 'string' )
+----
+COPY (UPSERT INTO ident@"for" TABLE error ORDER BY INDEX "index_after_order_by_before_at"@"interval" DESC RETURNING NOTHING) TO STDOUT WITH (ESCAPE 'string') -- normalized!
+COPY (UPSERT INTO ident@"for" TABLE error ORDER BY INDEX "index_after_order_by_before_at"@"interval" DESC RETURNING NOTHING) TO STDOUT WITH (ESCAPE ('string')) -- fully parenthesized
+COPY (UPSERT INTO ident@"for" TABLE error ORDER BY INDEX "index_after_order_by_before_at"@"interval" DESC RETURNING NOTHING) TO STDOUT WITH (ESCAPE '_') -- literals removed
+COPY (UPSERT INTO _@_ TABLE _ ORDER BY INDEX _@_ DESC RETURNING NOTHING) TO STDOUT WITH (ESCAPE 'string') -- identifiers removed
+
+# Test that unquoted reserved keywords parse as index names after '@'.
+parse
+SELECT 'a' FROM t@for
+----
+SELECT 'a' FROM t@"for" -- normalized!
+SELECT ('a') FROM t@"for" -- fully parenthesized
+SELECT '_' FROM t@"for" -- literals removed
+SELECT 'a' FROM _@_ -- identifiers removed
+
+parse
+SELECT 'a' FROM t@"for"
+----
+SELECT 'a' FROM t@"for"
+SELECT ('a') FROM t@"for" -- fully parenthesized
+SELECT '_' FROM t@"for" -- literals removed
+SELECT 'a' FROM _@_ -- identifiers removed
+
+parse
+SELECT 'a' FROM t@"select"
+----
+SELECT 'a' FROM t@"select"
+SELECT ('a') FROM t@"select" -- fully parenthesized
+SELECT '_' FROM t@"select" -- literals removed
+SELECT 'a' FROM _@_ -- identifiers removed
+
+parse
+SELECT 'a' FROM t@"table"
+----
+SELECT 'a' FROM t@"table"
+SELECT ('a') FROM t@"table" -- fully parenthesized
+SELECT '_' FROM t@"table" -- literals removed
+SELECT 'a' FROM _@_ -- identifiers removed
+
+parse
+SELECT 'a' FROM t@"from"
+----
+SELECT 'a' FROM t@"from"
+SELECT ('a') FROM t@"from" -- fully parenthesized
+SELECT '_' FROM t@"from" -- literals removed
 SELECT 'a' FROM _@_ -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -1381,17 +1381,17 @@ SELECT _ FROM _ ORDER BY INDEX _@_ DESC -- identifiers removed
 parse
 SELECT a FROM t ORDER BY INDEX t@primary
 ----
-SELECT a FROM t ORDER BY INDEX t@primary
-SELECT (a) FROM t ORDER BY INDEX t@primary -- fully parenthesized
-SELECT a FROM t ORDER BY INDEX t@primary -- literals removed
+SELECT a FROM t ORDER BY INDEX t@"primary" -- normalized!
+SELECT (a) FROM t ORDER BY INDEX t@"primary" -- fully parenthesized
+SELECT a FROM t ORDER BY INDEX t@"primary" -- literals removed
 SELECT _ FROM _ ORDER BY INDEX _@_ -- identifiers removed
 
 parse
 SELECT a FROM t ORDER BY INDEX t@like
 ----
-SELECT a FROM t ORDER BY INDEX t@like
-SELECT (a) FROM t ORDER BY INDEX t@like -- fully parenthesized
-SELECT a FROM t ORDER BY INDEX t@like -- literals removed
+SELECT a FROM t ORDER BY INDEX t@"like" -- normalized!
+SELECT (a) FROM t ORDER BY INDEX t@"like" -- fully parenthesized
+SELECT a FROM t ORDER BY INDEX t@"like" -- literals removed
 SELECT _ FROM _ ORDER BY INDEX _@_ -- identifiers removed
 
 parse

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -519,7 +519,10 @@ func (ih *IndexFlags) Format(ctx *FmtCtx) {
 	ctx.WriteByte('@')
 	if ih.IndexOnlyHint() {
 		if ih.Index != "" {
-			ctx.FormatNode(&ih.Index)
+			// Format as a restricted identifier so that reserved keywords are
+			// quoted. The parser has LALR conflicts that prevent reserved keywords
+			// from being accepted as unquoted index names after '@'.
+			ctx.FormatNode((*Name)(&ih.Index))
 		} else {
 			ctx.Printf("[%d]", ih.IndexID)
 		}
@@ -919,7 +922,10 @@ func (node *Order) Format(ctx *FmtCtx) {
 			ctx.WriteString("INDEX ")
 			ctx.FormatNode(&node.Table)
 			ctx.WriteByte('@')
-			ctx.FormatNode(&node.Index)
+			// Format as a restricted identifier so that reserved keywords are
+			// quoted. The parser has LALR conflicts that prevent reserved keywords
+			// from being accepted as unquoted index names after '@'.
+			ctx.FormatNode((*Name)(&node.Index))
 		}
 	}
 	if node.Direction != DefaultDirection {

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -140,7 +140,10 @@ func (n *TableIndexName) Format(ctx *FmtCtx) {
 		// The table is specified.
 		ctx.FormatNode(&n.Table)
 		ctx.WriteByte('@')
-		ctx.FormatNode(&n.Index)
+		// Format as a restricted identifier so that reserved keywords are
+		// quoted. The parser has LALR conflicts that prevent reserved keywords
+		// from being accepted as unquoted index names after '@'.
+		ctx.FormatNode((*Name)(&n.Index))
 		return
 	}
 


### PR DESCRIPTION
Fix a parse-format-reparse roundtrip bug. The formatter output reserved keywords as bare identifiers after '@' (e.g. `@for`), which could cause syntax errors on re-parse due to LALR conflicts.

The original failure involved `UPSERT INTO ident @ FOR * TABLE ...`: the parser accepted FOR as an index name because '\*' (opt_descendant) separated it from TABLE. But '\*' is not stored in the AST, so the formatter dropped it and output `ident@for TABLE ...`. Without the separator, the LALR parser hit a conflict at `FOR TABLE` and failed.

Format index names after '@' as restricted identifiers (Name instead of UnrestrictedName) so reserved keywords are quoted. This matches the existing approach in TableIndexName.Format() for the no-table case.

Fixes: #165400

Release note: None