### PR TITLE
release-25.2: kvserver: stop treating split/merge trigger errors as replica corruption

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -96,7 +96,6 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_kr_pretty//:pretty",

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
 )
 
@@ -895,18 +894,13 @@ func RunCommitTrigger(
 			ctx, rec, batch, *ms, ct.SplitTrigger, txn.WriteTimestamp,
 		)
 		if err != nil {
-			if info := pebble.ExtractDataCorruptionInfo(err); info != nil {
-				// We want to handle the data corruption error here because it's possible
-				// that a file that an external SSTable references got deleted. We want to
-				// fail the split and propagate the error, but we don't want to crash the
-				// process. An excise command could be used to get out of this data
-				// corruption.
-				return result.Result{}, err
-			} else {
-				// Otherwise, failing the split is a critical error. We should crash
-				// the process and report a replica corruption.
-				return result.Result{}, kvpb.MaybeWrapReplicaCorruptionError(ctx, err)
-			}
+			// Errors from split trigger evaluation simply fail the split,
+			// which will be retried. Previously, non-data-corruption errors
+			// were wrapped in ReplicaCorruptionError (crashing the process),
+			// but this was problematic because transient I/O errors (e.g.
+			// cloud storage timeouts) would be misidentified as corruption.
+			// See #165558.
+			return result.Result{}, err
 		}
 		*ms = newMS
 		return res, nil
@@ -914,18 +908,13 @@ func RunCommitTrigger(
 	if mt := ct.GetMergeTrigger(); mt != nil {
 		res, err := mergeTrigger(ctx, rec, batch, ms, mt, txn.WriteTimestamp)
 		if err != nil {
-			if info := pebble.ExtractDataCorruptionInfo(err); info != nil {
-				// We want to handle the data corruption error here because it's
-				// possible that a file that an external SSTable references got deleted.
-				// We want to fail the merge and propagate the error, but we don't want
-				// to crash the process. An excise command could be used to get out of
-				// this data corruption.
-				return result.Result{}, err
-			} else {
-				// Otherwise, failing the merge is a critical error. We should crash
-				// the process and report a replica corruption.
-				return result.Result{}, kvpb.MaybeWrapReplicaCorruptionError(ctx, err)
-			}
+			// Errors from merge trigger evaluation simply fail the merge,
+			// which will be retried. Previously, non-data-corruption errors
+			// were wrapped in ReplicaCorruptionError (crashing the process),
+			// but this was problematic because transient I/O errors (e.g.
+			// cloud storage timeouts) would be misidentified as corruption.
+			// See #165558.
+			return result.Result{}, err
 		}
 		return res, nil
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -4303,12 +4303,6 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var exitStatus exit.Code
-	log.SetExitFunc(true /* hideStack */, func(i exit.Code) {
-		exitStatus = i
-	})
-	defer log.ResetExitFunc()
-
 	ctx := context.Background()
 	tc := testContext{}
 	stopper := stop.NewStopper()
@@ -4343,13 +4337,9 @@ func TestEndTxnWithMalformedSplitTrigger(t *testing.T) {
 	}
 
 	assignSeqNumsForReqs(txn, &args)
-	expErr := regexp.QuoteMeta("replica corruption (processed=true): range does not match splits")
+	expErr := "range does not match splits"
 	if _, pErr := tc.SendWrappedWith(h, &args); !testutils.IsPError(pErr, expErr) {
 		t.Errorf("unexpected error: %s", pErr)
-	}
-
-	if exitStatus != exit.FatalError() {
-		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #167289.

/cc @cockroachdb/release

---

Previously, `maybeWrapReplicaCorruptionError` in `RunCommitTrigger`
escalated any unrecognized error from split/merge trigger evaluation to
a `ReplicaCorruptionError`, which crashes the process via
`setCorruptRaftMuLocked`. This meant that transient I/O errors (e.g.
cloud storage network timeouts during `MVCCIsSpanEmpty`) would fatal
the node despite not indicating actual data corruption.

Remove the corruption wrapping so that these errors simply fail the
split or merge, which will be retried.

This is a minimal fix suitable for backporting. Follow-up work can
remove the now-no-op `maybeWrapReplicaCorruptionError` wrapper entirely.

Fixes-26.2: #165558
Epic: CRDB-61447

Release note (bug fix): Fixed a bug where transient I/O errors (such
as cloud storage network timeouts) during split or merge trigger
evaluation were misidentified as replica corruption, causing the node
to crash. These errors now correctly fail the operation, which is
retried automatically.

Release justification: bug fix: transient I/O errors during split/merge incorrectly crash the node