### PR TITLE
release-25.2: roachtest: restore version-aware snapshot prefix for index backfill tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -66,6 +66,17 @@ var indexBackfillVariants = []indexBackfillVariant{
 	},
 }
 
+// versionedSnapshotPrefix returns a snapshot prefix that includes the major
+// version (e.g., "index-backfill-tpce-100k-bw-v26-2") so that each major
+// release uses its own snapshots. This is needed because snapshot data may
+// not be compatible across major versions. Dots are replaced with dashes to
+// match the GCE snapshot naming convention used by snapshotName().
+func versionedSnapshotPrefix(t test.Test) string {
+	v := t.BuildVersion()
+	major := strings.ReplaceAll(v.Major().String(), ".", "-")
+	return fmt.Sprintf("%s-%s", t.SnapshotPrefix(), major)
+}
+
 func registerIndexBackfill(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
@@ -106,17 +117,16 @@ func runIndexBackfill(
 	withCgroupLimiting bool,
 	withProvisionedBandwidth bool,
 ) {
+	snapshotPrefix := versionedSnapshotPrefix(t)
 	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
-		// TODO(irfansharif): Search by taking in the other parts of the
-		// snapshot fingerprint, i.e. the node count, the version, etc.
-		NamePrefix: t.SnapshotPrefix(),
+		NamePrefix: snapshotPrefix,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(snapshots) == 0 {
 		t.L().Printf("no existing snapshots found for %s (%s), doing pre-work",
-			t.Name(), t.SnapshotPrefix())
+			t.Name(), snapshotPrefix)
 
 		// Set up TPC-E with 100k customers. Do so using a published
 		// CRDB release, since we'll use this state to generate disk
@@ -163,7 +173,7 @@ func runIndexBackfill(
 		c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
 		// Create the aforementioned snapshots.
-		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
+		snapshots, err = c.CreateSnapshot(ctx, snapshotPrefix)
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				// Another concurrent run may have already created snapshots
@@ -174,11 +184,11 @@ func runIndexBackfill(
 			}
 		} else {
 			t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
-				len(snapshots), t.SnapshotPrefix())
+				len(snapshots), snapshotPrefix)
 		}
 	} else {
 		t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
-			len(snapshots), t.SnapshotPrefix())
+			len(snapshots), snapshotPrefix)
 
 		if !t.SkipInit() {
 			roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -431,8 +431,9 @@ func runSingleNodeIndexBackfill(
 
 func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Check for existing snapshots.
+	snapshotPrefix := versionedSnapshotPrefix(t)
 	snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
-		NamePrefix: t.SnapshotPrefix(),
+		NamePrefix: snapshotPrefix,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -442,7 +443,7 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		// No existing snapshots - need to initialize TPC-E and create snapshots.
 		// Use a published CRDB release so the snapshot has a well-defined internal
 		// version that can be upgraded to any newer version.
-		t.L().Printf("=== NO EXISTING SNAPSHOTS FOUND for prefix %q ===", t.SnapshotPrefix())
+		t.L().Printf("=== NO EXISTING SNAPSHOTS FOUND for prefix %q ===", snapshotPrefix)
 		t.L().Printf("=== WILL CREATE NEW SNAPSHOTS after TPC-E init ===")
 
 		// Get the latest predecessor release version.
@@ -503,8 +504,8 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
 		// Create snapshots.
-		t.Status(fmt.Sprintf("creating snapshots with prefix %q", t.SnapshotPrefix()))
-		snapshots, err = c.CreateSnapshot(ctx, t.SnapshotPrefix())
+		t.Status(fmt.Sprintf("creating snapshots with prefix %q", snapshotPrefix))
+		snapshots, err = c.CreateSnapshot(ctx, snapshotPrefix)
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				// Another concurrent run may have already created snapshots
@@ -514,11 +515,11 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 				t.Fatal(err)
 			}
 		} else {
-			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), t.SnapshotPrefix())
+			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), snapshotPrefix)
 		}
 	} else {
 		t.L().Printf("found %d existing snapshot(s) with prefix %q",
-			len(snapshots), t.SnapshotPrefix())
+			len(snapshots), snapshotPrefix)
 		roachtestutil.CopySnapshotDataToNodes(ctx, t, c, snapshots)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #168033 on behalf of @angeladietz.

----

Previously, `versionedSnapshotPrefix` was removed in #167915, which
caused `ListSnapshots` to search using a prefix that matches snapshots
from any CockroachDB version. On release branches (e.g., release-25.4),
this led to the test picking up a v26.1 snapshot, which is incompatible
and causes a startup failure: "store last used with cockroach version
v26.1 is too high for running version v25.4."

This restores `versionedSnapshotPrefix` so that each major release uses
its own snapshots. As well, dots in the major version are now replaced
with dashes (e.g., "v26-2" instead of "v26.2") to match the GCE
snapshot naming convention used by `snapshotName()` in roachprod. Without
this, the prefix would never match any snapshot name since GCE does not
allow dots.

Fixes: #168002
Fixes: #168005
Fixes: #168006
Fixes: #168007
Fixes: #168008
Fixes: #168011

Epic: none

----

Release justification: