### PR TITLE
logical: extract DistSQL planner to standalone file

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "create_logical_replication_stmt.go",
         "dead_letter_queue.go",
+        "distsql_planner.go",
         "logical_replication_dist.go",
         "logical_replication_job.go",
         "logical_replication_writer_processor.go",

--- a/pkg/crosscluster/logical/distsql_planner.go
+++ b/pkg/crosscluster/logical/distsql_planner.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+)
+
+// LogicalReplicationPlanner generates a physical plan for logical replication.
+// An initial plan is generated during job startup and the replanner will
+// periodically call GeneratePlan to recalculate the best plan. If the newly
+// generated plan differs significantly from the initial plan, the entire
+// distSQL flow is shut down and a new initial plan will be created.
+type LogicalReplicationPlanner struct {
+	Job        *jobs.Job
+	JobExecCtx sql.JobExecContext
+	Client     streamclient.Client
+}
+
+// LogicalReplicationPlanInfo contains metadata about a logical replication
+// physical plan.
+type LogicalReplicationPlanInfo struct {
+	SourceSpans      []roachpb.Span
+	PartitionPgUrls  []string
+	DestTableBySrcID map[descpb.ID]dstTableMetadata
+	// WriteProcessorCount is the number of processors writing data on the
+	// destination cluster (offline or otherwise).
+	WriteProcessorCount int
+}
+
+// MakeLogicalReplicationPlanner creates a new LogicalReplicationPlanner.
+func MakeLogicalReplicationPlanner(
+	jobExecCtx sql.JobExecContext, job *jobs.Job, client streamclient.Client,
+) LogicalReplicationPlanner {
+	return LogicalReplicationPlanner{
+		Job:        job,
+		JobExecCtx: jobExecCtx,
+		Client:     client,
+	}
+}
+
+// GetSourcePlan fetches the logical replication plan from the source cluster.
+// It is the shared setup used by planRowReplication, planOfflineInitialScan,
+// and transaction mode replication planning.
+func (p *LogicalReplicationPlanner) GetSourcePlan(
+	ctx context.Context,
+) (streamclient.LogicalReplicationPlan, error) {
+	progress := p.Job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
+	payload := p.Job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
+
+	asOf := progress.ReplicatedTime
+	if asOf.IsEmpty() {
+		asOf = payload.ReplicationStartTime
+	}
+
+	req := streampb.LogicalReplicationPlanRequest{
+		PlanAsOf: asOf,
+		// During an offline initial scan, we need to replicate the whole table, not
+		// just the primary keys.
+		UseTableSpan: payload.CreateTable && progress.ReplicatedTime.IsEmpty(),
+		StreamID:     streampb.StreamID(payload.StreamID),
+	}
+	for _, pair := range payload.ReplicationPairs {
+		req.TableIDs = append(req.TableIDs, pair.SrcDescriptorID)
+	}
+
+	return p.Client.PlanLogicalReplication(ctx, req)
+}
+
+// GeneratePlan creates a new physical plan for row replication. It is called
+// by the replanner to detect topology changes and trigger re-planning.
+func (p *LogicalReplicationPlanner) GeneratePlan(
+	ctx context.Context, dsp *sql.DistSQLPlanner,
+) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
+	sourcePlan, err := p.GetSourcePlan(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	plan, planCtx, _, err := p.planRowReplication(ctx, dsp, sourcePlan)
+	return plan, planCtx, err
+}

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -18,11 +18,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/ingeststopped"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/externalcatalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -276,75 +274,6 @@ func loadOnlineReplicatedTime(
 		return hlc.Timestamp{}
 	}
 	return progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication.ReplicatedTime
