### PR TITLE
release-26.2: inspect: fix false row count mismatch errors after IMPORT

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2267,6 +2267,11 @@ type InspectTestingKnobs struct {
 	// OnCheckComplete is called after a check completes. The check interface
 	// is passed to allow the callback to extract metadata (e.g., row counts).
 	OnCheckComplete func(check interface{}) error
+	// OverrideSpans, if set, replaces the primary index spans before they
+	// are passed to PartitionSpans. This gives tests control over the exact
+	// spans used by the inspect job, bypassing the span merge logic in
+	// DistSQL planning.
+	OverrideSpans func(spans []roachpb.Span) []roachpb.Span
 }
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/physicalplan",
         "//pkg/sql/privilege",
+        "//pkg/sql/rowenc",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/rowexec",
         "//pkg/sql/schemachanger/scexec",

--- a/pkg/sql/inspect/check_helpers.go
+++ b/pkg/sql/inspect/check_helpers.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -21,9 +22,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/spanutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -256,8 +259,13 @@ func spanForFullRegion(
 	return span, nil
 }
 
-// getPredicateAndQueryArgs generates query bounds from the span to limit the query to the specified range.
-// When no rows are found in a span, an empty predicate is returned.
+// getPredicateAndQueryArgs generates query bounds from the span to limit the
+// query to the specified range. When the span contains rows, the bounds are
+// derived from the first and last row values. When it does not and
+// needBoundsWhenEmpty is true, the bounds are derived directly from the span's
+// Key and EndKey. hasRows indicates which case applied. When
+// needBoundsWhenEmpty is false and the span is empty, an empty predicate is
+// returned and hasRows is false.
 func getPredicateAndQueryArgs(
 	ctx context.Context,
 	cfg *execinfra.ServerConfig,
@@ -267,16 +275,17 @@ func getPredicateAndQueryArgs(
 	asOf hlc.Timestamp,
 	pkColNames []string,
 	endPlaceholderOffset int,
-) (predicate string, queryArgs []interface{}, err error) {
+	needBoundsWhenEmpty bool,
+) (predicate string, queryArgs []interface{}, hasRows bool, err error) {
 	// Assert that we get meaningful spans
 	if span.Key.Equal(span.EndKey) || len(span.Key) == 0 || len(span.EndKey) == 0 {
-		return "", nil, errors.AssertionFailedf("received invalid span: Key=%x EndKey=%x", span.Key, span.EndKey)
+		return "", nil, false, errors.AssertionFailedf("received invalid span: Key=%x EndKey=%x", span.Key, span.EndKey)
 	}
 
 	// Get primary key metadata for span conversion
 	pkColTypes, err := spanutils.GetPKColumnTypes(tableDesc, priIndex.IndexDesc())
 	if err != nil {
-		return "", nil, errors.Wrap(err, "getting primary key column types")
+		return "", nil, false, errors.Wrap(err, "getting primary key column types")
 	}
 
 	pkColDirs := make([]catenumpb.IndexColumn_Direction, priIndex.NumKeyColumns())
@@ -294,46 +303,116 @@ func getPredicateAndQueryArgs(
 		len(tableDesc.GetFamilies()), span, alloc, asOf,
 	)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "converting span to query bounds")
+		return "", nil, false, errors.Wrap(err, "converting span to query bounds")
 	}
 
