### PR TITLE
ui/db-console: add "Changed only" filter to cluster settings page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.scss
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.scss
@@ -6,3 +6,10 @@
 .settings-note {
   padding: 18px 0;
 }
+
+.settings-changed-only {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.tsx
@@ -83,15 +83,21 @@ export function Settings({ history }: RouteComponentProps): React.ReactElement {
     ascending: true,
     columnTitle: "lastUpdated",
   });
+  const [changedOnly, setChangedOnly] = useState(false);
 
   const { settingValues, isLoading, error } = useClusterSettings();
 
   const renderTable = (wantPublic: boolean) => {
-    const dataArray = settingsToIterableArray(settingValues);
+    let dataArray = settingsToIterableArray(settingValues).filter(obj =>
+      wantPublic ? obj.public : !obj.public,
+    );
+    if (changedOnly) {
+      dataArray = dataArray.filter(obj => obj.last_updated != null);
+    }
 
     return (
       <SortedTable
-        data={dataArray.filter(obj => (wantPublic ? obj.public : !obj.public))}
+        data={dataArray}
         columns={columns}
         sortSetting={sortSetting}
         onChangeSortSetting={(ss: SortSetting) =>
@@ -115,6 +121,14 @@ export function Settings({ history }: RouteComponentProps): React.ReactElement {
         error={error}
         render={() => (
           <div>
+            <label className="settings-changed-only">
+              <input
+                type="checkbox"
+                checked={changedOnly}
+                onChange={e => setChangedOnly(e.target.checked)}
+              />
+              Changed only
+            </label>
             <p className="settings-note">
               Note that some settings have been redacted for security purposes.
             </p>


### PR DESCRIPTION
Stacked on #168260.

Add a "Changed only" checkbox to the cluster settings report page that,
when checked, hides settings that have never been explicitly overridden.
This makes it easy to see at a glance which settings have been customized
on a cluster. Settings that were explicitly `SET CLUSTER SETTING` — even
if the value happens to match the current default — remain visible, since
they have a non-null `last_updated` timestamp.

Epic: none
Release note (ui change): Added a "Changed only" checkbox to the
Cluster Settings report page in DB Console. When checked, only
settings that have been explicitly overridden are shown.