### PR TITLE
roachtest/operations: add long-running operation support

### DIFF
--- a/pkg/cmd/roachtest/operation_impl.go
+++ b/pkg/cmd/roachtest/operation_impl.go
@@ -23,7 +23,7 @@ import (
 var errOperationFatal = errors.New("o.Fatal() was called")
 
 type operationImpl struct {
-	workerId        int
+	workerLabel     string
 	spec            *registry.OperationSpec
 	clusterSettings install.ClusterSettings
 	startOpts       option.StartOpts
@@ -80,7 +80,7 @@ func (o *operationImpl) Status(args ...interface{}) {
 
 	o.mu.status = fmt.Sprint(args...)
 	if !o.L().Closed() {
-		o.L().PrintfCtxDepth(context.TODO(), 3, "[%d] operation status: %s", o.workerId, o.mu.status)
+		o.L().PrintfCtxDepth(context.TODO(), 3, "[%s] operation status: %s", o.workerLabel, o.mu.status)
 	}
 }
 
@@ -135,7 +135,7 @@ func (o *operationImpl) addFailure(depth int, format string, args ...interface{}
 	msg := reportFailure.Error()
 
 	failureNum := len(o.mu.failures)
-	o.L().Printf("[%d] operation failure #%d: %s", o.workerId, failureNum, msg)
+	o.L().Printf("[%s] operation failure #%d: %s", o.workerLabel, failureNum, msg)
 }
 
 func (o *operationImpl) Failed() bool {

--- a/pkg/cmd/roachtest/operations/probe_ranges.go
+++ b/pkg/cmd/roachtest/operations/probe_ranges.go
@@ -84,23 +84,25 @@ func runProbeRanges(
 
 func registerProbeRanges(r registry.Registry) {
 	r.AddOperation(registry.OperationSpec{
-		Name:               "probe-ranges/read",
-		Owner:              registry.OwnerKV, // Contact SRE first, as they own the prober.
-		Timeout:            30 * time.Minute,
-		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCannotRunConcurrently,
-		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase, registry.OperationRequiresZeroUnavailableRanges},
+		Name:             "probe-ranges/read",
+		Owner:            registry.OwnerKV, // Contact SRE first, as they own the prober.
+		Timeout:          1 * time.Hour,
+		CompatibleClouds: registry.AllClouds,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Cadence:          1 * time.Hour,
+		LongRunning:      true,
 		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 			return runProbeRanges(ctx, o, c, false)
 		},
 	})
 	r.AddOperation(registry.OperationSpec{
-		Name:               "probe-ranges/write",
-		Owner:              registry.OwnerKV, // Contact SRE first, as they own the prober.
-		Timeout:            30 * time.Minute,
-		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCannotRunConcurrently,
-		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase, registry.OperationRequiresZeroUnavailableRanges},
+		Name:             "probe-ranges/write",
+		Owner:            registry.OwnerKV, // Contact SRE first, as they own the prober.
+		Timeout:          1 * time.Hour,
+		CompatibleClouds: registry.AllClouds,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Cadence:          1 * time.Hour,
+		LongRunning:      true,
 		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 			return runProbeRanges(ctx, o, c, true)
 		},

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -97,6 +97,19 @@ type OperationSpec struct {
 	// not degrade cluster state during the wait.
 	DeferCleanup bool
 
+	// LongRunning marks this operation as long-running. Long-running
+	// operations execute in a dedicated goroutine, separate from the normal
+	// worker pool, and run sequentially (one at a time). Their Run()
+	// functions are expected to take a long time (e.g., consistency checks,
+	// range probes). Long-running operations must be non-destructive to
+	// cluster state — never kill nodes, network-partition.
+	LongRunning bool
+
+	// Cadence overrides the global --wait-before-next-execution interval for
+	// this specific operation. When zero, the global default applies.
+	// Available for all operations (both normal and long-running).
+	Cadence time.Duration
+
 	// Run is the operation function. It returns an OperationCleanup if this
 	// operation requires additional cleanup steps afterwards (eg. dropping an
 	// extra column that was created). A nil return value indicates no cleanup
@@ -104,11 +117,22 @@ type OperationSpec struct {
 	Run func(ctx context.Context, o operation.Operation, c cluster.Cluster) OperationCleanup
 }
 
-// NamePrefix returns the first part of `o.Name` after splitting with delimiter `/`
+// NamePrefix returns the first part of `o.Name` after splitting with delimiter `/`.
 func (o *OperationSpec) NamePrefix() string {
 	parts := strings.Split(o.Name, "/")
 	if len(parts) > 0 {
 		return parts[0]
 	}
 	return o.Name
+}
+
+// DedupKey returns the key used to deduplicate concurrent operation runs.
+// Short-lived operations use the name prefix so that variants like
+// "drain/node-1" and "drain/node-2" are mutually exclusive. Long-running
+// operations use the full name so each variant can run independently.
+func (o *OperationSpec) DedupKey() string {
+	if o.LongRunning {
+		return o.Name
+	}
+	return o.NamePrefix()
 }

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -293,10 +293,10 @@ func (r *opsRunner) selectOperationToRun(
 	if opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
 		r.status.lockOperationSelection = true
 		// selected operation cannot run concurrently with other operations —
-		// wait for other running operations to finish.
+		// wait for other running operations and pending cleanups to finish.
 		workerLabel := strconv.Itoa(workerID)
 		for {
-			if len(r.status.running) == 0 {
+			if len(r.status.running) == 0 && len(r.status.pendingCleanup) == 0 {
 				break
 			}
 			r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, opSpec.NamePrefix(), workerStateWaitingLock)

--- a/pkg/cmd/roachtest/run_operation.go
+++ b/pkg/cmd/roachtest/run_operation.go
@@ -8,12 +8,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"math/rand"
 	"net/http"
 	"os"
 	"slices"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -39,6 +39,14 @@ import (
 
 const baseSleepTime = 15
 
+// operationPool identifies which worker pool an operation belongs to.
+type operationPool int
+
+const (
+	normalPool operationPool = iota + 1
+	longRunningPool
+)
+
 // deferredCleanup holds everything needed to run a cleanup that was
 // deferred by a DeferCleanup operation. It is enqueued with a future
 // executeAt time and processed by the cleanup processor goroutine.
@@ -54,7 +62,6 @@ type deferredCleanup struct {
 type opsRunner struct {
 	clusterName string
 	nodeCount   int
-	opsToRun    []registry.OperationSpec
 
 	workloadClusterName string
 	workloadNodes       int
@@ -78,13 +85,17 @@ type opsRunner struct {
 
 	status struct {
 		syncutil.Mutex
-		// locks out worker from selecting operation to run
+		// lockOperationSelection prevents normal-pool workers from
+		// selecting new operations while an exclusive operation is
+		// draining. Long-running workers are exempt.
 		lockOperationSelection bool
 		// condition variable used to wait for running operation to finish
 		// before running an operation which cannotRunConcurrently
 		operationRunCompleted sync.Cond
-		running               map[string]struct{}
-		lastRun               map[string]time.Time
+		// running maps operation dedup keys to their pool so that
+		// exclusive normal operations only drain same-pool entries.
+		running map[string]operationPool
+		lastRun map[string]time.Time
 		// pendingCleanup tracks operations with deferred cleanup waiting
 		// to execute. Prevents re-selection until cleanup completes.
 		pendingCleanup map[string]struct{}
@@ -114,11 +125,20 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 		return err
 	}
 
+	// Split operations into normal and long-running lists.
+	var normalOps, longRunningOps []registry.OperationSpec
+	for _, op := range opSpecs {
+		if op.LongRunning {
+			longRunningOps = append(longRunningOps, op)
+		} else {
+			normalOps = append(normalOps, op)
+		}
+	}
+
 	metrics := newOperationMetrics(r.PromFactory())
 	or := opsRunner{
 		clusterName:             clusterName,
 		nodeCount:               cluster.VMs.Len(),
-		opsToRun:                opSpecs,
 		seed:                    seed,
 		logger:                  l,
 		metrics:                 metrics,
@@ -127,7 +147,7 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 		waitBeforeNextExecution: roachtestflags.WaitBeforeNextExecution,
 		runForever:              roachtestflags.RunForever,
 	}
-	or.status.running = make(map[string]struct{})
+	or.status.running = make(map[string]operationPool)
 	or.status.lastRun = make(map[string]time.Time)
 	or.status.pendingCleanup = make(map[string]struct{})
 	or.status.operationRunCompleted.L = &or.status
@@ -164,10 +184,18 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 	var wg errgroup.Group
 	runForever := roachtestflags.RunForever
 	parallelism := min(roachtestflags.OperationParallelism, roachtestflags.MaxOperationParallelism)
-	for i := 1; i <= parallelism; i++ {
-		idx := i
+	if len(normalOps) > 0 {
+		for i := 1; i <= parallelism; i++ {
+			label := fmt.Sprintf("worker-%d", i)
+			wg.Go(func() error {
+				or.runWorker(ctx, label, runForever, normalOps, normalPool)
+				return nil
+			})
+		}
+	}
+	if len(longRunningOps) > 0 {
 		wg.Go(func() error {
-			or.runWorker(ctx, idx, runForever)
+			or.runWorker(ctx, "long-running", runForever, longRunningOps, longRunningPool)
 			return nil
 		})
 	}
@@ -178,38 +206,75 @@ func runOperations(register func(registry.Registry), filter, skip, clusterName s
 	return wgErr
 }
 
-// setWorkerState updates the workerCurrentOperation gauge for a worker,
-// clearing the previous state and setting the new one.
-func (r *opsRunner) setWorkerState(workerLabel, prevOp, prevState, newOp, newState string) {
-	if prevOp != "" && prevState != "" {
-		r.metrics.workerCurrentOperation.
-			WithLabelValues(workerLabel, prevOp, prevState).Set(0)
+// workerStateTracker tracks the current metric state for a single worker,
+// clearing the previous gauge value before setting the new one.
+type workerStateTracker struct {
+	label    string
+	metrics  *operationMetrics
+	curOp    string
+	curState string
+}
+
+func newWorkerStateTracker(label string, metrics *operationMetrics) *workerStateTracker {
+	w := &workerStateTracker{label: label, metrics: metrics}
+	w.setIdle()
+	return w
+}
+
+// transition clears the current gauge and sets the new (op, state) pair.
+func (w *workerStateTracker) transition(op, state string) {
+	if w.curOp != "" && w.curState != "" {
+		w.metrics.workerCurrentOperation.
+			WithLabelValues(w.label, w.curOp, w.curState).Set(0)
 	}
-	if newOp != "" && newState != "" {
-		r.metrics.workerCurrentOperation.
-			WithLabelValues(workerLabel, newOp, newState).Set(1)
+	w.curOp, w.curState = op, state
+	if op != "" && state != "" {
+		w.metrics.workerCurrentOperation.
+			WithLabelValues(w.label, op, state).Set(1)
 	}
 }
 
-// runWorker manages the infinite loop for one operation runner worker.
-func (r *opsRunner) runWorker(ctx context.Context, workerIdx int, runForever bool) {
-	rng := rand.New(rand.NewSource(r.seed + int64(workerIdx)))
-	workerLabel := strconv.Itoa(workerIdx)
+func (w *workerStateTracker) setIdle() {
+	w.transition(workerOperationIdle, workerStateIdle)
+}
 
-	// Start idle.
-	r.setWorkerState(workerLabel, "", "", workerOperationIdle, workerStateIdle)
+func (w *workerStateTracker) setExecuting(opName string) {
+	w.transition(opName, workerStateExecuting)
+}
+
+func (w *workerStateTracker) clear() { w.transition("", "") }
+
+// runWorker manages the loop for one operation runner worker. It
+// selects operations from the given ops slice, executes them, and
+// repeats until the context is cancelled or runForever is false.
+// Both normal and long-running workers use this method — the only
+// difference is the ops slice they receive.
+func (r *opsRunner) runWorker(
+	ctx context.Context,
+	workerLabel string,
+	runForever bool,
+	ops []registry.OperationSpec,
+	pool operationPool,
+) {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(workerLabel))
+	rng := rand.New(rand.NewSource(r.seed + int64(h.Sum64())))
+	ws := newWorkerStateTracker(workerLabel, r.metrics)
+	consecutiveMisses := 0
 
 	for {
-		if err := ctx.Err(); err != nil {
-			r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, "", "")
+		if ctx.Err() != nil {
+			ws.clear()
 			return
 		}
 
-		opSpec := r.selectOperationToRun(ctx, rng, workerIdx)
+		opSpec := r.selectOperationToRun(ctx, rng, ws, ops, pool)
 		if opSpec == nil {
-			// Already idle, stay idle.
+			consecutiveMisses++
 			sleepDuration := time.Duration(baseSleepTime+rng.Intn(baseSleepTime)) * time.Second
-			r.logger.Printf("[%d] couldn't find candidate operation to run, sleeping for %s", workerIdx, sleepDuration)
+			if consecutiveMisses == 1 || consecutiveMisses%10 == 0 {
+				r.logger.Printf("[%s] couldn't find candidate operation to run (x%d), sleeping for %s", workerLabel, consecutiveMisses, sleepDuration)
+			}
 			select {
 			case <-time.After(sleepDuration):
 			case <-ctx.Done():
@@ -217,31 +282,19 @@ func (r *opsRunner) runWorker(ctx context.Context, workerIdx int, runForever boo
 			}
 			continue
 		}
+		consecutiveMisses = 0
 
-		r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, opSpec.NamePrefix(), workerStateExecuting)
-		_, deferred := r.runOperation(ctx, opSpec, rng, workerIdx)
-		func() {
-			r.status.Lock()
-			defer r.status.Unlock()
-			defer r.status.operationRunCompleted.Broadcast()
-			if r.status.lockOperationSelection && opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
-				r.status.lockOperationSelection = false
-			}
-			delete(r.status.running, opSpec.NamePrefix())
-			r.status.lastRun[opSpec.NamePrefix()] = timeutil.Now()
-			if deferred {
-				r.status.pendingCleanup[opSpec.NamePrefix()] = struct{}{}
-			}
-		}()
-
-		r.setWorkerState(workerLabel, opSpec.NamePrefix(), workerStateExecuting, workerOperationIdle, workerStateIdle)
+		ws.setExecuting(opSpec.NamePrefix())
+		_, deferred := r.runOperation(ctx, opSpec, rng, workerLabel)
+		r.completeOperation(opSpec, deferred)
+		ws.setIdle()
 
 		if !runForever {
-			r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, "", "")
+			ws.clear()
 			return
 		}
 		sleepDuration := time.Duration(1+rng.Intn(2)) * time.Minute
-		r.logger.Printf("[%d] going idle for %s", workerIdx, sleepDuration)
+		r.logger.Printf("[%s] going idle for %s", workerLabel, sleepDuration)
 		select {
 		case <-time.After(sleepDuration):
 		case <-ctx.Done():
@@ -250,63 +303,97 @@ func (r *opsRunner) runWorker(ctx context.Context, workerIdx int, runForever boo
 	}
 }
 
-// selectOperationToRun picks one operation to run, that hasn't been run for at least waitBeforeNextExecution time.
-func (r *opsRunner) selectOperationToRun(
-	ctx context.Context, rng *rand.Rand, workerID int,
-) *registry.OperationSpec {
+// runningCount returns the number of operations currently executing
+// in the given pool. Caller must hold r.status.Lock.
+func (r *opsRunner) runningCount(pool operationPool) int {
+	count := 0
+	for _, p := range r.status.running {
+		if p == pool {
+			count++
+		}
+	}
+	return count
+}
 
-	if err := ctx.Err(); err != nil {
+// completeOperation updates the status maps after an operation finishes.
+// It removes the operation from running, records lastRun time, optionally
+// marks deferred cleanup, and broadcasts to unblock waiting workers.
+func (r *opsRunner) completeOperation(opSpec *registry.OperationSpec, deferred bool) {
+	r.status.Lock()
+	defer r.status.Unlock()
+	defer r.status.operationRunCompleted.Broadcast()
+	if r.status.lockOperationSelection &&
+		opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
+		r.status.lockOperationSelection = false
+	}
+	key := opSpec.DedupKey()
+	delete(r.status.running, key)
+	r.status.lastRun[key] = timeutil.Now()
+	if deferred {
+		r.status.pendingCleanup[key] = struct{}{}
+	}
+}
+
+// selectOperationToRun picks one operation from ops to run, that hasn't
+// been run for at least its cadence interval (or the global default).
+func (r *opsRunner) selectOperationToRun(
+	ctx context.Context,
+	rng *rand.Rand,
+	ws *workerStateTracker,
+	ops []registry.OperationSpec,
+	pool operationPool,
+) *registry.OperationSpec {
+	if ctx.Err() != nil {
 		return nil
 	}
 
-	// randomly select a candidate operation to run
-	opSpec := r.opsToRun[rng.Intn(len(r.opsToRun))]
+	// Randomly select a candidate operation to run.
+	opSpec := ops[rng.Intn(len(ops))]
 
 	r.status.Lock()
 	defer r.status.Unlock()
 
-	// operation which cannotRunConcurrently with other operation is currently
-	// running by another worker — blocking operation selection for now.
-	if r.status.lockOperationSelection {
+	// An exclusive operation is currently running — skip selection.
+	// Long-running workers are exempt: registration validation
+	// guarantees long-running ops are never exclusive.
+	if pool == normalPool && r.status.lockOperationSelection {
 		return nil
 	}
 
-	// operation is already running, choose another one
-	if _, ok := r.status.running[opSpec.NamePrefix()]; ok {
+	if _, ok := r.status.running[opSpec.DedupKey()]; ok {
+		return nil
+	}
+	if _, ok := r.status.pendingCleanup[opSpec.DedupKey()]; ok {
 		return nil
 	}
 
-	// Operation has a deferred cleanup pending; choose another one.
-	if _, ok := r.status.pendingCleanup[opSpec.NamePrefix()]; ok {
-		return nil
-	}
-
-	// If the time since the last run of the operation has not exceeded its
-	// cadence, choose another operation.
-	if lastRun, ok := r.status.lastRun[opSpec.NamePrefix()]; ok {
-		nextRunTime := lastRun.Add(r.waitBeforeNextExecution)
-		if timeutil.Now().Before(nextRunTime) {
+	// Per-operation Cadence overrides the global waitBeforeNextExecution.
+	if lastRun, ok := r.status.lastRun[opSpec.DedupKey()]; ok {
+		cadence := r.waitBeforeNextExecution
+		if opSpec.Cadence > 0 {
+			cadence = opSpec.Cadence
+		}
+		if timeutil.Now().Before(lastRun.Add(cadence)) {
 			return nil
 		}
 	}
 
-	if opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
+	if pool == normalPool &&
+		opSpec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
 		r.status.lockOperationSelection = true
-		// selected operation cannot run concurrently with other operations —
-		// wait for other running operations and pending cleanups to finish.
-		workerLabel := strconv.Itoa(workerID)
-		for {
-			if len(r.status.running) == 0 && len(r.status.pendingCleanup) == 0 {
-				break
+		for r.runningCount(normalPool) > 0 {
+			if ctx.Err() != nil {
+				r.status.lockOperationSelection = false
+				return nil
 			}
-			r.setWorkerState(workerLabel, workerOperationIdle, workerStateIdle, opSpec.NamePrefix(), workerStateWaitingLock)
-			r.logger.Printf("[%d] operation: %s waiting for other operation to complete", workerID, opSpec.Name)
+			ws.transition(opSpec.NamePrefix(), workerStateWaitingLock)
+			r.logger.Printf("[%s] operation: %s waiting for other operation to complete", ws.label, opSpec.Name)
 			r.status.operationRunCompleted.Wait()
-			r.setWorkerState(workerLabel, opSpec.NamePrefix(), workerStateWaitingLock, workerOperationIdle, workerStateIdle)
+			ws.setIdle()
 		}
 	}
 
-	r.status.running[opSpec.NamePrefix()] = struct{}{}
+	r.status.running[opSpec.DedupKey()] = pool
 	return &opSpec
 }
 
@@ -436,7 +523,7 @@ func (r *opsRunner) processCleanups(cleanups []deferredCleanup) {
 		func() {
 			r.status.Lock()
 			defer r.status.Unlock()
-			delete(r.status.pendingCleanup, opName)
+			delete(r.status.pendingCleanup, dc.opSpec.DedupKey())
 			r.status.operationRunCompleted.Broadcast()
 		}()
 	}
@@ -448,13 +535,12 @@ func (r *opsRunner) processCleanups(cleanups []deferredCleanup) {
 // execution and cleanupDeferred is returned as true. The caller must
 // add the operation to pendingCleanup under the status lock.
 func (r *opsRunner) runOperation(
-	ctx context.Context, opSpec *registry.OperationSpec, rng *rand.Rand, workerIdx int,
+	ctx context.Context, opSpec *registry.OperationSpec, rng *rand.Rand, workerLabel string,
 ) (error, bool) {
 	// operationRunID is used for datadog event aggregation and logging.
 	operationRunID := rng.Uint64()
 	opName := opSpec.NamePrefix()
 	owner := string(opSpec.Owner)
-	workerLabel := strconv.Itoa(workerIdx)
 
 	r.metrics.activeOps.WithLabelValues(opName, workerLabel).Inc()
 	defer r.metrics.activeOps.WithLabelValues(opName, workerLabel).Dec()
@@ -490,7 +576,7 @@ func (r *opsRunner) runOperation(
 		startOpts:       config.StartOpts,
 		l:               r.logger,
 		spec:            opSpec,
-		workerId:        workerIdx,
+		workerLabel:     workerLabel,
 	}
 
 	cSpec := spec.ClusterSpec{NodeCount: r.nodeCount}

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -108,6 +108,15 @@ func (r *testRegistryImpl) prepareOpSpec(spec *registry.OperationSpec) error {
 		return fmt.Errorf(`%s: unknown owner %q`, spec.Name, spec.Owner)
 	}
 
+	if spec.LongRunning &&
+		spec.CanRunConcurrently == registry.OperationCannotRunConcurrently {
+		return fmt.Errorf(
+			"%s: LongRunning operations cannot use OperationCannotRunConcurrently; "+
+				"the long-running pool is single-threaded so exclusivity is implicit",
+			spec.Name,
+		)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Previously, all operations shared the same worker pool and cadence, which meant long-running operations (e.g., probe-ranges or consistency checks on large clusters) could block workers for extended periods, starving other operations.

Introduce a `LongRunning` flag on OperationSpec that causes marked operations to execute in a dedicated goroutine, separate from the normal worker pool. Add a per-operation `Cadence` field that overrides the global `--wait-before-next-execution` interval.

Epic: none
Release note: None
