### PR TITLE
release-26.2: schemachanger: fix condition for table being dropped in alter locality

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_locality.go
@@ -47,7 +47,7 @@ func AlterTableLocality(b BuildCtx, t *tree.AlterTableLocality) {
 	tableID := tbl.TableID
 	tableName := t.Name.Object()
 
-	if elts.Filter(notFilter(publicTargetFilter)) != nil {
+	if elts.Filter(notFilter(publicTargetFilter)).FilterTable() != nil {
 		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			"table %q is being dropped, try again later", tbl))
 	}


### PR DESCRIPTION
Backport 1/1 commits from #167928 on behalf of @shghasemi.

----

This commit fixes a bug where ALTER LOCALITY checked for any elements being dropped instead of the table.

Fixes: #167925

Release note: None

----

Release justification: Bug fix.