### PR TITLE
roachtest: deflake online-restore recovery

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -584,7 +584,8 @@ func (d *BackupRestoreTestDriver) deleteSSTFromBackup(
 		return errors.Wrap(rows.Err(), "error iterating over SHOW BACKUP FILES")
 	}
 	if len(ssts) == 0 {
-		return errors.Newf("unexpectedly found no SST files to delete in backup %q of collection %q", backupID, collection.uri())
+		l.Printf("no SST files to delete in backup %q of collection %q", backupID, collection.uri())
+		return nil
 	}
 	uri, err := url.Parse(collection.uri())
 	if err != nil {


### PR DESCRIPTION
The recent change to the faster `SHOW BACKUPS` (#167996) broke online restore reovery as it added a requirement that every backup had an SST file to be deleted. Prior to this change, we only deleted SST files that we saw. This breaks in cases where we have empty incrementals, as is possible with the schemachange workload. This commit updates the recovery roachtest to simply skip over backups that have no SST files.

Fixes: #168209

Release note: None