### PR TITLE
release-26.2: kvserverbase: add COCKROACH_DISABLE_MMA env var override

### DIFF
--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -44,7 +44,7 @@ const (
 type allocationBenchSpec struct {
 	nodes, cpus int
 	load        allocBenchLoad
-	lbrMode     string // see kvserverbase.LoadBasedRebalancingMode
+	lbrMode     string // see kvserverbase.GetLoadBasedRebalancingMode
 
 	startRecord time.Duration
 	samples     int

--- a/pkg/kv/followerreads/followerreads_test.go
+++ b/pkg/kv/followerreads/followerreads_test.go
@@ -840,7 +840,7 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 
 	// Further down, we'll set up the test to pin the lease to store 1. Turn off
 	// load based rebalancing to make sure it doesn't move.
-	kvserverbase.LoadBasedRebalancingMode.Override(ctx, &settings.SV, kvserverbase.LBRebalancingOff)
+	kvserverbase.OverrideLoadBasedRebalancingMode(ctx, &settings.SV, kvserverbase.LBRebalancingOff)
 
 	// NB: Tenants need capabilities to be able to relocate ranges.
 	if !tc.Server(0).DeploymentMode().IsSingleTenant() {

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2835,7 +2835,7 @@ func (t TransferLeaseDecision) String() string {
 // LBRebalancingMultiMetricOnly mode is active. To enable both multi-metric and
 // count-based rebalancing, use LBRebalancingMultiMetricAndCount mode instead.
 func (a *Allocator) CountBasedRebalancingDisabled() bool {
-	return kvserverbase.LoadBasedRebalancingMode.Get(&a.st.SV) == kvserverbase.LBRebalancingMultiMetricOnly
+	return kvserverbase.GetLoadBasedRebalancingMode(&a.st.SV) == kvserverbase.LBRebalancingMultiMetricOnly
 }
 
 // ShouldTransferLease returns true if the specified store is overfull in terms

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1469,7 +1469,7 @@ func (s *state) RegisterConfigChangeListener(listener ConfigChangeListener) {
 func (s *state) SetClusterSetting(Key string, Value interface{}) {
 	switch Key {
 	case "LBRebalancingMode":
-		kvserverbase.LoadBasedRebalancingMode.Override(context.Background(), &s.settings.ST.SV, kvserverbase.LBRebalancingMode(Value.(int64)))
+		kvserverbase.OverrideLoadBasedRebalancingMode(context.Background(), &s.settings.ST.SV, kvserverbase.LBRebalancingMode(Value.(int64)))
 	case "LBRebalancingObjective":
 		kvserver.LoadBasedRebalancingObjective.Override(context.Background(), &s.settings.ST.SV, kvserver.LBRebalancingObjective(Value.(int64)))
 	default:

--- a/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
@@ -193,7 +193,7 @@ func (src *storeRebalancerControl) phasePrologue(
 			s, src.storeID,
 			kvserver.LoadBasedRebalancingObjective.Get(&src.settings.ST.SV).ToDimension(),
 		),
-		kvserverbase.LoadBasedRebalancingMode.Get(&src.settings.ST.SV),
+		kvserverbase.GetLoadBasedRebalancingMode(&src.settings.ST.SV),
 	)
 
 	if !src.sr.ShouldRebalanceStore(ctx, rctx) {

--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/debugutil",
+        "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -113,10 +113,10 @@ var MVCCGCQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
-// LoadBasedRebalancingMode controls whether range rebalancing takes
+// loadBasedRebalancingMode controls whether range rebalancing takes
 // additional variables such as write load and disk usage into account.
 // If disabled, rebalancing is done purely based on replica count.
-var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
+var loadBasedRebalancingMode = settings.RegisterEnumSetting(
 	settings.SystemOnly,
 	"kv.allocator.load_based_rebalancing",
 	"whether to rebalance based on the distribution of load across stores",
@@ -142,7 +142,7 @@ func GetLoadBasedRebalancingMode(sv *settings.Values) LBRebalancingMode {
 	if disableMMA {
 		return LBRebalancingOff
 	}
-	return LoadBasedRebalancingMode.Get(sv)
+	return loadBasedRebalancingMode.Get(sv)
 }
 
 // OverrideLoadBasedRebalancingMode overrides the load-based rebalancing
@@ -150,7 +150,7 @@ func GetLoadBasedRebalancingMode(sv *settings.Values) LBRebalancingMode {
 func OverrideLoadBasedRebalancingMode(
 	ctx context.Context, sv *settings.Values, mode LBRebalancingMode,
 ) {
-	LoadBasedRebalancingMode.Override(ctx, sv, mode)
+	loadBasedRebalancingMode.Override(ctx, sv, mode)
 }
 
 // LoadBasedRebalancingModeIsMMA returns true if the load-based rebalancing mode

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/redact"
 )
@@ -130,10 +131,32 @@ var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
 	settings.WithPublic,
 )
 
+// disableMMA is an emergency kill switch that forces the load-based
+// rebalancing mode to LBRebalancingOff regardless of the cluster setting.
+// Use when MMA causes crashes too frequent to change the setting.
+var disableMMA = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_MMA", false)
+
+// GetLoadBasedRebalancingMode returns the current load-based rebalancing
+// mode. If COCKROACH_DISABLE_MMA is set, it always returns LBRebalancingOff.
+func GetLoadBasedRebalancingMode(sv *settings.Values) LBRebalancingMode {
+	if disableMMA {
+		return LBRebalancingOff
+	}
+	return LoadBasedRebalancingMode.Get(sv)
+}
+
+// OverrideLoadBasedRebalancingMode overrides the load-based rebalancing
+// mode. Intended for use in tests.
+func OverrideLoadBasedRebalancingMode(
+	ctx context.Context, sv *settings.Values, mode LBRebalancingMode,
+) {
+	LoadBasedRebalancingMode.Override(ctx, sv, mode)
+}
+
 // LoadBasedRebalancingModeIsMMA returns true if the load-based rebalancing mode
 // uses the multi-metric store rebalancer.
 var LoadBasedRebalancingModeIsMMA = func(sv *settings.Values) bool {
-	mode := LoadBasedRebalancingMode.Get(sv)
+	mode := GetLoadBasedRebalancingMode(sv)
 	return mode == LBRebalancingMultiMetricOnly || mode == LBRebalancingMultiMetricAndCount
 }
 

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -131,18 +131,21 @@ var loadBasedRebalancingMode = settings.RegisterEnumSetting(
 	settings.WithPublic,
 )
 
-// disableMMA is an emergency kill switch that forces the load-based
-// rebalancing mode to LBRebalancingOff regardless of the cluster setting.
+// disableMMA is an emergency kill switch that prevents MMA modes from being
+// used. When set and the cluster setting is an MMA mode, the mode falls back
+// to LBRebalancingLeasesAndReplicas. Non-MMA modes are returned as-is.
 // Use when MMA causes crashes too frequent to change the setting.
 var disableMMA = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_MMA", false)
 
-// GetLoadBasedRebalancingMode returns the current load-based rebalancing
-// mode. If COCKROACH_DISABLE_MMA is set, it always returns LBRebalancingOff.
+// GetLoadBasedRebalancingMode returns the current load-based rebalancing mode.
+// If COCKROACH_DISABLE_MMA is set and the mode is an MMA mode, it falls back
+// to LBRebalancingLeasesAndReplicas.
 func GetLoadBasedRebalancingMode(sv *settings.Values) LBRebalancingMode {
-	if disableMMA {
-		return LBRebalancingOff
+	mode := loadBasedRebalancingMode.Get(sv)
+	if disableMMA && mode.IsMMA() {
+		return LBRebalancingLeasesAndReplicas
 	}
-	return loadBasedRebalancingMode.Get(sv)
+	return mode
 }
 
 // OverrideLoadBasedRebalancingMode overrides the load-based rebalancing
@@ -156,8 +159,7 @@ func OverrideLoadBasedRebalancingMode(
 // LoadBasedRebalancingModeIsMMA returns true if the load-based rebalancing mode
 // uses the multi-metric store rebalancer.
 var LoadBasedRebalancingModeIsMMA = func(sv *settings.Values) bool {
-	mode := GetLoadBasedRebalancingMode(sv)
-	return mode == LBRebalancingMultiMetricOnly || mode == LBRebalancingMultiMetricAndCount
+	return GetLoadBasedRebalancingMode(sv).IsMMA()
 }
 
 // LBRebalancingMode controls if and when we do store-level rebalancing
@@ -186,6 +188,11 @@ const (
 	// replica counts goal may be in conflict with the store-level load goal.
 	LBRebalancingMultiMetricAndCount
 )
+
+// IsMMA returns true if the mode uses the multi-metric store rebalancer.
+func (m LBRebalancingMode) IsMMA() bool {
+	return m == LBRebalancingMultiMetricOnly || m == LBRebalancingMultiMetricAndCount
+}
 
 func (m LBRebalancingMode) String() string {
 	return redact.StringWithoutMarkers(m)

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -73,7 +73,7 @@ func newMMAStoreRebalancer(
 func (m *mmaStoreRebalancer) run(ctx context.Context, stopper *stop.Stopper) {
 	timer := time.NewTicker(jitteredInterval(allocator.LoadBasedRebalanceInterval.Get(&m.st.SV)))
 	defer timer.Stop()
-	log.KvDistribution.Infof(ctx, "starting multi-metric store rebalancer with mode=%v", kvserverbase.LoadBasedRebalancingMode.Get(&m.st.SV))
+	log.KvDistribution.Infof(ctx, "starting multi-metric store rebalancer with mode=%v", kvserverbase.GetLoadBasedRebalancingMode(&m.st.SV))
 
 	for {
 		select {

--- a/pkg/kv/kvserver/mmaintegration/thrashing.go
+++ b/pkg/kv/kvserver/mmaintegration/thrashing.go
@@ -108,7 +108,7 @@ import (
 func (as *AllocatorSync) BuildMMARebalanceAdvisor(
 	existing roachpb.StoreID, cands []roachpb.StoreID,
 ) *mmaprototype.MMARebalanceAdvisor {
-	if kvserverbase.LoadBasedRebalancingMode.Get(&as.st.SV) != kvserverbase.LBRebalancingMultiMetricAndCount {
+	if kvserverbase.GetLoadBasedRebalancingMode(&as.st.SV) != kvserverbase.LBRebalancingMultiMetricAndCount {
 		return mmaprototype.NoopMMARebalanceAdvisor()
 	}
 	return as.mmaAllocator.BuildMMARebalanceAdvisor(existing, cands)

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -83,7 +83,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	for _, server := range tc.Servers {
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
-		kvserverbase.LoadBasedRebalancingMode.Override(ctx, &st.SV, kvserverbase.LBRebalancingOff)
+		kvserverbase.OverrideLoadBasedRebalancingMode(ctx, &st.SV, kvserverbase.LBRebalancingOff)
 	}
 
 	const newRanges = 10

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -168,7 +168,7 @@ func NewStoreRebalancer(
 			return !rq.store.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty()
 		},
 		disabled: func() bool {
-			mode := kvserverbase.LoadBasedRebalancingMode.Get(&st.SV)
+			mode := kvserverbase.GetLoadBasedRebalancingMode(&st.SV)
 			return mode == kvserverbase.LBRebalancingOff || kvserverbase.LoadBasedRebalancingModeIsMMA(&st.SV) ||
 				rq.store.cfg.TestingKnobs.DisableStoreRebalancer
 		},
@@ -214,9 +214,9 @@ type RebalanceContext struct {
 }
 
 // RebalanceMode returns the mode of the store rebalancer. See
-// kvserverbase.LoadBasedRebalancingMode.
+// kvserverbase.GetLoadBasedRebalancingMode.
 func (sr *StoreRebalancer) RebalanceMode() kvserverbase.LBRebalancingMode {
-	return kvserverbase.LoadBasedRebalancingMode.Get(&sr.st.SV)
+	return kvserverbase.GetLoadBasedRebalancingMode(&sr.st.SV)
 }
 
 // RebalanceDimension returns the dimension the store rebalancer is balancing.

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -58,7 +58,7 @@ func createTestClusterArgs(ctx context.Context, numReplicas, numVoters int32) ba
 	zoneCfg.NumVoters = proto.Int32(numVoters)
 
 	clusterSettings := cluster.MakeTestingClusterSettings()
-	kvserverbase.LoadBasedRebalancingMode.Override(ctx, &clusterSettings.SV, kvserverbase.LBRebalancingOff)
+	kvserverbase.OverrideLoadBasedRebalancingMode(ctx, &clusterSettings.SV, kvserverbase.LBRebalancingOff)
 	kvserverbase.MergeQueueEnabled.Override(ctx, &clusterSettings.SV, false)
 
 	// Set allocator intervals to scan faster to help with recovery from race


### PR DESCRIPTION
Backport 5/5 commits from #167897 on behalf of @tbg.

----

## Summary

- Add a `COCKROACH_DISABLE_MMA` environment variable that forces
  `kv.allocator.load_based_rebalancing` to `off`, regardless of the cluster
  setting value. This is an emergency kill switch for when MMA causes crashes
  too frequent to change the setting through normal means.
- Unexport the `LoadBasedRebalancingMode` setting variable so all access goes
  through `GetLoadBasedRebalancingMode`, preventing callers from bypassing the
  override.

Early commits are mechanical migrations of `.Get()` and `.Override()` call
sites; the last commit unexports the setting.

Epic: none

----

Release justification: low risk changes pre mortem AI