### PR TITLE
admission: rename tenant to group 

### DIFF
--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -61,7 +61,7 @@
 // The interfaces involved:
 // - requester: handles all requests for a particular WorkKind. Implemented by
 //   WorkQueue. The requester implementation is responsible for controlling
-//   the admission order within a WorkKind based on tenant fairness,
+//   the admission order within a WorkKind based on group fairness,
 //   importance of work etc.
 // - granter: the counterpart to requester which grants admission tokens or
 //   slots. The implementations are slotGranter, tokenGranter,
@@ -131,17 +131,17 @@ import (
 )
 
 // burstQualification is an optional behavior of certain WorkQueues (which
-// implement requester), that differentiate between tenants that are qualified
+// implement requester), that differentiate between groups that are qualified
 // to burst (in their token consumption) and those that are not. This is a
-// dynamic attribute of a tenant, based on token consumption history
-// maintained in the WorkQueue. The ordering of tenants is also affected in
-// that burstable tenants are ordered before non-burstable tenants.
+// dynamic attribute of a group, based on token consumption history
+// maintained in the WorkQueue. The ordering of groups is also affected in
+// that burstable groups are ordered before non-burstable groups.
 type burstQualification uint8
 
 const (
 	// Order matters here. A higher priority burstQualification must use a
 	// lower ordinal than a lower priority burstQualification (see
-	// tenantHeap.Less for a place where this invariant is relied on).
+	// groupHeap.Less for a place where this invariant is relied on).
 	canBurst burstQualification = iota
 	noBurst
 	numBurstQualifications

--- a/pkg/util/admission/cpu_time_token_burst.go
+++ b/pkg/util/admission/cpu_time_token_burst.go
@@ -7,25 +7,25 @@ package admission
 
 import "github.com/cockroachdb/redact"
 
-// cpuTimeBurstBucket is a per-tenant token bucket that determines whether a
-// tenant qualifies for burst priority. If a tenant qualifies, two things
+// cpuTimeBurstBucket is a per-group token bucket that determines whether a
+// group qualifies for burst priority. If a group qualifies, two things
 // happen:
 //
-//  1. In the WorkQueue, its work sorts above the work of tenants that don't
+//  1. In the WorkQueue, its work sorts above the work of groups that don't
 //     qualify for burst priority.
-//  2. It has access to more CPU time tokens than tenants that don't qualify
+//  2. It has access to more CPU time tokens than groups that don't qualify
 //     (see cpu_time_token_granter.go for more).
 //
-// These two things are related. Since canBurst tenants have access to more
-// CPU time than noBurst tenants, it is important that work from a
-// canBurst tenant always sorts before work from a noBurst tenant -- else
+// These two things are related. Since canBurst groups have access to more
+// CPU time than noBurst groups, it is important that work from a
+// canBurst group always sorts before work from a noBurst group -- else
 // available capacity is left on the table.
 //
 // The bucket works as follows:
 //   - Tokens are added periodically via refill(), called by
 //     cpuTimeTokenAllocator.
 //   - Tokens are deducted when work is admitted, etc. via adjust().
-//   - A tenant qualifies for burst (canBurst) when bucket is > 90% full.
+//   - A group qualifies for burst (canBurst) when bucket is > 90% full.
 //   - The bucket can go negative (down to -capacity/4) to allow recovery.
 //
 // The bucket capacity is derived from the noBurst refill rate in
@@ -43,14 +43,14 @@ type cpuTimeBurstBucket struct {
 }
 
 func (m *cpuTimeBurstBucket) init(capacity int64, disabled bool) {
-	// The bucket of a new tenant is inited full. This implies that
-	// a tenant can burst when its work first appears on a KV node.
+	// The bucket of a new group is inited full. This implies that
+	// a group can burst when its work first appears on a KV node.
 	// After <= 1s, the bucket state should track the usage of the
 	// tenant accurately.
 	*m = cpuTimeBurstBucket{tokens: capacity, capacity: capacity, disabled: disabled}
 }
 
-// burstQualification returns whether this tenant qualifies for burst
+// burstQualification returns whether this group qualifies for burst
 // priority. See the comments above cpuTimeBurstBucket for more.
 func (m *cpuTimeBurstBucket) burstQualification() burstQualification {
 	if m.disabled {
@@ -81,7 +81,7 @@ func (m *cpuTimeBurstBucket) adjust(delta int64) {
 
 // refill adds tokens to the bucket and updates capacity. This is called
 // periodically by cpuTimeTokenAllocator (every 1ms). The token count is capped
-// at capacity and floored at -capacity/4. The negative floor allows tenants
+// at capacity and floored at -capacity/4. The negative floor allows groups
 // that have gone into debt (consumed more than their share) to recover over
 // time rather than being disqualified from bursting for arbitrarily long periods
 // of time.

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -249,7 +249,7 @@ var _ cpuTimeTokenAllocatorI = &cpuTimeTokenAllocator{}
 type cpuTimeTokenAllocator struct {
 	granter *cpuTimeTokenGranter
 	// queues holds references to WorkQueues for each resource tier. Used to
-	// refill per-tenant burst buckets that determine queue priority ordering.
+	// refill per-group burst buckets that determine queue priority ordering.
 	// See cpu_time_token_burst.go for more.
 	queues   [numResourceTiers]workQueueIForAllocator
 	settings *cluster.Settings
@@ -351,7 +351,7 @@ func computeMinimums(r rates) minimums {
 // capacities. allocateTokens adds tokens evenly among the expected remaining
 // ticks in the interval.
 // INVARIANT: remainingTicks >= 1.
-// TODO(josh): Expand to cover tenant-specific token buckets too.
+// TODO(josh): Expand to cover group-specific token buckets too.
 func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval int64) {
 	allocateFunc := func(total int64, allocated int64, remainingTicks int64) (toAllocate int64) {
 		remainingTokens := total - allocated
@@ -392,9 +392,9 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	// in CC, we scrape metrics once every 10s.
 	a.refill(allocations, bucketCapacities, bucketMinimums, false /* updateMetrics */)
 
-	// Refill per-tenant burst buckets in the WorkQueues. The burst bucket
+	// Refill per-group burst buckets in the WorkQueues. The burst bucket
 	// refill rate and capacity should be 1/4th of the noBurst refill rate
-	// and capacity (for the corresponding resource tier). If a tenant's
+	// and capacity (for the corresponding resource tier). If a group's
 	// bucket is mostly full, we allow it to get priority in the queue (see
 	// cpu_time_token_burst.go for more). With cluster settings at their
 	// default values, this implies that an application tenant can burst,
@@ -455,7 +455,7 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 	a.refill(deltaRefillRates, bucketCapacities, bucketMinimums, true /* updateMetrics */)
 	a.refillRates = newRefillRates
 
-	// Apply the delta to the per-tenant burst buckets also.
+	// Apply the delta to the per-group burst buckets also.
 	for resourceTier := range numResourceTiers {
 		toAdd := deltaRefillRates[resourceTier][noBurst] / 4
 		burstCapacity := bucketCapacities[resourceTier][noBurst] / 4

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -176,7 +176,7 @@ func (coord *CPUGrantCoordinators) GetSQLWorkQueue(workKind WorkKind) *WorkQueue
 // CPUGrantCoordinators manages.
 func (coord *CPUGrantCoordinators) SetTenantWeights(weights map[uint64]uint32) {
 	coord.slotsCoord.GetWorkQueue(KVWork).SetTenantWeights(weights)
-	coord.cpuTimeCoord.setTenantWeights(weights)
+	coord.cpuTimeCoord.setGroupWeights(weights)
 }
 
 // GetRunnableCountCallback returns a callback of type
@@ -237,7 +237,7 @@ func makeCPUTimeTokenGrantCoordinator(
 	for tier := resourceTier(0); tier < numResourceTiers; tier++ {
 		opts := makeWorkQueueOptions(KVWork)
 		opts.mode = usesCPUTimeTokens
-		opts.perTenantAggMetrics = &tenantAggMetrics{
+		opts.perGroupAggMetrics = &groupAggMetrics{
 			admittedCount:  metrics.AdmittedCountPerTenant[tier],
 			waitTimeNanos:  metrics.WaitTimeNanosPerTenant[tier],
 			tokensUsed:     metrics.TokensUsedPerTenant[tier],
@@ -288,7 +288,7 @@ func (coord *cpuTimeTokenGrantCoordinator) getWorkQueue(tier resourceTier) *Work
 	return coord.queues[tier].(*WorkQueue)
 }
 
-func (coord *cpuTimeTokenGrantCoordinator) setTenantWeights(weights map[uint64]uint32) {
+func (coord *cpuTimeTokenGrantCoordinator) setGroupWeights(weights map[uint64]uint32) {
 	for tier := range coord.queues {
 		coord.queues[tier].(*WorkQueue).SetTenantWeights(weights)
 	}

--- a/pkg/util/admission/cpu_time_token_metrics.go
+++ b/pkg/util/admission/cpu_time_token_metrics.go
@@ -136,7 +136,7 @@ type cpuTimeTokenMetrics struct {
 	WaitTimeNanosPerTenant [numResourceTiers]*aggmetric.AggCounter
 
 	// TokensUsedPerTenant and TokensReturnedPerTenant track per-tenant
-	// token consumption and returns via adjustTenantUsedLocked. Together
+	// token consumption and returns via adjustGroupUsedLocked. Together
 	// they give per-tenant visibility into token flow.
 	TokensUsedPerTenant     [numResourceTiers]*aggmetric.AggCounter
 	TokensReturnedPerTenant [numResourceTiers]*aggmetric.AggCounter

--- a/pkg/util/admission/elastic_cpu_work_queue.go
+++ b/pkg/util/admission/elastic_cpu_work_queue.go
@@ -48,7 +48,7 @@ type elasticCPUInternalWorkQueue interface {
 	requester
 	Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error)
 	SetTenantWeights(tenantWeights map[uint64]uint32)
-	adjustGroupUsed(tenantID roachpb.TenantID, additionalUsed int64)
+	adjustGroupUsed(groupID roachpb.TenantID, additionalUsed int64)
 }
 
 func makeElasticCPUWorkQueue(

--- a/pkg/util/admission/elastic_cpu_work_queue.go
+++ b/pkg/util/admission/elastic_cpu_work_queue.go
@@ -48,7 +48,7 @@ type elasticCPUInternalWorkQueue interface {
 	requester
 	Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error)
 	SetTenantWeights(tenantWeights map[uint64]uint32)
-	adjustTenantUsed(tenantID roachpb.TenantID, additionalUsed int64)
+	adjustGroupUsed(tenantID roachpb.TenantID, additionalUsed int64)
 }
 
 func makeElasticCPUWorkQueue(
@@ -106,7 +106,7 @@ func (e *ElasticCPUWorkQueue) AdmittedWorkDone(h *ElasticCPUWorkHandle) {
 
 	e.metrics.PreWorkNanos.Inc(h.preWork.Nanoseconds())
 	_, difference := h.overLimitInner()
-	e.workQueue.adjustTenantUsed(h.tenantID, difference.Nanoseconds())
+	e.workQueue.adjustGroupUsed(h.tenantID, difference.Nanoseconds())
 	if h.bypassedAdmission {
 		e.metrics.bypassedAdmissionCumNanos.Add(difference.Nanoseconds())
 	}

--- a/pkg/util/admission/elastic_cpu_work_queue_test.go
+++ b/pkg/util/admission/elastic_cpu_work_queue_test.go
@@ -167,11 +167,11 @@ func (t *testElasticCPUInternalWorkQueue) SetTenantWeights(tenantWeights map[uin
 	panic("unimplemented")
 }
 
-func (t *testElasticCPUInternalWorkQueue) adjustTenantUsed(
+func (t *testElasticCPUInternalWorkQueue) adjustGroupUsed(
 	tenantID roachpb.TenantID, additionalUsed int64,
 ) {
 	if !t.disabled {
-		fmt.Fprintf(&t.buf, "adjust-tenant-used: tenant=%s additional-used=%s",
+		fmt.Fprintf(&t.buf, "adjust-group-used: tenant=%s additional-used=%s",
 			tenantID.String(), time.Duration(additionalUsed).String())
 	}
 }

--- a/pkg/util/admission/elastic_cpu_work_queue_test.go
+++ b/pkg/util/admission/elastic_cpu_work_queue_test.go
@@ -168,11 +168,11 @@ func (t *testElasticCPUInternalWorkQueue) SetTenantWeights(tenantWeights map[uin
 }
 
 func (t *testElasticCPUInternalWorkQueue) adjustGroupUsed(
-	tenantID roachpb.TenantID, additionalUsed int64,
+	groupID roachpb.TenantID, additionalUsed int64,
 ) {
 	if !t.disabled {
-		fmt.Fprintf(&t.buf, "adjust-group-used: tenant=%s additional-used=%s",
-			tenantID.String(), time.Duration(additionalUsed).String())
+		fmt.Fprintf(&t.buf, "adjust-group-used: group=%s additional-used=%s",
+			groupID.String(), time.Duration(additionalUsed).String())
 	}
 }
 

--- a/pkg/util/admission/replicated_write_admission_test.go
+++ b/pkg/util/admission/replicated_write_admission_test.go
@@ -311,28 +311,28 @@ func printWorkQueue(q *WorkQueue) string {
 	var buf strings.Builder
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	buf.WriteString(fmt.Sprintf("len(tenant-heap)=%d", len(q.mu.tenantHeap)))
-	if len(q.mu.tenantHeap) > 0 {
-		buf.WriteString(fmt.Sprintf(" top-tenant=t%d", q.mu.tenantHeap[0].id))
+	buf.WriteString(fmt.Sprintf("len(group-heap)=%d", len(q.mu.groupHeap)))
+	if len(q.mu.groupHeap) > 0 {
+		buf.WriteString(fmt.Sprintf(" top-group=t%d", q.mu.groupHeap[0].id))
 	}
 	var ids []uint64
-	for id := range q.mu.tenants {
+	for id := range q.mu.groups {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	for _, id := range ids {
-		tenant := q.mu.tenants[id]
-		buf.WriteString(fmt.Sprintf("\n tenant=t%d weight=%d fifo-threshold=%s used=%s",
-			tenant.id,
-			tenant.weight,
-			admissionpb.WorkPriority(tenant.fifoPriorityThreshold),
-			printTrimmedBytes(int64(tenant.used)),
+		group := q.mu.groups[id]
+		buf.WriteString(fmt.Sprintf("\n group=t%d weight=%d fifo-threshold=%s used=%s",
+			group.id,
+			group.weight,
+			admissionpb.WorkPriority(group.fifoPriorityThreshold),
+			printTrimmedBytes(int64(group.used)),
 		))
-		if len(tenant.waitingWorkHeap) > 0 {
+		if len(group.waitingWorkHeap) > 0 {
 			buf.WriteString("\n")
 
-			for i := range tenant.waitingWorkHeap {
-				w := tenant.waitingWorkHeap[i]
+			for i := range group.waitingWorkHeap {
+				w := group.waitingWorkHeap[i]
 				if i != 0 {
 					buf.WriteString("\n")
 				}

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue
@@ -22,9 +22,9 @@ id 2: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 3, w: 1, fifo: -128
- tenant-id: 54 used: 8, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 3, w: 1, fifo: -128
+ group-id: 54 used: 8, w: 1, fifo: -128
 burst-buckets: t53=fullness=0.0% tokens=-3 capacity=0 qual=no_burst t54=fullness=0.0% tokens=-8 capacity=0 qual=no_burst
 
 # requested-count at admit time was 3. cpu-time below is 1. This
@@ -42,9 +42,9 @@ returnGrant 2
 # tenant with tenant ID 53.
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
- tenant-id: 54 used: 8, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: 54 used: 8, w: 1, fifo: -128
 burst-buckets: t53=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t54=fullness=0.0% tokens=-8 capacity=0 qual=no_burst
 
 # In this case, measured CPU usage was more than predicted CPU usage.
@@ -56,9 +56,9 @@ tookWithoutPermission 7
 # Same here. Used is adjusted, to reflect actual usage.
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
- tenant-id: 54 used: 15, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: 54 used: 15, w: 1, fifo: -128
 burst-buckets: t53=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t54=fullness=0.0% tokens=-15 capacity=0 qual=no_burst
 
 ###
@@ -96,9 +96,9 @@ id 1000: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
- tenant-id: 54 used: 101, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: 54 used: 101, w: 1, fifo: -128
 burst-buckets: t53=fullness=99.0% tokens=99 capacity=100 qual=can_burst t54=fullness=-1.0% tokens=-1 capacity=100 qual=no_burst
 
 set-try-get-return-value v=false
@@ -144,7 +144,7 @@ tryGet: input can_burst, returning false
 # See Less implementation in WorkQueue. We clear used to be sure
 # that the reason the WorkQueue sorts the heap the way it does below
 # is the burstQualifications.
-gc-tenants-and-reset-used
+gc-groups-and-reset-used
 ----
 
 granted chain-id=1
@@ -201,9 +201,9 @@ refill-burst-buckets to-add=100 capacity=100
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 1, w: 1, fifo: -128
- tenant-id: 2 used: 1, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
 burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 # Since both burst buckets are full, both tenants can burst.
@@ -214,9 +214,9 @@ id 3: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 2, w: 1, fifo: -128
- tenant-id: 2 used: 1, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 2, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
 burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=4 tenant=2 requested-count=1
@@ -226,9 +226,9 @@ id 4: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 2, w: 1, fifo: -128
- tenant-id: 2 used: 2, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 2, w: 1, fifo: -128
+ group-id: 2 used: 2, w: 1, fifo: -128
 burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # Bucket started at 100 tokens. First call to Admit removed 1 token.
@@ -241,9 +241,9 @@ id 5: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 9, w: 1, fifo: -128
- tenant-id: 2 used: 2, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 9, w: 1, fifo: -128
+ group-id: 2 used: 2, w: 1, fifo: -128
 burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # Bucket started at 100 tokens. First call to Admit removed 1 token.
@@ -257,9 +257,9 @@ id 6: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 9, w: 1, fifo: -128
- tenant-id: 2 used: 12, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 9, w: 1, fifo: -128
+ group-id: 2 used: 12, w: 1, fifo: -128
 burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
 
 # 100-1-7-1 = 91 tokens in the bucket. So tenant 1 can burst still.
@@ -270,9 +270,9 @@ id 7: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 10, w: 1, fifo: -128
- tenant-id: 2 used: 12, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 2 used: 12, w: 1, fifo: -128
 burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
 
 # 100-1-10-1 = 88. Tenant 2 cannot burst this time.
@@ -283,9 +283,9 @@ id 8: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 10, w: 1, fifo: -128
- tenant-id: 2 used: 13, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 2 used: 13, w: 1, fifo: -128
 burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 # 100-1-7-1-1 = 90. So this call to Admit, tenant 1 can burst, but
@@ -297,9 +297,9 @@ id 9: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 11, w: 1, fifo: -128
- tenant-id: 2 used: 13, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 11, w: 1, fifo: -128
+ group-id: 2 used: 13, w: 1, fifo: -128
 burst-buckets: t1=fullness=90.0% tokens=90 capacity=100 qual=no_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 admit id=10 tenant=1 requested-count=1
@@ -309,9 +309,9 @@ id 10: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 12, w: 1, fifo: -128
- tenant-id: 2 used: 13, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 12, w: 1, fifo: -128
+ group-id: 2 used: 13, w: 1, fifo: -128
 burst-buckets: t1=fullness=89.0% tokens=89 capacity=100 qual=no_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 # Fill to full again. Both tenants thus can burst.
@@ -344,9 +344,9 @@ refill-burst-buckets to-add=10 capacity=100
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 100000013, w: 1, fifo: -128
- tenant-id: 2 used: 14, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 100000013, w: 1, fifo: -128
+ group-id: 2 used: 14, w: 1, fifo: -128
 burst-buckets: t1=fullness=-25.0% tokens=-25 capacity=100 qual=no_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 refill-burst-buckets to-add=116 capacity=100
@@ -354,9 +354,9 @@ refill-burst-buckets to-add=116 capacity=100
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 100000013, w: 1, fifo: -128
- tenant-id: 2 used: 14, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 100000013, w: 1, fifo: -128
+ group-id: 2 used: 14, w: 1, fifo: -128
 burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=14 tenant=1 requested-count=1
@@ -391,9 +391,9 @@ id 16: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 101000015, w: 1, fifo: -128
- tenant-id: 2 used: 14, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 101000015, w: 1, fifo: -128
+ group-id: 2 used: 14, w: 1, fifo: -128
 burst-buckets: t1=fullness=-999900.0% tokens=-999900 capacity=100 qual=no_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 work-done id=16 cpu-time=1
@@ -402,9 +402,9 @@ returnGrant 999999
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 100000016, w: 1, fifo: -128
- tenant-id: 2 used: 14, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 100000016, w: 1, fifo: -128
+ group-id: 2 used: 14, w: 1, fifo: -128
 burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=17 tenant=1 requested-count=10
@@ -424,9 +424,9 @@ refill-burst-buckets to-add=20 capacity=20
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 100000027, w: 1, fifo: -128
- tenant-id: 2 used: 14, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 100000027, w: 1, fifo: -128
+ group-id: 2 used: 14, w: 1, fifo: -128
 burst-buckets: t1=fullness=100.0% tokens=20 capacity=20 qual=can_burst t2=fullness=100.0% tokens=20 capacity=20 qual=can_burst
 
 admit id=19 tenant=1 requested-count=2
@@ -472,8 +472,8 @@ refill-burst-buckets to-add=100 capacity=100
 # and adjust the burst bucket state.
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
 burst-buckets: t53=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 admit id=2 tenant=53 requested-count=5
@@ -483,8 +483,8 @@ id 2: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 6, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 6, w: 1, fifo: -128
 burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=can_burst
 
 set-try-get-return-value v=false
@@ -496,8 +496,8 @@ tryGet: input can_burst, returning false
 
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 6, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: 53
+ group-id: 53 used: 6, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=can_burst
 
 granted chain-id=1
@@ -508,8 +508,8 @@ granted: returned 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 7, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 7, w: 1, fifo: -128
 burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=can_burst
 
 work-done id=1 cpu-time=2
@@ -518,8 +518,8 @@ tookWithoutPermission 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 8, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 8, w: 1, fifo: -128
 burst-buckets: t53=fullness=92.0% tokens=92 capacity=100 qual=can_burst
 
 work-done id=2 cpu-time=3
@@ -528,8 +528,8 @@ returnGrant 2
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 6, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 6, w: 1, fifo: -128
 burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=can_burst
 
 admit id=4 tenant=53 requested-count=1 bypass
@@ -539,8 +539,8 @@ id 4: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 7, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 7, w: 1, fifo: -128
 burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=can_burst
 
 set-try-get-return-value v=false
@@ -556,8 +556,8 @@ id 5: admit failed
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 7, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 7, w: 1, fifo: -128
 burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=can_burst
 
 # Check the transition to no burst.
@@ -576,6 +576,6 @@ id 7: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 13, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 13, w: 1, fifo: -128
 burst-buckets: t53=fullness=87.0% tokens=87 capacity=100 qual=no_burst

--- a/pkg/util/admission/testdata/elastic_cpu_work_queue
+++ b/pkg/util/admission/testdata/elastic_cpu_work_queue
@@ -63,7 +63,7 @@ handle:      50ms
 admitted-work-done running=10ms allotted=50ms
 ----
 granter:    return-grant=40ms
-work-queue: adjust-tenant-used: tenant=system additional-used=-40ms
+work-queue: adjust-group-used: tenant=system additional-used=-40ms
 metrics:    acquired=50ms returned=40ms max-available=8s
 
 # Repeat the same but this time simulate what happens if we've taken less than
@@ -83,7 +83,7 @@ handle:      50ms
 admitted-work-done running=70ms allotted=50ms
 ----
 granter:    took-without-permission=20ms
-work-queue: adjust-tenant-used: tenant=system additional-used=20ms
+work-queue: adjust-group-used: tenant=system additional-used=20ms
 metrics:    acquired=70ms returned=0s max-available=8s
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/elastic_cpu_work_queue
+++ b/pkg/util/admission/testdata/elastic_cpu_work_queue
@@ -63,7 +63,7 @@ handle:      50ms
 admitted-work-done running=10ms allotted=50ms
 ----
 granter:    return-grant=40ms
-work-queue: adjust-group-used: tenant=system additional-used=-40ms
+work-queue: adjust-group-used: group=system additional-used=-40ms
 metrics:    acquired=50ms returned=40ms max-available=8s
 
 # Repeat the same but this time simulate what happens if we've taken less than
@@ -83,7 +83,7 @@ handle:      50ms
 admitted-work-done running=70ms allotted=50ms
 ----
 granter:    took-without-permission=20ms
-work-queue: adjust-group-used: tenant=system additional-used=20ms
+work-queue: adjust-group-used: group=system additional-used=20ms
 metrics:    acquired=70ms returned=0s max-available=8s
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/class_segmentation
+++ b/pkg/util/admission/testdata/replicated_write_admission/class_segmentation
@@ -23,11 +23,11 @@ admit tenant=t1 pri=high-pri create-time=2us size=1B range=r1 log-position=4/21
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=high-pri create-time=2µs size=1B range=r1 log-position=4/21]
-[elastic work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[elastic work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=low-pri create-time=1µs size=1B range=r1 log-position=4/20]
 
 # Produce 1B worth of regular tokens and verify that it only admits work
@@ -44,10 +44,10 @@ admitted [tenant=t1 pri=high-pri create-time=2µs size=1B range=r1 log-position=
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=0
- tenant=t1 weight=1 fifo-threshold=low-pri used=1B
-[elastic work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=0
+ group=t1 weight=1 fifo-threshold=low-pri used=1B
+[elastic work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=low-pri create-time=1µs size=1B range=r1 log-position=4/20]
 
 # Do the same for elastic tokens.

--- a/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_different_range
+++ b/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_different_range
@@ -23,11 +23,11 @@ admit tenant=t1 pri=normal-pri create-time=1us size=1B range=r2 log-position=4/2
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1µs size=1B range=r2 log-position=4/21]
   [1: pri=normal-pri create-time=5µs size=1B range=r1 log-position=4/20]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Produce 1B worth of regular tokens.
 granter class=regular adjust-tokens=+1B
@@ -45,9 +45,9 @@ admitted [tenant=t1 pri=normal-pri create-time=1µs size=1B range=r2 log-positio
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=5µs size=1B range=r1 log-position=4/20]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_same_range
+++ b/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_same_range
@@ -22,11 +22,11 @@ admit tenant=t1 pri=normal-pri create-time=1us size=1B range=r1 log-position=4/2
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=5µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=5.001µs size=1B range=r1 log-position=4/21]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Produce 1B worth of regular tokens.
 granter class=regular adjust-tokens=+1B
@@ -44,9 +44,9 @@ admitted [tenant=t1 pri=normal-pri create-time=5µs size=1B range=r1 log-positio
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=5.001µs size=1B range=r1 log-position=4/21]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/high_pri_low_position
+++ b/pkg/util/admission/testdata/replicated_write_admission/high_pri_low_position
@@ -21,11 +21,11 @@ admit tenant=t1 pri=high-pri create-time=1.002us size=1B range=r1 log-position=4
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=high-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
   [1: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Produce 1B worth of regular tokens.
 granter class=regular adjust-tokens=+1B
@@ -43,9 +43,9 @@ admitted [tenant=t1 pri=high-pri create-time=1.002µs size=1B range=r1 log-posit
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/overview
+++ b/pkg/util/admission/testdata/replicated_write_admission/overview
@@ -17,10 +17,10 @@ admit tenant=t1 pri=normal-pri create-time=1.001us size=1B range=r1 log-position
 print
 ----
 physical-stats: work-count=1 written-bytes=1B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Admit a second request. Since there's already a request waiting, we don't get
 # the fast path.
@@ -31,11 +31,11 @@ admit tenant=t1 pri=normal-pri create-time=1.002us size=1B range=r1 log-position
 print
 ----
 physical-stats: work-count=2 written-bytes=1B ingested-bytes=1B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21 ingested ]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Produce 2B worth of regular tokens.
 granter class=regular adjust-tokens=+2B
@@ -63,8 +63,8 @@ granter adjust-tokens=+0B
 print
 ----
 physical-stats: work-count=2 written-bytes=1B ingested-bytes=1B
-[regular work queue]: len(tenant-heap)=0
- tenant=t1 weight=1 fifo-threshold=low-pri used=2B
-[elastic work queue]: len(tenant-heap)=0
+[regular work queue]: len(group-heap)=0
+ group=t1 weight=1 fifo-threshold=low-pri used=2B
+[elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/tenant_fairness
+++ b/pkg/util/admission/testdata/replicated_write_admission/tenant_fairness
@@ -25,14 +25,14 @@ admit tenant=t2 pri=normal-pri create-time=1.002us size=1B range=r2 log-position
 print
 ----
 physical-stats: work-count=4 written-bytes=4B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=2 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=2 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
- tenant=t2 weight=1 fifo-threshold=low-pri used=0B
+ group=t2 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r2 log-position=5/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r2 log-position=5/21]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Produce 2B worth of regular tokens.
 granter class=regular adjust-tokens=+2B
@@ -59,11 +59,11 @@ granter adjust-tokens=+0B
 print
 ----
 physical-stats: work-count=4 written-bytes=4B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=2 top-tenant=t1
- tenant=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=2 top-group=t1
+ group=t1 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
- tenant=t2 weight=1 fifo-threshold=low-pri used=1B
+ group=t2 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.002µs size=1B range=r2 log-position=5/21]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/tenant_weights
+++ b/pkg/util/admission/testdata/replicated_write_admission/tenant_weights
@@ -49,20 +49,20 @@ admit tenant=t2 pri=normal-pri create-time=1.005us size=1B range=r2 log-position
 print
 ----
 physical-stats: work-count=10 written-bytes=10B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=2 top-tenant=t2
- tenant=t1 weight=2 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=2 top-group=t2
+ group=t1 weight=2 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
   [2: pri=normal-pri create-time=1.003µs size=1B range=r1 log-position=4/22]
   [3: pri=normal-pri create-time=1.004µs size=1B range=r1 log-position=4/23]
   [4: pri=normal-pri create-time=1.005µs size=1B range=r1 log-position=4/24]
- tenant=t2 weight=5 fifo-threshold=low-pri used=0B
+ group=t2 weight=5 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r2 log-position=5/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r2 log-position=5/21]
   [2: pri=normal-pri create-time=1.003µs size=1B range=r2 log-position=5/22]
   [3: pri=normal-pri create-time=1.004µs size=1B range=r2 log-position=5/23]
   [4: pri=normal-pri create-time=1.005µs size=1B range=r2 log-position=5/24]
-[elastic work queue]: len(tenant-heap)=0
+[elastic work queue]: len(group-heap)=0
 
 # Produce 7B worth of regular tokens.
 granter class=regular adjust-tokens=+7B
@@ -96,12 +96,12 @@ granter adjust-tokens=+0B
 print
 ----
 physical-stats: work-count=10 written-bytes=10B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=1 top-tenant=t1
- tenant=t1 weight=2 fifo-threshold=low-pri used=2B
+[regular work queue]: len(group-heap)=1 top-group=t1
+ group=t1 weight=2 fifo-threshold=low-pri used=2B
   [0: pri=normal-pri create-time=1.003µs size=1B range=r1 log-position=4/22]
   [1: pri=normal-pri create-time=1.004µs size=1B range=r1 log-position=4/23]
   [2: pri=normal-pri create-time=1.005µs size=1B range=r1 log-position=4/24]
- tenant=t2 weight=5 fifo-threshold=low-pri used=5B
-[elastic work queue]: len(tenant-heap)=0
+ group=t2 weight=5 fifo-threshold=low-pri used=5B
+[elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/store_work_queue
+++ b/pkg/util/admission/testdata/store_work_queue
@@ -3,8 +3,8 @@ init
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:1}
 
@@ -22,9 +22,9 @@ storeWriteDone regular: originalTokens 1, doneBytes(write 0,ingested 0) returnin
 
 set-store-request-estimates write-tokens=100
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
@@ -40,10 +40,10 @@ id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeTokens:100 w
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 101, w: 1, fifo: -128
- tenant-id: 55 used: 100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 101, w: 1, fifo: -128
+ group-id: 55 used: 100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
@@ -60,11 +60,11 @@ storeWriteDone regular: originalTokens 100, doneBytes(write 0,ingested 0) return
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 1 top tenant: 57
- tenant-id: 53 used: 101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 0]
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 1 top group: 57
+ group-id: 53 used: 101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 0]
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
@@ -76,11 +76,11 @@ granted regular: returned 100
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
@@ -90,21 +90,21 @@ storeWriteDone regular: originalTokens 100, doneBytes(write 0,ingested 1000000) 
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
 
 set-store-request-estimates write-tokens=10000
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:10000}
 
@@ -114,11 +114,11 @@ storeWriteDone regular: originalTokens 100, doneBytes(write 2000,ingested 1000) 
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:10000}
 
@@ -128,21 +128,21 @@ storeWriteDone regular: originalTokens 0, doneBytes(write 1000,ingested 1000000)
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0} writeBytes:0} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
 stats-to-ignore ingested-bytes=12000 ingested-into-L0-bytes=9000 write-bytes=1500
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -165,12 +165,12 @@ granted elastic: returned 10000
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 10000, w: 1, fifo: -128
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 10000, w: 1, fifo: -128
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -184,13 +184,13 @@ id 6: admit succeeded with handle {tenantID:{InternalValue:54} writeTokens:10000
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 10000, w: 1, fifo: -128
- tenant-id: 54 used: 10000, w: 1, fifo: -128
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 10000, w: 1, fifo: -128
+ group-id: 54 used: 10000, w: 1, fifo: -128
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -200,13 +200,13 @@ storeWriteDone elastic: originalTokens 10000, doneBytes(write 1000,ingested 0) r
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 10200, w: 1, fifo: -128
- tenant-id: 54 used: 10000, w: 1, fifo: -128
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 10200, w: 1, fifo: -128
+ group-id: 54 used: 10000, w: 1, fifo: -128
 stats:{workCount:15 writeAccountedBytes:4000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:5 writeAccountedBytes:3000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -216,12 +216,12 @@ storeWriteDone elastic: originalTokens 10000, doneBytes(write 0,ingested 500) re
 
 print
 ----
-regular workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 50101, w: 1, fifo: -128
- tenant-id: 55 used: 600, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-elastic workqueue: closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 10200, w: 1, fifo: -128
- tenant-id: 54 used: 10500, w: 1, fifo: -128
+regular workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 50101, w: 1, fifo: -128
+ group-id: 55 used: 600, w: 1, fifo: -128
+ group-id: 57 used: 2100, w: 1, fifo: -128
+elastic workqueue: closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 10200, w: 1, fifo: -128
+ group-id: 54 used: 10500, w: 1, fifo: -128
 stats:{workCount:16 writeAccountedBytes:4000 ingestedAccountedBytes:2001500 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0} writeBytes:1500} aboveRaftStats:{workCount:6 writeAccountedBytes:3000 ingestedAccountedBytes:1001500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -11,8 +11,8 @@ id 1: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
 
 # tryGet will return false, so work will queue up.
 set-try-get-return-value v=false
@@ -24,8 +24,8 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: 53
+ group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
 
 admit id=3 tenant=53 priority=0 create-time-millis=2 bypass=false
 ----
@@ -34,8 +34,8 @@ admit id=3 tenant=53 priority=0 create-time-millis=2 bypass=false
 # in the heap because of a smaller create-time-millis.
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: 53
+ group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
 
 # Request from tenant 71.
 admit id=4 tenant=71 priority=-128 create-time-millis=4 bypass=false
@@ -49,9 +49,9 @@ admit id=5 tenant=71 priority=0 create-time-millis=5 bypass=false
 # Tenant 71 is the top of the heap since has not used any cpu time.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 71
- tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100] [1: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 71
+ group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100] [1: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -63,9 +63,9 @@ granted: returned 1
 # favor of tenant 71.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # Cancel a request from tenant 53.
 cancel-work id=3
@@ -74,9 +74,9 @@ id 3: admit failed
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # The work admitted for tenant 53 is done and consumed no cpu-time
 work-done id=1 cpu-time=0
@@ -86,9 +86,9 @@ returnGrant 1
 # Tenant 53 has used no cpu, so it becomes the top of the heap.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # Requests from a system and application tenant bypass admission control,
 # but are reflected in the WorkQueue state.
@@ -104,10 +104,10 @@ id 9: admit succeeded
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 1 used: 1, w: 1, fifo: -128
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: 71 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # The bypass work is done and consumed 10 and 0 cpu nanos respectively.
 work-done id=6 cpu-time=10
@@ -120,10 +120,10 @@ returnGrant 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 1 used: 10, w: 1, fifo: -128
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # Another request from tenant 53, which is behind the existing request in the heap.
 admit id=7 tenant=53 priority=0 create-time-millis=5 bypass=false
@@ -131,10 +131,10 @@ admit id=7 tenant=53 priority=0 create-time-millis=5 bypass=false
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 1 used: 10, w: 1, fifo: -128
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=7
 ----
@@ -146,10 +146,10 @@ granted: returned 1
 # favor of tenant 53.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 1 used: 10, w: 1, fifo: -128
- tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 53
+ group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # The work admitted for tenant 53 is done and has consumed 20 cpu nanos, so
 # tenant 71 moves to the top of the heap.
@@ -159,17 +159,17 @@ returnGrant 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 71
- tenant-id: 1 used: 10, w: 1, fifo: -128
- tenant-id: 53 used: 20, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 71
+ group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 53 used: 20, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
-gc-tenants-and-reset-used
+gc-groups-and-reset-used
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 71
- tenant-id: 1 used: 0, w: 1, fifo: -128
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- tenant-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 71
+ group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=9
 ----
@@ -180,10 +180,10 @@ granted: returned 1
 # Tenant 71 has used 1 cpu nano.
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 1 used: 0, w: 1, fifo: -128
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 1 top group: 53
+ group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: 71 used: 1, w: 1, fifo: -128
 
 # Try to return more cpu than used, to check that there is no overflow.
 work-done id=4 cpu-time=-5
@@ -192,10 +192,10 @@ returnGrant 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 1 used: 0, w: 1, fifo: -128
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- tenant-id: 71 used: 0, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 1 top group: 53
+ group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: 71 used: 0, w: 1, fifo: -128
 
 granted chain-id=10
 ----
@@ -206,10 +206,10 @@ granted: returned 1
 # No more waiting requests.
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 0, w: 1, fifo: -128
- tenant-id: 53 used: 1, w: 1, fifo: -128
- tenant-id: 71 used: 0, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: 71 used: 0, w: 1, fifo: -128
 
 # Granted returns false.
 granted chain-id=10
@@ -218,10 +218,10 @@ granted: returned 0
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 0, w: 1, fifo: -128
- tenant-id: 53 used: 1, w: 1, fifo: -128
- tenant-id: 71 used: 0, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: 71 used: 0, w: 1, fifo: -128
 
 init
 ----
@@ -236,13 +236,13 @@ tryGet: returning false
 # Make the request wait long enough that we switch to LIFO.
 advance-time millis=205
 ----
-closed epoch: 2 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 2 groupHeap len: 1 top group: 53
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 print
 ----
-closed epoch: 2 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 2 groupHeap len: 1 top group: 53
+ group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -252,14 +252,14 @@ granted: returned 1
 
 print
 ----
-closed epoch: 2 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: -128
+closed epoch: 2 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: -128
 
 # Switch to LIFO since request waited for 205ms.
 advance-time millis=100
 ----
-closed epoch: 3 tenantHeap len: 0
- tenant-id: 53 used: 1, w: 1, fifo: 1
+closed epoch: 3 groupHeap len: 0
+ group-id: 53 used: 1, w: 1, fifo: 1
 
 admit id=2 tenant=53 priority=0 create-time-millis=50 bypass=false
 ----
@@ -274,8 +274,8 @@ admit id=4 tenant=53 priority=0 create-time-millis=400 bypass=false
 # Two requests are in closed epochs and one is in open epoch.
 print
 ----
-closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 1, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 399, epoch: 3, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 50, epoch: 0, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: 53
+ group-id: 53 used: 1, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 399, epoch: 3, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 50, epoch: 0, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
 
 # Latest request in closed epoch is granted.
 granted chain-id=6
@@ -294,8 +294,8 @@ granted: returned 1
 # Only request is in open epoch.
 print
 ----
-closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: 53
+ group-id: 53 used: 3, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
 
 # Add request to closed epoch.
 admit id=5 tenant=53 priority=0 create-time-millis=300 bypass=false
@@ -309,8 +309,8 @@ admit id=6 tenant=53 priority=0 create-time-millis=500 bypass=false
 # Open epochs heap is ordered in rough FIFO.
 print
 ----
-closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: 53
+ group-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # Add high priority request in open epoch 5.
 admit id=7 tenant=53 priority=127 create-time-millis=550 bypass=false
@@ -320,14 +320,14 @@ admit id=7 tenant=53 priority=127 create-time-millis=550 bypass=false
 # threshold, and so is still using FIFO ordering.
 print
 ----
-closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: 53
+ group-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # Make the request wait for 60ms so we don't switch back to fifo.
 advance-time millis=60
 ----
-closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: 53
+ group-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=8
 ----
@@ -347,14 +347,14 @@ admit id=8 tenant=53 priority=0 create-time-millis=350 bypass=false
 
 print
 ----
-closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: 53
+ group-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # One request moved from open to closed epoch heap.
 advance-time millis=40
 ----
-closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 4 groupHeap len: 1 top group: 53
+ group-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=10
 ----
@@ -364,8 +364,8 @@ granted: returned 1
 
 print
 ----
-closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 6, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 4 groupHeap len: 1 top group: 53
+ group-id: 53 used: 6, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=11
 ----
@@ -375,8 +375,8 @@ granted: returned 1
 
 print
 ----
-closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 7, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 4 groupHeap len: 1 top group: 53
+ group-id: 53 used: 7, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # Can dequeue from the open epochs heap if nothing else is remaining.
 granted chain-id=12
@@ -387,8 +387,8 @@ granted: returned 1
 
 print
 ----
-closed epoch: 4 tenantHeap len: 0
- tenant-id: 53 used: 8, w: 1, fifo: 1
+closed epoch: 4 groupHeap len: 0
+ group-id: 53 used: 8, w: 1, fifo: 1
 
 # Add a request for an already closed epoch.
 admit id=9 tenant=53 priority=0 create-time-millis=380 bypass=false
@@ -397,14 +397,14 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 4 groupHeap len: 1 top group: 53
+ group-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This time advance means the previous request will see significant queueing.
 advance-time millis=100
 ----
-closed epoch: 5 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 5 groupHeap len: 1 top group: 53
+ group-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This request in an already closed epoch gets ahead because of higher
 # create-time-millis.
@@ -413,8 +413,8 @@ admit id=10 tenant=53 priority=0 create-time-millis=390 bypass=false
 
 print
 ----
-closed epoch: 5 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 390, epoch: 3, qt: 605, lifo-ordering] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 5 groupHeap len: 1 top group: 53
+ group-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 390, epoch: 3, qt: 605, lifo-ordering] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 granted chain-id=12
 ----
@@ -424,14 +424,14 @@ granted: returned 1
 
 print
 ----
-closed epoch: 5 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 9, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 5 groupHeap len: 1 top group: 53
+ group-id: 53 used: 9, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This advance will switch all priorities back to FIFO.
 advance-time millis=100
 ----
-closed epoch: 6 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 6 groupHeap len: 1 top group: 53
+ group-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 admit id=11 tenant=53 priority=0 create-time-millis=610 bypass=false
 ----
@@ -444,8 +444,8 @@ admit id=12 tenant=53 priority=-128 create-time-millis=615 bypass=false
 # has the highest create time.
 print
 ----
-closed epoch: 6 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 610, epoch: 6, qt: 705] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [2: pri: low-pri, ct: 615, epoch: 6, qt: 705]
+closed epoch: 6 groupHeap len: 1 top group: 53
+ group-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 610, epoch: 6, qt: 705] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [2: pri: low-pri, ct: 615, epoch: 6, qt: 705]
 
 granted chain-id=13
 ----
@@ -457,8 +457,8 @@ granted: returned 1
 # is preferred.
 print
 ----
-closed epoch: 6 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 10, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [1: pri: low-pri, ct: 615, epoch: 6, qt: 705]
+closed epoch: 6 groupHeap len: 1 top group: 53
+ group-id: 53 used: 10, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [1: pri: low-pri, ct: 615, epoch: 6, qt: 705]
 
 granted chain-id=14
 ----
@@ -476,8 +476,8 @@ granted: returned 1
 # latency, switch that back to LIFO.
 advance-time millis=100
 ----
-closed epoch: 7 tenantHeap len: 0
- tenant-id: 53 used: 12, w: 1, fifo: 1
+closed epoch: 7 groupHeap len: 0
+ group-id: 53 used: 12, w: 1, fifo: 1
 
 # Add a request whose epoch is not closed.
 admit id=13 tenant=53 priority=0 create-time-millis=810 bypass=false
@@ -486,8 +486,8 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 7 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 12, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 810, epoch: 8, qt: 805]
+closed epoch: 7 groupHeap len: 1 top group: 53
+ group-id: 53 used: 12, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 810, epoch: 8, qt: 805]
 
 # Cancel that request.
 cancel-work id=13
@@ -496,21 +496,21 @@ id 13: admit failed
 
 print
 ----
-closed epoch: 7 tenantHeap len: 0
- tenant-id: 53 used: 12, w: 1, fifo: 1
+closed epoch: 7 groupHeap len: 0
+ group-id: 53 used: 12, w: 1, fifo: 1
 
 # Closed epoch advances. The FIFO threshold is not changed since the only
 # request was canceled.
 advance-time millis=100
 ----
-closed epoch: 8 tenantHeap len: 0
- tenant-id: 53 used: 12, w: 1, fifo: 1
+closed epoch: 8 groupHeap len: 0
+ group-id: 53 used: 12, w: 1, fifo: 1
 
 # Closed epoch advances. All priorities are now subject to FIFO.
 advance-time millis=100
 ----
-closed epoch: 9 tenantHeap len: 0
- tenant-id: 53 used: 12, w: 1, fifo: -128
+closed epoch: 9 groupHeap len: 0
+ group-id: 53 used: 12, w: 1, fifo: -128
 
 # Test tenant weights.
 init
@@ -522,7 +522,7 @@ set-try-get-return-value v=false
 # Empty map is fine.
 set-tenant-weights weights=
 ----
-closed epoch: 0 tenantHeap len: 0
+closed epoch: 0 groupHeap len: 0
 
 # Tenant 5 gets a weight of 1.
 admit id=1 tenant=5 priority=0 create-time-millis=1 bypass=false
@@ -531,29 +531,29 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 5
- tenant-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: 5
+ group-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Weight is unchanged for tenant 5.
 set-tenant-weights weights=10:11
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 5
- tenant-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: 5
+ group-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Now tenant 5 has a new weight.
 set-tenant-weights weights=5:6,10:11
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 5
- tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: 5
+ group-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 admit id=2 tenant=10 priority=0 create-time-millis=1 bypass=false
 ----
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 10
- tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 0, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 10
+ group-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 0, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=1
 ----
@@ -570,9 +570,9 @@ granted: returned 1
 # Both tenants are using 1 slot.
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 5 used: 1, w: 6, fifo: -128
- tenant-id: 10 used: 1, w: 11, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 5 used: 1, w: 6, fifo: -128
+ group-id: 10 used: 1, w: 11, fifo: -128
 
 # Add additional requests for each tenant
 admit id=3 tenant=5 priority=0 create-time-millis=1 bypass=false
@@ -585,9 +585,9 @@ admit id=4 tenant=10 priority=0 create-time-millis=1 bypass=false
 # The top of the heap is tenant 10 since it has a higher weight.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 10
- tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 1, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 10
+ group-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 1, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Grant to tenant 10 so it is using 2 slots.
 granted chain-id=3
@@ -598,9 +598,9 @@ granted: returned 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 1 top tenant: 5
- tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 2, w: 11, fifo: -128
+closed epoch: 0 groupHeap len: 1 top group: 5
+ group-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 2, w: 11, fifo: -128
 
 # Another request from tenant 10.
 admit id=5 tenant=10 priority=0 create-time-millis=1 bypass=false
@@ -609,32 +609,32 @@ admit id=5 tenant=10 priority=0 create-time-millis=1 bypass=false
 # Tenant 10's weight is not high enough for it to be the top of the heap.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 5
- tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 2, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 5
+ group-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 2, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Increase tenant 10's weight so it becomes the top of the heap. Weight
 # scaling is also applied here to make the max weight 20, and reduce tenant
 # 5's weight to 4.
 set-tenant-weights weights=5:6,10:30
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 10
- tenant-id: 5 used: 1, w: 4, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 2, w: 20, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 10
+ group-id: 5 used: 1, w: 4, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 2, w: 20, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Restore all weights to 1. Tenant 5 is now top of the heap.
 set-tenant-weights weights=5:1,10:1
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 5
- tenant-id: 5 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 5
+ group-id: 5 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Adjust weights to make tenant 10 just slightly preferable over tenant 5.
 set-tenant-weights weights=5:6,10:13
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 10
- tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 2, w: 13, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 10
+ group-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 2, w: 13, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Add another request for tenant 10.
 admit id=6 tenant=10 priority=0 create-time-millis=1 bypass=false
@@ -650,17 +650,17 @@ granted: returned 1
 # of the heap.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 5
- tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 3, w: 13, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 5
+ group-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 3, w: 13, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Bump up tenant 10's weight to a huge value. Tenant 5's weight is not scaled
 # down to 0, since the minimum weight is 1.
 set-tenant-weights weights=5:1,10:100000
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 10
- tenant-id: 5 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 10 used: 3, w: 20, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: 10
+ group-id: 5 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 10 used: 3, w: 20, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -708,28 +708,28 @@ admit id=8 tenant=8 priority=0 create-time-millis=1 bypass=false
 
 print
 ----
-closed epoch: 0 tenantHeap len: 8 top tenant: 1
- tenant-id: 1 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 2 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 3 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 4 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 6 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 7 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 8 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 8 top group: 1
+ group-id: 1 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 2 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 3 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 4 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 6 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 7 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 8 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 # Set weights for 7 out of the 8 tenants.
 set-tenant-weights weights=1:2,2:3,3:4,4:5,5:6,7:8,8:9
 ----
-closed epoch: 0 tenantHeap len: 8 top tenant: 8
- tenant-id: 1 used: 0, w: 2, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 2 used: 0, w: 3, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 3 used: 0, w: 4, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 4 used: 0, w: 5, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 6 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 7 used: 0, w: 8, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- tenant-id: 8 used: 0, w: 9, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 8 top group: 8
+ group-id: 1 used: 0, w: 2, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 2 used: 0, w: 3, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 3 used: 0, w: 4, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 4 used: 0, w: 5, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 6 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 7 used: 0, w: 8, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 8 used: 0, w: 9, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=1
 ----
@@ -781,15 +781,15 @@ granted: returned 1
 
 print
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 1, w: 2, fifo: -128
- tenant-id: 2 used: 1, w: 3, fifo: -128
- tenant-id: 3 used: 1, w: 4, fifo: -128
- tenant-id: 4 used: 1, w: 5, fifo: -128
- tenant-id: 5 used: 1, w: 6, fifo: -128
- tenant-id: 6 used: 1, w: 1, fifo: -128
- tenant-id: 7 used: 1, w: 8, fifo: -128
- tenant-id: 8 used: 1, w: 9, fifo: -128
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 1, w: 2, fifo: -128
+ group-id: 2 used: 1, w: 3, fifo: -128
+ group-id: 3 used: 1, w: 4, fifo: -128
+ group-id: 4 used: 1, w: 5, fifo: -128
+ group-id: 5 used: 1, w: 6, fifo: -128
+ group-id: 6 used: 1, w: 1, fifo: -128
+ group-id: 7 used: 1, w: 8, fifo: -128
+ group-id: 8 used: 1, w: 9, fifo: -128
 
 # If all work should bypass AC, it is admitted without checking
 # resource availability in the granter. That is, we should see

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -307,7 +307,9 @@ type WorkQueue struct {
 
 	mu struct {
 		syncutil.Mutex
-		// Groups with waiting work.
+		// Groups with waiting work. In serverless mode each group is a
+		// SQL tenant keyed by tenant ID; in resource manager mode each
+		// group is a resource group keyed by resource group ID.
 		groupHeap groupHeap
 		// All groups, including those without waiting work. Periodically cleaned.
 		groups       map[uint64]*groupInfo
@@ -1656,7 +1658,10 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 	return priority
 }
 
-// groupInfo is the per-group information in the groupHeap.
+// groupInfo is the per-group information in the groupHeap. A group
+// represents a SQL tenant in serverless mode or a resource group in
+// resource manager mode; id is the tenant ID or resource group ID
+// respectively.
 type groupInfo struct {
 	id uint64
 	// The weight assigned to the group. Must be > 0.
@@ -1729,9 +1734,10 @@ type groupMetrics struct {
 	tokensReturned *aggmetric.Counter
 }
 
-// groupHeap is a heap of groups with waiting work, ordered in increasing
-// order of groupInfo.used/groupInfo.weight (weights are an optional
-// feature, and default to 1). That is, we prefer groups that are using less.
+// groupHeap is a heap of groups with waiting work, ordered by burst
+// qualification (canBurst before noBurst) then by used/weight ratio
+// in increasing order (weights are an optional feature, and default
+// to 1). That is, we prefer groups that are using less.
 type groupHeap []*groupInfo
 
 var _ heap.Interface = (*groupHeap)(nil)

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -666,7 +666,7 @@ type AdmitResponse struct {
 	// If true, admission control is enabled.
 	Enabled bool
 
-	tenantID roachpb.TenantID
+	groupID roachpb.TenantID
 	// requestedCount is the number of slots or tokens taken at Admit time.
 	// It is useful to return, so that in AdmittedWorkDone, we can adjust
 	// the deduction, in cases where we have more information, such as in
@@ -753,7 +753,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		info.RequestedCount = group.cpuTimeTokenEstimator.estimateTokensToBeUsed()
 	}
 	admitResponse := AdmitResponse{
-		tenantID:       info.TenantID,
+		groupID:        info.TenantID,
 		requestedCount: info.RequestedCount,
 	}
 
@@ -1080,7 +1080,7 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// NB: additionalUsed can be negative here (in case the initial estimate was
 		// too pessimistic).
 		if additionalUsed != 0 {
-			group, ok := q.mu.groups[resp.tenantID.ToUint64()]
+			group, ok := q.mu.groups[resp.groupID.ToUint64()]
 			if ok {
 				q.adjustGroupUsedLocked(group, additionalUsed)
 			}
@@ -1095,7 +1095,7 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// in this code path, that is, at admission time.
 		if q.mode == usesCPUTimeTokens {
 			q.mu.defaultCPUTimeTokenEstimator.workDone(cpuTime.Nanoseconds())
-			group, ok := q.mu.groups[resp.tenantID.ToUint64()]
+			group, ok := q.mu.groups[resp.groupID.ToUint64()]
 			// If the group struct doesn't exist, it has been GCed due to a lack of
 			// activity. In this case, we do not leverage the grunning measurement
 			// for future estimates.
@@ -1249,10 +1249,10 @@ func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 // in AdmittedWorkDone. The additionalUsed count can be negative, in which
 // case it is returning unused resources. This is only for WorkQueue's own
 // accounting -- it should not call into granter.
-func (q *WorkQueue) adjustGroupUsed(tenantID roachpb.TenantID, delta int64) {
+func (q *WorkQueue) adjustGroupUsed(groupID roachpb.TenantID, delta int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	tid := tenantID.ToUint64()
+	tid := groupID.ToUint64()
 	group, ok := q.mu.groups[tid]
 	if !ok {
 		return

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -268,14 +268,14 @@ func (r LogPosition) Less(o LogPosition) bool {
 }
 
 // WorkQueue maintains a queue of work waiting to be admitted. Ordering of
-// work is achieved via 2 heaps: a tenant heap orders the tenants with waiting
+// work is achieved via 2 heaps: a group heap orders the groups with waiting
 // work in increasing order of used slots or tokens, optionally adjusted by
-// tenant weights. Within each tenant, the waiting work is ordered based on
-// priority and create time. Tenants with non-zero values of used slots or
+// group weights. Within each group, the waiting work is ordered based on
+// priority and create time. Groups with non-zero values of used slots or
 // tokens are tracked even if they have no more waiting work. Token usage is
 // reset to zero every second. The choice of 1 second of memory for token
 // distribution fairness is somewhat arbitrary. The same 1 second interval is
-// also used to garbage collect tenants who have no waiting requests and no
+// also used to garbage collect groups who have no waiting requests and no
 // used slots or tokens.
 //
 // Usage example:
@@ -307,18 +307,18 @@ type WorkQueue struct {
 
 	mu struct {
 		syncutil.Mutex
-		// Tenants with waiting work.
-		tenantHeap tenantHeap
-		// All tenants, including those without waiting work. Periodically cleaned.
-		tenants       map[uint64]*tenantInfo
-		tenantWeights struct {
+		// Groups with waiting work.
+		groupHeap groupHeap
+		// All groups, including those without waiting work. Periodically cleaned.
+		groups       map[uint64]*groupInfo
+		groupWeights struct {
 			mu syncutil.Mutex
 			// active refers to the currently active weights. mu is held for updates
 			// to the inactive weights, to prevent concurrent updates. After
 			// updating the inactive weights, it is made active by swapping with
 			// active, while also holding WorkQueue.mu. Therefore, reading
-			// tenantWeights.active does not require tenantWeights.mu. For lock
-			// ordering, tenantWeights.mu precedes WorkQueue.mu.
+			// groupWeights.active does not require groupWeights.mu. For lock
+			// ordering, groupWeights.mu precedes WorkQueue.mu.
 			//
 			// The maps are lazily allocated.
 			active, inactive map[uint64]uint32
@@ -331,7 +331,7 @@ type WorkQueue struct {
 		maxQueueDelayToSwitchToLifo time.Duration
 		// Only used if mode == usesCPUTimeTokens.
 		defaultCPUTimeTokenEstimator cpuTimeTokenEstimator
-		// burstBucketCapacity is the capacity for newly created tenant burst
+		// burstBucketCapacity is the capacity for newly created group burst
 		// buckets. Note that buckets init full, so burstBucketCapacity is also
 		// the starting token count. Updated by refillBurstBuckets. Only used
 		// if mode == usesCPUTimeTokens.
@@ -344,17 +344,17 @@ type WorkQueue struct {
 	metrics      *WorkQueueMetrics
 	stopCh       chan struct{}
 
-	// perTenantAggMetrics holds the parent AggCounters for per-tenant
+	// perGroupAggMetrics holds the parent AggCounters for per-group
 	// metrics. Only set when mode == usesCPUTimeTokens.
-	perTenantAggMetrics *tenantAggMetrics
+	perGroupAggMetrics *groupAggMetrics
 
 	timeSource timeutil.TimeSource
 	knobs      *TestingKnobs
 }
 
-// tenantAggMetrics groups the parent AggCounters from which per-tenant
+// groupAggMetrics groups the parent AggCounters from which per-group
 // child counters are created via AddChild.
-type tenantAggMetrics struct {
+type groupAggMetrics struct {
 	admittedCount  *aggmetric.AggCounter
 	waitTimeNanos  *aggmetric.AggCounter
 	tokensUsed     *aggmetric.AggCounter
@@ -367,19 +367,19 @@ type workQueueOptions struct {
 	mode           workQueueMode
 	tiedToRange    bool
 	usesAsyncAdmit bool
-	// perTenantAggMetrics holds the parent AggCounters for per-tenant
+	// perGroupAggMetrics holds the parent AggCounters for per-group
 	// metrics. Only set when mode == usesCPUTimeTokens. See
 	// cpuTimeTokenMetrics for details.
-	perTenantAggMetrics *tenantAggMetrics
+	perGroupAggMetrics *groupAggMetrics
 
 	// timeSource can be set to non-nil for tests. If nil,
 	// the timeutil.DefaultTimeSource will be used.
 	timeSource timeutil.TimeSource
 	// The epoch closing goroutine can be disabled for tests.
 	disableEpochClosingGoroutine bool
-	// The background resetting of used and GC'ing of tenants can be disabled
+	// The background resetting of used and GC'ing of groups can be disabled
 	// for tests.
-	disableGCTenantsAndResetUsed bool
+	disableGCGroupsAndResetUsed bool
 	// knobs, if set, provides testing knobs to the work queue.
 	knobs *TestingKnobs
 }
@@ -451,7 +451,7 @@ func initWorkQueue(
 	q.logThreshold = log.Every(5 * time.Minute)
 	q.metrics = metrics
 	q.stopCh = stopCh
-	q.perTenantAggMetrics = opts.perTenantAggMetrics
+	q.perGroupAggMetrics = opts.perGroupAggMetrics
 	q.timeSource = timeSource
 	q.knobs = knobs
 	q.mu.defaultCPUTimeTokenEstimator = cpuTimeTokenEstimator{}
@@ -459,16 +459,16 @@ func initWorkQueue(
 	func() {
 		q.mu.Lock()
 		defer q.mu.Unlock()
-		q.mu.tenants = make(map[uint64]*tenantInfo)
+		q.mu.groups = make(map[uint64]*groupInfo)
 		q.sampleEpochLIFOSettingsLocked()
 	}()
-	if !opts.disableGCTenantsAndResetUsed {
+	if !opts.disableGCGroupsAndResetUsed {
 		go func() {
 			ticker := time.NewTicker(time.Second)
 			for {
 				select {
 				case <-ticker.C:
-					q.gcTenantsResetUsedAndUpdateEstimators()
+					q.gcGroupsResetUsedAndUpdateEstimators()
 				case <-stopCh:
 					// Channel closed.
 					return
@@ -515,9 +515,9 @@ const (
 	usesCPUTimeTokens
 )
 
-func isInTenantHeap(tenant *tenantInfo) bool {
-	// If there is some waiting work, this tenant is in tenantHeap.
-	return len(tenant.waitingWorkHeap) > 0 || len(tenant.openEpochsHeap) > 0
+func isInGroupHeap(group *groupInfo) bool {
+	// If there is some waiting work, this group is in groupHeap.
+	return len(group.waitingWorkHeap) > 0 || len(group.openEpochsHeap) > 0
 }
 
 func (q *WorkQueue) timeNow() time.Time {
@@ -621,26 +621,26 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 		doLog = epochLIFOEnabled && q.logThreshold.ShouldLog()
 		return doLog
 	}
-	for _, tenant := range q.mu.tenants {
-		prevThreshold := tenant.fifoPriorityThreshold
-		tenant.fifoPriorityThreshold =
-			tenant.priorityStates.getFIFOPriorityThresholdAndReset(
-				tenant.fifoPriorityThreshold, q.mu.epochLengthNanos, q.mu.maxQueueDelayToSwitchToLifo)
+	for _, group := range q.mu.groups {
+		prevThreshold := group.fifoPriorityThreshold
+		group.fifoPriorityThreshold =
+			group.priorityStates.getFIFOPriorityThresholdAndReset(
+				group.fifoPriorityThreshold, q.mu.epochLengthNanos, q.mu.maxQueueDelayToSwitchToLifo)
 		if !epochLIFOEnabled {
-			tenant.fifoPriorityThreshold = int(admissionpb.LowPri)
+			group.fifoPriorityThreshold = int(admissionpb.LowPri)
 		}
-		if tenant.fifoPriorityThreshold != prevThreshold && doLogFunc() {
+		if group.fifoPriorityThreshold != prevThreshold && doLogFunc() {
 			logVerb := redact.SafeString("is")
-			if tenant.fifoPriorityThreshold != prevThreshold {
+			if group.fifoPriorityThreshold != prevThreshold {
 				logVerb = "changed to"
 			}
-			// TODO(sumeer): export this as a per-tenant metric somehow. We could
+			// TODO(sumeer): export this as a per-group metric somehow. We could
 			// start with this being a per-WorkQueue metric for only the system
-			// tenant. However, currently we share metrics across WorkQueues --
+			// group. However, currently we share metrics across WorkQueues --
 			// specifically all the store WorkQueues share the same metric. We
 			// should eliminate that sharing and make those per store metrics.
-			log.Dev.Infof(q.ambientCtx, "%s: FIFO threshold for tenant %d %s %d",
-				q.workKind, tenant.id, logVerb, tenant.fifoPriorityThreshold)
+			log.Dev.Infof(q.ambientCtx, "%s: FIFO threshold for group %d %s %d",
+				q.workKind, group.id, logVerb, group.fifoPriorityThreshold)
 		}
 		// Note that we are ignoring the new priority threshold and only
 		// dequeueing the ones that are in the closed epoch. It is possible to
@@ -648,13 +648,13 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 		// makes them no longer subject to LIFO, but they will need to wait here
 		// until their epochs close. This is considered acceptable since the
 		// priority threshold should not fluctuate rapidly.
-		for len(tenant.openEpochsHeap) > 0 {
-			work := tenant.openEpochsHeap[0]
+		for len(group.openEpochsHeap) > 0 {
+			work := group.openEpochsHeap[0]
 			if work.epoch > epoch {
 				break
 			}
-			heap.Pop(&tenant.openEpochsHeap)
-			heap.Push(&tenant.waitingWorkHeap, work)
+			heap.Pop(&group.openEpochsHeap)
+			heap.Push(&group.waitingWorkHeap, work)
 		}
 	}
 }
@@ -721,36 +721,36 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	}
 	q.metrics.incRequested(info.Priority)
 
-	tenantID := info.TenantID.ToUint64()
+	groupID := info.TenantID.ToUint64()
 	// The code in this method does not use defer to unlock the mutex because it
 	// needs the flexibility of selectively unlocking on a certain code path.
 	// When changing the code, be careful in making sure the mutex is properly
 	// unlocked on all code paths.
 	q.mu.Lock()
-	tenant, ok := q.mu.tenants[tenantID]
+	group, ok := q.mu.groups[groupID]
 	if !ok {
-		// See comment below about CPU time token estimation. If no tenantInfo
-		// struct exists for a tenant, then there is no cpuTimeTokenEstimator
-		// dedicated to that tenant yet. When we create the tenantInfo struct
+		// See comment below about CPU time token estimation. If no groupInfo
+		// struct exists for a group, then there is no cpuTimeTokenEstimator
+		// dedicated to that group yet. When we create the groupInfo struct
 		// here, we also create the estimator. We init the estimator using a
-		// global estimator that sees workload across all tenants.
-		tenant = newTenantInfo(tenantID, q.getTenantWeightLocked(tenantID),
+		// global estimator that sees workload across all groups.
+		group = newGroupInfo(groupID, q.getGroupWeightLocked(groupID),
 			q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
-			q.perTenantAggMetrics)
-		q.mu.tenants[tenantID] = tenant
+			q.perGroupAggMetrics)
+		q.mu.groups[groupID] = group
 	}
 	// If mode == usesCPUTimeTokens, WorkQueue does CPU time token estimation.
 	// When Admit is called, the request hasn't yet executed, so we do not
 	// know how much CPU time will be used by goroutines used to service it.
 	// When AdmittedWorkDone is called, the request is done executing, so we have
 	// a measurement of CPU time used servicing the request, courtesy of grunning.
-	// tenant.estimator uses past measurements from grunning to make estimates
+	// group.estimator uses past measurements from grunning to make estimates
 	// in this code path, that is, at admission time.
 	//
 	// Skip the estimator when callerSetRequestedCount is true (see above).
 	if q.mode == usesCPUTimeTokens && !q.knobs.DisableCPUTimeTokenEstimation &&
 		!callerSetRequestedCount {
-		info.RequestedCount = tenant.cpuTimeTokenEstimator.estimateTokensToBeUsed()
+		info.RequestedCount = group.cpuTimeTokenEstimator.estimateTokensToBeUsed()
 	}
 	admitResponse := AdmitResponse{
 		tenantID:       info.TenantID,
@@ -776,9 +776,9 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		info.BypassAdmission = true
 	}
 	if info.BypassAdmission {
-		q.adjustTenantUsedLocked(tenant, info.RequestedCount)
-		if tenant.perTenantMetrics.admittedCount != nil {
-			tenant.perTenantMetrics.admittedCount.Inc(1)
+		q.adjustGroupUsedLocked(group, info.RequestedCount)
+		if group.perGroupMetrics.admittedCount != nil {
+			group.perGroupMetrics.admittedCount.Inc(1)
 		}
 		q.mu.Unlock()
 		q.granter.tookWithoutPermission(info.RequestedCount)
@@ -792,24 +792,24 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// Tell priorityStates about this received work. We don't tell it about work
 	// that has bypassed admission control, since priorityStates is deciding the
 	// threshold for LIFO queueing based on observed admission latency.
-	tenant.priorityStates.requestAtPriority(info.Priority)
+	group.priorityStates.requestAtPriority(info.Priority)
 
-	burstQual := tenant.cpuTimeBurstBucket.burstQualification()
-	if (len(q.mu.tenantHeap) == 0 ||
-		// tenant not in heap, so doesn't have waiting requests, and is canBurst, while
+	burstQual := group.cpuTimeBurstBucket.burstQualification()
+	if (len(q.mu.groupHeap) == 0 ||
+		// group not in heap, so doesn't have waiting requests, and is canBurst, while
 		// the top of the heap was noBurst.
-		(tenant.heapIndex < 0 &&
+		(group.heapIndex < 0 &&
 			burstQual == canBurst &&
-			q.mu.tenantHeap[0].cpuTimeBurstBucket.burstQualification() == noBurst)) &&
+			q.mu.groupHeap[0].cpuTimeBurstBucket.burstQualification() == noBurst)) &&
 		!q.knobs.DisableWorkQueueFastPath {
 		// Fast-path. Try to grab token/slot.
 		// Optimistically update used to avoid locking again.
-		q.adjustTenantUsedLocked(tenant, info.RequestedCount)
+		q.adjustGroupUsedLocked(group, info.RequestedCount)
 		// Save the admittedCount counter before releasing the mutex,
-		// since tenant may be GC'd and its counters Unlink'd after
+		// since group may be GC'd and its counters Unlink'd after
 		// unlock. Inc after Unlink is safe: the aggregate parent counter
 		// still gets the increment (see aggmetric.Counter.Unlink docs).
-		admittedCount := tenant.perTenantMetrics.admittedCount
+		admittedCount := group.perGroupMetrics.admittedCount
 		q.mu.Unlock()
 		// We have unlocked q.mu, so another concurrent request can also do tryGet
 		// and get ahead of this request. We don't need to be fair for such
@@ -831,14 +831,14 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 				// the waiting heap (and fixing the heap).
 				if log.V(1) {
 					log.Dev.Infof(ctx, "fast-path: admitting t%d pri=%s r%s log-position=%s ingested=%t",
-						tenantID, info.Priority,
+						groupID, info.Priority,
 						info.ReplicatedWorkInfo.RangeID,
 						info.ReplicatedWorkInfo.LogPosition.String(),
 						info.ReplicatedWorkInfo.Ingested,
 					)
 				}
 				q.onAdmittedReplicatedWork.admittedReplicatedWork(
-					roachpb.MustMakeTenantID(tenantID),
+					roachpb.MustMakeTenantID(groupID),
 					info.Priority,
 					info.ReplicatedWorkInfo,
 					info.RequestedCount,
@@ -867,16 +867,16 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// the state of the requesters to see if there is any queued work that
 		// can be granted admission.
 		q.mu.Lock()
-		// The tenant could have been removed. See the comment where the
-		// tenantInfo struct is declared.
-		tenant, ok = q.mu.tenants[tenantID]
+		// The group could have been removed. See the comment where the
+		// groupInfo struct is declared.
+		group, ok = q.mu.groups[groupID]
 		if !ok {
-			tenant = newTenantInfo(tenantID, q.getTenantWeightLocked(tenantID),
+			group = newGroupInfo(groupID, q.getGroupWeightLocked(groupID),
 				q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
-				q.perTenantAggMetrics)
-			q.mu.tenants[tenantID] = tenant
+				q.perGroupAggMetrics)
+			q.mu.groups[groupID] = group
 		}
-		q.adjustTenantUsedLocked(tenant, -info.RequestedCount)
+		q.adjustGroupUsedLocked(group, -info.RequestedCount)
 	}
 
 	// Check for cancellation.
@@ -898,22 +898,22 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	}
 	// Push onto heap(s).
 	ordering := fifoWorkOrdering
-	if int(info.Priority) < tenant.fifoPriorityThreshold {
+	if int(info.Priority) < group.fifoPriorityThreshold {
 		ordering = lifoWorkOrdering
 	}
 	work := newWaitingWork(info.Priority, ordering, info.CreateTime, info.RequestedCount, startTime, q.mu.epochLengthNanos)
 	work.replicated = info.ReplicatedWorkInfo
 
-	inTenantHeap := isInTenantHeap(tenant)
+	inGroupHeap := isInGroupHeap(group)
 	if work.epoch <= q.mu.closedEpochThreshold || ordering == fifoWorkOrdering {
-		heap.Push(&tenant.waitingWorkHeap, work)
+		heap.Push(&group.waitingWorkHeap, work)
 	} else {
-		heap.Push(&tenant.openEpochsHeap, work)
+		heap.Push(&group.openEpochsHeap, work)
 	}
-	if !inTenantHeap {
-		heap.Push(&q.mu.tenantHeap, tenant)
+	if !inGroupHeap {
+		heap.Push(&q.mu.groupHeap, group)
 	}
-	// Else already in tenantHeap.
+	// Else already in groupHeap.
 
 	// Release the lock.
 	q.mu.Unlock()
@@ -922,11 +922,11 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	if info.ReplicatedWorkInfo.Enabled {
 		if log.V(1) {
 			q.mu.Lock()
-			queueLen := tenant.waitingWorkHeap.Len()
+			queueLen := group.waitingWorkHeap.Len()
 			q.mu.Unlock()
 
 			log.Dev.Infof(ctx, "async-path: len(waiting-work)=%d: enqueued t%d pri=%s r%s log-position=%s ingested=%t",
-				queueLen, tenantID, info.Priority,
+				queueLen, groupID, info.Priority,
 				info.ReplicatedWorkInfo.RangeID,
 				info.ReplicatedWorkInfo.LogPosition,
 				info.ReplicatedWorkInfo.Ingested,
@@ -960,13 +960,13 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// since it is possible that all work at this priority is exceeding the
 		// deadline and being cancelled. The risk here is that if the deadlines
 		// are too short, we could underestimate the actual wait time.
-		tenant.priorityStates.updateDelayLocked(work.priority, waitDur, true /* canceled */)
+		group.priorityStates.updateDelayLocked(work.priority, waitDur, true /* canceled */)
 		if work.heapIndex == -1 {
 			// No longer in heap. Raced with token/slot grant. Don't bother
-			// decrementing tenant.used since we don't want to race with the gc
-			// goroutine that sets used=0 and could have GC'd tenant and returned it
+			// decrementing group.used since we don't want to race with the gc
+			// goroutine that sets used=0 and could have GC'd group and returned it
 			// to the sync.Pool. We can fix this if needed by calling
-			// adjustTenantUsedLocked.
+			// adjustGroupUsedLocked.
 			q.mu.Unlock()
 			q.granter.returnGrant(info.RequestedCount)
 			// The channel is sent to after releasing mu, so we don't need to hold
@@ -977,12 +977,12 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 			q.granter.continueGrantChain(chainID)
 		} else {
 			if work.inWaitingWorkHeap {
-				tenant.waitingWorkHeap.remove(work)
+				group.waitingWorkHeap.remove(work)
 			} else {
-				tenant.openEpochsHeap.remove(work)
+				group.openEpochsHeap.remove(work)
 			}
-			if !isInTenantHeap(tenant) {
-				q.mu.tenantHeap.remove(tenant)
+			if !isInGroupHeap(group) {
+				q.mu.groupHeap.remove(group)
 			}
 			q.mu.Unlock()
 		}
@@ -1063,16 +1063,16 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		q.mu.Lock()
 		defer q.mu.Unlock()
 
-		// adjustTenantUsed adjusts `tenant.used`. This tracks usage of resources
-		// over a time interval. `tenant.used` is how the WorkQueue implements
+		// adjustGroupUsed adjusts `group.used`. This tracks usage of resources
+		// over a time interval. `group.used` is how the WorkQueue implements
 		// fair-sharing of resources.
 		//
 		// At admission time (as part of the call to Admit),
-		// q.adjustTenantUsed(tenantID, resp.requestedCount) is called. Now that the
+		// q.adjustGroupUsed(groupID, resp.requestedCount) is called. Now that the
 		// request is done executing, we have a measurement of CPU usage incurred by
-		// the request from grunning. So we adjust tenant.used again, correcting our
+		// the request from grunning. So we adjust group.used again, correcting our
 		// earlier estimate. (In the case of slot-based AC, resp.requestedCount
-		// equals 1 nanosecond, so the change to tenant.used made here is the only
+		// equals 1 nanosecond, so the change to group.used made here is the only
 		// significant one. With CPU time token AC, a more plausible estimate of CPU
 		// time incurred by a request is available at admission time (see
 		// cpu_time_token_estimation.go for more).
@@ -1080,9 +1080,9 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// NB: additionalUsed can be negative here (in case the initial estimate was
 		// too pessimistic).
 		if additionalUsed != 0 {
-			tenant, ok := q.mu.tenants[resp.tenantID.ToUint64()]
+			group, ok := q.mu.groups[resp.tenantID.ToUint64()]
 			if ok {
-				q.adjustTenantUsedLocked(tenant, additionalUsed)
+				q.adjustGroupUsedLocked(group, additionalUsed)
 			}
 		}
 
@@ -1091,16 +1091,16 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// know how much CPU time will be used by goroutines used to service it.
 		// When AdmittedWorkDone is called, the request is done executing, so we have
 		// a measurement of CPU time used servicing the request, courtesy of grunning.
-		// tenant.estimator uses past measurements from grunning to make estimates
+		// group.estimator uses past measurements from grunning to make estimates
 		// in this code path, that is, at admission time.
 		if q.mode == usesCPUTimeTokens {
 			q.mu.defaultCPUTimeTokenEstimator.workDone(cpuTime.Nanoseconds())
-			tenant, ok := q.mu.tenants[resp.tenantID.ToUint64()]
-			// If the tenant struct doesn't exist, it has been GCed due to a lack of
+			group, ok := q.mu.groups[resp.tenantID.ToUint64()]
+			// If the group struct doesn't exist, it has been GCed due to a lack of
 			// activity. In this case, we do not leverage the grunning measurement
 			// for future estimates.
 			if ok {
-				tenant.cpuTimeTokenEstimator.workDone(cpuTime.Nanoseconds())
+				group.cpuTimeTokenEstimator.workDone(cpuTime.Nanoseconds())
 			}
 		}
 	}()
@@ -1134,17 +1134,17 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 func (q *WorkQueue) hasWaitingRequests() (bool, burstQualification) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if len(q.mu.tenantHeap) == 0 {
+	if len(q.mu.groupHeap) == 0 {
 		return false, noBurst /*arbitrary*/
 	}
-	return true, q.mu.tenantHeap[0].cpuTimeBurstBucket.burstQualification()
+	return true, q.mu.groupHeap[0].cpuTimeBurstBucket.burstQualification()
 }
 
 func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 	// Reduce critical section by getting time before mutex acquisition.
 	now := q.timeNow()
 	q.mu.Lock()
-	if len(q.mu.tenantHeap) == 0 {
+	if len(q.mu.groupHeap) == 0 {
 		q.mu.Unlock()
 		return 0
 	}
@@ -1152,30 +1152,30 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 		q.mu.Unlock()
 		return 0
 	}
-	tenant := q.mu.tenantHeap[0]
+	group := q.mu.groupHeap[0]
 	var item *waitingWork
-	if len(tenant.waitingWorkHeap) > 0 {
-		item = heap.Pop(&tenant.waitingWorkHeap).(*waitingWork)
+	if len(group.waitingWorkHeap) > 0 {
+		item = heap.Pop(&group.waitingWorkHeap).(*waitingWork)
 	} else {
-		item = heap.Pop(&tenant.openEpochsHeap).(*waitingWork)
+		item = heap.Pop(&group.openEpochsHeap).(*waitingWork)
 	}
 	waitDur := now.Sub(item.enqueueingTime)
-	tenant.priorityStates.updateDelayLocked(item.priority, waitDur, false /* canceled */)
-	q.adjustTenantUsedLocked(tenant, item.requestedCount)
-	if tenant.perTenantMetrics.admittedCount != nil {
-		tenant.perTenantMetrics.admittedCount.Inc(1)
-		tenant.perTenantMetrics.waitTimeNanos.Inc(waitDur.Nanoseconds())
+	group.priorityStates.updateDelayLocked(item.priority, waitDur, false /* canceled */)
+	q.adjustGroupUsedLocked(group, item.requestedCount)
+	if group.perGroupMetrics.admittedCount != nil {
+		group.perGroupMetrics.admittedCount.Inc(1)
+		group.perGroupMetrics.waitTimeNanos.Inc(waitDur.Nanoseconds())
 	}
-	if !isInTenantHeap(tenant) {
-		q.mu.tenantHeap.remove(tenant)
+	if !isInGroupHeap(group) {
+		q.mu.groupHeap.remove(group)
 	}
 	// Get the value of requestedCount before releasing the mutex, since after
 	// releasing Admit can notice that item is no longer in the heap and call
 	// releaseWaitingWork to return item to the waitingWorkPool.
 	requestedCount := item.requestedCount
-	// Cannot read tenant after release q.mu, since tenant may get GC'd and
+	// Cannot read group after release q.mu, since group may get GC'd and
 	// reused.
-	tenantID := tenant.id
+	groupID := group.id
 	q.mu.Unlock()
 
 	if !item.replicated.Enabled {
@@ -1186,11 +1186,11 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 		// to replicated writes.
 		if log.V(1) {
 			q.mu.Lock()
-			queueLen := tenant.waitingWorkHeap.Len()
+			queueLen := group.waitingWorkHeap.Len()
 			q.mu.Unlock()
 
 			log.Dev.Infof(q.ambientCtx, "async-path: len(waiting-work)=%d dequeued t%d pri=%s r%s log-position=%s ingested=%t",
-				queueLen, tenantID, item.priority,
+				queueLen, groupID, item.priority,
 				item.replicated.RangeID,
 				item.replicated.LogPosition,
 				item.replicated.Ingested,
@@ -1198,7 +1198,7 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 		}
 		defer releaseWaitingWork(item)
 		q.onAdmittedReplicatedWork.admittedReplicatedWork(
-			roachpb.MustMakeTenantID(tenantID),
+			roachpb.MustMakeTenantID(groupID),
 			item.priority,
 			item.replicated,
 			item.requestedCount,
@@ -1216,26 +1216,26 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 	return requestedCount
 }
 
-// gcTenantsResetUsedAndUpdateEstimators does three things:
-//  1. It resets tenant.used, which is the resource count over which the
+// gcGroupsResetUsedAndUpdateEstimators does three things:
+//  1. It resets group.used, which is the resource count over which the
 //     WorkQueue does fair-sharing. That is, fair-sharing is done over
 //     intervals that are sized at the frequency with which this
 //     function is called (as of 1/9/26, every 1s).
-//  2. It GCs tenantInfo entries, if a tenant has seen no workload over
+//  2. It GCs groupInfo entries, if a group has seen no workload over
 //     the interval.
 //  3. It updates CPU time token estimators. The estimators are only used
 //     if mode == usesCPUTimeTokens.
-func (q *WorkQueue) gcTenantsResetUsedAndUpdateEstimators() {
+func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.mu.defaultCPUTimeTokenEstimator.update()
-	// With large numbers of active tenants, this iteration could hold the lock
+	// With large numbers of active groups, this iteration could hold the lock
 	// longer than desired. We could break this iteration into smaller parts if
 	// needed.
-	for id, info := range q.mu.tenants {
-		if info.used == 0 && !isInTenantHeap(info) {
-			delete(q.mu.tenants, id)
-			releaseTenantInfo(info)
+	for id, info := range q.mu.groups {
+		if info.used == 0 && !isInGroupHeap(info) {
+			delete(q.mu.groups, id)
+			releaseGroupInfo(info)
 		} else {
 			info.cpuTimeTokenEstimator.update()
 			info.used = 0
@@ -1245,46 +1245,46 @@ func (q *WorkQueue) gcTenantsResetUsedAndUpdateEstimators() {
 	}
 }
 
-// adjustTenantUsed is used internally by StoreWorkQueue, and by the KV queue
+// adjustGroupUsed is used internally by StoreWorkQueue, and by the KV queue
 // in AdmittedWorkDone. The additionalUsed count can be negative, in which
 // case it is returning unused resources. This is only for WorkQueue's own
 // accounting -- it should not call into granter.
-func (q *WorkQueue) adjustTenantUsed(tenantID roachpb.TenantID, delta int64) {
+func (q *WorkQueue) adjustGroupUsed(tenantID roachpb.TenantID, delta int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	tid := tenantID.ToUint64()
-	tenant, ok := q.mu.tenants[tid]
+	group, ok := q.mu.groups[tid]
 	if !ok {
 		return
 	}
-	q.adjustTenantUsedLocked(tenant, delta)
+	q.adjustGroupUsedLocked(group, delta)
 }
 
-func (q *WorkQueue) adjustTenantUsedLocked(tenant *tenantInfo, delta int64) {
+func (q *WorkQueue) adjustGroupUsedLocked(group *groupInfo, delta int64) {
 	if delta < 0 {
 		toReturn := uint64(-delta)
-		if tenant.used < toReturn {
-			tenant.used = 0
+		if group.used < toReturn {
+			group.used = 0
 		} else {
-			tenant.used -= toReturn
+			group.used -= toReturn
 		}
 	} else {
-		tenant.used += uint64(delta)
+		group.used += uint64(delta)
 	}
-	if tenant.perTenantMetrics.tokensUsed != nil {
+	if group.perGroupMetrics.tokensUsed != nil {
 		if delta > 0 {
-			tenant.perTenantMetrics.tokensUsed.Inc(delta)
+			group.perGroupMetrics.tokensUsed.Inc(delta)
 		} else if delta < 0 {
-			tenant.perTenantMetrics.tokensReturned.Inc(-delta)
+			group.perGroupMetrics.tokensReturned.Inc(-delta)
 		}
 	}
 	if q.mode == usesCPUTimeTokens {
 		// Burst bucket tracks available budget, so we negate delta: consuming
 		// resources (positive delta to used) depletes the burst bucket.
-		tenant.cpuTimeBurstBucket.adjust(-delta)
+		group.cpuTimeBurstBucket.adjust(-delta)
 	}
-	if isInTenantHeap(tenant) {
-		q.mu.tenantHeap.fix(tenant)
+	if isInGroupHeap(group) {
+		q.mu.groupHeap.fix(group)
 	}
 }
 
@@ -1299,7 +1299,7 @@ func (q *WorkQueue) AdmittedSQLWorkDone(tenantID roachpb.TenantID, remaining int
 	if remaining < 0 && buildutil.CrdbTestBuild {
 		log.Dev.Fatalf(q.ambientCtx, "AdmittedSQLWorkDone: remaining %d is negative", remaining)
 	}
-	q.adjustTenantUsed(tenantID, -remaining)
+	q.adjustGroupUsed(tenantID, -remaining)
 	if remaining < 0 {
 		// Should never happen, but account for it defensively.
 		q.granter.tookWithoutPermission(-remaining)
@@ -1308,21 +1308,21 @@ func (q *WorkQueue) AdmittedSQLWorkDone(tenantID roachpb.TenantID, remaining int
 	}
 }
 
-// refillBurstBuckets adds tokens to all tenant burst buckets and updates
+// refillBurstBuckets adds tokens to all group burst buckets and updates
 // their capacity. This is called by cpuTimeTokenAllocator periodically (every
-// 1ms). If a tenant's burst qualification changes as a result of the refill,
-// the tenant's position in the tenantHeap is updated to maintain correct
+// 1ms). If a group's burst qualification changes as a result of the refill,
+// the group's position in the groupHeap is updated to maintain correct
 // priority ordering.
 func (q *WorkQueue) refillBurstBuckets(toAdd int64, capacity int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.mu.burstBucketCapacity = capacity
-	for _, tenant := range q.mu.tenants {
-		prevBurstQual := tenant.cpuTimeBurstBucket.burstQualification()
-		tenant.cpuTimeBurstBucket.refill(toAdd, capacity)
-		curBurstQual := tenant.cpuTimeBurstBucket.burstQualification()
-		if prevBurstQual != curBurstQual && isInTenantHeap(tenant) {
-			q.mu.tenantHeap.fix(tenant)
+	for _, group := range q.mu.groups {
+		prevBurstQual := group.cpuTimeBurstBucket.burstQualification()
+		group.cpuTimeBurstBucket.refill(toAdd, capacity)
+		curBurstQual := group.cpuTimeBurstBucket.burstQualification()
+		if prevBurstQual != curBurstQual && isInGroupHeap(group) {
+			q.mu.groupHeap.fix(group)
 		}
 	}
 }
@@ -1336,22 +1336,22 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	s.Printf("closed epoch: %d ", q.mu.closedEpochThreshold)
-	s.Printf("tenantHeap len: %d", len(q.mu.tenantHeap))
-	if len(q.mu.tenantHeap) > 0 {
-		s.Printf(" top tenant: %d", q.mu.tenantHeap[0].id)
+	s.Printf("groupHeap len: %d", len(q.mu.groupHeap))
+	if len(q.mu.groupHeap) > 0 {
+		s.Printf(" top group: %d", q.mu.groupHeap[0].id)
 	}
 	var ids []uint64
-	for id := range q.mu.tenants {
+	for id := range q.mu.groups {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	for _, id := range ids {
-		tenant := q.mu.tenants[id]
-		s.Printf("\n tenant-id: %d used: %d, w: %d, fifo: %d", tenant.id, tenant.used,
-			tenant.weight, tenant.fifoPriorityThreshold)
-		if len(tenant.waitingWorkHeap) > 0 {
+		group := q.mu.groups[id]
+		s.Printf("\n group-id: %d used: %d, w: %d, fifo: %d", group.id, group.used,
+			group.weight, group.fifoPriorityThreshold)
+		if len(group.waitingWorkHeap) > 0 {
 			// Sort items within waitingWorkHeap
-			sortedWaitingWorkHeap := slices.Clone(tenant.waitingWorkHeap)
+			sortedWaitingWorkHeap := slices.Clone(group.waitingWorkHeap)
 			sort.Sort(&sortedWaitingWorkHeap)
 			s.Printf(" waiting work heap:")
 			for i := range sortedWaitingWorkHeap {
@@ -1366,9 +1366,9 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 					sortedWaitingWorkHeap[i].enqueueingTime.UnixNano()/int64(time.Millisecond), workOrdering)
 			}
 		}
-		if len(tenant.openEpochsHeap) > 0 {
+		if len(group.openEpochsHeap) > 0 {
 			// Sort items within openEpochsHeap
-			sortedOpenEpochsHeap := slices.Clone(tenant.openEpochsHeap)
+			sortedOpenEpochsHeap := slices.Clone(group.openEpochsHeap)
 			sort.Sort(&sortedOpenEpochsHeap)
 			s.Printf(" open epochs heap:")
 			for i := range sortedOpenEpochsHeap {
@@ -1386,30 +1386,30 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 			if i > 0 {
 				s.Printf(" ")
 			}
-			tenant := q.mu.tenants[id]
-			s.Printf("t%d=%s", id, &tenant.cpuTimeBurstBucket)
+			group := q.mu.groups[id]
+			s.Printf("t%d=%s", id, &group.cpuTimeBurstBucket)
 		}
 	}
 }
 
-// Weight for tenants that are not assigned a weight. This typically applies
-// to tenants which weren't on this node in the prior call to
-// SetTenantWeights. Additionally, it is also the minimum tenant weight.
-const defaultTenantWeight = 1
+// Weight for groups that are not assigned a weight. This typically applies
+// to groups which weren't on this node in the prior call to
+// SetTenantWeights. Additionally, it is also the minimum group weight.
+const defaultGroupWeight = 1
 
-// The current cap on the weight of a tenant. We don't allow a single tenant
-// to use more than cap times the number of resources of the smallest tenant.
+// The current cap on the weight of a group. We don't allow a single group
+// to use more than cap times the number of resources of the smallest group.
 // For KV slots, we have seen a range of slot counts from 50-200 for 16 cpu
 // nodes, for a KV50 workload, depending on how we set
 // admission.kv_slot_adjuster.overload_threshold. We don't want to starve
-// small tenants, so the cap is currently set to 20. A more sophisticated fair
+// small groups, so the cap is currently set to 20. A more sophisticated fair
 // sharing scheme would not need such a cap.
-const tenantWeightCap = 20
+const groupWeightCap = 20
 
-func (q *WorkQueue) getTenantWeightLocked(tenantID uint64) uint32 {
-	weight, ok := q.mu.tenantWeights.active[tenantID]
+func (q *WorkQueue) getGroupWeightLocked(groupID uint64) uint32 {
+	weight, ok := q.mu.groupWeights.active[groupID]
 	if !ok {
-		weight = defaultTenantWeight
+		weight = defaultGroupWeight
 	}
 	return weight
 }
@@ -1424,64 +1424,66 @@ func (q *WorkQueue) SetOverrideAllToBypassAdmission(override bool) {
 
 // SetTenantWeights sets the weight of tenants, using the provided tenant ID
 // => weight map. A nil map will result in all tenants having the same weight.
-func (q *WorkQueue) SetTenantWeights(tenantWeights map[uint64]uint32) {
-	q.mu.tenantWeights.mu.Lock()
-	defer q.mu.tenantWeights.mu.Unlock()
-	if q.mu.tenantWeights.inactive == nil {
-		q.mu.tenantWeights.inactive = make(map[uint64]uint32)
+//
+// TODO(wenyihu): rename to SetGroupWeights.
+func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
+	q.mu.groupWeights.mu.Lock()
+	defer q.mu.groupWeights.mu.Unlock()
+	if q.mu.groupWeights.inactive == nil {
+		q.mu.groupWeights.inactive = make(map[uint64]uint32)
 	}
 	// Remove all elements from the inactive map.
-	for k := range q.mu.tenantWeights.inactive {
-		delete(q.mu.tenantWeights.inactive, k)
+	for k := range q.mu.groupWeights.inactive {
+		delete(q.mu.groupWeights.inactive, k)
 	}
-	// Compute the max weight in the new map, for enforcing the tenantWeightCap.
+	// Compute the max weight in the new map, for enforcing the groupWeightCap.
 	maxWeight := uint32(1)
-	for _, v := range tenantWeights {
+	for _, v := range groupWeights {
 		if v > maxWeight {
 			maxWeight = v
 		}
 	}
 	scaling := float64(1)
-	if maxWeight > tenantWeightCap {
-		scaling = tenantWeightCap / float64(maxWeight)
+	if maxWeight > groupWeightCap {
+		scaling = groupWeightCap / float64(maxWeight)
 	}
 	// Populate the weights in the inactive map.
-	for k, v := range tenantWeights {
+	for k, v := range groupWeights {
 		w := uint32(math.Ceil(float64(v) * scaling))
-		if w < defaultTenantWeight {
-			w = defaultTenantWeight
+		if w < defaultGroupWeight {
+			w = defaultGroupWeight
 		}
-		q.mu.tenantWeights.inactive[k] = w
+		q.mu.groupWeights.inactive[k] = w
 	}
 	// Establish the new active map.
 	func() {
 		q.mu.Lock()
 		defer q.mu.Unlock()
-		q.mu.tenantWeights.active, q.mu.tenantWeights.inactive =
-			q.mu.tenantWeights.inactive, q.mu.tenantWeights.active
+		q.mu.groupWeights.active, q.mu.groupWeights.inactive =
+			q.mu.groupWeights.inactive, q.mu.groupWeights.active
 	}()
-	// Create a slice for storing all the tenantIDs. We use this to split the
+	// Create a slice for storing all the groupIDs. We use this to split the
 	// update to the data-structures that require holding q.mu, in case there
-	// are 1000s of tenants (we don't want to hold q.mu for long durations).
-	tenantIDs := func() []uint64 {
+	// are 1000s of groups (we don't want to hold q.mu for long durations).
+	groupIDs := func() []uint64 {
 		q.mu.Lock()
 		defer q.mu.Unlock()
-		tIDs := make([]uint64, len(q.mu.tenants))
+		gIDs := make([]uint64, len(q.mu.groups))
 		i := 0
-		for k := range q.mu.tenants {
-			tIDs[i] = k
+		for k := range q.mu.groups {
+			gIDs[i] = k
 			i++
 		}
-		return tIDs
+		return gIDs
 	}()
-	// Any tenants not in tenantIDs will see the latest weight when their
-	// tenantInfo is created. The existing ones need their weights to be
+	// Any groups not in groupIDs will see the latest weight when their
+	// groupInfo is created. The existing ones need their weights to be
 	// updated.
 
-	// tenantIDs[index] represents the next tenantID that needs to be updated.
+	// groupIDs[index] represents the next groupID that needs to be updated.
 	var index int
-	n := len(tenantIDs)
-	// updateNextBatch acquires q.mu and updates a batch of tenants.
+	n := len(groupIDs)
+	// updateNextBatch acquires q.mu and updates a batch of groups.
 	updateNextBatch := func() (repeat bool) {
 		q.mu.Lock()
 		defer q.mu.Unlock()
@@ -1491,13 +1493,13 @@ func (q *WorkQueue) SetTenantWeights(tenantWeights map[uint64]uint32) {
 			if index >= n {
 				return false
 			}
-			tenantID := tenantIDs[index]
-			tenantInfo := q.mu.tenants[tenantID]
-			weight := q.getTenantWeightLocked(tenantID)
-			if tenantInfo != nil && tenantInfo.weight != weight {
-				tenantInfo.weight = weight
-				if isInTenantHeap(tenantInfo) {
-					q.mu.tenantHeap.fix(tenantInfo)
+			groupID := groupIDs[index]
+			gi := q.mu.groups[groupID]
+			weight := q.getGroupWeightLocked(groupID)
+			if gi != nil && gi.weight != weight {
+				gi.weight = weight
+				if isInGroupHeap(gi) {
+					q.mu.groupHeap.fix(gi)
 				}
 			}
 			index++
@@ -1544,8 +1546,8 @@ type priorityState struct {
 
 // priorityStates tracks information about admission requests and admission
 // grants at various priorities. It is used to set a priority threshold for
-// LIFO queuing. There is one priorityStates per tenant, since it is embedded
-// in a tenantInfo.
+// LIFO queuing. There is one priorityStates per group, since it is embedded
+// in a groupInfo.
 type priorityStates struct {
 	// In increasing order of priority. Expected to not have more than 10
 	// elements, so a linear search is fast. The slice is emptied after each
@@ -1654,15 +1656,15 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 	return priority
 }
 
-// tenantInfo is the per-tenant information in the tenantHeap.
-type tenantInfo struct {
+// groupInfo is the per-group information in the groupHeap.
+type groupInfo struct {
 	id uint64
-	// The weight assigned to the tenant. Must be > 0.
+	// The weight assigned to the group. Must be > 0.
 	weight uint32
 	// used is computed over an interval and periodically reset. Ordering
-	// between tenants, for fair sharing, utilizes this value.
+	// between groups, for fair sharing, utilizes this value.
 	//
-	// - For slots, used represents cpu time duration consumed by the tenant. It
+	// - For slots, used represents cpu time duration consumed by the group. It
 	//   is incremented by 1 (for non-elastic work) or some prediction of cpu
 	//   time (for elastic work) when the work is admitted. A correction is
 	//   applied when the work is done based on the actual cpu time consumed.
@@ -1670,17 +1672,17 @@ type tenantInfo struct {
 	//   that will be consumed is deducted at admission time, and a correction
 	//   is applied later.
 	//
-	// tenantInfo will not be GC'd until both used==0 and
+	// groupInfo will not be GC'd until both used==0 and
 	// len(waitingWorkHeap)==0.
 	//
 	// The used value is reset to 0 periodically. This creates a risk since
-	// callers of Admit hold references to tenantInfo. We do not want a race
-	// condition where the tenantInfo held in Admit is returned to the
+	// callers of Admit hold references to groupInfo. We do not want a race
+	// condition where the groupInfo held in Admit is returned to the
 	// sync.Pool. Note that this race is almost impossible to reproduce in
 	// practice since GC loop runs at 1s intervals and needs two iterations to
-	// GC a tenantInfo -- first to reset used=0 and then the next time to GC it.
+	// GC a groupInfo -- first to reset used=0 and then the next time to GC it.
 	// We fix this by being careful in the code of Admit by not reusing a
-	// reference to tenantInfo, and instead grab a new reference from the map.
+	// reference to groupInfo, and instead grab a new reference from the map.
 	//
 	// The above fix for the GC race condition is insufficient to prevent
 	// overflow of the used field if the reset to used=0 happens between used++
@@ -1707,49 +1709,49 @@ type tenantInfo struct {
 	// See the code in Admit that calls estimateTokensToBeUsed for more on this.
 	cpuTimeTokenEstimator cpuTimeTokenEstimator
 
-	// cpuTimeBurstBucket tracks whether this tenant qualifies for burst
+	// cpuTimeBurstBucket tracks whether this group qualifies for burst
 	// priority. Only used if mode == usesCPUTimeTokens. See
 	// cpu_time_token_burst.go for more.
 	cpuTimeBurstBucket cpuTimeBurstBucket
 
-	// perTenantMetrics holds per-tenant admission metric children. Only
+	// perGroupMetrics holds per-group admission metric children. Only
 	// set when mode == usesCPUTimeTokens. See cpuTimeTokenMetrics for
 	// details.
-	perTenantMetrics tenantMetrics
+	perGroupMetrics groupMetrics
 }
 
-// tenantMetrics groups the per-tenant metric children that are created
-// via AggCounter.AddChild for each tenant.
-type tenantMetrics struct {
+// groupMetrics groups the per-group metric children that are created
+// via AggCounter.AddChild for each group.
+type groupMetrics struct {
 	admittedCount  *aggmetric.Counter
 	waitTimeNanos  *aggmetric.Counter
 	tokensUsed     *aggmetric.Counter
 	tokensReturned *aggmetric.Counter
 }
 
-// tenantHeap is a heap of tenants with waiting work, ordered in increasing
-// order of tenantInfo.used/tenantInfo.weight (weights are an optional
-// feature, and default to 1). That is, we prefer tenants that are using less.
-type tenantHeap []*tenantInfo
+// groupHeap is a heap of groups with waiting work, ordered in increasing
+// order of groupInfo.used/groupInfo.weight (weights are an optional
+// feature, and default to 1). That is, we prefer groups that are using less.
+type groupHeap []*groupInfo
 
-var _ heap.Interface = (*tenantHeap)(nil)
+var _ heap.Interface = (*groupHeap)(nil)
 
-var tenantInfoPool = sync.Pool{
+var groupInfoPool = sync.Pool{
 	New: func() interface{} {
-		return &tenantInfo{}
+		return &groupInfo{}
 	},
 }
 
-func newTenantInfo(
+func newGroupInfo(
 	id uint64,
 	weight uint32,
 	mode workQueueMode,
 	cpuTimeTokenEstimate int64,
 	burstBucketCapacity int64,
-	aggMetrics *tenantAggMetrics,
-) *tenantInfo {
-	ti := tenantInfoPool.Get().(*tenantInfo)
-	*ti = tenantInfo{
+	aggMetrics *groupAggMetrics,
+) *groupInfo {
+	ti := groupInfoPool.Get().(*groupInfo)
+	*ti = groupInfo{
 		id:                    id,
 		weight:                weight,
 		waitingWorkHeap:       ti.waitingWorkHeap,
@@ -1767,23 +1769,23 @@ func newTenantInfo(
 		burstBucketCapacity, mode != usesCPUTimeTokens /* disable */)
 	if aggMetrics != nil {
 		tid := strconv.FormatUint(id, 10)
-		ti.perTenantMetrics.admittedCount = aggMetrics.admittedCount.AddChild(tid)
-		ti.perTenantMetrics.waitTimeNanos = aggMetrics.waitTimeNanos.AddChild(tid)
-		ti.perTenantMetrics.tokensUsed = aggMetrics.tokensUsed.AddChild(tid)
-		ti.perTenantMetrics.tokensReturned = aggMetrics.tokensReturned.AddChild(tid)
+		ti.perGroupMetrics.admittedCount = aggMetrics.admittedCount.AddChild(tid)
+		ti.perGroupMetrics.waitTimeNanos = aggMetrics.waitTimeNanos.AddChild(tid)
+		ti.perGroupMetrics.tokensUsed = aggMetrics.tokensUsed.AddChild(tid)
+		ti.perGroupMetrics.tokensReturned = aggMetrics.tokensReturned.AddChild(tid)
 	}
 	return ti
 }
 
-func releaseTenantInfo(ti *tenantInfo) {
-	if isInTenantHeap(ti) {
-		panic("tenantInfo has non-empty heap")
+func releaseGroupInfo(ti *groupInfo) {
+	if isInGroupHeap(ti) {
+		panic("groupInfo has non-empty heap")
 	}
-	if ti.perTenantMetrics.admittedCount != nil {
-		ti.perTenantMetrics.admittedCount.Unlink()
-		ti.perTenantMetrics.waitTimeNanos.Unlink()
-		ti.perTenantMetrics.tokensUsed.Unlink()
-		ti.perTenantMetrics.tokensReturned.Unlink()
+	if ti.perGroupMetrics.admittedCount != nil {
+		ti.perGroupMetrics.admittedCount.Unlink()
+		ti.perGroupMetrics.waitTimeNanos.Unlink()
+		ti.perGroupMetrics.tokensUsed.Unlink()
+		ti.perGroupMetrics.tokensReturned.Unlink()
 	}
 	// NB: {waitingWorkHeap,openEpochsHeap}.Pop nil the slice elements when
 	// removing, so we are not inadvertently holding any references.
@@ -1794,32 +1796,32 @@ func releaseTenantInfo(ti *tenantInfo) {
 		ti.openEpochsHeap = nil
 	}
 
-	*ti = tenantInfo{
+	*ti = groupInfo{
 		waitingWorkHeap: ti.waitingWorkHeap,
 		openEpochsHeap:  ti.openEpochsHeap,
 		priorityStates:  makePriorityStates(ti.priorityStates.ps),
 	}
-	tenantInfoPool.Put(ti)
+	groupInfoPool.Put(ti)
 }
 
-func (th *tenantHeap) fix(item *tenantInfo) {
+func (th *groupHeap) fix(item *groupInfo) {
 	heap.Fix(th, item.heapIndex)
 }
 
-func (th *tenantHeap) remove(item *tenantInfo) {
+func (th *groupHeap) remove(item *groupInfo) {
 	heap.Remove(th, item.heapIndex)
 }
 
-func (th *tenantHeap) Len() int {
+func (th *groupHeap) Len() int {
 	return len(*th)
 }
 
-func (th *tenantHeap) Less(i, j int) bool {
-	// First, order by burstQualification: canBurst tenants come before
-	// noBurst tenants. canBurst tenants have access to more CPU time
+func (th *groupHeap) Less(i, j int) bool {
+	// First, order by burstQualification: canBurst groups come before
+	// noBurst groups. canBurst groups have access to more CPU time
 	// than noBurst -- see cpu_time_token_granter.go for details -- so
-	// it is important that work from a canBurst tenant always sorts
-	// before work from a noBurst tenant -- else available capacity is
+	// it is important that work from a canBurst group always sorts
+	// before work from a noBurst group -- else available capacity is
 	// left on the table.
 	iBurstQual := (*th)[i].cpuTimeBurstBucket.burstQualification()
 	jBurstQual := (*th)[j].cpuTimeBurstBucket.burstQualification()
@@ -1827,16 +1829,16 @@ func (th *tenantHeap) Less(i, j int) bool {
 		return iBurstQual < jBurstQual
 	}
 	// Beyond burstQualification (which is only enabled on CPU time token
-	// AC today), for tenant fairness, we use used_i/weight_i <
+	// AC today), for group fairness, we use used_i/weight_i <
 	// used_j/weight_j to determine order. In case of a tie, prioritize
-	// items with higher weight, and then items with lower tenant id.
+	// items with higher weight, and then items with lower group id.
 	//
 	// A reader may wonder if sorting on just used has the same effect
 	// as sorting on burstQualification first and used second. It is indeed
 	// similar, but it is not the same -- for example, used is reset every
 	// 1s, thus right after a reset it can fall out of sync with
 	// cpuTimeBurstBucket's burstQualification method. The source of truth
-	// for whether a tenant can burst is cpuTimeBurstBucket's
+	// for whether a group can burst is cpuTimeBurstBucket's
 	// burstQualification method, so we must call it here.
 	if (*th)[i].used*uint64((*th)[j].weight) == (*th)[j].used*uint64((*th)[i].weight) {
 		if (*th)[i].weight == (*th)[j].weight {
@@ -1847,20 +1849,20 @@ func (th *tenantHeap) Less(i, j int) bool {
 	return (*th)[i].used*uint64((*th)[j].weight) < (*th)[j].used*uint64((*th)[i].weight)
 }
 
-func (th *tenantHeap) Swap(i, j int) {
+func (th *groupHeap) Swap(i, j int) {
 	(*th)[i], (*th)[j] = (*th)[j], (*th)[i]
 	(*th)[i].heapIndex = i
 	(*th)[j].heapIndex = j
 }
 
-func (th *tenantHeap) Push(x interface{}) {
+func (th *groupHeap) Push(x interface{}) {
 	n := len(*th)
-	item := x.(*tenantInfo)
+	item := x.(*groupInfo)
 	item.heapIndex = n
 	*th = append(*th, item)
 }
 
-func (th *tenantHeap) Pop() interface{} {
+func (th *groupHeap) Pop() interface{} {
 	old := *th
 	n := len(old)
 	item := old[n-1]
@@ -1929,8 +1931,8 @@ var waitingWorkPool = sync.Pool{
 // transactions that get admitted to have finished all their work.
 //
 // Note that LIFO queueing will only happen at bottleneck nodes, and decided
-// on a (tenant, priority) basis. So if there is even a single bottleneck node
-// for a (tenant, priority), the above delay will occur. When the epoch closes
+// on a (group, priority) basis. So if there is even a single bottleneck node
+// for a (group, priority), the above delay will occur. When the epoch closes
 // at the bottleneck node, the creation time for this transaction will be
 // sufficiently in the past, so the non-bottleneck nodes (using FIFO) will
 // prioritize it over recent transactions. Note that there is an inversion in
@@ -1999,7 +2001,7 @@ func releaseWaitingWork(ww *waitingWork) {
 	waitingWorkPool.Put(ww)
 }
 
-// waitingWorkHeap is a heap of waiting work within a tenant. It is ordered in
+// waitingWorkHeap is a heap of waiting work within a group. It is ordered in
 // decreasing order of priority, and within the same priority in increasing
 // order of createTime (to prefer older work) for FIFO, and in decreasing
 // order of createTime for LIFO. In the LIFO case the heap only contains
@@ -2071,7 +2073,7 @@ func (wwh *waitingWorkHeap) Pop() interface{} {
 	return item
 }
 
-// openEpochsHeap is a heap of waiting work within a tenant that will be
+// openEpochsHeap is a heap of waiting work within a group that will be
 // subject to LIFO ordering (when transferred to the waitingWorkHeap) and
 // whose epoch is not yet closed. See the Less method for the ordering applied
 // here.
@@ -2270,7 +2272,7 @@ func (m *WorkQueueMetrics) recordBypassedAdmission(priority admissionpb.WorkPrio
 
 func (m *WorkQueueMetrics) recordFastPathAdmission(priority admissionpb.WorkPriority) {
 	// Explicitly record a zero wait queue duration when we're able to acquire
-	// tokens/slots without needing to add ourselves to tenant heaps. Explicitly
+	// tokens/slots without needing to add ourselves to group heaps. Explicitly
 	// recording zeros ensure that our histograms are accurate with respect to
 	// all work going through admission control.
 	m.total.WaitDurations.RecordValue(0)
@@ -2523,7 +2525,7 @@ func (q *StoreWorkQueue) admittedReplicatedWork(
 	if !coordMuLocked {
 		q.coordMu.Unlock()
 	}
-	q.q[wc].adjustTenantUsed(tenantID, additionalTokensNeeded)
+	q.q[wc].adjustGroupUsed(tenantID, additionalTokensNeeded)
 
 	// Inform callers of the entry we just admitted.
 	//
@@ -2588,7 +2590,7 @@ func (q *StoreWorkQueue) AdmittedWorkDone(h StoreWorkHandle, doneInfo StoreWorkD
 	}
 	q.updateStoreStatsAfterWorkDone(1, doneInfo, false, true)
 	additionalTokens := q.granters[h.workClass].storeWriteDone(h.writeTokens, doneInfo)
-	q.q[h.workClass].adjustTenantUsed(h.tenantID, additionalTokens)
+	q.q[h.workClass].adjustGroupUsed(h.tenantID, additionalTokens)
 	return nil
 }
 
@@ -2634,9 +2636,9 @@ func (q *StoreWorkQueue) updateStoreStatsAfterWorkDone(
 }
 
 // SetTenantWeights passes through to WorkQueue.SetTenantWeights.
-func (q *StoreWorkQueue) SetTenantWeights(tenantWeights map[uint64]uint32) {
+func (q *StoreWorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 	for i := range q.q {
-		q.q[i].SetTenantWeights(tenantWeights)
+		q.q[i].SetTenantWeights(groupWeights)
 	}
 }
 

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -215,7 +215,7 @@ func TestWorkQueueBasic(t *testing.T) {
 				timeSource = timeutil.NewManualTime(initialTime)
 				opts.timeSource = timeSource
 				opts.disableEpochClosingGoroutine = true
-				opts.disableGCTenantsAndResetUsed = true
+				opts.disableGCGroupsAndResetUsed = true
 				q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 					workKind, tg, st, metrics, opts).(*WorkQueue)
 				if d.HasArg("override-all-to-bypass") {
@@ -356,8 +356,8 @@ func TestWorkQueueBasic(t *testing.T) {
 				q.tryCloseEpoch(timeSource.Now())
 				return q.String()
 
-			case "gc-tenants-and-reset-used":
-				q.gcTenantsResetUsedAndUpdateEstimators()
+			case "gc-groups-and-reset-used":
+				q.gcGroupsResetUsedAndUpdateEstimators()
 				return q.String()
 
 			default:
@@ -429,10 +429,10 @@ func TestCPUTimeTokenWorkQueue(t *testing.T) {
 				timeSource = timeutil.NewManualTime(initialTime)
 				opts.timeSource = timeSource
 				opts.disableEpochClosingGoroutine = true
-				opts.disableGCTenantsAndResetUsed = true
+				opts.disableGCGroupsAndResetUsed = true
 				opts.mode = usesCPUTimeTokens
 				cpuMetrics := makeCPUTimeTokenMetrics()
-				opts.perTenantAggMetrics = &tenantAggMetrics{
+				opts.perGroupAggMetrics = &groupAggMetrics{
 					admittedCount:  cpuMetrics.AdmittedCountPerTenant[systemTenant],
 					waitTimeNanos:  cpuMetrics.WaitTimeNanosPerTenant[systemTenant],
 					tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
@@ -548,8 +548,8 @@ func TestCPUTimeTokenWorkQueue(t *testing.T) {
 				q.refillBurstBuckets(toAdd, capacity)
 				return ""
 
-			case "gc-tenants-and-reset-used":
-				q.gcTenantsResetUsedAndUpdateEstimators()
+			case "gc-groups-and-reset-used":
+				q.gcGroupsResetUsedAndUpdateEstimators()
 				return ""
 
 			default:
@@ -590,7 +590,7 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 	opts := makeWorkQueueOptions(KVWork)
 	opts.mode = usesCPUTimeTokens
 	cpuMetrics := makeCPUTimeTokenMetrics()
-	opts.perTenantAggMetrics = &tenantAggMetrics{
+	opts.perGroupAggMetrics = &groupAggMetrics{
 		admittedCount:  cpuMetrics.AdmittedCountPerTenant[systemTenant],
 		waitTimeNanos:  cpuMetrics.WaitTimeNanosPerTenant[systemTenant],
 		tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
@@ -599,7 +599,7 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 	timeSource = timeutil.NewManualTime(initialTime)
 	opts.timeSource = timeSource
 	opts.disableEpochClosingGoroutine = true
-	opts.disableGCTenantsAndResetUsed = true
+	opts.disableGCGroupsAndResetUsed = true
 	st = cluster.MakeTestingClusterSettings()
 	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 		KVWork, tg, st, metrics, opts).(*WorkQueue)
@@ -640,7 +640,7 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 		q.AdmittedWorkDone(resp1, 150*time.Millisecond)
 
 		if i%10 == 0 {
-			q.gcTenantsResetUsedAndUpdateEstimators()
+			q.gcGroupsResetUsedAndUpdateEstimators()
 		}
 	}
 
@@ -672,7 +672,7 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 		q.AdmittedWorkDone(resp2, 350*time.Millisecond)
 
 		if i%10 == 0 {
-			q.gcTenantsResetUsedAndUpdateEstimators()
+			q.gcGroupsResetUsedAndUpdateEstimators()
 		}
 	}
 
@@ -697,12 +697,12 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 
 	// This is a test of GC. If a call to update happens without any
 	// work happening during that interval, the tenant's estimator should be
-	// GCed. The first call to gcTenantsResetUsedAndUpdateEstimators resets
+	// GCed. The first call to gcGroupsResetUsedAndUpdateEstimators resets
 	// the interval over which activity is checked. The second call GCes the
 	// per-tenant estimators. So tenant 1 & tenant 2 should use the global
 	// estimator, just like tenant 3.
-	q.gcTenantsResetUsedAndUpdateEstimators()
-	q.gcTenantsResetUsedAndUpdateEstimators()
+	q.gcGroupsResetUsedAndUpdateEstimators()
+	q.gcGroupsResetUsedAndUpdateEstimators()
 	resp1, err = q.Admit(ctx, info1)
 	require.NoError(t, err)
 	checkEstimation(resp1, 250*time.Millisecond)
@@ -730,7 +730,7 @@ func makeCPUTimeTokenWorkQueue(t *testing.T) (q *WorkQueue, tg *testGranter, cle
 	opts := makeWorkQueueOptions(KVWork)
 	opts.mode = usesCPUTimeTokens
 	cpuMetrics := makeCPUTimeTokenMetrics()
-	opts.perTenantAggMetrics = &tenantAggMetrics{
+	opts.perGroupAggMetrics = &groupAggMetrics{
 		admittedCount:  cpuMetrics.AdmittedCountPerTenant[systemTenant],
 		waitTimeNanos:  cpuMetrics.WaitTimeNanosPerTenant[systemTenant],
 		tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
@@ -738,7 +738,7 @@ func makeCPUTimeTokenWorkQueue(t *testing.T) (q *WorkQueue, tg *testGranter, cle
 	}
 	opts.timeSource = timeutil.NewManualTime(initialTime)
 	opts.disableEpochClosingGoroutine = true
-	opts.disableGCTenantsAndResetUsed = true
+	opts.disableGCGroupsAndResetUsed = true
 
 	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 		KVWork, tg, st, metrics, opts).(*WorkQueue)
@@ -768,7 +768,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			q.AdmittedWorkDone(resp, 50*time.Millisecond)
 			if i%10 == 0 {
-				q.gcTenantsResetUsedAndUpdateEstimators()
+				q.gcGroupsResetUsedAndUpdateEstimators()
 			}
 		}
 
@@ -850,10 +850,10 @@ func TestSQLCPUAdmission(t *testing.T) {
 	})
 }
 
-// TestWorkQueueTokenResetRace induces racing between tenantInfo.used
-// decrements and tenantInfo.used resets that used to fail until we eliminated
-// the code that decrements tenantInfo.used for tokens. It would also trigger
-// a used-after-free bug where the tenantInfo being used in Admit had been
+// TestWorkQueueTokenResetRace induces racing between groupInfo.used
+// decrements and groupInfo.used resets that used to fail until we eliminated
+// the code that decrements groupInfo.used for tokens. It would also trigger
+// a used-after-free bug where the groupInfo being used in Admit had been
 // returned to the sync.Pool because the used value was reset.
 func TestWorkQueueTokenResetRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -936,7 +936,7 @@ func TestWorkQueueTokenResetRace(t *testing.T) {
 				// This hot loop with GC calls is able to trigger the previously buggy
 				// code by squeezing in multiple times between the token grant and
 				// cancellation.
-				q.gcTenantsResetUsedAndUpdateEstimators()
+				q.gcGroupsResetUsedAndUpdateEstimators()
 			}
 		}
 	}()
@@ -1062,7 +1062,7 @@ func TestStoreWorkQueueBasic(t *testing.T) {
 				opts.mode = usesTokens
 				opts.timeSource = timeutil.NewManualTime(timeutil.FromUnixMicros(0))
 				opts.disableEpochClosingGoroutine = true
-				opts.disableGCTenantsAndResetUsed = true
+				opts.disableGCGroupsAndResetUsed = true
 				st = cluster.MakeTestingClusterSettings()
 				var mockCoordMu syncutil.Mutex
 				q = makeStoreWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()), roachpb.StoreID(1),


### PR DESCRIPTION
Epic: none 
Release note: none
Part of: https://github.com/cockroachdb/cockroach/issues/168382

---
**admission: update tenant to group in comments across CTT files**

This change updates comments in the CPU time token files to use
"group" where the comment refers to internal concepts (burst
qualification, token buckets, refill rates). References to the
public API or to SQL tenants specifically are left unchanged.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: rename tenant to group in WorkQueue internals**

Mechanical rename of internal types, fields, methods, constants,
and local variables from "tenant" to "group." The WorkQueue's
per-entity fair-sharing bookkeeping serves both SQL tenants
(serverless) and resource groups (resource manager). This rename
makes the internals mode-agnostic.

Note that public API names (`SetTenantWeights`, `WorkInfo.TenantID`,
`AdmittedSQLWorkDone`), metric names, and parameters typed as
`roachpb.TenantID` are unchanged.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: rename shared-path params from tenantID to groupID**

This change renames `AdmitResponse.tenantID` and the
`adjustGroupUsed` parameter to `groupID`. These are internal to
`WorkQueue`, which is shared between serverless and resource
manager modes - the identifier may represent a resource group,
not a SQL tenant.

Structs used only by serverless paths (`StoreWorkHandle`,
`ElasticCPUWorkHandle`) retain `tenantID` since the value is
always a `roachpb.TenantID`.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: add dual-role doc comments on group types**

This change documents that `groupInfo`, `groupHeap`, and
`mu.groupHeap` represent either a SQL tenant (serverless) or a
resource group (resource manager). The `groupHeap` comment is
updated to describe burst qualification ordering.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

