### PR TITLE
opt: use inverted index for st_dwithin with zero distance 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -586,3 +586,87 @@ SELECT _ST_3DDWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 1)'::geometry, 1)
 true
 
 subtest end
+
+# Regression test for #127265: st_dwithin with distance=0 should use
+# inverted index (equivalent to st_intersects).
+subtest st_dwithin_zero_distance
+
+statement ok
+CREATE TABLE geo_dwithin_zero (
+  id INT PRIMARY KEY,
+  geom GEOMETRY,
+  geog GEOGRAPHY,
+  INVERTED INDEX (geom),
+  INVERTED INDEX (geog)
+);
+
+statement ok
+INSERT INTO geo_dwithin_zero VALUES
+  (1, 'POINT(1 1)', 'POINT(1 1)'),
+  (2, 'POINT(2 2)', 'POINT(2 2)'),
+  (3, 'LINESTRING(0 0, 1 1)', 'LINESTRING(0 0, 1 1)'),
+  (4, 'POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))', 'SRID=4326;POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))');
+
+# st_dwithin with distance=0 should match the same rows as st_intersects. The
+# corresponding plan-shape assertion (that the inverted index is used) lives in
+# pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial, which runs
+# only under the local config and has stable EXPLAIN output.
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geom, 'POINT(1 1)'::geometry, 0) ORDER BY id
+----
+1
+3
+4
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 0) ORDER BY id
+----
+1
+3
+4
+
+# NULL arguments to st_dwithin should yield NULL (and thus no rows from
+# WHERE). The inverted index path short-circuits on NULL args via
+# extractInfoFromExpr, so these queries fall through to a regular filter;
+# the assertions confirm the distance=0 optimization does not change
+# observable behavior for NULL inputs.
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geom, NULL::geometry, 0) ORDER BY id
+----
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, NULL::geography, 0) ORDER BY id
+----
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geom, 'POINT(1 1)'::geometry, NULL) ORDER BY id
+----
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, NULL) ORDER BY id
+----
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 0, NULL) ORDER BY id
+----
+
+# NULL values in the indexed column should not match.
+statement ok
+INSERT INTO geo_dwithin_zero VALUES (5, NULL, NULL)
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geom, 'POINT(1 1)'::geometry, 0) ORDER BY id
+----
+1
+3
+4
+
+query I
+SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 0) ORDER BY id
+----
+1
+3
+4
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -210,3 +210,57 @@ regions: <hidden>
                   spans: 31 spans
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzcVmFv4kYT_v7-itF8SaLXEbu2Q7mtKtEQrqVtjgjQVaeC0MY7IRa217e7bogiflb_QH9ZtXaIAj1o6Z1Uqf6wMM_OPp6ZZ0brJ7QfMxQ47v_U701gCW9Hw2tYkJ47eZsR_Px9f9QH6-Zp4chYSpw9PRmPBlffhO03vPP1zXDwbnIaM8ZYBPUPi85OhPiuP7zuT0YfAs-Vn8FwdNUfweUHWGKAhVb0TuZkUfyCHGcBlkYnZK02HnqqHQZqhYIFmBZl5Tw8CzDRhlA8oUtdRihw4mMckVRkWgwDVORkmtW0Lyl0fQDztFC0wgB7OqvywgpYNpFhgONSeqA1xcvpdHWnptMVi_zC_mLB82PP8CmCLBREDLS7J2MxwB_fg0_XCih4YxpapNqH5Mi6BnJpTgLY7789nzD6wYKiRCtSAsIGvH10ZMGQVAJ4Gy4bdDG66UEis8y-OJYyNRvHGAO8ft_rgXVUQqKrwsEprVwrLdyZAFbXtXEgWu5zyOUKcsq1eQSZZTqRzsfF6hhupUvuyYKuXFk5Ad6_jn8DhDhbB9hYz0JbJxeEgr_qjMEVCrYO_n5zDIpfyThSb9PMkSHT4tsdstnvr0oDuoAuF2B9L4B10jhRaxt9dTGdMq8t8xIeXBCoUMce8y3xp54Y-rJ0fbx1grXcjXqNbZ3Msu2moBUllUt1sQ0fEsbv2Y8ZOMpLUKldQmXlgr6AbuGObvwY3X7QafE80-GBmW7-zcslPX56rv8Tg1VZUmCdIZmT-df0jHb0DI_R82X-om01G1zsXi6MM-6vkZCF7fYb9vrptb_lnZg3Rod1eCeO-zE_Ea_vm2549kUn6DPKFu-ULTqmbGNtHJlWvF20Lv__Pxv2z0jjYieN-Jg0RmRLXVjaSmPfm9jOm875ehYgqQU13wVWVyahG6OT2rcxhzVRDSiyrtnljTEoNlvNDL1cIq-Z-EGmcD8T32UKDzJF-5nCXaboIFO8nynaZYoPMl0cqtMswLtMP8xThQI3Q3j-iWXzoD8gF9Y3wPheP9S0k8fSy3cnM0sBXsslXZEjk6dFal2aoHCmovX6f38EAAD__-7rWJw=
+
+# Regression test for #127265: st_dwithin with distance=0 should use the
+# inverted index (equivalent to st_intersects). The functional check (that the
+# right rows are returned) lives in pkg/sql/logictest/testdata/logic_test/geospatial_zm.
+statement ok
+CREATE TABLE geo_dwithin_zero (
+  id INT PRIMARY KEY,
+  geom GEOMETRY,
+  geog GEOGRAPHY,
+  INVERTED INDEX (geom),
+  INVERTED INDEX (geog)
+)
+
+# Geometry: st_dwithin with distance=0 should produce an inverted index scan.
+query T
+EXPLAIN SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geom, 'POINT(1 1)'::geometry, 0)
+----
+distribution: local
+·
+• filter
+│ filter: st_dwithin(geom, '0101000000000000000000F03F000000000000F03F', 0.0)
+│
+└── • index join
+    │ table: geo_dwithin_zero@geo_dwithin_zero_pkey
+    │
+    └── • inverted filter
+        │ inverted column: geom_inverted_key
+        │ num spans: 31
+        │
+        └── • scan
+              missing stats
+              table: geo_dwithin_zero@geo_dwithin_zero_geom_idx
+              spans: 31 spans
+
+# Geography: st_dwithin with distance=0 should produce an inverted index scan.
+query T
+EXPLAIN SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 0)
+----
+distribution: local
+·
+• filter
+│ filter: st_dwithin(geog, '0101000020E6100000000000000000F03F000000000000F03F', 0.0)
+│
+└── • index join
+    │ table: geo_dwithin_zero@geo_dwithin_zero_pkey
+    │
+    └── • inverted filter
+        │ inverted column: geog_inverted_key
+        │ num spans: 31
+        │
+        └── • scan
+              missing stats
+              table: geo_dwithin_zero@geo_dwithin_zero_geog_idx
+              spans: 31 spans

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -106,6 +106,25 @@ func getSpanExprForGeographyIndex(
 				"parameter %s is not float", additionalParams[0].ResolvedType())
 		}
 		distanceMeters := float64(*d)
