### PR TITLE
kvstorage: stage a WAG event for replica creation

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -459,6 +459,7 @@ go_test(
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/kvstorage/snaprecv",
         "//pkg/kv/kvserver/kvstorage/wag",
+        "//pkg/kv/kvserver/kvstorage/wag/wagpb",
         "//pkg/kv/kvserver/leases",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     name = "kvstorage_test",
     srcs = [
         "cluster_version_test.go",
+        "create_test.go",
         "datadriven_test.go",
         "destroy_test.go",
         "init_test.go",

--- a/pkg/kv/kvserver/kvstorage/create_test.go
+++ b/pkg/kv/kvserver/kvstorage/create_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUninitializedReplica(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	storage.DisableMetamorphicSimpleValueEncoding(t) // for deterministic output
+
+	id := roachpb.FullReplicaID{RangeID: 123, ReplicaID: 3}
+
+	runWithEngines(t, func(t *testing.T, e Engines) {
+		ctx := context.Background()
+		out := testMutateSep(t, "create", e, func(rw ReadWriter, w *wag.Writer) {
+			require.NoError(t, CreateUninitializedReplica(
+				ctx, rw.State, RaftRO(e.LogEngine()), w, 1 /* storeID */, id,
+			))
+		})
+		echotestRequire(t, out)
+	})
+}

--- a/pkg/kv/kvserver/kvstorage/create_test.go
+++ b/pkg/kv/kvserver/kvstorage/create_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUninitializedReplica(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	storage.DisableMetamorphicSimpleValueEncoding(t) // for deterministic output
+
+	runWithEngines(t, func(t *testing.T, e Engines) {
+		ctx := context.Background()
+		out := testMutateSep(t, "create", e, func(rw ReadWriter, w *wag.Writer) {
+			require.NoError(t, CreateUninitializedReplica(
+				ctx, rw.State, rw.Raft.RO, w, 1, /* storeID */
+				roachpb.FullReplicaID{RangeID: 123, ReplicaID: 3},
+			))
+		})
+		echotestRequire(t, out)
+	})
+}

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -103,17 +105,6 @@ func (r LoadedReplicaState) check(storeID roachpb.StoreID) error {
 	return nil
 }
 
-// CreateUninitReplicaTODO is the plan for splitting CreateUninitializedReplica
-// into cross-engine writes.
-//
-//  1. Log storage write (durable):
-//     1.1. Write WAG node with the state machine mutation (2).
-//  2. State machine mutation:
-//     2.1. Write the new RaftReplicaID.
-//
-// TODO(sep-raft-log): support the status quo in which only 2.1 is written.
-const CreateUninitReplicaTODO = 0
-
 // CreateUninitializedReplica creates an uninitialized replica in storage.
 // Returns kvpb.RaftGroupDeletedError if this replica can not be created
 // because it has been deleted.
@@ -121,6 +112,7 @@ func CreateUninitializedReplica(
 	ctx context.Context,
 	stateRW State,
 	raftRO RaftRO,
+	w *wag.Writer,
 	storeID roachpb.StoreID,
 	id roachpb.FullReplicaID,
 ) error {
@@ -148,7 +140,7 @@ func CreateUninitializedReplica(
 	// Before this point, raft and state machine state of this replica are
 	// non-existent. The only RangeID-specific key that can be present is the
 	// RangeTombstone inspected above.
-	_ = CreateUninitReplicaTODO
+	w.AddEvent(wagpb.MakeAddr(id, 0), wagpb.EventCreate)
 	if err := sl.SetRaftReplicaID(ctx, stateRW.WO, id.ReplicaID); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -121,6 +123,7 @@ func CreateUninitializedReplica(
 	ctx context.Context,
 	stateRW State,
 	raftRO RaftRO,
+	w *wag.Writer,
 	storeID roachpb.StoreID,
 	id roachpb.FullReplicaID,
 ) error {
@@ -149,6 +152,7 @@ func CreateUninitializedReplica(
 	// non-existent. The only RangeID-specific key that can be present is the
 	// RangeTombstone inspected above.
 	_ = CreateUninitReplicaTODO
+	w.AddEvent(wagpb.MakeAddr(id, 0), wagpb.EventCreate)
 	if err := sl.SetRaftReplicaID(ctx, stateRW.WO, id.ReplicaID); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/testdata/TestCreateUninitializedReplica-one-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestCreateUninitializedReplica-one-eng.txt
@@ -1,0 +1,4 @@
+echo
+----
+>> create:
+Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:3 

--- a/pkg/kv/kvserver/kvstorage/testdata/TestCreateUninitializedReplica-sep-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestCreateUninitializedReplica-sep-eng.txt
@@ -1,0 +1,7 @@
+echo
+----
+>> create/state:
+(matches WAG node)
+>> create/raft:
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/3:0,EventCreate)
+> Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:3 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -210,6 +210,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					} else {
 						err = kvstorage.CreateUninitializedReplica(
 							ctx, kvstorage.WrapState(b.State()), kvstorage.RaftRO(tc.eng.LogEngine()),
+							b.WagWriter(),
 							1, /* StoreID */
 							roachpb.FullReplicaID{RangeID: rs.desc.RangeID, ReplicaID: repl.ReplicaID},
 						)

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -184,12 +184,19 @@ func (s *Store) tryGetOrCreateReplica(
 	// be accessed by someone holding a reference to, or currently creating a
 	// Replica for this rangeID, and that's us.
 
-	_ = kvstorage.CreateUninitReplicaTODO
-	// TODO(sep-raft-log): needs both engines due to tombstone (which lives on
-	// statemachine).
+	// Use a read-write batch (not a write-only batch) because
+	// CreateUninitializedReplica needs to read back the RaftReplicaID it writes
+	// as part of its LoadReplicaState verification step.
+	b := s.batchFactory.NewBatch()
+	defer b.Close()
 	if err := kvstorage.CreateUninitializedReplica(
-		ctx, kvstorage.TODOState(s.StateEngine()), s.LogEngine(), s.StoreID(), id,
+		ctx, kvstorage.WrapState(b.State()),
+		kvstorage.RaftRO(s.LogEngine()),
+		b.WagWriter(), s.StoreID(), id,
 	); err != nil {
+		return nil, false, err
+	}
+	if err := b.Commit(true /* sync */); err != nil {
 		return nil, false, err
 	}
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -123,8 +124,9 @@ type testStoreOpts struct {
 	// If createSystemRanges is not set, the store will have a single range. If
 	// set, the store will have all the system ranges that are generally created
 	// for a cluster at boostrap.
-	createSystemRanges bool
-	bootstrapVersion   roachpb.Version // defaults to TestingClusterVersion
+	createSystemRanges  bool
+	bootstrapVersion    roachpb.Version // defaults to TestingClusterVersion
+	useSeparatedEngines bool
 }
 
 func (opts *testStoreOpts) splits() (_kvs []roachpb.KeyValue, _splits []roachpb.RKey) {
@@ -225,7 +227,14 @@ func createTestStoreWithoutStart(
 	// to do the same (with some effort). That's unlikely to happen soon, so
 	// let's continue to use the system config span.
 	cfg.SpanConfigsDisabled = true
-	eng := kvstorage.MakeEngines(storage.NewDefaultInMemForTesting())
+	var eng kvstorage.Engines
+	if opts.useSeparatedEngines {
+		eng = kvstorage.MakeSeparatedEnginesForTesting(
+			storage.NewDefaultInMemForTesting(), storage.NewDefaultInMemForTesting(),
+		)
+	} else {
+		eng = kvstorage.MakeEngines(storage.NewDefaultInMemForTesting())
+	}
 	stopper.AddCloser(&eng)
 	require.Nil(t, cfg.Transport)
 
@@ -4429,6 +4438,53 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 		ctx, tc.store.StateEngine())
 	require.NoError(t, err)
 	require.True(t, mark.Is(7))
+}
+
+// TestStoreGetOrCreateReplicaWritesWAGNode tests that creating an uninitialized
+// replica via getOrCreateReplica writes a WAG EventCreate node to the log
+// engine.
+func TestStoreGetOrCreateReplicaWritesWAGNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 123))
+	cfg := TestStoreConfig(hlc.NewClockForTesting(manual))
+	cfg.TestingKnobs.DontCloseTimestamps = true
+	cfg.TestingKnobs.DisableMergeWaitForReplicasInit = true
+	store := createTestStoreWithConfig(
+		ctx, t, stopper, testStoreOpts{useSeparatedEngines: true}, &cfg,
+	)
+
+	id := roachpb.FullReplicaID{RangeID: 42, ReplicaID: 7}
+	repl, created, err := store.getOrCreateReplica(ctx, id, &roachpb.ReplicaDescriptor{
+		NodeID:    store.NodeID(),
+		StoreID:   store.StoreID(),
+		ReplicaID: id.ReplicaID,
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	repl.raftMu.Unlock()
+
+	// Scan the log engine for WAG nodes and verify an EventCreate was written
+	// for the replica we just created.
+	var it wag.Iterator
+	var found bool
+	for _, node := range it.Iter(ctx, store.LogEngine()) {
+		for _, ev := range node.Events {
+			if ev.Addr.RangeID == id.RangeID {
+				require.Equal(t, wagpb.EventCreate, ev.Type)
+				require.Equal(t, id.ReplicaID, ev.Addr.ReplicaID)
+				require.EqualValues(t, 0, ev.Addr.Index)
+				found = true
+			}
+		}
+	}
+	require.NoError(t, it.Error())
+	require.True(t, found, "expected to find an EventCreate WAG node for r%d", id.RangeID)
 }
 
 // TestSplitPreApplyInitializesTruncatedState ensures that the Raft truncated

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -6,7 +6,10 @@ create-replica range-id=1
 ----
 created replica: (n1,s1):3
 state engine:
-Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:3 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/3:0,EventCreate)
+> Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:3 
 
 # Make the uninitialized replica vote.
 update-hard-state range-id=1 term=10 vote=2

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/legacy_split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/legacy_split_trigger.txt
@@ -42,7 +42,10 @@ create-replica range-id=2
 ----
 created replica: (n1,s1):1
 state engine:
-Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:0,EventCreate)
+> Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
 
 # Apply the split. splitPreApply should detect the legacy keys in the state
 # engine batch and clear them, since they belong on the log engine side.
@@ -54,7 +57,7 @@ log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
@@ -41,7 +41,10 @@ create-replica range-id=2
 ----
 created replica: (n1,s1):1
 state engine:
-Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:0,EventCreate)
+> Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
 
 # Destroy the RHS replica before applying the split. This simulates the case
 # where the RHS replica was removed from the store before the split was applied.
@@ -50,7 +53,7 @@ destroy-replica range-id=2
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:0,EventDestroy)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r2/1:0,EventDestroy)
 > Put: 0,0 /Local/RangeID/2/u/RangeTombstone (0x01698a757266746200): next_replica_id:4 
 > Delete: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): 
 
