### PR TITLE
release-26.2: roachtest: remove cypress job messages assertion

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/jobs.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/pages/jobs.cy.ts
@@ -77,12 +77,6 @@ describe("jobs page", () => {
     cy.get('[class*="job-messages"]').contains("Kind");
     cy.get('[class*="job-messages"]').contains("Message");
 
-    // Verify events table has at least one row
-    cy.get('[class*="job-messages"] table tbody tr').should(
-      "have.length.at.least",
-      1,
-    );
-
     // switch to advance debugging tab
     cy.contains("Advanced Debugging").click();
     cy.location("hash").should("match", /\/jobs\/\d+\?tab=profiler/);


### PR DESCRIPTION
Backport 1/1 commits from #167579 on behalf of @jasonlmfong.

----

The current cypress test for the jobs page asserts that there is at least one event that occurred. This can fail when the job is in-progress, leading to test flakes like 167199 and 167575.

This change removes the check for the minimum number of events.

Closes: #167575
Epic: None
Release note: None

----

Release justification: test only change, removing an assertion that is flakey