### PR TITLE
ci: fix lint_test panic in affected-targets unit test runs

### DIFF
--- a/build/github/affected-targets.sh
+++ b/build/github/affected-targets.sh
@@ -79,8 +79,9 @@ fi
 
 # Let Bazel resolve which candidates are real source file targets, find the
 # build rules that own them, then find all go_test targets that transitively
-# depend on those rules. One query, fully authoritative.
-QUERY="kind('go_test', rdeps(//pkg/..., same_pkg_direct_rdeps(set(${CANDIDATES}))))"
+# depend on those rules. Exclude integration-tagged tests, which require
+# bespoke setup (e.g. lint_test needs GO_SDK) and have their own CI jobs.
+QUERY="kind('go_test', rdeps(//pkg/..., same_pkg_direct_rdeps(set(${CANDIDATES})))) except attr('tags', 'integration', //pkg/...)"
 
 # Temporarily disable errexit so we can inspect the query exit code.
 set +e

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -73,11 +73,12 @@ const cockroachDB = "github.com/cockroachdb/cockroach"
 //go:embed gcassert_paths.txt
 var rawGcassertPaths string
 
-func init() {
+func TestMain(m *testing.M) {
 	if bazel.BuiltWithBazel() {
 		goSdk := os.Getenv("GO_SDK")
 		if goSdk == "" {
-			panic("expected GO_SDK")
+			fmt.Println("GO_SDK not set; skipping lint tests (require bespoke CI setup)")
+			os.Exit(0)
 		}
 		if err := os.Setenv("PATH", fmt.Sprintf("%s%c%s", filepath.Join(goSdk, "bin"), os.PathListSeparator, os.Getenv("PATH"))); err != nil {
 			panic(err)
@@ -86,6 +87,7 @@ func init() {
 			panic(err)
 		}
 	}
+	os.Exit(m.Run())
 }
 
 func dirCmd(

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -257,8 +257,8 @@ func maybeSkip(t SkippableTest, reason string, args ...interface{}) {
 
 var miscNightly = envutil.EnvOrDefaultBool("COCKROACH_MISC_NIGHTLY", false)
 
-// IfNotMiscNightly skips this test unless the COCKROACH_MISC_NIGHTLY env var is
-// set to 'true'.
+// IfNotMiscNightly skips this test unless the COCKROACH_MISC_NIGHTLY
+// env var is set to 'true'.
 //
 // Does not respect COCKROACH_FORCE_RUN_SKIPPED_TESTS.
 func IfNotMiscNightly(t SkippableTest) {


### PR DESCRIPTION
## Summary

- `affected-targets.sh` computes individual test targets via `rdeps` and
  passes them directly to `bazel test`, bypassing the `tags = ["-integration"]`
  filter on `//pkg:all_tests`. This caused `//pkg/testutils/lint:lint_test` to
  run without the required `GO_SDK` env var, panicking in `init()`.
- First commit filters integration-tagged tests out of the affected-targets
  query.
- Second commit is defense-in-depth: replaces the `init()` panic with a
  `TestMain` that skips gracefully when `GO_SDK` is missing.
- Third commit makes a "useless but harmless" tiny edit to a direct dependency of the `lint` package,
   thus making sure that passing CI on this PR serves as confirmation of the fix.

This PR also stops `./dev test ./pkg/lint` from crashing (the lint tests no-op instead now).

Epic: none