### PR TITLE
sql: check for context cancellation in routine tail-call loop

### DIFF
--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -266,6 +266,14 @@ func (g *routineGenerator) Start(ctx context.Context, txn *kv.Txn) (err error) {
 	var prevSteppingMode kv.SteppingMode
 	var prevSeqNum enginepb.TxnSeq
 	for {
+		// Check for context cancellation on each iteration. This is necessary
+		// for PLpgSQL loops, which are compiled into recursive continuation
+		// routines that execute via tail-call optimization in this loop. Without
+		// this check, a loop with many iterations can run indefinitely even after
+		// a statement timeout has fired.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if g.expr.EnableStepping && !enabledStepping {
 			prevSteppingMode = txn.ConfigureStepping(ctx, kv.SteppingEnabled)
 			prevSeqNum = txn.GetReadSeqNum()


### PR DESCRIPTION
The PLpgSQL FOR loop is compiled into recursive continuation routines that execute iteratively via tail-call optimization in routineGenerator.Start(). This loop had no context cancellation check, which seems to have resulted in queries ignoring statement timeout.

Add a ctx.Err() check at the top of each iteration so that context cancellation (from statement timeouts, query cancellation, etc.) is respected promptly. It's not entirely clear why context cancellation checks during routine body execution/planning aren't sufficient, but this change should help cover any gaps.

Fixes: #168095
Release note: None