### PR TITLE
kvserver: surface per-range diagnostics for stuck drains

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"sync"
@@ -1925,6 +1926,14 @@ func TestLeaseExpirationBasedDrainTransferWithProscribed(t *testing.T) {
 
 	var failedOnce sync.Once
 	failedCh := make(chan struct{})
+	// failReacquire, when true, causes the proposal filter to reject the
+	// draining replica's attempts to reacquire a proscribed lease. It is
+	// toggled off later in the test (once the "reacquiring proscribed lease"
+	// diagnostic has been observed) so that subsequent iterations fall
+	// through to the TransferLease path and exercise the "shedding lease"
+	// diagnostic as well.
+	var failReacquire atomic.Bool
+	failReacquire.Store(true)
 	failLeaseTransfers := func(fail bool) {
 		l.filterMu.Lock()
 		defer l.filterMu.Unlock()
@@ -1941,6 +1950,12 @@ func TestLeaseExpirationBasedDrainTransferWithProscribed(t *testing.T) {
 						target, raftutil.ReplicaStateProbe))
 				}
 			}
+			if failReacquire.Load() && filterArgs.Req.IsSingleRequestLeaseRequest() {
+				target := filterArgs.Req.Requests[0].GetRequestLease().Lease.Replica
+				if target == l.replica1Desc {
+					return kvpb.NewErrorf("injected lease reacquisition failure")
+				}
+			}
 			return nil
 		}
 	}
