### PR TITLE
backup: retry export on intent resolver batcher timeout

### DIFF
--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -8,6 +8,7 @@ package backup
 import (
 	"context"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
@@ -556,16 +557,31 @@ func runBackupProcessor(
 								return nil
 							})
 						if exportRequestErr != nil {
-							// If we got a write intent error because we requested it rather
-							// than blocking, either put the request on the back of the queue
-							// to revisit later or, if the request was resuming in the middle
-							// of a key, reattempt it immediately.
-							if lockErr, ok := pErr.GetDetail().(*kvpb.WriteIntentError); ok && header.WaitPolicy == lock.WaitPolicy_Error {
+							// Check if this is a timeout from the intent resolver
+							// batcher, which indicates the span has unresolved intents.
+							// Ideally KV would surface these as WriteIntentErrors
+							// directly, but for now the intent resolver returns a
+							// TimeoutError whose operation name identifies it.
+							var isIrBatcherTimeout bool
+							if te := (*timeutil.TimeoutError)(nil); errors.As(exportRequestErr, &te) {
+								isIrBatcherTimeout = strings.Contains(string(te.Operation()), "intent_resolver")
+							}
+							// If we got a write intent error (or an intent resolver
+							// batcher timeout) because we requested non-blocking intent
+							// handling, either put the request on the back of the queue
+							// to revisit later or, if the request was resuming in the
+							// middle of a key, reattempt it immediately.
+							lockErr, isWriteIntentErr := pErr.GetDetail().(*kvpb.WriteIntentError)
+							if (isWriteIntentErr && header.WaitPolicy == lock.WaitPolicy_Error) || isIrBatcherTimeout {
 								// TODO(dt): send a progress update to update job progress to note
 								// the intents being hit.
 								span.lastTried = timeutil.Now()
 								span.attempts++
-								log.VEventf(ctx, 1, "retrying ExportRequest for span %s; encountered WriteIntentError: %s", span.span, lockErr.Error())
+								if isWriteIntentErr {
+									log.VEventf(ctx, 1, "retrying ExportRequest for span %s; encountered WriteIntentError: %s", span.span, lockErr.Error())
+								} else {
+									log.VEventf(ctx, 1, "retrying ExportRequest for span %s; intent resolver batcher timed out: %s", span.span, exportRequestErr)
+								}
 								// If we're not mid-span we can put this on the the queue to
 								// give it time to resolve on its own while we work on other
 								// spans; if we've flushed any of this span though we finish it

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -7659,6 +7659,74 @@ func TestBackupDoesNotHangOnIntent(t *testing.T) {
 	require.Error(t, tx.Commit())
 }
 
+// TestBackupRetriesOnIRBatcherTimeout verifies that backup retries an
+// ExportRequest when the intent resolver batcher times out, rather than
+// failing with a timeout error. The intent resolver batcher timeout
+// produces a TimeoutError with an operation name starting with
+// "intent_resolver", which backup treats like a WriteIntentError.
+func TestBackupRetriesOnIRBatcherTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t)
+
+	// Create a TimeoutError that looks like it came from the intent
+	// resolver batcher. We use RunWithTimeout since TimeoutError fields
+	// are unexported.
+	irTimeoutErr := timeutil.RunWithTimeout(
+		context.Background(),
+		"intent_resolver_ir_batcher.sendBatch",
+		time.Nanosecond,
+		func(ctx context.Context) error {
+			time.Sleep(time.Millisecond)
+			return ctx.Err()
+		},
+	)
+	require.Error(t, irTimeoutErr)
+	require.True(t, errors.HasType(irTimeoutErr, (*timeutil.TimeoutError)(nil)))
+
+	// Inject the IR batcher timeout for the first few ExportRequests.
+	// After that, let them succeed so that backup completes.
+	var injectCount atomic.Int32
+	const maxInjects = 3
+	params := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					TestingRequestFilter: func(
+						ctx context.Context, ba *kvpb.BatchRequest,
+					) *kvpb.Error {
+						for _, ru := range ba.Requests {
+							if _, ok := ru.GetInner().(*kvpb.ExportRequest); ok {
+								if injectCount.Add(1) <= maxInjects {
+									return kvpb.NewError(irTimeoutErr)
+								}
+							}
+						}
+						return nil
+					},
+				},
+			},
+		},
+	}
+
+	const numAccounts = 10
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
+		t, singleNode, numAccounts, InitManualReplication, params,
+	)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.read_with_priority_after = '100ms'")
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.read_retry_delay = '10ms'")
+
+	// Backup should succeed despite the injected IR batcher timeouts
+	// because the retry logic treats them like WriteIntentErrors.
+	sqlDB.Exec(t, "BACKUP TABLE data.bank INTO 'nodelocal://1/ir-timeout'")
+
+	// Verify that we actually injected timeouts.
+	require.GreaterOrEqual(t, injectCount.Load(), int32(maxInjects))
+}
+
 func TestRestoreTypeDescriptorsRollBack(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
When the intent resolver batcher times out during an ExportRequest, backup now retries the span instead of failing. The timeout produces a TimeoutError whose operation name contains "intent_resolver", which we detect and handle the same way as a WriteIntentError.

Release note: None
Epic: none