### PR TITLE
cli: add upload-server destination for debug zip upload

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -88,6 +88,8 @@ go_library(
         "zip_per_node.go",
         "zip_table_registry.go",
         "zip_upload.go",
+        "zip_upload_blob.go",
+        "zip_upload_server.go",
         "zip_upload_table_dumps.go",
         ":gen-keytype-stringer",  # keep
     ],
@@ -417,6 +419,8 @@ go_test(
         "zip_table_registry_test.go",
         "zip_tenant_test.go",
         "zip_test.go",
+        "zip_upload_blob_test.go",
+        "zip_upload_server_test.go",
         "zip_upload_table_dumps_test.go",
         "zip_upload_test.go",
     ],

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1591,6 +1591,15 @@ func init() {
 	f.BoolVar(&debugZipUploadOpts.dryRun, "dry-run", false, "run in dry-run mode without making any actual uploads")
 	f.Lookup("dry-run").Hidden = true
 
+	f.StringVar(&debugZipUploadOpts.destination, "destination", "datadog",
+		"upload destination: datadog or upload-server")
+	f.StringVar(&debugZipUploadOpts.uploadServerAPIKey, "upload-server-api-key",
+		getEnvOrDefault(uploadServerAPIKeyEnvVar, ""),
+		"API key for the CRL upload server (used with --destination=upload-server)")
+	f.StringVar(&debugZipUploadOpts.uploadServerURL, "upload-server-url",
+		"",
+		"base URL of the CRL upload server (required with --destination=upload-server)")
+
 	f = debugDecodeKeyCmd.Flags()
 	f.Var(&decodeKeyOptions.encoding, "encoding", "key argument encoding")
 	f.BoolVar(&decodeKeyOptions.userKey, "user-key", false, "key type")

--- a/pkg/cli/zip_cmd.go
+++ b/pkg/cli/zip_cmd.go
@@ -27,11 +27,21 @@ requires the cluster to be live.
 	RunE: clierrorplus.MaybeDecorateError(runDebugZip),
 }
 
