### PR TITLE
kvserver: fix flake in TestTenantCtx

### DIFF
--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -397,7 +397,32 @@ func TestTenantRateLimiter(t *testing.T) {
 	require.True(t, matched, "did not match %s:\n\n%s", tenantMetricStr, m)
 }
 
-// Test that KV requests made by a tenant get a context annotated with the tenant ID.
+// TestTenantCtx verifies that KV requests made by a SQL tenant get a context
+// annotated with the tenant ID.
+//
+// The test sets up a host server with a TestingRequestFilter that intercepts
+// Scan and PushTxn requests whose key contains a "magic" value. It then starts
+// a tenant, creates a table, and uses two concurrent transactions to generate
+// these requests:
+//
+//  1. tx1 inserts a row with the magic key, placing an intent (or lock) at KV.
+//  2. tx2 does a SELECT on the same key, which produces a Scan request that
+//     encounters tx1's intent and triggers a PushTxn to resolve the conflict.
+//
+// The filter checks that the Scan carries the tenant ID in its context (since
+// it originates from the tenant's SQL layer), while the PushTxn does NOT carry
+// it (since pushes are internal KV operations).
+//
+// Flake history:
+//   - #158493: Meta2 range lookups matched the magic key but lacked tenant
+//     context. Fixed by skipping Meta2-prefixed keys in the filter.
+//   - #167600: The filter used blocking sends on unbuffered channels. When
+//     the test failed (e.g., due to a slow CI machine hitting the 3s timeout),
+//     tx1 was never rolled back, leaving tx2's SELECT blocked on the intent
+//     forever. The stopper couldn't shut down the blocked goroutines, turning
+//     a 3s timeout into a 12+ minute hang. Fixed by deferring tx1.Rollback(),
+//     using buffered channels with non-blocking sends to prevent filter
+//     goroutines from blocking indefinitely, and increasing the timeout.
 func TestTenantCtx(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -437,8 +462,9 @@ func TestTenantCtx(t *testing.T) {
 							pushReq = ba.Requests[0].GetInner().(*kvpb.PushTxnRequest)
 						}
 
-						t.Logf("received request with key: %s, isTenantRequest: %t, tenID: %d",
-							key.String(), isTenantRequest, tenID)
+						method := ba.Requests[0].GetInner().Method()
+						t.Logf("received %s with key: %s, isTenantRequest: %t, tenID: %d, isSingle: %t",
+							method, key.String(), isTenantRequest, tenID, ba.IsSingleRequest())
 
 						switch {
 						case scanReq != nil:
@@ -506,18 +532,22 @@ func TestTenantCtx(t *testing.T) {
 			return tx2.Rollback()
 		})
 
-		// Wait for tx2 goroutine to send the PushTxn request, and then roll back tx1
-		// to unblock tx2.
+		// REPRO(#167600): Use a 1ns timeout to deterministically force the
+		// timeout path. This exposes the stopper hang: after t.Fatal, tx1 is
+		// never rolled back (tx2 stays blocked on the intent), and the
+		// unbuffered channel sends in the filter block goroutines. The test
+		// will hang until the overall test timeout kills it.
+		const waitTimeout = time.Nanosecond
 		select {
 		case err := <-scanErr:
 			require.NoError(t, err)
-		case <-time.After(3 * time.Second):
+		case <-time.After(waitTimeout):
 			t.Fatal("timed out waiting for Scan")
 		}
 		select {
 		case err := <-pushErr:
 			require.NoError(t, err)
-		case <-time.After(3 * time.Second):
+		case <-time.After(waitTimeout):
 			t.Fatal("timed out waiting for PushTxn")
 		}
 		require.NoError(t, tx1.Rollback())

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -430,8 +430,13 @@ func TestTenantCtx(t *testing.T) {
 	tenantID := serverutils.TestTenantID()
 
 	testutils.RunTrueAndFalse(t, "shared-process tenant", func(t *testing.T, sharedProcess bool) {
-		scanErr := make(chan error)
-		pushErr := make(chan error)
+		// Use buffered channels so the filter never blocks request
+		// processing. Without buffering, a channel send in the filter would
+		// block the goroutine evaluating the request. If the test has already
+		// failed (e.g., timeout), nobody reads the channel, and the blocked
+		// goroutine prevents the stopper from shutting down.
+		scanErr := make(chan error, 1)
+		pushErr := make(chan error, 1)
 		s := serverutils.StartServerOnly(t, base.TestServerArgs{
 			// Disable the default test tenant since we're going to create our own.
 			DefaultTestTenant: base.TestControlsTenantsExplicitly,
@@ -473,16 +478,26 @@ func TestTenantCtx(t *testing.T) {
 								err = errors.Newf("expected Scan to run as the expected tenant (%d), but it isn't. tenant request: %t, tenantID: %d",
 									tenantID, isTenantRequest, tenID)
 							}
-							scanErr <- err
+							// Non-blocking send: if the channel buffer is full
+							// (duplicate Scan or test already completed), don't
+							// block this goroutine — that would prevent the request
+							// from completing and the stopper from shutting down.
+							select {
+							case scanErr <- err:
+							default:
+							}
 							return nil
 						case pushReq != nil:
-							// Check that the Push request no longer has the txn request; RPCs
-							// done by KV do not identify the tenant.
+							// Check that the Push request no longer has the txn
+							// request; RPCs done by KV do not identify the tenant.
 							var err error
 							if isTenantRequest {
 								err = errors.Newf("got unexpected tenant in push: %d", tenID)
 							}
-							pushErr <- err
+							select {
+							case pushErr <- err:
+							default:
+							}
 							return nil
 						default:
 							// Unrecognized requests pass through.
@@ -511,10 +526,17 @@ func TestTenantCtx(t *testing.T) {
 			defer tsql.Close()
 		}
 
-		_, err := tsql.Exec("create table t (x int primary key, y int, family (x), family (y))")
+		_, err := tsql.Exec(
+			"create table t (x int primary key, y int, family (x), family (y))",
+		)
 		require.NoError(t, err)
 		tx1, err := tsql.BeginTx(ctx, nil /* opts */)
 		require.NoError(t, err)
+		// Ensure tx1 is always rolled back, even if the test fails early.
+		// tx2's SELECT is blocked by tx1's intent; without this, a test
+		// failure would leave tx2 blocked forever, preventing the stopper
+		// from shutting down.
+		t.Cleanup(func() { _ = tx1.Rollback() })
 		_, err = tx1.Exec("insert into t(x) values ($1)", magicKey)
 		require.NoError(t, err)
 
@@ -532,12 +554,9 @@ func TestTenantCtx(t *testing.T) {
 			return tx2.Rollback()
 		})
 
-		// REPRO(#167600): Use a 1ns timeout to deterministically force the
-		// timeout path. This exposes the stopper hang: after t.Fatal, tx1 is
-		// never rolled back (tx2 stays blocked on the intent), and the
-		// unbuffered channel sends in the filter block goroutines. The test
-		// will hang until the overall test timeout kills it.
-		const waitTimeout = time.Nanosecond
+		// Use a generous timeout to account for slow CI machines
+		// (ARM64, high contention, etc.).
+		const waitTimeout = 30 * time.Second
 		select {
 		case err := <-scanErr:
 			require.NoError(t, err)


### PR DESCRIPTION
The test uses a `TestingRequestFilter` to intercept Scan and PushTxn
requests. Three issues made the test flaky:

1. The filter used blocking sends on unbuffered channels. If the test
   timed out or failed, nobody would read from the channels, leaving
   the filter goroutines blocked forever and preventing the stopper
   from shutting down.

2. When the test failed (e.g., timeout waiting for Scan/PushTxn), tx1
   was never rolled back. Since tx2's SELECT is blocked on tx1's
   intent, tx2 stayed blocked forever — again preventing the stopper
   from shutting down.

3. The wait timeout was 3 seconds, which is marginal on slow CI
   machines (ARM64 under load). When the timeout fired, issues 1 and 2
   turned a 3-second failure into a 12+ minute stopper hang.

Fix by:
- Using buffered channels (capacity 1) with non-blocking sends so the
  filter never blocks request processing.
- Adding `t.Cleanup` to always roll back tx1, even on early test failure.
- Increasing the wait timeout to 30 seconds.
- Improving diagnostic logging to include request method and batch size.

The commits are structured as repro → fix → revert-repro per the
deflake workflow. The repro commit uses a 1ns timeout to force the
timeout path; the fix commit replaces it with the real fix; the
revert-repro is a no-op since the fix already overwrote the injection.
The three commits squash cleanly to just the fix.

Fixes: #167600
Epic: none
Release note: None