### PR TITLE
ci/ai: teach /investigate to read jepsen artifacts

### DIFF
--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -186,6 +186,32 @@ Artifacts can be large; explore with listing first if unsure of the
 exact path, but for roachtests the pattern above works on the first
 try.
 
+**Jepsen artifacts:** Jepsen roachtests (tests named `jepsen/*`) produce
+different artifacts from typical roachtests. On failure, the primary
+artifact is `failure-logs.tbz` — a bzip2-compressed tar archive bundled
+**inside** `artifacts.zip`. Extract it in two steps:
+
+```bash
+unzip -j "$DEST/artifacts.zip" "failure-logs.tbz" -d "$DEST"
+tar -xjf "$DEST/failure-logs.tbz" -C "$DEST"
+```
+
+The archive contains:
+
+```
+invoke.log                          # stdout/stderr from the Jepsen JAR
+store/latest/                       # Jepsen output directory
+  jepsen.log                        # main Jepsen execution log
+  jepsen-version.txt                # Jepsen version used
+  <ip>/                             # per-node subdirectory (one per CRDB node)
+    cockroach.stderr                # CockroachDB stderr output
+    trace.pcap                      # network packet capture
+    version.txt                     # CockroachDB version
+```
+
+For Jepsen failures, read `.github/prompts/jepsen-triage.md` for
+detailed triage steps, common failure patterns, and key log signatures.
+
 Log files are generally large. Prefer searching them with grep first
 to find interesting sections, but `test.log` is often worth reading
 in full.

--- a/.github/prompts/jepsen-triage.md
+++ b/.github/prompts/jepsen-triage.md
@@ -1,0 +1,92 @@
+# Jepsen Failure Triage
+
+This file supplements `investigate.md` with Jepsen-specific guidance.
+Read it when investigating a `jepsen/*` roachtest failure.
+
+## Key Files (in priority order)
+
+1. **`invoke.log`** — stdout/stderr from the Jepsen JAR. The most
+   informative artifact for understanding what went wrong.
+2. **`jepsen.log`** — structured Jepsen test log. Only exists if setup
+   succeeded and the workload started.
+3. **Per-node `cockroach.stderr`** — CockroachDB process output per
+   node. Useful for correlating node-level errors.
+
+Also read `pkg/cmd/roachtest/tests/jepsen.go` for the test harness
+logic, known-exception handling, and artifact collection code.
+
+## Triage Steps
+
+### 1. Classify the top-level error from `test.log`
+
+- `"timed out"` at `jepsen.go` — 40-minute overall timeout hit.
+  Proceed to `invoke.log` to determine which phase hung.
+- `"COMMAND_PROBLEM: exit status 254"` — Jepsen exited with error
+  (exit code 255, remapped). Check `invoke.log` for the cause.
+
+### 2. Determine the failure phase from `invoke.log`
+
+Grep for these patterns:
+
+| Pattern | Meaning |
+|---------|---------|
+| `"Oh jeez, I'm sorry, Jepsen broke"` | Jepsen crashed. Read the `"Caused by"` chain on subsequent lines. |
+| `"Run complete"` | Workload finished — failure is in analysis or teardown. If absent, test hung during setup or execution. |
+| `"Analyzing..."` (no result after) | Analysis-phase hang, typically generating HTML timeline on a large history. |
+| `PSQLException` | SQL error from CockroachDB — examine the message for the underlying cause. |
+| `RuntimeException: timeout` in `setup!` | Nemesis disrupted the cluster before workers connected. |
+| `ntpdate` + `"no server suitable for synchronization found"` | NTP teardown failure. |
+
+### 3. On timeout, check the JVM thread dump
+
+When the test times out, `invoke.log` contains a JVM thread dump
+(from `pkill -QUIT java`). Look for threads stuck in:
+
+- `clj_ssh.ssh$ssh_exec` — stuck SSH command on a remote node.
+- `jepsen.checker.timeline$html` — analysis phase generating HTML.
+- `CyclicBarrier.await` — threads waiting at a synchronization
+  barrier; find the thread that is *not* at the barrier to
+  identify what is blocking progress.
+
+### 4. Check the consistency verdict in `jepsen.log`
+
+- `"Everything looks good! ✓"` or `:valid? true` — consistency
+  check passed.
+- `"Analysis invalid!"` or `:valid? false` — **consistency
+  violation detected**. This is the most critical finding.
+- `:fail` and `:info` operation results — individual operation
+  errors during the workload.
+
+### 5. Check for known benign exceptions
+
+The test harness (`jepsen.go`) auto-ignores certain exceptions.
+If the error matches one of these, the failure would normally be
+skipped. Cross-reference with the grep in `jepsen.go:~414`:
+`BrokenBarrierException`, `InterruptedException`,
+`ArrayIndexOutOfBoundsException`, `NullPointerException`,
+`clj-ssh scp failure`, `RuntimeException: Connection to`.
+
+## Failure Context
+
+Jepsen tests go through distinct phases: setup, workload
+execution, analysis, and teardown. Determining which phase failed
+is more important than matching specific error messages — use the
+triage steps above to identify the phase, then investigate the
+root cause within that phase.
+
+If the failure is in teardown (e.g., NTP errors), the workload
+and analysis may have completed successfully — always check the
+consistency verdict in `jepsen.log` before concluding the test
+failed.
+
+`PSQLException` in `invoke.log` indicates a SQL-level error from
+CockroachDB. Read the full exception message and trace to
+understand the cause — do not assume it matches a previously
+seen pattern.
+
+## Cross-build correlation
+
+If multiple `jepsen/*` tests fail in the same TeamCity build,
+check whether they share a common failure pattern (e.g., all
+timed out in setup). This suggests a systemic issue with the
+build environment rather than individual test bugs.


### PR DESCRIPTION
Previously, the `/investigate` prompt had no awareness of Jepsen test artifacts. Jepsen roachtests produce a `failure-logs.tbz` archive (bundled inside `artifacts.zip`) containing Jepsen-specific logs (`invoke.log`, `jepsen.log`, per-node `cockroach.stderr`) that are structurally different from typical roachtest artifacts.

This was inadequate because the investigator had no guidance on how to extract or analyze these files, leading to incomplete investigations of `jepsen/*` test failures.

This patch addresses it by adding Jepsen artifact documentation to `investigate.md` (download/extract instructions, directory structure) and a separate `jepsen-triage.md` file with detailed triage steps, key log patterns, and thread dump analysis guidance. The triage file is loaded on-demand only for Jepsen failures, keeping the main prompt lean.

Fixes #168252

Epic: none
Release note: None