### PR TITLE
cli/interactive_tests: fix flaky TestDockerCLI_test_socket_name

### DIFF
--- a/pkg/cli/interactive_tests/test_socket_name.tcl
+++ b/pkg/cli/interactive_tests/test_socket_name.tcl
@@ -13,7 +13,7 @@ send "mkdir -p $longname\r"
 eexpect ":/# "
 
 start_test "Check derived Unix socket name is printed in server output"
-send "$argv start-single-node --insecure --listen-addr=`cat /etc/hostname`:0 --pid-file=logs/server_pid --socket-dir=.\r"
+send "$argv start-single-node --insecure --listen-addr=127.0.0.1:0 --pid-file=logs/server_pid --socket-dir=.\r"
 eexpect "CockroachDB node starting"
 expect {
     -re "sql:.*@\[^:\]*:(\[^/\]*)/" { set sql_port $expect_out(1,string) }
@@ -33,17 +33,27 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 start_test "Check that the socket is locked from reuse while the server is running."
-# We use 127.0.0.1 so as to not overlap with the default address 0.0.0.0 selected above.
+# Use 127.0.0.2 (different from 127.0.0.1 above) so the TCP bind succeeds and
+# the test isolates the Unix socket lock behavior. Both servers share the same
+# --socket-dir and port, so the socket filename is the same.
 # We also need a different data directory to avoid a conflict there.
-send "$argv start-single-node --insecure --listen-addr=127.0.0.1:$sql_port --http-addr=:0 --socket-dir=. -s=path=logs/other\r"
+send "$argv start-single-node --insecure --listen-addr=127.0.0.2:$sql_port --http-addr=:0 --socket-dir=. -s=path=logs/other\r"
 eexpect ERROR
 eexpect "Socket appears locked by process"
 eexpect ":/# "
 end_test
 
 start_test "Check that stopping the first process abruptly enables the 2nd process to start"
-system "kill -9 `cat logs/server_pid`"
-send "$argv start-single-node --insecure --listen-addr=127.0.0.1:$sql_port --http-addr=:0 --socket-dir=. -s=path=logs/other\r"
+# Kill the server and wait for the process to fully exit so the Unix socket
+# lock file becomes reclaimable by the replacement server.
+system "PID=\$(cat logs/server_pid); kill -9 \$PID
+        for i in \$(seq 1 30); do
+          kill -0 \$PID 2>/dev/null || exit 0
+          sleep 0.1
+        done
+        echo 'process still alive'
+        exit 1"
+send "$argv start-single-node --insecure --listen-addr=127.0.0.2:$sql_port --http-addr=:0 --socket-dir=. -s=path=logs/other\r"
 eexpect "CockroachDB node starting"
 system "test -S .s.PGSQL.$sql_port"
 system "test -r .s.PGSQL.$sql_port.lock"


### PR DESCRIPTION
Previously, this test used `cat /etc/hostname` to bind the first server, and then `127.0.0.1` for subsequent servers, assuming they wouldn't overlap. In Docker environments where the hostname resolves to `127.0.0.1`, both servers bind to the same TCP address, causing the second server to fail at TCP bind with "address already in use" before reaching the Unix socket lock check. The test then times out waiting for "Socket appears locked by process".

Fix by using distinct loopback addresses (`127.0.0.1` for server 1, `127.0.0.2` for servers 2/3) so the TCP addresses never conflict and the test properly isolates the Unix socket lock behavior. Also wait for the killed process to fully exit before starting the replacement server, to avoid a secondary race on port release.

Fixes: #156674
Fixes: #127046
Epic: none

Release note: None