### PR TITLE
sql/sqlstats: keep track of aggregated_ts in memory

### DIFF
--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -689,11 +689,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	}
 	skip.UnderRace(t, "test is too slow to run under race")
 
-	// Aug 30 2021 19:50:00 GMT+0000
-	aggregatedTs := int64(1630353000)
-	oneMinAfterAggregatedTs := aggregatedTs + 60
 	statsKnobs := sqlstats.CreateTestingKnobs()
-	statsKnobs.StubTimeNow = func() time.Time { return timeutil.Unix(aggregatedTs, 0) }
 	statsKnobs.SynchronousSQLStats = true
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
@@ -707,6 +703,11 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	})
 	defer testCluster.Stopper().Stop(context.Background())
 
+	// Use the real current time (truncated to the default 1-hour aggregation
+	// interval) to build the endpoint time range, since AggregatedTs is now
+	// stamped at record time using timeutil.Now().
+	aggregatedTs := timeutil.Now().Truncate(time.Hour).Unix()
+	oneMinAfterAggregatedTs := aggregatedTs + 60
 	endpoint := fmt.Sprintf("combinedstmts?start=%d&end=%d", aggregatedTs-3600, oneMinAfterAggregatedTs)
 	findJobQuery := "SELECT status FROM crdb_internal.jobs WHERE statement = 'CREATE INDEX idx_age ON football.public.players (age) STORING (name)';"
 	testAppName := "TestCombinedStatementsWithFullScans"

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -7,6 +7,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
@@ -21,19 +22,35 @@ import (
 )
 
 // DrainSqlStatsRespBuilder is a builder for the DrainSqlStatsResponse. When
-// adding StatementStatistics and TransactionStatistics,  it will merge the
-// new statistic with an existing one, if it already exists in the map.
+// adding StatementStatistics and TransactionStatistics, it will merge the
+// new statistic with an existing one if it already exists in the map.
+// Merging takes the aggregated timestamp into account so that stats from
+// different aggregation windows are not combined.
 type DrainSqlStatsRespBuilder struct {
 	stmtFingerprintCount map[appstatspb.StmtFingerprintID]struct{}
-	stmtMap              map[appstatspb.StatementStatisticsKey]*appstatspb.CollectedStatementStatistics
-	txnMap               map[appstatspb.TransactionFingerprintID]*appstatspb.CollectedTransactionStatistics
+	stmtMap              map[stmtDrainKey]*appstatspb.CollectedStatementStatistics
+	txnMap               map[txnDrainKey]*appstatspb.CollectedTransactionStatistics
+}
+
+// stmtDrainKey includes the aggregated timestamp so that stats from different
+// aggregation windows are not merged together during drain.
+type stmtDrainKey struct {
+	key          appstatspb.StatementStatisticsKey
+	aggregatedTs time.Time
+}
+
+// txnDrainKey includes the aggregated timestamp so that stats from different
+// aggregation windows are not merged together during drain.
+type txnDrainKey struct {
+	fingerprintID appstatspb.TransactionFingerprintID
+	aggregatedTs  time.Time
 }
 
 func NewDrainSqlStatsRespBuilder() *DrainSqlStatsRespBuilder {
 	return &DrainSqlStatsRespBuilder{
 		stmtFingerprintCount: make(map[appstatspb.StmtFingerprintID]struct{}),
-		stmtMap:              make(map[appstatspb.StatementStatisticsKey]*appstatspb.CollectedStatementStatistics),
-		txnMap:               make(map[appstatspb.TransactionFingerprintID]*appstatspb.CollectedTransactionStatistics),
+		stmtMap:              make(map[stmtDrainKey]*appstatspb.CollectedStatementStatistics),
+		txnMap:               make(map[txnDrainKey]*appstatspb.CollectedTransactionStatistics),
 	}
 }
 
