### PR TITLE
staging-v25.4.8: importer: sanitize cloud storage URIs in error messages

### DIFF
--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -217,6 +217,10 @@ func readInputFiles(
 		default:
 		}
 		if err := func() error {
+			sanitizedDataFile, sanitizeErr := cloud.SanitizeExternalStorageURI(dataFile, nil)
+			if sanitizeErr != nil {
+				sanitizedDataFile = "<uri_failed_to_redact>"
+			}
 			conf, err := cloud.ExternalStorageConfFromURI(dataFile, user)
 			if err != nil {
 				return err
@@ -258,7 +262,7 @@ func readInputFiles(
 								pgcode.DataCorrupted,
 								"too many parsing errors (%d) encountered for file %s",
 								countRejected,
-								dataFile,
+								sanitizedDataFile,
 							)
 						}
 						buf = append(buf, s...)
@@ -296,11 +300,11 @@ func readInputFiles(
 				})
 
 				if err := grp.Wait(); err != nil {
-					return errors.Wrapf(err, "%s", dataFile)
+					return errors.Wrapf(err, "%s", sanitizedDataFile)
 				}
 			} else {
 				if err := fileFunc(ctx, src, dataFileIndex, resumePos[dataFileIndex], nil /* rejected */); err != nil {
-					return errors.Wrapf(err, "%s", dataFile)
+					return errors.Wrapf(err, "%s", sanitizedDataFile)
 				}
 			}
 			return nil


### PR DESCRIPTION
Backport 1/1 commits from #167949.

/cc @cockroachdb/release

---

Backport 1/1 commits from #164881 on behalf of @mw5h.

----

## Summary

- Sanitize cloud storage URIs in `readInputFiles` error messages using
  `cloud.SanitizeExternalStorageURI` to strip credentials before including
  them in user-visible errors.
- Fixes three error paths: the "too many parsing errors" pgerror and both
  `errors.Wrapf` calls that annotate errors with the file path.

Resolves: #151884

Release note (bug fix): Fixed a bug where IMPORT error messages
could include unredacted cloud storage credentials from the source
URI. Credentials are now stripped from URIs before they appear in
error messages.

----

Release justification: Important security fix for an issue encountered by a customer.

Release justification: 
