### PR TITLE
release-26.1: roachtest,roachprod: fix snapshot handling in index backfill tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -148,6 +148,11 @@ func runIndexBackfill(
 					t.Fatal(err)
 				}
 
+				// Save the current binary before overwriting with the
+				// predecessor. We restore it after snapshot creation so
+				// the workload phase runs the current version.
+				c.Run(ctx, option.WithNodes(c.All()), "cp ./cockroach ./cockroach.current")
+
 				// Copy over the binary to ./cockroach and run it from
 				// there. This test captures disk snapshots, which are
 				// fingerprinted using the binary version found in this
@@ -189,6 +194,10 @@ func runIndexBackfill(
 			t.L().Printf("created %d new snapshot(s) with prefix %q, using this state",
 				len(snapshots), snapshotPrefix)
 		}
+
+		// Restore the current binary so the workload phase runs the
+		// current version instead of the predecessor.
+		c.Run(ctx, option.WithNodes(c.All()), "cp ./cockroach.current ./cockroach")
 	} else {
 		t.L().Printf("using %d pre-existing snapshot(s) with prefix %q",
 			len(snapshots), snapshotPrefix)

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -486,6 +486,11 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 			t.Fatal(err)
 		}
 
+		// Save the current binary before overwriting with the predecessor.
+		// We restore it after snapshot creation so the workload phase runs
+		// the current version.
+		c.Run(ctx, option.WithNodes(c.All()), "cp ./cockroach ./cockroach.current")
+
 		// Copy over the binary to ./cockroach and run it from there. This test
 		// captures disk snapshots, which are fingerprinted using the binary
 		// version found in this path.
@@ -550,6 +555,10 @@ func doInitSingleNodeIndexBackfill(ctx context.Context, t test.Test, c cluster.C
 		} else {
 			t.L().Printf("=== CREATED %d NEW SNAPSHOT(S) with prefix %q ===", len(snapshots), snapshotPrefix)
 		}
+
+		// Restore the current binary so the workload phase runs the
+		// current version instead of the predecessor.
+		c.Run(ctx, option.WithNodes(c.All()), "cp ./cockroach.current ./cockroach")
 	} else {
 		t.L().Printf("found %d existing snapshot(s) with prefix %q",
 			len(snapshots), snapshotPrefix)

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -639,6 +639,10 @@ func (p *Provider) ListVolumeSnapshots(
 		"--format", "json(name,id)",
 	}
 	var filters []string
+	// Only list snapshots that are fully created. Without this filter,
+	// a concurrent run could pick up a snapshot still being uploaded,
+	// causing "resource is not ready" errors when creating disks from it.
+	filters = append(filters, "status:READY")
 	if vslo.NamePrefix != "" {
 		filters = append(filters, fmt.Sprintf("name:%s", vslo.NamePrefix))
 	}


### PR DESCRIPTION
Backport 2/2 commits from #168145 on behalf of @angeladietz.

----

Two fixes for snapshot-related failures in the index backfill roachtests.

**Commit 1: roachtest: restore current binary after snapshot creation**

Previously, the index backfill roachtests overwrote `./cockroach` with a
predecessor binary for snapshot creation but never restored the current
binary afterward. When no snapshots existed (first run with a new
version-aware prefix), the workload phase would start the predecessor
binary instead of the current version, causing failures like `unknown
cluster setting 'bulkio.index_backfill.elastic_control.enabled'`.

Now, we save the current binary to `./cockroach.current` before
overwriting it, and restore it after snapshot creation completes.

Fixes #168107
Fixes #168004

**Commit 2: roachprod: filter GCE snapshots by READY status**

Previously, `ListVolumeSnapshots` did not filter by snapshot status. When
multiple nightly CI runs created snapshots concurrently, a test could
pick up a snapshot that was still being uploaded, causing "resource is
not ready" errors when trying to create a disk from it.

Now, we add a `status:READY` filter to the GCE snapshot listing so only
fully-created snapshots are returned.

Fixes #168106

Release note: None
Epic: None

----

Release justification: