### PR TITLE
changefeedccl: allow 5 inflight produce requests per broker in kafka v2 sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -77,6 +77,10 @@ func newKafkaSinkClientV2(
 	baseOpts := []kgo.Opt{
 		// Disable idempotency to maintain parity with the v1 sink and not add surface area for unknowns.
 		kgo.DisableIdempotentWrite(),
+		// Allow up to 5 concurrent produce requests per broker, matching the
+		// Sarama client's default. This is safe because ParallelIO handles
+		// ordering independently of franz-go.
+		kgo.MaxProduceRequestsInflightPerBroker(5),
 
 		kgo.SeedBrokers(bootstrapBrokers...),
 		kgo.WithLogger(kgoLogAdapter{ctx: ctx}),

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -291,14 +291,15 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	baseExpectedOpts := map[string]any{
-		"ClientID":                 "CockroachDB",
-		"ProducerBatchCompression": []kgo.CompressionCodec{kgo.NoCompression()},
-		"RequiredAcks":             kgo.LeaderAck(),
-		"MaxVersions":              kversion.Stable(), // We don't set this but it's kgo's default.
-		"DialTLSConfig":            (*tls.Config)(nil),
-		"SASL":                     ([]sasl.Mechanism)(nil),
-		"DisableIdempotentWrite":   true,
-		"MaxBufferedRecords":       int64(1000), // This is the default that we set.
+		"ClientID":                            "CockroachDB",
+		"ProducerBatchCompression":            []kgo.CompressionCodec{kgo.NoCompression()},
+		"RequiredAcks":                        kgo.LeaderAck(),
+		"MaxVersions":                         kversion.Stable(), // We don't set this but it's kgo's default.
+		"DialTLSConfig":                       (*tls.Config)(nil),
+		"SASL":                                ([]sasl.Mechanism)(nil),
+		"DisableIdempotentWrite":              true,
+		"MaxProduceRequestsInflightPerBroker": 5,
+		"MaxBufferedRecords":                  int64(1000), // This is the default that we set.
 	}
 	baseBatchCfg := sinkBatchConfig{}
 


### PR DESCRIPTION
Previously the franz-go kafka v2 sink defaulted to 1 inflight produce request per broker (MaxProduceRequestsInflightPerBroker). This was unnecessarily conservative since ParallelIO handles ordering independently of franz-go. Increase to 5, matching the Sarama v1 sink's default, to improve throughput.

Fixes: #165388

Release note (performance improvement): The kafka v2 changefeed sink now allows up to 5 concurrent produce requests per broker, matching the v1 sink's behavior and improving throughput.