+		// At distance=0, the spans produced by geogIdx.DWithin are equivalent
+		// to those of geogIdx.Intersects: DWithin builds the same cell
+		// covering of geog and then expands it by an angle proportional to
+		// the distance, which is a no-op at distance=0 regardless of the
+		// use_spheroid argument. We delegate to Intersects because it avoids
+		// an upstream check in the DWithin path that produces empty spans at
+		// distance=0 and prevents index acceleration. Note that this
+		// equivalence is only at the index-span layer; ST_DWithin and
+		// ST_Intersects can disagree at the function level (in particular,
+		// spheroid vs. sphere math for geography), but the recheck of the
+		// original ST_DWithin filter on top of the inverted scan preserves
+		// the original semantics.
+		if distanceMeters == 0 {
+			unionKeySpans, err := geogIdx.Intersects(ctx, geog)
+			if err != nil {
+				return nil, err
+			}
+			return invertedexpr.GeoUnionKeySpansToSpanExpr(unionKeySpans), nil
+		}
 		useSpheroid := geogfn.UseSpheroid
 		if len(additionalParams) == 2 {
 			b, ok := additionalParams[1].(*tree.DBool)
@@ -191,6 +210,22 @@ func getSpanExprForGeometryIndex(
 
 	case geoindex.DWithin:
 		distance := getDistanceParam(additionalParams)
+		// At distance=0, the spans produced by geomIdx.DWithin are equivalent
+		// to those of geomIdx.Intersects: DWithin buffers geom by the
+		// distance and then computes Intersects spans on the result, and
+		// buffering by 0 is a no-op (modulo a degenerate case where it
+		// produces an empty geometry, which is what made the existing path
+		// produce empty spans and prevented index acceleration). Note that
+		// this equivalence is only at the index-span layer; the recheck of
+		// the original ST_DWithin filter on top of the inverted scan
+		// preserves the function-level semantics.
+		if distance == 0 {
+			unionKeySpans, err := geomIdx.Intersects(ctx, geom)
+			if err != nil {
+				return nil, err
+			}
+			return invertedexpr.GeoUnionKeySpansToSpanExpr(unionKeySpans), nil
+		}
 		unionKeySpans, err := geomIdx.DWithin(ctx, geom, distance)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION

Previously, ST_DWithin(col, geom, 0) could not use an inverted index
scan because the zero distance produced no buffer expansion (geometry)
or radius expansion (geography), resulting in empty key spans that the
optimizer treated as non-invertible. Allowing inverted index scans can
help with performance and matches the behavior of ST_Intersects.

Since ST_DWithin(a, b, 0) is semantically equivalent to
ST_Intersects(a, b), this commit delegates to the Intersects index
span generation path when the distance parameter is exactly 0. This
applies to both geometry and geography inverted indexes.

Resolves: #127265

Release note: None