### PR TITLE
sql: use fully-qualified name in `SET SCHEMA` DDL

### DIFF
--- a/pkg/sql/catalog/descs/helpers.go
+++ b/pkg/sql/catalog/descs/helpers.go
@@ -70,11 +70,32 @@ func CheckObjectNameCollision(
 	if err != nil || d == nil {
 		return err
 	}
-	maybeQualifiedName := name.Object()
+
+	// If necessary, look up the parts to get a fully-qualified name.
+	var qualifiedName string
 	if name.Catalog() != "" && name.Schema() != "" {
-		maybeQualifiedName = name.FQString()
+		qualifiedName = name.FQString()
+	} else {
+		g := tc.ByIDWithLeased(txn).Get()
+
+		dbDesc, err := g.Database(ctx, parentID)
+		if err != nil {
+			return err
+		}
+		schemaDesc, err := g.Schema(ctx, parentSchemaID)
+		if err != nil {
+			return err
+		}
+
+		tn := tree.MakeTableNameWithSchema(
+			tree.Name(dbDesc.GetName()),
+			tree.Name(schemaDesc.GetName()),
+			tree.Name(name.Object()),
+		)
+		qualifiedName = tn.FQString()
 	}
-	return sqlerrors.MakeObjectAlreadyExistsError(d.DescriptorProto(), maybeQualifiedName)
+
+	return sqlerrors.MakeObjectAlreadyExistsError(d.DescriptorProto(), qualifiedName)
 }
 
 func getObjectPrefix(

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -57,7 +57,7 @@ ALTER TYPE new__name RENAME TO newname
 statement ok
 CREATE TABLE conflict (x INT)
 
-statement error pq: relation \"conflict\" already exists
+statement error pq: relation "test\.public\.conflict" already exists
 ALTER TYPE newname RENAME TO conflict
 
 # Renames should try and move around the array type to find a valid name.

--- a/pkg/sql/logictest/testdata/logic_test/set_schema
+++ b/pkg/sql/logictest/testdata/logic_test/set_schema
@@ -24,8 +24,7 @@ ALTER TABLE t SET SCHEMA does_not_exist
 statement ok
 CREATE TABLE s2.t();
 
-# use regex to accept both the legacy and the declarative schema changer format
-statement error pq: relation "(test.s2.)?t" already exists
+statement error pq: relation "test.s2.t" already exists
 ALTER TABLE t SET SCHEMA s2
 
 # Ensure we cannot set schema to a virtual schema.
@@ -297,7 +296,7 @@ ALTER TYPE typ SET SCHEMA does_not_exist
 statement ok
 CREATE TYPE s2.typ AS ENUM ()
 
-statement error type "typ" already exists
+statement error type "test.s2.typ" already exists
 ALTER TYPE typ SET SCHEMA s2
 
 # Ensure we cannot set schema to a virtual schema.
@@ -455,3 +454,69 @@ CREATE TYPE typ5 AS ENUM ()
 
 statement error pq: user testuser does not have CREATE privilege on schema s1
 ALTER TYPE typ5 SET SCHEMA s1
+
+# Tests for mixed-case and special characters in names.
+subtest mixed_case_names
+
+user root
+
+statement ok
+CREATE SCHEMA "MixedCase"
+
+statement ok
+CREATE SCHEMA "Another-Schema"
+
+statement ok
+CREATE TABLE "MixedTable"(x INT)
+
+statement ok
+INSERT INTO "MixedTable" VALUES (1)
+
+statement ok
+ALTER TABLE "MixedTable" SET SCHEMA "MixedCase"
+
+query I
+SELECT * FROM "MixedCase"."MixedTable"
+----
+1
+
+statement error pq: relation "MixedTable" does not exist
+SELECT * FROM "MixedTable"
+
+statement ok
+ALTER TABLE "MixedCase"."MixedTable" SET SCHEMA "Another-Schema"
+
+query I
+SELECT * FROM "Another-Schema"."MixedTable"
+----
+1
+
+statement error pq: relation "MixedCase.MixedTable" does not exist
+SELECT * FROM "MixedCase"."MixedTable"
+
+# Test with a type that has mixed-case name.
+statement ok
+CREATE TYPE "MixedCase"."MyType" AS ENUM ('value')
+
+statement ok
+ALTER TYPE "MixedCase"."MyType" SET SCHEMA "Another-Schema"
+
+statement ok
+SELECT 'value'::"Another-Schema"."MyType"
+
+statement error pq: type "MixedCase.MyType" does not exist
+SELECT 'value'::"MixedCase"."MyType"
+
+# Test collision detection with mixed-case names.
+statement ok
+CREATE TABLE "MixedCase"."DuplicateTable"(x INT)
+
+statement ok
+CREATE TABLE "Another-Schema"."DuplicateTable"(x INT)
+
+statement error pq: relation "test\.\\"Another-Schema\\"\.\\"DuplicateTable\\"" already exists
+ALTER TABLE "MixedCase"."DuplicateTable" SET SCHEMA "Another-Schema"
+
+user testuser
+
+subtest end


### PR DESCRIPTION
The DDL implementations use fully-qualified names
which reduce ambiguity. This change adds lookups
so an FQN can be used in legacy schemachanger `SET
SCHEMA` statements.

Epic: CRDB-31325

Release note: None
