### PR TITLE
release-26.2: cluster-ui: fix webpack bundle issues

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
-        pnpm build
+        pnpm build:release
 
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
-        pnpm build
+        pnpm build:release
 
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "26.2.0",
+  "version": "26.2.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --mode=production",
+    "build:release": "npm-run-all -p build:typescript build:release-bundle",
+    "build:release-bundle": "NODE_ENV=production webpack --mode=production --env inline-assets",
     "build:typescript": "tsc",
     "build:watch": "webpack --watch --mode=development --env WEBPACK_WATCH",
     "tsc:watch": "node build/typescript/watchWithMultipleDests.js --no-interactive",

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-          type: "asset/inline",
+          type: env["inline-assets"] ? "asset/inline" : "asset",
           exclude: /node_modules/,
         },
         // Styles in current project use SCSS preprocessing language with CSS modules.

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-          type: "asset",
+          type: "asset/inline",
           exclude: /node_modules/,
         },
         // Styles in current project use SCSS preprocessing language with CSS modules.

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -70,6 +70,7 @@ module.exports = (env, argv) => {
             {
               loader: "css-loader",
               options: {
+                sourceMap: false,
                 modules: {
                   localIdentName: "[local]--[hash:base64:5]",
                 }
@@ -84,7 +85,7 @@ module.exports = (env, argv) => {
         // dir so it can access external dependencies.
         {
           test: /(?<!\.module)\.scss/,
-          use: ["style-loader", "css-loader", "sass-loader"],
+          use: ["style-loader", { loader: "css-loader", options: { sourceMap: false } }, "sass-loader"],
           exclude: /node_modules/,
         },
         {
@@ -142,6 +143,7 @@ module.exports = (env, argv) => {
             {
               loader: "esbuild-loader",
               options: {
+                sourceMap: false,
                 loader: "css",
                 minify: true,
               },

--- a/pkg/ui/workspaces/db-console/jest.config.js
+++ b/pkg/ui/workspaces/db-console/jest.config.js
@@ -223,7 +223,7 @@ module.exports = {
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: [],
+  transformIgnorePatterns: ["node_modules/@cockroachlabs/cluster-ui/dist"],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,


### PR DESCRIPTION
Backport:
  * 2/2 commits from "cluster-ui: fix font inlining and reduce webpack bundle size" (#168071)
  * 1/1 commits from "cluster-ui: only inline assets for npm release builds" (#168254)

Please see individual PRs for details.

/cc @cockroachdb/release

release justification: fixes build issues introduced after webpack upgrade