### PR TITLE
workload: add enum type deps to trigger function bodies

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2242,11 +2242,11 @@ func (og *operationGenerator) alterTypeDropValue(ctx context.Context, tx pgx.Tx)
 		return nil, err
 	}
 
-	// TODO(chrisseto): We're currently missing cases around enum members being
-	// referenced as it's quite difficult to tell if an individual member is
-	// referenced. Unreferenced members can be dropped but referenced members may
-	// not. For now, we skip over all enums where the type itself is being
-	// referenced.
+	// It's difficult to tell if an individual enum member is referenced, so
+	// for the success case we allow any non-dropping member regardless of
+	// whether the type has references, and flag DependentObjectsStillExist as
+	// a potential error when the selected member's type is referenced.
+	var pickedReferenced bool
 
 	stmt, code, err := Generate[*tree.AlterType](og.params.rng, og.produceError(), []GenerationCase{
 		// Fail to drop values from a type that doesn't exist.
@@ -2255,22 +2255,36 @@ func (og *operationGenerator) alterTypeDropValue(ctx context.Context, tx pgx.Tx)
 		{pgcode.ObjectNotInPrerequisiteState, `{ with (EnumValue true false) } ALTER TYPE { .name } DROP VALUE { .value } { end }`},
 		// Fail to drop values that don't exist.
 		{pgcode.UndefinedObject, `{ with (EnumValue false false) } ALTER TYPE { .name } DROP VALUE 'ValueThatDoesntExist' { end }`},
-		// Successful drop of an enum value.
-		{pgcode.SuccessfulCompletion, `{ with (EnumValue false false) } ALTER TYPE { .name } DROP VALUE { .value } { end }`},
+		// Successful drop of an enum value. The member may belong to a
+		// referenced type, in which case the drop could fail.
+		{pgcode.SuccessfulCompletion, `{ with (AnyEnumValue false) } ALTER TYPE { .name } DROP VALUE { .value } { end }`},
 	}, template.FuncMap{
 		"EnumValue": func(dropping, referenced bool) (map[string]any, error) {
 			return PickOne(og.params.rng, util.Filter(enumMembers, func(enum map[string]any) bool {
 				return enum["has_references"].(bool) == referenced && enum["dropping"].(bool) == dropping
 			}))
 		},
+		"AnyEnumValue": func(dropping bool) (map[string]any, error) {
+			member, err := PickOne(og.params.rng, util.Filter(enumMembers, func(enum map[string]any) bool {
+				return enum["dropping"].(bool) == dropping
+			}))
+			if err == nil {
+				pickedReferenced = member["has_references"].(bool)
+			}
+			return member, err
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return newOpStmt(stmt, codesWithConditions{
+	opStmt := newOpStmt(stmt, codesWithConditions{
 		{code, true},
-	}), nil
+	})
+	if pickedReferenced {
+		opStmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
+	}
+	return opStmt, nil
 }
 
 func (og *operationGenerator) renameColumn(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
@@ -4484,19 +4498,6 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 				COALESCE((descriptor->'state')::INT != 0, false) AS non_public
 			FROM enums
 		`)
-	enumMemberQuery := With([]CTE{
-		{"descriptors", descJSONQuery},
-		{"enums", enumDescsQuery},
-		{"enum_members", enumMemberDescsQuery},
-	}, `SELECT
-				quote_ident(schema_id::REGNAMESPACE::TEXT) || '.' || quote_ident(name) AS name,
-				quote_literal(member->>'logicalRepresentation') AS value,
-				(
-					COALESCE(member->>'direction' = 'REMOVE', false) OR
-					COALESCE(member->>'capability' = 'READ_ONLY', false)
-				) AS non_public
-			FROM enum_members
-		`)
 	schemasQuery := With([]CTE{
 		{"descriptors", descJSONQuery},
 	}, `SELECT quote_ident(name) FROM descriptors WHERE descriptor ? 'schema'`)
@@ -4519,7 +4520,7 @@ FROM
 	if err != nil {
 		return nil, err
 	}
-	enumMembers, err := Collect(ctx, og, tx, pgx.RowToMap, enumMemberQuery)
+	enumMembers, err := og.collectEnumMembers(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -5681,11 +5682,36 @@ func (og *operationGenerator) createTriggerFunction(
 		}
 	}
 
+	// Sometimes include an enum cast expression to exercise trigger-enum
+	// dependency tracking (TriggerDeps.uses_type_ids).
+	enumSelectStmt := ""
+	if og.randIntn(2) == 0 {
+		enumMembers, err := og.collectEnumMembers(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+		var publicEnumExprs []string
+		for _, member := range enumMembers {
+			if member["non_public"].(bool) {
+				continue
+			}
+			publicEnumExprs = append(publicEnumExprs,
+				fmt.Sprintf(`(%s::%s IS NULL)`, member["value"], member["name"]))
+		}
+		if len(publicEnumExprs) > 0 {
+			picked, err := PickOne(og.params.rng, publicEnumExprs)
+			if err != nil {
+				return nil, err
+			}
+			enumSelectStmt = fmt.Sprintf("SELECT %s;", picked)
+		}
+	}
+
 	// The trigger function always returns NEW to avoid breaking inserts.
 	opStmt := makeOpStmt(OpStmtDDL)
 	opStmt.sql = fmt.Sprintf(
-		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
-		resolvedName, seqSelectStmt, selectStmt.sql,
+		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
+		resolvedName, seqSelectStmt, enumSelectStmt, selectStmt.sql,
 	)
 	og.LogMessage(fmt.Sprintf("createTriggerFunction: %s", opStmt.sql))
 
@@ -5764,12 +5790,16 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 		{code: pgcode.UndefinedTable, condition: !triggerTableExists},
 	})
 	opStmt.potentialExecErrors.addAll(codesWithConditions{
-		// References within the trigger function are evaluated lazily when the
-		// TRIGGER is created. Not when the function is created. What may have
-		// existed when the function was created could no longer exist.
+		// References within the trigger function body (tables, functions,
+		// columns, enum types, enum members) are evaluated lazily at CREATE
+		// TRIGGER time, not when the function is created. Any referenced
+		// object may have been dropped or transitioned to a non-public state
+		// in the interim.
 		{code: pgcode.UndefinedTable, condition: true},
 		{code: pgcode.UndefinedFunction, condition: true},
 		{code: pgcode.UndefinedColumn, condition: true},
+		{code: pgcode.UndefinedObject, condition: true},
+		{code: pgcode.InvalidParameterValue, condition: true},
 	})
 
 	return opStmt, nil
@@ -5802,6 +5832,28 @@ func (og *operationGenerator) dropTrigger(ctx context.Context, tx pgx.Tx) (*opSt
 type triggerInfo struct {
 	table       tree.TableName
 	triggerName string
+}
+
+// collectEnumMembers returns all enum members in the current database. Each
+// result row is a map with keys "name" (qualified enum type name), "value"
+// (quoted member literal), and "non_public" (bool indicating a DROPPING member).
+func (og *operationGenerator) collectEnumMembers(
+	ctx context.Context, tx pgx.Tx,
+) ([]map[string]any, error) {
+	q := With([]CTE{
+		{"descriptors", descJSONQuery},
+		{"enums", enumDescsQuery},
+		{"enum_members", enumMemberDescsQuery},
+	}, `SELECT
+			quote_ident(schema_id::REGNAMESPACE::TEXT) || '.' || quote_ident(name) AS name,
+			quote_literal(member->>'logicalRepresentation') AS value,
+			(
+				COALESCE(member->>'direction' = 'REMOVE', false) OR
+				COALESCE(member->>'capability' = 'READ_ONLY', false)
+			) AS non_public
+		FROM enum_members
+	`)
+	return Collect(ctx, og, tx, pgx.RowToMap, q)
 }
 
 // findExistingTriggerFunctions returns existing trigger functions (RETURNS


### PR DESCRIPTION
Address gap 2 from
https://github.com/cockroachdb/cockroach/issues/167410:

- Gap 2: `createTriggerFunction` now sometimes embeds an enum cast expression like `('val'::schema.my_enum IS NULL)` in the trigger function body, exercising trigger-to-enum type dependency tracking (`TriggerDeps.uses_type_ids`). The enum member discovery query is extracted into a shared `collectEnumMembers` helper used by both `createFunction` and `createTriggerFunction`.

Epic: CRDB-48029
Informs: https://github.com/cockroachdb/cockroach/issues/167410

Release note: None