### PR TITLE
release-25.2: importer: transfer ownership to SQL Foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,9 +75,9 @@
 /pkg/sql/delegate/*job*.go   @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/sql/vecindex/           @cockroachdb/sql-queries-prs
 
-/pkg/sql/importer/           @cockroachdb/sql-queries-prs
+/pkg/sql/importer/           @cockroachdb/sql-foundations
 /pkg/sql/importer/export*    @cockroachdb/cdc-prs
-/pkg/ccl/importerccl/        @cockroachdb/sql-queries-prs
+/pkg/ccl/importerccl/        @cockroachdb/sql-foundations
 
 /pkg/sql/appstatspb           @cockroachdb/obs-prs
 /pkg/sql/contention/          @cockroachdb/obs-prs
@@ -108,11 +108,15 @@
 /pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations
 
 /pkg/ccl/schemachangerccl/   @cockroachdb/sql-foundations
+/pkg/sql/bulkmerge/          @cockroachdb/sql-foundations
+/pkg/sql/bulksst/            @cockroachdb/sql-foundations
+/pkg/sql/bulkutil/           @cockroachdb/sql-foundations
 /pkg/sql/catalog/            @cockroachdb/sql-foundations
 /pkg/sql/catalog/multiregion @cockroachdb/sql-foundations
 /pkg/sql/doctor/             @cockroachdb/sql-foundations
 /pkg/sql/gcjob/              @cockroachdb/sql-foundations
 /pkg/sql/gcjob_test/         @cockroachdb/sql-foundations
+/pkg/sql/importer/           @cockroachdb/sql-foundations
 /pkg/sql/privilege/          @cockroachdb/sql-foundations
 /pkg/sql/schemachange/       @cockroachdb/sql-foundations
 /pkg/sql/schemachanger/      @cockroachdb/sql-foundations

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -80,7 +80,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "import/nodeShutdown/worker",
-		Owner:   registry.OwnerSQLQueries,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(4),
 		// Uses gs://cockroach-fixtures-us-east1. See:
 		// https://github.com/cockroachdb/cockroach/issues/105968
@@ -98,7 +98,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 	})
 	r.Add(registry.TestSpec{
 		Name:    "import/nodeShutdown/coordinator",
-		Owner:   registry.OwnerSQLQueries,
+		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(4),
 		// Uses gs://cockroach-fixtures-us-east1. See:
 		// https://github.com/cockroachdb/cockroach/issues/105968
@@ -158,7 +158,7 @@ func registerImportTPCC(r registry.Registry) {
 		timeout := 5 * time.Hour
 		r.Add(registry.TestSpec{
 			Name:              testName,
-			Owner:             registry.OwnerSQLQueries,
+			Owner:             registry.OwnerSQLFoundations,
 			Benchmark:         true,
 			Cluster:           r.MakeClusterSpec(numNodes),
 			CompatibleClouds:  registry.AllExceptAWS,
@@ -194,7 +194,7 @@ func registerImportTPCC(r registry.Registry) {
 	testName := fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses)
 	r.Add(registry.TestSpec{
 		Name:              testName,
-		Owner:             registry.OwnerSQLQueries,
+		Owner:             registry.OwnerSQLFoundations,
 		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.GCEZones(geoZones)),
 		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Nightly),
@@ -228,7 +228,7 @@ func registerImportTPCH(r registry.Registry) {
 		item := item
 		r.Add(registry.TestSpec{
 			Name:      fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
-			Owner:     registry.OwnerSQLQueries,
+			Owner:     registry.OwnerSQLFoundations,
 			Benchmark: true,
 			Cluster:   r.MakeClusterSpec(item.nodes),
 			// Uses gs://cockroach-fixtures-us-east1. See:
@@ -357,7 +357,7 @@ func registerImportDecommissioned(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "import/decommissioned",
-		Owner:            registry.OwnerSQLQueries,
+		Owner:            registry.OwnerSQLFoundations,
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
Backport 1/1 commits from #167978.

/cc @cockroachdb/release

---

SQL Foundations is taking ownership of IMPORT, so new issues and PRs should be sent to them.

Epic: None
Release Note: None

Release justification: Administrative change only.
