### PR TITLE
kvserver: truncate sideload suffix on replica destruction on sep engines

### DIFF
--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -46,6 +46,8 @@ type SideloadStorage interface {
 	Clear(context.Context) error
 	// TruncateTo removes all files belonging to an index <= the given index.
 	TruncateTo(_ context.Context, index kvpb.RaftIndex) error
+	// TruncateAfter removes all files belonging to an index > the given index.
+	TruncateAfter(_ context.Context, index kvpb.RaftIndex) error
 	// Stats returns the number and the total size of the sideloaded entries in
 	// the given log span.
 	Stats(_ context.Context, _ kvpb.RaftSpan) (entries uint64, size int64, _ error)

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -8,6 +8,7 @@ package logstore
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -181,7 +182,18 @@ func (ss *DiskSideloadStorage) Clear(_ context.Context) error {
 
 // TruncateTo implements SideloadStorage.
 func (ss *DiskSideloadStorage) TruncateTo(ctx context.Context, lastIndex kvpb.RaftIndex) error {
-	span := kvpb.RaftSpan{Last: lastIndex}
+	return ss.purgeSpan(ctx, kvpb.RaftSpan{Last: lastIndex})
+}
+
+// TruncateAfter implements SideloadStorage.
+func (ss *DiskSideloadStorage) TruncateAfter(ctx context.Context, index kvpb.RaftIndex) error {
+	return ss.purgeSpan(ctx, kvpb.RaftSpan{After: index, Last: math.MaxUint64})
+}
+
+// purgeSpan iterates all sideloaded files and deletes those with an index
+// contained in the given span. If all files are deleted, the sideloaded
+// directory is removed as well.
+func (ss *DiskSideloadStorage) purgeSpan(ctx context.Context, span kvpb.RaftSpan) error {
 	deletedAll := true
 	if err := ss.forEach(ctx, func(index kvpb.RaftIndex, filename string) (bool, error) {
 		if !span.Contains(index) {
@@ -190,8 +202,7 @@ func (ss *DiskSideloadStorage) TruncateTo(ctx context.Context, lastIndex kvpb.Ra
 		}
 		// index is in (span.After, span.Last].
 		// TODO(pav-kv): don't compute the size in purgeFile.
-		_, err := ss.purgeFile(ctx, filename)
-		if err != nil {
+		if _, err := ss.purgeFile(ctx, filename); err != nil {
 			return false, err
 		}
 		return true, nil

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -360,6 +360,80 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 	}
 }
 
+// TestSideloadStorageTruncation tests TruncateAfter and TruncateTo on a
+// storage with sideloaded files.
+func TestSideloadStorageTruncation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const term = kvpb.RaftTerm(1)
+	allIndexes := []kvpb.RaftIndex{5, 10, 15}
+	tests := []struct {
+		op        string // "from" or "to"
+		index     kvpb.RaftIndex
+		wantFiles []kvpb.RaftIndex
+	}{
+		{op: "to", index: 3, wantFiles: []kvpb.RaftIndex{5, 10, 15}},
+		{op: "to", index: 5, wantFiles: []kvpb.RaftIndex{10, 15}},
+		{op: "to", index: 7, wantFiles: []kvpb.RaftIndex{10, 15}},
+		{op: "to", index: 10, wantFiles: []kvpb.RaftIndex{15}},
+		{op: "to", index: 15, wantFiles: nil},
+		{op: "to", index: 100, wantFiles: nil},
+		{op: "after", index: 2, wantFiles: nil},
+		{op: "after", index: 4, wantFiles: nil},
+		{op: "after", index: 6, wantFiles: []kvpb.RaftIndex{5}},
+		{op: "after", index: 9, wantFiles: []kvpb.RaftIndex{5}},
+		{op: "after", index: 14, wantFiles: []kvpb.RaftIndex{5, 10}},
+		{op: "after", index: 100, wantFiles: []kvpb.RaftIndex{5, 10, 15}},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			ctx := context.Background()
+			eng := storage.NewDefaultInMemForTesting()
+			defer eng.Close()
+			ss := newTestingSideloadStorage(eng)
+			// Populate files at indexes 5, 10, 15.
+			for _, i := range allIndexes {
+				require.NoError(t, ss.Put(ctx, i, term, []byte("data")))
+			}
+
+			// Run the truncation.
+			switch tc.op {
+			case "to":
+				require.NoError(t, ss.TruncateTo(ctx, tc.index))
+			case "after":
+				require.NoError(t, ss.TruncateAfter(ctx, tc.index))
+			default:
+				t.Fatalf("unknown op: %s", tc.op)
+			}
+
+			// Check which files remain.
+			wantRemaining := make(map[kvpb.RaftIndex]struct{})
+			for _, i := range tc.wantFiles {
+				wantRemaining[i] = struct{}{}
+			}
+			for _, i := range allIndexes {
+				_, err := ss.Get(ctx, i, term)
+				if _, ok := wantRemaining[i]; ok {
+					require.NoErrorf(t, err, "index %d should be present", i)
+				} else {
+					require.ErrorIs(t, err, errSideloadedFileNotFound,
+						"index %d should be deleted", i)
+				}
+			}
+
+			// Check directory existence.
+			_, err := ss.fs.Stat(ss.dir)
+			if tc.wantFiles == nil {
+				require.True(t, oserror.IsNotExist(err), "dir should be removed")
+			} else {
+				require.NoError(t, err, "dir should still exist")
+			}
+		})
+	}
+}
+
 func TestRaftSSTableSideloadingInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -86,9 +86,19 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context) {
 	// belonging to replicas which aren't present. A crash before a call to
 	// postDestroyRaftMuLocked or hitting an error below will currently leave the
 	// files around forever.
-	if err := r.logStorage.ls.Sideload.Clear(ctx); err != nil {
-		log.KvDistribution.Warningf(ctx, "failed to clear sideloaded storage: %v", err)
-		err = nil // ignore intentionally
+	if r.store.EnginesSeparated() {
+		// On separated engines, only delete sideloaded files belonging to the
+		// unapplied suffix of the raft log (entries after RaftAppliedIndex). The
+		// applied prefix's sideloaded files are cleaned up later by WAGTruncator.
+		if err := r.logStorage.ls.Sideload.TruncateAfter(ctx, r.shMu.state.RaftAppliedIndex); err != nil {
+			log.KvDistribution.Warningf(ctx, "failed to truncate sideloaded storage suffix: %v", err)
+			err = nil // ignore intentionally
+		}
+	} else {
+		if err := r.logStorage.ls.Sideload.Clear(ctx); err != nil {
+			log.KvDistribution.Warningf(ctx, "failed to clear sideloaded storage: %v", err)
+			err = nil // ignore intentionally
+		}
 	}
 
 	// Release the reference to this tenant in metrics, we know the tenant ID is


### PR DESCRIPTION
Instead of deleting all sideloaded files after commiting replica destruction, we should only delete the sideloaded files belonging to the unapplied suffix with separate engines. The reason is that we might need the prefix for WAG truncation. Deleting the prefix is the responsibility of the WAGTruncator when the WAG node is durably committed.

Release note: None

Fixes: #168120