### PR TITLE
kvstorage: stage a WAG event for replica subsumption

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "replica_mark_test.go",
         "stateloader_test.go",
         "storage_test.go",
+        "subsume_test.go",
         "wag_replay_test.go",
         "wag_truncator_test.go",
     ],

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -215,7 +215,10 @@ func destroyReplicaImpl(
 // SubsumeReplica is like DestroyReplica, but it does not delete the user keys
 // (and the corresponding system and lock table keys). The latter are inherited
 // by the subsuming range.
-func SubsumeReplica(ctx context.Context, rw ReadWriter, info DestroyReplicaInfo) error {
+func SubsumeReplica(
+	ctx context.Context, rw ReadWriter, w *wag.Writer, info DestroyReplicaInfo,
+) error {
+	w.AddEvent(wagpb.MakeAddr(info.FullReplicaID, info.RaftAppliedIndex), wagpb.EventSubsume)
 	info.Keys = roachpb.RSpan{} // forget about the user keys
 	return destroyReplicaImpl(ctx, rw, info, MergedTombstoneReplicaID)
 }

--- a/pkg/kv/kvserver/kvstorage/destroy_test.go
+++ b/pkg/kv/kvserver/kvstorage/destroy_test.go
@@ -38,43 +38,6 @@ func TestDestroyReplica(t *testing.T) {
 
 	storage.DisableMetamorphicSimpleValueEncoding(t) // for deterministic output
 
-	printBatch := func(name string, b storage.WriteBatch) string {
-		str, err := print.DecodeWriteBatch(b.Repr())
-		require.NoError(t, err)
-		return fmt.Sprintf(">> %s:\n%s", name, str)
-	}
-	mutate := func(name string, eng storage.Engine, write func(storage.Writer)) string {
-		b := eng.NewWriteBatch()
-		defer b.Close()
-		write(b)
-		str := printBatch(name, b)
-		require.NoError(t, b.Commit(false))
-		return str
-	}
-	mutateSep := func(name string, eng Engines, write func(ReadWriter, *wag.Writer)) string {
-		b := makeTestBatch(eng)
-		defer b.close()
-		w := wag.MakeWriter(&wag.Seq{})
-		write(b.readWriter(), &w)
-
-		var str string
-		if eng.Separated() {
-			stateRepr := b.batch.Repr()
-			require.NoError(t, w.Flush(b.raftBatch, stateRepr))
-			// The WAG writer should always be non-empty in this test — the
-			// caller wants a cross-engine write that goes through WAG. Verify
-			// the raft batch's WAG node embeds the state engine batch, and
-			// elide the redundant state output.
-			require.True(t, wag.AssertMutationBatch(t, b.raftBatch.Repr(), stateRepr))
-			str = fmt.Sprintf(">> %s/state:\n(matches WAG node)\n", name)
-			str += printBatch(name+"/raft", b.raftBatch)
-		} else {
-			str = printBatch(name, b.batch)
-		}
-		require.NoError(t, b.commit())
-		return str
-	}
-
 	r := replicaInfo{
 		id:      roachpb.FullReplicaID{RangeID: 123, ReplicaID: 3},
 		hs:      raftpb.HardState{Term: 5, Commit: 14},
@@ -84,13 +47,13 @@ func TestDestroyReplica(t *testing.T) {
 		applied: 12,
 	}
 
-	runTest := func(t *testing.T, e Engines) {
+	runWithEngines(t, func(t *testing.T, e Engines) {
 		ctx := context.Background()
-		out := mutate("raft", e.LogEngine(), func(w storage.Writer) {
+		out := testMutate(t, "raft", e.LogEngine(), func(w storage.Writer) {
 			r.createRaftState(ctx, t, w)
-		}) + mutate("state", e.StateEngine(), func(w storage.Writer) {
+		}) + testMutate(t, "state", e.StateEngine(), func(w storage.Writer) {
 			r.createStateMachine(ctx, t, w)
-		}) + mutateSep("destroy", e, func(rw ReadWriter, w *wag.Writer) {
+		}) + testMutateSep(t, "destroy", e, func(rw ReadWriter, w *wag.Writer) {
 			require.NoError(t, DestroyReplica(
 				ctx, rw, w,
 				DestroyReplicaInfo{
@@ -101,29 +64,12 @@ func TestDestroyReplica(t *testing.T) {
 				}, r.id.ReplicaID+1,
 			))
 		})
-
-		out = strings.ReplaceAll(out, "\n\n", "\n")
-		name := strings.ReplaceAll(t.Name(), "/", "-") + ".txt"
-		echotest.Require(t, out, filepath.Join(datapathutils.TestDataPath(t), name))
-	}
-
-	t.Run("one-eng", func(t *testing.T) {
-		eng := storage.NewDefaultInMemForTesting()
-		defer eng.Close()
-		runTest(t, MakeEngines(eng))
+		echotestRequire(t, out)
 	})
-	t.Run("sep-eng", func(t *testing.T) {
-		eng := storage.NewDefaultInMemForTesting()
-		defer eng.Close()
-		runTest(t, MakeSeparatedEnginesForTesting(eng, eng))
-	})
-
 }
 
 // replicaInfo contains the basic info about the replica, used for generating
 // its storage counterpart.
-//
-// TODO(pav-kv): make it reusable for other tests.
 type replicaInfo struct {
 	id      roachpb.FullReplicaID
 	hs      raftpb.HardState
@@ -182,6 +128,79 @@ func createRangeData(t *testing.T, w storage.Writer, span roachpb.RSpan) {
 		}.ToEngineKey(nil)
 		require.NoError(t, w.PutEngineKey(ek, nil))
 	}
+}
+
+// testMutate writes a batch to a single engine and returns a printable
+// representation of the batch contents.
+func testMutate(t *testing.T, name string, eng storage.Engine, write func(storage.Writer)) string {
+	t.Helper()
+	b := eng.NewWriteBatch()
+	defer b.Close()
+	write(b)
+	str := testPrintBatch(t, name, b)
+	require.NoError(t, b.Commit(false))
+	return str
+}
+
+// testMutateSep writes a batch using the separated engine ReadWriter and WAG
+// writer, and returns a printable representation of the batch contents.
+func testMutateSep(
+	t *testing.T, name string, eng Engines, write func(ReadWriter, *wag.Writer),
+) string {
+	t.Helper()
+	b := makeTestBatch(eng)
+	defer b.close()
+	w := wag.MakeWriter(&wag.Seq{})
+	write(b.readWriter(), &w)
+
+	var str string
+
+	if eng.Separated() {
+		stateRepr := b.batch.Repr()
+		require.NoError(t, w.Flush(b.raftBatch, stateRepr))
+		// The WAG writer should always be non-empty in this test — the
+		// caller wants a cross-engine write that goes through WAG. Verify
+		// the raft batch's WAG node embeds the state engine batch, and
+		// elide the redundant state output.
+		require.True(t, wag.AssertMutationBatch(t, b.raftBatch.Repr(), stateRepr))
+		str = fmt.Sprintf(">> %s/state:\n(matches WAG node)\n", name)
+		str += testPrintBatch(t, name+"/raft", b.raftBatch)
+	} else {
+		str = testPrintBatch(t, name, b.batch)
+	}
+	require.NoError(t, b.commit())
+	return str
+}
+
+func testPrintBatch(t *testing.T, name string, b storage.WriteBatch) string {
+	t.Helper()
+	str, err := print.DecodeWriteBatch(b.Repr())
+	require.NoError(t, err)
+	return fmt.Sprintf(">> %s:\n%s", name, str)
+}
+
+// echotestRequire strips double newlines from the output and asserts it matches
+// the testdata file for the current test.
+func echotestRequire(t *testing.T, out string) {
+	t.Helper()
+	out = strings.ReplaceAll(out, "\n\n", "\n")
+	name := strings.ReplaceAll(t.Name(), "/", "-") + ".txt"
+	echotest.Require(t, out, filepath.Join(datapathutils.TestDataPath(t), name))
+}
+
+// runWithEngines runs a test function under both single-engine and
+// separated-engine configurations.
+func runWithEngines(t *testing.T, fn func(t *testing.T, e Engines)) {
+	t.Run("one-eng", func(t *testing.T) {
+		eng := storage.NewDefaultInMemForTesting()
+		defer eng.Close()
+		fn(t, MakeEngines(eng))
+	})
+	t.Run("sep-eng", func(t *testing.T) {
+		eng := storage.NewDefaultInMemForTesting()
+		defer eng.Close()
+		fn(t, MakeSeparatedEnginesForTesting(eng, eng))
+	})
 }
 
 type testBatch struct {

--- a/pkg/kv/kvserver/kvstorage/subsume_test.go
+++ b/pkg/kv/kvserver/kvstorage/subsume_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubsumeReplica(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	storage.DisableMetamorphicSimpleValueEncoding(t) // for deterministic output
+
+	r := replicaInfo{
+		id:      roachpb.FullReplicaID{RangeID: 123, ReplicaID: 3},
+		hs:      raftpb.HardState{Term: 5, Commit: 14},
+		ts:      kvserverpb.RaftTruncatedState{Index: 10, Term: 5},
+		keys:    roachpb.RSpan{Key: []byte("a"), EndKey: []byte("z")},
+		last:    15,
+		applied: 12,
+	}
+
+	runWithEngines(t, func(t *testing.T, e Engines) {
+		ctx := context.Background()
+		out := testMutate(t, "raft", e.LogEngine(), func(w storage.Writer) {
+			r.createRaftState(ctx, t, w)
+		}) + testMutate(t, "state", e.StateEngine(), func(w storage.Writer) {
+			r.createStateMachine(ctx, t, w)
+		}) + testMutateSep(t, "subsume", e, func(rw ReadWriter, w *wag.Writer) {
+			require.NoError(t, SubsumeReplica(ctx, rw, w, DestroyReplicaInfo{
+				FullReplicaID:    r.id,
+				RaftAppliedIndex: r.applied,
+				Keys:             r.keys,
+				Separated:        e.Separated(),
+			}))
+		})
+		echotestRequire(t, out)
+	})
+}

--- a/pkg/kv/kvserver/kvstorage/testdata/TestSubsumeReplica-one-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestSubsumeReplica-one-eng.txt
@@ -1,0 +1,31 @@
+echo
+----
+>> raft:
+Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:5 vote:0 commit:14 lead:0 lead_epoch:0 
+Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:10 term:5 
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:11 (0x0169f67b757266746c000000000000000b00): Term:5 Index:11 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): Term:5 Index:12 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): Term:5 Index:13 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): Term:5 Index:14 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): Term:5 Index:15 Type:EntryNormal : EMPTY
+>> state:
+Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:3 
+Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:3 
+Put: 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 0.012345678,0
+Put: 0.000000001,0 /Local/Range"a"/RangeDescriptor (0x016b126100017264736300000000000000000109): ""
+Put: /Local/Range"a"/RangeDescriptor/Intent/00000000-0000-0000-0000-000000000000: 
+Put: 0.000000001,0 "a" (0x6100000000000000000109): ""
+Put: "a"/Intent/00000000-0000-0000-0000-000000000000: 
+Put: 0.000000001,0 "y\xff" (0x79ff00000000000000000109): ""
+Put: "y\xff"/Intent/00000000-0000-0000-0000-000000000000: 
+>> subsume:
+Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:2147483647 
+Delete (Sized at 39): 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:11 (0x0169f67b757266746c000000000000000b00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 
+Delete: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 
+Delete (Sized at 33): 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): 
+Delete (Sized at 34): 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 

--- a/pkg/kv/kvserver/kvstorage/testdata/TestSubsumeReplica-sep-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestSubsumeReplica-sep-eng.txt
@@ -1,0 +1,32 @@
+echo
+----
+>> raft:
+Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:5 vote:0 commit:14 lead:0 lead_epoch:0 
+Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:10 term:5 
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:11 (0x0169f67b757266746c000000000000000b00): Term:5 Index:11 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): Term:5 Index:12 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): Term:5 Index:13 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): Term:5 Index:14 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): Term:5 Index:15 Type:EntryNormal : EMPTY
+>> state:
+Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:3 
+Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:3 
+Put: 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 0.012345678,0
+Put: 0.000000001,0 /Local/Range"a"/RangeDescriptor (0x016b126100017264736300000000000000000109): ""
+Put: /Local/Range"a"/RangeDescriptor/Intent/00000000-0000-0000-0000-000000000000: 
+Put: 0.000000001,0 "a" (0x6100000000000000000109): ""
+Put: "a"/Intent/00000000-0000-0000-0000-000000000000: 
+Put: 0.000000001,0 "y\xff" (0x79ff00000000000000000109): ""
+Put: "y\xff"/Intent/00000000-0000-0000-0000-000000000000: 
+>> subsume/state:
+(matches WAG node)
+>> subsume/raft:
+Delete (Sized at 39): 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): 
+Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 
+Delete (Sized at 33): 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): 
+Delete (Sized at 34): 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/3:12,EventSubsume)
+> Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:2147483647 
+> Delete: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -35,7 +35,7 @@ func MakeWriter(seq *Seq) Writer {
 // disabled returns true if the Writer is disabled and no WAG nodes should be
 // written.
 func (w *Writer) disabled() bool {
-	return w.seq == nil
+	return w == nil || w.seq == nil
 }
 
 // Empty returns true if no events have been staged on this Writer.

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -382,7 +382,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		rhsRepl.readOnlyCmdMu.Unlock()
 
 		if err := kvstorage.SubsumeReplica(
-			ctx, b.ReadWriter(), rhsRepl.destroyInfoRaftMuLocked(),
+			ctx, b.ReadWriter(), b.batch.WagWriter(), rhsRepl.destroyInfoRaftMuLocked(),
 		); err != nil {
 			return errors.Wrapf(err, "unable to subsume replica before merge")
 		}

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -461,7 +461,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					require.NoError(t, kvstorage.SubsumeReplica(ctx, kvstorage.ReadWriter{
 						State: kvstorage.WrapState(b.State()),
 						Raft:  kvstorage.Raft{RO: tc.eng.LogEngine(), WO: b.Raft()},
-					}, kvstorage.DestroyReplicaInfo{
+					}, b.WagWriter(), kvstorage.DestroyReplicaInfo{
 						FullReplicaID: rhsRS.replica.FullReplicaID,
 						// TODO(pav-kv): support the applied index properly.
 						RaftAppliedIndex: kvpb.RaftIndex(rhsRS.replica.hs.Commit),

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -347,10 +347,13 @@ func (s *snapWriter) subsumeReplica(ctx context.Context, sub kvstorage.DestroyRe
 		if raftWO == nil {
 			raftWO = w
 		}
+		// TODO(sep-raft-log): plumb the WAG writer from the snapshot application
+		// path. Snapshot WAG population is not yet wired up (see the TODO in
+		// snapWriter.commit), so pass a nil writer for now.
 		return kvstorage.SubsumeReplica(ctx, kvstorage.ReadWriter{
 			State: kvstorage.State{RO: s.eng.StateEngine(), WO: kvstorage.StateWO(w)},
 			Raft:  kvstorage.Raft{RO: s.eng.LogEngine(), WO: raftWO},
-		}, sub)
+		}, nil /* w */, sub)
 	})
 }
 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
