### PR TITLE
server/status: use histogram buckets for codeowner metric count

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -17947,7 +17947,7 @@ layers:
       owner: cockroachdb/obs-prs
     - name: obs.metric_export.codeowner.metric_count
       exported_name: obs_metric_export_codeowner_metric_count
-      description: Metric count per CODEOWNER team as ingested (histograms expand to computed metrics)
+      description: Metric count per CODEOWNER team in the Prometheus scrape (histograms expand to buckets plus count and sum)
       y_axis_label: Metrics
       type: GAUGE
       unit: COUNT

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -164,7 +164,7 @@ func newScrapeMetrics() *ScrapeMetrics {
 		}, []string{"metric_name"}),
 		OwnerMetricCount: metric.NewExportedGaugeVec(metric.Metadata{
 			Name:        "obs.metric_export.codeowner.metric_count",
-			Help:        "Metric count per CODEOWNER team as ingested (histograms expand to computed metrics)",
+			Help:        "Metric count per CODEOWNER team in the Prometheus scrape (histograms expand to buckets plus count and sum)",
 			Measurement: "Metrics",
 			Unit:        metric.Unit_COUNT,
 		}, []string{"codeowner"}),
@@ -575,15 +575,16 @@ func countTimeSeriesLines(data []byte) int64 {
 	return count
 }
 
-// countFamilyMetrics counts the number of individual metrics a
-// MetricFamily produces as ingested by downstream systems like
-// Datadog. HELP/TYPE overhead is omitted and histograms expand
-// into their computed metrics (percentiles, count, sum, avg, max).
+// countFamilyMetrics counts the number of individual time series a
+// MetricFamily produces in the Prometheus scrape output. HELP/TYPE
+// overhead is omitted. Histograms expand into their buckets plus
+// _count and _sum lines.
 func countFamilyMetrics(family *prometheusgo.MetricFamily) int64 {
 	var count int64
 	for _, m := range family.Metric {
-		if m.Histogram != nil {
-			count += int64(len(metric.HistogramMetricComputers))
+		if h := m.Histogram; h != nil {
+			// Each histogram produces one line per bucket, plus _count and _sum.
+			count += int64(len(h.Bucket)) + 2
 		} else {
 			count++
 		}

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -1540,9 +1540,9 @@ func TestScrapeMetrics(t *testing.T) {
 }
 
 // TestCountFamilyMetrics verifies that countFamilyMetrics correctly
-// counts the number of individual metrics a MetricFamily produces as
-// ingested by downstream systems (histograms expand to computed
-// metrics, no HELP/TYPE overhead).
+// counts the number of individual time series a MetricFamily produces
+// in the Prometheus scrape output (histograms expand to buckets plus
+// _count and _sum, no HELP/TYPE overhead).
 func TestCountFamilyMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -1585,7 +1585,7 @@ func TestCountFamilyMetrics(t *testing.T) {
 			expected: 3,
 		},
 		{
-			name: "histogram expands to computed metrics",
+			name: "histogram expands to buckets plus count and sum",
 			family: &prometheusgo.MetricFamily{
 				Name: str("test_histo"),
 				Type: mtype(prometheusgo.MetricType_HISTOGRAM),
@@ -1601,7 +1601,8 @@ func TestCountFamilyMetrics(t *testing.T) {
 					}},
 				},
 			},
-			expected: int64(len(metric.HistogramMetricComputers)),
+			// 3 buckets + _count + _sum = 5
+			expected: 5,
 		},
 		{
 			name: "empty family",


### PR DESCRIPTION
## Summary

Switch `countFamilyMetrics` to count actual Prometheus histogram buckets
(plus `_count` and `_sum`) instead of metric computers. This matches the
outgoing scrape output and aligns with what is already on the 26.2 branch.

Fixes: none
Epic: none
Release note: None