### PR TITLE
ui: bound SWR error retries by default

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.spec.tsx
@@ -320,7 +320,7 @@ describe("useSwrWithClusterId", () => {
     expect(spyUseSWR).toHaveBeenCalledWith(
       expectedKey,
       expect.anything(),
-      undefined,
+      expect.objectContaining({ errorRetryCount: 3 }),
     );
 
     renderHook(() => useSwrImmutableWithClusterId(key, (): void => null), {
@@ -329,7 +329,7 @@ describe("useSwrWithClusterId", () => {
     expect(spyUseSWRImmutable).toHaveBeenCalledWith(
       expectedKey,
       expect.anything(),
-      undefined,
+      expect.objectContaining({ errorRetryCount: 3 }),
     );
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
@@ -13,6 +13,11 @@ import useSWRMutation, { SWRMutationConfiguration } from "swr/mutation";
 import { ClusterDetailsContext } from "../contexts";
 import { ISortedTablePagination } from "../sortedtable";
 
+// Cap error retries. SWR defaults to infinite exponential backoff,
+// which hammers a down server, especially with polling hooks.
+// See also: db-console/src/app.tsx SWRConfig provider.
+const DEFAULT_ERROR_RETRY_COUNT = 3;
+
 export const usePrevious = <T>(value: T): T | undefined => {
   const ref = useRef<T>();
   useEffect(() => {
@@ -144,7 +149,10 @@ export const useSwrWithClusterId = <
   config?: SWROptions,
 ): SWRResponse<Data, Error, SWROptions> => {
   const keyWithClusterId = useSwrKeyWithClusterId(key) as SWRKey;
-  return useSWR(keyWithClusterId, fetcher, config);
+  return useSWR(keyWithClusterId, fetcher, {
+    errorRetryCount: DEFAULT_ERROR_RETRY_COUNT,
+    ...config,
+  } as SWROptions);
 };
 
 /**
@@ -169,7 +177,10 @@ export const useSwrImmutableWithClusterId = <
   config?: SWROptions,
 ): SWRResponse<Data, Error, SWROptions> => {
   const keyWithClusterId = useSwrKeyWithClusterId(key) as SWRKey;
-  return useSWRImmutable(keyWithClusterId, fetcher, config);
+  return useSWRImmutable(keyWithClusterId, fetcher, {
+    errorRetryCount: DEFAULT_ERROR_RETRY_COUNT,
+    ...config,
+  } as SWROptions);
 };
 
 /**

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -20,6 +20,7 @@ import { Provider, ReactReduxContext } from "react-redux";
 import { Redirect, Route, Switch } from "react-router-dom";
 import "react-select/dist/react-select.css";
 import { Action, Store } from "redux";
+import { SWRConfig } from "swr";
 
 import { TimezoneProvider } from "src/contexts/timezoneProvider";
 import { AdminUIState } from "src/redux/state";
@@ -114,415 +115,425 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
 
   return (
     <Provider store={store} context={ReactReduxContext}>
-      <ConnectedRouter history={history} context={ReactReduxContext}>
-        <CockroachCloudContext.Provider value={false}>
-          <TimezoneProvider>
-            {/* Apply CRL theme twice, with ConfigProvider instance from Db Console and
+      <SWRConfig value={{ errorRetryCount: 3 }}>
+        <ConnectedRouter history={history} context={ReactReduxContext}>
+          <CockroachCloudContext.Provider value={false}>
+            <TimezoneProvider>
+              {/* Apply CRL theme twice, with ConfigProvider instance from Db Console and
              imported instance from Cluster UI as it applies theme imported components only. */}
-            <ClusterUIConfigProvider theme={crlTheme} prefixCls={"crdb-ant"}>
-              <ConfigProvider theme={crlTheme} prefixCls={"crdb-ant"}>
-                <Switch>
-                  {/* login */}
-                  {createLoginRoute()}
-                  {createLogoutRoute(store)}
-                  <Route path="/jwt/:oidc" component={JwtAuthTokenPage} />
-                  <Route path="/">
-                    <Layout>
-                      <Switch>
-                        <Redirect exact from="/" to="/overview" />
-                        {/* overview page */}
-                        {visualizationRoutes()}
+              <ClusterUIConfigProvider theme={crlTheme} prefixCls={"crdb-ant"}>
+                <ConfigProvider theme={crlTheme} prefixCls={"crdb-ant"}>
+                  <Switch>
+                    {/* login */}
+                    {createLoginRoute()}
+                    {createLogoutRoute(store)}
+                    <Route path="/jwt/:oidc" component={JwtAuthTokenPage} />
+                    <Route path="/">
+                      <Layout>
+                        <Switch>
+                          <Redirect exact from="/" to="/overview" />
+                          {/* overview page */}
+                          {visualizationRoutes()}
 
-                        {/* time series metrics */}
-                        <Redirect
-                          exact
-                          from="/metrics"
-                          to="/metrics/overview/cluster"
-                        />
-                        <Redirect
-                          exact
-                          from={`/metrics/:${dashboardNameAttr}`}
-                          to={`/metrics/:${dashboardNameAttr}/cluster`}
-                        />
-                        <Route
-                          exact
-                          path={`/metrics/:${dashboardNameAttr}/cluster`}
-                          component={NodeGraphs}
-                        />
-                        <Redirect
-                          exact
-                          path={`/metrics/:${dashboardNameAttr}/node`}
-                          to={`/metrics/:${dashboardNameAttr}/cluster`}
-                        />
-                        <Route
-                          exact
-                          path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
-                          component={NodeGraphs}
-                        />
-                        <Route
-                          exact
-                          path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}/tenant/:${tenantNameAttr}`}
-                          component={NodeGraphs}
-                        />
-                        <Route
-                          exact
-                          path={`/metrics/:${dashboardNameAttr}/cluster/tenant/:${tenantNameAttr}`}
-                          component={NodeGraphs}
-                        />
+                          {/* time series metrics */}
+                          <Redirect
+                            exact
+                            from="/metrics"
+                            to="/metrics/overview/cluster"
+                          />
+                          <Redirect
+                            exact
+                            from={`/metrics/:${dashboardNameAttr}`}
+                            to={`/metrics/:${dashboardNameAttr}/cluster`}
+                          />
+                          <Route
+                            exact
+                            path={`/metrics/:${dashboardNameAttr}/cluster`}
+                            component={NodeGraphs}
+                          />
+                          <Redirect
+                            exact
+                            path={`/metrics/:${dashboardNameAttr}/node`}
+                            to={`/metrics/:${dashboardNameAttr}/cluster`}
+                          />
+                          <Route
+                            exact
+                            path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
+                            component={NodeGraphs}
+                          />
+                          <Route
+                            exact
+                            path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}/tenant/:${tenantNameAttr}`}
+                            component={NodeGraphs}
+                          />
+                          <Route
+                            exact
+                            path={`/metrics/:${dashboardNameAttr}/cluster/tenant/:${tenantNameAttr}`}
+                            component={NodeGraphs}
+                          />
 
-                        {/* node details */}
-                        <Redirect exact from="/node" to="/overview/list" />
-                        <Route
-                          exact
-                          path={`/node/:${nodeIDAttr}`}
-                          component={NodeOverview}
-                        />
-                        <Route
-                          exact
-                          path={`/node/:${nodeIDAttr}/logs`}
-                          component={NodeLogs}
-                        />
+                          {/* node details */}
+                          <Redirect exact from="/node" to="/overview/list" />
+                          <Route
+                            exact
+                            path={`/node/:${nodeIDAttr}`}
+                            component={NodeOverview}
+                          />
+                          <Route
+                            exact
+                            path={`/node/:${nodeIDAttr}/logs`}
+                            component={NodeLogs}
+                          />
 
-                        {/* events & jobs */}
-                        <Route path="/events" component={EventPage} />
-                        <Route exact path="/jobs" component={JobsPage} />
-                        <Route
-                          path={`/jobs/:${idAttr}`}
-                          component={JobDetails}
-                        />
+                          {/* events & jobs */}
+                          <Route path="/events" component={EventPage} />
+                          <Route exact path="/jobs" component={JobsPage} />
+                          <Route
+                            path={`/jobs/:${idAttr}`}
+                            component={JobDetails}
+                          />
 
-                        <Route
-                          exact
-                          path="/schedules"
-                          component={SchedulesPage}
-                        />
-                        <Route
-                          path={`/schedules/:${idAttr}`}
-                          component={ScheduleDetails}
-                        />
+                          <Route
+                            exact
+                            path="/schedules"
+                            component={SchedulesPage}
+                          />
+                          <Route
+                            path={`/schedules/:${idAttr}`}
+                            component={ScheduleDetails}
+                          />
 
-                        {/* databases */}
-                        <Route
-                          exact
-                          path={"/databases"}
-                          component={DatabasesPageV2}
-                        />
-                        <Route
-                          exact
-                          path={`/databases/:${databaseIDAttr}`}
-                          component={DatabaseDetailsPageV2}
-                        />
-                        <Route
-                          exact
-                          path={`/table/:${tableIdAttr}`}
-                          component={TableDetailsPageV2}
-                        />
-                        <Redirect
-                          from={`/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                          to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                        />
+                          {/* databases */}
+                          <Route
+                            exact
+                            path={"/databases"}
+                            component={DatabasesPageV2}
+                          />
+                          <Route
+                            exact
+                            path={`/databases/:${databaseIDAttr}`}
+                            component={DatabaseDetailsPageV2}
+                          />
+                          <Route
+                            exact
+                            path={`/table/:${tableIdAttr}`}
+                            component={TableDetailsPageV2}
+                          />
+                          <Redirect
+                            from={`/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                            to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                          />
 
-                        <Redirect exact from="/database" to="/databases" />
-                        <Redirect
-                          exact
-                          from={`/database/:${databaseNameAttr}/table`}
-                          to={`/database/:${databaseNameAttr}`}
-                        />
-                        <Route
-                          exact
-                          path={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index/:${indexNameAttr}`}
-                          component={IndexDetailsPage}
-                        />
-                        <Redirect
-                          exact
-                          from={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index`}
-                          to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                        />
+                          <Redirect exact from="/database" to="/databases" />
+                          <Redirect
+                            exact
+                            from={`/database/:${databaseNameAttr}/table`}
+                            to={`/database/:${databaseNameAttr}`}
+                          />
+                          <Route
+                            exact
+                            path={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index/:${indexNameAttr}`}
+                            component={IndexDetailsPage}
+                          />
+                          <Redirect
+                            exact
+                            from={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index`}
+                            to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                          />
 
-                        {/* data distribution */}
-                        <Route
-                          exact
-                          path="/data-distribution"
-                          component={DataDistributionPage}
-                        />
+                          {/* data distribution */}
+                          <Route
+                            exact
+                            path="/data-distribution"
+                            component={DataDistributionPage}
+                          />
 
-                        {/* SQL activity */}
-                        <Route
-                          exact
-                          path="/sql-activity"
-                          component={SQLActivityPage}
-                        />
+                          {/* SQL activity */}
+                          <Route
+                            exact
+                            path="/sql-activity"
+                            component={SQLActivityPage}
+                          />
 
-                        {/* Active executions */}
-                        <Route
-                          exact
-                          path={`/execution/statement/:${executionIdAttr}`}
-                          component={ActiveStatementDetails}
-                        />
+                          {/* Active executions */}
+                          <Route
+                            exact
+                            path={`/execution/statement/:${executionIdAttr}`}
+                            component={ActiveStatementDetails}
+                          />
 
-                        <Route
-                          exact
-                          path={`/execution/transaction/:${executionIdAttr}`}
-                          component={ActiveTransactionDetails}
-                        />
+                          <Route
+                            exact
+                            path={`/execution/transaction/:${executionIdAttr}`}
+                            component={ActiveTransactionDetails}
+                          />
 
-                        {/* statement statistics */}
-                        <Redirect
-                          exact
-                          from={`/statements`}
-                          to={`/sql-activity?${tabAttr}=Statements&${viewAttr}=fingerprints`}
-                        />
-                        <Redirect
-                          exact
-                          from={`/statements/:${appAttr}`}
-                          to={`/statements?${appAttr}=:${appAttr}`}
-                        />
-                        <Route
-                          exact
-                          path={`/statement/:${statementAttr}`}
-                          component={StatementDetails}
-                        />
-                        <Route
-                          exact
-                          path={`/statement/:${implicitTxnAttr}/:${statementAttr}`}
-                          render={RedirectToStatementDetails}
-                        />
-                        <Redirect
-                          exact
-                          from={`/statement`}
-                          to={`/sql-activity?${tabAttr}=Statements&view=fingerprints`}
-                        />
+                          {/* statement statistics */}
+                          <Redirect
+                            exact
+                            from={`/statements`}
+                            to={`/sql-activity?${tabAttr}=Statements&${viewAttr}=fingerprints`}
+                          />
+                          <Redirect
+                            exact
+                            from={`/statements/:${appAttr}`}
+                            to={`/statements?${appAttr}=:${appAttr}`}
+                          />
+                          <Route
+                            exact
+                            path={`/statement/:${statementAttr}`}
+                            component={StatementDetails}
+                          />
+                          <Route
+                            exact
+                            path={`/statement/:${implicitTxnAttr}/:${statementAttr}`}
+                            render={RedirectToStatementDetails}
+                          />
+                          <Redirect
+                            exact
+                            from={`/statement`}
+                            to={`/sql-activity?${tabAttr}=Statements&view=fingerprints`}
+                          />
 
-                        {/* sessions */}
-                        <Redirect
-                          exact
-                          from={`/sessions`}
-                          to={`/sql-activity?${tabAttr}=Sessions`}
-                        />
-                        <Route
-                          exact
-                          path={`/session/:${sessionAttr}`}
-                          component={SessionDetails}
-                        />
+                          {/* sessions */}
+                          <Redirect
+                            exact
+                            from={`/sessions`}
+                            to={`/sql-activity?${tabAttr}=Sessions`}
+                          />
+                          <Route
+                            exact
+                            path={`/session/:${sessionAttr}`}
+                            component={SessionDetails}
+                          />
 
-                        {/* transactions */}
-                        <Redirect
-                          exact
-                          from={`/transactions`}
-                          to={`/sql-activity?${tabAttr}=Transactions`}
-                        />
-                        <Route
-                          exact
-                          path={`/transaction/:${txnFingerprintIdAttr}`}
-                          component={TransactionDetails}
-                        />
-                        <Redirect
-                          exact
-                          from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
-                          to={`/transaction/:${txnFingerprintIdAttr}`}
-                        />
+                          {/* transactions */}
+                          <Redirect
+                            exact
+                            from={`/transactions`}
+                            to={`/sql-activity?${tabAttr}=Transactions`}
+                          />
+                          <Route
+                            exact
+                            path={`/transaction/:${txnFingerprintIdAttr}`}
+                            component={TransactionDetails}
+                          />
+                          <Redirect
+                            exact
+                            from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
+                            to={`/transaction/:${txnFingerprintIdAttr}`}
+                          />
 
-                        {/* Insights */}
-                        <Route
-                          exact
-                          path="/insights"
-                          component={InsightsOverviewPage}
-                        />
-                        <Route
-                          path={`/insights/transaction/:${idAttr}`}
-                          component={TransactionInsightDetailsPage}
-                        />
-                        <Route
-                          path={`/insights/statement/:${idAttr}`}
-                          component={StatementInsightDetailsPage}
-                        />
+                          {/* Insights */}
+                          <Route
+                            exact
+                            path="/insights"
+                            component={InsightsOverviewPage}
+                          />
+                          <Route
+                            path={`/insights/transaction/:${idAttr}`}
+                            component={TransactionInsightDetailsPage}
+                          />
+                          <Route
+                            path={`/insights/statement/:${idAttr}`}
+                            component={StatementInsightDetailsPage}
+                          />
 
-                        {/* cluster explorer */}
-                        <Route
-                          exact
-                          path="/cluster-explorer"
-                          component={ClusterExplorerPage}
-                        />
+                          {/* cluster explorer */}
+                          <Route
+                            exact
+                            path="/cluster-explorer"
+                            component={ClusterExplorerPage}
+                          />
 
-                        {/* debug pages */}
-                        <Route exact path="/debug" component={Debug} />
-                        <Route
-                          path="/debug/tracez"
-                          component={SnapshotRouter}
-                        />
-                        <Route
-                          exact
-                          path="/debug/redux"
-                          component={ReduxDebug}
-                        />
-                        <Route
-                          exact
-                          path="/debug/chart"
-                          component={CustomChart}
-                        />
-                        <Route
-                          exact
-                          path="/debug/metrics_workspace"
-                          component={MetricsWorkspace}
-                        />
-                        <Route
-                          exact
-                          path="/debug/enqueue_range"
-                          component={EnqueueRange}
-                        />
-                        <Route
-                          exact
-                          path="/debug/hotranges"
-                          component={HotRanges}
-                        />
-                        <Route
-                          exact
-                          path="/debug/hotranges/:node_id"
-                          component={HotRanges}
-                        />
-                        <Route
-                          exact
-                          path={`/keyvisualizer`}
-                          component={KeyVisualizerPage}
-                        />
-                        <Route path="/raft">
-                          <Raft>
-                            <Switch>
-                              <Redirect exact from="/raft" to="/raft/ranges" />
-                              <Route
-                                exact
-                                path="/raft/ranges"
-                                component={RaftRanges}
-                              />
-                              <Route
-                                exact
-                                path="/raft/messages/all"
-                                component={RaftMessages}
-                              />
-                              <Route
-                                exact
-                                path={`/raft/messages/node/:${nodeIDAttr}`}
-                                component={RaftMessages}
-                              />
-                            </Switch>
-                          </Raft>
-                        </Route>
+                          {/* debug pages */}
+                          <Route exact path="/debug" component={Debug} />
+                          <Route
+                            path="/debug/tracez"
+                            component={SnapshotRouter}
+                          />
+                          <Route
+                            exact
+                            path="/debug/redux"
+                            component={ReduxDebug}
+                          />
+                          <Route
+                            exact
+                            path="/debug/chart"
+                            component={CustomChart}
+                          />
+                          <Route
+                            exact
+                            path="/debug/metrics_workspace"
+                            component={MetricsWorkspace}
+                          />
+                          <Route
+                            exact
+                            path="/debug/enqueue_range"
+                            component={EnqueueRange}
+                          />
+                          <Route
+                            exact
+                            path="/debug/hotranges"
+                            component={HotRanges}
+                          />
+                          <Route
+                            exact
+                            path="/debug/hotranges/:node_id"
+                            component={HotRanges}
+                          />
+                          <Route
+                            exact
+                            path={`/keyvisualizer`}
+                            component={KeyVisualizerPage}
+                          />
+                          <Route path="/raft">
+                            <Raft>
+                              <Switch>
+                                <Redirect
+                                  exact
+                                  from="/raft"
+                                  to="/raft/ranges"
+                                />
+                                <Route
+                                  exact
+                                  path="/raft/ranges"
+                                  component={RaftRanges}
+                                />
+                                <Route
+                                  exact
+                                  path="/raft/messages/all"
+                                  component={RaftMessages}
+                                />
+                                <Route
+                                  exact
+                                  path={`/raft/messages/node/:${nodeIDAttr}`}
+                                  component={RaftMessages}
+                                />
+                              </Switch>
+                            </Raft>
+                          </Route>
 
-                        <Route
-                          exact
-                          path="/reports/problemranges"
-                          component={ProblemRanges}
-                        />
-                        <Route
-                          exact
-                          path={`/reports/problemranges/:${nodeIDAttr}`}
-                          component={ProblemRanges}
-                        />
-                        <Route
-                          exact
-                          path="/reports/localities"
-                          component={Localities}
-                        />
-                        <Route
-                          exact
-                          path={`/reports/network/:${nodeIDAttr}`}
-                          component={Network}
-                        />
-                        <Redirect
-                          from={`/reports/network`}
-                          to={`/reports/network/region`}
-                        />
-                        <Route exact path="/reports/nodes" component={Nodes} />
-                        <Route
-                          exact
-                          path="/reports/nodes/history"
-                          component={ConnectedDecommissionedNodeHistory}
-                        />
-                        <Route
-                          exact
-                          path="/reports/settings"
-                          component={Settings}
-                        />
-                        <Route
-                          exact
-                          path={`/reports/certificates/:${nodeIDAttr}`}
-                          component={Certificates}
-                        />
-                        <Route
-                          exact
-                          path={`/reports/range/:${rangeIDAttr}`}
-                          component={Range}
-                        />
-                        <Route
-                          exact
-                          path={`/reports/stores/:${nodeIDAttr}`}
-                          component={Stores}
-                        />
-                        <Route
-                          exact
-                          path={`/reports/diagnosticshistory`}
-                          component={DiagnosticsHistoryPage}
-                        />
-                        {/* Redirect old statement diagnostics route to new tabbed page */}
-                        <Redirect
-                          exact
-                          from={`/reports/statements/diagnosticshistory`}
-                          to={`/reports/diagnosticshistory?tab=Statements`}
-                        />
-                        {/* hot ranges */}
-                        <Route
-                          exact
-                          path={`/topranges`}
-                          component={HotRangesPage}
-                        />
-                        {/* old route redirects */}
-                        <Route
-                          exact
-                          path={`/hotranges`}
-                          component={HotRangesPage}
-                        />
-                        <Redirect
-                          exact
-                          from="/cluster"
-                          to="/metrics/overview/cluster"
-                        />
-                        <Redirect
-                          from={`/cluster/all/:${dashboardNameAttr}`}
-                          to={`/metrics/:${dashboardNameAttr}/cluster`}
-                        />
-                        <Redirect
-                          from={`/cluster/node/:${nodeIDAttr}/:${dashboardNameAttr}`}
-                          to={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
-                        />
-                        <Redirect
-                          exact
-                          from="/cluster/nodes"
-                          to="/overview/list"
-                        />
-                        <Redirect
-                          exact
-                          from={`/cluster/nodes/:${nodeIDAttr}`}
-                          to={`/node/:${nodeIDAttr}`}
-                        />
-                        <Redirect
-                          from={`/cluster/nodes/:${nodeIDAttr}/logs`}
-                          to={`/node/:${nodeIDAttr}/logs`}
-                        />
-                        <Redirect from="/cluster/events" to="/events" />
+                          <Route
+                            exact
+                            path="/reports/problemranges"
+                            component={ProblemRanges}
+                          />
+                          <Route
+                            exact
+                            path={`/reports/problemranges/:${nodeIDAttr}`}
+                            component={ProblemRanges}
+                          />
+                          <Route
+                            exact
+                            path="/reports/localities"
+                            component={Localities}
+                          />
+                          <Route
+                            exact
+                            path={`/reports/network/:${nodeIDAttr}`}
+                            component={Network}
+                          />
+                          <Redirect
+                            from={`/reports/network`}
+                            to={`/reports/network/region`}
+                          />
+                          <Route
+                            exact
+                            path="/reports/nodes"
+                            component={Nodes}
+                          />
+                          <Route
+                            exact
+                            path="/reports/nodes/history"
+                            component={ConnectedDecommissionedNodeHistory}
+                          />
+                          <Route
+                            exact
+                            path="/reports/settings"
+                            component={Settings}
+                          />
+                          <Route
+                            exact
+                            path={`/reports/certificates/:${nodeIDAttr}`}
+                            component={Certificates}
+                          />
+                          <Route
+                            exact
+                            path={`/reports/range/:${rangeIDAttr}`}
+                            component={Range}
+                          />
+                          <Route
+                            exact
+                            path={`/reports/stores/:${nodeIDAttr}`}
+                            component={Stores}
+                          />
+                          <Route
+                            exact
+                            path={`/reports/diagnosticshistory`}
+                            component={DiagnosticsHistoryPage}
+                          />
+                          {/* Redirect old statement diagnostics route to new tabbed page */}
+                          <Redirect
+                            exact
+                            from={`/reports/statements/diagnosticshistory`}
+                            to={`/reports/diagnosticshistory?tab=Statements`}
+                          />
+                          {/* hot ranges */}
+                          <Route
+                            exact
+                            path={`/topranges`}
+                            component={HotRangesPage}
+                          />
+                          {/* old route redirects */}
+                          <Route
+                            exact
+                            path={`/hotranges`}
+                            component={HotRangesPage}
+                          />
+                          <Redirect
+                            exact
+                            from="/cluster"
+                            to="/metrics/overview/cluster"
+                          />
+                          <Redirect
+                            from={`/cluster/all/:${dashboardNameAttr}`}
+                            to={`/metrics/:${dashboardNameAttr}/cluster`}
+                          />
+                          <Redirect
+                            from={`/cluster/node/:${nodeIDAttr}/:${dashboardNameAttr}`}
+                            to={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
+                          />
+                          <Redirect
+                            exact
+                            from="/cluster/nodes"
+                            to="/overview/list"
+                          />
+                          <Redirect
+                            exact
+                            from={`/cluster/nodes/:${nodeIDAttr}`}
+                            to={`/node/:${nodeIDAttr}`}
+                          />
+                          <Redirect
+                            from={`/cluster/nodes/:${nodeIDAttr}/logs`}
+                            to={`/node/:${nodeIDAttr}/logs`}
+                          />
+                          <Redirect from="/cluster/events" to="/events" />
 
-                        <Redirect exact from="/nodes" to="/overview/list" />
+                          <Redirect exact from="/nodes" to="/overview/list" />
 
-                        {/* 404 */}
-                        <Route path="*" component={NotFound} />
-                      </Switch>
-                    </Layout>
-                  </Route>
-                </Switch>
-              </ConfigProvider>
-            </ClusterUIConfigProvider>
-          </TimezoneProvider>
-        </CockroachCloudContext.Provider>
-      </ConnectedRouter>
+                          {/* 404 */}
+                          <Route path="*" component={NotFound} />
+                        </Switch>
+                      </Layout>
+                    </Route>
+                  </Switch>
+                </ConfigProvider>
+              </ClusterUIConfigProvider>
+            </TimezoneProvider>
+          </CockroachCloudContext.Provider>
+        </ConnectedRouter>
+      </SWRConfig>
     </Provider>
   );
 };


### PR DESCRIPTION
SWR defaults to unlimited exponential-backoff retries on error. When the server is unavailable, every hook retries indefinitely: for the ~20 polling hooks that use refreshInterval, error retries compound with scheduled refreshes, flooding the server with requests.

Cap retries to 3 (~14s with default backoff) in two places:
1. cluster-ui wrapper hooks (useSwrWithClusterId, useSwrImmutableWithClusterId) — covers all 21 cluster-ui call sites and protects Cockroach Cloud consumers that lack their own SWRConfig.
2. A global SWRConfig provider in db-console's app.tsx — covers the 3 direct useSWR calls in db-console that bypass cluster-ui wrappers.

Individual hooks can still override this retry count (e.g. useMetrics keeps its own errorRetryCount: 2).

Epic: None
Release note: None