### PR TITLE
build/deploy: default COCKROACH_USER to root in docker entrypoint

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -118,7 +118,7 @@ set_env_var() {
 # setup_env is to set up the environment variables.
 setup_env() {
   set_env_var "COCKROACH_DATABASE" "defaultdb"
-  set_env_var "COCKROACH_USER"
+  set_env_var "COCKROACH_USER" "root"
   set_env_var "COCKROACH_PASSWORD"
 }
 


### PR DESCRIPTION
When COCKROACH_USER isn't set, setup_db in the docker entrypoint calls run_sql_query without a -e flag, which opens an interactive cockroach sql session that blocks forever. This prevents docker-entrypoint-initdb.d scripts from ever running.

Defaulting to 'root' is safe since it's always present as CockroachDB's built-in admin user, and it's what most people expect when running the docker image without explicit user configuration.

Fixes #110997