### PR TITLE
sql/sem/tree: fix data race on StrVal embedded datum fields

### DIFF
--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -205,6 +205,7 @@ go_test(
         "col_types_test.go",
         "collatedstring_test.go",
         "compare_test.go",
+        "constant_race_test.go",
         "constant_test.go",
         "create_routine_test.go",
         "datum_alloc_test.go",

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -473,8 +473,15 @@ type StrVal struct {
 	scannedAsBytes bool
 
 	// The following fields are used to avoid allocating Datums on type resolution.
-	resString DString
-	resBytes  DBytes
+	// resString always caches DString(s) regardless of the target type (e.g.
+	// bpchar trimming is applied on top of the cached value, not stored into it).
+	// The resAs* flags indicate whether the field has been populated; once set
+	// the field must not be overwritten, because other goroutines may be reading
+	// it through pointers stored in a shared QueryCache memo.
+	resString   DString
+	resBytes    DBytes
+	resAsString bool
+	resAsBytes  bool
 }
 
 // NewStrVal constructs a StrVal instance. This is used during
@@ -621,7 +628,10 @@ func (expr *StrVal) ResolveAsType(
 		// We're looking at typing a byte literal constant into some value type.
 		switch typ.Family() {
 		case types.BytesFamily:
-			expr.resBytes = DBytes(expr.s)
+			if !expr.resAsBytes {
+				expr.resBytes = DBytes(expr.s)
+				expr.resAsBytes = true
+			}
 			return &expr.resBytes, nil
 		case types.EnumFamily:
 			e, err := MakeDEnumFromPhysicalRepresentation(typ, []byte(expr.s))
@@ -632,7 +642,10 @@ func (expr *StrVal) ResolveAsType(
 		case types.UuidFamily:
 			return ParseDUuidFromBytes([]byte(expr.s))
 		case types.StringFamily:
-			expr.resString = DString(expr.s)
+			if !expr.resAsString {
+				expr.resString = DString(expr.s)
+				expr.resAsString = true
+			}
 			return &expr.resString, nil
 		}
 		return nil, errors.AssertionFailedf("attempt to type byte array literal to %s", typ.SQLStringForError())
@@ -644,12 +657,14 @@ func (expr *StrVal) ResolveAsType(
 	case types.AnyFamily:
 		fallthrough
 	case types.StringFamily:
+		if !expr.resAsString {
+			expr.resString = DString(expr.s)
+			expr.resAsString = true
+		}
 		switch typ.Oid() {
 		case oid.T_aclitem:
-			expr.resString = DString(expr.s)
 			return NewDACLItemFromDString(&expr.resString)
 		case oid.T_name:
-			expr.resString = DString(expr.s)
 			return NewDNameFromDString(&expr.resString), nil
 		case oid.T_bpchar:
 			// TODO(mgartner): This should probably use the same logic in
@@ -657,10 +672,9 @@ func (expr *StrVal) ResolveAsType(
 			// eval.performCastWithoutPrecisionTruncation. casts use (see the
 			// cast package). We might be able to replace this entire function
 			// with logic in those functions.
-			expr.resString = DString(strings.TrimRight(expr.s, " "))
-			return &expr.resString, nil
+			d := DString(strings.TrimRight(string(expr.resString), " "))
+			return &d, nil
 		default:
-			expr.resString = DString(expr.s)
 			return &expr.resString, nil
 		}
 
@@ -699,7 +713,10 @@ func (expr *StrVal) ResolveAsType(
 		// we return a CastExpr and let the conversion happen at evaluation time. We
 		// still want to error out if the conversion is not possible though (this is
 		// used when resolving overloads).
-		expr.resString = DString(expr.s)
+		if !expr.resAsString {
+			expr.resString = DString(expr.s)
+			expr.resAsString = true
+		}
 		c := NewTypedCastExpr(&expr.resString, typ)
 		return c.TypeCheck(ctx, semaCtx, typ)
 	}

--- a/pkg/sql/sem/tree/constant_race_test.go
+++ b/pkg/sql/sem/tree/constant_race_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tree_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConstantConcurrentTypeCheck verifies that calling ResolveAsType on a
+// StrVal or NumVal concurrently does not race with reading a datum returned by
+// a previous ResolveAsType call. This is a regression test for #166362, where
+// the embedded resString field was written by ResolveAsType on one goroutine
+// while another goroutine read through a *DString pointer previously returned
+// (e.g. via a shared QueryCache memo).
+func TestConstantConcurrentTypeCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
+
+	testCases := []struct {
+		name   string
+		expr   string
+		typ    *types.T
+		readFn func(tree.TypedExpr)
+	}{
+		{
+			name: "string",
+			expr: "'hello world'",
+			typ:  types.String,
+			readFn: func(e tree.TypedExpr) {
+				d, ok := tree.AsDString(e)
+				if !ok {
+					panic("expected DString")
+				}
+				_ = string(d)
+			},
+		},
+		{
+			name: "int",
+			expr: "42",
+			typ:  types.Int,
+			readFn: func(e tree.TypedExpr) {
+				_ = tree.MustBeDInt(e)
+			},
+		},
+		{
+			name: "float",
+			expr: "3.14",
+			typ:  types.Float,
+			readFn: func(e tree.TypedExpr) {
+				_ = tree.MustBeDFloat(e)
+			},
+		},
+		{
+			name: "decimal",
+			expr: "1.23456",
+			typ:  types.Decimal,
+			readFn: func(e tree.TypedExpr) {
+				_ = tree.MustBeDDecimal(e)
+			},
+		},
+		{
+			name: "bytes",
+			expr: "b'\\x01\\x02'",
+			typ:  types.Bytes,
+			readFn: func(e tree.TypedExpr) {
+				_ = string(*e.(*tree.DBytes))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tc.expr)
+			require.NoError(t, err)
+
+			// Initial type-check populates the embedded field and returns a
+			// pointer into it (e.g. &StrVal.resString).
+			typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, tc.typ)
+			require.NoError(t, err)
+
+			readFn := tc.readFn
+			const iters = 2000
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			// One goroutine reads through the returned datum pointer, as
+			// execution would via a shared QueryCache memo.
+			go func() {
+				defer wg.Done()
+				for range iters {
+					readFn(typedExpr)
+				}
+			}()
+
+			// Another goroutine re-type-checks the same AST node, as
+			// SetIndexRecommendations does via optbuilder.Build.
+			var typeCheckErr error
+			go func() {
+				defer wg.Done()
+				for range iters {
+					if _, err := tree.TypeCheck(ctx, expr, &semaCtx, tc.typ); err != nil {
+						typeCheckErr = err
+						return
+					}
+				}
+			}()
+
+			wg.Wait()
+			require.NoError(t, typeCheckErr)
+		})
+	}
+}


### PR DESCRIPTION
StrVal.ResolveAsType() returns pointers to embedded fields (resString, resBytes) to avoid heap allocations. When a memo containing these pointers is stored in the shared QueryCache, other connections can read through them while SetIndexRecommendations() re-type-checks the same AST node, writing to the same fields concurrently.

Add resAsString/resAsBytes guards (matching NumVal's existing pattern) so that once an embedded field is populated, subsequent ResolveAsType calls skip the write. The QueryCache mutex provides the happens-before guarantee for cross-connection readers.

Also make resString always store DString(s) regardless of target type; for bpchar, the trailing-space trim is applied to a local copy instead.

Fixes: #166362
Release note: None