@@ -64,20 +64,22 @@ Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x
 apply-merge range-id=1
 ----
 state engine:
-Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
-Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
-Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): 
-Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): 
-Delete (Sized at 28): 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 
-Delete (Sized at 43): 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): 
-Delete (Sized at 34): 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): 
-Delete (Sized at 44): 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): 
-Delete (Sized at 36): 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 
-Put: 0,0 /Local/RangeID/2/u/RangeTombstone (0x01698a757266746200): next_replica_id:2147483647 
-Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): 
+(matches WAG node)
 log engine:
 Delete (Sized at 38): 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): 
 Delete (Sized at 32): 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): 
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:10,EventSubsume)
+> Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
+> Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
+> Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): 
+> Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): 
+> Delete (Sized at 28): 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 
+> Delete (Sized at 43): 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): 
+> Delete (Sized at 34): 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): 
+> Delete (Sized at 44): 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): 
+> Delete (Sized at 36): 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 
+> Put: 0,0 /Local/RangeID/2/u/RangeTombstone (0x01698a757266746200): next_replica_id:2147483647 
+> Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): 
 
 # After the merge, only the LHS should remain, now spanning [a, z).
 # The RHS range should be gone from the test context.


### PR DESCRIPTION
- Extract test helpers from `TestDestroyReplica` to make them reusable.
- Add `TestSubsumeReplica` using the shared helpers.
- Wire up `SubsumeReplica` to write an `EventSubsume` WAG node, mirroring
  `DestroyReplica`'s `EventDestroy`. The snapshot application path doesn't
  have things wired up yet, so that's left for a future patch.

Part of #165186