### PR TITLE
metric: enable prometheus native histograms by default

### DIFF
--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_gogo_protobuf//proto",
-        "@com_github_kr_pretty//:pretty",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -326,7 +326,7 @@ func HdrEnabled() bool {
 // conventional and native histograms are exported.
 const useNativeHistogramsEnvVar = "COCKROACH_ENABLE_PROMETHEUS_NATIVE_HISTOGRAMS"
 
-var nativeHistogramsEnabled = envutil.EnvOrDefaultBool(useNativeHistogramsEnvVar, false)
+var nativeHistogramsEnabled = envutil.EnvOrDefaultBool(useNativeHistogramsEnvVar, true)
 
 // nativeHistogramsBucketFactorEnvVar can be used to override the default
 // bucket size exponential factor for Prometheus native histograms, if enabled.
@@ -342,6 +342,19 @@ var nativeHistogramsBucketFactor = envutil.EnvOrDefaultFloat64(nativeHistogramsB
 const nativeHistogramsBucketCountMultiplierEnvVar = "COCKROACH_PROMETHEUS_NATIVE_HISTOGRAMS_BUCKET_COUNT_MULTIPLIER"
 
 var nativeHistogramsBucketCountMultiplier = envutil.EnvOrDefaultFloat64(nativeHistogramsBucketCountMultiplierEnvVar, 1)
+
+// applyNativeHistogramOpts configures native histogram options on the given
+// prometheus.HistogramOpts if native histograms are enabled. Native histograms
+// use their own internal exponential bucketing scheme, so this works regardless
+// of the classic bucket distribution.
+func applyNativeHistogramOpts(opts *prometheus.HistogramOpts, numBuckets int) {
+	if nativeHistogramsEnabled {
+		opts.NativeHistogramBucketFactor = nativeHistogramsBucketFactor
+		opts.NativeHistogramMaxBucketNumber = uint32(
+			float64(numBuckets) * nativeHistogramsBucketCountMultiplier,
+		)
+	}
+}
 
 // maxLabelValuesEnvVar can be used to configure the maximum number of distinct
 // label value combinations for high cardinality metrics before eviction starts.
@@ -443,10 +456,7 @@ func newHistogram(
 	opts := prometheus.HistogramOpts{
 		Buckets: buckets,
 	}
-	if bucketConfig.distribution == Exponential && nativeHistogramsEnabled {
-		opts.NativeHistogramBucketFactor = nativeHistogramsBucketFactor
-		opts.NativeHistogramMaxBucketNumber = uint32(float64(len(buckets)) * nativeHistogramsBucketCountMultiplier)
-	}
+	applyNativeHistogramOpts(&opts, len(buckets))
 	cum := prometheus.NewHistogram(opts)
 	h := &Histogram{
 		Metadata: meta,
@@ -625,6 +635,7 @@ func NewManualWindowHistogram(
 	opts := prometheus.HistogramOpts{
 		Buckets: buckets,
 	}
+	applyNativeHistogramOpts(&opts, len(buckets))
 	cum := prometheus.NewHistogram(opts)
 	// We initialize the histogram with the same bucket bounds as the cumulative
 	// histogram.
@@ -1703,6 +1714,7 @@ func NewExportedHistogramVec(
 		Name:    metadata.Name,
 		Help:    metadata.Help,
 	}
+	applyNativeHistogramOpts(&opts, len(opts.Buckets))
 	promVec := prometheus.NewHistogramVec(opts, vec.orderedLabelNames)
 	return &HistogramVec{
 		Metadata: metadata,

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"reflect"
 	"sort"
 	"sync"
 	"testing"
@@ -18,7 +17,6 @@ import (
 
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/kr/pretty"
 	"github.com/prometheus/client_golang/prometheus"
 	prometheusgo "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -273,24 +271,22 @@ func TestHistogram(t *testing.T) {
 		expSum += float64(m)
 	}
 
-	act := *h.ToPrometheusMetric().Histogram
-	exp := prometheusgo.Histogram{
-		SampleCount: u(len(measurements)),
-		SampleSum:   &expSum,
-		Bucket: []*prometheusgo.Bucket{
-			{CumulativeCount: u(1), UpperBound: f(1)},
-			{CumulativeCount: u(3), UpperBound: f(5)},
-			{CumulativeCount: u(4), UpperBound: f(10)},
-			{CumulativeCount: u(6), UpperBound: f(25)},
-			{CumulativeCount: u(9), UpperBound: f(100)},
-			// NB: 200 is greater than the largest defined bucket so prometheus
-			// puts it in an implicit bucket with +Inf as the upper bound.
-		},
-	}
+	act := h.ToPrometheusMetric().Histogram
+	require.Equal(t, u(len(measurements)), act.SampleCount)
+	require.Equal(t, &expSum, act.SampleSum)
+	require.Equal(t, []*prometheusgo.Bucket{
+		{CumulativeCount: u(1), UpperBound: f(1)},
+		{CumulativeCount: u(3), UpperBound: f(5)},
+		{CumulativeCount: u(4), UpperBound: f(10)},
+		{CumulativeCount: u(6), UpperBound: f(25)},
+		{CumulativeCount: u(9), UpperBound: f(100)},
+		// NB: 200 is greater than the largest defined bucket so prometheus
+		// puts it in an implicit bucket with +Inf as the upper bound.
+	}, act.Bucket)
 
-	if !reflect.DeepEqual(act, exp) {
-		t.Fatalf("expected differs from actual: %s", pretty.Diff(exp, act))
-	}
+	// Assert that native histogram schema is defined (native histograms are on
+	// by default).
+	require.NotNil(t, act.Schema)
 
 	histWindow := h.WindowedSnapshot()
 	require.Equal(t, 0.0, histWindow.ValueAtQuantile(0))
@@ -298,27 +294,42 @@ func TestHistogram(t *testing.T) {
 	require.Equal(t, 17.5, histWindow.ValueAtQuantile(50))
 	require.Equal(t, 75.0, histWindow.ValueAtQuantile(80))
 	require.Equal(t, 100.0, histWindow.ValueAtQuantile(99.99))
-
-	// Assert that native histogram schema is not defined
-	require.Nil(t, h.ToPrometheusMetric().Histogram.Schema)
 }
 
 func TestNativeHistogram(t *testing.T) {
-	defer func(enabled bool) {
-		nativeHistogramsEnabled = enabled
-	}(nativeHistogramsEnabled)
-	nativeHistogramsEnabled = true
-	h := NewHistogram(HistogramOptions{
-		Mode:     HistogramModePrometheus,
-		Metadata: Metadata{},
-		Duration: time.Hour,
-		BucketConfig: staticBucketConfig{
-			distribution: Exponential,
-		},
+	t.Run("enabled by default", func(t *testing.T) {
+		h := NewHistogram(HistogramOptions{
+			Mode:         HistogramModePrometheus,
+			Metadata:     Metadata{},
+			Duration:     time.Hour,
+			BucketConfig: IOLatencyBuckets,
+		})
+		require.NotNil(t, h.ToPrometheusMetric().Histogram.Schema)
 	})
 
-	// Assert that native histogram schema is defined
-	require.NotNil(t, h.ToPrometheusMetric().Histogram.Schema)
+	t.Run("disabled via env var", func(t *testing.T) {
+		defer func(enabled bool) {
+			nativeHistogramsEnabled = enabled
+		}(nativeHistogramsEnabled)
+		nativeHistogramsEnabled = false
+
+		h := NewHistogram(HistogramOptions{
+			Mode:         HistogramModePrometheus,
+			Metadata:     Metadata{},
+			Duration:     time.Hour,
+			BucketConfig: IOLatencyBuckets,
+		})
+		require.Nil(t, h.ToPrometheusMetric().Histogram.Schema)
+	})
+
+	t.Run("manual window histogram", func(t *testing.T) {
+		h := NewManualWindowHistogram(
+			Metadata{},
+			IOLatencyBuckets.GetBucketsFromBucketConfig(),
+			true, /* withRotate */
+		)
+		require.NotNil(t, h.ToPrometheusMetric().Histogram.Schema)
+	})
 }
 
 func TestManualWindowHistogram(t *testing.T) {
@@ -362,24 +373,18 @@ func TestManualWindowHistogram(t *testing.T) {
 	require.NoError(t, histogram.Write(pMetric))
 	h.Update(histogram, pMetric.Histogram)
 
-	act := *h.ToPrometheusMetric().Histogram
-	exp := prometheusgo.Histogram{
-		SampleCount: u(len(measurements)),
-		SampleSum:   &expSum,
-		Bucket: []*prometheusgo.Bucket{
-			{CumulativeCount: u(1), UpperBound: f(1)},
-			{CumulativeCount: u(3), UpperBound: f(5)},
-			{CumulativeCount: u(4), UpperBound: f(10)},
-			{CumulativeCount: u(6), UpperBound: f(25)},
-			{CumulativeCount: u(9), UpperBound: f(100)},
-			// NB: 200 is greater than the largest defined bucket so prometheus
-			// puts it in an implicit bucket with +Inf as the upper bound.
-		},
-	}
-
-	if !reflect.DeepEqual(act, exp) {
-		t.Fatalf("expected differs from actual: %s", pretty.Diff(exp, act))
-	}
+	act := h.ToPrometheusMetric().Histogram
+	require.Equal(t, u(len(measurements)), act.SampleCount)
+	require.Equal(t, &expSum, act.SampleSum)
+	require.Equal(t, []*prometheusgo.Bucket{
+		{CumulativeCount: u(1), UpperBound: f(1)},
+		{CumulativeCount: u(3), UpperBound: f(5)},
+		{CumulativeCount: u(4), UpperBound: f(10)},
+		{CumulativeCount: u(6), UpperBound: f(25)},
+		{CumulativeCount: u(9), UpperBound: f(100)},
+		// NB: 200 is greater than the largest defined bucket so prometheus
+		// puts it in an implicit bucket with +Inf as the upper bound.
+	}, act.Bucket)
 
 	// Rotate and RecordValue are not supported when using Update. See comment on
 	// NewManualWindowHistogram.
@@ -411,22 +416,16 @@ func TestManualWindowHistogram(t *testing.T) {
 	histogram.Observe(5)
 	histogram.Observe(5)
 
-	act = *h.WindowedSnapshot().h
-	exp = prometheusgo.Histogram{
-		SampleCount: u(len(measurements) + len(measurements2)),
-		SampleSum:   &expSum,
-		Bucket: []*prometheusgo.Bucket{
-			{CumulativeCount: u(1), UpperBound: f(1)},
-			{CumulativeCount: u(4), UpperBound: f(5)},
-			{CumulativeCount: u(5), UpperBound: f(10)},
-			{CumulativeCount: u(8), UpperBound: f(25)},
-			{CumulativeCount: u(12), UpperBound: f(100)},
-		},
-	}
-
-	if !reflect.DeepEqual(act, exp) {
-		t.Fatalf("expected differs from actual: %s", pretty.Diff(exp, act))
-	}
+	actW := h.WindowedSnapshot().h
+	require.Equal(t, u(len(measurements)+len(measurements2)), actW.SampleCount)
+	require.Equal(t, &expSum, actW.SampleSum)
+	require.Equal(t, []*prometheusgo.Bucket{
+		{CumulativeCount: u(1), UpperBound: f(1)},
+		{CumulativeCount: u(4), UpperBound: f(5)},
+		{CumulativeCount: u(5), UpperBound: f(10)},
+		{CumulativeCount: u(8), UpperBound: f(25)},
+		{CumulativeCount: u(12), UpperBound: f(100)},
+	}, actW.Bucket)
 }
 
 // TestValueAtQuantileWithEmptyBuckets verifies that ValueAtQuantile does not

--- a/pkg/util/metric/prometheus_exporter_test.go
+++ b/pkg/util/metric/prometheus_exporter_test.go
@@ -185,10 +185,6 @@ func TestPrometheusExporter(t *testing.T) {
 }
 
 func TestPrometheusExporterNativeHistogram(t *testing.T) {
-	defer func(enabled bool) {
-		nativeHistogramsEnabled = enabled
-	}(nativeHistogramsEnabled)
-	nativeHistogramsEnabled = true
 	r := NewRegistry()
 
 	histogram := NewHistogram(HistogramOptions{

--- a/pkg/util/metric/testdata/histogram.txt
+++ b/pkg/util/metric/testdata/histogram.txt
@@ -40,5 +40,27 @@ echo
       "cumulative_count": 4,
       "upper_bound": 30
     }
+  ],
+  "schema": 3,
+  "zero_threshold": 2.938735877055719e-39,
+  "zero_count": 0,
+  "positive_span": [
+    {
+      "offset": 0,
+      "length": 1
+    },
+    {
+      "offset": 18,
+      "length": 1
+    },
+    {
+      "offset": 7,
+      "length": 1
+    }
+  ],
+  "positive_delta": [
+    1,
+    1,
+    -1
   ]
 }


### PR DESCRIPTION
## Summary

- Extracts a shared `applyNativeHistogramOpts` helper to deduplicate native histogram configuration across all histogram constructor paths.
- Closes gaps where `NewManualWindowHistogram` and `NewExportedHistogramVec` did not apply native histogram options.
- Removes the exponential-only distribution restriction (native histograms use their own internal exponential bucketing).
- Flips the `COCKROACH_ENABLE_PROMETHEUS_NATIVE_HISTOGRAMS` default from `false` to `true`.

This is safe because native histograms use dual emission: both classic per-bucket counters and native histogram data are exported simultaneously. Existing scrapers continue to work unchanged. Users can revert via `COCKROACH_ENABLE_PROMETHEUS_NATIVE_HISTOGRAMS=false`.

Epic: none

Release note (ops change): Prometheus native histograms are now
enabled by default. When scraping CockroachDB metrics via protobuf
format, Prometheus servers configured with native histogram support
will receive the more compact native histogram representation
alongside classic per-bucket counters. No action is required for
existing setups. To revert to the previous behavior, set the
environment variable COCKROACH_ENABLE_PROMETHEUS_NATIVE_HISTOGRAMS=false.