### PR TITLE
roachtest: fix mixed version backup test and use_backups_with_ids

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -217,7 +217,7 @@ func (d *BackupRestoreTestDriver) verifyBackupCollection(
 	internalSystemJobs bool,
 	mvHelper *mixedversion.Helper,
 ) error {
-	rj, err := d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs)
+	rj, err := d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs, nil)
 	if err != nil {
 		return fmt.Errorf("error restoring backup: %w", err)
 	}
@@ -239,7 +239,7 @@ func (d *BackupRestoreTestDriver) verifyBackupCollection(
 			"encountered version mismatch error due to mixed-version upgrade, retrying restore: %v",
 			jobErr,
 		)
-		rj, err = d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs)
+		rj, err = d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs, mvHelper)
 		if err != nil {
 			return fmt.Errorf("error restoring backup: %w", err)
 		}
@@ -634,6 +634,7 @@ func (d *BackupRestoreTestDriver) Restore(
 	bc *backupCollection,
 	checkFiles bool,
 	internalSystemJobs bool,
+	mvHelper *mixedversion.Helper,
 ) (*RestoreJob, error) {
 	restoreStmt, restoredTables, restoreDB := d.buildRestoreStatement(bc)
 	if _, isTableBackup := bc.btype.(*tableBackup); isTableBackup {
@@ -646,7 +647,7 @@ func (d *BackupRestoreTestDriver) Restore(
 		}
 	}
 	if checkFiles {
-		if err := d.testUtils.checkFiles(ctx, rng, bc); err != nil {
+		if err := d.testUtils.checkFiles(ctx, rng, bc, mvHelper); err != nil {
 			return nil, fmt.Errorf("backup %s: check_files failed: %w", bc.name, err)
 		}
 	}
@@ -675,8 +676,9 @@ func (d *BackupRestoreTestDriver) RestoreSync(
 	bc *backupCollection,
 	checkFiles bool,
 	internalSystemJobs bool,
+	mvHelper *mixedversion.Helper,
 ) (*RestoreJob, error) {
-	rj, err := d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs)
+	rj, err := d.Restore(ctx, l, rng, bc, checkFiles, internalSystemJobs, mvHelper)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -361,7 +361,8 @@ func backupRestoreChaos(ctx context.Context, t test.Test, c cluster.Cluster) {
 	t.Monitor().ExpectProcessDead(failureNodes)
 
 	restoreJob, err := d.Restore(
-		ctx, t.L(), testRNG, collection, false /* checkFiles */, true, /* internalSystemJobs */
+		ctx, t.L(), testRNG, collection,
+		false /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
 	)
 	require.NoError(t, err)
 	injectAndRecoverFailure(

--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -100,6 +100,8 @@ var (
 	schemaChangeDB = "schemachange"
 
 	v231CV = "23.1"
+
+	v262CV = "26.2"
 )
 
 type CommonTestUtils struct {
@@ -711,7 +713,7 @@ func (u *CommonTestUtils) enableJobAdoption(
 // that the latest backup in the collection passed is valid. This step
 // is skipped if the feature is not available.
 func (u *CommonTestUtils) checkFiles(
-	ctx context.Context, rng *rand.Rand, collection *backupCollection,
+	ctx context.Context, rng *rand.Rand, collection *backupCollection, mvHelper *mixedversion.Helper,
 ) error {
 	options := []string{"check_files"}
 	if opt := collection.encryptionOption(); opt != nil {
@@ -720,7 +722,13 @@ func (u *CommonTestUtils) checkFiles(
 	// TODO (kev-cao): Need to update this once we've decided how we want to
 	// handle CHECK FILES under the new SHOW BACKUPS.
 	_, conn := u.RandomDB(rng, u.roachNodes)
-	defer disableUseBackupsWithIDs(ctx, u.t, conn)()
+	if mvHelper != nil {
+		if hasUseBackupsWithIDs, err := mvHelper.ClusterVersionAtLeast(rng, v262CV); err != nil {
+			return err
+		} else if hasUseBackupsWithIDs {
+			defer disableUseBackupsWithIDs(ctx, u.t, conn)()
+		}
+	}
 	checkFilesStmt := fmt.Sprintf(
 		"SHOW BACKUP LATEST IN '%s' WITH %s",
 		collection.uri(), strings.Join(options, ", "),

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -1043,7 +1043,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 		t.L().Printf("performing online restore of backup")
 		if _, err := d.RestoreSync(
 			ctx, t.L(), testRNG, collection,
-			false /* checkFiles */, true, /* internalSystemJobs */
+			false /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
In #167996, we updated the roachtest logic to the new `SHOW BACKUPS`. In a mixed-version backup test, however, we may be on a Cockroach binary that does not yet have the `use_backups_with_ids` session variable. This commit updates the test to check the cluster version before using that session variable.

Fixes: #168208

Relese note: None