### PR TITLE
roachtest: restrict failover tests to GCE only

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -134,7 +134,7 @@ func registerFailover(r registry.Registry) {
 			Benchmark:              true,
 			Timeout:                45 * time.Minute,
 			Cluster:                r.MakeClusterSpec(8, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2)),
-			CompatibleClouds:       registry.AllExceptAWS,
+			CompatibleClouds:       registry.OnlyGCE,
 			Suites:                 registry.Suites(registry.Nightly),
 			Leases:                 leases,
 			PostProcessPerfMetrics: failoverAggregateFunction,
@@ -147,7 +147,7 @@ func registerFailover(r registry.Registry) {
 			Benchmark:              true,
 			Timeout:                45 * time.Minute,
 			Cluster:                r.MakeClusterSpec(7, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2)),
-			CompatibleClouds:       registry.AllExceptAWS,
+			CompatibleClouds:       registry.OnlyGCE,
 			Suites:                 registry.Suites(registry.Nightly),
 			Leases:                 leases,
 			PostProcessPerfMetrics: failoverAggregateFunction,
@@ -160,7 +160,7 @@ func registerFailover(r registry.Registry) {
 			Benchmark:              true,
 			Timeout:                45 * time.Minute,
 			Cluster:                r.MakeClusterSpec(8, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2)),
-			CompatibleClouds:       registry.AllExceptAWS,
+			CompatibleClouds:       registry.OnlyGCE,
 			Suites:                 registry.Suites(registry.Nightly),
 			Leases:                 leases,
 			PostProcessPerfMetrics: failoverAggregateFunction,
@@ -170,7 +170,7 @@ func registerFailover(r registry.Registry) {
 		for _, failureMode := range allFailureModes {
 			clusterOpts := make([]spec.Option, 0)
 			clusterOpts = append(clusterOpts, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2))
-			clouds := registry.AllExceptAWS
+			clouds := registry.OnlyGCE
 
 			var postValidation registry.PostValidation
 			if failureMode == failureModeDiskStall {
@@ -204,7 +204,7 @@ func registerFailover(r registry.Registry) {
 			r.Add(registry.TestSpec{
 				Name:                   fmt.Sprintf("failover/liveness/%s%s", failureMode, leasesStr),
 				Owner:                  registry.OwnerKV,
-				CompatibleClouds:       registry.AllExceptAWS,
+				CompatibleClouds:       registry.OnlyGCE,
 				Suites:                 registry.Suites(registry.Weekly),
 				Benchmark:              true,
 				Timeout:                45 * time.Minute,
@@ -219,7 +219,7 @@ func registerFailover(r registry.Registry) {
 			r.Add(registry.TestSpec{
 				Name:                   fmt.Sprintf("failover/system-non-liveness/%s%s", failureMode, leasesStr),
 				Owner:                  registry.OwnerKV,
-				CompatibleClouds:       registry.AllExceptAWS,
+				CompatibleClouds:       registry.OnlyGCE,
 				Suites:                 registry.Suites(registry.Weekly),
 				Benchmark:              true,
 				Timeout:                45 * time.Minute,


### PR DESCRIPTION
These tests use 7-8 nodes with 2 vCPUs, and on IBM/s390x VMs the
sequential node startup takes ~3 minutes. By that time, Raft liveness
heartbeats on earlier nodes have degraded, causing ranges to become
permanently leaderless. This causes the cluster settings SQL that runs
at the end of startup to fail with "replica unavailable".

This has been a recurring infra flake across multiple failover test
variants on IBM (see #168103, #168105, #167460, #167464). The failover
tests are benchmarks measuring recovery latency, so running them on
resource-constrained s390x VMs doesn't produce meaningful signal. The
failover/chaos and failover/non-system/disk-stall variants were already
GCE-only.

Fixes: #168305
Epic: none

Release note: None