### PR TITLE
kvserver: clear lock table on replica removal

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -329,6 +329,14 @@ type RangeStateListener interface {
 	// into.
 	OnRangeMerge()
 
+	// OnReplicaRemoval informs the concurrency manager that this replica is
+	// being removed. It clears and disables the lock table and txn wait-queue,
+	// releasing any waiters. This ensures that requests waiting in the lock
+	// table are not stranded when a replica is removed without going through
+	// the normal merge trigger path (e.g. dangling subsume via replica GC,
+	// subsumed by snapshot).
+	OnReplicaRemoval()
+
 	// OnReplicaSnapshotApplied informs the concurrency manager that its replica
 	// has received a snapshot from another replica in its range.
 	OnReplicaSnapshotApplied()

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -786,9 +786,13 @@ func (m *managerImpl) OnRangeSplit(rhsStartKey roachpb.Key) []roachpb.LockAcquis
 
 // OnRangeMerge implements the RangeStateListener interface.
 func (m *managerImpl) OnRangeMerge() {
-	// Disable all queues - the range is being merged into its LHS neighbor.
-	// It will no longer be informed about all state transitions to locks and
-	// transactions.
+	m.OnReplicaRemoval()
+}
+
+// OnReplicaRemoval implements the RangeStateListener interface.
+func (m *managerImpl) OnReplicaRemoval() {
+	// Disable all queues - the replica is being removed and will no longer be
+	// informed about all state transitions to locks and transactions.
 	const disable = true
 	m.lt.Clear(disable)
 	m.twq.Clear(disable)
@@ -834,7 +838,7 @@ func (m *managerImpl) exportUnreplicatedLocks() ([]*roachpb.LockAcquisition, int
 	return acquisitions, approximateBatchSize
 }
 
-// TestingLockTableString implements the MetricExporter interface.
+// TestingLockTableString implements the TestingAccessor interface.
 func (m *managerImpl) TestingLockTableString() string {
 	return m.lt.String()
 }

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -572,6 +572,13 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				})
 				return c.waitAndCollect(t, mon)
 
+			case "on-replica-removal":
+				mon.runSync("remove replica", func(ctx context.Context) {
+					log.Event(ctx, "complete")
+					m.OnReplicaRemoval()
+				})
+				return c.waitAndCollect(t, mon)
+
 			case "debug-latch-manager":
 				metrics := m.LatchMetrics()
 				output := []string{

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -1084,3 +1084,100 @@ finish req=req2
 
 reset namespace
 ----
+
+# -------------------------------------------------------------
+# OnReplicaRemoval - removing a replica clears the lock-table
+# and disables it, just like OnRangeMerge. This is critical for
+# the dangling subsume path where OnRangeMerge is never called.
+# See #167995.
+#
+# Setup: txn1 acquires lock on k
+#
+# Test:  txn2 enters lock's wait-queue
+#        replica is removed
+#        txn2 proceeds (lock table cleared)
+#        lock-table is disabled
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  put key=k value=v
+----
+
+new-request name=req2 txn=txn2 ts=10,1
+  put key=k value=v
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k
+----
+[-] acquire lock: txn 00000001 acquiring Unreplicated Exclusive lock on ‹"k"›
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+debug-lock-table
+----
+num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: waiting in lock wait-queues
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+debug-lock-table
+----
+num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 18, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+
+on-replica-removal
+----
+[-] remove replica: complete
+[2] sequence req2: lock wait-queue event: done waiting
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+debug-lock-table
+----
+num=0
+
+# Verify that the lock table is disabled: discovered locks are ignored.
+handle-lock-conflict-error req=req2 lease-seq=1
+  lock txn=txn1 key=k
+----
+[3] handle lock conflict error req2: discovered lock on ‹"k"› not added to disabled lock table
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -151,6 +151,13 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	// log the replica to be removed.
 	log.KvDistribution.Infof(ctx, "removing replica r%d/%d (%s)", rep.RangeID, rep.replicaID, reason)
 
+	// Clear the lock table and txn wait-queue to release any waiters. In the
+	// normal merge path, OnRangeMerge handles this before we get here. But when
+	// a replica is removed without applying the merge trigger (e.g. dangling
+	// subsume via replica GC, subsumed by snapshot), OnRangeMerge is never
+	// called and waiters would be stuck forever. See #167995.
+	rep.concMgr.OnReplicaRemoval()
+
 	s.mu.Lock()
 	if it := s.getOverlappingKeyRangeLocked(desc); it.repl != rep {
 		// This is a fatal error because uninitialized replicas shouldn't make it


### PR DESCRIPTION
When a replica is removed without applying the merge trigger (dangling subsume via replica GC, or subsumed by Raft snapshot), `OnRangeMerge` is never called and lock table waiters become permanently stuck. This is because the waiter resolves the intent via the post-merge range (wrong lock table), and the signal it is waiting for never arrives on the pre-merge RHS lock table.

Fix this by adding `OnReplicaRemoval()` to the concurrency manager, which clears and disables the lock table and txn wait-queue — the same operation `OnRangeMerge` performs. Call it from `removeInitializedReplicaRaftMuLocked` so that all replica removal paths (merge trigger, dangling subsume GC, snapshot subsumption, rebalance) release any stranded waiters. `OnRangeMerge` now delegates to `OnReplicaRemoval` to avoid duplication.

Fixes: #167995
Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)