### PR TITLE
release-26.2: roachtest: enable revision history backups in OR roundtrip

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -1541,9 +1541,8 @@ func (rh revisionHistory) String() string {
 // creating a new backup. Each backup option has a 50% chance of being
 // included.
 func newBackupOptions(rng *rand.Rand, onlineRestoreExpected bool) []backupOption {
-	possibleOpts := []backupOption{}
+	possibleOpts := []backupOption{revisionHistory{}}
 	if !onlineRestoreExpected {
-		possibleOpts = append(possibleOpts, revisionHistory{})
 		possibleOpts = append(possibleOpts, newEncryptionPassphrase(rng))
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #167788 on behalf of @kev-cao.

----

This commit enables revision history backups in our OR roundtrip tests.

Resolves: #163240

Release note: None

----

Release justification: Test-only change.