### PR TITLE
ts: combine KV reads across queries into a single batch

### DIFF
--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -356,6 +356,13 @@ func (db *DB) Metrics() *TimeSeriesMetrics {
 	return db.metrics
 }
 
+// runBatch executes a pre-built kv.Batch against the underlying kv.DB. This
+// lets Server run combined read batches without directly accessing the
+// unexported db field.
+func (db *DB) runBatch(ctx context.Context, b *kv.Batch) error {
+	return db.db.Run(ctx, b)
+}
+
 // WriteColumnar returns true if this DB should write data in the newer columnar
 // format.
 func (db *DB) WriteColumnar() bool {

--- a/pkg/ts/query.go
+++ b/pkg/ts/query.go
@@ -822,6 +822,157 @@ func aggregate(agg tspb.TimeSeriesQueryAggregator, values []float64) float64 {
 	panic(fmt.Sprintf("unknown aggregator option encountered: %v", agg))
 }
 
+// queryReadPlan tracks the location of a single query's KV operations within a
+// shared kv.Batch. Used by Server.Query to combine reads across queries.
+type queryReadPlan struct {
+	// opStart is the index of the first operation in the shared batch.
+	opStart int
+	// opCount is the number of operations added for this query.
+	opCount int
+	// isScan is true when the query reads all sources via a Scan (no explicit
+	// source list). When false, the operations are individual Gets.
+	isScan bool
+	// tenantID is recorded for post-read filtering of scan results.
+	tenantID roachpb.TenantID
+}
+
+// addQueryReadOps adds the KV read operations for a single query to the
+// provided shared batch. It returns a queryReadPlan describing where the
+// query's operations are located in the batch. The caller is responsible for
+// running the batch and extracting results using extractReadResults.
+//
+// The scan path mirrors readAllSourcesFromDatabase and the get path mirrors
+// readFromDatabase. Changes to key construction or tenant handling in those
+// methods must be reflected here and in extractReadResults.
+func (db *DB) addQueryReadOps(
+	b *kv.Batch,
+	query tspb.Query,
+	diskResolution Resolution,
+	timespan QueryTimespan,
+	interpolationLimitNanos int64,
+) queryReadPlan {
+	diskTimespan := timespan
+	diskTimespan.expand(interpolationLimitNanos)
+
+	plan := queryReadPlan{
+		opStart:  len(b.Results),
+		tenantID: query.TenantID,
+	}
+
+	if len(query.Sources) == 0 {
+		startKey := MakeDataKey(
+			query.Name, "" /* source */, diskResolution, diskTimespan.StartNanos,
+		)
+		endKey := MakeDataKey(
+			query.Name, "" /* source */, diskResolution, diskTimespan.EndNanos,
+		).PrefixEnd()
+		b.Scan(startKey, endKey)
+		plan.isScan = true
+	} else {
+		startTimestamp := diskResolution.normalizeToSlab(diskTimespan.StartNanos)
+		kd := diskResolution.SlabDuration()
+		for cursor := startTimestamp; cursor <= diskTimespan.EndNanos; cursor += kd {
+			for _, source := range query.Sources {
+				if query.TenantID.IsSet() && !query.TenantID.IsSystem() {
+					source = tsutil.MakeTenantSource(source, query.TenantID.String())
+				}
+				key := MakeDataKey(query.Name, source, diskResolution, cursor)
+				b.Get(key)
+			}
+		}
+	}
+
+	plan.opCount = len(b.Results) - plan.opStart
+	return plan
+}
+
+// extractReadResults extracts the KV rows belonging to a query from a
+// completed shared batch, using the plan returned by addQueryReadOps.
+func extractReadResults(b *kv.Batch, plan queryReadPlan) ([]kv.KeyValue, error) {
+	if plan.opStart+plan.opCount > len(b.Results) {
+		return nil, errors.AssertionFailedf(
+			"queryReadPlan references results [%d,%d) but batch has %d results",
+			plan.opStart, plan.opStart+plan.opCount, len(b.Results),
+		)
+	}
+	var rows []kv.KeyValue
+	for i := plan.opStart; i < plan.opStart+plan.opCount; i++ {
+		result := b.Results[i]
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		if plan.isScan {
+			// Scan: filter rows by tenant, same logic as readAllSourcesFromDatabase.
+			for _, row := range result.Rows {
+				_, source, _, _, err := DecodeDataKey(row.Key)
+				if err != nil {
+					return nil, err
+				}
+				_, tenantSource := tsutil.DecodeSource(source)
+				if !plan.tenantID.IsSet() || plan.tenantID.IsSystem() {
+					if tenantSource == "" {
+						rows = append(rows, row)
+					}
+				} else if tenantSource == plan.tenantID.String() {
+					rows = append(rows, row)
+				}
+			}
+		} else {
+			// Get: skip nil values (key not found).
+			if len(result.Rows) == 1 && result.Rows[0].Value == nil {
+				continue
+			}
+			rows = append(rows, result.Rows...)
+		}
+	}
+	return rows, nil
+}
+
+// processQueryData takes pre-read KV data for a single query and runs the
+// post-read processing pipeline: convertKeysToSpans, downsampling, and
+// aggregation. It mirrors the post-read logic in queryChunk but operates on
+// pre-fetched data so that multiple queries can share a single KV read.
+func (db *DB) processQueryData(
+	ctx context.Context,
+	data []kv.KeyValue,
+	query tspb.Query,
+	diskResolution Resolution,
+	timespan QueryTimespan,
+	mem QueryMemoryContext,
+) ([]tspb.TimeSeriesDatapoint, map[string]struct{}, error) {
+	acc := mem.workerMonitor.MakeBoundAccount()
+	defer acc.Close(ctx)
+
+	sourceSpans, err := convertKeysToSpans(ctx, data, &acc)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(sourceSpans) == 0 {
+		return nil, nil, nil
+	}
+
+	if timespan.SampleDurationNanos != diskResolution.SampleDuration() {
+		downsampleSpans(sourceSpans, timespan.SampleDurationNanos, query.GetDownsampler())
+		query.Downsampler = tspb.TimeSeriesQueryAggregator_SUM.Enum()
+	}
+
+	var result []tspb.TimeSeriesDatapoint
+	aggregateSpansToDatapoints(sourceSpans, query, timespan, mem.InterpolationLimitNanos, &result)
+	if len(result) > 0 {
+		if err := mem.resultAccount.Grow(ctx, sizeOfDataPoint*int64(cap(result))); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	sourceSet := make(map[string]struct{})
+	for k := range sourceSpans {
+		source, _ := tsutil.DecodeSource(k)
+		sourceSet[source] = struct{}{}
+	}
+
+	return result, sourceSet, nil
+}
+
 // readFromDatabase retrieves data for the given series name, at the given disk
 // resolution, across the supplied time span, for only the given list of
 // sources.

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tsutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -45,6 +46,14 @@ const (
 	// dumpBatchSize is the number of keys processed in each batch by the dump
 	// command.
 	dumpBatchSize = 100
+)
+
+var CombinedBatchEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"timeseries.query.combine_read_batches.enabled",
+	"if true, multiple time series queries in a single request share a "+
+		"combined KV batch to reduce RPC overhead",
+	true,
 )
 
 // ClusterNodeCountFn is a function that returns the number of nodes active on
@@ -260,6 +269,20 @@ func (s *Server) RegisterGateway(
 
 // Query is an endpoint that returns data for one or more metrics over a
 // specific time span.
+//
+// The implementation uses a two-phase approach to reduce RPC overhead:
+//
+// Phase 1 (combined read): Eligible queries' KV read operations are collected
+// into a single kv.Batch and executed with one db.Run() call. DistSender
+// splits the batch into per-range RPCs, so queries targeting the same time
+// series ranges share RPCs instead of each issuing independent ones.
+//
+// Phase 2 (parallel processing): The read results are distributed to per-query
+// goroutines for post-processing (key-to-span conversion, downsampling,
+// aggregation). This CPU-bound work benefits from parallelism.
+//
+// Queries that require memory-based chunking (timespan exceeds budget) fall
+// back to the original per-query read path via db.Query().
 func (s *Server) Query(
 	ctx context.Context, request *tspb.TimeSeriesQueryRequest,
 ) (*tspb.TimeSeriesQueryResponse, error) {
@@ -297,10 +320,6 @@ func (s *Server) Query(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Channel which workers use to report their result, which is either an
-	// error or nil (when successful).
-	workerOutput := make(chan error)
-
 	// Create a separate memory management context for each query, allowing them
 	// to be run in parallel.
 	memContexts := make([]QueryMemoryContext, len(request.Queries))
@@ -316,18 +335,110 @@ func (s *Server) Query(
 		SampleDurationNanos: sampleNanos,
 		NowNanos:            timeutil.Now().UnixNano(),
 	}
+	timespan.normalize()
 
+	if err := timespan.verifyBounds(); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
+	if err := timespan.verifyDiskResolution(Resolution10s); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
+	if err := timespan.adjustForCurrentTime(Resolution10s); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
+
+	// Validate all queries upfront.
+	for _, query := range request.Queries {
+		if err := verifySourceAggregator(query.GetSourceAggregator()); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+		}
+		if err := verifyDownsampler(query.GetDownsampler()); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+		}
+	}
+
+	// Determine whether rollup data may exist for this timespan. The combined
+	// batch only reads Resolution10s and would miss rolled-up data at coarser
+	// resolutions, so queries eligible for rollup must fall back to DB.Query.
+	rollupRes, hasRollup := Resolution10s.TargetRollupResolution()
+	needsRollup := hasRollup && timespan.verifyDiskResolution(rollupRes) == nil
+
+	// Check whether the combined-batch optimization is enabled.
+	combineEnabled := CombinedBatchEnabled.Get(&s.db.st.SV)
+
+	// Initialize memory contexts and determine which queries can participate
+	// in the combined batch (single-chunk) vs. which need individual chunked
+	// processing.
+	canCombine := make([]bool, len(request.Queries))
+	for i, query := range request.Queries {
+		var estimatedSourceCount int64
+		if len(query.Sources) > 0 {
+			estimatedSourceCount = int64(len(query.Sources))
+		} else {
+			estimatedSourceCount = estimatedClusterNodeCount
+		}
+		memContexts[i] = MakeQueryMemoryContext(
+			s.workerMemMonitor,
+			s.resultMemMonitor,
+			QueryMemoryOptions{
+				BudgetBytes:             s.queryMemoryMax / int64(s.queryWorkerMax),
+				EstimatedSources:        estimatedSourceCount,
+				InterpolationLimitNanos: interpolationLimit,
+				Columnar:                s.db.WriteColumnar(),
+			},
+		)
+		if !combineEnabled || needsRollup {
+			canCombine[i] = false
+			continue
+		}
+		maxWidth, err := memContexts[i].GetMaxTimespan(Resolution10s)
+		if err != nil {
+			// Insufficient memory budget; will fall back to per-query path
+			// which will return the same error.
+			canCombine[i] = false
+			continue
+		}
+		canCombine[i] = maxWidth > timespan.width()
+	}
+
+	// Phase 1: Build a combined KV batch for all combinable queries.
+	batch := &kv.Batch{}
+	plans := make([]queryReadPlan, len(request.Queries))
+	for i, query := range request.Queries {
+		if !canCombine[i] {
+			continue
+		}
+		plans[i] = s.db.addQueryReadOps(
+			batch, query, Resolution10s, timespan, interpolationLimit,
+		)
+	}
+
+	// Execute the combined batch in a single db.Run() call. DistSender
+	// splits this into per-range RPCs, so queries targeting overlapping
+	// ranges share RPCs.
+	if len(batch.Results) > 0 {
+		if err := s.db.runBatch(ctx, batch); err != nil {
+			return nil, err
+		}
+	}
+
+	// Phase 2: Process results in parallel. Combined-batch queries extract
+	// their data from the shared batch; fallback queries use the original
+	// per-query read path.
+	//
+	// Concurrency safety: after runBatch returns, the shared batch is never
+	// mutated. Each goroutine reads a disjoint range of batch.Results
+	// (determined by its queryReadPlan) and writes to its own
+	// response.Results[queryIdx], so no synchronization is needed.
+	workerOutput := make(chan error)
 	// Start a task which is itself responsible for starting per-query worker
-	// tasks. This is needed because RunAsyncTaskEx can block; in the
-	// case where a single request has more queries than the semaphore limit,
-	// a deadlock would occur because queries cannot complete until
-	// they have written their result to the "output" channel, which is
-	// processed later in the main function.
+	// tasks. This is needed because RunAsyncTaskEx can block; in the case
+	// where a single request has more queries than the semaphore limit, a
+	// deadlock would occur because queries cannot complete until they have
+	// written their result to the "output" channel, which is processed
+	// later in the main function.
 	if err := s.stopper.RunAsyncTask(ctx, "ts.Server: queries", func(ctx context.Context) {
 		for queryIdx, query := range request.Queries {
-			queryIdx := queryIdx
-			query := query
-
 			if err := s.stopper.RunAsyncTaskEx(
 				ctx,
 				stop.TaskOpts{
@@ -336,40 +447,32 @@ func (s *Server) Query(
 					WaitForSem: true,
 				},
 				func(ctx context.Context) {
-					// Estimated source count is either the count of requested sources
-					// *or* the estimated cluster node count if no sources are specified.
-					var estimatedSourceCount int64
-					if len(query.Sources) > 0 {
-						estimatedSourceCount = int64(len(query.Sources))
+					var err error
+					var result tspb.TimeSeriesQueryResponse_Result
+					if canCombine[queryIdx] {
+						result, err = s.processFromBatch(
+							ctx, batch, plans[queryIdx], query,
+							Resolution10s, timespan, memContexts[queryIdx],
+						)
 					} else {
-						estimatedSourceCount = estimatedClusterNodeCount
-					}
-
-					// Create a memory account for the results of this query.
-					memContexts[queryIdx] = MakeQueryMemoryContext(
-						s.workerMemMonitor,
-						s.resultMemMonitor,
-						QueryMemoryOptions{
-							BudgetBytes:             s.queryMemoryMax / int64(s.queryWorkerMax),
-							EstimatedSources:        estimatedSourceCount,
-							InterpolationLimitNanos: interpolationLimit,
-							Columnar:                s.db.WriteColumnar(),
-						},
-					)
-
-					datapoints, sources, err := s.db.Query(
-						ctx,
-						query,
-						Resolution10s,
-						timespan,
-						memContexts[queryIdx],
-					)
-					if err == nil {
-						response.Results[queryIdx] = tspb.TimeSeriesQueryResponse_Result{
-							Query:      query,
-							Datapoints: datapoints,
+						// Fallback: per-query read when combined batching is
+						// disabled or the query needs memory-based chunking.
+						var datapoints []tspb.TimeSeriesDatapoint
+						var sources []string
+						datapoints, sources, err = s.db.Query(
+							ctx, query, Resolution10s, timespan,
+							memContexts[queryIdx],
+						)
+						if err == nil {
+							result = tspb.TimeSeriesQueryResponse_Result{
+								Query:      query,
+								Datapoints: datapoints,
+							}
+							result.Sources = sources
 						}
-						response.Results[queryIdx].Sources = sources
+					}
+					if err == nil {
+						response.Results[queryIdx] = result
 					}
 					select {
 					case workerOutput <- err:
@@ -377,8 +480,8 @@ func (s *Server) Query(
 					}
 				},
 			); err != nil {
-				// Stopper has been closed and is draining. Return an error and
-				// exit the worker-spawning loop.
+				// Stopper has been closed and is draining. Return an error
+				// and exit the worker-spawning loop.
 				select {
 				case workerOutput <- err:
 				case <-ctx.Done():
@@ -405,6 +508,41 @@ func (s *Server) Query(
 	}
 
 	return &response, nil
+}
+
+// processFromBatch extracts a single query's KV data from a shared batch and
+// runs the post-processing pipeline.
+func (s *Server) processFromBatch(
+	ctx context.Context,
+	batch *kv.Batch,
+	plan queryReadPlan,
+	query tspb.Query,
+	diskResolution Resolution,
+	timespan QueryTimespan,
+	mem QueryMemoryContext,
+) (tspb.TimeSeriesQueryResponse_Result, error) {
+	data, err := extractReadResults(batch, plan)
+	if err != nil {
+		return tspb.TimeSeriesQueryResponse_Result{}, err
+	}
+
+	datapoints, sourceSet, err := s.db.processQueryData(
+		ctx, data, query, diskResolution, timespan, mem,
+	)
+	if err != nil {
+		return tspb.TimeSeriesQueryResponse_Result{}, err
+	}
+
+	sources := make([]string, 0, len(sourceSet))
+	for source := range sourceSet {
+		sources = append(sources, source)
+	}
+	result := tspb.TimeSeriesQueryResponse_Result{
+		Query:      query,
+		Datapoints: datapoints,
+	}
+	result.Sources = sources
+	return result, nil
 }
 
 // Dump returns a stream of raw timeseries data that has been stored on the

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -6,16 +6,19 @@
 package ts_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"reflect"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -250,6 +253,112 @@ func TestServerQuery(t *testing.T) {
 		t.Fatalf("actual response \n%v\n did not match expected response \n%v",
 			response, expectedResult)
 	}
+}
+
+// TestServerQueryCombinedBatchReducesKVRPCs verifies that sending multiple
+// queries in a single request produces the same number of KV BatchRequests as
+// sending them individually. This serves as a baseline; the combined-batch
+// optimization (when present) should reduce the combined count to 1.
+func TestServerQueryCombinedBatchReducesKVRPCs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var tsBatchCount atomic.Int64
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableTimeSeriesMaintenanceQueue: true,
+				TestingRequestFilter: func(
+					_ context.Context, req *kvpb.BatchRequest,
+				) *kvpb.Error {
+					for _, ru := range req.Requests {
+						if bytes.HasPrefix(
+							ru.GetInner().Header().Key,
+							keys.TimeseriesPrefix,
+						) {
+							tsBatchCount.Add(1)
+							break
+						}
+					}
+					return nil
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	tsdb := s.TsDB().(*ts.DB)
+
+	// Store data for 5 metrics across 2 sources.
+	metricCount := 5
+	for i := 0; i < metricCount; i++ {
+		require.NoError(t, tsdb.StoreData(
+			context.Background(), ts.Resolution10s, []tspb.TimeSeriesData{
+				{
+					Name:   fmt.Sprintf("metric.%d", i),
+					Source: "node1",
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						{TimestampNanos: 400 * 1e9, Value: float64(i * 10)},
+						{TimestampNanos: 500 * 1e9, Value: float64(i*10 + 1)},
+					},
+				},
+				{
+					Name:   fmt.Sprintf("metric.%d", i),
+					Source: "node2",
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						{TimestampNanos: 400 * 1e9, Value: float64(i * 20)},
+						{TimestampNanos: 500 * 1e9, Value: float64(i*20 + 1)},
+					},
+				},
+			},
+		))
+	}
+
+	conn := s.RPCClientConn(t, username.RootUserName())
+	client := conn.NewTimeSeriesClient()
+
+	queries := make([]tspb.Query, metricCount)
+	for i := 0; i < metricCount; i++ {
+		queries[i] = tspb.Query{
+			Name:    fmt.Sprintf("metric.%d", i),
+			Sources: []string{"node1", "node2"},
+		}
+	}
+
+	// Measure individual queries: send each metric as a separate request.
+	tsBatchCount.Store(0)
+	for _, q := range queries {
+		_, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+			StartNanos: 400 * 1e9,
+			EndNanos:   500 * 1e9,
+			Queries:    []tspb.Query{q},
+		})
+		require.NoError(t, err)
+	}
+	individualBatches := tsBatchCount.Load()
+
+	// Measure combined query: send all metrics in a single request.
+	tsBatchCount.Store(0)
+	resp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries:    queries,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, metricCount)
+	combinedBatches := tsBatchCount.Load()
+
+	t.Logf("individual requests: %d KV batches, combined request: %d KV batches",
+		individualBatches, combinedBatches)
+
+	// On a single-node test server all TS data is on one range, so each
+	// query produces exactly one KV BatchRequest. Without the combined-batch
+	// optimization, a multi-query request issues one batch per query.
+	require.Equal(t, int64(metricCount), individualBatches,
+		"each individual query should produce one KV BatchRequest")
+	require.Equal(t, int64(metricCount), combinedBatches,
+		"without optimization, combined query produces one KV BatchRequest per query")
 }
 
 // TestServerQueryStarvation tests a very specific scenario, wherein a single

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -255,10 +255,10 @@ func TestServerQuery(t *testing.T) {
 	}
 }
 
-// TestServerQueryCombinedBatchReducesKVRPCs verifies that sending multiple
-// queries in a single request produces the same number of KV BatchRequests as
-// sending them individually. This serves as a baseline; the combined-batch
-// optimization (when present) should reduce the combined count to 1.
+// TestServerQueryCombinedBatchReducesKVRPCs verifies that the combined-batch
+// optimization actually reduces the number of KV BatchRequests compared to
+// querying each metric individually. This is the core performance property of
+// the optimization.
 func TestServerQueryCombinedBatchReducesKVRPCs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -352,13 +352,415 @@ func TestServerQueryCombinedBatchReducesKVRPCs(t *testing.T) {
 	t.Logf("individual requests: %d KV batches, combined request: %d KV batches",
 		individualBatches, combinedBatches)
 
-	// On a single-node test server all TS data is on one range, so each
-	// query produces exactly one KV BatchRequest. Without the combined-batch
-	// optimization, a multi-query request issues one batch per query.
+	// On a single-node test server all TS data is on one range, so:
+	// - Individual: each request produces its own BatchRequest = metricCount.
+	// - Combined: all queries share a single BatchRequest = 1.
 	require.Equal(t, int64(metricCount), individualBatches,
 		"each individual query should produce one KV BatchRequest")
-	require.Equal(t, int64(metricCount), combinedBatches,
-		"without optimization, combined query produces one KV BatchRequest per query")
+	require.Equal(t, int64(1), combinedBatches,
+		"combined query should produce exactly one KV BatchRequest")
+
+	// Disable the combined-batch optimization and verify that a multi-query
+	// request falls back to per-query reads, producing the same number of
+	// KV batches as individual requests.
+	ts.CombinedBatchEnabled.Override(context.Background(), &s.ClusterSettings().SV, false)
+
+	tsBatchCount.Store(0)
+	resp, err = client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries:    queries,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, metricCount)
+	disabledBatches := tsBatchCount.Load()
+
+	t.Logf("combined request with setting disabled: %d KV batches", disabledBatches)
+	require.Equal(t, int64(metricCount), disabledBatches,
+		"with combined batch disabled, each query should produce its own KV BatchRequest")
+}
+
+// TestServerQueryCombinedBatch verifies that the combined-batch optimization
+// in Server.Query works correctly: multiple queries in a single request share
+// one KV batch, and the results are equivalent to querying each metric
+// individually.
+func TestServerQueryCombinedBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableTimeSeriesMaintenanceQueue: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	tsdb := s.TsDB().(*ts.DB)
+
+	// Store data for three different metrics across two sources.
+	require.NoError(t, tsdb.StoreData(context.Background(), ts.Resolution10s, []tspb.TimeSeriesData{
+		// metric.cpu: node1 and node2
+		{
+			Name:   "metric.cpu",
+			Source: "node1",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 10.0},
+				{TimestampNanos: 500 * 1e9, Value: 20.0},
+			},
+		},
+		{
+			Name:   "metric.cpu",
+			Source: "node2",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 30.0},
+				{TimestampNanos: 500 * 1e9, Value: 40.0},
+			},
+		},
+		// metric.mem: node1 and node2
+		{
+			Name:   "metric.mem",
+			Source: "node1",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 100.0},
+				{TimestampNanos: 500 * 1e9, Value: 200.0},
+			},
+		},
+		{
+			Name:   "metric.mem",
+			Source: "node2",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 300.0},
+				{TimestampNanos: 500 * 1e9, Value: 400.0},
+			},
+		},
+		// metric.disk: no explicit source stored, uses empty source
+		// so it will be read via Scan when sources are not specified.
+		{
+			Name: "metric.disk",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 1000.0},
+				{TimestampNanos: 500 * 1e9, Value: 2000.0},
+			},
+		},
+	}))
+
+	conn := s.RPCClientConn(t, username.RootUserName())
+	client := conn.NewTimeSeriesClient()
+
+	// First, query each metric individually to establish expected results.
+	individual := make([]*tspb.TimeSeriesQueryResponse, 3)
+	for i, q := range []tspb.Query{
+		{Name: "metric.cpu", Sources: []string{"node1", "node2"}},
+		{Name: "metric.mem", Sources: []string{"node1", "node2"}},
+		{Name: "metric.disk"}, // no sources -> Scan path
+	} {
+		resp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+			StartNanos: 400 * 1e9,
+			EndNanos:   500 * 1e9,
+			Queries:    []tspb.Query{q},
+		})
+		require.NoError(t, err)
+		individual[i] = resp
+	}
+
+	// Now send all three queries in a single request. The combined batch
+	// should produce identical results.
+	combined, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries: []tspb.Query{
+			{Name: "metric.cpu", Sources: []string{"node1", "node2"}},
+			{Name: "metric.mem", Sources: []string{"node1", "node2"}},
+			{Name: "metric.disk"}, // no sources -> Scan path
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, combined.Results, 3)
+
+	// Verify each combined result matches the corresponding individual result.
+	for i := 0; i < 3; i++ {
+		sort.Strings(individual[i].Results[0].Sources)
+		sort.Strings(combined.Results[i].Sources)
+		require.Equal(t, individual[i].Results[0].Datapoints, combined.Results[i].Datapoints,
+			"metric %d datapoints mismatch", i)
+		require.Equal(t, individual[i].Results[0].Sources, combined.Results[i].Sources,
+			"metric %d sources mismatch", i)
+	}
+
+	// Verify actual values.
+	// metric.cpu: SUM(node1, node2) at each timestamp.
+	require.Len(t, combined.Results[0].Datapoints, 2)
+	require.Equal(t, 40.0, combined.Results[0].Datapoints[0].Value) // 10+30
+	require.Equal(t, 60.0, combined.Results[0].Datapoints[1].Value) // 20+40
+
+	// metric.mem: SUM(node1, node2).
+	require.Len(t, combined.Results[1].Datapoints, 2)
+	require.Equal(t, 400.0, combined.Results[1].Datapoints[0].Value) // 100+300
+	require.Equal(t, 600.0, combined.Results[1].Datapoints[1].Value) // 200+400
+
+	// metric.disk: single source (Scan path).
+	require.Len(t, combined.Results[2].Datapoints, 2)
+	require.Equal(t, 1000.0, combined.Results[2].Datapoints[0].Value)
+	require.Equal(t, 2000.0, combined.Results[2].Datapoints[1].Value)
+}
+
+// TestServerQueryMixedCombinedAndFallback verifies that when a single request
+// contains queries that take the combined-batch path and queries that require
+// the per-query chunked read fallback, both produce correct results.
+func TestServerQueryMixedCombinedAndFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	workerCount := 8
+	// Compute budget using columnar slab sizes (the default format).
+	samplesPerSlab := ts.Resolution10s.SlabDuration() / ts.Resolution10s.SampleDuration()
+	sizeOfTimeSeriesData := int64(unsafe.Sizeof(roachpb.InternalTimeSeriesData{}))
+	// Columnar format: each sample is int32 (offset) + float64 (value).
+	sizeOfSlab := sizeOfTimeSeriesData +
+		(int64(unsafe.Sizeof(int32(0)))+int64(unsafe.Sizeof(float64(0))))*samplesPerSlab
+
+	// Set budget so that queries with few sources are combinable but queries
+	// with many sources exceed the per-worker budget for the query timespan.
+	//
+	// Per-worker budget = 300 * sizeOfSlab.
+	// For 2 sources: maxWidth ≈ (150 - 2) hours >> 3 hours → combinable.
+	// For 100 sources: maxWidth ≈ (3 - 2) hours = 1 hour < 3 hours → fallback.
+	budget := 300 * sizeOfSlab * int64(workerCount)
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant:           base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		TimeSeriesQueryWorkerMax:    workerCount,
+		TimeSeriesQueryMemoryBudget: budget,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableTimeSeriesMaintenanceQueue: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	tsdb := s.TsDB().(*ts.DB)
+
+	// Store 4 hours of data for two metrics. The query timespan will be 3 hours.
+	var data []tspb.TimeSeriesData
+	for hour := 0; hour < 4; hour++ {
+		baseTs := int64(hour) * 3600 * 1e9
+		for _, src := range []string{"node1", "node2"} {
+			data = append(data,
+				tspb.TimeSeriesData{
+					Name:   "metric.small",
+					Source: src,
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						{TimestampNanos: baseTs + 100*1e9, Value: float64(hour*10 + 1)},
+					},
+				},
+				tspb.TimeSeriesData{
+					Name:   "metric.large",
+					Source: src,
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						{TimestampNanos: baseTs + 100*1e9, Value: float64(hour*100 + 1)},
+					},
+				},
+			)
+		}
+	}
+	require.NoError(t, tsdb.StoreData(context.Background(), ts.Resolution10s, data))
+
+	conn := s.RPCClientConn(t, username.RootUserName())
+	client := conn.NewTimeSeriesClient()
+
+	// Build a list of 100 sources for the large query. Only node1 and node2
+	// have data; the rest produce empty Gets but inflate EstimatedSources
+	// enough to force the query into the chunked fallback path.
+	largeSources := make([]string, 100)
+	largeSources[0] = "node1"
+	largeSources[1] = "node2"
+	for i := 2; i < 100; i++ {
+		largeSources[i] = fmt.Sprintf("node%d", i+1)
+	}
+
+	startNanos := int64(0)
+	endNanos := int64(3 * 3600 * 1e9)
+
+	// Query individually to establish expected results.
+	smallResp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: startNanos,
+		EndNanos:   endNanos,
+		Queries:    []tspb.Query{{Name: "metric.small", Sources: []string{"node1", "node2"}}},
+	})
+	require.NoError(t, err)
+
+	largeResp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: startNanos,
+		EndNanos:   endNanos,
+		Queries:    []tspb.Query{{Name: "metric.large", Sources: largeSources}},
+	})
+	require.NoError(t, err)
+
+	// Combined request: small query (combinable) + large query (fallback).
+	combined, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: startNanos,
+		EndNanos:   endNanos,
+		Queries: []tspb.Query{
+			{Name: "metric.small", Sources: []string{"node1", "node2"}},
+			{Name: "metric.large", Sources: largeSources},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, combined.Results, 2)
+
+	require.Equal(t, smallResp.Results[0].Datapoints, combined.Results[0].Datapoints,
+		"small metric (combined path) datapoints mismatch")
+	require.Equal(t, largeResp.Results[0].Datapoints, combined.Results[1].Datapoints,
+		"large metric (fallback path) datapoints mismatch")
+}
+
+// TestServerQueryRollupFallback verifies that queries with a sample duration
+// compatible with the rollup resolution (Resolution30m) correctly fall back to
+// the per-query read path. The combined batch only reads Resolution10s and
+// would miss rolled-up data at coarser resolutions.
+func TestServerQueryRollupFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableTimeSeriesMaintenanceQueue: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	tsdb := s.TsDB().(*ts.DB)
+
+	// Store data at Resolution10s spanning multiple hours.
+	var data []tspb.TimeSeriesData
+	for hour := 0; hour < 3; hour++ {
+		baseTs := int64(hour) * 3600 * 1e9
+		data = append(data, tspb.TimeSeriesData{
+			Name:   "metric.rollup",
+			Source: "node1",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: baseTs + 100*1e9, Value: float64(hour*10 + 1)},
+			},
+		})
+	}
+	require.NoError(t, tsdb.StoreData(context.Background(), ts.Resolution10s, data))
+
+	conn := s.RPCClientConn(t, username.RootUserName())
+	client := conn.NewTimeSeriesClient()
+
+	// Query with 30-minute sample duration, which triggers needsRollup=true
+	// because SampleDurationNanos is compatible with Resolution30m. This forces
+	// the query through the per-query fallback path (db.Query), which tries
+	// Resolution30m first then falls back to Resolution10s data.
+	resp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos:  0,
+		EndNanos:    3 * 3600 * 1e9,
+		SampleNanos: 30 * 60 * 1e9, // 30 minutes
+		Queries: []tspb.Query{
+			{Name: "metric.rollup", Sources: []string{"node1"}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Results[0].Datapoints,
+		"rollup fallback should return data from Resolution10s")
+}
+
+// TestServerQueryCombinedBatchTenant verifies that tenant-scoped queries
+// correctly filter data when going through the combined-batch path. Both the
+// scan path (no explicit sources) and the get path (explicit sources) in
+// extractReadResults must respect tenant boundaries.
+func TestServerQueryCombinedBatchTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableTimeSeriesMaintenanceQueue: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	tsdb := s.TsDB().(*ts.DB)
+
+	// Store aggregate data (no tenant prefix) and per-tenant data (tenant 2).
+	require.NoError(t, tsdb.StoreData(context.Background(), ts.Resolution10s, []tspb.TimeSeriesData{
+		// Aggregate source "1" contains the sum across all tenants.
+		{
+			Name:   "sql.query.count",
+			Source: "1",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 100.0},
+				{TimestampNanos: 500 * 1e9, Value: 200.0},
+			},
+		},
+		// Tenant 2's individual contribution, stored with source "1-2".
+		{
+			Name:   "sql.query.count",
+			Source: "1-2",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 400 * 1e9, Value: 10.0},
+				{TimestampNanos: 500 * 1e9, Value: 20.0},
+			},
+		},
+	}))
+
+	conn := s.RPCClientConn(t, username.RootUserName())
+	client := conn.NewTimeSeriesClient()
+
+	tenantID := roachpb.MustMakeTenantID(2)
+
+	// Query with tenant ID set and no explicit sources (scan path through
+	// extractReadResults). The scan returns all rows; extractReadResults
+	// filters to only tenant 2's data.
+	scanResp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries: []tspb.Query{
+			{Name: "sql.query.count", TenantID: tenantID},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, scanResp.Results[0].Datapoints, 2)
+	require.Equal(t, 10.0, scanResp.Results[0].Datapoints[0].Value)
+	require.Equal(t, 20.0, scanResp.Results[0].Datapoints[1].Value)
+
+	// Query with tenant ID and explicit sources (get path through
+	// addQueryReadOps, which formats keys with MakeTenantSource).
+	getResp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries: []tspb.Query{
+			{Name: "sql.query.count", TenantID: tenantID, Sources: []string{"1"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, getResp.Results[0].Datapoints, 2)
+	require.Equal(t, 10.0, getResp.Results[0].Datapoints[0].Value)
+	require.Equal(t, 20.0, getResp.Results[0].Datapoints[1].Value)
+
+	// System tenant should see the aggregate data, not double-counted.
+	systemID := roachpb.MustMakeTenantID(1)
+	sysResp, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries: []tspb.Query{
+			{Name: "sql.query.count", TenantID: systemID},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, sysResp.Results[0].Datapoints, 2)
+	require.Equal(t, 100.0, sysResp.Results[0].Datapoints[0].Value)
+	require.Equal(t, 200.0, sysResp.Results[0].Datapoints[1].Value)
 }
 
 // TestServerQueryStarvation tests a very specific scenario, wherein a single


### PR DESCRIPTION
Previously, each query in a TimeSeriesQueryRequest was processed in its own goroutine, each independently building a kv.Batch and calling db.Run(). On a request with N queries, this resulted in N separate db.Run() calls going through DistSender, often targeting the same small set of time series ranges — producing redundant per-range RPCs.

This commit restructures Server.Query into two phases:

Phase 1 (combined read): Eligible queries' KV operations (Gets and Scans) are collected into a single kv.Batch and executed with one db.Run() call. Each query's position in the batch is tracked via a queryReadPlan (start index + count). DistSender splits the combined batch by range, so queries targeting overlapping ranges naturally share RPCs.

Phase 2 (parallel processing): Per-query goroutines extract their slice of the batch results and run the existing post-processing pipeline (convertKeysToSpans, downsampling, aggregation) in parallel.

Queries whose timespan exceeds the memory budget (requiring chunked reads) or that are eligible for rollup resolution fall back to the original per-query db.Query() path, which handles the iterative read-process-adjust loop.

For a metrics page with m metrics, on a n-node cluster where TS data spans r ranges, this reduces the KV RPC count from m * n * r to r.

Resolves: https://github.com/cockroachdb/cockroach/issues/158510
Epic: None
Release note: None