### PR TITLE
release-25.4: roachtestutil: mark GetProfile failures as infrastructure flakes

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/roachprod",
         "//pkg/roachprod/config",
+        "//pkg/roachprod/errors",
         "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",


### PR DESCRIPTION
Backport 1/1 commits from #162296.

/cc @cockroachdb/release

---

Previously, when `GetProfile` failed to fetch a CPU profile (e.g., because another profile was already in progress), the test would fail without being marked as an infrastructure flake. This caused unnecessary noise in test failure tracking.

This change wraps GetProfile errors with `rperrors.TransientFailure` so they are automatically detected as infrastructure flakes by roachtest's existing detection mechanism. Failed tests will now be labeled with `X-infra-flake` and routed to Test Eng instead of the test's owning team.

Additionally, the retry timeout was increased from a fixed 15 seconds to `duration + 30 seconds` to account for the profile collection duration plus additional retry time.

Fixes: #158734

Release note: None

Release justification: Fix test flake: mark GetProfile failures as infrastructure flakes and increase retry timeout (fixes #168221)
