### PR TITLE
sql/tests: disable statement timeout during query oracle setup

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -327,14 +327,23 @@ func runOneRoundQueryComparison(
 
 		setup := sqlsmith.Setups[qct.setupName](rnd)
 
+		// Temporarily disable the statement timeout during setup since these are
+		// administrative DDL statements (CREATE TABLE, CREATE INDEX, etc.) that
+		// can exceed the normal timeout on slow hardware (e.g. s390x).
 		t.Status("executing setup")
 		t.L().Printf("setup:\n%s", strings.Join(setup, "\n"))
+		if _, err := conn.Exec("SET statement_timeout = 0"); err != nil {
+			t.Fatal(err)
+		}
 		for _, stmt := range setup {
 			if _, err := conn.Exec(stmt); err != nil {
 				t.Fatal(err)
 			} else {
 				logStmt(stmt)
 			}
+		}
+		if _, err := conn.Exec(setStmtTimeout); err != nil {
+			t.Fatal(err)
 		}
 
 		conn2 := conn


### PR DESCRIPTION
The seed table setup for query comparison roachtests executes DDL statements (CREATE TYPE, CREATE TABLE, CREATE INDEX) as a single multi-statement batch under a 1-minute statement_timeout. On slow hardware (s390x/IBM), the cumulative schema change time can exceed this limit, causing spurious test failures.

Temporarily disable the statement timeout during setup execution and re-enable it afterward. The setup consists of administrative DDL that doesn't need to be bounded by the query testing timeout.

Fixes #168104

Release note: None