### PR TITLE
tenantcapabilitieswatcher: fix nil deref removing placeholder entry

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher.go
@@ -395,13 +395,25 @@ func (w *Watcher) removeEntryForTenantIDLocked(ctx context.Context, tid roachpb.
 	if log.V(2) {
 		log.Dev.Infof(ctx, "removing tenant entry %d from cache", tid)
 	}
+
 	// Not finding the ID in the store is expected if we see a
-	// duplicate delete.
-	if entry, ok := w.mu.store[tid]; ok {
+	// duplicate delete. A duplicate delete interleaved with a
+	// getInternal call can also result is us finding an entry
+	// with a nil value for the embedded Entry struct.
+	if entry, ok := w.mu.store[tid]; ok && entry.Entry != nil {
 		delete(w.mu.byName, entry.Name)
 	}
 	delete(w.mu.lastUpdate, tid)
 	delete(w.mu.store, tid)
+}
+
+// TestingRemoveEntry removes the entry for the given tenant ID from
+// the cache. This is used to test that removal handles placeholder
+// entries (with nil embedded Entry) created by getInternal.
+func (w *Watcher) TestingRemoveEntry(ctx context.Context, tid roachpb.TenantID) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.removeEntryForTenantIDLocked(ctx, tid)
 }
 
 func (w *Watcher) TestingRestart() {

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -34,6 +36,46 @@ import (
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRemoveEntryWithPlaceholder verifies that removing a tenant entry
+// does not panic when the store contains a placeholder entry with a
+// nil embedded Entry pointer, as created by getInternal when a reader
+// queries a tenant that hasn't been seen by the rangefeed yet.
+//
+// Regression test for a nil pointer dereference in
+// removeEntryForTenantIDLocked.
+func TestRemoveEntryWithPlaceholder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	w := tenantcapabilitieswatcher.New(
+		hlc.NewClockForTesting(nil),
+		st,
+		nil,   /* rangeFeedFactory — unused, rangefeed not started */
+		0,     /* tenantsTableID */
+		nil,   /* stopper */
+		1<<20, /* bufferMemLimit */
+		nil,   /* knobs */
+	)
+
+	tenantID := roachpb.MustMakeTenantID(10)
+
+	// GetInfo calls getInternal which inserts a placeholder entry
+	// with a nil embedded *Entry into the store.
+	_, _, found := w.GetInfo(tenantID)
+	require.False(t, found)
+
+	// Removing the placeholder entry must not panic.
+	w.TestingRemoveEntry(ctx, tenantID)
+
+	// The entry should be gone.
+	entries := w.TestingFlushCapabilitiesState()
+	for _, e := range entries {
+		require.NotEqual(t, tenantID, e.TenantID)
+	}
+}
 
 // TestDataDriven runs datadriven tests against the
 // tenentcapabilitieswatcher.Watcher struct. The syntax is as follows:


### PR DESCRIPTION
The Watcher's getInternal method inserts a placeholder watcherEntry
with a nil embedded *Entry pointer when a reader queries capabilities
for a tenant not yet seen by the rangefeed. If removeEntryForTenantIDLocked
was later called for that tenant, it accessed entry.Name through the nil
embedded pointer, causing a panic.

This can occur when a rangefeed restart re-delivers a delete event for
a tenant whose entry was already removed during a previous rangefeed
lifetime. If a reader called GetInfo for that tenant in the interim,
the store contains only the nil-Entry placeholder, and the re-delivered
delete dereferences it.

Epic: none