### PR TITLE
release-26.2: bench/rttanalysis: fix TestBenchmarkExpectation load and coverage

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -79,5 +79,6 @@ go_test(
         "//pkg/util/envutil",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/bench/rttanalysis/validate_benchmark_data.go
+++ b/pkg/bench/rttanalysis/validate_benchmark_data.go
@@ -77,7 +77,7 @@ func runBenchmarkExpectationTests(t *testing.T, r *Registry) {
 
 	var results resultSet
 	var wg sync.WaitGroup
-	concurrency := ((system.NumCPU() - 1) / r.numNodes) + 1 // arbitrary
+	concurrency := min(4, ((system.NumCPU()-1)/r.numNodes)+1) //arbitrary
 	limiter := quotapool.NewIntPool("rttanalysis", uint64(concurrency))
 	isRewrite := *rewriteFlag
 	for b, cases := range r.r {
@@ -153,10 +153,12 @@ func mergeExpectations(existing, new benchmarkExpectations) (merged benchmarkExp
 // always run with metamorphic testing enabled in CI.
 func execTestSubprocess(t *testing.T) {
 	var args []string
+	testRunPassed := false
 	flag.CommandLine.Visit(func(f *flag.Flag) {
 		vs := f.Value.String()
 		switch f.Name {
 		case "test.run":
+			testRunPassed = true
 			// Only run the current outermost test in the subprocess.
 			prefix := "^" + regexp.QuoteMeta(t.Name()) + "$"
 			if idx := strings.Index(vs, "/"); idx >= 0 {
@@ -176,6 +178,9 @@ func execTestSubprocess(t *testing.T) {
 		}
 		args = append(args, "--"+f.Name+"="+vs)
 	})
+	if !testRunPassed {
+		args = append(args, "--test.run=^"+regexp.QuoteMeta(t.Name())+"$")
+	}
 	args = append(args, "--test.bench=^$") // disable benchmarks
 	args = append(args, flag.CommandLine.Args()...)
 	cmd := exec.Command(os.Args[0], args...)

--- a/pkg/bench/rttanalysis/validate_benchmark_data_test.go
+++ b/pkg/bench/rttanalysis/validate_benchmark_data_test.go
@@ -6,15 +6,48 @@
 package rttanalysis
 
 import (
+	"fmt"
+	"reflect"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/stretchr/testify/require"
 )
 
 // NOTE: If you change the number of shards, you must also update the
 // shard_count in BUILD.bazel to match.
 const shardCount = 5
+
+// shardFunctions is the list of shard functions, which should match the
+// shard count.
+var shardFunctions = []func(t *testing.T){TestBenchmarkExpectationShard1,
+	TestBenchmarkExpectationShard2,
+	TestBenchmarkExpectationShard3,
+	TestBenchmarkExpectationShard4,
+	TestBenchmarkExpectationShard5}
+
+const shardFunctionPrefix = "TestBenchmarkExpectationShard"
+
+func init() {
+	// Assert that the shard count matches.
+	if len(shardFunctions) != shardCount {
+		panic(fmt.Sprintf("shardCount mismatch: %d != %d", len(shardFunctions), shardCount))
+	}
+	// Validate the function names have the expected format.
+	for i, shardFunction := range shardFunctions {
+		// Extract the function name only.
+		fullName := runtime.FuncForPC(reflect.ValueOf(shardFunction).Pointer()).Name()
+		lastDot := strings.LastIndex(fullName, ".")
+		functionName := fullName[lastDot+1:]
+		expectedFunctionName := fmt.Sprintf("%s%d", shardFunctionPrefix, i+1)
+		if functionName != expectedFunctionName {
+			panic(fmt.Sprintf("shard function name mismatch: %s != %s", functionName, expectedFunctionName))
+		}
+	}
+}
 
 // Validate that shardCount matches TEST_TOTAL_SHARDS environment variable at init time
 var _ = func() int {
@@ -32,18 +65,33 @@ var _ = func() int {
 	return 0
 }()
 
+// extractShardIndex returns the shard index from the callers function name.
+func extractShardIndex(t *testing.T) int {
+	pc, _, _, _ := runtime.Caller(1)
+	fullName := runtime.FuncForPC(pc).Name()
+	lastDot := strings.LastIndex(fullName, ".")
+	funcName := fullName[lastDot+1:]
+	idx, err := strconv.Atoi(strings.TrimPrefix(funcName, shardFunctionPrefix))
+	require.NoError(t, err)
+	return idx
+}
+
 func TestBenchmarkExpectationShard1(t *testing.T) {
-	reg.RunExpectationsSharded(t, 1, shardCount)
+	reg.RunExpectationsSharded(t, extractShardIndex(t), shardCount)
 }
 
 func TestBenchmarkExpectationShard2(t *testing.T) {
-	reg.RunExpectationsSharded(t, 2, shardCount)
+	reg.RunExpectationsSharded(t, extractShardIndex(t), shardCount)
 }
 
 func TestBenchmarkExpectationShard3(t *testing.T) {
-	reg.RunExpectationsSharded(t, 3, shardCount)
+	reg.RunExpectationsSharded(t, extractShardIndex(t), shardCount)
 }
 
 func TestBenchmarkExpectationShard4(t *testing.T) {
-	reg.RunExpectationsSharded(t, 4, shardCount)
+	reg.RunExpectationsSharded(t, extractShardIndex(t), shardCount)
+}
+
+func TestBenchmarkExpectationShard5(t *testing.T) {
+	reg.RunExpectationsSharded(t, extractShardIndex(t), shardCount)
 }


### PR DESCRIPTION
Backport 1/1 commits from #167921 on behalf of @fqazi.

----

Previously, TestBenchmarkExpectation sharded tests could fail in CI due to resource exhaustion and timeouts. This was caused by two main issues:
1. execTestSubprocess did not pass the -test.run flag to the subprocess, causing each shard's subprocess to attempt to run the entire package.
2. Benchmark concurrency was tied to system.NumCPU(), which resulted in too many concurrent CockroachDB servers on high-core machines.

Additionally, TestBenchmarkExpectationShard5 was missing from the test file, meaning a portion of the benchmarks were never being validated.

This commit fixes these issues by:
- Explicitly passing the current test filter to the subprocess in execTestSubprocess.
- Capping the benchmark concurrency to 4.
- Adding the missing TestBenchmarkExpectationShard5.

Fixes: #167341

Release note: None

----

Release justification: test only change 