### PR TITLE
vecindex: improve EXPLAIN ANALYZE stats for vector search

### DIFF
--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -40,6 +40,10 @@ type vectorSearchProcessor struct {
 	targetCount uint64
 
 	pkDecoder vecstore.PKDecoder
+
+	contentionEventsListener  execstats.ContentionEventsListener
+	scanStatsListener         execstats.ScanStatsListener
+	tenantConsumptionListener execstats.TenantConsumptionListener
 }
 
 var _ execinfra.RowSourcedProcessor = &vectorSearchProcessor{}
@@ -96,6 +100,9 @@ func newVectorSearchProcessor(
 	}
 
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
+		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+			v.contentionEventsListener.Init(flowTxn.ID())
+		}
 		v.ExecStatsForTrace = v.execStatsForTrace
 	}
 
@@ -104,7 +111,10 @@ func newVectorSearchProcessor(
 
 // Start is part of the RowSource interface.
 func (v *vectorSearchProcessor) Start(ctx context.Context) {
-	v.StartInternal(ctx, "vector search")
+	v.StartInternal(
+		ctx, "vector search", &v.contentionEventsListener,
+		&v.scanStatsListener, &v.tenantConsumptionListener,
+	)
 }
 
 // Next is part of the RowSource interface.
@@ -178,16 +188,23 @@ func (v *vectorSearchProcessor) Child(nth int, verbose bool) execopnode.OpNode {
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (v *vectorSearchProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	kvStats := v.searcher.KVStats()
-	return &execinfrapb.ComponentStats{
+	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BatchRequestsIssued: optional.MakeUint(uint64(kvStats.BatchRequestsIssued)),
 			BytesRead:           optional.MakeUint(uint64(kvStats.KVBytesRead)),
 			KVPairsRead:         optional.MakeUint(uint64(kvStats.KVPairsRead)),
 			KVTime:              optional.MakeTimeValue(kvStats.KVTime),
 			KVCPUTime:           optional.MakeTimeValue(time.Duration(kvStats.KVCPUTime)),
+			ContentionTime:      optional.MakeTimeValue(v.contentionEventsListener.GetContentionTime()),
+			LockWaitTime:        optional.MakeTimeValue(v.contentionEventsListener.GetLockWaitTime()),
+			LatchWaitTime:       optional.MakeTimeValue(v.contentionEventsListener.GetLatchWaitTime()),
 		},
 		Output: v.OutputHelper.Stats(),
 	}
+	ret.Exec.ConsumedRU = optional.MakeUint(v.tenantConsumptionListener.GetConsumedRU())
+	scanStats := v.scanStatsListener.GetScanStats()
+	execstats.PopulateKVMVCCStats(&ret.KV, &scanStats)
+	return ret
 }
 
 // generateMeta produces trailing metadata containing accumulated KV metrics
@@ -227,6 +244,10 @@ type vectorMutationSearchProcessor struct {
 
 	searcher   vecindex.MutationSearcher
 	isIndexPut bool
+
+	contentionEventsListener  execstats.ContentionEventsListener
+	scanStatsListener         execstats.ScanStatsListener
+	tenantConsumptionListener execstats.TenantConsumptionListener
 }
 
 var _ execinfra.RowSourcedProcessor = &vectorMutationSearchProcessor{}
@@ -287,6 +308,9 @@ func newVectorMutationSearchProcessor(
 	}
 
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
+		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+			v.contentionEventsListener.Init(flowTxn.ID())
+		}
 		v.ExecStatsForTrace = v.execStatsForTrace
 	}
 
