### PR TITLE
build/deploy: fix docker init scripts blocking when COCKROACH_USER is unset

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -154,13 +154,11 @@ setup_db() {
   create_defaultdb
   create_default_user
 
-  local init_env_query=( --certs-dir="$certs_dir" )
   if [[ -n "$COCKROACH_USER" ]]; then
-    init_env_query+=( -e "GRANT ALL ON DATABASE "$COCKROACH_DATABASE" TO "$COCKROACH_USER"" \
-                      -e "GRANT admin TO "$COCKROACH_USER" " )
+    run_sql_query --certs-dir="$certs_dir" \
+                  -e "GRANT ALL ON DATABASE "$COCKROACH_DATABASE" TO "$COCKROACH_USER"" \
+                  -e "GRANT admin TO "$COCKROACH_USER" "
   fi
-
-  run_sql_query "${init_env_query[@]}"
 }
 
 # process_init_files run all the init scripts from /docker-entrypoint-initdb.d.


### PR DESCRIPTION
## Summary

Fixes #110997.

- When `COCKROACH_USER` is not set, `setup_db()` called `run_sql_query` with only `--certs-dir` and no `-e` flag, causing `cockroach sql` to open an interactive session that blocks indefinitely
- This prevented `/docker-entrypoint-initdb.d` scripts from ever running
- Moved the `run_sql_query` call inside the `COCKROACH_USER` conditional so it only executes when there are actual GRANT statements to run

## Root cause

In `build/deploy/cockroach.sh`, the `setup_db()` function built an `init_env_query` array starting with `--certs-dir="$certs_dir"`. The `-e` flags for GRANT statements were only appended when `COCKROACH_USER` was set. However, `run_sql_query "${init_env_query[@]}"` was called unconditionally. Without any `-e` flag, `cockroach sql` opens an interactive session, blocking execution and preventing `process_init_files` from running.

## Test plan

- [x] Run `docker run -v init-db.sql:/docker-entrypoint-initdb.d/init-db.sql cockroachdb/cockroach start-single-node --insecure` **without** `COCKROACH_USER` set and verify init scripts execute
- [x] Run the same command **with** `COCKROACH_USER=myuser` and verify GRANT statements still execute correctly
- [x] Verify existing behavior is preserved when `COCKROACH_USER` and `COCKROACH_PASSWORD` are both set