### PR TITLE
release-24.3: revertccl: deflake TestRevertSpansFanout

### DIFF
--- a/pkg/ccl/revertccl/BUILD.bazel
+++ b/pkg/ccl/revertccl/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "//pkg/sql/sem/catid",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/ccl/revertccl/revert_test.go
+++ b/pkg/ccl/revertccl/revert_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -38,6 +39,7 @@ import (
 func TestRevertSpansFanout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRaceWithIssue(t, 165807, "flaky under race")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Fixes: #165807

Release note: None

---

Release justification: Test-only change.