### PR TITLE
kvstorage: add live WAG truncation

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_time//rate",

--- a/pkg/kv/kvserver/kvstorage/wag/store.go
+++ b/pkg/kv/kvserver/kvstorage/wag/store.go
@@ -65,6 +65,11 @@ func (s *Seq) Next() uint64 {
 	return s.index.Add(1)
 }
 
+// Load returns the last used WAG sequence number.
+func (s *Seq) Load() uint64 {
+	return s.index.Load()
+}
+
 // Write puts the WAG node under the specific sequence number into the given
 // writer. The index must have been allocated to the caller by the sequencer.
 func Write(w storage.Writer, index uint64, node wagpb.Node) error {

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -8,6 +8,7 @@ package kvstorage
 import (
 	"context"
 	"math"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -46,6 +47,9 @@ type WAGTruncator struct {
 	// filled. This makes an invariant: only an entire prefix is truncated which
 	// allows more efficient Pebble scans that skip over tombstones.
 	initIndex uint64
+	// truncIndex is the index of the last WAG node that was successfully
+	// truncated.
+	truncIndex atomic.Uint64
 }
 
 // NewWAGTruncator creates a WAGTruncator.
@@ -55,17 +59,16 @@ func NewWAGTruncator(st *cluster.Settings, eng Engines, seq *wag.Seq) *WAGTrunca
 
 // truncateAppliedNodes deletes the longest fully applied prefix of the WAG.
 // Does so iteratively, splitting its work into batches.
-func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context, startIndex uint64) error {
+func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context) error {
 	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer stateReader.Close()
-	nextIndex := startIndex
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		b := t.eng.LogEngine().NewWriteBatch()
 		truncatedIdx, err := t.truncateAppliedWAGNodeAndClearRaftState(
-			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader, nextIndex,
+			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader,
 		)
 		if err == nil && truncatedIdx != 0 {
 			err = b.Commit(false /* sync */)
@@ -79,17 +82,14 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context, startIndex uint
 		}
 		// At this point we know that the last truncation succeeded and the batch
 		// was committed, and we can move on to the next node.
-		nextIndex = truncatedIdx + 1
+		t.truncIndex.Store(truncatedIdx)
 	}
 }
 
-// truncateAppliedWAGNodeAndClearRaftState deletes a WAG node if all of its
-// events have been applied to the state engine. For nodes containing
+// truncateAppliedWAGNodeAndClearRaftState deletes the first WAG node if all of
+// its events have been applied to the state engine. For nodes containing
 // EventDestroy or EventSubsume events, it also clears the corresponding raft
 // log prefix from the engine and the sideloaded entries storage.
-//
-// It iterates from truncateIndex and attempts to delete the first WAG node it
-// sees.
 //
 // Returns the index of the last WAG node that was deleted, or 0 if no nodes
 // were deleted.
@@ -101,12 +101,13 @@ func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context, startIndex uint
 // raft.WO.
 // TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
 func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
