### PR TITLE
crosscluster/physical: fail cutover to LATEST during initial scan

### DIFF
--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -564,6 +564,12 @@ func alterTenantJobCutover(
 
 	replicatedTimeAtCutover := replicationutils.ReplicatedTimeFromProgress(&progress)
 	if replicatedTimeAtCutover.IsEmpty() {
+		if alterTenantStmt.Cutover.Latest {
+			return hlc.Timestamp{}, errors.Newf(
+				"replicated tenant %q (%d) has not yet replicated any data; "+
+					"cannot cut over to latest replicated time",
+				tenantName, tenInfo.ID)
+		}
 		replicatedTimeAtCutover = details.ReplicationStartTime
 	}
 

--- a/pkg/crosscluster/physical/testdata/add_early_cutover
+++ b/pkg/crosscluster/physical/testdata/add_early_cutover
@@ -1,5 +1,5 @@
-# This test ensures 1) the user can set a cutover before the initial scan completes; 2) cannot set a
-# cutover time before the replicatedStartTime.
+# This test ensures 1) the user cannot cut over to LATEST before the initial scan completes;
+# 2) cannot set a cutover time before the replicatedStartTime.
 
 create-replication-clusters
 ----
@@ -22,7 +22,7 @@ query-sql as=destination-system regex-error=(.*before earliest safe cutover.*)
 ALTER TENANT "destination" COMPLETE REPLICATION TO SYSTEM TIME '$pre'
 ----
 
-exec-sql as=destination-system
+query-sql as=destination-system regex-error=(.*has not yet replicated any data.*)
 ALTER TENANT "destination" COMPLETE REPLICATION TO LATEST
 ----
 


### PR DESCRIPTION
Previously, `ALTER VIRTUAL CLUSTER ... COMPLETE REPLICATION TO LATEST` during the initial scan would silently fall back to using the replication start time as the cutover timestamp. But, LATEST implies cutover would be quick, but the initial scan could take hours. Further, LATEST implies its going to grab the latest replicated time, but there isn't one.

Now, the command returns an error when issued before the initial scan completes and no replicated time has been recorded. Cutover to an explicit `SYSTEM TIME` timestamp remains available during initial scan.

Fixes: #168256

Release note (ops change): `ALTER VIRTUAL CLUSTER ... COMPLETE REPLICATION TO LATEST` now returns an error if issued before the initial scan has replicated any data.