### PR TITLE
release-26.1: kvserver: stop wrapping AbortSpan errors as ReplicaCorruptionError

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2718,8 +2718,7 @@ func checkIfTxnAborted(
 	var entry roachpb.AbortSpanEntry
 	aborted, err := rec.AbortSpan().Get(ctx, reader, txn.ID, &entry)
 	if err != nil {
-		return kvpb.NewError(kvpb.MaybeWrapReplicaCorruptionError(ctx,
-			errors.Wrap(err, "could not read from AbortSpan")))
+		return kvpb.NewError(errors.Wrap(err, "could not read from AbortSpan"))
 	}
 	if aborted {
 		// We hit the cache, so let the transaction restart.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3374,18 +3374,9 @@ func TestReplicaNoTSCacheIncrementWithinTxn(t *testing.T) {
 // TestReplicaAbortSpanReadError verifies that an error is returned
 // to the client in the event that a AbortSpan entry is found but is
 // not decodable.
-//
-// This doubles as a test that replica corruption errors are propagated
-// and handled correctly.
 func TestReplicaAbortSpanReadError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	var exitStatus exit.Code
-	log.SetExitFunc(true /* hideStack */, func(i exit.Code) {
-		exitStatus = i
-	})
-	defer log.ResetExitFunc()
 
 	ctx := context.Background()
 	tc := testContext{}
@@ -3415,12 +3406,8 @@ func TestReplicaAbortSpanReadError(t *testing.T) {
 	_, pErr := tc.SendWrappedWith(kvpb.Header{
 		Txn: txn,
 	}, args)
-	if !testutils.IsPError(pErr, "replica corruption") {
-		t.Fatal(pErr)
-	}
-	if exitStatus != exit.FatalError() {
-		t.Fatalf("did not fatal (exit status %d)", exitStatus)
-	}
+	require.True(t, testutils.IsPError(pErr, "could not read from AbortSpan"),
+		"unexpected error: %s", pErr)
 }
 
 // TestReplicaAbortSpanOnlyWithIntent verifies that a transactional command


### PR DESCRIPTION
Backport 1/2 commits from #167295.

/cc @cockroachdb/release

---

AbortSpan read errors were wrapped as `ReplicaCorruptionError`, causing the
node to fatal via `setCorruptRaftMuLocked`. This was overly aggressive: a
failure to read from the AbortSpan is not indicative of replica corruption.
Transient I/O errors would crash the node instead of being returned to the
caller.

This is the last remaining production call site that produces
`ReplicaCorruptionError` (the split/merge trigger wrapping was removed in
#167289).

Informs: #165558
Epic: none

Release justification: Low-risk bug fix. One-line change that stops wrapping
a non-corruption error as `ReplicaCorruptionError`, preventing unnecessary
node crashes on transient I/O errors during AbortSpan reads.