### PR TITLE
ci: opt T-kv into auto-investigate for test failures

### DIFF
--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -92,7 +92,8 @@ jobs:
       (github.event_name == 'issues' &&
        github.event.issue.pull_request == null &&
        contains(github.event.issue.labels.*.name, 'C-test-failure') &&
-       contains(github.event.issue.labels.*.name, 'T-sql-queries')) ||
+       (contains(github.event.issue.labels.*.name, 'T-sql-queries') ||
+        contains(github.event.issue.labels.*.name, 'T-kv'))) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request == null &&
        (github.event.comment.body == '/investigate' ||


### PR DESCRIPTION
Add the `T-kv` label to the auto-trigger condition so that issues
carrying both `C-test-failure` and `T-kv` automatically invoke the
investigate workflow, matching the pattern established for
`T-sql-queries` in #168393.

Epic: none

Release note: None