### PR TITLE
allocator/mmaprototype: convert remove-target Fatalf to ok-return

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -454,16 +454,20 @@ func MakeReplicaTypeChange(
 	return change
 }
 
-// makeRebalanceReplicaChanges creates to replica changes, adding a replica and
+// makeRebalanceReplicaChanges creates two replica changes, adding a replica and
 // removing another. If the replica being rebalanced is the current
 // leaseholder, the impact of the rebalance also includes the lease load.
+//
+// Returns ok=false if the removeTarget is not found in existingReplicas, which
+// can happen if an external change (e.g. replicate queue) removed the replica
+// before the rebalancer's state was refreshed.
 func makeRebalanceReplicaChanges(
 	ctx context.Context,
 	rangeID roachpb.RangeID,
 	existingReplicas []StoreIDAndReplicaState,
 	rLoad RangeLoad,
 	addTarget, removeTarget roachpb.ReplicationTarget,
-) [2]ReplicaChange {
+) (_ [2]ReplicaChange, ok bool) {
 	var remove StoreIDAndReplicaState
 	for _, replica := range existingReplicas {
 		if replica.StoreID == removeTarget.StoreID {
@@ -471,7 +475,9 @@ func makeRebalanceReplicaChanges(
 		}
 	}
 	if remove == (StoreIDAndReplicaState{}) {
-		log.KvDistribution.Fatalf(ctx, "remove target %s not in existing replicas", removeTarget)
+		log.KvDistribution.Warningf(ctx,
+			"remove target %s not in existing replicas for r%d", removeTarget, rangeID)
+		return [2]ReplicaChange{}, false
 	}
 
 	addIDAndType := ReplicaIDAndType{
@@ -480,7 +486,7 @@ func makeRebalanceReplicaChanges(
 	}
 	addReplicaChange := MakeAddReplicaChange(rangeID, rLoad, addIDAndType, addTarget)
 	removeReplicaChange := MakeRemoveReplicaChange(rangeID, rLoad, remove.ReplicaState, removeTarget)
-	return [2]ReplicaChange{addReplicaChange, removeReplicaChange}
+	return [2]ReplicaChange{addReplicaChange, removeReplicaChange}, true
 }
 
 func mapReplicaTypeToVoterOrNonVoter(rType roachpb.ReplicaType) roachpb.ReplicaType {

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -631,8 +631,12 @@ func (re *rebalanceEnv) rebalanceReplicas(
 				"add=%v==remove_target=%v range_id=%v candidates=%v",
 				addTarget, removeTarget, rangeID, cands.candidates))
 		}
-		replicaChanges := makeRebalanceReplicaChanges(ctx,
+		replicaChanges, ok := makeRebalanceReplicaChanges(ctx,
 			rangeID, rstate.replicas, rstate.load, addTarget, removeTarget)
+		if !ok {
+			re.passObs.replicaShed(rangeTransient)
+			continue
+		}
 		rangeChange := MakePendingRangeChange(rangeID, replicaChanges[:])
 		if err = re.preCheckOnApplyReplicaChanges(rangeChange); err != nil {
 			panic(errors.Wrapf(err, "pre-check failed for replica changes: %v for %v",

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -637,8 +637,9 @@ func TestClusterState(t *testing.T) {
 							add, remove, _ := parseChangeAddRemove(t, parts[1])
 							addTarget := roachpb.ReplicationTarget{NodeID: cs.stores[add].NodeID, StoreID: add}
 							removeTarget := roachpb.ReplicationTarget{NodeID: cs.stores[remove].NodeID, StoreID: remove}
-							rebalanceChanges := makeRebalanceReplicaChanges(
+							rebalanceChanges, ok := makeRebalanceReplicaChanges(
 								ctx, rangeID, rState.replicas, rState.load, addTarget, removeTarget)
+							require.True(t, ok, "remove target not found in replicas")
 							changes = append(changes, rebalanceChanges[:]...)
 						}
 					}


### PR DESCRIPTION
`makeRebalanceReplicaChanges` fatals when the remove target is not found
in existing replicas. This can happen when an external change (e.g.
replicate queue) removes a replica before the rebalancer's adjusted state
is refreshed by the next `StoreLeaseholderMsg`.

Change the function to return an `ok` bool instead of fataling. Callers
skip the range when the target is missing.

Part of: #167723
Epic: none
Release note: None