### PR TITLE
sql: respect search_path in format_type for user-defined types

### DIFF
--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -1878,7 +1878,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
       AND pg_catalog.pg_type_is_visible(t.oid)
 ORDER BY 1, 2
 Schema,Name,Description
-public,public.mytyp,
+public,mytyp,
 
 cli
 \dT %int[]

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4560,11 +4560,15 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
      AND pg_catalog.pg_type_is_visible(t.oid)
 ORDER BY 1, 2;
 ----
-Schema  Name                    Description
-public  public.concat_enum      ·
-public  public.custom_typ       ·
-public  public.roach_dwellings  ·
-public  public.testenum         ·
+Schema      Name                       Description
+public      concat_enum                ·
+public      custom_typ                 ·
+public      roach_dwellings            ·
+public      testenum                   ·
+
+skipif config local-legacy-schema-changer
+statement ok
+RESET search_path;
 
 subtest end
 
@@ -4712,5 +4716,133 @@ query T
 SELECT substring_index('a..b..c..d', '..', 9223372036854775807);
 ----
 a..b..c..d
+
+subtest end
+
+
+subtest format_type_name_resolution
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE SCHEMA roach_prod;
+CREATE SCHEMA roach_dev;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET search_path=public, roach_prod;
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE TYPE roach_prod.roach_dwellings_final AS ENUM ('roach_motel','roach_kitchen','roach_bathroom','roach_house');
+CREATE TYPE roach_dev.roach_dwellings AS ENUM ('roach_motel','roach_kitchen','roach_bathroom','roach_house');
+CREATE TYPE roach_dev.roach_dwellings_v8 AS ENUM ('roach_motel','roach_kitchen','roach_bathroom','roach_house', 'roach_office');
+
+# This select statement validates that format_type uses fully qualified names
+# names when a name is aliased or not in the search_path.
+skipif config local-legacy-schema-changer
+query TT colnames
+SELECT n.nspname AS "Schema",
+         pg_catalog.format_type(t.oid, NULL) AS "Name"
+    FROM pg_catalog.pg_type t
+LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+   WHERE (t.typrelid = 0
+         OR (SELECT c.relkind = 'c'
+               FROM pg_catalog.pg_class c
+              WHERE c.oid = t.typrelid))
+     AND (NOT EXISTS(
+         SELECT 1
+           FROM pg_catalog.pg_type el
+          WHERE el.oid = t.typelem AND el.typarray = t.oid))
+     AND n.nspname !~ '^pg_'
+     AND n.nspname <> 'information_schema'
+     AND n.nspname <> 'crdb_internal'
+ORDER BY 1, 2;
+----
+Schema      Name
+public      concat_enum
+public      custom_typ
+public      foo_type
+public      roach_dwellings
+public      testenum
+roach_dev   roach_dev.roach_dwellings
+roach_dev   roach_dev.roach_dwellings_v8
+roach_prod  roach_dwellings_final
+
+# Add roach_dev in the path, which will cause roach_dwellings_v8 to
+# use a non-full qualified name. However, roach_dev.roach_dwellings will still
+# still use a full qualified name because its alised by public.roach_dwellings.
+skipif config local-legacy-schema-changer
+statement ok
+SET search_path=public, roach_dev, roach_prod;
+
+skipif config local-legacy-schema-changer
+query TT colnames
+SELECT n.nspname AS "Schema",
+         pg_catalog.format_type(t.oid, NULL) AS "Name"
+    FROM pg_catalog.pg_type t
+LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+   WHERE (t.typrelid = 0
+         OR (SELECT c.relkind = 'c'
+               FROM pg_catalog.pg_class c
+              WHERE c.oid = t.typrelid))
+     AND (NOT EXISTS(
+         SELECT 1
+           FROM pg_catalog.pg_type el
+          WHERE el.oid = t.typelem AND el.typarray = t.oid))
+     AND n.nspname !~ '^pg_'
+     AND n.nspname <> 'information_schema'
+     AND n.nspname <> 'crdb_internal'
+ORDER BY 1, 2;
+----
+Schema      Name
+public      concat_enum
+public      custom_typ
+public      foo_type
+public      roach_dwellings
+public      testenum
+roach_dev   roach_dev.roach_dwellings
+roach_dev   roach_dwellings_v8
+roach_prod  roach_dwellings_final
+
+# Have roach_dwellings aliased in roach_prod, and its fully
+# resolve name will appear below because the public.roach_dwellings
+# is first in the search_path.
+skipif config local-legacy-schema-changer
+statement ok
+CREATE TYPE roach_prod.roach_dwellings AS ENUM ('roach_motel','roach_kitchen','roach_bathroom','roach_house');
+
+skipif config local-legacy-schema-changer
+query TT colnames
+SELECT n.nspname AS "Schema",
+         pg_catalog.format_type(t.oid, NULL) AS "Name"
+    FROM pg_catalog.pg_type t
+LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+   WHERE (t.typrelid = 0
+         OR (SELECT c.relkind = 'c'
+               FROM pg_catalog.pg_class c
+              WHERE c.oid = t.typrelid))
+     AND (NOT EXISTS(
+         SELECT 1
+           FROM pg_catalog.pg_type el
+          WHERE el.oid = t.typelem AND el.typarray = t.oid))
+     AND n.nspname !~ '^pg_'
+     AND n.nspname <> 'information_schema'
+     AND n.nspname <> 'crdb_internal'
+ORDER BY 1, 2;
+----
+Schema      Name
+public      concat_enum
+public      custom_typ
+public      foo_type
+public      roach_dwellings
+public      testenum
+roach_dev   roach_dev.roach_dwellings
+roach_dev   roach_dwellings_v8
+roach_prod  roach_dwellings_final
+roach_prod  roach_prod.roach_dwellings
+
+skipif config local-legacy-schema-changer
+statement ok
+RESET search_path;
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -100,4 +100,3 @@ EXPLAIN ANALYZE (DISTSQL) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) A
 # LocalPlanNodes (#62261).
 query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"c_p_fkey\"
 EXPLAIN ANALYZE (DEBUG) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)
