### PR TITLE
changefeedccl: add column headers option to changefeed csv format

### DIFF
--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -102,9 +102,10 @@ type flushReq struct {
 // attributes contain additional metadata which may be emitted alongside a row
 // but separate from the encoded keys and values.
 type attributes struct {
-	tableName string
-	headers   map[string][]byte
-	mvcc      hlc.Timestamp
+	tableName       string
+	headers         map[string][]byte
+	mvcc            hlc.Timestamp
+	csvColumnHeader []byte
 }
 
 type rowEvent struct {
@@ -112,6 +113,7 @@ type rowEvent struct {
 	val             []byte
 	topicDescriptor TopicDescriptor
 	headers         rowHeaders
+	csvColumnHeader []byte
 
 	alloc kvevent.Alloc
 	mvcc  hlc.Timestamp
@@ -198,6 +200,7 @@ func (s *batchingSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,
@@ -209,6 +212,7 @@ func (s *batchingSink) EmitRow(
 	payload.val = value
 	payload.topicDescriptor = topic
 	payload.headers = headers
+	payload.csvColumnHeader = csvColumnHeader
 	payload.mvcc = mvcc
 	payload.alloc = alloc
 
@@ -311,9 +315,10 @@ func (sb *sinkBatch) Append(ctx context.Context, e *rowEvent) {
 	}
 
 	sb.buffer.Append(ctx, e.key, e.val, attributes{
-		tableName: e.topicDescriptor.GetTableName(),
-		headers:   e.headers,
-		mvcc:      e.mvcc,
+		tableName:       e.topicDescriptor.GetTableName(),
+		headers:         e.headers,
+		mvcc:            e.mvcc,
+		csvColumnHeader: e.csvColumnHeader,
 	})
 
 	sb.keys.Add(hashToInt(sb.hasher, e.key))

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1349,9 +1349,11 @@ func validateSink(
 	}
 
 	// If there's no projection we may need to force some options to ensure messages
-	// have enough information.
+	// have enough information. Formats like CSV and Parquet inherently include all
+	// columns in every row, so key_in_value is unnecessary.
 	if details.Select == `` {
-		if requiresKeyInValue(canarySink) {
+		format := changefeedbase.FormatType(details.Opts[changefeedbase.OptFormat])
+		if requiresKeyInValue(canarySink) && formatSupportsKeyInValue(format) {
 			if err = opts.ForceKeyInValue(); err != nil {
 				return err
 			}
@@ -1385,6 +1387,17 @@ func requiresKeyInValue(s Sink) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// formatSupportsKeyInValue returns true if the given format
+// supports key_in_value.
+func formatSupportsKeyInValue(f changefeedbase.FormatType) bool {
+	switch f {
+	case changefeedbase.OptFormatCSV, changefeedbase.OptFormatParquet:
+		return false
+	default:
+		return true
 	}
 }
 
@@ -1543,6 +1556,23 @@ func validateDetailsAndOptions(
 				changefeedbase.OptPartitionAlg,
 				changefeedbase.PartitionAlgEnabled.Name(),
 			)
+		}
+	}
+
+	encOpts, err := opts.GetEncodingOptions()
+	if err != nil {
+		return err
+	}
+	if encOpts.CsvHeader {
+		if details.SinkURI == `` {
+			return errors.Newf(
+				`%s is not supported for sinkless changefeeds`,
+				changefeedbase.OptCsvHeader)
+		}
+		if len(details.TargetSpecifications) > 1 || isDBLevelChangefeed(details) {
+			return errors.Newf(
+				`%s is not supported for changefeeds targeting multiple tables`,
+				changefeedbase.OptCsvHeader)
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7759,6 +7759,14 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `format=csv is only usable with initial_scan_only`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format = csv`, `kafka://nope`,
 	)
+	sqlDB.ExpectErrWithTimeout(
+		t, `this sink is incompatible with option csv_header`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH format=csv, csv_header, initial_scan_only`, `kafka://nope`,
+	)
+	sqlDB.ExpectErrWithTimeout(
+		t, `csv_header is only usable with format=csv`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH csv_header`, `experimental-nodelocal://1/bar`,
+	)
 
 	var tsCurrent string
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsCurrent)
@@ -10590,6 +10598,7 @@ func (s *memoryHoggingSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,
@@ -10640,6 +10649,7 @@ func (s *countEmittedRowsSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	_headers rowHeaders,
@@ -11687,6 +11697,90 @@ func TestChangefeedPubsubResolvedMessages(t *testing.T) {
 	}
 
 	cdcTest(t, testFn, feedTestForceSink("pubsub"))
+}
+
+// TestChangefeedCSVHeaderRowCDCQueries exercises csv_header with CDC query
+// features: ALTER TABLE adding a column, column reordering via projection,
+func TestChangefeedCSVHeaderRowCDCQueries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	readLines := func(t *testing.T, f cdctest.TestFeed, n int) []string {
+		var lines []string
+		for len(lines) < n {
+			m, err := f.Next()
+			require.NoError(t, err)
+			if len(m.Value) > 0 {
+				lines = append(lines, string(m.Value))
+			}
+		}
+		return lines
+	}
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE csv_cdc (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO csv_cdc VALUES (1, 'before')`)
+		sqlDB.Exec(t, `ALTER TABLE csv_cdc ADD COLUMN c BOOL DEFAULT true`)
+		sqlDB.Exec(t, `INSERT INTO csv_cdc VALUES (2, 'after', false)`)
+
+		t.Run("alter-table", func(t *testing.T) {
+			foo := feed(t, f, `CREATE CHANGEFEED FOR csv_cdc WITH format=csv, csv_header, initial_scan_only`)
+			defer closeFeed(t, foo)
+
+			lines := readLines(t, foo, 3)
+			require.Equal(t, "a,b,c", lines[0], "header must include the added column")
+			require.Len(t, lines, 3, "expected header + 2 data rows")
+		})
+
+		t.Run("reorder-columns", func(t *testing.T) {
+			foo := feed(t, f,
+				`CREATE CHANGEFEED WITH format=csv, csv_header, initial_scan_only AS SELECT c, a FROM csv_cdc`)
+			defer closeFeed(t, foo)
+
+			lines := readLines(t, foo, 2)
+			require.Equal(t, "c,a", lines[0], "header must match projection order")
+		})
+	}
+
+	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+}
+
+// TestChangefeedCSVHeaderRowWebhook checks that WITH csv_header and batched
+// webhook_sink_config, each HTTP POST body begins with the CSV column header
+// as the first bytes, and that header appears only once per POST — not before
+// every row in the batch.
+func TestChangefeedCSVHeaderRowWebhook(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const wantHeader = "a,b"
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE csv_hdr (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO csv_hdr VALUES (1, 'x'), (2, 'y'), (3, 'z'), (4, 'w'), (5, 'u'), (6, 'v')`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR csv_hdr WITH format=csv, csv_header, initial_scan_only, webhook_sink_config='{"Flush":{"Messages":4,"Bytes":8192,"Frequency":"1h"},"Retry":{"Backoff":"5ms"}}'`)
+		defer closeFeed(t, foo)
+
+		var posts []string
+		for len(posts) < 2 {
+			m, err := foo.Next()
+			require.NoError(t, err)
+			posts = append(posts, string(m.Value))
+		}
+
+		for i := range posts {
+			require.True(t, strings.HasPrefix(posts[i], wantHeader),
+				"POST %d: first bytes must be the CSV column header %q", i, wantHeader)
+			require.Equal(t, 1, strings.Count(posts[i], wantHeader),
+				"POST %d: column header %q must appear exactly once (not before each row in the batch)", i, wantHeader)
+		}
+		require.Greater(t, len(posts[0]), len(posts[1]), "first batch (4 rows) should be larger than second (2 rows)")
+	}
+
+	cdcTest(t, testFn, feedTestForceSink("webhook"))
 }
 
 // TestCloudstorageBufferedBytesMetric tests the metric which tracks the number
@@ -13727,11 +13821,12 @@ func (s *closeTrackingSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,
 ) error {
-	return s.wrapped.EmitRow(ctx, topic, key, value, updated, mvcc, alloc, headers)
+	return s.wrapped.EmitRow(ctx, topic, key, value, csvColumnHeader, updated, mvcc, alloc, headers)
 }
 
 func (s *closeTrackingSink) Flush(ctx context.Context) error {

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -117,6 +117,7 @@ const (
 	OptMinCheckpointFrequency             = `min_checkpoint_frequency`
 	OptUpdatedTimestamps                  = `updated`
 	OptMVCCTimestamps                     = `mvcc_timestamp`
+	OptCsvHeader                          = `csv_header`
 	OptDiff                               = `diff`
 	OptCompression                        = `compression`
 	OptSchemaChangeEvents                 = `schema_change_events`
@@ -439,6 +440,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptHeadersJSONColumnName:              stringOption,
 	OptExtraHeaders:                       jsonOption,
 	OptPartitionAlg:                       enum("fnv-1a", "murmur2"),
+	OptCsvHeader:                          flagOption,
 }
 
 // CommonOptions is options common to all sinks
@@ -463,10 +465,10 @@ var SQLValidOptions map[string]struct{} = nil
 var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaRegistry, OptKafkaSinkConfig, OptHeadersJSONColumnName, OptExtraHeaders, OptPartitionAlg)
 
 // CloudStorageValidOptions is options exclusive to cloud storage sink
-var CloudStorageValidOptions = makeStringSet(OptCompression)
+var CloudStorageValidOptions = makeStringSet(OptCompression, OptCsvHeader)
 
 // WebhookValidOptions is options exclusive to webhook sink
-var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig, OptCompression, OptExtraHeaders)
+var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig, OptCompression, OptExtraHeaders, OptCsvHeader)
 
 // PubsubValidOptions is options exclusive to pubsub sink
 var PubsubValidOptions = makeStringSet(OptPubsubSinkConfig)
@@ -913,6 +915,7 @@ type EncodingOptions struct {
 	CustomKeyColumn             string
 	EnrichedProperties          map[EnrichedProperty]struct{}
 	HeadersJSONColName          string
+	CsvHeader                   bool
 }
 
 // GetEncodingOptions populates and validates an EncodingOptions.
@@ -955,6 +958,7 @@ func (s StatementOptions) GetEncodingOptions() (EncodingOptions, error) {
 	_, o.MVCCTimestamps = s.m[OptMVCCTimestamps]
 	_, o.Diff = s.m[OptDiff]
 	_, o.EncodeJSONValueNullAsObject = s.m[OptEncodeJSONValueNullAsObject]
+	_, o.CsvHeader = s.m[OptCsvHeader]
 
 	o.SchemaRegistryURI = s.m[OptConfluentSchemaRegistry]
 	o.AvroSchemaPrefix = s.m[OptAvroSchemaPrefix]
@@ -1001,6 +1005,10 @@ func (e EncodingOptions) Validate() error {
 
 	if e.HeadersJSONColName != `` && (e.Format != OptFormatJSON && e.Format != OptFormatAvro) {
 		return errors.Errorf(`%s is only usable with %s=%s/%s`, OptHeadersJSONColumnName, OptFormat, OptFormatJSON, OptFormatAvro)
+	}
+
+	if e.CsvHeader && e.Format != OptFormatCSV {
+		return errors.Errorf(`%s is only usable with %s=%s`, OptCsvHeader, OptFormat, OptFormatCSV)
 	}
 
 	// TODO(#140110): refactor this logic.

--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -71,6 +71,27 @@ func (e *csvEncoder) EncodeValue(
 	return e.buf.Bytes(), nil
 }
 
+// EncodeCSVHeaderRow encodes a single CSV record of column names in the same
+// order as EncodeValue.
+func (e *csvEncoder) EncodeCSVHeaderRow(_ context.Context, row cdcevent.Row) ([]byte, error) {
+	if row.IsDeleted() {
+		return nil, errors.AssertionFailedf(`cannot encode CSV header for deleted rows`)
+	}
+	e.buf.Reset()
+	if err := row.ForEachColumn().Col(func(col cdcevent.ResultColumn) error {
+		e.formatter.Reset()
+		e.formatter.WriteString(col.Name)
+		return e.writer.WriteField(&e.formatter.Buffer)
+	}); err != nil {
+		return nil, err
+	}
+	if err := e.writer.FinishRecord(); err != nil {
+		return nil, err
+	}
+	e.writer.Flush()
+	return e.buf.Bytes(), nil
+}
+
 // EncodeResolvedTimestamp implements the Encoder interface.
 func (e *csvEncoder) EncodeResolvedTimestamp(
 	_ context.Context, _ string, resolved hlc.Timestamp,

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -523,6 +523,28 @@ func TestAvroArrayCap(t *testing.T) {
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
 }
 
+func TestCSVEncodeCSVHeaderRow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tableDesc, err := parseTableDesc(`CREATE TABLE t (rowid INT PRIMARY KEY, "na,me" STRING)`)
+	require.NoError(t, err)
+	row := rowenc.EncDatumRow{
+		rowenc.EncDatum{Datum: tree.NewDInt(1)},
+		rowenc.EncDatum{Datum: tree.NewDString("x")},
+	}
+	cdcRow := cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
+	enc := newCSVEncoder(changefeedbase.EncodingOptions{})
+	ctx := context.Background()
+	hdr, err := enc.EncodeCSVHeaderRow(ctx, cdcRow)
+	require.NoError(t, err)
+	hdr = append([]byte(nil), hdr...)
+	val, err := enc.EncodeValue(ctx, eventContext{}, cdcRow, cdcevent.Row{})
+	require.NoError(t, err)
+	require.Equal(t, "rowid,\"na,me\"", string(hdr))
+	require.Equal(t, "1,x", string(val))
+}
+
 func TestCollatedString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -488,9 +488,18 @@ func (c *kvEventToRowConsumer) encodeAndEmit(
 	}
 	c.scratch, valueCopy = c.scratch.Copy(encodedValue)
 
+	// Encode the CSV header row if the csv_header option is set.
+	var csvColumnHeader []byte
+	if c.encodingOpts.CsvHeader && c.encodingOpts.Format == changefeedbase.OptFormatCSV {
+		csvColumnHeader, err = c.encodeCSVHeaderRow(ctx, updatedRow)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Since we're done processing/converting this event, and will not use much more
 	// than len(key)+len(bytes) worth of resources, adjust allocation to match.
-	alloc.AdjustBytesToTarget(ctx, int64(len(keyCopy)+len(valueCopy)))
+	alloc.AdjustBytesToTarget(ctx, int64(len(keyCopy)+len(valueCopy)+len(csvColumnHeader)))
 	timer.End()
 
 	headers, err := c.makeRowHeaders(ctx, updatedRow)
@@ -500,7 +509,7 @@ func (c *kvEventToRowConsumer) encodeAndEmit(
 
 	c.metrics.Timers.EmitRow.Time(func() {
 		err = c.sink.EmitRow(
-			ctx, topic, keyCopy, valueCopy, schemaTS, updatedRow.MvccTimestamp, alloc, headers,
+			ctx, topic, keyCopy, valueCopy, csvColumnHeader, schemaTS, updatedRow.MvccTimestamp, alloc, headers,
 		)
 	})
 	if err != nil {
@@ -598,6 +607,22 @@ func (c *kvEventToRowConsumer) encodeForParquet(
 		return err
 	}
 	return nil
+}
+
+func (c *kvEventToRowConsumer) encodeCSVHeaderRow(
+	ctx context.Context, updatedRow cdcevent.Row,
+) ([]byte, error) {
+	hEnc, ok := c.encoder.(*csvEncoder)
+	if !ok {
+		return nil, errors.AssertionFailedf("expected csv encoder for csv format with %s", changefeedbase.OptCsvHeader)
+	}
+	hdr, err := hEnc.EncodeCSVHeaderRow(ctx, updatedRow)
+	if err != nil {
+		return nil, err
+	}
+	var csvColumnHeader []byte
+	c.scratch, csvColumnHeader = c.scratch.Copy(hdr)
+	return csvColumnHeader, nil
 }
 
 // Flush is a noop for the kvEventToRowConsumer because it does not buffer any events.

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -106,6 +106,7 @@ func (parquetSink *parquetCloudStorageSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -110,6 +110,7 @@ type EventSink interface {
 		ctx context.Context,
 		topic TopicDescriptor,
 		key, value []byte,
+		csvColumnHeader []byte,
 		updated, mvcc hlc.Timestamp,
 		alloc kvevent.Alloc,
 		headers rowHeaders,
@@ -388,11 +389,12 @@ func (s errorWrapperSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,
 ) error {
-	if err := s.wrapped.(EventSink).EmitRow(ctx, topic, key, value, updated, mvcc, alloc, headers); err != nil {
+	if err := s.wrapped.(EventSink).EmitRow(ctx, topic, key, value, csvColumnHeader, updated, mvcc, alloc, headers); err != nil {
 		return changefeedbase.MarkRetryableError(err)
 	}
 	return nil
@@ -480,6 +482,7 @@ func (s *bufferSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	r kvevent.Alloc,
 	_headers rowHeaders,
@@ -592,6 +595,7 @@ func (n *nullSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	r kvevent.Alloc,
 	_headers rowHeaders,
@@ -671,13 +675,14 @@ func (s *safeSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,
 ) error {
 	s.Lock()
 	defer s.Unlock()
-	return s.wrapped.EmitRow(ctx, topic, key, value, updated, mvcc, alloc, headers)
+	return s.wrapped.EmitRow(ctx, topic, key, value, csvColumnHeader, updated, mvcc, alloc, headers)
 }
 
 func (s *safeSink) Flush(ctx context.Context) error {

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -362,6 +362,10 @@ type cloudStorageSink struct {
 
 	// testingKnobs may be nil if no knobs are set.
 	testingKnobs *TestingKnobs
+
+	// csvHeaderRow, when true with .csv extension, writes csvColumnHeader bytes once at
+	// the start of each in-memory file buffer (before the first data row).
+	csvHeaderRow bool
 }
 
 type flushRequest struct {
@@ -477,6 +481,7 @@ func makeCloudStorageSink(
 		// would require a bit of refactoring.
 		s.ext = `.csv`
 		s.rowDelimiter = []byte{'\n'}
+		s.csvHeaderRow = encodingOpts.CsvHeader
 	case changefeedbase.OptFormatParquet:
 		s.ext = `.parquet`
 		s.rowDelimiter = nil
@@ -567,6 +572,7 @@ func (s *cloudStorageSink) EmitRow(
 	ctx context.Context,
 	topic TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,
@@ -598,6 +604,15 @@ func (s *cloudStorageSink) EmitRow(
 		return err
 	}
 	file.mergeAlloc(&alloc)
+
+	if s.csvHeaderRow && file.numMessages == 0 && len(csvColumnHeader) > 0 {
+		if _, err := file.Write(csvColumnHeader); err != nil {
+			return err
+		}
+		if _, err := file.Write(s.rowDelimiter); err != nil {
+			return err
+		}
+	}
 
 	if _, err := file.Write(value); err != nil {
 		return err

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -213,7 +213,7 @@ func TestCloudStorageSink(t *testing.T) {
 		defer func() { require.NoError(t, s.Close()) }()
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 
 		require.Equal(t, []string{
@@ -273,9 +273,9 @@ func TestCloudStorageSink(t *testing.T) {
 				// the ordering among these two files is non-deterministic as either of them could
 				// be flushed first (and thus be assigned fileID 0).
 				var pool testAllocPool
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), pool.alloc(), nil))
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), pool.alloc(), nil))
-				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3), ts(3), pool.alloc(), nil))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), pool.alloc(), nil))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), nil, ts(1), ts(1), pool.alloc(), nil))
+				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), nil, ts(3), ts(3), pool.alloc(), nil))
 				require.NoError(t, s.Flush(ctx))
 				require.EqualValues(t, 0, pool.used())
 				expected := []string{
@@ -293,7 +293,7 @@ func TestCloudStorageSink(t *testing.T) {
 				require.Equal(t, expected, actual)
 
 				// Without a flush, nothing new shows up.
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc, nil))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), nil, ts(3), ts(3), zeroAlloc, nil))
 				actual = slurpDir(t)
 				sort.Strings(actual)
 				require.Equal(t, expected, actual)
@@ -312,9 +312,9 @@ func TestCloudStorageSink(t *testing.T) {
 				// after the rows emitted above.
 				require.True(t, forwardFrontier(sf, testSpan, 4))
 				require.NoError(t, s.Flush(ctx))
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4), ts(4), zeroAlloc, nil))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), nil, ts(4), ts(4), zeroAlloc, nil))
 				t1.Version = 2
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5), ts(5), zeroAlloc, nil))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), nil, ts(5), ts(5), zeroAlloc, nil))
 				require.NoError(t, s.Flush(ctx))
 				expected = []string{
 					"v4\n",
@@ -358,8 +358,8 @@ func TestCloudStorageSink(t *testing.T) {
 		// Each node writes some data at the same timestamp. When this data is
 		// written out, the files have different names and don't conflict because
 		// the sinks have different job session IDs.
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
-		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s1.Flush(ctx))
 		require.NoError(t, s2.Flush(ctx))
 		require.Equal(t, []string{
@@ -393,8 +393,8 @@ func TestCloudStorageSink(t *testing.T) {
 		s1R.(*cloudStorageSink).jobSessionID = "a"
 		s2R.(*cloudStorageSink).jobSessionID = "b"
 		// Each resends the data it did before.
-		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
-		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s1R.Flush(ctx))
 		require.NoError(t, s2R.Flush(ctx))
 		// s1 data ends up being overwritten, s2 data ends up duplicated.
@@ -436,17 +436,17 @@ func TestCloudStorageSink(t *testing.T) {
 		s2.(*cloudStorageSink).jobSessionID = "b" // Force deterministic job session ID.
 
 		// Good job writes
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(2), ts(2), zeroAlloc, nil))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v2`), nil, ts(2), ts(2), zeroAlloc, nil))
 		require.NoError(t, s1.Flush(ctx))
 
 		// Zombie job writes partial duplicate data
-		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s2.Flush(ctx))
 
 		// Good job continues. There are duplicates in the data but nothing was
 		// lost.
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc, nil))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v3`), nil, ts(3), ts(3), zeroAlloc, nil))
 		require.NoError(t, s1.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\nv2\n",
@@ -476,7 +476,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// Writing more than the max file size chunks the file up and flushes it
 		// out as necessary.
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc, nil))
+			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), nil, ts(i), ts(i), zeroAlloc, nil))
 		}
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
@@ -499,7 +499,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// Some more data is written. Some of it flushed out because of the max
 		// file size.
 		for i := int64(6); i < 10; i++ {
-			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc, nil))
+			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), nil, ts(i), ts(i), zeroAlloc, nil))
 		}
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
@@ -623,7 +623,7 @@ func TestCloudStorageSink(t *testing.T) {
 						require.NoError(t, err)
 						require.NoError(t, s.Flush(ctx))
 
-						require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), hlcTime, hlcTime, zeroAlloc, nil))
+						require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), nil, hlcTime, hlcTime, zeroAlloc, nil))
 					}
 
 					require.NoError(t, s.Flush(ctx)) // Flush the last file
@@ -649,8 +649,8 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Simulate initial scan, which emits data at a timestamp, then an equal
 		// resolved timestamp.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is1`), ts(1), ts(1), zeroAlloc, nil))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is2`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is1`), nil, ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is2`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(1)))
 
@@ -660,13 +660,13 @@ func TestCloudStorageSink(t *testing.T) {
 		// be after the resolved timestamp emitted above.
 		require.True(t, forwardFrontier(sf, testSpan, 2))
 		require.NoError(t, s.Flush(ctx))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), ts(2), ts(2), zeroAlloc, nil))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), ts(3).Prev(), ts(3).Prev(), zeroAlloc, nil))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), ts(3), ts(3), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), nil, ts(2), ts(2), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), nil, ts(3).Prev(), ts(3).Prev(), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), nil, ts(3), ts(3), zeroAlloc, nil))
 		require.True(t, forwardFrontier(sf, testSpan, 3))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(3)))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), ts(3).Next(), ts(3).Next(), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), nil, ts(3).Next(), ts(3).Next(), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(4)))
 
@@ -681,7 +681,7 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Test that files with timestamp lower than the least resolved timestamp
 		// as of file creation time are ignored.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), ts(1).Next(), ts(1).Next(), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), nil, ts(1).Next(), ts(1).Next(), zeroAlloc, nil))
 		require.Equal(t, []string{
 			"is1\nis2\n",
 			`{"resolved":"1.0000000000"}`,
@@ -705,13 +705,13 @@ func TestCloudStorageSink(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, s.Close()) }()
 
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		t1.Version = 1
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), nil, ts(1), ts(1), zeroAlloc, nil))
 		// Make the first file exceed its file size threshold. This should trigger a flush
 		// for the first file but not the second one.
 		t1.Version = 0
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -719,9 +719,9 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Now make the file with the newer schema exceed its file size threshold and ensure
 		// that the file with the older schema is flushed (and ordered) before.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), nil, ts(1), ts(1), zeroAlloc, nil))
 		t1.Version = 1
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -730,9 +730,9 @@ func TestCloudStorageSink(t *testing.T) {
 		}, slurpDir(t))
 
 		// Calling `Flush()` on the sink should emit files in the order of their schema IDs.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		t1.Version = 0
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), nil, ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -769,7 +769,7 @@ func TestCloudStorageSink(t *testing.T) {
 				// Write few megs worth of data.
 				for n := 0; n < 20; n++ {
 					eventTS := ts(int64(n + 1))
-					require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc, nil))
+					require.NoError(t, s.EmitRow(ctx, topic, noKey, data, nil, eventTS, eventTS, zeroAlloc, nil))
 				}
 
 				// Close the sink.  That's it -- we rely on leaktest detector to determine
@@ -815,7 +815,7 @@ func TestCloudStorageSink(t *testing.T) {
 					// Write few megs worth of data.
 					for n := 0; n < 20; n++ {
 						eventTS := ts(int64(n + 1))
-						require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc, nil))
+						require.NoError(t, s.EmitRow(ctx, topic, noKey, data, nil, eventTS, eventTS, zeroAlloc, nil))
 					}
 					cancledCtx, cancel := context.WithCancel(ctx)
 					cancel()
@@ -823,7 +823,7 @@ func TestCloudStorageSink(t *testing.T) {
 					// Write 1 more piece of data.  We want to make sure that when error happens
 					// (context cancellation in this case) that any resources used by compression
 					// codec are released (this is checked by leaktest).
-					require.Equal(t, context.Canceled, s.EmitRow(cancledCtx, topic, noKey, data, ts(1), ts(1), zeroAlloc, nil))
+					require.Equal(t, context.Canceled, s.EmitRow(cancledCtx, topic, noKey, data, nil, ts(1), ts(1), zeroAlloc, nil))
 				}()
 			})
 		}
@@ -902,7 +902,7 @@ func TestCloudStorageSinkFastGzip(t *testing.T) {
 			newTopic := makeTopic(fmt.Sprintf(`t%d`, i))
 			byteSlice := make([]byte, sizeInBytes)
 			ts := hlc.Timestamp{WallTime: int64(i)}
-			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, ts, ts, zeroAlloc, nil)
+			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, nil, ts, ts, zeroAlloc, nil)
 		}
 
 		// Flush the files and close the sink. Any leaks should be caught after the
@@ -928,7 +928,7 @@ func TestCloudStorageSinkFastGzip(t *testing.T) {
 			byteSlice := make([]byte, sizeInBytes)
 			ts := hlc.Timestamp{WallTime: int64(i)}
 			newTopic.Version++
-			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, ts, ts, zeroAlloc, nil)
+			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, nil, ts, ts, zeroAlloc, nil)
 		}
 
 		// Flush the files and close the sink. Any leaks should be caught after the
@@ -936,6 +936,108 @@ func TestCloudStorageSinkFastGzip(t *testing.T) {
 		_ = s.(*cloudStorageSink).flushTopicVersions(ctx, newTopic.GetTableName(), int64(newTopic.GetVersion()))
 		_ = s.Close()
 	})
+}
+
+// TestCloudStorageSinkCSVHeaderRow verifies that with format=csv and csv_header,
+// csvColumnHeader bytes are written once at the start of each new output file
+// (before the first row), with row delimiters matching other CSV rows.
+func TestCloudStorageSinkCSVHeaderRow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	externalIODir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	gzipDecompress := func(t *testing.T, compressed []byte) []byte {
+		r, err := gzip.NewReader(bytes.NewReader(compressed))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, r.Close()) }()
+		decompressed, err := io.ReadAll(r)
+		require.NoError(t, err)
+		return decompressed
+	}
+
+	slurpDir := func(t *testing.T) []string {
+		var files []string
+		walkDirFn := func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			file, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if strings.HasSuffix(path, ".gz") {
+				file = gzipDecompress(t, file)
+			}
+			files = append(files, string(file))
+			return nil
+		}
+		absRoot := filepath.Join(externalIODir, testDir(t))
+		require.NoError(t, os.MkdirAll(absRoot, 0755))
+		require.NoError(t, filepath.WalkDir(absRoot, walkDirFn))
+		return files
+	}
+
+	settings := cluster.MakeTestingClusterSettings()
+	opts := changefeedbase.EncodingOptions{
+		Format:    changefeedbase.OptFormatCSV,
+		Envelope:  changefeedbase.OptEnvelopeWrapped,
+		CsvHeader: true,
+	}
+
+	clientFactory := blobs.TestBlobServiceClient(externalIODir)
+	externalStorageFromURI := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage,
+		error) {
+		var options cloud.ExternalStorageOptions
+		for _, opt := range opts {
+			opt(&options)
+		}
+		require.Equal(t, options.ClientName, "cdc")
+
+		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, settings,
+			clientFactory,
+			user,
+			nil, /* db */
+			nil, /* limiters */
+			cloud.NilMetrics,
+			opts...)
+	}
+	user := username.RootUserName()
+
+	t1 := makeTopic(`t1`)
+	testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+	sf, err := span.MakeFrontier(testSpan)
+	require.NoError(t, err)
+	timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
+
+	s, err := makeCloudStorageSink(
+		ctx, sinkURI(t, unlimitedFileSize), 1, settings, opts,
+		timestampOracle, externalStorageFromURI, user, nil, nil,
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
+	var noKey []byte
+
+	const wantHeader = "id,name"
+	hdr := []byte(wantHeader)
+	row1 := []byte("1,alice")
+	row2 := []byte("2,bob")
+
+	require.NoError(t, s.EmitRow(ctx, t1, noKey, row1, hdr, ts(1), ts(1), zeroAlloc, nil))
+	require.NoError(t, s.EmitRow(ctx, t1, noKey, row2, hdr, ts(1), ts(1), zeroAlloc, nil))
+	require.NoError(t, s.Flush(ctx))
+
+	contents := slurpDir(t)
+	require.Len(t, contents, 1, "expected a single CSV file")
+	want := wantHeader + "\n" + "1,alice" + "\n" + "2,bob" + "\n"
+	require.Equal(t, want, contents[0])
 }
 
 func testDir(t *testing.T) string {

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -373,6 +373,7 @@ func (s *kafkaSink) EmitRow(
 	ctx context.Context,
 	topicDescr TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	headers rowHeaders,

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -72,6 +72,7 @@ func (e *externalConnectionKafkaSink) EmitRow(
 	_ context.Context,
 	_ TopicDescriptor,
 	_, _ []byte,
+	_ []byte,
 	_, _ hlc.Timestamp,
 	_ kvevent.Alloc,
 	_ rowHeaders,

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -214,7 +214,7 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 			return rec.Topic == `_u2603_` && string(rec.Key) == `k☃` && string(rec.Value) == `v☃`
 		})).Times(1).Return(nil)
 
-		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		testutils.SucceedsSoon(t, func() error {
 			select {
@@ -237,7 +237,7 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 			return rec.Topic == `general` && string(rec.Key) == `k☃` && string(rec.Value) == `v☃`
 		})).Times(1).Return(nil)
 
-		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		testutils.SucceedsSoon(t, func() error {
 			select {
@@ -260,7 +260,7 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 			return rec.Topic == `prefix-_u2603_` && string(rec.Key) == `k☃` && string(rec.Value) == `v☃`
 		})).Times(1).Return(nil)
 
-		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		testutils.SucceedsSoon(t, func() error {
 			select {

--- a/pkg/ccl/changefeedccl/sink_pulsar.go
+++ b/pkg/ccl/changefeedccl/sink_pulsar.go
@@ -132,6 +132,7 @@ func (p *pulsarSink) EmitRow(
 	td TopicDescriptor,
 	key []byte,
 	value []byte,
+	csvColumnHeader []byte,
 	updated hlc.Timestamp,
 	mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -130,6 +130,7 @@ func (s *sqlSink) EmitRow(
 	ctx context.Context,
 	topicDescr TopicDescriptor,
 	key, value []byte,
+	csvColumnHeader []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 	_headers rowHeaders,

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -315,7 +315,7 @@ func TestKafkaSink(t *testing.T) {
 
 	// Timeout
 	require.NoError(t,
-		sink.EmitRow(ctx, topic(`t`), []byte(`1`), nil, zeroTS, zeroTS, zeroAlloc, nil))
+		sink.EmitRow(ctx, topic(`t`), []byte(`1`), nil, nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 	m1 := <-p.inputCh
 	for i := 0; i < 2; i++ {
@@ -332,14 +332,14 @@ func TestKafkaSink(t *testing.T) {
 	// Mixed success and error.
 	var pool testAllocPool
 	require.NoError(t, sink.EmitRow(ctx,
-		topic(`t`), []byte(`2`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		topic(`t`), []byte(`2`), nil, nil, zeroTS, zeroTS, pool.alloc(), nil))
 	m2 := <-p.inputCh
 	require.NoError(t, sink.EmitRow(
-		ctx, topic(`t`), []byte(`3`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		ctx, topic(`t`), []byte(`3`), nil, nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 	m3 := <-p.inputCh
 	require.NoError(t, sink.EmitRow(
-		ctx, topic(`t`), []byte(`4`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		ctx, topic(`t`), []byte(`4`), nil, nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 	m4 := <-p.inputCh
 	go func() { p.successesCh <- m2 }()
@@ -354,7 +354,7 @@ func TestKafkaSink(t *testing.T) {
 
 	// Check simple success again after error
 	require.NoError(t, sink.EmitRow(
-		ctx, topic(`t`), []byte(`5`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		ctx, topic(`t`), []byte(`5`), nil, nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 	m5 := <-p.inputCh
 	go func() { p.successesCh <- m5 }()
@@ -372,7 +372,7 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	sink, cleanup := makeTestKafkaSink(t, noTopicPrefix, defaultTopicName, p, `☃`)
 	defer cleanup()
 
-	if err := sink.EmitRow(ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil); err != nil {
+	if err := sink.EmitRow(ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), nil, zeroTS, zeroTS, zeroAlloc, nil); err != nil {
 		t.Fatal(err)
 	}
 	m := <-p.inputCh
@@ -393,7 +393,7 @@ func TestKafkaTopicNameProvided(t *testing.T) {
 	defer cleanup()
 
 	// all messages go to the general topic
-	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	m := <-p.inputCh
 	require.Equal(t, topicOverride, m.Topic)
 }
@@ -411,7 +411,7 @@ func TestKafkaTopicNameWithPrefix(t *testing.T) {
 	defer clenaup()
 
 	// the prefix is applied and the name is escaped
-	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sink.EmitRow(ctx, topic("particular0"), []byte(`k☃`), []byte(`v☃`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	m := <-p.inputCh
 	require.Equal(t, `prefix-_u2603_`, m.Topic)
 }
@@ -438,7 +438,7 @@ func BenchmarkEmitRow(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		require.NoError(b, sink.EmitRow(ctx, topic, []byte(`k☃`), []byte(`v☃`), hlc.Timestamp{}, zeroTS, zeroAlloc, nil))
+		require.NoError(b, sink.EmitRow(ctx, topic, []byte(`k☃`), []byte(`v☃`), nil, hlc.Timestamp{}, zeroTS, zeroAlloc, nil))
 	}
 
 	b.ReportAllocs()
@@ -512,7 +512,7 @@ func TestSQLSink(t *testing.T) {
 	require.NoError(t, sink.Flush(ctx))
 
 	// With one row, nothing flushes until Flush is called.
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v0`), zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v0`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	sqlDB.CheckQueryResults(t, `SELECT key, value FROM sink ORDER BY PRIMARY KEY sink`,
 		[][]string{},
 	)
@@ -528,7 +528,7 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`0`}})
 	for i := 0; i < sqlSinkRowBatchSize+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v`+strconv.Itoa(i)), zeroTS, zeroTS, zeroAlloc, nil))