@@ -41,8 +58,9 @@ func (b *DrainSqlStatsRespBuilder) AddStmtStats(
 	stmtStats []*appstatspb.CollectedStatementStatistics,
 ) {
 	for _, stmt := range stmtStats {
-		if existingStmt, ok := b.stmtMap[stmt.Key]; !ok {
-			b.stmtMap[stmt.Key] = stmt
+		dk := stmtDrainKey{key: stmt.Key, aggregatedTs: stmt.AggregatedTs}
+		if existingStmt, ok := b.stmtMap[dk]; !ok {
+			b.stmtMap[dk] = stmt
 		} else {
 			existingStmt.Stats.Add(&stmt.Stats)
 		}
@@ -57,8 +75,12 @@ func (b *DrainSqlStatsRespBuilder) AddTxnStats(
 	txnStats []*appstatspb.CollectedTransactionStatistics,
 ) {
 	for _, txn := range txnStats {
-		if existingTx, ok := b.txnMap[txn.TransactionFingerprintID]; !ok {
-			b.txnMap[txn.TransactionFingerprintID] = txn
+		dk := txnDrainKey{
+			fingerprintID: txn.TransactionFingerprintID,
+			aggregatedTs:  txn.AggregatedTs,
+		}
+		if existingTx, ok := b.txnMap[dk]; !ok {
+			b.txnMap[dk] = txn
 		} else {
 			existingTx.Stats.Add(&txn.Stats)
 		}

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -139,8 +139,10 @@ func statementsLocal(
 	for i, stmt := range stmtStats {
 		resp.Statements[i] = serverpb.StatementsResponse_CollectedStatementStatistics{
 			Key: serverpb.StatementsResponse_ExtendedStatementStatisticsKey{
-				KeyData: stmt.Key,
-				NodeID:  nodeID,
+				KeyData:             stmt.Key,
+				NodeID:              nodeID,
+				AggregatedTs:        stmt.AggregatedTs,
+				AggregationInterval: stmt.AggregationInterval,
 			},
 			ID:    stmt.ID,
 			Stats: stmt.Stats,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -7095,10 +7095,6 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 			return nil, nil, err
 		}
 
-		s := p.extendedEvalCtx.persistedSQLStats
-		curAggTs := s.ComputeAggregatedTs()
-		aggInterval := s.GetAggregationInterval()
-
 		const numDatums = 10
 		row := make(tree.Datums, numDatums)
 		worker := func(ctx context.Context, pusher rowPusher) error {
@@ -7106,8 +7102,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 				SortedAppNames: true,
 				SortedKey:      true,
 			}, func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
-
-				aggregatedTs, err := tree.MakeDTimestampTZ(curAggTs, time.Microsecond)
+				aggregatedTs, err := tree.MakeDTimestampTZ(statistics.AggregatedTs, time.Microsecond)
 				if err != nil {
 					return err
 				}
@@ -7132,7 +7127,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 				plan := sqlstatsutil.ExplainTreePlanNodeToJSON(&statistics.Stats.SensitiveInfo.MostRecentPlanDescription)
 
 				aggInterval := tree.NewDInterval(
-					duration.MakeDuration(aggInterval.Nanoseconds(), 0, 0),
+					duration.MakeDuration(statistics.AggregationInterval.Nanoseconds(), 0, 0),
 					types.DefaultIntervalTypeMetadata)
 
 				indexRecommendations := tree.NewDArray(types.String)
@@ -7528,10 +7523,6 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
 			return nil, nil, err
 		}
 
-		s := p.extendedEvalCtx.persistedSQLStats
-		curAggTs := s.ComputeAggregatedTs()
-		aggInterval := s.GetAggregationInterval()
-
 		const numDatums = 6
 		row := make(tree.Datums, numDatums)
 		worker := func(ctx context.Context, pusher rowPusher) error {
@@ -7541,8 +7532,7 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
 			}, func(
 				ctx context.Context,
 				statistics *appstatspb.CollectedTransactionStatistics) error {
-
-				aggregatedTs, err := tree.MakeDTimestampTZ(curAggTs, time.Microsecond)
+				aggregatedTs, err := tree.MakeDTimestampTZ(statistics.AggregatedTs, time.Microsecond)
 				if err != nil {
 					return err
 				}
@@ -7560,7 +7550,7 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
 				}
 
 				aggInterval := tree.NewDInterval(
-					duration.MakeDuration(aggInterval.Nanoseconds(), 0, 0),
+					duration.MakeDuration(statistics.AggregationInterval.Nanoseconds(), 0, 0),
 					types.DefaultIntervalTypeMetadata)
 
 				row = append(row[:0],

--- a/pkg/sql/sqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/cluster_settings.go
@@ -148,3 +148,16 @@ var GatewayNodeEnabled = settings.RegisterBoolSetting(
 		"be stored as 0.",
 	false,
 	settings.WithPublic)
+
+// SQLStatsAggregationInterval is the cluster setting that controls the
+// aggregation interval for SQL execution statistics. Stats are bucketed
+// into windows of this duration at record time.
+var SQLStatsAggregationInterval = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"sql.stats.aggregation.interval",
+	"the interval at which SQL execution statistics are aggregated into "+
+		"time windows; this value must be greater than or equal to "+
+		"sql.stats.flush.interval",
+	time.Hour,
+	settings.NonNegativeDurationWithMaximum(time.Hour*24),
+)

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/errors"
 	"github.com/robfig/cron/v3"
 )
@@ -107,16 +108,8 @@ var SQLStatsCleanupRecurrence = settings.RegisterStringSetting(
 	settings.WithPublic,
 )
 
-// SQLStatsAggregationInterval is the cluster setting that controls the aggregation
-// interval for stats when we flush to disk.
-var SQLStatsAggregationInterval = settings.RegisterDurationSetting(
-	settings.ApplicationLevel,
-	"sql.stats.aggregation.interval",
-	"the interval at which we aggregate SQL execution statistics upon flush, "+
-		"this value must be greater than or equal to sql.stats.flush.interval",
-	time.Hour,
-	settings.NonNegativeDurationWithMaximum(time.Hour*24),
-)
+// SQLStatsAggregationInterval is an alias for sqlstats.SQLStatsAggregationInterval.
+var SQLStatsAggregationInterval = sqlstats.SQLStatsAggregationInterval
 
 // CompactionJobRowsToDeletePerTxn is the cluster setting that controls
 // how many rows in the statement/transaction_statistics tables gets deleted

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -28,20 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-type flushBucket struct {
-	aggInterval  time.Duration
-	aggregatedTs time.Time
-	nodeID       base.SQLInstanceID
-}
-
-func (s *PersistedSQLStats) getBucket() flushBucket {
-	return flushBucket{
-		aggInterval:  s.GetAggregationInterval(),
-		aggregatedTs: s.ComputeAggregatedTs(),
-		nodeID:       s.GetEnabledSQLInstanceID(),
-	}
-}
-
 // MaybeFlush flushes in-memory sql stats into a system table, returning true if the flush
 // was attempted. Any errors encountered will be logged as warning. We may return
 // without attempting to flush any sql stats if any of the following are true:
@@ -113,8 +99,8 @@ func (s *PersistedSQLStats) MaybeFlushWithDrainer(
 			fingerprintCount, s.SQLStats.GetTotalFingerprintBytes(), timeutil.Since(lastFlush))
 	}
 
-	bucket := s.getBucket()
-	s.flush(ctx, stopper, &bucket, stmtStats, txnStats)
+	nodeID := s.GetEnabledSQLInstanceID()
+	s.flush(ctx, stopper, nodeID, stmtStats, txnStats)
 	s.cfg.FlushLatency.RecordValue(s.getTimeNow().Sub(flushBegin).Nanoseconds())
 
 	if s.cfg.Knobs != nil && s.cfg.Knobs.OnStmtStatsFlushFinished != nil {
@@ -181,12 +167,12 @@ func (s *PersistedSQLStats) StmtsLimitSizeReached(ctx context.Context) (bool, er
 func (s *PersistedSQLStats) flush(
 	ctx context.Context,
 	stopper *stop.Stopper,
-	flushBucket *flushBucket,
+	nodeID base.SQLInstanceID,
 	stmtStats []*appstatspb.CollectedStatementStatistics,
 	txnStats []*appstatspb.CollectedTransactionStatistics,
 ) {
 	if s.cfg.Knobs != nil && s.cfg.Knobs.FlushInterceptor != nil {
-		s.cfg.Knobs.FlushInterceptor(ctx, stopper, flushBucket.aggregatedTs, stmtStats, txnStats)
+		s.cfg.Knobs.FlushInterceptor(ctx, stopper, stmtStats, txnStats)
 		return
 	}
 
@@ -198,7 +184,7 @@ func (s *PersistedSQLStats) flush(
 
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
-		s.flushStmtStatsInBatches(ctx, stmtStats, flushBucket)
+		s.flushStmtStatsInBatches(ctx, stmtStats, nodeID)
 	})
 	if err != nil {
 		log.Dev.Warningf(ctx, "failed to execute sql-stmt-stats-flush task, %s", err.Error())
@@ -211,7 +197,7 @@ func (s *PersistedSQLStats) flush(
 
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
-		s.flushTxnStatsInBatches(ctx, txnStats, flushBucket)
+		s.flushTxnStatsInBatches(ctx, txnStats, nodeID)
 	})
 	if err != nil {
 		log.Dev.Warningf(ctx, "failed to execute sql-txn-stats-flush task, %s", err.Error())
@@ -223,7 +209,9 @@ func (s *PersistedSQLStats) flush(
 }
 
 func (s *PersistedSQLStats) flushTxnStatsInBatches(
-	ctx context.Context, stats []*appstatspb.CollectedTransactionStatistics, flushBucket *flushBucket,
+	ctx context.Context,
+	stats []*appstatspb.CollectedTransactionStatistics,
+	nodeID base.SQLInstanceID,
 ) {
 	batchSize := int(SQLStatsFlushBatchSize.Get(&s.cfg.Settings.SV))
 	for i := 0; i < len(stats); i += batchSize {
@@ -232,7 +220,7 @@ func (s *PersistedSQLStats) flushTxnStatsInBatches(
 			end = len(stats)
 		}
 		batch := stats[i:end]
-		if err := doFlushTxnStats(ctx, batch, flushBucket, s.cfg.DB); err != nil {
+		if err := doFlushTxnStats(ctx, batch, nodeID, s.cfg.DB); err != nil {
 			s.cfg.FlushesFailed.Inc(1)
 			log.Dev.Warningf(ctx, "failed to flush transaction statistics: %s", err)
 		} else {
@@ -242,7 +230,7 @@ func (s *PersistedSQLStats) flushTxnStatsInBatches(
 }
 
 func (s *PersistedSQLStats) flushStmtStatsInBatches(
-	ctx context.Context, stats []*appstatspb.CollectedStatementStatistics, flushBucket *flushBucket,
+	ctx context.Context, stats []*appstatspb.CollectedStatementStatistics, nodeID base.SQLInstanceID,
 ) {
 	batchSize := int(SQLStatsFlushBatchSize.Get(&s.cfg.Settings.SV))
 	for i := 0; i < len(stats); i += batchSize {
@@ -251,30 +239,13 @@ func (s *PersistedSQLStats) flushStmtStatsInBatches(
 			end = len(stats)
 		}
 		batch := stats[i:end]
-		if err := doFlushStmtStats(ctx, batch, flushBucket, s.cfg.DB); err != nil {
+		if err := doFlushStmtStats(ctx, batch, nodeID, s.cfg.DB); err != nil {
 			s.cfg.FlushesFailed.Inc(1)
 			log.Dev.Warningf(ctx, "failed to flush statement statistics: %s", err)
 		} else {
 			s.cfg.FlushesSuccessful.Inc(1)
 		}
 	}
-}
-
-// ComputeAggregatedTs returns the aggregation timestamp to assign
-// in-memory SQL stats during storage or aggregation.
-func (s *PersistedSQLStats) ComputeAggregatedTs() time.Time {
-	interval := SQLStatsAggregationInterval.Get(&s.cfg.Settings.SV)
-	now := s.getTimeNow()
-
-	aggTs := now.Truncate(interval)
-
-	return aggTs
-}
-
-// GetAggregationInterval returns the current aggregation interval
-// used by PersistedSQLStats.
-func (s *PersistedSQLStats) GetAggregationInterval() time.Duration {
-	return SQLStatsAggregationInterval.Get(&s.cfg.Settings.SV)
 }
 
 func (s *PersistedSQLStats) getTimeNow() time.Time {
@@ -297,7 +268,7 @@ SET
 func doFlushTxnStats(
 	ctx context.Context,
 	stats []*appstatspb.CollectedTransactionStatistics,
-	bucket *flushBucket,
+	nodeID base.SQLInstanceID,
 	db isql.DB,
 ) error {
 	var args []interface{}
@@ -321,13 +292,13 @@ func doFlushTxnStats(
 		placeholders = append(placeholders, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d)",
 			i*7+1, i*7+2, i*7+3, i*7+4, i*7+5, i*7+6, i*7+7))
 		args = append(args,
-			bucket.aggregatedTs,     // aggregated_ts
-			serializedFingerprintID, // fingerprint_id
-			stat.App,                // app_name
-			bucket.nodeID,           // node_id
-			bucket.aggInterval,      // agg_interval
-			metadata,                // metadata
-			statistics,              // statistics
+			stat.AggregatedTs,        // aggregated_ts
+			serializedFingerprintID,  // fingerprint_id
+			stat.App,                 // app_name
+			nodeID,                   // node_id
+			stat.AggregationInterval, // agg_interval
+			metadata,                 // metadata
+			statistics,               // statistics
 		)
 	}
 
@@ -355,7 +326,7 @@ SET
 func doFlushStmtStats(
 	ctx context.Context,
 	stats []*appstatspb.CollectedStatementStatistics,
-	flushBucket *flushBucket,
+	nodeID base.SQLInstanceID,
 	db isql.DB,
 ) error {
 	var args []interface{}
@@ -391,13 +362,13 @@ func doFlushStmtStats(
 			i*11+1, i*11+2, i*11+3, i*11+4, i*11+5, i*11+6, i*11+7, i*11+8, i*11+9, i*11+10, i*11+11))
 
 		args = append(args,
-			flushBucket.aggregatedTs,           // aggregated_ts
+			stat.AggregatedTs,                  // aggregated_ts
 			serializedFingerprintID,            // fingerprint_id
 			serializedTransactionFingerprintID, // transaction_fingerprint_id
 			serializedPlanHash,                 // plan_hash
 			stat.Key.App,                       // app_name
-			flushBucket.nodeID,                 // node_id
-			flushBucket.aggInterval,            // agg_interval
+			nodeID,                             // node_id
+			stat.AggregationInterval,           // agg_interval
 			metadata,                           // metadata
 			statistics,                         // statistics
 			plan,                               // plan

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -918,7 +918,7 @@ func TestPersistedSQLStats_Flush(t *testing.T) {
 			DisableElasticCPUAdmission: true,
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: &sqlstats.TestingKnobs{
-					FlushInterceptor: func(ctx context.Context, stopper *stop.Stopper, aggregatedTs time.Time, stmtStats []*appstatspb.CollectedStatementStatistics, txnStats []*appstatspb.CollectedTransactionStatistics) {
+					FlushInterceptor: func(ctx context.Context, stopper *stop.Stopper, stmtStats []*appstatspb.CollectedStatementStatistics, txnStats []*appstatspb.CollectedTransactionStatistics) {
 						for _, stmt := range stmtStats {
 							if stmt.Key.App == appName {
 								flushedStmtStats++
@@ -1005,6 +1005,104 @@ func TestPersistedSQLStats_Flush(t *testing.T) {
 		require.Equal(t, 2, flushedStmtStats)
 		require.Equal(t, 2, flushedTxnStats)
 	})
+}
+
+// TestFlushUsesRecordTimeAggregatedTs verifies that stats carry their own
+// aggregated_ts from record time and that the flush path writes those
+// per-stat timestamps to the system tables. Previously, the flush path
+// computed a single aggregated_ts at flush time and applied it uniformly,
+// which could attribute stats to the wrong aggregation window when the
+// flush was delayed.
+func TestFlushUsesRecordTimeAggregatedTs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Record the current hour boundary before executing any queries. The
+	// recording-time aggregated_ts must be truncated to this boundary.
+	// We also accept the next hour in case the test crosses an hour boundary.
+	now := timeutil.Now()
+	expectedAggTs := now.Truncate(time.Hour)
+	nextHourAggTs := expectedAggTs.Add(time.Hour)
+
+	var interceptedStmts []*appstatspb.CollectedStatementStatistics
+	var interceptedTxns []*appstatspb.CollectedTransactionStatistics
+	var mu syncutil.Mutex
+
+	appName := "record_time_agg_test"
+
+	srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DisableElasticCPUAdmission: true,
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: &sqlstats.TestingKnobs{
+				FlushInterceptor: func(
+					ctx context.Context,
+					stopper *stop.Stopper,
+					stmtStats []*appstatspb.CollectedStatementStatistics,
+					txnStats []*appstatspb.CollectedTransactionStatistics,
+				) {
+					mu.Lock()
+					defer mu.Unlock()
+					for _, s := range stmtStats {
+						if s.Key.App == appName {
+							interceptedStmts = append(interceptedStmts, s)
+						}
+					}
+					for _, tx := range txnStats {
+						if tx.App == appName {
+							interceptedTxns = append(interceptedTxns, tx)
+						}
+					}
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	sqlConn := sqlutils.MakeSQLRunner(conn)
+	obsConn := sqlutils.MakeSQLRunner(s.SQLConn(t))
+
+	sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.flush.minimum_interval = '0s'")
+	sqlConn.Exec(t, fmt.Sprintf("SET application_name = '%s'", appName))
+
+	sqlConn.Exec(t, "SELECT 1")
+	sqlConn.Exec(t, "SELECT 1, 2")
+	sqlstatstestutil.WaitForStatementEntriesAtLeast(t, obsConn, 2,
+		sqlstatstestutil.StatementFilter{App: appName})
+
+	pss := s.SQLServer().(*sql.Server).GetSQLStatsProvider()
+	pss.MaybeFlush(ctx, s.AppStopper())
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.NotEmpty(t, interceptedStmts, "expected intercepted statement stats")
+	require.NotEmpty(t, interceptedTxns, "expected intercepted transaction stats")
+
+	// Every flushed stat must carry a non-zero AggregatedTs that was set at
+	// record time (by ObserveTransaction), not by the flush path.
+	for _, stmt := range interceptedStmts {
+		require.False(t, stmt.AggregatedTs.IsZero(),
+			"statement stat should have non-zero AggregatedTs (query: %s)", stmt.Key.Query)
+		require.NotZero(t, stmt.AggregationInterval,
+			"statement stat should have non-zero AggregationInterval")
+		aggTs := stmt.AggregatedTs.UTC()
+		require.True(t, aggTs.Equal(expectedAggTs) || aggTs.Equal(nextHourAggTs),
+			"statement AggregatedTs %v should match recording-time hour boundary %v (or %v if hour rolled over)",
+			aggTs, expectedAggTs, nextHourAggTs)
+	}
+	for _, txn := range interceptedTxns {
+		require.False(t, txn.AggregatedTs.IsZero(),
+			"transaction stat should have non-zero AggregatedTs")
+		require.NotZero(t, txn.AggregationInterval,
+			"transaction stat should have non-zero AggregationInterval")
+		aggTs := txn.AggregatedTs.UTC()
+		require.True(t, aggTs.Equal(expectedAggTs) || aggTs.Equal(nextHourAggTs),
+			"transaction AggregatedTs %v should match recording-time hour boundary %v (or %v if hour rolled over)",
+			aggTs, expectedAggTs, nextHourAggTs)
+	}
 }
 
 type stubTime struct {

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -127,6 +127,13 @@ func (s *SQLStats) getStatsForApplication(appName string) *ssmemstorage.Containe
 	return a
 }
 
+func (s *SQLStats) getTimeNow() time.Time {
+	if s.knobs != nil && s.knobs.StubTimeNow != nil {
+		return s.knobs.StubTimeNow()
+	}
+	return timeutil.Now()
+}
+
 // resetAndMaybeDumpStats clears all the stored per-app, per-statement and
 // per-transaction statistics. If target is not nil, then the stats in s will be
 // flushed into target.
@@ -203,6 +210,12 @@ func (s *SQLStats) ObserveTransaction(
 		return
 	}
 
+	// Compute the aggregation timestamp once for the entire batch so that
+	// all statements and their enclosing transaction land in the same
+	// aggregation window.
+	interval := sqlstats.SQLStatsAggregationInterval.Get(&s.st.SV)
+	aggTs := s.getTimeNow().Truncate(interval)
+
 	// Retrieve application container.
 	var application string
 	if transaction != nil {
@@ -215,6 +228,8 @@ func (s *SQLStats) ObserveTransaction(
 	// Record statements.
 	var discardedCount int64
 	for _, stmt := range statements {
+		stmt.AggregatedTs = aggTs
+		stmt.AggInterval = interval
 		if stmt.App != application {
 			application = stmt.App
 			appStats = s.getStatsForApplication(application)
@@ -229,7 +244,8 @@ func (s *SQLStats) ObserveTransaction(
 	// executed in connections with an outer transaction are not
 	// recorded with their transaction.
 	if transaction != nil {
-		// Write statements.
+		transaction.AggregatedTs = aggTs
+		transaction.AggInterval = interval
 		err := appStats.RecordTransaction(ctx, transaction)
 		if err != nil {
 			discardedCount++

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -1920,6 +1920,79 @@ func TestTransactionLatencies(t *testing.T) {
 
 }
 
+// TestObserveTransactionStampsAggregationTimestamp verifies that
+// ObserveTransaction stamps all statements and the transaction with the same
+// non-zero AggregatedTs and AggInterval.
+func TestObserveTransactionStampsAggregationTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	st := cluster.MakeTestingClusterSettings()
+	sqlstats.SQLStatsAggregationInterval.Override(ctx, &st.SV, time.Hour)
+	sqlstats.MaxMemSQLStatsStmtFingerprints.Override(ctx, &st.SV, 100000)
+	sqlstats.MaxMemSQLStatsTxnFingerprints.Override(ctx, &st.SV, 100000)
+
+	// Stub the time to a known value mid-hour so we can assert
+	// the exact truncated timestamp.
+	stubNow := time.Date(2026, 3, 15, 10, 30, 45, 0, time.UTC)
+	expectedAggTs := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+
+	monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
+		Name:     mon.MakeName("test-observe"),
+		Settings: st,
+	})
+
+	sqlStats := sslocal.NewSQLStats(
+		st,
+		sqlstats.MaxMemSQLStatsStmtFingerprints,
+		sqlstats.MaxMemSQLStatsTxnFingerprints,
+		nil, /* curMemoryBytesCount */
+		nil, /* maxMemoryBytesHist */
+		nil, /* discardedStatsCount */
+		monitor,
+		nil, /* reportingSink */
+		&sqlstats.TestingKnobs{
+			StubTimeNow: func() time.Time { return stubNow },
+		},
+	)
+
+	stmts := []*sqlstats.RecordedStmtStats{
+		{
+			FingerprintID: 1,
+			Query:         "SELECT _",
+			App:           "test-app",
+		},
+		{
+			FingerprintID: 2,
+			Query:         "INSERT INTO _ VALUES (_)",
+			App:           "test-app",
+		},
+		{
+			FingerprintID: 3,
+			Query:         "UPDATE _ SET _ = _",
+			App:           "test-app",
+		},
+	}
+	txn := &sqlstats.RecordedTxnStats{
+		FingerprintID: 100,
+		Application:   "test-app",
+		Committed:     true,
+	}
+
+	sqlStats.ObserveTransaction(ctx, txn, stmts)
+
+	// All stats should have the stubbed time truncated to the hour boundary.
+	require.Equal(t, expectedAggTs, txn.AggregatedTs)
+	require.Equal(t, time.Hour, txn.AggInterval)
+	for i, s := range stmts {
+		require.Equal(t, expectedAggTs, s.AggregatedTs,
+			"statement %d should have same AggregatedTs as transaction", i)
+		require.Equal(t, time.Hour, s.AggInterval,
+			"statement %d should have 1h AggInterval", i)
+	}
+}
+
 func createNewSqlStats() *sslocal.SQLStats {
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -97,8 +97,10 @@ func (s *StmtStatsIterator) Next() bool {
 			PlanHash:                 stmtKey.planHash,
 			TransactionFingerprintID: stmtKey.transactionFingerprintID,
 		},
-		ID:    statementStats.ID,
-		Stats: data,
+		ID:                  statementStats.ID,
+		Stats:               data,
+		AggregatedTs:        stmtKey.aggregatedTs,
+		AggregationInterval: stmtKey.aggInterval,
 	}
 
 	return true
@@ -166,12 +168,12 @@ func (t *TxnStatsIterator) Next() bool {
 		return false
 	}
 
-	txnKey := t.txnKeys[t.idx]
+	key := t.txnKeys[t.idx]
 
 	// We don't want to create the key if it doesn't exist, so it's okay to
 	// pass nil for the statementFingerprintIDs, as they are only set when a key is
 	// constructed.
-	txnStats := t.container.getStatsForTxnWithKey(txnKey)
+	txnStats := t.container.getStatsForTxnWithKey(key)
 
 	// If the key is not found (and we expected to find it), the table must
 	// have been cleared between now and the time we read all the keys. In
@@ -187,7 +189,9 @@ func (t *TxnStatsIterator) Next() bool {
 		StatementFingerprintIDs:  txnStats.statementFingerprintIDs,
 		App:                      t.container.appName,
 		Stats:                    txnStats.mu.data,
-		TransactionFingerprintID: txnKey,
+		TransactionFingerprintID: key.transactionFingerprintID,
+		AggregatedTs:             key.aggregatedTs,
+		AggregationInterval:      key.aggInterval,
 	}
 
 	return true

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -36,6 +36,14 @@ type stmtKey struct {
 	fingerprintID            appstatspb.StmtFingerprintID
 	planHash                 uint64
 	transactionFingerprintID appstatspb.TransactionFingerprintID
+	aggregatedTs             time.Time
+	aggInterval              time.Duration
+}
+
+type txnKey struct {
+	transactionFingerprintID appstatspb.TransactionFingerprintID
+	aggregatedTs             time.Time
+	aggInterval              time.Duration
 }
 
 // sampledPlanKey is used by the Optimizer to determine if we should build a full EXPLAIN plan.
@@ -50,10 +58,12 @@ func (p sampledPlanKey) size() int64 {
 }
 
 func (s stmtKey) size() int64 {
-	return int64(unsafe.Sizeof(invalidStmtFingerprintID))
+	return int64(unsafe.Sizeof(s))
 }
 
-const invalidStmtFingerprintID = 0
+func (t txnKey) size() int64 {
+	return int64(unsafe.Sizeof(t))
+}
 
 // Container holds per-application statement and transaction statistics.
 type Container struct {
@@ -73,7 +83,7 @@ type Container struct {
 		syncutil.Mutex
 
 		stmts map[stmtKey]*stmtStats
-		txns  map[appstatspb.TransactionFingerprintID]*txnStats
+		txns  map[txnKey]*txnStats
 
 		// sampledStatementCache records if the statement has been sampled via
 		// tracing. sampledPlanKey is used as the key to the map as it does not
@@ -111,7 +121,7 @@ func New(
 	}
 
 	s.mu.stmts = make(map[stmtKey]*stmtStats)
-	s.mu.txns = make(map[appstatspb.TransactionFingerprintID]*txnStats)
+	s.mu.txns = make(map[txnKey]*txnStats)
 	s.mu.sampledStatementCache = make(map[sampledPlanKey]struct{})
 
 	return s
@@ -209,6 +219,8 @@ func NewTempContainerFromExistingStmtStats(
 			fingerprintID:            statistics[i].ID,
 			planHash:                 statistics[i].Key.KeyData.PlanHash,
 			transactionFingerprintID: statistics[i].Key.KeyData.TransactionFingerprintID,
+			aggregatedTs:             statistics[i].Key.AggregatedTs,
+			aggInterval:              statistics[i].Key.AggregationInterval,
 		}
 		stmtStats, _, throttled :=
 			container.tryCreateStatsForStmtWithKeyLocked(key, sampledPlanKey{
@@ -278,8 +290,13 @@ func NewTempContainerFromExistingTxnStats(
 		}
 		// Since we just created the container and haven't exposed it yet, we
 		// don't need to take a lock on it.
+		key := txnKey{
+			transactionFingerprintID: statistics[i].StatsData.TransactionFingerprintID,
+			aggregatedTs:             statistics[i].StatsData.AggregatedTs,
+			aggInterval:              statistics[i].StatsData.AggregationInterval,
+		}
 		txnStats, _, throttled := container.tryCreateStatsForTxnWithKey(
-			statistics[i].StatsData.TransactionFingerprintID,
+			key,
 			statistics[i].StatsData.StatementFingerprintIDs)
 		if throttled {
 			return nil /* container */, nil /* remaining */, ErrFingerprintLimitReached
@@ -445,14 +462,14 @@ func (s *Container) tryCreateStatsForStmtWithKeyLocked(
 	return stats, true /* created */, false /* throttled */
 }
 
-func (s *Container) getStatsForTxnWithKey(key appstatspb.TransactionFingerprintID) *txnStats {
+func (s *Container) getStatsForTxnWithKey(key txnKey) *txnStats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.mu.txns[key]
 }
 
 func (s *Container) tryCreateStatsForTxnWithKey(
-	key appstatspb.TransactionFingerprintID, stmtFingerprintIDs []appstatspb.StmtFingerprintID,
+	key txnKey, stmtFingerprintIDs []appstatspb.StmtFingerprintID,
 ) (stats *txnStats, created, throttled bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -505,7 +522,7 @@ func (s *Container) DrainStats(
 	var stmts map[stmtKey]*stmtStats
 
 	transactionStats := make([]*appstatspb.CollectedTransactionStatistics, 0)
-	var txns map[appstatspb.TransactionFingerprintID]*txnStats
+	var txns map[txnKey]*txnStats
 
 	func() {
 		s.mu.Lock()
@@ -544,8 +561,10 @@ func (s *Container) DrainStats(
 				PlanHash:                 key.planHash,
 				TransactionFingerprintID: key.transactionFingerprintID,
 			},
-			ID:    stmt.ID,
-			Stats: data,
+			ID:                  stmt.ID,
+			Stats:               data,
+			AggregatedTs:        key.aggregatedTs,
+			AggregationInterval: key.aggInterval,
 		})
 	}
 
@@ -560,7 +579,9 @@ func (s *Container) DrainStats(
 			StatementFingerprintIDs:  txn.statementFingerprintIDs,
 			App:                      s.appName,
 			Stats:                    stats,
-			TransactionFingerprintID: key,
+			TransactionFingerprintID: key.transactionFingerprintID,
+			AggregatedTs:             key.aggregatedTs,
+			AggregationInterval:      key.aggInterval,
 		})
 	}
 	return statementStats, transactionStats
@@ -582,7 +603,7 @@ func (s *Container) clearLocked(ctx context.Context) {
 	// Clear the map, to release the memory; make the new map somewhat already
 	// large for the likely future workload.
 	s.mu.stmts = make(map[stmtKey]*stmtStats, len(s.mu.stmts)/2)
-	s.mu.txns = make(map[appstatspb.TransactionFingerprintID]*txnStats, len(s.mu.txns)/2)
+	s.mu.txns = make(map[txnKey]*txnStats, len(s.mu.txns)/2)
 	s.mu.sampledStatementCache = make(map[sampledPlanKey]struct{}, len(s.mu.sampledStatementCache)/2)
 	if s.knobs != nil && s.knobs.OnAfterClear != nil {
 		s.knobs.OnAfterClear()
@@ -601,7 +622,10 @@ func (s *Container) Free(ctx context.Context) {
 func (s *Container) freeLocked(ctx context.Context) {
 	s.acc.Clear(ctx)
 	if s.uniqueServerCount != nil {
-		s.uniqueServerCount.freeByCnt(int64(len(s.mu.stmts)), int64(len(s.mu.txns)))
+		s.uniqueServerCount.freeByCnt(
+			int64(len(s.mu.stmts)),
+			int64(len(s.mu.txns)),
+		)
 	}
 }
 
@@ -679,10 +703,10 @@ func (s *Container) Add(ctx context.Context, other *Container) (err error) {
 	}
 
 	// Do what we did above for the statMap for the txn Map now.
-	txnMap := func() map[appstatspb.TransactionFingerprintID]*txnStats {
+	txnMap := func() map[txnKey]*txnStats {
 		other.mu.Lock()
 		defer other.mu.Unlock()
-		txnMap := make(map[appstatspb.TransactionFingerprintID]*txnStats)
+		txnMap := make(map[txnKey]*txnStats)
 		for k, v := range other.mu.txns {
 			txnMap[k] = v
 		}
@@ -720,7 +744,7 @@ func (s *Container) Add(ctx context.Context, other *Container) (err error) {
 			defer t.mu.Unlock()
 
 			if created {
-				estimatedAllocBytes := t.sizeUnsafeLocked() + k.Size() + 8 /* TransactionFingerprintID hash */
+				estimatedAllocBytes := t.sizeUnsafeLocked() + k.size() + 8 /* txnKey hash */
 				// We still want to continue this loop to merge stats that are already
 				// present in our map that do not require allocation.
 				if latestErr := func() error {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -50,6 +50,8 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 		fingerprintID:            value.FingerprintID,
 		planHash:                 value.PlanHash,
 		transactionFingerprintID: value.TransactionFingerprintID,
+		aggregatedTs:             value.AggregatedTs,
+		aggInterval:              value.AggInterval,
 	}
 
 	// Get the statistics object.
@@ -209,7 +211,12 @@ func (s *Container) RecordTransaction(ctx context.Context, value *sqlstats.Recor
 	s.recordTransactionHighLevelStats(value.TransactionTimeSec, value.Committed, value.ImplicitTxn)
 
 	// Get the statistics object.
-	stats, created, throttled := s.tryCreateStatsForTxnWithKey(value.FingerprintID, value.StatementFingerprintIDs)
+	key := txnKey{
+		transactionFingerprintID: value.FingerprintID,
+		aggregatedTs:             value.AggregatedTs,
+		aggInterval:              value.AggInterval,
+	}
+	stats, created, throttled := s.tryCreateStatsForTxnWithKey(key, value.StatementFingerprintIDs)
 
 	if throttled {
 		return ErrFingerprintLimitReached
@@ -226,14 +233,14 @@ func (s *Container) RecordTransaction(ctx context.Context, value *sqlstats.Recor
 	// fingerprints for this app. We also abort the operation and return an error.
 	if created {
 		estimatedMemAllocBytes :=
-			stats.sizeUnsafeLocked() + value.FingerprintID.Size() + 8 /* hash of transaction key */
+			stats.sizeUnsafeLocked() + key.size() + 8 /* hash of transaction key */
 		if err := func() error {
 			// If the monitor is nil, we do not track memory usage.
 			if s.acc != nil {
 				if err := s.acc.Grow(ctx, estimatedMemAllocBytes); err != nil {
 					s.mu.Lock()
 					defer s.mu.Unlock()
-					delete(s.mu.txns, value.FingerprintID)
+					delete(s.mu.txns, key)
 					return ErrMemoryPressure
 				}
 			}

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -99,14 +99,22 @@ func TestContainer_Add(t *testing.T) {
 			nil,
 		)
 
-		// Add some statement stats to the source container
+		// Use a fixed aggregation timestamp for all stats in this test.
+		aggTs := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+		aggInterval := time.Hour
+
+		// Add some statement stats to the source container.
 		mockedStmtKey := stmtKey{
 			fingerprintID: 1,
+			aggregatedTs:  aggTs,
+			aggInterval:   aggInterval,
 		}
 		stmtStats := &sqlstats.RecordedStmtStats{
 			FingerprintID:      1,
 			Query:              "SELECT * FROM test_table",
 			Database:           "test_db",
+			AggregatedTs:       aggTs,
+			AggInterval:        aggInterval,
 			ServiceLatencySec:  0.1,
 			RowsAffected:       10,
 			IdleLatencySec:     0.01,
@@ -125,10 +133,12 @@ func TestContainer_Add(t *testing.T) {
 		}
 		require.NoError(t, src.RecordStatement(ctx, stmtStats))
 
-		// Add some transaction stats to the source container
+		// Add some transaction stats to the source container.
 		txnFingerprintID := appstatspb.TransactionFingerprintID(123)
 		txnStats := &sqlstats.RecordedTxnStats{
 			FingerprintID:  txnFingerprintID,
+			AggregatedTs:   aggTs,
+			AggInterval:    aggInterval,
 			RowsAffected:   10,
 			ServiceLatency: 1,
 			RetryLatency:   2,
@@ -148,10 +158,14 @@ func TestContainer_Add(t *testing.T) {
 		// but decrease any appstatspb.NumericStats averages.
 		emptyStmtStatsKey := stmtKey{
 			fingerprintID: 321,
+			aggregatedTs:  aggTs,
+			aggInterval:   aggInterval,
 		}
 		reducedStmtStats := &sqlstats.RecordedStmtStats{
 			FingerprintID:      appstatspb.StmtFingerprintID(321),
 			Query:              "SELECT * FROM test_table",
+			AggregatedTs:       aggTs,
+			AggInterval:        aggInterval,
 			ServiceLatencySec:  50,
 			RowsAffected:       1000,
 			IdleLatencySec:     10,
@@ -171,6 +185,8 @@ func TestContainer_Add(t *testing.T) {
 		reducedTxnFingerprintID := appstatspb.TransactionFingerprintID(321)
 		reducedTxnStats := &sqlstats.RecordedTxnStats{
 			FingerprintID:  reducedTxnFingerprintID,
+			AggregatedTs:   aggTs,
+			AggInterval:    aggInterval,
 			RowsAffected:   100,
 			ServiceLatency: 500 * time.Millisecond,
 			RetryLatency:   100 * time.Millisecond,
@@ -186,9 +202,13 @@ func TestContainer_Add(t *testing.T) {
 		require.NoError(t, dest.RecordTransaction(ctx, reducedTxnStats))
 		require.NoError(t, src.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
 			FingerprintID: appstatspb.StmtFingerprintID(321),
+			AggregatedTs:  aggTs,
+			AggInterval:   aggInterval,
 		}))
 		require.NoError(t, src.RecordTransaction(ctx, &sqlstats.RecordedTxnStats{
 			FingerprintID: reducedTxnFingerprintID,
+			AggregatedTs:  aggTs,
+			AggInterval:   aggInterval,
 		}))
 
 		for i := 0; i < 10; i++ {
@@ -196,8 +216,16 @@ func TestContainer_Add(t *testing.T) {
 			// Check results.
 			verifyStmtStatsMultiple(t, i+1, stmtStats, dest.getStatsForStmtWithKey(mockedStmtKey))
 			verifyStmtStatsReduced(t, i+2, reducedStmtStats, dest.getStatsForStmtWithKey(emptyStmtStatsKey))
-			verifyTxnStatsMultiple(t, i+1, txnStats, dest.getStatsForTxnWithKey(txnFingerprintID))
-			verifyTxnStatsReduced(t, i+2, reducedTxnStats, dest.getStatsForTxnWithKey(reducedTxnStats.FingerprintID))
+			verifyTxnStatsMultiple(t, i+1, txnStats, dest.getStatsForTxnWithKey(txnKey{
+				transactionFingerprintID: txnFingerprintID,
+				aggregatedTs:             aggTs,
+				aggInterval:              aggInterval,
+			}))
+			verifyTxnStatsReduced(t, i+2, reducedTxnStats, dest.getStatsForTxnWithKey(txnKey{
+				transactionFingerprintID: reducedTxnStats.FingerprintID,
+				aggregatedTs:             aggTs,
+				aggInterval:              aggInterval,
+			}))
 		}
 	})
 }
@@ -396,6 +424,96 @@ func TestContainerMemoryAccountClearing(t *testing.T) {
 	require.Greater(t, memUsedAfterFreeThenRealloc, int64(0), "Expected memory to be allocated after Free")
 
 	container.Clear(ctx)
+}
+
+// TestContainerCrossWindowAggregation verifies that stats recorded with
+// different aggregation timestamps are kept separate in the Container and
+// drained with their respective aggregated_ts values.
+func TestContainerCrossWindowAggregation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	// Set a 1-hour aggregation interval.
+	sqlstats.SQLStatsAggregationInterval.Override(ctx, &st.SV, time.Hour)
+
+	container := New(st,
+		nil, /* uniqueServerCount */
+		testMonitor(ctx, "test-cross-window", st),
+		"test-app",
+		nil, /* knobs */
+	)
+	defer container.Clear(ctx)
+
+	windowA := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	windowB := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+	fpID := appstatspb.StmtFingerprintID(42)
+	txnFpID := appstatspb.TransactionFingerprintID(99)
+
+	// Record a statement in window A.
+	err := container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:            fpID,
+		Query:                    "SELECT _",
+		AggregatedTs:             windowA,
+		AggInterval:              time.Hour,
+		TransactionFingerprintID: txnFpID,
+	})
+	require.NoError(t, err)
+
+	// Record the same fingerprint in window B.
+	err = container.RecordStatement(ctx, &sqlstats.RecordedStmtStats{
+		FingerprintID:            fpID,
+		Query:                    "SELECT _",
+		AggregatedTs:             windowB,
+		AggInterval:              time.Hour,
+		TransactionFingerprintID: txnFpID,
+	})
+	require.NoError(t, err)
+
+	// Record a transaction in window A.
+	err = container.RecordTransaction(ctx, &sqlstats.RecordedTxnStats{
+		FingerprintID: txnFpID,
+		AggregatedTs:  windowA,
+		AggInterval:   time.Hour,
+		Committed:     true,
+	})
+	require.NoError(t, err)
+
+	// Record the same txn fingerprint in window B.
+	err = container.RecordTransaction(ctx, &sqlstats.RecordedTxnStats{
+		FingerprintID: txnFpID,
+		AggregatedTs:  windowB,
+		AggInterval:   time.Hour,
+		Committed:     true,
+	})
+	require.NoError(t, err)
+
+	// Drain and verify the stats have separate entries per window.
+	stmtStats, txnStats := container.DrainStats(ctx)
+
+	require.Len(t, stmtStats, 2, "expected 2 statement stats entries (one per window)")
+	require.Len(t, txnStats, 2, "expected 2 transaction stats entries (one per window)")
+
+	stmtWindows := map[time.Time]bool{}
+	for _, s := range stmtStats {
+		stmtWindows[s.AggregatedTs] = true
+		require.Equal(t, time.Hour, s.AggregationInterval)
+		require.Equal(t, fpID, s.ID)
+		require.Equal(t, int64(1), s.Stats.Count, "each window should have count=1")
+	}
+	require.True(t, stmtWindows[windowA], "window A should be present")
+	require.True(t, stmtWindows[windowB], "window B should be present")
+
+	txnWindows := map[time.Time]bool{}
+	for _, tx := range txnStats {
+		txnWindows[tx.AggregatedTs] = true
+		require.Equal(t, time.Hour, tx.AggregationInterval)
+		require.Equal(t, txnFpID, tx.TransactionFingerprintID)
+		require.Equal(t, int64(1), tx.Stats.Count, "each window should have count=1")
+	}
+	require.True(t, txnWindows[windowA], "window A should be present")
+	require.True(t, txnWindows[windowB], "window B should be present")
 }
 
 func generateRandomKey() stmtKey {

--- a/pkg/sql/sqlstats/ssmemstorage/utils.go
+++ b/pkg/sql/sqlstats/ssmemstorage/utils.go
@@ -5,8 +5,6 @@
 
 package ssmemstorage
 
-import "github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
-
 type stmtList []stmtKey
 
 func (s stmtList) Len() int {
@@ -16,16 +14,16 @@ func (s stmtList) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 func (s stmtList) Less(i, j int) bool {
-	if s[i].fingerprintID < s[j].fingerprintID {
-		return true
+	if s[i].fingerprintID != s[j].fingerprintID {
+		return s[i].fingerprintID < s[j].fingerprintID
 	}
-	if s[i].fingerprintID > s[j].fingerprintID {
-		return false
+	if s[i].transactionFingerprintID != s[j].transactionFingerprintID {
+		return s[i].transactionFingerprintID < s[j].transactionFingerprintID
 	}
-	return s[i].transactionFingerprintID < s[j].transactionFingerprintID
+	return s[i].aggregatedTs.Before(s[j].aggregatedTs)
 }
 
-type txnList []appstatspb.TransactionFingerprintID
+type txnList []txnKey
 
 func (t txnList) Len() int {
 	return len(t)
@@ -36,5 +34,8 @@ func (t txnList) Swap(i, j int) {
 }
 
 func (t txnList) Less(i, j int) bool {
-	return t[i] < t[j]
+	if t[i].transactionFingerprintID != t[j].transactionFingerprintID {
+		return t[i].transactionFingerprintID < t[j].transactionFingerprintID
+	}
+	return t[i].aggregatedTs.Before(t[j].aggregatedTs)
 }

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -103,6 +103,12 @@ type RecordedStmtStats struct {
 	QueryTags                []sqlcommenter.QueryTag
 	UnderOuterTxn            bool
 	StatsRollout             eval.StatsRolloutSelection
+
+	// AggregatedTs and AggInterval, when non-zero, override the Container's
+	// own computation so that all statements in a transaction share the same
+	// aggregation window as the transaction itself.
+	AggregatedTs time.Time
+	AggInterval  time.Duration
 }
 
 var recordedStmtStatsSize = int64(unsafe.Sizeof(RecordedStmtStats{}))
@@ -177,6 +183,12 @@ type RecordedTxnStats struct {
 	// Normalized user name.
 	UserNormalized   string
 	InternalExecutor bool
+
+	// AggregatedTs and AggInterval, when non-zero, override the Container's
+	// own computation so that all statements in a transaction share the same
+	// aggregation window as the transaction itself.
+	AggregatedTs time.Time
+	AggInterval  time.Duration
 }
 
 // SSDrainer is the interface for draining or resetting sql stats.

--- a/pkg/sql/sqlstats/test_utils.go
+++ b/pkg/sql/sqlstats/test_utils.go
@@ -16,7 +16,6 @@ import (
 
 type FlushFn func(ctx context.Context,
 	stopper *stop.Stopper,
-	aggregatedTs time.Time,
 	stmtStats []*appstatspb.CollectedStatementStatistics,
 	txnStats []*appstatspb.CollectedTransactionStatistics,
 )


### PR DESCRIPTION
Previously, the aggregation timestamp and interval were not part of
RecordedStmtStats or RecordedTxnStats. They were computed at flush time
by the persisted stats subsystem, which meant the in-memory layer had
no awareness of aggregation windows.

This patch adds AggregatedTs and AggInterval fields to both
RecordedStmtStats and RecordedTxnStats. When non-zero, these fields
override the Container's own timestamp computation, allowing callers to
ensure all statements in a transaction share the same aggregation window.

-----

Previously, the in-memory stats container keyed statement stats by
(fingerprintID, planHash, transactionFingerprintID) and transaction
stats by transactionFingerprintID alone. This meant stats from different
aggregation windows were merged together in memory, and the aggregation
timestamp was only assigned at flush time — potentially placing stats
in the wrong window.

This patch adds aggregatedTs and aggInterval to both stmtKey and a new
txnKey struct, so that stats recorded in different aggregation windows
are kept as separate entries. The iterator and drain paths propagate
these per-key timestamps into CollectedStatementStatistics and
CollectedTransactionStatistics.

-----

Previously, the aggregation timestamp was computed at flush time by the
persisted stats layer. If a statement was recorded near the end of one
aggregation window but flushed in the next, it would be attributed to
the wrong window. Additionally, different statements within the same
transaction could end up in different windows.

This patch moves the timestamp computation to ObserveTransaction in
sslocal, so that all statements and their enclosing transaction are
stamped with the same aggregation window at record time. The
SQLStatsAggregationInterval cluster setting is relocated from
persistedsqlstats to sqlstats to avoid an import cycle.

-----

Previously, the flush path computed a single aggregated timestamp per
flush bucket and applied it uniformly to all stats being flushed. Now
that each stat carries its own AggregatedTs and AggregationInterval
from record time, the flush path reads these directly from each stat.

This patch removes the flushBucket struct entirely, updates
DrainSqlStatsRespBuilder to key by (fingerprint, aggregatedTs) so
stats from different windows are not merged during drain, updates the
crdb_internal virtual tables to use per-stat timestamps, and populates
AggregatedTs and AggregationInterval on the statements API response.

closes: CRDB-62907