### PR TITLE
release-26.2: workload: add version gate for canary stats storage param

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5954,6 +5954,14 @@ func (og *operationGenerator) setTableStorageParam(
 		if hasPgcodeBug {
 			stmt.potentialExecErrors.add(pgcode.Uncategorized)
 		}
+	} else if param == catpb.CanaryStatsWindowSettingName {
+		canaryNotSupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_2.Version())
+		if err != nil {
+			return nil, err
+		}
+		if canaryNotSupported {
+			stmt.potentialExecErrors.add(pgcode.FeatureNotSupported)
+		}
 	}
 
 	return stmt, nil


### PR DESCRIPTION
Backport 1/1 commits from #168253 on behalf of @shghasemi.

----

Setting the CanaryStatsWindowSettingName is not suppoerted when the cluster version is less than 26.2. A version check is added to the random workload to avoid flakes.

Fixes #168025
Fixes #168207

Release note: None

----

Release justification: Test-only chanage.