### PR TITLE
roachtest: enable DRPC metamorphically across roachtests

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -675,6 +675,7 @@ type clusterImpl struct {
 	localCertsDir string
 	expiration    time.Time
 	encAtRest     bool // use encryption at rest
+	useDRPC       bool // metamorphically enable DRPC (--use-new-rpc)
 
 	// clusterSettings are additional cluster settings set on the storage cluster startup.
 	clusterSettings map[string]string
@@ -2203,6 +2204,9 @@ func (c *clusterImpl) StartE(
 		settings.ClusterSettings[name] = value
 	}
 
+	// Propagate the metamorphic DRPC decision to roachprod.
+	startOpts.RoachprodOpts.UseDRPC = c.useDRPC
+
 	clusterSettingsOpts := c.configureClusterSettingOptions(c.clusterSettings, settings)
 
 	startOpts.RoachprodOpts.PreStartHooks = append(startOpts.RoachprodOpts.PreStartHooks, c.preStartHooks...)
@@ -2272,6 +2276,10 @@ func (c *clusterImpl) StartServiceForVirtualClusterE(
 	settings install.ClusterSettings,
 ) error {
 	l.Printf("starting virtual cluster")
+
+	// Propagate the metamorphic DRPC decision to roachprod.
+	startOpts.RoachprodOpts.UseDRPC = c.useDRPC
+
 	clusterSettingsOpts := c.configureClusterSettingOptions(c.virtualClusterSettings, settings)
 
 	// By default, we assume every node in the cluster is part of the

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -548,6 +548,15 @@ var (
 			startup but before the test body runs, so tests may override them.
 			Example: --start-setting=kv.range_split.by_load_enabled=false`,
 	})
+
+	ForceDRPC bool = false
+	_              = registerRunFlag(&ForceDRPC, FlagInfo{
+		Name: "force-drpc",
+		Usage: `
+			Force DRPC (--use-new-rpc) to be enabled for all tests.
+			Older binaries that don't support "--use-new-rpc" will
+			skip it automatically.`,
+	})
 )
 
 // The flags below override the final cluster configuration. They have no

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1123,6 +1123,34 @@ func (r *testRunner) runWorker(
 					}
 				}
 
+				// Enable DRPC either deterministically via --force-drpc
+				// or metamorphically with 50% probability. Metamorphic
+				// randomization is skipped for benchmarks and mixed-version
+				// suites. --force-drpc is always honored; for mixed-version
+				// suites a warning is logged since version gating happens
+				// per start call.
+				//
+				// N.B. forceDRPC/metamorphicDRPC=true means DRPC was
+				// *requested* for this test. Roachprod may still skip
+				// --use-new-rpc at start time if the binary version is
+				// too old or unknown.
+				isMixedVersion := t.spec.Suites.Contains(registry.MixedVersion)
+				if roachtestflags.ForceDRPC {
+					if isMixedVersion {
+						t.L().Printf("WARN: --force-drpc is set for mixed-version suite %s",
+							t.Name())
+					}
+					c.useDRPC = true
+					c.status("Enabling DRPC")
+					t.AddParam("forceDRPC", "true")
+				} else if !testSpec.Benchmark && !isMixedVersion && prng.Intn(2) == 0 {
+					c.useDRPC = true
+					c.status("Enabling DRPC")
+					t.AddParam("metamorphicDRPC", "true")
+				} else {
+					c.useDRPC = false
+				}
+
 				c.goCoverDir = t.GoCoverArtifactsDir()
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1123,6 +1123,30 @@ func (r *testRunner) runWorker(
 					}
 				}
 
+				// Enable DRPC either deterministically via --force-drpc
+				// or metamorphically with 50% probability. Metamorphic
+				// randomization is skipped for benchmarks and mixed-version
+				// suites. --force-drpc is always honored; for mixed-version
+				// suites a warning is logged since version gating happens
+				// per start call.
+				//
+				// N.B. metamorphicDRPC=true means DRPC was *requested* for
+				// this test. Roachprod may still skip --use-new-rpc at start
+				// time if the binary version is too old or unknown.
+				isMixedVersion := t.spec.Suites.Contains(registry.MixedVersion)
+				if roachtestflags.ForceDRPC || (!testSpec.Benchmark && !isMixedVersion && prng.Intn(2) == 0) {
+					if roachtestflags.ForceDRPC && isMixedVersion {
+						t.L().Printf("WARN: --force-drpc is set for mixed-version suite %s; "+
+							"version gating is per-start-batch, not per-node — "+
+							"ensure same-version nodes are started together", t.Name())
+					}
+					c.useDRPC = true
+					c.status("Enabling DRPC")
+					t.AddParam("metamorphicDRPC", "true")
+				} else {
+					c.useDRPC = false
+				}
+
 				c.goCoverDir = t.GoCoverArtifactsDir()
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -147,6 +147,11 @@ type StartOpts struct {
 	// N.B. may be nil if the version cannot be fetched.
 	Version *version.Version
 
+	// UseDRPC, if true, adds --use-new-rpc to the start arguments to
+	// enable the DRPC framework instead of gRPC. Only applied if the
+	// binary version supports it (v26.2+).
+	UseDRPC bool
+
 	// -- Options that apply only to the StartServiceForVirtualCluster target --
 	VirtualClusterName     string
 	VirtualClusterID       int
@@ -1162,6 +1167,21 @@ func execLoggingTemplate(data loggingTemplateData) (string, error) {
 	return buf.String(), nil
 }
 
+// shouldEnableDRPC reports whether --use-new-rpc should be added to the
+// start arguments for the given binary version. DRPC requires v26.2+.
+// Returns (true, "") when DRPC should be enabled, or (false, reason)
+// explaining why it was skipped.
+func shouldEnableDRPC(v *version.Version) (ok bool, reason string) {
+	if v == nil {
+		return false, "binary version unknown, skipping --use-new-rpc"
+	}
+	if v.Major().Year < 26 ||
+		(v.Major().Year == 26 && v.Major().Ordinal < 2) {
+		return false, fmt.Sprintf("--use-new-rpc not supported in %s, skipping", v)
+	}
+	return true, ""
+}
+
 // generateStartArgs generates cockroach binary arguments for starting a node.
 // The first argument is the command (e.g. "start").
 func (c *SyncedCluster) generateStartArgs(
@@ -1300,6 +1320,18 @@ func (c *SyncedCluster) generateStartArgs(
 
 	if startOpts.Target == StartDefault || startOpts.Target == StartServiceForVirtualCluster {
 		args = append(args, c.generateStartFlagsSQL(node, startOpts)...)
+	}
+
+	// DRPC (--use-new-rpc) is only supported in v26.2+. If the version is
+	// unknown (nil), we skip DRPC to avoid breaking binaries that don't
+	// support the flag.
+	if startOpts.UseDRPC {
+		if ok, reason := shouldEnableDRPC(startOpts.Version); ok {
+			l.Printf("DRPC: enabling --use-new-rpc for node %d (version %s)", node, startOpts.Version)
+			args = append(args, "--use-new-rpc")
+		} else {
+			l.Printf("WARN: %s", reason)
+		}
 	}
 
 	args = append(args, startOpts.ExtraArgs...)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -147,6 +147,11 @@ type StartOpts struct {
 	// N.B. may be nil if the version cannot be fetched.
 	Version *version.Version
 
+	// UseDRPC, if true, adds --use-new-rpc to the start arguments to
+	// enable the DRPC framework instead of gRPC. Only applied if the
+	// binary version supports it (v26.2+).
+	UseDRPC bool
+
 	// -- Options that apply only to the StartServiceForVirtualCluster target --
 	VirtualClusterName     string
 	VirtualClusterID       int
@@ -625,6 +630,14 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			startOpts.Version = parsedVersion
 		} else {
 			l.Printf("WARN: unable to fetch cockroach version: %s", err)
+		}
+
+		if startOpts.UseDRPC {
+			if ok, reason := shouldEnableDRPC(startOpts.Version); ok {
+				l.Printf("DRPC: enabling --use-new-rpc (version %s)", startOpts.Version)
+			} else {
+				l.Printf("WARN: DRPC requested but skipped: %s", reason)
+			}
 		}
 
 		l.Printf("%s (%s): starting cockroach processes", c.Name, startOpts.VirtualClusterName)
@@ -1162,6 +1175,21 @@ func execLoggingTemplate(data loggingTemplateData) (string, error) {
 	return buf.String(), nil
 }
 
+// shouldEnableDRPC reports whether --use-new-rpc should be added to the
+// start arguments for the given binary version. DRPC requires v26.2+.
+// Returns (true, "") when DRPC should be enabled, or (false, reason)
+// explaining why it was skipped.
+func shouldEnableDRPC(v *version.Version) (ok bool, reason string) {
+	if v == nil {
+		return false, "binary version unknown, skipping --use-new-rpc"
+	}
+	if v.Major().Year < 26 ||
+		(v.Major().Year == 26 && v.Major().Ordinal < 2) {
+		return false, fmt.Sprintf("--use-new-rpc not supported in %s, skipping", v)
+	}
+	return true, ""
+}
+
 // generateStartArgs generates cockroach binary arguments for starting a node.
 // The first argument is the command (e.g. "start").
 func (c *SyncedCluster) generateStartArgs(
@@ -1300,6 +1328,14 @@ func (c *SyncedCluster) generateStartArgs(
 
 	if startOpts.Target == StartDefault || startOpts.Target == StartServiceForVirtualCluster {
 		args = append(args, c.generateStartFlagsSQL(node, startOpts)...)
+	}
+
+	// DRPC (--use-new-rpc) is only supported in v26.2+. The decision is
+	// logged once per Start() call; here we just append the flag silently.
+	if startOpts.UseDRPC {
+		if ok, _ := shouldEnableDRPC(startOpts.Version); ok {
+			args = append(args, "--use-new-rpc")
+		}
 	}
 
 	args = append(args, startOpts.ExtraArgs...)


### PR DESCRIPTION
Previously, DRPC was only tested through unit tests across cockroach packages. This change adds metamorphic DRPC coverage to roachtests, enabling --use-new-rpc on 50% of non-benchmark, non-mixed-version test runs.

The implementation adds:
- A --force-drpc flag for deterministic CI runs
- Metamorphic 50% DRPC enablement in the test runner
- Version-gated --use-new-rpc injection in roachprod (v26.2+ only)
- DRPC propagation through both StartE and StartServiceForVirtualClusterE

When the binary version is unknown or too old, DRPC is silently skipped to avoid breaking older binaries. For mixed-version suites, metamorphic randomization is disabled but --force-drpc is honored with a warning, since the mixed-version framework restarts nodes individually and each restart re-probes the correct binary version.

Epic: CRDB-60171
Fixes: CRDB-62798
Fixes: CRDB-62799
Fixes: CRDB-62800
Release note: None