### PR TITLE
kvstorage: don't clear applied log with sep engines

### DIFF
--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -10,6 +10,7 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -72,6 +73,10 @@ const DestroyReplicaTODO = 0
 type DestroyReplicaInfo struct {
 	// FullReplicaID identifies the replica on its store.
 	roachpb.FullReplicaID
+	// RaftAppliedIndex is the replica's last applied raft log index before
+	// destruction. Used for constructing WAG dependency nodes. Zero for
+	// uninitialized replicas that never applied any log entries.
+	RaftAppliedIndex kvpb.RaftIndex
 	// Keys is the user key span of this replica, taken from its RangeDescriptor.
 	// Non-empty iff the replica is initialized.
 	Keys roachpb.RSpan

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -68,8 +68,6 @@ const DestroyReplicaTODO = 0
 
 // DestroyReplicaInfo contains the replica's metadata needed for its removal
 // from storage.
-//
-// TODO(pav-kv): for separated storage, add the applied raft log span. #152845
 type DestroyReplicaInfo struct {
 	// FullReplicaID identifies the replica on its store.
 	roachpb.FullReplicaID
@@ -80,6 +78,11 @@ type DestroyReplicaInfo struct {
 	// Keys is the user key span of this replica, taken from its RangeDescriptor.
 	// Non-empty iff the replica is initialized.
 	Keys roachpb.RSpan
+	// Separated indicates that the raft and state machine engines are separated.
+	// When true, only the unapplied suffix of the raft log is cleared (entries
+	// after RaftAppliedIndex), leaving the applied prefix for later log engine
+	// GC. When false, the entire raft log is cleared.
+	Separated bool
 }
 
 // DestroyReplica destroys the entirety of the replica's state in storage, and
@@ -123,7 +126,8 @@ func destroyReplicaImpl(
 	//
 	// All the code below is equivalent to clearing all the spans that the
 	// following SelectOpts represents, and leaving only the RangeTombstoneKey
-	// populated with the specified NextReplicaID.
+	// populated with the specified NextReplicaID. With separated engines, the
+	// applied prefix of the raft log is excluded and left for log engine GC.
 	if buildutil.CrdbTestBuild {
 		_ = rditer.SelectOpts{
 			ReplicatedByRangeID:   true,
@@ -132,16 +136,14 @@ func destroyReplicaImpl(
 		}
 	}
 
+	buf := keys.MakeRangeIDPrefixBuf(info.RangeID)
 	// First, clear all RangeID-local replicated keys. Also, include all
 	// RangeID-local unreplicated keys < RangeTombstoneKey as a drive-by, since we
 	// decided that these (currently none) belong to the state machine engine.
-	span := roachpb.Span{
-		Key:    keys.MakeRangeIDReplicatedPrefix(info.RangeID),
-		EndKey: keys.RangeTombstoneKey(info.RangeID),
-	}
 	if err := storage.ClearRangeWithHeuristic(
 		ctx, rw.State.RO, rw.State.WO,
-		span.Key, span.EndKey, ClearRangeThresholdPointKeys(),
+		buf.ReplicatedPrefix(), sl.RangeTombstoneKey(),
+		ClearRangeThresholdPointKeys(),
 	); err != nil {
 		return err
 	}
@@ -159,28 +161,38 @@ func destroyReplicaImpl(
 	//
 	// TODO(pav-kv): make a helper for piece-wise clearing, instead of using a
 	// series of ClearRangeWithHeuristic.
-	span = roachpb.Span{
-		Key:    span.EndKey.Next(), // RangeTombstoneKey.Next()
-		EndKey: keys.RaftReplicaIDKey(info.RangeID),
-	}
-	// TODO(#152845): with separated raft storage, clear only the unapplied suffix
-	// of the raft log, which is in this span.
-	if err := storage.ClearRangeWithHeuristic(
+	if info.Separated {
+		// With separated engines, only clear the unapplied suffix of the raft log.
+		// The applied entries are cleared during WAG garbage collection.
+		if err := storage.ClearRangeWithHeuristic(
+			ctx, rw.Raft.RO, rw.Raft.WO,
+			buf.RangeTombstoneKey().Next(), sl.RaftLogPrefix(),
+			ClearRangeThresholdPointKeys(),
+		); err != nil {
+			return err
+		}
+		if err := storage.ClearRangeWithHeuristic(
+			ctx, rw.Raft.RO, rw.Raft.WO,
+			buf.RaftLogKey(info.RaftAppliedIndex+1), sl.RaftReplicaIDKey(),
+			ClearRangeThresholdPointKeys(),
+		); err != nil {
+			return err
+		}
+	} else if err := storage.ClearRangeWithHeuristic(
 		ctx, rw.Raft.RO, rw.Raft.WO,
-		span.Key, span.EndKey, ClearRangeThresholdPointKeys(),
+		buf.RangeTombstoneKey().Next(), sl.RaftReplicaIDKey(),
+		ClearRangeThresholdPointKeys(),
 	); err != nil {
 		return err
 	}
 	if err := sl.ClearRaftReplicaID(rw.State.WO); err != nil {
 		return err
 	}
-	span = roachpb.Span{
-		Key:    span.EndKey.Next(), // RaftReplicaIDKey.Next()
-		EndKey: keys.MakeRangeIDUnreplicatedPrefix(info.RangeID).PrefixEnd(),
-	}
+
 	if err := storage.ClearRangeWithHeuristic(
 		ctx, rw.Raft.RO, rw.Raft.WO,
-		span.Key, span.EndKey, ClearRangeThresholdPointKeys(),
+		buf.RaftReplicaIDKey().Next(), sl.UnreplicatedPrefix().PrefixEnd(),
+		ClearRangeThresholdPointKeys(),
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/destroy_test.go
+++ b/pkg/kv/kvserver/kvstorage/destroy_test.go
@@ -82,7 +82,12 @@ func TestDestroyReplica(t *testing.T) {
 		}) + mutateSep("destroy", e, func(rw ReadWriter) {
 			require.NoError(t, DestroyReplica(
 				ctx, rw,
-				DestroyReplicaInfo{FullReplicaID: r.id, Keys: r.keys}, r.id.ReplicaID+1,
+				DestroyReplicaInfo{
+					FullReplicaID:    r.id,
+					RaftAppliedIndex: r.applied,
+					Keys:             r.keys,
+					Separated:        e.Separated(),
+				}, r.id.ReplicaID+1,
 			))
 		})
 

--- a/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica-sep-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica-sep-eng.txt
@@ -29,8 +29,6 @@ Delete (Sized at 11): 0.000000001,0 "a" (0x6100000000000000000109):
 Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109): 
 >> destroy/raft:
 Delete (Sized at 39): 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:11 (0x0169f67b757266746c000000000000000b00): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -465,7 +465,10 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 						Raft:  kvstorage.Raft{RO: tc.eng.LogEngine(), WO: b.Raft()},
 					}, kvstorage.DestroyReplicaInfo{
 						FullReplicaID: rhsRS.replica.FullReplicaID,
-						Keys:          rhsRS.desc.RSpan(),
+						// TODO(pav-kv): support the applied index properly.
+						RaftAppliedIndex: kvpb.RaftIndex(rhsRS.replica.hs.Commit),
+						Keys:             rhsRS.desc.RSpan(),
+						Separated:        tc.eng.Separated(),
 					}))
 				})
 				delete(tc.ranges, merge.RightDesc.RangeID)
