### PR TITLE
release-26.2: Update pkg/testutils/release/cockroach_releases.yaml

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -48,4 +48,5 @@
   latest: 26.1.2
   predecessor: "25.4"
 "26.2":
+  latest: 26.2.0-rc.1
   predecessor: "26.1"


### PR DESCRIPTION
Update pkg/testutils/release/cockroach_releases.yaml with recent values.

Epic: None
Release note: None
Release justification: test-only updates