### PR TITLE
release-25.2: backup: make compaction progress channel send context-aware

### DIFF
--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -104,9 +104,13 @@ func runCompactionPlan(
 	}
 	sql.FinalizePlan(ctx, planCtx, plan)
 
-	metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
+	metaFn := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {
-			progCh <- meta.BulkProcessorProgress
+			select {
+			case progCh <- meta.BulkProcessorProgress:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 
 		// TODO (kev-cao): Add channel for tracing aggregator events.


### PR DESCRIPTION
Backport 1/1 commits from #168046.

/cc @cockroachdb/release

---

## Summary

- Fix a deadlock in `runCompactionPlan` where a bare channel send to
  `progCh` blocks indefinitely when `checkpointLoop` exits early (e.g.
  due to a pausepoint or error), preventing the job from transitioning
  to "paused" status.
- Make the send context-aware via `select` on `ctx.Done()`.

Epic: none
Release note: None

---

Release justification: Fixes bug that causes backup compaction jobs to hang, preventing future compaction jobs from compressing the backup chain.