### PR TITLE
release-26.2:roachtest: deflake mixed-version backup timeouts

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -343,6 +343,7 @@ go_library(
         "@com_github_aws_smithy_go//logging",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_ttycolor//:ttycolor",

--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/version"
@@ -95,14 +94,6 @@ var (
 		"settings":     "SHOW CLUSTER SETTINGS",
 		"users":        "SHOW USERS",
 		"zones":        "SHOW ZONE CONFIGURATIONS",
-	}
-
-	// retry options while waiting for a backup to complete
-	backupCompletionRetryOptions = retry.Options{
-		InitialBackoff: 10 * time.Second,
-		MaxBackoff:     1 * time.Minute,
-		Multiplier:     1.5,
-		MaxRetries:     80,
 	}
 
 	possibleNumIncrementalBackups = []int{

--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -30,12 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 )
 
@@ -440,7 +442,6 @@ func (u *CommonTestUtils) setClusterSettings(
 func (u *CommonTestUtils) waitForJobSuccess(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand, jobID int, internalSystemJobs bool,
 ) (resErr error) {
-	var lastErr error
 	node := u.RandomNode(rng, u.roachNodes)
 	l.Printf("querying job status through node %d", node)
 
@@ -458,7 +459,14 @@ func (u *CommonTestUtils) waitForJobSuccess(
 	if internalSystemJobs {
 		jobsQuery = fmt.Sprintf("(%s)", jobutils.InternalSystemJobsBaseQuery)
 	}
-	r := retry.StartWithCtx(ctx, backupCompletionRetryOptions)
+
+	var lastStatus jobs.State
+	logThrottler := util.EveryMono(30 * time.Second)
+	r := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: time.Second,
+		MaxBackoff:     time.Second,
+		MaxDuration:    80 * time.Minute,
+	})
 	for r.Next() {
 		var status string
 		var payloadBytes []byte
@@ -466,26 +474,26 @@ func (u *CommonTestUtils) waitForJobSuccess(
 			fmt.Sprintf(`SELECT status, payload FROM %s`, jobsQuery), jobID,
 		).Scan(&status, &payloadBytes)
 		if err != nil {
-			lastErr = fmt.Errorf("error reading (status, payload) for job %d: %w", jobID, err)
-			l.Printf("%v", lastErr)
+			l.Printf("error reading (status, payload) for job %d: %v", jobID, err)
 			continue
 		}
 
 		if jobs.State(status) == jobs.StateFailed {
 			payload := &jobspb.Payload{}
 			if err := protoutil.Unmarshal(payloadBytes, payload); err == nil {
-				lastErr = fmt.Errorf("job %d failed with error: %s", jobID, payload.Error)
+				return fmt.Errorf("job %d failed with error: %s", jobID, payload.Error)
 			} else {
-				lastErr = fmt.Errorf("job %d failed, and could not unmarshal payload: %w", jobID, err)
+				return fmt.Errorf("job %d failed, and could not unmarshal payload: %w", jobID, err)
 			}
-
-			l.Printf("%v", lastErr)
-			break
 		}
 
 		if expected, actual := jobs.StateSucceeded, jobs.State(status); expected != actual {
-			lastErr = fmt.Errorf("job %d: current status %q, waiting for %q", jobID, actual, expected)
-			l.Printf("%v", lastErr)
+			// Log current status if there has been a change or if it has been long
+			// enough since the last update.
+			if logThrottler.ShouldProcess(crtime.NowMono()) || lastStatus != actual {
+				l.Printf("job %d: current status %q, waiting for %q", jobID, actual, expected)
+			}
+			lastStatus = actual
 			continue
 		}
 
@@ -493,11 +501,11 @@ func (u *CommonTestUtils) waitForJobSuccess(
 		return nil
 	}
 
-	if r.CurrentAttempt() >= backupCompletionRetryOptions.MaxRetries {
-		return fmt.Errorf("exhausted all %d retries waiting for job %d to finish, last err: %w", backupCompletionRetryOptions.MaxRetries, jobID, lastErr)
+	if err := ctx.Err(); err != nil {
+		return errors.Wrapf(err, "error waiting for job %d to finish", jobID)
 	}
 
-	return fmt.Errorf("error waiting for job to finish: %w", lastErr)
+	return errors.Newf("retries exhausted waiting for job %d to finish", jobID)
 }
 
 // runJobOnOneOf disables job adoption on cockroach nodes that are not


### PR DESCRIPTION
This commit updates the retry loop on the job poller to be duration-based instead of retry count based. This should hopefully reduce some of the recent test flakes due to exhausted retries.

Fixes: #167580

Release note: None

---

Release justification: Test-only change.