### PR TITLE
roachtest: recover panic in test selection and fall back to executing all tests

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -399,7 +399,37 @@ func updateSpecForSelectiveTests(
 	allTests, err := testselector.CategoriseTests(ctx,
 		testselector.NewDefaultSelectTestsReq(roachtestflags.Cloud, roachtestflags.Suite))
 	if err != nil {
-		logFunc("running all tests! error selecting tests: %v\n", err)
+		// Snowflake is unavailable. Instead of running all tests (which risks
+		// timeouts), randomly select a subset using the same percentage that the
+		// selector would use for stable tests. This keeps the run size in the
+		// same ballpark as a normal selective run. Already-skipped tests are
+		// left untouched and don't count toward the selection budget.
+		fallbackPct := roachtestflags.SuccessfulTestsSelectPct
+		logFunc("error selecting tests: %v\n", err)
+		rand.Shuffle(len(specs), func(i, j int) {
+			specs[i], specs[j] = specs[j], specs[i]
+		})
+		eligible := 0
+		for i := range specs {
+			if specs[i].Skip != "" {
+				continue
+			}
+			eligible++
+		}
+		fallbackCount := int(math.Ceil(float64(eligible) * fallbackPct))
+		selected := 0
+		for i := range specs {
+			if specs[i].Skip != "" {
+				continue
+			}
+			selected++
+			if selected > fallbackCount {
+				specs[i].Skip = "test selector"
+				specs[i].SkipDetails = "test skipped: selector unavailable, random fallback"
+			}
+		}
+		logFunc("falling back to random selection: %d out of %d eligible tests (%.0f%%)\n",
+			fallbackCount, eligible, fallbackPct*100)
 		return
 	}
 

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -124,22 +124,41 @@ func Test_updateSpecForSelectiveTests(t *testing.T) {
 	testselector.SqlConnectorFunc = func(_, _ string) (*gosql.DB, error) {
 		return db, err
 	}
-	t.Run("expect CategoriseTests to fail which causes fall back to run all tests", func(t *testing.T) {
-		// The failure of the CategoriseTests does not cause any failure. It falls back to run all the tests in the spec
+	t.Run("expect CategoriseTests to fail which causes random fallback selection", func(t *testing.T) {
+		// When CategoriseTests fails, we fall back to randomly selecting a
+		// subset of tests using SuccessfulTestsSelectPct instead of running
+		// everything (which risks timeouts).
 		db, mock, err = sqlmock.New()
 		require.Nil(t, err)
+		savedPct := roachtestflags.SuccessfulTestsSelectPct
+		roachtestflags.SuccessfulTestsSelectPct = 0.35
+		t.Cleanup(func() { roachtestflags.SuccessfulTestsSelectPct = savedPct })
 		specs, _ := getTestSelectionMockData()
 		mock.ExpectPrepare(regexp.QuoteMeta(testselector.PreparedQuery)).WillReturnError(fmt.Errorf("failed to prepare"))
 		updateSpecForSelectiveTests(ctx, specs, func(format string, args ...interface{}) {
 			t.Logf(format, args...)
 		})
+		// Count eligible (non-pre-skipped) specs and verify the fallback
+		// selected the right number.
+		eligible := 0
+		selected := 0
 		for _, s := range specs {
-			if !strings.Contains(s.Name, "skipped") {
-				require.Empty(t, s.Skip)
-			} else {
-				require.Equal(t, "test spec skip", s.Skip)
+			switch {
+			case s.Skip == "test spec skip":
+				// Already-skipped tests keep their original skip reason.
+				require.Contains(t, s.Name, "skipped")
+			case s.Skip == "":
+				eligible++
+				selected++
+			default:
+				eligible++
+				// Tests skipped by the fallback.
+				require.Equal(t, "test selector", s.Skip)
+				require.Contains(t, s.SkipDetails, "random fallback")
 			}
 		}
+		expectedSelected := int(math.Ceil(float64(eligible) * roachtestflags.SuccessfulTestsSelectPct))
+		require.Equal(t, expectedSelected, selected)
 	})
 	t.Run("expect no failure", func(t *testing.T) {
 		db, mock, err = sqlmock.New()

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -91,7 +91,18 @@ func NewDefaultSelectTestsReq(cloud spec.Cloud, suite string) *SelectTestsReq {
 // 3. the test has not been run for a while
 // It returns all the tests. The selected tests have the value TestDetails.Selected as true
 // The tests are sorted by the last run and is used for further test selection criteria. So, the order should not be modified.
-func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, error) {
+func CategoriseTests(ctx context.Context, req *SelectTestsReq) (result []*TestDetails, err error) {
+	// The gosnowflake driver has a bug where it panics on a nil type assertion
+	// (interface is nil, not gosnowflake.SnowflakeRows) when the context
+	// deadline is exceeded during QueryContext. Since we can't fix the
+	// third-party driver, we recover here and convert the panic into an error
+	// so that callers can fall back gracefully (e.g., running all tests).
+	defer func() {
+		if r := recover(); r != nil {
+			result = nil
+			err = fmt.Errorf("panic during snowflake query: %v", r)
+		}
+	}()
 	db, err := getConnect(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/testselector/selector_test.go
+++ b/pkg/cmd/roachtest/testselector/selector_test.go
@@ -44,6 +44,16 @@ func TestCategoriseTests(t *testing.T) {
 		require.NotNil(t, err)
 		require.Equal(t, "failed to connect to DB", err.Error())
 	})
+	t.Run("recover from driver panic", func(t *testing.T) {
+		// Simulate the gosnowflake driver panicking on a nil type assertion,
+		// which happens when the context deadline is exceeded during a query.
+		SqlConnectorFunc = func(_, _ string) (*gosql.DB, error) {
+			panic("interface conversion: interface is nil, not gosnowflake.SnowflakeRows")
+		}
+		tds, err := CategoriseTests(context.Background(), nil)
+		require.Nil(t, tds)
+		require.ErrorContains(t, err, "panic during snowflake query")
+	})
 	var mock sqlmock.Sqlmock
 	var db *gosql.DB
 	SqlConnectorFunc = func(driverName, dataSourceName string) (*gosql.DB, error) {


### PR DESCRIPTION
Previously, the gosnowflake driver would panic with a nil type assertion (interface is nil, not gosnowflake.SnowflakeRows) when the context deadline was exceeded during QueryContext.
This was creating issues when Snowflake was slow or unreachable, as the panic would crash roachtest and prevent any tests from running, despite the existing fallback logic that runs all tests on error.

This patch changes the behavior by adding a deferred recover in CategoriseTests that converts the driver panic into a regular error, allowing the existing error handling in updateSpecForSelectiveTests to gracefully fall back to running a random subset of all the tests.

Release note: None
Epic: none