### PR TITLE
ldr: fix fully-redacted error in job status message

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -126,10 +126,10 @@ func (r *logicalReplicationResumer) handleResumeError(
 		return nil
 	}
 	if jobs.IsPermanentJobError(err) {
-		r.updateStatusMessage(ctx, redact.Sprintf("permanent error: %s", err.Error()))
+		r.updateStatusMessage(ctx, redact.Sprintf("permanent error: %v", err))
 		return err
 	}
-	r.updateStatusMessage(ctx, redact.Sprintf("pausing after error: %s", err.Error()))
+	r.updateStatusMessage(ctx, redact.Sprintf("pausing after error: %v", err))
 	return jobs.MarkPauseRequestError(err)
 }
 

--- a/pkg/kv/kvserver/split_delay_helper.go
+++ b/pkg/kv/kvserver/split_delay_helper.go
@@ -180,7 +180,7 @@ func maybeDelaySplitToAvoidSnapshot(
 		slept += sleepDur
 
 		if err := ctx.Err(); err != nil {
-			problems = append(problems, redact.Sprintf("error: %s", err.Error()))
+			problems = append(problems, redact.Sprintf("error: %v", err))
 			break
 		}
 	}


### PR DESCRIPTION
The status message formatting used redact.Sprintf("permanent error: %s", err.Error()), which stringified the error into a plain string before passing it to the redaction layer. A plain string is treated as entirely unsafe, so .Redact() replaced it with ×, producing the useless status "permanent error: ‹×›".

Pass the error directly with %v so its SafeFormatter implementation is used and the message text survives redaction.

Fix the same pattern in split_delay_helper.go.

Release note (bug fix): Logical replication job status messages no longer show a fully-redacted error ("permanent error: ‹×›"). The actual error text is now preserved according to its internal redaction behavior.