### PR TITLE
ui: add latency heat-map coloring to canary plan distribution chart

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -5,6 +5,41 @@
 
 @import "src/core/index.module";
 
+.canary-chart-wrapper {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.latency-legend {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-left: 12px;
+  padding-top: 40px;
+  padding-bottom: 24px;
+  font-size: 11px;
+  color: #475872;
+
+  &__bar {
+    width: 14px;
+    flex: 1;
+    min-height: 60px;
+    margin: 4px 0;
+    border-radius: 3px;
+    // --latency-gradient is set on the parent .latency-legend from
+    // LATENCY_LEGEND_GRADIENT in timeseriesUtils.ts to keep the
+    // gradient in sync with latencyToColor.
+    background: var(--latency-gradient);
+  }
+
+  &__label {
+    margin-top: 4px;
+    font-size: 10px;
+    color: #8b96a9;
+  }
+}
+
 .text-link {
   white-space: nowrap;
   line-height: $line-height--medium;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -5,6 +5,34 @@
 
 @import "src/core/index.module";
 
+.latency-legend {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-left: 12px;
+  padding-top: 40px;
+  padding-bottom: 24px;
+  font-size: 11px;
+  color: #475872;
+
+  &__bar {
+    width: 14px;
+    flex: 1;
+    min-height: 60px;
+    margin: 4px 0;
+    border-radius: 3px;
+    // HSL values must match LATENCY_* constants in timeseriesUtils.ts.
+    background: linear-gradient(to bottom, hsl(261, 97%, 35%), hsl(261, 97%, 85%));
+  }
+
+  &__label {
+    margin-top: 4px;
+    font-size: 10px;
+    color: #8b96a9;
+  }
+}
+
 .text-link {
   white-space: nowrap;
   line-height: $line-height--medium;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -100,6 +100,8 @@ import {
   generateCanaryVsStableTimeseries,
   generatePlanDistributionTimeseries,
   generateCanaryVsStablePlanDistribution,
+  computeWeightedAvgLatencyByGist,
+  LATENCY_LEGEND_GRADIENT,
 } from "./timeseriesUtils";
 
 const { TabPane } = Tabs;
@@ -825,9 +827,15 @@ export function StatementDetails(
         statementStatisticsPerAggregatedTsAndPlanHash || [],
       );
 
-    const canaryPlanDistData = generateCanaryVsStablePlanDistribution(
-      statementStatisticsPerAggregatedTsAndPlanHash || [],
+    // Color-code the canary vs stable chart by per-gist latency.
+    const latencyByGist = computeWeightedAvgLatencyByGist(
+      statementStatisticsPerPlanHash || [],
     );
+    const { data: canaryPlanDistData, latencyRange: canaryLatencyRange } =
+      generateCanaryVsStablePlanDistribution(
+        statementStatisticsPerAggregatedTsAndPlanHash || [],
+        latencyByGist,
+      );
     const hasCanaryPlanData = canaryPlanDistData.length > 0;
 
     return (
@@ -885,19 +893,42 @@ export function StatementDetails(
           {hasCanaryPlanData && (
             <Row gutter={24}>
               <Col className="gutter-row" span={24}>
-                <GroupedBarChart
-                  data={canaryPlanDistData}
-                  yAxisUnits={AxisUnits.Count}
-                  title="Canary vs Stable Plan Distribution"
-                  tooltip={
-                    <>
-                      Shows plan distribution broken down by canary (newest) vs
-                      stable table statistics.
-                    </>
-                  }
-                  xScale={xScale}
-                  aggregationIntervalMillis={aggregationIntervalMillis}
-                />
+                <div className={cx("canary-chart-wrapper")}>
+                  <GroupedBarChart
+                    data={canaryPlanDistData}
+                    yAxisUnits={AxisUnits.Count}
+                    title="Canary vs Stable Plan Distribution"
+                    tooltip={
+                      <>
+                        Compares plan distribution between canary (newest table
+                        statistics) and stable (second-newest) executions. Left
+                        bars show canary execution counts, right bars show
+                        stable. Color intensity indicates average execution
+                        latency: darker purple = higher latency, lighter purple
+                        = lower latency.
+                      </>
+                    }
+                    xScale={xScale}
+                    aggregationIntervalMillis={aggregationIntervalMillis}
+                  />
+                  {canaryLatencyRange && (
+                    <div
+                      className={cx("latency-legend")}
+                      style={
+                        {
+                          "--latency-gradient": LATENCY_LEGEND_GRADIENT,
+                        } as React.CSSProperties
+                      }
+                    >
+                      <span>{Duration(canaryLatencyRange.maxNanos)}</span>
+                      <div className={cx("latency-legend__bar")} />
+                      <span>{Duration(canaryLatencyRange.minNanos)}</span>
+                      <span className={cx("latency-legend__label")}>
+                        Avg Latency
+                      </span>
+                    </div>
+                  )}
+                </div>
               </Col>
             </Row>
           )}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -825,9 +825,27 @@ export function StatementDetails(
         statementStatisticsPerAggregatedTsAndPlanHash || [],
       );
 
-    const canaryPlanDistData = generateCanaryVsStablePlanDistribution(
-      statementStatisticsPerAggregatedTsAndPlanHash || [],
-    );
+    // Compute weighted-average execution latency per plan gist so
+    // that the canary vs stable chart can color-code by latency.
+    const latencyByGist = new Map<string, number>();
+    const countByGist = new Map<string, number>();
+    (statementStatisticsPerPlanHash || []).forEach(plan => {
+      const gist = plan.stats?.plan_gists?.[0] || "unknown";
+      const count = longToInt(plan.stats?.count);
+      if (!count || count <= 0) return;
+      const lat = plan.stats?.run_lat?.mean ?? 0;
+      latencyByGist.set(gist, (latencyByGist.get(gist) || 0) + count * lat);
+      countByGist.set(gist, (countByGist.get(gist) || 0) + count);
+    });
+    latencyByGist.forEach((totalLat, gist) => {
+      latencyByGist.set(gist, totalLat / (countByGist.get(gist) || 1));
+    });
+
+    const { data: canaryPlanDistData, latencyRange: canaryLatencyRange } =
+      generateCanaryVsStablePlanDistribution(
+        statementStatisticsPerAggregatedTsAndPlanHash || [],
+        latencyByGist,
+      );
     const hasCanaryPlanData = canaryPlanDistData.length > 0;
 
     return (
@@ -885,19 +903,37 @@ export function StatementDetails(
           {hasCanaryPlanData && (
             <Row gutter={24}>
               <Col className="gutter-row" span={24}>
-                <GroupedBarChart
-                  data={canaryPlanDistData}
-                  yAxisUnits={AxisUnits.Count}
-                  title="Canary vs Stable Plan Distribution"
-                  tooltip={
-                    <>
-                      Shows plan distribution broken down by canary (newest) vs
-                      stable table statistics.
-                    </>
-                  }
-                  xScale={xScale}
-                  aggregationIntervalMillis={aggregationIntervalMillis}
-                />
+                <div style={{ display: "inline-flex", alignItems: "stretch" }}>
+                  <div>
+                    <GroupedBarChart
+                      data={canaryPlanDistData}
+                      yAxisUnits={AxisUnits.Count}
+                      title="Canary vs Stable Plan Distribution"
+                      tooltip={
+                        <>
+                          Compares plan distribution between canary (newest
+                          table statistics) and stable (second-newest)
+                          executions. Left bars show canary execution counts,
+                          right bars show stable. Color intensity indicates
+                          average execution latency: darker purple = higher
+                          latency, lighter purple = lower latency.
+                        </>
+                      }
+                      xScale={xScale}
+                      aggregationIntervalMillis={aggregationIntervalMillis}
+                    />
+                  </div>
+                  {canaryLatencyRange && (
+                    <div className={cx("latency-legend")}>
+                      <span>{Duration(canaryLatencyRange.max * 1e9)}</span>
+                      <div className={cx("latency-legend__bar")} />
+                      <span>{Duration(canaryLatencyRange.min * 1e9)}</span>
+                      <span className={cx("latency-legend__label")}>
+                        Avg Latency
+                      </span>
+                    </div>
+                  )}
+                </div>
               </Col>
             </Row>
           )}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -292,23 +292,76 @@ export function generateCanaryVsStableTimeseries(
     }));
 }
 
+// HSL parameters for the latency heat-map palette. These should stay in
+// sync with the gradient in .latency-legend__bar (statementDetails.module.scss).
+const LATENCY_HUE = 261;
+const LATENCY_SATURATION = 97;
+const LATENCY_LIGHTNESS_MIN = 35; // darkest (highest latency)
+const LATENCY_LIGHTNESS_MAX = 85; // lightest (lowest latency)
+
+// latencyToColor maps a latency value to a purple-tone HSL color.
+// Lower latency → lighter (higher lightness), higher → darker.
+function latencyToColor(lat: number, min: number, max: number): string {
+  const t = max === min ? 0.5 : (lat - min) / (max - min);
+  const lightness =
+    LATENCY_LIGHTNESS_MAX - t * (LATENCY_LIGHTNESS_MAX - LATENCY_LIGHTNESS_MIN);
+  return `hsl(${LATENCY_HUE}, ${LATENCY_SATURATION}%, ${lightness}%)`;
+}
+
 // generateCanaryVsStablePlanDistribution builds a grouped bar chart
 // with two bars per timestamp: canary (left) and stable (right).
 // Each bar is stacked by plan gist, showing execution counts.
+//
+// When latencyByGist is provided, plan gists are sorted by latency
+// ascending (lowest latency at the bottom of the stack) and each gist
+// is assigned a heat-map color (light purple = low latency, dark
+// purple = high latency). The latency range is returned so the caller
+// can render a legend.
 export function generateCanaryVsStablePlanDistribution(
   stats: StatementStatisticsPerAggregatedTsAndPlanHash[],
-): GroupedBarData {
-  // Collect unique plan gists and assign colors.
+  latencyByGist?: Map<string, number>,
+): { data: GroupedBarData; latencyRange?: { min: number; max: number } } {
+  // Collect unique plan gists.
   const planGistSet = new Set<string>();
   stats.forEach(stat => {
     const gist = stat.plan_gist || "unknown";
     planGistSet.add(gist);
   });
-  const planGists = Array.from(planGistSet).sort();
+
+  // Sort and color plan gists. When latency data is available, sort
+  // by latency ascending and use a purple heat-map. Otherwise fall
+  // back to evenly-spaced purple shades.
+  const planGistArray = Array.from(planGistSet);
+  let planGists: string[];
+  let latencyRange: { min: number; max: number } | undefined;
   const gistColors = new Map<string, string>();
-  planGists.forEach((gist, i) => {
-    gistColors.set(gist, SERIES_PALETTE[i % SERIES_PALETTE.length]);
-  });
+
+  const hasLatencyData =
+    latencyByGist &&
+    latencyByGist.size > 0 &&
+    planGistArray.some(g => latencyByGist.has(g));
+
+  if (hasLatencyData) {
+    planGists = planGistArray.sort(
+      (a, b) => (latencyByGist.get(a) || 0) - (latencyByGist.get(b) || 0),
+    );
+    const lats = planGists.map(g => latencyByGist.get(g) || 0);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    planGists.forEach((g, i) => {
+      gistColors.set(g, latencyToColor(lats[i], minLat, maxLat));
+    });
+    latencyRange = { min: minLat, max: maxLat };
+  } else {
+    planGists = planGistArray.sort();
+    const n = planGists.length;
+    planGists.forEach((gist, i) => {
+      // Use index as a synthetic "latency" so latencyToColor spreads
+      // colors evenly across the palette. When n<=1, min===max so
+      // latencyToColor uses its midpoint fallback (t=0.5).
+      gistColors.set(gist, latencyToColor(i, 0, n - 1));
+    });
+  }
 
   // Group stats by timestamp.
   type GistCounts = {
@@ -349,7 +402,7 @@ export function generateCanaryVsStablePlanDistribution(
     })
     .sort((a, b) => a - b);
 
-  return timestamps.map(ts => {
+  const data: GroupedBarData = timestamps.map(ts => {
     const entry = timeMap.get(ts);
     return {
       timestamp: ts,
@@ -373,4 +426,6 @@ export function generateCanaryVsStablePlanDistribution(
       ],
     };
   });
+
+  return { data, latencyRange };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -292,23 +292,100 @@ export function generateCanaryVsStableTimeseries(
     }));
 }
 
+// HSL parameters for the latency heat-map palette. These are the single
+// source of truth for both the per-gist bar colors and the legend
+// gradient (LATENCY_LEGEND_GRADIENT below).
+const LATENCY_HUE = 261;
+const LATENCY_SATURATION = 97;
+const LATENCY_LIGHTNESS_MIN = 35; // darkest (highest latency)
+const LATENCY_LIGHTNESS_MAX = 85; // lightest (lowest latency)
+
+const latencyHsl = (lightness: number): string =>
+  `hsl(${LATENCY_HUE}, ${LATENCY_SATURATION}%, ${lightness}%)`;
+
+// LATENCY_LEGEND_GRADIENT is the CSS background value to apply to the
+// legend bar so it stays in lock-step with latencyToColor.
+export const LATENCY_LEGEND_GRADIENT = `linear-gradient(to bottom, ${latencyHsl(
+  LATENCY_LIGHTNESS_MIN,
+)}, ${latencyHsl(LATENCY_LIGHTNESS_MAX)})`;
+
+// latencyToColor maps a latency value to a purple-tone HSL color.
+// Lower latency → lighter (higher lightness), higher → darker.
+function latencyToColor(lat: number, min: number, max: number): string {
+  const t = max === min ? 0.5 : (lat - min) / (max - min);
+  const lightness =
+    LATENCY_LIGHTNESS_MAX - t * (LATENCY_LIGHTNESS_MAX - LATENCY_LIGHTNESS_MIN);
+  return latencyHsl(lightness);
+}
+
+type CollectedStatementGroupedByPlanHash =
+  cockroach.server.serverpb.StatementDetailsResponse.ICollectedStatementGroupedByPlanHash;
+
+// computeWeightedAvgLatencyByGist returns the weighted-average run
+// latency per plan gist, in nanoseconds. The weight for each plan is
+// its execution count, so plans that ran more contribute more to the
+// average for their gist. Plans with no executions are skipped.
+//
+// Latencies are returned in nanoseconds so downstream consumers (color
+// mapping in generateCanaryVsStablePlanDistribution, Duration
+// formatting in the legend) all work in the same unit.
+export function computeWeightedAvgLatencyByGist(
+  plans: CollectedStatementGroupedByPlanHash[],
+): Map<string, number> {
+  const latencyByGist = new Map<string, number>();
+  const countByGist = new Map<string, number>();
+  plans.forEach(plan => {
+    const gist = plan.stats?.plan_gists?.[0] || "unknown";
+    const count = longToInt(plan.stats?.count);
+    if (!count || count <= 0) return;
+    const latNanos = (plan.stats?.run_lat?.mean ?? 0) * 1e9;
+    latencyByGist.set(gist, (latencyByGist.get(gist) || 0) + count * latNanos);
+    countByGist.set(gist, (countByGist.get(gist) || 0) + count);
+  });
+  latencyByGist.forEach((totalLat, gist) => {
+    latencyByGist.set(gist, totalLat / countByGist.get(gist));
+  });
+  return latencyByGist;
+}
+
 // generateCanaryVsStablePlanDistribution builds a grouped bar chart
 // with two bars per timestamp: canary (left) and stable (right).
 // Each bar is stacked by plan gist, showing execution counts.
+//
+// Plan gists are sorted by latency ascending (lowest latency at the
+// bottom of the stack) and each gist is assigned a heat-map color
+// (light purple = low latency, dark purple = high latency). The
+// latency range (in nanoseconds) is returned so the caller can render
+// a legend. Gists missing from latencyByGist are treated as 0.
 export function generateCanaryVsStablePlanDistribution(
   stats: StatementStatisticsPerAggregatedTsAndPlanHash[],
-): GroupedBarData {
-  // Collect unique plan gists and assign colors.
+  latencyByGist: Map<string, number>,
+): {
+  data: GroupedBarData;
+  latencyRange?: { minNanos: number; maxNanos: number };
+} {
+  // Collect unique plan gists.
   const planGistSet = new Set<string>();
   stats.forEach(stat => {
     const gist = stat.plan_gist || "unknown";
     planGistSet.add(gist);
   });
-  const planGists = Array.from(planGistSet).sort();
+
+  // Sort plan gists by latency ascending and assign heat-map colors.
+  const planGists = Array.from(planGistSet).sort(
+    (a, b) => (latencyByGist.get(a) || 0) - (latencyByGist.get(b) || 0),
+  );
   const gistColors = new Map<string, string>();
-  planGists.forEach((gist, i) => {
-    gistColors.set(gist, SERIES_PALETTE[i % SERIES_PALETTE.length]);
-  });
+  let latencyRange: { minNanos: number; maxNanos: number } | undefined;
+  if (planGists.length > 0) {
+    const lats = planGists.map(g => latencyByGist.get(g) || 0);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    planGists.forEach((g, i) => {
+      gistColors.set(g, latencyToColor(lats[i], minLat, maxLat));
+    });
+    latencyRange = { minNanos: minLat, maxNanos: maxLat };
+  }
 
   // Group stats by timestamp.
   type GistCounts = {
@@ -349,7 +426,7 @@ export function generateCanaryVsStablePlanDistribution(
     })
     .sort((a, b) => a - b);
 
-  return timestamps.map(ts => {
+  const data: GroupedBarData = timestamps.map(ts => {
     const entry = timeMap.get(ts);
     return {
       timestamp: ts,
@@ -373,4 +450,6 @@ export function generateCanaryVsStablePlanDistribution(
       ],
     };
   });
+
+  return { data, latencyRange };
 }


### PR DESCRIPTION
The latency coloring was added in 165850 but was not yet
migrated over in 166293 for simplicity.

Add back the functionality of color coding plan gists by their
weighted-average execution latency in the "Canary vs Stable
Plan Distribution" chart. A vertical legend is rendered with
the chart showing the latency range.

Epic: None
Release note: None

-----

Before: 
<img width="1227" height="466" alt="image" src="https://github.com/user-attachments/assets/1b9275dd-78b3-4805-9f9d-8aa2742eb304" />

After: 
<img width="1298" height="463" alt="image" src="https://github.com/user-attachments/assets/658d7bc4-c492-4200-914b-062771793c8e" />
