### PR TITLE
roachtest: deterministic benchmark kv|admission-control specs

### DIFF
--- a/pkg/cmd/roachtest/spec/BUILD.bazel
+++ b/pkg/cmd/roachtest/spec/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cluster_spec.go",
         "machine_type.go",
         "option.go",
+        "storage_variant.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec",
     visibility = ["//visibility:public"],

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -681,16 +681,7 @@ func (s *ClusterSpec) RoachprodOpts(
 			availableVolumeTypes = append(availableVolumeTypes, "local-ssd")
 		}
 
-		switch cloud {
-		case AWS:
-			availableVolumeTypes = append(availableVolumeTypes, "gp3", "io2")
-		case GCE:
-			availableVolumeTypes = append(availableVolumeTypes, "pd-ssd")
-		case Azure:
-			availableVolumeTypes = append(availableVolumeTypes, "premium-ssd", "premium-ssd-v2", "ultra-disk")
-		case IBM:
-			availableVolumeTypes = append(availableVolumeTypes, "10iops-tier")
-		}
+		availableVolumeTypes = append(availableVolumeTypes, CloudVolumeTypes(cloud)...)
 
 		if len(availableVolumeTypes) > 0 {
 			rng, _ := randutil.NewPseudoRand()

--- a/pkg/cmd/roachtest/spec/storage_variant.go
+++ b/pkg/cmd/roachtest/spec/storage_variant.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package spec
+
+// StorageVariant represents a specific storage configuration (volume type,
+// filesystem, or local SSD preference) that should be tested as a distinct,
+// named test variant. This replaces random volume type and filesystem
+// selection at cluster creation time, ensuring that each test run uses a
+// deterministic infrastructure configuration identified by its test name.
+//
+// Tests register one variant per StorageVariant, restricting each to the
+// appropriate cloud provider. For example, a test compatible with AllClouds
+// would produce separate registrations for "vol=gp3" (AWS-only),
+// "vol=pd-ssd" (GCE-only), and so on.
+//
+// Storage variants cover two orthogonal axes:
+//   - Volume type (remote storage): cloud-specific types like gp3, pd-ssd, etc.
+//   - Local SSD: uses PreferLocalSSD(), applicable on clouds that support it
+//     (GCE, AWS, Azure). IBM does not support local SSDs.
+//
+// These are separate because local SSD is controlled via PreferLocalSSD() /
+// DisableLocalSSD() flags, not via VolumeType(). Tests that use
+// DisableLocalSSD() should pass skipLocalSSD=true to the storageVariantRegs
+// helper to exclude local-SSD variants.
+type StorageVariant struct {
+	// Name is the suffix appended to the test name (e.g., "vol=gp3",
+	// "fs=xfs", "local-ssd"). The test registers as "<baseName>/<Name>".
+	Name string
+	// VolumeType is the cloud-specific volume type string (e.g., "gp3",
+	// "pd-ssd"). Empty means use the cloud provider's default.
+	VolumeType string
+	// FileSystem overrides the filesystem. Zero value (Ext4) means default.
+	FileSystem fileSystemType
+	// PreferLocalSSD, when true, adds the PreferLocalSSD() option instead
+	// of a VolumeType. This is mutually exclusive with VolumeType.
+	PreferLocalSSD bool
+	// Cloud restricts this variant to a specific cloud provider. AnyCloud
+	// means the variant is cloud-agnostic (e.g., filesystem variants).
+	Cloud Cloud
+}
+
+// IsLocalSSD returns true if this variant selects local-SSD storage.
+func (sv StorageVariant) IsLocalSSD() bool {
+	return sv.PreferLocalSSD
+}
+
+// ClusterSpecOptions returns the spec.Option values to apply when creating
+// a cluster for this variant.
+func (sv StorageVariant) ClusterSpecOptions() []Option {
+	var opts []Option
+	if sv.VolumeType != "" {
+		opts = append(opts, VolumeType(sv.VolumeType))
+	}
+	if sv.PreferLocalSSD {
+		opts = append(opts, PreferLocalSSD())
+	}
+	if sv.FileSystem != Ext4 {
+		opts = append(opts, SetFileSystem(sv.FileSystem))
+	}
+	return opts
+}
+
+// CloudVolumeTypes returns the available remote (non-local-SSD) volume types
+// for the given cloud provider. This is the single source of truth used by
+// both StorageVariants (for deterministic benchmark variants) and
+// RandomizeVolumeType (for non-benchmark coverage testing).
+func CloudVolumeTypes(cloud Cloud) []string {
+	switch cloud {
+	case AWS:
+		return []string{"gp3", "io2"}
+	case GCE:
+		return []string{"pd-ssd"}
+	case Azure:
+		return []string{"premium-ssd", "premium-ssd-v2", "ultra-disk"}
+	case IBM:
+		return []string{"10iops-tier"}
+	default:
+		return nil
+	}
+}
+
+// StorageVariants returns the standard set of non-default storage
+// configurations. Each entry produces a separate named test registration,
+// replacing the former RandomizeVolumeType() / RandomlyUseXfs() approach
+// for benchmark tests.
+//
+// The returned variants are the cross-product of:
+//   - Volume types: per-cloud types from CloudVolumeTypes, plus local-SSD
+//   - Filesystems: ext4 (default) and xfs
+//
+// This produces two variants per volume type (e.g., "vol=gp3" with ext4
+// and "vol=gp3/fs=xfs"). The base test (no variant suffix) always uses
+// the cloud's default volume type with ext4.
+//
+// Use the storageVariantRegs helper in the tests package to automatically
+// handle cloud filtering and local-SSD exclusion for tests with
+// DisableLocalSSD().
+func StorageVariants() []StorageVariant {
+	type baseVariant struct {
+		name           string
+		volumeType     string
+		preferLocalSSD bool
+		cloud          Cloud
+	}
+	bases := []baseVariant{}
+	for _, cloud := range []Cloud{AWS, GCE, Azure, IBM} {
+		for _, vt := range CloudVolumeTypes(cloud) {
+			bases = append(bases, baseVariant{
+				name:       "vol=" + vt,
+				volumeType: vt,
+				cloud:      cloud,
+			})
+		}
+	}
+	// Local SSD variant. Uses PreferLocalSSD() which is cloud-agnostic:
+	// it enables local SSDs where available (GCE AMD64, AWS with 'd'/'i3'
+	// machine types, Azure) and falls back to the default volume type
+	// otherwise. IBM does not support local SSDs, but the fallback
+	// handles that gracefully.
+	bases = append(bases, baseVariant{
+		name:           "local-ssd",
+		preferLocalSSD: true,
+		cloud:          AnyCloud,
+	})
+
+	// Cross with filesystems: ext4 (default) and xfs.
+	// XFS variant for the default volume type (the base test uses ext4).
+	variants := []StorageVariant{
+		{Name: "fs=xfs", FileSystem: Xfs, Cloud: AnyCloud},
+	}
+	// Cross each volume type / local-SSD base with both ext4 and xfs.
+	for _, b := range bases {
+		// ext4 variant (default filesystem, no suffix needed).
+		variants = append(variants, StorageVariant{
+			Name:           b.name,
+			VolumeType:     b.volumeType,
+			PreferLocalSSD: b.preferLocalSSD,
+			Cloud:          b.cloud,
+		})
+		// xfs variant.
+		variants = append(variants, StorageVariant{
+			Name:           b.name + "/fs=xfs",
+			VolumeType:     b.volumeType,
+			PreferLocalSSD: b.preferLocalSSD,
+			FileSystem:     Xfs,
+			Cloud:          b.cloud,
+		})
+	}
+	return variants
+}

--- a/pkg/cmd/roachtest/spec/storage_variant.go
+++ b/pkg/cmd/roachtest/spec/storage_variant.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package spec
+
+// StorageVariant represents a specific storage configuration (volume type,
+// filesystem, or local SSD preference) that should be tested as a distinct,
+// named test variant. This replaces random volume type and filesystem
+// selection at cluster creation time, ensuring that each test run uses a
+// deterministic infrastructure configuration identified by its test name.
+//
+// Tests register one variant per StorageVariant, restricting each to the
+// appropriate cloud provider. For example, a test compatible with AllClouds
+// would produce separate registrations for "vol=gp3" (AWS-only),
+// "vol=pd-ssd" (GCE-only), and so on.
+//
+// Storage variants cover two orthogonal axes:
+//   - Volume type (remote storage): cloud-specific types like gp3, pd-ssd, etc.
+//   - Local SSD: uses PreferLocalSSD(), applicable on clouds that support it
+//     (GCE, AWS, Azure). IBM does not support local SSDs.
+//
+// These are separate because local SSD is controlled via PreferLocalSSD() /
+// DisableLocalSSD() flags, not via VolumeType(). Tests that use
+// DisableLocalSSD() should pass skipLocalSSD=true to the storageVariantRegs
+// helper to exclude local-SSD variants.
+type StorageVariant struct {
+	// Name is the suffix appended to the test name (e.g., "vol=gp3",
+	// "fs=xfs", "local-ssd"). The test registers as "<baseName>/<Name>".
+	Name string
+	// VolumeType is the cloud-specific volume type string (e.g., "gp3",
+	// "pd-ssd"). Empty means use the cloud provider's default.
+	VolumeType string
+	// FileSystem overrides the filesystem. Zero value (Ext4) means default.
+	FileSystem fileSystemType
+	// PreferLocalSSD, when true, adds the PreferLocalSSD() option instead
+	// of a VolumeType. This is mutually exclusive with VolumeType.
+	PreferLocalSSD bool
+	// Cloud restricts this variant to a specific cloud provider. AnyCloud
+	// means the variant is cloud-agnostic (e.g., filesystem variants).
+	Cloud Cloud
+}
+
+// IsLocalSSD returns true if this variant selects local-SSD storage.
+func (sv StorageVariant) IsLocalSSD() bool {
+	return sv.PreferLocalSSD
+}
+
+// ClusterSpecOptions returns the spec.Option values to apply when creating
+// a cluster for this variant.
+func (sv StorageVariant) ClusterSpecOptions() []Option {
+	var opts []Option
+	if sv.VolumeType != "" {
+		opts = append(opts, VolumeType(sv.VolumeType))
+	}
+	if sv.PreferLocalSSD {
+		opts = append(opts, PreferLocalSSD())
+	}
+	opts = append(opts, SetFileSystem(sv.FileSystem))
+	return opts
+}
+
+// CloudVolumeTypes returns the available remote (non-local-SSD) volume types
+// for the given cloud provider. This is the single source of truth used by
+// both StorageVariants (for deterministic benchmark variants) and
+// RandomizeVolumeType (for non-benchmark coverage testing).
+func CloudVolumeTypes(cloud Cloud) []string {
+	switch cloud {
+	case AWS:
+		return []string{"gp3", "io2"}
+	case GCE:
+		return []string{"pd-ssd"}
+	case Azure:
+		return []string{"premium-ssd", "premium-ssd-v2", "ultra-disk"}
+	case IBM:
+		return []string{"10iops-tier"}
+	default:
+		return nil
+	}
+}
+
+// StorageVariants returns the standard set of non-default storage
+// configurations. Each entry produces a separate named test registration,
+// replacing the former RandomizeVolumeType() / RandomlyUseXfs() approach
+// for benchmark tests.
+//
+// The returned variants are the cross-product of:
+//   - Volume types: per-cloud types from CloudVolumeTypes, plus local-SSD
+//   - Filesystems: ext4 and xfs
+//
+// Every variant has an explicit filesystem suffix (e.g., "vol=gp3/fs=ext4"
+// and "vol=gp3/fs=xfs"). The base test (no variant suffix) uses the cloud's
+// default volume type and OS-default filesystem.
+//
+// Use the storageVariantRegs helper in the tests package to automatically
+// handle cloud filtering and local-SSD exclusion for tests with
+// DisableLocalSSD().
+func StorageVariants() []StorageVariant {
+	type baseVariant struct {
+		name           string
+		volumeType     string
+		preferLocalSSD bool
+		cloud          Cloud
+	}
+	bases := []baseVariant{}
+	for _, cloud := range []Cloud{AWS, GCE, Azure, IBM} {
+		for _, vt := range CloudVolumeTypes(cloud) {
+			bases = append(bases, baseVariant{
+				name:       "vol=" + vt,
+				volumeType: vt,
+				cloud:      cloud,
+			})
+		}
+	}
+	// Local SSD variant. Uses PreferLocalSSD() which is cloud-agnostic:
+	// it enables local SSDs where available (GCE AMD64, AWS with 'd'/'i3'
+	// machine types, Azure) and falls back to the default volume type
+	// otherwise. IBM does not support local SSDs, but the fallback
+	// handles that gracefully.
+	bases = append(bases, baseVariant{
+		name:           "local-ssd",
+		preferLocalSSD: true,
+		cloud:          AnyCloud,
+	})
+
+	// Cross with filesystems: ext4 (default) and xfs.
+	// Cross each volume type / local-SSD base with both ext4 and xfs.
+	var variants []StorageVariant
+	for _, b := range bases {
+		variants = append(variants, StorageVariant{
+			Name:           b.name + "/fs=ext4",
+			VolumeType:     b.volumeType,
+			PreferLocalSSD: b.preferLocalSSD,
+			FileSystem:     Ext4,
+			Cloud:          b.cloud,
+		})
+		variants = append(variants, StorageVariant{
+			Name:           b.name + "/fs=xfs",
+			VolumeType:     b.volumeType,
+			PreferLocalSSD: b.preferLocalSSD,
+			FileSystem:     Xfs,
+			Cloud:          b.cloud,
+		})
+	}
+	return variants
+}

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -199,6 +199,7 @@ go_library(
         "sqlsmith.go",
         "status_server.go",
         "stop_and_copy.go",
+        "storage_variant_helpers.go",
         "store_metrics.go",
         "super_region_failover.go",
         "sysbench.go",
@@ -389,6 +390,7 @@ go_test(
         "nodejs_helpers_test.go",
         "query_comparison_util_test.go",
         "restore_test.go",
+        "storage_variant_helpers_test.go",
         "sysbench_test.go",
         "tpcc_test.go",
         ":mocks_drt",  # keep

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -199,6 +199,7 @@ go_library(
         "sqlsmith.go",
         "status_server.go",
         "stop_and_copy.go",
+        "storage_variant_helpers.go",
         "store_metrics.go",
         "super_region_failover.go",
         "sysbench.go",

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -31,246 +31,250 @@ import (
 // bandwidth much higher than the provisioned one, the AC bandwidth limiter
 // paces the traffic at the set bandwidth limit.
 func registerDiskBandwidthOverload(r registry.Registry) {
-	r.Add(registry.TestSpec{
-		Name:      "admission-control/disk-bandwidth-limiter",
-		Owner:     registry.OwnerAdmissionControl,
-		Timeout:   3 * time.Hour,
-		Benchmark: true,
-		// Disabled on Azure and IBM due to inconsistent I/O performance
-		// causing the bandwidth lower-bound check to flake.
-		// See: https://github.com/cockroachdb/cockroach/issues/167455
-		CompatibleClouds: registry.AllExceptAzure.NoIBM(),
-		Suites:           registry.Suites(registry.Nightly),
+	// Disabled on Azure and IBM due to inconsistent I/O performance
+	// causing the bandwidth lower-bound check to flake.
+	// See: https://github.com/cockroachdb/cockroach/issues/167455
+	baseClouds := registry.AllExceptAzure.NoIBM()
+	baseSpecOpts := []spec.Option{
+		spec.CPU(8),
+		spec.WorkloadNode(),
+		spec.ReuseNone(),
 		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
-		Cluster: r.MakeClusterSpec(
-			2,
-			spec.CPU(8),
-			spec.WorkloadNode(),
-			spec.ReuseNone(),
-			spec.Arch(spec.AllExceptFIPS),
-			spec.RandomizeVolumeType(),
-			spec.RandomlyUseXfs(),
-		),
-		Leases: registry.MetamorphicLeases,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().NodeCount != 2 {
-				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
-			}
+		spec.Arch(spec.AllExceptFIPS),
+	}
+	for _, svReg := range storageVariantRegs(baseClouds, false) {
+		r.Add(registry.TestSpec{
+			Name:             "admission-control/disk-bandwidth-limiter" + svReg.nameSuffix,
+			Owner:            registry.OwnerAdmissionControl,
+			Timeout:          3 * time.Hour,
+			Benchmark:        true,
+			CompatibleClouds: svReg.clouds,
+			Suites:           registry.Suites(registry.Nightly),
+			Cluster: r.MakeClusterSpec(
+				2,
+				append(baseSpecOpts, svReg.specOpts...)...,
+			),
+			Leases: registry.MetamorphicLeases,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				if c.Spec().NodeCount != 2 {
+					t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
+				}
 
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
-				WithNodeExporter(c.CRDBNodes().InstallNodes()).
-				WithCluster(c.CRDBNodes().InstallNodes()).
-				WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
-			err := c.StartGrafana(ctx, t.L(), promCfg)
-			require.NoError(t, err)
+				promCfg := &prometheus.Config{}
+				promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+					WithNodeExporter(c.CRDBNodes().InstallNodes()).
+					WithCluster(c.CRDBNodes().InstallNodes()).
+					WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
+				err := c.StartGrafana(ctx, t.L(), promCfg)
+				require.NoError(t, err)
 
-			startOpts := option.NewStartOpts(option.NoBackupSchedule)
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
-				"--vmodule=io_load_listener=2")
-			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-			settings := install.MakeClusterSettings()
-			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
+				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+					"--vmodule=io_load_listener=2")
+				roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+				settings := install.MakeClusterSettings()
+				c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
-			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
-			require.NoError(t, err)
-			statCollector := clusterstats.NewStatsCollector(ctx, promClient)
+				promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+				require.NoError(t, err)
+				statCollector := clusterstats.NewStatsCollector(ctx, promClient)
 
-			roachtestutil.SetAdmissionControl(ctx, t, c, true)
+				roachtestutil.SetAdmissionControl(ctx, t, c, true)
 
-			const provisionedBandwidth = 128 << 20 // 128 MiB
-			t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s", provisionedBandwidth))
-			staller := roachtestutil.MakeCgroupDiskStaller(t, c,
-				true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
-			staller.Setup(ctx)
-			staller.Slow(ctx, c.CRDBNodes(), provisionedBandwidth /* bytesPerSecond */)
+				const provisionedBandwidth = 128 << 20 // 128 MiB
+				t.Status(fmt.Sprintf("limiting disk bandwidth to %d bytes/s", provisionedBandwidth))
+				staller := roachtestutil.MakeCgroupDiskStaller(t, c,
+					true /* readsToo */, false /* logsToo */, false /* disableStateValidation */)
+				staller.Setup(ctx)
+				staller.Slow(ctx, c.CRDBNodes(), provisionedBandwidth /* bytesPerSecond */)
 
-			// TODO(aaditya): Extend this test to also limit reads once we have a
-			// mechanism to pace read traffic in AC.
+				// TODO(aaditya): Extend this test to also limit reads once we have a
+				// mechanism to pace read traffic in AC.
 
-			// Initialize the kv databases.
-			t.Status(fmt.Sprintf("initializing kv dataset (<%s)", 2*time.Minute))
-			url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
-			const foregroundDB = " --db='regular_kv'"
-			const backgroundDB = " --db='background_kv'"
-
-			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
-				"./cockroach workload init kv --drop --insert-count=400 "+
-					"--max-block-bytes=256 --min-block-bytes=256"+foregroundDB+url)
-
-			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
-				"./cockroach workload init kv --drop --insert-count=400 "+
-					"--max-block-bytes=4096 --min-block-bytes=4096"+backgroundDB+url)
-
-			// Run foreground kv workload, QoS="regular".
-			duration := 45 * time.Minute
-			var monitoringStart, monitoringEnd time.Time
-			var totalBWValues []float64
-			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-			m.Go(func(ctx context.Context) error {
-				t.Status(fmt.Sprintf("starting foreground kv workload thread (<%s)", time.Minute))
-				dur := " --duration=" + duration.String()
+				// Initialize the kv databases.
+				t.Status(fmt.Sprintf("initializing kv dataset (<%s)", 2*time.Minute))
 				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
-				cmd := fmt.Sprintf("./cockroach workload run kv --concurrency=2 "+
-					"--splits=1000 --read-percent=50 --min-block-bytes=256 --max-block-bytes=256 "+
-					"--txn-qos='regular' --tolerate-errors %s %s %s",
-					foregroundDB, dur, url)
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
-				return nil
-			})
+				const foregroundDB = " --db='regular_kv'"
+				const backgroundDB = " --db='background_kv'"
 
-			// Run background kv workload, QoS="background".
-			m.Go(func(ctx context.Context) error {
-				t.Status(fmt.Sprintf("starting background kv workload thread (<%s)", time.Minute))
-				dur := " --duration=" + duration.String()
-				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
-				cmd := fmt.Sprintf("./cockroach workload run kv --concurrency=1024 "+
-					"--read-percent=0 --min-block-bytes=4096 --max-block-bytes=4096 "+
-					"--txn-qos='background' --tolerate-errors %s %s %s",
-					backgroundDB, dur, url)
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
-				return nil
-			})
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()),
+					"./cockroach workload init kv --drop --insert-count=400 "+
+						"--max-block-bytes=256 --min-block-bytes=256"+foregroundDB+url)
 
-			t.Status(fmt.Sprintf("waiting for workload to start and ramp up (<%s)", 15*time.Minute))
-			time.Sleep(15 * time.Minute)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()),
+					"./cockroach workload init kv --drop --insert-count=400 "+
+						"--max-block-bytes=4096 --min-block-bytes=4096"+backgroundDB+url)
 
-			db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
-			defer db.Close()
+				// Run foreground kv workload, QoS="regular".
+				duration := 45 * time.Minute
+				var monitoringStart, monitoringEnd time.Time
+				var totalBWValues []float64
+				m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+				m.Go(func(ctx context.Context) error {
+					t.Status(fmt.Sprintf("starting foreground kv workload thread (<%s)", time.Minute))
+					dur := " --duration=" + duration.String()
+					url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
+					cmd := fmt.Sprintf("./cockroach workload run kv --concurrency=2 "+
+						"--splits=1000 --read-percent=50 --min-block-bytes=256 --max-block-bytes=256 "+
+						"--txn-qos='regular' --tolerate-errors %s %s %s",
+						foregroundDB, dur, url)
+					c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
+					return nil
+				})
 
-			const bandwidthLimitMbs = 80 // 80 MiB
-			const maxUtilFraction = 0.8  // Also the default for the cluster setting.
-			if _, err := db.ExecContext(
-				// We intentionally set this to much lower than the provisioned value
-				// above to clearly show that the bandwidth limiter works.
-				ctx, fmt.Sprintf("SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '%dMiB'", bandwidthLimitMbs)); err != nil {
-				t.Fatalf("failed to set kvadmission.store.provisioned_bandwidth: %v", err)
-			}
-			if _, err := db.ExecContext(
-				ctx, fmt.Sprintf("SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = %f",
-					maxUtilFraction)); err != nil {
-				t.Fatalf("failed to set kvadmission.store.elastic_disk_bandwidth_max_util: %v", err)
-			}
+				// Run background kv workload, QoS="background".
+				m.Go(func(ctx context.Context) error {
+					t.Status(fmt.Sprintf("starting background kv workload thread (<%s)", time.Minute))
+					dur := " --duration=" + duration.String()
+					url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
+					cmd := fmt.Sprintf("./cockroach workload run kv --concurrency=1024 "+
+						"--read-percent=0 --min-block-bytes=4096 --max-block-bytes=4096 "+
+						"--txn-qos='background' --tolerate-errors %s %s %s",
+						backgroundDB, dur, url)
+					c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
+					return nil
+				})
 
-			t.Status(fmt.Sprintf(
-				"setting bandwidth limit to %dMiB/s, and waiting for it to take effect. (<%s)",
-				bandwidthLimitMbs, 2*time.Minute))
-			time.Sleep(5 * time.Minute)
+				t.Status(fmt.Sprintf("waiting for workload to start and ramp up (<%s)", 15*time.Minute))
+				time.Sleep(15 * time.Minute)
 
-			m.Go(func(ctx context.Context) error {
-				monitoringStart = timeutil.Now()
-				defer func() { monitoringEnd = timeutil.Now() }()
-				t.Status(fmt.Sprintf("starting monitoring thread (<%s)", time.Minute))
-				writeBWMetric := divQuery("rate(sys_host_disk_write_bytes[1m])", 1<<20 /* 1MiB */)
-				readBWMetric := divQuery("rate(sys_host_disk_read_bytes[1m])", 1<<20 /* 1MiB */)
-				getMetricVal := func(query string, label string) (float64, error) {
-					point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
+				db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
+				defer db.Close()
+
+				const bandwidthLimitMbs = 80 // 80 MiB
+				const maxUtilFraction = 0.8  // Also the default for the cluster setting.
+				if _, err := db.ExecContext(
+					// We intentionally set this to much lower than the provisioned value
+					// above to clearly show that the bandwidth limiter works.
+					ctx, fmt.Sprintf("SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '%dMiB'", bandwidthLimitMbs)); err != nil {
+					t.Fatalf("failed to set kvadmission.store.provisioned_bandwidth: %v", err)
+				}
+				if _, err := db.ExecContext(
+					ctx, fmt.Sprintf("SET CLUSTER SETTING kvadmission.store.elastic_disk_bandwidth_max_util = %f",
+						maxUtilFraction)); err != nil {
+					t.Fatalf("failed to set kvadmission.store.elastic_disk_bandwidth_max_util: %v", err)
+				}
+
+				t.Status(fmt.Sprintf(
+					"setting bandwidth limit to %dMiB/s, and waiting for it to take effect. (<%s)",
+					bandwidthLimitMbs, 2*time.Minute))
+				time.Sleep(5 * time.Minute)
+
+				m.Go(func(ctx context.Context) error {
+					monitoringStart = timeutil.Now()
+					defer func() { monitoringEnd = timeutil.Now() }()
+					t.Status(fmt.Sprintf("starting monitoring thread (<%s)", time.Minute))
+					writeBWMetric := divQuery("rate(sys_host_disk_write_bytes[1m])", 1<<20 /* 1MiB */)
+					readBWMetric := divQuery("rate(sys_host_disk_read_bytes[1m])", 1<<20 /* 1MiB */)
+					getMetricVal := func(query string, label string) (float64, error) {
+						point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
+						if err != nil {
+							t.L().Errorf("could not query prom %s", err.Error())
+							return 0, err
+						}
+						val := point[label]
+						if len(val) != 1 {
+							err = errors.Errorf(
+								"unexpected number %d of points for metric %s", len(val), query)
+							t.L().Errorf("%s", err.Error())
+							return 0, err
+						}
+						for storeID, v := range val {
+							t.L().Printf("%s(store=%s): %f", query, storeID, v.Value)
+							return v.Value, nil
+						}
+						// Unreachable.
+						panic("unreachable")
+					}
+
+					// Allow a 30% upper bound room for error.
+					const bandwidthUpperThreshold = bandwidthLimitMbs * maxUtilFraction * 1.30
+					// Allow a 20% lower bound room for error.
+					const bandwidthLowerThreshold = bandwidthLimitMbs * maxUtilFraction * 0.8
+					// Mean over 30*10 = 300s = 5m
+					const sampleCountForBW = 30
+					const collectionIntervalSeconds = 10.0
+					// Loop for ~20 minutes.
+					const numIterations = int(20 / (collectionIntervalSeconds / 60))
+					var writeBWValues []float64
+					numErrors := 0
+					numSuccesses := 0
+					for i := 0; i < numIterations; i++ {
+						time.Sleep(collectionIntervalSeconds * time.Second)
+						writeVal, err := getMetricVal(writeBWMetric, "node")
+						if err != nil {
+							numErrors++
+							continue
+						}
+						readVal, err := getMetricVal(readBWMetric, "node")
+						if err != nil {
+							numErrors++
+							continue
+						}
+						totalBW := writeVal + readVal
+						writeBWValues = append(writeBWValues, writeVal)
+						totalBWValues = append(totalBWValues, totalBW)
+						t.L().Printf("observed write BW: %f MiB/s, read BW: %f MiB/s, total BW: %f MiB/s",
+							writeVal, readVal, totalBW)
+						// We want to use the mean of the last 5m of data to avoid short-lived
+						// spikes causing failures.
+						if len(writeBWValues) >= sampleCountForBW {
+
+							// TODO(aaditya): We should be asserting on total bandwidth once reads
+							// are being paced.
+							latestSampleMeanForWriteBW := roachtestutil.GetMeanOverLastN(sampleCountForBW, writeBWValues)
+							latestSampleMeanForTotalBW := roachtestutil.GetMeanOverLastN(sampleCountForBW, totalBWValues)
+							t.L().Printf("mean write BW %f MiB/s, total BW %f MiB/s",
+								latestSampleMeanForWriteBW, latestSampleMeanForTotalBW)
+
+							if latestSampleMeanForWriteBW > bandwidthUpperThreshold {
+								t.Fatalf("mean write bandwidth %f exceeded threshold of %f",
+									latestSampleMeanForWriteBW, bandwidthUpperThreshold)
+							}
+							if latestSampleMeanForTotalBW < bandwidthLowerThreshold {
+								t.Fatalf("mean total bandwidth %f below threshold of %f",
+									latestSampleMeanForTotalBW, bandwidthLowerThreshold)
+							}
+							if latestSampleMeanForTotalBW > bandwidthUpperThreshold {
+								t.L().Printf("WARNING: mean total bandwidth %f exceeded threshold of %f, possibly because of lack of read shaping",
+									latestSampleMeanForTotalBW, bandwidthUpperThreshold)
+							}
+						}
+						numSuccesses++
+					}
+					t.Status(fmt.Sprintf("done monitoring, errors: %d successes: %d", numErrors, numSuccesses))
+					if numErrors > numSuccesses {
+						t.Fatalf("too many errors retrieving metrics")
+					}
+					return nil
+				})
+
+				m.Wait()
+
+				// Export mean total bandwidth as a scalar metric for roachperf,
+				// derived from the values collected during monitoring.
+				if !monitoringStart.IsZero() && !monitoringEnd.IsZero() {
+					_, err := statCollector.Exporter().Export(
+						ctx, c, t, false, /* dryRun */
+						monitoringStart, monitoringEnd,
+						[]clusterstats.AggQuery{},
+						func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+							if len(totalBWValues) == 0 {
+								return nil
+							}
+							return &roachtestutil.AggregatedMetric{
+								Name:           "mean_total_bandwidth",
+								Value:          roachtestutil.MetricPoint(roachtestutil.GetMeanOverLastN(len(totalBWValues), totalBWValues)),
+								Unit:           "MiB/s",
+								IsHigherBetter: true,
+							}
+						},
+					)
 					if err != nil {
-						t.L().Errorf("could not query prom %s", err.Error())
-						return 0, err
+						t.Fatal(err)
 					}
-					val := point[label]
-					if len(val) != 1 {
-						err = errors.Errorf(
-							"unexpected number %d of points for metric %s", len(val), query)
-						t.L().Errorf("%s", err.Error())
-						return 0, err
-					}
-					for storeID, v := range val {
-						t.L().Printf("%s(store=%s): %f", query, storeID, v.Value)
-						return v.Value, nil
-					}
-					// Unreachable.
-					panic("unreachable")
 				}
-
-				// Allow a 30% upper bound room for error.
-				const bandwidthUpperThreshold = bandwidthLimitMbs * maxUtilFraction * 1.30
-				// Allow a 20% lower bound room for error.
-				const bandwidthLowerThreshold = bandwidthLimitMbs * maxUtilFraction * 0.8
-				// Mean over 30*10 = 300s = 5m
-				const sampleCountForBW = 30
-				const collectionIntervalSeconds = 10.0
-				// Loop for ~20 minutes.
-				const numIterations = int(20 / (collectionIntervalSeconds / 60))
-				var writeBWValues []float64
-				numErrors := 0
-				numSuccesses := 0
-				for i := 0; i < numIterations; i++ {
-					time.Sleep(collectionIntervalSeconds * time.Second)
-					writeVal, err := getMetricVal(writeBWMetric, "node")
-					if err != nil {
-						numErrors++
-						continue
-					}
-					readVal, err := getMetricVal(readBWMetric, "node")
-					if err != nil {
-						numErrors++
-						continue
-					}
-					totalBW := writeVal + readVal
-					writeBWValues = append(writeBWValues, writeVal)
-					totalBWValues = append(totalBWValues, totalBW)
-					t.L().Printf("observed write BW: %f MiB/s, read BW: %f MiB/s, total BW: %f MiB/s",
-						writeVal, readVal, totalBW)
-					// We want to use the mean of the last 5m of data to avoid short-lived
-					// spikes causing failures.
-					if len(writeBWValues) >= sampleCountForBW {
-
-						// TODO(aaditya): We should be asserting on total bandwidth once reads
-						// are being paced.
-						latestSampleMeanForWriteBW := roachtestutil.GetMeanOverLastN(sampleCountForBW, writeBWValues)
-						latestSampleMeanForTotalBW := roachtestutil.GetMeanOverLastN(sampleCountForBW, totalBWValues)
-						t.L().Printf("mean write BW %f MiB/s, total BW %f MiB/s",
-							latestSampleMeanForWriteBW, latestSampleMeanForTotalBW)
-
-						if latestSampleMeanForWriteBW > bandwidthUpperThreshold {
-							t.Fatalf("mean write bandwidth %f exceeded threshold of %f",
-								latestSampleMeanForWriteBW, bandwidthUpperThreshold)
-						}
-						if latestSampleMeanForTotalBW < bandwidthLowerThreshold {
-							t.Fatalf("mean total bandwidth %f below threshold of %f",
-								latestSampleMeanForTotalBW, bandwidthLowerThreshold)
-						}
-						if latestSampleMeanForTotalBW > bandwidthUpperThreshold {
-							t.L().Printf("WARNING: mean total bandwidth %f exceeded threshold of %f, possibly because of lack of read shaping",
-								latestSampleMeanForTotalBW, bandwidthUpperThreshold)
-						}
-					}
-					numSuccesses++
-				}
-				t.Status(fmt.Sprintf("done monitoring, errors: %d successes: %d", numErrors, numSuccesses))
-				if numErrors > numSuccesses {
-					t.Fatalf("too many errors retrieving metrics")
-				}
-				return nil
-			})
-
-			m.Wait()
-
-			// Export mean total bandwidth as a scalar metric for roachperf,
-			// derived from the values collected during monitoring.
-			if !monitoringStart.IsZero() && !monitoringEnd.IsZero() {
-				_, err := statCollector.Exporter().Export(
-					ctx, c, t, false, /* dryRun */
-					monitoringStart, monitoringEnd,
-					[]clusterstats.AggQuery{},
-					func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
-						if len(totalBWValues) == 0 {
-							return nil
-						}
-						return &roachtestutil.AggregatedMetric{
-							Name:           "mean_total_bandwidth",
-							Value:          roachtestutil.MetricPoint(roachtestutil.GetMeanOverLastN(len(totalBWValues), totalBWValues)),
-							Unit:           "MiB/s",
-							IsHigherBetter: true,
-						}
-					},
-				)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-		},
-	})
+			},
+		})
+	}
 }

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -30,132 +30,135 @@ import (
 // the store. With admission control subjecting this low priority load to
 // elastic IO tokens, the overload is limited.
 func registerElasticIO(r registry.Registry) {
-	r.Add(registry.TestSpec{
-		Name:             "admission-control/elastic-io",
-		Owner:            registry.OwnerAdmissionControl,
-		Timeout:          time.Hour,
-		Benchmark:        true,
-		CompatibleClouds: registry.AllExceptAWS,
-		// TODO(sumeer): Reduce to weekly after working well.
-		Suites: registry.Suites(registry.Nightly),
-		// Tags:      registry.Tags(`weekly`),
-		// Second node is solely for Prometheus.
-		Cluster: r.MakeClusterSpec(
-			2,
-			spec.CPU(8),
-			spec.WorkloadNode(),
-			spec.RandomizeVolumeType(),
-			spec.RandomlyUseXfs(),
-		),
-		Leases: registry.MetamorphicLeases,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.IsLocal() {
-				t.Skip("IO overload test is not meant to run locally")
-			}
-			if c.Spec().NodeCount != 2 {
-				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
-			}
-
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
-				WithNodeExporter(c.CRDBNodes().InstallNodes()).
-				WithCluster(c.CRDBNodes().InstallNodes()).
-				WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana)
-			err := c.StartGrafana(ctx, t.L(), promCfg)
-			require.NoError(t, err)
-			startOpts := option.NewStartOpts(option.NoBackupSchedule)
-			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
-				"--vmodule=io_load_listener=2")
-			settings := install.MakeClusterSettings()
-			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
-			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
-			require.NoError(t, err)
-			statCollector := clusterstats.NewStatsCollector(ctx, promClient)
-			roachtestutil.SetAdmissionControl(ctx, t, c, true)
-			duration := 30 * time.Minute
-			t.Status("running workload")
-			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-			labels := map[string]string{
-				"duration":    fmt.Sprintf("%d", duration.Milliseconds()),
-				"concurrency": "512",
-			}
-			m.Go(func(ctx context.Context) error {
-				dur := " --duration=" + duration.String()
-				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
-				cmd := fmt.Sprintf("./cockroach workload run kv --init %s --concurrency=512 "+
-					"--splits=1000 --read-percent=0 --min-block-bytes=65536 --max-block-bytes=65536 "+
-					"--txn-qos=background --tolerate-errors --secure %s %s",
-					roachtestutil.GetWorkloadHistogramArgs(t, c, labels), dur, url)
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
-				return nil
-			})
-			m.Go(func(ctx context.Context) error {
-				const ioOverloadMetric = "admission_io_overload"
-				getMetricVal := func(metricName string) (float64, error) {
-					point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), metricName)
-					if err != nil {
-						t.L().Errorf("could not query prom %s", err.Error())
-						return 0, err
-					}
-					const labelName = "store"
-					val := point[labelName]
-					if len(val) != 1 {
-						err = errors.Errorf(
-							"unexpected number %d of points for metric %s", len(val), metricName)
-						t.L().Errorf("%s", err.Error())
-						return 0, err
-
-					}
-					for storeID, v := range val {
-						t.L().Printf("%s(store=%s): %f", metricName, storeID, v.Value)
-						return v.Value, nil
-					}
-					// Unreachable.
-					panic("unreachable")
+	baseClouds := registry.AllExceptAWS
+	baseSpecOpts := []spec.Option{
+		spec.CPU(8),
+		spec.WorkloadNode(),
+	}
+	for _, svReg := range storageVariantRegs(baseClouds, false) {
+		r.Add(registry.TestSpec{
+			Name:             "admission-control/elastic-io" + svReg.nameSuffix,
+			Owner:            registry.OwnerAdmissionControl,
+			Timeout:          time.Hour,
+			Benchmark:        true,
+			CompatibleClouds: svReg.clouds,
+			// TODO(sumeer): Reduce to weekly after working well.
+			Suites: registry.Suites(registry.Nightly),
+			// Second node is solely for Prometheus.
+			Cluster: r.MakeClusterSpec(
+				2,
+				append(baseSpecOpts, svReg.specOpts...)...,
+			),
+			Leases: registry.MetamorphicLeases,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				if c.IsLocal() {
+					t.Skip("IO overload test is not meant to run locally")
 				}
-				now := timeutil.Now()
-				endTime := now.Add(duration)
-				// We typically see fluctuations from 0.05 to 0.25 IO overload score
-				// because the elastic IO token logic gives 1.25*compaction-bandwidth
-				// tokens at 0.05 score and 0.75*compaction-bandwidth at 0.25 score,
-				// with 0.25 score being very rare. We leave some breathing room and
-				// pick a threshold of greater than 0.35 to fail the test. If elastic
-				// tokens are not working, the threshold of 0.35 will be easily
-				// breached, since regular tokens allow the score to exceed 0.5.
-				const ioOverloadThreshold = 0.35
-				const sampleCountForIOOverload = 12
-				var ioOverloadScore []float64
-				// Sleep initially for stability to be achieved, before measuring.
-				time.Sleep(5 * time.Minute)
-				for {
-					select {
-					case <-ctx.Done():
-						return ctx.Err()
-					default:
+				if c.Spec().NodeCount != 2 {
+					t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
+				}
+
+				promCfg := &prometheus.Config{}
+				promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+					WithNodeExporter(c.CRDBNodes().InstallNodes()).
+					WithCluster(c.CRDBNodes().InstallNodes()).
+					WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana)
+				err := c.StartGrafana(ctx, t.L(), promCfg)
+				require.NoError(t, err)
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
+				roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+					"--vmodule=io_load_listener=2")
+				settings := install.MakeClusterSettings()
+				c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
+				promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+				require.NoError(t, err)
+				statCollector := clusterstats.NewStatsCollector(ctx, promClient)
+				roachtestutil.SetAdmissionControl(ctx, t, c, true)
+				duration := 30 * time.Minute
+				t.Status("running workload")
+				m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+				labels := map[string]string{
+					"duration":    fmt.Sprintf("%d", duration.Milliseconds()),
+					"concurrency": "512",
+				}
+				m.Go(func(ctx context.Context) error {
+					dur := " --duration=" + duration.String()
+					url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
+					cmd := fmt.Sprintf("./cockroach workload run kv --init %s --concurrency=512 "+
+						"--splits=1000 --read-percent=0 --min-block-bytes=65536 --max-block-bytes=65536 "+
+						"--txn-qos=background --tolerate-errors --secure %s %s",
+						roachtestutil.GetWorkloadHistogramArgs(t, c, labels), dur, url)
+					c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
+					return nil
+				})
+				m.Go(func(ctx context.Context) error {
+					const ioOverloadMetric = "admission_io_overload"
+					getMetricVal := func(metricName string) (float64, error) {
+						point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), metricName)
+						if err != nil {
+							t.L().Errorf("could not query prom %s", err.Error())
+							return 0, err
+						}
+						const labelName = "store"
+						val := point[labelName]
+						if len(val) != 1 {
+							err = errors.Errorf(
+								"unexpected number %d of points for metric %s", len(val), metricName)
+							t.L().Errorf("%s", err.Error())
+							return 0, err
+
+						}
+						for storeID, v := range val {
+							t.L().Printf("%s(store=%s): %f", metricName, storeID, v.Value)
+							return v.Value, nil
+						}
+						// Unreachable.
+						panic("unreachable")
 					}
-					time.Sleep(10 * time.Second)
-					val, err := getMetricVal(ioOverloadMetric)
-					if err != nil {
-						continue
-					}
-					ioOverloadScore = append(ioOverloadScore, val)
-					// We want to use the mean of the last 2m of data to avoid short-lived
-					// spikes causing failures.
-					if len(ioOverloadScore) >= sampleCountForIOOverload {
-						latestSampleMeanIOOverloadScore :=
-							roachtestutil.GetMeanOverLastN(sampleCountForIOOverload, ioOverloadScore)
-						if latestSampleMeanIOOverloadScore > ioOverloadThreshold {
-							t.Fatalf("io-overload score mean %f over last %d iterations exceeded threshold",
-								latestSampleMeanIOOverloadScore, sampleCountForIOOverload)
+					now := timeutil.Now()
+					endTime := now.Add(duration)
+					// We typically see fluctuations from 0.05 to 0.25 IO overload score
+					// because the elastic IO token logic gives 1.25*compaction-bandwidth
+					// tokens at 0.05 score and 0.75*compaction-bandwidth at 0.25 score,
+					// with 0.25 score being very rare. We leave some breathing room and
+					// pick a threshold of greater than 0.35 to fail the test. If elastic
+					// tokens are not working, the threshold of 0.35 will be easily
+					// breached, since regular tokens allow the score to exceed 0.5.
+					const ioOverloadThreshold = 0.35
+					const sampleCountForIOOverload = 12
+					var ioOverloadScore []float64
+					// Sleep initially for stability to be achieved, before measuring.
+					time.Sleep(5 * time.Minute)
+					for {
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						default:
+						}
+						time.Sleep(10 * time.Second)
+						val, err := getMetricVal(ioOverloadMetric)
+						if err != nil {
+							continue
+						}
+						ioOverloadScore = append(ioOverloadScore, val)
+						// We want to use the mean of the last 2m of data to avoid short-lived
+						// spikes causing failures.
+						if len(ioOverloadScore) >= sampleCountForIOOverload {
+							latestSampleMeanIOOverloadScore :=
+								roachtestutil.GetMeanOverLastN(sampleCountForIOOverload, ioOverloadScore)
+							if latestSampleMeanIOOverloadScore > ioOverloadThreshold {
+								t.Fatalf("io-overload score mean %f over last %d iterations exceeded threshold",
+									latestSampleMeanIOOverloadScore, sampleCountForIOOverload)
+							}
+						}
+						if timeutil.Now().After(endTime) {
+							return nil
 						}
 					}
-					if timeutil.Now().After(endTime) {
-						return nil
-					}
-				}
-			})
-			m.Wait()
-		},
-	})
+				})
+				m.Wait()
+			},
+		})
+	}
 }

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -32,143 +32,145 @@ import (
 // intents. When intent resolution is not subject to admission control, the
 // LSM gets overloaded and has > 50 sub-levels.
 func registerIntentResolutionOverload(r registry.Registry) {
-	r.Add(registry.TestSpec{
-		Name:      "admission-control/intent-resolution",
-		Owner:     registry.OwnerAdmissionControl,
-		Timeout:   time.Hour,
-		Benchmark: true,
-		// TODO(sumeer): Reduce to weekly after working well.
-		// Tags:      registry.Tags(`weekly`),
-		// Second node is solely for Prometheus.
-		Cluster: r.MakeClusterSpec(
-			2,
-			spec.CPU(8),
-			spec.WorkloadNode(),
-			spec.RandomizeVolumeType(),
-			spec.RandomlyUseXfs(),
-		),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
-		Suites:           registry.Suites(registry.Nightly),
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().NodeCount != 2 {
-				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
-			}
-
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
-				WithNodeExporter(c.CRDBNodes().InstallNodes()).
-				WithCluster(c.CRDBNodes().InstallNodes()).
-				WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana)
-			err := c.StartGrafana(ctx, t.L(), promCfg)
-			require.NoError(t, err)
-
-			startOpts := option.NewStartOpts(option.NoBackupSchedule)
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
-				"--vmodule=io_load_listener=2")
-			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-			settings := install.MakeClusterSettings()
-			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
-
-			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
-			require.NoError(t, err)
-			statCollector := clusterstats.NewStatsCollector(ctx, promClient)
-
-			roachtestutil.SetAdmissionControl(ctx, t, c, true)
-			t.Status("running txn")
-			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-			m.Go(func(ctx context.Context) error {
-				db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
-				defer db.Close()
-				_, err := db.Exec(`CREATE TABLE test_table(id integer PRIMARY KEY, t TEXT)`)
-				if err != nil {
-					return err
+	baseClouds := registry.AllExceptAWS
+	baseSpecOpts := []spec.Option{
+		spec.CPU(8),
+		spec.WorkloadNode(),
+	}
+	for _, svReg := range storageVariantRegs(baseClouds, false) {
+		r.Add(registry.TestSpec{
+			Name:      "admission-control/intent-resolution" + svReg.nameSuffix,
+			Owner:     registry.OwnerAdmissionControl,
+			Timeout:   time.Hour,
+			Benchmark: true,
+			// Second node is solely for Prometheus.
+			Cluster: r.MakeClusterSpec(
+				2,
+				append(baseSpecOpts, svReg.specOpts...)...,
+			),
+			Leases:           registry.MetamorphicLeases,
+			CompatibleClouds: svReg.clouds,
+			Suites:           registry.Suites(registry.Nightly),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				if c.Spec().NodeCount != 2 {
+					t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
 				}
-				tx, err := db.BeginTx(ctx, &gosql.TxOptions{})
-				if err != nil {
-					return err
-				}
-				query := `INSERT INTO test_table(id, t) SELECT i, sha512(random()::text) FROM ` +
-					`generate_series(0, 75000000) AS t(i);`
-				_, err = tx.ExecContext(ctx, query)
-				if err != nil {
-					return err
-				}
-				t.Status("intents created, committing txn")
-				err = tx.Commit()
-				if err != nil {
-					return err
-				}
-				t.Status("waiting for async intent resolution to complete")
-				const subLevelMetric = "storage_l0_sublevels"
-				const intentCountMetric = "intentcount"
-				getMetricVal := func(metricName string) (float64, error) {
-					point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), metricName)
+
+				promCfg := &prometheus.Config{}
+				promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+					WithNodeExporter(c.CRDBNodes().InstallNodes()).
+					WithCluster(c.CRDBNodes().InstallNodes()).
+					WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana)
+				err := c.StartGrafana(ctx, t.L(), promCfg)
+				require.NoError(t, err)
+
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
+				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+					"--vmodule=io_load_listener=2")
+				roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+				settings := install.MakeClusterSettings()
+				c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
+
+				promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+				require.NoError(t, err)
+				statCollector := clusterstats.NewStatsCollector(ctx, promClient)
+
+				roachtestutil.SetAdmissionControl(ctx, t, c, true)
+				t.Status("running txn")
+				m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+				m.Go(func(ctx context.Context) error {
+					db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
+					defer db.Close()
+					_, err := db.Exec(`CREATE TABLE test_table(id integer PRIMARY KEY, t TEXT)`)
 					if err != nil {
-						t.L().Errorf("could not query prom %s", err.Error())
-						return 0, err
+						return err
 					}
-					const labelName = "store"
-					val := point[labelName]
-					if len(val) != 1 {
-						err = errors.Errorf(
-							"unexpected number %d of points for metric %s", len(val), metricName)
-						t.L().Errorf("%s", err.Error())
-						return 0, err
-					}
-					for storeID, v := range val {
-						t.L().Printf("%s(store=%s): %f", metricName, storeID, v.Value)
-						return v.Value, nil
-					}
-					// Unreachable.
-					panic("unreachable")
-				}
-				// Loop for up to 20 minutes. Intents take ~10min to resolve, and
-				// we're padding by another 10min.
-				const subLevelThreshold = 20
-				const sampleCountForL0Sublevel = 12
-				numErrors := 0
-				numSuccesses := 0
-				latestIntentCount := math.MaxInt
-				var l0SublevelCount []float64
-				for i := 0; i < 120; i++ {
-					time.Sleep(10 * time.Second)
-					val, err := getMetricVal(subLevelMetric)
+					tx, err := db.BeginTx(ctx, &gosql.TxOptions{})
 					if err != nil {
-						numErrors++
-						continue
+						return err
 					}
-					l0SublevelCount = append(l0SublevelCount, val)
-					// We want to use the mean of the last 2m of data to avoid short-lived
-					// spikes causing failures.
-					if len(l0SublevelCount) >= sampleCountForL0Sublevel {
-						latestSampleMeanL0Sublevels := roachtestutil.GetMeanOverLastN(sampleCountForL0Sublevel, l0SublevelCount)
-						if latestSampleMeanL0Sublevels > subLevelThreshold {
-							t.Fatalf("sub-level mean %f over last %d iterations exceeded threshold", latestSampleMeanL0Sublevels, sampleCountForL0Sublevel)
+					query := `INSERT INTO test_table(id, t) SELECT i, sha512(random()::text) FROM ` +
+						`generate_series(0, 75000000) AS t(i);`
+					_, err = tx.ExecContext(ctx, query)
+					if err != nil {
+						return err
+					}
+					t.Status("intents created, committing txn")
+					err = tx.Commit()
+					if err != nil {
+						return err
+					}
+					t.Status("waiting for async intent resolution to complete")
+					const subLevelMetric = "storage_l0_sublevels"
+					const intentCountMetric = "intentcount"
+					getMetricVal := func(metricName string) (float64, error) {
+						point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), metricName)
+						if err != nil {
+							t.L().Errorf("could not query prom %s", err.Error())
+							return 0, err
+						}
+						const labelName = "store"
+						val := point[labelName]
+						if len(val) != 1 {
+							err = errors.Errorf(
+								"unexpected number %d of points for metric %s", len(val), metricName)
+							t.L().Errorf("%s", err.Error())
+							return 0, err
+						}
+						for storeID, v := range val {
+							t.L().Printf("%s(store=%s): %f", metricName, storeID, v.Value)
+							return v.Value, nil
+						}
+						// Unreachable.
+						panic("unreachable")
+					}
+					// Loop for up to 20 minutes. Intents take ~10min to resolve, and
+					// we're padding by another 10min.
+					const subLevelThreshold = 20
+					const sampleCountForL0Sublevel = 12
+					numErrors := 0
+					numSuccesses := 0
+					latestIntentCount := math.MaxInt
+					var l0SublevelCount []float64
+					for i := 0; i < 120; i++ {
+						time.Sleep(10 * time.Second)
+						val, err := getMetricVal(subLevelMetric)
+						if err != nil {
+							numErrors++
+							continue
+						}
+						l0SublevelCount = append(l0SublevelCount, val)
+						// We want to use the mean of the last 2m of data to avoid short-lived
+						// spikes causing failures.
+						if len(l0SublevelCount) >= sampleCountForL0Sublevel {
+							latestSampleMeanL0Sublevels := roachtestutil.GetMeanOverLastN(sampleCountForL0Sublevel, l0SublevelCount)
+							if latestSampleMeanL0Sublevels > subLevelThreshold {
+								t.Fatalf("sub-level mean %f over last %d iterations exceeded threshold", latestSampleMeanL0Sublevels, sampleCountForL0Sublevel)
+							}
+						}
+						val, err = getMetricVal(intentCountMetric)
+						if err != nil {
+							numErrors++
+							continue
+						}
+						numSuccesses++
+						latestIntentCount = int(val)
+						if latestIntentCount < 10 {
+							break
 						}
 					}
-					val, err = getMetricVal(intentCountMetric)
-					if err != nil {
-						numErrors++
-						continue
+					t.Status(fmt.Sprintf("done waiting errors: %d successes: %d, intent-count: %d",
+						numErrors, numSuccesses, latestIntentCount))
+					if latestIntentCount > 20 {
+						t.Fatalf("too many intents left")
 					}
-					numSuccesses++
-					latestIntentCount = int(val)
-					if latestIntentCount < 10 {
-						break
+					if numErrors > numSuccesses {
+						t.Fatalf("too many errors retrieving metrics")
 					}
-				}
-				t.Status(fmt.Sprintf("done waiting errors: %d successes: %d, intent-count: %d",
-					numErrors, numSuccesses, latestIntentCount))
-				if latestIntentCount > 20 {
-					t.Fatalf("too many intents left")
-				}
-				if numErrors > numSuccesses {
-					t.Fatalf("too many errors retrieving metrics")
-				}
-				return nil
-			})
-			m.Wait()
-		},
-	})
+					return nil
+				})
+				m.Wait()
+			},
+		})
+	}
 }

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -33,36 +33,40 @@ import (
 // brought down. Upon restart, n3 starts to receive large amounts of snapshot
 // data. It is expected that l0 sublevel counts and p99 latencies remain stable.
 func registerSnapshotOverloadIO(r registry.Registry) {
-	spec := func(subtest string, cfg admissionControlSnapshotOverloadIOOpts) registry.TestSpec {
-		return registry.TestSpec{
-			Name:             "admission-control/snapshot-overload-io/" + subtest,
-			Owner:            registry.OwnerAdmissionControl,
-			Benchmark:        true,
-			CompatibleClouds: registry.OnlyGCE,
-			Suites:           registry.Suites(registry.Weekly),
-			Cluster: r.MakeClusterSpec(
-				4,
-				spec.CPU(4),
-				spec.WorkloadNode(),
-				spec.VolumeSize(cfg.volumeSize),
-				spec.ReuseNone(),
-				spec.DisableLocalSSD(),
-				spec.RandomizeVolumeType(),
-				spec.RandomlyUseXfs(),
-				// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
-				spec.Arch(spec.AllExceptFIPS),
-			),
-			Leases:  registry.MetamorphicLeases,
-			Timeout: 12 * time.Hour,
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runAdmissionControlSnapshotOverloadIO(ctx, t, c, cfg)
-			},
+	baseClouds := registry.OnlyGCE
+	addVariants := func(subtest string, cfg admissionControlSnapshotOverloadIOOpts) {
+		baseSpecOpts := []spec.Option{
+			spec.CPU(4),
+			spec.WorkloadNode(),
+			spec.VolumeSize(cfg.volumeSize),
+			spec.ReuseNone(),
+			spec.DisableLocalSSD(),
+			// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
+			spec.Arch(spec.AllExceptFIPS),
+		}
+		for _, svReg := range storageVariantRegs(baseClouds, true /* skipLocalSSD */) {
+			r.Add(registry.TestSpec{
+				Name:             "admission-control/snapshot-overload-io/" + subtest + svReg.nameSuffix,
+				Owner:            registry.OwnerAdmissionControl,
+				Benchmark:        true,
+				CompatibleClouds: svReg.clouds,
+				Suites:           registry.Suites(registry.Weekly),
+				Cluster: r.MakeClusterSpec(
+					4,
+					append(baseSpecOpts, svReg.specOpts...)...,
+				),
+				Leases:  registry.MetamorphicLeases,
+				Timeout: 12 * time.Hour,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runAdmissionControlSnapshotOverloadIO(ctx, t, c, cfg)
+				},
+			})
 		}
 	}
 
 	// This tests the ability of the storage engine to handle a high rate of
 	// snapshots while maintaining a healthy LSM shape and stable p99 latencies.
-	r.Add(spec("excise", admissionControlSnapshotOverloadIOOpts{
+	addVariants("excise", admissionControlSnapshotOverloadIOOpts{
 		// The test uses a large volume size to ensure high provisioned bandwidth
 		// from the cloud provider.
 		volumeSize: 2000,
@@ -75,11 +79,11 @@ func registerSnapshotOverloadIO(r registry.Registry) {
 		readPercent:                75,
 		workloadBlockBytes:         12288,
 		rebalanceRate:              "256MiB",
-	}))
+	})
 
 	// This tests the behaviour of snapshot ingestion in bandwidth constrained
 	// environments.
-	r.Add(spec("bandwidth", admissionControlSnapshotOverloadIOOpts{
+	addVariants("bandwidth", admissionControlSnapshotOverloadIOOpts{
 		// 2x headroom from the ~500GB pre-population of the test.
 		volumeSize:                 1000,
 		limitCompactionConcurrency: false,
@@ -87,8 +91,7 @@ func registerSnapshotOverloadIO(r registry.Registry) {
 		readPercent:                20,
 		workloadBlockBytes:         1024,
 		rebalanceRate:              "1GiB",
-	}))
-
+	})
 }
 
 type admissionControlSnapshotOverloadIOOpts struct {

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -343,17 +343,6 @@ func registerKV(r registry.Registry) {
 		if opts.nodes > 3 {
 			workloadNodeCPUs = opts.cpus
 		}
-		cSpec := r.MakeClusterSpec(
-			opts.nodes+1,
-			spec.CPU(opts.cpus),
-			spec.WorkloadNode(),
-			spec.WorkloadNodeCPU(workloadNodeCPUs),
-			spec.Disks(opts.ssds),
-			spec.RAID0(opts.raid0),
-			spec.RandomizeVolumeType(),
-			spec.RandomlyUseXfs(),
-		)
-
 		var clouds registry.CloudSet
 		tags := make(map[string]struct{})
 		if opts.ssds != 0 {
@@ -379,96 +368,115 @@ func registerKV(r registry.Registry) {
 			skipPostValidations = registry.PostValidationReplicaDivergence
 		}
 
-		r.Add(registry.TestSpec{
-			Name:      strings.Join(nameParts, "/"),
-			Owner:     owner,
-			Benchmark: true,
-			Cluster:   cSpec,
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runKV(ctx, t, c, opts)
-			},
-			CompatibleClouds:    clouds,
-			Suites:              suites,
-			EncryptionSupport:   encryption,
-			SkipPostValidations: skipPostValidations,
-		})
+		baseName := strings.Join(nameParts, "/")
+		baseSpecOpts := []spec.Option{
+			spec.CPU(opts.cpus),
+			spec.WorkloadNode(),
+			spec.WorkloadNodeCPU(workloadNodeCPUs),
+			spec.Disks(opts.ssds),
+			spec.RAID0(opts.raid0),
+		}
+		for _, svReg := range storageVariantRegs(clouds, false) {
+			cSpec := r.MakeClusterSpec(
+				opts.nodes+1,
+				append(baseSpecOpts, svReg.specOpts...)...,
+			)
+			r.Add(registry.TestSpec{
+				Name:      baseName + svReg.nameSuffix,
+				Owner:     owner,
+				Benchmark: true,
+				Cluster:   cSpec,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runKV(ctx, t, c, opts)
+				},
+				CompatibleClouds:    svReg.clouds,
+				Suites:              suites,
+				EncryptionSupport:   encryption,
+				SkipPostValidations: skipPostValidations,
+			})
+		}
 	}
 }
 
 func registerKVContention(r registry.Registry) {
 	const nodes = 4
-	r.Add(registry.TestSpec{
-		Name:      fmt.Sprintf("kv/contention/nodes=%d", nodes),
-		Owner:     registry.OwnerKV,
-		Benchmark: true,
-		Cluster: r.MakeClusterSpec(
-			nodes+1,
-			spec.WorkloadNode(),
-			spec.RandomizeVolumeType(),
-			spec.RandomlyUseXfs(),
-		),
-		CompatibleClouds: registry.AllExceptAWS,
-		Suites:           registry.Suites(registry.Nightly),
-		Leases:           registry.MetamorphicLeases,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			// Start the cluster with an extremely high txn liveness threshold.
-			// If requests ever get stuck on a transaction that was abandoned
-			// then it will take 10m for them to get unstuck, at which point the
-			// QPS threshold check in the test is guaranteed to fail.
-			settings := install.MakeClusterSettings()
-			settings.Env = append(settings.Env, "COCKROACH_TXN_LIVENESS_HEARTBEAT_MULTIPLIER=600")
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.CRDBNodes())
+	baseName := fmt.Sprintf("kv/contention/nodes=%d", nodes)
+	baseClouds := registry.AllExceptAWS
+	baseSpecOpts := []spec.Option{
+		spec.WorkloadNode(),
+	}
+	for _, svReg := range storageVariantRegs(baseClouds, false) {
+		r.Add(registry.TestSpec{
+			Name:      baseName + svReg.nameSuffix,
+			Owner:     registry.OwnerKV,
+			Benchmark: true,
+			Cluster: r.MakeClusterSpec(
+				nodes+1,
+				append(baseSpecOpts, svReg.specOpts...)...,
+			),
+			CompatibleClouds: svReg.clouds,
+			Suites:           registry.Suites(registry.Nightly),
+			Leases:           registry.MetamorphicLeases,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				// Start the cluster with an extremely high txn liveness threshold.
+				// If requests ever get stuck on a transaction that was abandoned
+				// then it will take 10m for them to get unstuck, at which point the
+				// QPS threshold check in the test is guaranteed to fail.
+				settings := install.MakeClusterSettings()
+				settings.Env = append(settings.Env, "COCKROACH_TXN_LIVENESS_HEARTBEAT_MULTIPLIER=600")
+				c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.CRDBNodes())
 
-			conn := c.Conn(ctx, t.L(), 1)
-			// Enable request tracing, which is a good tool for understanding
-			// how different transactions are interacting.
-			if _, err := conn.Exec(`
+				conn := c.Conn(ctx, t.L(), 1)
+				// Enable request tracing, which is a good tool for understanding
+				// how different transactions are interacting.
+				if _, err := conn.Exec(`
 				SET CLUSTER SETTING trace.debug.enable = true;
 			`); err != nil {
-				t.Fatal(err)
-			}
-			// Drop the deadlock detection delay because the test creates a
-			// large number transaction deadlocks.
-			if _, err := conn.Exec(`
+					t.Fatal(err)
+				}
+				// Drop the deadlock detection delay because the test creates a
+				// large number transaction deadlocks.
+				if _, err := conn.Exec(`
 				SET CLUSTER SETTING kv.lock_table.deadlock_detection_push_delay = '5ms'
 			`); err != nil && !strings.Contains(err.Error(), "unknown cluster setting") {
-				t.Fatal(err)
-			}
+					t.Fatal(err)
+				}
 
-			t.Status("running workload")
-			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-			m.Go(func(ctx context.Context) error {
-				// Write to a small number of keys to generate a large amount of
-				// contention. Use a relatively high amount of concurrency and
-				// aim to average one concurrent write for each key in the keyspace.
-				const cycleLength = 512
-				const concurrency = 128
-				const avgConcPerKey = 1
-				const batchSize = avgConcPerKey * (cycleLength / concurrency)
+				t.Status("running workload")
+				m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
+				m.Go(func(ctx context.Context) error {
+					// Write to a small number of keys to generate a large amount of
+					// contention. Use a relatively high amount of concurrency and
+					// aim to average one concurrent write for each key in the keyspace.
+					const cycleLength = 512
+					const concurrency = 128
+					const avgConcPerKey = 1
+					const batchSize = avgConcPerKey * (cycleLength / concurrency)
 
-				// Split the table so that each node can have a single leaseholder.
-				splits := nodes
+					// Split the table so that each node can have a single leaseholder.
+					splits := nodes
 
-				// Run the workload for an hour. Add a secondary index to avoid
-				// UPSERTs performing blind writes.
-				const duration = 1 * time.Hour
-				cmd := fmt.Sprintf("./cockroach workload run kv --init --secondary-index --duration=%s "+
-					"--cycle-length=%d --concurrency=%d --batch=%d --splits=%d {pgurl%s}",
-					duration, cycleLength, concurrency, batchSize, splits, c.CRDBNodes())
-				start := timeutil.Now()
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
-				end := timeutil.Now()
+					// Run the workload for an hour. Add a secondary index to avoid
+					// UPSERTs performing blind writes.
+					const duration = 1 * time.Hour
+					cmd := fmt.Sprintf("./cockroach workload run kv --init --secondary-index --duration=%s "+
+						"--cycle-length=%d --concurrency=%d --batch=%d --splits=%d {pgurl%s}",
+						duration, cycleLength, concurrency, batchSize, splits, c.CRDBNodes())
+					start := timeutil.Now()
+					c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
+					end := timeutil.Now()
 
-				// Assert that the average throughput stayed above a certain
-				// threshold. In this case, assert that max throughput only
-				// dipped below 50 qps for 10% of the time.
-				const minQPS = 50
-				verifyTxnPerSecond(ctx, c, t, c.Node(1), start, end, minQPS, 0.1)
-				return nil
-			})
-			m.Wait()
-		},
-	})
+					// Assert that the average throughput stayed above a certain
+					// threshold. In this case, assert that max throughput only
+					// dipped below 50 qps for 10% of the time.
+					const minQPS = 50
+					verifyTxnPerSecond(ctx, c, t, c.Node(1), start, end, minQPS, 0.1)
+					return nil
+				})
+				m.Wait()
+			},
+		})
+	}
 }
 
 func registerKVLongRunningTxn(r registry.Registry) {
@@ -790,12 +798,12 @@ func registerKVSplits(r registry.Registry) {
 		},
 	} {
 		item := item // for use in closure below
-		name := fmt.Sprintf("kv/splits/nodes=3/quiesce=%t/lease=%s", item.quiesce, item.leases)
+		baseName := fmt.Sprintf("kv/splits/nodes=3/quiesce=%t/lease=%s", item.quiesce, item.leases)
 		if item.envVars != nil {
-			name += "/tuned"
+			baseName += "/tuned"
 		}
 		r.Add(registry.TestSpec{
-			Name:    name,
+			Name:    baseName,
 			Owner:   registry.OwnerKV,
 			Timeout: item.timeout,
 			Cluster: r.MakeClusterSpec(

--- a/pkg/cmd/roachtest/tests/kv_rangefeed.go
+++ b/pkg/cmd/roachtest/tests/kv_rangefeed.go
@@ -497,27 +497,31 @@ func registerKVRangefeed(r registry.Registry) {
 		if cpus == 0 {
 			cpus = 8 // default
 		}
-		r.Add(registry.TestSpec{
-			Name:      testName,
-			Owner:     registry.OwnerKV,
-			Benchmark: true,
-			Cluster: r.MakeClusterSpec(
-				4,
-				spec.CPU(cpus),
-				spec.WorkloadNode(),
-				spec.WorkloadNodeCPU(4),
-				spec.RandomizeVolumeType(),
-				spec.RandomlyUseXfs(),
-			),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runKVRangefeed(ctx, t, c, opts)
-			},
-			// This test is compatible with all clouds, but suspected disk
-			// throughput issues (e.g. gp3 on AWS) and lower observability
-			// (no Grafana on AWS) prompted us to restrict to GCE for the
-			// time being. See #163197.
-			CompatibleClouds: registry.OnlyGCE,
-			Suites:           registry.Suites(registry.Nightly),
-		})
+		// This test is compatible with all clouds, but suspected disk
+		// throughput issues (e.g. gp3 on AWS) and lower observability
+		// (no Grafana on AWS) prompted us to restrict to GCE for the
+		// time being. See #163197.
+		baseClouds := registry.OnlyGCE
+		baseSpecOpts := []spec.Option{
+			spec.CPU(cpus),
+			spec.WorkloadNode(),
+			spec.WorkloadNodeCPU(4),
+		}
+		for _, svReg := range storageVariantRegs(baseClouds, false) {
+			r.Add(registry.TestSpec{
+				Name:      testName + svReg.nameSuffix,
+				Owner:     registry.OwnerKV,
+				Benchmark: true,
+				Cluster: r.MakeClusterSpec(
+					4,
+					append(baseSpecOpts, svReg.specOpts...)...,
+				),
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runKVRangefeed(ctx, t, c, opts)
+				},
+				CompatibleClouds: svReg.clouds,
+				Suites:           registry.Suites(registry.Nightly),
+			})
+		}
 	}
 }

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -63,12 +63,10 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 	if b.NumShards > 0 {
 		nameParts = append(nameParts, fmt.Sprintf("shards=%d", b.NumShards))
 	}
-	opts := []spec.Option{
+	baseSpecOpts := []spec.Option{
 		spec.CPU(b.CPUs),
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(b.CPUs),
-		spec.RandomizeVolumeType(),
-		spec.RandomlyUseXfs(),
 	}
 	switch b.KeyDistribution {
 	case sequential:
@@ -85,24 +83,27 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 		nameParts = append(nameParts, "2nd_idx")
 	}
 
-	name := strings.Join(nameParts, "/")
-	nodes := r.MakeClusterSpec(b.Nodes+1, opts...)
-	r.Add(registry.TestSpec{
-		Name: name,
-		// These tests don't have pass/fail conditions so we don't want to run them
-		// nightly. Currently they're only good for printing the results of a search
-		// for --max-rate.
-		// TODO(andrei): output something to roachperf and start running them
-		// nightly.
-		CompatibleClouds: registry.AllClouds,
-		Suites:           registry.ManualOnly,
-		Owner:            registry.OwnerKV,
-		Benchmark:        true,
-		Cluster:          nodes,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runKVBench(ctx, t, c, b)
-		},
-	})
+	baseName := strings.Join(nameParts, "/")
+	baseClouds := registry.AllClouds
+	for _, svReg := range storageVariantRegs(baseClouds, false) {
+		cSpec := r.MakeClusterSpec(b.Nodes+1, append(baseSpecOpts, svReg.specOpts...)...)
+		r.Add(registry.TestSpec{
+			Name: baseName + svReg.nameSuffix,
+			// These tests don't have pass/fail conditions so we don't want to run them
+			// nightly. Currently they're only good for printing the results of a search
+			// for --max-rate.
+			// TODO(andrei): output something to roachperf and start running them
+			// nightly.
+			CompatibleClouds: svReg.clouds,
+			Suites:           registry.ManualOnly,
+			Owner:            registry.OwnerKV,
+			Benchmark:        true,
+			Cluster:          cSpec,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runKVBench(ctx, t, c, b)
+			},
+		})
+	}
 }
 
 func registerKVBench(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/storage_variant_helpers.go
+++ b/pkg/cmd/roachtest/tests/storage_variant_helpers.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+)
+
+// storageVariantReg describes a test registration for a specific storage
+// configuration. storageVariantRegs returns the base registration (default
+// storage) as the first element, followed by one registration per applicable
+// StorageVariant.
+type storageVariantReg struct {
+	// nameSuffix is appended to the base test name (e.g., "/vol=gp3").
+	// Empty for the base registration.
+	nameSuffix string
+	// specOpts are additional spec.Option values to apply when constructing
+	// the cluster spec for this variant.
+	specOpts []spec.Option
+	// clouds is the CompatibleClouds value for this variant.
+	clouds registry.CloudSet
+}
+
+// storageVariantRegs returns the base registration plus one registration per
+// applicable StorageVariant for the given base cloud set. Variants that are
+// restricted to a cloud not in baseClouds are automatically excluded.
+//
+// skipLocalSSD should be set to true for tests that use DisableLocalSSD() or
+// otherwise cannot run with local SSDs (e.g., tests requiring a specific
+// VolumeSize). When true, local-SSD variants are excluded from the results.
+//
+// The first element is always the base registration (empty nameSuffix, no
+// extra specOpts, original baseClouds). Subsequent elements are storage
+// variants with their cloud set narrowed to the specific cloud.
+func storageVariantRegs(baseClouds registry.CloudSet, skipLocalSSD bool) []storageVariantReg {
+	regs := []storageVariantReg{
+		{clouds: baseClouds},
+	}
+	for _, sv := range spec.StorageVariants() {
+		if skipLocalSSD && sv.IsLocalSSD() {
+			continue
+		}
+		if sv.Cloud != spec.AnyCloud && !baseClouds.Contains(sv.Cloud) {
+			continue
+		}
+		variantClouds := baseClouds
+		if sv.Cloud != spec.AnyCloud {
+			variantClouds = registry.Clouds(sv.Cloud)
+		}
+		regs = append(regs, storageVariantReg{
+			nameSuffix: "/" + sv.Name,
+			specOpts:   sv.ClusterSpecOptions(),
+			clouds:     variantClouds,
+		})
+	}
+	return regs
+}

