### PR TITLE
changefeedccl: log internal sink retries

### DIFF
--- a/pkg/ccl/changefeedccl/parallel_io.go
+++ b/pkg/ccl/changefeedccl/parallel_io.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -31,6 +32,7 @@ import (
 // in an ioResult struct sent to resultCh.  After sending an error to resultCh
 // all workers are torn down and no further requests are received or handled.
 type ParallelIO struct {
+	everyN    log.EveryN
 	retryOpts retry.Options
 	wg        ctxgroup.Group
 	metrics   metricsRecorder
@@ -95,6 +97,7 @@ func NewParallelIO(
 		requestCh: make(chan AdmittedIORequest, quota),
 		resultCh:  make(chan IOResult, quota),
 		doneCh:    make(chan struct{}),
+		everyN:    log.Every(15 * time.Second),
 	}
 
 	wg.GoCtx(func(ctx context.Context) error {
@@ -253,13 +256,17 @@ func (p *ParallelIO) processIO(ctx context.Context, numEmitWorkers int) error {
 			}
 		}
 
-		initialSend := true
+		var lastErr error
 		return retry.WithMaxAttempts(ctx, p.retryOpts, p.retryOpts.MaxRetries+1, func() error {
-			if !initialSend {
+			if lastErr != nil {
 				p.metrics.recordInternalRetry(int64(r.Keys().Len()), false)
+				if p.everyN.ShouldLog() {
+					log.Changefeed.Infof(ctx, "internal retry of %d message(s) due to error: %v",
+						r.Keys().Len(), lastErr)
+				}
 			}
-			initialSend = false
-			return p.ioHandler(ctx, r)
+			lastErr = p.ioHandler(ctx, r)
+			return lastErr
 		})
 	}
 

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -1117,4 +1118,65 @@ func TestWebhookSinkClientTimeoutDefault(t *testing.T) {
 	require.NotNil(t, webhookOptsWithTimeout.ClientTimeout)
 	require.Equal(t, customTimeout, *webhookOptsWithTimeout.ClientTimeout,
 		"ClientTimeout should match the explicitly set value")
+}
+
+// TestWebhookSinkRetryLogging verifies that internal retries are logged.
+func TestWebhookSinkRetryLogging(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	spy := &changefeedLogSpy{}
+	cleanup := log.InterceptWith(context.Background(), spy)
+	defer cleanup()
+
+	ctx := context.Background()
+	opts := getGenericWebhookSinkOptions(struct {
+		key   string
+		value string
+	}{
+		key:   changefeedbase.OptWebhookSinkConfig,
+		value: `{"Retry":{"Backoff": "5ms", "Max": "2"}}`,
+	})
+	cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
+	require.NoError(t, err)
+
+	sinkDest, err := cdctest.StartMockWebhookSink(cert)
+	require.NoError(t, err)
+	defer sinkDest.Close()
+	// First request will fail, second request will succeed.
+	sinkDest.SetStatusCodes([]int{http.StatusTooManyRequests, http.StatusOK})
+
+	sinkDestHost, err := url.Parse(sinkDest.URL())
+	require.NoError(t, err)
+
+	params := sinkDestHost.Query()
+	params.Set(changefeedbase.SinkParamCACert, certEncoded)
+	sinkDestHost.RawQuery = params.Encode()
+
+	details := jobspb.ChangefeedDetails{
+		SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
+		Opts:    opts.AsMap(),
+	}
+
+	sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, 1 /* parallelism */, timeutil.DefaultTimeSource{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sinkSrc.Close()) }()
+
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc, nil))
+	// Flush will make 2 requests. The first request fails with statusTooManyRequests, which should
+	// log the error and retry. The second request succeeds with statusOK.
+	require.NoError(t, sinkSrc.Flush(ctx))
+
+	require.Equal(t, `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}],"length":1}`, sinkDest.Pop())
+
+	testutils.SucceedsSoon(t, func() error {
+		spy.Lock()
+		defer spy.Unlock()
+		for _, logMsg := range spy.logs {
+			if strings.Contains(logMsg, "internal retry") &&
+				strings.Contains(logMsg, "429 Too Many Requests") {
+				return nil
+			}
+		}
+		return errors.Newf("expected retry log not found, got: %v", spy.logs)
+	})
 }


### PR DESCRIPTION
A cloud customer has been experiencing lots of webhook sink retries,
and we have no idea why. Adding this will help us get some more 
visibility into what's going on.

Resolves: #168415
Release Note: None