### PR TITLE
sql,stats: add span-to-filter decoding for partial stats collection

### DIFF
--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -115,6 +115,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
+        "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -24,6 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -1406,6 +1409,124 @@ func (r *Refresher) addMisestimate(mis misestimate) {
 		newIdx++
 	}
 	r.misestimateSpans[id] = updatedSpans
+}
+
+// decodeIndexKey decodes the first key column of the given index key into
+// vals[0]. If the key only contains the TableID / IndexID pair, then vals[0]
+// will remain unset. An error is returned if decoding TableID / IndexID or the
+// first key datum fails for any reason.
+func decodeIndexKey(
+	codec keys.SQLCodec,
+	vals []rowenc.EncDatum,
+	colDirs []catenumpb.IndexColumn_Direction,
+	key []byte,
+) error {
+	key, err := codec.StripTenantPrefix(key)
+	if err != nil {
+		return err
+	}
+	key, _, _, err = rowenc.DecodePartialTableIDIndexID(key)
+	if err != nil {
+		return err
+	}
+	_, _, err = rowenc.DecodeKeyVals(vals, colDirs, key)
+	return err
+}
+
+// spanToBounds takes the given span and returns the filter expression to be
+// used in the Where clause of the partial statistics collections. Given the
+// current limitation of only being able to collect partial stats on a single
+// column, the keys of the span are truncated to a single key column.
+// TODO(#94076): re-evaluate once this limitation is lifted.
+func spanToBounds(
+	ctx context.Context, codec keys.SQLCodec, span roachpb.Span, info indexInfo, da *tree.DatumAlloc,
+) (string, error) {
+	var startArr, endArr [1]rowenc.EncDatum
+	colDirs := []catenumpb.IndexColumn_Direction{info.keyColumnDir}
+	err := decodeIndexKey(codec, startArr[:], colDirs, span.Key)
+	if err != nil {
+		return "", err
+	}
+	// The datum might be left unset, which indicates an open interval (i.e.
+	// scan from the beginning of the index).
+	if !startArr[0].IsUnset() {
+		err = startArr[0].EnsureDecoded(info.keyColumnType, da)
+		if err != nil {
+			return "", err
+		}
+	}
+	if len(span.EndKey) == 0 {
+		// This represented a Get request originally.
+		start := startArr[0].Datum
+		if start == nil {
+			// This code shouldn't be reachable, so we use a contradiction.
+			return "false", nil
+		}
+		return fmt.Sprintf("%s = %s", info.keyColumnName, start), nil
+	}
+	err = decodeIndexKey(codec, endArr[:], colDirs, span.EndKey)
+	if err != nil {
+		return "", err
+	}
+	// The datum might be left unset, which indicates an open interval (i.e.
+	// scan until the end of the index).
+	if !endArr[0].IsUnset() {
+		err = endArr[0].EnsureDecoded(info.keyColumnType, da)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	start := startArr[0].Datum
+	end := endArr[0].Datum
+	if start == tree.DNull || end == tree.DNull {
+		// For simplicity, we currently don't handle NULL boundaries.
+		// TODO(#168079): handle them.
+		return "false", nil
+	}
+
+	isDesc := info.keyColumnDir == catenumpb.IndexColumn_DESC
+	switch {
+	case start != nil && end != nil:
+		// Closed interval on both ends: [start, end]. Note that for simplicity
+		// the interval is inclusive on both ends. (In theory, we could've
+		// checked whether the whole 'end' key was decoded, in which case the
+		// 'end' datum would be exclusive.)
+		// TODO(#168079): make the end bound exclusive when possible.
+		//
+		// It's safe to use nil eval.Context as CompareContext given that we
+		// definitely don't have placeholders as our boundary datums.
+		cmp, err := start.Compare(ctx, (*eval.Context)(nil) /* cmpCtx */, end)
+		if err != nil {
+			return "", err
+		}
+		if cmp == 0 {
+			// The interval is reduced to an equality.
+			return fmt.Sprintf("%s = %s", info.keyColumnName, start), nil
+		}
+		// Inclusive of both ends since we might have cut off a part of the
+		// composite key.
+		if isDesc {
+			return fmt.Sprintf("%[2]s >= %[1]s AND %[1]s >= %[3]s", info.keyColumnName, start, end), nil
+		}
+		return fmt.Sprintf("%[2]s <= %[1]s AND %[1]s <= %[3]s", info.keyColumnName, start, end), nil
+	case start != nil:
+		// Half-open interval: [start, <end of index>).
+		if isDesc {
+			return fmt.Sprintf("%s <= %s", info.keyColumnName, start), nil
+		}
+		return fmt.Sprintf("%s >= %s", info.keyColumnName, start), nil
+	case end != nil:
+		// Half-open interval: (<start of index>, end].
+		if isDesc {
+			return fmt.Sprintf("%s >= %s", info.keyColumnName, end), nil
+		}
+		return fmt.Sprintf("%s <= %s", info.keyColumnName, end), nil
+	default:
+		// Full index scan. This code shouldn't be reachable, so we use a
+		// contradiction.
+		return "false", nil
+	}
 }
 
 // mostRecentAutomaticFullStat finds the most recent automatic statistic

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -16,12 +16,14 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -34,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -1430,5 +1433,302 @@ func TestAddMisestimateRandomized(t *testing.T) {
 			Spans:     new,
 		})
 		require.Equal(t, dedupAndMerge(append(old, new...)), r.misestimateSpans[id])
