### PR TITLE
kvstorage: Add WAGTruncator struct and initialize it

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kv/kvserver/spanset",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
@@ -38,6 +39,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_golang_x_time//rate",
     ],
 )
 

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -51,7 +51,7 @@ func (t *WAGTruncator) TruncateAll(ctx context.Context) error {
 		}
 		b := t.eng.LogEngine().NewWriteBatch()
 		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(
-			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader,
+			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader, 0, /* index */
 		)
 		if err == nil && truncated {
 			err = b.Commit(false /* sync */)
@@ -67,29 +67,43 @@ func (t *WAGTruncator) TruncateAll(ctx context.Context) error {
 	return nil
 }
 
-// truncateAppliedWAGNodeAndClearRaftState checks the first WAG node and
-// deletes it if all of its events have been applied to the state engine. For
-// nodes containing EventDestroy or EventSubsume events, it also clears the
-// corresponding raft log prefix from the engine and the sideloaded entries
-// storage.
-//
-// The caller must provide a stateRO reader with GuaranteedDurability so that
-// only state confirmed flushed to persistent storage is visible. This ensures
-// we never delete a WAG node whose mutations aren't flushed yet.
+// truncateAppliedWAGNodeAndClearRaftState deletes a WAG node if all of its
+// events have been applied to the state engine. For nodes containing
+// EventDestroy or EventSubsume events, it also clears the corresponding raft
+// log prefix from the engine and the sideloaded entries storage.
+// If truncateIndex is 0, the function deletes the first WAG node regardless of
+// its index. Otherwise, it only deletes the node matching truncateIndex if it
+// exists.
 //
 // Returns a boolean indicating whether a node was successfully truncated or
 // not. If the return value is false, it means that either there are no WAG
 // nodes left, or that the WAG node has not been applied to the state engine.
 // Also, an error is returned if the WAG node could not be fetched or deleted.
 //
-// The caller is responsible for creating and committing/closing the write batch
-// in raft.WO.
+// The caller must provide a stateRO reader with GuaranteedDurability so that
+// only state confirmed flushed to persistent storage is visible. This ensures
+// we never delete a WAG node whose mutations aren't flushed yet. The caller is
+// also responsible for creating and committing/closing the write batch in
+// raft.WO.
 // TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
 func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, raft Raft, stateRO StateRO,
+	ctx context.Context, raft Raft, stateRO StateRO, truncateIndex uint64,
 ) (bool, error) {
 	var iter wag.Iterator
-	for index, node := range iter.Iter(ctx, raft.RO) {
+	var iterStartKey roachpb.Key
+	if truncateIndex == 0 {
+		// Delete the first WAG node that exists, regardless of its index.
+		iterStartKey = keys.StoreWAGPrefix()
+	} else {
+		// Only delete the WAG node with the expected index.
+		iterStartKey = keys.StoreWAGNodeKey(truncateIndex)
+	}
+
+	for index, node := range iter.IterFrom(ctx, raft.RO, iterStartKey) {
+		if truncateIndex != 0 && truncateIndex != index {
+			return false, nil
+		}
+
 		// TODO(ibrahim): Right now, the canApplyWAGNode function returns a list of
 		// raftCatchUpTargets that are not needed for the purposes of truncation,
 		// consider refactoring the function to return only the needed info.
@@ -110,19 +124,8 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 			if event.Type != wagpb.EventDestroy && event.Type != wagpb.EventSubsume {
 				continue
 			}
-			if err := t.clearReplicaRaftLog(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
-				return false, errors.Wrapf(err, "clearing raft log for r%d", event.Addr.RangeID)
-			}
-			// In general, we shouldn't delete sideloaded files before committing the
-			// batch that deletes the Raft log entries. However, in this case, we
-			// know that the destroy/subsume event has already been flushed to disk,
-			// and the replica is destroyed. We will not need to reference the
-			// sideloaded files anymore. If we were to delay deleting them till
-			// after the batch is committed, we risk leaking the sideloaded files
-			// if a node crash happens after the batch is committed (and synced) and
-			// before the sideloaded files are deleted.
-			if err := t.clearSideloaded(ctx, event.Addr.RangeID, event.Addr.Index); err != nil {
-				return false, errors.Wrapf(err, "clearing sideloaded files for r%d", event.Addr.RangeID)
+			if err := t.clearReplicaRaftLogAndSideloaded(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
+				return false, err
 			}
 		}
 		return true, nil
@@ -130,24 +133,29 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 	return false, iter.Error()
 }
 
-// clearReplicaRaftLog clears raft log entries at or below the given index for
-// a destroyed or subsumed replica.
-func (t *WAGTruncator) clearReplicaRaftLog(
+// clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for
+// a destroyed or subsumed replica, and it also deletes the sideloaded files associated with the
+// deleted entries.
+func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
 ) error {
-	return storage.ClearRangeWithHeuristic(
+	if err := storage.ClearRangeWithHeuristic(
 		ctx, raft.RO, raft.WO,
 		keys.RaftLogPrefix(rangeID),           /* start */
 		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
 		ClearRangeThresholdPointKeys(),
-	)
-}
+	); err != nil {
+		return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
+	}
 
-// clearSideloaded clears sideloaded files belonging to raft log entries at or
-// below the given index for a destroyed or subsumed replica.
-func (t *WAGTruncator) clearSideloaded(
-	ctx context.Context, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
-) error {
+	// In general, we shouldn't delete sideloaded files before committing the
+	// batch that deletes the Raft log entries. However, in this case, we
+	// know that the destroy/subsume event has already been flushed to disk,
+	// and the replica is destroyed. We will not need to reference the
+	// sideloaded files anymore. If we were to delay deleting them till
+	// after the batch is committed, we risk leaking the sideloaded files
+	// if a node crash happens after the batch is committed (and synced) and
+	// before the sideloaded files are deleted.
 	// TODO(ibrahim): Consider doing some refactoring here to avoid creating a new
 	//  DiskSideloadStorage every time we want to clear some sideloaded files.
 	ss := logstore.NewDiskSideloadStorage(t.st, rangeID, t.eng.StateEngine().GetAuxiliaryDir(),

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -7,34 +7,64 @@ package kvstorage
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/time/rate"
 )
 
-// SideloadClearer truncates sideloaded files for a given range up to and
-// including the specified raft log index. Files beyond this index may belong
-// to a newer replica and must be preserved.
-// The SideloadClearer must also sync the sideloaded storage after truncation to
-// avoid leaking the files in case of a node crash.
-type SideloadClearer func(ctx context.Context, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex) error
+// WAGTruncator truncates applied WAG nodes and clears their associated raft
+// state (log entries and sideloaded files). It supports both offline and online
+// mode of operation:
+//   - [offline] during the store startup, truncate the WAG after it is
+//     replayed and made durable in the StateEngine.
+//   - [online] during the normal operation, truncate the WAG nodes that were
+//     durably applied to the state machine.
+//
+// TODO(ibrahim): Add the periodic truncation logic.
+type WAGTruncator struct {
+	st  *cluster.Settings
+	eng Engines
+}
 
-// clearReplicaRaftLog clears raft log entries at or below the given index for
-// a destroyed or subsumed replica.
-func clearReplicaRaftLog(
-	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
-) error {
-	return storage.ClearRangeWithHeuristic(
-		ctx, raft.RO, raft.WO,
-		keys.RaftLogPrefix(rangeID),           /* start */
-		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
-		ClearRangeThresholdPointKeys(),
-	)
+// NewWAGTruncator creates a WAGTruncator.
+func NewWAGTruncator(st *cluster.Settings, eng Engines) *WAGTruncator {
+	return &WAGTruncator{st: st, eng: eng}
+}
+
+// TruncateAll truncates all applied WAG nodes. It's meant to be used at engine
+// startup right after we replay the WAG nodes and sync the state engine.
+func (t *WAGTruncator) TruncateAll(ctx context.Context) error {
+	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
+	defer stateReader.Close()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		b := t.eng.LogEngine().NewWriteBatch()
+		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(
+			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader,
+		)
+		if err == nil && truncated {
+			err = b.Commit(false /* sync */)
+		}
+		b.Close()
+		if err != nil {
+			return err
+		}
+		if !truncated {
+			break
+		}
+	}
+	return nil
 }
 
 // truncateAppliedWAGNodeAndClearRaftState checks the first WAG node and
@@ -51,9 +81,12 @@ func clearReplicaRaftLog(
 // not. If the return value is false, it means that either there are no WAG
 // nodes left, or that the WAG node has not been applied to the state engine.
 // Also, an error is returned if the WAG node could not be fetched or deleted.
+//
+// The caller is responsible for creating and committing/closing the write batch
+// in raft.WO.
 // TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
-func truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, raft Raft, stateRO StateRO, clearSideloaded SideloadClearer,
+func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
+	ctx context.Context, raft Raft, stateRO StateRO,
 ) (bool, error) {
 	var iter wag.Iterator
 	for index, node := range iter.Iter(ctx, raft.RO) {
@@ -77,24 +110,52 @@ func truncateAppliedWAGNodeAndClearRaftState(
 			if event.Type != wagpb.EventDestroy && event.Type != wagpb.EventSubsume {
 				continue
 			}
-			if err := clearReplicaRaftLog(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
+			if err := t.clearReplicaRaftLog(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
 				return false, errors.Wrapf(err, "clearing raft log for r%d", event.Addr.RangeID)
 			}
-			if clearSideloaded != nil {
-				// In general, we shouldn't delete sideloaded files before committing the
-				// batch that deletes the Raft log entries. However, in this case, we
-				// know that the destroy/subsume event has already been flushed to disk,
-				// and the replica is destroyed. We will not need to reference the
-				// sideloaded files anymore. If we were to delay deleting them till
-				// after the batch is committed, we risk leaking the sideloaded files
-				// if a node crash happens after the batch is committed (and synced) and
-				// before the sideloaded files are deleted.
-				if err := clearSideloaded(ctx, event.Addr.RangeID, event.Addr.Index); err != nil {
-					return false, errors.Wrapf(err, "clearing sideloaded files for r%d", event.Addr.RangeID)
-				}
+			// In general, we shouldn't delete sideloaded files before committing the
+			// batch that deletes the Raft log entries. However, in this case, we
+			// know that the destroy/subsume event has already been flushed to disk,
+			// and the replica is destroyed. We will not need to reference the
+			// sideloaded files anymore. If we were to delay deleting them till
+			// after the batch is committed, we risk leaking the sideloaded files
+			// if a node crash happens after the batch is committed (and synced) and
+			// before the sideloaded files are deleted.
+			if err := t.clearSideloaded(ctx, event.Addr.RangeID, event.Addr.Index); err != nil {
+				return false, errors.Wrapf(err, "clearing sideloaded files for r%d", event.Addr.RangeID)
 			}
 		}
 		return true, nil
 	}
 	return false, iter.Error()
+}
+
+// clearReplicaRaftLog clears raft log entries at or below the given index for
+// a destroyed or subsumed replica.
+func (t *WAGTruncator) clearReplicaRaftLog(
+	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
+) error {
+	return storage.ClearRangeWithHeuristic(
+		ctx, raft.RO, raft.WO,
+		keys.RaftLogPrefix(rangeID),           /* start */
+		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
+		ClearRangeThresholdPointKeys(),
+	)
+}
+
+// clearSideloaded clears sideloaded files belonging to raft log entries at or
+// below the given index for a destroyed or subsumed replica.
+func (t *WAGTruncator) clearSideloaded(
+	ctx context.Context, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
+) error {
+	// TODO(ibrahim): Consider doing some refactoring here to avoid creating a new
+	//  DiskSideloadStorage every time we want to clear some sideloaded files.
+	ss := logstore.NewDiskSideloadStorage(t.st, rangeID, t.eng.StateEngine().GetAuxiliaryDir(),
+		rate.NewLimiter(rate.Inf, math.MaxInt64), t.eng.StateEngine().Env())
+	if err := ss.TruncateTo(ctx, lastIndex); err != nil {
+		return err
+	}
+	// We must sync the sideloaded storage after truncation to avoid leaking the
+	// files in case of a node crash.
+	return ss.Sync()
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -103,46 +103,12 @@ func (e *testEngines) listWAGNodes(t *testing.T) []uint64 {
 	return indices
 }
 
-// makeSideloadClearer returns a SideloadClearer that truncates sideloaded
-// files for a given range using disk-based sideload storage.
-func (e *testEngines) makeSideloadClearer(
-	st *cluster.Settings, baseDir string, env *fs.Env,
-) SideloadClearer {
-	return func(ctx context.Context, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex) error {
-		limiter := rate.NewLimiter(rate.Inf, math.MaxInt64)
-		ss := logstore.NewDiskSideloadStorage(st, rangeID, baseDir, limiter, env)
-		if err := ss.TruncateTo(ctx, lastIndex); err != nil {
-			return err
-		}
-		return ss.Sync()
-	}
-}
-
-// truncateWAGNodes repeatedly calls truncateAppliedWAGNodeAndClearRaftState
-// until no more nodes can be deleted.
-func (e *testEngines) truncateWAGNodes(t *testing.T, clearSideloaded SideloadClearer) {
-	t.Helper()
-	require.NoError(t, e.StateEngine().Flush())
-	stateReader := e.StateEngine().NewReader(storage.GuaranteedDurability)
-	defer stateReader.Close()
-	for {
-		b := e.LogEngine().NewBatch()
-		ok, err := truncateAppliedWAGNodeAndClearRaftState(context.Background(),
-			Raft{RO: e.LogEngine(), WO: b}, stateReader, clearSideloaded)
-		require.NoError(t, err)
-		require.NoError(t, b.Commit(false /* sync */))
-		b.Close()
-		if !ok {
-			return
-		}
-	}
-}
-
 func TestTruncateApplied(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
 	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
 	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
 	r2 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 2}
 	sl := MakeStateLoader(1 /* rangeID */)
@@ -274,8 +240,10 @@ func TestTruncateApplied(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
+			truncator := NewWAGTruncator(st, e.Engines)
 			tc.setup(t, &e)
-			e.truncateWAGNodes(t, nil /* clearSideloaded */)
+			require.NoError(t, e.stateEngine.Flush())
+			require.NoError(t, truncator.TruncateAll(ctx))
 			require.Equal(t, tc.wantWAGIndices, e.listWAGNodes(t))
 		})
 	}
@@ -289,6 +257,8 @@ func TestTruncateApplied(t *testing.T) {
 func TestTruncateAndClearRaftState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 
 	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
 	r2 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 2}
@@ -298,7 +268,7 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 		t.Run(eventType.String(), func(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
-			ctx := context.Background()
+			truncator := NewWAGTruncator(st, e.Engines)
 
 			// Write WAG nodes: init then destroy/subsume at index 20.
 			e.writeWAGNode(t, wagpb.Event{
@@ -323,18 +293,17 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 				e.writeRaftLogEntry(t, 1 /* rangeID */, kvpb.RaftIndex(idx))
 			}
 
-			// Create sideloaded files using the log engine's VFS.
-			st := cluster.MakeTestingClusterSettings()
-			baseDir := e.LogEngine().GetAuxiliaryDir()
-			env := e.LogEngine().Env()
+			// Create sideloaded files using the state engine's VFS, matching
+			// production where sideloaded entries are on the state engine.
+			baseDir := e.StateEngine().GetAuxiliaryDir()
+			env := e.StateEngine().Env()
 			limiter := rate.NewLimiter(rate.Inf, math.MaxInt64)
 			ss := logstore.NewDiskSideloadStorage(st, 1, baseDir, limiter, env)
 			for _, idx := range []kvpb.RaftIndex{10, 15, 20, 21, 25} {
 				require.NoError(t, ss.Put(ctx, idx, 1 /* term */, []byte("sst-data")))
 			}
-			clearer := e.makeSideloadClearer(st, baseDir, env)
-
-			e.truncateWAGNodes(t, clearer)
+			require.NoError(t, e.stateEngine.Flush())
+			require.NoError(t, truncator.TruncateAll(ctx))
 			// Raft entries <= 20 belong to the old replica and must be deleted. The
 			// rest shouldn't be deleted by the WAG truncator.
 			require.Equal(t,

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -327,3 +327,88 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 		})
 	}
 }
+
+// TestTruncateGapHandling verifies that truncateAppliedWAGNodeAndClearRaftState
+// handles gaps in WAG node indices correctly based on expectedIndex. When
+// expectedIndex is 0, the first node is deleted regardless of its index. When
+// non-zero, only the node at that exact index is deleted.
+//
+// The test sets up three WAG nodes with gaps between them:
+// [Index: 2] -> [Index: 4] -> [Index: 6]
+func TestTruncateGapHandling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	sl := MakeStateLoader(1 /* rangeID */)
+
+	for _, calls := range [][]struct {
+		index          uint64
+		wantTruncated  bool
+		wantWAGIndices []uint64
+	}{
+		{
+			// index=0 removes the first WAG node regardless of its index.
+			{index: 0, wantTruncated: true, wantWAGIndices: []uint64{4, 6}},
+			{index: 0, wantTruncated: true, wantWAGIndices: []uint64{6}},
+			{index: 0, wantTruncated: true, wantWAGIndices: nil},
+		},
+		{
+			// A non-existent index is a no-op.
+			{index: 1, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
+			{index: 3, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
+			{index: 5, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
+			{index: 7, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
+		},
+		{
+			// In theory, we can remove a WAG node at an index that is not the first.
+			{index: 4, wantTruncated: true, wantWAGIndices: []uint64{2, 6}},
+			{index: 6, wantTruncated: true, wantWAGIndices: []uint64{2}},
+			{index: 2, wantTruncated: true, wantWAGIndices: nil},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			e := makeTestEngines()
+			defer e.Close()
+			truncator := NewWAGTruncator(st, e.Engines)
+
+			// Write WAG nodes at indices 2, 4, 6.
+			e.seq.Next()
+			e.writeWAGNode(t, wagpb.Event{
+				Addr: wagpb.MakeAddr(r1, 0), Type: wagpb.EventCreate,
+			})
+			e.seq.Next()
+			e.writeWAGNode(t, wagpb.Event{
+				Addr: wagpb.MakeAddr(r1, 15), Type: wagpb.EventInit,
+			})
+			e.seq.Next()
+			e.writeWAGNode(t, wagpb.Event{
+				Addr: wagpb.MakeAddr(r1, 20), Type: wagpb.EventApply,
+			})
+
+			// Set applied state so all WAG nodes are considered applied.
+			require.NoError(t, sl.SetRaftReplicaID(ctx, e.StateEngine(), r1.ReplicaID))
+			require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
+				&kvserverpb.RangeAppliedState{RaftAppliedIndex: 20}))
+			require.NoError(t, e.stateEngine.Flush())
+
+			for _, c := range calls {
+				stateReader := e.StateEngine().NewReader(storage.GuaranteedDurability)
+				b := e.LogEngine().NewWriteBatch()
+				truncated, err := truncator.truncateAppliedWAGNodeAndClearRaftState(
+					ctx, Raft{RO: e.LogEngine(), WO: b}, stateReader, c.index,
+				)
+				require.NoError(t, err)
+				require.Equal(t, c.wantTruncated, truncated)
+				if truncated {
+					require.NoError(t, b.Commit(false /* sync */))
+				}
+				b.Close()
+				stateReader.Close()
+				require.Equal(t, c.wantWAGIndices, e.listWAGNodes(t))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR does the following:

1) Encapsulates the WAG Truncator logic inside a struct called WAGTruncator.
2) Adds the ability to truncate a WAG node by its index.

Release note: None

References: #167607

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>