### PR TITLE
changefeedccl: notify test synchronizer on resolved timestamp emission

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -721,6 +721,15 @@ func (s *notifyFlushSink) Flush(ctx context.Context) error {
 	return s.Sink.Flush(ctx)
 }
 
+// EmitResolvedTimestamp overrides the embedded Sink's method to notify the
+// test's sinkSynchronizer when a resolved timestamp is written.
+func (s *notifyFlushSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	defer s.sync.addFlush()
+	return s.Sink.EmitResolvedTimestamp(ctx, encoder, resolved)
+}
+
 func (s *notifyFlushSink) EncodeAndEmitRow(
 	ctx context.Context,
 	updatedRow cdcevent.Row,


### PR DESCRIPTION
Previously, `notifyFlushSink` only called `addFlush()` on `Flush()`, not on `EmitResolvedTimestamp()`. This meant that when the changeFrontier wrote RESOLVED files, the test's `cloudFeed.Next()` was not woken up.

Fix by overriding `EmitResolvedTimestamp` on `notifyFlushSink` to call `addFlush()`, matching the pattern already used by `Flush()`.

Informs: #139653
Epic: none
Release note: None