### PR TITLE
clusterversion/runbooks: fix M.1 predecessor guidance for cockroach_releases.yaml

### DIFF
--- a/pkg/clusterversion/runbooks/M1_bump_current_version.md
+++ b/pkg/clusterversion/runbooks/M1_bump_current_version.md
@@ -238,15 +238,21 @@ When bumping from version X.Y to X.Z (e.g., 26.1 → 26.2):
 
 1. **Do NOT change any existing mappings** - Keep all previous entries as-is
 2. **Find the latest mapping** - For example: `"26.1": predecessor: "25.4"`
-3. **Add a new entry** for the new version with the same predecessor:
+3. **Add a new entry** for the new version pointing to the previous dev series:
 ```yaml
 "26.1":
   predecessor: "25.4"
 "26.2":
-  predecessor: "25.4"   # Use same predecessor as 26.1
+  predecessor: "26.1"
 ```
 
-**Why:** Both 26.1 and 26.2 are development versions that haven't been released yet. They both should upgrade from the last stable release (25.4). This will be corrected later in M.3 when we add actual release data.
+**Why `26.1` and not `25.4`?** Even though 26.1 has not yet shipped as a stable release,
+`predecessorSeries()` in `pkg/testutils/release/releases.go` skips unreleased series
+(those with empty `Latest`) when walking the predecessor chain. So setting
+`predecessor: "26.1"` is safe and produces the same runtime behavior as pointing directly
+to the last stable release. The predecessor only becomes "live" once M.3 adds a `latest`
+to 26.1. Pointing directly to the immediate predecessor (`26.1`) is preferred over
+skipping it (`25.4`) because it correctly reflects the intended upgrade path.
 
 **Example for 26.1 → 26.2 bump:**
 ```bash
@@ -264,13 +270,11 @@ When bumping from version X.Y to X.Z (e.g., 26.1 → 26.2):
 "26.1":
   predecessor: "25.4"    # KEEP this entry
 "26.2":
-  predecessor: "25.4"    # ADD this entry
+  predecessor: "26.1"    # ADD this entry (points to immediate predecessor)
 
 # Verify your changes
 tail -10 pkg/testutils/release/cockroach_releases.yaml
 ```
-
-**Note:** In M.3, when the RC is published, the predecessor relationships will be updated to reflect the actual release hierarchy.
 
 **c) Regenerate scplan test outputs:**
 ```bash

--- a/pkg/clusterversion/runbooks/M1_bump_current_version_QUICK.md
+++ b/pkg/clusterversion/runbooks/M1_bump_current_version_QUICK.md
@@ -110,15 +110,14 @@ Manually update `pkg/testutils/release/cockroach_releases.yaml` — add an entry
 
 ```yaml
 "<NEW_VER>":
-  predecessor: "<PREV_STABLE>"
+  predecessor: "<OLD_VER>"
 ```
 
-**Why `<PREV_STABLE>` and not `<OLD_VER>`?** The `predecessor` field tracks the last
-*released* stable version before this one. At M.1 time, `<OLD_VER>` has not yet shipped
-as a stable release — it is still an in-development version on `release-<OLD_VER>`. So
-both `<OLD_VER>` and `<NEW_VER>` share the same last stable predecessor: `<PREV_STABLE>`.
-This is intentional and expected; it will look like N → N-2 rather than N → N-1, which
-can surprise reviewers.
+**Note:** At M.1 time, `<OLD_VER>` has not yet shipped as a stable release, so this will
+look like N → N-1 where N-1 is unreleased. This is safe: `predecessorSeries()` in
+`pkg/testutils/release/releases.go` already skips unreleased series (those with empty
+`Latest`) when walking the predecessor chain. The predecessor only becomes "live" (actually
+routing tests to that series' binaries) once M.3 adds a `latest` to `<OLD_VER>`.
 
 **IMPORTANT:** After `./dev gen bazel`, remove any `upgradeinterlockccl_test` lines
 from `pkg/BUILD.bazel` before committing. See MEMORY.md.


### PR DESCRIPTION
## Summary

The M.1 runbooks directed operators to set the new dev version's predecessor in `cockroach_releases.yaml` to the last *stable* release (series-2), with a note that it would be "corrected in M.3". This was unnecessary and confusing.

`predecessorSeries()` in `pkg/testutils/release/releases.go` already skips unreleased series (those with empty `Latest`) when walking the predecessor chain. Setting `predecessor: "<OLD_VER>"` at M.1 time is safe even though `<OLD_VER>` hasn't shipped yet — the code falls through to the next released series transparently. This behavior is covered by the existing `"skips unreleased predecessor"` test case in `releases_test.go`.

Update both runbooks to point to the immediate predecessor (`<OLD_VER>`) and explain why it's safe, removing the misleading "corrected in M.3" note.

Epic: none