### PR TITLE
release-25.4: sql: deflake TestStatusAPIContentionEvents

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1673,6 +1673,13 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 	}
 	if len(meta.TraceData) > 0 {
 		if span := tracing.SpanFromContext(r.ctx); span != nil {
+			// Note(davidh): I believe this import can be triggered multiple times
+			// during distsql execution and cause duplicate spans. This has only
+			// been triggered by test flakes so far. If we observe this in production
+			// we should consider adding some deduplication logic or accept that
+			// duplicate spans can occur. For now I'm leaving the behavior as-is
+			// because I don't introduce more allocation to the tracing logic.
+			// see also: exec_util.go:getMessagesForSubtrace which detects the dupe.
 			span.ImportRemoteRecording(meta.TraceData)
 		}
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3417,6 +3417,14 @@ func getMessagesForSubtrace(
 	span spanWithIndex, allSpans []tracingpb.RecordedSpan, seenSpans map[tracingpb.SpanID]struct{},
 ) ([]logRecordRow, error) {
 	if _, ok := seenSpans[span.SpanID]; ok {
+		// Note(davidh): If you're investigating a test flake that's
+		// triggering this error I believe it's triggered by behavior in
+		// DistSQLReceiver.pushMeta which calls span.ImportRemoteRecording.
+		// Consider changing this code to log the error and continue, or
+		// implement span deduplication on import. I've left this as-is for now
+		// since the problem occurs very rarely and only in tests and I think
+		// the consequences for a user would require tracing the same execution
+		// again, which can usually be done.
 		return nil, errors.Errorf("duplicate span %d", span.SpanID)
 	}
 	var allLogs []logRecordRow


### PR DESCRIPTION
Backport 1/1 commits from #162596.

/cc @cockroachdb/obs-inf

## Summary

Cherry-pick of #162596 to release-25.4. Adds detection for duplicate span errors in `TestStatusAPIContentionEvents` and ignores them since the test only cares about contention events, not tracing correctness. Also adds explanatory comments to the two callsites that trigger the duplicate span error.

Fixes #168226

Release justification: test-only change that deflakes a release blocker. No production code behavior is changed — the fix adds error handling in the test to tolerate a benign "duplicate span" race condition, and adds explanatory comments to the relevant callsites.

Epic: none