-

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -403,7 +403,7 @@ CREATE TYPE typ AS ENUM ('hello')
 query T
 SELECT format_type(oid, 0) FROM pg_catalog.pg_type WHERE typname = 'typ'
 ----
-public.typ
+typ
 
 # Nothing breaks if we put a non-existing oid into format_type.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/void
+++ b/pkg/sql/logictest/testdata/logic_test/void
@@ -187,4 +187,3 @@ CREATE TABLE t84224 (a STRING)
 
 statement error pgcode 42704 pq: array of type VOID is not supported
 SELECT ARRAY[a::VOID] FROM t84224
-

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1218,7 +1218,29 @@ FROM defaults_parsed
 					hasTypmod = true
 					typmod = int(tree.MustBeDInt(maybeTypmod))
 				}
-				return tree.NewDString(typ.SQLStandardNameWithTypmod(hasTypmod, typmod)), nil
+				// Postgres will append the type name with the schema if type is user defined
+				// and if it does not exist in the search_path.
+				isUserDefined := types.IsOIDUserDefinedType(oid)
+				useFQName := true
+				if isUserDefined && typ.TypeMeta.Name != nil {
+					// Based on the base name, see if the type resolves to the
+					// same OID as the user specified one.
+					lookupName, err := tree.NewUnresolvedObjectName(1, [3]string{typ.TypeMeta.Name.Basename()}, tree.NoAnnotation)
+					if err != nil {
+						return nil, err
+					}
+					resolvedTyp, err := evalCtx.Planner.ResolveType(ctx, lookupName)
+					if err != nil && pgerror.GetPGCode(err) != pgcode.UndefinedObject &&
+						!catalog.HasInactiveDescriptorError(err) {
+						return nil, err
+					}
+					// If the type resolved successfully, then determine if we looked up
+					// the same type. Resolution here can fail, which will just cause us
+					// to always fully qualify the name.
+					useFQName = err != nil || resolvedTyp.Oid() != oid
+				}
+
+				return tree.NewDString(typ.SQLStandardNameWithTypmod(hasTypmod, typmod, useFQName)), nil
 			},
 			Info: "Returns the SQL name of a data type that is " +
 				"identified by its type OID and possibly a type modifier. " +

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1887,7 +1887,7 @@ func (t *T) PGName() string {
 //
 //	SELECT format_type(pg_typeof(1::int)::regtype, NULL)
 func (t *T) SQLStandardName() string {
-	return t.SQLStandardNameWithTypmod(false, 0)
+	return t.SQLStandardNameWithTypmod(false, 0, true /* useFQName */)
 }
 
 var telemetryNameReplaceRegex = regexp.MustCompile("[^a-zA-Z0-9]")
@@ -1908,16 +1908,25 @@ func (t *T) TelemetryName() string {
 // varchar(20) would appear as character varying(20) when provided the typmod
 // value for varchar(20), which happens to be 24.
 //
+// useFQName indicates if the fully qualified name should be specified, which for
+// format_type will be used when the name exists and is not visible or aliased in the
+// search_path.
 // This function is full of special cases. See backend/utils/adt/format_type.c
 // in Postgres.
-func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
+func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int, useFQName bool) string {
+	maybeFQName := func() string {
+		if useFQName {
+			return t.TypeMeta.Name.FQName(false /* explicitCatalog */)
+		}
+		return t.TypeMeta.Name.Basename()
+	}
 	// Domain types share their base type's Family, so check for them before
 	// the Family switch to avoid returning the base type name.
 	if t.UserDefined() && t.TypeMeta.DomainData != nil {
 		if t.TypeMeta.Name == nil {
 			return fmt.Sprintf("@%d", t.Oid())
 		}
-		return t.TypeMeta.Name.FQName(false /* explicitCatalog */)
+		return maybeFQName()
 	}
 	var buf strings.Builder
 	switch t.Family() {
@@ -1935,10 +1944,10 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 		// If we have a typemod specified then pass it down when
 		// formatting the array type.
 		if !haveTypmod {
-			return t.ArrayContents().SQLStandardName() + "[]"
+			return t.ArrayContents().SQLStandardNameWithTypmod(false, 0, useFQName) + "[]"
 		} else {
 			ac := t.ArrayContents()
-			return ac.SQLStandardNameWithTypmod(haveTypmod, typmod) + "[]"
+			return ac.SQLStandardNameWithTypmod(haveTypmod, typmod, useFQName) + "[]"
 		}
 	case BitFamily:
 		if t.Oid() == oid.T_varbit {
@@ -2107,7 +2116,7 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 			}
 			// If we have a user-defined tuple type, use its user-defined name
 			// with schema qualification but without catalog.
-			return t.TypeMeta.Name.FQName(false /* explicitCatalog */)
+			return maybeFQName()
 		}
 		return "record"
 	case UnknownFamily:
@@ -2123,7 +2132,7 @@ func (t *T) SQLStandardNameWithTypmod(haveTypmod bool, typmod int) string {
 		if t.TypeMeta.Name == nil {
 			return fmt.Sprintf("@%d", t.Oid())
 		}
-		return t.TypeMeta.Name.FQName(false /* explicitCatalog */)
+		return maybeFQName()
 	case LTreeFamily:
 		return t.Name()
 	default:


### PR DESCRIPTION
Previously, format_type for user-defined types would always return the fully qualified name (e.g., public.my_type), even if the type was visible in the current search_path. This behavior differed from PostgreSQL, which only qualifies the name if the type is not visible.

This commit updates format_type to check if a user-defined type is visible in the current search_path. If it is, the base name is used; otherwise, the fully qualified name is returned. This aligns our behavior more closely with PostgreSQL and fixes failures in ORMs like ActiveRecord that expect this behavior.

Fixes: #167461
Epic: none
Release note: None