### PR TITLE
changefeedccl: downgrade grafana shutdown error to warning

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -446,7 +446,7 @@ func (ct *cdcTester) Close() {
 
 	if !ct.t.IsDebug() {
 		if err := ct.cluster.StopGrafana(ct.ctx, ct.logger, ct.t.ArtifactsDir()); err != nil {
-			ct.t.Errorf("error shutting down prometheus/grafana: %s", err)
+			ct.t.L().Printf("WARNING: error shutting down prometheus/grafana: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Previously, a failure to shut down prometheus/grafana in cdcTester.Close would fail the test, even when the actual CDC assertions passed. This caused failures across multiple frontier-persistence-benchmark variants, especially IBM/s390x.

Rather than removing the StopGrafana call entirely, downgrade the error to a warning log. We still attempt shutdown so that the prometheus snapshot gets dumped to the test artifacts directory if possible, but grafana metrics are also available through the centralized grafana instance, so a failed dump is not catastrophic.

Fixes: #167459
Fixes: #168097
Fixes: #168098

Release note: None