### PR TITLE
importer: fall back from distributed merge when ExternalIODir is absent

### DIFF
--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -780,6 +780,12 @@ func importPlanHook(
 			return pgerror.New(pgcode.FeatureNotSupported,
 				"distributed merge for IMPORT requires all nodes to be running version 26.2 or later")
 		}
+		// The distributed merge pipeline writes temporary SSTs to nodelocal
+		// storage, which requires ExternalIODir to be configured. When it is
+		// not available, fall back to the regular import path.
+		if useDistributedMerge && p.ExecCfg().ExternalIODir == "" {
+			useDistributedMerge = false
+		}
 
 		importDetails := jobspb.ImportDetails{
 			URIs:                  files,

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -135,6 +135,42 @@ func TestImportDistributedMerge(t *testing.T) {
 	require.Equal(t, [][]string{{"1", "jeff"}}, sqlDB.QueryStr(t, `SELECT id, name FROM customers`))
 }
 
+// TestImportDistributedMergeNoExternalIODir verifies that IMPORT with
+// distributed merge enabled falls back to the regular import path when
+// ExternalIODir is not configured. Without ExternalIODir, nodelocal storage is
+// unavailable, so the distributed merge pipeline cannot write temporary SSTs.
+func TestImportDistributedMergeNoExternalIODir(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// Intentionally omit ExternalIODir to simulate no-local-access.
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	// Serve CSV data over HTTP since nodelocal is unavailable.
+	csvData := "1,jeff,user@email.com"
+	httpSrv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(csvData))
+		}),
+	)
+	defer httpSrv.Close()
+
+	tdb.Exec(t, `SET CLUSTER SETTING bulkio.import.distributed_merge.enabled = true`)
+	tdb.Exec(t, `CREATE TABLE customers (id INT PRIMARY KEY, name STRING, email STRING)`)
+
+	// Should succeed: falls back to non-distributed-merge path when
+	// ExternalIODir is not configured.
+	tdb.Exec(t, `IMPORT INTO customers (id, name, email) CSV DATA ($1)`, httpSrv.URL)
+
+	require.Equal(t, [][]string{{"1", "jeff"}},
+		tdb.QueryStr(t, `SELECT id, name FROM customers`))
+}
+
 // TestImportDistributedMergeDuplicateDetection verifies that IMPORT with
 // distributed merge detects duplicate keys at each phase of the pipeline.
 // These tests cover the fixes for cases 4-6 described in #161447.


### PR DESCRIPTION
The distributed merge pipeline writes temporary SSTs to nodelocal storage, which requires ExternalIODir to be configured on every node. When ExternalIODir is empty the pipeline would fail at runtime. Detect this condition early in importPlanHook and fall back to the regular (non-distributed-merge) import path instead of failing.

A new test, TestImportDistributedMergeNoExternalIODir, starts a server without ExternalIODir and confirms that IMPORT INTO succeeds by transparently falling back.

Fixes #167837

Epic: CRDB-62563
Release note: None