-}
-
-// logicalReplicationPlanner generates a physical plan for logical replication.
-// An initial plan is generated during job startup and the replanner will
-// periodically call generatePlan to recalculate the best plan. If the newly
-// generated plan differs significantly from the initial plan, the entire
-// distSQL flow is shut down and a new initial plan will be created.
-type logicalReplicationPlanner struct {
-	job        *jobs.Job
-	jobExecCtx sql.JobExecContext
-	client     streamclient.Client
-}
-
-type logicalReplicationPlanInfo struct {
-	sourceSpans      []roachpb.Span
-	partitionPgUrls  []string
-	destTableBySrcID map[descpb.ID]dstTableMetadata
-	// Number of processors writing data on the destination cluster (offline or
-	// otherwise).
-	writeProcessorCount int
-}
-
-func makeLogicalReplicationPlanner(
-	jobExecCtx sql.JobExecContext, job *jobs.Job, client streamclient.Client,
-) logicalReplicationPlanner {
-	return logicalReplicationPlanner{
-		job:        job,
-		jobExecCtx: jobExecCtx,
-		client:     client,
-	}
-}
-
-// getSourcePlan fetches the logical replication plan from the source cluster.
-// It is the shared setup used by both planRowReplication and
-// planOfflineInitialScan.
-func (p *logicalReplicationPlanner) getSourcePlan(
-	ctx context.Context,
-) (streamclient.LogicalReplicationPlan, error) {
-	progress := p.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
-	payload := p.job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
-
-	asOf := progress.ReplicatedTime
-	if asOf.IsEmpty() {
-		asOf = payload.ReplicationStartTime
-	}
-
-	req := streampb.LogicalReplicationPlanRequest{
-		PlanAsOf: asOf,
-		// During an offline initial scan, we need to replicate the whole table, not
-		// just the primary keys.
-		UseTableSpan: payload.CreateTable && progress.ReplicatedTime.IsEmpty(),
-		StreamID:     streampb.StreamID(payload.StreamID),
-	}
-	for _, pair := range payload.ReplicationPairs {
-		req.TableIDs = append(req.TableIDs, pair.SrcDescriptorID)
-	}
-
-	return p.client.PlanLogicalReplication(ctx, req)
-}
-
-func (p *logicalReplicationPlanner) generatePlan(
-	ctx context.Context, dsp *sql.DistSQLPlanner,
-) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
-	sourcePlan, err := p.getSourcePlan(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	plan, planCtx, _, err := p.planRowReplication(ctx, dsp, sourcePlan)
-	return plan, planCtx, err
 }
 
 // rowHandler is responsible for handling checkpoints sent by logical

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2188,13 +2188,13 @@ func TestLogicalReplicationPlanner(t *testing.T) {
 		case <-time.After(testutils.SucceedsSoonDuration()):
 		}
 	}
-	planner := logicalReplicationPlanner{
-		job:        sj.Job,
-		jobExecCtx: jobExecCtx,
-		client:     client,
+	planner := LogicalReplicationPlanner{
+		Job:        sj.Job,
+		JobExecCtx: jobExecCtx,
+		Client:     client,
 	}
 	t.Run("generatePlan uses the replicationStartTime for planning if replication is unset", func(t *testing.T) {
-		_, _, _ = planner.generatePlan(ctx, jobExecCtx.DistSQLPlanner())
+		_, _, _ = planner.GeneratePlan(ctx, jobExecCtx.DistSQLPlanner())
 		requireAsOf(replicationStartTime)
 	})
 	t.Run("generatePlan uses the latest replicated time for planning", func(t *testing.T) {
@@ -2205,7 +2205,7 @@ func TestLogicalReplicationPlanner(t *testing.T) {
 			ju.UpdateProgress(md.Progress)
 			return nil
 		}))
-		_, _, _ = planner.generatePlan(ctx, jobExecCtx.DistSQLPlanner())
+		_, _, _ = planner.GeneratePlan(ctx, jobExecCtx.DistSQLPlanner())
 		requireAsOf(replicatedTime)
 	})
 }

--- a/pkg/crosscluster/logical/resume_create_table.go
+++ b/pkg/crosscluster/logical/resume_create_table.go
@@ -113,8 +113,8 @@ func (r *logicalReplicationResumer) runOfflineInitialScan(
 		return err
 	}
 
-	planner := makeLogicalReplicationPlanner(jobExecCtx, r.job, client)
-	sourcePlan, err := planner.getSourcePlan(ctx)
+	planner := MakeLogicalReplicationPlanner(jobExecCtx, r.job, client)
+	sourcePlan, err := planner.GetSourcePlan(ctx)
 	if err != nil {
 		return err
 	}
