### PR TITLE
release-24.3: storeliveness: bump idle timeout in TestTransportIdleSendQueue

### DIFF
--- a/pkg/kv/kvserver/storeliveness/transport_test.go
+++ b/pkg/kv/kvserver/storeliveness/transport_test.go
@@ -532,7 +532,7 @@ func TestTransportIdleSendQueue(t *testing.T) {
 	handler := tt.AddStore(receiver)
 
 	tt.transports[sender.NodeID].knobs.OverrideIdleTimeout = func() time.Duration {
-		return time.Millisecond
+		return 100 * time.Millisecond
 	}
 
 	// Send and receive a message.


### PR DESCRIPTION
This commit increases the idle timeout override in the test from 1ms to 100ms (to match the timeout on master). This allows the test more time for the initial message send/receive before the queue is considered idle.

Release note: None
Fixes: #168498

---

Release justification: Test only.