### PR TITLE
workload: add sequence deps to triggers and drop checks

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -149,6 +149,27 @@ func (og *operationGenerator) tableHasDependencies(
 	return og.scanBool(ctx, tx, q, tableName.Object(), tableName.Schema(), skipSelfRef)
 }
 
+// sequenceHasDependencies reports whether the given sequence has any schema
+// dependencies (e.g., column defaults, views, or trigger functions that
+// reference the sequence via nextval).
+func (og *operationGenerator) sequenceHasDependencies(
+	ctx context.Context, tx pgx.Tx, seqName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `
+	SELECT EXISTS(
+		SELECT fd.descriptor_name
+		  FROM crdb_internal.forward_dependencies AS fd
+		 WHERE fd.descriptor_id
+		       = (
+		            SELECT c.oid
+		              FROM pg_catalog.pg_class AS c
+		              JOIN pg_catalog.pg_namespace AS ns ON
+		                    ns.oid = c.relnamespace
+		             WHERE c.relname = $1 AND ns.nspname = $2
+		        )
+	)`, seqName.Object(), seqName.Schema())
+}
+
 func (og *operationGenerator) columnIsDependedOn(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name, includeFKs bool,
 ) (bool, error) {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2125,20 +2125,29 @@ func (og *operationGenerator) dropSequence(ctx context.Context, tx pgx.Tx) (*opS
 	if err != nil {
 		return nil, err
 	}
-	ifExists := og.randIntn(2) == 0
-	dropSeq := &tree.DropSequence{
-		Names:    tree.TableNames{*sequenceName},
-		IfExists: ifExists,
-	}
-
-	stmt := makeOpStmt(OpStmtDDL)
 	sequenceExists, err := og.sequenceExists(ctx, tx, sequenceName)
 	if err != nil {
 		return nil, err
 	}
-	if !sequenceExists && !ifExists {
-		stmt.expectedExecErrors.add(pgcode.UndefinedTable)
+	seqHasDependencies, err := og.sequenceHasDependencies(ctx, tx, sequenceName)
+	if err != nil {
+		return nil, err
 	}
+
+	dropBehavior := tree.DropBehavior(og.randIntn(3))
+
+	ifExists := og.randIntn(2) == 0
+	dropSeq := &tree.DropSequence{
+		Names:        tree.TableNames{*sequenceName},
+		IfExists:     ifExists,
+		DropBehavior: dropBehavior,
+	}
+
+	stmt := makeOpStmt(OpStmtDDL)
+	stmt.expectedExecErrors.addAll(codesWithConditions{
+		{pgcode.UndefinedTable, !ifExists && !sequenceExists},
+		{pgcode.DependentObjectsStillExist, dropBehavior != tree.DropCascade && seqHasDependencies},
+	})
 	stmt.sql = tree.Serialize(dropSeq)
 	return stmt, nil
 }
@@ -5657,11 +5666,26 @@ func (og *operationGenerator) createTriggerFunction(
 		return nil, err
 	}
 
+	// Sometimes include a sequence reference to exercise trigger-sequence
+	// dependency tracking.
+	seqSelectStmt := ""
+	if og.randIntn(2) == 0 {
+		seqName, err := og.randSequence(ctx, tx, og.alwaysExisting(), "")
+		if err != nil {
+			// No sequences exist — skip the sequence reference.
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return nil, err
+			}
+		} else {
+			seqSelectStmt = fmt.Sprintf("SELECT nextval('%s');", seqName.String())
+		}
+	}
+
 	// The trigger function always returns NEW to avoid breaking inserts.
 	opStmt := makeOpStmt(OpStmtDDL)
 	opStmt.sql = fmt.Sprintf(
-		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
-		resolvedName, selectStmt.sql,
+		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
+		resolvedName, seqSelectStmt, selectStmt.sql,
 	)
 	og.LogMessage(fmt.Sprintf("createTriggerFunction: %s", opStmt.sql))
 


### PR DESCRIPTION
Address gaps 3 and 9 from https://github.com/cockroachdb/cockroach/issues/167410:

- Gap 3: `createTriggerFunction` now sometimes embeds a `SELECT nextval('seq')` call in the trigger function body,
  exercising trigger-to-sequence dependency tracking.
- Gap 9: `dropSequence` now checks for dependent objects via a new `sequenceHasDependencies` helper and randomizes `DropBehavior`, mirroring the existing `dropTable`/`dropView` pattern. This ensures `DependentObjectsStillExist` errors are properly expected.

Epic: [CRDB-48029](https://cockroachlabs.atlassian.net/browse/CRDB-48029)
Informs: https://github.com/cockroachdb/cockroach/issues/167410

Release note: None