### PR TITLE
txnscheduler: plumb TxnID through scheduler instead of raw timestamp

### DIFF
--- a/pkg/crosscluster/logical/txnmode/txnmode.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode.go
@@ -356,21 +356,15 @@ func (p *TxnLdrCoordinator) stageSchedule(
 				// table capacity; it ensures the applier waits for all
 				// transactions up to that timestamp before applying.
 				schedulerTxn := txnscheduler.Transaction{
-					CommitTime: batch.transactions[i].TxnID.Timestamp,
-					Locks:      lockSet.Locks,
+					TxnID: batch.transactions[i].TxnID,
+					Locks: lockSet.Locks,
 				}
 				dependencies, eventHorizon := scheduler.Schedule(schedulerTxn, nil)
-
-				// Convert hlc.Timestamp dependencies to TxnIDs.
-				txnDeps := make([]ldrdecoder.TxnID, len(dependencies))
-				for j, ts := range dependencies {
-					txnDeps[j] = ldrdecoder.TxnID{Timestamp: ts, ApplierID: applierID}
-				}
 
 				// Send the scheduled transaction to the applier.
 				scheduled := txnapply.ScheduledTransaction{
 					Transaction:  batch.transactions[i],
-					Dependencies: txnDeps,
+					Dependencies: dependencies,
 					EventHorizon: eventHorizon,
 				}
 

--- a/pkg/crosscluster/logical/txnscheduler/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnscheduler/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnscheduler",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/crosscluster/logical/ldrdecoder",
         "//pkg/crosscluster/logical/txnlock",
         "//pkg/util/buildutil",
         "//pkg/util/hlc",
@@ -25,6 +26,7 @@ go_test(
     ],
     embed = [":txnscheduler"],
     deps = [
+        "//pkg/crosscluster/logical/ldrdecoder",
         "//pkg/crosscluster/logical/txnlock",
         "//pkg/util/hlc",
         "//pkg/util/randutil",

--- a/pkg/crosscluster/logical/txnscheduler/lock_list.go
+++ b/pkg/crosscluster/logical/txnscheduler/lock_list.go
@@ -5,7 +5,7 @@
 
 package txnscheduler
 
-import "github.com/cockroachdb/cockroach/pkg/util/hlc"
+import "github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
 
 // readLocksPerBlock is the number of read locks that can be stored in a single
 // lockBlock before a new block must be allocated.
@@ -40,8 +40,8 @@ type lockList struct {
 
 // lockBlock is a link in an unrolled linked list of read locks.
 type lockBlock struct {
-	writeLock hlc.Timestamp
-	readAlloc [readLocksPerBlock]hlc.Timestamp
+	writeLock ldrdecoder.TxnID
+	readAlloc [readLocksPerBlock]ldrdecoder.TxnID
 	readLocks int8
 	next      lockEntryIndex
 }
@@ -72,12 +72,12 @@ func (lt *lockTable) allocateList() lockList {
 }
 
 func (lt *lockTable) appendWriteDependency(
-	list lockList, dependencies []hlc.Timestamp,
-) []hlc.Timestamp {
+	list lockList, dependencies []ldrdecoder.TxnID,
+) []ldrdecoder.TxnID {
 	next := list.head
 	entry := &lt.locks[next]
 
-	if !entry.writeLock.IsEmpty() {
+	if entry.writeLock.IsSet() {
 		dependencies = append(dependencies, entry.writeLock)
 	}
 	for {
@@ -93,16 +93,16 @@ func (lt *lockTable) appendWriteDependency(
 }
 
 func (lt *lockTable) appendReadDependency(
-	list lockList, dependencies []hlc.Timestamp,
-) []hlc.Timestamp {
+	list lockList, dependencies []ldrdecoder.TxnID,
+) []ldrdecoder.TxnID {
 	head := &lt.locks[list.head]
-	if !head.writeLock.IsEmpty() {
+	if head.writeLock.IsSet() {
 		return append(dependencies, head.writeLock)
 	}
 	return dependencies
 }
 
-func (lt *lockTable) removeReadLock(list lockList, lock hlc.Timestamp) (lockList, bool) {
+func (lt *lockTable) removeReadLock(list lockList, lock ldrdecoder.TxnID) (lockList, bool) {
 	head := &lt.locks[list.head]
 	// Locks are removed in hlc order, so if the lock is present it is the first
 	// lock in the block. The lock may not be present if a write lock caused it
@@ -127,7 +127,7 @@ func (lt *lockTable) removeReadLock(list lockList, lock hlc.Timestamp) (lockList
 	}
 
 	copy(head.readAlloc[0:], head.readAlloc[1:head.readLocks+1])
-	head.readAlloc[head.readLocks] = hlc.Timestamp{}
+	head.readAlloc[head.readLocks] = ldrdecoder.TxnID{}
 
 	return list, true
 }
@@ -137,13 +137,13 @@ func (lt *lockTable) free(entry lockEntryIndex) {
 	lt.freeList = append(lt.freeList, entry)
 }
 
-func (lt *lockTable) removeWriteLock(list lockList, lock hlc.Timestamp) (lockList, bool) {
+func (lt *lockTable) removeWriteLock(list lockList, lock ldrdecoder.TxnID) (lockList, bool) {
 	head := &lt.locks[list.head]
 	if head.writeLock != lock {
 		return list, true
 	}
 
-	head.writeLock = hlc.Timestamp{}
+	head.writeLock = ldrdecoder.TxnID{}
 	if head.readLocks == 0 {
 		lt.free(list.head)
 		return lockList{}, false
@@ -152,7 +152,7 @@ func (lt *lockTable) removeWriteLock(list lockList, lock hlc.Timestamp) (lockLis
 	return list, true
 }
 
-func (lt *lockTable) recordWriteLock(list lockList, lock hlc.Timestamp) lockList {
+func (lt *lockTable) recordWriteLock(list lockList, lock ldrdecoder.TxnID) lockList {
 	head := &lt.locks[list.head]
 
 	// If there is more than one block of read locks, we need to free all but the
@@ -178,7 +178,7 @@ func (lt *lockTable) recordWriteLock(list lockList, lock hlc.Timestamp) lockList
 	}
 }
 
-func (lt *lockTable) recordReadLock(list lockList, lock hlc.Timestamp) lockList {
+func (lt *lockTable) recordReadLock(list lockList, lock ldrdecoder.TxnID) lockList {
 	tail := &lt.locks[list.tail]
 	if tail.readLocks < readLocksPerBlock {
 		tail.readAlloc[tail.readLocks] = lock

--- a/pkg/crosscluster/logical/txnscheduler/scheduler.go
+++ b/pkg/crosscluster/logical/txnscheduler/scheduler.go
@@ -8,6 +8,7 @@ package txnscheduler
 import (
 	"slices"
 
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnlock"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -73,15 +74,15 @@ type Scheduler struct {
 // Schedule requires the lock hashes within each transaction to be unique.
 // Duplicates must be filtered out at the lock synthesis phase.
 func (s *Scheduler) Schedule(
-	transaction Transaction, dependenciesBuffer []hlc.Timestamp,
-) ([]hlc.Timestamp, hlc.Timestamp) {
+	transaction Transaction, dependenciesBuffer []ldrdecoder.TxnID,
+) ([]ldrdecoder.TxnID, hlc.Timestamp) {
 	for s.lockTable.availableCapacity() < len(transaction.Locks) {
 		if s.transactions.Len() == 0 {
 			// If we still can't fit the transaction even after forgetting the locks of
 			// every tracked transaction it means the transaction is too big to fit in
 			// the table.
 			horizon := s.eventHorizon
-			s.eventHorizon = transaction.CommitTime
+			s.eventHorizon = transaction.TxnID.Timestamp
 			return nil, horizon
 		}
 		s.pushEventHorizon()
@@ -101,16 +102,16 @@ func (s *Scheduler) Schedule(
 			dependencies = s.lockTable.appendWriteDependency(entryIndex, dependencies)
 		}
 		if lock.Read {
-			s.lockMap[lock.Hash] = s.lockTable.recordReadLock(entryIndex, transaction.CommitTime)
+			s.lockMap[lock.Hash] = s.lockTable.recordReadLock(entryIndex, transaction.TxnID)
 		} else {
-			s.lockMap[lock.Hash] = s.lockTable.recordWriteLock(entryIndex, transaction.CommitTime)
+			s.lockMap[lock.Hash] = s.lockTable.recordWriteLock(entryIndex, transaction.TxnID)
 		}
 	}
 
 	// Its possible we ended up with duplicate dependencies if two transactions
 	// overlap on more than one lock. Filter it out here.
-	slices.SortFunc(dependencies, func(a hlc.Timestamp, b hlc.Timestamp) int {
-		return a.Compare(b)
+	slices.SortFunc(dependencies, func(a, b ldrdecoder.TxnID) int {
+		return a.Timestamp.Compare(b.Timestamp)
 	})
 	dependencies = slices.Compact(dependencies)
 
@@ -123,7 +124,7 @@ func (s *Scheduler) Schedule(
 func (s *Scheduler) pushEventHorizon() {
 	txn := s.transactions.GetFirst()
 	s.transactions.RemoveFirst()
-	s.eventHorizon = txn.CommitTime
+	s.eventHorizon = txn.TxnID.Timestamp
 	for _, lock := range txn.Locks {
 		locks, exists := s.lockMap[lock.Hash]
 		if !exists {
@@ -137,9 +138,9 @@ func (s *Scheduler) pushEventHorizon() {
 		}
 
 		if lock.Read {
-			locks, exists = s.lockTable.removeReadLock(locks, txn.CommitTime)
+			locks, exists = s.lockTable.removeReadLock(locks, txn.TxnID)
 		} else {
-			locks, exists = s.lockTable.removeWriteLock(locks, txn.CommitTime)
+			locks, exists = s.lockTable.removeWriteLock(locks, txn.TxnID)
 		}
 
 		if exists {

--- a/pkg/crosscluster/logical/txnscheduler/scheduler_benchmark_test.go
+++ b/pkg/crosscluster/logical/txnscheduler/scheduler_benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnlock"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -33,8 +34,8 @@ func createRandomTransactions(
 			})
 		}
 		result[i] = Transaction{
-			CommitTime: hlc.Timestamp{WallTime: int64(i + 1)},
-			Locks:      locks,
+			TxnID: ldrdecoder.TxnID{Timestamp: hlc.Timestamp{WallTime: int64(i + 1)}},
+			Locks: locks,
 		}
 	}
 	return result
@@ -45,7 +46,7 @@ func BenchmarkScheduler_Schedule(b *testing.B) {
 		for _, txnSize := range []int{1, 10, 50, 1000} {
 			b.Run(fmt.Sprintf("keyspace=%d/size=%d", keyspace, txnSize), func(b *testing.B) {
 				transactions := createRandomTransactions(b.N/txnSize, txnSize, keyspace, 0.8)
-				dependenciesBuffer := make([]hlc.Timestamp, 0, 100)
+				dependenciesBuffer := make([]ldrdecoder.TxnID, 0, 100)
 				scheduler := NewScheduler(1024 * 1024)
 				b.ResetTimer()
 				for _, txn := range transactions {

--- a/pkg/crosscluster/logical/txnscheduler/scheduler_test.go
+++ b/pkg/crosscluster/logical/txnscheduler/scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnlock"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -35,6 +36,9 @@ func TestScheduler(t *testing.T) {
 
 	makeHlc := func(t int) hlc.Timestamp {
 		return hlc.Timestamp{WallTime: int64(t)}
+	}
+	makeTxnID := func(t int) ldrdecoder.TxnID {
+		return ldrdecoder.TxnID{Timestamp: makeHlc(t)}
 	}
 
 	testCases := []testCase{
@@ -128,8 +132,8 @@ func TestScheduler(t *testing.T) {
 					})
 				}
 				transaction := Transaction{
-					CommitTime: makeHlc(txn.time),
-					Locks:      locks,
+					TxnID: makeTxnID(txn.time),
+					Locks: locks,
 				}
 				deps, horizon := scheduler.Schedule(transaction, nil)
 				require.Equal(t, makeHlc(txn.expectedHorizon), horizon)
@@ -140,7 +144,7 @@ func TestScheduler(t *testing.T) {
 
 				require.Equal(t, len(txn.expectedDependencies), len(deps))
 				for i, dep := range txn.expectedDependencies {
-					expectedDep := makeHlc(dep)
+					expectedDep := makeTxnID(dep)
 					require.Equal(t, expectedDep, deps[i])
 				}
 			}
@@ -171,6 +175,9 @@ func TestSchedulerAlternatingWriteReadRuns(t *testing.T) {
 	makeHlc := func(ts int) hlc.Timestamp {
 		return hlc.Timestamp{WallTime: int64(ts)}
 	}
+	makeTxnID := func(ts int) ldrdecoder.TxnID {
+		return ldrdecoder.TxnID{Timestamp: makeHlc(ts)}
+	}
 
 	rng := rand.New(rand.NewSource(42))
 	scheduler := NewScheduler(10000)
@@ -181,7 +188,7 @@ func TestSchedulerAlternatingWriteReadRuns(t *testing.T) {
 		ts++
 		t.Logf("txn: %d isRead: %t", ts, isRead)
 		return Transaction{
-			CommitTime: makeHlc(ts),
+			TxnID: makeTxnID(ts),
 			Locks: []txnlock.Lock{{
 				Hash: hash,
 				Read: isRead,
@@ -189,8 +196,8 @@ func TestSchedulerAlternatingWriteReadRuns(t *testing.T) {
 		}
 	}
 
-	var lastWriteTxn hlc.Timestamp
-	var readTxns []hlc.Timestamp
+	var lastWriteTxn ldrdecoder.TxnID
+	var readTxns []ldrdecoder.TxnID
 
 	for range 20 {
 		for range rng.Intn(10) + 1 {
@@ -200,12 +207,12 @@ func TestSchedulerAlternatingWriteReadRuns(t *testing.T) {
 			require.True(t, horizon.IsEmpty())
 
 			expect := readTxns
-			if !lastWriteTxn.IsEmpty() {
-				expect = append([]hlc.Timestamp{lastWriteTxn}, readTxns...)
+			if lastWriteTxn.IsSet() {
+				expect = append([]ldrdecoder.TxnID{lastWriteTxn}, readTxns...)
 			}
 			require.Equal(t, expect, dependencies)
 
-			lastWriteTxn = txn.CommitTime
+			lastWriteTxn = txn.TxnID
 			readTxns = nil
 		}
 
@@ -214,9 +221,9 @@ func TestSchedulerAlternatingWriteReadRuns(t *testing.T) {
 
 			dependencies, horizon := scheduler.Schedule(txn, nil)
 			require.True(t, horizon.IsEmpty())
-			require.Equal(t, []hlc.Timestamp{lastWriteTxn}, dependencies)
+			require.Equal(t, []ldrdecoder.TxnID{lastWriteTxn}, dependencies)
 
-			readTxns = append(readTxns, txn.CommitTime)
+			readTxns = append(readTxns, txn.TxnID)
 		}
 	}
 
@@ -254,20 +261,20 @@ func TestSchedulerRandomOracle(t *testing.T) {
 
 				// Filter out oracle dependencies at or before the event
 				// horizon. The scheduler subsumes these into the horizon.
-				var expectedDeps []hlc.Timestamp
+				var expectedDeps []ldrdecoder.TxnID
 				for _, dep := range oracleDeps[txnID] {
-					if gotHorizon.Less(dep) {
+					if gotHorizon.Less(dep.Timestamp) {
 						expectedDeps = append(expectedDeps, dep)
 					}
 				}
 
-				slices.SortFunc(gotDeps, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
+				slices.SortFunc(gotDeps, func(a, b ldrdecoder.TxnID) int {
+					return a.Timestamp.Compare(b.Timestamp)
 				})
 
 				require.Equal(t, expectedDeps, gotDeps,
 					"txnID=%d commitTime=%s horizon=%s",
-					txnID, txn.CommitTime, gotHorizon,
+					txnID, txn.TxnID, gotHorizon,
 				)
 			}
 
@@ -316,7 +323,7 @@ const (
 // {txn0, txn1}.
 func generateOracleTable(
 	rng *rand.Rand, numTransactions int, numLocks int,
-) (transactions []Transaction, oracleDeps [][]hlc.Timestamp) {
+) (transactions []Transaction, oracleDeps [][]ldrdecoder.TxnID) {
 	// Randomly select the distribution thresholds. noneThreshold is in
 	// [1,98] and readThreshold is in (noneThreshold, 99], so all three
 	// statuses always have a nonzero probability.
@@ -381,25 +388,25 @@ func generateOracleTable(
 	}
 
 	transactions = make([]Transaction, numTransactions)
-	oracleDeps = make([][]hlc.Timestamp, numTransactions)
+	oracleDeps = make([][]ldrdecoder.TxnID, numTransactions)
 	for txnID := range numTransactions {
 		transactions[txnID] = Transaction{
-			CommitTime: hlc.Timestamp{WallTime: int64(txnID + 1)},
-			Locks:      txnLocks[txnID],
+			TxnID: ldrdecoder.TxnID{Timestamp: hlc.Timestamp{WallTime: int64(txnID + 1)}},
+			Locks: txnLocks[txnID],
 		}
 
 		deps := depSets[txnID]
 		if len(deps) == 0 {
 			continue
 		}
-		ts := make([]hlc.Timestamp, 0, len(deps))
+		ids := make([]ldrdecoder.TxnID, 0, len(deps))
 		for dep := range deps {
-			ts = append(ts, hlc.Timestamp{WallTime: int64(dep + 1)})
+			ids = append(ids, ldrdecoder.TxnID{Timestamp: hlc.Timestamp{WallTime: int64(dep + 1)}})
 		}
-		slices.SortFunc(ts, func(a, b hlc.Timestamp) int {
-			return a.Compare(b)
+		slices.SortFunc(ids, func(a, b ldrdecoder.TxnID) int {
+			return a.Timestamp.Compare(b.Timestamp)
 		})
-		oracleDeps[txnID] = ts
+		oracleDeps[txnID] = ids
 	}
 	return transactions, oracleDeps
 }

--- a/pkg/crosscluster/logical/txnscheduler/transaction.go
+++ b/pkg/crosscluster/logical/txnscheduler/transaction.go
@@ -6,13 +6,13 @@
 package txnscheduler
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnlock"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // Transaction contains all of the information about a transaction needed to
 // identify its dependencies.
 type Transaction struct {
-	CommitTime hlc.Timestamp
-	Locks      []txnlock.Lock
+	TxnID ldrdecoder.TxnID
+	Locks []txnlock.Lock
 }


### PR DESCRIPTION
The scheduler now uses ldrdecoder.TxnID instead of hlc.Timestamp for transaction identity and dependency tracking. Since the applier ID is set on a transaction before it is scheduled, plumbing the full TxnID allows callers to see the applier IDs of a transaction's dependencies.

This increases the per-lock storage from 12 bytes (hlc.Timestamp) to 16 bytes (TxnID), resulting in ~8% higher latency and ~19% more B/op in microbenchmarks. The scheduler remains zero-alloc.

```
    │ old.txt      │          new.txt                     │
    │    sec/op    │    sec/op     vs base                │
    k=1000/sz=1     90.55n ±  3%   97.84n ±  7%   +8.06%
    k=1000/sz=10    73.40n ±  2%   80.02n ±  2%   +9.02%
    k=1000/sz=50    101.1n ±  2%   112.7n ±  4%  +11.47%
    k=1000/sz=1000  82.43n ±  2%   89.03n ±  6%   +8.01%
    k=10000/sz=1    115.6n ± 10%   135.8n ± 11%  +17.57%
    k=10000/sz=10   90.67n ±  5%   95.00n ±  6%        ~
    k=10000/sz=50   120.3n ±  6%   129.7n ±  5%   +7.77%
    k=10000/sz=1000 137.9n ±  8%   148.6n ±  8%   +7.76%
    k=100k/sz=1     317.5n ± 12%   310.7n ±  3%        ~
    k=100k/sz=10    186.0n ±  4%   208.3n ±  4%  +12.02%
    k=100k/sz=50    220.7n ± 11%   235.9n ±  7%   +6.86%
    k=100k/sz=1000  266.2n ± 27%   274.8n ±  2%        ~
    geomean         134.0n         144.4n         +7.77%
```

Epic: none

Release note: none