### PR TITLE
drt: rewrite of drt operation using failure injection

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/tests",
+        "//pkg/roachprod/failureinjection/failures",
         "//pkg/server/license/licensepb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/lexbase",

--- a/pkg/cmd/roachtest/operations/disk_stall.go
+++ b/pkg/cmd/roachtest/operations/disk_stall.go
@@ -12,60 +12,93 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 type cleanupDiskStall struct {
-	nodes   option.NodeListOption
-	staller roachtestutil.DiskStaller
+	failer *failures.Failer
+	// fullLifecycle indicates whether the failer owns the full Setup/Cleanup
+	// lifecycle. When true (cgroup), Cleanup calls both Recover and Cleanup.
+	// When false (dmsetup), Cleanup only calls Recover because Setup was
+	// performed at cluster creation time and calling Cleanup would destroy
+	// the dmsetup device permanently.
+	fullLifecycle bool
 }
 
 func (cl *cleanupDiskStall) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
-	if err := cl.staller.Unstall(ctx, cl.nodes); err != nil {
-		o.Fatalf("failed to unstall disk: %v", err)
-	}
-	o.Status("unstalled nodes; waiting 10 seconds before restarting")
-	time.Sleep(10 * time.Second)
-	// We might need to restart the node if it isn't live.
-	db, err := c.ConnE(ctx, o.L(), cl.nodes[0])
-	if err != nil {
-		c.Run(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
-		return
-	}
-	defer db.Close()
-	_, err = db.Query("SELECT 1")
-	if err != nil {
-		c.Run(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
+	o.Status("recovering from disk stall")
+	if cl.fullLifecycle {
+		// For cgroup: Cleanup auto-recovers if active, then tears down.
+		if err := cl.failer.Cleanup(ctx, o.L()); err != nil {
+			o.Fatalf("failed to cleanup disk stall: %v", err)
+		}
+	} else {
+		// For dmsetup: only recover, do not call Cleanup.
+		if err := cl.failer.Recover(ctx, o.L()); err != nil {
+			o.Fatalf("failed to recover from disk stall: %v", err)
+		}
 	}
 }
 
-func runDiskStall(
+func runDmsetupDiskStall(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
 ) (cleanup registry.OperationCleanup) {
-	defer func() {
-		if r := recover(); r != nil {
-			o.Errorf("error during disk stall: %v", r)
-		}
-	}()
 	rng, _ := randutil.NewPseudoRand()
 
 	nodes := c.All()
 	nid := nodes[rng.Intn(len(nodes))]
-	// Disable state validation since we run dmsetup Setup() during cluster creation and not part
-	// of the operation.
-	ds := roachtestutil.MakeDmsetupDiskStaller(o, c, true /* disableStateValidation */)
 
-	// Assign cleanup handler early, before stalling the disk.
-	cleanup = &cleanupDiskStall{
-		nodes:   c.Node(nid),
-		staller: ds,
+	// Disable state validation since dmsetup Setup() runs during cluster
+	// creation, not as part of this operation.
+	failer, args, err := roachtestutil.MakeDmsetupDiskStallFailer(
+		o.L(), c, c.Node(nid), true, /* disableStateValidation */
+	)
+	if err != nil {
+		o.Fatal(err)
 	}
 
-	o.Status(fmt.Sprintf("stalling disk on node %d", nid))
-	ds.Stall(ctx, c.Node(nid))
+	// Assign cleanup handler early, before stalling the disk.
+	cleanup = &cleanupDiskStall{failer: failer, fullLifecycle: false}
+
+	o.Status(fmt.Sprintf("stalling disk on node %d via dmsetup", nid))
+	if err := failer.Inject(ctx, o.L(), args); err != nil {
+		o.Fatal(err)
+	}
+
+	return cleanup
+}
+
+func runCgroupDiskStall(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) (cleanup registry.OperationCleanup) {
+	rng, _ := randutil.NewPseudoRand()
+
+	nodes := c.All()
+	nid := nodes[rng.Intn(len(nodes))]
+
+	failer, args, err := roachtestutil.MakeCgroupDiskStallFailer(
+		o.L(), c, c.Node(nid),
+		true,  /* stallWrites */
+		false, /* stallReads */
+		false, /* stallLogs */
+	)
+	if err != nil {
+		o.Fatal(err)
+	}
+	if err := failer.Setup(ctx, o.L(), args); err != nil {
+		o.Fatal(err)
+	}
+
+	// Assign cleanup handler early, before stalling the disk.
+	cleanup = &cleanupDiskStall{failer: failer, fullLifecycle: true}
+
+	o.Status(fmt.Sprintf("stalling disk on node %d via cgroup", nid))
+	if err := failer.Inject(ctx, o.L(), args); err != nil {
+		o.Fatal(err)
+	}
 
 	return cleanup
 }
@@ -77,7 +110,20 @@ func registerDiskStall(r registry.Registry) {
 		Timeout:            10 * time.Minute,
 		CompatibleClouds:   registry.OnlyGCE,
 		CanRunConcurrently: registry.OperationCannotRunConcurrentlyWithItself,
-		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
-		Run:                runDiskStall,
+		Dependencies: []registry.OperationDependency{
+			registry.OperationRequiresZeroUnderreplicatedRanges,
+		},
+		Run: runDmsetupDiskStall,
+	})
+	r.AddOperation(registry.OperationSpec{
+		Name:               "disk-stall/cgroup",
+		Owner:              registry.OwnerStorage,
+		Timeout:            10 * time.Minute,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCannotRunConcurrentlyWithItself,
+		Dependencies: []registry.OperationDependency{
+			registry.OperationRequiresZeroUnderreplicatedRanges,
+		},
+		Run: runCgroupDiskStall,
 	})
 }

--- a/pkg/cmd/roachtest/operations/network_partition.go
+++ b/pkg/cmd/roachtest/operations/network_partition.go
@@ -8,106 +8,118 @@ package operations
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 type cleanupNetworkPartition struct {
-	nodeID int
+	failer *failures.Failer
 }
 
 // Cleanup removes the network partition created by the operation.
+// Failer.Cleanup auto-recovers if a failure is still active.
 func (np *cleanupNetworkPartition) Cleanup(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
 ) {
-	o.Status(fmt.Sprintf("remove the partition on node n%d", np.nodeID))
-	c.Run(ctx, option.WithNodes(c.Node(np.nodeID)), `sudo iptables -F`)
+	o.Status("removing network partition")
+	if err := np.failer.Cleanup(ctx, o.L()); err != nil {
+		o.Fatalf("failed to cleanup network partition: %v", err)
+	}
 }
 
-// createNetworkPartition creates a network partition between two random nodes.
+// createNetworkPartialPartition creates a bidirectional network partition
+// between two random nodes.
 func createNetworkPartialPartition(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
 ) (cleanup registry.OperationCleanup) {
-	defer func() {
-		if r := recover(); r != nil {
-			o.Errorf("error during network partition: %v", r)
-		}
-	}()
 	nodeCount := c.Spec().NodeCount
 	if nodeCount <= 1 {
 		o.Fatal("not enough nodes to create a partition")
 	}
-	nodeID := rand.Intn(nodeCount) + 1
 
-	// Create a partial partition between two random nodes.
+	rng, _ := randutil.NewPseudoRand()
+	nodes := c.All()
+	nodeID := nodes[rng.Intn(len(nodes))]
+
+	// Choose a different node to partition from.
 	var otherNodeID int
-	// Choose a different nodeID to partition from.
 	for {
-		otherNodeID = rand.Intn(nodeCount) + 1
+		otherNodeID = nodes[rng.Intn(len(nodes))]
 		if otherNodeID != nodeID {
 			break
 		}
 	}
 
-	// Get the internal IPs of the remote node.
-	ips, err := c.InternalIP(ctx, o.L(), c.Node(otherNodeID))
+	o.Status(fmt.Sprintf(
+		"creating a partition between nodes n%d and n%d", nodeID, otherNodeID,
+	))
+
+	failer, args, err := roachtestutil.MakeBidirectionalPartitionFailer(
+		o.L(), c, c.Node(nodeID), c.Node(otherNodeID),
+	)
 	if err != nil {
 		o.Fatal(err)
 	}
-	otherNodeIP := ips[0]
-	o.Status(fmt.Sprintf("creating a partition between nodes n%d and n%d", nodeID, otherNodeID))
-
-	// Assign cleanup handler early, before adding iptables rules.
-	cleanup = &cleanupNetworkPartition{nodeID: nodeID}
-
-	// Block all input and output traffic between the two nodes.
-	if err = c.RunE(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp -s %s -j DROP`, otherNodeIP)); err != nil {
+	if err := failer.Setup(ctx, o.L(), args); err != nil {
 		o.Fatal(err)
 	}
-	if err = c.RunE(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp -d %s -j DROP`, otherNodeIP)); err != nil {
+
+	// Assign cleanup handler before injecting the failure.
+	cleanup = &cleanupNetworkPartition{failer: failer}
+
+	if err := failer.Inject(ctx, o.L(), args); err != nil {
 		o.Fatal(err)
 	}
 
 	return cleanup
 }
 
-// createNetworkFullPartition creates a network partition between a random node
-// and all other nodes.
+// createNetworkFullPartition creates a bidirectional network partition between
+// a random node and all other nodes in the cluster.
 func createNetworkFullPartition(
 	ctx context.Context, o operation.Operation, c cluster.Cluster,
 ) (cleanup registry.OperationCleanup) {
-	defer func() {
-		if r := recover(); r != nil {
-			o.Errorf("error during network partition: %v", r)
-		}
-	}()
 	nodeCount := c.Spec().NodeCount
 	if nodeCount <= 1 {
 		o.Fatal("not enough nodes to create a partition")
 	}
-	nodeID := rand.Intn(nodeCount) + 1
 
-	// Drop bi-directional traffic between the node and all other nodes on the
-	// pgport.
+	rng, _ := randutil.NewPseudoRand()
+	nodes := c.All()
+	nodeID := nodes[rng.Intn(len(nodes))]
+
+	// Build the list of all other nodes.
+	var otherNodes option.NodeListOption
+	for _, n := range nodes {
+		if n != nodeID {
+			otherNodes = append(otherNodes, n)
+		}
+	}
+
 	o.Status(fmt.Sprintf("partition node n%d from the cluster", nodeID))
 
-	// Assign cleanup handler early, before adding iptables rules.
-	cleanup = &cleanupNetworkPartition{nodeID: nodeID}
+	failer, args, err := roachtestutil.MakeBidirectionalPartitionFailer(
+		o.L(), c, c.Node(nodeID), otherNodes,
+	)
+	if err != nil {
+		o.Fatal(err)
+	}
+	if err := failer.Setup(ctx, o.L(), args); err != nil {
+		o.Fatal(err)
+	}
 
-	for _, rule := range []string{
-		fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --sport {pgport:%d} -j DROP`, nodeID),
-		fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport {pgport:%d} -j DROP`, nodeID),
-		fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --dport {pgport:%d} -j DROP`, nodeID),
-		fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport {pgport:%d} -j DROP`, nodeID),
-	} {
-		if err := c.RunE(ctx, option.WithNodes(c.Node(nodeID)), rule); err != nil {
-			o.Fatal(err)
-		}
+	// Assign cleanup handler before injecting the failure.
+	cleanup = &cleanupNetworkPartition{failer: failer}
+
+	if err := failer.Inject(ctx, o.L(), args); err != nil {
+		o.Fatal(err)
 	}
 
 	return cleanup
@@ -122,8 +134,10 @@ func registerNetworkPartition(r registry.Registry) {
 		Timeout:            1 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
 		CanRunConcurrently: registry.OperationCannotRunConcurrently,
-		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
-		Run:                createNetworkFullPartition,
+		Dependencies: []registry.OperationDependency{
+			registry.OperationRequiresZeroUnderreplicatedRanges,
+		},
+		Run: createNetworkFullPartition,
 	})
 	r.AddOperation(registry.OperationSpec{
 		Name:               "network-partition/partial",
@@ -131,7 +145,9 @@ func registerNetworkPartition(r registry.Registry) {
 		Timeout:            1 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
 		CanRunConcurrently: registry.OperationCannotRunConcurrently,
-		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
-		Run:                createNetworkPartialPartition,
+		Dependencies: []registry.OperationDependency{
+			registry.OperationRequiresZeroUnderreplicatedRanges,
+		},
+		Run: createNetworkPartialPartition,
 	})
 }

--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -8,58 +8,54 @@ package operations
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations/helpers"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 //lint:ignore U1000 temporarily disabled
 type cleanupNodeKill struct {
-	nodes option.NodeListOption
+	failer *failures.Failer
 }
 
 //lint:ignore U1000 temporarily disabled
 func (cl *cleanupNodeKill) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
-	db, err := c.ConnE(ctx, o.L(), cl.nodes[0])
-	if err != nil {
-		err = c.RunE(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
-		if err != nil {
-			o.Status(fmt.Sprintf("restarted node with error %s", err))
-		} else {
-			o.Status("restarted node with no error")
-		}
-		return
+	o.Status("recovering killed node")
+	if err := cl.failer.Recover(ctx, o.L()); err != nil {
+		o.Fatalf("failed to recover node: %v", err)
 	}
-	defer db.Close()
-	_, err = db.Query("SELECT 1")
-	if err != nil {
-		err = c.RunE(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
-		if err != nil {
-			o.Status(fmt.Sprintf("restarted node with error %s", err))
-		} else {
-			o.Status("restarted node with no error")
-		}
+	o.Status("waiting for node to stabilize")
+	if err := cl.failer.WaitForFailureToRecover(ctx, o.L()); err != nil {
+		o.Fatalf("node failed to stabilize: %v", err)
+	}
+	if err := cl.failer.Cleanup(ctx, o.L()); err != nil {
+		o.Fatalf("failed to cleanup: %v", err)
 	}
 }
 
 //lint:ignore U1000 temporarily disabled
 func nodeKillRunner(
-	signal int, drain bool,
+	graceful bool, drain bool, gracePeriod time.Duration,
 ) func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
-		return runNodeKill(ctx, o, c, signal, drain)
+		return runNodeKill(ctx, o, c, graceful, drain, gracePeriod)
 	}
 }
 
 //lint:ignore U1000 temporarily disabled
 func runNodeKill(
-	ctx context.Context, o operation.Operation, c cluster.Cluster, signal int, drain bool,
+	ctx context.Context,
+	o operation.Operation,
+	c cluster.Cluster,
+	graceful bool,
+	drain bool,
+	gracePeriod time.Duration,
 ) registry.OperationCleanup {
 	rng, _ := randutil.NewPseudoRand()
 	node := c.All().SeededRandNode(rng)
@@ -68,59 +64,79 @@ func runNodeKill(
 		helpers.DrainNode(ctx, o, c, node)
 	}
 
-	o.Status(fmt.Sprintf("killing node %s with signal %d", node.NodeIDsString(), signal))
-	if err := c.RunE(ctx, option.WithNodes(node), "pkill", fmt.Sprintf("-%d", signal), "-f", "cockroach\\ start"); err != nil {
+	failer, args, err := roachtestutil.MakeProcessKillFailer(
+		o.L(), c, node, graceful, gracePeriod,
+	)
+	if err != nil {
+		o.Fatal(err)
+	}
+	if err := failer.Setup(ctx, o.L(), args); err != nil {
 		o.Fatal(err)
 	}
 
-	o.Status(fmt.Sprintf("sent signal %d to node %s, waiting for process to exit", signal, node.NodeIDsString()))
-	for {
-		if err := ctx.Err(); err != nil {
-			// Context cancelled, but node was already killed successfully.
-			// Cleanup will still run and restart the node.
-			break
-		}
-		err := c.RunE(ctx, option.WithNodes(node), "pgrep", "-f", "cockroach\\ start")
-		if err != nil {
-			if strings.Contains(err.Error(), "status 1") {
-				// pgrep returns error code 1 if no processes are found.
-				o.Status(fmt.Sprintf("killed node %s with signal %d", node.NodeIDsString(), signal))
-				break
-			}
-			o.Fatal(err)
-		}
-		time.Sleep(1 * time.Second)
-	}
+	// Assign cleanup handler before injecting the failure so that cleanup
+	// runs even if Inject panics.
+	cleanup := &cleanupNodeKill{failer: failer}
 
-	return &cleanupNodeKill{nodes: node}
+	o.Status(fmt.Sprintf("killing node %s (graceful=%t)", node.NodeIDsString(), graceful))
+	if err := failer.Inject(ctx, o.L(), args); err != nil {
+		o.Fatal(err)
+	}
+	if err := failer.WaitForFailureToPropagate(ctx, o.L()); err != nil {
+		o.Fatal(err)
+	}
+	o.Status(fmt.Sprintf("killed node %s", node.NodeIDsString()))
+
+	return cleanup
 }
 
 //lint:ignore U1000 temporarily disabled
 func registerNodeKill(r registry.Registry) {
 	for _, spec := range []struct {
-		name     string
-		signal   int
-		drain    bool
-		downtime time.Duration
-		timeout  time.Duration
+		name        string
+		graceful    bool
+		drain       bool
+		gracePeriod time.Duration
+		downtime    time.Duration
+		timeout     time.Duration
 	}{
-		{"node-kill/sigkill/drain=true/downtime=10m", 9, true, 10 * time.Minute, 25 * time.Minute},
-
-		{"node-kill/sigkill/drain=false/downtime=10m", 9, false, 10 * time.Minute, 25 * time.Minute},
-
-		{"node-kill/sigterm/drain=true/downtime=10m", 15, true, 10 * time.Minute, 25 * time.Minute},
-
-		{"node-kill/sigterm/drain=false/downtime=10m", 15, false, 10 * time.Minute, 25 * time.Minute},
+		// SIGKILL + drain: drain first, then hard kill.
+		{
+			name:     "node-kill/sigkill/drain=true/downtime=10m",
+			graceful: false, drain: true, gracePeriod: 0,
+			downtime: 10 * time.Minute, timeout: 35 * time.Minute,
+		},
+		// SIGKILL, no drain.
+		{
+			name:     "node-kill/sigkill/drain=false/downtime=10m",
+			graceful: false, drain: false, gracePeriod: 0,
+			downtime: 10 * time.Minute, timeout: 35 * time.Minute,
+		},
+		// SIGTERM + drain: drain first, then graceful shutdown.
+		{
+			name:     "node-kill/sigterm/drain=true/downtime=10m",
+			graceful: true, drain: true, gracePeriod: 5 * time.Minute,
+			downtime: 10 * time.Minute, timeout: 35 * time.Minute,
+		},
+		// SIGTERM, no drain.
+		{
+			name:     "node-kill/sigterm/drain=false/downtime=10m",
+			graceful: true, drain: false, gracePeriod: 5 * time.Minute,
+			downtime: 10 * time.Minute, timeout: 35 * time.Minute,
+		},
 	} {
+		s := spec
 		r.AddOperation(registry.OperationSpec{
-			Name:               spec.name,
+			Name:               s.name,
 			Owner:              registry.OwnerServer,
-			Timeout:            spec.timeout,
+			Timeout:            s.timeout,
 			CompatibleClouds:   registry.AllClouds,
 			CanRunConcurrently: registry.OperationCannotRunConcurrently,
-			Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
-			WaitBeforeCleanup:  spec.downtime,
-			Run:                nodeKillRunner(spec.signal, spec.drain),
+			Dependencies: []registry.OperationDependency{
+				registry.OperationRequiresZeroUnderreplicatedRanges,
+			},
+			WaitBeforeCleanup: s.downtime,
+			Run:               nodeKillRunner(s.graceful, s.drain, s.gracePeriod),
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Rewrites DRT operations (disk stall, network partition, node kill) to use the
`roachprod/failureinjection/failures` framework instead of ad-hoc shell commands
(iptables, pkill, dmsetup).

- **disk_stall**: Replaces `DiskStaller` with `failures.Failer`. Splits into two
  registered operations: `disk-stall` (dmsetup, GCE-only) and `disk-stall/cgroup`
  (cgroup-based, all clouds). Cleanup distinguishes full-lifecycle (cgroup) from
  partial-lifecycle (dmsetup) teardown.
- **network_partition**: Replaces raw `iptables` commands with
  `MakeBidirectionalPartitionFailer`. Both full and partial partition operations
  now go through the `Failer` Setup/Inject/Recover/Cleanup lifecycle.
- **node_kill**: Replaces `pkill` + `pgrep` polling with `MakeProcessKillFailer`.
  Uses `graceful` bool and `gracePeriod` duration instead of raw signal numbers.
  Cleanup uses `Recover`/`WaitForFailureToRecover`/`Cleanup` instead of manually
  checking liveness and restarting via `cockroach.sh`.

Epic: none