### PR TITLE
admission: add resource group routing and per-group burst refill

### DIFF
--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
@@ -1,0 +1,143 @@
+###
+# This test exercises priority-based resource groups. When
+# set-priority-based-groups is enabled, work is routed to resource
+# groups based on WorkInfo.Priority rather than WorkInfo.TenantID:
+#   - priority >= 0 (NormalPri) -> group 1 (high)
+#   - priority < 0              -> group 2 (low)
+#
+# This means work from different tenants but the same priority band
+# shares the same group, and work from the same tenant but different
+# priority bands goes to different groups.
+#
+# Note: admit id= is a test-local handle for tracking admit results,
+# unrelated to tenant or group IDs.
+###
+init
+----
+
+set-try-get-return-value v=true
+----
+
+set-priority-based-groups v=true
+----
+
+# Admit high-priority work (priority=0, NormalPri). Should route to
+# group 1 regardless of tenant ID.
+admit id=1 tenant=10 priority=0 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 1: admit succeeded
+
+admit id=2 tenant=20 priority=0 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 2: admit succeeded
+
+# Both high-pri admits (different tenants) should land in group 1.
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 2, w: 1, fifo: -128
+burst-buckets: t1=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+
+# Admit low-priority work (priority=-30, BulkNormalPri). Should route
+# to group 2 regardless of tenant ID.
+admit id=3 tenant=10 priority=-30 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 3: admit succeeded
+
+admit id=4 tenant=20 priority=-30 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 4: admit succeeded
+
+# Print: should show two groups (1 and 2), not four tenant-based groups.
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 2, w: 1, fifo: -128
+ group-id: 2 used: 2, w: 1, fifo: -128
+burst-buckets: t1=fullness=0.0% tokens=-2 capacity=0 qual=no_burst t2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+
+###
+# Verify AdmittedWorkDone uses the correct group. Complete work from
+# different tenants and check that used is adjusted on the right group.
+###
+
+work-done id=1 cpu-time=100
+----
+tookWithoutPermission 99
+
+work-done id=3 cpu-time=200
+----
+tookWithoutPermission 199
+
+# Group 1 (high) should have used adjusted for id=1's cpu-time.
+# Group 2 (low) should have used adjusted for id=3's cpu-time.
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 101, w: 1, fifo: -128
+ group-id: 2 used: 201, w: 1, fifo: -128
+burst-buckets: t1=fullness=0.0% tokens=-101 capacity=0 qual=no_burst t2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
+
+###
+# Verify burst qualification works correctly with priority-based groups.
+# Set group 1 (high) to maxCPU and queue work.
+###
+
+set-max-cpu-groups group=1 v=true
+----
+
+set-try-get-return-value v=false
+----
+
+# Queue high-pri and low-pri work.
+admit id=5 tenant=10 priority=0 requested-count=1
+----
+tryGet: input can_burst, returning false
+
+admit id=6 tenant=10 priority=-30 requested-count=1
+----
+
+gc-groups-and-reset-used
+----
+
+# Group 1 (high, can_burst via maxCPU) should be granted before
+# group 2 (low, no_burst).
+granted chain-id=1
+----
+continueGrantChain 1
+id 5: admit succeeded
+granted: returned 1
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 6: admit succeeded
+granted: returned 1
+
+###
+# Disable priority-based groups. Work should now route by tenant ID.
+###
+
+set-try-get-return-value v=true
+----
+
+set-priority-based-groups v=false
+----
+
+admit id=7 tenant=50 priority=0 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 7: admit succeeded
+
+# Should show group 50 (tenant-based), not group 1.
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+ group-id: 50 used: 1, w: 1, fifo: -128
+burst-buckets: t1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst t2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst t50=fullness=0.0% tokens=-1 capacity=0 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
@@ -1,0 +1,120 @@
+###
+# This test exercises refillBurstBucketForGroup, which refills a
+# single group's burst bucket with per-group scaled amounts (as
+# opposed to refillBurstBuckets which applies uniform amounts to
+# all groups).
+#
+# Note: admit id= is a test-local handle for tracking admit results,
+# unrelated to tenant or group IDs.
+###
+init
+----
+
+set-try-get-return-value v=true
+----
+
+# Create three groups.
+admit id=1 tenant=10 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 1: admit succeeded
+
+admit id=2 tenant=20 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 2: admit succeeded
+
+admit id=3 tenant=30 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 3: admit succeeded
+
+# Refill only group 10 with a large amount. Groups 20 and 30 get nothing.
+# Group 10 should be at high fullness (can_burst), while groups 20 and
+# 30 remain at -1 tokens with capacity=0 (no_burst).
+refill-burst-bucket-for-group group=10 to-add=100 capacity=100
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 1, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+ group-id: 30 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+
+# Refill group 20 with a smaller amount. Group 20 should reach 49%
+# (no_burst). Group 30 still untouched.
+refill-burst-bucket-for-group group=20 to-add=50 capacity=100
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 1, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+ group-id: 30 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=49.0% tokens=49 capacity=100 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+
+###
+# Verify that refill-burst-bucket-for-group correctly updates the heap
+# when burst qualification changes. Queue work for groups 20 (49%,
+# no_burst) and 30 (no tokens, no_burst), then refill group 20 past
+# 90% to push it to can_burst. Group 20's work should be granted
+# before group 30's.
+###
+
+set-try-get-return-value v=false
+----
+
+admit id=4 tenant=20 requested-count=1
+----
+tryGet: input no_burst, returning false
+
+admit id=5 tenant=30 requested-count=1
+----
+
+gc-groups-and-reset-used
+----
+
+# Refill group 20 past the 90% threshold. This exercises the heap
+# fix path: refillBurstBucketLocked calls groupHeap.fix() when burst
+# qualification changes, transitioning group 20 to can_burst.
+refill-burst-bucket-for-group group=20 to-add=50 capacity=100
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 2 top group: 20
+ group-id: 10 used: 0, w: 1, fifo: -128
+ group-id: 20 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 30 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=99.0% tokens=99 capacity=100 qual=can_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+
+# Group 20 (now can_burst) should be granted before group 30 (no_burst).
+granted chain-id=1
+----
+continueGrantChain 1
+id 4: admit succeeded
+granted: returned 1
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 5: admit succeeded
+granted: returned 1
+
+###
+# Verify refill for a nonexistent group is a no-op.
+###
+
+refill-burst-bucket-for-group group=999 to-add=100 capacity=100
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 0, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+ group-id: 30 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=98.0% tokens=98 capacity=100 qual=can_burst t30=fullness=0.0% tokens=-2 capacity=0 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
@@ -1,0 +1,174 @@
+###
+# This test exercises SetMaxCPUGroups, which dynamically updates the
+# maxCPU flag on existing groups. When maxCPU transitions from false
+# to true, the group should immediately qualify for burst (can_burst).
+# When it transitions back, the group reverts to the 90%-fullness
+# check. The heap position is updated on each transition.
+#
+# Note: admit id= is a test-local handle for tracking admit results,
+# unrelated to tenant or group IDs.
+###
+init
+----
+
+set-try-get-return-value v=true
+----
+
+# Create two groups.
+admit id=1 tenant=10 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 1: admit succeeded
+
+admit id=2 tenant=20 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 2: admit succeeded
+
+# Refill to 50% fullness. Neither group qualifies for burst.
+refill-burst-buckets to-add=51 capacity=100
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 1, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=50.0% tokens=50 capacity=100 qual=no_burst t20=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+
+# Set group 10 to maxCPU=true via SetMaxCPUGroups. Group 10 should
+# now be can_burst despite being at only 50% fullness.
+set-max-cpu-groups group=10 v=true
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 1, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst t20=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+
+# Queue work for both groups.
+set-try-get-return-value v=false
+----
+
+admit id=3 tenant=20 requested-count=1
+----
+tryGet: input no_burst, returning false
+
+admit id=4 tenant=10 requested-count=1
+----
+tryGet: input can_burst, returning false
+
+gc-groups-and-reset-used
+----
+
+# Group 10 (can_burst via maxCPU) should be granted first.
+granted chain-id=1
+----
+continueGrantChain 1
+id 4: admit succeeded
+granted: returned 1
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 3: admit succeeded
+granted: returned 1
+
+###
+# Now revoke maxCPU from group 10. It should revert to no_burst
+# since its bucket is below 90%.
+###
+
+set-try-get-return-value v=true
+----
+
+set-max-cpu-groups group=10 v=false
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 1, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=49.0% tokens=49 capacity=100 qual=no_burst t20=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+
+# Both groups are now no_burst. New work should report no_burst.
+admit id=5 tenant=10 requested-count=1
+----
+tryGet: input no_burst, returning true
+id 5: admit succeeded
+
+###
+# Verify that SetMaxCPUGroups correctly updates the heap when burst
+# qualification changes while work is already queued. This exercises
+# the heap fix path: SetMaxCPUGroups calls groupHeap.fix() when it
+# transitions a group's burst qualification.
+###
+
+set-try-get-return-value v=false
+----
+
+admit id=6 tenant=10 requested-count=1
+----
+tryGet: input no_burst, returning false
+
+admit id=7 tenant=20 requested-count=1
+----
+
+gc-groups-and-reset-used
+----
+
+# Set maxCPU on group 10 while both groups have queued work. Group 10
+# should transition to can_burst and the heap should reorder.
+set-max-cpu-groups group=10 v=true
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 2 top group: 10
+ group-id: 10 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 20 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: t10=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst t20=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+
+# Group 10 (can_burst via maxCPU) should be granted before group 20.
+granted chain-id=1
+----
+continueGrantChain 1
+id 6: admit succeeded
+granted: returned 1
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 7: admit succeeded
+granted: returned 1
+
+set-try-get-return-value v=true
+----
+
+# Revoke maxCPU to restore state for subsequent tests.
+set-max-cpu-groups group=10 v=false
+----
+
+###
+# Set maxCPU on a group that doesn't exist yet. The flag should be
+# picked up when the group is first created via Admit.
+###
+
+set-max-cpu-groups group=30 v=true
+----
+
+admit id=8 tenant=30 requested-count=1
+----
+tryGet: input can_burst, returning true
+id 8: admit succeeded
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+ group-id: 10 used: 1, w: 1, fifo: -128
+ group-id: 20 used: 1, w: 1, fifo: -128
+ group-id: 30 used: 1, w: 1, fifo: -128
+burst-buckets: t10=fullness=47.0% tokens=47 capacity=100 qual=no_burst t20=fullness=48.0% tokens=48 capacity=100 qual=no_burst t30=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -307,11 +307,13 @@ type WorkQueue struct {
 
 	mu struct {
 		syncutil.Mutex
-		// Groups with waiting work. In serverless mode each group is a
-		// SQL tenant keyed by tenant ID; in resource manager mode each
-		// group is a resource group keyed by resource group ID.
+		// Groups with waiting work. In serverless mode each group is a SQL tenant
+		// keyed by tenant ID; in resource manager mode each group is a resource
+		// group keyed by resource group ID. Ordered by burst qualification then
+		// used/weight.
 		groupHeap groupHeap
-		// All groups, including those without waiting work. Periodically cleaned.
+		// All groups, including those without waiting work. Keyed by resource group
+		// ID. Periodically cleaned.
 		groups       map[uint64]*groupInfo
 		groupWeights struct {
 			mu syncutil.Mutex
@@ -325,6 +327,24 @@ type WorkQueue struct {
 			// The maps are lazily allocated.
 			active, inactive map[uint64]uint32
 		}
+		// maxCPUGroups maps resource group ID to whether that group always
+		// qualifies for burst (MAX_CPU). Only used if mode == usesCPUTimeTokens and
+		// admission.cpu_time_tokens.mode == "resource_manager".
+		maxCPUGroups map[uint64]bool
+
+		// useResourceGroup, when true, derives the resource group ID from
+		// WorkInfo.Priority instead of WorkInfo.TenantID. Used in Resource
+		// Manager mode to split work into foreground (priority >= NormalPri)
+		// and background (priority < NormalPri) groups.
+		//
+		// This is a bool rather than a live read of the cluster setting so
+		// that mode transitions can update this and all components have a
+		// consistent view.
+		//
+		// TODO(wenyihu): support mode transitions and consider
+		// replacing this with an enum for serverless vs RM mode.
+		useResourceGroup bool
+
 		// The highest epoch that is closed.
 		closedEpochThreshold int64
 		// Following values are copied from the cluster settings.
@@ -337,6 +357,12 @@ type WorkQueue struct {
 		// buckets. Note that buckets init full, so burstBucketCapacity is also
 		// the starting token count. Updated by refillBurstBuckets. Only used
 		// if mode == usesCPUTimeTokens.
+		//
+		// TODO(wenyihu6): For RM, a group that appears between refills will use
+		// burstBucketCapacity (which may be stale or zero) until the next refill
+		// delivers its correct per-group capacity within 1ms. We should plumb the
+		// per-group capacity to newGroupInfo at creation time so new groups don't
+		// wait for the next refill cycle.
 		burstBucketCapacity int64
 		// overrideAllToBypassAdmission, when true, causes all work to bypass
 		// admission control. Used by CPU time token AC.
@@ -667,7 +693,14 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 type AdmitResponse struct {
 	// If true, admission control is enabled.
 	Enabled bool
-
+	// groupID is the groupID under which this work was admitted. Used by
+	// AdmittedWorkDone to look up the correct groupInfo entry. groupID represents
+	// tenant in Serverless and resource group in resource group manager.
+	// TODO(wenyihu6): need to figure out the proto changes here
+	// TODO(wenyihu6): captures the key at admission time, so AdmittedWorkDone
+	// finds the right entry even if the mode switches between Admit and
+	// AdmittedWorkDone. Need to make sure lookup misses fail gracefully if the
+	// entry has been GCed after a mode switch.
 	groupID roachpb.TenantID
 	// requestedCount is the number of slots or tokens taken at Admit time.
 	// It is useful to return, so that in AdmittedWorkDone, we can adjust
@@ -675,6 +708,47 @@ type AdmitResponse struct {
 	// CPU time token AC, where a grunning-based measurement of CPU time
 	// is available by the time AdmittedWorkDone is called.
 	requestedCount int64
+}
+
+// Resource group IDs used in Resource Manager mode when
+// useResourceGroup is true. Work is split into two groups based on
+// WorkInfo.Priority.
+const (
+	// highResourceGroupID is used for work with priority >= NormalPri.
+	highResourceGroupID uint64 = 1
+	// lowResourceGroupID is used for work with priority < NormalPri.
+	lowResourceGroupID uint64 = 2
+)
+
+// priorityToResourceGroup maps a WorkPriority to one of the two
+// hardcoded resource groups. Used in Resource Manager mode.
+func priorityToResourceGroup(pri admissionpb.WorkPriority) uint64 {
+	if pri >= admissionpb.NormalPri {
+		return highResourceGroupID
+	}
+	return lowResourceGroupID
+}
+
+// setUseResourceGroup enables or disables priority-based resource
+// group derivation. When enabled, the resource group ID is derived
+// from WorkInfo.Priority instead of WorkInfo.TenantID.
+func (q *WorkQueue) setUseResourceGroup(enabled bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.mu.useResourceGroup = enabled
+}
+
+// groupIDForWorkLocked returns the resource group ID for the given
+// WorkInfo. In RM mode (useResourceGroup), the group is derived from
+// WorkInfo.Priority; otherwise it is the TenantID.
+//
+// REQUIRES: q.mu is held.
+func (q *WorkQueue) groupIDForWorkLocked(info WorkInfo) uint64 {
+	q.mu.AssertHeld()
+	if q.mu.useResourceGroup {
+		return priorityToResourceGroup(info.Priority)
+	}
+	return info.TenantID.ToUint64()
 }
 
 // Admit is called when requesting admission for some work. If
@@ -723,12 +797,14 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	}
 	q.metrics.incRequested(info.Priority)
 
-	groupID := info.TenantID.ToUint64()
 	// The code in this method does not use defer to unlock the mutex because it
 	// needs the flexibility of selectively unlocking on a certain code path.
 	// When changing the code, be careful in making sure the mutex is properly
 	// unlocked on all code paths.
 	q.mu.Lock()
+
+	groupID := q.groupIDForWorkLocked(info)
+
 	group, ok := q.mu.groups[groupID]
 	if !ok {
 		// See comment below about CPU time token estimation. If no groupInfo
@@ -736,10 +812,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// dedicated to that group yet. When we create the groupInfo struct
 		// here, we also create the estimator. We init the estimator using a
 		// global estimator that sees workload across all groups.
-		// TODO(wenyihu6): look up maxCPU from per-resource-group config here
+		maxCPU := q.getMaxCPULocked(groupID)
 		group = newGroupInfo(groupID, q.getGroupWeightLocked(groupID),
 			q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
-			false /* maxCPU */, q.perGroupAggMetrics)
+			maxCPU, q.perGroupAggMetrics)
 		q.mu.groups[groupID] = group
 	}
 	// If mode == usesCPUTimeTokens, WorkQueue does CPU time token estimation.
@@ -756,7 +832,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		info.RequestedCount = group.cpuTimeTokenEstimator.estimateTokensToBeUsed()
 	}
 	admitResponse := AdmitResponse{
-		groupID:        info.TenantID,
+		groupID:        roachpb.TenantID{InternalValue: groupID},
 		requestedCount: info.RequestedCount,
 	}
 
@@ -870,14 +946,20 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// the state of the requesters to see if there is any queued work that
 		// can be granted admission.
 		q.mu.Lock()
+
+		// Re-derive groupID: the mode may have changed while the lock
+		// was released (though mode transitions are not yet supported).
+		groupID = q.groupIDForWorkLocked(info)
+		admitResponse.groupID = roachpb.TenantID{InternalValue: groupID}
+
 		// The group could have been removed. See the comment where the
 		// groupInfo struct is declared.
 		group, ok = q.mu.groups[groupID]
 		if !ok {
-			// TODO(wenyihu6): look up maxCPU from per-resource-group config here
+			maxCPU := q.getMaxCPULocked(groupID)
 			group = newGroupInfo(groupID, q.getGroupWeightLocked(groupID),
 				q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
-				false /* maxCPU */, q.perGroupAggMetrics)
+				maxCPU, q.perGroupAggMetrics)
 			q.mu.groups[groupID] = group
 		}
 		q.adjustGroupUsedLocked(group, -info.RequestedCount)
@@ -1313,8 +1395,11 @@ func (q *WorkQueue) AdmittedSQLWorkDone(tenantID roachpb.TenantID, remaining int
 }
 
 // refillBurstBuckets adds tokens to all group burst buckets and updates
-// their capacity. This is called by cpuTimeTokenAllocator periodically (every
-// 1ms). If a group's burst qualification changes as a result of the refill,
+// their capacity. This is called by serverlessStrategy.refillBurst
+// periodically (every 1ms). toAdd and capacity are passed uniformly to
+// all tenants with no per-tenant scaling.
+//
+// If a group's burst qualification changes as a result of the refill,
 // the group's position in the groupHeap is updated to maintain correct
 // priority ordering.
 func (q *WorkQueue) refillBurstBuckets(toAdd int64, capacity int64) {
@@ -1322,12 +1407,45 @@ func (q *WorkQueue) refillBurstBuckets(toAdd int64, capacity int64) {
 	defer q.mu.Unlock()
 	q.mu.burstBucketCapacity = capacity
 	for _, group := range q.mu.groups {
-		prevBurstQual := group.cpuTimeBurstBucket.burstQualification()
-		group.cpuTimeBurstBucket.refill(toAdd, capacity)
-		curBurstQual := group.cpuTimeBurstBucket.burstQualification()
-		if prevBurstQual != curBurstQual && isInGroupHeap(group) {
-			q.mu.groupHeap.fix(group)
-		}
+		q.refillBurstBucketLocked(group, toAdd, capacity)
+	}
+}
+
+// refillBurstBucketForGroup adds tokens to a specific resource group's
+// burst bucket and updates its capacity. This is called by
+// rmStrategy.refillBurst with pre-scaled per-group amounts. For example,
+// a group with WEIGHT_CPU=10% gets toAdd and capacity equal to 10% of the
+// 100% CPU rate, so its burst bucket stays at steady state when the
+// group uses ~10% of node CPU.
+// TODO(wenyihu6): actually finish the plumbing from ^
+//
+// If the group's burst qualification changes, its position in the
+// groupHeap is updated.
+//
+// TODO(wenyihu6): investigate whether refill rates need a pre-warming
+// period after RM config changes. A sudden config swap (e.g. changing
+// which groups have maxCPU) could interact poorly with the filler's
+// model if it hasn't had time to stabilize at the new rates.
+func (q *WorkQueue) refillBurstBucketForGroup(groupID uint64, toAdd int64, capacity int64) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	group, ok := q.mu.groups[groupID]
+	if !ok {
+		return
+	}
+	q.mu.burstBucketCapacity = capacity
+	q.refillBurstBucketLocked(group, toAdd, capacity)
+}
+
+// refillBurstBucketLocked refills a group's burst bucket and fixes its
+// heap position if the burst qualification changed. q.mu must be held.
+func (q *WorkQueue) refillBurstBucketLocked(group *groupInfo, toAdd int64, capacity int64) {
+	q.mu.AssertHeld()
+	prevBurstQual := group.cpuTimeBurstBucket.burstQualification()
+	group.cpuTimeBurstBucket.refill(toAdd, capacity)
+	curBurstQual := group.cpuTimeBurstBucket.burstQualification()
+	if prevBurstQual != curBurstQual && isInGroupHeap(group) {
+		q.mu.groupHeap.fix(group)
 	}
 }
 
@@ -1416,6 +1534,43 @@ func (q *WorkQueue) getGroupWeightLocked(groupID uint64) uint32 {
 		weight = defaultGroupWeight
 	}
 	return weight
+}
+
+// getMaxCPULocked returns the maxCPU flag for the given resource
+// group. Returns false if the group is not in the map. See
+// cpuTimeBurstBucket for how this flag affects burst qualification.
+//
+// REQUIRES: q.mu is held.
+func (q *WorkQueue) getMaxCPULocked(groupID uint64) bool {
+	q.mu.AssertHeld()
+	if q.mu.maxCPUGroups != nil {
+		if maxCPU, ok := q.mu.maxCPUGroups[groupID]; ok {
+			return maxCPU
+		}
+	}
+	return false
+}
+
+// SetMaxCPUGroups replaces all per-resource-group maxCPU flags with
+// the provided map. Groups absent from the map revert to the default
+// (maxCPU=false). Existing groups have their burst buckets updated;
+// new groups will pick up their flag when created. The map is captured
+// by reference; the caller must not modify it after calling.
+func (q *WorkQueue) SetMaxCPUGroups(groups map[uint64]bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.mu.maxCPUGroups = groups
+	for id, group := range q.mu.groups {
+		maxCPU := q.getMaxCPULocked(id)
+		if group.cpuTimeBurstBucket.maxCPU != maxCPU {
+			prevQual := group.cpuTimeBurstBucket.burstQualification()
+			group.cpuTimeBurstBucket.maxCPU = maxCPU
+			curQual := group.cpuTimeBurstBucket.burstQualification()
+			if prevQual != curQual && isInGroupHeap(group) {
+				q.mu.groupHeap.fix(group)
+			}
+		}
+	}
 }
 
 // SetOverrideAllToBypassAdmission sets whether all work should bypass
