### PR TITLE
kvserver: consolidate stageDestroyReplica

### DIFF
--- a/pkg/kv/kvserver/client_replica_gc_test.go
+++ b/pkg/kv/kvserver/client_replica_gc_test.go
@@ -196,7 +196,7 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 }
 
 // TestReplicaGCQueueHandlesStagingError verifies that replica removal handles
-// errors from the staging phase (stageDestroyReplica) gracefully: the error
+// errors from the staging phase (stageDestroyRaftMuLocked) gracefully: the error
 // propagates without crashing, the replica survives intact, and a retry
 // succeeds once the error clears. Three removal paths are exercised:
 //

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -155,40 +155,40 @@ func (p *pendingReplicaDestruction) Close() {
 	p.batch.Close()
 }
 
-// stageDestroyReplica builds a batch that, when committed, will destroy the
-// replica's on-disk state and install a tombstone. The returned
+// stageDestroyRaftMuLocked builds a batch that, when committed, will destroy
+// the replica's on-disk state and install a tombstone. The returned
 // pendingReplicaDestruction must have Close called when it is no longer needed.
 //
-// This function performs engine reads (to validate replica ID and tombstone
+// This method performs engine reads (to validate replica ID and tombstone
 // state) and stages engine writes into a batch, but does not commit. If any
 // engine read fails (e.g. due to context cancellation or I/O error), the error
 // is returned and the caller can abort with no side effects.
-func stageDestroyReplica(
-	ctx context.Context,
-	bf *kvstorage.BatchFactory,
-	stateRO kvstorage.StateRO,
-	raftRO kvstorage.RaftRO,
-	info kvstorage.DestroyReplicaInfo,
-	nextReplicaID roachpb.ReplicaID,
-	ms enginepb.MVCCStats,
+func (r *Replica) stageDestroyRaftMuLocked(
+	ctx context.Context, nextReplicaID roachpb.ReplicaID,
 ) (pendingReplicaDestruction, error) {
+	r.raftMu.AssertHeld()
+	if fn := r.store.TestingKnobs().TestingReplicaDestroyErr; fn != nil {
+		if err := fn(); err != nil {
+			return pendingReplicaDestruction{}, err
+		}
+	}
 	stageTime := timeutil.Now()
-	batch := bf.NewWriteBatch()
+	batch := r.store.batchFactory.NewWriteBatch()
 	stateWO, raftWO := kvstorage.StateWO(batch.State()), batch.Raft()
 	if err := kvstorage.DestroyReplica(
 		ctx, kvstorage.ReadWriter{
-			State: kvstorage.State{RO: stateRO, WO: stateWO},
-			Raft:  kvstorage.Raft{RO: raftRO, WO: raftWO},
+			State: kvstorage.State{RO: r.store.StateEngine(), WO: stateWO},
+			Raft:  kvstorage.Raft{RO: r.store.LogEngine(), WO: raftWO},
 		},
-		info, nextReplicaID,
+		r.destroyInfoRaftMuLocked(), nextReplicaID,
 	); err != nil {
 		batch.Close()
 		return pendingReplicaDestruction{}, err
 	}
 	return pendingReplicaDestruction{
 		batch:       batch,
-		ms:          ms,
-		initialized: len(info.Keys.EndKey) > 0,
+		ms:          r.GetMVCCStats(),
+		initialized: r.shMu.state.Desc.IsInitialized(),
 		stageTime:   stageTime,
 		clearTime:   timeutil.Now(),
 	}, nil

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -132,18 +132,8 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	// If staging fails, we return the error with no side effects.
 	var pending pendingReplicaDestruction
 	if opts.DestroyData {
-		if fn := s.TestingKnobs().TestingReplicaDestroyErr; fn != nil {
-			if err := fn(); err != nil {
-				return nil, err
-			}
-		}
 		var err error
-		pending, err = stageDestroyReplica(
-			ctx, &s.batchFactory,
-			s.StateEngine(), s.LogEngine(),
-			rep.destroyInfoRaftMuLocked(), nextReplicaID,
-			rep.GetMVCCStats(),
-		)
+		pending, err = rep.stageDestroyRaftMuLocked(ctx, nextReplicaID)
 		if err != nil {
 			return nil, err
 		}
@@ -266,17 +256,7 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 	// Stage the engine work before any in-memory state changes. If the engine
 	// work fails (e.g. context cancellation, I/O error), we can return the error
 	// cleanly without leaving the replica in a half-destroyed state.
-	if fn := s.TestingKnobs().TestingReplicaDestroyErr; fn != nil {
-		if err := fn(); err != nil {
-			return err
-		}
-	}
-	pending, err := stageDestroyReplica(
-		ctx, &s.batchFactory,
-		s.StateEngine(), s.LogEngine(),
-		rep.destroyInfoRaftMuLocked(), nextReplicaID,
-		rep.GetMVCCStats(),
-	)
+	pending, err := rep.stageDestroyRaftMuLocked(ctx, nextReplicaID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`stageDestroyReplica` is only plumbing around `kvstorage.DestroyReplica` that probably won't move to `kvstorage` itself. Make it a `Replica` method so it can source its arguments from the receiver, removing duplicate parameter passing and knob preamble at both call sites.

Epic: none
Release note: None