@@ -477,9 +480,11 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				rs.mustGetReplicaDescriptor(t, roachpb.NodeID(1)) // ensure replica exists
 
 				destroyInfo := kvstorage.DestroyReplicaInfo{
-					FullReplicaID: rs.replica.FullReplicaID,
+					FullReplicaID:    rs.replica.FullReplicaID,
+					RaftAppliedIndex: kvpb.RaftIndex(rs.replica.hs.Commit),
+					Separated:        tc.eng.Separated(),
 				}
-				// NB: destriyInfo.Keys is only set for initialized replicas.
+				// NB: destroyInfo.Keys is only set for initialized replicas.
 				if rs.replica.initialized() {
 					destroyInfo.Keys = rs.desc.RSpan()
 				}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -853,6 +853,7 @@ func (r *Replica) destroyInfoRaftMuLocked() kvstorage.DestroyReplicaInfo {
 		FullReplicaID:    r.ID(),
 		RaftAppliedIndex: r.shMu.state.RaftAppliedIndex,
 		Keys:             r.shMu.state.Desc.RSpan(),
+		Separated:        r.store.EnginesSeparated(),
 	}
 }
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -850,8 +850,9 @@ func testingAssert(cond bool, msg string) {
 func (r *Replica) destroyInfoRaftMuLocked() kvstorage.DestroyReplicaInfo {
 	r.raftMu.AssertHeld()
 	return kvstorage.DestroyReplicaInfo{
-		FullReplicaID: r.ID(),
-		Keys:          r.shMu.state.Desc.RSpan(),
+		FullReplicaID:    r.ID(),
+		RaftAppliedIndex: r.shMu.state.RaftAppliedIndex,
+		Keys:             r.shMu.state.Desc.RSpan(),
 	}
 }
 


### PR DESCRIPTION
With separated engines, only clear the unapplied suffix of the raft log when destroying a replica. The applied log entries are left intact and deleted on WAG GC, after the application of these entries is durable. Before durable application, they are needed for a potential replay after crash/restart.

A new `Separated` field on `DestroyReplicaInfo` gates this behavior. When false (single engine), the entire raft log is cleared as before.

Part of #168120