@@ -1660,13 +1815,14 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 	return priority
 }
 
-// groupInfo is the per-group information in the groupHeap. A group
-// represents a SQL tenant in serverless mode or a resource group in
-// resource manager mode; id is the tenant ID or resource group ID
-// respectively.
+// groupInfo is the per-group information in the groupHeap. In Serverless mode,
+// the resource group ID is the tenant ID. In RM mode with useResourceGroup,
+// the resource group ID is derived from the work's priority (see
+// priorityToResourceGroup).
 type groupInfo struct {
 	id uint64
-	// The weight assigned to the group. Must be > 0.
+	// The weight assigned to the resource group. Must be > 0. For
+	// resource groups, this is WEIGHT_CPU.
 	weight uint32
 	// used is computed over an interval and periodically reset. Ordering
 	// between groups, for fair sharing, utilizes this value.

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -466,10 +466,14 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				ctx, cancel := context.WithCancel(context.Background())
 				var requestedCount int64
 				d.ScanArgs(t, "requested-count", &requestedCount)
+				var pri int
+				if d.HasArg("priority") {
+					d.ScanArgs(t, "priority", &pri)
+				}
 				wrkMap.set(id, &testWork{cancel: cancel})
 				workInfo := WorkInfo{
 					TenantID:        tenant,
-					Priority:        admissionpb.WorkPriority(0),
+					Priority:        admissionpb.WorkPriority(pri),
 					CreateTime:      int64(1) * int64(time.Millisecond),
 					BypassAdmission: bypass,
 					RequestedCount:  requestedCount,
@@ -564,11 +568,32 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				var v bool
 				d.ScanArgs(t, "group", &group)
 				d.ScanArgs(t, "v", &v)
+				// Build the full map from current state plus the new entry,
+				// then call the production SetMaxCPUGroups method.
 				q.mu.Lock()
-				if gi, ok := q.mu.groups[uint64(group)]; ok {
-					gi.cpuTimeBurstBucket.maxCPU = v
+				m := make(map[uint64]bool)
+				for k, val := range q.mu.maxCPUGroups {
+					m[k] = val
 				}
 				q.mu.Unlock()
+				m[uint64(group)] = v
+				q.SetMaxCPUGroups(m)
+				return ""
+
+			case "set-priority-based-groups":
+				var v bool
+				d.ScanArgs(t, "v", &v)
+				q.setUseResourceGroup(v)
+				return ""
+
+			case "refill-burst-bucket-for-group":
+				var group int
+				var toAdd int64
+				var capacity int64
+				d.ScanArgs(t, "group", &group)
+				d.ScanArgs(t, "to-add", &toAdd)
+				d.ScanArgs(t, "capacity", &capacity)
+				q.refillBurstBucketForGroup(uint64(group), toAdd, capacity)
 				return ""
 
 			default:


### PR DESCRIPTION
Epic: none 
Release note: none
On top of https://github.com/cockroachdb/cockroach/pull/168438. Only last commit.

**admission: add resource group routing and per-group burst refill**

This change adds the WorkQueue scaffolding for Resource Manager mode:

1. Priority-based group routing: when useResourceGroup is true,
   work is routed to one of two hardcoded resource groups based on
   WorkInfo.Priority (>= NormalPri -> group 1, < NormalPri ->
   group 2) instead of WorkInfo.TenantID.

2. Per-group burst refill: refillBurstBucketForGroup refills a
   single group's burst bucket with pre-scaled amounts, unlike
   refillBurstBuckets which applies uniform amounts to all groups.

3. SetMaxCPUGroups: dynamically updates maxCPU flags on existing
   groups and fixes their heap positions when burst qualification
   changes.

None of these APIs are called in production yet. The functional
behavior is unchanged - useResourceGroup defaults to false, so
Admit still routes by TenantID; refillBurstBucketForGroup and
SetMaxCPUGroups have no callers outside tests. These will be
wired up when the cpuTimeTokenGrantCoordinator learns to drive
RM mode transitions.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

