### PR TITLE
sql: add query, query_summary, and database columns to statement statistics views

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -7068,7 +7068,10 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
     statistics                 JSONB NOT NULL,
     sampled_plan               JSONB NOT NULL,
     aggregation_interval       INTERVAL NOT NULL,
-    index_recommendations      STRING[] NOT NULL
+    index_recommendations      STRING[] NOT NULL,
+    query                      STRING NOT NULL,
+    query_summary              STRING NOT NULL,
+    database                   STRING NOT NULL
 );`,
 	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, _ int64, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// TODO(azhng): we want to eventually implement memory accounting within the
@@ -7095,7 +7098,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 			return nil, nil, err
 		}
 
-		const numDatums = 10
+		const numDatums = 13
 		row := make(tree.Datums, numDatums)
 		worker := func(ctx context.Context, pusher rowPusher) error {
 			return memSQLStats.IterateStatementStats(ctx, sqlstats.IteratorOptions{
@@ -7138,16 +7141,19 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 				}
 
 				row = append(row[:0],
-					aggregatedTs,                        // aggregated_ts
-					fingerprintID,                       // fingerprint_id
-					transactionFingerprintID,            // transaction_fingerprint_id
-					planHash,                            // plan_hash
-					tree.NewDString(statistics.Key.App), // app_name
-					tree.NewDJSON(metadataJSON),         // metadata
-					tree.NewDJSON(statisticsJSON),       // statistics
-					tree.NewDJSON(plan),                 // plan
-					aggInterval,                         // aggregation_interval
-					indexRecommendations,                // index_recommendations
+					aggregatedTs,                                 // aggregated_ts
+					fingerprintID,                                // fingerprint_id
+					transactionFingerprintID,                     // transaction_fingerprint_id
+					planHash,                                     // plan_hash
+					tree.NewDString(statistics.Key.App),          // app_name
+					tree.NewDJSON(metadataJSON),                  // metadata
+					tree.NewDJSON(statisticsJSON),                // statistics
+					tree.NewDJSON(plan),                          // plan
+					aggInterval,                                  // aggregation_interval
+					indexRecommendations,                         // index_recommendations
+					tree.NewDString(statistics.Key.Query),        // query
+					tree.NewDString(statistics.Key.QuerySummary), // query_summary
+					tree.NewDString(statistics.Key.Database),     // database
 				)
 				if buildutil.CrdbTestBuild {
 					if len(row) != numDatums {
@@ -7178,7 +7184,10 @@ SELECT
   merge_statement_stats(DISTINCT statistics),
   max(sampled_plan),
   aggregation_interval,
-  array_remove(array_cat_agg(index_recommendations), NULL) AS index_recommendations
+  array_remove(array_cat_agg(index_recommendations), NULL) AS index_recommendations,
+  max(query) AS query,
+  max(query_summary) AS query_summary,
+  max(database) AS database
 FROM (
   SELECT
       aggregated_ts,
@@ -7190,7 +7199,10 @@ FROM (
       statistics,
       sampled_plan,
       aggregation_interval,
-      index_recommendations
+      index_recommendations,
+      query,
+      query_summary,
+      database
   FROM
       crdb_internal.cluster_statement_statistics
   UNION ALL
@@ -7204,9 +7216,12 @@ FROM (
           statistics,
           plan,
           agg_interval,
-          index_recommendations
+          index_recommendations,
+          query,
+          query_summary,
+          database
       FROM
-          system.statement_statistics
+          crdb_internal.statement_statistics_persisted
 )
 GROUP BY
   aggregated_ts,
@@ -7226,6 +7241,9 @@ GROUP BY
 		{Name: "sampled_plan", Typ: types.Jsonb},
 		{Name: "aggregation_interval", Typ: types.Interval},
 		{Name: "index_recommendations", Typ: types.StringArray},
+		{Name: "query", Typ: types.String},
+		{Name: "query_summary", Typ: types.String},
+		{Name: "database", Typ: types.String},
 	},
 }
 
@@ -7236,26 +7254,31 @@ var crdbInternalStmtStatsPersistedView = virtualSchemaView{
 	schema: `
 CREATE VIEW crdb_internal.statement_statistics_persisted AS
       SELECT