-	ctx context.Context, raft Raft, stateRO StateRO, truncateIndex uint64,
+	ctx context.Context, raft Raft, stateRO StateRO,
 ) (uint64, error) {
 	var iter wag.Iterator
+	truncateIndex := t.truncIndex.Load() + 1
 	iterStartKey := keys.StoreWAGNodeKey(truncateIndex)
 	for index, node := range iter.IterFrom(ctx, raft.RO, iterStartKey) {
-		if truncateIndex != index && index > t.initIndex {
+		if index != truncateIndex && index > t.initIndex {
 			// We cannot ignore gaps for WAG indices > initIndex.
 			return 0, nil
 		}

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -33,52 +33,66 @@ import (
 type WAGTruncator struct {
 	st  *cluster.Settings
 	eng Engines
+	seq *wag.Seq
+	// initIndex is the WAG index at which the sequencer and truncator were
+	// initialized. New WAG nodes are guaranteed to be written at > initIndex.
+	// Any gaps at <= initIndex are thus never filled.
+	//
+	// Due to concurrent WAG writes in normal operation, indices > initIndex may
+	// temporarily have gaps, guaranteed to be filled eventually. Only an abrupt
+	// shutdown/crash can cause these gaps to become permanent.
+	//
+	// We don't truncate ahead of gaps at > initIndex, and wait for them to be
+	// filled. This makes an invariant: only an entire prefix is truncated which
+	// allows more efficient Pebble scans that skip over tombstones.
+	initIndex uint64
 }
 
 // NewWAGTruncator creates a WAGTruncator.
-func NewWAGTruncator(st *cluster.Settings, eng Engines) *WAGTruncator {
-	return &WAGTruncator{st: st, eng: eng}
+func NewWAGTruncator(st *cluster.Settings, eng Engines, seq *wag.Seq) *WAGTruncator {
+	return &WAGTruncator{st: st, eng: eng, seq: seq, initIndex: seq.Load()}
 }
 
-// TruncateAll truncates all applied WAG nodes. It's meant to be used at engine
-// startup right after we replay the WAG nodes and sync the state engine.
-func (t *WAGTruncator) TruncateAll(ctx context.Context) error {
+// truncateAppliedNodes deletes the longest fully applied prefix of the WAG.
+// Does so iteratively, splitting its work into batches.
+func (t *WAGTruncator) truncateAppliedNodes(ctx context.Context, startIndex uint64) error {
 	stateReader := t.eng.StateEngine().NewReader(storage.GuaranteedDurability)
 	defer stateReader.Close()
+	nextIndex := startIndex
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		b := t.eng.LogEngine().NewWriteBatch()
-		truncated, err := t.truncateAppliedWAGNodeAndClearRaftState(
-			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader, 0, /* index */
+		truncatedIdx, err := t.truncateAppliedWAGNodeAndClearRaftState(
+			ctx, Raft{RO: t.eng.LogEngine(), WO: b}, stateReader, nextIndex,
 		)
-		if err == nil && truncated {
+		if err == nil && truncatedIdx != 0 {
 			err = b.Commit(false /* sync */)
 		}
 		b.Close()
 		if err != nil {
 			return err
 		}
-		if !truncated {
-			break
+		if truncatedIdx == 0 {
+			return nil
 		}
+		// At this point we know that the last truncation succeeded and the batch
+		// was committed, and we can move on to the next node.
+		nextIndex = truncatedIdx + 1
 	}
-	return nil
 }
 
 // truncateAppliedWAGNodeAndClearRaftState deletes a WAG node if all of its
 // events have been applied to the state engine. For nodes containing
 // EventDestroy or EventSubsume events, it also clears the corresponding raft
 // log prefix from the engine and the sideloaded entries storage.
-// If truncateIndex is 0, the function deletes the first WAG node regardless of
-// its index. Otherwise, it only deletes the node matching truncateIndex if it
-// exists.
 //
-// Returns a boolean indicating whether a node was successfully truncated or
-// not. If the return value is false, it means that either there are no WAG
-// nodes left, or that the WAG node has not been applied to the state engine.
-// Also, an error is returned if the WAG node could not be fetched or deleted.
+// It iterates from truncateIndex and attempts to delete the first WAG node it
+// sees.
+//
+// Returns the index of the last WAG node that was deleted, or 0 if no nodes
+// were deleted.
 //
 // The caller must provide a stateRO reader with GuaranteedDurability so that
 // only state confirmed flushed to persistent storage is visible. This ensures
@@ -88,35 +102,27 @@ func (t *WAGTruncator) TruncateAll(ctx context.Context) error {
 // TODO(ibrahim): Support deleting multiple WAG nodes within the same batch.
 func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 	ctx context.Context, raft Raft, stateRO StateRO, truncateIndex uint64,
-) (bool, error) {
+) (uint64, error) {
 	var iter wag.Iterator
-	var iterStartKey roachpb.Key
-	if truncateIndex == 0 {
-		// Delete the first WAG node that exists, regardless of its index.
-		iterStartKey = keys.StoreWAGPrefix()
-	} else {
-		// Only delete the WAG node with the expected index.
-		iterStartKey = keys.StoreWAGNodeKey(truncateIndex)
-	}
-
+	iterStartKey := keys.StoreWAGNodeKey(truncateIndex)
 	for index, node := range iter.IterFrom(ctx, raft.RO, iterStartKey) {
-		if truncateIndex != 0 && truncateIndex != index {
-			return false, nil
+		if truncateIndex != index && index > t.initIndex {
+			// We cannot ignore gaps for WAG indices > initIndex.
+			return 0, nil
 		}
-
 		// TODO(ibrahim): Right now, the canApplyWAGNode function returns a list of
 		// raftCatchUpTargets that are not needed for the purposes of truncation,
 		// consider refactoring the function to return only the needed info.
-		replayAction, err := canApplyWAGNode(ctx, node, stateRO)
+		action, err := canApplyWAGNode(ctx, node, stateRO)
 		if err != nil {
-			return false, err
+			return 0, err
 		}
-		if replayAction.apply {
+		if action.apply {
 			// If an event needs to be applied, the WAG node cannot be deleted yet.
-			return false, nil
+			return 0, nil
 		}
 		if err := wag.Delete(raft.WO, index); err != nil {
-			return false, err
+			return 0, err
 		}
 
 		// Clean up the raft log prefix of a destroyed/subsumed replica.
@@ -125,12 +131,12 @@ func (t *WAGTruncator) truncateAppliedWAGNodeAndClearRaftState(
 				continue
 			}
 			if err := t.clearReplicaRaftLogAndSideloaded(ctx, raft, event.Addr.RangeID, event.Addr.Index); err != nil {
-				return false, err
+				return 0, err
 			}
 		}
-		return true, nil
+		return index, nil
 	}
-	return false, iter.Error()
+	return 0, iter.Error()
 }
 
 // clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -22,6 +22,9 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// WAGTruncatorTestingKnobs contains testing knobs for the WAGTruncator.
+type WAGTruncatorTestingKnobs struct{}
+
 // WAGTruncator truncates applied WAG nodes and clears their associated raft
 // state (log entries and sideloaded files). It supports both offline and online
 // mode of operation:
@@ -50,6 +53,7 @@ type WAGTruncator struct {
 	// truncIndex is the index of the last WAG node that was successfully
 	// truncated.
 	truncIndex atomic.Uint64
+	knobs      WAGTruncatorTestingKnobs
 }
 
 // NewWAGTruncator creates a WAGTruncator.

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -18,22 +18,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/time/rate"
 )
 
 // WAGTruncatorTestingKnobs contains testing knobs for the WAGTruncator.
-type WAGTruncatorTestingKnobs struct{}
+type WAGTruncatorTestingKnobs struct {
+	// AfterTruncationCallback is called after each truncation attempt.
+	AfterTruncationCallback func()
+}
 
 // WAGTruncator truncates applied WAG nodes and clears their associated raft
-// state (log entries and sideloaded files). It supports both offline and online
-// mode of operation:
-//   - [offline] during the store startup, truncate the WAG after it is
-//     replayed and made durable in the StateEngine.
-//   - [online] during the normal operation, truncate the WAG nodes that were
-//     durably applied to the state machine.
-//
-// TODO(ibrahim): Add the periodic truncation logic.
+// state (log entries and sideloaded files).
 type WAGTruncator struct {
 	st  *cluster.Settings
 	eng Engines
@@ -53,12 +51,65 @@ type WAGTruncator struct {
 	// truncIndex is the index of the last WAG node that was successfully
 	// truncated.
 	truncIndex atomic.Uint64
-	knobs      WAGTruncatorTestingKnobs
+	// wakeCh is signaled when there are potential WAG nodes to truncate.
+	wakeCh chan struct{}
+	knobs  WAGTruncatorTestingKnobs
 }
 
 // NewWAGTruncator creates a WAGTruncator.
 func NewWAGTruncator(st *cluster.Settings, eng Engines, seq *wag.Seq) *WAGTruncator {
-	return &WAGTruncator{st: st, eng: eng, seq: seq, initIndex: seq.Load()}
+	return &WAGTruncator{
+		st:        st,
+		eng:       eng,
+		seq:       seq,
+		initIndex: seq.Load(),
+		wakeCh:    make(chan struct{}, 1),
+	}
+}
+
+// Start launches the background goroutine that performs WAG truncation.
+// TODO(ibrahim): Add a setting for keeping a suffix of the WAG for debugging.
+// For example, setting a maximum number of WAG nodes to retain for debugging
+// purposes. We could also pair it with some time threshold after which all WAG
+// nodes are automatically truncated to maintain a manageable size.
+func (t *WAGTruncator) Start(ctx context.Context, stopper *stop.Stopper) error {
+	return stopper.RunAsyncTask(ctx, "wag-truncation", func(ctx context.Context) {
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+		for {
+			select {
+			case <-t.wakeCh:
+				if err := t.truncateAppliedNodes(ctx); err != nil {
+					log.KvExec.Errorf(ctx, "truncating WAG: %v", err)
+				}
+				if cb := t.knobs.AfterTruncationCallback; cb != nil {
+					cb()
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+}
+
+// DurabilityAdvancedCallback is invoked whenever the state engine completes a
+// flush. It checks whether there could possibly be WAG nodes to truncate by
+// comparing truncIndex against seq.Load(). If there are potential
+// truncation opportunities, it sends a non-blocking signal to wake the
+// background goroutine. It must return quickly and must not call into the
+// engine to avoid deadlock (see storage.Engine.RegisterFlushCompletedCallback).
+func (t *WAGTruncator) DurabilityAdvancedCallback() {
+	// NB: logically, truncIndex > seq isn't possible because the
+	// sequencer index is incremented before the corresponding WAG node is
+	// written. Physically, the inversion is possible, depending on which
+	// variable is loaded first. Allow that, and treat as a no-op.
+	if t.truncIndex.Load() >= t.seq.Load() {
+		return
+	}
+	select {
+	case t.wakeCh <- struct{}{}:
+	default:
+	}
 }
 
 // truncateAppliedNodes deletes the longest fully applied prefix of the WAG.

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -262,7 +262,7 @@ func TestTruncateAppliedOnly(t *testing.T) {
 			tc.setup(t, &e)
 			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
 			require.NoError(t, e.stateEngine.Flush())
-			require.NoError(t, truncator.truncateAppliedNodes(ctx, 0 /* startIndex */))
+			require.NoError(t, truncator.truncateAppliedNodes(ctx))
 			require.Equal(t, tc.wantWAGIndices, e.listWAGNodes(t))
 		})
 	}
@@ -319,7 +319,7 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 				require.NoError(t, ss.Put(ctx, idx, 1 /* term */, []byte("sst-data")))
 			}
 			require.NoError(t, e.stateEngine.Flush())
-			require.NoError(t, truncator.truncateAppliedNodes(ctx, 1 /* startIndex */))
+			require.NoError(t, truncator.truncateAppliedNodes(ctx))
 			// Raft entries <= 20 belong to the old replica and must be deleted. The
 			// rest shouldn't be deleted by the WAG truncator.
 			require.Equal(t,
@@ -355,19 +355,20 @@ func TestTruncateAppliedNodes(t *testing.T) {
 	sl := MakeStateLoader(r1.RangeID)
 
 	for _, tc := range []struct {
-		wagIndices    []uint64
-		initIndex     uint64
-		wantRemaining []uint64
+		wagIndices     []uint64
+		initIndex      uint64
+		wantRemaining  []uint64
+		wantTruncIndex uint64
 	}{
-		{wagIndices: []uint64{}, initIndex: 0, wantRemaining: nil},
-		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 0, wantRemaining: nil},
-		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 2, wantRemaining: nil},
-		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 4, wantRemaining: nil},
-		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 0, wantRemaining: []uint64{2, 5, 6, 7, 10}},
-		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 2, wantRemaining: []uint64{5, 6, 7, 10}},
-		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 5, wantRemaining: []uint64{10}},
-		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 7, wantRemaining: []uint64{10}},
-		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 10, wantRemaining: nil},
+		{wagIndices: []uint64{}, initIndex: 0, wantRemaining: nil, wantTruncIndex: 0},
+		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 0, wantRemaining: nil, wantTruncIndex: 4},
+		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 2, wantRemaining: nil, wantTruncIndex: 4},
+		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 4, wantRemaining: nil, wantTruncIndex: 4},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 0, wantRemaining: []uint64{2, 5, 6, 7, 10}, wantTruncIndex: 0},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 2, wantRemaining: []uint64{5, 6, 7, 10}, wantTruncIndex: 2},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 5, wantRemaining: []uint64{10}, wantTruncIndex: 7},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 7, wantRemaining: []uint64{10}, wantTruncIndex: 7},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 10, wantRemaining: nil, wantTruncIndex: 10},
 	} {
 		t.Run("", func(t *testing.T) {
 			e := makeTestEngines()
@@ -379,8 +380,9 @@ func TestTruncateAppliedNodes(t *testing.T) {
 				&kvserverpb.RangeAppliedState{RaftAppliedIndex: 100}))
 			require.NoError(t, e.stateEngine.Flush())
 			truncator.initIndex = tc.initIndex
-			require.NoError(t, truncator.truncateAppliedNodes(ctx, 1 /* startIndex */))
+			require.NoError(t, truncator.truncateAppliedNodes(ctx))
 			require.Equal(t, tc.wantRemaining, e.listWAGNodes(t))
+			require.Equal(t, tc.wantTruncIndex, truncator.truncIndex.Load())
 		})
 	}
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
@@ -287,16 +288,10 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
 			// Write WAG nodes: init then destroy/subsume at index 20.
