### PR TITLE
props/physical: add printing of PlanGrams

### DIFF
--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -30,6 +30,16 @@ func (op Operator) String() string {
 	return opNames[opNameIndexes[op]:opNameIndexes[op+1]]
 }
 
+// CamelCase returns the camel-case name of the operator, matching how operator
+// names appear in .opt files, canned opt plans, and plangrams (e.g. "Scan",
+// "InnerJoin").
+func (op Operator) CamelCase() string {
+	if op >= Operator(len(opCamelCaseNames)-1) {
+		return fmt.Sprintf("Operator(%d)", op)
+	}
+	return opCamelCaseNames[opCamelCaseNameIndexes[op]:opCamelCaseNameIndexes[op+1]]
+}
+
 // SyntaxTag returns the name of the operator using the SQL syntax that most
 // closely matches it.
 func (op Operator) SyntaxTag() string {

--- a/pkg/sql/opt/operator_test.go
+++ b/pkg/sql/opt/operator_test.go
@@ -8,8 +8,22 @@ package opt
 import (
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 )
+
+// TestOperatorCamelCase verifies that CamelCase names for all operators contain
+// no whitespace and none of the punctuation characters forbidden in plangram
+// production names.
+func TestOperatorCamelCase(t *testing.T) {
+	const forbidden = "\"'\\:=()|; \t\n\r"
+	for op := Operator(1); op < NumOperators; op++ {
+		name := op.CamelCase()
+		if strings.ContainsAny(name, forbidden) {
+			t.Errorf("CamelCase(%d) = %q contains forbidden character", op, name)
+		}
+	}
+}
 
 // TestAggregateProperties verifies that the various helper functions for
 // various properties of aggregations handle all aggregation operators.

--- a/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
@@ -31,6 +31,7 @@ func (g *opsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 
 	g.genOperatorEnum()
 	g.genOperatorNames()
+	g.genOperatorCamelCaseNames()
 	g.genOperatorSyntaxTags()
 	g.genOperatorsByTag()
 }
@@ -63,6 +64,25 @@ func (g *opsGen) genOperatorNames() {
 	fmt.Fprintf(g.w, "const opNames = \"%s\"\n\n", names.String())
 
 	fmt.Fprintf(g.w, "var opNameIndexes = [...]uint32{%s%d}\n\n", indexes.String(), names.Len())
+}
+
+func (g *opsGen) genOperatorCamelCaseNames() {
+	var names bytes.Buffer
+	var indexes bytes.Buffer
+
+	fmt.Fprint(&names, "Unknown")
+	fmt.Fprint(&indexes, "0, ")
+
+	for _, define := range g.sorted {
+		fmt.Fprintf(&indexes, "%d, ", names.Len())
+		fmt.Fprint(&names, define.Name)
+	}
+
+	fmt.Fprintf(g.w, "const opCamelCaseNames = \"%s\"\n\n", names.String())
+
+	fmt.Fprintf(
+		g.w, "var opCamelCaseNameIndexes = [...]uint32{%s%d}\n\n", indexes.String(), names.Len(),
+	)
 }
 
 func (g *opsGen) genOperatorSyntaxTags() {

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/ops
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/ops
@@ -54,6 +54,10 @@ const opNames = "unknowncol-privateprojectprojectionsprojections-itemsort"
 
 var opNameIndexes = [...]uint32{0, 7, 18, 25, 36, 52, 56}
 
+const opCamelCaseNames = "UnknownColPrivateProjectProjectionsProjectionsItemSort"
+
+var opCamelCaseNameIndexes = [...]uint32{0, 7, 17, 24, 35, 50, 54}
+
 const opSyntaxTags = "UNKNOWNCOL PRIVATEPROJECTPROJECTIONSPROJECTIONS ITEMSORT"
 
 var opSyntaxTagIndexes = [...]uint32{0, 7, 18, 25, 36, 52, 56}

--- a/pkg/sql/opt/props/physical/BUILD.bazel
+++ b/pkg/sql/opt/props/physical/BUILD.bazel
@@ -20,6 +20,8 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sqlerrors",
+        "//pkg/util/buildutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -28,6 +30,7 @@ go_test(
     size = "small",
     srcs = [
         "distribution_test.go",
+        "plangram_test.go",
         "required_test.go",
     ],
     embed = [":physical"],
@@ -39,6 +42,7 @@ go_test(
         "//pkg/sql/opt/props",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -5,7 +5,14 @@
 
 package physical
 
-import "github.com/cockroachdb/cockroach/pkg/sql/opt"
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/errors"
+)
 
 //lint:file-ignore U1000 While this is stubbed out, ignore unused code.
 
@@ -37,12 +44,12 @@ import "github.com/cockroachdb/cockroach/pkg/sql/opt"
 //
 // A PlanGram that matches either of these two optimizer plans would be:
 //
-//	root: (SelectOp (IndexJoinOp scan));
-//	scan: (ScanOp Index=abc_b_idx) | (ScanOp Index=abc_c_idx);
+//	root: (Select (IndexJoin scan));
+//	scan: (Scan Index="abc_b_idx") | (Scan Index="abc_c_idx");
 //
 // The grammar is stored as a linked graph of terms, starting with the "root"
-// nonterminal. The graph could contain cycles (for example to match a plan with
-// a FK cascade cycle).
+// term. The graph could contain cycles (for example to match a plan with a FK
+// cascade cycle).
 //
 // PlanGrams are equivalent to top-down non-deterministic finite tree
 // automatons. We could compile the PlanGram into a state-table-based NFTA, but
@@ -51,6 +58,10 @@ import "github.com/cockroachdb/cockroach/pkg/sql/opt"
 // For some background see https://en.wikipedia.org/wiki/Regular_tree_grammar
 // and https://en.wikipedia.org/wiki/Tree_automaton.
 type PlanGram struct {
+	// root is the starting term, and can also be considered a "pseudo
+	// nonterminal" in the grammar consisting of a single production rule. But
+	// because of its construction this "root" nonterminal cannot be referenced
+	// from any other production rule.
 	root planGramTerm
 }
 
@@ -58,26 +69,47 @@ type PlanGram struct {
 // either the name of a nonterminal or an expression matching an optimizer
 // expression.
 type planGramTerm interface {
+	// visitProductions visits all left-hand-side nonterminals reachable from this
+	// term exactly once, using the visited map to avoid cycles. No particular
+	// traversal order is guaranteed. If the special "any" or "none" nonterminals
+	// are encountered, they are not visited.
+	visitProductions(visited map[*planGramProduction]struct{}, visit func(*planGramProduction))
 }
 
 // planGramProduction represents a left-hand-side nonterminal in the grammar,
-// which has a name and zero or more production rules. The nonterminal matches
-// the current optimizer sub-tree if any of its alternate production rules match
-// the current sub-tree.
+// which has an identifying name and one or more production rules. The
+// nonterminal matches the current optimizer sub-tree if any of its production
+// rules match the current sub-tree.
 type planGramProduction struct {
-	name       string
-	alternates []planGramTerm
+	// name is the symbol identifying the nonterminal in the grammar, which must
+	// be unique in the grammar, and must not be "root", "any", or "none". It must
+	// not contain any of the characters "'\:=()|; or whitespace. For clarity it
+	// is recommended that the name not match any optimizer operator name, but
+	// syntactically there's no problem with re-using an operator name.
+	name string
+	// rules are the set of production rules for this nonterminal. There must be
+	// at least one rule (which could be anyPlanGramTerm or nonePlanGramTerm if
+	// the nonterminal should match any optimizer sub-tree or no optimizer
+	// sub-tree, respectively).
+	rules []planGramTerm
 }
 
 // planGramExpr represents a right-hand-side expression in the grammar, matching
 // an optimizer expression. If the optimizer expression has children
-// (e.g. JoinOp) then those children are each represented by a term, and the
+// (e.g. InnerJoin) then those children are each represented by a term, and the
 // planGramExpr is a nonterminal. If the optimizer expression is nullary / a
-// leaf (e.g. ScanOp) then the planGramExpr is a terminal.
+// leaf (e.g. Scan) then the planGramExpr is a terminal.
 type planGramExpr struct {
 	op       opt.Operator
-	fields   map[string]string
+	fields   []planGramExprField
 	children []planGramTerm
+}
+
+// planGramExprField represents a single field of an optimizer expression. How
+// this matches the corresponding optgen field depends on the specific
+// expression and field.
+type planGramExprField struct {
+	key, val string
 }
 
 var _ planGramTerm = &planGramProduction{}
@@ -89,18 +121,136 @@ var _ planGramTerm = &planGramExpr{}
 var anyPlanGramTerm planGramTerm
 
 // nonePlanGramTerm is "none": a special nonterminal matching no optimizer
-// sub-trees. It is a nonterminal with zero production rules.
+// sub-trees. It is the only nonterminal with zero production rules.
 var nonePlanGramTerm planGramTerm = &planGramProduction{name: "none"}
 
-// AnyPlanGram is the PlanGram: "root: any". It matches any optimizer plan. For
+// AnyPlanGram is the PlanGram: "root: any;". It matches any optimizer plan. For
 // efficiency it is the zero value of PlanGram (and the zero value of PlanGram
-// can also be used directly to mean "root: any").
+// can also be used directly to mean "root: any;").
 var AnyPlanGram = PlanGram{anyPlanGramTerm}
 
-// NonePlanGram is the PlanGram: "root: none". It matches no optimizer plans.
+// NonePlanGram is the PlanGram: "root: none;". It matches no optimizer plans.
 var NonePlanGram = PlanGram{nonePlanGramTerm}
 
 // Any is true if this PlanGram matches any optimizer sub-tree.
 func (p PlanGram) Any() bool {
 	return p.root == nil
+}
+
+// FormatPretty writes the full PlanGram grammar to the buffer, starting with
+// the root, optionally with multiple lines.
+func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
+	if newlines {
+		defer b.WriteRune('\n')
+	}
+	if p.Any() {
+		b.WriteString("root: any;")
+		return
+	}
+	if p.root == nonePlanGramTerm {
+		b.WriteString("root: none;")
+		return
+	}
+
+	// formatTerm writes a RHS term to the buffer.
+	var formatTerm func(planGramTerm)
+	formatTerm = func(term planGramTerm) {
+		if term == nil {
+			b.WriteString("any")
+			return
+		}
+		if term == nonePlanGramTerm {
+			b.WriteString("none")
+			return
+		}
+		switch t := term.(type) {
+		case *planGramProduction:
+			// Assume nonterminal names don't need to be quoted.
+			b.WriteString(t.name)
+		case *planGramExpr:
+			b.WriteRune('(')
+			b.WriteString(t.op.CamelCase())
+			for _, field := range t.fields {
+				b.WriteRune(' ')
+				// Assume field names don't need to be quoted.
+				b.WriteString(field.key)
+				b.WriteRune('=')
+				b.WriteString(strconv.Quote(field.val))
+			}
+			for _, child := range t.children {
+				b.WriteRune(' ')
+				formatTerm(child)
+			}
+			b.WriteRune(')')
+		default:
+			if buildutil.CrdbTestBuild {
+				panic(errors.AssertionFailedf("unexpected planGramTerm type %T", t))
+			}
+		}
+	}
+
+	b.WriteString("root: ")
+	formatTerm(p.root)
+	b.WriteRune(';')
+
+	// Visit each LHS nonterminal reachable from the root, and for each, write all
+	// the production rules to the buffer.
+	visited := make(map[*planGramProduction]struct{})
+	p.root.visitProductions(visited, func(pp *planGramProduction) {
+		if newlines {
+			b.WriteRune('\n')
+		} else {
+			b.WriteRune(' ')
+		}
+		b.WriteString(pp.name)
+		for i, rule := range pp.rules {
+			if i == 0 {
+				b.WriteString(": ")
+			} else {
+				b.WriteString(" | ")
+			}
+			formatTerm(rule)
+		}
+		b.WriteRune(';')
+	})
+}
+
+// Format writes the full PlanGram grammar to the buffer, starting with the
+// root.
+func (p PlanGram) Format(b *bytes.Buffer) {
+	p.FormatPretty(b, false /* newlines */)
+}
+
+// String implements the fmt.Stringer interface.
+func (p PlanGram) String() string {
+	var b bytes.Buffer
+	p.FormatPretty(&b, false /* newlines */)
+	return b.String()
+}
+
+// visitProductions implements the planGramTerm interface.
+func (pp *planGramProduction) visitProductions(
+	visited map[*planGramProduction]struct{}, visit func(*planGramProduction),
+) {
+	if _, ok := visited[pp]; ok {
+		return
+	}
+	visited[pp] = struct{}{}
+	visit(pp)
+	for _, rule := range pp.rules {
+		if rule != nil && rule != nonePlanGramTerm {
+			rule.visitProductions(visited, visit)
+		}
+	}
+}
+
+// visitProductions implements the planGramTerm interface.
+func (pe *planGramExpr) visitProductions(
+	visited map[*planGramProduction]struct{}, visit func(*planGramProduction),
+) {
+	for _, child := range pe.children {
+		if child != nil && child != nonePlanGramTerm {
+			child.visitProductions(visited, visit)
+		}
+	}
 }

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package physical
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanGramFormatPretty(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	scan := &planGramProduction{
+		name: "scan",
+		rules: []planGramTerm{
+			&planGramExpr{
+				op: opt.ScanOp,
+				fields: []planGramExprField{
+					{key: "Index", val: "abc_b_idx"},
+				},
+			},
+			&planGramExpr{
+				op: opt.ScanOp,
+				fields: []planGramExprField{
+					{key: "Index", val: "abc_c_idx"},
+				},
+			},
+		},
+	}
+
+	cycle := &planGramProduction{name: "cycle"}
+	cycle.rules = []planGramTerm{
+		&planGramExpr{
+			op: opt.InnerJoinOp,
+			children: []planGramTerm{
+				cycle,
+				cycle,
+			},
+		},
+		scan,
+	}
+
+	tests := []struct {
+		name             string
+		plangram         PlanGram
+		expectedOneLine  string
+		expectedNewlines string
+	}{
+		{
+			name:             "zero value",
+			plangram:         PlanGram{},
+			expectedOneLine:  "root: any;",
+			expectedNewlines: "root: any;\n",
+		},
+		{
+			name:             "any",
+			plangram:         AnyPlanGram,
+			expectedOneLine:  "root: any;",
+			expectedNewlines: "root: any;\n",
+		},
+		{
+			name:             "none",
+			plangram:         NonePlanGram,
+			expectedOneLine:  "root: none;",
+			expectedNewlines: "root: none;\n",
+		},
+		{
+			name: "simple terminal",
+			plangram: PlanGram{root: &planGramExpr{
+				op: opt.ScanOp,
+				fields: []planGramExprField{
+					{key: "Index", val: "abc_a_idx"},
+				},
+			}},
+			expectedOneLine:  "root: (Scan Index=\"abc_a_idx\");",
+			expectedNewlines: "root: (Scan Index=\"abc_a_idx\");\n",
+		},
+		{
+			name: "expr with children",
+			plangram: PlanGram{root: &planGramExpr{
+				op: opt.SelectOp,
+				children: []planGramTerm{
+					&planGramExpr{op: opt.ScanOp},
+				},
+			}},
+			expectedOneLine:  "root: (Select (Scan));",
+			expectedNewlines: "root: (Select (Scan));\n",
+		},
+		{
+			name: "child referencing nil",
+			plangram: PlanGram{root: &planGramExpr{
+				op:       opt.SelectOp,
+				children: []planGramTerm{nil},
+			}},
+			expectedOneLine:  "root: (Select any);",
+			expectedNewlines: "root: (Select any);\n",
+		},
+		{
+			name: "child referencing any",
+			plangram: PlanGram{root: &planGramExpr{
+				op:       opt.SelectOp,
+				children: []planGramTerm{anyPlanGramTerm},
+			}},
+			expectedOneLine:  "root: (Select any);",
+			expectedNewlines: "root: (Select any);\n",
+		},
+		{
+			name: "child referencing none",
+			plangram: PlanGram{root: &planGramExpr{
+				op:       opt.SelectOp,
+				children: []planGramTerm{nonePlanGramTerm},
+			}},
+			expectedOneLine:  "root: (Select none);",
+			expectedNewlines: "root: (Select none);\n",
+		},
+		{
+			name: "with nonterminal production",
+			plangram: PlanGram{root: &planGramExpr{
+				op: opt.SelectOp,
+				children: []planGramTerm{
+					&planGramExpr{
+						op:       opt.IndexJoinOp,
+						children: []planGramTerm{scan},
+					},
+				},
+			}},
+			expectedOneLine: "root: (Select (IndexJoin scan)); scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");",
+			expectedNewlines: "root: (Select (IndexJoin scan));\n" +
+				"scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");\n",
+		},
+		{
+			name: "multiple fields",
+			plangram: PlanGram{root: &planGramExpr{
+				op: opt.ScanOp,
+				fields: []planGramExprField{
+					{key: "Table", val: "abc"},
+					{key: "Index", val: "abc_b_idx"},
+				},
+			}},
+			expectedOneLine:  "root: (Scan Table=\"abc\" Index=\"abc_b_idx\");",
+			expectedNewlines: "root: (Scan Table=\"abc\" Index=\"abc_b_idx\");\n",
+		},
+		{
+			name: "field value with special characters",
+			plangram: PlanGram{root: &planGramExpr{
+				op: opt.ScanOp,
+				fields: []planGramExprField{
+					{key: "Index", val: `has "quotes" and spaces`},
+				},
+			}},
+			expectedOneLine:  `root: (Scan Index="has \"quotes\" and spaces");`,
+			expectedNewlines: "root: (Scan Index=\"has \\\"quotes\\\" and spaces\");\n",
+		},
+		{
+			name:             "cyclical productions",
+			plangram:         PlanGram{root: cycle},
+			expectedOneLine:  "root: cycle; cycle: (InnerJoin cycle cycle) | scan; scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");",
+			expectedNewlines: "root: cycle;\ncycle: (InnerJoin cycle cycle) | scan;\nscan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			tc.plangram.FormatPretty(&b, false /* newlines */)
+			require.Equal(t, tc.expectedOneLine, b.String())
+			b.Reset()
+			tc.plangram.FormatPretty(&b, true /* newlines */)
+			require.Equal(t, tc.expectedNewlines, b.String())
+		})
+	}
+}

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -116,6 +116,9 @@ func (p *Required) String() string {
 	if p.RemoteBranch {
 		output("remote branch", func(buf *bytes.Buffer) { buf.WriteString("true") })
 	}
+	if !p.PlanGram.Any() {
+		output("plangram", p.PlanGram.Format)
+	}
 
 	// Handle empty properties case.
 	if buf.Len() == 0 {


### PR DESCRIPTION
### opt: add Operator.CamelCase function

To make plangrams look more like opt and canned opt plans, we want to
use camel case operator names. Add a new function.

Epic: None
Release note: None

---

### props/physical: add printing of PlanGrams

Add functions to print plangrams, and also clean up some of the structs
and comments.

Informs: #152053
Release note: None