@@ -1949,6 +1964,13 @@ func TestLeaseExpirationBasedDrainTransferWithProscribed(t *testing.T) {
 	// revoked (after evaluation, during raft proposal). In doing so, we leave the
 	// range with a PROSCRIBED lease.
 	failLeaseTransfers(true /* fail */)
+
+	// Capture the drain-start timestamp so the log-scanning assertion below only
+	// sees entries produced by this drain, and capture the target range ID so
+	// the regex doesn't accidentally match a stuck-drain entry from some other
+	// range (e.g. a system range) that happens to log concurrently.
+	drainStart := timeutil.Now().UnixNano()
+	targetRangeID := l.replica1.GetRangeID()
 
 	// Drain node 1.
 	drainedCh := make(chan struct{})
@@ -1966,6 +1988,56 @@ func TestLeaseExpirationBasedDrainTransferWithProscribed(t *testing.T) {
 		t.Fatalf("drain unexpectedly succeeded")
 	case <-time.After(10 * time.Millisecond):
 	}
+
+	// Verify the late-stage per-range diagnostic lines advertised in the
+	// release note for #65659. The first transferAllAway iteration
+	// intentionally discards its stuck list, so this test must observe a
+	// diagnostic produced by a later iteration to prove the retry-loop
+	// path is wired up.
+	awaitLogLines := func(re *regexp.Regexp, minEntries int) {
+		t.Helper()
+		testutils.SucceedsSoon(t, func() error {
+			log.FlushFiles()
+			entries, err := log.FetchEntriesFromFiles(drainStart, math.MaxInt64, 1000, re,
+				log.WithFlattenedSensitiveData)
+			if err != nil {
+				return err
+			}
+			if len(entries) < minEntries {
+				return errors.Newf("have %d drain-stuck log entries for %s, want >= %d",
+					len(entries), re, minEntries)
+			}
+			return nil
+		})
+	}
+	// Scope the regex to the target range so a concurrent stuck-drain
+	// entry for another range can't satisfy the assertion.
+	reacquireRE := regexp.MustCompile(fmt.Sprintf(
+		`drain stuck on r%d[:/].*blocked.*reacquiring proscribed lease:`, targetRangeID))
+	sheddingRE := regexp.MustCompile(fmt.Sprintf(
+		`drain stuck on r%d[:/].*blocked.*shedding lease:`, targetRangeID))
+	// Requiring two reacquire entries proves at least one retry iteration
+	// completed after the intentionally-discarded first iteration; a
+	// regression that logged the first iteration's stuck list would
+	// already have surfaced a shedding-lease entry by this point.
+	awaitLogLines(reacquireRE, 2)
+
+	// While reacquisitions are still rejected, every post-first iteration
+	// aborts before reaching the shed-lease path, so no shedding-lease
+	// entry can exist for the target range. This guards against a
+	// regression that logs the discarded first iteration.
+	log.FlushFiles()
+	preSheddingEntries, err := log.FetchEntriesFromFiles(drainStart, math.MaxInt64, 1000, sheddingRE,
+		log.WithFlattenedSensitiveData)
+	require.NoError(t, err)
+	require.Empty(t, preSheddingEntries,
+		"shedding-lease diagnostic emitted before reacquisitions were unblocked; "+
+			"first-iteration stuck list may no longer be discarded")
+
+	// Unblock reacquisitions so subsequent iterations reach the transfer
+	// path and emit "shedding lease:".
+	failReacquire.Store(false)
+	awaitLogLines(sheddingRE, 1)
 
 	// Stop failing lease transfers.
 	failLeaseTransfers(false /* fail */)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1842,6 +1842,92 @@ func (s *Store) AnnotateCtx(ctx context.Context) context.Context {
 	return s.cfg.AmbientCtx.AnnotateCtx(ctx)
 }
 
+// drainStuckRangesLogThreshold is the number of remaining replicas at or
+// below which the drain retry loop emits per-range diagnostics for failed
+// attempts. The same value caps how many entries addStuck collects per
+// iteration.
+const drainStuckRangesLogThreshold = 10
+
+// stuckRange records one failed lease transfer or reacquisition during a
+// drain iteration, for later per-range diagnostic logging.
+type stuckRange struct {
+	// desc is the range descriptor observed at the time of the failed
+	// attempt. A Replica's descriptor pointer is swapped on update rather
+	// than mutated in place (see (*Replica).setDescLockedRaftMuLocked),
+	// so retaining the snapshot pointer across goroutines is safe for
+	// read-only use.
+	desc *roachpb.RangeDescriptor
+	// lease is a snapshot of the lease observed at the start of the attempt.
+	lease roachpb.Lease
+	// reason is the pre-rendered cause of the failure (an error or a
+	// non-OK transfer outcome), so the consumer doesn't have to switch
+	// on the kind of failure.
+	reason redact.RedactableString
+	// blocked is the wall time spent in the single call that failed
+	// (transfer or reacquisition), not including queue wait.
+	blocked time.Duration
+}
+
+// drainIterResult is the outcome of a single drain iteration of
+// Store.SetDraining's transferAllAway closure. numRemaining is updated
+// concurrently by the per-replica goroutines spawned during the
+// iteration; stuck is appended to by the same goroutines under mu.
+// logStuckRanges is called from the single retry-loop goroutine after
+// wg.Wait() returns.
+//
+// Invariant: len(stuck) <= numRemaining. Every addStuck call corresponds
+// to a replica that was counted in numRemaining and will not decrement
+// it, so failures are a subset of remaining work. Combined with the cap
+// of drainStuckRangesLogThreshold on len(stuck), this means that when
+// logStuckRanges fires (numRemaining <= threshold), len(stuck) <=
+// threshold and the logged list is never silently truncated.
+type drainIterResult struct {
+	// numRemaining counts replicas whose drain attempt ran to completion
+	// (success or failure) during this iteration. The retry-loop caller
+	// uses it as an upper bound on ranges still blocking drain completion
+	// and reports it to the Drain RPC as progress.
+	numRemaining atomic.Int32
+	mu           struct {
+		syncutil.Mutex
+		// stuck holds one entry per failed attempt during this iteration,
+		// capped at drainStuckRangesLogThreshold.
+		stuck []stuckRange
+	}
+}
+
+// addStuck records a failed lease transfer or reacquisition, bounded by
+// drainStuckRangesLogThreshold to cap memory on a freshly draining node
+// where failures may be widespread. Entries past the cap are silently
+// dropped; this is safe because logStuckRanges suppresses output
+// entirely when numRemaining exceeds the threshold (see drainIterResult).
+func (res *drainIterResult) addStuck(sr stuckRange) {
+	res.mu.Lock()
+	defer res.mu.Unlock()
+	if len(res.mu.stuck) >= drainStuckRangesLogThreshold {
+		return
+	}
+	res.mu.stuck = append(res.mu.stuck, sr)
+}
+
+// logStuckRanges emits one info-level line per collected stuck entry,
+// but only when numRemaining is at or below drainStuckRangesLogThreshold.
+// Above the threshold, per-range logging is suppressed to avoid spam
+// while transient failures on a freshly draining node are expected; the
+// V(1) logging on the failure paths remains the only per-range output in
+// that regime.
+func (res *drainIterResult) logStuckRanges(ctx context.Context) {
+	if res.numRemaining.Load() > drainStuckRangesLogThreshold {
+		return
+	}
+	res.mu.Lock()
+	defer res.mu.Unlock()
+	for _, st := range res.mu.stuck {
+		log.KvDistribution.Infof(ctx,
+			"drain stuck on %s: lease %s, blocked %s: %s",
+			st.desc, st.lease, st.blocked, st.reason)
+	}
+}
+
 // SetDraining (when called with 'true') causes incoming lease transfers to be
 // rejected, prevents all of the Store's Replicas from acquiring or extending
 // range leases, and attempts to transfer away any leases owned.
@@ -1885,27 +1971,27 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 
 	var wg sync.WaitGroup
 
-	transferAllAway := func(transferCtx context.Context) int {
+	transferAllAway := func(transferCtx context.Context) *drainIterResult {
 		// Limit the number of concurrent lease transfers.
 		const leaseTransferConcurrency = 100
 		sem := quotapool.NewIntPool("Store.SetDraining", leaseTransferConcurrency)
 
-		// Incremented for every lease transfer attempted. We try to send the lease
-		// away, but this may not reliably work. Instead, we run the surrounding
-		// retry loop until there are no leases left (ignoring single-replica
-		// ranges).
-		var numTransfersAttempted int32
+		// res.numRemaining is incremented for every lease transfer attempted. We
+		// try to send the lease away, but this may not reliably work. Instead,
+		// we run the surrounding retry loop until there are no leases left
+		// (ignoring single-replica ranges).
+		res := &drainIterResult{}
 		newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
 			//
 			// We need to be careful about the case where the ctx has been canceled
 			// prior to the call to (*Stopper).RunAsyncTaskEx(). In that case,
 			// the goroutine is not even spawned. However, we don't want to
 			// mis-count the missing goroutine as the lack of transfer attempted.
-			// So what we do here is immediately increase numTransfersAttempted
+			// So what we do here is immediately increase res.numRemaining
 			// to count this replica, and then decrease it when it is known
 			// below that there is nothing to transfer (not lease holder and
 			// not raft leader).
-			atomic.AddInt32(&numTransfersAttempted, 1)
+			res.numRemaining.Add(1)
 			wg.Add(1)
 			if err := s.stopper.RunAsyncTaskEx(
 				r.AnnotateCtx(ctx),
@@ -1973,7 +2059,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 
 					if !needsLeaseTransfer && !needsLeaseReacquisition {
 						// Skip this replica.
-						atomic.AddInt32(&numTransfersAttempted, -1)
+						res.numRemaining.Add(-1)
 						return
 					}
 
@@ -1987,7 +2073,9 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 								drainingLeaseStatus.Lease, desc)
 						}
 
+						reacquireStart := timeutil.Now()
 						_, pErr := r.redirectOnOrAcquireLease(ctx)
+						reacquireDuration := timeutil.Since(reacquireStart)
 						if pErr != nil {
 							const failFormat = "failed to acquire proscribed lease %s for range %s when draining: %v"
 							infoArgs := []interface{}{drainingLeaseStatus.Lease, desc, pErr}
@@ -1996,6 +2084,13 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 							} else {
 								log.VErrEventf(ctx, 1 /* level */, failFormat, infoArgs...)
 							}
+
+							res.addStuck(stuckRange{
+								desc:    desc,
+								lease:   drainingLeaseStatus.Lease,
+								reason:  redact.Sprintf("reacquiring proscribed lease: %v", pErr),
+								blocked: reacquireDuration,
+							})
 							// The lease reacquisition failed. Either we no longer hold the
 							// lease or we will need to attempt to reacquire it again. Either
 							// way, handle this on a future iteration.
@@ -2026,11 +2121,11 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 						conf,
 						allocator.TransferLeaseOptions{ExcludeLeaseRepl: true},
 					)
-					duration := timeutil.Since(start).Microseconds()
+					duration := timeutil.Since(start)
 
 					if transferStatus != allocator.TransferOK {
 						const failFormat = "failed to transfer lease %s for range %s when draining: %v"
-						const durationFailFormat = "blocked for %d microseconds on transfer attempt"
+						const durationFailFormat = "blocked for %s on transfer attempt"
 
 						infoArgs := []interface{}{
 							drainingLeaseStatus.Lease,
@@ -2049,24 +2144,35 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 							log.VErrEventf(ctx, 1 /* level */, failFormat, infoArgs...)
 							log.VErrEventf(ctx, 1 /* level */, durationFailFormat, duration)
 						}
+
+						reason := redact.Sprintf("shedding lease: status=%s", transferStatus)
+						if err != nil {
+							reason = redact.Sprintf("%s: %v", reason, err)
+						}
+						res.addStuck(stuckRange{
+							desc:    desc,
+							lease:   drainingLeaseStatus.Lease,
+							reason:  reason,
+							blocked: duration,
+						})
 					}
 				}); err != nil {
 				if verbose || log.V(1) {
 					log.KvDistribution.Errorf(ctx, "error running draining task: %+v", err)
 				}
 				// The async task never ran (typically because the stopper is
-				// quiescing), so this replica's +1 on numTransfersAttempted
-				// doesn't reflect real work. Undo it so the retry loop can
-				// exit once in-flight work finishes rather than spinning on
-				// ghost counts until the outer transfer timeout fires.
-				atomic.AddInt32(&numTransfersAttempted, -1)
+				// quiescing), so this replica's +1 on res.numRemaining doesn't
+				// reflect real work. Undo it so the retry loop can exit once
+				// in-flight work finishes rather than spinning on ghost counts
+				// until the outer transfer timeout fires.
+				res.numRemaining.Add(-1)
 				wg.Done()
 				return false
 			}
 			return true
 		})
 		wg.Wait()
