### PR TITLE
kvserver: isolate subtests in TestReplicaLatchingOptimisticEvaluation…

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2796,49 +2796,6 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testutils.RunTrueAndFalse(t, "point-reads", func(t *testing.T, pointReads bool) {
-		baRead := &kvpb.BatchRequest{}
-		if pointReads {
-			gArgs1, gArgs2 := getArgsString("a"), getArgsString("b")
-			gArgs3, gArgs4 := getArgsString("c"), getArgsString("d")
-			baRead.Add(gArgs1, gArgs2, gArgs3, gArgs4)
-		} else {
-			// Split into two back-to-back scans for better test coverage.
-			sArgs1 := scanArgsString("a", "c")
-			sArgs2 := scanArgsString("c", "e")
-			baRead.Add(sArgs1, sArgs2)
-		}
-		// The state that will block a write while holding latches.
-		var blockKey, blockWriter atomic.Value
-		blockKey.Store(roachpb.Key("a"))
-		blockWriter.Store(false)
-		blockCh := make(chan struct{}, 1)
-		blockedCh := make(chan struct{}, 1)
-		// Setup filter to block the write.
-		tc := testContext{}
-		tsc := TestStoreConfig(nil)
-		tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
-			func(filterArgs kvserverbase.FilterArgs) *kvpb.Error {
-				// Make sure the direct GC path doesn't interfere with this test.
-				if !filterArgs.Req.Header().Key.Equal(blockKey.Load().(roachpb.Key)) {
-					return nil
-				}
-				if filterArgs.Req.Method() == kvpb.Put && blockWriter.Load().(bool) {
-					blockedCh <- struct{}{}
-					<-blockCh
-				}
-				return nil
-			}
-		ctx := context.Background()
-		stopper := stop.NewStopper()
-		defer stopper.Stop(ctx)
-		tc.StartWithStoreConfig(ctx, t, stopper, tsc)
-		// Write initial keys.
-		for _, k := range []string{"a", "b", "c", "d"} {
-			pArgs := putArgs([]byte(k), []byte("value"))
-			if _, pErr := tc.SendWrapped(&pArgs); pErr != nil {
-				t.Fatal(pErr)
-			}
-		}
 		testCases := []struct {
 			writeKey   string
 			limit      int64
@@ -2865,6 +2822,53 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 		}
 		for _, test := range testCases {
 			t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+				// Each subtest gets its own store to prevent async intent
+				// resolution from a previous subtest's writes from racing
+				// with the current subtest's optimistic read. See #167535.
+				baRead := &kvpb.BatchRequest{}
+				if pointReads {
+					gArgs1, gArgs2 := getArgsString("a"), getArgsString("b")
+					gArgs3, gArgs4 := getArgsString("c"), getArgsString("d")
+					baRead.Add(gArgs1, gArgs2, gArgs3, gArgs4)
+				} else {
+					// Split into two back-to-back scans for better test coverage.
+					sArgs1 := scanArgsString("a", "c")
+					sArgs2 := scanArgsString("c", "e")
+					baRead.Add(sArgs1, sArgs2)
+				}
+				// The state that will block a write while holding latches.
+				var blockKey, blockWriter atomic.Value
+				blockKey.Store(roachpb.Key("a"))
+				blockWriter.Store(false)
+				blockCh := make(chan struct{}, 1)
+				blockedCh := make(chan struct{}, 1)
+				// Setup filter to block the write.
+				tc := testContext{}
+				tsc := TestStoreConfig(nil)
+				tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
+					func(filterArgs kvserverbase.FilterArgs) *kvpb.Error {
+						// Make sure the direct GC path doesn't interfere with this test.
+						if !filterArgs.Req.Header().Key.Equal(blockKey.Load().(roachpb.Key)) {
+							return nil
+						}
+						if filterArgs.Req.Method() == kvpb.Put && blockWriter.Load().(bool) {
+							blockedCh <- struct{}{}
+							<-blockCh
+						}
+						return nil
+					}
+				ctx := context.Background()
+				stopper := stop.NewStopper()
+				defer stopper.Stop(ctx)
+				tc.StartWithStoreConfig(ctx, t, stopper, tsc)
+				// Write initial keys.
+				for _, k := range []string{"a", "b", "c", "d"} {
+					pArgs := putArgs([]byte(k), []byte("value"))
+					if _, pErr := tc.SendWrapped(&pArgs); pErr != nil {
+						t.Fatal(pErr)
+					}
+				}
+
 				errCh := make(chan *kvpb.Error, 2)
 				pArgs := putArgs([]byte(test.writeKey), []byte("value"))
 				blockKey.Store(roachpb.Key(test.writeKey))

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2837,8 +2837,7 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 					baRead.Add(sArgs1, sArgs2)
 				}
 				// The state that will block a write while holding latches.
-				var blockKey, blockWriter atomic.Value
-				blockKey.Store(roachpb.Key("a"))
+				var blockWriter atomic.Value
 				blockWriter.Store(false)
 				blockCh := make(chan struct{}, 1)
 				blockedCh := make(chan struct{}, 1)
@@ -2848,7 +2847,7 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 				tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
 					func(filterArgs kvserverbase.FilterArgs) *kvpb.Error {
 						// Make sure the direct GC path doesn't interfere with this test.
-						if !filterArgs.Req.Header().Key.Equal(blockKey.Load().(roachpb.Key)) {
+						if !filterArgs.Req.Header().Key.Equal(roachpb.Key(test.writeKey)) {
 							return nil
 						}
 						if filterArgs.Req.Method() == kvpb.Put && blockWriter.Load().(bool) {
@@ -2871,7 +2870,6 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 
 				errCh := make(chan *kvpb.Error, 2)
 				pArgs := putArgs([]byte(test.writeKey), []byte("value"))
-				blockKey.Store(roachpb.Key(test.writeKey))
 				blockWriter.Store(true)
 				go func() {
 					_, pErr := tc.SendWrapped(&pArgs)


### PR DESCRIPTION
Epic: none 
Release note: none

---
**kvserver: isolate subtests in TestReplicaLatchingOptimisticEvaluationKeyLimit**

This change moves the store, filter, and initial key setup inside each
subtest iteration so that every subtest runs against its own store.

The test was flaky because subtests shared a single store. Async intent
resolution from a previous subtest's `Put` could race with the current
subtest's optimistic read. `ResolveIntent` acquires `SpanReadWrite`
latches on user keys (see `cmd_resolve_intent.go`). When an async
`ResolveIntent` from a prior subtest holds a write latch on a key
(e.g. "a"), the current subtest's optimistic read detects a latch
conflict on its narrowed spans, falls back to pessimistic latching,
and waits on the blocked `Put`'s latch — which is stuck in the eval
filter. This creates a deadlock that times out the test.

Giving each subtest its own store eliminates the possibility of
cross-subtest async intent resolution interference.

Fixes #167535

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**kvserver: remove blockKey from TestReplicaLatchingOptimisticEvaluationKeyLimit**

This commit removes the `blockKey` `atomic.Value` from the test. The
variable was previously necessary because the eval filter was shared
across all subtests, so each iteration had to update `blockKey` to tell
the filter which key to block. Now that each subtest creates its own
filter, the closure captures `test.writeKey` directly and `blockKey`
is redundant.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

