### PR TITLE
ui: remove stale pnpm packageExtensions

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -63,240 +63,9 @@
         "[1] https://pnpm.io/npmrc#public-hoist-pattern",
         "[2] https://docs.aspect.build/rules/aspect_rules_js/docs/pnpm/#hoisting"
       ],
-      "rc-align@2.4.5": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-animate@2.11.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-animate@3.1.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-calendar@9.15.11": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-cascader@0.17.5": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-checkbox@2.1.8": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-collapse@1.11.8": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-dialog@7.x": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-drawer@3.1.3": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-dropdown@2.4.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-editor-core@0.8.10": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-editor-mention@1.1.13": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-form@2.4.11": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-hammerjs@0.6.10": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-input-number@4.5.9": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-mentions@0.4.2": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-menu@7.5.5": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-notification@3.3.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-pagination@3.5.0": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-progress@2.5.3": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-rate@2.5.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-resize-observer@0.1.3": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-select@9.2.3": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-slider@8.7.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-steps@3.5.0": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-switch@1.9.2": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-table@6.x": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-tabs@9.x": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-time-picker@3.7.3": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-tooltip@3.7.3": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-tree-select@2.9.4": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-tree@2.1.4": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-trigger@2.6.5": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-trigger@3.0.0": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-upload@2.9.4": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rc-util@4.21.1": {
-        "peerDependencies": {
-          "react": "16.12.0",
-          "react-dom": "16.12.0"
-        }
-      },
-      "rmc-feedback@2.0.0": {
-        "peerDependencies": {
-          "react": "16.x",
-          "react-dom": "16.x"
-        }
-      },
-      "// more phantom deps": [
-        "Likewise, a few other packages have 'phantom' dependencies."
-      ],
       "@storybook/builder-webpack4@6.3.1": {
         "devDependencies": {
           "react-dom": "16.12.0"
-        }
-      },
-      "antd@3.x": {
-        "peerDependencies": {
-          "@babel/runtime": "7.x",
-          "identity-obj-proxy": "3.x"
         }
       },
       "create-react-class@15.7.0": {
@@ -305,25 +74,10 @@
           "react-dom": "16.x"
         }
       },
-      "jest-environment-enzyme@7.1.2": {
-        "peerDependencies": {
-          "enzyme-adapter-react-16": "1.x"
-        }
-      },
-      "mini-store@2.0.0": {
-        "peerDependencies": {
-          "react": "16.x"
-        }
-      },
       "redux-saga-test-plan@4.0.0-beta.2": {
         "peerDependencies": {
           "@redux-saga/is": "1.x",
           "@redux-saga/symbols": "1.x"
-        }
-      },
-      "stylus-loader@3.0.2": {
-        "peerDependencies": {
-          "webpack": "*"
         }
       },
       "// babel transformations": [
@@ -331,22 +85,12 @@
         "require('@babel/runtime') appearing in transpiled source. This is",
         "technically a 'phantom' dependency as well, and must be declared here."
       ],