-// debugZipUploadCmd is a hidden command that uploads the generated debug.zip
-// to datadog. This will not apprear in the help text of the zip command.
+// debugZipUploadCmd is a hidden command that uploads the generated
+// debug.zip to an observability platform or CRL's upload server. This
+// will not appear in the help text of the zip command.
 var debugZipUploadCmd = &cobra.Command{
-	Use:    "upload <path to debug dir>",
-	Short:  "upload the contents of the debug.zip to an observability platform",
+	Use:   "upload <path to debug zip file or dir>",
+	Short: "upload debug zip artifacts to an observability platform or CRL upload server",
+	Long: `Upload debug zip data to a supported destination.
+
+Use --destination=datadog to upload extracted debug zip artifacts to Datadog.
+This requires a path to an extracted debug directory.
+
+Use --destination=upload-server to upload the raw debug.zip file to CRL's
+upload server. This requires a path to a .zip file and authentication via
+--upload-server-api-key and --upload-server-url.
+`,
 	Args:   cobra.ExactArgs(1),
 	Hidden: true,
 	RunE:   clierrorplus.MaybeDecorateError(runDebugZipUpload),

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -130,8 +130,12 @@ var debugZipUploadOpts = struct {
 	logFormat            string
 	maxConcurrentUploads int
 	dryRun               bool
+	destination          string // "datadog" (default) or "upload-server"
+	uploadServerAPIKey   string // API key for the CRL upload server
+	uploadServerURL      string // upload server base URL
 }{
 	maxConcurrentUploads: system.NumCPU() * 4,
+	destination:          "datadog",
 }
 
 // This is the list of all supported artifact types. The "possible values" part
@@ -306,12 +310,39 @@ func validateRedactionStatus(debugDirPath string) error {
 func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 	runtime.GOMAXPROCS(system.NumCPU())
 
+	dest := debugZipUploadOpts.destination
+	inputPath := args[0]
+
+	switch dest {
+	case "upload-server":
+		return runServerUpload(cmd.Context(), inputPath)
+	case "datadog":
+		return runDatadogUpload(cmd, inputPath)
+	default:
+		return errors.Newf(
+			"unsupported destination %q; valid values are: datadog, upload-server",
+			dest,
+		)
+	}
+}
+
+func runServerUpload(ctx context.Context, inputPath string) error {
+	if err := validateUploadServerReadiness(inputPath); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "\n=== uploading debug zip to upload server\n\n")
+
+	return uploadDebugZipViaServer(ctx, inputPath)
+}
+
+func runDatadogUpload(cmd *cobra.Command, inputPath string) error {
 	if err := validateZipUploadReadiness(); err != nil {
 		return err
 	}
 
 	// Check redaction status before proceeding with upload
-	if err := validateRedactionStatus(args[0]); err != nil {
+	if err := validateRedactionStatus(inputPath); err != nil {
 		return err
 	}
 
@@ -333,7 +364,7 @@ func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 	for _, artType := range artifactsToUpload {
 		fmt.Printf("\n=== uploading %s\n\n", artType)
 
-		if err := uploadZipArtifactFuncs[artType](cmd.Context(), uploadID, args[0]); err != nil {
+		if err := uploadZipArtifactFuncs[artType](cmd.Context(), uploadID, inputPath); err != nil {
 			// Log the error and continue with the next artifact
 			fmt.Printf("Failed to upload %s: %s\n", artType, err)
 		}

--- a/pkg/cli/zip_upload_blob.go
+++ b/pkg/cli/zip_upload_blob.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/errors"
+)
+
+// blobUploader abstracts uploading a file to blob storage.
+// Implementations exist for GCS (via the cloud package) and can be
+// extended to S3 or other providers in the future.
+type blobUploader interface {
+	// Upload uploads the file at srcPath to blob storage. The
+	// destination path is determined by the prefix configured at
+	// creation time. It returns the full destination path.
+	Upload(ctx context.Context, srcPath string) (destPath string, err error)
+
+	// Close releases any resources held by the uploader.
+	Close() error
+}
+
+// gcsBlobUploader uploads files to GCS using CockroachDB's cloud storage
+// infrastructure. It constructs a GCS URI with an embedded bearer token
+// and uses cloud.EarlyBootExternalStorageFromURI to create the storage
+// handle.
+type gcsBlobUploader struct {
+	bucket     string
+	pathPrefix string
+	token      string
+	storage    cloud.ExternalStorage
+}
+
+func newGCSBlobUploader(
+	ctx context.Context, bucket, pathPrefix, bearerToken string,
+) (*gcsBlobUploader, error) {
+	uri := fmt.Sprintf(
+		"gs://%s/%s?AUTH=specified&BEARER_TOKEN=%s",
+		bucket, pathPrefix, bearerToken,
+	)
+
+	es, err := cloud.EarlyBootExternalStorageFromURI(
+		ctx, uri,
+		base.ExternalIODirConfig{},
+		cluster.MakeClusterSettings(),
+		nil, // limiters
+		cloud.NilMetrics,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating GCS storage client")
+	}
+
+	return &gcsBlobUploader{
+		bucket:     bucket,
+		pathPrefix: pathPrefix,
+		token:      bearerToken,
+		storage:    es,
+	}, nil
+}
+
+func (u *gcsBlobUploader) Upload(ctx context.Context, srcPath string) (string, error) {
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return "", errors.Wrap(err, "opening zip file")
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return "", errors.Wrap(err, "getting file info")
+	}
+
+	destName := filepath.Base(srcPath)
+
+	w, err := u.storage.Writer(ctx, destName)
+	if err != nil {
+		return "", errors.Wrap(err, "creating storage writer")
+	}
+
+	pw := &progressWriter{
+		w:     w,
+		total: fi.Size(),
+	}
+
+	if _, err := io.Copy(pw, f); err != nil {
+		_ = w.Close()
+		return "", errors.Wrap(err, "uploading file")
+	}
+
+	if err := w.Close(); err != nil {
+		return "", errors.Wrapf(err,
+			"finalizing upload (credentials may have expired)")
+	}
+
+	destPath := fmt.Sprintf(
+		"gs://%s/%s/%s", u.bucket, u.pathPrefix, destName,
+	)
+	return destPath, nil
+}
+
+func (u *gcsBlobUploader) Close() error {
+	return u.storage.Close()
+}
+
+// newBlobUploader creates the appropriate blobUploader based on the
+// storage provider. Currently only GCS is supported;
+// Declared as a var to allow test injection.
+var newBlobUploader = func(
+	ctx context.Context, provider, bucket, prefix, token string,
+) (blobUploader, error) {
+	switch provider {
+	case "gcs":
+		return newGCSBlobUploader(ctx, bucket, prefix, token)
+	default:
+		return nil, errors.Newf("unsupported storage provider: %q", provider)
+	}
+}
+
+// progressWriter wraps an io.Writer and prints upload progress to
+// stderr on every write.
+type progressWriter struct {
+	w       io.Writer
+	total   int64
+	written int64
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n, err := pw.w.Write(p)
+	pw.written += int64(n)
+	if err == nil && pw.total > 0 {
+		pct := float64(pw.written) / float64(pw.total) * 100
+		fmt.Fprintf(os.Stderr, "\rUploading... %s / %s (%.1f%%)",
+			humanReadableSize(int(pw.written)),
+			humanReadableSize(int(pw.total)),
+			pct,
+		)
+		if pw.written == pw.total {
+			fmt.Fprintln(os.Stderr)
+		}
+	}
+	return n, err
+}

--- a/pkg/cli/zip_upload_blob_test.go
+++ b/pkg/cli/zip_upload_blob_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBlobUploader records calls for testing without GCS.
+type mockBlobUploader struct {
+	uploadedPath string
+	content      []byte
+	closed       bool
+	uploadErr    error
+	uploadCount  int
+}
+
+func (m *mockBlobUploader) Upload(_ context.Context, srcPath string) (string, error) {
+	m.uploadCount++
+	if m.uploadErr != nil {
+		return "", m.uploadErr
+	}
+	m.uploadedPath = srcPath
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", err
+	}
+	m.content = data
+	return "gs://test-bucket/test-prefix/" + filepath.Base(srcPath), nil
+}
+
+func (m *mockBlobUploader) Close() error {
+	m.closed = true
+	return nil
+}
+
+// TestNewBlobUploaderUnsupportedProvider verifies that newBlobUploader
+// returns an error for unsupported storage providers.
+func TestNewBlobUploaderUnsupportedProvider(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	_, err := newBlobUploader(
+		context.Background(), "s3", "bucket", "prefix", "token",
+	)
+	require.ErrorContains(t, err, "unsupported storage provider")
+}

--- a/pkg/cli/zip_upload_server.go
+++ b/pkg/cli/zip_upload_server.go
@@ -1,0 +1,323 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// uploadServerAPIKeyEnvVar is the environment variable for the upload
+	// server API key.
+	uploadServerAPIKeyEnvVar = "COCKROACH_UPLOAD_SERVER_API_KEY"
+
+	// uploadMaxRetries is the maximum number of retry attempts for
+	// uploading a debug zip to blob storage.0x
+	uploadMaxRetries = 5
+)
+
+// uploadServerHTTPClient is used for control-plane calls to the upload
+// server (session create, upload-token, complete). It has a 30-second
+// timeout to avoid blocking indefinitely on a hung server.
+var uploadServerHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+// uploadSessionInfo holds the result of creating an upload session.
+type uploadSessionInfo struct {
+	SessionID   string
+	UploadToken string
+	Bucket      string
+	Prefix      string
+	GCSToken    string
+}
+
+// createUploadSession exchanges the API key for a session with the
+// upload server, then fetches short-lived GCS credentials for direct
+// upload. The flow is:
+//  1. POST /api/v1/sessions with mode=direct → {session_id, upload_token}
+//  2. POST /api/v1/sessions/{id}/upload-token → {access_token, bucket, prefix}
+var createUploadSession = func(
+	ctx context.Context, serverURL, apiKey string,
+) (uploadSessionInfo, error) {
+
+	sessionID, uploadToken, err := createSession(ctx, serverURL, apiKey)
+	if err != nil {
+		return uploadSessionInfo{}, err
+	}
+
+	bucket, prefix, gcsToken, err := getUploadToken(
+		ctx, serverURL, sessionID, uploadToken,
+	)
+	if err != nil {
+		return uploadSessionInfo{}, err
+	}
+
+	return uploadSessionInfo{
+		SessionID:   sessionID,
+		UploadToken: uploadToken,
+		Bucket:      bucket,
+		Prefix:      prefix,
+		GCSToken:    gcsToken,
+	}, nil
+}
+
+// createSession calls POST /api/v1/sessions with mode=direct.
+func createSession(
+	ctx context.Context, serverURL, apiKey string,
+) (sessionID, uploadToken string, err error) {
+	body, err := json.Marshal(struct {
+		Mode string `json:"mode"`
+	}{Mode: "direct"})
+	if err != nil {
+		return "", "", errors.Wrap(err, "marshaling session request")
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		serverURL+"/api/v1/sessions",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return "", "", errors.Wrap(err, "building session request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := uploadServerHTTPClient.Do(req)
+	if err != nil {
+		return "", "", errors.Wrap(err, "creating session")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", errors.Wrap(err, "reading session response")
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", "", errors.Newf(
+			"session creation failed (%d): %s", resp.StatusCode, respBody,
+		)
+	}
+
+	var result struct {
+		SessionID   string `json:"session_id"`
+		UploadToken string `json:"upload_token"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", "", errors.Wrap(err, "parsing session response")
+	}
+
+	return result.SessionID, result.UploadToken, nil
+}
+
+// getUploadToken calls POST /api/v1/sessions/{id}/upload-token to
+// get short-lived GCS credentials for direct upload.
+func getUploadToken(
+	ctx context.Context, serverURL, sessionID, uploadToken string,
+) (bucket, prefix, accessToken string, err error) {
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/sessions/%s/upload-token", serverURL, sessionID),
+		nil,
+	)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "building upload-token request")
+	}
+	req.Header.Set("Authorization", "Bearer "+uploadToken)
+
+	resp, err := uploadServerHTTPClient.Do(req)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "fetching upload token")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "reading upload-token response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", "", errors.Newf(
+			"upload token request failed (%d): %s", resp.StatusCode, respBody,
+		)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Bucket      string `json:"bucket"`
+		Prefix      string `json:"prefix"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", "", "", errors.Wrap(err, "parsing upload-token response")
+	}
+
+	return result.Bucket, result.Prefix, result.AccessToken, nil
+}
+
+// completeUploadSession marks the session as complete on the upload
+// server via POST /api/v1/sessions/{id}/complete.
+var completeUploadSession = func(
+	ctx context.Context, serverURL, sessionID, uploadToken string,
+) error {
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/sessions/%s/complete", serverURL, sessionID),
+		nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "building complete request")
+	}
+	req.Header.Set("Authorization", "Bearer "+uploadToken)
+
+	resp, err := uploadServerHTTPClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "completing session")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return errors.Newf(
+			"session completion failed (%d): %s", resp.StatusCode, respBody,
+		)
+	}
+
+	return nil
+}
+
+// uploadDebugZipViaServer uploads the raw debug.zip file via the upload
+// server. The flow is:
+//  1. Create a session with the upload server (gets GCS credentials)
+//  2. Upload the zip directly to GCS using those credentials
+//  3. Mark the session complete
+func uploadDebugZipViaServer(ctx context.Context, zipFilePath string) error {
+
+	sess, err := createUploadSession(
+		ctx,
+		debugZipUploadOpts.uploadServerURL,
+		debugZipUploadOpts.uploadServerAPIKey,
+	)
+	if err != nil {
+		return errors.Wrap(err, "creating upload session")
+	}
+
+	fmt.Fprintf(os.Stderr, "Upload session: %s\n", sess.SessionID)
+
+	uploader, err := newBlobUploader(ctx, "gcs", sess.Bucket, sess.Prefix, sess.GCSToken)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cErr := uploader.Close(); cErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to close uploader: %v\n", cErr)
+		}
+	}()
+
+	uploadStart := timeutil.Now()
+
+	retryOpts := base.DefaultRetryOptions()
+	retryOpts.MaxRetries = uploadMaxRetries
+
+	for r := retry.Start(retryOpts); r.Next(); {
+		_, err = uploader.Upload(ctx, zipFilePath)
+		if err == nil {
+			break
+		}
+		fmt.Fprintf(os.Stderr, "Upload attempt failed: %v. Retrying...\n", err)
+	}
+	if err != nil {
+		return errors.Wrap(err, "upload failed after retries")
+	}
+
+	elapsed := timeutil.Since(uploadStart)
+
+	if err := completeUploadSession(
+		ctx,
+		debugZipUploadOpts.uploadServerURL,
+		sess.SessionID,
+		sess.UploadToken,
+	); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"Warning: file was uploaded but session completion failed: %v\n", err,
+		)
+		fmt.Fprintf(os.Stderr,
+			"The debug zip was uploaded but may not be processed automatically.\n",
+		)
+	} else {
+		fmt.Fprintf(os.Stderr, "Session %s completed\n", sess.SessionID)
+	}
+
+	if fi, statErr := os.Stat(zipFilePath); statErr == nil && elapsed.Seconds() > 0 {
+		throughput := float64(fi.Size()) / elapsed.Seconds() / (1024 * 1024)
+		fmt.Fprintf(os.Stderr,
+			"Uploaded debug zip in %s (%.1f MB/s).\n",
+			elapsed.Round(time.Second), throughput,
+		)
+	}
+	return nil
+}
+
+// validateUploadServerReadiness checks that the required flags are set
+// for upload-server uploads and that the input file is valid.
+func validateUploadServerReadiness(inputPath string) error {
+	if debugZipUploadOpts.uploadServerAPIKey == "" {
+		return errors.New(
+			"--upload-server-api-key is required for upload-server destination",
+		)
+	}
+
+	if debugZipUploadOpts.uploadServerURL == "" {
+		return errors.New(
+			"--upload-server-url is required for upload-server destination",
+		)
+	}
+
+	if !strings.HasSuffix(strings.ToLower(inputPath), ".zip") {
+		return errors.Newf(
+			"upload-server requires a .zip file, got %q", inputPath,
+		)
+	}
+
+	f, err := os.Open(inputPath)
+	if err != nil {
+		return errors.Wrapf(err, "cannot access %q", inputPath)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return errors.Wrapf(err, "cannot stat %q", inputPath)
+	}
+	if fi.Size() == 0 {
+		return errors.Newf("zip file %q is empty", inputPath)
+	}
+
+	// Verify the file starts with the ZIP magic number (PK\x03\x04).
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return errors.Wrapf(err, "reading %q", inputPath)
+	}
+	if magic != [4]byte{0x50, 0x4b, 0x03, 0x04} {
+		return errors.Newf("%q does not appear to be a valid zip file", inputPath)
+	}
+
+	return nil
+}