-	// If no rows exist in the primary index span, return an empty predicate
-	// and no query arguments. Callers decide how to handle this case.
+	encodedPkColNames := make([]string, len(pkColNames))
+	for i, colName := range pkColNames {
+		encodedPkColNames[i] = encodeColumnName(colName)
+	}
+
 	if !hasRows {
-		// Use empty predicate and no query arguments
-		predicate = ""
-		queryArgs = []interface{}{}
-	} else {
-		if len(bounds.Start) == 0 || len(bounds.End) == 0 {
-			return "", nil, errors.AssertionFailedf("query bounds from span didn't produce start or end: %+v", bounds)
+		if !needBoundsWhenEmpty {
+			return "", nil, false, nil
 		}
 
-		// Generate SQL predicate from the bounds
-		// Encode column names for SQL usage
-		encodedPkColNames := make([]string, len(pkColNames))
-		for i, colName := range pkColNames {
-			encodedPkColNames[i] = encodeColumnName(colName)
-		}
-		predicate, err = spanutils.RenderQueryBounds(encodedPkColNames, pkColDirs, pkColTypes, len(bounds.Start), len(bounds.End), true, endPlaceholderOffset)
+		// No rows exist in this span. Derive bounds directly from the span
+		// keys so callers still receive a predicate scoped to the span. The
+		// span.Key is inclusive and span.EndKey is exclusive, matching
+		// roachpb.Span conventions.
+		startDatums, err := decodeSpanKey(cfg.Codec, span.Key, pkColDirs, pkColTypes, alloc)
 		if err != nil {
-			return "", nil, errors.Wrap(err, "rendering query bounds")
+			return "", nil, false, errors.Wrap(err, "decoding span start key")
+		}
+		endDatums, err := decodeSpanKey(cfg.Codec, span.EndKey, pkColDirs, pkColTypes, alloc)
+		if err != nil {
+			return "", nil, false, errors.Wrap(err, "decoding span end key")
 		}
 
-		if strings.TrimSpace(predicate) == "" {
-			return "", nil, errors.AssertionFailedf("query bounds from span didn't produce predicate: %+v", bounds)
+		predicate, err = spanutils.RenderQueryBounds(
+			encodedPkColNames, pkColDirs, pkColTypes,
+			len(startDatums), len(endDatums),
+			true /* startIncl */, endPlaceholderOffset,
+		)
+		if err != nil {
+			return "", nil, false, errors.Wrap(err, "rendering span-key query bounds")
 		}
 
-		// Prepare query arguments: end bounds first, then start bounds
-		queryArgs = make([]interface{}, 0, len(bounds.End)+len(bounds.Start))
-		for _, datum := range bounds.End {
+		queryArgs = make([]interface{}, 0, len(endDatums)+len(startDatums))
+		for _, datum := range endDatums {
 			queryArgs = append(queryArgs, datum)
 		}
-		for _, datum := range bounds.Start {
+		for _, datum := range startDatums {
 			queryArgs = append(queryArgs, datum)
 		}
+
+		return predicate, queryArgs, false, nil
 	}
 
-	return predicate, queryArgs, nil
+	if len(bounds.Start) == 0 || len(bounds.End) == 0 {
+		return "", nil, false, errors.AssertionFailedf("query bounds from span didn't produce start or end: %+v", bounds)
+	}
+
+	predicate, err = spanutils.RenderQueryBounds(
+		encodedPkColNames, pkColDirs, pkColTypes,
+		len(bounds.Start), len(bounds.End),
+		true /* startIncl */, endPlaceholderOffset,
+	)
+	if err != nil {
+		return "", nil, false, errors.Wrap(err, "rendering query bounds")
+	}
+
+	if strings.TrimSpace(predicate) == "" {
+		return "", nil, false, errors.AssertionFailedf("query bounds from span didn't produce predicate: %+v", bounds)
+	}
+
+	// Prepare query arguments: end bounds first, then start bounds.
+	queryArgs = make([]interface{}, 0, len(bounds.End)+len(bounds.Start))
+	for _, datum := range bounds.End {
+		queryArgs = append(queryArgs, datum)
+	}
+	for _, datum := range bounds.Start {
+		queryArgs = append(queryArgs, datum)
+	}
+
+	return predicate, queryArgs, true, nil
+}
+
+// decodeSpanKey decodes a span boundary key into primary key datums. The key is
+// expected to start with the tenant prefix followed by the table/index prefix
+// and zero or more encoded PK column values. If the key contains only the
+// table/index prefix (no column values), an empty datum slice is returned.
+func decodeSpanKey(
+	codec keys.SQLCodec,
+	key roachpb.Key,
+	pkColDirs []catenumpb.IndexColumn_Direction,
+	pkColTypes []*types.T,
+	alloc *tree.DatumAlloc,
+) (tree.Datums, error) {
+	remainder, err := codec.StripTenantPrefix(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "stripping tenant prefix")
+	}
+	remainder, _, _, err = rowenc.DecodePartialTableIDIndexID(remainder)
+	if err != nil {
+		return nil, errors.Wrap(err, "decoding table/index ID")
+	}
+	if len(remainder) == 0 {
+		return nil, nil
+	}
+	vals := make([]rowenc.EncDatum, len(pkColTypes))
+	_, numVals, err := rowenc.DecodeKeyVals(vals, pkColDirs, remainder)
+	if err != nil {
+		return nil, errors.Wrap(err, "decoding key column values")
+	}
+	datums := make(tree.Datums, numVals)
+	for i := 0; i < numVals; i++ {
+		if err := vals[i].EnsureDecoded(pkColTypes[i], alloc); err != nil {
+			return nil, errors.Wrapf(err, "decoding datum at position %d", i)
+		}
+		datums[i] = vals[i].Datum
+	}
+	return datums, nil
 }
 
 // errorToInspectIssue converts internal errors to inspect issues so they can be

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -164,11 +164,13 @@ func (c *indexConsistencyCheck) Start(
 	otherColNames := colNames(otherColumns)
 	allColNames := colNames(c.columns)
 
-	// If no rows exist in the primary index span, we still need to check for dangling
-	// secondary index entries. We run the check with an empty predicate, which will
-	// scan the entire secondary index within the span. Any secondary index entries found
-	// will be dangling since there are no corresponding primary index rows.
-	predicate, queryArgs, err := getPredicateAndQueryArgs(ctx, cfg, span, c.tableDesc, c.priIndex, c.asOf, pkColNames, 1 /* endPlaceholderOffset */)
+	// If no rows exist in the primary index span, we still need to check for
+	// dangling secondary index entries. The check runs with a predicate derived
+	// from the span boundaries so that any secondary index entries found within
+	// the span are flagged as dangling since there are no corresponding primary
+	// index rows.
+	predicate, queryArgs, _, err := getPredicateAndQueryArgs(ctx, cfg, span, c.tableDesc, c.priIndex, c.asOf, pkColNames, 1, /* endPlaceholderOffset */
+		true /* needBoundsWhenEmpty */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/inspect/inspect_resumer.go
+++ b/pkg/sql/inspect/inspect_resumer.go
@@ -206,6 +206,10 @@ func (c *inspectResumer) planInspectProcessors(
 		return nil, nil, err
 	}
 
+	if knobs := jobExecCtx.ExecCfg().InspectTestingKnobs; knobs != nil && knobs.OverrideSpans != nil {
+		entirePKSpans = knobs.OverrideSpans(entirePKSpans)
+	}
+
 	spanPartitions, err := distSQLPlanner.PartitionSpans(ctx, planCtx, entirePKSpans, sql.PartitionSpansBoundDefault)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -139,7 +139,7 @@ func (c *rowCountCheck) CheckSpan(
 	}
 	c.tableDesc = tableDesc
 
-	predicate, queryArgs, err := getPredicateAndQueryArgs(
+	predicate, queryArgs, hasRows, err := getPredicateAndQueryArgs(
 		ctx,
 		&c.execCfg.DistSQLSrv.ServerConfig,
 		span,
@@ -147,15 +147,15 @@ func (c *rowCountCheck) CheckSpan(
 		c.tableDesc.GetPrimaryIndex(),
 		c.asOf,
 		c.tableDesc.TableDesc().PrimaryIndex.KeyColumnNames,
-		1, /* endPlaceholderOffset */
+		1,     /* endPlaceholderOffset */
+		false, /* needBoundsWhenEmpty */
 	)
 	if err != nil {
 		return err
 	}
 
-	// An empty predicate means the span has no rows so no further counting is
-	// necessary.
-	if predicate == "" {
+	// No rows in this span so no further counting is necessary.
+	if !hasRows {
 		return nil
 	}
 

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -13,15 +13,117 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRowCountCheckDoubleCountWithEmptySpan verifies that the row count
+// check produces the correct count when one of the primary index spans
+// contains no rows. The table is split so that the range [33, 36) is
+// empty while surrounding ranges hold 100 rows total. The OverrideSpans
+// testing knob injects pre-split sub-spans so the inspect job processes
+// the empty span separately rather than merging it during DistSQL
+// planning.
+func TestRowCountCheckDoubleCountWithEmptySpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// splitSpans is populated after the table is created and split. The
+	// closure below captures it by reference so the knob sees the final
+	// value when the inspect job runs.
+	var splitSpans []roachpb.Span
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			Inspect: &sql.InspectTestingKnobs{
+				OverrideSpans: func(spans []roachpb.Span) []roachpb.Span {
+					return splitSpans
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	codec := s.ApplicationLayer().Codec()
+	execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
+	r := sqlutils.MakeSQLRunner(db)
+
+	r.Exec(t, `CREATE DATABASE test`)
+
+	// Create a table with a secondary index. The secondary index causes
+	// indexConsistencyCheck instances to be created, which implement
+	// inspectCheckRowCount and provide row counts to rowCountCheck.
+	r.Exec(t, `CREATE TABLE test.t (id INT PRIMARY KEY, val INT, INDEX idx (val))`)
+	defer r.Exec(t, `DROP TABLE test.t`)
+
+	// Split the primary index into multiple ranges, creating an empty range
+	// [33, 36) with no rows.
+	r.Exec(t, `ALTER TABLE test.t SPLIT AT VALUES (33), (36)`)
+
+	// Insert rows only into non-empty ranges: [1, 30] and [41, 110].
+	// Range [33, 36) remains empty. Total: 100 rows.
+	r.Exec(t, `INSERT INTO test.t SELECT i, i*10 FROM generate_series(1, 30) AS g(i)`)
+	r.Exec(t, `INSERT INTO test.t SELECT i, i*10 FROM generate_series(41, 110) AS g(i)`)
+
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", "t")
+
+	// Compute sub-spans split at the range boundaries (id=33, id=36).
+	// On a single node PartitionSpans won't split at range boundaries, so
+	// we inject these via the OverrideSpans testing knob.
+	pkSpan := tableDesc.PrimaryIndexSpan(codec)
+	prefix := rowenc.MakeIndexKeyPrefix(
+		codec, tableDesc.GetID(), tableDesc.GetPrimaryIndex().GetID(),
+	)
+	key33 := encoding.EncodeVarintAscending(append([]byte(nil), prefix...), 33)
+	key36 := encoding.EncodeVarintAscending(append([]byte(nil), prefix...), 36)
+	splitSpans = []roachpb.Span{
+		{Key: pkSpan.Key, EndKey: key33},
+		{Key: key33, EndKey: key36},
+		{Key: key36, EndKey: pkSpan.EndKey},
+	}
+
+	expectedRowCount := uint64(100)
+	checks, err := ChecksForTable(ctx, &execCfg, tableDesc, &expectedRowCount)
+	require.NoError(t, err)
+	// With one secondary index + row count check = 2 checks.
+	require.Len(t, checks, 2)
+
+	var timestampStr string
+	r.QueryRow(t, "SELECT cluster_logical_timestamp()::STRING").Scan(&timestampStr)
+	asOfTimestamp, err := hlc.ParseHLC(timestampStr)
+	require.NoError(t, err)
+
+	job, err := TriggerJob(
+		ctx,
+		"test row count double counting bug",
+		&execCfg,
+		checks,
+		asOfTimestamp,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+
+	err = job.AwaitCompletion(ctx)
+	require.NoError(t, err, "inspect job should succeed with correct expected row count")
+
+	var jobStatus string
+	r.QueryRow(t,
+		`SELECT status FROM [SHOW JOBS] WHERE job_id = $1`,
+		job.ID(),
+	).Scan(&jobStatus)
+	require.Equal(t, "succeeded", jobStatus)
+}
 
 func TestRowCountCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -99,16 +99,16 @@ func (c *uniquenessCheck) Start(
 		keyColNames[i] = col.GetName()
 	}
 
-	lPredicate, lQueryArgs, err := getPredicateAndQueryArgs(
+	lPredicate, lQueryArgs, lHasRows, err := getPredicateAndQueryArgs(
 		ctx, cfg, span, c.tableDesc, c.tableDesc.GetPrimaryIndex(), c.asOf, keyColNames, 1, /* endPlaceholderOffset */
+		false, /* needBoundsWhenEmpty */
 	)
 	if err != nil {
 		return err
 	}
 
-	// An empty predicate means the local span has no rows so the check is done
-	// early.
-	if lPredicate == "" {
+	// No rows in this span so the check is done early.
+	if !lHasRows {
 		c.state = checkDone
 		return nil
 	}
@@ -232,16 +232,16 @@ func (c *uniquenessCheck) getRemotePredicatesAndQueryArgs(
 			}
 		}
 
-		rPredicate, rQueryArgs, err := getPredicateAndQueryArgs(
+		rPredicate, rQueryArgs, rHasRows, err := getPredicateAndQueryArgs(
 			ctx, cfg, remoteSpan, c.tableDesc, c.tableDesc.GetPrimaryIndex(), c.asOf, keyColNames, endPlaceholderOffset+len(remoteArgs)+1,
+			false, /* needBoundsWhenEmpty */
 		)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "getting predicate for region %q", region)
 		}
 
-		// An empty predicate means the remote span has no rows so the span in
-		// that region is skipped.
-		if rPredicate == "" {
+		// No rows in the remote span so the region is skipped.
+		if !rHasRows {
 			continue
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #168158 on behalf of @spilchen.

----

IMPORT validates data integrity by running an inspect job that checks the row count against the expected number of imported rows. When the primary index has an empty span (a range with no rows), the inspect job incorrectly inflates the accumulated row count, producing a spurious RowCountMismatch error. This makes it appear that the imported data is corrupt when the data is actually correct.

The root cause is in getPredicateAndQueryArgs, which returned an empty predicate for empty spans. Downstream queries then ran without a WHERE clause, counting all rows in the table instead of zero for the empty span. The fix derives query bounds directly from the span boundaries when no rows exist, keeping all queries properly scoped. The function now also returns a hasRows bool so callers can distinguish empty spans without relying on a sentinel empty string.

Closes #168001

Release note: None

----

Release justification: important bug fix for new feature in 26.2