### PR TITLE
admission: introduce CPU time token AC mode setting

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
     embed = [":admission"],
     deps = [
         "//pkg/cli/exit",
+        "//pkg/clusterversion",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/testutils/datapathutils",

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -37,6 +37,47 @@ var KVCPUTimeSystemUtilGoal = settings.RegisterFloatSetting(
 	0.95,
 	settings.FloatWithMinimum(minTargetUtilFrac))
 
+// KVCPUTimeUtilTarget is the non-burstable CPU utilization target in
+// resource manager mode. Resource groups that have not qualified for
+// burst are limited to this target.
+//
+// TODO(wenyihu): This setting is not yet consumed; it will be wired
+// into the filler when resourceManagerMode is implemented.
+var KVCPUTimeUtilTarget = settings.RegisterFloatSetting(
+	settings.SystemOnly,
+	"admission.cpu_time_tokens.target_util",
+	"the non-burstable CPU utilization target in resource manager mode "+
+		"(not yet active; reserved for future use), "+
+		"value is in the interval [0,1] where 1 means all cores",
+	0.75,
+	settings.FloatInRange(minTargetUtilFrac, 1.0))
+
+// KVCPUTimeUtilBurstDeltaRM is the delta added to KVCPUTimeUtilTarget
+// to compute the burstable utilization ceiling in resource manager
+// mode. For example, with target_util=0.75 and burst_delta_rm=0.25,
+// the burstable ceiling is 1.0. Resource groups configured with
+// FULLY_UTILIZE are always allowed to burst up to this ceiling.
+//
+// If target + delta exceeds 1.0, the burstable token bucket refill
+// rate will exceed the machine's CPU capacity. In practice this means
+// burstable work is never throttled by the token bucket (tokens
+// accumulate faster than they can be consumed). No other invariant
+// breaks because the token bucket simply acts as if it were infinite.
+// TODO(wenyihu): Confirm this ^.
+//
+// TODO(wenyihu): This setting is not yet consumed; it will be wired
+// into the filler when resourceManagerMode is implemented.
+var KVCPUTimeUtilBurstDeltaRM = settings.RegisterFloatSetting(
+	settings.SystemOnly,
+	"admission.cpu_time_tokens.target_util.burst_delta_rm",
+	"the delta added to admission.cpu_time_tokens.target_util to compute "+
+		"the burstable utilization ceiling in resource manager mode "+
+		"(not yet active; reserved for future use), "+
+		"value is in the interval (0,1]",
+	0.25,
+	settings.FloatInRange(0, 1.0),
+	settings.PositiveFloat)
+
 // Burstable work is given this much CPU headroom above non-burstable. See
 // resetInterval for more.
 var KVCPUTimeUtilBurstDelta = settings.RegisterFloatSetting(

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// Below two are the non-burstable utilization goals. See resetInterval for
-// more.
+// Serverless per-tier non-burstable utilization goals. See resetInterval
+// for more details.
 var KVCPUTimeAppUtilGoal = settings.RegisterFloatSetting(
 	settings.SystemOnly,
 	"admission.cpu_time_tokens.target_util.app_tenant",

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -17,14 +17,71 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
+// cpuTimeTokenACEnabled is the legacy bool setting for enabling CPU time
+// token AC. Deprecated in favor of cpuTimeTokenACMode. Kept registered
+// so that clusters upgrading from older versions (where this was set to
+// true) continue to function. The cpuTimeTokenACIsEnabled helper checks
+// cpuTimeTokenACMode first and falls back to this setting. This setting
+// will be retired in 26.4 once all clusters have migrated to the new
+// mode setting.
 var cpuTimeTokenACEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"admission.cpu_time_tokens.enabled",
 	"if true, CPU time token AC will be used for foreground KVWork, instead of slots-based AC -- "+
-		"note that this is not supported in production except on multi-tenant Serverless clusters",
+		"deprecated in favor of admission.cpu_time_tokens.mode",
 	false)
+
+// cpuTimeTokenMode selects between off (slot-based AC), Serverless
+// (2 WorkQueues, per-tier settings), and Resource Manager (1 WorkQueue,
+// resource groups) modes.
+type cpuTimeTokenMode int64
+
+const (
+	// offMode disables CPU time token AC; slot-based AC is used instead.
+	// When the mode is off, the legacy bool setting is checked as a
+	// fallback.
+	offMode cpuTimeTokenMode = iota
+	// serverlessMode uses 2 WorkQueues (systemTenant, appTenant), per-tier
+	// utilization targets, and 4 buckets (2 tiers x 2 burst quals).
+	serverlessMode
+	// resourceManagerMode will use 1 WorkQueue with N resource groups,
+	// a single utilization target, and 2 buckets (1 tier x 2 burst quals).
+	// TODO(wenyihu): In RM mode, only queue[0] should receive work;
+	// queue[1] will sit idle. This routing is not yet implemented.
+	resourceManagerMode
+)
+
+// cpuTimeTokenACMode selects the CPU time token admission control
+// mode. Can be changed at runtime without a restart. When set to off,
+// the legacy admission.cpu_time_tokens.enabled bool is checked as a
+// fallback for backward compatibility.
+//
+// This is ApplicationLevel to match the legacy cpuTimeTokenACEnabled
+// bool that it replaces. The class should be revisited when the
+// legacy bool is retired.
+var cpuTimeTokenACMode = settings.RegisterEnumSetting[cpuTimeTokenMode](
+	settings.ApplicationLevel,
+	"admission.cpu_time_tokens.mode",
+	"selects the CPU time token admission control mode: off uses "+
+		"slot-based AC (or falls back to the legacy enabled bool), "+
+		"serverless uses 2 queues with per-tier targets, "+
+		"resource_manager uses 1 queue with resource groups",
+	"off",
+	map[cpuTimeTokenMode]string{
+		offMode:             "off",
+		serverlessMode:      "serverless",
+		resourceManagerMode: "resource_manager",
+	},
+	settings.WithValidateEnum(func(val string) error {
+		if val == "resource_manager" {
+			return errors.New("resource_manager mode is not yet implemented")
+		}
+		return nil
+	}),
+)
 
 // cpuTimeTokenACKillSwitch is an env var kill switch that disables CPU time
 // token AC regardless of the cluster setting. This is useful when SQL is
@@ -32,48 +89,58 @@ var cpuTimeTokenACEnabled = settings.RegisterBoolSetting(
 var cpuTimeTokenACKillSwitch = envutil.EnvOrDefaultBool(
 	"COCKROACH_DISABLE_CPU_TIME_TOKEN_AC", false)
 
-// cpuTimeTokenACIsEnabled returns true if CPU time token AC is enabled. It
-// checks both the cluster setting and the env var kill switch. The kill switch
-// takes precedence over the cluster setting.
+// cpuTimeTokenACIsEnabled returns true if CPU time token AC is enabled.
+// It checks cpuTimeTokenACMode first; if that is off, it falls back
+// to the legacy cpuTimeTokenACEnabled bool for backward compatibility.
+// The env var kill switch takes precedence over both settings.
 func cpuTimeTokenACIsEnabled(sv *settings.Values) bool {
-	return !cpuTimeTokenACKillSwitch && cpuTimeTokenACEnabled.Get(sv)
+	if cpuTimeTokenACKillSwitch {
+		return false
+	}
+	if cpuTimeTokenACMode.Get(sv) != offMode {
+		return true
+	}
+	return cpuTimeTokenACEnabled.Get(sv)
 }
 
 var sqlCPUTimeTokenACEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"admission.sql_cpu_time_tokens.enabled",
 	"when true, SQL CPU usage is admitted through the same CPU time token "+
-		"budget as KV work; has no effect unless admission.cpu_time_tokens.enabled "+
-		"is also true",
+		"budget as KV work; has no effect unless CPU time token AC is enabled "+
+		"via admission.cpu_time_tokens.mode or the legacy enabled setting",
 	false,
 )
 
-// sqlCPUTimeTokenACIsEnabled returns true if SQL CPU usage is admitted through
-// the same CPU time token AC as KV work. It has no effect unless
-// admission.cpu_time_tokens.enabled is also true.
+// sqlCPUTimeTokenACIsEnabled returns true if SQL CPU usage is admitted
+// through the same CPU time token AC as KV work. It has no effect unless
+// CPU time token AC is enabled.
 func sqlCPUTimeTokenACIsEnabled(sv *settings.Values) bool {
 	return cpuTimeTokenACIsEnabled(sv) && sqlCPUTimeTokenACEnabled.Get(sv)
 }
 
-// CPUGrantCoordinators's main purpose is to act as a shim. Depending on
-// whether admission.cpu_time_tokens.enabled is true or false, a WorkQueue
-// that does slot-based or CPU time token AC is returned from
-// GetKVWorkQueue. This way, we support both, without requiring a process
-// restart.
+// CPUGrantCoordinators acts as a shim. Depending on
+// admission.cpu_time_tokens.mode (off, serverless, resource_manager),
+// a WorkQueue that does slot-based or CPU time token AC is returned
+// from GetKVWorkQueue. This way, we support both, without requiring a
+// process restart.
 type CPUGrantCoordinators struct {
 	st           *cluster.Settings
 	slotsCoord   *GrantCoordinator
 	cpuTimeCoord *cpuTimeTokenGrantCoordinator
 }
 
-// GetKVWorkQueue returns a WorkQueue to use for KVWork. If
-// admission.cpu_time_tokens.enabled is true, it returns a WorkQueue that
-// implements CPU time token AC. Else it returns a WorkQueue that does
-// slots-based AC. If CPU time token AC, there is one WorkQueue for system
-// tenant work and another for app tenant work. The system tenant WorkQueue
-// is backed by a granter that allows greater resource usage than the app
-// tenant WorkQueue. This is a prioritization scheme. For details regarding
-// the granters, see cpu_time_token_granter.go.
+// GetKVWorkQueue returns a WorkQueue to use for KVWork. If CPU time
+// token AC is enabled (via admission.cpu_time_tokens.mode or the legacy
+// enabled bool), it returns a WorkQueue that implements CPU time token
+// AC. Else it returns a WorkQueue that does slots-based AC.
+//
+// In serverless mode, there is one WorkQueue for system tenant work
+// and another for app tenant work. The system tenant WorkQueue is
+// backed by a granter that allows greater resource usage than the app
+// tenant WorkQueue. This is a prioritization scheme. In resource
+// manager mode, only queue[0] will be used (not yet implemented). For
+// details regarding the granters, see cpu_time_token_granter.go.
 func (coord *CPUGrantCoordinators) GetKVWorkQueue(isSystemTenant bool) *WorkQueue {
 	if !cpuTimeTokenACIsEnabled(&coord.st.SV) {
 		return coord.slotsCoord.GetWorkQueue(KVWork)
@@ -203,13 +270,15 @@ func makeCPUTimeTokenGrantCoordinator(
 				filler.start(ambientCtx.AnnotateCtx(context.Background()))
 			})
 		}
-		cpuTimeTokenACEnabled.SetOnChange(&settings.SV, func(ctx context.Context) {
+		startIfEnabled := func(ctx context.Context) {
 			if cpuTimeTokenACIsEnabled(&settings.SV) {
 				once.Do(func() {
 					filler.start(ambientCtx.AnnotateCtx(context.Background()))
 				})
 			}
-		})
+		}
+		cpuTimeTokenACMode.SetOnChange(&settings.SV, startIfEnabled)
+		cpuTimeTokenACEnabled.SetOnChange(&settings.SV, startIfEnabled)
 	}
 
 	return coordinator

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -9,12 +9,35 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
+
+// TestObsoleteCode contains nudges for cleanups that may be possible in the
+// future. When this test fails (which is necessarily a result of bumping the
+// MinSupportedVersion), please carry out the cleanups that are now possible or
+// file issues asking for them to be done.
+func TestObsoleteCode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	msv := clusterversion.RemoveDevOffset(clusterversion.MinSupported.Version())
+	t.Logf("MinSupported: %v", msv)
+
+	// When MinSupported is bumped above V26_3, the legacy
+	// cpuTimeTokenACEnabled bool (admission.cpu_time_tokens.enabled) can
+	// be removed along with the fallback logic in cpuTimeTokenACIsEnabled.
+	// All clusters will have the mode setting by then.
+	v26dot3 := clusterversion.RemoveDevOffset(clusterversion.V26_3.Version())
+	if !msv.LessEq(v26dot3) {
+		_ = cpuTimeTokenACEnabled
+		t.Fatalf("cpuTimeTokenACEnabled (admission.cpu_time_tokens.enabled) and " +
+			"its fallback in cpuTimeTokenACIsEnabled can be removed")
+	}
+}
 
 func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -29,38 +52,65 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	defer coords.Close()
 	cpuCoords := coords.RegularCPU
 
