### PR TITLE
sql/hints: fix prepared memo always invalidated after failed hint injection

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1241,6 +1241,8 @@ GO_TARGETS = [
     "//pkg/cmd/github-pull-request-make:github-pull-request-make_test",
     "//pkg/cmd/gossipsim:gossipsim",
     "//pkg/cmd/gossipsim:gossipsim_lib",
+    "//pkg/cmd/importrepl:importrepl",
+    "//pkg/cmd/importrepl:importrepl_lib",
     "//pkg/cmd/kv/datadoggen:datadoggen",
     "//pkg/cmd/kv/datadoggen:datadoggen_lib",
     "//pkg/cmd/kv/datadoggen:datadoggen_test",

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/security/username",
         "//pkg/settings/cluster",
+        "//pkg/sql/faketreeeval",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -531,7 +531,14 @@ func (m *Memo) IsStale(
 		m.clampLowHistogramSelectivity != evalCtx.SessionData().OptimizerClampLowHistogramSelectivity ||
 		m.clampInequalitySelectivity != evalCtx.SessionData().OptimizerClampInequalitySelectivity ||
 		m.useMaxFrequencySelectivity != evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity ||
-		m.usingHintInjection != (evalCtx.Planner != nil && evalCtx.Planner.UsingHintInjection()) ||
+		// A memo built with hint injection is stale when we're no longer using
+		// hint injection (e.g., hints failed at execution time and we need to
+		// fall back). But a memo built without hint injection is NOT stale when
+		// we're now using hint injection — this allows a prepared memo from a
+		// failed hint attempt to be reused without being invalidated on every
+		// execution. Changes to the hints themselves are detected separately by
+		// the hintIDs check in Metadata.CheckDependencies. See #167322.
+		(m.usingHintInjection && !(evalCtx.Planner != nil && evalCtx.Planner.UsingHintInjection())) ||
 		m.useSwapMutations != evalCtx.SessionData().UseSwapMutations ||
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -728,6 +729,39 @@ func TestMemoIsStale(t *testing.T) {
 	stale()
 	evalCtx.SessionData().RowSecurity = false
 	notStale()
+
+	// The usingHintInjection staleness check is one-directional (#167322). A
+	// memo built WITHOUT hints should NOT be stale when we're now using hint
+	// injection (allows reusing a prepared memo from a failed hint attempt). A
+	// memo built WITH hints SHOULD be stale when we're no longer using hint
+	// injection (needed for fallback after hint failure at execution time).
+	//
+	// The memo was built with Planner=nil, so usingHintInjection=false.
+	// Setting Planner to one that returns UsingHintInjection()=true should NOT
+	// make it stale.
+	evalCtx.Planner = &hintInjectionPlanner{}
+	notStale()
+
+	// Now build a memo WITH hint injection and verify the reverse: it should be
+	// stale when we're no longer using hint injection.
+	var oHint xform.Optimizer
+	opttestutils.BuildQuery(t, &oHint, catalog, &evalCtx, query)
+	oHint.Memo().Metadata().AddSchema(catalog.Schema())
+	// With the same planner, the hint memo should not be stale.
+	if isStale, err := oHint.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		t.Fatal(err)
+	} else if isStale {
+		t.Errorf("hint memo should not be stale with hint planner")
+	}
+	// Without hint injection, the hint memo should be stale.
+	evalCtx.Planner = nil
+	if isStale, err := oHint.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		t.Fatal(err)
+	} else if !isStale {
+		t.Errorf("hint memo should be stale without hint planner")
+	}
+
+	notStale() // original (non-hint) memo should still not be stale
 }
 
 // TestStatsAvailable tests that the statisticsBuilder correctly identifies
@@ -834,4 +868,14 @@ func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 			return tester.RunCommand(t, d)
 		})
 	})
+}
+
+// hintInjectionPlanner is a test planner that returns true for
+// UsingHintInjection.
+type hintInjectionPlanner struct {
+	faketreeeval.DummyEvalPlanner
+}
+
+func (p *hintInjectionPlanner) UsingHintInjection() bool {
+	return true
 }


### PR DESCRIPTION
When a prepared statement has externally-injected hints that fail during prepare, the memo is rebuilt without hints and cached. On every subsequent execute, makeOptimizerPlan sets usingHintInjection=true before checking the cached memo. IsStale sees the mismatch (memo has false, planner has true), clears the cached memo, and forces a full rebuild every execution.

Fix this by making the usingHintInjection staleness check one-directional: a memo built WITH hints is stale when executing WITHOUT hints (needed for fallback after hint failure at execution time), but a memo built WITHOUT hints is NOT stale when executing WITH hints. This allows the no-hint memo to be reused. Changes to the hints themselves are detected separately by the hintIDs check in Metadata.CheckDependencies.

Fixes: #167322

Release note: None