### PR TITLE
sql: add parser grammar and e2e tests for SHOW ROLES provisioning clauses

### DIFF
--- a/docs/generated/sql/bnf/show_locality.bnf
+++ b/docs/generated/sql/bnf/show_locality.bnf
@@ -1,2 +1,2 @@
 show_roles_stmt ::=
-	'SHOW' 'LOCALITY'
+	'SHOW' 'LOCALITY' opt_with_show_users_options opt_limit_clause

--- a/docs/generated/sql/bnf/show_roles_stmt.bnf
+++ b/docs/generated/sql/bnf/show_roles_stmt.bnf
@@ -1,2 +1,2 @@
 show_roles_stmt ::=
-	'SHOW' 'ROLES'
+	'SHOW' 'ROLES' opt_with_show_users_options opt_limit_clause

--- a/docs/generated/sql/bnf/show_users_stmt.bnf
+++ b/docs/generated/sql/bnf/show_users_stmt.bnf
@@ -1,2 +1,2 @@
 show_users_stmt ::=
-	'SHOW' 'USERS'
+	'SHOW' 'USERS' opt_with_show_users_options opt_limit_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1024,7 +1024,7 @@ show_survival_goal_stmt ::=
 	| 'SHOW' 'SURVIVAL' 'GOAL' 'FROM' 'DATABASE' database_name
 
 show_roles_stmt ::=
-	'SHOW' 'ROLES'
+	'SHOW' 'ROLES' opt_with_show_users_options opt_limit_clause
 
 show_savepoint_stmt ::=
 	'SHOW' 'SAVEPOINT' 'STATUS'
@@ -2308,12 +2308,12 @@ statements_or_queries ::=
 opt_show_ranges_options ::=
 	'WITH' show_ranges_options
 
-opt_compact ::=
-	'COMPACT'
-	| 
-
 opt_with_show_users_options ::=
 	'WITH' show_users_options_list
+	| 
+
+opt_compact ::=
+	'COMPACT'
 	| 
 
 from_with_implicit_for_alias ::=

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1066,7 +1066,7 @@ show_transfer_stmt ::=
 	| 'SHOW' 'TRANSFER' 'STATE'
 
 show_users_stmt ::=
-	'SHOW' 'USERS'
+	'SHOW' 'USERS' opt_with_show_users_options opt_limit_clause
 
 show_default_session_variables_for_role_stmt ::=
 	'SHOW' 'DEFAULT' 'SESSION' 'VARIABLES' 'FOR' role_or_group_or_user role_spec
@@ -2312,6 +2312,10 @@ opt_compact ::=
 	'COMPACT'
 	| 
 
+opt_with_show_users_options ::=
+	'WITH' show_users_options_list
+	| 
+
 from_with_implicit_for_alias ::=
 	'FROM'
 
@@ -3242,6 +3246,9 @@ show_job_options ::=
 show_ranges_options ::=
 	( 'TABLES' | 'INDEXES' | 'DETAILS' | 'KEYS' | 'ZONE' | 'EXPLAIN' ) ( ( ',' 'TABLES' | ',' 'INDEXES' | ',' 'DETAILS' | ',' 'EXPLAIN' | ',' 'KEYS' | ',' 'ZONE' ) )*
 
+show_users_options_list ::=
+	( show_users_option ) ( ( ',' show_users_option ) )*
+
 partition ::=
 	'PARTITION' partition_name
 
@@ -3854,6 +3861,10 @@ show_backup_options ::=
 
 schema_wildcard ::=
 	wildcard_pattern
