### PR TITLE
multiregion: fix locality validation for trigger/policy type refs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1793,3 +1793,57 @@ statement ok
 DROP DATABASE "DelimitedDB_113782" CASCADE
 
 subtest end
+
+# Regression test #168543: creating a trigger on a REGIONAL BY TABLE table
+# or a GLOBAL table should succeed even when the trigger function references
+# the multi-region enum type. Previously, descriptor validation incorrectly 
+# rejected the region enum reference added by the trigger's type dependencies.
+subtest trigger_with_region_enum_reference
+
+statement ok
+CREATE DATABASE trigger_mr_db PRIMARY REGION "us-east-1" REGIONS "us-east-1", "ca-central-1", "ap-southeast-2";
+
+statement ok
+USE trigger_mr_db;
+
+statement ok
+CREATE TABLE rbt_primary (k INT PRIMARY KEY, v STRING);
+
+statement ok
+CREATE TABLE global_t (k INT PRIMARY KEY, v STRING) LOCALITY GLOBAL;
+
+statement ok
+CREATE OR REPLACE FUNCTION trigger_fn_mr()
+RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+DECLARE
+  r crdb_internal_region;
+BEGIN
+  r := 'us-east-1';
+  RETURN NEW;
+END;
+$$;
+
+# This should succeed — the trigger function references the region enum, but
+# that is a legitimate non-locality-config type dependency.
+statement ok
+CREATE TRIGGER tr_rbt BEFORE INSERT ON rbt_primary FOR EACH ROW EXECUTE FUNCTION trigger_fn_mr();
+
+statement ok
+CREATE TRIGGER tr_global BEFORE INSERT ON global_t FOR EACH ROW EXECUTE FUNCTION trigger_fn_mr();
+
+# Verify the triggers work.
+statement ok
+INSERT INTO rbt_primary VALUES (1, 'a');
+
+statement ok
+INSERT INTO global_t VALUES (1, 'a');
+
+statement ok
+USE system;
+
+statement ok
+DROP DATABASE trigger_mr_db CASCADE;
+
+subtest end
+
+

--- a/pkg/sql/catalog/multiregion/validate_table.go
+++ b/pkg/sql/catalog/multiregion/validate_table.go
@@ -117,12 +117,27 @@ func ValidateTableLocalityConfig(
 			break
 		}
 	}
-	columnTypesTypeIDs := catalog.MakeDescriptorIDSet(typeIDsReferencedByColumns...)
+	// Build a set of type IDs that are referenced by non-locality-config
+	// sources: columns, triggers, and policies. The region enum ID may appear
+	// in the full typeIDs set due to any of these, and all are legitimate.
+	nonLocalityTypeIDs := catalog.MakeDescriptorIDSet(typeIDsReferencedByColumns...)
+	for _, trigger := range desc.GetTriggers() {
+		for _, id := range trigger.DependsOnTypes {
+			nonLocalityTypeIDs.Add(id)
+		}
+	}
+	for _, policy := range desc.GetPolicies() {
+		for _, id := range policy.DependsOnTypes {
+			nonLocalityTypeIDs.Add(id)
+		}
+	}
 	switch lc := lc.Locality.(type) {
 	case *catpb.LocalityConfig_Global_:
 		if regionEnumIDReferenced {
-			// Omit views since they may reference the multi-region enum type of the base table.
-			if !columnTypesTypeIDs.Contains(regionsEnumID) && !desc.IsView() {
+			// The region enum may be referenced by a column type, trigger, or
+			// policy. We also omit views since they may reference the
+			// multi-region enum type of the base table.
+			if !nonLocalityTypeIDs.Contains(regionsEnumID) && !desc.IsView() {
 				return errors.AssertionFailedf(
 					"expected no region Enum ID to be referenced by a GLOBAL TABLE: %q"+
 						" but found: %d",
@@ -232,11 +247,11 @@ func ValidateTableLocalityConfig(
 			}
 		} else {
 			if regionEnumIDReferenced {
-				// It may be the case that the multi-region type descriptor is used
-				// as the type of the table column. Validations should only fail if
-				// that is not the case. We omit views since they may reference the
-				// multi-region enum type of the base table.
-				if !columnTypesTypeIDs.Contains(regionsEnumID) && !desc.IsView() {
+				// The region enum may be referenced by a column type, trigger, or
+				// policy on this table. Validations should only fail if none of
+				// those are the source of the reference. We also omit views since
+				// they may reference the multi-region enum type of the base table.
+				if !nonLocalityTypeIDs.Contains(regionsEnumID) && !desc.IsView() {
 					return errors.AssertionFailedf(
 						"expected no region Enum ID to be referenced by a REGIONAL BY TABLE: %q homed in the "+
 							"primary region, but found: %d",


### PR DESCRIPTION
Previously, the locality config validation for REGIONAL BY TABLE tables homed in the primary region and GLOBAL tables would reject any reference to the region enum type that didn't come from a column type. This caused CREATE TRIGGER to fail with an internal error when the trigger function referenced the multi-region enum type (crdb_internal_region), because the trigger's type dependency was not recognized as a legitimate source.

The fix extends the validation to also consider type references from triggers and policies as legitimate, alongside column types and views.

Fixes: #168543
Fixes: #168534

Release note (bug fix): Fixed an internal error that occurred when creating a trigger on a REGIONAL BY TABLE or GLOBAL table when the trigger function referenced the multi-region enum type (crdb_internal_region).