### PR TITLE
logical: skip TestRandomTables under race

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -997,6 +997,7 @@ func TestFilterRangefeedInReplicationStream(t *testing.T) {
 func TestRandomTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderDeadlock(t)
+	skip.UnderRace(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
The random table generation can generate extremely expensive schemas, e.g. trigram index on a geometry cast to string, which times out under race.

Fixes: https://github.com/cockroachdb/cockroach/issues/168218
Release note: none