-			e.writeWAGNode(t, wagpb.Event{
-				Addr: wagpb.MakeAddr(r1, 10), Type: wagpb.EventInit,
-			})
-			e.writeWAGNode(t, wagpb.Event{
-				Addr: wagpb.MakeAddr(r1, 20), Type: eventType,
-			})
+			e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 10), Type: wagpb.EventInit})
+			e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 20), Type: eventType})
 			// Create a WAG node for a newer replica for the same range.
-			e.writeWAGNode(t, wagpb.Event{
-				Addr: wagpb.MakeAddr(r2, 0), Type: wagpb.EventCreate,
-			})
+			e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r2, 0), Type: wagpb.EventCreate})
 			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
 
 			// Tombstone confirms destruction/subsumption.
@@ -385,4 +380,85 @@ func TestTruncateAppliedNodes(t *testing.T) {
 			require.Equal(t, tc.wantTruncIndex, truncator.truncIndex.Load())
 		})
 	}
+}
+
+// TestWAGTruncatorBackground verifies that the WAGTruncator background
+// goroutine only truncates WAG nodes when both conditions are met: (1) the
+// state engine has flushed, and (2) there are WAG nodes that are eligible for
+// truncation.
+func TestWAGTruncatorBackground(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	e := makeTestEngines()
+	defer e.Close()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
+	sl := MakeStateLoader(r1.RangeID)
+
+	// Initialize replica state so events can be considered applied.
+	require.NoError(t, sl.SetRaftReplicaID(ctx, e.StateEngine(), r1.ReplicaID))
+	require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
+		&kvserverpb.RangeAppliedState{RaftAppliedIndex: 100}))
+
+	// Write two WAG nodes whose events are applied with a gap in between them.
+	// This is to simulate some WAG nodes at engine startup.
+	e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 10), Type: wagpb.EventInit})
+	e.seq.Next()
+	e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 20), Type: wagpb.EventApply})
+
+	// Start the periodic WAG truncation background task with a knob that
+	// signals when truncation completes, so the test can synchronize
+	// deterministically instead of polling.
+	truncator := NewWAGTruncator(st, e.Engines, &e.seq)
+	truncationDone := make(chan struct{}, 1)
+	truncator.knobs = WAGTruncatorTestingKnobs{
+		AfterTruncationCallback: func() {
+			truncationDone <- struct{}{}
+		},
+	}
+
+	// Start the periodic WAG truncation background task.
+	require.NoError(t, truncator.Start(ctx, stopper))
+	// Create a WAG node after startup.
+	e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 30), Type: wagpb.EventApply})
+	require.Equal(t, []uint64{1, 3, 4}, e.listWAGNodes(t))
+
+	flushAndWaitForTruncation := func() {
+		require.NoError(t, e.StateEngine().Flush())
+		truncator.DurabilityAdvancedCallback()
+		<-truncationDone
+	}
+	// We expect all WAG nodes to be truncated when the state engine is flushed.
+	flushAndWaitForTruncation()
+	require.Empty(t, e.listWAGNodes(t))
+	require.Equal(t, uint64(4), truncator.truncIndex.Load())
+
+	// Write two WAG nodes whose events are applied (index <= 100).
+	e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 40), Type: wagpb.EventApply})
+	e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 50), Type: wagpb.EventApply})
+	require.Equal(t, []uint64{5, 6}, e.listWAGNodes(t))
+
+	// Now flush the state engine and signal again. Both nodes should be
+	// truncated since their events are applied.
+	flushAndWaitForTruncation()
+	require.Empty(t, e.listWAGNodes(t))
+	require.Equal(t, uint64(6), truncator.truncIndex.Load())
+
+	// Write another WAG node but it is NOT applied yet.
+	e.writeWAGNode(t, wagpb.Event{Addr: wagpb.MakeAddr(r1, 200), Type: wagpb.EventApply})
+	flushAndWaitForTruncation()
+	// Node 7 should remain because its event isn't applied yet.
+	require.Equal(t, []uint64{7}, e.listWAGNodes(t))
+	require.Equal(t, uint64(6), truncator.truncIndex.Load())
+
+	// Advance the applied index past 200 and flush. Now node 7 should be
+	// truncated.
+	require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
+		&kvserverpb.RangeAppliedState{RaftAppliedIndex: 200}))
+	flushAndWaitForTruncation()
+	require.Empty(t, e.listWAGNodes(t))
+	require.Equal(t, uint64(7), truncator.truncIndex.Load())
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -52,6 +52,23 @@ func (e *testEngines) writeWAGNode(t *testing.T, event wagpb.Event) {
 	require.NoError(t, wag.Write(e.LogEngine(), index, wagpb.Node{Events: []wagpb.Event{event}}))
 }
 
