### PR TITLE
release-26.1: crosscluster/physical: fix ingest retry progress bug

### DIFF
--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -872,6 +872,23 @@ func TestStreamingAutoReplan(t *testing.T) {
 	c.WaitUntilReplicatedTime(cutoverTime, jobspb.JobID(ingestionJobID))
 
 	require.Greater(t, len(clientAddresses), 1)
+
+	// Verify that progress entries are strictly non-decreasing.
+	stats := replicationtestutils.TestingGetStreamIngestionStatsFromReplicationJob(
+		t, ctx, c.DestSysSQL, ingestionJobID,
+	)
+	replicationStartTime := stats.IngestionDetails.ReplicationStartTime
+	rows := c.DestSysSQL.QueryStr(t,
+		`SELECT resolved FROM system.job_progress_history WHERE job_id = $1 AND resolved IS NOT NULL ORDER BY written ASC`,
+		ingestionJobID,
+	)
+	var prevResolved hlc.Timestamp
+	for _, row := range rows {
+		resolved := replicationtestutils.DecimalTimeToHLC(t, row[0])
+		require.True(t, prevResolved.LessEq(resolved))
+		prevResolved = resolved
+	}
+	require.True(t, replicationStartTime.Less(prevResolved))
 }
 
 // TestStreamingReplanOnLag asserts that the c2c job retries if a node lags far
@@ -1705,9 +1722,9 @@ func splitPrimaryKeyIndexSpan(
 
 func TestAlterExternalConnection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	skip.UnderDeadlock(t)
 	skip.UnderRace(t)
-	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	pollingInterval := 100 * time.Millisecond
@@ -1751,6 +1768,7 @@ func TestAlterExternalConnection(t *testing.T) {
 		}
 		return nil
 	})
+	jobutils.WaitForJobToPause(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 
 	// Alter the external connection to fix the stream, and ensure replication resumes
 	c.DestSysSQL.Exec(c.T, fmt.Sprintf(`ALTER EXTERNAL CONNECTION "%s" AS "%s"`,

--- a/pkg/crosscluster/physical/stream_ingestion_job.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job.go
@@ -235,11 +235,10 @@ func ingestWithRetries(
 	ctx context.Context, execCtx sql.JobExecContext, resumer *streamIngestionResumer,
 ) error {
 	ro := getRetryPolicy(execCtx.ExecCfg().StreamingTestingKnobs)
-	var (
-		err                    error
-		previousPersistedSpans jobspb.ResolvedSpanEntries
-		currentPersistedSpans  jobspb.ResolvedSpanEntries
-	)
+
+	var err error
+	var previousPersistedSpans jobspb.ResolvedSpanEntries = resumer.job.Progress().Details.(*jobspb.Progress_StreamIngest).StreamIngest.Checkpoint.ResolvedSpans
+	currentPersistedSpans := previousPersistedSpans
 
 	for r := retry.Start(ro); r.Next(); {
 		err = ingest(ctx, execCtx, resumer)
@@ -255,6 +254,19 @@ func ingestWithRetries(
 		}
 		log.Dev.Infof(ctx, "hit retryable error %s", err)
 
+		// Reload the job's in-memory progress from the database so that we see accurate progress.
+		reloadErr := execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, t isql.Txn) error {
+			job, err := execCtx.ExecCfg().JobRegistry.LoadClaimedJobWithTxn(ctx, resumer.job.ID(), t)
+			if err != nil {
+				return err
+			}
+			resumer.job = job
+			return nil
+		})
+		if reloadErr != nil {
+			log.Dev.Warningf(ctx, "error loading job progress: %v", reloadErr)
+		}
+
 		currentPersistedSpans = resumer.job.Progress().Details.(*jobspb.Progress_StreamIngest).StreamIngest.Checkpoint.ResolvedSpans
 		if !currentPersistedSpans.Equal(previousPersistedSpans) {
 			// If the previous persisted spans are different than the current, it
@@ -262,6 +274,8 @@ func ingestWithRetries(
 			r.Reset()
 			log.Dev.Infof(ctx, "resolved spans have advanced since last retry, resetting retry counter")
 		}
+		previousPersistedSpans = currentPersistedSpans
+
 		if knobs := execCtx.ExecCfg().StreamingTestingKnobs; knobs != nil && knobs.AfterRetryIteration != nil {
 			knobs.AfterRetryIteration(err)
 		}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -875,6 +875,22 @@ func (r *Registry) LoadClaimedJob(ctx context.Context, jobID jobspb.JobID) (*Job
 	return j, nil
 }
 
+// LoadClaimedJobWithTxn is like LoadClaimedJob but uses the provided
+// transaction to load the job. Passing a nil transaction is equivalent
+// to calling LoadClaimedJob.
+func (r *Registry) LoadClaimedJobWithTxn(
+	ctx context.Context, jobID jobspb.JobID, txn isql.Txn,
+) (*Job, error) {
+	j, err := r.getClaimedJob(jobID)
+	if err != nil {
+		return nil, err
+	}
+	if err := j.WithTxn(txn).load(ctx); err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
 // LoadJobWithTxn does the same as above, but using the transaction passed in
 // the txn argument. Passing a nil transaction is equivalent to calling LoadJob
 // in that a transaction will be automatically created.


### PR DESCRIPTION
Backport 1/1 commits from #168094 on behalf of @andrew-r-thomas.

----

This patch fixes two bugs in `ingestWithRetries`.
1. the resumer's job never has its in memory progress updated within a
   single resume, as the frontier processor writes progress updates
   directly to the db via job id.
2. `previousPersistedSpans` is never updated, which, in combination with
   the above, means, unless the job is resumed more than once, the
   branch to reset the retrier is never taken, as they are both always
   zero-values.

The fix is to refresh the resumer's job and update the previous value
each loop iteration.

Fixes: #167384

Release note: None


----

Release justification: low risk change to fix severe bug