### PR TITLE
util/json/tokenizer,backup: fix 'occured' -> 'occurred' comment typos

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2489,7 +2489,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		}
 		// TODO(msbutler): ideally doDownloadFiles would not depend on job details
 		// and is instead passed an execCfg and the download spans and anything else
-		// it needs. If that occured, we would not need to update details above.
+		// it needs. If that occurred, we would not need to update details above.
 		if err := r.doDownloadFilesWithRetry(ctx, p); err != nil {
 			return err
 		}

--- a/pkg/util/json/tokenizer/scanner.go
+++ b/pkg/util/json/tokenizer/scanner.go
@@ -77,7 +77,7 @@ var whitespace = [256]bool{
 
 // Next returns a []byte referencing the next lexical token in the stream.
 // The []byte is valid until Next is called again.
-// If the stream is at its end, or an error has occured, Next returns a zero
+// If the stream is at its end, or an error has occurred, Next returns a zero
 // length []byte slice.
 //
 // A valid token begins with one of the following:


### PR DESCRIPTION
Two unrelated doc-comment `occured` typos:

- `pkg/util/json/tokenizer/scanner.go:80` — `Next` doc: `If the stream is at its end, or an error has occured, Next returns a zero`.
- `pkg/backup/restore_job.go:2492` — inline comment: `If that occured, we would not need to update details above`.

Doc/comment only, no behaviour change.