### PR TITLE
workload: add InvalidTextRepresentation to createTrigger expected errors

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5832,6 +5832,7 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 		{code: pgcode.UndefinedColumn, condition: true},
 		{code: pgcode.UndefinedObject, condition: true},
 		{code: pgcode.InvalidParameterValue, condition: true},
+		{code: pgcode.InvalidTextRepresentation, condition: true},
 	})
 
 	return opStmt, nil


### PR DESCRIPTION
Enum cast expressions in trigger function bodies (e.g. 'val'::enum_type) are evaluated lazily at CREATE TRIGGER time, not when the function is created. If an enum member is dropped between function creation and trigger creation, the cast fails with "invalid input value for enum" (pgcode 22P02 / InvalidTextRepresentation). Add this error code to the list of potential execution errors so the workload handles it gracefully.

Informs #167410
Closes #168574
Closes #168659
Release note: None
Epic: CRDB-48029