@@ -127,11 +127,11 @@ func (r *logicalReplicationResumer) runOfflineInitialScan(
 	if err != nil {
 		return err
 	}
-	if err := r.checkpointPartitionURIs(ctx, uris, planInfo.partitionPgUrls); err != nil {
+	if err := r.checkpointPartitionURIs(ctx, uris, planInfo.PartitionPgUrls); err != nil {
 		return err
 	}
 
-	frontier, err := span.MakeFrontierAt(replicatedTimeAtStart, planInfo.sourceSpans...)
+	frontier, err := span.MakeFrontierAt(replicatedTimeAtStart, planInfo.SourceSpans...)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (r *logicalReplicationResumer) runOfflineInitialScan(
 			job:                   r.job,
 			frontierUpdates:       heartbeatSender.FrontierUpdates,
 			rangeStats: replicationutils.NewAggregateRangeStatsCollector(
-				planInfo.writeProcessorCount,
+				planInfo.WriteProcessorCount,
 			),
 			r: r,
 		}
@@ -267,17 +267,17 @@ func (r *logicalReplicationResumer) maybePublishCreatedTables(
 	})
 }
 
-func (p *logicalReplicationPlanner) planOfflineInitialScan(
+func (p *LogicalReplicationPlanner) planOfflineInitialScan(
 	ctx context.Context, dsp *sql.DistSQLPlanner, sourcePlan streamclient.LogicalReplicationPlan,
-) (*sql.PhysicalPlan, *sql.PlanningCtx, logicalReplicationPlanInfo, error) {
+) (*sql.PhysicalPlan, *sql.PlanningCtx, LogicalReplicationPlanInfo, error) {
 	var (
-		execCfg  = p.jobExecCtx.ExecCfg()
-		evalCtx  = p.jobExecCtx.ExtendedEvalContext()
-		progress = p.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
-		payload  = p.job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
-		info     = logicalReplicationPlanInfo{
-			sourceSpans:     sourcePlan.SourceSpans,
-			partitionPgUrls: sourcePlan.Topology.SerializedClusterUris(),
+		execCfg  = p.JobExecCtx.ExecCfg()
+		evalCtx  = p.JobExecCtx.ExtendedEvalContext()
+		progress = p.Job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
+		payload  = p.Job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
+		info     = LogicalReplicationPlanInfo{
+			SourceSpans:     sourcePlan.SourceSpans,
+			PartitionPgUrls: sourcePlan.Topology.SerializedClusterUris(),
 		}
 	)
 
@@ -326,7 +326,7 @@ func (p *logicalReplicationPlanner) planOfflineInitialScan(
 		destNodeLocalities,
 		payload.ReplicationStartTime,
 		progress.Checkpoint,
-		p.job.ID(),
+		p.Job.ID(),
 		streampb.StreamID(payload.StreamID),
 		rekeys,
 		payload.MetricsLabel,
@@ -343,7 +343,7 @@ func (p *logicalReplicationPlanner) planOfflineInitialScan(
 				SQLInstanceID: instanceID,
 				Core:          execinfrapb.ProcessorCoreUnion{LogicalReplicationOfflineScan: &spec},
 			})
-			info.writeProcessorCount++
+			info.WriteProcessorCount++
 		}
 	}
 

--- a/pkg/crosscluster/logical/resume_row.go
+++ b/pkg/crosscluster/logical/resume_row.go
@@ -73,8 +73,8 @@ func (r *logicalReplicationResumer) ingest(
 		return err
 	}
 
-	planner := makeLogicalReplicationPlanner(jobExecCtx, r.job, client)
-	sourcePlan, err := planner.getSourcePlan(ctx)
+	planner := MakeLogicalReplicationPlanner(jobExecCtx, r.job, client)
+	sourcePlan, err := planner.GetSourcePlan(ctx)
 	if err != nil {
 		return err
 	}
@@ -83,18 +83,18 @@ func (r *logicalReplicationResumer) ingest(
 		return err
 	}
 
-	if err := r.checkpointPartitionURIs(ctx, uris, planInfo.partitionPgUrls); err != nil {
+	if err := r.checkpointPartitionURIs(ctx, uris, planInfo.PartitionPgUrls); err != nil {
 		return err
 	}
 	// Update the local progress copy as it was just updated.
 	progress = r.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
 
-	dlqClient := InitDeadLetterQueueClient(execCfg.InternalDB.Executor(), planInfo.destTableBySrcID)
+	dlqClient := InitDeadLetterQueueClient(execCfg.InternalDB.Executor(), planInfo.DestTableBySrcID)
 	if err := dlqClient.Create(ctx); err != nil {
 		return errors.Wrap(err, "failed to create dead letter queue")
 	}
 
-	frontier, err := span.MakeFrontierAt(replicatedTimeAtStart, planInfo.sourceSpans...)
+	frontier, err := span.MakeFrontierAt(replicatedTimeAtStart, planInfo.SourceSpans...)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (r *logicalReplicationResumer) ingest(
 
 	replanner, stopReplanner := sql.PhysicalPlanChangeChecker(ctx,
 		initialPlan,
-		planner.generatePlan,
+		planner.GeneratePlan,
 		jobExecCtx,
 		replanOracle,
 		func() time.Duration { return crosscluster.LogicalReplanFrequency.Get(execCfg.SV()) },
@@ -148,7 +148,7 @@ func (r *logicalReplicationResumer) ingest(
 			job:                   r.job,
 			frontierUpdates:       heartbeatSender.FrontierUpdates,
 			rangeStats: replicationutils.NewAggregateRangeStatsCollector(
-				planInfo.writeProcessorCount,
+				planInfo.WriteProcessorCount,
 			),
 			r: r,
 		}
@@ -206,18 +206,18 @@ func getNodes(plan *sql.PhysicalPlan) (src, dst map[string]struct{}, nodeCount i
 	return src, dst, count
 }
 
-func (p *logicalReplicationPlanner) planRowReplication(
+func (p *LogicalReplicationPlanner) planRowReplication(
 	ctx context.Context, dsp *sql.DistSQLPlanner, sourcePlan streamclient.LogicalReplicationPlan,
-) (*sql.PhysicalPlan, *sql.PlanningCtx, logicalReplicationPlanInfo, error) {
+) (*sql.PhysicalPlan, *sql.PlanningCtx, LogicalReplicationPlanInfo, error) {
 	var (
-		execCfg  = p.jobExecCtx.ExecCfg()
-		evalCtx  = p.jobExecCtx.ExtendedEvalContext()
-		progress = p.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
-		payload  = p.job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
-		info     = logicalReplicationPlanInfo{
-			sourceSpans:      sourcePlan.SourceSpans,
-			partitionPgUrls:  sourcePlan.Topology.SerializedClusterUris(),
-			destTableBySrcID: make(map[descpb.ID]dstTableMetadata),
+		execCfg  = p.JobExecCtx.ExecCfg()
+		evalCtx  = p.JobExecCtx.ExtendedEvalContext()
+		progress = p.Job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
+		payload  = p.Job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
+		info     = LogicalReplicationPlanInfo{
+			SourceSpans:      sourcePlan.SourceSpans,
+			PartitionPgUrls:  sourcePlan.Topology.SerializedClusterUris(),
+			DestTableBySrcID: make(map[descpb.ID]dstTableMetadata),
 		}
 	)
 
@@ -272,7 +272,7 @@ func (p *logicalReplicationPlanner) planRowReplication(
 				DestinationTableName:          dstTableDesc.GetName(),
 				DestinationFunctionOID:        uint32(fnOID),
 			}
-			info.destTableBySrcID[descpb.ID(pair.SrcDescriptorID)] = dstTableMetadata{
+			info.DestTableBySrcID[descpb.ID(pair.SrcDescriptorID)] = dstTableMetadata{
 				database: dbDesc.GetName(),
 				schema:   scDesc.GetName(),
 				table:    dstTableDesc.GetName(),
@@ -307,7 +307,7 @@ func (p *logicalReplicationPlanner) planRowReplication(
 		progress.Checkpoint,
 		tableMetadataByDestID,
 		sourcePlan.SourceTypes,
-		p.job.ID(),
+		p.Job.ID(),
 		streampb.StreamID(payload.StreamID),
 		payload.Discard,
 		payload.Mode,
@@ -338,7 +338,7 @@ func (p *logicalReplicationPlanner) planRowReplication(
 					LogicalReplicationWriter: &sp,
 				},
 			})
-			info.writeProcessorCount++
+			info.WriteProcessorCount++
 		}
 	}
 


### PR DESCRIPTION
Move the LogicalReplicationPlanner type, its constructor, GetSourcePlan,
and GeneratePlan methods from logical_replication_job.go to a dedicated
distsql_planner.go file. Export all names so the planner infrastructure
can be reused by the txnmode subpackage.

This is a pure refactoring with no behavior changes. All three LDR modes
(offline initial scan, row replication, and transaction mode) can now
use the same planner infrastructure through a consistent API.

Epic: CRDB-61213

Release note: none