### PR TITLE
kvstorage: Add batching to the WAGTruncator

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/kv/kvserver/spanset",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",

--- a/pkg/kv/kvserver/kvstorage/wag/store.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store.go
@@ -109,6 +109,7 @@ func (it *Iterator) Iter(ctx context.Context, r storage.Reader) iter.Seq2[uint64
 
 // IterFrom is similar to Iter, but allows specifying a starting point for the
 // iteration.
+// TODO(ibrahim): Make this function take a WAG index instead of a key.
 func (it *Iterator) IterFrom(
 	ctx context.Context, r storage.Reader, seekKey roachpb.Key,
 ) iter.Seq2[uint64, wagpb.Node] {

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -16,12 +16,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/time/rate"
+)
+
+var wagTruncatorBatchSize = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"kv.wag.truncator_batch_size",
+	"number of WAG nodes to delete per write batch during truncation",
+	16,
+	settings.IntInRange(1, 1024),
 )
 
 // WAGTruncatorTestingKnobs contains testing knobs for the WAGTruncator.
@@ -118,39 +127,39 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer stateReader.Close()
 	for {
-		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(ctx, stateReader)
+		truncated, err := t.truncateBatch(ctx, stateReader)
 		if err != nil || !truncated {
 			return err
 		}
 	}
 }
 
-// truncateAppliedWAGNodeAndClearRaftState deletes the first WAG node if all of
-// its events have been applied to the state engine. For nodes containing
+// truncateBatch deletes up to a batch-sized prefix of WAG nodes if all of
+// their events have been applied to the state engine. For nodes containing
 // EventDestroy or EventSubsume events, it also clears the corresponding raft
 // log prefix from the engine and the sideloaded entries storage.
 //
-// Returns a bool indicating whether a WAG node was deleted or not.
+// Returns a bool indicating whether some WAG nodes were deleted or not.
 //
 // The caller must provide a stateRO reader with GuaranteedDurability so that
 // only state confirmed flushed to persistent storage is visible. This ensures
 // we never delete a WAG node whose mutations aren't flushed yet. The caller is
 // also responsible for creating and committing/closing the write batch in
 // raft.WO.
-// TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
-func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, stateRO StateRO,
-) (bool, error) {
+func (t *WAGTruncator) truncateBatch(ctx context.Context, stateRO StateRO) (bool, error) {
+	batchSize := wagTruncatorBatchSize.Get(&t.st.SV)
+	var count int64
 	var iter wag.Iterator
 	truncated := t.truncIndex.Load()
-	iterStartKey := keys.StoreWAGNodeKey(truncated)
+
 	b := t.eng.LogEngine().NewWriteBatch()
 	defer b.Close()
-
-	for index, node := range iter.IterFrom(ctx, t.eng.LogEngine(), iterStartKey) {
+	for index, node := range iter.IterFrom(
+		ctx, t.eng.LogEngine(), keys.StoreWAGNodeKey(truncated+1),
+	) {
 		if index != truncated+1 && index > t.initIndex {
 			// We cannot ignore gaps for WAG indices > initIndex.
-			return false, nil
+			break
 		}
 		// TODO(ibrahim): Right now, the canApplyWAGNode function returns a list of
 		// raftCatchUpTargets that are not needed for the purposes of truncation,
@@ -161,7 +170,7 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 		}
 		if action.apply {
 			// If an event needs to be applied, the WAG node cannot be deleted yet.
-			return false, nil
+			break
 		}
 		if err := wag.Delete(b, index); err != nil {
 			return false, err
@@ -172,21 +181,27 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 			if event.Type != wagpb.EventDestroy && event.Type != wagpb.EventSubsume {
 				continue
 			}
-			if err = t.clearReplicaRaftLogAndSideloaded(
-				ctx, Raft{RO: t.eng.LogEngine(), WO: b}, event.Addr.RangeID, event.Addr.Index,
+			if err = t.clearReplicaRaftLogAndSideloaded(ctx,
+				Raft{RO: t.eng.LogEngine(), WO: b}, event.Addr.RangeID, event.Addr.Index,
 			); err != nil {
 				return false, err
 			}
 		}
-		truncated = index
 
-		if err = b.Commit(false /* sync */); err != nil {
-			return false, err
+		truncated = index
+		count++
+		if count >= batchSize {
+			break
 		}
-		t.truncIndex.Store(truncated)
-		return true, nil
 	}
-	return false, iter.Error() // either no more WAG nodes or iter hit an error
+	if err := iter.Error(); err != nil || count == 0 {
+		return false, err
+	}
+	if err := b.Commit(false /* sync */); err != nil {
+		return false, err
+	}
+	t.truncIndex.Store(truncated)
+	return true, nil
 }
 
 // clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -16,12 +16,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/time/rate"
+)
+
+var wagTruncatorBatchSize = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"kv.wag.truncator_batch_size",
+	"number of WAG nodes to delete per write batch during truncation",
+	8,
+	settings.IntInRange(1, 1024),
 )
 
 // WAGTruncatorTestingKnobs contains testing knobs for the WAGTruncator.
@@ -118,39 +127,39 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer stateReader.Close()
 	for {
-		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(ctx, stateReader)
+		truncated, err := t.truncateBatch(ctx, stateReader)
 		if err != nil || !truncated {
 			return err
 		}
 	}
 }
 
