### PR TITLE
cluster-ui: fix font inlining and reduce webpack bundle size

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-          type: "asset",
+          type: "asset/inline",
           exclude: /node_modules/,
         },
         // Styles in current project use SCSS preprocessing language with CSS modules.

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -70,6 +70,7 @@ module.exports = (env, argv) => {
             {
               loader: "css-loader",
               options: {
+                sourceMap: false,
                 modules: {
                   localIdentName: "[local]--[hash:base64:5]",
                 }
@@ -84,7 +85,7 @@ module.exports = (env, argv) => {
         // dir so it can access external dependencies.
         {
           test: /(?<!\.module)\.scss/,
-          use: ["style-loader", "css-loader", "sass-loader"],
+          use: ["style-loader", { loader: "css-loader", options: { sourceMap: false } }, "sass-loader"],
           exclude: /node_modules/,
         },
         {
@@ -142,6 +143,7 @@ module.exports = (env, argv) => {
             {
               loader: "esbuild-loader",
               options: {
+                sourceMap: false,
                 loader: "css",
                 minify: true,
               },

--- a/pkg/ui/workspaces/db-console/jest.config.js
+++ b/pkg/ui/workspaces/db-console/jest.config.js
@@ -222,7 +222,7 @@ module.exports = {
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: [],
+  transformIgnorePatterns: ["node_modules/@cockroachlabs/cluster-ui/dist"],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,


### PR DESCRIPTION
## Summary

Two fixes to the cluster-ui webpack config:

- **Fix font files emitted as separate assets**: The webpack 5 migration
  (`5daa5d3fb9e`) replaced `url-loader` with webpack 5's native
  `type: "asset"` for handling font and image files. However, the old
  `url-loader` config used `limit: true` (a boolean), which caused all
  assets to be inlined as base64 data URLs regardless of file size.
  With `type: "asset"`, webpack 5 uses a default 8KB threshold — files
  larger than 8KB are emitted as standalone `.woff`/`.woff2` files into
  `dist/js/`. This fixes the issue by using `type: "asset/inline"`,
  matching the previous behavior.

- **Disable CSS source maps**: Source maps were being generated for CSS
  modules, non-module SCSS, and esbuild-minified CSS, inflating the
  webpack output. Disabling `sourceMap` in css-loader and esbuild-loader
  reduces the bundle size.

Epic: none
Release note: None