+	}
+}
+
+func TestSpanToBounds(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const tableID = 100
+	const indexID = 1
+
+	asc := catenumpb.IndexColumn_ASC
+	desc := catenumpb.IndexColumn_DESC
+
+	encodeInt := func(key roachpb.Key, v int, dir catenumpb.IndexColumn_Direction) roachpb.Key {
+		if dir == desc {
+			return encoding.EncodeVarintDescending(key, int64(v))
+		}
+		return encoding.EncodeVarintAscending(key, int64(v))
+	}
+
+	encodeString := func(
+		key roachpb.Key, s string, dir catenumpb.IndexColumn_Direction,
+	) roachpb.Key {
+		if dir == desc {
+			return encoding.EncodeStringDescending(key, s)
+		}
+		return encoding.EncodeStringAscending(key, s)
+	}
+
+	// makeIntKey builds a key with an optional leading integer datum, plus
+	// optional extra trailing bytes.
+	makeIntKey := func(
+		val *int, dir catenumpb.IndexColumn_Direction, extra ...byte,
+	) roachpb.Key {
+		key := keys.MakeTableIDIndexID(nil /* key */, tableID, indexID)
+		if val != nil {
+			key = encodeInt(key, *val, dir)
+		}
+		key = append(key, extra...)
+		return key
+	}
+
+	// makeStringKey builds a key with an optional leading string datum, plus
+	// optional extra trailing bytes.
+	makeStringKey := func(
+		val *string, dir catenumpb.IndexColumn_Direction, extra ...byte,
+	) roachpb.Key {
+		key := keys.MakeTableIDIndexID(nil /* key */, tableID, indexID)
+		if val != nil {
+			key = encodeString(key, *val, dir)
+		}
+		key = append(key, extra...)
+		return key
+	}
+
+	intPtr := func(v int) *int { return &v }
+	strPtr := func(s string) *string { return &s }
+
+	const colName = "c"
+
+	testCases := []struct {
+		name     string
+		span     roachpb.Span
+		dir      catenumpb.IndexColumn_Direction // asc if unset
+		colType  *types.T                        // types.Int if unset
+		expected string
+	}{
+		// --- Int column ---
+		{
+			name:     "int Get ASC",
+			span:     roachpb.Span{Key: makeIntKey(intPtr(42), asc)},
+			expected: "c = 42",
+		},
+		{
+			name:     "int Get no datum is contradiction",
+			span:     roachpb.Span{Key: makeIntKey(nil, asc)},
+			expected: "false",
+		},
+		{
+			name: "int closed interval ASC same value",
+			span: roachpb.Span{
+				// Note that this is an invalid span, but that's ok.
+				Key:    makeIntKey(intPtr(10), asc),
+				EndKey: makeIntKey(intPtr(10), asc),
+			},
+			expected: "c = 10",
+		},
+		{
+			name: "int closed interval ASC different values",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(5), asc),
+				EndKey: makeIntKey(intPtr(15), asc),
+			},
+			expected: "5 <= c AND c <= 15",
+		},
+		{
+			name: "int closed interval DESC different values",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(15), desc),
+				EndKey: makeIntKey(intPtr(5), desc),
+			},
+			dir:      desc,
+			expected: "15 >= c AND c >= 5",
+		},
+		{
+			name: "int half-open start only ASC",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(10), asc),
+				EndKey: makeIntKey(nil, asc),
+			},
+			expected: "c >= 10",
+		},
+		{
+			name: "int half-open start only DESC",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(10), desc),
+				EndKey: makeIntKey(nil, desc),
+			},
+			dir:      desc,
+			expected: "c <= 10",
+		},
+		{
+			name: "int half-open end only ASC",
+			span: roachpb.Span{
+				Key:    makeIntKey(nil, asc),
+				EndKey: makeIntKey(intPtr(20), asc),
+			},
+			expected: "c <= 20",
+		},
+		{
+			name: "int half-open end only DESC",
+			span: roachpb.Span{
+				Key:    makeIntKey(nil, desc),
+				EndKey: makeIntKey(intPtr(20), desc),
+			},
+			dir:      desc,
+			expected: "c >= 20",
+		},
+		{
+			name: "full index scan is contradiction",
+			span: roachpb.Span{
+				Key:    makeIntKey(nil, asc),
+				EndKey: keys.MakeTableIDIndexID(nil /* key */, tableID, indexID+1),
+			},
+			expected: "false",
+		},
+		{
+			name: "int negative values",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(-100), asc),
+				EndKey: makeIntKey(intPtr(-1), asc),
+			},
+			expected: "-100 <= c AND c <= -1",
+		},
+		{
+			name:     "int zero value Get",
+			span:     roachpb.Span{Key: makeIntKey(intPtr(0), asc)},
+			expected: "c = 0",
+		},
+
+		// --- String column ---
+		{
+			name:     "string Get ASC",
+			span:     roachpb.Span{Key: makeStringKey(strPtr("hello"), asc)},
+			colType:  types.String,
+			expected: "c = 'hello'",
+		},
+		{
+			name: "string closed interval ASC",
+			span: roachpb.Span{
+				Key:    makeStringKey(strPtr("aaa"), asc),
+				EndKey: makeStringKey(strPtr("zzz"), asc),
+			},
+			colType:  types.String,
+			expected: "'aaa' <= c AND c <= 'zzz'",
+		},
+		{
+			name: "string closed interval DESC",
+			span: roachpb.Span{
+				Key:    makeStringKey(strPtr("zzz"), desc),
+				EndKey: makeStringKey(strPtr("aaa"), desc),
+			},
+			dir:      desc,
+			colType:  types.String,
+			expected: "'zzz' >= c AND c >= 'aaa'",
+		},
+		{
+			name: "string half-open start ASC",
+			span: roachpb.Span{
+				Key:    makeStringKey(strPtr("foo"), asc),
+				EndKey: makeStringKey(nil, asc),
+			},
+			colType:  types.String,
+			expected: "c >= 'foo'",
+		},
+		{
+			name: "string half-open end ASC",
+			span: roachpb.Span{
+				Key:    makeStringKey(nil, asc),
+				EndKey: makeStringKey(strPtr("bar"), asc),
+			},
+			colType:  types.String,
+			expected: "c <= 'bar'",
+		},
+		{
+			name:     "string with special characters",
+			span:     roachpb.Span{Key: makeStringKey(strPtr("it's"), asc)},
+			colType:  types.String,
+			expected: "c = e'it\\'s'",
+		},
+
+		// --- Composite keys (trailing bytes from a second column) ---
+		{
+			// Same first-column value with different trailing bytes from a
+			// second column. Since the function strips trailing bytes via
+			// remainingKey, the first-column prefix is identical, reducing
+			// to equality.
+			name: "composite same first col trailing ASC",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(10), asc, 0x01),
+				EndKey: makeIntKey(intPtr(10), asc, 0x02),
+			},
+			expected: "c = 10",
+		},
+		{
+			// Different first-column values with trailing bytes still
+			// produce a range on the first column.
+			name: "composite different first col with trailing ASC",
+			span: roachpb.Span{
+				Key:    makeIntKey(intPtr(5), asc, 0x01),
+				EndKey: makeIntKey(intPtr(15), asc, 0x02),
+			},
+			expected: "5 <= c AND c <= 15",
+		},
+		{
+			name: "composite string with trailing ASC",
+			span: roachpb.Span{
+				Key:    makeStringKey(strPtr("abc"), asc, 0x01),
+				EndKey: makeStringKey(strPtr("abc"), asc, 0xFF),
+			},
+			colType:  types.String,
+			expected: "c = 'abc'",
+		},
+		{
+			// Simulate a real composite index (c INT, v INT) where the
+			// span covers (c=5, v=1) to (c=5, v=100). The second-column
+			// encoded values differ but the first-column value is the
+			// same, so we get equality on c.
+			name: "composite with different second Int column",
+			span: roachpb.Span{
+				Key:    encodeInt(makeIntKey(intPtr(5), asc), 1, asc),
+				EndKey: encodeInt(makeIntKey(intPtr(5), asc), 100, asc),
+			},
+			expected: "c = 5",
+		},
+		{
+			// Composite index (c INT, v INT), span covers (c=1, v=50)
+			// to (c=10, v=50). Different first-column values produce a
+			// range.
+			name: "composite with different first col and encoded second col",
+			span: roachpb.Span{
+				Key:    encodeInt(makeIntKey(intPtr(1), asc), 50, asc),
+				EndKey: encodeInt(makeIntKey(intPtr(10), asc), 50, asc),
+			},
+			expected: "1 <= c AND c <= 10",
+		},
+		{
+			// Composite index (c STRING, v INT), span covers
+			// (c='foo', v=1) to (c='foo', v=99).
+			name: "composite String first col with different second Int col",
+			span: roachpb.Span{
+				Key:    encodeInt(makeStringKey(strPtr("foo"), asc), 1, asc),
+				EndKey: encodeInt(makeStringKey(strPtr("foo"), asc), 99, asc),
+			},
+			colType:  types.String,
+			expected: "c = 'foo'",
+		},
+	}
+
+	var da tree.DatumAlloc
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colType := tc.colType
+			if colType == nil {
+				colType = types.Int
+			}
+			info := indexInfo{
+				tableID:       tableID,
+				indexID:       indexID,
+				keyColumnName: colName,
+				keyColumnDir:  tc.dir,
+				keyColumnType: colType,
+			}
+			result, err := spanToBounds(context.Background(), keys.SystemSQLCodec, tc.span, info, &da)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, result)
+		})
 	}
 }


### PR DESCRIPTION
Add `spanToBounds` which decodes index key spans into SQL filter expressions (e.g. `5 <= c AND c <= 15`) to be used as WHERE clauses when collecting partial "fixup" table statistics. The function handles ASC/DESC key directions, equality, half-open and closed intervals, composite keys (truncating to the first column). For simplicity, NULLs in the boundaries are handled by resulting in a contradiction.

Informs: #152995.
Epic: None
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>