-// truncateAppliedWAGNodeAndClearRaftState deletes the first WAG node if all of
-// its events have been applied to the state engine. For nodes containing
+// truncateBatch deletes up to a batch-sized prefix of WAG nodes if all of
+// their events have been applied to the state engine. For nodes containing
 // EventDestroy or EventSubsume events, it also clears the corresponding raft
-// log prefix from the engine and the sideloaded entries storage.
+// log prefix from the engine and the sideloaded entries.
 //
-// Returns a bool indicating whether a WAG node was deleted or not.
+// Returns a bool indicating whether some WAG nodes were deleted or not.
 //
 // The caller must provide a stateRO reader with GuaranteedDurability so that
 // only state confirmed flushed to persistent storage is visible. This ensures
 // we never delete a WAG node whose mutations aren't flushed yet. The caller is
 // also responsible for creating and committing/closing the write batch in
 // raft.WO.
-// TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
-func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, stateRO StateRO,
-) (bool, error) {
+func (t *WAGTruncator) truncateBatch(ctx context.Context, stateRO StateRO) (bool, error) {
+	batchSize := wagTruncatorBatchSize.Get(&t.st.SV)
+	var count int64
 	var iter wag.Iterator
-	truncateIndex := t.truncIndex.Load() + 1
-	iterStartKey := keys.StoreWAGNodeKey(truncateIndex)
+	targetIndex := t.truncIndex.Load() + 1
+
 	b := t.eng.LogEngine().NewWriteBatch()
 	defer b.Close()
-
-	for index, node := range iter.IterFrom(ctx, t.eng.LogEngine(), iterStartKey) {
-		if index != truncateIndex && index > t.initIndex {
+	for index, node := range iter.IterFrom(
+		ctx, t.eng.LogEngine(), keys.StoreWAGNodeKey(targetIndex),
+	) {
+		if index != targetIndex && index > t.initIndex {
 			// We cannot ignore gaps for WAG indices > initIndex.
-			return false, nil
+			break
 		}
 		// TODO(ibrahim): Right now, the canApplyWAGNode function returns a list of
 		// raftCatchUpTargets that are not needed for the purposes of truncation,
@@ -161,7 +170,7 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 		}
 		if action.apply {
 			// If an event needs to be applied, the WAG node cannot be deleted yet.
-			return false, nil
+			break
 		}
 		if err := wag.Delete(b, index); err != nil {
 			return false, err
@@ -178,13 +187,23 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 			}
 		}
 
-		if err = b.Commit(false); err != nil {
-			return false, err
+		targetIndex = index + 1
+		count++
+		if count >= batchSize {
+			break
 		}
-		t.truncIndex.Store(index)
-		return true, nil
 	}
-	return false, iter.Error() // either no more WAG nodes or iter hit an error
+	if count == 0 {
+		return false, nil
+	}
+	if err := iter.Error(); err != nil {
+		return false, err
+	}
+	if err := b.Commit(false); err != nil {
+		return false, err
+	}
+	t.truncIndex.Store(targetIndex - 1) // targetIndex is pointing at the last index truncated + 1.
+	return true, nil
 }
 
 // clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -118,26 +118,10 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer stateReader.Close()
 	for {
-		if err := ctx.Err(); err != nil {
+		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(ctx, stateReader)
+		if err != nil || !truncated {
 			return err
 		}
-		b := t.eng.LogEngine().NewWriteBatch()
-		truncatedIdx, err := t.truncateAppliedWAGNodeAndClearRaftState(
-			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader,
-		)
-		if err == nil && truncatedIdx != 0 {
-			err = b.Commit(false /* sync */)
-		}
-		b.Close()
-		if err != nil {
-			return err
-		}
-		if truncatedIdx == 0 {
-			return nil
-		}
-		// At this point we know that the last truncation succeeded and the batch
-		// was committed, and we can move on to the next node.
-		t.truncIndex.Store(truncatedIdx)
 	}
 }
 
@@ -146,8 +130,7 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 // EventDestroy or EventSubsume events, it also clears the corresponding raft
 // log prefix from the engine and the sideloaded entries storage.
 //
-// Returns the index of the last WAG node that was deleted, or 0 if no nodes
-// were deleted.
+// Returns a bool indicating whether a WAG node was deleted or not.
 //
 // The caller must provide a stateRO reader with GuaranteedDurability so that
 // only state confirmed flushed to persistent storage is visible. This ensures
@@ -156,29 +139,32 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 // raft.WO.
 // TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
 func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, raft Raft, stateRO StateRO,
-) (uint64, error) {
+	ctx context.Context, stateRO StateRO,
+) (bool, error) {
 	var iter wag.Iterator
-	truncateIndex := t.truncIndex.Load() + 1
-	iterStartKey := keys.StoreWAGNodeKey(truncateIndex)
-	for index, node := range iter.IterFrom(ctx, raft.RO, iterStartKey) {
-		if index != truncateIndex && index > t.initIndex {
+	truncated := t.truncIndex.Load()
+	iterStartKey := keys.StoreWAGNodeKey(truncated)
+	b := t.eng.LogEngine().NewWriteBatch()
+	defer b.Close()
+
+	for index, node := range iter.IterFrom(ctx, t.eng.LogEngine(), iterStartKey) {
+		if index != truncated+1 && index > t.initIndex {
 			// We cannot ignore gaps for WAG indices > initIndex.
-			return 0, nil
+			return false, nil
 		}
 		// TODO(ibrahim): Right now, the canApplyWAGNode function returns a list of
 		// raftCatchUpTargets that are not needed for the purposes of truncation,
 		// consider refactoring the function to return only the needed info.
 		action, err := canApplyWAGNode(ctx, node, stateRO)
 		if err != nil {
-			return 0, err
+			return false, err
 		}
 		if action.apply {
 			// If an event needs to be applied, the WAG node cannot be deleted yet.
-			return 0, nil
+			return false, nil
 		}
-		if err := wag.Delete(raft.WO, index); err != nil {
-			return 0, err
+		if err := wag.Delete(b, index); err != nil {
+			return false, err
 		}
 
 		// Clean up the raft log prefix of a destroyed/subsumed replica.
@@ -186,13 +172,21 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 			if event.Type != wagpb.EventDestroy && event.Type != wagpb.EventSubsume {
 				continue
 			}
-			if err := t.clearReplicaRaftLogAndSideloaded(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
-				return 0, err
+			if err = t.clearReplicaRaftLogAndSideloaded(
+				ctx, Raft{RO: t.eng.LogEngine(), WO: b}, event.Addr.RangeID, event.Addr.Index,
+			); err != nil {
+				return false, err
 			}
 		}
-		return index, nil
+		truncated = index
+
+		if err = b.Commit(false /* sync */); err != nil {
+			return false, err
+		}
+		t.truncIndex.Store(truncated)
+		return true, nil
 	}
-	return 0, iter.Error()
+	return false, iter.Error() // either no more WAG nodes or iter hit an error
 }
 
 // clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -118,26 +118,10 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer stateReader.Close()
 	for {
-		if err := ctx.Err(); err != nil {
+		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(ctx, stateReader)
+		if err != nil || !truncated {
 			return err
 		}
-		b := t.eng.LogEngine().NewWriteBatch()
-		truncatedIdx, err := t.truncateAppliedWAGNodeAndClearRaftState(
-			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader,
-		)
-		if err == nil && truncatedIdx != 0 {
-			err = b.Commit(false /* sync */)
-		}
-		b.Close()
-		if err != nil {
-			return err
-		}
-		if truncatedIdx == 0 {
-			return nil
-		}
-		// At this point we know that the last truncation succeeded and the batch
-		// was committed, and we can move on to the next node.
-		t.truncIndex.Store(truncatedIdx)
 	}
 }
 
@@ -146,8 +130,7 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 // EventDestroy or EventSubsume events, it also clears the corresponding raft
 // log prefix from the engine and the sideloaded entries storage.
 //
-// Returns the index of the last WAG node that was deleted, or 0 if no nodes
-// were deleted.
+// Returns a bool indicating whether a WAG node was deleted or not.
 //
 // The caller must provide a stateRO reader with GuaranteedDurability so that
 // only state confirmed flushed to persistent storage is visible. This ensures
@@ -156,29 +139,32 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 // raft.WO.
 // TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
 func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, raft Raft, stateRO StateRO,
-) (uint64, error) {
+	ctx context.Context, stateRO StateRO,
+) (bool, error) {
 	var iter wag.Iterator
 	truncateIndex := t.truncIndex.Load() + 1
 	iterStartKey := keys.StoreWAGNodeKey(truncateIndex)
-	for index, node := range iter.IterFrom(ctx, raft.RO, iterStartKey) {
+	b := t.eng.LogEngine().NewWriteBatch()
+	defer b.Close()
+
+	for index, node := range iter.IterFrom(ctx, t.eng.LogEngine(), iterStartKey) {
 		if index != truncateIndex && index > t.initIndex {
 			// We cannot ignore gaps for WAG indices > initIndex.
-			return 0, nil
+			return false, nil
 		}
 		// TODO(ibrahim): Right now, the canApplyWAGNode function returns a list of
 		// raftCatchUpTargets that are not needed for the purposes of truncation,
 		// consider refactoring the function to return only the needed info.
 		action, err := canApplyWAGNode(ctx, node, stateRO)
 		if err != nil {
-			return 0, err
+			return false, err
 		}
 		if action.apply {
 			// If an event needs to be applied, the WAG node cannot be deleted yet.
-			return 0, nil
+			return false, nil
 		}
-		if err := wag.Delete(raft.WO, index); err != nil {
-			return 0, err
+		if err := wag.Delete(b, index); err != nil {
+			return false, err
 		}
 
 		// Clean up the raft log prefix of a destroyed/subsumed replica.
@@ -186,13 +172,19 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 			if event.Type != wagpb.EventDestroy && event.Type != wagpb.EventSubsume {
 				continue
 			}
-			if err := t.clearReplicaRaftLogAndSideloaded(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
-				return 0, err
+			if err = t.clearReplicaRaftLogAndSideloaded(ctx,
+				Raft{RO: t.eng.LogEngine(), WO: b}, event.Addr.RangeID, event.Addr.Index); err != nil {
+				return false, err
 			}
 		}
-		return index, nil
+
+		if err = b.Commit(false); err != nil {
+			return false, err
+		}
+		t.truncIndex.Store(index)
+		return true, nil
 	}
-	return 0, iter.Error()
+	return false, iter.Error() // either no more WAG nodes or iter hit an error
 }
 
 // clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -7,6 +7,7 @@ package kvstorage
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
@@ -54,13 +55,16 @@ func (e *testEngines) writeWAGNode(t *testing.T, event wagpb.Event) {
 }
 
 // writeWAGNodesAt writes WAG nodes at the specified WAG sequence indices for
-// the given replica. Each node contains an EventApply event with its raft index
-// set to the WAG entry index + 10.
-func (e *testEngines) writeWAGNodesAt(t *testing.T, wagIndices []uint64, r roachpb.FullReplicaID) {
+// the given replica. Each node contains an EventApply event with its raft
+// index set to the corresponding entry in raftIndices.
+func (e *testEngines) writeWAGNodesAt(
+	t *testing.T, wagIndices []uint64, raftIndices []kvpb.RaftIndex, r roachpb.FullReplicaID,
+) {
 	t.Helper()
+	require.Equal(t, len(wagIndices), len(raftIndices))
 	for idx, wagIdx := range wagIndices {
 		event := wagpb.Event{
-			Addr: wagpb.MakeAddr(r, kvpb.RaftIndex(idx+10)),
+			Addr: wagpb.MakeAddr(r, raftIndices[idx]),
 			Type: wagpb.EventApply,
 		}
 		require.NoError(t, wag.Write(
@@ -368,7 +372,11 @@ func TestTruncateAppliedNodes(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
-			e.writeWAGNodesAt(t, tc.wagIndices, r1)
+			raftIndices := make([]kvpb.RaftIndex, len(tc.wagIndices))
+			for i := range raftIndices {
+				raftIndices[i] = kvpb.RaftIndex(i + 1)
+			}
+			e.writeWAGNodesAt(t, tc.wagIndices, raftIndices, r1)
 			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
 			require.NoError(t, sl.SetRaftReplicaID(ctx, e.StateEngine(), r1.ReplicaID))
 			require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
@@ -461,4 +469,108 @@ func TestWAGTruncatorBackground(t *testing.T) {
 	flushAndWaitForTruncation()
 	require.Empty(t, e.listWAGNodes(t))
 	require.Equal(t, uint64(7), truncator.truncIndex.Load())
+}
+
+// TestTruncateBatching verifies that truncateBatch() respects the batch size
+// setting.
+//
+// WAG layout: indices [3, 7, 10, 11, 12], and node at index 12 is not durably
+// applied.
+func TestTruncateBatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	sl := MakeStateLoader(r1.RangeID)
+	wagNodeIndices := []uint64{3, 7, 10, 11, 12}
+	raftIndices := []kvpb.RaftIndex{1, 2, 3, 4, 5}
+	for _, tc := range []struct {
+		init          uint64
+		batch         int64
+		wantRemaining []uint64
+		wantTrunc     uint64
+	}{
+		{init: 0, batch: 1, wantRemaining: []uint64{3, 7, 10, 11, 12}, wantTrunc: 0},
+		{init: 0, batch: 8, wantRemaining: []uint64{3, 7, 10, 11, 12}, wantTrunc: 0},
+		{init: 3, batch: 1, wantRemaining: []uint64{7, 10, 11, 12}, wantTrunc: 3},
+		{init: 3, batch: 8, wantRemaining: []uint64{7, 10, 11, 12}, wantTrunc: 3},
+		{init: 7, batch: 1, wantRemaining: []uint64{7, 10, 11, 12}, wantTrunc: 3},
+		{init: 7, batch: 2, wantRemaining: []uint64{10, 11, 12}, wantTrunc: 7},
+		{init: 7, batch: 8, wantRemaining: []uint64{10, 11, 12}, wantTrunc: 7},
+		{init: 10, batch: 1, wantRemaining: []uint64{7, 10, 11, 12}, wantTrunc: 3},
+		{init: 10, batch: 4, wantRemaining: []uint64{12}, wantTrunc: 11},
+		// Node 11 isn't applied yet, so it's not truncated.
+		{init: 10, batch: 8, wantRemaining: []uint64{12}, wantTrunc: 11},
+	} {
+		t.Run("", func(t *testing.T) {
+			st := cluster.MakeTestingClusterSettings()
+			wagTruncatorBatchSize.Override(ctx, &st.SV, tc.batch)
+			e := makeTestEngines()
+			defer e.Close()
+			e.writeWAGNodesAt(t, wagNodeIndices, raftIndices, r1)
+			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
+			truncator.initIndex = tc.init
+
+			require.NoError(t, sl.SetRaftReplicaID(ctx, e.StateEngine(), r1.ReplicaID))
+			// The last WAG entry has raft index of 5, set the applied index to 4 to
+			// make the last WAG node ineligible for truncation.
+			require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
+				&kvserverpb.RangeAppliedState{RaftAppliedIndex: kvpb.RaftIndex(4)}))
+			require.NoError(t, e.stateEngine.Flush())
+
+			stateReader := e.StateEngine().NewReader(storage.GuaranteedDurability)
+			defer stateReader.Close()
+			truncated, err := truncator.truncateBatch(ctx, stateReader)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.wantRemaining) != len(wagNodeIndices), truncated)
+			require.Equal(t, tc.wantRemaining, e.listWAGNodes(t))
+			require.Equal(t, tc.wantTrunc, truncator.truncIndex.Load())
+		})
+	}
+}
+
+// BenchmarkWAGTruncation measures the cost of truncating WAG nodes at different
+// batch sizes. It uses an in-memory engine so it doesn't really test the real
+// thing, but it should give an idea of the improvement of different batch
+// sizes.
+func BenchmarkWAGTruncation(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	sl := MakeStateLoader(r1.RangeID)
+	for _, batchSize := range []int64{1, 4, 8, 16, 32, 64} {
+		b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
+			b.StopTimer()
+			st := cluster.MakeTestingClusterSettings()
+			wagTruncatorBatchSize.Override(ctx, &st.SV, batchSize)
+			eng := storage.NewDefaultInMemForTesting()
+			defer eng.Close()
+			engines := MakeEngines(eng)
+			var seq wag.Seq
+			truncator := NewWAGTruncator(st, engines, &seq)
+
+			// Write numNodes WAG nodes that are all eligible for truncation.
+			for j := 0; j < b.N; j++ {
+				index := seq.Next()
+				require.NoError(b, wag.Write(eng, index, wagpb.Node{
+					Events: []wagpb.Event{{
+						Addr: wagpb.MakeAddr(r1, kvpb.RaftIndex(j+1)),
+						Type: wagpb.EventApply,
+					}},
+				}))
+			}
+			require.NoError(b, sl.SetRaftReplicaID(ctx, eng, r1.ReplicaID))
+			require.NoError(b, sl.SetRangeAppliedState(
+				ctx, eng, &kvserverpb.RangeAppliedState{
+					RaftAppliedIndex: kvpb.RaftIndex(b.N + 1),
+				}))
+			require.NoError(b, eng.Flush())
+
+			b.StartTimer()
+			err := truncator.truncateAppliedNodes(ctx)
+			b.StopTimer()
+			require.NoError(b, err)
+			require.Equal(b, uint64(b.N), truncator.truncIndex.Load())
+		})
+	}
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -7,6 +7,7 @@ package kvstorage
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
@@ -55,12 +56,12 @@ func (e *testEngines) writeWAGNode(t *testing.T, event wagpb.Event) {
 
 // writeWAGNodesAt writes WAG nodes at the specified WAG sequence indices for
 // the given replica. Each node contains an EventApply event with its raft index
-// set to the WAG entry index + 10.
+// set to the WAG entry index + 1.
 func (e *testEngines) writeWAGNodesAt(t *testing.T, wagIndices []uint64, r roachpb.FullReplicaID) {
 	t.Helper()
 	for idx, wagIdx := range wagIndices {
 		event := wagpb.Event{
-			Addr: wagpb.MakeAddr(r, kvpb.RaftIndex(idx+10)),
+			Addr: wagpb.MakeAddr(r, kvpb.RaftIndex(idx+1)),
 			Type: wagpb.EventApply,
 		}
 		require.NoError(t, wag.Write(
@@ -461,4 +462,116 @@ func TestWAGTruncatorBackground(t *testing.T) {
 	flushAndWaitForTruncation()
 	require.Empty(t, e.listWAGNodes(t))
 	require.Equal(t, uint64(7), truncator.truncIndex.Load())
+}
+
+// TestTruncateBatching verifies that truncateBatch() respects the batch size
+// setting.
+//
+// WAG layout: indices [3, 7, 10, 11, 12], and node at index 12 is not durably
+// applied.
+func TestTruncateBatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	sl := MakeStateLoader(r1.RangeID)
+	wagNodeIndices := []uint64{3, 7, 10, 11, 12}
+	for _, tc := range []struct {
+		initIndex      uint64
+		batchSize      int64
+		wantTruncated  bool
+		wantRemaining  []uint64
+		wantTruncIndex uint64
+	}{
+		{initIndex: 0, batchSize: 1, wantTruncated: false, wantRemaining: []uint64{3, 7, 10, 11, 12}, wantTruncIndex: 0},
+		{initIndex: 0, batchSize: 8, wantTruncated: false, wantRemaining: []uint64{3, 7, 10, 11, 12}, wantTruncIndex: 0},
+		{initIndex: 3, batchSize: 1, wantTruncated: true, wantRemaining: []uint64{7, 10, 11, 12}, wantTruncIndex: 3},
+		{initIndex: 3, batchSize: 8, wantTruncated: true, wantRemaining: []uint64{7, 10, 11, 12}, wantTruncIndex: 3},
+		{initIndex: 7, batchSize: 1, wantTruncated: true, wantRemaining: []uint64{7, 10, 11, 12}, wantTruncIndex: 3},
+		{initIndex: 7, batchSize: 2, wantTruncated: true, wantRemaining: []uint64{10, 11, 12}, wantTruncIndex: 7},
+		{initIndex: 7, batchSize: 8, wantTruncated: true, wantRemaining: []uint64{10, 11, 12}, wantTruncIndex: 7},
+		{initIndex: 10, batchSize: 1, wantTruncated: true, wantRemaining: []uint64{7, 10, 11, 12}, wantTruncIndex: 3},
+		{initIndex: 10, batchSize: 4, wantTruncated: true, wantRemaining: []uint64{12}, wantTruncIndex: 11},
+		// Node 11 isn't applied yet, so it's not truncated.
+		{initIndex: 10, batchSize: 8, wantTruncated: true, wantRemaining: []uint64{12}, wantTruncIndex: 11},
+	} {
+		t.Run("", func(t *testing.T) {
+			st := cluster.MakeTestingClusterSettings()
+			wagTruncatorBatchSize.Override(ctx, &st.SV, tc.batchSize)
+			e := makeTestEngines()
+			defer e.Close()
+			e.writeWAGNodesAt(t, wagNodeIndices, r1)
+			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
+			truncator.initIndex = tc.initIndex
+
+			require.NoError(t, sl.SetRaftReplicaID(ctx, e.StateEngine(), r1.ReplicaID))
+			// Ensure that the last WAG node isn't applied.
+			require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
+				&kvserverpb.RangeAppliedState{RaftAppliedIndex: kvpb.RaftIndex(len(wagNodeIndices) - 1)}))
+			require.NoError(t, e.stateEngine.Flush())
+
+			stateReader := e.StateEngine().NewReader(storage.GuaranteedDurability)
+			defer stateReader.Close()
+			truncated, err := truncator.truncateBatch(ctx, stateReader)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTruncated, truncated)
+			require.Equal(t, tc.wantRemaining, e.listWAGNodes(t))
+			require.Equal(t, tc.wantTruncIndex, truncator.truncIndex.Load())
+		})
+	}
+}
+
+// BenchmarkWAGTruncation measures the cost of truncating WAG nodes at different
+// batch sizes. It uses an in-memory engine so it doesn't really test the real
+// thing, but it should give an idea of the improvement of different batch
+// sizes.
+func BenchmarkWAGTruncation(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	sl := MakeStateLoader(r1.RangeID)
+	for _, batchSize := range []int64{1, 4, 8, 16, 32, 64} {
+		b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
+			b.StopTimer()
+			st := cluster.MakeTestingClusterSettings()
+			wagTruncatorBatchSize.Override(ctx, &st.SV, batchSize)
+			eng := storage.NewDefaultInMemForTesting()
+			defer eng.Close()
+			engines := MakeEngines(eng)
+			var seq wag.Seq
+			truncator := NewWAGTruncator(st, engines, &seq)
+
+			// Write numNodes WAG nodes that are all eligible for
+			// truncation.
+			for j := 0; j < b.N; j++ {
+				index := seq.Next()
+				if err := wag.Write(eng, index, wagpb.Node{
+					Events: []wagpb.Event{{
+						Addr: wagpb.MakeAddr(r1, kvpb.RaftIndex(j+1)),
+						Type: wagpb.EventApply,
+					}},
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := sl.SetRaftReplicaID(ctx, eng, r1.ReplicaID); err != nil {
+				b.Fatal(err)
+			}
+			if err := sl.SetRangeAppliedState(ctx, eng,
+				&kvserverpb.RangeAppliedState{
+					RaftAppliedIndex: kvpb.RaftIndex(b.N + 1),
+				}); err != nil {
+				b.Fatal(err)
+			}
+			if err := eng.Flush(); err != nil {
+				b.Fatal(err)
+			}
+
+			b.StartTimer()
+			err := truncator.truncateAppliedNodes(ctx)
+			b.StopTimer()
+			require.NoError(b, err)
+			require.Equal(b, truncator.truncIndex.Load(), uint64(b.N))
+		})
+	}
 }


### PR DESCRIPTION
This PR adds the ability to truncate multiple WAG nodes in a single batch. It adds the cluster setting `kv.wag.truncator_batch_size` to control the batch size.

Batch sizes benchmark: 

```
BenchmarkWAGTruncation/batchSize=1                247114             15261 ns/op            1002 B/op         20 allocs/op
BenchmarkWAGTruncation/batchSize=4                396939              5533 ns/op             608 B/op         11 allocs/op
BenchmarkWAGTruncation/batchSize=8                452824              5220 ns/op             549 B/op         10 allocs/op
BenchmarkWAGTruncation/batchSize=16               447286              4400 ns/op             505 B/op          9 allocs/op
BenchmarkWAGTruncation/batchSize=32               512752              2402 ns/op             503 B/op          9 allocs/op
BenchmarkWAGTruncation/batchSize=64               484096              3737 ns/op             481 B/op          9 allocs/op
```

References: #167607

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>