### PR TITLE
sql: fix unnecessary plan cache rebuilds for routines with equivalent param types

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare_cache
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare_cache
@@ -406,3 +406,61 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' 
 ----
 rebuilding cached memo
 reusing cached memo
+
+# ------------------------------------------------------------------------------
+# Regression test for #168304: routines with parameter types that have different
+# OIDs from the argument types (e.g., VARCHAR param with STRING argument) should
+# cache.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE t_vc (k INT PRIMARY KEY, s STRING)
+
+statement ok
+INSERT INTO t_vc VALUES (1, 'hello'), (2, 'world')
+
+statement ok
+CREATE FUNCTION f_vc(x VARCHAR) RETURNS INT LANGUAGE SQL AS 'SELECT length(x)'
+
+statement ok
+PREPARE p_vc AS SELECT f_vc(s) FROM t_vc WHERE k = $1
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_vc(1);
+EXECUTE p_vc(2);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+reusing cached memo
+reusing cached memo
+
+# TODO(drewk): Same as above, but with two overloads. This does not cache
+# because we rely on the single-overload special case to handle mismatched OIDs.
+statement ok
+CREATE FUNCTION f_vc2(x VARCHAR) RETURNS INT LANGUAGE SQL AS 'SELECT length(x)';
+CREATE FUNCTION f_vc2(x INT) RETURNS INT LANGUAGE SQL AS 'SELECT x';
+
+statement ok
+PREPARE p_vc2 AS SELECT f_vc2(s) FROM t_vc WHERE k = $1
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+EXECUTE p_vc2(1);
+EXECUTE p_vc2(2);
+
+statement ok
+SET TRACING = "off";
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+----
+rebuilding cached memo
+rebuilding cached memo

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -588,46 +588,14 @@ func (md *Metadata) CheckDependencies(
 				if err != nil {
 					return false, maybeSwallowMetadataResolveErr(err)
 				}
-				routineObj := tree.RoutineObj{
-					FuncName: name.ToRoutineName(),
-					Params:   make(tree.RoutineParams, len(dep.invocationTypes)),
-				}
-				for i := 0; i < len(routineObj.Params); i++ {
-					routineObj.Params[i] = tree.RoutineParam{
-						Type: dep.invocationTypes[i],
-						// Since we're not in the DROP context, it's sufficient
-						// to specify only the input parameters.
-						Class: tree.RoutineParamIn,
-						// Note that we don't need to specify the DefaultVal
-						// here because invocationTypes specifies the argument
-						// schema that was actually used. Instead, we will ask
-						// for matching overloads to use their DEFAULT
-						// expressions if necessary.
-					}
-				}
-				// NOTE: We match for all types of routines here, including
-				// procedures so that if a function has been dropped and a
-				// procedure is created with the same signature, we do not get a
-				// "<func> is not a function" error here. Instead, we'll return
-				// false and attempt to rebuild the statement.
-				routineType := tree.UDFRoutine | tree.BuiltinRoutine | tree.ProcedureRoutine
-				// Always allowing using DEFAULT expressions for input
-				// parameters since the signature of the routine might have
-				// changed even though the invocation remained the same.
-				const tryDefaultExprs = true
-				toCheck, err := definition.MatchOverload(
-					ctx,
-					optCatalog,
-					&routineObj,
-					&evalCtx.SessionData().SearchPath,
-					routineType,
-					false, /* inDropContext */
-					tryDefaultExprs,
+				toCheck, err := matchOverloadByTypes(
+					ctx, optCatalog, definition, name.ToRoutineName(),
+					dep.invocationTypes, &evalCtx.SessionData().SearchPath,
 				)
 				// We cannot check the version here, because we only resolve the
 				// function signature by name. We will check the version below when
 				// resolving by OID.
-				if err != nil || toCheck.Oid != overload.Oid {
+				if err != nil || toCheck == nil || toCheck.Oid != overload.Oid {
 					return false, maybeSwallowMetadataResolveErr(err)
 				}
 			}
@@ -697,6 +665,63 @@ func (md *Metadata) CheckDependencies(
 		md.digest.Unlock()
 	}
 	return true, nil
+}
+
+// matchOverloadByTypes constructs a tree.RoutineObj from the given routine name
+// and argument types, then calls MatchOverload to find the matching overload.
+// All routine types (UDF, builtin, procedure) are considered, and DEFAULT
+// expressions are tried when matching.
+func matchOverloadByTypes(
+	ctx context.Context,
+	typeRes tree.TypeReferenceResolver,
+	definition *tree.ResolvedFunctionDefinition,
+	routineName tree.RoutineName,
+	argTypes []*types.T,
+	searchPath tree.SearchPath,
+) (*tree.Overload, error) {
+	if len(definition.Overloads) == 0 {
+		return nil, nil
+	} else if len(definition.Overloads) == 1 {
+		// Fast path: if there's only one candidate, check if it's the same as the
+		// one resolved while building the plan.
+		return definition.Overloads[0].Overload, nil
+	}
+	routineObj := tree.RoutineObj{
+		FuncName: routineName,
+		Params:   make(tree.RoutineParams, len(argTypes)),
+	}
+	for i := 0; i < len(routineObj.Params); i++ {
+		routineObj.Params[i] = tree.RoutineParam{
+			Type: argTypes[i],
+			// Since we're not in the DROP context, it's sufficient
+			// to specify only the input parameters.
+			Class: tree.RoutineParamIn,
+			// Note that we don't need to specify the DefaultVal
+			// here because invocationTypes specifies the argument
+			// schema that was actually used. Instead, we will ask
+			// for matching overloads to use their DEFAULT
+			// expressions if necessary.
+		}
+	}
+	// NOTE: We match for all types of routines here, including
+	// procedures so that if a function has been dropped and a
+	// procedure is created with the same signature, we do not get a
+	// "<func> is not a function" error here. Instead, we'll return
+	// false and attempt to rebuild the statement.
+	routineType := tree.UDFRoutine | tree.BuiltinRoutine | tree.ProcedureRoutine
+	// Always allowing using DEFAULT expressions for input
+	// parameters since the signature of the routine might have
+	// changed even though the invocation remained the same.
+	const tryDefaultExprs = true
+	const inDropContext = false
+	ol, err := definition.MatchOverload(
+		ctx, typeRes, &routineObj, searchPath,
+		routineType, inDropContext, tryDefaultExprs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ol.Overload, nil
 }
 
 // handleMetadataResolveErr swallows errors that are thrown when a database


### PR DESCRIPTION
Previously, when checking whether a cached query plan was still valid, `MatchOverload` was used to re-resolve routine references. This used strict OID comparison (`MatchOid`) for parameter types, which would fail when the argument type and parameter type were equivalent but had different OIDs (e.g., STRING OID 25 vs VARCHAR OID 1043). This caused the cached memo to be rebuilt on every execution.

Fix this for the common single-overload case by returning the overload directly without going through `MatchOverload`. The multi-overload case still has the issue and will be addressed separately. No release note, since this will be in the same release as #162057.

Fixes #168304

Release note: None