### PR TITLE
release-25.2: roachtest: create kafka topics manually before consuming

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -245,6 +245,18 @@ func (ct *cdcTester) setupSink(args feedArgs) string {
 		kafka.mon = ct.mon
 		kafka.validateOrder = args.kafkaArgs.validateOrder
 
+		// Manually create Kafka topics so that topic consumers can start
+		// without racing on auto-creation by the changefeed.
+		for _, target := range args.targets {
+			topic := target
+			if i := strings.LastIndex(topic, "."); i != -1 {
+				topic = topic[i+1:]
+			}
+			if err := kafka.createTopic(ct.ctx, topic); err != nil {
+				ct.t.Fatal(err)
+			}
+		}
+
 		if err := kafka.startTopicConsumers(ct.ctx, args.targets, ct.doneCh); err != nil {
 			ct.t.Fatal(err)
 		}
@@ -2230,10 +2242,10 @@ func registerCDC(r registry.Registry) {
 			// topics that changefeeds need but not for all topics on the kafka
 			// cluster. The test verifies the work by 1. creating lots of random kafka
 			// topics on the kafka cluster 2. running some tpcc workload with a
-			// changefeed configured to watch all tpcc tables (note that cdc creates
-			// kafka topics for every target tables internally) 3. assert that
-			// changefeed only fetches metadata for tpcc tables but not for other
-			// random topics created in 1.
+			// changefeed configured to watch all tpcc tables (note that even though
+			// cdc creates kafka topics for every target table internally, we create
+			// them ourselves to avoid a race) 3. assert that changefeed only fetches
+			// metadata for tpcc tables but not for other random topics created in 1.
 
 			// Run minimal level of tpcc workload and changefeed.
 			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30s"})


### PR DESCRIPTION
Backport 1/1 commits from #165458 on behalf of @aerfrei.

----

Previously, Kafka topic consumers were started in setupSink before
the changefeed was created without being explicitly created. This
meant consumers could call Partitions() before the topics existed
in Kafka if the changefeed didn't create them in time. While Kafka can
auto-create topics on metadata requests, this didn't always succeed,
likely due to a race with leader, resulting in
  "Request was for a topic or partition that does not exist on this
  broker".
The error was buffered in the monitor's errgroup and only
surfaced at shutdown.

Manually creating the topics ensures this doesn't happen and the test
doesn't flake.

Fixes: https://github.com/cockroachdb/cockroach/issues/164590
Fixes: https://github.com/cockroachdb/cockroach/issues/162293
Fixes: https://github.com/cockroachdb/cockroach/issues/163153
Fixes: https://github.com/cockroachdb/cockroach/issues/155512
Fixes: https://github.com/cockroachdb/cockroach/issues/160064
Fixes: https://github.com/cockroachdb/cockroach/issues/155675

Release note: None

----

Release justification: Test only. 