### PR TITLE
sql/gcjob: add defensive nil checks for zone config in refreshTenant

### DIFF
--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -284,7 +284,7 @@ func getIndexTTL(tableTTL int32, placeholder *zonepb.ZoneConfig, indexID descpb.
 
 func getTableTTL(defTTL int32, zoneCfg *zonepb.ZoneConfig) int32 {
 	ttlSeconds := defTTL
-	if zoneCfg != nil {
+	if zoneCfg != nil && zoneCfg.GC != nil {
 		ttlSeconds = zoneCfg.GC.TTLSeconds
 	}
 	return ttlSeconds
@@ -426,7 +426,7 @@ func refreshTenant(
 	tenantTTLSeconds := execCfg.DefaultZoneConfig.GC.TTLSeconds
 	zoneCfg, err := cfg.GetZoneConfigForObject(keys.SystemSQLCodec, keys.TenantsRangesID)
 	if err == nil {
-		tenantTTLSeconds = zoneCfg.GC.TTLSeconds
+		tenantTTLSeconds = getTableTTL(tenantTTLSeconds, zoneCfg)
 	} else {
 		log.Dev.Errorf(ctx, "zone config for tenants range: err = %+v", err)
 	}


### PR DESCRIPTION
Previously, refreshTenant would panic if GetZoneConfigForObject returned a nil zone configuration or if the zone configuration had a nil GC policy. This occurred during tenant garbage collection if the system configuration was partially available or if the specific zone configuration was missing.

This commit adds defensive nil checks for the retrieved zone configuration and its garbage collection policy. It also leverages the getTableTTL helper to ensures the system correctly falls back to default TTL values when specific zone configurations are unavailable.

Resolves: #167562
Epic: none

Release note (bug fix): Fixed a nil pointer dereference in the refreshTenant function during tenant garbage collection. This occurred when the system attempted to access a missing zone configuration or GC policy for the tenants range.