@@ -295,7 +319,10 @@ func newVectorMutationSearchProcessor(
 
 // Start is part of the RowSource interface.
 func (v *vectorMutationSearchProcessor) Start(ctx context.Context) {
-	ctx = v.StartInternal(ctx, "vector mutation search")
+	ctx = v.StartInternal(
+		ctx, "vector mutation search", &v.contentionEventsListener,
+		&v.scanStatsListener, &v.tenantConsumptionListener,
+	)
 	v.input.Start(ctx)
 }
 
@@ -443,15 +470,22 @@ func (v *vectorMutationSearchProcessor) Child(nth int, verbose bool) execopnode.
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (v *vectorMutationSearchProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	kvStats := v.searcher.KVStats()
-	return &execinfrapb.ComponentStats{
+	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BatchRequestsIssued: optional.MakeUint(uint64(kvStats.BatchRequestsIssued)),
 			BytesRead:           optional.MakeUint(uint64(kvStats.KVBytesRead)),
 			KVPairsRead:         optional.MakeUint(uint64(kvStats.KVPairsRead)),
 			KVTime:              optional.MakeTimeValue(kvStats.KVTime),
 			KVCPUTime:           optional.MakeTimeValue(time.Duration(kvStats.KVCPUTime)),
+			ContentionTime:      optional.MakeTimeValue(v.contentionEventsListener.GetContentionTime()),
+			LockWaitTime:        optional.MakeTimeValue(v.contentionEventsListener.GetLockWaitTime()),
+			LatchWaitTime:       optional.MakeTimeValue(v.contentionEventsListener.GetLatchWaitTime()),
 		},
 	}
+	ret.Exec.ConsumedRU = optional.MakeUint(v.tenantConsumptionListener.GetConsumedRU())
+	scanStats := v.scanStatsListener.GetScanStats()
+	execstats.PopulateKVMVCCStats(&ret.KV, &scanStats)
+	return ret
 }
 
 // generateMeta produces trailing metadata with KV metrics.

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -7,6 +7,7 @@ package rowexec
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -15,12 +16,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
+	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/errors"
 )
@@ -78,10 +81,24 @@ func newVectorSearchProcessor(
 		flowCtx,
 		processorID,
 		nil, /* memMonitor */
-		execinfra.ProcStateOpts{},
+		execinfra.ProcStateOpts{
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				// We need to generate metadata before closing the processor
+				// because InternalClose() updates v.Ctx to the "original"
+				// context.
+				trailingMeta := v.generateMeta()
+				v.InternalClose()
+				return trailingMeta
+			},
+		},
 	); err != nil {
 		return nil, err
 	}
+
+	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
+		v.ExecStatsForTrace = v.execStatsForTrace
+	}
+
 	return &v, nil
 }
 
@@ -158,6 +175,44 @@ func (v *vectorSearchProcessor) Child(nth int, verbose bool) execopnode.OpNode {
 	panic(errors.AssertionFailedf("invalid index %d", nth))
 }
 
+// execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
+func (v *vectorSearchProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
+	kvStats := v.searcher.KVStats()
+	return &execinfrapb.ComponentStats{
+		KV: execinfrapb.KVStats{
+			BatchRequestsIssued: optional.MakeUint(uint64(kvStats.BatchRequestsIssued)),
+			BytesRead:           optional.MakeUint(uint64(kvStats.KVBytesRead)),
+			KVPairsRead:         optional.MakeUint(uint64(kvStats.KVPairsRead)),
+			KVTime:              optional.MakeTimeValue(kvStats.KVTime),
+			KVCPUTime:           optional.MakeTimeValue(time.Duration(kvStats.KVCPUTime)),
+		},
+		Output: v.OutputHelper.Stats(),
+	}
+}
+
+// generateMeta produces trailing metadata containing accumulated KV metrics
+// and, if applicable, the leaf transaction's final state.
+func (v *vectorSearchProcessor) generateMeta() []execinfrapb.ProducerMetadata {
+	kvStats := v.searcher.KVStats()
+
+	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
+	meta := &trailingMeta[0]
+
+	meta.Metrics = execinfrapb.GetMetricsMeta()
+	meta.Metrics.KVCPUTime = kvStats.KVCPUTime
+	meta.Metrics.BytesRead = kvStats.KVBytesRead
+
+	// Currently, vector search is not distributed, but when distribution
+	// support is added, the processor will run on remote nodes using a
+	// LeafTxn. This propagates the leaf's final state back to the RootTxn
+	// on the gateway for transaction correctness.
+	if tfs := execinfra.GetLeafTxnFinalState(v.Ctx(), v.FlowCtx.Txn); tfs != nil {
+		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
+	}
+
+	return trailingMeta
+}
+
 type vectorMutationSearchProcessor struct {
 	execinfra.ProcessorBase
 	input      execinfra.RowSource
@@ -218,10 +273,23 @@ func newVectorMutationSearchProcessor(
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{v.input},
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				// We need to generate metadata before closing the processor
+				// because InternalClose() updates v.Ctx to the "original"
+				// context.
+				trailingMeta := v.generateMeta()
+				v.InternalClose()
+				return trailingMeta
+			},
 		},
 	); err != nil {
 		return nil, err
 	}