--- a/pkg/cmd/roachtest/tests/storage_variant_helpers_test.go
+++ b/pkg/cmd/roachtest/tests/storage_variant_helpers_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageVariantRegs(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseClouds       registry.CloudSet
+		skipLocalSSD     bool
+		expectedSuffixes []string
+	}{
+		{
+			name:       "all clouds includes all volume types and local-ssd",
+			baseClouds: registry.AllClouds,
+			expectedSuffixes: []string{
+				"",
+				"/vol=gp3/fs=ext4", "/vol=gp3/fs=xfs",
+				"/vol=io2/fs=ext4", "/vol=io2/fs=xfs",
+				"/vol=pd-ssd/fs=ext4", "/vol=pd-ssd/fs=xfs",
+				"/vol=premium-ssd/fs=ext4", "/vol=premium-ssd/fs=xfs",
+				"/vol=premium-ssd-v2/fs=ext4", "/vol=premium-ssd-v2/fs=xfs",
+				"/vol=ultra-disk/fs=ext4", "/vol=ultra-disk/fs=xfs",
+				"/vol=10iops-tier/fs=ext4", "/vol=10iops-tier/fs=xfs",
+				"/local-ssd/fs=ext4", "/local-ssd/fs=xfs",
+			},
+		},
+		{
+			name:         "all clouds skip local-ssd",
+			baseClouds:   registry.AllClouds,
+			skipLocalSSD: true,
+			expectedSuffixes: []string{
+				"",
+				"/vol=gp3/fs=ext4", "/vol=gp3/fs=xfs",
+				"/vol=io2/fs=ext4", "/vol=io2/fs=xfs",
+				"/vol=pd-ssd/fs=ext4", "/vol=pd-ssd/fs=xfs",
+				"/vol=premium-ssd/fs=ext4", "/vol=premium-ssd/fs=xfs",
+				"/vol=premium-ssd-v2/fs=ext4", "/vol=premium-ssd-v2/fs=xfs",
+				"/vol=ultra-disk/fs=ext4", "/vol=ultra-disk/fs=xfs",
+				"/vol=10iops-tier/fs=ext4", "/vol=10iops-tier/fs=xfs",
+			},
+		},
+		{
+			name:       "single cloud excludes other clouds volume types",
+			baseClouds: registry.OnlyAWS,
+			expectedSuffixes: []string{
+				"",
+				"/vol=gp3/fs=ext4", "/vol=gp3/fs=xfs",
+				"/vol=io2/fs=ext4", "/vol=io2/fs=xfs",
+				"/local-ssd/fs=ext4", "/local-ssd/fs=xfs",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			regs := storageVariantRegs(tc.baseClouds, tc.skipLocalSSD)
+
+			var suffixes []string
+			for _, r := range regs {
+				suffixes = append(suffixes, r.nameSuffix)
+			}
+			require.Equal(t, tc.expectedSuffixes, suffixes)
+
+			// The first element is always the base registration.
+			require.Empty(t, regs[0].nameSuffix)
+			require.Empty(t, regs[0].specOpts)
+			require.Equal(t, tc.baseClouds, regs[0].clouds)
+
+			// All non-base variants have spec options including filesystem.
+			for _, r := range regs[1:] {
+				require.NotEmpty(t, r.specOpts, "variant %s should have spec options", r.nameSuffix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Starting with #159010, benchmark tests (kv, kvbench, kv_rangefeed, and admission-control) used RandomizeVolumeType() and RandomlyUseXfs() to randomly select volume types and filesystems at cluster creation time.

This was inadequate because random infrastructure selection pollutes roachperf dashboards: runs cannot be compared when one used gp3 and another io2, and the volume type/filesystem is not reflected in the test name, making roachperf results non-reproducible.

This patch changes the behavior by replacing randomization in benchmark tests with explicit, named test variants per volume type and filesystem. Each variant gets a deterministic name (e.g., kv0/.../vol=gp3 or kv0/.../vol=gp3/fs=xfs) and is restricted to its cloud provider via CompatibleClouds. The base test (original name, no suffix) is preserved for continuity with existing roachperf history.

Key design decisions:
- Volume types are defined once in CloudVolumeTypes(), used by both StorageVariants() (benchmark variants) and the existing RandomizeVolumeType() code path (non-benchmark coverage tests).
- Local SSD is a separate axis using PreferLocalSSD(), not VolumeType. Tests with DisableLocalSSD() pass skipLocalSSD=true to exclude it.
- Filesystem (ext4/xfs) is crossed with each volume type variant, producing two tests per volume type (ext4 default + xfs).
- Non-benchmark tests (kv/gracefuldraining, kv/splits, kv/restart, kv/rangelookups, storage/large_kv) retain RandomizeVolumeType() / RandomlyUseXfs() since they don't report to roachperf and benefit from broad coverage without the variant explosion.

Informs: #168520
Epic: none
Release note: none