### PR TITLE
kvserver: deflake TestTenantCtx

### DIFF
--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -418,13 +418,17 @@ func TestTenantCtx(t *testing.T) {
 
 						tenID, isTenantRequest := roachpb.ClientTenantFromContext(ctx)
 						key := ba.Requests[0].GetInner().Header().Key
-						keyRecognized := strings.Contains(key.String(), magicKey)
-						if !keyRecognized {
+
+						// Only match keys in the tenant's keyspace. System table
+						// operations (jobs, schema changes, etc.) can have auto-generated
+						// IDs that coincidentally contain the magic substring, causing
+						// false positives (#167600). This also subsumes the previous
+						// Meta2 prefix check (#158493).
+						tenantPrefix := keys.MakeTenantPrefix(tenantID)
+						if !bytes.HasPrefix(key, tenantPrefix) {
 							return nil
 						}
-
-						// Skip meta2 range lookups as they don't carry tenant context.
-						if bytes.HasPrefix(key, keys.Meta2Prefix) {
+						if !strings.Contains(key.String(), magicKey) {
 							return nil
 						}
 


### PR DESCRIPTION
The TestingRequestFilter in TestTenantCtx matched requests using
`strings.Contains(key.String(), magicKey)`, which is too broad — it
matches any key whose string representation contains the magic
substring "424242". In the CI failure [1], the filter matched system
table key `/Table/15/1/1164642424264654849/0` (the jobs table) because
job ID `1164642424264654849` contains "424242" at position 5. Since
system table operations lack tenant context, the filter reported a
false-positive error ("expected Scan to run as tenant 10, got
isTenantRequest=false"). The first filter match sent the error into the
unbuffered `scanErr` channel, and after the 3s timeout `t.Fatal` was
called — but tx1 was never rolled back, leaving tx2 blocked on tx1's
intent and the stopper unable to shut down, turning a quick test
failure into a 14-minute hang.

Fix the filter to check `bytes.HasPrefix(key, tenantPrefix)` first,
restricting matches to the tenant's keyspace. This eliminates false
positives from system table operations and subsumes the previous Meta2
prefix check (https://github.com/cockroachdb/cockroach/issues/158493).

[1] https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Ci_TestsAwsLinuxArm64_UnitTests/21299834

Fixes: https://github.com/cockroachdb/cockroach/issues/167600
Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>