### PR TITLE
util/pretty: rewrite pretty-printer to be iterative

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -611,7 +611,6 @@ go_library(
         "//pkg/util/mon",
         "//pkg/util/optional",
         "//pkg/util/pprofutil",
-        "//pkg/util/pretty",
         "//pkg/util/protoutil",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/memzipper"
-	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
@@ -279,15 +278,7 @@ func (b *stmtBundleBuilder) buildPrettyStatement(stmtRawSQL string) error {
 		cfg.ValueRedaction = b.flags.RedactValues
 		var err error
 		b.stmt, err = cfg.Pretty(b.plan.stmt.AST)
-		if errors.Is(err, pretty.ErrPrettyMaxRecursionDepthExceeded) {
-			// Use the raw statement string if pretty-printing fails.
-			b.stmt = stmtRawSQL
-			// If we're collecting a redacted bundle, redact the raw SQL
-			// completely.
-			if b.flags.RedactValues && b.stmt != "" {
-				b.stmt = string(redact.RedactedMarker())
-			}
-		} else if err != nil {
+		if err != nil {
 			return err
 		}
 

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -124,7 +124,6 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/ltree",
         "//pkg/util/mon",
-        "//pkg/util/pretty",
         "//pkg/util/protoutil",
         "//pkg/util/randident",
         "//pkg/util/randident/randidentcfg",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -90,7 +90,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ltree"
-	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
@@ -12866,11 +12865,7 @@ func prettyStatement(p tree.PrettyCfg, stmt string) (string, error) {
 	var formattedStmt strings.Builder
 	for idx := range stmts {
 		p, err := p.Pretty(stmts[idx].AST)
-		if errors.Is(err, pretty.ErrPrettyMaxRecursionDepthExceeded) {
-			// If pretty-printing the statement fails, use the original
-			// statement.
-			p = stmt
-		} else if err != nil {
+		if err != nil {
 			return "", err
 		}
 		formattedStmt.WriteString(p)

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/pretty"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -229,8 +229,9 @@ func TestPrettyBigStatement(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "excessive memory usage")
 
-	// Create a SELECT statement with a 1 million item IN expression. Without
-	// mitigation, this can cause stack overflows - see #91197.
+	// Create a SELECT statement with a 1 million item IN expression.
+	// The iterative pretty-printing algorithm handles this without
+	// stack overflow - see #91197.
 	var sb strings.Builder
 	sb.WriteString("SELECT * FROM foo WHERE id IN (")
 	for i := 0; i < 1_000_000; i++ {
@@ -248,7 +249,7 @@ func TestPrettyBigStatement(t *testing.T) {
 
 	cfg := tree.DefaultPrettyCfg()
 	_, err = cfg.Pretty(stmt.AST)
-	assert.Errorf(t, err, "max call stack depth of be exceeded")
+	require.NoError(t, err)
 }
 
 func BenchmarkPrettyData(b *testing.B) {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/errors"
 )
 
@@ -187,11 +186,7 @@ func formatViewQueryForDisplay(
 		}
 		var prettyErr error
 		query, prettyErr = cfg.Pretty(parsed.AST)
-		if errors.Is(prettyErr, pretty.ErrPrettyMaxRecursionDepthExceeded) {
-			// Use simple printing if pretty-printing fails.
-			query = tree.AsStringWithFlags(parsed.AST, tree.FmtParsable)
-			return
-		} else if prettyErr != nil {
+		if prettyErr != nil {
 			err = prettyErr
 			return
 		}

--- a/pkg/util/pretty/pretty.go
+++ b/pkg/util/pretty/pretty.go
@@ -6,71 +6,27 @@
 package pretty
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
-// See the referenced paper in the package documentation for explanations
-// of the below code. Methods, variables, and implementation details were
-// made to resemble it as close as possible.
-
-// docBest represents a selected document as described by the type
-// "Doc" in the referenced paper (not "DOC"). This is the
-// less-abstract representation constructed during "best layout"
-// selection.
-type docBest struct {
-	tag docBestType
-	i   docPos
-	s   string
-	d   *docBest
-}
-
-type docBestType int
-
-const (
-	textB docBestType = iota
-	lineB
-	hardlineB
-	spacesB
-	keywordB
-	failB
-)
-
-// Pretty returns a pretty-printed string for the Doc d at line length
-// n and tab width t. Keyword Docs are filtered through keywordTransform
-// if not nil. keywordTransform must not change the visible length of its
-// argument. It can, for example, add invisible characters like control codes
-// (colors, etc.).
-func Pretty(
-	d Doc, n int, useTabs bool, tabWidth int, keywordTransform func(string) string,
-) (_ string, retErr error) {
-	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
-
-	var sb strings.Builder
-	b := beExec{
-		w:                int16(n),
-		tabWidth:         int16(tabWidth),
-		memoBe:           make(map[beArgs]*docBest),
-		memoiDoc:         make(map[iDoc]*iDoc),
-		keywordTransform: keywordTransform,
-	}
-	ldoc := b.best(d)
-	b.layout(&sb, useTabs, ldoc)
-	return sb.String(), nil
-}
-
-// w is the max line width.
-func (b *beExec) best(x Doc) *docBest {
-	return b.be(docPos{0, 0}, b.iDoc(docPos{0, 0}, x, nil))
-}
+// See the referenced paper in the package documentation for the
+// original algorithm. This implementation uses the same document
+// model (union, flatten, group) but processes it greedily and
+// iteratively: each union is resolved by checking if the flat
+// branch fits on the current line and committing to one branch
+// without rendering both. Output is written directly to a
+// strings.Builder with no intermediate representation; this is
+// possible because fitness is checked on the Doc tree (via
+// fits) before committing, so there is no need to build the
+// layout first and inspect it afterward.
 
 // iDoc represents the type [(Int,DOC)] in the paper,
 // extended with arbitrary string prefixes (not just int).
-// We'll use linked lists because this makes the
-// recursion more efficient than slices.
+// We store them in linked lists to linearize the Doc tree
+// for iterative processing.
 type iDoc struct {
 	d    Doc
 	next *iDoc
@@ -87,240 +43,185 @@ type beExec struct {
 	w int16
 	// tabWidth is the virtual tab width.
 	tabWidth int16
+	// useTabs controls whether indentation uses tab characters.
+	useTabs bool
 
-	// memoBe internalizes the results of the be function, so that the
-	// same value is not computed multiple times.
-	memoBe map[beArgs]*docBest
-
-	// memo internalizes iDoc objects to ensure they are unique in memory,
-	// and we can use pointer-pointer comparisons.
-	memoiDoc map[iDoc]*iDoc
-
-	// docAlloc speeds up the allocations of be()'s return values
-	// by (*beExec).newDocBest() defined below.
-	docAlloc []docBest
-
-	// idocAlloc speeds up the allocations by (*beExec).iDoc() defined
-	// below.
+	// idocAlloc speeds up the allocations by (*beExec).newiDoc()
+	// defined below.
 	idocAlloc []iDoc
 
 	// keywordTransform filters keywords if not nil.
 	keywordTransform func(string) string
-
-	// beDepth is the depth of recursive calls of be. It is used to detect deep
-	// call stacks before a stack overflow occurs.
-	beDepth int
 }
 
-// maxBeDepth is the maximum allowed recursive call depth of be. If the depth
-// exceeds this value, be will panic.
-const maxBeDepth = 50_000
+// Pretty returns a pretty-printed string for the Doc d at line length
+// n and tab width t. Keyword Docs are filtered through keywordTransform
+// if not nil. keywordTransform must not change the visible length of its
+// argument. It can, for example, add invisible characters like control codes
+// (colors, etc.).
+func Pretty(
+	d Doc, n int, useTabs bool, tabWidth int, keywordTransform func(string) string,
+) (_ string, retErr error) {
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
-// ErrPrettyMaxRecursionDepthExceeded is returned from Pretty when the maximum
-// recursion depth of function invoked by Pretty is exceeded.
-var ErrPrettyMaxRecursionDepthExceeded = errors.AssertionFailedf("max recursion depth exceeded")
-
-func (b *beExec) be(k docPos, xlist *iDoc) *docBest {
-	b.beDepth++
-	defer func() { b.beDepth-- }()
-	if b.beDepth > maxBeDepth {
-		panic(ErrPrettyMaxRecursionDepthExceeded)
+	var sb strings.Builder
+	b := beExec{
+		w:                int16(n),
+		tabWidth:         int16(tabWidth),
+		useTabs:          useTabs,
+		keywordTransform: keywordTransform,
 	}
-
-	// Shortcut: be k [] = Nil
-	if xlist == nil {
-		return nil
-	}
-
-	// If we've computed this result before, short cut here too.
-	memoKey := beArgs{k: k, d: xlist}
-	if cached, ok := b.memoBe[memoKey]; ok {
-		return cached
-	}
-
-	// General case.
-
-	d := *xlist
-	z := xlist.next
-
-	// Note: we'll need to memoize the result below.
-	var res *docBest
-
-	switch t := d.d.(type) {
-	case nilDoc:
-		res = b.be(k, z)
-	case failDoc:
-		res = b.newDocBest(docBest{tag: failB})
-	case *concat:
-		res = b.be(k, b.iDoc(d.i, t.a, b.iDoc(d.i, t.b, z)))
-	case nests:
-		res = b.be(k, b.iDoc(docPos{d.i.tabs, d.i.spaces + t.n}, t.d, z))
-	case nestt:
-		res = b.be(k, b.iDoc(docPos{d.i.tabs + 1 + d.i.spaces/b.tabWidth, 0}, t.d, z))
-	case text:
-		res = b.newDocBest(docBest{
-			tag: textB,
-			s:   string(t),
-			d:   b.be(docPos{k.tabs, k.spaces + int16(len(t))}, z),
-		})
-	case keyword:
-		res = b.newDocBest(docBest{
-			tag: keywordB,
-			s:   string(t),
-			d:   b.be(docPos{k.tabs, k.spaces + int16(len(t))}, z),
-		})
-	case line, softbreak:
-		res = b.newDocBest(docBest{
-			tag: lineB,
-			i:   d.i,
-			d:   b.be(d.i, z),
-		})
-	case hardline:
-		res = b.newDocBest(docBest{
-			tag: hardlineB,
-			i:   d.i,
-			d:   b.be(d.i, z),
-		})
-	case *union:
-		res = b.better(k,
-			b.be(k, b.iDoc(d.i, t.x, z)),
-			// We eta-lift the second argument to avoid eager evaluation.
-			func() *docBest {
-				return b.be(k, b.iDoc(d.i, t.y, z))
-			},
-		)
-	case *scolumn:
-		res = b.be(k, b.iDoc(d.i, t.f(k.spaces), z))
-	case *snesting:
-		res = b.be(k, b.iDoc(d.i, t.f(d.i.spaces), z))
-	case pad:
-		res = b.newDocBest(docBest{
-			tag: spacesB,
-			i:   docPos{spaces: t.n},
-			d:   b.be(docPos{k.tabs, k.spaces + t.n}, z),
-		})
-	default:
-		panic(fmt.Errorf("unknown type: %T", d.d))
-	}
-
-	// Memoize so we don't compute the same result twice.
-	b.memoBe[memoKey] = res
-
-	return res
+	b.be(&sb, docPos{0, 0}, b.newiDoc(docPos{0, 0}, d, nil))
+	return sb.String(), nil
 }
 
-// newDocBest makes a new docBest on the heap. Allocations
-// are batched for more efficiency.
-func (b *beExec) newDocBest(d docBest) *docBest {
-	buf := &b.docAlloc
-	if len(*buf) == 0 {
-		*buf = make([]docBest, 100)
-	}
-	r := &(*buf)[0]
-	*r = d
-	*buf = (*buf)[1:]
-	return r
-}
+// be iteratively selects the best layout for the document represented
+// by xlist and writes it directly to sb. Structural cases (nil,
+// concat, nest, union, etc.) transform the iDoc list. Content cases
+// (text, keyword, line, pad) write to sb and advance.
+func (b *beExec) be(sb *strings.Builder, k docPos, xlist *iDoc) {
+	for {
+		if xlist == nil {
+			return
+		}
 
-// iDoc retrieves the unique instance of iDoc in memory for the given
-// values of i, s, d and z. The object is constructed if it does not
-// exist yet.
-//
-// The results of this function guarantee that the pointer addresses
-// are equal if the arguments used to construct the value were equal.
-func (b *beExec) iDoc(i docPos, d Doc, z *iDoc) *iDoc {
-	idoc := iDoc{i: i, d: d, next: z}
-	if m, ok := b.memoiDoc[idoc]; ok {
-		return m
-	}
-	r := b.newiDoc(idoc)
-	b.memoiDoc[idoc] = r
-	return r
-}
+		d := *xlist
+		z := xlist.next
 
-// newiDoc makes a new iDoc on the heap. Allocations are batched
-// for more efficiency. Do not use this directly! Instead
-// use the iDoc() method defined above.
-func (b *beExec) newiDoc(d iDoc) *iDoc {
-	buf := &b.idocAlloc
-	if len(*buf) == 0 {
-		*buf = make([]iDoc, 100)
-	}
-	r := &(*buf)[0]
-	*r = d
-	*buf = (*buf)[1:]
-	return r
-}
-
-type beArgs struct {
-	d *iDoc
-	k docPos
-}
-
-func (b *beExec) better(k docPos, x *docBest, y func() *docBest) *docBest {
-	remainder := b.w - k.spaces - k.tabs*b.tabWidth
-	if fits(remainder, x) {
-		return x
-	}
-	return y()
-}
-
-func fits(w int16, x *docBest) bool {
-	if w < 0 {
-		return false
-	}
-	if x == nil {
-		// Nil doc.
-		return true
-	}
-	switch x.tag {
-	case textB, keywordB:
-		return fits(w-int16(len(x.s)), x.d)
-	case lineB, hardlineB:
-		return true
-	case spacesB:
-		return fits(w-x.i.spaces, x.d)
-	case failB:
-		return false
-	default:
-		panic(fmt.Errorf("unknown type: %d", x.tag))
-	}
-}
-
-func (b *beExec) layout(sb *strings.Builder, useTabs bool, d *docBest) {
-	for ; d != nil; d = d.d {
-		switch d.tag {
-		case textB:
-			sb.WriteString(d.s)
-		case keywordB:
-			if b.keywordTransform != nil {
-				sb.WriteString(b.keywordTransform(d.s))
+		switch t := d.d.(type) {
+		// Structural cases: transform the iDoc list.
+		case nilDoc:
+			xlist = z
+		case *concat:
+			xlist = b.newiDoc(d.i, t.a, b.newiDoc(d.i, t.b, z))
+		case nests:
+			xlist = b.newiDoc(
+				docPos{d.i.tabs, d.i.spaces + t.n}, t.d, z,
+			)
+		case nestt:
+			xlist = b.newiDoc(
+				docPos{d.i.tabs + 1 + d.i.spaces/b.tabWidth, 0},
+				t.d, z,
+			)
+		case *scolumn:
+			xlist = b.newiDoc(d.i, t.f(k.spaces), z)
+		case *snesting:
+			xlist = b.newiDoc(d.i, t.f(d.i.spaces), z)
+		case *union:
+			// Greedily choose the flat (x) branch if it fits.
+			flat := b.newiDoc(d.i, t.x, z)
+			if b.fits(k, flat) {
+				xlist = flat
 			} else {
-				sb.WriteString(d.s)
+				xlist = b.newiDoc(d.i, t.y, z)
 			}
-		case lineB, hardlineB:
+		// Content cases: write directly to sb and advance.
+		case text:
+			sb.WriteString(string(t))
+			k = docPos{k.tabs, k.spaces + int16(len(t))}
+			xlist = z
+		case keyword:
+			s := string(t)
+			if b.keywordTransform != nil {
+				sb.WriteString(b.keywordTransform(s))
+			} else {
+				sb.WriteString(s)
+			}
+			k = docPos{k.tabs, k.spaces + int16(len(t))}
+			xlist = z
+		case line, softbreak, hardline:
 			sb.WriteByte('\n')
 			// Fill the tabs first.
 			padTabs := d.i.tabs * b.tabWidth
-			if useTabs {
+			if b.useTabs {
 				for i := int16(0); i < d.i.tabs; i++ {
 					sb.WriteByte('\t')
 				}
 				padTabs = 0
 			}
-
 			// Fill the remaining spaces.
 			for i := int16(0); i < padTabs+d.i.spaces; i++ {
 				sb.WriteByte(' ')
 			}
-		case spacesB:
-			for i := int16(0); i < d.i.spaces; i++ {
+			k = d.i
+			xlist = z
+		case pad:
+			for i := int16(0); i < t.n; i++ {
 				sb.WriteByte(' ')
 			}
-		case failB:
-			panic(errors.AssertionFailedf("failB should never reach layout"))
+			k = docPos{k.tabs, k.spaces + t.n}
+			xlist = z
+		// Error cases.
+		case failDoc:
+			panic(errors.AssertionFailedf("failDoc should never be reached"))
 		default:
-			panic(fmt.Errorf("unknown type: %d", d.tag))
+			panic(errors.AssertionFailedf("unknown type: %T", d.d))
 		}
 	}
+}
+
+// fits checks whether the first line of the document represented
+// by xlist fits within the remaining line width given position k.
+func (b *beExec) fits(k docPos, xlist *iDoc) bool {
+	for {
+		if k.spaces+k.tabs*b.tabWidth > b.w {
+			return false
+		}
+		if xlist == nil {
+			return true
+		}
+		d := *xlist
+		z := xlist.next
+		switch t := d.d.(type) {
+		case nilDoc:
+			xlist = z
+		case *concat:
+			xlist = b.newiDoc(d.i, t.a, b.newiDoc(d.i, t.b, z))
+		case nests:
+			xlist = b.newiDoc(
+				docPos{d.i.tabs, d.i.spaces + t.n}, t.d, z,
+			)
+		case nestt:
+			xlist = b.newiDoc(
+				docPos{d.i.tabs + 1 + d.i.spaces/b.tabWidth, 0},
+				t.d, z,
+			)
+		case *scolumn:
+			xlist = b.newiDoc(d.i, t.f(k.spaces), z)
+		case *snesting:
+			xlist = b.newiDoc(d.i, t.f(d.i.spaces), z)
+		case text:
+			k = docPos{k.tabs, k.spaces + int16(len(t))}
+			xlist = z
+		case keyword:
+			k = docPos{k.tabs, k.spaces + int16(len(t))}
+			xlist = z
+		case line, softbreak, hardline:
+			return true
+		case *union:
+			// We only need to check the broken (y) branch since the union
+			// invariant tells us it will have a shorter first line.
+			xlist = b.newiDoc(d.i, t.y, z)
+		case pad:
+			k = docPos{k.tabs, k.spaces + t.n}
+			xlist = z
+		case failDoc:
+			return false
+		default:
+			panic(errors.AssertionFailedf("unknown type: %T", d.d))
+		}
+	}
+}
+
+// newiDoc makes a new iDoc on the heap. Allocations are batched
+// for more efficiency.
+func (b *beExec) newiDoc(i docPos, d Doc, z *iDoc) *iDoc {
+	buf := &b.idocAlloc
+	if len(*buf) == 0 {
+		*buf = make([]iDoc, 100)
+	}
+	r := &(*buf)[0]
+	*r = iDoc{i: i, d: d, next: z}
+	*buf = (*buf)[1:]
+	return r
 }


### PR DESCRIPTION
The pretty-printer has been rewritten to use iteration instead of
recursion, alleviating previous concerns about stack overflows.
The code has also been simplified to no longer need memoization or
an intermediate representation. Instead, unions are resolved greedily
by checking fitness on the Doc tree directly, avoiding the need to
build out entire intermediate representation chains for paths that
aren't selected.

Benchmark improvements:
```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
           │   old.txt    │               new.txt               │
           │    sec/op    │   sec/op     vs base                │
PrettyData   70.227m ± 2%   3.635m ± 1%  -94.82% (p=0.000 n=10)

           │    old.txt    │               new.txt                │
           │     B/op      │     B/op      vs base                │
PrettyData   33.719Mi ± 0%   2.521Mi ± 0%  -92.52% (p=0.000 n=10)

           │   old.txt   │               new.txt               │
           │  allocs/op  │  allocs/op   vs base                │
PrettyData   8.507k ± 0%   1.681k ± 0%  -80.24% (p=0.000 n=10)
```

Informs #91197
Fixes #110375
Fixes #167483

Release note (performance improvement): Pretty-printing of large SQL
statements will no longer fail due to exceeding max recursion depth.