### PR TITLE
geo: implement ST_3DDWithin and ST_3DDistance

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1721,6 +1721,8 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
+<tr><td><a name="_st_3ddwithin"></a><code>_st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, using 3D Euclidean distance. This variant does not utilize any spatial index.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="_st_contains"></a><code>_st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant does not utilize any spatial index.</p>
@@ -1866,6 +1868,10 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <tr><td><a name="postgis_version"></a><code>postgis_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="postgis_wagyu_version"></a><code>postgis_wagyu_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3ddistance"></a><code>st_3ddistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional minimum Cartesian distance between two geometries. If either geometry has no Z component, this is equivalent to ST_Distance.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3ddwithin"></a><code>st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, using 3D Euclidean distance.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="st_3dlength"></a><code>st_3dlength(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional or 2-dimensional length of the geometry.</p>
 <p>Note ST_3DLength is only valid for LineString or MultiLineString.

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1685,6 +1685,8 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
+<tr><td><a name="_st_3ddwithin"></a><code>_st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, using 3D Euclidean distance. This variant does not utilize any spatial index.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="_st_contains"></a><code>_st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant does not utilize any spatial index.</p>
@@ -1830,6 +1832,10 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <tr><td><a name="postgis_version"></a><code>postgis_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="postgis_wagyu_version"></a><code>postgis_wagyu_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3ddistance"></a><code>st_3ddistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional minimum Cartesian distance between two geometries. If either geometry has no Z component, this is equivalent to ST_Distance.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3ddwithin"></a><code>st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, using 3D Euclidean distance.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="st_3dlength"></a><code>st_3dlength(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional or 2-dimensional length of the geometry.</p>
 <p>Note ST_3DLength is only valid for LineString or MultiLineString.

--- a/pkg/geo/geomfn/coord.go
+++ b/pkg/geo/geomfn/coord.go
@@ -60,3 +60,104 @@ func coordEqual(a geom.Coord, b geom.Coord) bool {
 func coordMag2(c geom.Coord) float64 {
 	return coordDot(c, c)
 }
+
+// coordGetZ returns the Z value from a coordinate, or 0 if no Z is present.
+func coordGetZ(c geom.Coord) float64 {
+	if len(c) > 2 {
+		return c[2]
+	}
+	return 0
+}
+
+// coordAdd3D adds two coordinates in 3D and returns a new result.
+func coordAdd3D(a geom.Coord, b geom.Coord) geom.Coord {
+	return geom.Coord{a.X() + b.X(), a.Y() + b.Y(), coordGetZ(a) + coordGetZ(b)}
+}
+
+// coordSub3D subtracts two coordinates in 3D and returns a new result.
+func coordSub3D(a geom.Coord, b geom.Coord) geom.Coord {
+	return geom.Coord{a.X() - b.X(), a.Y() - b.Y(), coordGetZ(a) - coordGetZ(b)}
+}
+
+// coordMul3D multiplies a 3D coord by a scalar and returns the new result.
+func coordMul3D(a geom.Coord, s float64) geom.Coord {
+	return geom.Coord{a.X() * s, a.Y() * s, coordGetZ(a) * s}
+}
+
+// coordDot3D returns the dot product of two 3D coord vectors.
+func coordDot3D(a geom.Coord, b geom.Coord) float64 {
+	return a.X()*b.X() + a.Y()*b.Y() + coordGetZ(a)*coordGetZ(b)
+}
+
+// coordNorm2_3D returns the squared norm of a 3D coordinate vector.
+func coordNorm2_3D(c geom.Coord) float64 {
+	return coordDot3D(c, c)
+}
+
+// coordNorm3D returns the Euclidean norm of a 3D coordinate vector.
+func coordNorm3D(c geom.Coord) float64 {
+	return math.Sqrt(coordNorm2_3D(c))
+}
+
+// coordEqual3D returns whether two coordinates are equal in 3D.
+func coordEqual3D(a geom.Coord, b geom.Coord) bool {
+	return a.X() == b.X() && a.Y() == b.Y() && coordGetZ(a) == coordGetZ(b)
+}
+
+// closest3DSegmentSegment finds the closest pair of points on 3D
+// segments [a0, a1] and [b0, b1], using the standard parameterized
+// approach (see Ericson, "Real-Time Collision Detection", §5.1.9).
+// Returns the closest point on segment A and the closest point on
+// segment B as XYZ coordinates.
+func closest3DSegmentSegment(a0, a1, b0, b1 geom.Coord) (geom.Coord, geom.Coord) {
+	const epsilon = 1e-30
+	d1 := coordSub3D(a1, a0)
+	d2 := coordSub3D(b1, b0)
+	r := coordSub3D(a0, b0)
+	a := coordDot3D(d1, d1)
+	e := coordDot3D(d2, d2)
+	f := coordDot3D(d2, r)
+
+	var s, t float64
+	switch {
+	case a <= epsilon && e <= epsilon:
+		// Both segments are degenerate points.
+		return a0, b0
+	case a <= epsilon:
+		// Segment A is a degenerate point; project onto B.
+		t = clamp01(f / e)
+	default:
+		c := coordDot3D(d1, r)
+		if e <= epsilon {
+			// Segment B is a degenerate point; project onto A.
+			s = clamp01(-c / a)
+		} else {
+			// General nondegenerate case.
+			b := coordDot3D(d1, d2)
+			denom := a*e - b*b
+			if denom != 0 {
+				s = clamp01((b*f - c*e) / denom)
+			}
+			t = (b*s + f) / e
+			if t < 0 {
+				t = 0
+				s = clamp01(-c / a)
+			} else if t > 1 {
+				t = 1
+				s = clamp01((b - c) / a)
+			}
+		}
+	}
+	return coordAdd3D(a0, coordMul3D(d1, s)), coordAdd3D(b0, coordMul3D(d2, t))
+}
+
+// clamp01 clamps v to [0, 1].
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -555,6 +555,339 @@ func (u *geomMaxDistanceUpdater) FlipGeometries() {
 	u.geometricalObjOrder = -u.geometricalObjOrder
 }
 
+// MinDistance3D returns the 3D minimum distance between geometries A and B.
+// For 2D geometries, Z is treated as 0, so this degrades to 2D distance.
+// This returns a geo.EmptyGeometryError if either A or B is EMPTY.
+func MinDistance3D(a geo.Geometry, b geo.Geometry) (float64, error) {
+	if a.SRID() != b.SRID() {
+		return 0, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return 0, err
+	}
+	return minDistance3DInternal(a, b, 0, geo.EmptyBehaviorOmit)
+}
+
+// DWithin3D determines if any part of geometry A is within D units of
+// geometry B using 3D Euclidean distance.
+// DWithin3D is equivalent to ST_3DDistance(a, b) <= d.
+func DWithin3D(a geo.Geometry, b geo.Geometry, d float64) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	if d < 0 {
+		return false, pgerror.Newf(
+			pgcode.InvalidParameterValue, "dwithin distance cannot be less than zero",
+		)
+	}
+	// Use the 2D bounding box as a conservative fast-reject filter.
+	// If 2D bounding boxes don't overlap by d, the 3D distance is at
+	// least as large.
+	if !a.CartesianBoundingBox().Buffer(d, d).Intersects(b.CartesianBoundingBox()) {
+		return false, nil
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return false, err
+	}
+	dist, err := minDistance3DInternal(a, b, d, geo.EmptyBehaviorError)
+	if err != nil {
+		if geo.IsEmptyGeometryError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return dist <= d, nil
+}
+
+// normalizeFor3D drops the M dimension from inputs so that coord[2] is
+// always Z (or the coord has no Z at all). This matches PostGIS semantics:
+// M is not used in 3D distance calculations, and missing Z is treated as
+// "any value" (effectively 2D distance, since both sides degrade together).
+func normalizeFor3D(a, b geo.Geometry) (geo.Geometry, geo.Geometry, error) {
+	a, err := stripMDimension(a)
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, err
+	}
+	b, err = stripMDimension(b)
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, err
+	}
+	return a, b, nil
+}
+
+// stripMDimension converts an XYM geometry to XY and an XYZM geometry to
+// XYZ. Other layouts pass through unchanged.
+func stripMDimension(g geo.Geometry) (geo.Geometry, error) {
+	t, err := g.AsGeomT()
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	switch t.Layout() {
+	case geom.XYM:
+		return ForceLayout(g, geom.XY)
+	case geom.XYZM:
+		return ForceLayout(g, geom.XYZ)
+	}
+	return g, nil
+}
+
+// minDistance3DInternal finds the 3D minimum distance between two geometries.
+func minDistance3DInternal(
+	a geo.Geometry, b geo.Geometry, stopAfter float64, emptyBehavior geo.EmptyBehavior,
+) (float64, error) {
+	u := newGeomMinDistance3DUpdater(stopAfter)
+	c := &geomDistance3DCalculator{
+		updater:               u,
+		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
+	}
+	return distanceInternal(a, b, c, emptyBehavior)
+}
+
+// geomMinDistance3DUpdater finds the minimum distance using 3D geom
+// calculations. Methods return early if the minimum distance found is
+// <= stopAfter.
+type geomMinDistance3DUpdater struct {
+	currentValue float64
+	stopAfter    float64
+	coordA       geom.Coord
+	coordB       geom.Coord
+
+	geometricalObjOrder geometricalObjectsOrder
+
+	// planeDistance is set by the 3D calculator's PointIntersectsLinearRing
+	// when a point is inside a polygon's XY projection. It holds the
+	// perpendicular distance from the point to the polygon's plane.
+	// A negative value means no plane distance is pending.
+	planeDistance float64
+}
+
+var _ geodist.DistanceUpdater = (*geomMinDistance3DUpdater)(nil)
+
+func newGeomMinDistance3DUpdater(stopAfter float64) *geomMinDistance3DUpdater {
+	return &geomMinDistance3DUpdater{
+		currentValue:        math.MaxFloat64,
+		stopAfter:           stopAfter,
+		planeDistance:       -1,
+		geometricalObjOrder: geometricalObjectsNotFlipped,
+	}
+}
+
+// Distance implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistance3DUpdater) Distance() float64 {
+	return u.currentValue
+}
+
+// Update implements the geodist.DistanceUpdater interface.
+//
+// Returns true (request early exit) whenever the running minimum is at
+// or below stopAfter, regardless of whether this call updated it. This
+// lets edge-crosser-supplied candidates (which set the minimum from
+// inside ChainCrossing without being able to signal early exit through
+// the EdgeCrosser API) propagate via the next Update call.
+func (u *geomMinDistance3DUpdater) Update(aPoint geodist.Point, bPoint geodist.Point) bool {
+	a := aPoint.GeomPoint
+	b := bPoint.GeomPoint
+
+	dist := coordNorm3D(coordSub3D(a, b))
+	if dist < u.currentValue || u.coordA == nil {
+		u.currentValue = dist
+		if u.geometricalObjOrder == geometricalObjectsFlipped {
+			u.coordA = b
+			u.coordB = a
+		} else {
+			u.coordA = a
+			u.coordB = b
+		}
+	}
+	return u.currentValue <= u.stopAfter
+}
+
+// OnIntersects implements the geodist.DistanceUpdater interface.
+//
+// In the 3D case, this is only called from polygon-containment paths in
+// geodist (onPointToPolygon, onLineStringToPolygon, onPolygonToPolygon),
+// each of which calls PointIntersectsLinearRing on a polygon ring
+// immediately before. That call sets planeDistance to the perpendicular
+// distance from the point to the polygon's plane. We use that as the 3D
+// distance rather than treating containment as zero distance. Edge
+// crossings are handled separately by the 3D edge crosser, which never
+// triggers OnIntersects.
+func (u *geomMinDistance3DUpdater) OnIntersects(p geodist.Point) bool {
+	dist := u.planeDistance
+	u.planeDistance = -1
+	if dist < 0 {
+		// Should not happen: a polygon-containment path always sets
+		// planeDistance via PointIntersectsLinearRing first. Treat as
+		// zero distance so we still produce a sensible answer.
+		dist = 0
+	}
+	if dist < u.currentValue || u.coordA == nil {
+		u.currentValue = dist
+		u.coordA = p.GeomPoint
+		u.coordB = p.GeomPoint
+	}
+	return u.currentValue <= u.stopAfter
+}
+
+// IsMaxDistance implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistance3DUpdater) IsMaxDistance() bool {
+	return false
+}
+
+// FlipGeometries implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistance3DUpdater) FlipGeometries() {
+	u.geometricalObjOrder = -u.geometricalObjOrder
+}
+
+// geomDistance3DCalculator implements geodist.DistanceCalculator using
+// 3D coordinate math. Point-in-polygon and edge crossing tests remain
+// 2D (XY projection), matching PostGIS behavior for 3D geometries.
+type geomDistance3DCalculator struct {
+	updater               geodist.DistanceUpdater
+	boundingBoxIntersects bool
+}
+
+var _ geodist.DistanceCalculator = (*geomDistance3DCalculator)(nil)
+
+// DistanceUpdater implements geodist.DistanceCalculator.
+func (c *geomDistance3DCalculator) DistanceUpdater() geodist.DistanceUpdater {
+	return c.updater
+}
+
+// BoundingBoxIntersects implements geodist.DistanceCalculator.
+func (c *geomDistance3DCalculator) BoundingBoxIntersects() bool {
+	return c.boundingBoxIntersects
+}
+
+// NewEdgeCrosser implements geodist.DistanceCalculator.
+//
+// Returns a 3D-aware crosser: instead of detecting 2D intersections
+// (which are meaningless in 3D — segments may project to crossing lines
+// in XY while being far apart in Z), it computes the true 3D
+// segment-segment minimum distance and feeds the closest pair to the
+// updater. The crosser never reports a crossing, so OnIntersects is
+// never called from edge iteration.
+func (c *geomDistance3DCalculator) NewEdgeCrosser(
+	edge geodist.Edge, startPoint geodist.Point,
+) geodist.EdgeCrosser {
+	updater, ok := c.updater.(*geomMinDistance3DUpdater)
+	if !ok {
+		return nil
+	}
+	return &geom3DEdgeCrosser{
+		updater:    updater,
+		edgeV0:     edge.V0.GeomPoint,
+		edgeV1:     edge.V1.GeomPoint,
+		nextEdgeV0: startPoint.GeomPoint,
+	}
+}
+
+// PointIntersectsLinearRing implements geodist.DistanceCalculator.
+// Point-in-polygon containment is a 2D topological operation (XY
+// projection). When the point is inside, we pre-compute the
+// perpendicular distance from the point to the polygon's plane and
+// store it in the updater so OnIntersects can use it instead of 0.
+func (c *geomDistance3DCalculator) PointIntersectsLinearRing(
+	point geodist.Point, linearRing geodist.LinearRing,
+) bool {
+	side := findPointSideOfLinearRing(point, linearRing)
+	switch side {
+	case insideLinearRing, onLinearRing:
+		if u, ok := c.updater.(*geomMinDistance3DUpdater); ok {
+			u.planeDistance = perpendicularDistanceToRingPlane(
+				point.GeomPoint, linearRing,
+			)
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// ClosestPointToEdge implements geodist.DistanceCalculator using 3D
+// projection. The formula r = dot(AC, AB) / norm2(AB) generalizes
+// naturally to 3D.
+func (c *geomDistance3DCalculator) ClosestPointToEdge(
+	e geodist.Edge, p geodist.Point,
+) (geodist.Point, bool) {
+	if coordEqual3D(e.V0.GeomPoint, e.V1.GeomPoint) {
+		return e.V0, coordEqual3D(e.V0.GeomPoint, p.GeomPoint)
+	}
+	if coordEqual3D(p.GeomPoint, e.V0.GeomPoint) {
+		return p, true
+	}
+	if coordEqual3D(p.GeomPoint, e.V1.GeomPoint) {
+		return p, true
+	}
+
+	ac := coordSub3D(p.GeomPoint, e.V0.GeomPoint)
+	ab := coordSub3D(e.V1.GeomPoint, e.V0.GeomPoint)
+	r := coordDot3D(ac, ab) / coordNorm2_3D(ab)
+	if r < 0 || r > 1 {
+		return p, false
+	}
+	return geodist.Point{
+		GeomPoint: coordAdd3D(e.V0.GeomPoint, coordMul3D(ab, r)),
+	}, true
+}
+
+// geom3DEdgeCrosser computes the true 3D segment-segment minimum
+// distance for each edge pair and feeds the closest pair to the
+// updater. ChainCrossing always returns (false, _) so the caller never
+// invokes OnIntersects from edge iteration; the global minimum is
+// determined by the updater across all candidates.
+type geom3DEdgeCrosser struct {
+	updater    *geomMinDistance3DUpdater
+	edgeV0     geom.Coord
+	edgeV1     geom.Coord
+	nextEdgeV0 geom.Coord
+}
+
+var _ geodist.EdgeCrosser = (*geom3DEdgeCrosser)(nil)
+
+// ChainCrossing implements geodist.EdgeCrosser.
+func (c *geom3DEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.Point) {
+	nextEdgeV1 := p.GeomPoint
+	pA, pB := closest3DSegmentSegment(c.edgeV0, c.edgeV1, c.nextEdgeV0, nextEdgeV1)
+	c.nextEdgeV0 = nextEdgeV1
+	c.updater.Update(geodist.Point{GeomPoint: pA}, geodist.Point{GeomPoint: pB})
+	return false, geodist.Point{}
+}
+
+// perpendicularDistanceToRingPlane computes the perpendicular distance
+// from a point to the plane defined by a linear ring. The plane is
+// determined from the first three non-collinear vertices of the ring.
+// If all vertices are collinear or the ring has fewer than 3 vertices,
+// this falls back to 0 (treating the ring as degenerate).
+func perpendicularDistanceToRingPlane(p geom.Coord, ring geodist.LinearRing) float64 {
+	n := ring.NumVertexes()
+	if n < 3 {
+		return 0
+	}
+	v0 := ring.Vertex(0).GeomPoint
+	// Find two edges that form a non-degenerate normal vector.
+	for i := 1; i < n-1; i++ {
+		v1 := ring.Vertex(i).GeomPoint
+		v2 := ring.Vertex(i + 1).GeomPoint
+		e1 := coordSub3D(v1, v0)
+		e2 := coordSub3D(v2, v0)
+		// Cross product e1 x e2 gives the plane normal.
+		nx := e1[1]*e2[2] - e1[2]*e2[1]
+		ny := e1[2]*e2[0] - e1[0]*e2[2]
+		nz := e1[0]*e2[1] - e1[1]*e2[0]
+		normN := math.Sqrt(nx*nx + ny*ny + nz*nz)
+		if normN == 0 {
+			continue
+		}
+		// Distance = |dot(p - v0, normal)| / |normal|.
+		d := coordSub3D(p, v0)
+		return math.Abs(d[0]*nx+d[1]*ny+d[2]*nz) / normN
+	}
+	return 0
+}
+
 // geomDistanceCalculator implements geodist.DistanceCalculator
 type geomDistanceCalculator struct {
 	updater               geodist.DistanceUpdater

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -555,6 +555,429 @@ func (u *geomMaxDistanceUpdater) FlipGeometries() {
 	u.geometricalObjOrder = -u.geometricalObjOrder
 }
 
+// MinDistance3D returns the 3D minimum distance between geometries A and B.
+// For 2D geometries, Z is treated as 0, so this degrades to 2D distance.
+// This returns a geo.EmptyGeometryError if either A or B is EMPTY.
+func MinDistance3D(a geo.Geometry, b geo.Geometry) (float64, error) {
+	if a.SRID() != b.SRID() {
+		return 0, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return 0, err
+	}
+	return minDistance3DInternal(a, b, 0, geo.EmptyBehaviorOmit)
+}
+
+// DWithin3D determines if any part of geometry A is within D units of
+// geometry B using 3D Euclidean distance.
+// DWithin3D is equivalent to ST_3DDistance(a, b) <= d.
+func DWithin3D(a geo.Geometry, b geo.Geometry, d float64) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	if d < 0 {
+		return false, pgerror.Newf(
+			pgcode.InvalidParameterValue, "dwithin distance cannot be less than zero",
+		)
+	}
+	// Use the 2D bounding box as a conservative fast-reject filter.
+	// If 2D bounding boxes don't overlap by d, the 3D distance is at
+	// least as large.
+	if !a.CartesianBoundingBox().Buffer(d, d).Intersects(b.CartesianBoundingBox()) {
+		return false, nil
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return false, err
+	}
+	dist, err := minDistance3DInternal(a, b, d, geo.EmptyBehaviorError)
+	if err != nil {
+		if geo.IsEmptyGeometryError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return dist <= d, nil
+}
+
+// normalizeFor3D drops the M dimension from inputs so that coord[2] is
+// always Z (or the coord has no Z at all). This matches PostGIS semantics:
+// M is not used in 3D distance calculations, and missing Z is treated as
+// "any value" (effectively 2D distance, since both sides degrade together).
+func normalizeFor3D(a, b geo.Geometry) (geo.Geometry, geo.Geometry, error) {
+	a, err := stripMDimension(a)
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, err
+	}
+	b, err = stripMDimension(b)
+	if err != nil {
+		return geo.Geometry{}, geo.Geometry{}, err
+	}
+	return a, b, nil
+}
+
+// stripMDimension converts an XYM geometry to XY and an XYZM geometry to
+// XYZ. Other layouts pass through unchanged.
+func stripMDimension(g geo.Geometry) (geo.Geometry, error) {
+	t, err := g.AsGeomT()
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	switch t.Layout() {
+	case geom.XYM:
+		return ForceLayout(g, geom.XY)
+	case geom.XYZM:
+		return ForceLayout(g, geom.XYZ)
+	}
+	return g, nil
+}
+
+// minDistance3DInternal finds the 3D minimum distance between two geometries.
+func minDistance3DInternal(
+	a geo.Geometry, b geo.Geometry, stopAfter float64, emptyBehavior geo.EmptyBehavior,
+) (float64, error) {
+	u := newGeomMinDistance3DUpdater(stopAfter)
+	c := &geomDistance3DCalculator{
+		updater:               u,
+		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
+	}
+	return distanceInternal(a, b, c, emptyBehavior)
+}
+
+// geomMinDistance3DUpdater finds the minimum distance using 3D geom
+// calculations. Methods return early if the minimum distance found is
+// <= stopAfter.
+type geomMinDistance3DUpdater struct {
+	currentValue float64
+	stopAfter    float64
+	coordA       geom.Coord
+	coordB       geom.Coord
+
+	geometricalObjOrder geometricalObjectsOrder
+
+	// planeDistance is set by the 3D calculator's PointIntersectsLinearRing
+	// when a point is inside a polygon's XY projection. It holds the
+	// perpendicular distance from the point to the polygon's plane.
+	// A negative value means no plane distance is pending.
+	planeDistance float64
+}
+
+var _ geodist.DistanceUpdater = (*geomMinDistance3DUpdater)(nil)
+
+func newGeomMinDistance3DUpdater(stopAfter float64) *geomMinDistance3DUpdater {
+	return &geomMinDistance3DUpdater{
+		currentValue:        math.MaxFloat64,
+		stopAfter:           stopAfter,
+		planeDistance:       -1,
+		geometricalObjOrder: geometricalObjectsNotFlipped,
+	}
+}
+
+// Distance implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistance3DUpdater) Distance() float64 {
+	return u.currentValue
+}
+
+// Update implements the geodist.DistanceUpdater interface.
+//
+// Returns true (request early exit) whenever the running minimum is at
+// or below stopAfter, regardless of whether this call updated it. This
+// lets edge-crosser-supplied candidates (which set the minimum from
+// inside ChainCrossing without being able to signal early exit through
+// the EdgeCrosser API) propagate via the next Update call.
+func (u *geomMinDistance3DUpdater) Update(aPoint geodist.Point, bPoint geodist.Point) bool {
+	a := aPoint.GeomPoint
+	b := bPoint.GeomPoint
+
+	dist := coordNorm3D(coordSub3D(a, b))
+	if dist < u.currentValue || u.coordA == nil {
+		u.currentValue = dist
+		if u.geometricalObjOrder == geometricalObjectsFlipped {
+			u.coordA = b
+			u.coordB = a
+		} else {
+			u.coordA = a
+			u.coordB = b
+		}
+	}
+	return u.currentValue <= u.stopAfter
+}
+
+// OnIntersects implements the geodist.DistanceUpdater interface.
+//
+// In the 3D case, this is only called from polygon-containment paths in
+// geodist (onPointToPolygon, onLineStringToPolygon, onPolygonToPolygon),
+// each of which calls PointIntersectsLinearRing on a polygon ring
+// immediately before. That call sets planeDistance to the perpendicular
+// distance from the point to the polygon's plane. We use that as the 3D
+// distance rather than treating containment as zero distance. Edge
+// crossings are handled separately by the 3D edge crosser, which never
+// triggers OnIntersects.
+func (u *geomMinDistance3DUpdater) OnIntersects(p geodist.Point) bool {
+	dist := u.planeDistance
+	u.planeDistance = -1
+	if dist < 0 {
+		// Should not happen: a polygon-containment path always sets
+		// planeDistance via PointIntersectsLinearRing first. Treat as
+		// zero distance so we still produce a sensible answer.
+		dist = 0
+	}
+	if dist < u.currentValue || u.coordA == nil {
+		u.currentValue = dist
+		u.coordA = p.GeomPoint
+		u.coordB = p.GeomPoint
+	}
+	return u.currentValue <= u.stopAfter
+}
+
+// IsMaxDistance implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistance3DUpdater) IsMaxDistance() bool {
+	return false
+}
+
+// FlipGeometries implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistance3DUpdater) FlipGeometries() {
+	u.geometricalObjOrder = -u.geometricalObjOrder
+}
+
+// geomDistance3DCalculator implements geodist.DistanceCalculator using
+// 3D coordinate math. Point-in-polygon and edge crossing tests remain
+// 2D (XY projection), matching PostGIS behavior for 3D geometries.
+type geomDistance3DCalculator struct {
+	updater               geodist.DistanceUpdater
+	boundingBoxIntersects bool
+}
+
+var _ geodist.DistanceCalculator = (*geomDistance3DCalculator)(nil)
+
+// DistanceUpdater implements geodist.DistanceCalculator.
+func (c *geomDistance3DCalculator) DistanceUpdater() geodist.DistanceUpdater {
+	return c.updater
+}
+
+// BoundingBoxIntersects implements geodist.DistanceCalculator.
+func (c *geomDistance3DCalculator) BoundingBoxIntersects() bool {
+	return c.boundingBoxIntersects
+}
+
+// NewEdgeCrosser implements geodist.DistanceCalculator.
+//
+// Returns a 3D-aware crosser: instead of detecting 2D intersections
+// (which are meaningless in 3D — segments may project to crossing lines
+// in XY while being far apart in Z), it computes the true 3D
+// segment-segment minimum distance and feeds the closest pair to the
+// updater. The crosser never reports a crossing, so OnIntersects is
+// never called from edge iteration.
+func (c *geomDistance3DCalculator) NewEdgeCrosser(
+	edge geodist.Edge, startPoint geodist.Point,
+) geodist.EdgeCrosser {
+	updater, ok := c.updater.(*geomMinDistance3DUpdater)
+	if !ok {
+		return nil
+	}
+	return &geom3DEdgeCrosser{
+		updater:    updater,
+		edgeV0:     edge.V0.GeomPoint,
+		edgeV1:     edge.V1.GeomPoint,
+		nextEdgeV0: startPoint.GeomPoint,
+	}
+}
+
+// PointIntersectsLinearRing implements geodist.DistanceCalculator.
+//
+// Containment for a 3D polygon is an in-plane test: the point's
+// perpendicular foot on the polygon's plane must lie inside the
+// polygon. The plane is projected orthographically into 2D by dropping
+// the coordinate axis whose component dominates the plane normal (the
+// most numerically stable shadow), and a 2D winding-number test runs
+// on the projected foot. Testing the original point's projection
+// rather than the foot's would be incorrect for tilted polygons: a
+// point's XY shadow can fall inside the polygon's XY shadow while its
+// perpendicular foot lies outside the polygon, producing a too-small
+// distance. This matches PostGIS's lw_dist3d_pt_poly /
+// project_point_on_plane / pt_in_ring_3d sequence.
+//
+// When the foot is inside the polygon, the perpendicular distance from
+// the point to the plane is stored in the updater so OnIntersects can
+// use it instead of treating containment as zero distance.
+func (c *geomDistance3DCalculator) PointIntersectsLinearRing(
+	point geodist.Point, linearRing geodist.LinearRing,
+) bool {
+	nx, ny, nz, v0, ok := ringPlaneNormal(linearRing)
+	if !ok {
+		// Degenerate ring (fewer than 3 vertices, or all collinear):
+		// fall back to the 2D XY winding check. There is no meaningful
+		// plane, so leave planeDistance unset and let OnIntersects treat
+		// containment as zero distance.
+		side := findPointSideOfLinearRing(point, linearRing)
+		return side == insideLinearRing || side == onLinearRing
+	}
+	// Project the input point perpendicularly onto the polygon's plane.
+	// foot = p - t*n, where t = ((p - v0) · n) / (n · n).
+	p := point.GeomPoint
+	d := coordSub3D(p, v0)
+	norm2 := nx*nx + ny*ny + nz*nz
+	t := (d[0]*nx + d[1]*ny + d[2]*nz) / norm2
+	foot := geom.Coord{p[0] - t*nx, p[1] - t*ny, coordGetZ(p) - t*nz}
+	if !pointInRingProjected(foot, linearRing, dominantNormalAxis(nx, ny, nz)) {
+		return false
+	}
+	if u, ok := c.updater.(*geomMinDistance3DUpdater); ok {
+		// Perpendicular distance from p to the plane: |t| * |n|.
+		u.planeDistance = math.Abs(t) * math.Sqrt(norm2)
+	}
+	return true
+}
+
+// ClosestPointToEdge implements geodist.DistanceCalculator using 3D
+// projection. The formula r = dot(AC, AB) / norm2(AB) generalizes
+// naturally to 3D.
+func (c *geomDistance3DCalculator) ClosestPointToEdge(
+	e geodist.Edge, p geodist.Point,
+) (geodist.Point, bool) {
+	if coordEqual3D(e.V0.GeomPoint, e.V1.GeomPoint) {
+		return e.V0, coordEqual3D(e.V0.GeomPoint, p.GeomPoint)
+	}
+	if coordEqual3D(p.GeomPoint, e.V0.GeomPoint) {
+		return p, true
+	}
+	if coordEqual3D(p.GeomPoint, e.V1.GeomPoint) {
+		return p, true
+	}
+
+	ac := coordSub3D(p.GeomPoint, e.V0.GeomPoint)
+	ab := coordSub3D(e.V1.GeomPoint, e.V0.GeomPoint)
+	r := coordDot3D(ac, ab) / coordNorm2_3D(ab)
+	if r < 0 || r > 1 {
+		return p, false
+	}
+	return geodist.Point{
+		GeomPoint: coordAdd3D(e.V0.GeomPoint, coordMul3D(ab, r)),
+	}, true
+}
+
+// geom3DEdgeCrosser computes the true 3D segment-segment minimum
+// distance for each edge pair and feeds the closest pair to the
+// updater. ChainCrossing always returns (false, _) so the caller never
+// invokes OnIntersects from edge iteration; the global minimum is
+// determined by the updater across all candidates.
+type geom3DEdgeCrosser struct {
+	updater    *geomMinDistance3DUpdater
+	edgeV0     geom.Coord
+	edgeV1     geom.Coord
+	nextEdgeV0 geom.Coord
+}
+
+var _ geodist.EdgeCrosser = (*geom3DEdgeCrosser)(nil)
+
+// ChainCrossing implements geodist.EdgeCrosser.
+func (c *geom3DEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.Point) {
+	nextEdgeV1 := p.GeomPoint
+	pA, pB := closest3DSegmentSegment(c.edgeV0, c.edgeV1, c.nextEdgeV0, nextEdgeV1)
+	c.nextEdgeV0 = nextEdgeV1
+	c.updater.Update(geodist.Point{GeomPoint: pA}, geodist.Point{GeomPoint: pB})
+	return false, geodist.Point{}
+}
+
+// ringPlaneNormal returns the plane normal of a linear ring computed
+// from its first non-collinear edge pair, along with the ring's first
+// vertex (a point on the plane). It returns ok=false if the ring has
+// fewer than 3 vertices or all vertices are collinear, in which case
+// the ring does not define a plane.
+func ringPlaneNormal(ring geodist.LinearRing) (nx, ny, nz float64, v0 geom.Coord, ok bool) {
+	n := ring.NumVertexes()
+	if n < 3 {
+		return 0, 0, 0, geom.Coord{}, false
+	}
+	v0 = ring.Vertex(0).GeomPoint
+	for i := 1; i < n-1; i++ {
+		v1 := ring.Vertex(i).GeomPoint
+		v2 := ring.Vertex(i + 1).GeomPoint
+		e1 := coordSub3D(v1, v0)
+		e2 := coordSub3D(v2, v0)
+		// Cross product e1 x e2 gives the plane normal.
+		nx = e1[1]*e2[2] - e1[2]*e2[1]
+		ny = e1[2]*e2[0] - e1[0]*e2[2]
+		nz = e1[0]*e2[1] - e1[1]*e2[0]
+		if nx*nx+ny*ny+nz*nz > 0 {
+			return nx, ny, nz, v0, true
+		}
+	}
+	return 0, 0, 0, geom.Coord{}, false
+}
+
+// dominantNormalAxis returns the index (0=X, 1=Y, 2=Z) of the axis
+// whose component dominates the plane normal. Dropping that axis when
+// projecting the plane to 2D maximizes the projected polygon's area,
+// which keeps the in-plane point-in-polygon test numerically stable
+// for steeply tilted polygons.
+func dominantNormalAxis(nx, ny, nz float64) int {
+	ax, ay, az := math.Abs(nx), math.Abs(ny), math.Abs(nz)
+	switch {
+	case ax >= ay && ax >= az:
+		return 0
+	case ay >= az:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// project2D returns the orthographic projection of c onto the plane
+// formed by the two coordinate axes other than drop. The two returned
+// values are c's coordinates on the kept axes, in increasing axis order
+// (e.g. drop=1 keeps X then Z).
+func project2D(c geom.Coord, drop int) (u, v float64) {
+	switch drop {
+	case 0:
+		return c[1], c[2]
+	case 1:
+		return c[0], c[2]
+	default:
+		return c[0], c[1]
+	}
+}
+
+// pointInRingProjected runs the 2D winding-number point-in-polygon
+// test on the orthographic projection of p and ring obtained by
+// dropping the coordinate at drop. Returns true when the projected
+// point lies inside or on the projected ring.
+//
+// This mirrors the structure of findPointSideOfLinearRing but operates
+// on projected (u, v) coordinates rather than raw (X, Y), so it is
+// usable on a polygon's plane regardless of orientation.
+func pointInRingProjected(p geom.Coord, ring geodist.LinearRing, drop int) bool {
+	pu, pv := project2D(p, drop)
+	windingNumber := 0
+	for edgeIdx, numEdges := 0, ring.NumEdges(); edgeIdx < numEdges; edgeIdx++ {
+		e := ring.Edge(edgeIdx)
+		v0u, v0v := project2D(e.V0.GeomPoint, drop)
+		v1u, v1v := project2D(e.V1.GeomPoint, drop)
+		if v0u == v1u && v0v == v1v {
+			continue
+		}
+		vMin := math.Min(v0v, v1v)
+		vMax := math.Max(v0v, v1v)
+		if pv > vMax || pv < vMin {
+			continue
+		}
+		// Sign of (pu, pv) relative to the directed edge from
+		// (v0u, v0v) to (v1u, v1v): >0 right, <0 left, =0 on the line.
+		sign := (pu-v0u)*(v1v-v0v) - (v1u-v0u)*(pv-v0v)
+		if sign == 0 && v0u <= pu && pu <= v1u {
+			return true
+		}
+		if sign < 0 && v0v <= pv && pv < v1v {
+			windingNumber++
+		}
+		if sign > 0 && v1v <= pv && pv < v0v {
+			windingNumber--
+		}
+	}
+	return windingNumber != 0
+}
+
 // geomDistanceCalculator implements geodist.DistanceCalculator
 type geomDistanceCalculator struct {
 	updater               geodist.DistanceUpdater

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -632,6 +632,261 @@ func TestDFullyWithin(t *testing.T) {
 	})
 }
 
+var distance3DTestCases = []struct {
+	desc                string
+	a                   string
+	b                   string
+	expectedMinDistance float64
+}{
+	{
+		"Same 3D POINTs",
+		"POINT Z(1 2 3)",
+		"POINT Z(1 2 3)",
+		0,
+	},
+	{
+		"Different 3D POINTs",
+		"POINT Z(0 0 0)",
+		"POINT Z(1 1 1)",
+		1.7320508075688772,
+	},
+	{
+		"3D POINTs differ only in Z",
+		"POINT Z(0 0 0)",
+		"POINT Z(0 0 5)",
+		5,
+	},
+	{
+		"2D POINTs (no Z)",
+		"POINT(0 0)",
+		"POINT(3 4)",
+		5,
+	},
+	{
+		"2D POINTs (no Z) different",
+		"POINT(1 1)",
+		"POINT(2 1)",
+		1,
+	},
+	{
+		"3D POINT to 3D LINESTRING",
+		"POINT Z(5 3 4)",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		5,
+	},
+	{
+		"3D POINT above 3D LINESTRING",
+		"POINT Z(0 0 10)",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		10,
+	},
+	{
+		"3D parallel LINESTRINGs",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		"LINESTRING Z(0 5 0, 10 5 0)",
+		5,
+	},
+	{
+		"3D skew LINESTRINGs",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		"LINESTRING Z(5 5 5, 5 5 10)",
+		7.0710678118654755,
+	},
+	{
+		"3D POINT to 3D POLYGON",
+		"POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0))",
+		"POINT Z(5 5 3)",
+		3,
+	},
+	{
+		"3D MULTIPOINTs",
+		"MULTIPOINT Z((0 0 0), (10 10 10))",
+		"MULTIPOINT Z((1 0 0), (0 1 0))",
+		1,
+	},
+	{
+		// 2D-projected lines cross at (5,5) but are 10 apart in Z.
+		"3D LINESTRINGs crossing in XY but offset in Z",
+		"LINESTRING Z(0 0 0, 10 10 0)",
+		"LINESTRING Z(10 0 10, 0 10 10)",
+		10,
+	},
+	{
+		// 3D segments truly cross at (5,5,5).
+		"3D LINESTRINGs truly crossing in 3D",
+		"LINESTRING Z(0 0 0, 10 10 10)",
+		"LINESTRING Z(10 0 0, 0 10 10)",
+		0,
+	},
+	{
+		// XYM coordinates: M is not Z; PostGIS treats both as 2D.
+		"XYM POINTs degrade to 2D",
+		"POINT M(0 0 100)",
+		"POINT M(0 0 0)",
+		0,
+	},
+	{
+		// XYZM: Z is index 2, M is index 3.
+		"XYZM POINTs use Z and ignore M",
+		"POINT ZM(0 0 5 100)",
+		"POINT ZM(0 0 0 0)",
+		5,
+	},
+	{
+		// Mixed XYM and XY degrades to 2D distance.
+		"XYM POINT vs XY POINT degrades to 2D",
+		"POINT M(0 0 5)",
+		"POINT(3 4)",
+		5,
+	},
+	{
+		// Polygon at z=0 with a hole; line above the hole at z=100.
+		// The line endpoints' XY projections fall inside the polygon,
+		// so 3D distance is the perpendicular drop to the polygon plane.
+		"LINESTRING above POLYGON with hole",
+		"POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0), (3 3 0, 7 3 0, 7 7 0, 3 7 0, 3 3 0))",
+		"LINESTRING Z(2 5 100, 8 5 100)",
+		100,
+	},
+	{
+		// Two disjoint LINESTRINGs in the XY plane.
+		"disjoint LINESTRINGs in XY",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		"LINESTRING Z(20 0 0, 30 0 0)",
+		10,
+	},
+	{
+		// Parallel vertical LINESTRINGs offset in X.
+		"parallel vertical LINESTRINGs",
+		"LINESTRING Z(0 0 0, 0 0 10)",
+		"LINESTRING Z(5 0 0, 5 0 10)",
+		5,
+	},
+}
+
+func TestMinDistance3D(t *testing.T) {
+	for _, tc := range distance3DTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := MinDistance3D(a, b)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expectedMinDistance, ret, 1e-10)
+
+			// Verify symmetry.
+			ret, err = MinDistance3D(b, a)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expectedMinDistance, ret, 1e-10)
+		})
+	}
+
+	t.Run("zero distance", func(t *testing.T) {
+		a := geo.MustParseGeometry("POINT Z(1 2 3)")
+		b := geo.MustParseGeometry("POINT Z(1 2 3)")
+		ret, err := MinDistance3D(a, b)
+		require.NoError(t, err)
+		require.Equal(t, 0.0, ret)
+	})
+
+	t.Run("errors for EMPTY geometries", func(t *testing.T) {
+		for _, tc := range emptyDistanceTestCases {
+			t.Run(fmt.Sprintf("%s to %s", tc.a, tc.b), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+				_, err = MinDistance3D(a, b)
+				require.Error(t, err)
+				require.True(t, geo.IsEmptyGeometryError(err))
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := MinDistance3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestDWithin3D(t *testing.T) {
+	for _, tc := range distance3DTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			// At exact distance and above, should be within.
+			for _, val := range []float64{
+				tc.expectedMinDistance,
+				tc.expectedMinDistance + 0.1,
+				tc.expectedMinDistance + 1,
+				tc.expectedMinDistance * 2,
+			} {
+				t.Run(fmt.Sprintf("within:%f", val), func(t *testing.T) {
+					dwithin, err := DWithin3D(a, b, val)
+					require.NoError(t, err)
+					require.True(t, dwithin)
+
+					dwithin, err = DWithin3D(b, a, val)
+					require.NoError(t, err)
+					require.True(t, dwithin)
+				})
+			}
+
+			// Below the distance, should not be within.
+			for _, val := range []float64{
+				tc.expectedMinDistance - 0.1,
+				tc.expectedMinDistance - 1,
+				tc.expectedMinDistance / 2,
+			} {
+				if val > 0 {
+					t.Run(fmt.Sprintf("not_within:%f", val), func(t *testing.T) {
+						dwithin, err := DWithin3D(a, b, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+
+						dwithin, err = DWithin3D(b, a, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+					})
+				}
+			}
+		})
+	}
+
+	t.Run("returns false for EMPTY geometries", func(t *testing.T) {
+		for _, tc := range emptyDistanceTestCases {
+			t.Run(fmt.Sprintf("%s to %s", tc.a, tc.b), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+				dwithin, err := DWithin3D(a, b, 0)
+				require.NoError(t, err)
+				require.False(t, dwithin)
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := DWithin3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB, 1)
+		requireMismatchingSRIDError(t, err)
+	})
+
+	t.Run("errors if distance < 0", func(t *testing.T) {
+		_, err := DWithin3D(
+			geo.MustParseGeometry("POINT Z(1 2 3)"),
+			geo.MustParseGeometry("POINT Z(4 5 6)"),
+			-0.01,
+		)
+		require.Error(t, err)
+	})
+}
+
 func TestLongestLineString(t *testing.T) {
 	for _, tc := range distanceTestCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -632,6 +632,276 @@ func TestDFullyWithin(t *testing.T) {
 	})
 }
 
+var distance3DTestCases = []struct {
+	desc                string
+	a                   string
+	b                   string
+	expectedMinDistance float64
+}{
+	{
+		"Same 3D POINTs",
+		"POINT Z(1 2 3)",
+		"POINT Z(1 2 3)",
+		0,
+	},
+	{
+		"Different 3D POINTs",
+		"POINT Z(0 0 0)",
+		"POINT Z(1 1 1)",
+		1.7320508075688772,
+	},
+	{
+		"3D POINTs differ only in Z",
+		"POINT Z(0 0 0)",
+		"POINT Z(0 0 5)",
+		5,
+	},
+	{
+		"2D POINTs (no Z)",
+		"POINT(0 0)",
+		"POINT(3 4)",
+		5,
+	},
+	{
+		"2D POINTs (no Z) different",
+		"POINT(1 1)",
+		"POINT(2 1)",
+		1,
+	},
+	{
+		"3D POINT to 3D LINESTRING",
+		"POINT Z(5 3 4)",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		5,
+	},
+	{
+		"3D POINT above 3D LINESTRING",
+		"POINT Z(0 0 10)",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		10,
+	},
+	{
+		"3D parallel LINESTRINGs",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		"LINESTRING Z(0 5 0, 10 5 0)",
+		5,
+	},
+	{
+		"3D skew LINESTRINGs",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		"LINESTRING Z(5 5 5, 5 5 10)",
+		7.0710678118654755,
+	},
+	{
+		"3D POINT to 3D POLYGON",
+		"POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0))",
+		"POINT Z(5 5 3)",
+		3,
+	},
+	{
+		// Regression test: with a 2D point inside the polygon's XY footprint,
+		// projection onto the polygon's plane must not assume the point has
+		// a Z coordinate.
+		"2D POINT inside 2D POLYGON XY footprint",
+		"POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+		"POINT(5 5)",
+		0,
+	},
+	{
+		"2D POINT outside 2D POLYGON",
+		"POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+		"POINT(15 5)",
+		5,
+	},
+	{
+		"3D MULTIPOINTs",
+		"MULTIPOINT Z((0 0 0), (10 10 10))",
+		"MULTIPOINT Z((1 0 0), (0 1 0))",
+		1,
+	},
+	{
+		// 2D-projected lines cross at (5,5) but are 10 apart in Z.
+		"3D LINESTRINGs crossing in XY but offset in Z",
+		"LINESTRING Z(0 0 0, 10 10 0)",
+		"LINESTRING Z(10 0 10, 0 10 10)",
+		10,
+	},
+	{
+		// 3D segments truly cross at (5,5,5).
+		"3D LINESTRINGs truly crossing in 3D",
+		"LINESTRING Z(0 0 0, 10 10 10)",
+		"LINESTRING Z(10 0 0, 0 10 10)",
+		0,
+	},
+	{
+		// XYM coordinates: M is not Z; PostGIS treats both as 2D.
+		"XYM POINTs degrade to 2D",
+		"POINT M(0 0 100)",
+		"POINT M(0 0 0)",
+		0,
+	},
+	{
+		// XYZM: Z is index 2, M is index 3.
+		"XYZM POINTs use Z and ignore M",
+		"POINT ZM(0 0 5 100)",
+		"POINT ZM(0 0 0 0)",
+		5,
+	},
+	{
+		// Mixed XYM and XY degrades to 2D distance.
+		"XYM POINT vs XY POINT degrades to 2D",
+		"POINT M(0 0 5)",
+		"POINT(3 4)",
+		5,
+	},
+	{
+		// Polygon at z=0 with a hole; line above the hole at z=100.
+		// The line endpoints' XY projections fall inside the polygon,
+		// so 3D distance is the perpendicular drop to the polygon plane.
+		"LINESTRING above POLYGON with hole",
+		"POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0), (3 3 0, 7 3 0, 7 7 0, 3 7 0, 3 3 0))",
+		"LINESTRING Z(2 5 100, 8 5 100)",
+		100,
+	},
+	{
+		// Two disjoint LINESTRINGs in the XY plane.
+		"disjoint LINESTRINGs in XY",
+		"LINESTRING Z(0 0 0, 10 0 0)",
+		"LINESTRING Z(20 0 0, 30 0 0)",
+		10,
+	},
+	{
+		// Parallel vertical LINESTRINGs offset in X.
+		"parallel vertical LINESTRINGs",
+		"LINESTRING Z(0 0 0, 0 0 10)",
+		"LINESTRING Z(5 0 0, 5 0 10)",
+		5,
+	},
+}
+
+func TestMinDistance3D(t *testing.T) {
+	for _, tc := range distance3DTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := MinDistance3D(a, b)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expectedMinDistance, ret, 1e-10)
+
+			// Verify symmetry.
+			ret, err = MinDistance3D(b, a)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expectedMinDistance, ret, 1e-10)
+		})
+	}
+
+	t.Run("zero distance", func(t *testing.T) {
+		a := geo.MustParseGeometry("POINT Z(1 2 3)")
+		b := geo.MustParseGeometry("POINT Z(1 2 3)")
+		ret, err := MinDistance3D(a, b)
+		require.NoError(t, err)
+		require.Equal(t, 0.0, ret)
+	})
+
+	t.Run("errors for EMPTY geometries", func(t *testing.T) {
+		for _, tc := range emptyDistanceTestCases {
+			t.Run(fmt.Sprintf("%s to %s", tc.a, tc.b), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+				_, err = MinDistance3D(a, b)
+				require.Error(t, err)
+				require.True(t, geo.IsEmptyGeometryError(err))
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := MinDistance3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestDWithin3D(t *testing.T) {
+	for _, tc := range distance3DTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			// At exact distance and above, should be within.
+			for _, val := range []float64{
+				tc.expectedMinDistance,
+				tc.expectedMinDistance + 0.1,
+				tc.expectedMinDistance + 1,
+				tc.expectedMinDistance * 2,
+			} {
+				t.Run(fmt.Sprintf("within:%f", val), func(t *testing.T) {
+					dwithin, err := DWithin3D(a, b, val)
+					require.NoError(t, err)
+					require.True(t, dwithin)
+
+					dwithin, err = DWithin3D(b, a, val)
+					require.NoError(t, err)
+					require.True(t, dwithin)
+				})
+			}
+
+			// Below the distance, should not be within.
+			for _, val := range []float64{
+				tc.expectedMinDistance - 0.1,
+				tc.expectedMinDistance - 1,
+				tc.expectedMinDistance / 2,
+			} {
+				if val > 0 {
+					t.Run(fmt.Sprintf("not_within:%f", val), func(t *testing.T) {
+						dwithin, err := DWithin3D(a, b, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+
+						dwithin, err = DWithin3D(b, a, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+					})
+				}
+			}
+		})
+	}
+
+	t.Run("returns false for EMPTY geometries", func(t *testing.T) {
+		for _, tc := range emptyDistanceTestCases {
+			t.Run(fmt.Sprintf("%s to %s", tc.a, tc.b), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+				dwithin, err := DWithin3D(a, b, 0)
+				require.NoError(t, err)
+				require.False(t, dwithin)
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := DWithin3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB, 1)
+		requireMismatchingSRIDError(t, err)
+	})
+
+	t.Run("errors if distance < 0", func(t *testing.T) {
+		_, err := DWithin3D(
+			geo.MustParseGeometry("POINT Z(1 2 3)"),
+			geo.MustParseGeometry("POINT Z(4 5 6)"),
+			-0.01,
+		)
+		require.Error(t, err)
+	})
+}
+
 func TestLongestLineString(t *testing.T) {
 	for _, tc := range distanceTestCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -423,3 +423,110 @@ SELECT st_asmvtgeom(
           1::INT4
         )::GEOMETRY
         FROM t106884;
+
+subtest st_3ddistance
+
+# Basic 3D point-to-point distance.
+query R
+SELECT ST_3DDistance('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry)
+----
+1.7320508075688772
+
+# Z-only difference.
+query R
+SELECT ST_3DDistance('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 5)'::geometry)
+----
+5
+
+# Same point returns 0.
+query R
+SELECT ST_3DDistance('POINT Z(1 2 3)'::geometry, 'POINT Z(1 2 3)'::geometry)
+----
+0
+
+# 2D geometry fallback (no Z means Z=0).
+query R
+SELECT ST_3DDistance('POINT(0 0)'::geometry, 'POINT(3 4)'::geometry)
+----
+5
+
+# 3D point to 3D linestring.
+query R
+SELECT ST_3DDistance('POINT Z(5 3 4)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry)
+----
+5
+
+# 3D point above 3D polygon (perpendicular plane distance).
+query R
+SELECT ST_3DDistance('POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0))'::geometry, 'POINT Z(5 5 3)'::geometry)
+----
+3
+
+# Empty geometry returns NULL.
+query R
+SELECT ST_3DDistance('POINT EMPTY'::geometry, 'POINT Z(1 1 1)'::geometry)
+----
+NULL
+
+# SRID mismatch errors.
+query error operation on mixed SRIDs
+SELECT ST_3DDistance(
+  ST_SetSRID('POINT Z(0 0 0)'::geometry, 4326),
+  ST_SetSRID('POINT Z(1 1 1)'::geometry, 3857)
+)
+
+subtest end
+
+subtest st_3ddwithin
+
+# Point within 3D distance.
+query B
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, 2)
+----
+true
+
+# Point not within 3D distance.
+query B
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, 1)
+----
+false
+
+# Boundary inclusive: distance equals threshold returns true.
+query B
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 0 0)'::geometry, 1)
+----
+true
+
+# 2D vs 3D difference: 2D says within, 3D says not within because Z differs.
+query BB
+SELECT
+  ST_DWithin(
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;POINT(-72.1235 42.3521 4)'),2163::int),
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;LINESTRING(-72.1260 42.45 15, -72.123 42.1546 20)'),2163::int),
+    126.8::float
+  ),
+  ST_3DDWithin(
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;POINT(-72.1235 42.3521 4)'),2163::int),
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;LINESTRING(-72.1260 42.45 15, -72.123 42.1546 20)'),2163::int),
+    126.8::float
+  )
+----
+true  false
+
+# Empty geometry returns false.
+query B
+SELECT ST_3DDWithin('GEOMETRYCOLLECTION EMPTY'::geometry, 'POINT Z(1 1 1)'::geometry, 100)
+----
+false
+
+# Negative distance errors.
+query error dwithin distance cannot be less than zero
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, -1)
+
+# _st_3ddwithin alias works.
+query B
+SELECT _ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 1)'::geometry, 1)
+----
+true
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -423,3 +423,166 @@ SELECT st_asmvtgeom(
           1::INT4
         )::GEOMETRY
         FROM t106884;
+
+subtest st_3ddistance
+
+# Basic 3D point-to-point distance.
+query R
+SELECT ST_3DDistance('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry)
+----
+1.7320508075688772
+
+# Z-only difference.
+query R
+SELECT ST_3DDistance('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 5)'::geometry)
+----
+5
+
+# Same point returns 0.
+query R
+SELECT ST_3DDistance('POINT Z(1 2 3)'::geometry, 'POINT Z(1 2 3)'::geometry)
+----
+0
+
+# 2D geometry fallback (no Z means Z=0).
+query R
+SELECT ST_3DDistance('POINT(0 0)'::geometry, 'POINT(3 4)'::geometry)
+----
+5
+
+# 3D point to 3D linestring.
+query R
+SELECT ST_3DDistance('POINT Z(5 3 4)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry)
+----
+5
+
+# 3D point above 3D polygon (perpendicular plane distance).
+query R
+SELECT ST_3DDistance('POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0))'::geometry, 'POINT Z(5 5 3)'::geometry)
+----
+3
+
+# Tilted polygon: the point's XY shadow (0.5, 0.5) lies inside the
+# polygon's XY footprint, but the point's perpendicular foot on the
+# polygon's plane (10x - z = 0) lands at (1.985, 0.5, 19.85), which is
+# outside the polygon. Containment must be tested in the polygon's
+# plane, not the XY projection; otherwise the perpendicular plane
+# distance (~1.49) is wrongly returned. The closest point is on the
+# top edge at (1, 0.5, 10), giving sqrt(0.25 + 100) ~ 10.0125.
+query R
+SELECT ST_3DDistance(
+  'POINT Z (0.5 0.5 20)'::geometry,
+  'POLYGON Z ((0 0 0, 1 0 10, 1 1 10, 0 1 0, 0 0 0))'::geometry
+)
+----
+10.012492197250394
+
+query B
+SELECT ST_3DDWithin(
+  'POINT Z (0.5 0.5 20)'::geometry,
+  'POLYGON Z ((0 0 0, 1 0 10, 1 1 10, 0 1 0, 0 0 0))'::geometry,
+  5
+)
+----
+false
+
+query B
+SELECT ST_3DDWithin(
+  'POINT Z (0.5 0.5 20)'::geometry,
+  'POLYGON Z ((0 0 0, 1 0 10, 1 1 10, 0 1 0, 0 0 0))'::geometry,
+  11
+)
+----
+true
+
+# Tilted polygon, foot lies inside: the perpendicular plane distance is
+# the correct answer. Plane 3x + 4z = 12, normal dominant on Z. The
+# foot of (2, 2, 3) lands at (1.28, 2, 2.04), inside the XY footprint.
+query R
+SELECT ST_3DDistance(
+  'POINT Z (2 2 3)'::geometry,
+  'POLYGON Z ((0 0 3, 4 0 0, 4 4 0, 0 4 3, 0 0 3))'::geometry
+)
+----
+1.2
+
+# Same polygon, but the point's XY shadow is inside the XY footprint
+# while the foot lands outside the polygon. Naively trusting the XY
+# containment check would yield the perpendicular plane distance 6.8;
+# the correct answer is the edge distance ~7.28.
+query R
+SELECT ST_3DDistance(
+  'POINT Z (2 2 10)'::geometry,
+  'POLYGON Z ((0 0 3, 4 0 0, 4 4 0, 0 4 3, 0 0 3))'::geometry
+)
+----
+7.280109889280518
+
+# Empty geometry returns NULL.
+query R
+SELECT ST_3DDistance('POINT EMPTY'::geometry, 'POINT Z(1 1 1)'::geometry)
+----
+NULL
+
+# SRID mismatch errors.
+query error operation on mixed SRIDs
+SELECT ST_3DDistance(
+  ST_SetSRID('POINT Z(0 0 0)'::geometry, 4326),
+  ST_SetSRID('POINT Z(1 1 1)'::geometry, 3857)
+)
+
+subtest end
+
+subtest st_3ddwithin
+
+# Point within 3D distance.
+query B
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, 2)
+----
+true
+
+# Point not within 3D distance.
+query B
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, 1)
+----
+false
+
+# Boundary inclusive: distance equals threshold returns true.
+query B
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 0 0)'::geometry, 1)
+----
+true
+
+# 2D vs 3D difference: 2D says within, 3D says not within because Z differs.
+query BB
+SELECT
+  ST_DWithin(
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;POINT(-72.1235 42.3521 4)'),2163::int),
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;LINESTRING(-72.1260 42.45 15, -72.123 42.1546 20)'),2163::int),
+    126.8::float
+  ),
+  ST_3DDWithin(
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;POINT(-72.1235 42.3521 4)'),2163::int),
+    ST_Transform(ST_GeomFromEWKT('SRID=4326;LINESTRING(-72.1260 42.45 15, -72.123 42.1546 20)'),2163::int),
+    126.8::float
+  )
+----
+true  false
+
+# Empty geometry returns false.
+query B
+SELECT ST_3DDWithin('GEOMETRYCOLLECTION EMPTY'::geometry, 'POINT Z(1 1 1)'::geometry, 100)
+----
+false
+
+# Negative distance errors.
+query error dwithin distance cannot be less than zero
+SELECT ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, -1)
+
+# _st_3ddwithin alias works.
+query B
+SELECT _ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 1)'::geometry, 1)
+----
+true
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2932,6 +2932,9 @@ var builtinOidsArray = []string{
 	2977: `gcd(a: decimal, b: decimal) -> decimal`,
 	2978: `lcm(a: decimal, b: decimal) -> decimal`,
 	2979: `st_distancespheroid(geometry_a: geometry, geometry_b: geometry, spheroid: string) -> float`,
+	2980: `st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
+	2981: `st_3ddistance(geometry_a: geometry, geometry_b: geometry) -> float`,
+	2982: `_st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2905,6 +2905,9 @@ var builtinOidsArray = []string{
 	2950: `pg_get_statisticsobjdef(statobj_oid: oid) -> string`,
 	2951: `crdb_internal.zone_config_for_key(key: bytes) -> jsonb`,
 	2952: `crdb_internal.zone_config_span_end(key: bytes) -> bytes`,
+	2953: `st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
+	2954: `st_3ddistance(geometry_a: geometry, geometry_b: geometry) -> float`,
+	2955: `_st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3146,6 +3146,83 @@ The requested number of points must be not larger than 65336.`,
 		defProps(),
 		lengthOverloadGeometry1,
 	),
+	"st_3ddistance": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MinDistance3D(a.Geometry, b.Geometry)
+				if err != nil {
+					if geo.IsEmptyGeometryError(err) {
+						return tree.DNull, nil
+					}
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the 3-dimensional minimum Cartesian distance between two geometries. " +
+					"If either geometry has no Z component, this is equivalent to ST_Distance.",
+			},
+			volatility.Immutable,
+		),
+	),
+	"st_3ddwithin": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "geometry_a", Typ: types.Geometry},
+				{Name: "geometry_b", Typ: types.Geometry},
+				{Name: "distance", Typ: types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(
+				_ context.Context, _ *eval.Context, args tree.Datums,
+			) (tree.Datum, error) {
+				a := tree.MustBeDGeometry(args[0])
+				b := tree.MustBeDGeometry(args[1])
+				dist := tree.MustBeDFloat(args[2])
+				ret, err := geomfn.DWithin3D(a.Geometry, b.Geometry, float64(dist))
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if any of geometry_a is within distance units of geometry_b, " +
+					"using 3D Euclidean distance.",
+			}.String(),
+			Volatility: volatility.Immutable,
+		},
+	),
+	"_st_3ddwithin": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "geometry_a", Typ: types.Geometry},
+				{Name: "geometry_b", Typ: types.Geometry},
+				{Name: "distance", Typ: types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(
+				_ context.Context, _ *eval.Context, args tree.Datums,
+			) (tree.Datum, error) {
+				a := tree.MustBeDGeometry(args[0])
+				b := tree.MustBeDGeometry(args[1])
+				dist := tree.MustBeDFloat(args[2])
+				ret, err := geomfn.DWithin3D(a.Geometry, b.Geometry, float64(dist))
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if any of geometry_a is within distance units of geometry_b, " +
+					"using 3D Euclidean distance. This variant does not utilize any spatial index.",
+			}.String(),
+			Volatility: volatility.Immutable,
+		},
+	),
 	"st_3dlength": makeBuiltin(
 		defProps(),
 		length3DOverloadGeometry1,


### PR DESCRIPTION
These PostGIS-compatible functions compute 3D Euclidean distance between geometries. ST_3DDistance returns the minimum 3D distance, and ST_3DDWithin returns whether two geometries are within a given 3D distance of each other. Unlike their 2D counterparts, Z coordinates participate in the distance calculation.

The implementation reuses the existing 2D distance infrastructure (geodist.ShapeDistance, geometry iterators, shape wrappers) by providing a 3D-aware DistanceCalculator that uses 3D coordinate math for point projection and distance computation. For polygons, when a point's XY projection falls inside the polygon, the perpendicular distance to the polygon's plane is computed correctly.

For geometries without Z coordinates, Z is treated as 0, so the functions degrade to 2D distance, matching PostGIS semantics.

Also registers the _st_3ddwithin alias for PostgreSQL compatibility.

Resolves: #60862
Resolves: #60863
TREQ-1382

Release note (sql change): Added support for the ST_3DDistance and ST_3DDWithin geospatial functions, which compute minimum distance and within-distance checks using 3D Euclidean distance. These functions consider the Z coordinate of geometries, unlike their 2D counterparts ST_Distance and ST_DWithin.