### PR TITLE
release-26.2: roachtest: add exit code 13 for storage invariant violations

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -53,6 +53,11 @@ const (
 	// occur with any of the other exit codes.
 	ExitCodeGithubPostFailed = 12
 
+	// ExitCodeStorageInvariantViolation is the exit code indicating that a
+	// storage invariant violation (e.g., raft log corruption, Pebble checksum
+	// mismatch) was detected during a roachtest run.
+	ExitCodeStorageInvariantViolation = 13
+
 	// runnerLogsDir is the dir under the artifacts root where the test runner log
 	// and other runner-related logs (i.e. cluster creation logs) will be written.
 	runnerLogsDir = "_runner-logs"
@@ -287,7 +292,9 @@ Example:
 
 	if err := rootCmd.Execute(); err != nil {
 		code := 1
-		if errors.Is(err, errGithubPostFailed) {
+		if errors.Is(err, errStorageInvariantViolation) {
+			code = ExitCodeStorageInvariantViolation
+		} else if errors.Is(err, errGithubPostFailed) {
 			code = ExitCodeGithubPostFailed
 		} else if errors.Is(err, errSomeClusterProvisioningFailed) {
 			code = ExitCodeClusterProvisioningFailed

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -74,6 +74,10 @@ var (
 	// worker encountered an error when trying to POST to GitHub
 	errGithubPostFailed = fmt.Errorf("failed to POST to GitHub")
 
+	// errStorageInvariantViolation error sent after a run in [testRunner.Run]
+	// if any worker detected a storage invariant violation.
+	errStorageInvariantViolation = fmt.Errorf("potential data corruption: storage invariant violation detected")
+
 	prometheusNameSpace = "roachtest"
 	// prometheusScrapeInterval should be consistent with the scrape interval defined in
 	// https://grafana.testeng.crdb.io/prometheus/config
@@ -303,6 +307,10 @@ type testRunner struct {
 
 	// numGithubPostErrs Counts GitHub post errors across all workers
 	numGithubPostErrs int32
+
+	// storageInvariantViolation is set when a storage invariant violation
+	// is detected by maybeSaveClusterDueToInvariantProblems.
+	storageInvariantViolation atomic.Bool
 }
 
 type perfMetricsCollector struct {
@@ -581,6 +589,10 @@ func (r *testRunner) Run(
 	// For the errors that don't short-circuit the pipeline run, return a joined
 	// error and leave case handling to the caller
 	var err error
+	if r.storageInvariantViolation.Load() {
+		shout(ctx, l, lopt.stdout, "potential data corruption: invariant violation detected")
+		err = errors.Join(err, errStorageInvariantViolation)
+	}
 	if r.numGithubPostErrs > 0 {
 		shout(ctx, l, lopt.stdout, "%d errors occurred while posting to github", r.numGithubPostErrs)
 		err = errors.Join(err, errGithubPostFailed)
@@ -2044,6 +2056,7 @@ func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 				snapName = "<failed>"
 			}
 			c.Save(ctx, "invariant problem - snap name "+snapName, t.L())
+			r.storageInvariantViolation.Store(true)
 			t.Error("invariant problem - snap name " + snapName + ":\n" + det.Stdout)
 			return
 		}

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -1103,4 +1104,46 @@ func TestRunnerProvisionErrorGithubError(t *testing.T) {
 	// Assert test runner workers' error counts are as expected
 	require.Equal(t, runner.numGithubPostErrs, int32(1), "expected exactly 1 github post errors")
 	require.Equal(t, runner.numClusterErrs, int32(1), "expected exactly 1 cluster errors")
+}
+
+func TestRunnerInvariantViolation(t *testing.T) {
+	for _, testFailed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("failed=%t", testFailed), func(t *testing.T) {
+			ctx := context.Background()
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+			cr := newClusterRegistry()
+			runner := newUnitTestRunner(cr, stopper)
+
+			var buf syncedBuffer
+			copt := defaultClusterOpt()
+			lopt := defaultLoggingOpt(&buf)
+			test := registry.TestSpec{
+				Name:             `invariant`,
+				Owner:            OwnerUnitTest,
+				Timeout:          10 * time.Second,
+				Cluster:          spec.MakeClusterSpec(0),
+				CompatibleClouds: registry.AllClouds,
+				Suites:           registry.Suites(registry.Nightly),
+				CockroachBinary:  registry.StandardCockroach,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					if testFailed {
+						t.Fatal("boom")
+					}
+				},
+			}
+
+			// Simulate an invariant violation detected during teardown.
+			runner.storageInvariantViolation.Store(true)
+
+			github := defaultGithub(runner.config.disableIssue)
+			err := runner.Run(ctx, []registry.TestSpec{test}, 1, /* count */
+				defaultParallelism, copt, testOpts{}, lopt, github)
+
+			require.ErrorIs(t, err, errStorageInvariantViolation)
+			if testFailed {
+				require.ErrorIs(t, err, errTestsFailed)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #167798 on behalf of @williamchoe3.

----

When `maybeSaveClusterDueToInvariantProblems` detects storage corruption
(raft log corruption, Pebble checksum mismatch), roachtest now exits
with code 13 (`ExitCodeStorageInvariantViolation`) instead of the generic
code 10 (test failure). This lets TeamCity fire a dedicated alert for
potential data corruption.

Informs #167367
Epic: none

----

Release justification: test only