### PR TITLE
roachtest: fix ttl-restart/checkpoint timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/ttl_restart.go
+++ b/pkg/cmd/roachtest/tests/ttl_restart.go
@@ -257,12 +257,42 @@ func runTTLRestartCheckpoint(ctx context.Context, t test.Test, c cluster.Cluster
 			return errors.Wrap(err, "setting checkpoint interval")
 		}
 
+		// Limit processor concurrency to 1 so that the processor's main span
+		// loop blocks between sends, causing intermediate UpdateProgress calls
+		// to report completed spans back to the coordinator.
+		if _, err := db.ExecContext(ctx, "SET CLUSTER SETTING sql.ttl.processor_concurrency = 1"); err != nil {
+			return errors.Wrap(err, "setting processor concurrency")
+		}
+
 		if err := setupTableAndData(ctx, t, db); err != nil {
 			return err
 		}
 
-		// Use lower rate limits than the restart test so the job runs long
-		// enough for checkpoints to be written before we stop a node.
+		// Add additional splits beyond the original 3 ranges. Processors
+		// only report completed spans — with 1 span per processor, no
+		// intermediate checkpoints are written. After splitting, we
+		// redistribute leases round-robin so consecutive ranges land on
+		// different nodes. PartitionSpans merges contiguous same-node
+		// ranges, so interleaving is required to give each processor
+		// multiple non-contiguous spans.
+		t.Status("add additional splits for checkpoint granularity")
+		if _, err := db.ExecContext(ctx, `ALTER TABLE ttldb.tab1 SPLIT AT VALUES
+			(1000), (2000), (3000), (4000), (5000),
+			(7000), (8000), (9000), (10000), (11000),
+			(13000), (14000), (15000), (16000), (17000)`); err != nil {
+			return errors.Wrap(err, "adding additional splits")
+		}
+
+		t.Status("redistribute leases round-robin for interleaved spans")
+		testutils.SucceedsSoon(t, func() error {
+			return distributeLeases(ctx, t, db)
+		})
+		leases, err := gatherLeaseDistribution(ctx, t, db)
+		if err != nil {
+			return errors.Wrap(err, "gathering lease distribution after redistribution")
+		}
+		showLeaseDistribution(t, leases)
+
 		jobInfo, err := enableTTLAndWaitForJobWithRateLimit(ctx, t, c, db, 50 /* rateLimit */)
 		if err != nil {
 			return err
@@ -329,6 +359,13 @@ func runTTLRestartCheckpoint(ctx context.Context, t test.Test, c cluster.Cluster
 		t.L().Printf("stopping node %d", stoppedNode)
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Nodes(stoppedNode))
 
+		// Resume the job. With the node down, the job replans across the
+		// surviving nodes and should load the persisted checkpoint.
+		t.Status("resume TTL job")
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("RESUME JOB %d", jobInfo.JobID)); err != nil {
+			return errors.Wrap(err, "resuming TTL job")
+		}
+
 		// Wait for the TTL job to restart.
 		t.Status("ensure TTL job restarts")
 		testutils.SucceedsWithin(t, func() error {
@@ -374,7 +411,7 @@ func runTTLRestartCheckpoint(ctx context.Context, t test.Test, c cluster.Cluster
 			jobInfo, err = findRunningJob(ctx, t, c, db, &jobInfo,
 				true /* expectJobRestart */, true /* allowJobSucceeded */)
 			return err
-		}, 6*time.Minute)
+		}, 12*time.Minute)
 
 		return nil
 	})
@@ -411,21 +448,23 @@ func showLeaseDistribution(t test.Test, leases leaseInfoSlice) {
 	}
 }
 
-// distributeLeases redistributes the ranges evenly across the cluster.
+// distributeLeases redistributes the ranges round-robin across the cluster nodes.
 func distributeLeases(ctx context.Context, t test.Test, db *gosql.DB) error {
+	const numNodes = 3
 	ranges, err := db.QueryContext(ctx, showRangesQuery)
 	if err != nil {
 		return errors.Wrapf(err, "error querying the ranges")
 	}
 	defer ranges.Close()
-	var nextLeaseHolder int
-	for nextLeaseHolder = 1; ranges.Next(); nextLeaseHolder++ {
+	rangeIdx := 0
+	for ranges.Next() {
 		var rangeID, leaseHolder int
 		if err := ranges.Scan(&rangeID, &leaseHolder); err != nil {
 			return err
 		}
-		if leaseHolder != nextLeaseHolder {
-			alterStmt := fmt.Sprintf("ALTER RANGE %d RELOCATE LEASE TO %d", rangeID, nextLeaseHolder)
+		targetNode := (rangeIdx % numNodes) + 1
+		if leaseHolder != targetNode {
+			alterStmt := fmt.Sprintf("ALTER RANGE %d RELOCATE LEASE TO %d", rangeID, targetNode)
 			row := db.QueryRowContext(ctx, alterStmt)
 			var pretty, result string
 			if err := row.Scan(&rangeID, &pretty, &result); err != nil {
@@ -434,15 +473,17 @@ func distributeLeases(ctx context.Context, t test.Test, db *gosql.DB) error {
 			if result != "ok" {
 				return errors.Newf("failed to alter range %d: %s", rangeID, result)
 			}
-			t.L().Printf("Relocated lease of range %d to node %d", rangeID, nextLeaseHolder)
+			t.L().Printf("Relocated lease of range %d to node %d", rangeID, targetNode)
 		}
+		rangeIdx++
 	}
-	const expectedLeaseHolders = 3
-	if actual := nextLeaseHolder - 1; actual != expectedLeaseHolders {
-		return errors.Newf("expected %d leaseholders, but got %d", expectedLeaseHolders, actual)
+	if err := ranges.Err(); err != nil {
+		return err
+	}
+	if rangeIdx == 0 {
+		return errors.New("no ranges found")
 	}
 	return nil
-
 }
 
 // findRunningJob checks the current state of the TTL job and returns metadata


### PR DESCRIPTION
The checkpoint test was failing because with only 3 ranges across 3 nodes, each processor had 1 span. The processor only reports completed spans via UpdateProgress during its main loop iteration, which finishes before the single span completes. No checkpoint data appears in system.job_info until the job is nearly done, racing with the 2-minute timeout.

Add 15 splits (18 ranges, ~6 per processor) and set processor_concurrency=1 so the main loop blocks waiting for workers. Bump the rate limit from 50 to 100 so each ~1000-row span completes in ~10s, under the 15s replan frequency.

Fixes #168213

Release note: None