+
+	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
+		v.ExecStatsForTrace = v.execStatsForTrace
+	}
+
 	return &v, nil
 }
 
@@ -370,6 +438,42 @@ func (v *vectorMutationSearchProcessor) Child(nth int, verbose bool) execopnode.
 		panic("input to vector mutation search is not an execopnode.OpNode")
 	}
 	panic(errors.AssertionFailedf("invalid index %d", nth))
+}
+
+// execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
+func (v *vectorMutationSearchProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
+	kvStats := v.searcher.KVStats()
+	return &execinfrapb.ComponentStats{
+		KV: execinfrapb.KVStats{
+			BatchRequestsIssued: optional.MakeUint(uint64(kvStats.BatchRequestsIssued)),
+			BytesRead:           optional.MakeUint(uint64(kvStats.KVBytesRead)),
+			KVPairsRead:         optional.MakeUint(uint64(kvStats.KVPairsRead)),
+			KVTime:              optional.MakeTimeValue(kvStats.KVTime),
+			KVCPUTime:           optional.MakeTimeValue(time.Duration(kvStats.KVCPUTime)),
+		},
+	}
+}
+
+// generateMeta produces trailing metadata with KV metrics.
+func (v *vectorMutationSearchProcessor) generateMeta() []execinfrapb.ProducerMetadata {
+	kvStats := v.searcher.KVStats()
+
+	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
+	meta := &trailingMeta[0]
+
+	meta.Metrics = execinfrapb.GetMetricsMeta()
+	meta.Metrics.KVCPUTime = kvStats.KVCPUTime
+	meta.Metrics.BytesRead = kvStats.KVBytesRead
+
+	// Currently, vector mutation search is not distributed, but when
+	// distribution support is added, the processor will run on remote
+	// nodes using a LeafTxn. This propagates the leaf's final state back
+	// to the RootTxn on the gateway for transaction correctness.
+	if tfs := execinfra.GetLeafTxnFinalState(v.Ctx(), v.FlowCtx.Txn); tfs != nil {
+		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
+	}
+
+	return trailingMeta
 }
 
 func getVectorIndexForSearch(

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -801,6 +801,8 @@ func (vi *Index) searchForUpdateHelper(
 	// so it will not reflect the effects of this operation. That's OK, since it's
 	// not necessary to split at exactly the point where the partition becomes
 	// oversized.
+	// NB: This runs on the Store (not the Txn), so its KV cost is not
+	// reflected in the processor's KVStats.
 	partitionKey := result.ChildKey.PartitionKey
 	count, err := vi.store.EstimatePartitionCount(ctx, idxCtx.treeKey, partitionKey)
 	if err != nil {

--- a/pkg/sql/vecindex/mutation_searcher.go
+++ b/pkg/sql/vecindex/mutation_searcher.go
@@ -50,8 +50,15 @@ func (s *MutationSearcher) Init(
 ) {
 	s.idx = idx
 	s.txn.Init(evalCtx, idx.Store().(*vecstore.Store), txn, getFullVectorsFetchSpec)
+	s.txn.EnableKVStats()
 	s.idxCtx.Init(&s.txn)
 	s.evalCtx = evalCtx
+}
+
+// KVStats returns a snapshot of the cumulative KV statistics collected during
+// mutation search operations.
+func (s *MutationSearcher) KVStats() vecstore.KVStats {
+	return s.txn.KVStats()
 }
 
 // SearchForInsert triggers a search for the partition in which to insert the

--- a/pkg/sql/vecindex/searcher.go
+++ b/pkg/sql/vecindex/searcher.go
@@ -51,6 +51,7 @@ func (s *Searcher) Init(
 ) {
 	s.idx = idx
 	s.txn.Init(evalCtx, idx.Store().(*vecstore.Store), txn, fullVecFetchSpec)
+	s.txn.EnableKVStats()
 	s.idxCtx.Init(&s.txn)
 	s.evalCtx = evalCtx
 
@@ -78,6 +79,12 @@ func (s *Searcher) Search(ctx context.Context, prefix roachpb.Key, vec vector.T)
 	s.results = s.searchSet.PopResults()
 	s.resultIdx = 0
 	return nil
+}
+
+// KVStats returns a snapshot of the cumulative KV statistics collected during
+// search operations.
+func (s *Searcher) KVStats() vecstore.KVStats {
+	return s.txn.KVStats()
 }
 
 // NextResult iterates over search results. It returns nil when there are no

--- a/pkg/sql/vecindex/vecindex_test.go
+++ b/pkg/sql/vecindex/vecindex_test.go
@@ -465,6 +465,10 @@ func TestVecSearchKVStats(t *testing.T) {
 	require.Regexp(t, `KV pairs read: [1-9]`, vsSection)
 	require.Regexp(t, `KV bytes read: [1-9]`, vsSection)
 	require.Regexp(t, `KV gRPC calls: [1-9]`, vsSection)
+
+	// Verify that MVCC scan stats from the ScanStatsListener are present.
+	require.Regexp(t, `MVCC step count \(ext/int\): \d+/\d+`, vsSection)
+	require.Regexp(t, `MVCC seek count \(ext/int\): \d+/\d+`, vsSection)
 }
 
 // TestVecMutationSearchKVStats verifies that KV statistics are reported in
@@ -529,6 +533,8 @@ func TestVecMutationSearchKVStats(t *testing.T) {
 	require.Regexp(t, `KV pairs read: [1-9]`, insertSection)
 	require.Regexp(t, `KV bytes read: [1-9]`, insertSection)
 	require.Regexp(t, `KV gRPC calls: [1-9]`, insertSection)
+	require.Regexp(t, `MVCC step count \(ext/int\): \d+/\d+`, insertSection)
+	require.Regexp(t, `MVCC seek count \(ext/int\): \d+/\d+`, insertSection)
 
 	// Verify UPDATE mutation search has KV stats. UPDATE produces two
 	// vector mutation search nodes (del + put). extractSection captures
@@ -541,6 +547,8 @@ func TestVecMutationSearchKVStats(t *testing.T) {
 	require.Regexp(t, `KV pairs read: [1-9]`, updateSection)
 	require.Regexp(t, `KV bytes read: [1-9]`, updateSection)
 	require.Regexp(t, `KV gRPC calls: [1-9]`, updateSection)
+	require.Regexp(t, `MVCC step count \(ext/int\): \d+/\d+`, updateSection)
+	require.Regexp(t, `MVCC seek count \(ext/int\): \d+/\d+`, updateSection)
 
 	// Verify DELETE mutation search has KV stats.
 	deleteRows := runner.QueryStr(t,
@@ -551,6 +559,8 @@ func TestVecMutationSearchKVStats(t *testing.T) {
 	require.Regexp(t, `KV pairs read: [1-9]`, deleteSection)
 	require.Regexp(t, `KV bytes read: [1-9]`, deleteSection)
 	require.Regexp(t, `KV gRPC calls: [1-9]`, deleteSection)
+	require.Regexp(t, `MVCC step count \(ext/int\): \d+/\d+`, deleteSection)
+	require.Regexp(t, `MVCC seek count \(ext/int\): \d+/\d+`, deleteSection)
 }
 
 // TestVecIndexDeletion tests that rows can be properly deleted from a vector index.

--- a/pkg/sql/vecindex/vecindex_test.go
+++ b/pkg/sql/vecindex/vecindex_test.go
@@ -410,6 +410,149 @@ func insertVectors(t *testing.T, runner *sqlutils.SQLRunner, startId int, vector
 	runner.Exec(t, query, args...)
 }
 
+// TestVecSearchKVStats verifies that KV statistics (gRPC calls, bytes read,
+// pairs read, KV time) are reported in EXPLAIN ANALYZE output for vector
+// search operations.
+// See https://github.com/cockroachdb/cockroach/issues/146695.
+func TestVecSearchKVStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	defer srv.Stopper().Stop(ctx)
+
+	runner.Exec(t, `CREATE TABLE t (
+		id INT PRIMARY KEY,
+		vec VECTOR(2),
+		VECTOR INDEX idx (vec) WITH (min_partition_size=1, max_partition_size=5),
+		FAMILY (id, vec)
+	)`)
+
+	runner.Exec(t, `INSERT INTO t (id, vec) VALUES
+		(1, '[1, 2]'),
+		(2, '[7, 4]'),
+		(3, '[4, 3]'),
+		(4, '[8, 11]'),
+		(5, '[14, 1]'),
+		(6, '[0, 0]'),
+		(7, '[0, 4]'),
+		(8, '[-2, 8]'),
+		(9, '[5, 6]')`)
+
+	rows := runner.QueryStr(t,
+		`EXPLAIN ANALYZE (VERBOSE) SELECT id, vec FROM t@idx ORDER BY vec <-> '[3, 3]' LIMIT 5`)
+
+	// Extract the vector search section from the plan output.
+	var inVectorSearch bool
+	var vectorSearchOutput strings.Builder
+	for _, row := range rows {
+		line := row[0]
+		if strings.Contains(line, "• vector search") {
+			inVectorSearch = true
+		}
+		if inVectorSearch {
+			vectorSearchOutput.WriteString(line)
+			vectorSearchOutput.WriteString("\n")
+		}
+	}
+	vsSection := vectorSearchOutput.String()
+	require.NotEmpty(t, vsSection, "vector search section not found in plan")
+
+	// Verify that the vector search node reports KV stats with non-zero values.
+	require.Regexp(t, `KV time: [1-9]`, vsSection)
+	require.Regexp(t, `KV pairs read: [1-9]`, vsSection)
+	require.Regexp(t, `KV bytes read: [1-9]`, vsSection)
+	require.Regexp(t, `KV gRPC calls: [1-9]`, vsSection)
+}
+
+// TestVecMutationSearchKVStats verifies that KV statistics are reported in
+// EXPLAIN ANALYZE output for vector mutation search operations (INSERT, UPDATE,
+// DELETE). See https://github.com/cockroachdb/cockroach/issues/146695.
+func TestVecMutationSearchKVStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	defer srv.Stopper().Stop(ctx)
+
+	runner.Exec(t, `CREATE TABLE t (
+		id INT PRIMARY KEY,
+		vec VECTOR(2),
+		VECTOR INDEX idx (vec) WITH (min_partition_size=1, max_partition_size=5),
+		FAMILY (id, vec)
+	)`)
+
+	runner.Exec(t, `INSERT INTO t (id, vec) VALUES
+		(1, '[1, 2]'),
+		(2, '[7, 4]'),
+		(3, '[4, 3]'),
+		(4, '[8, 11]'),
+		(5, '[14, 1]'),
+		(6, '[0, 0]'),
+		(7, '[0, 4]'),
+		(8, '[-2, 8]'),
+		(9, '[5, 6]')`)
+
+	// extractSection extracts lines belonging to the first occurrence of
+	// the given node header. It stops when a different node (marked by "•")
+	// is encountered at the same or higher level.
+	extractSection := func(rows [][]string, header string) string {
+		var inSection bool
+		var out strings.Builder
+		for _, row := range rows {
+			line := row[0]
+			if !inSection {
+				if strings.Contains(line, header) {
+					inSection = true
+				}
+			} else if strings.Contains(line, "•") {
+				break
+			}
+			if inSection {
+				out.WriteString(line)
+				out.WriteString("\n")
+			}
+		}
+		return out.String()
+	}
+
+	// Verify INSERT mutation search has KV stats.
+	insertRows := runner.QueryStr(t,
+		`EXPLAIN ANALYZE (VERBOSE) INSERT INTO t (id, vec) VALUES (10, '[3, 3]')`)
+	insertSection := extractSection(insertRows, "• vector mutation search")
+	require.NotEmpty(t, insertSection, "vector mutation search section not found")
+	require.Regexp(t, `KV time: [1-9]`, insertSection)
+	require.Regexp(t, `KV pairs read: [1-9]`, insertSection)
+	require.Regexp(t, `KV bytes read: [1-9]`, insertSection)
+	require.Regexp(t, `KV gRPC calls: [1-9]`, insertSection)
+
+	// Verify UPDATE mutation search has KV stats. UPDATE produces two
+	// vector mutation search nodes (del + put). extractSection captures
+	// from the first occurrence to the end, which covers both nodes.
+	updateRows := runner.QueryStr(t,
+		`EXPLAIN ANALYZE (VERBOSE) UPDATE t SET vec = '[9, 9]' WHERE id = 1`)
+	updateSection := extractSection(updateRows, "• vector mutation search")
+	require.NotEmpty(t, updateSection, "vector mutation search section not found")
+	require.Regexp(t, `KV time: [1-9]`, updateSection)
+	require.Regexp(t, `KV pairs read: [1-9]`, updateSection)
+	require.Regexp(t, `KV bytes read: [1-9]`, updateSection)
+	require.Regexp(t, `KV gRPC calls: [1-9]`, updateSection)
+
+	// Verify DELETE mutation search has KV stats.
+	deleteRows := runner.QueryStr(t,
+		`EXPLAIN ANALYZE (VERBOSE) DELETE FROM t WHERE id = 9`)
+	deleteSection := extractSection(deleteRows, "• vector mutation search")
+	require.NotEmpty(t, deleteSection, "vector mutation search section not found")
+	require.Regexp(t, `KV time: [1-9]`, deleteSection)
+	require.Regexp(t, `KV pairs read: [1-9]`, deleteSection)
+	require.Regexp(t, `KV bytes read: [1-9]`, deleteSection)
+	require.Regexp(t, `KV gRPC calls: [1-9]`, deleteSection)
+}
+
 // TestVecIndexDeletion tests that rows can be properly deleted from a vector index.
 func TestVecIndexDeletion(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/intsets",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "//pkg/util/unique",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -7,6 +7,7 @@ package vecstore
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -28,9 +29,27 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/errors"
 )
+
+// KVStats tracks cumulative KV-layer statistics for vector index operations.
+// It is populated by Txn during batch execution and read after the operation
+// completes. It is not thread-safe.
+type KVStats struct {
+	// BatchRequestsIssued is the number of KV batch requests executed.
+	BatchRequestsIssued int64
+	// KVBytesRead is the total number of bytes read from KV.
+	KVBytesRead int64
+	// KVPairsRead is the total number of KV pairs read.
+	KVPairsRead int64
+	// KVTime is the wall-clock time spent in KV batch execution.
+	KVTime time.Duration
+	// KVCPUTime is the CPU time reported by KV, in nanoseconds. This uses
+	// int64 (not time.Duration) to match the BatchResponse.CPUTime field.
+	KVCPUTime int64
+}
 
 // Txn provides a context to make transactional changes to a vector index.
 // Calling methods here will use the wrapped KV Txn to update the vector index's
@@ -50,6 +69,12 @@ type Txn struct {
 	// fullVecFetchSpec is used to fetch vectors from the primary index.
 	fullVecFetchSpec *vecstorepb.GetFullVectorsFetchSpec
 	pkDecoder        PKDecoder
+
+	// kvStats accumulates KV statistics during batch execution.
+	kvStats KVStats
+
+	// collectKVStats indicates whether KV statistics should be collected.
+	collectKVStats bool
 
 	// Retained allocations to prevent excessive reallocation.
 	tmpSpans   []roachpb.Span
@@ -86,6 +111,19 @@ func (tx *Txn) Init(
 	} else {
 		tx.lockDurability = kvpb.GuaranteedDurability
 	}
+}
+
+// EnableKVStats enables collection of KV statistics during batch execution.
+// Statistics can be retrieved via the KVStats method.
+func (tx *Txn) EnableKVStats() {
+	tx.collectKVStats = true
+	tx.kvStats = KVStats{}
+}
+
+// KVStats returns a snapshot of the cumulative KV statistics collected during
+// batch execution.
+func (tx *Txn) KVStats() KVStats {
+	return tx.kvStats
 }
 
 // GetPartitionMetadata implements the cspann.Txn interface.
@@ -131,7 +169,7 @@ func (tx *Txn) GetPartitionMetadata(
 		}
 
 		// Run the batch.
-		if err := tx.kv.Run(ctx, b); err != nil {
+		if err := tx.runAndRecordStats(ctx, b); err != nil {
 			return nil, errors.Wrapf(err, "getting partition metadata for %d", partitionKey)
 		}
 
@@ -177,7 +215,7 @@ func (tx *Txn) AddToPartition(
 	// key in order to prevent splits/merges from interfering.
 	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
 	b.GetForShare(metadataKey, tx.lockDurability)
-	err := tx.kv.Run(ctx, b)
+	err := tx.runAndRecordStats(ctx, b)
 	if err != nil {
 		return errors.Wrapf(err, "locking partition %d for add", partitionKey)
 	}
@@ -214,7 +252,7 @@ func (tx *Txn) AddToPartition(
 	b.Put(entryKey, encodedValue)
 
 	// Run the batch.
-	if err = tx.kv.Run(ctx, b); err != nil {
+	if err = tx.runAndRecordStats(ctx, b); err != nil {
 		return errors.Wrapf(err, "adding vector to partition %d", partitionKey)
 	}
 	return nil
@@ -240,7 +278,7 @@ func (tx *Txn) RemoveFromPartition(
 	// Get partition metadata, needed to quantize the vector. Lock the metadata
 	// key in order to prevent splits/merges from interfering.
 	b.GetForShare(metadataKey, tx.lockDurability)
-	if err := tx.kv.Run(ctx, b); err != nil {
+	if err := tx.runAndRecordStats(ctx, b); err != nil {
 		return errors.Wrapf(err, "locking partition %d for add", partitionKey)
 	}
 
@@ -253,7 +291,7 @@ func (tx *Txn) RemoveFromPartition(
 	entryKey := vecencoding.EncodePrefixVectorKey(metadataKey, level)
 	entryKey = vecencoding.EncodeChildKey(entryKey, childKey)
 	b.Del(entryKey)
-	if err := tx.kv.Run(ctx, b); err != nil {
+	if err := tx.runAndRecordStats(ctx, b); err != nil {
 		return err
 	}
 	// We ignore key not found for the deleted child.
@@ -289,7 +327,7 @@ func (tx *Txn) SearchPartitions(
 		}
 	}
 
-	if err := tx.kv.Run(ctx, b); err != nil {
+	if err := tx.runAndRecordStats(ctx, b); err != nil {
 		return err
 	}
 
@@ -538,6 +576,7 @@ func (tx *Txn) getFullVectorsFromPK(
 	})
 	defer fetcher.Close(ctx)
 
+	start := timeutil.Now()
 	err = fetcher.StartScan(
 		ctx,
 		tx.tmpSpans,
@@ -564,6 +603,18 @@ func (tx *Txn) getFullVectorsFromPK(
 		}
 	}
 
+	// Unlike other methods that use runAndRecordStats to wrap tx.kv.Run(),
+	// this method uses a row.Fetcher which manages its own KV batches
+	// internally. Read the fetcher's accumulated stats after the scan
+	// completes.
+	if tx.collectKVStats {
+		tx.kvStats.KVTime += timeutil.Since(start)
+		tx.kvStats.BatchRequestsIssued += fetcher.GetBatchRequestsIssued()
+		tx.kvStats.KVBytesRead += fetcher.GetBytesRead()
+		tx.kvStats.KVPairsRead += fetcher.GetKVPairsRead()
+		tx.kvStats.KVCPUTime += fetcher.GetKVCPUTime()
+	}
+
 	return err
 }
 
@@ -586,7 +637,7 @@ func (tx *Txn) getFullVectorsFromPartitionMetadata(
 		b.Get(metadataKey)
 	}
 
-	if err := tx.kv.Run(ctx, b); err != nil {
+	if err := tx.runAndRecordStats(ctx, b); err != nil {
 		return errors.Wrapf(err, "fetching partition metadata for GetFullVectors")
 	}
 
@@ -647,7 +698,7 @@ func (tx *Txn) createRootPartition(
 	// the root partition. CPut always "sees" the latest version of the metadata
 	// record.
 	b.CPut(metadataKey, encoded, nil /* expValue */)
-	if err := tx.kv.Run(ctx, b); err != nil {
+	if err := tx.runAndRecordStats(ctx, b); err != nil {
 		return cspann.PartitionMetadata{}, errors.Wrapf(err, "creating root partition metadata")
 	}
 	return metadata, nil
@@ -661,4 +712,30 @@ func (tx *Txn) QuantizeAndEncode(
 ) (quantized []byte, err error) {
 	// Quantize and encode the randomized vector.
 	return tx.codec.EncodeVector(partitionKey, randomizedVec, centroid)
+}
+
+// runAndRecordStats runs the given KV batch and, if stats collection is
+// enabled, accumulates timing and I/O statistics from the response.
+func (tx *Txn) runAndRecordStats(ctx context.Context, b *kv.Batch) error {
+	if !tx.collectKVStats {
+		return tx.kv.Run(ctx, b)
+	}
+
+	start := timeutil.Now()
+	if err := tx.kv.Run(ctx, b); err != nil {
+		return err
+	}
+
+	tx.kvStats.KVTime += timeutil.Since(start)
+	tx.kvStats.BatchRequestsIssued++
+
+	resp := b.RawResponse()
+	tx.kvStats.KVCPUTime += resp.CPUTime
+	for _, ru := range resp.Responses {
+		header := ru.GetInner().Header()
+		tx.kvStats.KVBytesRead += header.NumBytes
+		tx.kvStats.KVPairsRead += header.NumKeys
+	}
+
+	return nil
 }


### PR DESCRIPTION
Improve EXPLAIN ANALYZE observability for vector index operations
by adding KV stats and trace listeners to both vectorSearchProcessor
and vectorMutationSearchProcessor.

The first commit adds core KV stats and moves KVStats from cspann
to vecstore; the second adds trace listeners for contention, MVCC
scan stats, and tenant RU consumption.

Fixes: #146695
Epic: none