+// writeWAGNodesAt writes WAG nodes at the specified WAG sequence indices for
+// the given replica. Each node contains an EventApply event with its raft index
+// set to the WAG entry index + 10.
+func (e *testEngines) writeWAGNodesAt(t *testing.T, wagIndices []uint64, r roachpb.FullReplicaID) {
+	t.Helper()
+	for idx, wagIdx := range wagIndices {
+		event := wagpb.Event{
+			Addr: wagpb.MakeAddr(r, kvpb.RaftIndex(idx+10)),
+			Type: wagpb.EventApply,
+		}
+		require.NoError(t, wag.Write(
+			e.LogEngine(), wagIdx, wagpb.Node{Events: []wagpb.Event{event}},
+		))
+	}
+	require.NoError(t, e.seq.Init(context.Background(), e.LogEngine()))
+}
+
 // writeRaftLogEntry writes a dummy raft log entry to the log engine.
 func (e *testEngines) writeRaftLogEntry(
 	t *testing.T, rangeID roachpb.RangeID, index kvpb.RaftIndex,
@@ -103,7 +120,9 @@ func (e *testEngines) listWAGNodes(t *testing.T) []uint64 {
 	return indices
 }
 
-func TestTruncateApplied(t *testing.T) {
+// TestTruncateAppliedOnly verifies that we only truncate WAG nodes that are
+// durably applied.
+func TestTruncateAppliedOnly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
@@ -240,20 +259,19 @@ func TestTruncateApplied(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
-			truncator := NewWAGTruncator(st, e.Engines)
 			tc.setup(t, &e)
+			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
 			require.NoError(t, e.stateEngine.Flush())
-			require.NoError(t, truncator.TruncateAll(ctx))
+			require.NoError(t, truncator.truncateAppliedNodes(ctx, 0 /* startIndex */))
 			require.Equal(t, tc.wantWAGIndices, e.listWAGNodes(t))
 		})
 	}
 }
 
