### PR TITLE
release-26.2: sql: swap CODEOWNERS between SQL Foundations and SQL Queries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,8 +64,8 @@
 /pkg/sql/execinfrapb/processors_bulk_io.proto     @cockroachdb/disaster-recovery
 /pkg/sql/execinfrapb/processors_changefeeds.proto @cockroachdb/cdc-prs
 /pkg/sql/execinfrapb/processors_export.proto      @cockroachdb/cdc-prs
-/pkg/sql/execinfrapb/processors_ttl.proto         @cockroachdb/sql-foundations
-/pkg/sql/execinfrapb/processors_inspect.proto     @cockroachdb/sql-foundations
+/pkg/sql/execinfrapb/processors_ttl.proto         @cockroachdb/sql-queries-prs
+/pkg/sql/execinfrapb/processors_inspect.proto     @cockroachdb/sql-queries-prs
 /pkg/sql/exec_factory_util.go          @cockroachdb/sql-queries-prs
 #!/pkg/sql/exec_log*.go                @cockroachdb/sql-queries-noreview
 #!/pkg/sql/exec_util*.go               @cockroachdb/sql-queries-noreview
@@ -82,6 +82,8 @@
 /pkg/sql/job_exec_context*   @cockroachdb/sql-queries-prs @cockroachdb/jobs-prs
 /pkg/sql/delegate/*job*.go   @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/sql/vecindex/           @cockroachdb/sql-queries-prs
+/pkg/sql/partition*.go       @cockroachdb/sql-queries-prs
+/pkg/sql/temporary_schema*   @cockroachdb/sql-queries-prs
 #!/pkg/sql/BUILD.bazel       @cockroachdb/sql-queries-noreview
 
 
@@ -99,18 +101,25 @@
 /pkg/sql/pg_catalog.go       @cockroachdb/sql-foundations
 /pkg/sql/show_create*.go     @cockroachdb/sql-foundations
 /pkg/sql/lex/                @cockroachdb/sql-foundations
-/pkg/sql/partitioning/       @cockroachdb/sql-foundations
+/pkg/sql/partitioning/       @cockroachdb/sql-queries-prs
 /pkg/sql/pgwire/             @cockroachdb/sql-foundations
 /pkg/sql/pgwire/auth.go      @cockroachdb/sql-foundations @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/sql/pgwire/identmap/    @cockroachdb/sql-foundations @cockroachdb/product-security
 /pkg/sql/sem/builtins/       @cockroachdb/sql-foundations
+/pkg/sql/sem/plpgsqltree/    @cockroachdb/sql-foundations
 /pkg/sql/vtable/             @cockroachdb/sql-foundations
 
 /pkg/sql/sessiondata/        @cockroachdb/sql-foundations
 /pkg/sql/tests/rsg_test.go   @cockroachdb/sql-foundations
-/pkg/sql/ttl                 @cockroachdb/sql-foundations
+/pkg/sql/ttl                 @cockroachdb/sql-queries-prs
 /pkg/sql/spanutils/          @cockroachdb/sql-foundations
-/pkg/sql/inspect/            @cockroachdb/sql-foundations
+/pkg/sql/inspect/            @cockroachdb/sql-queries-prs
+/pkg/sql/copy/               @cockroachdb/sql-foundations
+/pkg/sql/copy_*.go           @cockroachdb/sql-foundations
+/pkg/sql/plpgsql/            @cockroachdb/sql-foundations
+/pkg/sql/routine.go          @cockroachdb/sql-foundations
+/pkg/sql/function_references.go @cockroachdb/sql-foundations
+/pkg/sql/show_trigger.go     @cockroachdb/sql-foundations
 
 /pkg/sql/syntheticprivilege/      @cockroachdb/sql-foundations
 /pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations
@@ -120,7 +129,7 @@
 /pkg/sql/bulksst/            @cockroachdb/sql-foundations
 /pkg/sql/bulkutil/           @cockroachdb/sql-foundations
 /pkg/sql/catalog/            @cockroachdb/sql-foundations
-/pkg/sql/catalog/multiregion @cockroachdb/sql-foundations
+/pkg/sql/catalog/multiregion @cockroachdb/sql-queries-prs
 /pkg/sql/doctor/             @cockroachdb/sql-foundations
 /pkg/sql/gcjob/              @cockroachdb/sql-foundations
 /pkg/sql/gcjob_test/         @cockroachdb/sql-foundations
@@ -418,7 +427,7 @@
 #!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng-prs @cockroachdb/upgrade-prs
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
-/pkg/ccl/multiregionccl/     @cockroachdb/sql-foundations
+/pkg/ccl/multiregionccl/     @cockroachdb/sql-queries-prs
 /pkg/ccl/multitenantccl/     @cockroachdb/server-prs
 /pkg/ccl/multitenant/tenantcostclient/ @cockroachdb/sql-queries-prs
 /pkg/ccl/multitenant/tenantcostserver/ @cockroachdb/sql-queries-prs
@@ -528,6 +537,13 @@
 /pkg/cmd/roachtest/tests/ruby_pg.go	      @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/sequelize.go	    @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/typeorm.go	      @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/copy.go                         @cockroachdb/sql-foundations
+/pkg/cmd/roachtest/tests/copyfrom.go                     @cockroachdb/sql-foundations
+/pkg/cmd/roachtest/tests/inspect_throughput.go           @cockroachdb/sql-queries-prs
+/pkg/cmd/roachtest/tests/ttl_restart.go                  @cockroachdb/sql-queries-prs
+/pkg/cmd/roachtest/tests/multi_region_system_database.go @cockroachdb/sql-queries-prs
+/pkg/cmd/roachtest/tests/mixed_version_multi_region.go   @cockroachdb/sql-queries-prs
+/pkg/cmd/roachtest/tests/super_region_failover.go        @cockroachdb/sql-queries-prs
 /pkg/cmd/label-merged-pr/    @cockroachdb/dev-inf
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -2121,7 +2121,7 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.num_active_spans
       exported_name: jobs_row_level_ttl_num_active_spans
       description: Number of active spans the TTL job is deleting from.
@@ -2132,7 +2132,7 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.resume_completed
       exported_name: jobs_row_level_ttl_resume_completed
       labeled_name: 'jobs.resume{name: row_level_ttl, status: completed}'
@@ -2167,7 +2167,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: Correlate this metric with the metric jobs.row_level_ttl.rows_selected to ensure all the rows that should be deleted are actually getting deleted.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.rows_selected
       exported_name: jobs_row_level_ttl_rows_selected
       description: Number of rows selected for deletion by the row level TTL job.
@@ -2178,7 +2178,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: Correlate this metric with the metric jobs.row_level_ttl.rows_deleted to ensure all the rows that should be deleted are actually getting deleted.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.select_duration
       exported_name: jobs_row_level_ttl_select_duration
       description: Duration for select requests during row level TTL.
@@ -2189,7 +2189,7 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.span_total_duration
       exported_name: jobs_row_level_ttl_span_total_duration
       description: Duration for processing a span during row level TTL.
@@ -2200,7 +2200,7 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.total_expired_rows
       exported_name: jobs_row_level_ttl_total_expired_rows
       description: Approximate number of rows that have expired the TTL on the TTL table.
@@ -2211,7 +2211,7 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.total_rows
       exported_name: jobs_row_level_ttl_total_rows
       description: Approximate number of rows on the TTL table.
@@ -2222,7 +2222,7 @@ layers:
       derivative: NONE
       how_to_use: See Description.
       visibility: ESSENTIAL
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: schedules.scheduled-row-level-ttl-executor.failed
       exported_name: schedules_scheduled_row_level_ttl_executor_failed
       labeled_name: 'schedules{name: scheduled-row-level-ttl-executor, status: failed}'
@@ -5550,7 +5550,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.inspect.num_active_spans
       exported_name: jobs_inspect_num_active_spans
       description: Number of spans currently being processed by INSPECT jobs
@@ -5559,7 +5559,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.inspect.protected_age_sec
       exported_name: jobs_inspect_protected_age_sec
       labeled_name: 'jobs.protected_age_sec{type: inspect}'
@@ -5618,7 +5618,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.inspect.runs_with_issues
       exported_name: jobs_inspect_runs_with_issues
       description: Number of INSPECT jobs that found at least one issue
@@ -5627,7 +5627,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.inspect.spans_processed
       exported_name: jobs_inspect_spans_processed
       description: Number of spans processed by INSPECT jobs
@@ -5636,7 +5636,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.key_visualizer.currently_idle
       exported_name: jobs_key_visualizer_currently_idle
       labeled_name: 'jobs{type: key_visualizer, status: currently_idle}'
@@ -6693,7 +6693,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-      owner: cockroachdb/sql-foundations
+      owner: cockroachdb/sql-queries
     - name: jobs.row_level_ttl.protected_age_sec
       exported_name: jobs_row_level_ttl_protected_age_sec
       labeled_name: 'jobs.protected_age_sec{type: row_level_ttl}'

--- a/pkg/cmd/roachtest/tests/admission_control_inspect.go
+++ b/pkg/cmd/roachtest/tests/admission_control_inspect.go
@@ -44,7 +44,7 @@ func makeInspectAdmissionControlTest(
 	return registry.TestSpec{
 		Name:                fmt.Sprintf("inspect/admission-control/nodes=%d/cpu=%d/rows=%d", numCRDBNodes, numCPUs, numRows),
 		Timeout:             timeout,
-		Owner:               registry.OwnerSQLFoundations,
+		Owner:               registry.OwnerSQLQueries,
 		Benchmark:           true,
 		CompatibleClouds:    registry.AllExceptAWS,
 		Suites:              registry.Suites(registry.Weekly),

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -202,7 +202,7 @@ func registerCopyFrom(r registry.Registry) {
 		tc := tc
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("copyfrom/crdb-atomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
-			Owner:            registry.OwnerSQLQueries,
+			Owner:            registry.OwnerSQLFoundations,
 			Benchmark:        true,
 			Cluster:          r.MakeClusterSpec(tc.nodes),
 			CompatibleClouds: registry.AllExceptAWS,
@@ -214,7 +214,7 @@ func registerCopyFrom(r registry.Registry) {
 		})
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("copyfrom/crdb-nonatomic/sf=%d/nodes=%d", tc.sf, tc.nodes),
-			Owner:            registry.OwnerSQLQueries,
+			Owner:            registry.OwnerSQLFoundations,
 			Benchmark:        true,
 			Cluster:          r.MakeClusterSpec(tc.nodes),
 			CompatibleClouds: registry.AllExceptAWS,
@@ -226,7 +226,7 @@ func registerCopyFrom(r registry.Registry) {
 		})
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("copyfrom/pg/sf=%d/nodes=%d", tc.sf, tc.nodes),
-			Owner:            registry.OwnerSQLQueries,
+			Owner:            registry.OwnerSQLFoundations,
 			Benchmark:        true,
 			Cluster:          r.MakeClusterSpec(tc.nodes),
 			CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/inspect_throughput.go
+++ b/pkg/cmd/roachtest/tests/inspect_throughput.go
@@ -93,7 +93,7 @@ func makeInspectThroughputTest(
 
 	return registry.TestSpec{
 		Name:                name,
-		Owner:               registry.OwnerSQLFoundations,
+		Owner:               registry.OwnerSQLQueries,
 		Benchmark:           true,
 		Cluster:             r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.CPU(numCPUs)),
 		CompatibleClouds:    registry.OnlyGCE,

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -25,7 +25,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(3, spec.Geo(), spec.GatherCores(), spec.GCEZones("us-east1-b,us-west1-b,us-central1-b"))
 	r.Add(registry.TestSpec{
 		Name:             "schemachange/multiregion/system-database",
-		Owner:            registry.OwnerSQLFoundations,
+		Owner:            registry.OwnerSQLQueries,
 		Timeout:          time.Hour * 1,
 		Cluster:          clusterSpec,
 		CompatibleClouds: registry.OnlyGCE,

--- a/pkg/cmd/roachtest/tests/super_region_failover.go
+++ b/pkg/cmd/roachtest/tests/super_region_failover.go
@@ -31,7 +31,7 @@ import (
 func registerSuperRegionFailover(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:  "multi-region/super-region-failover",
-		Owner: registry.OwnerSQLFoundations,
+		Owner: registry.OwnerSQLQueries,
 		// The test kills nodes and expects them to be dead at the end of
 		// scenario 1 (before recovery). We recover them, but we also need
 		// SkipPostValidations in case the test fails mid-scenario.

--- a/pkg/cmd/roachtest/tests/ttl_restart.go
+++ b/pkg/cmd/roachtest/tests/ttl_restart.go
@@ -30,7 +30,7 @@ func registerTTLRestart(r registry.Registry) {
 	for numRestartNodes := 1; numRestartNodes <= 2; numRestartNodes++ {
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("ttl-restart/num-restart-nodes=%d", numRestartNodes),
-			Owner:            registry.OwnerSQLFoundations,
+			Owner:            registry.OwnerSQLQueries,
 			Cluster:          r.MakeClusterSpec(3),
 			Leases:           registry.MetamorphicLeases,
 			CompatibleClouds: registry.AllClouds,

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -267,25 +267,25 @@ owners:
   jobs_claimed_jobs: cockroachdb/jobs
   jobs_expired_pts_records: cockroachdb/jobs
   jobs_fail_or_cancel: cockroachdb/jobs
-  jobs_inspect_issues_found: cockroachdb/sql-foundations
-  jobs_inspect_num_active_spans: cockroachdb/sql-foundations
-  jobs_inspect_runs: cockroachdb/sql-foundations
-  jobs_inspect_runs_with_issues: cockroachdb/sql-foundations
-  jobs_inspect_spans_processed: cockroachdb/sql-foundations
+  jobs_inspect_issues_found: cockroachdb/sql-queries
+  jobs_inspect_num_active_spans: cockroachdb/sql-queries
+  jobs_inspect_runs: cockroachdb/sql-queries
+  jobs_inspect_runs_with_issues: cockroachdb/sql-queries
+  jobs_inspect_spans_processed: cockroachdb/sql-queries
   jobs_metrics_task_failed: cockroachdb/jobs
   jobs_protected_age_sec: cockroachdb/jobs
   jobs_protected_record_count: cockroachdb/jobs
   jobs_resume: cockroachdb/jobs
   jobs_resumed_claimed_jobs: cockroachdb/jobs
-  jobs_row_level_ttl_delete_duration: cockroachdb/sql-foundations
-  jobs_row_level_ttl_num_active_spans: cockroachdb/sql-foundations
-  jobs_row_level_ttl_num_delete_batch_retries: cockroachdb/sql-foundations
-  jobs_row_level_ttl_rows_deleted: cockroachdb/sql-foundations
-  jobs_row_level_ttl_rows_selected: cockroachdb/sql-foundations
-  jobs_row_level_ttl_select_duration: cockroachdb/sql-foundations
-  jobs_row_level_ttl_span_total_duration: cockroachdb/sql-foundations
-  jobs_row_level_ttl_total_expired_rows: cockroachdb/sql-foundations
-  jobs_row_level_ttl_total_rows: cockroachdb/sql-foundations
+  jobs_row_level_ttl_delete_duration: cockroachdb/sql-queries
+  jobs_row_level_ttl_num_active_spans: cockroachdb/sql-queries
+  jobs_row_level_ttl_num_delete_batch_retries: cockroachdb/sql-queries
+  jobs_row_level_ttl_rows_deleted: cockroachdb/sql-queries
+  jobs_row_level_ttl_rows_selected: cockroachdb/sql-queries
+  jobs_row_level_ttl_select_duration: cockroachdb/sql-queries
+  jobs_row_level_ttl_span_total_duration: cockroachdb/sql-queries
+  jobs_row_level_ttl_total_expired_rows: cockroachdb/sql-queries
+  jobs_row_level_ttl_total_rows: cockroachdb/sql-queries
   jobs_running_non_idle: cockroachdb/jobs
   keybytes: cockroachdb/kv
   keycount: cockroachdb/kv


### PR DESCRIPTION
Backport 1/1 commits from #168323.

/cc @cockroachdb/release

---

This is the full ownership swap between the SQL Foundations and SQL Queries teams. IMPORT was previously moved to SQL Foundations in #167978.

Moving to SQL Queries:
- INSPECT
- Row-level TTL
- Temp tables
- Partitioning (drop partition)
- Multi-region

Moving to SQL Foundations:
- COPY
- Stored procedures
- UDFs
- Triggers

Release note: None
Epic: none

Release justification: code ownership change only