### PR TITLE
sql: fix flaky TestRepeatableReadLogic_select_for_share_write_buffering

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_share
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share
@@ -53,7 +53,7 @@ UPDATE t SET a = 2 WHERE a = 1
 
 skipif config weak-iso-level-configs
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/1/0  Shared         Unreplicated  SERIALIZABLE     true     true
@@ -62,7 +62,7 @@ test           public       t           /Table/106/1/1/0  Shared         Unrepli
 
 onlyif config local-read-committed
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability  isolation_level  granted  contended
 test           public       t           /Table/106/1/1/0  Shared         Replicated  READ_COMMITTED   true     true
@@ -71,7 +71,7 @@ test           public       t           /Table/106/1/1/0  Shared         Replica
 
 onlyif config local-repeatable-read
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability  isolation_level  granted  contended
 test           public       t           /Table/106/1/1/0  Shared         Replicated  REPEATABLE_READ  true     true
@@ -123,7 +123,7 @@ SELECT * FROM t WHERE a = 2 FOR SHARE
 user testuser2
 
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 
@@ -150,14 +150,14 @@ SET enable_shared_locking_for_serializable = true
 
 skipif config weak-iso-level-configs
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/2/0  Shared         Unreplicated  SERIALIZABLE     true     false
 
 onlyif config weak-iso-level-configs
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 
@@ -173,7 +173,7 @@ user root
 
 skipif config weak-iso-level-configs
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/2/0  Shared         Unreplicated  SERIALIZABLE     true     false
@@ -181,7 +181,7 @@ test           public       t           /Table/106/1/2/0  Shared         Unrepli
 
 onlyif config weak-iso-level-configs
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 

--- a/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share_write_buffering
@@ -64,14 +64,9 @@ SET kv_transaction_buffered_writes_enabled = true;
 statement async writeReq count 1
 UPDATE t SET a = 2 WHERE a = 1
 
-# Since we executed the stmt above asynchronously, we're likely to get a new
-# connection here, so we must set the session variable on it too.
-statement ok
-SET kv_transaction_buffered_writes_enabled = true;
-
 onlyif config local-read-committed
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/1/0  Shared         Unreplicated  READ_COMMITTED   true     true
@@ -80,7 +75,7 @@ test           public       t           /Table/106/1/1/0  Shared         Unrepli
 
 onlyif config local-repeatable-read
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/1/0  Shared         Unreplicated  REPEATABLE_READ  true     true
@@ -124,18 +119,24 @@ SELECT * FROM t WHERE a = 2 FOR SHARE
 ----
 2
 
-user testuser2
+# Use newsession to discard the extra pooled connection that the async
+# statement mechanism created earlier, ensuring BEGIN and the subsequent
+# FOR SHARE go to the same connection with write buffering enabled.
+user testuser2 newsession
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
 
 onlyif config local-read-committed
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/2/0  Shared         Unreplicated  READ_COMMITTED   true     false
 
 onlyif config local-repeatable-read
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/2/0  Shared         Unreplicated  REPEATABLE_READ  true     false
@@ -152,7 +153,7 @@ user root
 
 onlyif config local-read-committed
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/2/0  Shared         Unreplicated  READ_COMMITTED   true     false
@@ -160,7 +161,7 @@ test           public       t           /Table/106/1/2/0  Shared         Unrepli
 
 onlyif config local-repeatable-read
 query TTTTTTTBB colnames,retry,rowsort
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name = 'test'
 ----
 database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
 test           public       t           /Table/106/1/2/0  Shared         Unreplicated  REPEATABLE_READ  true     false
@@ -209,8 +210,10 @@ user root
 # 1: Shared
 # 2: None
 
-query I
-BEGIN;
+statement ok
+BEGIN
+
+query I retry
 SELECT * FROM t FOR UPDATE SKIP LOCKED
 ----
 2


### PR DESCRIPTION
The `statement async` mechanism creates a second connection in testuser2's database/sql pool. After `awaitstatement`, `BEGIN` and subsequent queries are separate pool operations that can land on different connections — one without `kv_transaction_buffered_writes_enabled` set, causing Replicated instead of Unreplicated lock durability.

Fix by using `user testuser2 newsession` to create a fresh single-connection pool before the critical section. Also filter cluster_locks queries to `database_name = 'test'` to avoid system table lock noise, and add `retry` to a `FOR UPDATE SKIP LOCKED` query that could see leftover locks.

Fixes: #167896

Release note: None