### PR TITLE
sql/types: allow unmarshaling of user-defined nested arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/domain
+++ b/pkg/sql/logictest/testdata/logic_test/domain
@@ -737,3 +737,38 @@ statement ok
 DROP DOMAIN d_atom
 
 subtest end
+
+subtest domain_over_array
+# Test domains over array types, which create internal nested array aliases.
+# These aliases must be unmarshalable even though nested arrays are not
+# fully supported for execution/storage.
+
+statement ok
+CREATE DOMAIN d_array AS INT[]
+
+# Checking the create statement involves unmarshaling the alias.
+query T
+SELECT create_statement FROM crdb_internal.create_type_statements WHERE descriptor_name = 'd_array'
+----
+CREATE DOMAIN public.d_array AS INT8[]
+
+# Creating an array of this domain: d_array[] works without DistSQL.
+# Internally this is represented as INT[][].
+# While we can't use it in a table yet, creating it shouldn't panic background tasks.
+# We can test that its SQL string representation is correct.
+skipif config fakedist
+skipif config fakedist-disk
+skipif config fakedist-vec-off
+query T
+SELECT '{}'::d_array[]
+----
+{}
+
+# Attempting to use a truly nested array should still fail at the SQL level.
+statement error nested array unsupported as column type: int[][]
+CREATE TABLE t (a d_array[])
+
+statement ok
+DROP DOMAIN d_array
+
+subtest end

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1690,7 +1690,11 @@ func RemapUserDefinedTypeOIDs(t *T, newOID, newArrayOID oid.Oid) {
 
 // UserDefined returns whether or not t is a user defined type.
 func (t *T) UserDefined() bool {
-	return IsOIDUserDefinedType(t.Oid())
+	// A type is user-defined if its OID is in the user-defined range.
+	// We also consider it user-defined if it has OID 0 (unassigned) but
+	// contains UDTMetadata; this happens during parsing and descriptor
+	// construction before an ID is allocated.
+	return IsOIDUserDefinedType(t.Oid()) || (t.Oid() == 0 && t.InternalType.UDTMetadata != nil)
 }
 
 // IsOIDUserDefinedType returns whether or not o corresponds to a user
@@ -2726,8 +2730,12 @@ func (t *T) upgradeType() error {
 			t.InternalType.Oid = CalcArrayOid(t.ArrayContents())
 		}
 
-		// Marshaling/unmarshaling nested arrays is not yet supported.
-		if t.ArrayContents().Family() == ArrayFamily {
+		// Marshaling/unmarshaling nested arrays is not yet supported in general,
+		// but they are required for user defined types (like domains over arrays)
+		// which store their internal structure using this format. This is safe
+		// because existing runtime and storage-level blocks (e.g., in colinfo)
+		// still prevent multidimensional arrays from being used as column types.
+		if t.ArrayContents().Family() == ArrayFamily && !t.ArrayContents().UserDefined() {
 			return errors.AssertionFailedf("nested array should never be unmarshaled")
 		}
 

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -531,8 +531,9 @@ func TestTypes(t *testing.T) {
 
 			// Roundtrip type by marshaling, then unmarshaling. Only do this for non-
 			// nested array types (since we don't yet support marshaling/ummarshaling
-			// nested arrays).
-			if tc.actual.Family() == ArrayFamily && tc.actual.ArrayContents().Family() == ArrayFamily {
+			// nested arrays), except for user defined types.
+			if tc.actual.Family() == ArrayFamily && tc.actual.ArrayContents().Family() == ArrayFamily &&
+				!tc.actual.ArrayContents().UserDefined() {
 				return
 			}
 


### PR DESCRIPTION
CockroachDB supports domains over array types, which internally creates nested array aliases (e.g., interval[][]). Previously, upgradeType had an assertion that explicitly forbade unmarshaling nested arrays, which caused panics in background processes like spanconfigsqlwatcher when encountering these valid descriptors.

To address this, this patch relaxes that assertion to allow nested arrays for user-defined types while maintaining the guard for standard types. It also updates UserDefined() to correctly identify types with UDTMetadata but unassigned OIDs (OID 0), which can occur during parsing and descriptor construction.

Resolves: #167545
Epic: none
Release note: None