@@ -59,7 +62,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0
@@ -102,7 +105,10 @@ create-replica range-id=3 replica-id=5
 ----
 created replica: (n1,s1):5
 state engine:
-Put: 0,0 /Local/RangeID/3/u/RaftReplicaID (0x01698b757266747200): replica_id:5 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r3/5:0,EventCreate)
+> Put: 0,0 /Local/RangeID/3/u/RaftReplicaID (0x01698b757266747200): replica_id:5 
 
 # Apply the split. The RHS is detected as destroyed because its ReplicaID (5)
 # is higher than the one in the split trigger (1).
@@ -111,7 +117,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r1/1:12,EventSplit)
+Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): (r1/1:12,EventSplit)
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,1 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004,0
@@ -145,7 +151,10 @@ create-replica range-id=4 replica-id=1
 ----
 created replica: (n1,s1):1
 state engine:
-Put: 0,0 /Local/RangeID/4/u/RaftReplicaID (0x01698c757266747200): replica_id:1 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): (r4/1:0,EventCreate)
+> Put: 0,0 /Local/RangeID/4/u/RaftReplicaID (0x01698c757266747200): replica_id:1 
 
 apply-split range-id=1
 ----
@@ -155,7 +164,7 @@ log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r1/1:13,EventSplit)
+Put: 0,0 /Local/Store/wag/7 (0x01737761676e000000000000000700): (r1/1:13,EventSplit)
 > Put: 0,0 /Local/Range"c"/QueueLastProcessed/"consistencyChecker" (0x016b12630001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,2 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -39,7 +39,10 @@ create-replica range-id=2
 ----
 created replica: (n1,s1):1
 state engine:
-Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:0,EventCreate)
+> Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1 
 
 # apply-split applies the stashed batch and runs splitPreApply. It automatically
 # detects that the RHS replica exists and initializes it.
