### PR TITLE
ui/db-console: remove V8 compilation cache workaround

### DIFF
--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -257,7 +257,7 @@ jest_test(
         "test.Pool": "large",
     },
     node_modules = ":node_modules",
-    shard_count = 4,
+    shard_count = 8,
 )
 
 # HTTP schema generation tools for converting swagger.json to OpenAPI and TypeScript types.

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -225,8 +225,6 @@ jest_test(
     args = [
         # Increase the JS heap size: https://nodejs.org/docs/latest-v16.x/api/cli.html#--max-old-space-sizesize-in-megabytes
         "--node_options=--max-old-space-size=8192",
-        # Prevent a v8-internal leak of compiled bytecode: https://github.com/facebook/jest/issues/11956#issuecomment-1401094780
-        "--node_options=--no-compilation-cache",
         # Populate the global.gc() function during JS execution:
         # https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/flags/flag-definitions.h#L1484-L1487
         "--node_options=--expose-gc",


### PR DESCRIPTION
## Summary

The `--no-compilation-cache`, `--expose-gc`, and `--logHeapUsage` flags
were added in #97179 to work around a V8 memory leak in Node 16.11.0+
that caused CI machines to become unresponsive (facebook/jest#11956).

Since then, the project has upgraded to Node 22.11.0, which uses V8 12.x
(vs V8 9.x in Node 16). The underlying leak has been fixed in newer V8
versions, making these workarounds unnecessary.

Removing these flags allows V8 to cache compiled bytecode within each
test shard, which should significantly reduce test startup overhead.
The `--max-old-space-size=8192` heap limit is retained as a safety net.

Epic: none

Release note: None