+			sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v`+strconv.Itoa(i)), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	}
 	// Should have auto flushed after sqlSinkRowBatchSize
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`3`}})
@@ -540,9 +540,9 @@ func TestSQLSink(t *testing.T) {
 
 	// Two tables interleaved in time
 	var pool testAllocPool
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v0`), zeroTS, zeroTS, pool.alloc(), nil))
-	require.NoError(t, sink.EmitRow(ctx, barTopic, []byte(`kbar`), []byte(`v0`), zeroTS, zeroTS, pool.alloc(), nil))
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v1`), zeroTS, zeroTS, pool.alloc(), nil))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v0`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+	require.NoError(t, sink.EmitRow(ctx, barTopic, []byte(`kbar`), []byte(`v0`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`kfoo`), []byte(`v1`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 	require.NoError(t, sink.Flush(ctx))
 	require.EqualValues(t, 0, pool.used())
 	sqlDB.CheckQueryResults(t, `SELECT topic, key, value FROM sink ORDER BY PRIMARY KEY sink`,
@@ -556,11 +556,11 @@ func TestSQLSink(t *testing.T) {
 	// guarantee that at lease two of them end up in the same partition.
 	for i := 0; i < sqlSinkNumPartitions+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v0`), zeroTS, zeroTS, zeroAlloc, nil))
+			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v0`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	}
 	for i := 0; i < sqlSinkNumPartitions+1; i++ {
 		require.NoError(t,
-			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v1`), zeroTS, zeroTS, zeroAlloc, nil))
+			sink.EmitRow(ctx, fooTopic, []byte(`v`+strconv.Itoa(i)), []byte(`v1`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	}
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t, `SELECT partition, key, value FROM sink ORDER BY PRIMARY KEY sink`,
@@ -582,7 +582,7 @@ func TestSQLSink(t *testing.T) {
 	// Emit resolved
 	var e testEncoder
 	require.NoError(t, sink.EmitResolvedTimestamp(ctx, e, zeroTS))
-	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`foo0`), []byte(`v0`), zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`foo0`), []byte(`v0`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	require.NoError(t, sink.EmitResolvedTimestamp(ctx, e, hlc.Timestamp{WallTime: 1}))
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t,
@@ -885,7 +885,7 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	testTopic := topic(`t`)
 	var pool testAllocPool
 	for i := 0; i < 10; i++ {
-		require.NoError(t, sink.EmitRow(ctx, testTopic, key, val, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sink.EmitRow(ctx, testTopic, key, val, nil, zeroTS, zeroTS, pool.alloc(), nil))
 	}
 	require.EqualValues(t, 10, pool.used())
 

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -103,8 +103,8 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 
 	// test an insert row entry
 	var pool testAllocPool
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 	require.NoError(t, sinkSrc.Flush(ctx))
 	testutils.SucceedsSoon(t, func() error {
 		remaining := pool.used()
@@ -120,7 +120,7 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 		`{"payload":[{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}],"length":1}`)
 
 	// test a delete row entry
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1002]"), []byte(`{"after":null,"key":[1002],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1002]"), []byte(`{"after":null,"key":[1002],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 	require.NoError(t, sinkSrc.Flush(ctx))
 
 	require.Equal(t,
@@ -177,7 +177,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, err)
 
 		// now sink's client accepts no custom certs, should reject the server's cert and fail
-		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		require.Regexp(t, "x509", sinkSrcNoCert.Flush(context.Background()))
 
@@ -192,7 +192,7 @@ func TestWebhookSink(t *testing.T) {
 
 		// sink should throw an error if server is unreachable
 		sinkDest.Close()
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		err = sinkSrc.Flush(context.Background())
 		require.Error(t, err)
@@ -206,7 +206,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, err)
 
 		// sink's client should not accept the endpoint's use of HTTP (expects HTTPS)
-		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		flushErr := sinkSrcWrongProtocol.Flush(context.Background())
 		require.True(t, testutils.IsError(flushErr, "webhook sink request failed"), flushErr)
@@ -305,7 +305,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		delete(details.Opts, changefeedbase.OptWebhookAuthHeader)
 		sinkSrcNoCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
-		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		flushErrNoCreds := sinkSrcNoCreds.Flush(context.Background())
 		require.True(t, testutils.IsError(flushErrNoCreds, "webhook sink HTTP error"), flushErrNoCreds)
@@ -318,7 +318,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		sinkSrcWrongCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		flushErrWrongCreds := sinkSrcWrongCreds.Flush(context.Background())
 		require.True(t, testutils.IsError(flushErrWrongCreds, "webhook sink HTTP error"), flushErrWrongCreds)
@@ -407,7 +407,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 
 		flushErr := sinkSrc.Flush(context.Background())
 		require.True(t, testutils.IsError(flushErr, "webhook sink HTTP error"), flushErr)
@@ -451,7 +451,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 		flushErr := sinkSrc.Flush(context.Background())
 		require.True(t, testutils.IsError(flushErr, "webhook sink HTTP error"), flushErr)
@@ -495,11 +495,11 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, mt)
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 		require.NoError(t, sinkSrc.Flush(context.Background()))
 		require.Equal(t, sinkDest.Pop(), `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"},`+
@@ -522,8 +522,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		require.Equal(t, sinkDest.Latest(), "")
 
 		// messages without a full batch should not send
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 		require.Equal(t, sinkDest.Latest(), "")
 
 		require.NoError(t, sinkSrc.Close())
@@ -558,11 +558,11 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 		require.NoError(t, sinkSrc.Flush(context.Background()))
 		require.Equal(t, sinkDest.Pop(), `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"},`+
@@ -572,8 +572,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 			`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}],"length":5}`)
 
 		// messages without a full batch should not send
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 		require.Equal(t, sinkDest.Latest(), "")
 
 		require.NoError(t, sinkSrc.Close())
@@ -618,8 +618,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		}
 
 		// send incomplete batch
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, pool.alloc(), nil))
 
 		// no messages at first
 		require.Equal(t, sinkDest.Latest(), "")
@@ -686,7 +686,7 @@ func TestWebhookSinkShutsDownOnError(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+		require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 		// error should be propagated immediately in the next call
 		flushErr := sinkSrc.Flush(ctx)
 		require.True(t, testutils.IsError(flushErr, "webhook sink HTTP error"), flushErr)
@@ -769,7 +769,7 @@ func TestWebhookSinkRetry(t *testing.T) {
 	sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, 1 /* parallelism */, timeutil.DefaultTimeSource{})
 	require.NoError(t, err)
 
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	require.NoError(t, sinkSrc.Flush(ctx))
 
 	require.Equal(t, `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}],"length":1}`, sinkDest.Pop())
@@ -867,6 +867,7 @@ func TestWebhookSinkCompression(t *testing.T) {
 		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{},
 			[]byte("[1001]"),
 			[]byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`),
+			nil,
 			zeroTS,
 			zeroTS,
 			zeroAlloc, nil))
@@ -954,6 +955,7 @@ func TestWebhookSinkCompressionWithBatching(t *testing.T) {
 		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{},
 			[]byte("[1001]"),
 			[]byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`),
+			nil,
 			zeroTS,
 			zeroTS,
 			zeroAlloc, nil))
@@ -963,6 +965,7 @@ func TestWebhookSinkCompressionWithBatching(t *testing.T) {
 		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{},
 			[]byte("[1002]"),
 			[]byte(`{"after":{"col1":"val2","rowid":1001},"key":[1002],"topic:":"foo"}`),
+			nil,
 			zeroTS,
 			zeroTS,
 			zeroAlloc, nil))
@@ -1053,6 +1056,7 @@ func TestWebhookSinkErrorCompressedResponse(t *testing.T) {
 		require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{},
 			[]byte("[1001]"),
 			[]byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`),
+			nil,
 			zeroTS,
 			zeroTS,
 			zeroAlloc, nil))
@@ -1088,6 +1092,72 @@ func TestWebhookSinkErrorCompressedResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWebhookSinkCSVHeaderRow verifies that when csvColumnHeader bytes are supplied
+// (as with WITH csv_header and format=csv), the webhook CSV buffer prepends them
+// once at the start of each batched POST body.
+func TestWebhookSinkCSVHeaderRow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
+	require.NoError(t, err)
+	sinkDest, err := cdctest.StartMockWebhookSink(cert)
+	require.NoError(t, err)
+	defer sinkDest.Close()
+
+	opts := getGenericWebhookSinkOptions(struct {
+		key   string
+		value string
+	}{
+		key:   changefeedbase.OptCsvHeader,
+		value: ``,
+	}, struct {
+		key   string
+		value string
+	}{
+		key:   changefeedbase.OptFormat,
+		value: string(changefeedbase.OptFormatCSV),
+	}, struct {
+		key   string
+		value string
+	}{
+		key:   changefeedbase.OptWebhookSinkConfig,
+		value: `{"Flush":{"Messages":2,"Frequency":"1s"},"Retry":{"Backoff":"5ms"}}`,
+	})
+
+	sinkDestHost, err := url.Parse(sinkDest.URL())
+	require.NoError(t, err)
+	params := sinkDestHost.Query()
+	params.Set(changefeedbase.SinkParamCACert, certEncoded)
+	sinkDestHost.RawQuery = params.Encode()
+
+	details := jobspb.ChangefeedDetails{
+		SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
+		Opts:    opts.AsMap(),
+	}
+
+	sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, 1 /* parallelism */, timeutil.DefaultTimeSource{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sinkSrc.Close()) }()
+
+	const wantHeader = "id,name"
+	row1 := []byte("1,alice")
+	row2 := []byte("2,bob")
+	hdr := []byte(wantHeader)
+
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, nil, row1, hdr, zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, nil, row2, hdr, zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sinkSrc.Flush(ctx))
+
+	wantBody := "id,name\n1,alice\n2,bob"
+	testutils.SucceedsSoon(t, func() error {
+		if got := sinkDest.Latest(); got != wantBody {
+			return errors.Newf("got %q want %q", got, wantBody)
+		}
+		return nil
+	})
 }
 
 // TestWebhookSinkClientTimeoutDefault verifies that the webhook_client_timeout
@@ -1161,7 +1231,7 @@ func TestWebhookSinkRetryLogging(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, sinkSrc.Close()) }()
 
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), nil, zeroTS, zeroTS, zeroAlloc, nil))
 	// Flush will make 2 requests. The first request fails with statusTooManyRequests, which should
 	// log the error and retry. The second request succeeds with statusOK.
 	require.NoError(t, sinkSrc.Flush(ctx))

--- a/pkg/ccl/changefeedccl/sink_webhook_v2.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_v2.go
@@ -363,7 +363,16 @@ type webhookCSVBuffer struct {
 var _ BatchBuffer = (*webhookCSVBuffer)(nil)
 
 // Append implements the BatchBuffer interface.
-func (cb *webhookCSVBuffer) Append(ctx context.Context, key []byte, value []byte, _ attributes) {
+func (cb *webhookCSVBuffer) Append(
+	ctx context.Context, key []byte, value []byte, attrs attributes,
+) {
+	if len(cb.bytes) == 0 && len(attrs.csvColumnHeader) > 0 {
+		cb.bytes = append(cb.bytes, attrs.csvColumnHeader...)
+		cb.bytes = append(cb.bytes, '\n')
+	}
+	if cb.messageCount >= 1 {
+		cb.bytes = append(cb.bytes, '\n')
+	}
 	cb.bytes = append(cb.bytes, value...)
 	cb.messageCount += 1
 }

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1157,24 +1157,34 @@ func (f *cloudFeedFactory) Feed(
 	}
 	createStmt := parsed.AST.(*tree.CreateChangefeed)
 
-	if createStmt.Select != nil {
+	formatSpecified := false
+	explicitEnvelope := false
+	specifiedFormat := ``
+	for _, opt := range createStmt.Options {
+		if string(opt.Key) == changefeedbase.OptFormat {
+			formatSpecified = true
+			if opt.Value != nil {
+				val, err := exprAsString(opt.Value)
+				if err == nil {
+					specifiedFormat = val
+				}
+			}
+		}
+		if string(opt.Key) == changefeedbase.OptEnvelope {
+			explicitEnvelope = true
+		}
+	}
+
+	formatSupportsKeyInValue :=
+		specifiedFormat != string(changefeedbase.OptFormatCSV) &&
+			specifiedFormat != string(changefeedbase.OptFormatParquet)
+	if createStmt.Select != nil && formatSupportsKeyInValue {
 		createStmt.Options = append(createStmt.Options,
 			// Normally, cloud storage requires key_in_value; but if we use bare envelope,
 			// this option is not required.  However, we need it to make this
 			// test feed work -- so, set it.
 			tree.KVOption{Key: changefeedbase.OptKeyInValue},
 		)
-	}
-
-	formatSpecified := false
-	explicitEnvelope := false
-	for _, opt := range createStmt.Options {
-		if string(opt.Key) == changefeedbase.OptFormat {
-			formatSpecified = true
-		}
-		if string(opt.Key) == changefeedbase.OptEnvelope {
-			explicitEnvelope = true
-		}
 	}
 
 	if !formatSpecified {
@@ -2266,7 +2276,23 @@ func (f *webhookFeedFactory) Feed(create string, args ...interface{}) (cdctest.T
 
 	// required value
 	createStmt.Options = append(createStmt.Options, tree.KVOption{Key: changefeedbase.OptTopicInValue})
-	if createStmt.Select != nil {
+
+	specifiedFormat := ``
+	for _, opt := range createStmt.Options {
+		if string(opt.Key) == changefeedbase.OptFormat {
+			if opt.Value != nil {
+				val, err := exprAsString(opt.Value)
+				if err == nil {
+					specifiedFormat = val
+				}
+			}
+		}
+	}
+
+	formatSupportsKeyInValue :=
+		specifiedFormat != string(changefeedbase.OptFormatCSV) &&
+			specifiedFormat != string(changefeedbase.OptFormatParquet)
+	if createStmt.Select != nil && formatSupportsKeyInValue {
 		// Normally, webhook requires key_in_value; but if we use bare envelope,
 		// this option is not required.  However, we need it to make this
 		// test feed work -- so, set it.


### PR DESCRIPTION
This adds a column headers option `csv_header` for csv format, currently supported by webhook and cloud storage sinks. When enabled it streams the row of column header.

Epic: CRDB-53409

Informs: #166611 

Release note (general change ): CREATE CHANGEFEED statement now supports `csv_header` option, which can be used on csv format for webhook and cloud storage, it will stream row of column header. On webhook sinks, the first bytes of each HTTP POST body are the column header line (when batching allows multiple rows per request, the header appears once at the start of that body). On cloud storage sinks, the same header line is written once at the beginning of each CSV file the changefeed creates

Release note (backward-incompatible change): csv rows in the http/webhook
sink are now separated by a newline. Previously, all rows in a batch were
concatenated on a single line.