### PR TITLE
kvserver: deflake TestReplicaLatchingOptimisticEvaluationKeyLimit

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2816,6 +2816,10 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 		// Setup filter to block the write.
 		tc := testContext{}
 		tsc := TestStoreConfig(nil)
+		// Force synchronous intent resolution to prevent async ResolveIntent
+		// from a previous subtest's write from racing with the current
+		// subtest's optimistic read. See #167535.
+		tsc.TestingKnobs.IntentResolverKnobs.ForceSyncIntentResolution = true
 		tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
 			func(filterArgs kvserverbase.FilterArgs) *kvpb.Error {
 				// Make sure the direct GC path doesn't interfere with this test.


### PR DESCRIPTION
Epic: none 
Release note: none

---
**kvserver: deflake TestReplicaLatchingOptimisticEvaluationKeyLimit**

This test was flaky because subtests share a single store, and async
intent resolution from a previous subtest's `Put` could race with the
current subtest's optimistic read. `ResolveIntent` acquires
`SpanReadWrite` latches on user keys (see `cmd_resolve_intent.go`).
When an async `ResolveIntent` from a prior subtest holds a write latch
on a key (e.g. "a"), the current subtest's optimistic read detects a
latch conflict on its narrowed spans, falls back to pessimistic
latching, and waits on the blocked `Put`'s latch — which is stuck in
the eval filter. This creates a deadlock that times out the test.

This commit forces synchronous intent resolution via the
`ForceSyncIntentResolution` testing knob so that all intent resolution
completes before the `Put` returns, eliminating the cross-subtest race.

Fixes #167535

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