--- a/pkg/cli/zip_upload_server_test.go
+++ b/pkg/cli/zip_upload_server_test.go
@@ -1,0 +1,330 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateUploadServerReadiness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "debug.zip")
+	require.NoError(t, os.WriteFile(zipPath, []byte("PK\x03\x04fake-zip-content"), 0644))
+
+	notAZipPath := filepath.Join(tmpDir, "notazip.zip")
+	require.NoError(t, os.WriteFile(notAZipPath, []byte("not-a-zip-file"), 0644))
+
+	emptyZipPath := filepath.Join(tmpDir, "empty.zip")
+	require.NoError(t, os.WriteFile(emptyZipPath, nil, 0644))
+
+	dirPath := filepath.Join(tmpDir, "debug-dir")
+	require.NoError(t, os.Mkdir(dirPath, 0755))
+
+	origOpts := debugZipUploadOpts
+	defer func() { debugZipUploadOpts = origOpts }()
+
+	tests := []struct {
+		name    string
+		input   string
+		setup   func()
+		wantErr string
+	}{
+		{
+			name:  "valid",
+			input: zipPath,
+			setup: func() {
+				debugZipUploadOpts.uploadServerAPIKey = "test-key"
+				debugZipUploadOpts.uploadServerURL = "https://example.com"
+			},
+		},
+		{
+			name:  "not a zip file",
+			input: dirPath,
+			setup: func() {
+				debugZipUploadOpts.uploadServerAPIKey = "key"
+				debugZipUploadOpts.uploadServerURL = "https://example.com"
+			},
+			wantErr: "upload-server requires a .zip file",
+		},
+		{
+			name:  "invalid zip magic bytes",
+			input: notAZipPath,
+			setup: func() {
+				debugZipUploadOpts.uploadServerAPIKey = "key"
+				debugZipUploadOpts.uploadServerURL = "https://example.com"
+			},
+			wantErr: "does not appear to be a valid zip file",
+		},
+		{
+			name:  "empty zip file",
+			input: emptyZipPath,
+			setup: func() {
+				debugZipUploadOpts.uploadServerAPIKey = "key"
+				debugZipUploadOpts.uploadServerURL = "https://example.com"
+			},
+			wantErr: "is empty",
+		},
+		{
+			name:  "missing api key",
+			input: zipPath,
+			setup: func() {
+				debugZipUploadOpts.uploadServerAPIKey = ""
+				debugZipUploadOpts.uploadServerURL = "https://example.com"
+			},
+			wantErr: "--upload-server-api-key is required",
+		},
+		{
+			name:  "missing upload server url",
+			input: zipPath,
+			setup: func() {
+				debugZipUploadOpts.uploadServerAPIKey = "key"
+				debugZipUploadOpts.uploadServerURL = ""
+			},
+			wantErr: "--upload-server-url is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			debugZipUploadOpts = origOpts
+			tt.setup()
+			err := validateUploadServerReadiness(tt.input)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestUploadDebugZipViaServerSessionFailure verifies that an upload
+// server session creation failure is propagated correctly.
+func TestUploadDebugZipViaServerSessionFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	zipPath := setupUploadTest(t, []byte("fake-zip"), "bad-key", "https://fake.example.com")
+
+	createUploadSession = func(
+		_ context.Context, _, _ string,
+	) (uploadSessionInfo, error) {
+		return uploadSessionInfo{}, errors.New("401 Unauthorized: invalid API key")
+	}
+
+	err := uploadDebugZipViaServer(context.Background(), zipPath)
+	require.ErrorContains(t, err, "creating upload session")
+	require.ErrorContains(t, err, "invalid API key")
+}
+
+// TestUploadDebugZipViaServerSuccess exercises the full upload-server
+// flow end-to-end with all three var functions mocked. Verifies that
+// session creation, upload, and completion are all called correctly.
+func TestUploadDebugZipViaServerSuccess(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	zipContent := []byte("PK-fake-zip-content")
+	zipPath := setupUploadTest(t, zipContent, "test-key", "https://fake.example.com")
+
+	mock := &mockBlobUploader{}
+	var (
+		completeCalled    bool
+		completeSessionID string
+		completeToken     string
+	)
+
+	createUploadSession = func(
+		_ context.Context, serverURL, apiKey string,
+	) (uploadSessionInfo, error) {
+		require.Equal(t, "https://fake.example.com", serverURL)
+		require.Equal(t, "test-key", apiKey)
+		return uploadSessionInfo{
+			SessionID:   "ses_test",
+			UploadToken: "tok_test",
+			Bucket:      "bucket",
+			Prefix:      "prefix",
+			GCSToken:    "gcs-token",
+		}, nil
+	}
+
+	newBlobUploader = func(
+		_ context.Context, provider, bucket, prefix, token string,
+	) (blobUploader, error) {
+		require.Equal(t, "gcs", provider)
+		require.Equal(t, "bucket", bucket)
+		require.Equal(t, "prefix", prefix)
+		require.Equal(t, "gcs-token", token)
+		return mock, nil
+	}
+
+	completeUploadSession = func(
+		_ context.Context, serverURL, sessionID, uploadToken string,
+	) error {
+		completeCalled = true
+		completeSessionID = sessionID
+		completeToken = uploadToken
+		return nil
+	}
+
+	err := uploadDebugZipViaServer(context.Background(), zipPath)
+	require.NoError(t, err)
+
+	require.Equal(t, zipPath, mock.uploadedPath)
+	require.Equal(t, zipContent, mock.content)
+
+	require.True(t, completeCalled)
+	require.Equal(t, "ses_test", completeSessionID)
+	require.Equal(t, "tok_test", completeToken)
+}
+
+// TestUploadDebugZipViaServerRetryThenSuccess verifies that a
+// transient upload failure is retried and succeeds on a subsequent
+// attempt.
+func TestUploadDebugZipViaServerRetryThenSuccess(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	zipPath := setupUploadTest(t, []byte("PK-data"), "key", "https://fake.example.com")
+
+	failsRemaining := 2
+
+	createUploadSession = func(
+		_ context.Context, _, _ string,
+	) (uploadSessionInfo, error) {
+		return uploadSessionInfo{
+			SessionID:   "ses",
+			UploadToken: "tok",
+			Bucket:      "b",
+			Prefix:      "p",
+			GCSToken:    "gcs-tok",
+		}, nil
+	}
+
+	callCount := 0
+	wrapperMock := &funcBlobUploader{
+		uploadFn: func(ctx context.Context, srcPath string) (string, error) {
+			callCount++
+			if callCount <= failsRemaining {
+				return "", errors.New("transient network error")
+			}
+			return "gs://b/p/" + filepath.Base(srcPath), nil
+		},
+		closeFn: func() error { return nil },
+	}
+
+	newBlobUploader = func(
+		_ context.Context, _, _, _, _ string,
+	) (blobUploader, error) {
+		return wrapperMock, nil
+	}
+
+	completeUploadSession = func(
+		_ context.Context, _, _, _ string,
+	) error {
+		return nil
+	}
+
+	err := uploadDebugZipViaServer(context.Background(), zipPath)
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount)
+}
+
+// TestUploadDebugZipViaServerCompletionFailure verifies that a session
+// completion failure does not cause the overall upload to fail.
+func TestUploadDebugZipViaServerCompletionFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	zipPath := setupUploadTest(t, []byte("PK-data"), "key", "https://fake.example.com")
+
+	createUploadSession = func(
+		_ context.Context, _, _ string,
+	) (uploadSessionInfo, error) {
+		return uploadSessionInfo{
+			SessionID:   "ses",
+			UploadToken: "tok",
+			Bucket:      "b",
+			Prefix:      "p",
+			GCSToken:    "gcs-tok",
+		}, nil
+	}
+
+	newBlobUploader = func(
+		_ context.Context, _, _, _, _ string,
+	) (blobUploader, error) {
+		return &mockBlobUploader{}, nil
+	}
+
+	completeUploadSession = func(
+		_ context.Context, _, _, _ string,
+	) error {
+		return errors.New("server returned 500")
+	}
+
+	// Upload should succeed despite completion failure.
+	err := uploadDebugZipViaServer(context.Background(), zipPath)
+	require.NoError(t, err)
+}
+
+// TestRunDebugZipUploadRouting verifies that runDebugZipUpload routes
+// to the correct handler based on the destination flag.
+func TestRunDebugZipUploadRouting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	origOpts := debugZipUploadOpts
+	defer func() { debugZipUploadOpts = origOpts }()
+
+	debugZipUploadOpts.destination = "invalid-dest"
+
+	err := runDebugZipUpload(nil, []string{"/tmp/fake.zip"})
+	require.ErrorContains(t, err, "unsupported destination")
+	require.ErrorContains(t, err, "invalid-dest")
+}
+
+// setupUploadTest creates a temporary zip file and saves/restores the
+// package-level upload globals. It returns the path to the zip file.
+func setupUploadTest(t *testing.T, zipContent []byte, apiKey, serverURL string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "debug.zip")
+	require.NoError(t, os.WriteFile(zipPath, zipContent, 0644))
+
+	origOpts := debugZipUploadOpts
+	origCreate := createUploadSession
+	origComplete := completeUploadSession
+	origNewUploader := newBlobUploader
+	t.Cleanup(func() {
+		debugZipUploadOpts = origOpts
+		createUploadSession = origCreate
+		completeUploadSession = origComplete
+		newBlobUploader = origNewUploader
+	})
+
+	debugZipUploadOpts.uploadServerAPIKey = apiKey
+	debugZipUploadOpts.uploadServerURL = serverURL
+	return zipPath
+}
+
+// funcBlobUploader is a blobUploader backed by function values, used
+// for tests that need custom upload behavior per call.
+type funcBlobUploader struct {
+	uploadFn func(ctx context.Context, srcPath string) (string, error)
+	closeFn  func() error
+}
+
+func (f *funcBlobUploader) Upload(ctx context.Context, srcPath string) (string, error) {
+	return f.uploadFn(ctx, srcPath)
+}
+
+func (f *funcBlobUploader) Close() error {
+	return f.closeFn()
+}


### PR DESCRIPTION
Add support for uploading debug zip files directly to blob storage via CRL's upload server. The upload flow creates a session with the server to obtain short-lived GCS credentials, uploads the zip file directly to GCS, and marks the session complete.

The implementation is split across two files for clear separation of concerns:
- zip_upload_blob.go: reusable blob storage abstraction (blobUploader interface, GCS implementation, progress writer)
- zip_upload_server.go: upload server session lifecycle (create session, get upload token, complete session, validation)

The existing Datadog upload path is preserved and remains the default. Users select the upload server via --destination=upload-server along with --upload-server-api-key and --upload-server-url flags.

Part of: CRDB-61946
Epic: CRDB-60645

Release note: None