### PR TITLE
kv: expose byte limits through Txn and DB scan APIs

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -544,11 +544,16 @@ func (db *DB) scan(
 	str kvpb.KeyLockingStrengthType,
 	readConsistency kvpb.ReadConsistencyType,
 	dur kvpb.KeyLockingDurabilityType,
+	opts ...ScanOption,
 ) ([]KeyValue, error) {
+	cfg := buildScanConfig(opts)
 	b := &Batch{}
 	b.Header.ReadConsistency = readConsistency
 	if maxRows > 0 {
 		b.Header.MaxSpanRequestKeys = maxRows
+	}
+	if cfg.targetBytes > 0 {
+		b.Header.TargetBytes = cfg.targetBytes
 	}
 	b.Header.IsReverse = isReverse
 	b.scan(begin, end, isReverse, str, dur)
@@ -561,9 +566,13 @@ func (db *DB) scan(
 //
 // The returned []KeyValue will contain up to maxRows elements.
 //
+// Use WithTargetBytes to set a byte limit on the response size. When both
+// maxRows and a byte limit are set, the scan stops as soon as either limit is
+// reached.
+//
 // key can be either a byte slice or a string.
-func (db *DB) Scan(ctx context.Context, begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	return db.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.NonLocking, kvpb.CONSISTENT, kvpb.Invalid)
+func (db *DB) Scan(ctx context.Context, begin, end interface{}, maxRows int64, opts ...ScanOption) ([]KeyValue, error) {
+	return db.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.NonLocking, kvpb.CONSISTENT, kvpb.Invalid, opts...)
 }
 
 // ScanForUpdate retrieves the rows between begin (inclusive) and end
@@ -574,10 +583,10 @@ func (db *DB) Scan(ctx context.Context, begin, end interface{}, maxRows int64) (
 //
 // key can be either a byte slice or a string.
 func (db *DB) ScanForUpdate(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
 	return db.scan(
-		ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForUpdate, kvpb.CONSISTENT, dur,
+		ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForUpdate, kvpb.CONSISTENT, dur, opts...,
 	)
 }
 
@@ -589,10 +598,10 @@ func (db *DB) ScanForUpdate(
 //
 // key can be either a byte slice or a string.
 func (db *DB) ScanForShare(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
 	return db.scan(
-		ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForShare, kvpb.CONSISTENT, dur,
+		ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForShare, kvpb.CONSISTENT, dur, opts...,
 	)
 }
 
@@ -601,11 +610,15 @@ func (db *DB) ScanForShare(
 //
 // The returned []KeyValue will contain up to maxRows elements.
 //
+// Use WithTargetBytes to set a byte limit on the response size. When both
+// maxRows and a byte limit are set, the scan stops as soon as either limit is
+// reached.
+//
 // key can be either a byte slice or a string.
 func (db *DB) ReverseScan(
-	ctx context.Context, begin, end interface{}, maxRows int64,
+	ctx context.Context, begin, end interface{}, maxRows int64, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return db.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.NonLocking, kvpb.CONSISTENT, kvpb.Invalid)
+	return db.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.NonLocking, kvpb.CONSISTENT, kvpb.Invalid, opts...)
 }
 
 // ReverseScanForUpdate retrieves the rows between begin (inclusive) and end
@@ -616,10 +629,10 @@ func (db *DB) ReverseScan(
 //
 // key can be either a byte slice or a string.
 func (db *DB) ReverseScanForUpdate(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
 	return db.scan(
-		ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForUpdate, kvpb.CONSISTENT, dur,
+		ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForUpdate, kvpb.CONSISTENT, dur, opts...,
 	)
 }
 
@@ -631,10 +644,10 @@ func (db *DB) ReverseScanForUpdate(
 //
 // key can be either a byte slice or a string.
 func (db *DB) ReverseScanForShare(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
 	return db.scan(
-		ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForShare, kvpb.CONSISTENT, dur,
+		ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForShare, kvpb.CONSISTENT, dur, opts...,
 	)
 }
 

--- a/pkg/kv/scan_options.go
+++ b/pkg/kv/scan_options.go
@@ -1,0 +1,33 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kv
+
+// ScanOption configures the behavior of Scan and ReverseScan operations.
+type ScanOption func(*scanConfig)
+
+type scanConfig struct {
+	targetBytes int64
+}
+
+// WithTargetBytes sets a byte limit on the scan response. When non-zero, the
+// scan will stop after the cumulative size of returned keys and values exceeds
+// this threshold. At least one key-value pair is always returned regardless of
+// the limit. When combined with maxRows, both limits apply and the scan stops
+// as soon as either is reached. A ResumeSpan is returned in the Result when
+// the byte limit causes early termination.
+func WithTargetBytes(targetBytes int64) ScanOption {
+	return func(c *scanConfig) {
+		c.targetBytes = targetBytes
+	}
+}
+
+func buildScanConfig(opts []ScanOption) scanConfig {
+	var cfg scanConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return cfg
+}

--- a/pkg/kv/scan_options_test.go
+++ b/pkg/kv/scan_options_test.go
@@ -1,0 +1,155 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kv_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestDB_ScanWithTargetBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, db := setup(t)
+	defer s.Stopper().Stop(context.Background())
+	ctx := context.Background()
+
+	b := db.NewTxn(ctx, "setup").NewBatch()
+	b.Put("aa", "1")
+	b.Put("ab", strings.Repeat("x", 1024))
+	b.Put("ac", "3")
+	b.Put("ad", "4")
+	if err := db.Run(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without target bytes: return all rows.
+	rows, err := db.Scan(ctx, "a", "b", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows without byte limit, got %d", len(rows))
+	}
+
+	// With a small target bytes limit: should return fewer rows than the full
+	// set. The limit is best-effort; at least one row is always returned.
+	rows, err = db.Scan(ctx, "a", "b", 0, kv.WithTargetBytes(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected at least one row with target bytes")
+	}
+	if len(rows) >= 4 {
+		t.Fatalf("expected fewer than 4 rows with a 1-byte limit, got %d", len(rows))
+	}
+}
+
+func TestDB_ReverseScanWithTargetBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, db := setup(t)
+	defer s.Stopper().Stop(context.Background())
+	ctx := context.Background()
+
+	b := db.NewTxn(ctx, "setup").NewBatch()
+	b.Put("aa", "1")
+	b.Put("ab", strings.Repeat("x", 1024))
+	b.Put("ac", "3")
+	b.Put("ad", "4")
+	if err := db.Run(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.ReverseScan(ctx, "a", "b", 0, kv.WithTargetBytes(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected at least one row with target bytes")
+	}
+	if len(rows) >= 4 {
+		t.Fatalf("expected fewer than 4 rows with a 1-byte limit, got %d", len(rows))
+	}
+	// Reverse scan should start from the end.
+	if string(rows[0].Key) != "ad" {
+		t.Fatalf("expected first reverse-scan row key 'ad', got %q", rows[0].Key)
+	}
+}
+
+func TestTxn_ScanWithTargetBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, db := setup(t)
+	defer s.Stopper().Stop(context.Background())
+	ctx := context.Background()
+
+	b := db.NewTxn(ctx, "setup").NewBatch()
+	b.Put("aa", "1")
+	b.Put("ab", strings.Repeat("x", 1024))
+	b.Put("ac", "3")
+	b.Put("ad", "4")
+	if err := db.Run(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		rows, err := txn.Scan(ctx, "a", "b", 0)
+		if err != nil {
+			return err
+		}
+		if len(rows) != 4 {
+			t.Fatalf("expected 4 rows without byte limit, got %d", len(rows))
+		}
+
+		rows, err = txn.Scan(ctx, "a", "b", 0, kv.WithTargetBytes(1))
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			t.Fatal("expected at least one row with target bytes")
+		}
+		if len(rows) >= 4 {
+			t.Fatalf("expected fewer than 4 rows with a 1-byte limit, got %d", len(rows))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanWithTargetBytesAndMaxRows(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, db := setup(t)
+	defer s.Stopper().Stop(context.Background())
+	ctx := context.Background()
+
+	b := db.NewTxn(ctx, "setup").NewBatch()
+	b.Put("aa", "1")
+	b.Put("ab", "2")
+	b.Put("ac", "3")
+	b.Put("ad", "4")
+	if err := db.Run(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both maxRows and targetBytes set. maxRows=2 should cap the result
+	// regardless of a generous byte limit.
+	rows, err := db.Scan(ctx, "a", "b", 2, kv.WithTargetBytes(1<<20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows (capped by maxRows), got %d", len(rows))
+	}
+}

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -738,10 +738,15 @@ func (txn *Txn) scan(
 	isReverse bool,
 	str kvpb.KeyLockingStrengthType,
 	dur kvpb.KeyLockingDurabilityType,
+	opts ...ScanOption,
 ) ([]KeyValue, error) {
+	cfg := buildScanConfig(opts)
 	b := txn.NewBatch()
 	if maxRows > 0 {
 		b.Header.MaxSpanRequestKeys = maxRows
+	}
+	if cfg.targetBytes > 0 {
+		b.Header.TargetBytes = cfg.targetBytes
 	}
 	b.Header.IsReverse = isReverse
 	b.scan(begin, end, isReverse, str, dur)
@@ -755,11 +760,15 @@ func (txn *Txn) scan(
 // The returned []KeyValue will contain up to maxRows elements (or all results
 // when zero is supplied).
 //
+// Use WithTargetBytes to set a byte limit on the response size. When both
+// maxRows and a byte limit are set, the scan stops as soon as either limit is
+// reached.
+//
 // key can be either a byte slice or a string.
 func (txn *Txn) Scan(
-	ctx context.Context, begin, end interface{}, maxRows int64,
+	ctx context.Context, begin, end interface{}, maxRows int64, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.NonLocking, kvpb.Invalid)
+	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.NonLocking, kvpb.Invalid, opts...)
 }
 
 // ScanForUpdate retrieves the rows between begin (inclusive) and end
@@ -771,9 +780,9 @@ func (txn *Txn) Scan(
 //
 // key can be either a byte slice or a string.
 func (txn *Txn) ScanForUpdate(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForUpdate, dur)
+	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForUpdate, dur, opts...)
 }
 
 // ScanForShare retrieves the rows between begin (inclusive) and end (exclusive)
@@ -785,9 +794,9 @@ func (txn *Txn) ScanForUpdate(
 //
 // key can be either a byte slice or a string.
 func (txn *Txn) ScanForShare(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForShare, dur)
+	return txn.scan(ctx, begin, end, maxRows, false /* isReverse */, kvpb.ForShare, dur, opts...)
 }
 
 // ReverseScan retrieves the rows between begin (inclusive) and end (exclusive)
@@ -796,11 +805,15 @@ func (txn *Txn) ScanForShare(
 // The returned []KeyValue will contain up to maxRows elements (or all results
 // when zero is supplied).
 //
+// Use WithTargetBytes to set a byte limit on the response size. When both
+// maxRows and a byte limit are set, the scan stops as soon as either limit is
+// reached.
+//
 // key can be either a byte slice or a string.
 func (txn *Txn) ReverseScan(
-	ctx context.Context, begin, end interface{}, maxRows int64,
+	ctx context.Context, begin, end interface{}, maxRows int64, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.NonLocking, kvpb.Invalid)
+	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.NonLocking, kvpb.Invalid, opts...)
 }
 
 // ReverseScanForUpdate retrieves the rows between begin (inclusive) and end
@@ -812,9 +825,9 @@ func (txn *Txn) ReverseScan(
 //
 // key can be either a byte slice or a string.
 func (txn *Txn) ReverseScanForUpdate(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForUpdate, dur)
+	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForUpdate, dur, opts...)
 }
 
 // ReverseScanForShare retrieves the rows between begin (inclusive) and end
@@ -826,9 +839,9 @@ func (txn *Txn) ReverseScanForUpdate(
 //
 // key can be either a byte slice or a string.
 func (txn *Txn) ReverseScanForShare(
-	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType,
+	ctx context.Context, begin, end interface{}, maxRows int64, dur kvpb.KeyLockingDurabilityType, opts ...ScanOption,
 ) ([]KeyValue, error) {
-	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForShare, dur)
+	return txn.scan(ctx, begin, end, maxRows, true /* isReverse */, kvpb.ForShare, dur, opts...)
 }
 
 // Iterate performs a paginated scan and applying the function f to every page.


### PR DESCRIPTION
Adds a variadic `ScanOption` mechanism to all `Scan` and `ReverseScan` methods on `kv.Txn` and `kv.DB`, starting with `WithTargetBytes`.

Currently callers that want byte-bounded scans have to drop down to the `Batch` API, manually set `b.Header.TargetBytes`, call `Run`, and parse the result. This change lets them write:

```go
rows, err := txn.Scan(ctx, begin, end, maxRows, kv.WithTargetBytes(1<<20))
```

The approach is fully backward-compatible: existing callers pass no options and behave identically. Future scan options (e.g. `AllowEmpty`, `WholeRowsOfSize`) can be added to `ScanOption` without any signature changes.

Changes:
- New `ScanOption` functional-option type and `WithTargetBytes` constructor in `pkg/kv/scan_options.go`.
- Internal `scan()` helpers on `Txn` and `DB` accept `...ScanOption` and set `b.Header.TargetBytes` when non-zero.
- All 12 public scan methods (`Scan`, `ScanForUpdate`, `ScanForShare`, `ReverseScan`, `ReverseScanForUpdate`, `ReverseScanForShare` on both `Txn` and `DB`) forward options to the internal helper.
- Tests covering byte-limited scans, reverse scans, and combined maxRows + targetBytes limits.

Fixes #63661