+
+show_users_option ::=
+	'SOURCE' '=' a_expr
+	| 'LAST' 'LOGIN' 'BEFORE' a_expr
 
 show_hints_options ::=
 	'DETAILS'

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -153,7 +153,7 @@ func TryDelegate(
 		return d.delegateShowTransactions(t)
 
 	case *tree.ShowUsers:
-		return d.delegateShowRoles()
+		return d.delegateShowRolesExtended(t)
 
 	case *tree.ShowDefaultSessionVariablesForRole:
 		return d.delegateShowDefaultSessionVariablesForRole(t)

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -129,7 +129,7 @@ func TryDelegate(
 		return d.delegateShowRoleGrants(t)
 
 	case *tree.ShowRoles:
-		return d.delegateShowRoles()
+		return d.delegateShowRolesExtended(t.Options, t.Limit)
 
 	case *tree.ShowSchemas:
 		return d.delegateShowSchemas(t)
@@ -153,7 +153,7 @@ func TryDelegate(
 		return d.delegateShowTransactions(t)
 
 	case *tree.ShowUsers:
-		return d.delegateShowRolesExtended(t)
+		return d.delegateShowRolesExtended(t.Options, t.Limit)
 
 	case *tree.ShowDefaultSessionVariablesForRole:
 		return d.delegateShowDefaultSessionVariablesForRole(t)

--- a/pkg/sql/delegate/show_roles.go
+++ b/pkg/sql/delegate/show_roles.go
@@ -38,21 +38,22 @@ ORDER BY 1;
 	return d.parse(selectClause + selectLastLoginTime + endingClauses)
 }
 
-// delegateShowRolesExtended implements SHOW USERS with optional
-// provisioning filter clauses (SOURCE, LAST LOGIN BEFORE) and LIMIT.
-// It is dispatched from the ShowUsers case in the delegate switch.
-// When no options are specified, it falls back to delegateShowRoles.
-func (d *delegator) delegateShowRolesExtended(n *tree.ShowUsers) (tree.Statement, error) {
-	if (n.Options == nil || n.Options.IsDefault()) && n.Limit == nil {
+// delegateShowRolesExtended implements SHOW USERS / SHOW ROLES with optional
+// provisioning filter clauses (SOURCE, LAST LOGIN BEFORE) and LIMIT. When
+// no options are specified, it falls back to delegateShowRoles.
+func (d *delegator) delegateShowRolesExtended(
+	options *tree.ShowUsersOptions, limit *tree.Limit,
+) (tree.Statement, error) {
+	if (options == nil || options.IsDefault()) && limit == nil {
 		return d.delegateShowRoles()
 	}
 
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Roles)
 
 	var whereExprs []string
-	if n.Options != nil {
-		if n.Options.Source != nil {
-			sourceStr := tree.AsStringWithFlags(n.Options.Source, tree.FmtBareStrings)
+	if options != nil {
+		if options.Source != nil {
+			sourceStr := tree.AsStringWithFlags(options.Source, tree.FmtBareStrings)
 			whereExprs = append(whereExprs, fmt.Sprintf(
 				`EXISTS (
 	SELECT 1 FROM system.role_options AS src
@@ -61,10 +62,10 @@ func (d *delegator) delegateShowRolesExtended(n *tree.ShowUsers) (tree.Statement
 		AND src.value = %s
 )`, lexbase.EscapeSQLString(sourceStr)))
 		}
-		if n.Options.LastLoginBefore != nil {
+		if options.LastLoginBefore != nil {
 			// Users with a NULL estimated_last_login_time are excluded from
 			// the result since NULL comparisons evaluate to NULL, not true.
-			tsExpr := tree.AsStringWithFlags(n.Options.LastLoginBefore, tree.FmtParsable)
+			tsExpr := tree.AsStringWithFlags(options.LastLoginBefore, tree.FmtParsable)
 			whereExprs = append(whereExprs, fmt.Sprintf(
 				"u.estimated_last_login_time < (%s)::TIMESTAMPTZ",
 				tsExpr))
@@ -78,8 +79,8 @@ func (d *delegator) delegateShowRolesExtended(n *tree.ShowUsers) (tree.Statement
 	}
 
 	var limitClause string
-	if n.Limit != nil && n.Limit.Count != nil {
-		limitClause = fmt.Sprintf("\nLIMIT %s", tree.AsString(n.Limit.Count))
+	if limit != nil && limit.Count != nil {
+		limitClause = fmt.Sprintf("\nLIMIT %s", tree.AsString(limit.Count))
 	}
 
 	query := fmt.Sprintf(`

--- a/pkg/sql/delegate/show_roles.go
+++ b/pkg/sql/delegate/show_roles.go
@@ -38,13 +38,10 @@ ORDER BY 1;
 	return d.parse(selectClause + selectLastLoginTime + endingClauses)
 }
 
-// delegateShowRolesExtended implements SHOW ROLES with optional
-// provisioning filter clauses (SOURCE, LAST LOGIN BEFORE)
-// and LIMIT. When no options are specified, it falls back to
-// delegateShowRoles.
-//
-// TODO(sourav): Wire this into the delegate dispatch for ShowUsers;
-// currently only exercised by unit tests.
+// delegateShowRolesExtended implements SHOW USERS with optional
+// provisioning filter clauses (SOURCE, LAST LOGIN BEFORE) and LIMIT.
+// It is dispatched from the ShowUsers case in the delegate switch.
+// When no options are specified, it falls back to delegateShowRoles.
 func (d *delegator) delegateShowRolesExtended(n *tree.ShowUsers) (tree.Statement, error) {
 	if (n.Options == nil || n.Options.IsDefault()) && n.Limit == nil {
 		return d.delegateShowRoles()

--- a/pkg/sql/delegate/show_roles_test.go
+++ b/pkg/sql/delegate/show_roles_test.go
@@ -141,7 +141,7 @@ func TestDelegateShowRolesExtended(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, d := makeCtx()
-			stmt, err := d.delegateShowRolesExtended(tc.node)
+			stmt, err := d.delegateShowRolesExtended(tc.node.Options, tc.node.Limit)
 			require.NoError(t, err)
 			require.NotNil(t, stmt)
 
@@ -176,7 +176,7 @@ func TestDelegateShowRolesExtendedSQLInjection(t *testing.T) {
 			Source: tree.NewStrVal("ldap:evil' OR 1=1 --"),
 		},
 	}
-	stmt, err := d.delegateShowRolesExtended(n)
+	stmt, err := d.delegateShowRolesExtended(n.Options, n.Limit)
 	require.NoError(t, err)
 
 	query := tree.AsString(stmt)
@@ -192,7 +192,7 @@ func TestDelegateShowRolesExtendedSQLInjection(t *testing.T) {
 			LastLoginBefore: tree.NewStrVal("2024-01-01' OR 1=1 --"),
 		},
 	}
-	stmt2, err := d.delegateShowRolesExtended(n2)
+	stmt2, err := d.delegateShowRolesExtended(n2.Options, n2.Limit)
 	require.NoError(t, err)
 
 	query2 := tree.AsString(stmt2)

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -307,6 +307,21 @@ SHOW USERS WITH SOURCE = 'ldap:ldap.example.com'
 ----
 NOTICE: estimated_last_login_time is computed on a best effort basis; it is not guaranteed to capture every login event
 
+# SHOW ROLES WITH SOURCE returns the same results as SHOW USERS WITH SOURCE.
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com']
+----
+username    options                                member_of
+prov_user1  {PROVISIONSRC=ldap:ldap.example.com}   {}
+prov_user2  {PROVISIONSRC=ldap:ldap.example.com}   {}
+
+# SHOW ROLES LIMIT works the same as SHOW USERS LIMIT.
+query TTT colnames
+select username, options, member_of from [SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 1]
+----
+username    options                                member_of
+prov_user1  {PROVISIONSRC=ldap:ldap.example.com}   {}
+
 # Clean up provisioned users.
 statement ok
 DROP USER prov_user1
@@ -378,6 +393,13 @@ SELECT username, options, member_of FROM [SHOW USERS WITH LAST LOGIN BEFORE ('$l
 ----
 username  options  member_of
 
+# SHOW ROLES WITH LAST LOGIN BEFORE behaves the same as SHOW USERS.
+query TTT colnames
+SELECT username, options, member_of FROM [SHOW ROLES WITH LAST LOGIN BEFORE ('$login_time'::timestamptz + '1 minute'::interval)] WHERE username = 'testuser2'
+----
+username   options  member_of
+testuser2  {}       {admin}
+
 subtest end
 
 subtest show_users_combined_options
@@ -395,6 +417,13 @@ SELECT estimated_last_login_time FROM system.users WHERE username = 'testuser2'
 # SHOW USERS with both SOURCE and LAST LOGIN BEFORE filters combined.
 query TTT colnames
 SELECT username, options, member_of FROM [SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE ('$combined_login_time'::timestamptz + '1 minute'::interval)] WHERE username = 'testuser2'
+----
+username   options                                member_of
+testuser2  {PROVISIONSRC=ldap:ldap.example.com}   {admin}
+
+# Same combined query with SHOW ROLES.
+query TTT colnames
+SELECT username, options, member_of FROM [SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE ('$combined_login_time'::timestamptz + '1 minute'::interval)] WHERE username = 'testuser2'
 ----
 username   options                                member_of
 testuser2  {PROVISIONSRC=ldap:ldap.example.com}   {admin}

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -253,6 +253,72 @@ CREATE user IF NOT EXISTS testuser
 
 subtest end
 
+subtest show_users_provisioning_filters
+
+user root
+
+# Create users with provisioning source for filter testing.
+statement ok
+CREATE USER prov_user1 PROVISIONSRC 'ldap:ldap.example.com'
+
+statement ok
+CREATE USER prov_user2 PROVISIONSRC 'ldap:ldap.example.com'
+
+statement ok
+CREATE USER prov_user3 PROVISIONSRC 'oidc:okta.example.com'
+
+# SHOW USERS WITH SOURCE filters to only users with matching PROVISIONSRC.
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS WITH SOURCE = 'ldap:ldap.example.com']
+----
+username    options                                member_of
+prov_user1  {PROVISIONSRC=ldap:ldap.example.com}   {}
+prov_user2  {PROVISIONSRC=ldap:ldap.example.com}   {}
+
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS WITH SOURCE = 'oidc:okta.example.com']
+----
+username    options                                member_of
+prov_user3  {PROVISIONSRC=oidc:okta.example.com}   {}
+
+# No users with this source.
+query TTT colnames
+select username, options, member_of from [SHOW USERS WITH SOURCE = 'nonexistent']
+----
+username  options  member_of
+
+# SHOW USERS WITH LIMIT restricts the number of returned rows.
+query TTT colnames
+select username, options, member_of from [SHOW USERS WITH SOURCE = 'ldap:ldap.example.com' LIMIT 1]
+----
+username    options                                member_of
+prov_user1  {PROVISIONSRC=ldap:ldap.example.com}   {}
+
+# SHOW USERS LIMIT (without WITH) limits from all users.
+query T nosort
+select username from [SHOW USERS LIMIT 2]
+----
+admin
+foo
+
+# SHOW USERS notice is still emitted with the extended form.
+query T noticetrace
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com'
+----
+NOTICE: estimated_last_login_time is computed on a best effort basis; it is not guaranteed to capture every login event
+
+# Clean up provisioned users.
+statement ok
+DROP USER prov_user1
+
+statement ok
+DROP USER prov_user2
+
+statement ok
+DROP USER prov_user3
+
+subtest end
+
 subtest validate_estimated_last_login_time
 
 user testuser2
@@ -272,5 +338,75 @@ query I retry
 SELECT count(*) FROM system.users WHERE estimated_last_login_time IS NOT NULL AND username = 'testuser2'
 ----
 1
+
+subtest end
+
+subtest show_users_last_login_before
+
+user testuser2
+
+# Connect as testuser2 to populate estimated_last_login_time.
+query T
+SHOW session_user
+----
+testuser2
+
+user root
+
+# The estimated_last_login_time is not guaranteed to be populated synchronously,
+# so we poll until testuser2's entry was updated with the last login time.
+query I retry
+SELECT count(*) FROM system.users WHERE estimated_last_login_time IS NOT NULL AND username = 'testuser2'
+----
+1
+
+let $login_time
+SELECT estimated_last_login_time FROM system.users WHERE username = 'testuser2'
+
+# SHOW USERS WITH LAST LOGIN BEFORE should include testuser2 when the threshold
+# is after their login time.
+query TTT colnames
+SELECT username, options, member_of FROM [SHOW USERS WITH LAST LOGIN BEFORE ('$login_time'::timestamptz + '1 minute'::interval)] WHERE username = 'testuser2'
+----
+username   options  member_of
+testuser2  {}       {admin}
+
+# SHOW USERS WITH LAST LOGIN BEFORE should exclude testuser2 when the threshold
+# is before their login time.
+query TTT colnames
+SELECT username, options, member_of FROM [SHOW USERS WITH LAST LOGIN BEFORE ('$login_time'::timestamptz - '1 minute'::interval)] WHERE username = 'testuser2'
+----
+username  options  member_of
+
+subtest end
+
+subtest show_users_combined_options
+
+user root
+
+# Reuse testuser2 who already has an estimated_last_login_time from the
+# earlier subtest. Add a provisioning source so we can test combined filters.
+statement ok
+ALTER USER testuser2 PROVISIONSRC 'ldap:ldap.example.com'
+
+let $combined_login_time
+SELECT estimated_last_login_time FROM system.users WHERE username = 'testuser2'
+
+# SHOW USERS with both SOURCE and LAST LOGIN BEFORE filters combined.
+query TTT colnames
+SELECT username, options, member_of FROM [SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE ('$combined_login_time'::timestamptz + '1 minute'::interval)] WHERE username = 'testuser2'
+----
+username   options                                member_of
+testuser2  {PROVISIONSRC=ldap:ldap.example.com}   {admin}
+
+# Excluding by login time should filter out even when source matches.
+query TTT colnames
+SELECT username, options, member_of FROM [SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE ('$combined_login_time'::timestamptz - '1 minute'::interval)] WHERE username = 'testuser2'
+----
+username  options  member_of
+
+# Clean up the provisioning source.
+statement ok
+ALTER USER testuser2 PROVISIONSRC NULL
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -434,8 +434,9 @@ SELECT username, options, member_of FROM [SHOW USERS WITH SOURCE = 'ldap:ldap.ex
 ----
 username  options  member_of
 
-# Clean up the provisioning source.
+# Clean up: drop testuser2 since we cannot ALTER PROVISIONSRC on a
+# provisioned user (setting it to NULL is also blocked).
 statement ok
-ALTER USER testuser2 PROVISIONSRC NULL
+DROP USER testuser2
 
 subtest end

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -763,6 +763,9 @@ func (u *sqlSymUnion) showBackupDetails() tree.ShowBackupDetails {
 func (u *sqlSymUnion) showBackupOptions() *tree.ShowBackupOptions {
   return u.val.(*tree.ShowBackupOptions)
 }
+func (u *sqlSymUnion) showUsersOptions() *tree.ShowUsersOptions {
+  return u.val.(*tree.ShowUsersOptions)
+}
 func (u *sqlSymUnion) showBackupTimeFilter() *tree.ShowBackupTimeFilter {
   return u.val.(*tree.ShowBackupTimeFilter)
 }
@@ -1502,6 +1505,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %type <tree.ShowBackupDetails> show_backup_details
 %type <*tree.ShowJobOptions> show_job_options show_job_options_list
 %type <*tree.ShowBackupOptions> opt_with_show_backup_options show_backup_options show_backup_options_list opt_with_show_backups_options show_backups_options show_backups_options_list
+%type <*tree.ShowUsersOptions> opt_with_show_users_options show_users_option show_users_options_list
 %type <*tree.ShowBackupTimeFilter> opt_show_backups_time_filter_clause
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list copy_generic_options copy_generic_options_list
 %type <str> import_format
@@ -10306,14 +10310,54 @@ show_create_external_connections_stmt:
 
 // %Help: SHOW USERS - list defined users
 // %Category: Priv
-// %Text: SHOW USERS
+// %Text:
+// SHOW USERS [WITH <options>] [LIMIT <n>]
+//
+// Options:
+//   SOURCE = <string>
+//   LAST LOGIN BEFORE <expr>
 // %SeeAlso: CREATE USER, DROP USER, WEBDOCS/show-users.html
 show_users_stmt:
-  SHOW USERS
+  SHOW USERS opt_with_show_users_options opt_limit_clause
   {
-    $$.val = &tree.ShowUsers{}
+    $$.val = &tree.ShowUsers{
+      Options: $3.showUsersOptions(),
+      Limit:   $4.limit(),
+    }
   }
 | SHOW USERS error // SHOW HELP: SHOW USERS
+
+opt_with_show_users_options:
+  WITH show_users_options_list
+  {
+    $$.val = $2.showUsersOptions()
+  }
+| /* EMPTY */
+  {
+    $$.val = (*tree.ShowUsersOptions)(nil)
+  }
+
+show_users_options_list:
+  show_users_option
+  {
+    $$.val = $1.showUsersOptions()
+  }
+| show_users_options_list ',' show_users_option
+  {
+    if err := $1.showUsersOptions().CombineWith($3.showUsersOptions()); err != nil {
+      return setErr(sqllex, err)
+    }
+  }
+
+show_users_option:
+  SOURCE '=' a_expr
+  {
+    $$.val = &tree.ShowUsersOptions{Source: $3.expr()}
+  }
+| LAST LOGIN BEFORE a_expr
+  {
+    $$.val = &tree.ShowUsersOptions{LastLoginBefore: $4.expr()}
+  }
 
 // %Help: SHOW DEFAULT SESSION VARIABLES FOR ROLE - list default session variables for role
 // %Category: Priv

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -10379,12 +10379,20 @@ show_default_session_variables_for_role_stmt:
 
 // %Help: SHOW ROLES - list defined roles
 // %Category: Priv
-// %Text: SHOW ROLES
+// %Text:
+// SHOW ROLES [WITH <options>] [LIMIT <n>]
+//
+// Options:
+//   SOURCE = <string>
+//   LAST LOGIN BEFORE <expr>
 // %SeeAlso: CREATE ROLE, ALTER ROLE, DROP ROLE
 show_roles_stmt:
-  SHOW ROLES
+  SHOW ROLES opt_with_show_users_options opt_limit_clause
   {
-    $$.val = &tree.ShowRoles{}
+    $$.val = &tree.ShowRoles{
+      Options: $3.showUsersOptions(),
+      Limit:   $4.limit(),
+    }
   }
 | SHOW ROLES error // SHOW HELP: SHOW ROLES
 

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -650,12 +650,68 @@ SHOW USERS -- literals removed
 SHOW USERS -- identifiers removed
 
 parse
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com'
+----
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com'
+SHOW USERS WITH SOURCE = ('ldap:ldap.example.com') -- fully parenthesized
+SHOW USERS WITH SOURCE = '_' -- literals removed
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com' -- identifiers removed
+
+parse
+SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01'
+----
+SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01'
+SHOW USERS WITH LAST LOGIN BEFORE ('2024-01-01') -- fully parenthesized
+SHOW USERS WITH LAST LOGIN BEFORE '_' -- literals removed
+SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01' -- identifiers removed
+
+parse
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01'
+----
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01'
+SHOW USERS WITH SOURCE = ('ldap:ldap.example.com'), LAST LOGIN BEFORE ('2024-01-01') -- fully parenthesized
+SHOW USERS WITH SOURCE = '_', LAST LOGIN BEFORE '_' -- literals removed
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01' -- identifiers removed
+
+parse
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
+----
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
+SHOW USERS WITH SOURCE = ('ldap:ldap.example.com') LIMIT (10) -- fully parenthesized
+SHOW USERS WITH SOURCE = '_' LIMIT _ -- literals removed
+SHOW USERS WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10 -- identifiers removed
+
+parse
+SHOW USERS LIMIT 5
+----
+SHOW USERS LIMIT 5
+SHOW USERS LIMIT (5) -- fully parenthesized
+SHOW USERS LIMIT _ -- literals removed
+SHOW USERS LIMIT 5 -- identifiers removed
+
+parse
 EXPLAIN SHOW USERS
 ----
 EXPLAIN SHOW USERS
 EXPLAIN SHOW USERS -- fully parenthesized
 EXPLAIN SHOW USERS -- literals removed
 EXPLAIN SHOW USERS -- identifiers removed
+
+error
+SHOW USERS WITH SOURCE = 'a', SOURCE = 'b'
+----
+at or near "EOF": syntax error: SOURCE option specified multiple times
+DETAIL: source SQL:
+SHOW USERS WITH SOURCE = 'a', SOURCE = 'b'
+                                          ^
+
+error
+SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01', LAST LOGIN BEFORE '2025-01-01'
+----
+at or near "EOF": syntax error: LAST LOGIN BEFORE option specified multiple times
+DETAIL: source SQL:
+SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01', LAST LOGIN BEFORE '2025-01-01'
+                                                                              ^
 
 parse
 SHOW JOB 1234

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -634,6 +634,46 @@ SHOW ROLES -- literals removed
 SHOW ROLES -- identifiers removed
 
 parse
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com'
+----
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com'
+SHOW ROLES WITH SOURCE = ('ldap:ldap.example.com') -- fully parenthesized
+SHOW ROLES WITH SOURCE = '_' -- literals removed
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com' -- identifiers removed
+
+parse
+SHOW ROLES WITH LAST LOGIN BEFORE '2024-01-01'
+----
+SHOW ROLES WITH LAST LOGIN BEFORE '2024-01-01'
+SHOW ROLES WITH LAST LOGIN BEFORE ('2024-01-01') -- fully parenthesized
+SHOW ROLES WITH LAST LOGIN BEFORE '_' -- literals removed
+SHOW ROLES WITH LAST LOGIN BEFORE '2024-01-01' -- identifiers removed
+
+parse
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01'
+----
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01'
+SHOW ROLES WITH SOURCE = ('ldap:ldap.example.com'), LAST LOGIN BEFORE ('2024-01-01') -- fully parenthesized
+SHOW ROLES WITH SOURCE = '_', LAST LOGIN BEFORE '_' -- literals removed
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01' -- identifiers removed
+
+parse
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
+----
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10
+SHOW ROLES WITH SOURCE = ('ldap:ldap.example.com') LIMIT (10) -- fully parenthesized
+SHOW ROLES WITH SOURCE = '_' LIMIT _ -- literals removed
+SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10 -- identifiers removed
+
+parse
+SHOW ROLES LIMIT 5
+----
+SHOW ROLES LIMIT 5
+SHOW ROLES LIMIT (5) -- fully parenthesized
+SHOW ROLES LIMIT _ -- literals removed
+SHOW ROLES LIMIT 5 -- identifiers removed
+
+parse
 EXPLAIN SHOW ROLES
 ----
 EXPLAIN SHOW ROLES
@@ -706,11 +746,27 @@ SHOW USERS WITH SOURCE = 'a', SOURCE = 'b'
                                           ^
 
 error
+SHOW ROLES WITH SOURCE = 'a', SOURCE = 'b'
+----
+at or near "EOF": syntax error: SOURCE option specified multiple times
+DETAIL: source SQL:
+SHOW ROLES WITH SOURCE = 'a', SOURCE = 'b'
+                                          ^
+
+error
 SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01', LAST LOGIN BEFORE '2025-01-01'
 ----
 at or near "EOF": syntax error: LAST LOGIN BEFORE option specified multiple times
 DETAIL: source SQL:
 SHOW USERS WITH LAST LOGIN BEFORE '2024-01-01', LAST LOGIN BEFORE '2025-01-01'
+                                                                              ^
+
+error
+SHOW ROLES WITH LAST LOGIN BEFORE '2024-01-01', LAST LOGIN BEFORE '2025-01-01'
+----
+at or near "EOF": syntax error: LAST LOGIN BEFORE option specified multiple times
+DETAIL: source SQL:
+SHOW ROLES WITH LAST LOGIN BEFORE '2024-01-01', LAST LOGIN BEFORE '2025-01-01'
                                                                               ^
 
 parse

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -1118,11 +1118,21 @@ func (node *ShowDefaultSessionVariablesForRole) Format(ctx *FmtCtx) {
 
 // ShowRoles represents a SHOW ROLES statement.
 type ShowRoles struct {
+	Options *ShowUsersOptions
+	Limit   *Limit
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRoles) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ROLES")
+	if node.Options != nil && !node.Options.IsDefault() {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(node.Options)
+	}
+	if node.Limit != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(node.Limit)
+	}
 }
 
 // ShowRanges represents a SHOW RANGES statement.

--- a/pkg/sql/sem/tree/show_users_test.go
+++ b/pkg/sql/sem/tree/show_users_test.go
@@ -90,6 +90,82 @@ func TestShowUsersFormat(t *testing.T) {
 	}
 }
 
+func TestShowRolesFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name     string
+		node     *tree.ShowRoles
+		expected string
+	}{
+		{
+			name:     "no options",
+			node:     &tree.ShowRoles{},
+			expected: "SHOW ROLES",
+		},
+		{
+			name: "source only",
+			node: &tree.ShowRoles{
+				Options: &tree.ShowUsersOptions{
+					Source: tree.NewStrVal("ldap:ldap.example.com"),
+				},
+			},
+			expected: "SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com'",
+		},
+		{
+			name: "last login before only",
+			node: &tree.ShowRoles{
+				Options: &tree.ShowUsersOptions{
+					LastLoginBefore: tree.NewStrVal("2024-01-01"),
+				},
+			},
+			expected: "SHOW ROLES WITH LAST LOGIN BEFORE '2024-01-01'",
+		},
+		{
+			name: "both options",
+			node: &tree.ShowRoles{
+				Options: &tree.ShowUsersOptions{
+					Source:          tree.NewStrVal("ldap:ldap.example.com"),
+					LastLoginBefore: tree.NewStrVal("2024-01-01"),
+				},
+			},
+			expected: "SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2024-01-01'",
+		},
+		{
+			name: "source with limit",
+			node: &tree.ShowRoles{
+				Options: &tree.ShowUsersOptions{
+					Source: tree.NewStrVal("ldap:ldap.example.com"),
+				},
+				Limit: &tree.Limit{Count: tree.NewDInt(10)},
+			},
+			expected: "SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com' LIMIT 10",
+		},
+		{
+			name: "limit only",
+			node: &tree.ShowRoles{
+				Limit: &tree.Limit{Count: tree.NewDInt(5)},
+			},
+			expected: "SHOW ROLES LIMIT 5",
+		},
+		{
+			name: "nil options pointer",
+			node: &tree.ShowRoles{
+				Options: nil,
+			},
+			expected: "SHOW ROLES",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tree.AsString(tc.node)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
 func TestShowUsersOptionsCombineWith(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
## Summary

- Extend the SQL parser grammar to support `SHOW ROLES [WITH <options>] [LIMIT <n>]`, reusing the same `opt_with_show_users_options` rules as SHOW USERS
- Add parser tests for the new SHOW ROLES syntax (SOURCE, LAST LOGIN BEFORE, combined options, LIMIT)
- Add duplicate option error tests for both SHOW USERS and SHOW ROLES
- Add e2e logic tests: SHOW ROLES WITH SOURCE, SHOW ROLES WITH LAST LOGIN BEFORE, and combined SOURCE + LAST LOGIN BEFORE for both SHOW USERS and SHOW ROLES
- Regenerate BNF docs

Part 3 of 3 — depends on #168023.

Informs: CRDB-62959
Epic: none

Release note (sql change): `SHOW ROLES` now supports the same optional
filtering clauses as `SHOW USERS`. Both statements accept:

- `WITH SOURCE = '<string>'` — filter users/roles by their provisioning
  source (PROVISIONSRC role option value)
- `WITH LAST LOGIN BEFORE <expr>` — filter users/roles whose estimated
  last login time is before the given timestamp
- `LIMIT <n>` — limit the number of returned rows
- Combined options: `WITH SOURCE = '...', LAST LOGIN BEFORE '...' LIMIT <n>`

Duplicate options (e.g., `SOURCE = 'a', SOURCE = 'b'`) produce a parse
error.

Examples:
```sql
SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com';
SHOW ROLES WITH LAST LOGIN BEFORE '2025-01-01';
SHOW ROLES WITH SOURCE = 'ldap:ldap.example.com', LAST LOGIN BEFORE '2025-01-01' LIMIT 10;
SHOW ROLES LIMIT 5;
```

These clauses were previously only available on `SHOW USERS`. Since
SHOW USERS and SHOW ROLES are interchangeable, both now support the
full extended syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)