-// TestTruncateAndClearRaftState verifies that
-// truncateAppliedWAGNodeAndClearRaftState only clears raft log entries and
-// sideloaded files up to the destroyed/subsumed replica's last index. Entries
-// and files beyond that index may belong to a newer replica and must be
-// preserved.
+// TestTruncateAndClearRaftState verifies that WAG truncation only clears raft
+// log entries and sideloaded files up to the destroyed/subsumed replica's last
+// index. Entries and files beyond that index may belong to a newer replica and
+// must be preserved.
 func TestTruncateAndClearRaftState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -268,8 +286,6 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 		t.Run(eventType.String(), func(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
-			truncator := NewWAGTruncator(st, e.Engines)
-
 			// Write WAG nodes: init then destroy/subsume at index 20.
 			e.writeWAGNode(t, wagpb.Event{
 				Addr: wagpb.MakeAddr(r1, 10), Type: wagpb.EventInit,
@@ -277,11 +293,11 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 			e.writeWAGNode(t, wagpb.Event{
 				Addr: wagpb.MakeAddr(r1, 20), Type: eventType,
 			})
-
 			// Create a WAG node for a newer replica for the same range.
 			e.writeWAGNode(t, wagpb.Event{
 				Addr: wagpb.MakeAddr(r2, 0), Type: wagpb.EventCreate,
 			})
+			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
 
 			// Tombstone confirms destruction/subsumption.
 			require.NoError(t, sl.SetRangeTombstone(ctx, e.StateEngine(),
@@ -303,7 +319,7 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 				require.NoError(t, ss.Put(ctx, idx, 1 /* term */, []byte("sst-data")))
 			}
 			require.NoError(t, e.stateEngine.Flush())
-			require.NoError(t, truncator.TruncateAll(ctx))
+			require.NoError(t, truncator.truncateAppliedNodes(ctx, 1 /* startIndex */))
 			// Raft entries <= 20 belong to the old replica and must be deleted. The
 			// rest shouldn't be deleted by the WAG truncator.
 			require.Equal(t,
@@ -328,87 +344,43 @@ func TestTruncateAndClearRaftState(t *testing.T) {
 	}
 }
 
-// TestTruncateGapHandling verifies that truncateAppliedWAGNodeAndClearRaftState
-// handles gaps in WAG node indices correctly based on expectedIndex. When
-// expectedIndex is 0, the first node is deleted regardless of its index. When
-// non-zero, only the node at that exact index is deleted.
-//
-// The test sets up three WAG nodes with gaps between them:
-// [Index: 2] -> [Index: 4] -> [Index: 6]
-func TestTruncateGapHandling(t *testing.T) {
+// TestTruncateAppliedNodes exercises truncateAppliedNodes() across different
+// combinations of WAG node and initial indices.
+func TestTruncateAppliedNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-
 	r1 := roachpb.FullReplicaID{RangeID: 1, ReplicaID: 1}
-	sl := MakeStateLoader(1 /* rangeID */)
+	sl := MakeStateLoader(r1.RangeID)
 
-	for _, calls := range [][]struct {
-		index          uint64
-		wantTruncated  bool
-		wantWAGIndices []uint64
+	for _, tc := range []struct {
+		wagIndices    []uint64
+		initIndex     uint64
+		wantRemaining []uint64
 	}{
-		{
-			// index=0 removes the first WAG node regardless of its index.
-			{index: 0, wantTruncated: true, wantWAGIndices: []uint64{4, 6}},
-			{index: 0, wantTruncated: true, wantWAGIndices: []uint64{6}},
-			{index: 0, wantTruncated: true, wantWAGIndices: nil},
-		},
-		{
-			// A non-existent index is a no-op.
-			{index: 1, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
-			{index: 3, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
-			{index: 5, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
-			{index: 7, wantTruncated: false, wantWAGIndices: []uint64{2, 4, 6}},
-		},
-		{
-			// In theory, we can remove a WAG node at an index that is not the first.
-			{index: 4, wantTruncated: true, wantWAGIndices: []uint64{2, 6}},
-			{index: 6, wantTruncated: true, wantWAGIndices: []uint64{2}},
-			{index: 2, wantTruncated: true, wantWAGIndices: nil},
-		},
+		{wagIndices: []uint64{}, initIndex: 0, wantRemaining: nil},
+		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 0, wantRemaining: nil},
+		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 2, wantRemaining: nil},
+		{wagIndices: []uint64{1, 2, 3, 4}, initIndex: 4, wantRemaining: nil},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 0, wantRemaining: []uint64{2, 5, 6, 7, 10}},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 2, wantRemaining: []uint64{5, 6, 7, 10}},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 5, wantRemaining: []uint64{10}},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 7, wantRemaining: []uint64{10}},
+		{wagIndices: []uint64{2, 5, 6, 7, 10}, initIndex: 10, wantRemaining: nil},
 	} {
 		t.Run("", func(t *testing.T) {
 			e := makeTestEngines()
 			defer e.Close()
-			truncator := NewWAGTruncator(st, e.Engines)
-
-			// Write WAG nodes at indices 2, 4, 6.
-			e.seq.Next()
-			e.writeWAGNode(t, wagpb.Event{
-				Addr: wagpb.MakeAddr(r1, 0), Type: wagpb.EventCreate,
-			})
-			e.seq.Next()
-			e.writeWAGNode(t, wagpb.Event{
-				Addr: wagpb.MakeAddr(r1, 15), Type: wagpb.EventInit,
-			})
-			e.seq.Next()
-			e.writeWAGNode(t, wagpb.Event{
-				Addr: wagpb.MakeAddr(r1, 20), Type: wagpb.EventApply,
-			})
-
-			// Set applied state so all WAG nodes are considered applied.
+			e.writeWAGNodesAt(t, tc.wagIndices, r1)
+			truncator := NewWAGTruncator(st, e.Engines, &e.seq)
 			require.NoError(t, sl.SetRaftReplicaID(ctx, e.StateEngine(), r1.ReplicaID))
 			require.NoError(t, sl.SetRangeAppliedState(ctx, e.StateEngine(),
-				&kvserverpb.RangeAppliedState{RaftAppliedIndex: 20}))
+				&kvserverpb.RangeAppliedState{RaftAppliedIndex: 100}))
 			require.NoError(t, e.stateEngine.Flush())
-
-			for _, c := range calls {
-				stateReader := e.StateEngine().NewReader(storage.GuaranteedDurability)
-				b := e.LogEngine().NewWriteBatch()
-				truncated, err := truncator.truncateAppliedWAGNodeAndClearRaftState(
-					ctx, Raft{RO: e.LogEngine(), WO: b}, stateReader, c.index,
-				)
-				require.NoError(t, err)
-				require.Equal(t, c.wantTruncated, truncated)
-				if truncated {
-					require.NoError(t, b.Commit(false /* sync */))
-				}
-				b.Close()
-				stateReader.Close()
-				require.Equal(t, c.wantWAGIndices, e.listWAGNodes(t))
-			}
+			truncator.initIndex = tc.initIndex
+			require.NoError(t, truncator.truncateAppliedNodes(ctx, 1 /* startIndex */))
+			require.Equal(t, tc.wantRemaining, e.listWAGNodes(t))
 		})
 	}
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -911,7 +911,8 @@ type DurabilityRequirement int8
 const (
 	// StandardDurability is what should normally be used.
 	StandardDurability DurabilityRequirement = iota
-	// GuaranteedDurability is an advanced option (only for raftLogTruncator).
+	// GuaranteedDurability is an advanced option (only for raftLogTruncator
+	// and WAGTruncator).
 	GuaranteedDurability
 )
 


### PR DESCRIPTION
This PR does the following:

1) adds the ability to perform live WAG truncation. It keeps track of the last successfully truncated WAG node index, and only attempts to perform a round of WAG truncation if (1) The state engine flushes, and (2) There is a higher WAG sequence number than the last one we truncated.
2) Merges offline and online truncation into one concept.
3) Introduce TestingKnobs to the WAGTruncator.

References: #167607

Release note: None