-          aggregated_ts,
-          fingerprint_id,
-          transaction_fingerprint_id,
-          plan_hash,
-          app_name,
-          node_id,
-          agg_interval,
-          metadata,
-          statistics,
-          plan,
-          index_recommendations,
-          indexes_usage,
-          execution_count,
-          service_latency,
-          cpu_sql_nanos,
-          contention_time,
-          total_estimated_execution_time,
-          p99_latency
+          ss.aggregated_ts,
+          ss.fingerprint_id,
+          ss.transaction_fingerprint_id,
+          ss.plan_hash,
+          ss.app_name,
+          ss.node_id,
+          ss.agg_interval,
+          ss.metadata,
+          ss.statistics,
+          ss.plan,
+          ss.index_recommendations,
+          ss.indexes_usage,
+          ss.execution_count,
+          ss.service_latency,
+          ss.cpu_sql_nanos,
+          ss.contention_time,
+          ss.total_estimated_execution_time,
+          ss.p99_latency,
+          COALESCE(s.fingerprint, ss.metadata->>'query', '') AS query,
+          COALESCE(s.summary, ss.metadata->>'querySummary', '') AS query_summary,
+          COALESCE(s.db, ss.metadata->>'db', '') AS database
       FROM
-          system.statement_statistics`,
+          system.statement_statistics AS ss
+      LEFT JOIN
+          system.statements AS s ON ss.fingerprint_id = s.fingerprint_id`,
 	resultColumns: colinfo.ResultColumns{
 		{Name: "aggregated_ts", Typ: types.TimestampTZ},
 		{Name: "fingerprint_id", Typ: types.Bytes},
@@ -7275,6 +7298,9 @@ CREATE VIEW crdb_internal.statement_statistics_persisted AS
 		{Name: "contention_time", Typ: types.Float},
 		{Name: "total_estimated_execution_time", Typ: types.Float},
 		{Name: "p99_latency", Typ: types.Float},
+		{Name: "query", Typ: types.String},
+		{Name: "query_summary", Typ: types.String},
+		{Name: "database", Typ: types.String},
 	},
 }
 
