### PR TITLE
catalog: add Statement and RoutineBody type aliases

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -10603,7 +10603,7 @@ $$;
 		require.Equal(t, 111, int(fnDesc.GetID()))
 		require.Equal(t, 104, int(fnDesc.GetParentID()))
 		require.Equal(t, 106, int(fnDesc.GetParentSchemaID()))
-		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(110:::REGCLASS);", string(fnDesc.GetFunctionBody()))
 		require.Equal(t, 100108, int(fnDesc.GetParams()[0].Type.Oid()))
 		require.Equal(t, []descpb.ID{107, 110}, fnDesc.GetDependsOn())
 		require.Equal(t, []descpb.ID{108, 109}, fnDesc.GetDependsOnTypes())
@@ -10656,7 +10656,7 @@ $$;
 		require.Equal(t, 112, int(fnDesc.GetParentID()))
 		require.Equal(t, 114, int(fnDesc.GetParentSchemaID()))
 		// Make sure db name and IDs are rewritten in function body.
-		require.Equal(t, "SELECT a FROM db1_new.sc1.tbl1;\nSELECT nextval(118:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, "SELECT a FROM db1_new.sc1.tbl1;\nSELECT nextval(118:::REGCLASS);", string(fnDesc.GetFunctionBody()))
 		require.Equal(t, 100116, int(fnDesc.GetParams()[0].Type.Oid()))
 		require.Equal(t, []descpb.ID{115, 118}, fnDesc.GetDependsOn())
 		require.Equal(t, []descpb.ID{116, 117}, fnDesc.GetDependsOnTypes())

--- a/pkg/ccl/changefeedccl/cdceval/cdc_prev.go
+++ b/pkg/ccl/changefeedccl/cdceval/cdc_prev.go
@@ -185,7 +185,7 @@ func (c *prevCol) HasNullDefault() bool {
 	return false
 }
 
-func (c *prevCol) GetDefaultExpr() string {
+func (c *prevCol) GetDefaultExpr() catpb.Expression {
 	return ""
 }
 
@@ -193,7 +193,7 @@ func (c *prevCol) HasOnUpdate() bool {
 	return false
 }
 
-func (c *prevCol) GetOnUpdateExpr() string {
+func (c *prevCol) GetOnUpdateExpr() catpb.Expression {
 	return ""
 }
 
@@ -201,7 +201,7 @@ func (c *prevCol) IsComputed() bool {
 	return false
 }
 
-func (c *prevCol) GetComputeExpr() string {
+func (c *prevCol) GetComputeExpr() catpb.Expression {
 	return ""
 }
 

--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -89,7 +89,6 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_gogo_protobuf//proto",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_gogo_protobuf//proto",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
-	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +62,7 @@ func MakeColumnDesc(id descpb.ColumnID) *descpb.ColumnDescriptor {
 		Name:        "c" + strconv.Itoa(int(id)),
 		ID:          id,
 		Type:        types.Bool,
-		DefaultExpr: proto.String("true"),
+		DefaultExpr: new(descpb.Expression("true")),
 	}
 }
 

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed/schematestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,7 +127,7 @@ func TestTableEventIsPrimaryIndexChange(t *testing.T) {
 					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
 					col := td.TableDesc().Mutations[0].GetColumn()
 					col.Nullable = true
-					col.ComputeExpr = proto.String("1")
+					col.ComputeExpr = new(descpb.Expression("1"))
 					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
 				}(),
 				After: mkTableDesc(42, 4, ts(4), 2, 1),
@@ -210,7 +210,7 @@ func TestTableEventIsOnlyPrimaryIndexChange(t *testing.T) {
 					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
 					col := td.TableDesc().Mutations[0].GetColumn()
 					col.Nullable = true
-					col.ComputeExpr = proto.String("1")
+					col.ComputeExpr = new(descpb.Expression("1"))
 					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
 				}(),
 				After: mkTableDesc(42, 4, ts(4), 2, 1),
@@ -326,7 +326,7 @@ func TestTableEventFilter(t *testing.T) {
 					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
 					col := td.TableDesc().Mutations[0].GetColumn()
 					col.Nullable = true
-					col.ComputeExpr = proto.String("1")
+					col.ComputeExpr = new(descpb.Expression("1"))
 					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
 				}(),
 				After: mkTableDesc(42, 4, ts(4), 2, 1),

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -1025,7 +1025,6 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
-        "@org_golang_google_protobuf//proto",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -144,7 +144,8 @@ func (p *planner) addColumnImpl(
 		if err != nil {
 			return err
 		}
-		col.ComputeExpr = &serializedExpr
+		expr := descpb.Expression(serializedExpr)
+		col.ComputeExpr = &expr
 	}
 
 	if !col.Virtual {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -331,7 +331,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					if err != nil {
 						return err
 					}
-					idx.Predicate = expr
+					idx.Predicate = descpb.Expression(expr)
 				}
 
 				idx, err = params.p.configureIndexDescForNewIndexPartitioning(
@@ -1388,7 +1388,7 @@ func updateNonComputedColExpr(
 	tab *tabledesc.Mutable,
 	col catalog.Column,
 	newExpr tree.Expr,
-	exprField **string,
+	exprField **descpb.Expression,
 	op tree.SchemaExprContext,
 ) error {
 	if col.IsGeneratedAsIdentity() {
@@ -1414,7 +1414,8 @@ func updateNonComputedColExpr(
 			return err
 		}
 
-		*exprField = &s
+		expr := descpb.Expression(s)
+		*exprField = &expr
 	}
 
 	if err := updateSequenceDependencies(params, tab, col, op); err != nil {
@@ -1479,7 +1480,7 @@ func updateSequenceDependencies(
 		colExprKind    tabledesc.ColExprKind
 		colExprContext tree.SchemaExprContext
 		exists         func() bool
-		get            func() string
+		get            func() catpb.Expression
 	}{
 		{
 			colExprKind:    tabledesc.DefaultExpr,
@@ -1497,7 +1498,7 @@ func updateSequenceDependencies(
 		if !colExpr.exists() {
 			continue
 		}
-		untypedExpr, err := parser.ParseExpr(colExpr.get())
+		untypedExpr, err := parser.ParseExpr(string(colExpr.get()))
 		if err != nil {
 			panic(err)
 		}
@@ -2101,7 +2102,7 @@ func dropColumnImpl(
 			idx.CollectKeySuffixColumnIDs().Contains(colToDrop.GetID()) ||
 			idx.CollectSecondaryStoredColumnIDs().Contains(colToDrop.GetID())
 		if idx.IsPartial() {
-			expr, err := parser.ParseExpr(idx.GetPredicate())
+			expr, err := parser.ParseExpr(string(idx.GetPredicate()))
 			if err != nil {
 				return nil, err
 			}
@@ -2146,7 +2147,7 @@ func dropColumnImpl(
 	// Drop non-index-backed unique constraints which reference the column.
 	for _, uwoi := range tableDesc.EnforcedUniqueConstraintsWithoutIndex() {
 		if uwoi.IsPartial() {
-			expr, err := parser.ParseExpr(uwoi.GetPredicate())
+			expr, err := parser.ParseExpr(string(uwoi.GetPredicate()))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -248,7 +248,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 	enumOID := catid.TypeIDToOID(enumTypeID)
 
 	var newColumnID *descpb.ColumnID
-	var newColumnDefaultExpr *string
+	var newColumnDefaultExpr *descpb.Expression
 
 	if !createDefaultRegionCol {
 		// If the column is not public, we cannot use it yet.
@@ -380,8 +380,8 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 		if err != nil {
 			return err
 		}
-		s := tree.Serialize(finalDefaultExpr)
-		newColumnDefaultExpr = &s
+		expr := descpb.Expression(tree.Serialize(finalDefaultExpr))
+		newColumnDefaultExpr = &expr
 		newColumnID = &col.ID
 	}
 
@@ -421,7 +421,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityFromOrToRegionalByRow(
 	mutationIdxAllowedInSameTxn *int,
 	newColumnName *tree.Name,
 	newColumnID *descpb.ColumnID,
-	newColumnDefaultExpr *string,
+	newColumnDefaultExpr *descpb.Expression,
 	pkColumnNames []string,
 	pkColumnDirections []catenumpb.IndexColumn_Direction,
 ) error {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1661,7 +1661,7 @@ func ValidateConstraint(
 					return validateUniqueConstraint(
 						ctx, tableDesc, uwi.GetName(),
 						uwi.CollectKeyColumnIDs().Ordered(),
-						uwi.GetPredicate(),
+						string(uwi.GetPredicate()),
 						indexIDForValidation,
 						txn,
 						sessionData.User(),
@@ -1860,7 +1860,7 @@ func countExpectedRowsForInvertedIndex(
 	// exist" error.
 	var colNameOrExpr string
 	if col.IsExpressionIndexColumn() {
-		colNameOrExpr = col.GetComputeExpr()
+		colNameOrExpr = string(col.GetComputeExpr())
 	} else {
 		// Format the column name so that it can be parsed if it has special
 		// characters, like "-" or a newline.
@@ -2222,7 +2222,7 @@ func countIndexRowsAndMaybeCheckUniqueness(
 					tableDesc,
 					idx.GetName(),
 					idx.IndexDesc().KeyColumnIDs[idx.ImplicitPartitioningColumnCount():],
-					idx.GetPredicate(),
+					string(idx.GetPredicate()),
 					desc.GetPrimaryIndexID(), /* indexIDForValidation */
 					txn,
 					username.NodeUserName(),
@@ -2933,7 +2933,7 @@ func validateUniqueWithoutIndexConstraintInTxn(
 				tableDesc,
 				uc.Name,
 				uc.ColumnIDs,
-				uc.Predicate,
+				string(uc.Predicate),
 				0, /* indexIDForValidation */
 				txn,
 				user,

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/bulkutil",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catenumpb",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/fetchpb",

--- a/pkg/sql/backfill/index_backfiller_cols.go
+++ b/pkg/sql/backfill/index_backfiller_cols.go
@@ -8,6 +8,7 @@ package backfill
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
@@ -220,8 +221,8 @@ func indexColumns(idx catalog.Index) (s catalog.TableColSet) {
 func addIndexColumnsFromExpressions(
 	s catalog.TableColSet, table catalog.TableDescriptor, addIndexes []catalog.Index,
 ) (catalog.TableColSet, error) {
-	addReferencesFromExpression := func(expression string) error {
-		expr, err := parser.ParseExpr(expression)
+	addReferencesFromExpression := func(expression catpb.Expression) error {
+		expr, err := parser.ParseExpr(string(expression))
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/backfill_test.go
+++ b/pkg/sql/backfill_test.go
@@ -41,7 +41,7 @@ func (c constraintToUpdateForTest) CheckDesc() *descpb.TableDescriptor_CheckCons
 }
 
 // GetExpr implements the catalog.CheckConstraint interface.
-func (c constraintToUpdateForTest) GetExpr() string {
+func (c constraintToUpdateForTest) GetExpr() catpb.Expression {
 	return c.desc.Check.Expr
 }
 

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -30,7 +30,7 @@ func TestIndexForDisplay(t *testing.T) {
 	table := tree.Name("bar")
 	tableName := tree.MakeTableNameWithSchema(database, catconstants.PublicSchemaName, table)
 
-	compExpr := "a + b"
+	compExpr := catpb.Expression("a + b")
 	cols := []descpb.ColumnDescriptor{
 		// a INT
 		{

--- a/pkg/sql/catalog/catpb/expression.go
+++ b/pkg/sql/catalog/catpb/expression.go
@@ -5,9 +5,20 @@
 
 package catpb
 
+// Expression, Statement, and RoutineBody are all strings that encode SQL,
+// however the distinction exists to denote how to parse each string.
+
 // Expression is a SQL expression encoded as a string.
 // This type exists for use as a cast type in protobufs to annotate which
 // fields hold SQL expressions.
-//
-// TODO(ajwerner): adopt this in descpb.
 type Expression string
+
+// Statement is a SQL statement encoded as a string.
+// This type exists for use as a cast type in protobufs to annotate which
+// fields hold full SQL statements.
+type Statement string
+
+// RoutineBody is a PL/pgSQL routine body encoded as a string.
+// This type exists for use as a cast type in protobufs to annotate which
+// fields hold PL/pgSQL function bodies.
+type RoutineBody string

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/sql/catalog/catenumpb",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -98,11 +98,11 @@ func (desc *ColumnDescriptor) SQLStringNotHumanReadable() string {
 	}
 	if desc.DefaultExpr != nil {
 		f.WriteString(" DEFAULT ")
-		f.WriteString(*desc.DefaultExpr)
+		f.WriteString(string(*desc.DefaultExpr))
 	}
 	if desc.IsComputed() {
 		f.WriteString(" AS (")
-		f.WriteString(*desc.ComputeExpr)
+		f.WriteString(string(*desc.ComputeExpr))
 		f.WriteString(") STORED")
 	}
 	return f.CloseAndGetString()

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -7,6 +7,7 @@ package descpb
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -119,6 +120,15 @@ const (
 
 // PGAttributeNum is a custom type for ColumnDescriptor's PGAttributeNum field.
 type PGAttributeNum = catid.PGAttributeNum
+
+// Expression is a SQL expression encoded as a string.
+type Expression = catpb.Expression
+
+// Statement is a SQL statement encoded as a string.
+type Statement = catpb.Statement
+
+// RoutineBody is a PL/pgSQL routine body encoded as a string.
+type RoutineBody = catpb.RoutineBody
 
 // ColumnID is a custom type for ColumnDescriptor IDs.
 type ColumnID = catid.ColumnID

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -112,7 +112,8 @@ message UniqueWithoutIndexConstraint {
   // Predicate, if it's not empty, indicates that the constraint is a partial
   // unique constraint with Predicate as the expression. Columns are referred to
   // in the expression by their name.
-  optional string predicate = 5 [(gogoproto.nullable) = false];
+  optional string predicate = 5 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Expression"];
 
   // Used within the table descriptor to uniquely identify individual
   // constraints.
@@ -134,7 +135,7 @@ message ColumnDescriptor {
   // as output to display to a user. User defined types within DefaultExpr
   // have been serialized in a internal format. Instead, use one of the
   // schemaexpr.FormatExpr* functions.
-  optional string default_expr = 5;
+  optional string default_expr = 5 [(gogoproto.casttype) = "Expression"];
   reserved 9;
 
   // On update expression to use to populate the column on update if no
@@ -142,7 +143,7 @@ message ColumnDescriptor {
   // as output to display to a user. User defined types within OnUpdateExpr
   // have been serialized in a internal format. Instead, use one of the
   // schemaexpr.FormatExpr* functions.
-  optional string on_update_expr = 18;
+  optional string on_update_expr = 18 [(gogoproto.casttype) = "Expression"];
 
   // A hidden column does not appear in star expansion, but can be referenced in
   // queries and can be viewed when inspecting a table via SHOW CREATE TABLE. A
@@ -183,7 +184,7 @@ message ColumnDescriptor {
   // as output to display to a user. User defined types within ComputeExpr
   // have been serialized in a internal format. Instead, use one of the
   // schemaexpr.FormatExpr* functions.
-  optional string compute_expr = 11;
+  optional string compute_expr = 11 [(gogoproto.casttype) = "Expression"];
 
   // A computed column can be stored or virtual.
   // Virtual can only be true if there is a compute expression.
@@ -446,7 +447,8 @@ message IndexDescriptor {
   // a partial index. Columns are referred to in the expression by their name.
   // TODO(mgartner): Update the comment to explain that columns are referenced
   // by their ID once #49766 is addressed.
-  optional string predicate = 23 [(gogoproto.nullable) = false];
+  optional string predicate = 23 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Expression"];
 
   // UseDeletePreservingEncoding, if true, causes the index to be encoded with
   // an additional bit that indicates whether or not the value has been deleted.
@@ -561,7 +563,8 @@ message TriggerDescriptor {
 
   // An optional boolean condition that must be satisfied for the trigger to
   // execute. Empty if a WHEN clause was not specified.
-  optional string when_expr = 8 [(gogoproto.nullable) = false];
+  optional string when_expr = 8 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Expression"];
 
   // The ID of the function that is executed when the trigger is fired.
   optional uint32 func_id = 9 [(gogoproto.customname) = "FuncID", (gogoproto.nullable) = false,(gogoproto.casttype) = "ID"];
@@ -572,7 +575,8 @@ message TriggerDescriptor {
   // The PL/pgSQL statements that make up the body of the trigger function. This
   // is stored with the trigger descriptor with by-name references to
   // user-defined objects replaced with ID references.
-  optional string func_body = 11 [(gogoproto.nullable) = false];
+  optional string func_body = 11 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "RoutineBody"];
 
   // If true, indicates that the trigger is active.
   optional bool enabled = 12 [(gogoproto.nullable) = false];
@@ -659,7 +663,7 @@ message PrimaryKeySwap {
     // context on what the database is. The default expression should be already
     // serialized in the same internal format as default_expr on the
     // ColumnDescriptor.
-    optional string new_regional_by_row_column_default_expr = 4;
+    optional string new_regional_by_row_column_default_expr = 4 [(gogoproto.casttype) = "Expression"];
   }
   // LocalityConfigSwap is set for ALTER TABLE SET LOCALITY when the command
   // requires PK changes. If set, additional zone configurations are set to
@@ -684,7 +688,8 @@ message ComputedColumnSwap {
   optional uint32 old_column_id = 2 [(gogoproto.nullable) = false, (gogoproto.casttype) = "ColumnID"];
   // inverse_expr is the expression used to compute values for the old column
   // once it is swapped for the new column.
-  optional string inverse_expr = 3 [(gogoproto.nullable) = false];
+  optional string inverse_expr = 3 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Expression"];
 }
 
 // MaterializedViewRefresh is a mutation corresponding to a request to
@@ -735,7 +740,8 @@ message PolicyDescriptor {
 
   // UsingExpr defines the condition applied to read existing rows. If this
   // field is omitted, the policy will not be used for reads.
-  optional string using_expr = 6 [(gogoproto.nullable) = false];
+  optional string using_expr = 6 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Expression"];
 
   // UsingColumnIDs is an ordered list of column IDs used by the USING expression.
   repeated uint32 using_column_ids = 11 [(gogoproto.customname) = "UsingColumnIDs",
@@ -744,7 +750,8 @@ message PolicyDescriptor {
   // WithCheck defines the condition applied to validate new rows during
   // write operations (e.g., INSERT or UPDATE). If omitted, the UsingExpr
   // will serve as a fallback, provided it is defined.
-  optional string with_check_expr = 7 [(gogoproto.nullable) = false];
+  optional string with_check_expr = 7 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Expression"];
 
   // WithCheckColumnIDs is an ordered list of column IDs used by the WITH CHECK
   // expression.
@@ -1068,7 +1075,8 @@ message TableDescriptor {
     // to a user. User defined types within Expr have been serialized
     // in a internal format. Instead, use one of the schemaexpr.FormatExpr*
     // functions.
-    optional string expr = 1 [(gogoproto.nullable) = false];
+    optional string expr = 1 [(gogoproto.nullable) = false,
+      (gogoproto.casttype) = "Expression"];
     optional string name = 2 [(gogoproto.nullable) = false];
     optional ConstraintValidity validity = 3 [(gogoproto.nullable) = false];
     reserved 4;
@@ -1102,7 +1110,8 @@ message TableDescriptor {
   //
   // Note: The presence of this field is used to determine whether or not
   // a TableDescriptor represents a view.
-  optional string view_query = 24 [(gogoproto.nullable) = false];
+  optional string view_query = 24 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Statement"];
   // IsMaterializedView indicates whether this view is materialized or not.
   // A materialized view has the view query results stored durably on disk
   // as a table. The data on disk is refreshed with the REFRESH MATERIALIZED
@@ -1271,7 +1280,8 @@ message TableDescriptor {
 
   reserved 33;
 
-  optional string create_query = 34 [(gogoproto.nullable) = false];
+  optional string create_query = 34 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "Statement"];
 
   // Starting in 19.2 CreateAsOfTime is initialized to zero for the first
   // version of a table and is populated from the MVCC timestamp of the read
@@ -1944,7 +1954,8 @@ message FunctionDescriptor {
 
   // function_body contains all statements/expression in specified languages in one string.
   // SQL statements in this string are rewritten with fully qualified table names.
-  optional string function_body = 8 [(gogoproto.nullable) = false];
+  optional string function_body = 8 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "RoutineBody"];
 
   optional cockroach.sql.catalog.catpb.Function.Volatility volatility = 9 [(gogoproto.nullable) = false];
   optional bool leak_proof = 10 [(gogoproto.nullable) = false];

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -388,7 +388,7 @@ type TableDescriptor interface {
 
 	// GetCreateQuery returns the full CREATE TABLE AS query that was used for
 	// table's creation. Only valid if IsAs is true.
-	GetCreateQuery() string
+	GetCreateQuery() catpb.Statement
 	// GetCreateAsOfTime returns the transaction timestamp that this table was
 	// created at, for materialized views and CREATE TABLE AS. Only valid if
 	// IsAs or MaterializedView returns true.
@@ -396,7 +396,7 @@ type TableDescriptor interface {
 
 	// GetViewQuery returns this view's CREATE VIEW declaration. Only valid if
 	// IsView is true.
-	GetViewQuery() string
+	GetViewQuery() catpb.Statement
 
 	// GetDropTime returns the timestamp at which the table is truncated or
 	// dropped. It's represented as the current time in nanoseconds since the
@@ -1118,7 +1118,7 @@ type FunctionDescriptor interface {
 	GetNullInputBehavior() catpb.Function_NullInputBehavior
 
 	// GetFunctionBody returns the function body string.
-	GetFunctionBody() string
+	GetFunctionBody() catpb.RoutineBody
 
 	// GetParams returns a list of all parameters of the function.
 	GetParams() []descpb.FunctionDescriptor_Parameter

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -629,7 +629,7 @@ func (desc *Mutable) SetLang(v catpb.Function_Language) {
 }
 
 // SetFuncBody sets the function body.
-func (desc *Mutable) SetFuncBody(v string) {
+func (desc *Mutable) SetFuncBody(v descpb.RoutineBody) {
 	desc.FunctionBody = v
 }
 
@@ -1029,7 +1029,7 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	}
 	ret = &tree.Overload{
 		Oid:           catid.FuncIDToOID(desc.ID),
-		Body:          desc.FunctionBody,
+		Body:          string(desc.FunctionBody),
 		Type:          routineType,
 		Version:       uint64(desc.Version),
 		Language:      desc.getCreateExprLang(),
@@ -1139,7 +1139,7 @@ func (desc *immutable) ToCreateExpr() (ret *tree.CreateRoutine, err error) {
 	ret.Options = append(ret.Options, desc.getCreateExprVolatility())
 	ret.Options = append(ret.Options, tree.RoutineLeakproof(desc.LeakProof))
 	ret.Options = append(ret.Options, desc.getCreateExprNullInputBehavior())
-	ret.Options = append(ret.Options, tree.RoutineBodyStr(desc.FunctionBody))
+	ret.Options = append(ret.Options, tree.RoutineBodyStr(string(desc.FunctionBody)))
 	ret.Options = append(ret.Options, desc.getCreateExprLang())
 	ret.Options = append(ret.Options, desc.getCreateExprSecurity())
 	return ret, nil

--- a/pkg/sql/catalog/randgen/templates.go
+++ b/pkg/sql/catalog/randgen/templates.go
@@ -185,7 +185,7 @@ outer:
 	}
 }
 
-var uniqueRowIDString = "unique_rowid()"
+var uniqueRowIDString = descpb.Expression("unique_rowid()")
 
 // defaultTemplate provides a simple test template that is used when
 // the caller does not specify any template.

--- a/pkg/sql/catalog/redact/redact.go
+++ b/pkg/sql/catalog/redact/redact.go
@@ -92,21 +92,21 @@ func redactTableDescriptor(d *descpb.TableDescriptor) (errs []error) {
 	return errs
 }
 
-func redactQuery(sql *string) error {
-	q, err := parser.ParseOne(*sql)
+func redactQuery(sql *descpb.Statement) error {
+	q, err := parser.ParseOne(string(*sql))
 	if err != nil {
 		*sql = "_"
 		return err
 	}
 	fmtCtx := tree.NewFmtCtx(tree.FmtHideConstants)
 	q.AST.Format(fmtCtx)
-	*sql = fmtCtx.String()
+	*sql = descpb.Statement(fmtCtx.String())
 	return nil
 }
 
 func redactIndex(idx *descpb.IndexDescriptor) error {
 	redactPartitioning(&idx.Partitioning)
-	return errors.Wrap(redactExprStr(&idx.Predicate), "partial predicate")
+	return errors.Wrap(redactExpr(&idx.Predicate), "partial predicate")
 }
 
 func redactColumn(col *descpb.ColumnDescriptor) (errs []error) {
@@ -116,23 +116,23 @@ func redactColumn(col *descpb.ColumnDescriptor) (errs []error) {
 		}
 	}
 	if ce := col.ComputeExpr; ce != nil {
-		handleErr(errors.Wrap(redactExprStr(ce), "compute expr"))
+		handleErr(errors.Wrap(redactExpr(ce), "compute expr"))
 	}
 	if de := col.DefaultExpr; de != nil {
-		handleErr(errors.Wrap(redactExprStr(de), "default expr"))
+		handleErr(errors.Wrap(redactExpr(de), "default expr"))
 	}
 	if ue := col.OnUpdateExpr; ue != nil {
-		handleErr(errors.Wrap(redactExprStr(ue), "on-update expr"))
+		handleErr(errors.Wrap(redactExpr(ue), "on-update expr"))
 	}
 	return errs
 }
 
 func redactCheckConstraints(chk *descpb.TableDescriptor_CheckConstraint) error {
-	return redactExprStr(&chk.Expr)
+	return redactExpr(&chk.Expr)
 }
 
 func redactUniqueWithoutIndexConstraint(uwi *descpb.UniqueWithoutIndexConstraint) error {
-	return redactExprStr(&uwi.Predicate)
+	return redactExpr(&uwi.Predicate)
 }
 
 func redactTypeDescriptor(d *descpb.TypeDescriptor) {
@@ -186,24 +186,17 @@ func redactPartitioning(p *catpb.PartitioningDescriptor) {
 }
 
 func redactExpr(expr *catpb.Expression) error {
-	str := string(*expr)
-	err := redactExprStr(&str)
-	*expr = catpb.Expression(str)
-	return err
-}
-
-func redactExprStr(expr *string) error {
 	if *expr == "" {
 		return nil
 	}
-	parsedExpr, err := parser.ParseExpr(*expr)
+	parsedExpr, err := parser.ParseExpr(string(*expr))
 	if err != nil {
 		*expr = "_"
 		return err
 	}
 	fmtCtx := tree.NewFmtCtx(tree.FmtHideConstants)
 	parsedExpr.Format(fmtCtx)
-	*expr = fmtCtx.String()
+	*expr = descpb.Expression(fmtCtx.String())
 	return nil
 }
 
@@ -214,7 +207,7 @@ func redactFunctionDescriptor(desc *descpb.FunctionDescriptor) (errs []error) {
 		}
 	}
 
-	if err := redactFunctionBodyStr(desc.Lang, &desc.FunctionBody); err != nil {
+	if err := redactFunctionBodyStr(desc.Lang, (*string)(&desc.FunctionBody)); err != nil {
 		return []error{err}
 	}
 	if scs := desc.DeclarativeSchemaChangerState; scs != nil {

--- a/pkg/sql/catalog/redact/redact_test.go
+++ b/pkg/sql/catalog/redact/redact_test.go
@@ -65,7 +65,7 @@ $$`)
 		)
 		mut := tabledesc.NewBuilder(view.TableDesc()).BuildCreatedMutableTable()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k, v, e FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_')`, mut.ViewQuery)
+		require.Equal(t, `SELECT k, v, e FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_')`, string(mut.ViewQuery))
 	})
 
 	t.Run("create table as", func(t *testing.T) {
@@ -74,14 +74,14 @@ $$`)
 		)
 		mut := tabledesc.NewBuilder(ctas.TableDesc()).BuildCreatedMutableTable()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k, v, e FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_')`, mut.CreateQuery)
+		require.Equal(t, `SELECT k, v, e FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_')`, string(mut.CreateQuery))
 	})
 
 	t.Run("create function sql", func(t *testing.T) {
 		fn := desctestutils.TestingGetFunctionDescriptor(kvDB, codec, "defaultdb", "public", "f1")
 		mut := funcdesc.NewBuilder(fn.FuncDesc()).BuildCreatedMutableFunction()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k FROM defaultdb.public.kv WHERE v != '_'; SELECT k FROM defaultdb.public.kv WHERE v = '_'; SELECT k FROM defaultdb.public.kv WHERE e != '_'; SELECT k FROM defaultdb.public.kv WHERE e = '_';`, mut.FunctionBody)
+		require.Equal(t, `SELECT k FROM defaultdb.public.kv WHERE v != '_'; SELECT k FROM defaultdb.public.kv WHERE v = '_'; SELECT k FROM defaultdb.public.kv WHERE e != '_'; SELECT k FROM defaultdb.public.kv WHERE e = '_';`, string(mut.FunctionBody))
 	})
 
 	t.Run("create function plpgsql", func(t *testing.T) {
@@ -96,6 +96,6 @@ BEGIN
 SELECT k FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_':::@100104);
 RETURN x + _;
 END;
-`, mut.FunctionBody)
+`, string(mut.FunctionBody))
 	})
 }

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -117,33 +117,33 @@ func TableDescs(
 			func(expr *string, typ catalog.DescExprType) error {
 				switch typ {
 				case catalog.SQLExpr:
-					newExpr, err := rewriteTypesInExpr(*expr, descriptorRewrites)
+					newExpr, err := rewriteTypesInExpr((catpb.Expression)(*expr), descriptorRewrites)
 					if err != nil {
 						return err
 					}
-					*expr = newExpr
+					*expr = string(newExpr)
 
-					newExpr, err = rewriteSequencesInExpr(*expr, descriptorRewrites)
+					newExpr, err = rewriteSequencesInExpr((catpb.Expression)(*expr), descriptorRewrites)
 					if err != nil {
 						return err
 					}
-					*expr = newExpr
+					*expr = string(newExpr)
 
-					newExpr, err = rewriteFunctionsInExpr(*expr, descriptorRewrites)
+					newExpr, err = rewriteFunctionsInExpr((catpb.Expression)(*expr), descriptorRewrites)
 					if err != nil {
 						return err
 					}
-					*expr = newExpr
+					*expr = string(newExpr)
 				case catalog.SQLStmt, catalog.PLpgSQLStmt:
 					lang := catpb.Function_SQL
 					if typ == catalog.PLpgSQLStmt {
 						lang = catpb.Function_PLPGSQL
 					}
-					newExpr, err := rewriteRoutineBody(descriptorRewrites, *expr, overrideDB, lang)
+					newExpr, err := rewriteRoutineBody(descriptorRewrites, (catpb.RoutineBody)(*expr), overrideDB, lang)
 					if err != nil {
 						return err
 					}
-					*expr = newExpr
+					*expr = string(newExpr)
 				default:
 					return errors.AssertionFailedf("unexpected expression type")
 				}
@@ -587,7 +587,7 @@ func makeDBNameReplaceFunc(newDB string) func(ctx *tree.FmtCtx, tn *tree.TableNa
 // rewriteViewQueryDBNames rewrites the passed table's ViewQuery replacing all
 // non-empty db qualifiers with `newDB`.
 func rewriteViewQueryDBNames(table *tabledesc.Mutable, newDB string) error {
-	stmt, err := parser.ParseOne(table.ViewQuery)
+	stmt, err := parser.ParseOne(string(table.ViewQuery))
 	if err != nil {
 		return pgerror.Wrapf(err, pgcode.Syntax,
 			"failed to parse underlying query from view %q", table.Name)
@@ -598,18 +598,18 @@ func rewriteViewQueryDBNames(table *tabledesc.Mutable, newDB string) error {
 		tree.FmtReformatTableNames(makeDBNameReplaceFunc(newDB)),
 	)
 	f.FormatNode(stmt.AST)
-	table.ViewQuery = f.CloseAndGetString()
+	table.ViewQuery = descpb.Statement(f.CloseAndGetString())
 	return nil
 }
 
 func rewriteFunctionBodyDBNames(
-	fnBody string, newDB string, lang catpb.Function_Language,
-) (string, error) {
+	fnBody catpb.RoutineBody, newDB string, lang catpb.Function_Language,
+) (catpb.RoutineBody, error) {
 	replaceFunc := makeDBNameReplaceFunc(newDB)
 	switch lang {
 	case catpb.Function_SQL:
 		fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-		stmts, err := parser.Parse(fnBody)
+		stmts, err := parser.Parse(string(fnBody))
 		if err != nil {
 			return "", err
 		}
@@ -625,10 +625,10 @@ func rewriteFunctionBodyDBNames(
 			fmtCtx.WriteString(f.CloseAndGetString())
 			fmtCtx.WriteString(";")
 		}
-		return fmtCtx.CloseAndGetString(), nil
+		return catpb.RoutineBody(fmtCtx.CloseAndGetString()), nil
 
 	case catpb.Function_PLPGSQL:
-		stmt, err := plpgsqlparser.Parse(fnBody)
+		stmt, err := plpgsqlparser.Parse(string(fnBody))
 		if err != nil {
 			return "", err
 		}
@@ -637,7 +637,7 @@ func rewriteFunctionBodyDBNames(
 			tree.FmtReformatTableNames(replaceFunc),
 		)
 		fmtCtx.FormatNode(stmt.AST)
-		return fmtCtx.CloseAndGetString(), nil
+		return catpb.RoutineBody(fmtCtx.CloseAndGetString()), nil
 
 	default:
 		return "", errors.AssertionFailedf("unexpected function language %s", lang)
@@ -646,35 +646,39 @@ func rewriteFunctionBodyDBNames(
 
 // rewriteTypesInExpr rewrites all explicit ID type references in the input
 // expression string according to rewrites.
-func rewriteTypesInExpr(expr string, rewrites jobspb.DescRewriteMap) (string, error) {
-	parsed, err := parser.ParseExpr(expr)
+func rewriteTypesInExpr(
+	expr catpb.Expression, rewrites jobspb.DescRewriteMap,
+) (catpb.Expression, error) {
+	parsed, err := parser.ParseExpr(string(expr))
 	if err != nil {
 		return "", err
 	}
 	ctx := makeTypeReplaceFmtCtx(rewrites)
 	ctx.FormatNode(parsed)
-	return ctx.CloseAndGetString(), nil
+	return catpb.Expression(ctx.CloseAndGetString()), nil
 }
 
 // rewriteTypesInView rewrites all explicit ID type references in the input view
 // query string according to rewrites.
-func rewriteTypesInView(viewQuery string, rewrites jobspb.DescRewriteMap) (string, error) {
-	stmt, err := parser.ParseOne(viewQuery)
+func rewriteTypesInView(
+	viewQuery catpb.Statement, rewrites jobspb.DescRewriteMap,
+) (catpb.Statement, error) {
+	stmt, err := parser.ParseOne(string(viewQuery))
 	if err != nil {
 		return "", err
 	}
 	ctx := makeTypeReplaceFmtCtx(rewrites)
 	ctx.FormatNode(stmt.AST)
-	return ctx.CloseAndGetString(), nil
+	return catpb.Statement(ctx.CloseAndGetString()), nil
 }
 
 func rewriteTypesInRoutine(
-	fnBody string, rewrites jobspb.DescRewriteMap, lang catpb.Function_Language,
-) (string, error) {
+	fnBody catpb.RoutineBody, rewrites jobspb.DescRewriteMap, lang catpb.Function_Language,
+) (catpb.RoutineBody, error) {
 	switch lang {
 	case catpb.Function_SQL:
 		fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-		stmts, err := parser.Parse(fnBody)
+		stmts, err := parser.Parse(string(fnBody))
 		if err != nil {
 			return "", err
 		}
@@ -687,16 +691,16 @@ func rewriteTypesInRoutine(
 			fmtCtx.WriteString(typeReplaceCtx.CloseAndGetString())
 			fmtCtx.WriteString(";")
 		}
-		return fmtCtx.CloseAndGetString(), nil
+		return catpb.RoutineBody(fmtCtx.CloseAndGetString()), nil
 
 	case catpb.Function_PLPGSQL:
-		stmt, err := plpgsqlparser.Parse(fnBody)
+		stmt, err := plpgsqlparser.Parse(string(fnBody))
 		if err != nil {
 			return "", err
 		}
 		typeReplaceCtx := makeTypeReplaceFmtCtx(rewrites)
 		typeReplaceCtx.FormatNode(stmt.AST)
-		return typeReplaceCtx.CloseAndGetString(), nil
+		return catpb.RoutineBody(typeReplaceCtx.CloseAndGetString()), nil
 
 	default:
 		return "", errors.AssertionFailedf("unexpected function language: %v", lang)
@@ -721,8 +725,10 @@ func makeTypeReplaceFmtCtx(rewrites jobspb.DescRewriteMap) *tree.FmtCtx {
 
 // rewriteSequencesInExpr rewrites all sequence IDs in the input expression
 // string according to rewrites.
-func rewriteSequencesInExpr(expr string, rewrites jobspb.DescRewriteMap) (string, error) {
-	parsed, err := parser.ParseExpr(expr)
+func rewriteSequencesInExpr(
+	expr catpb.Expression, rewrites jobspb.DescRewriteMap,
+) (catpb.Expression, error) {
+	parsed, err := parser.ParseExpr(string(expr))
 	if err != nil {
 		return "", err
 	}
@@ -731,11 +737,13 @@ func rewriteSequencesInExpr(expr string, rewrites jobspb.DescRewriteMap) (string
 	if err != nil {
 		return "", err
 	}
-	return newExpr.String(), nil
+	return catpb.Expression(newExpr.String()), nil
 }
 
-func rewriteFunctionsInExpr(expr string, rewrites jobspb.DescRewriteMap) (string, error) {
-	parsed, err := parser.ParseExpr(expr)
+func rewriteFunctionsInExpr(
+	expr catpb.Expression, rewrites jobspb.DescRewriteMap,
+) (catpb.Expression, error) {
+	parsed, err := parser.ParseExpr(string(expr))
 	if err != nil {
 		return "", err
 	}
@@ -765,7 +773,7 @@ func rewriteFunctionsInExpr(expr string, rewrites jobspb.DescRewriteMap) (string
 	if err != nil {
 		return "", err
 	}
-	return newExpr.String(), nil
+	return catpb.Expression(newExpr.String()), nil
 }
 
 func makeSequenceReplaceFunc(
@@ -795,8 +803,10 @@ func makeSequenceReplaceFunc(
 
 // rewriteSequencesInView walks the given viewQuery and
 // rewrites all sequence IDs in it according to rewrites.
-func rewriteSequencesInView(viewQuery string, rewrites jobspb.DescRewriteMap) (string, error) {
-	stmt, err := parser.ParseOne(viewQuery)
+func rewriteSequencesInView(
+	viewQuery catpb.Statement, rewrites jobspb.DescRewriteMap,
+) (catpb.Statement, error) {
+	stmt, err := parser.ParseOne(string(viewQuery))
 	if err != nil {
 		return "", err
 	}
@@ -804,17 +814,17 @@ func rewriteSequencesInView(viewQuery string, rewrites jobspb.DescRewriteMap) (s
 	if err != nil {
 		return "", err
 	}
-	return newStmt.String(), nil
+	return catpb.Statement(newStmt.String()), nil
 }
 
 func rewriteSequencesInFunction(
-	fnBody string, rewrites jobspb.DescRewriteMap, lang catpb.Function_Language,
-) (string, error) {
+	fnBody catpb.RoutineBody, rewrites jobspb.DescRewriteMap, lang catpb.Function_Language,
+) (catpb.RoutineBody, error) {
 	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
 	replaceSeqFunc := makeSequenceReplaceFunc(rewrites)
 	switch lang {
 	case catpb.Function_SQL:
-		stmts, err := parser.Parse(fnBody)
+		stmts, err := parser.Parse(string(fnBody))
 		if err != nil {
 			return "", err
 		}
@@ -831,7 +841,7 @@ func rewriteSequencesInFunction(
 		}
 
 	case catpb.Function_PLPGSQL:
-		stmt, err := plpgsqlparser.Parse(fnBody)
+		stmt, err := plpgsqlparser.Parse(string(fnBody))
 		if err != nil {
 			return "", err
 		}
@@ -842,7 +852,7 @@ func rewriteSequencesInFunction(
 	default:
 		return "", errors.AssertionFailedf("unexpected function language %s", lang)
 	}
-	return fmtCtx.CloseAndGetString(), nil
+	return catpb.RoutineBody(fmtCtx.CloseAndGetString()), nil
 }
 
 // RewriteIDsInTypesT rewrites all ID's in the input types.T using the input
@@ -873,9 +883,10 @@ func RewriteIDsInTypesT(typ *types.T, descriptorRewrites jobspb.DescRewriteMap) 
 // rewriteRoutineBody rewrites a set of SQL or PL/pgSQL statements.
 func rewriteRoutineBody(
 	descriptorRewrites jobspb.DescRewriteMap,
-	fnBody, overrideDB string,
+	fnBody catpb.RoutineBody,
+	overrideDB string,
 	fnLang catpb.Function_Language,
-) (string, error) {
+) (catpb.RoutineBody, error) {
 	if overrideDB != "" {
 		dbNameReplaced, err := rewriteFunctionBodyDBNames(fnBody, overrideDB, fnLang)
 		if err != nil {
@@ -1199,7 +1210,7 @@ func rewriteSchemaChangerState(
 			if *expr == "" {
 				return nil
 			}
-			newExpr, err := rewriteTypesInExpr(string(*expr), descriptorRewrites)
+			newExpr, err := rewriteTypesInExpr(*expr, descriptorRewrites)
 			if err != nil {
 				return errors.Wrapf(err, "rewriting expression type references: %q", *expr)
 			}
@@ -1211,7 +1222,7 @@ func rewriteSchemaChangerState(
 			if err != nil {
 				return errors.Wrapf(err, "rewriting expression function references: %q", newExpr)
 			}
-			*expr = catpb.Expression(newExpr)
+			*expr = newExpr
 			return nil
 		}); err != nil {
 			return err

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//pkg/clusterversion",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/catalog/schemaexpr/check_constraint.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint.go
@@ -103,7 +103,7 @@ func (b *CheckConstraintBuilder) Build(
 	constraintID := b.desc.TableDesc().GetNextConstraintID()
 	b.desc.TableDesc().NextConstraintID++
 	return &descpb.TableDescriptor_CheckConstraint{
-		Expr:                  expr,
+		Expr:                  descpb.Expression(expr),
 		Name:                  name,
 		ColumnIDs:             colIDs.Ordered(),
 		FromHashShardedColumn: c.FromHashShardedColumn,

--- a/pkg/sql/catalog/schemaexpr/check_constraint_test.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -42,7 +43,7 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 		name          string
 		expr          string
 		expectedValid bool
-		expectedExpr  string
+		expectedExpr  catpb.Expression
 		expectedName  string
 	}{
 		// Respect custom names.

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -151,8 +152,8 @@ func FormatColumnForDisplay(
 
 // RenameColumn replaces any occurrence of the column from in expr with to, and
 // returns a string representation of the new expression.
-func RenameColumn(expr string, from tree.Name, to tree.Name) (string, error) {
-	parsed, err := parserutils.ParseExpr(expr)
+func RenameColumn(expr catpb.Expression, from tree.Name, to tree.Name) (catpb.Expression, error) {
+	parsed, err := parserutils.ParseExpr(string(expr))
 	if err != nil {
 		return "", err
 	}
@@ -178,7 +179,7 @@ func RenameColumn(expr string, from tree.Name, to tree.Name) (string, error) {
 		return "", err
 	}
 
-	return renamed.String(), nil
+	return catpb.Expression(renamed.String()), nil
 }
 
 // iterColDescriptors iterates over the expression's variable columns and

--- a/pkg/sql/catalog/schemaexpr/column_test.go
+++ b/pkg/sql/catalog/schemaexpr/column_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -82,8 +83,8 @@ func TestRenameColumn(t *testing.T) {
 	to := tree.Name("bar")
 
 	testData := []struct {
-		expr     string
-		expected string
+		expr     catpb.Expression
+		expected catpb.Expression
 	}{
 		{"foo", "bar"},
 		{"foo = 1", "bar = 1"},
@@ -93,7 +94,7 @@ func TestRenameColumn(t *testing.T) {
 	}
 
 	for _, d := range testData {
-		t.Run(d.expr, func(t *testing.T) {
+		t.Run(string(d.expr), func(t *testing.T) {
 			res, err := RenameColumn(d.expr, from, to)
 			if err != nil {
 				t.Fatalf("%s: unexpected error: %s", d.expr, err)

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -245,7 +245,7 @@ func ValidateColumnHasNoDependents(desc catalog.TableDescriptor, col catalog.Col
 			continue
 		}
 
-		expr, err := parserutils.ParseExpr(c.GetComputeExpr())
+		expr, err := parserutils.ParseExpr(string(c.GetComputeExpr()))
 		if err != nil {
 			// At this point, we should be able to parse the computed expression.
 			return errors.WithAssertionFailure(err)
@@ -302,7 +302,7 @@ func MakeComputedExprs(
 	exprStrings := make([]string, 0, len(input))
 	for _, col := range input {
 		if col.IsComputed() {
-			exprStrings = append(exprStrings, col.GetComputeExpr())
+			exprStrings = append(exprStrings, string(col.GetComputeExpr()))
 		}
 	}
 

--- a/pkg/sql/catalog/schemaexpr/default_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/default_exprs.go
@@ -21,7 +21,7 @@ import (
 // Returns "" if neither exists.
 func colDefaultExpr(col catalog.Column) string {
 	if col.HasDefault() {
-		return col.GetDefaultExpr()
+		return string(col.GetDefaultExpr())
 	}
 	colType := col.GetType()
 	if colType.TypeMeta.DomainData != nil {

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -214,7 +214,7 @@ func HasValidColumnReferences(desc catalog.TableDescriptor, rootExpr tree.Expr) 
 func FormatExprForDisplay(
 	ctx context.Context,
 	desc catalog.TableDescriptor,
-	exprStr string,
+	exprStr catpb.Expression,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
@@ -239,7 +239,7 @@ func FormatExprForDisplay(
 func FormatExprForExpressionIndexDisplay(
 	ctx context.Context,
 	desc catalog.TableDescriptor,
-	exprStr string,
+	exprStr catpb.Expression,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
@@ -273,7 +273,7 @@ func makeColumnLookupFnForTableDesc(desc catalog.TableDescriptor) ColumnLookupFn
 func ParseTriggerWhenExprForDisplay(
 	ctx context.Context,
 	tableTyp *types.T,
-	exprStr string,
+	exprStr catpb.Expression,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	fmtFlags tree.FmtFlags,
@@ -300,7 +300,7 @@ func ParseTriggerWhenExprForDisplay(
 func formatExprForDisplayImpl(
 	ctx context.Context,
 	lookupFn ColumnLookupFn,
-	exprStr string,
+	exprStr catpb.Expression,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
@@ -330,7 +330,7 @@ func formatExprForDisplayImpl(
 func parseExprForDisplayImpl(
 	ctx context.Context,
 	lookupFn ColumnLookupFn,
-	exprStr string,
+	exprStr catpb.Expression,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	fmtFlags tree.FmtFlags,
@@ -346,12 +346,12 @@ func parseExprForDisplayImpl(
 func deserializeExprForFormatting(
 	ctx context.Context,
 	lookupFn ColumnLookupFn,
-	exprStr string,
+	exprStr catpb.Expression,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	fmtFlags tree.FmtFlags,
 ) (tree.Expr, error) {
-	expr, err := parserutils.ParseExpr(exprStr)
+	expr, err := parserutils.ParseExpr(string(exprStr))
 	if err != nil {
 		return nil, err
 	}
@@ -549,7 +549,7 @@ func ValidateTTLExpression(
 		return nil
 	}
 	expirationExpr := rowLevelTTL.ExpirationExpr
-	if hasRef, err := validateExpressionDoesNotDependOnColumn(tableDesc, string(expirationExpr), col.GetID()); err != nil {
+	if hasRef, err := validateExpressionDoesNotDependOnColumn(tableDesc, expirationExpr, col.GetID()); err != nil {
 		return err
 	} else if hasRef {
 		return sqlerrors.NewAlterDependsOnExpirationExprError(op, "column", string(col.ColName()), tn.Object(), string(expirationExpr))
@@ -584,7 +584,7 @@ func ValidatePolicyExpressionsDoNotDependOnColumn(
 	tableDesc catalog.TableDescriptor, dependentCol catalog.Column, objType, op string,
 ) error {
 	for _, p := range tableDesc.GetPolicies() {
-		checkExpr := func(expr string) error {
+		checkExpr := func(expr catpb.Expression) error {
 			if hasRef, err := validateExpressionDoesNotDependOnColumn(tableDesc, expr, dependentCol.GetID()); err != nil {
 				return err
 			} else if hasRef {
@@ -614,7 +614,7 @@ func ValidatePartialIndex(
 ) error {
 	for _, idx := range tableDesc.AllIndexes() {
 		if idx.IsPartial() {
-			expr, err := parserutils.ParseExpr(idx.GetPredicate())
+			expr, err := parserutils.ParseExpr(string(idx.GetPredicate()))
 			if err != nil {
 				return err
 			}
@@ -749,8 +749,8 @@ func GetUDFIDs(e tree.Expr) (catalog.DescriptorIDSet, error) {
 // GetUDFIDsFromExprStr extracts all UDF descriptor ids from the given
 // expression string, assuming that the UDF names has been replaced with OID
 // references. It's a convenient wrapper of GetUDFIDs.
-func GetUDFIDsFromExprStr(exprStr string) (catalog.DescriptorIDSet, error) {
-	expr, err := parserutils.ParseExpr(exprStr)
+func GetUDFIDsFromExprStr(exprStr catpb.Expression) (catalog.DescriptorIDSet, error) {
+	expr, err := parserutils.ParseExpr(string(exprStr))
 	if err != nil {
 		return catalog.DescriptorIDSet{}, err
 	}
@@ -758,9 +758,11 @@ func GetUDFIDsFromExprStr(exprStr string) (catalog.DescriptorIDSet, error) {
 }
 
 func validateExpressionDoesNotDependOnColumn(
-	tableDesc catalog.TableDescriptor, expirationExpr string, dependentColID descpb.ColumnID,
+	tableDesc catalog.TableDescriptor,
+	expirationExpr catpb.Expression,
+	dependentColID descpb.ColumnID,
 ) (bool, error) {
-	expr, err := parserutils.ParseExpr(expirationExpr)
+	expr, err := parserutils.ParseExpr(string(expirationExpr))
 	if err != nil {
 		// At this point, we should be able to parse the expression.
 		return false, errors.WithAssertionFailure(err)

--- a/pkg/sql/catalog/schemaexpr/hash_sharded_compute_expr.go
+++ b/pkg/sql/catalog/schemaexpr/hash_sharded_compute_expr.go
@@ -5,14 +5,17 @@
 
 package schemaexpr
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
 
 // MakeHashShardComputeExpr creates the serialized computed expression for a hash shard
 // column based on the column names and the number of buckets. The expression will be
 // of the form:
 //
 //	mod(fnv32(md5(crdb_internal.datums_to_bytes(...))),buckets)
-func MakeHashShardComputeExpr(colNames []string, buckets int) *string {
+func MakeHashShardComputeExpr(colNames []string, buckets int) *catpb.Expression {
 	unresolvedFunc := func(funcName string) tree.ResolvableFunctionReference {
 		return tree.ResolvableFunctionReference{
 			FunctionReference: &tree.UnresolvedName{
@@ -53,6 +56,6 @@ func MakeHashShardComputeExpr(colNames []string, buckets int) *string {
 			},
 		}
 	}
-	res := tree.Serialize(modBuckets(hashedColumnsExpr()))
+	res := catpb.Expression(tree.Serialize(modBuckets(hashedColumnsExpr())))
 	return &res
 }

--- a/pkg/sql/catalog/schemaexpr/partial_index.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index.go
@@ -184,7 +184,7 @@ func makePartialIndexHelper(
 func (pi partialIndexHelper) makePartialIndexExpr(
 	ctx context.Context, idx catalog.Index,
 ) (tree.TypedExpr, catalog.TableColSet, error) {
-	expr, err := parserutils.ParseExpr(idx.GetPredicate())
+	expr, err := parserutils.ParseExpr(string(idx.GetPredicate()))
 	if err != nil {
 		return nil, catalog.TableColSet{}, err
 	}

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -154,44 +154,44 @@ CREATE SEQUENCE system.role_id_seq START 100 MINVALUE 100 MAXVALUE 2147483647;`
 	commitLatSqDiffComputeExpr = `(((statistics->'statistics':::STRING)->'commitLat':::STRING)->'sqDiff':::STRING)::FLOAT8`
 )
 
-var indexUsageComputeExprStr = indexUsageComputeExpr
-var executionCountComputeExprStr = executionCountComputeExpr
-var serviceLatencyComputeExprStr = serviceLatencyComputeExpr
-var cpuSqlNanosComputeExprStr = cpuSqlNanosComputeExpr
-var contentionTimeComputeExprStr = contentionTimeComputeExpr
-var totalEstimatedExecutionTimeExprStr = totalEstimatedExecutionTimeExpr
-var p99LatencyComputeExprStr = p99LatencyComputeExpr
-var execSampleCountComputeExprStr = execStatsExecCountComputeExpr
-var svcLatSumComputeExprStr = serviceLatencyComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8"
-var cpuSqlNanosSumComputeExprStr = cpuSqlNanosComputeExpr + " * " + execStatsExecCountComputeExpr + "::FLOAT8"
-var contentionTimeSumComputeExprStr = contentionTimeComputeExpr + " * " + execStatsExecCountComputeExpr + "::FLOAT8"
+var indexUsageComputeExprStr = descpb.Expression(indexUsageComputeExpr)
+var executionCountComputeExprStr = descpb.Expression(executionCountComputeExpr)
+var serviceLatencyComputeExprStr = descpb.Expression(serviceLatencyComputeExpr)
+var cpuSqlNanosComputeExprStr = descpb.Expression(cpuSqlNanosComputeExpr)
+var contentionTimeComputeExprStr = descpb.Expression(contentionTimeComputeExpr)
+var totalEstimatedExecutionTimeExprStr = descpb.Expression(totalEstimatedExecutionTimeExpr)
+var p99LatencyComputeExprStr = descpb.Expression(p99LatencyComputeExpr)
+var execSampleCountComputeExprStr = descpb.Expression(execStatsExecCountComputeExpr)
+var svcLatSumComputeExprStr = descpb.Expression(serviceLatencyComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8")
+var cpuSqlNanosSumComputeExprStr = descpb.Expression(cpuSqlNanosComputeExpr + " * " + execStatsExecCountComputeExpr + "::FLOAT8")
+var contentionTimeSumComputeExprStr = descpb.Expression(contentionTimeComputeExpr + " * " + execStatsExecCountComputeExpr + "::FLOAT8")
 
 // sum_sq expressions: sqDiff + count * mean^2 (enables aggregation for stddev calculation)
 // Note: parenthesization must match what SQL produces: sqDiff + ((count * mean) * mean)
-var svcLatSumSqComputeExprStr = svcLatSqDiffComputeExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + serviceLatencyComputeExpr + ") * " + serviceLatencyComputeExpr + ")"
-var cpuSqlNanosSumSqComputeExprStr = cpuSqlNanosSqDiffComputeExpr + " + ((" + execStatsExecCountComputeExpr + "::FLOAT8 * " + cpuSqlNanosComputeExpr + ") * " + cpuSqlNanosComputeExpr + ")"
-var contentionTimeSumSqComputeExprStr = contentionTimeSqDiffComputeExpr + " + ((" + execStatsExecCountComputeExpr + "::FLOAT8 * " + contentionTimeComputeExpr + ") * " + contentionTimeComputeExpr + ")"
+var svcLatSumSqComputeExprStr = descpb.Expression(svcLatSqDiffComputeExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + serviceLatencyComputeExpr + ") * " + serviceLatencyComputeExpr + ")")
+var cpuSqlNanosSumSqComputeExprStr = descpb.Expression(cpuSqlNanosSqDiffComputeExpr + " + ((" + execStatsExecCountComputeExpr + "::FLOAT8 * " + cpuSqlNanosComputeExpr + ") * " + cpuSqlNanosComputeExpr + ")")
+var contentionTimeSumSqComputeExprStr = descpb.Expression(contentionTimeSqDiffComputeExpr + " + ((" + execStatsExecCountComputeExpr + "::FLOAT8 * " + contentionTimeComputeExpr + ") * " + contentionTimeComputeExpr + ")")
 
 // kv_cpu_time_nanos expressions
-var kvCpuTimeNanosSumComputeExprStr = kvCpuTimeNanosComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8"
-var kvCpuTimeNanosSumSqComputeExprStr = kvCpuTimeNanosSqDiffComputeExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + kvCpuTimeNanosComputeExpr + ") * " + kvCpuTimeNanosComputeExpr + ")"
+var kvCpuTimeNanosSumComputeExprStr = descpb.Expression(kvCpuTimeNanosComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8")
+var kvCpuTimeNanosSumSqComputeExprStr = descpb.Expression(kvCpuTimeNanosSqDiffComputeExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + kvCpuTimeNanosComputeExpr + ") * " + kvCpuTimeNanosComputeExpr + ")")
 
 // admission_wait_time expressions
-var admissionWaitTimeSumComputeExprStr = admissionWaitTimeComputeExpr + " * " + execStatsExecCountComputeExpr + "::FLOAT8"
-var admissionWaitTimeSumSqComputeExprStr = admissionWaitTimeSqDiffComputeExpr + " + ((" + execStatsExecCountComputeExpr + "::FLOAT8 * " + admissionWaitTimeComputeExpr + ") * " + admissionWaitTimeComputeExpr + ")"
+var admissionWaitTimeSumComputeExprStr = descpb.Expression(admissionWaitTimeComputeExpr + " * " + execStatsExecCountComputeExpr + "::FLOAT8")
+var admissionWaitTimeSumSqComputeExprStr = descpb.Expression(admissionWaitTimeSqDiffComputeExpr + " + ((" + execStatsExecCountComputeExpr + "::FLOAT8 * " + admissionWaitTimeComputeExpr + ") * " + admissionWaitTimeComputeExpr + ")")
 
 // rows/bytes expressions - these use executionCountComputeExpr (from statistics.cnt)
-var rowsReadSumComputeExprStr = rowsReadComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8"
-var rowsWrittenSumComputeExprStr = rowsWrittenComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8"
-var bytesReadSumComputeExprStr = bytesReadComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8"
-var bytesReadSumSqComputeExprStr = bytesReadSqDiffExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + bytesReadComputeExpr + ") * " + bytesReadComputeExpr + ")"
+var rowsReadSumComputeExprStr = descpb.Expression(rowsReadComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8")
+var rowsWrittenSumComputeExprStr = descpb.Expression(rowsWrittenComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8")
+var bytesReadSumComputeExprStr = descpb.Expression(bytesReadComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8")
+var bytesReadSumSqComputeExprStr = descpb.Expression(bytesReadSqDiffExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + bytesReadComputeExpr + ") * " + bytesReadComputeExpr + ")")
 
 // max retries expression
-var maxRetriesComputeExprStr = maxRetriesComputeExpr
+var maxRetriesComputeExprStr = descpb.Expression(maxRetriesComputeExpr)
 
 // commit latency expressions (transaction_statistics only)
-var commitLatSumComputeExprStr = commitLatComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8"
-var commitLatSumSqComputeExprStr = commitLatSqDiffComputeExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + commitLatComputeExpr + ") * " + commitLatComputeExpr + ")"
+var commitLatSumComputeExprStr = descpb.Expression(commitLatComputeExpr + " * " + executionCountComputeExpr + "::FLOAT8")
+var commitLatSumSqComputeExprStr = descpb.Expression(commitLatSqDiffComputeExpr + " + ((" + executionCountComputeExpr + "::FLOAT8 * " + commitLatComputeExpr + ") * " + commitLatComputeExpr + ")")
 
 // These system tables are not part of the system config.
 const (
@@ -1435,9 +1435,9 @@ var (
 	// TABLE statements for both statement and transaction tables in a SQL shell.
 	// If we are to change how we compute hash values in the future, we need to
 	// modify these two expressions as well.
-	sqlStmtHashComputeExpr   = `mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8:::INT8)`
-	sqlTxnHashComputeExpr    = `mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id)), 8:::INT8)`
-	timestampHashComputeExpr = `mod(fnv32(md5(crdb_internal.datums_to_bytes(created_at))), 16:::INT8)`
+	sqlStmtHashComputeExpr   = descpb.Expression(`mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8:::INT8)`)
+	sqlTxnHashComputeExpr    = descpb.Expression(`mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id)), 8:::INT8)`)
+	timestampHashComputeExpr = descpb.Expression(`mod(fnv32(md5(crdb_internal.datums_to_bytes(created_at))), 16:::INT8)`)
 )
 
 const (
@@ -1722,9 +1722,9 @@ var (
 			pk("id"),
 		))
 
-	falseBoolString = "false"
-	trueBoolString  = "true"
-	zeroIntString   = "0:::INT8"
+	falseBoolString = descpb.Expression("false")
+	trueBoolString  = descpb.Expression("true")
+	zeroIntString   = descpb.Expression("0:::INT8")
 
 	// UsersTable is the descriptor for the users table.
 	UsersTable = makeSystemTable(
@@ -2030,7 +2030,7 @@ var (
 		)
 	}
 
-	uuidV4String = "uuid_v4()"
+	uuidV4String = descpb.Expression("uuid_v4()")
 
 	// EventLogTable is the descriptor for the event log table.
 	EventLogTable = makeSystemTable(
@@ -2077,7 +2077,7 @@ var (
 			},
 		))
 
-	uniqueRowIDString = "unique_rowid()"
+	uniqueRowIDString = descpb.Expression("unique_rowid()")
 
 	// RangeEventTable is the descriptor for the range log table.
 	RangeEventTable = makeSystemTable(
@@ -2131,7 +2131,7 @@ var (
 			pk("key"),
 		))
 
-	nowString = "now():::TIMESTAMP"
+	nowString = descpb.Expression("now():::TIMESTAMP")
 
 	// JobsTable is the descriptor for the jobs table.
 	JobsTable = makeSystemTable(
@@ -2741,7 +2741,7 @@ var (
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
 				Name:         "check_singleton",
-				Expr:         "singleton",
+				Expr:         descpb.Expression("singleton"),
 				ColumnIDs:    []descpb.ColumnID{1},
 				ConstraintID: tbl.NextConstraintID,
 			}}
@@ -2845,7 +2845,7 @@ var (
 			pk("id"),
 		))
 
-	emptyString = "'':::STRING"
+	emptyString = descpb.Expression("'':::STRING")
 
 	// TODO(andrei): Add a foreign key reference to the statement_diagnostics table when
 	// it no longer requires us to create an index on statement_diagnostics_id.
@@ -2893,7 +2893,7 @@ var (
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
 				Name:         "check_sampling_probability",
-				Expr:         "sampling_probability BETWEEN 0.0:::FLOAT8 AND 1.0:::FLOAT8",
+				Expr:         descpb.Expression("sampling_probability BETWEEN 0.0:::FLOAT8 AND 1.0:::FLOAT8"),
 				ColumnIDs:    []descpb.ColumnID{8},
 				ConstraintID: tbl.NextConstraintID,
 			}}
@@ -2995,7 +2995,7 @@ var (
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
 				Name:         "check_sampling_probability",
-				Expr:         "sampling_probability BETWEEN 0.0:::FLOAT8 AND 1.0:::FLOAT8",
+				Expr:         descpb.Expression("sampling_probability BETWEEN 0.0:::FLOAT8 AND 1.0:::FLOAT8"),
 				ColumnIDs:    []descpb.ColumnID{9},
 				ConstraintID: tbl.NextConstraintID,
 			}}
@@ -3027,7 +3027,7 @@ var (
 			pk("id"),
 		))
 
-	nowTZString = "now():::TIMESTAMPTZ"
+	nowTZString = descpb.Expression("now():::TIMESTAMPTZ")
 
 	// ScheduledJobsTable is the descriptor for the scheduled jobs table.
 	ScheduledJobsTable = makeSystemTable(
@@ -3183,7 +3183,7 @@ var (
 			},
 		))
 
-	defaultIndexRec = "ARRAY[]:::STRING[]"
+	defaultIndexRec = descpb.Expression("ARRAY[]:::STRING[]")
 
 	// StatementStatisticsTable is the descriptor for the SQL statement stats table.
 	// It stores statistics for statement fingerprints.
@@ -3343,12 +3343,12 @@ var (
 				StoreColumnIDs:     []descpb.ColumnID{14, 20, 21, 22, 23, 27, 24, 25, 26, 28, 29, 30, 31, 32, 33, 34, 35},
 				StoreColumnNames:   []string{"execution_count", "exec_sample_count", "svc_lat_sum", "cpu_sql_nanos_sum", "contention_time_sum", "kv_cpu_time_nanos_sum", "svc_lat_sum_sq", "cpu_sql_nanos_sum_sq", "contention_time_sum_sq", "kv_cpu_time_nanos_sum_sq", "admission_wait_time_sum", "admission_wait_time_sum_sq", "rows_read_sum", "rows_written_sum", "bytes_read_sum", "bytes_read_sum_sq", "max_retries"},
 				Version:            descpb.StrictIndexColumnIDGuaranteesVersion,
-				Predicate:          "app_name NOT LIKE '$ internal%':::STRING",
+				Predicate:          descpb.Expression("app_name NOT LIKE '$ internal%':::STRING"),
 			},
 		),
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)"),
 				Name:                  "check_crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{11},
@@ -3495,12 +3495,12 @@ var (
 				StoreColumnIDs:     []descpb.ColumnID{9, 15, 16, 17, 18, 22, 19, 20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 				StoreColumnNames:   []string{"execution_count", "exec_sample_count", "svc_lat_sum", "cpu_sql_nanos_sum", "contention_time_sum", "kv_cpu_time_nanos_sum", "svc_lat_sum_sq", "cpu_sql_nanos_sum_sq", "contention_time_sum_sq", "kv_cpu_time_nanos_sum_sq", "admission_wait_time_sum", "admission_wait_time_sum_sq", "rows_read_sum", "rows_written_sum", "bytes_read_sum", "bytes_read_sum_sq", "max_retries", "commit_lat_sum", "commit_lat_sum_sq"},
 				Version:            descpb.StrictIndexColumnIDGuaranteesVersion,
-				Predicate:          "app_name NOT LIKE '$ internal%':::STRING",
+				Predicate:          descpb.Expression("app_name NOT LIKE '$ internal%':::STRING"),
 			},
 		),
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)"),
 				Name:                  "check_crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{8},
@@ -4054,7 +4054,7 @@ var (
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
 				Name:         "check_bounds",
-				Expr:         "start_key < end_key",
+				Expr:         descpb.Expression("start_key < end_key"),
 				ColumnIDs:    []descpb.ColumnID{1, 2},
 				ConstraintID: tbl.NextConstraintID,
 			}}
@@ -4126,7 +4126,7 @@ var (
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
 				Name:         "single_row",
-				Expr:         "singleton",
+				Expr:         descpb.Expression("singleton"),
 				ColumnIDs:    []descpb.ColumnID{1},
 				ConstraintID: tbl.NextConstraintID,
 			}}
@@ -4436,7 +4436,7 @@ var (
 			}),
 	)
 
-	genRandomUUIDString = "gen_random_uuid()"
+	genRandomUUIDString = descpb.Expression("gen_random_uuid()")
 
 	SpanStatsUniqueKeysTable = makeSystemTable(
 		SpanStatsUniqueKeysTableSchema,
@@ -4696,7 +4696,7 @@ var (
 		),
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_created_at_database_id_index_id_table_id_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_created_at_database_id_index_id_table_id_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)"),
 				Name:                  "check_crdb_internal_created_at_database_id_index_id_table_id_shard_16",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{6},
@@ -4708,7 +4708,7 @@ var (
 		},
 	)
 
-	timeRangeHashComputeExpr = `mod(fnv32(md5(crdb_internal.datums_to_bytes(end_time, start_time))), 16:::INT8)`
+	timeRangeHashComputeExpr = descpb.Expression(`mod(fnv32(md5(crdb_internal.datums_to_bytes(end_time, start_time))), 16:::INT8)`)
 
 	TransactionExecInsightsTable = makeSystemTable(
 		TxnExecutionStatsTableSchema,
@@ -4828,7 +4828,7 @@ var (
 		),
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_end_time_start_time_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_end_time_start_time_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)"),
 				Name:                  "check_crdb_internal_end_time_start_time_shard_16",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{23},
@@ -5004,7 +5004,7 @@ var (
 		),
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_end_time_start_time_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_end_time_start_time_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)"),
 				Name:                  "check_crdb_internal_end_time_start_time_shard_16",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{29},
@@ -5016,7 +5016,7 @@ var (
 		},
 	)
 
-	crdbInternalTableIdLastUpdatedShardStr = crdbInternalTableIdLastUpdatedShard
+	crdbInternalTableIdLastUpdatedShardStr = descpb.Expression(crdbInternalTableIdLastUpdatedShard)
 
 	TableMetadata = makeSystemTable(
 		TableMetadataTableSchema,
@@ -5224,7 +5224,7 @@ var (
 			},
 		), func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_last_updated_table_id_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_last_updated_table_id_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)"),
 				Name:                  "check_crdb_internal_last_updated_table_id_shard_16",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{18},
@@ -5261,7 +5261,7 @@ var (
 		),
 	)
 
-	inspectErrorsExpirationString = "current_timestamp():::TIMESTAMPTZ + '90 days':::INTERVAL"
+	inspectErrorsExpirationString = descpb.Expression("current_timestamp():::TIMESTAMPTZ + '90 days':::INTERVAL")
 
 	InspectErrorsTable = makeSystemTable(
 		InspectErrorsTableSchema,
@@ -5313,7 +5313,7 @@ var (
 		},
 	)
 
-	statementHintsComputeExpr                = "fnv64(fingerprint)"
+	statementHintsComputeExpr                = descpb.Expression("fnv64(fingerprint)")
 	StatementHintsHashIndexID descpb.IndexID = 2
 	StatementHintsTable                      = makeSystemTable(
 		StatementHintsTableSchema,
@@ -5360,8 +5360,8 @@ var (
 		),
 	)
 
-	clusterMetricsDefaultLabels        = "'{}':::JSONB"
-	clusterMetricsLastUpdatedShardExpr = `mod(fnv32(md5(crdb_internal.datums_to_bytes(last_updated))), 8:::INT8)`
+	clusterMetricsDefaultLabels        = descpb.Expression("'{}':::JSONB")
+	clusterMetricsLastUpdatedShardExpr = descpb.Expression(`mod(fnv32(md5(crdb_internal.datums_to_bytes(last_updated))), 8:::INT8)`)
 	ClusterMetricsTable                = makeSystemTable(
 		ClusterMetricsTableSchema,
 		systemTable(
@@ -5444,7 +5444,7 @@ var (
 		),
 		func(tbl *descpb.TableDescriptor) {
 			tbl.Checks = []*descpb.TableDescriptor_CheckConstraint{{
-				Expr:                  "crdb_internal_last_updated_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)",
+				Expr:                  descpb.Expression("crdb_internal_last_updated_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8)"),
 				Name:                  "check_crdb_internal_last_updated_shard_8",
 				Validity:              descpb.ConstraintValidity_Validated,
 				ColumnIDs:             []descpb.ColumnID{8},

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -173,7 +173,7 @@ type Index interface {
 	IsNotVisible() bool
 	IsCreatedExplicitly() bool
 	GetInvisibility() float64
-	GetPredicate() string
+	GetPredicate() catpb.Expression
 	GetType() idxtype.T
 	GetGeoConfig() geopb.Config
 	GetVecConfig() vecpb.Config
@@ -343,21 +343,21 @@ type Column interface {
 
 	// GetDefaultExpr returns the column default expression if it exists,
 	// empty string otherwise.
-	GetDefaultExpr() string
+	GetDefaultExpr() catpb.Expression
 
 	// HasOnUpdate returns true iff the column has an on update expression set.
 	HasOnUpdate() bool
 
 	// GetOnUpdateExpr returns the column on update expression if it exists,
 	// empty string otherwise.
-	GetOnUpdateExpr() string
+	GetOnUpdateExpr() catpb.Expression
 
 	// IsComputed returns true iff the column is a computed column.
 	IsComputed() bool
 
 	// GetComputeExpr returns the column computed expression if it exists,
 	// empty string otherwise.
-	GetComputeExpr() string
+	GetComputeExpr() catpb.Expression
 
 	// IsHidden returns true iff the column is not visible.
 	IsHidden() bool
@@ -502,7 +502,7 @@ type UniqueConstraint interface {
 	IsPartial() bool
 
 	// GetPredicate returns the partial predicate if there is one, "" otherwise.
-	GetPredicate() string
+	GetPredicate() catpb.Expression
 }
 
 // UniqueWithIndexConstraint is an interface around a unique constraint
@@ -526,7 +526,7 @@ type CheckConstraint interface {
 	CheckDesc() *descpb.TableDescriptor_CheckConstraint
 
 	// GetExpr returns the check expression as a string.
-	GetExpr() string
+	GetExpr() catpb.Expression
 
 	// NumReferencedColumns returns the number of column references in the check
 	// expression. Note that a column may be referenced multiple times in an
@@ -560,7 +560,7 @@ type CheckConstraintValidator interface {
 	GetName() string
 
 	// GetExpr returns the check expression as a string.
-	GetExpr() string
+	GetExpr() catpb.Expression
 
 	// IsRLSConstraint returns true iff ths check constraint is the synthethic one
 	// to enforce row-level security policies.

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -138,7 +138,6 @@ go_test(
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
-        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -111,13 +111,13 @@ func (w column) HasNullDefault() bool {
 	// that the default expressions is not parsable. Somebody with a context
 	// who needs to use it will be in a better place to log it. If it is not
 	// parsable, it is not NULL.
-	defaultExpr, _ := parserutils.ParseExpr(w.GetDefaultExpr())
+	defaultExpr, _ := parserutils.ParseExpr(string(w.GetDefaultExpr()))
 	return defaultExpr == tree.DNull
 }
 
 // GetDefaultExpr returns the column default expression if it exists,
 // empty string otherwise.
-func (w column) GetDefaultExpr() string {
+func (w column) GetDefaultExpr() catpb.Expression {
 	if !w.HasDefault() {
 		return ""
 	}
@@ -131,7 +131,7 @@ func (w column) HasOnUpdate() bool {
 
 // GetOnUpdateExpr returns the column on update expression if it exists,
 // empty string otherwise.
-func (w column) GetOnUpdateExpr() string {
+func (w column) GetOnUpdateExpr() catpb.Expression {
 	if !w.HasOnUpdate() {
 		return ""
 	}
@@ -145,7 +145,7 @@ func (w column) IsComputed() bool {
 
 // GetComputeExpr returns the column computed expression if it exists,
 // empty string otherwise.
-func (w column) GetComputeExpr() string {
+func (w column) GetComputeExpr() catpb.Expression {
 	if !w.IsComputed() {
 		return ""
 	}

--- a/pkg/sql/catalog/tabledesc/constraint.go
+++ b/pkg/sql/catalog/tabledesc/constraint.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -52,7 +53,7 @@ func (c checkConstraint) CheckDesc() *descpb.TableDescriptor_CheckConstraint {
 }
 
 // GetExpr implements the catalog.CheckConstraint interface.
-func (c checkConstraint) GetExpr() string {
+func (c checkConstraint) GetExpr() catpb.Expression {
 	return c.desc.Expr
 }
 
@@ -142,7 +143,7 @@ type rlsSyntheticCheckConstraint struct {
 var _ catalog.CheckConstraintValidator = (*rlsSyntheticCheckConstraint)(nil)
 
 // GetExpr implements the catalog.CheckConstraintValidator interface.
-func (r rlsSyntheticCheckConstraint) GetExpr() string {
+func (r rlsSyntheticCheckConstraint) GetExpr() catpb.Expression {
 	panic(errors.AssertionFailedf("not implemented"))
 }
 
@@ -219,7 +220,7 @@ func (c uniqueWithoutIndexConstraint) IsPartial() bool {
 }
 
 // GetPredicate implements the catalog.UniqueConstraint interface.
-func (c uniqueWithoutIndexConstraint) GetPredicate() string {
+func (c uniqueWithoutIndexConstraint) GetPredicate() catpb.Expression {
 	return c.desc.Predicate
 }
 

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -141,7 +141,7 @@ func (w index) IsCreatedExplicitly() bool {
 // GetPredicate returns the empty string when the index is not partial,
 // otherwise it returns the corresponding expression of the partial index.
 // Columns are referred to in the expression by their name.
-func (w index) GetPredicate() string {
+func (w index) GetPredicate() catpb.Expression {
 	return w.desc.Predicate
 }
 

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -276,7 +276,7 @@ func TestIndexInterface(t *testing.T) {
 	}
 
 	// Check particular index features.
-	require.Equal(t, "c4 = 'x':::STRING", s5.GetPredicate())
+	require.Equal(t, "c4 = 'x':::STRING", string(s5.GetPredicate()))
 	require.Equal(t, "crdb_internal_c5_shard_8", s4.GetShardColumnName())
 	require.Equal(t, int32(2), s6.GetGeoConfig().S2Geography.S2Config.LevelMod)
 	require.Equal(t, int32(3), s7.GetVecConfig().Dims)

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -280,17 +280,17 @@ func ForEachExprStringInTableDesc(
 	// Helpers for each schema element type that can contain an expression.
 	doCol := func(c *descpb.ColumnDescriptor) error {
 		if c.HasDefault() {
-			if err := f(c.DefaultExpr, catalog.SQLExpr); err != nil {
+			if err := f((*string)(c.DefaultExpr), catalog.SQLExpr); err != nil {
 				return err
 			}
 		}
 		if c.IsComputed() {
-			if err := f(c.ComputeExpr, catalog.SQLExpr); err != nil {
+			if err := f((*string)(c.ComputeExpr), catalog.SQLExpr); err != nil {
 				return err
 			}
 		}
 		if c.HasOnUpdate() {
-			if err := f(c.OnUpdateExpr, catalog.SQLExpr); err != nil {
+			if err := f((*string)(c.OnUpdateExpr), catalog.SQLExpr); err != nil {
 				return err
 			}
 		}
@@ -298,38 +298,38 @@ func ForEachExprStringInTableDesc(
 	}
 	doIndex := func(i catalog.Index) error {
 		if i.IsPartial() {
-			return f(&i.IndexDesc().Predicate, catalog.SQLExpr)
+			return f((*string)(&i.IndexDesc().Predicate), catalog.SQLExpr)
 		}
 		return nil
 	}
 	doCheck := func(c *descpb.TableDescriptor_CheckConstraint) error {
-		return f(&c.Expr, catalog.SQLExpr)
+		return f((*string)(&c.Expr), catalog.SQLExpr)
 	}
 	doUwi := func(uwi *descpb.UniqueWithoutIndexConstraint) error {
 		if uwi.Predicate != "" {
-			return f(&uwi.Predicate, catalog.SQLExpr)
+			return f((*string)(&uwi.Predicate), catalog.SQLExpr)
 		}
 		return nil
 	}
 	doTrigger := func(t *descpb.TriggerDescriptor) error {
 		if t.WhenExpr != "" {
-			if err := f(&t.WhenExpr, catalog.SQLExpr); err != nil {
+			if err := f((*string)(&t.WhenExpr), catalog.SQLExpr); err != nil {
 				return err
 			}
 		}
 		if t.FuncBody == "" {
 			panic(errors.AssertionFailedf("expected non-empty trigger function body"))
 		}
-		return f(&t.FuncBody, catalog.PLpgSQLStmt)
+		return f((*string)(&t.FuncBody), catalog.PLpgSQLStmt)
 	}
 	doPolicy := func(p *descpb.PolicyDescriptor) error {
 		if p.UsingExpr != "" {
-			if err := f(&p.UsingExpr, catalog.SQLExpr); err != nil {
+			if err := f((*string)(&p.UsingExpr), catalog.SQLExpr); err != nil {
 				return err
 			}
 		}
 		if p.WithCheckExpr != "" {
-			if err := f(&p.WithCheckExpr, catalog.SQLExpr); err != nil {
+			if err := f((*string)(&p.WithCheckExpr), catalog.SQLExpr); err != nil {
 				return err
 			}
 		}
@@ -762,11 +762,10 @@ func (desc *Mutable) ensurePrimaryKey() error {
 		nameExists := func(name string) bool {
 			return catalog.FindColumnByName(desc, name) != nil
 		}
-		s := "unique_rowid()"
 		col := &descpb.ColumnDescriptor{
 			Name:        GenerateUniqueName("rowid", nameExists),
 			Type:        types.Int,
-			DefaultExpr: &s,
+			DefaultExpr: new(catpb.Expression("unique_rowid()")),
 			Hidden:      true,
 			Nullable:    false,
 		}
@@ -2013,7 +2012,7 @@ func MakeNotNullCheckConstraint(
 
 	return &descpb.TableDescriptor_CheckConstraint{
 		Name:                name,
-		Expr:                tree.Serialize(expr),
+		Expr:                catpb.Expression(tree.Serialize(expr)),
 		Validity:            validity,
 		ColumnIDs:           []descpb.ColumnID{col.GetID()},
 		IsNonNullConstraint: true,

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -817,8 +817,8 @@ func TestKeysPerRow(t *testing.T) {
 
 func TestColumnNeedsBackfill(t *testing.T) {
 	// Define variable strings here such that we can pass their address below.
-	null := "NULL"
-	four := "4:::INT8"
+	null := catpb.Expression("NULL")
+	four := catpb.Expression("4:::INT8")
 
 	// Create Column Descriptors that reflect the definition of a column with a
 	// default value of NULL that was set implicitly, one that was set explicitly,

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -185,8 +185,7 @@ func MakeColumnDefDescs(
 		// Otherwise we want to keep the default expression nil.
 		if ret.DefaultExpr != tree.DNull {
 			d.DefaultExpr.Expr = ret.DefaultExpr
-			s := tree.Serialize(d.DefaultExpr.Expr)
-			col.DefaultExpr = &s
+			col.DefaultExpr = new(descpb.Expression(tree.Serialize(d.DefaultExpr.Expr)))
 		}
 	}
 
@@ -208,8 +207,7 @@ func MakeColumnDefDescs(
 		}
 
 		d.OnUpdateExpr.Expr = ret.OnUpdateExpr
-		s := tree.Serialize(d.OnUpdateExpr.Expr)
-		col.OnUpdateExpr = &s
+		col.OnUpdateExpr = new(descpb.Expression(tree.Serialize(d.OnUpdateExpr.Expr)))
 	}
 
 	if d.IsComputed() {
@@ -218,8 +216,7 @@ func MakeColumnDefDescs(
 		// descriptor. Callers must validate the expression with
 		// schemaexpr.ValidateComputedColumnExpression once all possible
 		// reference columns are part of the table descriptor.
-		s := tree.Serialize(d.Computed.Expr)
-		col.ComputeExpr = &s
+		col.ComputeExpr = new(descpb.Expression(tree.Serialize(d.Computed.Expr)))
 	}
 
 	if d.PrimaryKey.IsPrimaryKey || (d.Unique.IsUnique && !d.Unique.WithoutIndex) {
@@ -574,7 +571,7 @@ func RenameColumnInTable(
 	newName tree.Name,
 	isShardColumnRenameable func(shardCol catalog.Column, newShardColName tree.Name) (bool, error),
 ) error {
-	renameInExpr := func(expr *string) error {
+	renameInExpr := func(expr *descpb.Expression) error {
 		newExpr, renameErr := schemaexpr.RenameColumn(*expr, col.ColName(), newName)
 		if renameErr != nil {
 			return renameErr
@@ -610,12 +607,10 @@ func RenameColumnInTable(
 
 	// Rename the column in the TTL expiration expression.
 	if tableDesc.HasRowLevelTTL() {
-		if expirationExpr := tableDesc.GetRowLevelTTL().ExpirationExpr; expirationExpr != "" {
-			expirationExprStr := string(expirationExpr)
-			if err := renameInExpr(&expirationExprStr); err != nil {
+		if ttl := tableDesc.GetRowLevelTTL(); ttl.ExpirationExpr != "" {
+			if err := renameInExpr(&ttl.ExpirationExpr); err != nil {
 				return err
 			}
-			tableDesc.GetRowLevelTTL().ExpirationExpr = catpb.Expression(expirationExprStr)
 		}
 	}
 

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -1151,7 +1151,7 @@ func maybeUpgradeSequenceReferenceForTable(
 
 		// Upgrade sequence reference in DEFAULT expression, if any.
 		if col.HasDefault() {
-			hasUpgradedInDefault, err := seqexpr.UpgradeSequenceReferenceInExpr(col.DefaultExpr, usedSequenceIDToNames)
+			hasUpgradedInDefault, err := seqexpr.UpgradeSequenceReferenceInExpr((*string)(col.DefaultExpr), usedSequenceIDToNames)
 			if err != nil {
 				return hasUpgraded, err
 			}
@@ -1160,7 +1160,7 @@ func maybeUpgradeSequenceReferenceForTable(
 
 		// Upgrade sequence reference in ON UPDATE expression, if any.
 		if col.HasOnUpdate() {
-			hasUpgradedInOnUpdate, err := seqexpr.UpgradeSequenceReferenceInExpr(col.OnUpdateExpr, usedSequenceIDToNames)
+			hasUpgradedInOnUpdate, err := seqexpr.UpgradeSequenceReferenceInExpr((*string)(col.OnUpdateExpr), usedSequenceIDToNames)
 			if err != nil {
 				return hasUpgraded, err
 			}
@@ -1203,7 +1203,7 @@ func maybeUpgradeSequenceReferenceForView(
 		return false, newExpr, err
 	}
 
-	stmt, err := parserutils.ParseOne(viewDesc.GetViewQuery())
+	stmt, err := parserutils.ParseOne(string(viewDesc.GetViewQuery()))
 	if err != nil {
 		return hasUpgraded, err
 	}
@@ -1213,7 +1213,7 @@ func maybeUpgradeSequenceReferenceForView(
 		return hasUpgraded, err
 	}
 
-	viewDesc.ViewQuery = newStmt.String()
+	viewDesc.ViewQuery = descpb.Statement(newStmt.String())
 
 	return hasUpgraded, err
 }

--- a/pkg/sql/catalog/tabledesc/table_desc_test.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_test.go
@@ -286,7 +286,6 @@ func TestFixMissingSequenceIdentityRefs(t *testing.T) {
 		name                  string
 		input, expectedOutput descpb.TableDescriptor
 	}
-	defaultExpr := "nextval('sq1')"
 	testData := []testCase{
 		{
 			name: "missing sequence references for identity",
@@ -298,7 +297,7 @@ func TestFixMissingSequenceIdentityRefs(t *testing.T) {
 					ID:                      1,
 					Type:                    types.Int,
 					GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_ALWAYS,
-					DefaultExpr:             &defaultExpr,
+					DefaultExpr:             new(descpb.Expression("nextval('sq1')")),
 					OwnsSequenceIds:         []descpb.ID{23},
 					UsesSequenceIds:         nil,
 				},
@@ -312,7 +311,7 @@ func TestFixMissingSequenceIdentityRefs(t *testing.T) {
 					ID:                      1,
 					Type:                    types.Int,
 					GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_ALWAYS,
-					DefaultExpr:             &defaultExpr,
+					DefaultExpr:             new(descpb.Expression("nextval('sq1')")),
 					OwnsSequenceIds:         []descpb.ID{23},
 					UsesSequenceIds:         []descpb.ID{23},
 				},

--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -108,21 +108,21 @@ func ValidateTTLExpirationColumn(desc catalog.TableDescriptor) error {
 	if err != nil {
 		return errors.Wrapf(err, "expected column %s", catpb.TTLDefaultExpirationColumnName)
 	}
-	expectedStr := `current_timestamp():::TIMESTAMPTZ + ` + string(intervalExpr)
-	if col.GetDefaultExpr() != expectedStr {
+	expectedExpr := catpb.Expression(`current_timestamp():::TIMESTAMPTZ + ` + string(intervalExpr))
+	if col.GetDefaultExpr() != expectedExpr {
 		return pgerror.Newf(
 			pgcode.InvalidTableDefinition,
 			"expected DEFAULT expression of %s to be ( %s ), but got: ( %s )",
 			catpb.TTLDefaultExpirationColumnName,
-			expectedStr, col.GetDefaultExpr(),
+			expectedExpr, col.GetDefaultExpr(),
 		)
 	}
-	if col.GetOnUpdateExpr() != expectedStr {
+	if col.GetOnUpdateExpr() != expectedExpr {
 		return pgerror.Newf(
 			pgcode.InvalidTableDefinition,
 			"expected ON UPDATE expression of %s to be ( %s ), but got: ( %s )",
 			catpb.TTLDefaultExpirationColumnName,
-			expectedStr, col.GetOnUpdateExpr(),
+			expectedExpr, col.GetOnUpdateExpr(),
 		)
 	}
 

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1265,7 +1265,7 @@ func (desc *wrapper) validateColumns() error {
 
 		if column.IsComputed() {
 			// Verify that the computed column expression is valid.
-			expr, err := parserutils.ParseExpr(column.GetComputeExpr())
+			expr, err := parserutils.ParseExpr(string(column.GetComputeExpr()))
 			if err != nil {
 				return err
 			}
@@ -1481,12 +1481,12 @@ func (desc *wrapper) validateTriggers() error {
 
 		// Verify that the WHEN expression and function body statements are valid.
 		if trigger.WhenExpr != "" {
-			_, err := parserutils.ParseExpr(trigger.WhenExpr)
+			_, err := parserutils.ParseExpr(string(trigger.WhenExpr))
 			if err != nil {
 				return err
 			}
 		}
-		_, err := parserutils.PLpgSQLParse(trigger.FuncBody)
+		_, err := parserutils.PLpgSQLParse(string(trigger.FuncBody))
 		if err != nil {
 			return err
 		}
@@ -1553,7 +1553,7 @@ func (desc *wrapper) validateCheckConstraints(
 		}
 
 		// Verify that the check's expression is valid.
-		expr, err := parserutils.ParseExpr(chk.GetExpr())
+		expr, err := parserutils.ParseExpr(string(chk.GetExpr()))
 		if err != nil {
 			return err
 		}
@@ -1607,7 +1607,7 @@ func (desc *wrapper) validateUniqueWithoutIndexConstraints(
 		}
 
 		if c.IsPartial() {
-			expr, err := parserutils.ParseExpr(c.GetPredicate())
+			expr, err := parserutils.ParseExpr(string(c.GetPredicate()))
 			if err != nil {
 				return err
 			}
@@ -1812,7 +1812,7 @@ func (desc *wrapper) validateTableIndexes(
 			}
 		}
 		if idx.IsPartial() {
-			expr, err := parserutils.ParseExpr(idx.GetPredicate())
+			expr, err := parserutils.ParseExpr(string(idx.GetPredicate()))
 			if err != nil {
 				return err
 			}
@@ -2282,13 +2282,13 @@ func (desc *wrapper) validatePolicyRoles(p *descpb.PolicyDescriptor) error {
 // validatePolicyExprs will validate the expressions within the policy.
 func (desc *wrapper) validatePolicyExprs(p *descpb.PolicyDescriptor) error {
 	if p.WithCheckExpr != "" {
-		_, err := parserutils.ParseExpr(p.WithCheckExpr)
+		_, err := parserutils.ParseExpr(string(p.WithCheckExpr))
 		if err != nil {
 			return errors.Wrapf(err, "WITH CHECK expression %q is invalid", p.WithCheckExpr)
 		}
 	}
 	if p.UsingExpr != "" {
-		_, err := parserutils.ParseExpr(p.UsingExpr)
+		_, err := parserutils.ParseExpr(string(p.UsingExpr))
 		if err != nil {
 			return errors.Wrapf(err, "USING expression %q is invalid", p.UsingExpr)
 		}
@@ -2440,7 +2440,7 @@ func ValidateRBRTableUsingConstraint(
 		if !col.IsComputed() {
 			continue
 		}
-		expr, err := parserutils.ParseExpr(col.GetComputeExpr())
+		expr, err := parserutils.ParseExpr(string(col.GetComputeExpr()))
 		if err != nil {
 			// At this point, we should be able to parse the computed expression.
 			return errors.WithAssertionFailure(err)

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"google.golang.org/protobuf/proto"
 )
 
 type validateStatus int
@@ -468,12 +467,12 @@ func TestValidateCoversAllDescriptorFields(t *testing.T) {
 func TestValidateTableDesc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	computedExpr := "1 + 1"
+	computedExpr := descpb.Expression("1 + 1")
 	generatedAsIdentitySequenceOptionExpr := " START 2 INCREMENT 3 CACHE 10"
 	boolTrue := true
 	negativeOne := int64(-1)
 	negativeOneFloat := float64(-1)
-	pointer := func(s string) *string {
+	pointer := func(s descpb.Expression) *descpb.Expression {
 		return &s
 	}
 
@@ -2319,8 +2318,8 @@ func TestValidateTableDesc(t *testing.T) {
 					{
 						ID:           1,
 						Name:         "bar",
-						ComputeExpr:  proto.String("'blah'"),
-						OnUpdateExpr: proto.String("'blah'"),
+						ComputeExpr:  pointer("'blah'"),
+						OnUpdateExpr: pointer("'blah'"),
 					},
 				},
 				Families: []descpb.ColumnFamilyDescriptor{
@@ -2341,7 +2340,7 @@ func TestValidateTableDesc(t *testing.T) {
 						Name:                    "bar",
 						GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_ALWAYS,
 						UsesSequenceIds:         []descpb.ID{32},
-						OnUpdateExpr:            proto.String("'blah'"),
+						OnUpdateExpr:            pointer("'blah'"),
 					},
 				},
 				Families: []descpb.ColumnFamilyDescriptor{
@@ -2363,7 +2362,7 @@ func TestValidateTableDesc(t *testing.T) {
 						GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_BY_DEFAULT,
 						UsesSequenceIds:         []descpb.ID{32},
 
-						OnUpdateExpr: proto.String("'blah'"),
+						OnUpdateExpr: pointer("'blah'"),
 					},
 				},
 				Families: []descpb.ColumnFamilyDescriptor{
@@ -3423,7 +3422,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	pointer := func(s string) *string {
+	pointer := func(s descpb.Expression) *descpb.Expression {
 		return &s
 	}
 

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -49,7 +49,7 @@ func validateCheckExpr(
 	semaCtx *tree.SemaContext,
 	txn isql.Txn,
 	sessionData *sessiondata.SessionData,
-	exprStr string,
+	exprStr catpb.Expression,
 	tableDesc *tabledesc.Mutable,
 	indexIDForValidation descpb.IndexID,
 ) (violatingRow tree.Datums, formattedCkExpr string, err error) {
@@ -494,7 +494,7 @@ func (p *planner) RevalidateUniqueConstraint(
 					tableDesc,
 					index.GetName(),
 					index.IndexDesc().KeyColumnIDs[index.ImplicitPartitioningColumnCount():],
-					index.GetPredicate(),
+					string(index.GetPredicate()),
 					0, /* indexIDForValidation */
 					p.InternalSQLTxn(),
 					p.User(),
@@ -514,7 +514,7 @@ func (p *planner) RevalidateUniqueConstraint(
 				tableDesc,
 				uc.GetName(),
 				uc.CollectKeyColumnIDs().Ordered(),
-				uc.GetPredicate(),
+				string(uc.GetPredicate()),
 				0, /* indexIDForValidation */
 				p.InternalSQLTxn(),
 				p.User(),
@@ -574,7 +574,7 @@ func RevalidateUniqueConstraintsInTable(
 				tableDesc,
 				index.GetName(),
 				index.IndexDesc().KeyColumnIDs[index.ImplicitPartitioningColumnCount():],
-				index.GetPredicate(),
+				string(index.GetPredicate()),
 				0, /* indexIDForValidation */
 				txn,
 				user,
@@ -594,7 +594,7 @@ func RevalidateUniqueConstraintsInTable(
 				tableDesc,
 				uc.GetName(),
 				uc.CollectKeyColumnIDs().Ordered(),
-				uc.GetPredicate(),
+				string(uc.GetPredicate()),
 				0, /* indexIDForValidation */
 				txn,
 				user,

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -605,7 +605,7 @@ func setFuncOptions(
 				return err
 			}
 		}
-		udfDesc.SetFuncBody(body)
+		udfDesc.SetFuncBody(descpb.RoutineBody(body))
 	}
 	return nil
 }

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -74,7 +74,7 @@ SELECT b FROM defaultdb.public.t@t_idx_b;
 SELECT c FROM defaultdb.public.t@t_idx_c;
 SELECT a FROM defaultdb.public.v;
 SELECT nextval(105:::REGCLASS);`,
-			funcDesc.GetFunctionBody())
+			string(funcDesc.GetFunctionBody()))
 
 		sort.Slice(funcDesc.GetDependsOn(), func(i, j int) bool {
 			return funcDesc.GetDependsOn()[i] < funcDesc.GetDependsOn()[j]
@@ -220,7 +220,7 @@ $$;
 			`SELECT b FROM defaultdb.public.t1@t1_idx_b;
 SELECT a FROM defaultdb.public.v1;
 SELECT nextval(106:::REGCLASS);`,
-			funcDesc.GetFunctionBody())
+			string(funcDesc.GetFunctionBody()))
 
 		sort.Slice(funcDesc.GetDependsOn(), func(i, j int) bool {
 			return funcDesc.GetDependsOn()[i] < funcDesc.GetDependsOn()[j]
@@ -264,7 +264,7 @@ $$;
 			`SELECT b FROM defaultdb.public.t2@t2_idx_b;
 SELECT a FROM defaultdb.public.v2;
 SELECT nextval(107:::REGCLASS);`,
-			funcDesc.GetFunctionBody())
+			string(funcDesc.GetFunctionBody()))
 
 		sort.Slice(funcDesc.GetDependsOn(), func(i, j int) bool {
 			return funcDesc.GetDependsOn()[i] < funcDesc.GetDependsOn()[j]

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -296,7 +296,7 @@ func makeIndexDescriptor(
 		if err != nil {
 			return nil, err
 		}
-		indexDesc.Predicate = expr
+		indexDesc.Predicate = descpb.Expression(expr)
 	}
 
 	if err := indexDesc.FillColumns(columns); err != nil {
@@ -524,7 +524,7 @@ func replaceExpressionElemsWithVirtualCols(
 ) error {
 	findExistingExprIndexCol := func(expr string) (colName string, ok bool) {
 		for _, col := range desc.AllColumns() {
-			if col.IsExpressionIndexColumn() && col.GetComputeExpr() == expr {
+			if col.IsExpressionIndexColumn() && string(col.GetComputeExpr()) == expr {
 				return col.GetName(), true
 			}
 		}
@@ -596,11 +596,11 @@ func replaceExpressionElemsWithVirtualCols(
 				Name:         colName,
 				Inaccessible: true,
 				Type:         typ,
-				ComputeExpr:  &expr,
+				ComputeExpr:  new(descpb.Expression(expr)),
 				Virtual:      true,
 				Nullable:     true,
 			}
-			if fnIDs, err := schemaexpr.GetUDFIDsFromExprStr(expr); err != nil {
+			if fnIDs, err := schemaexpr.GetUDFIDsFromExprStr(descpb.Expression(expr)); err != nil {
 				return err
 			} else {
 				col.UsesFunctionIds = fnIDs.Ordered()

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -940,7 +940,7 @@ func createStatsDefaultColumns(
 		// inverted index stats, and json type columns should respect the
 		// sql.stats.non_indexed_json_histograms.enabled cluster setting.
 		if idx.IsPartial() {
-			expr, err := parser.ParseExpr(idx.GetPredicate())
+			expr, err := parser.ParseExpr(string(idx.GetPredicate()))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -843,7 +843,7 @@ func ResolveUniqueWithoutIndexConstraint(
 		Name:         constraintName,
 		TableID:      tbl.ID,
 		ColumnIDs:    columnIDs,
-		Predicate:    predicate,
+		Predicate:    descpb.Expression(predicate),
 		Validity:     validity,
 		ConstraintID: tbl.NextConstraintID,
 	}
@@ -1313,7 +1313,7 @@ func newTableDescIfAs(
 	if err != nil {
 		return nil, err
 	}
-	desc.CreateQuery = createQuery
+	desc.CreateQuery = descpb.Statement(createQuery)
 	return desc, nil
 }
 
@@ -1774,7 +1774,7 @@ func NewTableDesc(
 	for i := range desc.Columns {
 		col := &desc.Columns[i]
 		if col.IsComputed() {
-			expr, err := parser.ParseExpr(*col.ComputeExpr)
+			expr, err := parser.ParseExpr(string(*col.ComputeExpr))
 			if err != nil {
 				return nil, err
 			}
@@ -1783,7 +1783,8 @@ func NewTableDesc(
 			if err != nil {
 				return nil, err
 			}
-			col.ComputeExpr = &deqExpr
+			computeExpr := descpb.Expression(deqExpr)
+			col.ComputeExpr = &computeExpr
 		}
 	}
 
@@ -1875,7 +1876,8 @@ func NewTableDesc(
 				if err != nil {
 					return nil, err
 				}
-				col.ColumnDesc().ComputeExpr = &serializedExpr
+				expr := descpb.Expression(serializedExpr)
+				col.ColumnDesc().ComputeExpr = &expr
 			}
 		}
 	}
@@ -1999,7 +2001,7 @@ func NewTableDesc(
 				if err != nil {
 					return nil, err
 				}
-				idx.Predicate = expr
+				idx.Predicate = descpb.Expression(expr)
 			}
 			if err := addSecondaryIdx(idx, d.StorageParams); err != nil {
 				return nil, err
@@ -2115,7 +2117,7 @@ func NewTableDesc(
 				if err != nil {
 					return nil, err
 				}
-				idx.Predicate = expr
+				idx.Predicate = descpb.Expression(expr)
 			}
 			if d.PrimaryKey {
 				if err := addPrimaryIdx(idx, d.StorageParams); err != nil {
@@ -2686,7 +2688,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 			if c.DefaultExpr != nil {
 				_, shouldCopyColumnDefault := shouldCopyColumnDefaultSet[c.Name]
 				if opts.Has(tree.LikeTableOptDefaults) || shouldCopyColumnDefault {
-					def.DefaultExpr.Expr, err = parser.ParseExpr(*c.DefaultExpr)
+					def.DefaultExpr.Expr, err = parser.ParseExpr(string(*c.DefaultExpr))
 					if err != nil {
 						return nil, err
 					}
@@ -2696,7 +2698,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 				if opts.Has(tree.LikeTableOptGenerated) {
 					def.Computed.Computed = true
 					def.Computed.Virtual = c.Virtual
-					def.Computed.Expr, err = parser.ParseExpr(*c.ComputeExpr)
+					def.Computed.Expr, err = parser.ParseExpr(string(*c.ComputeExpr))
 					if err != nil {
 						return nil, err
 					}
@@ -2704,7 +2706,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 			}
 			if c.OnUpdateExpr != nil {
 				if opts.Has(tree.LikeTableOptDefaults) {
-					def.OnUpdateExpr.Expr, err = parser.ParseExpr(*c.OnUpdateExpr)
+					def.OnUpdateExpr.Expr, err = parser.ParseExpr(string(*c.OnUpdateExpr))
 					if err != nil {
 						return nil, err
 					}
@@ -2718,7 +2720,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 					Name:                  tree.Name(c.Name),
 					FromHashShardedColumn: c.FromHashShardedColumn,
 				}
-				def.Expr, err = parser.ParseExpr(c.Expr)
+				def.Expr, err = parser.ParseExpr(string(c.Expr))
 				if err != nil {
 					return nil, err
 				}
@@ -2741,7 +2743,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 				}
 				defs = append(defs, &def)
 				if c.IsPartial() {
-					def.Predicate, err = parser.ParseExpr(c.Predicate)
+					def.Predicate, err = parser.ParseExpr(string(c.Predicate))
 					if err != nil {
 						return nil, err
 					}
@@ -2787,7 +2789,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 					}
 					if col.IsExpressionIndexColumn() {
 						elem.Column = ""
-						elem.Expr, err = parser.ParseExpr(col.GetComputeExpr())
+						elem.Expr, err = parser.ParseExpr(string(col.GetComputeExpr()))
 						if err != nil {
 							return nil, err
 						}
@@ -2813,7 +2815,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 					}
 				}
 				if idx.IsPartial() {
-					indexDef.Predicate, err = parser.ParseExpr(idx.GetPredicate())
+					indexDef.Predicate, err = parser.ParseExpr(string(idx.GetPredicate()))
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -452,7 +452,7 @@ func makeViewTableDesc(
 		privileges,
 		persistence,
 	)
-	desc.ViewQuery = viewQuery
+	desc.ViewQuery = descpb.Statement(viewQuery)
 	if isMultiRegion {
 		desc.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
 	}
@@ -462,15 +462,15 @@ func makeViewTableDesc(
 		if err != nil {
 			return tabledesc.Mutable{}, err
 		}
-		desc.ViewQuery = sequenceReplacedQuery
+		desc.ViewQuery = descpb.Statement(sequenceReplacedQuery)
 	}
 
-	typeReplacedQuery, err := serializeUserDefinedTypes(ctx, semaCtx, desc.ViewQuery,
+	typeReplacedQuery, err := serializeUserDefinedTypes(ctx, semaCtx, string(desc.ViewQuery),
 		false /* multiStmt */, "view queries")
 	if err != nil {
 		return tabledesc.Mutable{}, err
 	}
-	desc.ViewQuery = typeReplacedQuery
+	desc.ViewQuery = descpb.Statement(typeReplacedQuery)
 
 	if err := addResultColumns(ctx, semaCtx, evalCtx, st, &desc, resultColumns); err != nil {
 		return tabledesc.Mutable{}, err
@@ -737,22 +737,22 @@ func (p *planner) replaceViewDesc(
 	backRefMutables map[descpb.ID]*tabledesc.Mutable,
 ) (*tabledesc.Mutable, error) {
 	// Set the query to the new query.
-	toReplace.ViewQuery = n.viewQuery
+	toReplace.ViewQuery = descpb.Statement(n.viewQuery)
 
 	if sc != nil {
 		updatedQuery, err := replaceSeqNamesWithIDs(ctx, sc, n.viewQuery, false /* multiStmt */)
 		if err != nil {
 			return nil, err
 		}
-		toReplace.ViewQuery = updatedQuery
+		toReplace.ViewQuery = descpb.Statement(updatedQuery)
 	}
 
-	typeReplacedQuery, err := serializeUserDefinedTypes(ctx, p.SemaCtx(), toReplace.ViewQuery,
+	typeReplacedQuery, err := serializeUserDefinedTypes(ctx, p.SemaCtx(), string(toReplace.ViewQuery),
 		false /* multiStmt */, "view queries")
 	if err != nil {
 		return nil, err
 	}
-	toReplace.ViewQuery = typeReplacedQuery
+	toReplace.ViewQuery = descpb.Statement(typeReplacedQuery)
 
 	// Update view options if specified in the replacement.
 	if n.createView.Options != nil {

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -539,7 +539,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if len(virtComputedCols) != 0 {
 		exprStrings := make([]string, 0, len(virtComputedCols))
 		for _, col := range virtComputedCols {
-			exprStrings = append(exprStrings, col.GetComputeExpr())
+			exprStrings = append(exprStrings, string(col.GetComputeExpr()))
 		}
 
 		virtComputedExprs, err := parser.ParseExprs(exprStrings)

--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -84,7 +84,7 @@ SELECT b FROM defaultdb.public.t@t_idx_b;
 SELECT c FROM defaultdb.public.t@t_idx_c;
 SELECT a FROM defaultdb.public.v;
 SELECT nextval(%d:::REGCLASS);`, seqID)
-		require.Equal(t, expectedBody, funcDesc.GetFunctionBody())
+		require.Equal(t, expectedBody, string(funcDesc.GetFunctionBody()))
 
 		sort.Slice(funcDesc.GetDependsOn(), func(i, j int) bool {
 			return funcDesc.GetDependsOn()[i] < funcDesc.GetDependsOn()[j]

--- a/pkg/sql/hints/testutils.go
+++ b/pkg/sql/hints/testutils.go
@@ -24,10 +24,6 @@ import (
 // The tableID parameter specifies the ID to use for the descriptor. Pass
 // descpb.InvalidID if the ID will be set later (e.g., by InjectLegacyTable).
 func GetOldStatementHintsDescriptor(tableID descpb.ID) *descpb.TableDescriptor {
-	uniqueRowIDString := "unique_rowid()"
-	nowTZString := "now():::TIMESTAMPTZ"
-	statementHintsComputeExpr := "fnv64(fingerprint)"
-
 	return &descpb.TableDescriptor{
 		Name:                    string(catconstants.StatementHintsTableName),
 		ID:                      tableID,
@@ -35,11 +31,11 @@ func GetOldStatementHintsDescriptor(tableID descpb.ID) *descpb.TableDescriptor {
 		UnexposedParentSchemaID: keys.PublicSchemaID,
 		Version:                 1,
 		Columns: []descpb.ColumnDescriptor{
-			{Name: "row_id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString, Nullable: false},
-			{Name: "hash", ID: 2, Type: types.Int, Hidden: true, ComputeExpr: &statementHintsComputeExpr, Nullable: false},
+			{Name: "row_id", ID: 1, Type: types.Int, DefaultExpr: new(descpb.Expression("unique_rowid()")), Nullable: false},
+			{Name: "hash", ID: 2, Type: types.Int, Hidden: true, ComputeExpr: new(descpb.Expression("fnv64(fingerprint)")), Nullable: false},
 			{Name: "fingerprint", ID: 3, Type: types.String, Nullable: false},
 			{Name: "hint", ID: 4, Type: types.Bytes, Nullable: false},
-			{Name: "created_at", ID: 5, Type: types.TimestampTZ, DefaultExpr: &nowTZString, Nullable: false},
+			{Name: "created_at", ID: 5, Type: types.TimestampTZ, DefaultExpr: new(descpb.Expression("now():::TIMESTAMPTZ")), Nullable: false},
 			// NOTE: hint_type, hint_name, enabled, and database columns
 			// (IDs 6, 7, 8, 9) are NOT included.
 		},

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -64,7 +64,6 @@ import (
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 )
 
 // TestIndexBackfiller tests the MVCC-compatible index backfill with temporary indexes.
@@ -309,7 +308,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 					ID:             mut.NextColumnID,
 					Type:           types.Int,
 					Nullable:       false,
-					DefaultExpr:    proto.String("42"),
+					DefaultExpr:    new(descpb.Expression("42")),
 					Hidden:         false,
 					PGAttributeNum: descpb.PGAttributeNum(mut.NextColumnID),
 				}
@@ -322,7 +321,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 					ID:             mut.NextColumnID,
 					Type:           types.Int,
 					Nullable:       false,
-					ComputeExpr:    proto.String("i + def"),
+					ComputeExpr:    new(descpb.Expression("i + def")),
 					Hidden:         false,
 					PGAttributeNum: descpb.PGAttributeNum(mut.NextColumnID),
 				}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1737,16 +1737,16 @@ https://www.postgresql.org/docs/9.5/infoschema-views.html`,
 				// TODO(a-robinson): Insert column aliases into view query once we
 				// have a semantic query representation to work with (#10083).
 				return addRow(
-					tree.NewDString(db.GetName()),         // table_catalog
-					tree.NewDString(sc.GetName()),         // table_schema
-					tree.NewDString(table.GetName()),      // table_name
-					tree.NewDString(table.GetViewQuery()), // view_definition
-					tree.DNull,                            // check_option
-					noString,                              // is_updatable
-					noString,                              // is_insertable_into
-					noString,                              // is_trigger_updatable
-					noString,                              // is_trigger_deletable
-					noString,                              // is_trigger_insertable_into
+					tree.NewDString(db.GetName()),                 // table_catalog
+					tree.NewDString(sc.GetName()),                 // table_schema
+					tree.NewDString(table.GetName()),              // table_name
+					tree.NewDString(string(table.GetViewQuery())), // view_definition
+					tree.DNull, // check_option
+					noString,   // is_updatable
+					noString,   // is_insertable_into
+					noString,   // is_trigger_updatable
+					noString,   // is_trigger_deletable
+					noString,   // is_trigger_insertable_into
 				)
 			})
 	},
@@ -2480,7 +2480,7 @@ https://www.postgresql.org/docs/current/infoschema-triggers.html`,
 						// Handle action condition (WHEN clause).
 						var actionCondition tree.Datum = tree.DNull
 						if trigger.WhenExpr != "" {
-							actionCondition = tree.NewDString(trigger.WhenExpr)
+							actionCondition = tree.NewDString(string(trigger.WhenExpr))
 						}
 
 						// Handle transition table names

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -827,7 +827,7 @@ func (ov *optView) IsSystemView() bool {
 
 // Query is part of the cat.View interface.
 func (ov *optView) Query() string {
-	return ov.desc.GetViewQuery()
+	return string(ov.desc.GetViewQuery())
 }
 
 // ColumnNameCount is part of the cat.View interface.
@@ -1066,9 +1066,9 @@ func newOptTable(
 				col.GetType(),
 				col.IsNullable(),
 				visibility,
-				cd.DefaultExpr,
-				cd.ComputeExpr,
-				cd.OnUpdateExpr,
+				(*string)(cd.DefaultExpr),
+				(*string)(cd.ComputeExpr),
+				(*string)(cd.OnUpdateExpr),
 				mapGeneratedAsIdentityType(col.GetGeneratedAsIdentityType()),
 				cd.GeneratedAsIdentitySequenceOption,
 			)
@@ -1086,7 +1086,7 @@ func newOptTable(
 				col.GetType(),
 				col.IsNullable(),
 				visibility,
-				col.GetComputeExpr(),
+				string(col.GetComputeExpr()),
 			)
 		}
 	}
@@ -1114,9 +1114,9 @@ func newOptTable(
 				sysCol.GetType(),
 				sysCol.IsNullable(),
 				cat.MaybeHidden(sysCol.IsHidden()),
-				cd.DefaultExpr,
-				cd.ComputeExpr,
-				cd.OnUpdateExpr,
+				(*string)(cd.DefaultExpr),
+				(*string)(cd.ComputeExpr),
+				(*string)(cd.OnUpdateExpr),
 				mapGeneratedAsIdentityType(sysCol.GetGeneratedAsIdentityType()),
 				cd.GeneratedAsIdentitySequenceOption,
 			)
@@ -1136,7 +1136,7 @@ func newOptTable(
 			name:         u.GetName(),
 			table:        ot.ID(),
 			columns:      u.CollectKeyColumnIDs().Ordered(),
-			predicate:    u.GetPredicate(),
+			predicate:    string(u.GetPredicate()),
 			withoutIndex: true,
 			validity:     u.GetConstraintValidity(),
 		}
@@ -1257,7 +1257,7 @@ func newOptTable(
 					canUseTombstones: canUseTombstones,
 					// One would assume that this would be idx.Ordinal(), but they can differ during schema change
 					tombstoneIndexOrdinal: i,
-					predicate:             idx.GetPredicate(),
+					predicate:             string(idx.GetPredicate()),
 					// TODO(rytaft): will we ever support an unvalidated unique constraint
 					// here?
 					validity:            descpb.ConstraintValidity_Validated,
@@ -1270,7 +1270,7 @@ func newOptTable(
 					table:               ot.ID(),
 					columns:             idx.IndexDesc().KeyColumnIDs[idx.IndexDesc().ExplicitColumnStartIdx():],
 					withoutIndex:        true,
-					predicate:           idx.GetPredicate(),
+					predicate:           string(idx.GetPredicate()),
 					validity:            descpb.ConstraintValidity_Validated,
 					canElideUniqueCheck: true,
 				})
@@ -1360,7 +1360,7 @@ func newOptTable(
 	for i := range activeChecks {
 		check := activeChecks[i]
 		ot.checkConstraints = append(ot.checkConstraints, optCheckConstraint{
-			constraint:  check.GetExpr(),
+			constraint:  string(check.GetExpr()),
 			validated:   check.GetConstraintValidity() == descpb.ConstraintValidity_Validated,
 			columnCount: len(check.CheckDesc().ColumnIDs),
 			lookupColumnOrdinal: func(j int) (int, error) {
@@ -2023,7 +2023,7 @@ func (oi *optIndex) VectorColumn() cat.IndexColumn {
 // expression and true if the index is a partial index. If the index is not
 // partial, the empty string and false is returned.
 func (oi *optIndex) Predicate() (string, bool) {
-	return oi.idx.GetPredicate(), oi.idx.GetPredicate() != ""
+	return string(oi.idx.GetPredicate()), oi.idx.GetPredicate() != ""
 }
 
 // Zone is part of the cat.Index interface.
@@ -2601,9 +2601,9 @@ func newOptVirtualTable(
 			d.GetType(),
 			d.IsNullable(),
 			cat.MaybeHidden(d.IsHidden()),
-			cd.DefaultExpr,
-			cd.ComputeExpr,
-			cd.OnUpdateExpr,
+			(*string)(cd.DefaultExpr),
+			(*string)(cd.ComputeExpr),
+			(*string)(cd.OnUpdateExpr),
 			mapGeneratedAsIdentityType(d.GetGeneratedAsIdentityType()),
 			cd.GeneratedAsIdentitySequenceOption,
 		)
@@ -2779,7 +2779,7 @@ func (ot *optVirtualTable) CheckCount() int {
 func (ot *optVirtualTable) Check(i int) cat.CheckConstraint {
 	check := ot.desc.EnforcedCheckConstraints()[i]
 	return &optCheckConstraint{
-		constraint:  check.GetExpr(),
+		constraint:  string(check.GetExpr()),
 		validated:   check.GetConstraintValidity() == descpb.ConstraintValidity_Validated,
 		columnCount: len(check.CheckDesc().ColumnIDs),
 		lookupColumnOrdinal: func(j int) (int, error) {
@@ -3064,7 +3064,7 @@ func (oi *optVirtualIndex) Predicate() (string, bool) {
 		return "", false
 	}
 	pred := oi.idx.GetPredicate()
-	return pred, pred != ""
+	return string(pred), pred != ""
 }
 
 // Zone is part of the cat.Index interface.
@@ -3275,10 +3275,10 @@ func getOptTriggers(descTriggers []descpb.TriggerDescriptor) []optTrigger {
 			newTransitionAlias: tree.Name(descTrigger.NewTransitionAlias),
 			oldTransitionAlias: tree.Name(descTrigger.OldTransitionAlias),
 			forEachRow:         descTrigger.ForEachRow,
-			whenExpr:           descTrigger.WhenExpr,
+			whenExpr:           string(descTrigger.WhenExpr),
 			funcID:             cat.StableID(descTrigger.FuncID),
 			funcArgs:           funcArgs,
-			funcBody:           descTrigger.FuncBody,
+			funcBody:           string(descTrigger.FuncBody),
 			enabled:            descTrigger.Enabled,
 		}
 	}
@@ -3296,9 +3296,9 @@ func getOptPolicies(descPolicies []descpb.PolicyDescriptor) cat.Policies {
 		policy := cat.Policy{
 			Name:               tree.Name(descPolicy.Name),
 			ID:                 descPolicy.ID,
-			UsingExpr:          descPolicy.UsingExpr,
+			UsingExpr:          string(descPolicy.UsingExpr),
 			UsingColumnIDs:     descPolicy.UsingColumnIDs,
-			WithCheckExpr:      descPolicy.WithCheckExpr,
+			WithCheckExpr:      string(descPolicy.WithCheckExpr),
 			WithCheckColumnIDs: descPolicy.WithCheckColumnIDs,
 			Command:            descPolicy.Command,
 		}
@@ -3330,12 +3330,12 @@ func collectTypes(col catalog.Column) (descpb.IDs, error) {
 
 	// Collect UDTs in default expression, computed column and the column type itself.
 	if col.HasDefault() {
-		if err := addOIDsInExpr(col.GetDefaultExpr()); err != nil {
+		if err := addOIDsInExpr(string(col.GetDefaultExpr())); err != nil {
 			return nil, err
 		}
 	}
 	if col.IsComputed() {
-		if err := addOIDsInExpr(col.GetComputeExpr()); err != nil {
+		if err := addOIDsInExpr(string(col.GetComputeExpr())); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2513,8 +2513,8 @@ https://www.postgresql.org/docs/9.5/view-pg-indexes.html`,
 // without database-qualified table names (e.g. "db.public.t" becomes
 // "public.t"). PostgreSQL does not have cross-database references, so
 // view definitions should only use schema-qualified names.
-func viewQueryWithoutDatabasePrefix(viewQuery string) (string, error) {
-	stmt, err := parser.ParseOne(viewQuery)
+func viewQueryWithoutDatabasePrefix(viewQuery catpb.Statement) (catpb.Statement, error) {
+	stmt, err := parser.ParseOne(string(viewQuery))
 	if err != nil {
 		return "", err
 	}
@@ -2533,7 +2533,7 @@ func viewQueryWithoutDatabasePrefix(viewQuery string) (string, error) {
 		}),
 	)
 	fmtCtx.FormatNode(stmt.AST)
-	return fmtCtx.CloseAndGetString(), nil
+	return catpb.Statement(fmtCtx.CloseAndGetString()), nil
 }
 
 // indexDefFromDescriptor creates an index definition (`CREATE INDEX ... ON (...)`) from
@@ -2667,8 +2667,8 @@ https://www.postgresql.org/docs/9.6/view-pg-matviews.html`,
 					owner,                         // matviewowner
 					tree.DNull,                    // tablespace
 					tree.MakeDBool(len(desc.PublicNonPrimaryIndexes()) > 0), // hasindexes
-					tree.DBoolTrue,                 // ispopulated
-					tree.NewDString(viewQuery+";"), // definition
+					tree.DBoolTrue,                         // ispopulated
+					tree.NewDString(string(viewQuery+";")), // definition
 				)
 			})
 	},
@@ -3259,11 +3259,11 @@ func addPgProcUDFRow(
 		argNames,                                        // proargnames
 		argDefaults,                                     // proargdefaults
 		tree.DNull,                                      // protrftypes
-		tree.NewDString(fnDesc.GetFunctionBody()),       // prosrc
-		tree.DNull,                                      // probin
-		tree.DNull,                                      // prosqlbody
-		tree.DNull,                                      // proconfig
-		proacl,                                          // proacl
+		tree.NewDString(string(fnDesc.GetFunctionBody())), // prosrc
+		tree.DNull, // probin
+		tree.DNull, // prosqlbody
+		tree.DNull, // proconfig
+		proacl,     // proacl
 	)
 }
 
@@ -3889,7 +3889,7 @@ https://www.postgresql.org/docs/16/catalog-pg-trigger.html`,
 					// tgqual: WHEN condition expression (internal format).
 					var tgqual tree.Datum = tree.DNull
 					if trigger.WhenExpr != "" {
-						tgqual = tree.NewDString(trigger.WhenExpr)
+						tgqual = tree.NewDString(string(trigger.WhenExpr))
 					}
 
 					if err := addRow(
@@ -5705,10 +5705,10 @@ https://www.postgresql.org/docs/9.5/view-pg-views.html`,
 					}
 				}
 				return addRow(
-					tree.NewDName(sc.GetName()),    // schemaname
-					tree.NewDName(desc.GetName()),  // viewname
-					owner,                          // viewowner
-					tree.NewDString(viewQuery+";"), // definition
+					tree.NewDName(sc.GetName()),            // schemaname
+					tree.NewDName(desc.GetName()),          // viewname
+					owner,                                  // viewowner
+					tree.NewDString(string(viewQuery+";")), // definition
 				)
 			})
 	},
@@ -5920,7 +5920,7 @@ func (h oidHasher) writeUniqueConstraint(uc catalog.UniqueWithoutIndexConstraint
 
 func (h oidHasher) writeCheckConstraint(check catalog.CheckConstraint) {
 	h.writeStr(check.GetName())
-	h.writeStr(check.GetExpr())
+	h.writeStr(string(check.GetExpr()))
 }
 
 func (h oidHasher) writeForeignKeyConstraint(fk catalog.ForeignKeyConstraint) {

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -296,7 +296,7 @@ func DecodeRowInfo(
 	values := make([]string, len(cols))
 	for i := range cols {
 		if cols[i].IsExpressionIndexColumn() {
-			names[i] = cols[i].GetComputeExpr()
+			names[i] = string(cols[i].GetComputeExpr())
 		} else {
 			names[i] = cols[i].GetName()
 		}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -366,7 +366,7 @@ func (sc *SchemaChanger) validateBackfillQueryIntoTable(
 func (sc *SchemaChanger) backfillQueryIntoTable(
 	ctx context.Context,
 	table catalog.TableDescriptor,
-	query string,
+	query catpb.Statement,
 	ts hlc.Timestamp,
 	opName redact.SafeString,
 	backfillAsUser username.SQLUsername,
@@ -441,7 +441,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			}
 		}
 
-		stmt, err := parser.ParseOne(query)
+		stmt, err := parser.ParseOne(string(query))
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1351,7 +1351,7 @@ CREATE TABLE t.test (
 	if len(tableDesc.EnforcedCheckConstraints()) != 1 {
 		checkExprs := make([]string, 0)
 		for i := range tableDesc.EnforcedCheckConstraints() {
-			checkExprs = append(checkExprs, tableDesc.EnforcedCheckConstraints()[i].GetExpr())
+			checkExprs = append(checkExprs, string(tableDesc.EnforcedCheckConstraints()[i].GetExpr()))
 		}
 		t.Fatalf("Expected 1 check but got %d with CHECK expr %s ", len(tableDesc.EnforcedCheckConstraints()), strings.Join(checkExprs, ", "))
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -878,7 +878,7 @@ func maybeCreateAndAddShardCol(
 		return shardColName, existingShardColID
 	}
 	expr := schemaexpr.MakeHashShardComputeExpr(colNames, shardBuckets)
-	parsedExpr, err := parser.ParseExpr(*expr)
+	parsedExpr, err := parser.ParseExpr(string(*expr))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -391,7 +391,7 @@ func (w *walkCtx) walkRelation(tbl catalog.TableDescriptor) {
 		if ttl := tbl.GetRowLevelTTL(); ttl != nil {
 			// We pull out the TTL expression so that we can build proper column
 			// dependencies with whatever column is used.
-			ttlExpr, err := w.newExpression(string(ttl.GetTTLExpr()))
+			ttlExpr, err := w.newExpression(ttl.GetTTLExpr())
 			if err != nil {
 				panic(err)
 			}
@@ -934,14 +934,14 @@ func (w *walkCtx) walkTrigger(tbl catalog.TableDescriptor, t *descpb.TriggerDesc
 		w.ev(scpb.Status_PUBLIC, &scpb.TriggerWhen{
 			TableID:   tbl.GetID(),
 			TriggerID: t.ID,
-			WhenExpr:  t.WhenExpr,
+			WhenExpr:  string(t.WhenExpr),
 		})
 	}
 	w.ev(scpb.Status_PUBLIC, &scpb.TriggerFunctionCall{
 		TableID:   tbl.GetID(),
 		TriggerID: t.ID,
 		FuncID:    t.FuncID,
-		FuncBody:  t.FuncBody,
+		FuncBody:  string(t.FuncBody),
 		FuncArgs:  t.FuncArgs,
 	})
 	w.ev(scpb.Status_PUBLIC, &scpb.TriggerDeps{
@@ -1105,7 +1105,7 @@ func (w *walkCtx) walkFunction(fnDesc catalog.FunctionDescriptor) {
 			Type:  *typeT,
 		}
 		if param.DefaultExpr != nil {
-			expr, err := w.newExpression(*param.DefaultExpr)
+			expr, err := w.newExpression(catpb.Expression(*param.DefaultExpr))
 			if err != nil {
 				panic(err)
 			}
@@ -1147,7 +1147,7 @@ func (w *walkCtx) walkFunction(fnDesc catalog.FunctionDescriptor) {
 
 	fnBody := &scpb.FunctionBody{
 		FunctionID:  fnDesc.GetID(),
-		Body:        fnDesc.GetFunctionBody(),
+		Body:        string(fnDesc.GetFunctionBody()),
 		Lang:        catpb.FunctionLanguage{Lang: fnDesc.GetLanguage()},
 		UsesTypeIDs: fnDesc.GetDependsOnTypes(),
 	}

--- a/pkg/sql/schemachanger/scdecomp/helpers.go
+++ b/pkg/sql/schemachanger/scdecomp/helpers.go
@@ -58,8 +58,8 @@ func maybeMutationStatus(mm catalog.TableElementMaybeMutation) scpb.Status {
 
 // newExpression parses the expression and walks its AST to collect all by-ID
 // type and sequence references into an scpb.Expression expression wrapper.
-func (w *walkCtx) newExpression(expr string) (*scpb.Expression, error) {
-	e, err := parser.ParseExpr(expr)
+func (w *walkCtx) newExpression(expr catpb.Expression) (*scpb.Expression, error) {
+	e, err := parser.ParseExpr(string(expr))
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (w *walkCtx) newExpression(expr string) (*scpb.Expression, error) {
 		return nil, err
 	}
 	return &scpb.Expression{
-		Expr:                catpb.Expression(expr),
+		Expr:                expr,
 		UsesTypeIDs:         typIDs.Ordered(),
 		UsesSequenceIDs:     seqIDs.Ordered(),
 		UsesFunctionIDs:     referencedFnIDs.Ordered(),

--- a/pkg/sql/schemachanger/scexec/scmutationexec/column.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/column.go
@@ -143,8 +143,8 @@ func (i *immediateVisitor) updateColumnComputeExpression(
 	if expr == nil {
 		clearComputedExpr(col)
 	} else {
-		expr := string(*expr)
-		col.ComputeExpr = &expr
+		e := *expr
+		col.ComputeExpr = &e
 	}
 	if err := updateColumnExprSequenceUsage(col); err != nil {
 		return err
@@ -379,7 +379,7 @@ func (i *immediateVisitor) AddColumnDefaultExpression(
 		return err
 	}
 	d := col.ColumnDesc()
-	expr := string(op.Default.Expr)
+	expr := op.Default.Expr
 	d.DefaultExpr = &expr
 	seqRefs := catalog.MakeDescriptorIDSet(d.UsesSequenceIds...)
 	for _, seqID := range op.Default.UsesSequenceIDs {
@@ -436,7 +436,7 @@ func (i *immediateVisitor) AddColumnOnUpdateExpression(
 		return err
 	}
 	d := col.ColumnDesc()
-	expr := string(op.OnUpdate.Expr)
+	expr := op.OnUpdate.Expr
 	d.OnUpdateExpr = &expr
 	refs := catalog.MakeDescriptorIDSet(d.UsesSequenceIds...)
 	for _, seqID := range op.OnUpdate.UsesSequenceIDs {
@@ -498,8 +498,7 @@ func clearComputedExpr(col *descpb.ColumnDescriptor) {
 	// the expression for a column that still exists (e.g., a stored column), we do
 	// want to remove the expression.
 	if col.Virtual {
-		null := tree.Serialize(tree.DNull)
-		col.ComputeExpr = &null
+		col.ComputeExpr = new(descpb.Expression(tree.Serialize(tree.DNull)))
 	} else {
 		col.ComputeExpr = nil
 	}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/constraint.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/constraint.go
@@ -69,7 +69,7 @@ func (i *immediateVisitor) AddCheckConstraint(
 	}
 
 	ck := &descpb.TableDescriptor_CheckConstraint{
-		Expr:                  string(op.CheckExpr),
+		Expr:                  op.CheckExpr,
 		Name:                  tabledesc.ConstraintNamePlaceholder(op.ConstraintID),
 		Validity:              op.Validity,
 		ColumnIDs:             op.ColumnIDs,
@@ -519,7 +519,7 @@ func (i *immediateVisitor) AddUniqueWithoutIndexConstraint(
 		Name:         tabledesc.ConstraintNamePlaceholder(op.ConstraintID),
 		Validity:     op.Validity,
 		ConstraintID: op.ConstraintID,
-		Predicate:    string(op.PartialExpr),
+		Predicate:    op.PartialExpr,
 	}
 	if op.Validity == descpb.ConstraintValidity_Unvalidated {
 		// Unvalidated constraint doesn't need to transition through an intermediate

--- a/pkg/sql/schemachanger/scexec/scmutationexec/function.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/function.go
@@ -95,7 +95,7 @@ func (i *immediateVisitor) SetFunctionBody(ctx context.Context, op scop.SetFunct
 	if err != nil {
 		return err
 	}
-	fn.SetFuncBody(op.Body.Body)
+	fn.SetFuncBody(descpb.RoutineBody(op.Body.Body))
 	fn.SetLang(op.Body.Lang.Lang)
 	return nil
 }

--- a/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
@@ -269,7 +270,7 @@ func enqueueIndexMutation(
 
 func updateColumnExprSequenceUsage(d *descpb.ColumnDescriptor) error {
 	var all catalog.DescriptorIDSet
-	for _, expr := range [3]*string{d.ComputeExpr, d.DefaultExpr, d.OnUpdateExpr} {
+	for _, expr := range [3]*descpb.Expression{d.ComputeExpr, d.DefaultExpr, d.OnUpdateExpr} {
 		if expr == nil {
 			continue
 		}
@@ -285,7 +286,7 @@ func updateColumnExprSequenceUsage(d *descpb.ColumnDescriptor) error {
 
 func updateColumnExprFunctionsUsage(d *descpb.ColumnDescriptor) error {
 	var all catalog.DescriptorIDSet
-	for _, expr := range [3]*string{d.ComputeExpr, d.DefaultExpr, d.OnUpdateExpr} {
+	for _, expr := range [3]*descpb.Expression{d.ComputeExpr, d.DefaultExpr, d.OnUpdateExpr} {
 		if expr == nil {
 			continue
 		}
@@ -299,8 +300,8 @@ func updateColumnExprFunctionsUsage(d *descpb.ColumnDescriptor) error {
 	return nil
 }
 
-func sequenceIDsInExpr(expr string) (ids catalog.DescriptorIDSet, _ error) {
-	e, err := parser.ParseExpr(expr)
+func sequenceIDsInExpr(expr catpb.Expression) (ids catalog.DescriptorIDSet, _ error) {
+	e, err := parser.ParseExpr(string(expr))
 	if err != nil {
 		return ids, err
 	}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -112,7 +112,7 @@ func (i *immediateVisitor) SetAddedIndexPartialPredicate(
 		return err
 	}
 	idx := mut.AsIndex().IndexDesc()
-	idx.Predicate = string(op.Expr)
+	idx.Predicate = op.Expr
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scexec/scmutationexec/policy.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/policy.go
@@ -108,7 +108,7 @@ func (i *immediateVisitor) SetPolicyWithCheckExpression(
 	if err != nil {
 		return err
 	}
-	policy.WithCheckExpr = op.Expr
+	policy.WithCheckExpr = descpb.Expression(op.Expr)
 	policy.WithCheckColumnIDs = op.ColumnIDs
 	return nil
 }
@@ -120,7 +120,7 @@ func (i *immediateVisitor) SetPolicyUsingExpression(
 	if err != nil {
 		return err
 	}
-	policy.UsingExpr = op.Expr
+	policy.UsingExpr = descpb.Expression(op.Expr)
 	policy.UsingColumnIDs = op.ColumnIDs
 	return nil
 }

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -291,7 +291,7 @@ func (i *immediateVisitor) UpdateTableBackReferencesInSequences(
 				ids.ForEach(forwardRefs.Add)
 			}
 			for _, p := range tbl.GetPolicies() {
-				for _, pexpr := range []string{p.WithCheckExpr, p.UsingExpr} {
+				for _, pexpr := range []descpb.Expression{p.WithCheckExpr, p.UsingExpr} {
 					if pexpr != "" {
 						ids, err := sequenceIDsInExpr(pexpr)
 						if err != nil {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/trigger.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/trigger.go
@@ -99,7 +99,7 @@ func (i *immediateVisitor) SetTriggerWhen(ctx context.Context, op scop.SetTrigge
 	if err != nil {
 		return err
 	}
-	trigger.WhenExpr = op.When.WhenExpr
+	trigger.WhenExpr = descpb.Expression(op.When.WhenExpr)
 	return nil
 }
 
@@ -112,7 +112,7 @@ func (i *immediateVisitor) SetTriggerFunctionCall(
 	}
 	trigger.FuncID = op.FunctionCall.FuncID
 	trigger.FuncArgs = op.FunctionCall.FuncArgs
-	trigger.FuncBody = op.FunctionCall.FuncBody
+	trigger.FuncBody = descpb.RoutineBody(op.FunctionCall.FuncBody)
 	return nil
 }
 

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -737,7 +737,7 @@ func maybeAddSequenceDependencies(
 		if err != nil {
 			return nil, err
 		}
-		s := tree.Serialize(newExpr)
+		s := descpb.Expression(tree.Serialize(newExpr))
 		switch colExprKind {
 		case tabledesc.DefaultExpr:
 			col.DefaultExpr = &s

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -196,7 +196,7 @@ func formatViewQueryForDisplay(
 	if err != nil {
 		log.Dev.Warningf(ctx, "error deserializing user defined types for view %s (%v): %+v",
 			desc.GetName(), desc.GetID(), err)
-		return desc.GetViewQuery(), nil
+		return string(desc.GetViewQuery()), nil
 	}
 
 	// Convert sequences referenced by ID in the view back to their names.
@@ -368,7 +368,7 @@ func formatViewQueryTypesForDisplay(
 			return true, expr, nil
 		}
 		formattedExpr, err := schemaexpr.FormatExprForDisplay(
-			ctx, desc, expr.String(), evalCtx, semaCtx, sessionData, tree.FmtParsable,
+			ctx, desc, catpb.Expression(expr.String()), evalCtx, semaCtx, sessionData, tree.FmtParsable,
 		)
 		if err != nil {
 			return false, expr, err
@@ -381,7 +381,7 @@ func formatViewQueryTypesForDisplay(
 	}
 
 	viewQuery := desc.GetViewQuery()
-	stmt, err := parser.ParseOne(viewQuery)
+	stmt, err := parser.ParseOne(string(viewQuery))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -463,13 +463,13 @@ func TestSerializedUDTsInTableDescriptor(t *testing.T) {
 
 	ctx := context.Background()
 	getDefault := func(desc catalog.TableDescriptor) string {
-		return desc.PublicColumns()[0].GetDefaultExpr()
+		return string(desc.PublicColumns()[0].GetDefaultExpr())
 	}
 	getComputed := func(desc catalog.TableDescriptor) string {
-		return desc.PublicColumns()[0].GetComputeExpr()
+		return string(desc.PublicColumns()[0].GetComputeExpr())
 	}
 	getCheck := func(desc catalog.TableDescriptor) string {
-		return desc.EnforcedCheckConstraints()[0].GetExpr()
+		return string(desc.EnforcedCheckConstraints()[0].GetExpr())
 	}
 	testdata := []struct {
 		colSQL       string
@@ -610,7 +610,7 @@ func TestSerializedUDTsInView(t *testing.T) {
 			t.Fatal(err)
 		}
 		desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "test", "v")
-		foundViewQuery := desc.GetViewQuery()
+		foundViewQuery := string(desc.GetViewQuery())
 		expected := os.Expand(tc.expectedExpr, expander{"OID": oid}.mapping)
 		if expected != foundViewQuery {
 			t.Errorf("for view %s, found %s, expected %s", tc.viewQuery, foundViewQuery, expected)

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -747,9 +747,9 @@ func visitExprToCheckEnumValueUsage(
 // findUsagesOfEnumValue takes an expr, type ID and a enum member of that type,
 // and checks if the expr uses that enum member.
 func findUsagesOfEnumValue(
-	exprStr string, member *descpb.TypeDescriptor_EnumMember, typeID descpb.ID,
+	exprStr catpb.Expression, member *descpb.TypeDescriptor_EnumMember, typeID descpb.ID,
 ) (bool, error) {
-	expr, err := parser.ParseExpr(exprStr)
+	expr, err := parser.ParseExpr(string(exprStr))
 	if err != nil {
 		return false, err
 	}
@@ -772,7 +772,7 @@ func findUsagesOfEnumValue(
 // findUsagesOfEnumValueInViewQuery takes a view query, type ID and an
 // enum member of that type, and checks if the view query uses that enum member.
 func findUsagesOfEnumValueInViewQuery(
-	viewQuery string, member *descpb.TypeDescriptor_EnumMember, typeID descpb.ID,
+	viewQuery catpb.Statement, member *descpb.TypeDescriptor_EnumMember, typeID descpb.ID,
 ) (bool, error) {
 	var foundUsage, foundUsageInCurrentWalk bool
 	visitFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
@@ -782,7 +782,7 @@ func findUsagesOfEnumValueInViewQuery(
 		return recurse, newExpr, err
 	}
 
-	stmt, err := parser.ParseOne(viewQuery)
+	stmt, err := parser.ParseOne(string(viewQuery))
 	if err != nil {
 		return false, err
 	}
@@ -814,7 +814,7 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromUDF(
 	}
 	switch udfDesc.GetLanguage() {
 	case catpb.Function_SQL:
-		parsedStmts, err := parser.Parse(udfDesc.GetFunctionBody())
+		parsedStmts, err := parser.Parse(string(udfDesc.GetFunctionBody()))
 		if err != nil {
 			return err
 		}
@@ -828,7 +828,7 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromUDF(
 			}
 		}
 	case catpb.Function_PLPGSQL:
-		stmt, err := plpgsql.Parse(udfDesc.GetFunctionBody())
+		stmt, err := plpgsql.Parse(string(udfDesc.GetFunctionBody()))
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse routine %s", udfDesc.GetName())
 		}

--- a/pkg/upgrade/upgrades/v26_2_add_statement_statistics_computed_columns_test.go
+++ b/pkg/upgrade/upgrades/v26_2_add_statement_statistics_computed_columns_test.go
@@ -238,15 +238,15 @@ func TestTransactionStatisticsComputedColumnsMigration(t *testing.T) {
 // table descriptor that was being used before adding the new computed columns,
 // covering index, and dropping old metric indexes.
 func getOldStatementStatisticsDescriptor() *descpb.TableDescriptor {
-	defaultIndexRec := "ARRAY[]:::STRING[]"
-	sqlStmtHashComputeExpr := "mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8:::INT8)"
-	indexUsageComputeExpr := "(statistics->'statistics':::STRING)->'indexes':::STRING"
-	executionCountComputeExpr := "((statistics->'statistics':::STRING)->'cnt':::STRING)::INT8"
-	serviceLatencyComputeExpr := "(((statistics->'statistics':::STRING)->'svcLat':::STRING)->'mean':::STRING)::FLOAT8"
-	cpuSqlNanosComputeExpr := "(((statistics->'execution_statistics':::STRING)->'cpuSQLNanos':::STRING)->'mean':::STRING)::FLOAT8"
-	contentionTimeComputeExpr := "(((statistics->'execution_statistics':::STRING)->'contentionTime':::STRING)->'mean':::STRING)::FLOAT8"
-	totalEstimatedExecutionTimeExpr := "((statistics->'statistics':::STRING)->>'cnt':::STRING)::FLOAT8 * (((statistics->'statistics':::STRING)->'svcLat':::STRING)->>'mean':::STRING)::FLOAT8"
-	p99LatencyComputeExpr := "(((statistics->'statistics':::STRING)->'latencyInfo':::STRING)->'p99':::STRING)::FLOAT8"
+	defaultIndexRec := catpb.Expression("ARRAY[]:::STRING[]")
+	sqlStmtHashComputeExpr := catpb.Expression("mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8:::INT8)")
+	indexUsageComputeExpr := catpb.Expression("(statistics->'statistics':::STRING)->'indexes':::STRING")
+	executionCountComputeExpr := catpb.Expression("((statistics->'statistics':::STRING)->'cnt':::STRING)::INT8")
+	serviceLatencyComputeExpr := catpb.Expression("(((statistics->'statistics':::STRING)->'svcLat':::STRING)->'mean':::STRING)::FLOAT8")
+	cpuSqlNanosComputeExpr := catpb.Expression("(((statistics->'execution_statistics':::STRING)->'cpuSQLNanos':::STRING)->'mean':::STRING)::FLOAT8")
+	contentionTimeComputeExpr := catpb.Expression("(((statistics->'execution_statistics':::STRING)->'contentionTime':::STRING)->'mean':::STRING)::FLOAT8")
+	totalEstimatedExecutionTimeExpr := catpb.Expression("((statistics->'statistics':::STRING)->>'cnt':::STRING)::FLOAT8 * (((statistics->'statistics':::STRING)->'svcLat':::STRING)->>'mean':::STRING)::FLOAT8")
+	p99LatencyComputeExpr := catpb.Expression("(((statistics->'statistics':::STRING)->'latencyInfo':::STRING)->'p99':::STRING)::FLOAT8")
 
 	return &descpb.TableDescriptor{
 		Name:                    string(catconstants.StatementStatisticsTableName),
@@ -507,13 +507,13 @@ func getOldStatementStatisticsDescriptor() *descpb.TableDescriptor {
 // table descriptor that was being used before adding the new computed columns,
 // covering index, and dropping old metric indexes.
 func getOldTransactionStatisticsDescriptor() *descpb.TableDescriptor {
-	sqlTxnHashComputeExpr := `mod(fnv32("crdb_internal.datums_to_bytes"(aggregated_ts, app_name, fingerprint_id, node_id)), 8:::INT8)`
-	executionCountComputeExpr := "((statistics->'statistics':::STRING)->'cnt':::STRING)::INT8"
-	serviceLatencyComputeExpr := "(((statistics->'statistics':::STRING)->'svcLat':::STRING)->'mean':::STRING)::FLOAT8"
-	cpuSqlNanosComputeExpr := "(((statistics->'execution_statistics':::STRING)->'cpuSQLNanos':::STRING)->'mean':::STRING)::FLOAT8"
-	contentionTimeComputeExpr := "(((statistics->'execution_statistics':::STRING)->'contentionTime':::STRING)->'mean':::STRING)::FLOAT8"
-	totalEstimatedExecutionTimeExpr := "((statistics->'statistics':::STRING)->>'cnt':::STRING)::FLOAT8 * (((statistics->'statistics':::STRING)->'svcLat':::STRING)->>'mean':::STRING)::FLOAT8"
-	p99LatencyComputeExpr := "(((statistics->'statistics':::STRING)->'latencyInfo':::STRING)->'p99':::STRING)::FLOAT8"
+	sqlTxnHashComputeExpr := catpb.Expression(`mod(fnv32("crdb_internal.datums_to_bytes"(aggregated_ts, app_name, fingerprint_id, node_id)), 8:::INT8)`)
+	executionCountComputeExpr := catpb.Expression("((statistics->'statistics':::STRING)->'cnt':::STRING)::INT8")
+	serviceLatencyComputeExpr := catpb.Expression("(((statistics->'statistics':::STRING)->'svcLat':::STRING)->'mean':::STRING)::FLOAT8")
+	cpuSqlNanosComputeExpr := catpb.Expression("(((statistics->'execution_statistics':::STRING)->'cpuSQLNanos':::STRING)->'mean':::STRING)::FLOAT8")
+	contentionTimeComputeExpr := catpb.Expression("(((statistics->'execution_statistics':::STRING)->'contentionTime':::STRING)->'mean':::STRING)::FLOAT8")
+	totalEstimatedExecutionTimeExpr := catpb.Expression("((statistics->'statistics':::STRING)->>'cnt':::STRING)::FLOAT8 * (((statistics->'statistics':::STRING)->'svcLat':::STRING)->>'mean':::STRING)::FLOAT8")
+	p99LatencyComputeExpr := catpb.Expression("(((statistics->'statistics':::STRING)->'latencyInfo':::STRING)->'p99':::STRING)::FLOAT8")
 
 	return &descpb.TableDescriptor{
 		Name:                    string(catconstants.TransactionStatisticsTableName),

--- a/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
+++ b/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
@@ -258,9 +258,6 @@ func TestCanaryStatsDelayDelete(t *testing.T) {
 // system.table_statistics table descriptor that was being used
 // before adding the delayDelete column to the current version.
 func getOldTableStatisticsDescriptor() *descpb.TableDescriptor {
-	uniqueRowIDString := "unique_rowid()"
-	nowString := "now()"
-	zeroIntString := "0:::INT8"
 	return &descpb.TableDescriptor{
 		Name:                    string(catconstants.TableStatisticsTableName),
 		ID:                      keys.TableStatisticsTableID,
@@ -269,15 +266,15 @@ func getOldTableStatisticsDescriptor() *descpb.TableDescriptor {
 		Version:                 1,
 		Columns: []descpb.ColumnDescriptor{
 			{Name: "tableID", ID: 1, Type: types.Int},
-			{Name: "statisticID", ID: 2, Type: types.Int, DefaultExpr: &uniqueRowIDString},
+			{Name: "statisticID", ID: 2, Type: types.Int, DefaultExpr: new(descpb.Expression("unique_rowid()"))},
 			{Name: "name", ID: 3, Type: types.String, Nullable: true},
 			{Name: "columnIDs", ID: 4, Type: types.IntArray},
-			{Name: "createdAt", ID: 5, Type: types.Timestamp, DefaultExpr: &nowString},
+			{Name: "createdAt", ID: 5, Type: types.Timestamp, DefaultExpr: new(descpb.Expression("now()"))},
 			{Name: "rowCount", ID: 6, Type: types.Int},
 			{Name: "distinctCount", ID: 7, Type: types.Int},
 			{Name: "nullCount", ID: 8, Type: types.Int},
 			{Name: "histogram", ID: 9, Type: types.Bytes, Nullable: true},
-			{Name: "avgSize", ID: 10, Type: types.Int, DefaultExpr: &zeroIntString},
+			{Name: "avgSize", ID: 10, Type: types.Int, DefaultExpr: new(descpb.Expression("0:::INT8"))},
 			{Name: "partialPredicate", ID: 11, Type: types.String, Nullable: true},
 			{Name: "fullStatisticID", ID: 12, Type: types.Int, Nullable: true},
 			// Note: delayDelete column (ID 13) is intentionally omitted for the old descriptor

--- a/pkg/upgrade/upgrades/v26_2_stmt_diag_request_id_test.go
+++ b/pkg/upgrade/upgrades/v26_2_stmt_diag_request_id_test.go
@@ -91,7 +91,6 @@ func TestStmtDiagnosticsRequestIDMigration(t *testing.T) {
 // getOldStatementDiagnosticsDescriptor returns the system.statement_diagnostics
 // table descriptor that was being used before adding the request_id column.
 func getOldStatementDiagnosticsDescriptor() *descpb.TableDescriptor {
-	uniqueRowIDString := "unique_rowid()"
 	return &descpb.TableDescriptor{
 		Name:                    string(catconstants.StatementDiagnosticsTableName),
 		ID:                      keys.StatementDiagnosticsTableID,
@@ -99,7 +98,7 @@ func getOldStatementDiagnosticsDescriptor() *descpb.TableDescriptor {
 		UnexposedParentSchemaID: keys.PublicSchemaID,
 		Version:                 1,
 		Columns: []descpb.ColumnDescriptor{
-			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString, Nullable: false},
+			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: new(descpb.Expression("unique_rowid()")), Nullable: false},
 			{Name: "statement_fingerprint", ID: 2, Type: types.String, Nullable: false},
 			{Name: "statement", ID: 3, Type: types.String, Nullable: false},
 			{Name: "collected_at", ID: 4, Type: types.TimestampTZ, Nullable: false},


### PR DESCRIPTION
This change adds the Statement and RoutineBody type aliases alongside the existing Expression alias.
These aliases are now used throughout catalog instead of the previous raw string.

This will be used to indicate how a SQL string should be parsed, which is needed in the future to teach
our reflection based walk how to visit and find all descriptor IDs.

Epic: none
Release note: none
Fixes: none