@@ -51,7 +54,7 @@ log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit)
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0
@@ -91,7 +94,10 @@ create-replica range-id=3
 ----
 created replica: (n1,s1):1
 state engine:
-Put: 0,0 /Local/RangeID/3/u/RaftReplicaID (0x01698b757266747200): replica_id:1 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r3/1:0,EventCreate)
+> Put: 0,0 /Local/RangeID/3/u/RaftReplicaID (0x01698b757266747200): replica_id:1 
 
 apply-split range-id=1
 ----
@@ -101,7 +107,7 @@ log engine:
 Put: 0,0 /Local/RangeID/3/u/RaftHardState (0x01698b757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/3/u/RaftTruncatedState (0x01698b757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:12,EventSplit)
+Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r1/1:12,EventSplit)
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004,0
@@ -127,7 +133,10 @@ create-replica range-id=4
 ----
 created replica: (n1,s1):1
 state engine:
-Put: 0,0 /Local/RangeID/4/u/RaftReplicaID (0x01698c757266747200): replica_id:1 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): (r4/1:0,EventCreate)
+> Put: 0,0 /Local/RangeID/4/u/RaftReplicaID (0x01698c757266747200): replica_id:1 
 
 apply-split range-id=2
 ----
@@ -137,7 +146,7 @@ log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r2/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): (r2/1:11,EventSplit)
 > Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
@@ -6,7 +6,10 @@ create-replica range-id=1
 ----
 created replica: (n1,s1):5
 state engine:
-Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:5 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/5:0,EventCreate)
+> Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:5 
 
 # Make the uninitialized replica vote.
 update-hard-state range-id=1 term=10 vote=2
@@ -47,7 +50,10 @@ create-replica range-id=1 replica-id=10
 ----
 created replica: (n1,s1):10
 state engine:
-Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:10 
+(matches WAG node)
+log engine:
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/10:0,EventCreate)
+> Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:10 
 
 # TODO(pav-kv): HardState of the previous replica should not be inherited.
 print-range-state


### PR DESCRIPTION
`CreateUninitializedReplica` now accepts a `*wag.Writer` and stages an `EventCreate` WAG node before writing the `RaftReplicaID`. The event uses raft index 0, since uninitialized replicas have no raft log.

While here, the store caller (`tryGetOrCreateReplica`) is upgraded from `TODOState` to a proper `kvstorage.Batch`, which gives us a WAG writer to pass through.

References: https://github.com/cockroachdb/cockroach/issues/165186
Release note: None