### PR TITLE
sql/schemachanger: block DROP TYPE if domain dependencies exist

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/domain
+++ b/pkg/sql/logictest/testdata/logic_test/domain
@@ -696,11 +696,12 @@ subtest end
 
 subtest domain_enum_base_type
 
-# Domain over enum type: creation succeeds but casting and back-references
-# don't fully work yet. The domain type inherits EnumFamily from the base
-# type but lacks the EnumData hydration metadata needed for string-to-enum
-# parsing. Back-references from the domain to the enum are also incomplete.
-# TODO(#27796): Fix domain-over-enum support (casting, back-references).
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', 'ecstatic');
+CREATE DOMAIN positive_mood AS mood CHECK (VALUE IN ('happy', 'ecstatic'));
+
+statement error pgcode 2BP01 cannot drop type "mood" because other objects \(\[test.public.positive_mood\]\) still depend on it
+DROP TYPE mood;
 
 subtest end
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -614,6 +614,12 @@ func (p *planner) getFullyQualifiedNamesFromIDs(
 				return nil, err
 			}
 			fullyQualifiedNames = append(fullyQualifiedNames, fName.FQString())
+		case catalog.TypeDescriptor:
+			typeName, err := p.getQualifiedTypeName(ctx, t)
+			if err != nil {
+				return nil, err
+			}
+			fullyQualifiedNames = append(fullyQualifiedNames, typeName.FQString())
 		}
 	}
 	return fullyQualifiedNames, nil

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -216,9 +216,11 @@ func (w *walkCtx) walkType(typ catalog.TypeDescriptor) {
 			})
 		}
 	} else if domain := typ.AsDomainTypeDescriptor(); domain != nil {
+		baseType := newTypeT(domain.GetBaseType())
 		w.ev(descriptorStatus(typ), &scpb.DomainType{
 			TypeID:      domain.GetID(),
 			ArrayTypeID: domain.GetArrayTypeID(),
+			BaseTypeT:   *baseType,
 		})
 	} else {
 		panic(errors.AssertionFailedf("unsupported type kind %q", typ.GetKind()))

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -702,6 +702,7 @@ message CompositeType {
 message DomainType {
   uint32 type_id = 1 [(gogoproto.customname) = "TypeID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 array_type_id = 2 [(gogoproto.customname) = "ArrayTypeID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  TypeT base_type_t = 3 [(gogoproto.nullable) = false];
 }
 
 message Schema {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -157,6 +157,7 @@ object DomainType
 
 DomainType :  TypeID
 DomainType :  ArrayTypeID
+DomainType :  BaseTypeT
 
 object EnumType
 


### PR DESCRIPTION
Previously, we allowed dropping enum types even if dependencies existed from domains. This was because the declarative schema changer was not aware of the dependencies. Additionally, the legacy schema changer did not generate proper errors for these dependencies. This patch, modifies the domain type schema changer element to include the base type, so that these dependencies are correctly detected. It also fixes the error message generated by the legacy schema changer.

Fixes: #167521

Release note: None