### PR TITLE
server: add match timeout to RPC/SQL cmux to prevent shutdown hang

### DIFF
--- a/pkg/server/start_listen.go
+++ b/pkg/server/start_listen.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cmux"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -104,7 +105,7 @@ func startListenRPCAndSQL(
 	// either via the returned startRPCServer() or upon stopping.
 	var serveOnMux sync.Once
 
-	m := cmux.New(ln)
+	m := cmux.NewWithTimeout(ln, time.Minute)
 	// cmux auto-retries Accept() by default. Tell it
 	// to stop doing work if we see a request to shut down.
 	m.HandleError(func(err error) bool {


### PR DESCRIPTION
The RPC/SQL connection multiplexer (cmux) was created without a match timeout, causing indefinite hangs during server shutdown when a connection was mid-match in a blocking protocol matcher.

The cmux runs protocol matchers sequentially on each accepted connection: pgwire, then DRPC, then gRPC (catch-all). Any matcher that performs a blocking read can hang if the connection doesn't provide enough bytes. The pgwire matcher (`pgwire.Match`) blocks reading the startup message, and the DRPC matcher (`start_drpc_listener.go`) calls `io.ReadFull` to read 8 bytes (the "DRPC!!!1" header). A silent connection, one that sends no data, would block in the very first matcher (pgwire), never reaching the catch-all. This has been a latent issue since before DRPC was added; the introduction of the DRPC matcher (#146744) widened the surface area by adding another blocking read point and requiring more total bytes to pass through to the catch-all.

The deadlock chain during shutdown:

  1. `Stopper.ShouldQuiesce()` fires, `ln.Close()` stops new accepts.
  2. `cmux.Serve()` exits its accept loop, enters defer: `close(donec)` then `wg.Wait()`, waiting for all in-flight `serve()` goroutines.
  3. A `serve()` goroutine is stuck in a matcher's blocking read, holding the WaitGroup.
  4. `wg.Wait()` blocks, `Serve()` never returns, the "serve-mux" stopper task never completes, `Stopper.Quiesce()` hangs, and the test times out.

Each cmux matcher receives a "sniffer" (`bufferedReader`) that replays all bytes read by prior matchers before reading new bytes from the wire. So when the DRPC matcher runs, it first replays bytes the pgwire matcher already consumed, then attempts to read more from the connection. For any real protocol client that sends enough data (pgwire startup >= 8 bytes, gRPC HTTP/2 preface = 24 bytes, DRPC header = 8 bytes), the matcher resolves instantly. However, silent connections (health probes, port scanners, or connections where the client hasn't written yet) cause a blocking matcher to hang indefinitely.

The timeout affects all protocols going through this cmux, not just DRPC. Since matchers run sequentially, a gRPC connection from a client that delays sending its HTTP/2 preface would also block in the DRPC matcher waiting for 8 bytes, never reaching the gRPC catch-all matcher. Similarly for DRPC itself: `drpcmigrate.HeaderConn` sends the "DRPC!!!1" header lazily on the first Write (not on connect), so there's a brief window between TCP connect and the first RPC call where the server-side matcher is waiting for data. In TLS mode (production), this window is closed by the TLS handshake which triggers the header write. In insecure mode (tests), the window exists but is negligible since the dial and first RPC happen back-to-back.

Fix by using `cmux.NewWithTimeout` with a 30-second timeout, matching the pattern already used for the HTTP cmux (`server_http.go`). The timeout sets a read deadline on the connection before matching. Once a protocol is matched, the deadline is cleared. 30 seconds is well beyond what any legitimate client needs for the initial protocol handshake.

Fixes: #167501
Epic: none
Release note: None