-	defer func(prev bool) {
-		cpuTimeTokenACEnabled.Override(context.Background(), &settings.SV, prev)
-	}(cpuTimeTokenACEnabled.Get(&settings.SV))
+	ctx := context.Background()
+	defer func(prevMode cpuTimeTokenMode, prevEnabled bool) {
+		cpuTimeTokenACMode.Override(ctx, &settings.SV, prevMode)
+		cpuTimeTokenACEnabled.Override(ctx, &settings.SV, prevEnabled)
+	}(cpuTimeTokenACMode.Get(&settings.SV), cpuTimeTokenACEnabled.Get(&settings.SV))
 
-	// Test that if setting is disabled, WorkQueues uses slots, else they
-	// use CPU time tokens.
-	cpuTimeTokenACEnabled.Override(context.Background(), &settings.SV, false)
+	// Both settings off: slot-based AC.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
-	// If CPU time token AC is disabled, we use one WorkQueue for both
-	// system & app tenant work.
 	require.Equal(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 
-	cpuTimeTokenACEnabled.Override(context.Background(), &settings.SV, true)
+	// Mode set to serverless: CPU time token AC.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, serverlessMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
-	// If CPU time token AC is enabled, we use one WorkQueue for system
-	// tenant work & a second WorkQueue for app tenant work.
 	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 
-	// Test that the env var kill switch overrides the cluster setting.
-	// Even with the setting enabled, the kill switch forces slot-based AC.
+	// Mode set to resource_manager: CPU time token AC.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, resourceManagerMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
+
+	// Legacy bool fallback: mode is off but enabled=true enables CTT AC.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, true)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
+
+	// Kill switch overrides all modes.
 	defer func(prev bool) {
 		cpuTimeTokenACKillSwitch = prev
 	}(cpuTimeTokenACKillSwitch)
+
+	// Kill switch overrides serverlessMode.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, serverlessMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
 	cpuTimeTokenACKillSwitch = true
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 	require.Equal(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 
-	// Disabling the kill switch restores CPU time token AC (setting is
-	// still enabled).
+	// Kill switch overrides resourceManagerMode.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, resourceManagerMode)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+
+	// Kill switch overrides legacy bool fallback.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, true)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+
+	// Disabling kill switch restores CPU time token AC.
 	cpuTimeTokenACKillSwitch = false
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -199,9 +199,11 @@ func NewGrantCoordinators(
 			sqlKVWorkQueue.SetOverrideAllToBypassAdmission(override)
 			sqlSQLWorkQueue.SetOverrideAllToBypassAdmission(override)
 		}
-		cpuTimeTokenACEnabled.SetOnChange(&st.SV, func(ctx context.Context) {
+		onSettingChange := func(ctx context.Context) {
 			setLatestOverride()
-		})
+		}
+		cpuTimeTokenACMode.SetOnChange(&st.SV, onSettingChange)
+		cpuTimeTokenACEnabled.SetOnChange(&st.SV, onSettingChange)
 		// Initialize.
 		setLatestOverride()
 	}


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/168382
Epic: none 
Release note: none

---
**admission: introduce CPU time token AC mode setting**

The existing `admission.cpu_time_tokens.enabled` bool setting cannot be
changed to an enum in-place: the stored value has type code `"b"`, and
the new version would expect `"e"`, causing `checkType()` to reject it
on upgrade. The setting would silently fall back to its default,
disabling CPU time token AC without operator awareness.

This change introduces a new enum setting,
`admission.cpu_time_tokens.mode`, with three modes: `off` (default),
`serverless`, and `resource_manager`. The `cpuTimeTokenACIsEnabled`
helper checks `cpuTimeTokenACMode` first; if the mode is `off`, it
falls back to the legacy bool for backward compatibility. The legacy
bool is kept active (not retired) through 26.3 to avoid coupling the
release to a cluster setting change. It will be retired in 26.4 once
all clusters have migrated to the new setting.

Both `SetOnChange` registrations (filler goroutine startup and SQL
work bypass) now listen to both settings so that changes to either
take effect.

Future commits will wire up the `resource_manager` mode to use a
single WorkQueue with resource groups.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: add resource manager utilization target settings**

This change adds two cluster settings for resource manager mode:

- `admission.cpu_time_tokens.target_util` (default 0.75): the
  non-burstable CPU utilization target.
- `admission.cpu_time_tokens.target_util.burst_delta_rm` (default 0.25):
  the delta added to the non-burstable target to compute the burstable
  ceiling. Resource groups configured with FULLY_UTILIZE are always
  allowed to burst up to this ceiling (e.g. 0.75 + 0.25 = 1.0).

Unlike the existing per-tier settings (`target_util.app_tenant` and
`target_util.system_tenant`) used in serverless mode, resource manager
mode uses a single non-burstable target with a burst delta across all
resource groups.

The settings are defined but not yet consumed. Future commits will wire
them into the allocator when resource_manager mode is active.

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

