### PR TITLE
importer: transfer ownership to SQL Foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,6 @@
 /pkg/sql/vecindex/           @cockroachdb/sql-queries-prs
 #!/pkg/sql/BUILD.bazel       @cockroachdb/sql-queries-noreview
 
-/pkg/sql/importer/           @cockroachdb/sql-queries-prs
 
 /pkg/sql/appstatspb           @cockroachdb/obs-prs
 /pkg/sql/contention/          @cockroachdb/obs-prs
@@ -114,11 +113,15 @@
 /pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations
 
 /pkg/ccl/schemachangerccl/   @cockroachdb/sql-foundations
+/pkg/sql/bulkmerge/          @cockroachdb/sql-foundations
+/pkg/sql/bulksst/            @cockroachdb/sql-foundations
+/pkg/sql/bulkutil/           @cockroachdb/sql-foundations
 /pkg/sql/catalog/            @cockroachdb/sql-foundations
 /pkg/sql/catalog/multiregion @cockroachdb/sql-foundations
 /pkg/sql/doctor/             @cockroachdb/sql-foundations
 /pkg/sql/gcjob/              @cockroachdb/sql-foundations
 /pkg/sql/gcjob_test/         @cockroachdb/sql-foundations
+/pkg/sql/importer/           @cockroachdb/sql-foundations
 /pkg/sql/privilege/          @cockroachdb/sql-foundations
 /pkg/sql/schemachange/       @cockroachdb/sql-foundations
 /pkg/sql/schemachanger/      @cockroachdb/sql-foundations

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -373,7 +373,7 @@ func registerImport(r registry.Registry) {
 				name := fmt.Sprintf("import/%s/distmerge=%v/nodes=%d", ts.subtestName, distMerge, numNodes)
 				r.Add(registry.TestSpec{
 					Name:              name,
-					Owner:             registry.OwnerSQLQueries,
+					Owner:             registry.OwnerSQLFoundations,
 					Benchmark:         testSpec.benchmark,
 					Timeout:           importTestTimeout,
 					Cluster:           r.MakeClusterSpec(numNodes),
@@ -1016,7 +1016,7 @@ func registerImportTPCC(r registry.Registry) {
 		timeout := 5 * time.Hour
 		r.Add(registry.TestSpec{
 			Name:              testName,
-			Owner:             registry.OwnerSQLQueries,
+			Owner:             registry.OwnerSQLFoundations,
 			Benchmark:         true,
 			Cluster:           r.MakeClusterSpec(numNodes),
 			CompatibleClouds:  registry.AllExceptAWS,
@@ -1052,7 +1052,7 @@ func registerImportTPCC(r registry.Registry) {
 	testName := fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses)
 	r.Add(registry.TestSpec{
 		Name:              testName,
-		Owner:             registry.OwnerSQLQueries,
+		Owner:             registry.OwnerSQLFoundations,
 		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.GCEZones(geoZones)),
 		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Nightly),


### PR DESCRIPTION
SQL Foundations is taking ownership of IMPORT, so new issues and PRs should be sent to them.

Epic: None
Release Note: None