### PR TITLE
ui/cluster-ui: fix empty cluster settings page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
@@ -25,7 +25,7 @@ export function getClusterSettings(
 ): Promise<SettingsResponseMessage> {
   const urlParams = new URLSearchParams();
   urlParams.append("unredacted_values", "true");
-  if (req.keys) {
+  if (req.keys?.length) {
     urlParams.append("keys", req.keys.join(","));
   }
 
@@ -75,7 +75,9 @@ const formatProtoResponse = (
       value: kv.value,
       type: kv.type as ClusterSettingType,
       description: kv.description,
-      lastUpdated: TimestampToMoment(kv.last_updated),
+      lastUpdated: kv.last_updated?.seconds?.toNumber()
+        ? TimestampToMoment(kv.last_updated)
+        : null,
       public: kv.public ?? false,
     };
   });


### PR DESCRIPTION
Since f55d3b341c20 (2026-03-24), the cluster settings report page has
been broken — both tables render empty. The refactor changed
`useClusterSettings` to create an empty `SettingsRequest({})`, but
`getClusterSettings` still checked `if (req.keys)` to decide whether
to append a `keys` query parameter. Protobuf repeated fields default
to `[]`, which is truthy in JS, so `keys=` (empty string) was always
appended. The server interprets this as "return settings matching
these specific keys: (none)" and returns a zero-length response.

Fix by checking `req.keys?.length` instead.

Epic: none