### PR TITLE
sql/indexrec: support vector index recommendations

### DIFF
--- a/pkg/sql/opt/indexrec/candidate.go
+++ b/pkg/sql/opt/indexrec/candidate.go
@@ -6,12 +6,15 @@
 package indexrec
 
 import (
+	"slices"
+
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 )
 
@@ -42,6 +45,10 @@ import (
 //  7. For JSON and array columns, we create single column inverted indexes. We
 //     also create the following multi-column combination candidates for each
 //     inverted column: eq + 'inverted column', EQ + 'inverted column'.
+//  8. For vector columns used in distance expressions (<->, <=>, <#>), we
+//     create single column vector indexes. We also create the following
+//     multi-column combination candidates for each vector column:
+//     eq + 'vector column', EQ + 'vector column'.
 //
 // TODO(nehageorge): Add a rule for columns that are referenced in the statement
 // but do not fall into one of these categories. In order to account for this,
@@ -50,12 +57,30 @@ import (
 // RFC for inspiration: https://github.com/cockroachdb/cockroach/pull/71784. We
 // may also consider matching more types of SQL expressions, including LIKE
 // expressions.
-func FindIndexCandidateSet(rootExpr opt.Expr, md *opt.Metadata) map[cat.Table][][]cat.IndexColumn {
+func FindIndexCandidateSet(
+	rootExpr opt.Expr, md *opt.Metadata,
+) (map[cat.Table][][]cat.IndexColumn, IndexCandidateAttrs) {
 	var candidateSet indexCandidateSet
 	candidateSet.init(md)
 	candidateSet.categorizeIndexCandidates(rootExpr)
 	candidateSet.combineIndexCandidates()
-	return candidateSet.overallCandidates
+	return candidateSet.overallCandidates, candidateSet.candidateAttrs
+}
+
+// IndexCandidateAttrs stores additional attributes associated with index
+// candidates that cannot be expressed through index columns alone, such as
+// the distance metric for vector index candidates.
+type IndexCandidateAttrs struct {
+	// VectorDistMetrics maps vector column stable IDs to the distance metrics
+	// observed for that column. A column may have multiple metrics when the
+	// same vector column is used with different distance operators in a single
+	// query (e.g., v <-> x and v <=> x).
+	VectorDistMetrics map[cat.StableID][]vecpb.DistanceMetric
+}
+
+// init allocates memory for the maps in IndexCandidateAttrs.
+func (a *IndexCandidateAttrs) init() {
+	a.VectorDistMetrics = make(map[cat.StableID][]vecpb.DistanceMetric)
 }
 
 // indexCandidateSet stores potential indexes that could be recommended for a
@@ -66,7 +91,9 @@ type indexCandidateSet struct {
 	rangeCandidates    map[cat.Table][][]cat.IndexColumn
 	joinCandidates     map[cat.Table][][]cat.IndexColumn
 	invertedCandidates map[cat.Table][][]cat.IndexColumn
+	vectorCandidates   map[cat.Table][][]cat.IndexColumn
 	overallCandidates  map[cat.Table][][]cat.IndexColumn
+	candidateAttrs     IndexCandidateAttrs
 }
 
 // init allocates memory for the maps in the set.
@@ -77,7 +104,9 @@ func (ics *indexCandidateSet) init(md *opt.Metadata) {
 	ics.rangeCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 	ics.joinCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 	ics.invertedCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+	ics.vectorCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 	ics.overallCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+	ics.candidateAttrs.init()
 }
 
 // combineIndexCandidates adds index candidates that are combinations of
@@ -89,13 +118,14 @@ func (ics *indexCandidateSet) combineIndexCandidates() {
 	copyIndexes(ics.rangeCandidates, ics.overallCandidates)
 	copyIndexes(ics.joinCandidates, ics.overallCandidates)
 	copyIndexes(ics.invertedCandidates, ics.overallCandidates)
+	copyIndexes(ics.vectorCandidates, ics.overallCandidates)
 
 	numTables := len(ics.overallCandidates)
 	equalJoinCandidates := make(map[cat.Table][][]cat.IndexColumn, numTables)
 	equalGroupedCandidates := make(map[cat.Table][][]cat.IndexColumn, numTables)
 
 	// Construct EQ, EQ + R, J + R, EQ + J, EQ + J + R, eq + (inverted),
-	// EQ + (inverted).
+	// EQ + (inverted), eq + V, EQ + V.
 	groupIndexesByTable(ics.equalCandidates, equalGroupedCandidates)
 	copyIndexes(equalGroupedCandidates, ics.overallCandidates)
 	constructIndexCombinations(equalGroupedCandidates, ics.rangeCandidates, ics.overallCandidates)
@@ -105,6 +135,8 @@ func (ics *indexCandidateSet) combineIndexCandidates() {
 	constructIndexCombinations(equalJoinCandidates, ics.rangeCandidates, ics.overallCandidates)
 	constructIndexCombinations(ics.equalCandidates, ics.invertedCandidates, ics.overallCandidates)
 	constructIndexCombinations(equalGroupedCandidates, ics.invertedCandidates, ics.overallCandidates)
+	constructIndexCombinations(ics.equalCandidates, ics.vectorCandidates, ics.overallCandidates)
+	constructIndexCombinations(equalGroupedCandidates, ics.vectorCandidates, ics.overallCandidates)
 }
 
 // categorizeIndexCandidates finds potential index candidates for a given
@@ -193,9 +225,49 @@ func (ics *indexCandidateSet) categorizeIndexCandidates(expr opt.Expr) {
 	case *memo.BBoxIntersectsExpr:
 		ics.addVariableExprIndex(expr.Left, ics.overallCandidates)
 		ics.addVariableExprIndex(expr.Right, ics.overallCandidates)
+	case *memo.VectorDistanceExpr:
+		ics.addVectorIndex(expr.Left, expr.Right, vecpb.L2SquaredDistance)
+	case *memo.VectorCosDistanceExpr:
+		ics.addVectorIndex(expr.Left, expr.Right, vecpb.CosineDistance)
+	case *memo.VectorNegInnerProductExpr:
+		ics.addVectorIndex(expr.Left, expr.Right, vecpb.InnerProductDistance)
 	}
 	for i, n := 0, expr.ChildCount(); i < n; i++ {
 		ics.categorizeIndexCandidates(expr.Child(i))
+	}
+}
+
+// addVectorIndex adds a single-column vector index candidate for any PGVector
+// column found in the left or right operands of a vector distance expression,
+// and records the associated distance metric.
+func (ics *indexCandidateSet) addVectorIndex(
+	left, right opt.Expr, distanceMetric vecpb.DistanceMetric,
+) {
+	for _, expr := range []opt.Expr{left, right} {
+		if v, ok := expr.(*memo.VariableExpr); ok {
+			col := v.Col
+			colMeta := ics.md.ColumnMeta(col)
+			if colMeta.Type.Family() == types.PGVectorFamily {
+				ics.addSingleColumnIndex(col, false /* desc */, ics.vectorCandidates)
+
+				// If there's no base table for the column, skip recording
+				// the distance metric.
+				if colMeta.Table == 0 {
+					continue
+				}
+
+				table := ics.md.Table(colMeta.Table)
+				ordinal := colMeta.Table.ColumnOrdinal(col)
+				stableColID := table.Column(ordinal).ColID()
+
+				// Append the metric if not already tracked for this column.
+				if !slices.Contains(ics.candidateAttrs.VectorDistMetrics[stableColID], distanceMetric) {
+					ics.candidateAttrs.VectorDistMetrics[stableColID] = append(
+						ics.candidateAttrs.VectorDistMetrics[stableColID], distanceMetric,
+					)
+				}
+			}
+		}
 	}
 }
 

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -45,6 +45,10 @@ type hypotheticalIndex struct {
 
 	// typ indicates the type of the index - forward, inverted, or vector.
 	typ idxtype.T
+
+	// vectorConfig stores the vector index configuration, including the distance
+	// metric. Only set for vector indexes.
+	vectorConfig *vecpb.Config
 }
 
 var _ cat.Index = &hypotheticalIndex{}
@@ -56,13 +60,19 @@ func (hi *hypotheticalIndex) init(
 	indexOrd int,
 	typ idxtype.T,
 	zone cat.Zone,
+	vecConfig *vecpb.Config,
 ) {
+	if typ == idxtype.VECTOR && vecConfig == nil {
+		panic(errors.AssertionFailedf("vector index requires non-nil vecConfig"))
+	}
+
 	hi.tab = tab
 	hi.name = name
 	hi.cols = cols
 	hi.indexOrdinal = indexOrd
 	hi.typ = typ
 	hi.zone = zone
+	hi.vectorConfig = vecConfig
 
 	// Build an index column ordinal set.
 	var colsOrdSet intsets.Fast
@@ -178,7 +188,10 @@ func (hi *hypotheticalIndex) InvertedColumn() cat.IndexColumn {
 
 // VectorColumn is part of the cat.Index interface.
 func (hi *hypotheticalIndex) VectorColumn() cat.IndexColumn {
-	panic(errors.AssertionFailedf("hypothetical indexes do not have vector columns"))
+	if hi.Type() != idxtype.VECTOR {
+		panic(errors.AssertionFailedf("non-vector indexes do not have vector columns"))
+	}
+	return hi.cols[len(hi.cols)-1]
 }
 
 // Predicate is part of the cat.Index interface.
@@ -232,7 +245,10 @@ func (hi *hypotheticalIndex) GeoConfig() geopb.Config {
 
 // VecConfig is part of the cat.Index interface.
 func (hi *hypotheticalIndex) VecConfig() *vecpb.Config {
-	return nil
+	if hi.Type() != idxtype.VECTOR {
+		return nil
+	}
+	return hi.vectorConfig
 }
 
 // Version is part of the cat.Index interface.
@@ -253,6 +269,19 @@ func (hi *hypotheticalIndex) Partition(i int) cat.Partition {
 // IsTemporaryIndexForBackfill is part of the cat.Index interface.
 func (hi *hypotheticalIndex) IsTemporaryIndexForBackfill() bool {
 	return false
+}
+
+// isVecConfigCompatible returns true if the existing index has the same vector
+// configuration as the hypothetical index. For non-vector hypothetical indexes
+// this always returns true. For vector hypothetical indexes, the existing index
+// must also be a vector index with the same distance metric (e.g., an L2 index
+// is not interchangeable with a cosine index on the same column).
+func (hi *hypotheticalIndex) isVecConfigCompatible(existingIndex cat.Index) bool {
+	if hi.typ != idxtype.VECTOR || hi.vectorConfig == nil {
+		return true
+	}
+	return existingIndex.Type() == idxtype.VECTOR &&
+		existingIndex.VecConfig().DistanceMetric == hi.vectorConfig.DistanceMetric
 }
 
 // hasSameExplicitCols checks whether the given existing index has identical

--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 )
 
@@ -24,7 +25,7 @@ import (
 // cat.StableID to its constructed HypotheticalTable. These tables will be used
 // to update the table query metadata when making index recommendations.
 func BuildOptAndHypTableMaps(
-	c cat.Catalog, indexCandidates map[cat.Table][][]cat.IndexColumn,
+	c cat.Catalog, indexCandidates map[cat.Table][][]cat.IndexColumn, attrs IndexCandidateAttrs,
 ) (optTables, hypTables map[cat.StableID]cat.Table) {
 	numTables := len(indexCandidates)
 	hypTables = make(map[cat.StableID]cat.Table, numTables)
@@ -36,10 +37,26 @@ func BuildOptAndHypTableMaps(
 		hypTable.init(c, t)
 
 		for _, indexCols := range indexes {
-			indexOrd := hypTable.Table.IndexCount() + len(hypIndexes)
 			lastKeyCol := indexCols[len(indexCols)-1]
-			// TODO (Shivam): Index recommendations should not only allow JSON columns
-			// to be part of inverted indexes since they are also forward indexable.
+
+			// Vector indexes: create one hypothetical index per distance
+			// metric observed for this column. The same column may have been
+			// used with different distance operators (e.g., v <-> x and
+			// v <=> x).
+			if lastKeyCol.DatumType().Family() == types.PGVectorFamily {
+				for _, distMetric := range attrs.VectorDistMetrics[lastKeyCol.ColID()] {
+					hypIndexes = hypTable.maybeAddHypIndex(
+						hypIndexes, indexCols, idxtype.VECTOR, t.Zone(),
+						&vecpb.Config{DistanceMetric: distMetric},
+					)
+				}
+
+				continue
+			}
+
+			// TODO (Shivam): Index recommendations should not only allow JSON
+			// columns to be part of inverted indexes since they are also
+			// forward indexable.
 			indexType := idxtype.FORWARD
 			if !colinfo.ColumnTypeIsIndexable(lastKeyCol.DatumType()) ||
 				lastKeyCol.DatumType().Family() == types.JsonFamily {
@@ -48,23 +65,10 @@ func BuildOptAndHypTableMaps(
 				invertedCol := hypTable.addInvertedCol(lastKeyCol.Column)
 				indexCols[len(indexCols)-1] = cat.IndexColumn{Column: invertedCol}
 			}
-			var hypIndex hypotheticalIndex
-			hypIndex.init(
-				&hypTable,
-				tree.Name(fmt.Sprintf("_hyp_%d", indexOrd)),
-				indexCols,
-				indexOrd,
-				indexType,
-				t.Zone(),
-			)
 
-			// Do not add hypothetical inverted indexes for which there is an existing
-			// index with the same key. Inverted indexes do not have stored columns,
-			// so we should not make a recommendation if the same index already
-			// exists.
-			if indexType != idxtype.INVERTED || hypTable.existingRedundantIndex(&hypIndex) == nil {
-				hypIndexes = append(hypIndexes, hypIndex)
-			}
+			hypIndexes = hypTable.maybeAddHypIndex(
+				hypIndexes, indexCols, indexType, t.Zone(), nil, /* vecConfig */
+			)
 		}
 
 		hypTable.hypotheticalIndexes = hypIndexes
@@ -73,6 +77,41 @@ func BuildOptAndHypTableMaps(
 	}
 
 	return optTables, hypTables
+}
+
+// maybeAddHypIndex creates a hypothetical index and appends it to hypIndexes
+// if it is not redundant with an existing index on the table. The vecConfig
+// parameter provides vector index configuration; it is nil for non-vector
+// indexes.
+func (ht *HypotheticalTable) maybeAddHypIndex(
+	hypIndexes []hypotheticalIndex,
+	indexCols []cat.IndexColumn,
+	indexType idxtype.T,
+	zone cat.Zone,
+	vecConfig *vecpb.Config,
+) []hypotheticalIndex {
+	indexOrd := ht.Table.IndexCount() + len(hypIndexes)
+
+	var hypIndex hypotheticalIndex
+	hypIndex.init(
+		ht,
+		tree.Name(fmt.Sprintf("_hyp_%d", indexOrd)),
+		indexCols,
+		indexOrd,
+		indexType,
+		zone,
+		vecConfig,
+	)
+
+	// Do not add hypothetical inverted or vector indexes for which there is
+	// an existing index with the same key. These index types do not have
+	// stored columns, so we should not make a recommendation if the same
+	// index already exists.
+	if (indexType != idxtype.INVERTED && indexType != idxtype.VECTOR) || ht.existingRedundantIndex(&hypIndex) == nil {
+		hypIndexes = append(hypIndexes, hypIndex)
+	}
+
+	return hypIndexes
 }
 
 // HypotheticalTable is a wrapper around cat.Table, used for creating index
@@ -164,7 +203,8 @@ func (ht *HypotheticalTable) existingRedundantIndex(index *hypotheticalIndex) ca
 		existingIndex := ht.Table.Index(i)
 		indexExists := index.hasSameExplicitCols(existingIndex)
 		_, isPartialIndex := existingIndex.Predicate()
-		if indexExists && !isPartialIndex && existingIndex.GetInvisibility() == 0.0 {
+		if indexExists && !isPartialIndex && existingIndex.GetInvisibility() == 0.0 &&
+			index.isVecConfigCompatible(existingIndex) {
 			return existingIndex
 		}
 	}

--- a/pkg/sql/opt/indexrec/hypothetical_table_test.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table_test.go
@@ -13,7 +13,7 @@ func TestBuildOptAndHypTableMaps(t *testing.T) {
 	table2 := tables[1]
 	indexCandidates := testIndexCandidates1(tables, indexCols)
 
-	oldTables, hypTables := BuildOptAndHypTableMaps(nil, indexCandidates)
+	oldTables, hypTables := BuildOptAndHypTableMaps(nil, indexCandidates, IndexCandidateAttrs{})
 
 	if oldTables[table1.ID()] != table1 {
 		t.Errorf("expected table1 to be %+v,\n got %+v\n", table1, oldTables[table1.ID()])

--- a/pkg/sql/opt/indexrec/rec.go
+++ b/pkg/sql/opt/indexrec/rec.go
@@ -15,7 +15,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/errors"
 )
 
 // Type represents the type of index recommendation for Rec.
@@ -84,6 +86,8 @@ func (rc recCollector) addIndexRec(md *opt.Metadata, expr opt.Expr) {
 	case *memo.ZigzagJoinExpr:
 		rc.addIndex(md, expr.LeftIndex, expr.Cols, expr.LeftTable)
 		rc.addIndex(md, expr.RightIndex, expr.Cols, expr.RightTable)
+	case *memo.VectorSearchExpr:
+		rc.addIndex(md, expr.Index, expr.Cols, expr.Table)
 	}
 	for i, n := 0, expr.ChildCount(); i < n; i++ {
 		rc.addIndexRec(md, expr.Child(i))
@@ -165,6 +169,12 @@ func findBestExistingIndexToReplace(
 		}
 		if existingIndex.GetInvisibility() != 0.0 {
 			if hypIndex.hasPrefixOfExplicitCols(existingIndex) {
+				// For vector indexes, the invisible index must use the same
+				// distance metric to be a valid ALTER VISIBLE candidate. An
+				// invisible L2 index cannot serve a cosine distance query.
+				if !hypIndex.isVecConfigCompatible(existingIndex) {
+					continue
+				}
 				existingIndexAllCols := getAllCols(existingIndex)
 				if newStoredCols.Difference(existingIndexAllCols).Empty() {
 					// There exists an invisible index containing every explicit column in
@@ -184,12 +194,15 @@ func findBestExistingIndexToReplace(
 		}
 
 		existingIndexStoredCols := getStoredCols(existingIndex)
-		// hasSameExplicitCols returns true iff the existing index and hypIndex has
-		// the same explicit columns. If hypIndex is inverted, it also makes sure
-		// that their inverted column comes from the same source column.
-		hasSameExplicitCols := hypIndex.hasSameExplicitCols(existingIndex)
-		if hasSameExplicitCols {
-			// If hasSameExplicitCols, this existing index is a candidate for
+		// isReplacementCandidate is true iff the existing index and hypIndex
+		// have the same explicit columns (with matching inverted source columns
+		// for inverted indexes) and compatible vector index configuration.
+		isReplacementCandidate := hypIndex.hasSameExplicitCols(existingIndex)
+		if isReplacementCandidate && !hypIndex.isVecConfigCompatible(existingIndex) {
+			isReplacementCandidate = false
+		}
+		if isReplacementCandidate {
+			// If isReplacementCandidate, this existing index is a candidate for
 			// potential index replacement.
 			//
 			// storedColsDiffSet is the list of cols that are in actuallyScannedCol
@@ -465,7 +478,14 @@ func (ir *indexRecommendation) indexCols() []tree.IndexElem {
 			direction = tree.Descending
 		}
 
-		indexCols[i] = tree.IndexElem{Column: colName, Direction: direction}
+		// The operator class is only set on the last column of a vector index,
+		// which is the vector column itself. Preceding columns are prefix columns.
+		var opClass tree.Name
+		if ir.index.Type() == idxtype.VECTOR && i == len(ir.index.cols)-1 {
+			opClass = tree.Name(vecOpClassName(ir.index.vectorConfig.DistanceMetric))
+		}
+
+		indexCols[i] = tree.IndexElem{Column: colName, Direction: direction, OpClass: opClass}
 	}
 
 	return indexCols
@@ -484,4 +504,19 @@ func (ir *indexRecommendation) storingColumns() []tree.Name {
 		storingCols = append(storingCols, colName)
 	})
 	return storingCols
+}
+
+// vecOpClassName returns the operator class name for a given vector distance
+// metric, used in the CREATE VECTOR INDEX recommendation output.
+func vecOpClassName(metric vecpb.DistanceMetric) string {
+	switch metric {
+	case vecpb.L2SquaredDistance:
+		return "vector_l2_ops"
+	case vecpb.CosineDistance:
+		return "vector_cosine_ops"
+	case vecpb.InnerProductDistance:
+		return "vector_ip_ops"
+	default:
+		panic(errors.AssertionFailedf("unknown distance metric %d", metric))
+	}
 }

--- a/pkg/sql/opt/indexrec/testdata/vector
+++ b/pkg/sql/opt/indexrec/testdata/vector
@@ -1,0 +1,538 @@
+# This file tests index candidates and index recommendations for vector
+# indexes.
+
+exec-ddl
+CREATE TABLE t1 (k INT PRIMARY KEY, i INT, v VECTOR(3))
+----
+
+# Ensure that vector columns used in distance expressions are added as index
+# candidates.
+index-candidates
+SELECT * FROM t1 ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+t1:
+ (v)
+
+# Recommend a vector index with vector_l2_ops for L2 distance (<->).
+index-recommendations
+SELECT * FROM t1 ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+creation: CREATE VECTOR INDEX ON t.public.t1 (v vector_l2_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null i:2 v:3  [hidden: column6:6]
+ ├── internal-ordering: +6
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.8343856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (3)-->(6)
+ ├── ordering: +6
+ └── project
+      ├── columns: column6:6 k:1!null i:2 v:3
+      ├── immutable
+      ├── cost: 64.96
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (3)-->(6)
+      ├── inner-join (lookup t1)
+      │    ├── columns: k:1!null i:2 v:3
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.74
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── vector-search t1@_hyp_1,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:3 <-> '[1,2,3]' [as=column6:6, outer=(3), immutable]
+
+# Recommend a vector index with vector_cosine_ops for cosine distance (<=>).
+index-recommendations
+SELECT * FROM t1 ORDER BY v <=> '[1,2,3]' LIMIT 5
+----
+creation: CREATE VECTOR INDEX ON t.public.t1 (v vector_cosine_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null i:2 v:3  [hidden: column6:6]
+ ├── internal-ordering: +6
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.8343856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (3)-->(6)
+ ├── ordering: +6
+ └── project
+      ├── columns: column6:6 k:1!null i:2 v:3
+      ├── immutable
+      ├── cost: 64.96
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (3)-->(6)
+      ├── inner-join (lookup t1)
+      │    ├── columns: k:1!null i:2 v:3
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.74
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── vector-search t1@_hyp_1,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:3 <=> '[1,2,3]' [as=column6:6, outer=(3), immutable]
+
+# Recommend a vector index with vector_ip_ops for negative inner product (<#>).
+index-recommendations
+SELECT * FROM t1 ORDER BY v <#> '[1,2,3]' LIMIT 5
+----
+creation: CREATE VECTOR INDEX ON t.public.t1 (v vector_ip_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null i:2 v:3  [hidden: column6:6]
+ ├── internal-ordering: +6
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.8343856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (3)-->(6)
+ ├── ordering: +6
+ └── project
+      ├── columns: column6:6 k:1!null i:2 v:3
+      ├── immutable
+      ├── cost: 64.96
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (3)-->(6)
+      ├── inner-join (lookup t1)
+      │    ├── columns: k:1!null i:2 v:3
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.74
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── vector-search t1@_hyp_1,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:3 <#> '[1,2,3]' [as=column6:6, outer=(3), immutable]
+
+# Ensure that a vector index is recommended when the constant is on the left
+# side of the distance operator. The CommuteVar normalization rule swaps the
+# operands so that the variable is on the left.
+index-recommendations
+SELECT * FROM t1 ORDER BY '[1,2,3]' <-> v LIMIT 5
+----
+creation: CREATE VECTOR INDEX ON t.public.t1 (v vector_l2_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null i:2 v:3  [hidden: column6:6]
+ ├── internal-ordering: +6
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.8343856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (3)-->(6)
+ ├── ordering: +6
+ └── project
+      ├── columns: column6:6 k:1!null i:2 v:3
+      ├── immutable
+      ├── cost: 64.96
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (3)-->(6)
+      ├── inner-join (lookup t1)
+      │    ├── columns: k:1!null i:2 v:3
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.74
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── vector-search t1@_hyp_1,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:3 <-> '[1,2,3]' [as=column6:6, outer=(3), immutable]
+
+# Ensure that equality prefix columns combined with a vector column are added
+# as index candidates.
+index-candidates
+SELECT * FROM t1 WHERE i = 1 ORDER BY v <-> '[1,2,3]' LIMIT 1
+----
+t1:
+ (i)
+ (i, v)
+ (v)
+
+# Recommend a vector index with an equality prefix column when there is an
+# equality predicate combined with a vector distance ordering.
+index-recommendations
+SELECT * FROM t1 WHERE i = 1 ORDER BY v <-> '[1,2,3]' LIMIT 1
+----
+creation: CREATE VECTOR INDEX ON t.public.t1 (i, v vector_l2_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null i:2!null v:3  [hidden: column6:6]
+ ├── internal-ordering: +6 opt(2)
+ ├── k: 1
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── cost: 16.33
+ ├── cost-flags: unbounded-cardinality
+ ├── key: ()
+ ├── fd: ()-->(1-3,6)
+ └── project
+      ├── columns: column6:6 k:1!null i:2 v:3
+      ├── immutable
+      ├── cost: 16.24
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (3)-->(6)
+      ├── inner-join (lookup t1)
+      │    ├── columns: k:1!null i:2 v:3
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 16.18
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── vector-search t1@_hyp_3,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 1
+      │    │    ├── prefix constraint: /2
+      │    │    │    └── [/1 - /1]
+      │    │    ├── cost: 0.04
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:3 <-> '[1,2,3]' [as=column6:6, outer=(3), immutable]
+
+# Ensure that no new vector index is recommended when an identical visible
+# vector index already exists.
+exec-ddl
+CREATE VECTOR INDEX existing_vec ON t1 (v)
+----
+
+index-recommendations
+SELECT * FROM t1 ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+no index recommendations
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null i:2 v:3  [hidden: column6:6]
+ ├── internal-ordering: +6
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.8343856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (3)-->(6)
+ ├── ordering: +6
+ └── project
+      ├── columns: column6:6 k:1!null i:2 v:3
+      ├── immutable
+      ├── cost: 64.96
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (3)-->(6)
+      ├── inner-join (lookup t1)
+      │    ├── columns: k:1!null i:2 v:3
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.74
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    ├── vector-search t1@existing_vec,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:3 <-> '[1,2,3]' [as=column6:6, outer=(3), immutable]
+
+# Ensure that an ALTER INDEX VISIBLE recommendation is made when an invisible
+# vector index exists that would satisfy the query.
+exec-ddl
+CREATE TABLE t2 (k INT PRIMARY KEY, v VECTOR(3), VECTOR INDEX idx_v_invisible (v) NOT VISIBLE)
+----
+
+index-recommendations
+SELECT * FROM t2 ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+alteration: ALTER INDEX t.public.t2@idx_v_invisible VISIBLE;
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null v:2  [hidden: column5:5]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.5843856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5 k:1!null v:2
+      ├── immutable
+      ├── cost: 64.76
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── inner-join (lookup t2)
+      │    ├── columns: k:1!null v:2
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.54
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── vector-search t2@_hyp_2,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+
+# Ensure that an invisible vector index with a DIFFERENT distance metric does
+# NOT get an ALTER VISIBLE recommendation. A new index with the correct metric
+# should be created instead.
+exec-ddl
+CREATE TABLE t2b (k INT PRIMARY KEY, v VECTOR(3), VECTOR INDEX idx_l2_invisible (v) NOT VISIBLE)
+----
+
+index-recommendations
+SELECT * FROM t2b ORDER BY v <=> '[1,2,3]' LIMIT 5
+----
+creation: CREATE VECTOR INDEX ON t.public.t2b (v vector_cosine_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null v:2  [hidden: column5:5]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.5843856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5 k:1!null v:2
+      ├── immutable
+      ├── cost: 64.76
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── inner-join (lookup t2b)
+      │    ├── columns: k:1!null v:2
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.54
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── vector-search t2b@_hyp_2,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:2 <=> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+
+# Ensure that a vector index with a different distance metric is recommended
+# even when an existing vector index on the same column exists. An L2 index
+# should not suppress a cosine recommendation.
+exec-ddl
+CREATE TABLE t3 (k INT PRIMARY KEY, v VECTOR(3), VECTOR INDEX existing_l2 (v))
+----
+
+index-recommendations
+SELECT * FROM t3 ORDER BY v <=> '[1,2,3]' LIMIT 5
+----
+creation: CREATE VECTOR INDEX ON t.public.t3 (v vector_cosine_ops);
+--
+optimal plan:
+top-k
+ ├── columns: k:1!null v:2  [hidden: column5:5]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.5843856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5 k:1!null v:2
+      ├── immutable
+      ├── cost: 64.76
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── inner-join (lookup t3)
+      │    ├── columns: k:1!null v:2
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.54
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── vector-search t3@_hyp_2,vector
+      │    │    ├── columns: k:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:2 <=> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+
+# Ensure that two different distance operators on the same vector column in a
+# single query produce separate index recommendations.
+exec-ddl
+CREATE TABLE t4 (k INT PRIMARY KEY, v VECTOR(3))
+----
+
+index-recommendations
+(SELECT * FROM t4 ORDER BY v <-> '[1,2,3]' LIMIT 5) UNION ALL (SELECT * FROM t4 ORDER BY v <=> '[1,2,3]' LIMIT 5)
+----
+creation: CREATE VECTOR INDEX ON t.public.t4 (v vector_l2_ops);
+creation: CREATE VECTOR INDEX ON t.public.t4 (v vector_cosine_ops);
+--
+optimal plan:
+union-all
+ ├── columns: k:11!null v:12
+ ├── left columns: t4.k:1 t4.v:2
+ ├── right columns: t4.k:6 t4.v:7
+ ├── cardinality: [0 - 10]
+ ├── immutable
+ ├── cost: 131.278771
+ ├── cost-flags: unbounded-cardinality
+ ├── top-k
+ │    ├── columns: t4.k:1!null t4.v:2 column5:5
+ │    ├── internal-ordering: +5
+ │    ├── k: 5
+ │    ├── cardinality: [0 - 5]
+ │    ├── immutable
+ │    ├── cost: 65.5843856
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2), (2)-->(5)
+ │    └── project
+ │         ├── columns: column5:5 t4.k:1!null t4.v:2
+ │         ├── immutable
+ │         ├── cost: 64.76
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2), (2)-->(5)
+ │         ├── inner-join (lookup t4)
+ │         │    ├── columns: t4.k:1!null t4.v:2
+ │         │    ├── key columns: [1] = [1]
+ │         │    ├── lookup columns are key
+ │         │    ├── cost: 64.54
+ │         │    ├── cost-flags: unbounded-cardinality
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2)
+ │         │    ├── vector-search t4@_hyp_1,vector
+ │         │    │    ├── columns: t4.k:1!null
+ │         │    │    ├── target nearest neighbors: 5
+ │         │    │    ├── cost: 0.12
+ │         │    │    ├── cost-flags: unbounded-cardinality
+ │         │    │    ├── key: (1)
+ │         │    │    └── '[1,2,3]'
+ │         │    └── filters (true)
+ │         └── projections
+ │              └── t4.v:2 <-> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+ └── top-k
+      ├── columns: t4.k:6!null t4.v:7 column10:10
+      ├── internal-ordering: +10
+      ├── k: 5
+      ├── cardinality: [0 - 5]
+      ├── immutable
+      ├── cost: 65.5843856
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (6)
+      ├── fd: (6)-->(7), (7)-->(10)
+      └── project
+           ├── columns: column10:10 t4.k:6!null t4.v:7
+           ├── immutable
+           ├── cost: 64.76
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (6)
+           ├── fd: (6)-->(7), (7)-->(10)
+           ├── inner-join (lookup t4)
+           │    ├── columns: t4.k:6!null t4.v:7
+           │    ├── key columns: [6] = [6]
+           │    ├── lookup columns are key
+           │    ├── cost: 64.54
+           │    ├── cost-flags: unbounded-cardinality
+           │    ├── key: (6)
+           │    ├── fd: (6)-->(7)
+           │    ├── vector-search t4@_hyp_2,vector
+           │    │    ├── columns: t4.k:6!null
+           │    │    ├── target nearest neighbors: 5
+           │    │    ├── cost: 0.12
+           │    │    ├── cost-flags: unbounded-cardinality
+           │    │    ├── key: (6)
+           │    │    └── '[1,2,3]'
+           │    └── filters (true)
+           └── projections
+                └── t4.v:7 <=> '[1,2,3]' [as=column10:10, outer=(7), immutable]

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -7,6 +7,8 @@
 # handle both combinations.
 [CommuteVar, Normalize]
 (Eq | Ne | Is | IsNot | Plus | Mult | Bitand | Bitor | Bitxor
+        | VectorDistance | VectorCosDistance
+        | VectorNegInnerProduct
     $left:^(Variable)
     $right:(Variable)
 )

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -19,6 +19,10 @@ CREATE TABLE c (c CHAR PRIMARY KEY)
 ----
 
 exec-ddl
+CREATE TABLE t (k INT PRIMARY KEY, v VECTOR(3))
+----
+
+exec-ddl
 CREATE TABLE b
 (
     k INT PRIMARY KEY,
@@ -66,6 +70,24 @@ project
       ├── k:1 & (i:2 ^ 2) [as=x:14, outer=(1,2), immutable]
       ├── k:1 | (i:2 ^ 2) [as=y:15, outer=(1,2), immutable]
       └── k:1 # (i:2 * i:2) [as=z:16, outer=(1,2), immutable]
+
+# Commute vector distance operators so that the variable is on the left.
+norm expect=CommuteVar
+SELECT
+    '[1,2,3]' <-> v AS r,
+    '[1,2,3]' <=> v AS s,
+    '[1,2,3]' <#> v AS t
+FROM t
+----
+project
+ ├── columns: r:5 s:6 t:7
+ ├── immutable
+ ├── scan t
+ │    └── columns: v:2
+ └── projections
+      ├── v:2 <-> '[1,2,3]' [as=r:5, outer=(2), immutable]
+      ├── v:2 <=> '[1,2,3]' [as=s:6, outer=(2), immutable]
+      └── v:2 <#> '[1,2,3]' [as=t:7, outer=(2), immutable]
 
 # --------------------------------------------------
 # CommuteConst

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2235,7 +2235,7 @@ func (ot *OptTester) IndexCandidates() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	indexCandidates := indexrec.FindIndexCandidateSet(expr, ot.f.Memo().Metadata())
+	indexCandidates, _ := indexrec.FindIndexCandidateSet(expr, ot.f.Memo().Metadata())
 
 	// Build a formatted string to output from the map of indexCandidates.
 	tablesOutput := make([]string, 0, len(indexCandidates))
@@ -2278,8 +2278,8 @@ func (ot *OptTester) IndexRecommendations() (string, error) {
 		return "", err
 	}
 	md := ot.f.Memo().Metadata()
-	indexCandidates := indexrec.FindIndexCandidateSet(normExpr, md)
-	_, hypTables := indexrec.BuildOptAndHypTableMaps(ot.catalog, indexCandidates)
+	indexCandidates, candidateAttrs := indexrec.FindIndexCandidateSet(normExpr, md)
+	_, hypTables := indexrec.BuildOptAndHypTableMaps(ot.catalog, indexCandidates, candidateAttrs)
 
 	optExpr, err := ot.OptimizeWithTables(hypTables)
 	if err != nil {

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -4404,9 +4404,9 @@ top-k
       └── projections
            └── vec1:9 <-> vec2:10 [as=column15:15, outer=(9,10), immutable]
 
-# Currently, the vector column must be the left argument.
-# TODO(drewk, mw5h): add a normalization rule to flip the args.
-opt expect-not=GenerateVectorSearch
+# The CommuteVar normalization rule flips the args so that the variable is on
+# the left, enabling GenerateVectorSearch to match.
+opt expect=GenerateVectorSearch
 SELECT * FROM index_tab ORDER BY '[3,1,2]' <-> vec1 LIMIT 5;
 ----
 top-k
@@ -4423,19 +4423,20 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-11), (9)-->(15)
-      ├── scan index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
-      │    ├── partial index predicates
-      │    │    ├── index_tab_vec1_idx1: filters
-      │    │    │    └── latitude:4 > 0 [outer=(4), constraints=(/4: [/1 - ]; tight)]
-      │    │    ├── index_tab_data2_vec2_idx: filters
-      │    │    │    └── data2:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
-      │    │    └── index_tab_longitude_vec3_idx: filters
-      │    │         └── longitude:5 IN (1, 2) [outer=(5), constraints=(/5: [/1 - /1] [/2 - /2]; tight)]
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── key: (1)
-      │    └── fd: (1)-->(2-11)
+      │    ├── fd: (1)-->(2-11)
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
       └── projections
-           └── '[3,1,2]' <-> vec1:9 [as=column15:15, outer=(9), immutable]
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
 
 # Currently, there can be no extra filters beyond those used to constrain index
 # prefix columns, if any.

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -1210,8 +1210,8 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 
 	// Walk through the fully normalized memo to determine index candidates and
 	// create hypothetical tables.
-	indexCandidates := indexrec.FindIndexCandidateSet(f.Memo().RootExpr(), f.Metadata())
-	optTables, hypTables := indexrec.BuildOptAndHypTableMaps(opc.catalog, indexCandidates)
+	indexCandidates, candidateAttrs := indexrec.FindIndexCandidateSet(f.Memo().RootExpr(), f.Metadata())
+	optTables, hypTables := indexrec.BuildOptAndHypTableMaps(opc.catalog, indexCandidates, candidateAttrs)
 
 	// Optimize with the saved memo and hypothetical tables. Walk through the
 	// optimal plan to determine index recommendations.


### PR DESCRIPTION
Previously, the index recommendation engine did not recognize vector distance expressions (<->, <=>, <#>), so EXPLAIN could not suggest vector indexes for queries like ORDER BY v <-> '[1,2,3]' LIMIT k.

This change extends the index recommendation engine with vector index support. Vector distance expressions are now detected during candidate discovery, and hypothetical vector indexes are built with the correct distance metric so the optimizer can explore vector search plans. The recommendation output emits CREATE VECTOR INDEX with the appropriate operator class (vector_l2_ops, vector_cosine_ops, vector_ip_ops). Equality prefix + vector column combinations and redundancy checks for existing vector indexes are also supported.

Vector distance ops are added to the CommuteVar normalization rule so that candidates are found regardless of operand order.

Fixes: #146146
Epic: none

Release note (sql change): EXPLAIN now recommends vector indexes for queries that use vector distance operators (<->, <=>, <#>) with ORDER BY ... LIMIT, including support for equality prefix columns and all three distance metrics (L2, cosine, inner product).