### PR TITLE
cluster-ui: only inline assets for npm release builds

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
-        pnpm build
+        pnpm build:release
 
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
-        pnpm build
+        pnpm build:release
 
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --mode=production",
+    "build:release": "npm-run-all -p build:typescript build:release-bundle",
+    "build:release-bundle": "NODE_ENV=production webpack --mode=production --env inline-assets",
     "build:typescript": "tsc",
     "build:watch": "webpack --watch --mode=development --env WEBPACK_WATCH",
     "tsc:watch": "node build/typescript/watchWithMultipleDests.js --no-interactive",

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-          type: "asset/inline",
+          type: env["inline-assets"] ? "asset/inline" : "asset",
           exclude: /node_modules/,
         },
         // Styles in current project use SCSS preprocessing language with CSS modules.


### PR DESCRIPTION
## Summary
- Changes cluster-ui's webpack config to use `asset` by default instead of `asset/inline` for images and fonts, reducing bundle size for db-console builds.
- Adds a `build:release` script that passes `--env inline-assets` to produce a self-contained npm package with base64-inlined assets.
- Updates the GitHub Actions publish workflows (`cluster-ui-release.yml` and `cluster-ui-release-next.yml`) to use `build:release`.

Epic: none