### PR TITLE
rpc: remove noisy drpc server error log

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -389,9 +389,6 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 	mux := drpcmux.NewWithInterceptors(unaryInterceptors, streamInterceptors)
 
 	d.Server = drpcserver.NewWithOptions(mux, drpcserver.Options{
-		Log: func(err error) {
-			log.Dev.Warningf(context.Background(), "drpc server error %v", err)
-		},
 		// The reader's max buffer size defaults to 4mb, and if it is exceeded (such
 		// as happens with AddSSTable) the RPCs fail.
 		Manager: drpcmanager.Options{


### PR DESCRIPTION
The Log callback on the DRPC server fires on routine errors (e.g. connection resets, context cancellations), adding noise without actionable signal.

Epic: none
Release note: None