### PR TITLE
schemachange: add DependentObjectsStillExist as potential commit error for DROP VALUE

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2303,6 +2303,7 @@ func (og *operationGenerator) alterTypeDropValue(ctx context.Context, tx pgx.Tx)
 	})
 	if pickedReferenced {
 		opStmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
+		og.potentialCommitErrors.add(pgcode.DependentObjectsStillExist)
 	}
 	return opStmt, nil
 }


### PR DESCRIPTION
When dropping an enum value that belongs to a referenced type, the schema change validation can fail at commit time with DependentObjectsStillExist if the value is used by a routine or other dependent object.

Part of #168543

Release note: None