-		return int(numTransfersAttempted)
+		return res
 	}
 
 	// Give all replicas at least one chance to transfer.
@@ -2074,7 +2180,12 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 	// value for raftLeadershipTransferWait is too low to iterate
 	// through all the replicas at least once, and the drain
 	// condition on the remaining value will never be reached.
-	if numRemaining := transferAllAway(ctx); numRemaining > 0 {
+	//
+	// The stuck list from this first call is intentionally discarded: on a
+	// freshly draining node it may be large and dominated by transient
+	// failures. Per-range diagnostics are only logged from the retry loop
+	// below, once the drain is nearly complete.
+	if numRemaining := int(transferAllAway(ctx).numRemaining.Load()); numRemaining > 0 {
 		// Report progress to the Drain RPC.
 		if reporter != nil {
 			reporter(numRemaining, "range lease iterations")
@@ -2101,7 +2212,8 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 			// Avoid retry.ForDuration because of https://github.com/cockroachdb/cockroach/issues/25091.
 			for r := retry.StartWithCtx(ctx, opts); r.Next(); {
 				err = nil
-				if numRemaining := transferAllAway(ctx); numRemaining > 0 {
+				res := transferAllAway(ctx)
+				if numRemaining := int(res.numRemaining.Load()); numRemaining > 0 {
 					// Report progress to the Drain RPC.
 					if reporter != nil {
 						reporter(numRemaining, "range lease iterations")
@@ -2109,6 +2221,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 					err = errors.Errorf("waiting for %d replicas to transfer their lease away", numRemaining)
 					if everySecond.ShouldLog() {
 						log.KvDistribution.Infof(ctx, "%v", err)
+						res.logStuckRanges(ctx)
 					}
 				}
 				if err == nil {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2054,6 +2054,12 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 				if verbose || log.V(1) {
 					log.KvDistribution.Errorf(ctx, "error running draining task: %+v", err)
 				}
+				// The async task never ran (typically because the stopper is
+				// quiescing), so this replica's +1 on numTransfersAttempted
+				// doesn't reflect real work. Undo it so the retry loop can
+				// exit once in-flight work finishes rather than spinning on
+				// ghost counts until the outer transfer timeout fires.
+				atomic.AddInt32(&numTransfersAttempted, -1)
 				wg.Done()
 				return false
 			}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -380,6 +381,112 @@ func TestStoreConfigSetDefaultsNumStores(t *testing.T) {
 			require.Equal(t, tc.expectConc, cfg.RaftSchedulerConcurrency)
 		})
 	}
+}
+
+// TestDrainIterResultLogStuckRanges verifies that logStuckRanges emits a
+// line per entry when numRemaining is at or below the threshold, and
+// suppresses the list entirely above it. Combined with the cap on
+// len(stuck), this means an emitted diagnostic list is never silently
+// truncated: in the logging regime (numRemaining <= threshold),
+// len(stuck) <= threshold by construction.
+func TestDrainIterResultLogStuckRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.Scope(t)
+	defer sc.Close(t)
+
+	mkStuck := func(n int) []stuckRange {
+		out := make([]stuckRange, n)
+		for i := range out {
+			out[i] = stuckRange{
+				desc:    &roachpb.RangeDescriptor{RangeID: roachpb.RangeID(i + 1)},
+				reason:  redact.Sprintf("probe-reason-%d", i+1),
+				blocked: time.Millisecond,
+			}
+		}
+		return out
+	}
+
+	tests := []struct {
+		name              string
+		numRemaining      int
+		numStuck          int
+		expectedLogOutput int
+	}{
+		{
+			name:              "at threshold emits all",
+			numRemaining:      drainStuckRangesLogThreshold,
+			numStuck:          drainStuckRangesLogThreshold,
+			expectedLogOutput: drainStuckRangesLogThreshold,
+		},
+		{
+			name:              "below threshold emits all",
+			numRemaining:      1,
+			numStuck:          1,
+			expectedLogOutput: 1,
+		},
+		{
+			name:              "above threshold suppresses",
+			numRemaining:      drainStuckRangesLogThreshold + 1,
+			numStuck:          drainStuckRangesLogThreshold,
+			expectedLogOutput: 0,
+		},
+		// numRemaining=0 with stuck entries cannot occur in practice (failures
+		// are a subset of remaining work), but guards the suppression predicate
+		// against a future `>` -> `>=` flip.
+		{
+			name:              "zero remaining with stuck still emits",
+			numRemaining:      0,
+			numStuck:          3,
+			expectedLogOutput: 3,
+		},
+		{
+			name:              "empty stuck is a no-op",
+			numRemaining:      0,
+			numStuck:          0,
+			expectedLogOutput: 0,
+		},
+	}
+
+	re := regexp.MustCompile(`drain stuck on r\d+.*probe-reason-`)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := timeutil.Now().UnixNano()
+			res := &drainIterResult{}
+			res.numRemaining.Store(int32(tc.numRemaining))
+			res.mu.stuck = mkStuck(tc.numStuck)
+			res.logStuckRanges(context.Background())
+			log.FlushFiles()
+			entries, err := log.FetchEntriesFromFiles(before, math.MaxInt64, 100, re,
+				log.WithFlattenedSensitiveData)
+			require.NoError(t, err)
+			require.Len(t, entries, tc.expectedLogOutput)
+		})
+	}
+
+	// Concurrently call addStuck from many more goroutines than the cap
+	// allows. This exercises the mutex (under -race) and verifies the cap
+	// is enforced without over-append.
+	t.Run("concurrent addStuck respects cap", func(t *testing.T) {
+		const goroutines = 100
+		require.Greater(t, goroutines, drainStuckRangesLogThreshold,
+			"test must attempt more adds than the cap allows")
+
+		res := &drainIterResult{}
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				res.addStuck(stuckRange{
+					desc:    &roachpb.RangeDescriptor{RangeID: roachpb.RangeID(i + 1)},
+					reason:  redact.Sprintf("probe-reason-%d", i+1),
+					blocked: time.Millisecond,
+				})
+			}(i)
+		}
+		wg.Wait()
+		require.Len(t, res.mu.stuck, drainStuckRangesLogThreshold)
+	})
 }
 
 // TestStoreInitAndBootstrap verifies store initialization and bootstrap.


### PR DESCRIPTION
closes #65659

When a graceful drain stalls, operators currently see only an
aggregate "drain remaining: N" line. Per-range failure detail
exists but is gated on V(1), which isn't available on deployed
clusters - so drains that don't complete before SIGKILL leave
no record of which ranges were blocking them.

Once the drain is nearly done (<= 10 replicas left to transfer),
the node log now includes one line per stuck range: range
descriptor, current lease, the reason the last attempt failed
(transfer status or error), and how long it was blocked. Output
is rate-limited to once per second via the existing gate, and
per-range collection is capped so a freshly draining node can't
balloon memory.

The first commit is a small bug fix: the drain retry loop was
leaving a stale +1 on its attempt counter when the async task
failed to spawn (e.g. stopper quiescing), causing the loop to
spin on ghost counts until the outer timeout fired. The effect
was masked by that timeout, but it inflated the "drain remaining"
value reported on shutdown. Split out for easier backporting.

Epic: none