-      "jest-enzyme@7.1.2": {
-        "peerDependencies": {
-          "@babel/runtime": "7.x"
-        }
-      },
       "jest-runner@27.5.1": {
         "peerDependencies": {
           "@babel/runtime": "7.x"
         }
       },
       "jest-environment-jsdom@27.5.1": {
-        "peerDependencies": {
-          "@babel/runtime": "7.x"
-        }
-      },
-      "enzyme-matchers@7.1.2": {
         "peerDependencies": {
           "@babel/runtime": "7.x"
         }

--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   nwsapi: 2.2.0
   '@cockroachlabs/cluster-ui>yargs-parser': 13.1.2
 
-packageExtensionsChecksum: f03a6ac29a2e646ae57bda3f9fc03971
+packageExtensionsChecksum: c19bfd9e62063e43a4e883559d341e91
 
 patchedDependencies:
   topojson@3.0.2:
@@ -140,7 +140,7 @@ importers:
         version: 4.6.15(dayjs@1.11.19)(luxon@3.5.0)(moment@2.29.4)(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
       rc-progress:
         specifier: 2.5.3
-        version: 2.5.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
+        version: 2.5.3
       react:
         specifier: 16.12.0
         version: 16.12.0
@@ -625,7 +625,7 @@ importers:
         version: 3.5.0(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
       rc-progress:
         specifier: ^2.2.1
-        version: 2.5.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
+        version: 2.5.3
       react:
         specifier: 16.12.0
         version: 16.12.0
@@ -9345,9 +9345,6 @@ packages:
 
   rc-align@2.4.5:
     resolution: {integrity: sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==}
-    peerDependencies:
-      react: 16.12.0
-      react-dom: 16.12.0
 
   rc-animate@2.11.1:
     resolution: {integrity: sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==}
@@ -9357,9 +9354,6 @@ packages:
 
   rc-calendar@9.15.11:
     resolution: {integrity: sha512-qv0VXfAAnysMWJigxaP6se4bJHvr17D9qsLbi8BOpdgEocsS0RkgY1IUiFaOVYKJDy/EyLC447O02sV/y5YYBg==}
-    peerDependencies:
-      react: 16.12.0
-      react-dom: 16.12.0
 
   rc-cascader@3.27.1:
     resolution: {integrity: sha512-VLdilQWBEZ0niK6MYEQzkY8ciGADEn8FFVtM0w0I1VBKit1kI9G7Z46E22CVudakHe+JaV8SSlQ6Tav2R2KaUg==}
@@ -9414,8 +9408,6 @@ packages:
     resolution: {integrity: sha512-8BL+FNlFLTOY/A5X6tU35GQJLSIpsmqpwn/tFAYQTczXc4dMJ33ggtH248Cum8+LS0jLTsJKG2L4Qp+1CkY+sA==}
     peerDependencies:
       prop-types: ^15.0
-      react: 16.12.0
-      react-dom: 16.12.0
 
   rc-image@7.9.0:
     resolution: {integrity: sha512-l4zqO5E0quuLMCtdKfBgj4Suv8tIS011F5k1zBBlK25iMjjiNHxA0VeTzGFtUZERSA45gvpXDg8/P6qNLjR25g==}
@@ -9512,9 +9504,6 @@ packages:
 
   rc-progress@2.5.3:
     resolution: {integrity: sha512-K2fa4CnqGehLZoMrdmBeZ86ONSTVcdk5FlqetbwJ3R/+42XfqhwQVOjWp2MH4P7XSQOMAGcNOy1SFfCP3415sg==}
-    peerDependencies:
-      react: 16.12.0
-      react-dom: 16.12.0
 
   rc-progress@4.0.0:
     resolution: {integrity: sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==}
@@ -9609,9 +9598,6 @@ packages:
 
   rc-trigger@2.6.5:
     resolution: {integrity: sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==}
-    peerDependencies:
-      react: 16.12.0
-      react-dom: 16.12.0
 
   rc-upload@4.7.0:
     resolution: {integrity: sha512-eUwxYNHlsYe5vYhKFAUGrQG95JrnPzY+BmPi1Daq39fWNl/eOc7v4UODuWrVp2LFkQBuV3cMCG/I68iub6oBrg==}
@@ -9621,9 +9607,6 @@ packages:
 
   rc-util@4.21.1:
     resolution: {integrity: sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==}
-    peerDependencies:
-      react: 16.12.0
-      react-dom: 16.12.0
 
   rc-util@5.39.3:
     resolution: {integrity: sha512-j9wOELkLQ8gC/NkUg3qg9mHZcJf+5mYYv40JrDHqnaf8VSycji4pCf7kJ5fdTXQPDIF0vr5zpb/T2HdrMs9rWA==}
@@ -24069,14 +24052,12 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 4.46.0(webpack-cli@5.1.4)
 
-  rc-align@2.4.5(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
+  rc-align@2.4.5:
     dependencies:
       babel-runtime: 6.26.0
       dom-align: 1.12.4
       prop-types: 15.8.1
-      rc-util: 4.21.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
+      rc-util: 4.21.1
 
   rc-animate@2.11.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
     dependencies:
@@ -24085,7 +24066,7 @@ snapshots:
       css-animation: 1.6.1
       prop-types: 15.8.1
       raf: 3.4.1
-      rc-util: 4.21.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
+      rc-util: 4.21.1
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
       react-lifecycles-compat: 3.0.4
@@ -24097,10 +24078,11 @@ snapshots:
       moment: 2.29.4
       prop-types: 15.8.1
       rc-trigger: 2.6.5(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      rc-util: 4.21.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
+      rc-util: 4.21.1
       react-lifecycles-compat: 3.0.4
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   rc-cascader@3.27.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
     dependencies:
@@ -24186,10 +24168,11 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       lodash: 4.17.20
       prop-types: 15.5.10
-      rc-util: 4.21.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
+      rc-util: 4.21.1
       warning: 4.0.3
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   rc-image@7.9.0(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
     dependencies:
@@ -24319,12 +24302,10 @@ snapshots:
       luxon: 3.5.0
       moment: 2.29.4
 
-  rc-progress@2.5.3(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
+  rc-progress@2.5.3:
     dependencies:
       babel-runtime: 6.26.0
       prop-types: 15.5.10
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
     transitivePeerDependencies:
       - encoding
 
@@ -24464,12 +24445,13 @@ snapshots:
       babel-runtime: 6.26.0
       classnames: 2.3.2
       prop-types: 15.8.1
-      rc-align: 2.4.5(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
+      rc-align: 2.4.5
       rc-animate: 2.11.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      rc-util: 4.21.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0)
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
+      rc-util: 4.21.1
       react-lifecycles-compat: 3.0.4
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   rc-upload@4.7.0(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
     dependencies:
@@ -24479,12 +24461,10 @@ snapshots:
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
 
-  rc-util@4.21.1(react-dom@16.12.0(react@16.12.0))(react@16.12.0):
+  rc-util@4.21.1:
     dependencies:
       add-dom-event-listener: 1.1.0
       prop-types: 15.8.1
-      react: 16.12.0
-      react-dom: 16.12.0(react@16.12.0)
       react-is: 16.13.1
       react-lifecycles-compat: 3.0.4
       shallowequal: 1.1.0


### PR DESCRIPTION
## Summary

Remove 43 stale `pnpm.packageExtensions` entries from `pkg/ui/package.json`
that reference package versions no longer in the lockfile. These are leftover
from the antd v3 era — all 36 rc-* component entries, plus rmc-feedback,
mini-store, antd@3.x, jest-environment-enzyme, jest-enzyme, enzyme-matchers,
and stylus-loader.

This is prep work to reduce noise ahead of a React 18 migration.

Epic: none
Release note: None