### PR TITLE
roachtest: migrate to new SHOW BACKUPS

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -278,6 +278,7 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) error {
 	conn := bd.c.Conn(ctx, bd.t.L(), 1)
 	defer conn.Close()
 	sql := sqlutils.MakeSQLRunner(conn)
+	sql.Exec(bd.t, "SET use_backups_with_ids = true")
 	fixtureURI := bd.registry.URI(bd.fixture.DataPath)
 	const (
 		WaitingFirstFull = iota
@@ -312,11 +313,14 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) error {
 			}
 		case RunningIncrementals:
 			var backupCount int
-			// We track completed backups via SHOW BACKUP as opposed to SHOW JOBs in
+			// We track completed backups via SHOW BACKUPS as opposed to SHOW JOBs in
 			// the case that a fixture runs for a long enough time that old backup
 			// jobs stop showing up in SHOW JOBS.
+			// Since some fixtures have more than 50 backups in their collections, we
+			// set both OLDER THAN and NEWER THAN to avoid pagination.
 			backupCountQuery := fmt.Sprintf(
-				`SELECT count(DISTINCT end_time) FROM [SHOW BACKUP FROM LATEST IN '%s']`, fixtureURI.String(),
+				`SELECT count(*) FROM [SHOW BACKUPS IN '%s' OLDER THAN 'now' NEWER THAN '-1w']`,
+				fixtureURI.String(),
 			)
 			sql.QueryRow(bd.t, backupCountQuery).Scan(&backupCount)
 			bd.t.L().Printf(`%d scheduled backups taken`, backupCount)
@@ -482,11 +486,11 @@ func (bd *backupDriver) getLatestAOST(ctx context.Context) string {
 	conn := bd.c.Conn(ctx, bd.t.L(), 1)
 	defer conn.Close()
 	sql := sqlutils.MakeSQLRunner(conn)
+	sql.Exec(bd.t, "SET use_backups_with_ids = true")
 	uri := bd.registry.URI(bd.fixture.DataPath)
 	query := fmt.Sprintf(
 		`SELECT end_time FROM
 		[SHOW BACKUP FROM LATEST IN '%s']
-		ORDER BY end_time DESC
 		LIMIT 1`,
 		uri.String(),
 	)

--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -507,6 +507,44 @@ func (d BackupRestoreTestDriver) getORDownloadJobID(
 func (d *BackupRestoreTestDriver) deleteSSTFromBackupLayers(
 	ctx context.Context, l *logger.Logger, db *gosql.DB, collection *backupCollection,
 ) error {
+	if _, err := db.ExecContext(ctx, "SET use_backups_with_ids = true"); err != nil {
+		return err
+	}
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT id FROM [SHOW BACKUPS IN $1]`,
+		collection.uri(),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed to query for backup ids in %q", collection.uri())
+	}
+	defer rows.Close()
+	var backupIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return errors.Wrap(err, "error scanning SHOW BACKUPS row")
+		}
+		backupIDs = append(backupIDs, id)
+	}
+
+	for _, backupID := range backupIDs {
+		if err := d.deleteSSTFromBackup(ctx, l, db, collection, backupID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteSSTFromBackup deletes one SST file from the specified backup in a
+// collection.
+func (d *BackupRestoreTestDriver) deleteSSTFromBackup(
+	ctx context.Context,
+	l *logger.Logger,
+	db *gosql.DB,
+	collection *backupCollection,
+	backupID string,
+) error {
 	type sstInfo struct {
 		path, start, end string
 		bytes, rows      int
@@ -519,7 +557,7 @@ func (d *BackupRestoreTestDriver) deleteSSTFromBackupLayers(
 		// the missing file.
 		`WITH with_dir AS (
 			SELECT *, regexp_replace(path, '/[^/]+\.sst$', '') AS dir
-			FROM [SHOW BACKUP FILES FROM LATEST IN $1]
+			FROM [SHOW BACKUP FILES FROM $1 IN $2]
 		)
 		SELECT path, start_pretty, end_pretty, size_bytes, rows
 		FROM (
@@ -527,10 +565,11 @@ func (d *BackupRestoreTestDriver) deleteSSTFromBackupLayers(
 			FROM with_dir
 		)
 		WHERE rn = 1`,
+		backupID,
 		collection.uri(),
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to query for backup files in %q", collection.uri())
+		return errors.Wrapf(err, "failed to query for backup files in backup %q of collection %q", backupID, collection.uri())
 	}
 	defer rows.Close()
 	var ssts []sstInfo
@@ -545,7 +584,7 @@ func (d *BackupRestoreTestDriver) deleteSSTFromBackupLayers(
 		return errors.Wrap(rows.Err(), "error iterating over SHOW BACKUP FILES")
 	}
 	if len(ssts) == 0 {
-		return errors.Newf("unexpectedly found no SST files to delete in %q", collection.uri())
+		return errors.Newf("unexpectedly found no SST files to delete in backup %q of collection %q", backupID, collection.uri())
 	}
 	uri, err := url.Parse(collection.uri())
 	if err != nil {
@@ -576,7 +615,7 @@ func (d *BackupRestoreTestDriver) deleteSSTFromBackupLayers(
 			return errors.Wrapf(
 				err, "failed to rename sst %s from backup %s in collection %s",
 				sst.path,
-				collection.name,
+				backupID,
 				uri,
 			)
 		}
@@ -962,8 +1001,11 @@ func (cb *CollectionBuilder) TakeCompacted(
 
 	var fullPath string
 	_, db := cb.driver.testUtils.RandomDB(cb.rng, cb.driver.roachNodes)
+	if _, err := db.ExecContext(ctx, "SET use_backups_with_ids = true"); err != nil {
+		return 0, err
+	}
 	row := db.QueryRowContext(ctx, fmt.Sprintf(
-		`SELECT path FROM [SHOW BACKUPS IN '%s'] ORDER BY path DESC LIMIT 1`,
+		`SELECT full_subdir FROM [SHOW BACKUPS IN '%s' WITH DEBUG] LIMIT 1`,
 		cb.collection.uri(),
 	))
 	if err := row.Scan(&fullPath); err != nil {

--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -716,12 +717,16 @@ func (u *CommonTestUtils) checkFiles(
 	if opt := collection.encryptionOption(); opt != nil {
 		options = append(options, opt.String())
 	}
-
+	// TODO (kev-cao): Need to update this once we've decided how we want to
+	// handle CHECK FILES under the new SHOW BACKUPS.
+	_, conn := u.RandomDB(rng, u.roachNodes)
+	defer disableUseBackupsWithIDs(ctx, u.t, conn)()
 	checkFilesStmt := fmt.Sprintf(
 		"SHOW BACKUP LATEST IN '%s' WITH %s",
 		collection.uri(), strings.Join(options, ", "),
 	)
-	return u.Exec(ctx, rng, checkFilesStmt)
+	_, err := conn.Exec(checkFilesStmt)
+	return err
 }
 
 func supportsCheckFiles(rng *rand.Rand, h *mixedversion.Helper) (bool, error) {
@@ -950,4 +955,20 @@ func prepSchemaChangeWorkload(
 		return err
 	}
 	return nil
+}
+
+// disableUseBackupsWithIDs disables the `use_backups_with_ids` session
+// setting and returns a function that restores the previous value. As we
+// migrate towards the new SHOW BACKUPS, this is used as a stop-gap until all
+// old instances are cleaned up.
+func disableUseBackupsWithIDs(ctx context.Context, t test.Test, db *gosql.DB) func() {
+	var oldValue string
+	err := db.QueryRowContext(ctx, "SHOW use_backups_with_ids").Scan(&oldValue)
+	require.NoError(t, err, "failed to query use_backups_with_ids cluster setting")
+	_, err = db.ExecContext(ctx, "SET use_backups_with_ids = false")
+	require.NoError(t, err, "failed to set use_backups_with_ids cluster setting")
+	return func() {
+		_, err := db.ExecContext(ctx, fmt.Sprintf("SET use_backups_with_ids = %s", oldValue))
+		require.NoError(t, err, "failed to restore use_backups_with_ids cluster setting")
+	}
 }

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -842,6 +842,9 @@ func (rd *restoreDriver) getAOST(ctx context.Context) {
 	var aost string
 	conn := rd.c.Conn(ctx, rd.t.L(), 1)
 	defer conn.Close()
+	// TODO (kev-cao): Once the restore roachtests are updated to use the IDs, we
+	// can remove this.
+	defer disableUseBackupsWithIDs(ctx, rd.t, conn)()
 	aostCmd := rd.sp.getFullBackupEndTimeCmd(ctx, rd.t, rd.collectionURI)
 	err := conn.QueryRowContext(ctx, aostCmd).Scan(&aost)
 	require.NoError(rd.t, err, fmt.Sprintf("aost cmd failed: %s", aostCmd))

--- a/pkg/cmd/roachtest/tests/s3_clone_backup_restore.go
+++ b/pkg/cmd/roachtest/tests/s3_clone_backup_restore.go
@@ -154,44 +154,37 @@ type s3BackupRestoreValidator struct {
 
 // checkBackups verifies that there is exactly one full and one incremental backup.
 func (v *s3BackupRestoreValidator) checkBackups(ctx context.Context, conn *gosql.DB) {
-	backups := conn.QueryRowContext(ctx, "SHOW BACKUPS IN 'external://backup_bucket'")
-	var path string
-	if err := backups.Scan(&path); err != nil {
+	if _, err := conn.ExecContext(ctx, "SET use_backups_with_ids = true"); err != nil {
 		v.t.Fatal(err)
 	}
-
-	rows, err := conn.QueryContext(ctx,
-		"SELECT backup_type from [SHOW BACKUP $1 IN 'external://backup_bucket'] WHERE object_type='table'",
-		path)
-
+	rows, err := conn.QueryContext(
+		ctx,
+		"SELECT start_time IS NULL FROM [SHOW BACKUPS IN 'external://backup_bucket' WITH DEBUG]",
+	)
 	if err != nil {
 		v.t.Fatal(err)
 	}
-	var foundFull, foundIncr bool
-	var rowCount int
+	fulls, incs := 0, 0
 	for rows.Next() {
-		var backupType string
-		if err := rows.Scan(&backupType); err != nil {
+		var isFull bool
+		if err := rows.Scan(&isFull); err != nil {
 			v.t.Fatal(err)
 		}
-		if backupType == "full" {
-			foundFull = true
+		if isFull {
+			fulls++
+		} else {
+			incs++
 		}
-		if backupType == "incremental" {
-			foundIncr = true
-		}
-		rowCount++
 	}
-	if !foundFull {
+	if fulls == 0 {
 		v.t.Fatal(errors.Errorf("full backup not found"))
 	}
-	if !foundIncr {
+	if incs == 0 {
 		v.t.Fatal(errors.Errorf("incremental backup not found"))
 	}
-	if rowCount > 2 {
+	if fulls+incs > 2 {
 		v.t.Fatal(errors.Errorf("found more than 2 backups"))
 	}
-
 }
 
 // runImportForS3CloneTesting import the data used to test the S3 clone backup/restore

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -156,8 +156,11 @@ func saveArtifacts(ctx context.Context, t test.Test, c cluster.Cluster, storeDir
 	if err != nil {
 		t.L().Printf("Failed execute backup command on node 1: %v\n", err.Error())
 	}
+	if _, err := db.Exec("SET use_backups_with_ids = true"); err != nil {
+		t.L().Printf("Failed to set use_backups_with_ids on node 1: %v\n", err.Error())
+	}
 	var backupPath string
-	if err := db.QueryRow("SELECT path FROM [SHOW BACKUPS IN 'nodelocal://1/schemachange']").Scan(&backupPath); err != nil {
+	if err := db.QueryRow("SELECT path FROM [SHOW BACKUPS IN 'nodelocal://1/schemachange' WITH DEBUG]").Scan(&backupPath); err != nil {
 		t.L().Printf("Failed to get backup path from node 1: %v\n", err.Error())
 	}
 	remoteBackupFilePath := filepath.Join(storeDirectory, "extern", "schemachange", backupPath)


### PR DESCRIPTION
This commit migrates the majority of SHOW BACKUPS calls in our roachtests to the new SHOW BACKUPS UX.

Resolves: #163237

Release note: None