### PR TITLE
roachtest: increase HTTP timeout in follower-reads test

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -772,7 +772,7 @@ func verifySQLLatency(
 			SourceAggregator: tspb.TimeSeriesQueryAggregator_MAX.Enum(),
 		}},
 	}
-	client := roachtestutil.DefaultHTTPClient(c, l)
+	client := roachtestutil.DefaultHTTPClient(c, l, roachtestutil.HTTPTimeout(15*time.Second))
 	var response tspb.TimeSeriesQueryResponse
 	if err := client.PostProtobuf(ctx, url, &request, &response); err != nil {
 		t.Fatal(err)
@@ -852,6 +852,7 @@ func verifyHighFollowerReadRatios(
 	// is running on a multitenant deployment.
 	client := roachtestutil.DefaultHTTPClient(
 		c, l, roachtestutil.VirtualCluster(install.SystemInterfaceName),
+		roachtestutil.HTTPTimeout(15*time.Second),
 	)
 	var response tspb.TimeSeriesQueryResponse
 	if err := client.PostProtobuf(ctx, url, &request, &response); err != nil {
@@ -947,6 +948,7 @@ func getFollowerReadCounts(ctx context.Context, t test.Test, c cluster.Cluster) 
 			// is running on a multitenant deployment.
 			client := roachtestutil.DefaultHTTPClient(
 				c, l, roachtestutil.VirtualCluster(install.SystemInterfaceName),
+				roachtestutil.HTTPTimeout(15*time.Second),
 			)
 			resp, err := client.Get(ctx, url)
 			if err != nil {


### PR DESCRIPTION
The follower-reads roachtest (survival=region/locality=global/
reads=bounded-staleness) failed with a context deadline exceeded
on an HTTP request to the timeseries API. The test's HTTP clients
were using the default 3s timeout (httputil.StandardHTTPTimeout).

The 3s HTTP timeout is too tight for a multi-region cluster
under load, especially with runtime assertions enabled. The
timeout must cover both the auth session validation and the
actual timeseries query. Increase to 15s, matching what
status_server, db_console_endpoints, and mixed_version_sql_stats
tests use for their HTTP API requests.

Fixes: https://github.com/cockroachdb/cockroach/issues/167574

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>