@@ -7284,25 +7310,30 @@ var crdbInternalStmtActivityView = virtualSchemaView{
 	schema: `
 CREATE VIEW crdb_internal.statement_activity AS
       SELECT
-				aggregated_ts,
-				fingerprint_id,
-				transaction_fingerprint_id,
-				plan_hash,
-				app_name,
-				agg_interval,
-				metadata,
-				statistics,
-				plan,
-				index_recommendations,
-				execution_count,
-				execution_total_seconds,
-				execution_total_cluster_seconds,
-				contention_time_avg_seconds,
-				cpu_sql_avg_nanos,
-				service_latency_avg_seconds,
-				service_latency_p99_seconds
+          sa.aggregated_ts,
+          sa.fingerprint_id,
+          sa.transaction_fingerprint_id,
+          sa.plan_hash,
+          sa.app_name,
+          sa.agg_interval,
+          sa.metadata,
+          sa.statistics,
+          sa.plan,
+          sa.index_recommendations,
+          sa.execution_count,
+          sa.execution_total_seconds,
+          sa.execution_total_cluster_seconds,
+          sa.contention_time_avg_seconds,
+          sa.cpu_sql_avg_nanos,
+          sa.service_latency_avg_seconds,
+          sa.service_latency_p99_seconds,
+          COALESCE(s.fingerprint, sa.metadata->>'query', '') AS query,
+          COALESCE(s.summary, sa.metadata->>'querySummary', '') AS query_summary,
+          COALESCE(s.db, sa.metadata->>'db', '') AS database
       FROM
-          system.statement_activity`,
+          system.statement_activity AS sa
+      LEFT JOIN
+          system.statements AS s ON sa.fingerprint_id = s.fingerprint_id`,
 	resultColumns: colinfo.ResultColumns{
 		{Name: "aggregated_ts", Typ: types.TimestampTZ},
 		{Name: "fingerprint_id", Typ: types.Bytes},
@@ -7321,6 +7352,9 @@ CREATE VIEW crdb_internal.statement_activity AS
 		{Name: "cpu_sql_avg_nanos", Typ: types.Float},
 		{Name: "service_latency_avg_seconds", Typ: types.Float},
 		{Name: "service_latency_p99_seconds", Typ: types.Float},
+		{Name: "query", Typ: types.String},
+		{Name: "query_summary", Typ: types.String},
+		{Name: "database", Typ: types.String},
 	},
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1446,10 +1446,43 @@ REVOKE SYSTEM VIEWACTIVITY FROM testuser
 
 # Regression tests for not setting SQL stats provider in the backfill (#76710).
 statement ok
-CREATE TABLE t76710_1 AS SELECT * FROM crdb_internal.statement_statistics;
-
-statement ok
 CREATE MATERIALIZED VIEW t76710_2 AS SELECT fingerprint_id FROM crdb_internal.cluster_statement_statistics;
+
+subtest end
+
+
+subtest statement_statistics_columns
+
+# Validate that crdb_internal.cluster_statement_statistics includes query,
+# query_summary, and database columns.
+query TTTTTTTTTTTTT colnames
+SELECT * FROM crdb_internal.cluster_statement_statistics WHERE aggregated_ts < '1970-01-01'
+----
+aggregated_ts  fingerprint_id  transaction_fingerprint_id  plan_hash  app_name  metadata  statistics  sampled_plan  aggregation_interval  index_recommendations  query  query_summary  database
+
+# Validate that crdb_internal.statement_statistics includes query,
+# query_summary, and database columns.
+skipif config local-mixed-25.4 local-mixed-26.1
+query TTTTTTTTTTTTT colnames
+SELECT * FROM crdb_internal.statement_statistics WHERE aggregated_ts < '1970-01-01'
+----
+aggregated_ts  fingerprint_id  transaction_fingerprint_id  plan_hash  app_name  metadata  statistics  sampled_plan  aggregation_interval  index_recommendations  query  query_summary  database
+
+# Validate that crdb_internal.statement_statistics_persisted includes query,
+# query_summary, and database columns.
+skipif config local-mixed-25.4 local-mixed-26.1
+query TTTTTITTTTTTIRRRRRTTT colnames
+SELECT * FROM crdb_internal.statement_statistics_persisted WHERE aggregated_ts < '1970-01-01'
+----
+aggregated_ts  fingerprint_id  transaction_fingerprint_id  plan_hash  app_name  node_id  agg_interval  metadata  statistics  plan  index_recommendations  indexes_usage  execution_count  service_latency  cpu_sql_nanos  contention_time  total_estimated_execution_time  p99_latency  query  query_summary  database
+
+# Validate that crdb_internal.statement_activity includes query,
+# query_summary, and database columns.
+skipif config local-mixed-25.4 local-mixed-26.1
+query TTTTTTTTTTIRRRRRRTTT colnames
+SELECT * FROM crdb_internal.statement_activity WHERE aggregated_ts < '1970-01-01'
+----
+aggregated_ts  fingerprint_id  transaction_fingerprint_id  plan_hash  app_name  agg_interval  metadata  statistics  plan  index_recommendations  execution_count  execution_total_seconds  execution_total_cluster_seconds  contention_time_avg_seconds  cpu_sql_avg_nanos  service_latency_avg_seconds  service_latency_p99_seconds  query  query_summary  database
 
 subtest end
 
@@ -1604,24 +1637,24 @@ FROM crdb_internal.create_procedure_statements
 WHERE procedure_name IN ('p', 'p2')
 ORDER BY procedure_id;
 ----
-104  test  105  public  142  p   CREATE PROCEDURE public.p(INT8)
+104  test  105  public  141  p   CREATE PROCEDURE public.p(INT8)
                                    LANGUAGE SQL
                                    SECURITY INVOKER
                                    AS $$
-                                   SELECT 1;
-                                 $$
-104  test  105  public  143  p   CREATE PROCEDURE public.p(STRING, b INT8)
+                                     SELECT 1;
+                                   $$
+104  test  105  public  142  p   CREATE PROCEDURE public.p(STRING, b INT8)
                                    LANGUAGE SQL
                                    SECURITY INVOKER
                                    AS $$
-                                   SELECT 'hello';
-                                 $$
-104  test  145  sc      146  p2  CREATE PROCEDURE sc.p2(STRING)
+                                     SELECT 'hello';
+                                   $$
+104  test  144  sc      145  p2  CREATE PROCEDURE sc.p2(STRING)
                                    LANGUAGE SQL
                                    SECURITY INVOKER
                                    AS $$
-                                   SELECT 'hello';
-                                 $$
+                                     SELECT 'hello';
+                                   $$
 
 statement ok
 CREATE DATABASE test_cross_db;
@@ -1635,30 +1668,30 @@ FROM "".crdb_internal.create_procedure_statements
 WHERE procedure_name IN ('p', 'p2', 'p_cross_db')
 ORDER BY procedure_id;
 ----
-104  test           105  public  142  p           CREATE PROCEDURE public.p(INT8)
+104  test           105  public  141  p           CREATE PROCEDURE public.p(INT8)
                                                     LANGUAGE SQL
                                                     SECURITY INVOKER
                                                     AS $$
-                                                    SELECT 1;
-                                                  $$
-104  test           105  public  143  p           CREATE PROCEDURE public.p(STRING, b INT8)
+                                                      SELECT 1;
+                                                    $$
+104  test           105  public  142  p           CREATE PROCEDURE public.p(STRING, b INT8)
                                                     LANGUAGE SQL
                                                     SECURITY INVOKER
                                                     AS $$
-                                                    SELECT 'hello';
-                                                  $$
-104  test           145  sc      146  p2          CREATE PROCEDURE sc.p2(STRING)
+                                                      SELECT 'hello';
+                                                    $$
+104  test           144  sc      145  p2          CREATE PROCEDURE sc.p2(STRING)
                                                     LANGUAGE SQL
                                                     SECURITY INVOKER
                                                     AS $$
-                                                    SELECT 'hello';
-                                                  $$
-147  test_cross_db  148  public  149  p_cross_db  CREATE PROCEDURE public.p_cross_db()
+                                                      SELECT 'hello';
+                                                    $$
+146  test_cross_db  147  public  148  p_cross_db  CREATE PROCEDURE public.p_cross_db()
                                                     LANGUAGE SQL
                                                     SECURITY INVOKER
                                                     AS $$
-                                                    SELECT 1;
-                                                  $$
+                                                      SELECT 1;
+                                                    $$
 
 statement ok
 DROP PROCEDURE p(INT);
@@ -1783,13 +1816,13 @@ CREATE TYPE other_db.public.enum1 AS ENUM ('yo');
 query ITTITTT
 SELECT * FROM "".crdb_internal.create_type_statements WHERE descriptor_name = 'enum1' and database_name = 'other_db'
 ----
-124  other_db  public  155  enum1  CREATE TYPE public.enum1 AS ENUM ('yo')  {yo}
+124  other_db  public  154  enum1  CREATE TYPE public.enum1 AS ENUM ('yo')  {yo}
 
 # This uses the virtual index. descriptor_id is an int in the vtable.
 query ITTITTT
 SELECT * FROM "".crdb_internal.create_type_statements WHERE descriptor_id = (('other_db.public.enum1'::regtype::int) - 100000)
 ----
-124  other_db  public  155  enum1  CREATE TYPE public.enum1 AS ENUM ('yo')  {yo}
+124  other_db  public  154  enum1  CREATE TYPE public.enum1 AS ENUM ('yo')  {yo}
 
 # Repeat above two queries but apply only for the current database. We do this by omitting the "".
 # This one uses the full table scan.

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
@@ -56,5 +57,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlstats/sqlstats_test.go
+++ b/pkg/sql/sqlstats/sqlstats_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDataDrivenTest(t *testing.T) {
@@ -82,6 +84,80 @@ func TestDataDrivenTest(t *testing.T) {
 			return ""
 		})
 	})
+}
+
+// TestStmtStatsQueryColumns verifies that the query, query_summary,
+// and database columns are populated in crdb_internal.cluster_statement_statistics
+// and in the persisted views that join with system.statements.
+func TestStmtStatsQueryColumns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: &sqlstats.TestingKnobs{
+				SynchronousSQLStats: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	appName := "TestStmtStatsQueryColumns"
+
+	// Execute a statement with a known app name and database.
+	execConn := s.SQLConn(t)
+	defer execConn.Close()
+	execDB := sqlutils.MakeSQLRunner(execConn)
+	execDB.Exec(t, "SET APPLICATION_NAME = $1", appName)
+	execDB.Exec(t, "CREATE DATABASE testdb")
+	execDB.Exec(t, "USE testdb")
+	execDB.Exec(t, "SELECT 1")
+
+	obsDB := sqlutils.MakeSQLRunner(conn)
+
+	// Verify in-memory cluster_statement_statistics has the new columns populated.
+	var query, querySummary, database string
+	obsDB.QueryRow(t,
+		`SELECT query, query_summary, database
+		 FROM crdb_internal.cluster_statement_statistics
+		 WHERE app_name = $1 AND query LIKE '%SELECT _'`, appName,
+	).Scan(&query, &querySummary, &database)
+
+	require.NotEmpty(t, query, "query column should be populated")
+	require.Contains(t, query, "SELECT")
+	require.NotEmpty(t, querySummary, "query_summary column should be populated")
+	require.Equal(t, "testdb", database, "database column should match the database used")
+
+	// Flush stats to disk so the persisted views have data.
+	s.SQLServer().(*sql.Server).GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
+
+	// Verify statement_statistics_persisted populates query/query_summary/database
+	// via the JOIN with system.statements.
+	var pQuery, pQuerySummary, pDatabase string
+	obsDB.QueryRow(t,
+		`SELECT query, query_summary, database
+		 FROM crdb_internal.statement_statistics_persisted
+		 WHERE app_name = $1 AND query LIKE '%SELECT _'`, appName,
+	).Scan(&pQuery, &pQuerySummary, &pDatabase)
+
+	require.NotEmpty(t, pQuery, "persisted: query column should be populated")
+	require.Contains(t, pQuery, "SELECT")
+	require.NotEmpty(t, pQuerySummary, "persisted: query_summary column should be populated")
+	require.Equal(t, "testdb", pDatabase, "persisted: database column should match")
+
+	// Verify the merged statement_statistics view also has the columns.
+	var mQuery, mQuerySummary, mDatabase string
+	obsDB.QueryRow(t,
+		`SELECT query, query_summary, database
+		 FROM crdb_internal.statement_statistics
+		 WHERE app_name = $1 AND query LIKE '%SELECT _'`, appName,
+	).Scan(&mQuery, &mQuerySummary, &mDatabase)
+
+	require.NotEmpty(t, mQuery, "merged view: query column should be populated")
+	require.NotEmpty(t, mQuerySummary, "merged view: query_summary column should be populated")
+	require.Equal(t, "testdb", mDatabase, "merged view: database column should match")
 }
 
 func GetStats(t *testing.T, conn *sqlutils.SQLRunner, appName string, dbName string) string {


### PR DESCRIPTION
## Summary

Add three new columns (`query`, `query_summary`, `database`) to the following
crdb_internal virtual tables and views:

- **cluster_statement_statistics**: populated from in-memory stats Key fields
- **statement_statistics**: merged view (union of in-memory + persisted)
- **statement_statistics_persisted**: populated via LEFT JOIN with
  `system.statements`, falling back to metadata JSON fields
- **statement_activity**: populated via LEFT JOIN with `system.statements`,
  falling back to metadata JSON fields

These columns surface the query text, summary, and originating database
directly in the virtual table schema, avoiding the need for callers to
parse the metadata JSONB column. The persisted and activity views use
COALESCE to prefer data from `system.statements` (populated during flush)
and fall back to extracting from the metadata JSONB when the statements
table entry doesn't exist yet.

Resolves: CRDB-62871
Epic: CRDB-62868

Release note (sql change): Added query, query_summary, and database
columns to crdb_internal.cluster_statement_statistics,
crdb_internal.statement_statistics, crdb_internal.statement_statistics_persisted,
and crdb_internal.statement_activity virtual tables. These columns expose
the statement text, summary, and originating database directly without
requiring callers to parse the metadata JSONB column.