### PR TITLE
security: revert increase timeout fix TestOIDCAuthorization_RoleGrantAndRevoke flake

### DIFF
--- a/pkg/security/oidcauth/authorization_oidc_test.go
+++ b/pkg/security/oidcauth/authorization_oidc_test.go
@@ -309,7 +309,6 @@ func TestOIDCAuthorization_TokenPaths(t *testing.T) {
 			rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
 			client, err := rpcCtx.GetHTTPClient()
 			require.NoError(t, err)
-			client.Timeout = 30 * time.Second
 			// Prevent automatic redirects so we can capture cookies and headers.
 			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
@@ -378,7 +377,6 @@ func TestOIDCAuthorization_UserinfoPaths(t *testing.T) {
 	rpc := app.NewClientRPCContext(ctx, username.TestUserName())
 	cl, err := rpc.GetHTTPClient()
 	require.NoError(t, err)
-	cl.Timeout = 30 * time.Second
 	cl.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 	// Create an RSA key pair for signing and verifying tokens.
@@ -659,6 +657,7 @@ func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
 		state := loc.Query().Get("state")
 
 		// Step 2: simulate the IdP redirect to /oidc/v1/callback.
+		// Use retry logic to handle transient timing issues during stress tests.
 		cbReq, _ := http.NewRequest("GET",
 			app.AdminURL().WithPath("/oidc/v1/callback").String(), nil)
 		cbReq.AddCookie(stateCookie)
@@ -667,8 +666,47 @@ func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
 		q.Set("code", "dummy")
 		cbReq.URL.RawQuery = q.Encode()
 
-		cbResp, err := client.Do(cbReq)
-		require.NoError(t, err)
+		// Retry the callback request with an exponential backoff to handle timing issues
+		// that can occur during stress runs or with race detection enabled.
+		const maxRetries = 3
+		var cbResp *http.Response
+		var lastErr error
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			if attempt > 0 {
+				// Exponential backoff: 100ms, 200ms
+				backoff := time.Duration(100<<uint(attempt-1)) * time.Millisecond
+				t.Logf("Retrying OIDC callback after %v (attempt %d/%d)", backoff, attempt+1, maxRetries)
+				time.Sleep(backoff)
+			}
+
+			cbResp, err = client.Do(cbReq)
+			if err == nil {
+				// Success
+				break
+			}
+
+			lastErr = err
+			// Check if this is a timeout error that we should retry
+			var urlErr *url.Error
+			if errors.As(err, &urlErr) && (urlErr.Timeout() || urlErr.Temporary()) {
+				t.Logf("OIDC callback timeout/temporary error (attempt %d/%d): %v", attempt+1, maxRetries, err)
+				continue
+			}
+
+			// Non-retriable error, fail fast
+			break
+		}
+
+		if lastErr != nil && err != nil {
+			// All retries exhausted or non-retriable error
+			t.Fatalf("OIDC callback failed after %d attempts: %v\n"+
+				"Note: This timeout does not indicate a security or functional failure. "+
+				"The OIDC authorization logic still properly fails unauthorized requests. "+
+				"This is a test timing issue, likely due to system load during stress testing.",
+				maxRetries, lastErr)
+		}
+
+		require.NoError(t, err, "OIDC callback request should succeed")
 		require.Equal(t, expectedStatus, cbResp.StatusCode)
 	}
 
@@ -676,7 +714,6 @@ func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
 	rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
 	client, err := rpcCtx.GetHTTPClient()
 	require.NoError(t, err)
-	client.Timeout = 30 * time.Second
 	// Prevent automatic redirects so we can capture cookies and headers.
 	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 


### PR DESCRIPTION
## Summary

This reverts PR #167913 (commit 3691c2d0147), which was an auto-generated
fix that removed the retry logic from `performOIDCLogin` and replaced it
with increased client timeouts.

- PR #161381 already properly fixed the flaky test (#159262) by adding
  retry logic with exponential backoff
- PR #167913 was filed against a duplicate issue (#167912) and
  unnecessarily removed the working fix from #161381

Reverts #167913

Epic: none

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)