### PR TITLE
release: dynamically determine predecessor versions for REPOSITORIES.bzl

### DIFF
--- a/pkg/cmd/release/update_releases.go
+++ b/pkg/cmd/release/update_releases.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/template"
@@ -101,18 +102,12 @@ func updateReleasesFiles(_ *cobra.Command, _ []string) (retErr error) {
 	if err := saveResultsInYaml(result); err != nil {
 		return err
 	}
-	currentSeries := currentVersion.Format("%X.%Y")
-	predecessor := findLatestReleasedPredecessor(result, currentSeries)
-	if predecessor == "" {
-		return fmt.Errorf("could not determine predecessor version for version %+v", currentVersion)
-	}
-	predecessorSeries := version.MustParse("v" + predecessor).Format("%X.%Y")
-	prePredecessor := findLatestReleasedPredecessor(result, predecessorSeries)
-	if prePredecessor == "" {
-		return fmt.Errorf("could not determine predecessor's predecessor version for version %+v", currentVersion)
+	predecessorVersions, err := findRequiredPredecessorVersions(result, currentVersion)
+	if err != nil {
+		return err
 	}
 	fmt.Printf("writing data to %s\n", logictestReposFile)
-	if err := generateRepositoriesFile(prePredecessor, predecessor); err != nil {
+	if err := generateRepositoriesFile(predecessorVersions...); err != nil {
 		return err
 	}
 	fmt.Printf("done\n")
@@ -248,6 +243,104 @@ func findLatestReleasedPredecessor(data map[string]release.Series, series string
 		cur = s.Predecessor
 	}
 	return ""
+}
+
+// findRequiredPredecessorVersions discovers which released predecessor
+// versions are needed by scanning for cockroach-go-testserver-*
+// directories under the logictest test trees. Each such directory
+// corresponds to a release series that needs a binary in
+// REPOSITORIES.bzl. We walk the predecessor chain from the current
+// version, collecting released versions until all required series are
+// covered.
+func findRequiredPredecessorVersions(
+	data map[string]release.Series, currentVersion version.Version,
+) ([]string, error) {
+	requiredSeries, err := findTestserverSeries()
+	if err != nil {
+		return nil, err
+	}
+	return collectPredecessorVersions(data, currentVersion, requiredSeries)
+}
+
+// collectPredecessorVersions walks the predecessor chain from
+// currentVersion, collecting released versions until all series in
+// requiredSeries are covered. Returns the versions sorted oldest first.
+func collectPredecessorVersions(
+	data map[string]release.Series, currentVersion version.Version, requiredSeries map[string]bool,
+) ([]string, error) {
+	var versions []string
+	covered := map[string]bool{}
+	cur := currentVersion.Format("%X.%Y")
+	visited := map[string]bool{}
+	for len(covered) < len(requiredSeries) {
+		latest := findLatestReleasedPredecessor(data, cur)
+		if latest == "" {
+			break
+		}
+		latestVersion := version.MustParse("v" + latest)
+		series := latestVersion.Format("%X.%Y")
+		if visited[series] {
+			break
+		}
+		visited[series] = true
+		if requiredSeries[series] {
+			versions = append(versions, latest)
+			covered[series] = true
+		}
+		cur = series
+	}
+
+	var missing []string
+	for series := range requiredSeries {
+		if !covered[series] {
+			missing = append(missing, series)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf(
+			"could not find released versions for required testserver series: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return version.MustParse("v"+versions[i]).Compare(version.MustParse("v"+versions[j])) < 0
+	})
+
+	return versions, nil
+}
+
+// testserverDirs lists the directories under the logictest test trees
+// that contain cockroach-go-testserver-* tests. These are relative
+// paths, consistent with releaseDataFile and logictestReposFile; the
+// tool is expected to run from the repository root.
+var testserverDirs = []string{
+	"pkg/sql/logictest/tests",
+	"pkg/ccl/logictestccl/tests",
+}
+
+// findTestserverSeries scans for cockroach-go-testserver-* directories
+// and returns the set of release series they correspond to.
+func findTestserverSeries() (map[string]bool, error) {
+	series := map[string]bool{}
+	for _, dir := range testserverDirs {
+		matches, err := filepath.Glob(
+			filepath.Join(dir, "cockroach-go-testserver-*"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning for testserver directories: %w", err)
+		}
+		for _, m := range matches {
+			base := filepath.Base(m)
+			s := strings.TrimPrefix(base, "cockroach-go-testserver-")
+			series[s] = true
+		}
+	}
+	if len(series) == 0 {
+		return nil, fmt.Errorf("no cockroach-go-testserver-* directories found")
+	}
+	return series, nil
 }
 
 // loadExistingReleaseData reads the current cockroach_releases.yaml

--- a/pkg/cmd/release/update_releases.go
+++ b/pkg/cmd/release/update_releases.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/template"
@@ -101,18 +102,12 @@ func updateReleasesFiles(_ *cobra.Command, _ []string) (retErr error) {
 	if err := saveResultsInYaml(result); err != nil {
 		return err
 	}
-	currentSeries := currentVersion.Format("%X.%Y")
-	predecessor := findLatestReleasedPredecessor(result, currentSeries)
-	if predecessor == "" {
-		return fmt.Errorf("could not determine predecessor version for version %+v", currentVersion)
-	}
-	predecessorSeries := version.MustParse("v" + predecessor).Format("%X.%Y")
-	prePredecessor := findLatestReleasedPredecessor(result, predecessorSeries)
-	if prePredecessor == "" {
-		return fmt.Errorf("could not determine predecessor's predecessor version for version %+v", currentVersion)
+	predecessorVersions, err := findRequiredPredecessorVersions(result, currentVersion)
+	if err != nil {
+		return err
 	}
 	fmt.Printf("writing data to %s\n", logictestReposFile)
-	if err := generateRepositoriesFile(prePredecessor, predecessor); err != nil {
+	if err := generateRepositoriesFile(predecessorVersions...); err != nil {
 		return err
 	}
 	fmt.Printf("done\n")
@@ -248,6 +243,109 @@ func findLatestReleasedPredecessor(data map[string]release.Series, series string
 		cur = s.Predecessor
 	}
 	return ""
+}
+
+// findRequiredPredecessorVersions discovers which released predecessor
+// versions are needed by scanning for cockroach-go-testserver-*
+// directories under the logictest test trees. Each such directory
+// corresponds to a release series that needs a binary in
+// REPOSITORIES.bzl. We walk the predecessor chain from the current
+// version, collecting released versions until all required series are
+// covered.
+func findRequiredPredecessorVersions(
+	data map[string]release.Series, currentVersion version.Version,
+) ([]string, error) {
+	requiredSeries, err := findTestserverSeries()
+	if err != nil {
+		return nil, err
+	}
+	return collectPredecessorVersions(data, currentVersion, requiredSeries)
+}
+
+// collectPredecessorVersions walks the predecessor chain from
+// currentVersion, collecting released versions until all series in
+// requiredSeries are covered. Returns the versions sorted oldest first.
+func collectPredecessorVersions(
+	data map[string]release.Series, currentVersion version.Version, requiredSeries map[string]bool,
+) ([]string, error) {
+	var versions []string
+	covered := map[string]bool{}
+	cur := currentVersion.Format("%X.%Y")
+	visited := map[string]bool{}
+	for len(covered) < len(requiredSeries) {
+		latest := findLatestReleasedPredecessor(data, cur)
+		if latest == "" {
+			break
+		}
+		latestVersion := version.MustParse("v" + latest)
+		series := latestVersion.Format("%X.%Y")
+		if visited[series] {
+			break
+		}
+		visited[series] = true
+		versions = append(versions, latest)
+		if requiredSeries[series] {
+			covered[series] = true
+		}
+		cur = series
+	}
+
+	var missing []string
+	for series := range requiredSeries {
+		if !covered[series] {
+			missing = append(missing, series)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf(
+			"could not find released versions for required testserver series: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	// Parse versions once and sort by parsed value.
+	parsed := make([]version.Version, len(versions))
+	for i, v := range versions {
+		parsed[i] = version.MustParse("v" + v)
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return parsed[i].Compare(parsed[j]) < 0
+	})
+
+	return versions, nil
+}
+
+// testserverDirs lists the directories under the logictest test trees
+// that contain cockroach-go-testserver-* tests. These are relative
+// paths, consistent with releaseDataFile and logictestReposFile; the
+// tool is expected to run from the repository root.
+var testserverDirs = []string{
+	"pkg/sql/logictest/tests",
+	"pkg/ccl/logictestccl/tests",
+}
+
+// findTestserverSeries scans for cockroach-go-testserver-* directories
+// and returns the set of release series they correspond to.
+func findTestserverSeries() (map[string]bool, error) {
+	series := map[string]bool{}
+	for _, dir := range testserverDirs {
+		matches, err := filepath.Glob(
+			filepath.Join(dir, "cockroach-go-testserver-*"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning for testserver directories: %w", err)
+		}
+		for _, m := range matches {
+			base := filepath.Base(m)
+			s := strings.TrimPrefix(base, "cockroach-go-testserver-")
+			series[s] = true
+		}
+	}
+	if len(series) == 0 {
+		return nil, fmt.Errorf("no cockroach-go-testserver-* directories found")
+	}
+	return series, nil
 }
 
 // loadExistingReleaseData reads the current cockroach_releases.yaml

--- a/pkg/cmd/release/update_releases_test.go
+++ b/pkg/cmd/release/update_releases_test.go
@@ -373,6 +373,83 @@ func Test_simulatePR167081(t *testing.T) {
 		"pre-predecessor should be 25.4.5")
 }
 
+// Test_collectPredecessorVersions_PR168432 reproduces the scenario from
+// PR #168432 where 26.2 gets an RC release, causing the old
+// two-predecessor logic to drop the 25.4 binary that
+// cockroach-go-testserver-25.4 tests need.
+func Test_collectPredecessorVersions_PR168432(t *testing.T) {
+	data := map[string]release.Series{
+		"25.3": {Latest: "25.3.7", Predecessor: "25.2"},
+		"25.4": {Latest: "25.4.8", Predecessor: "25.3"},
+		"26.1": {Latest: "26.1.2", Predecessor: "25.4"},
+		"26.2": {Latest: "26.2.0-rc.1", Predecessor: "26.1"},
+		"26.3": {Predecessor: "26.2"},
+	}
+	currentVersion := version.MustParse("v26.3.0")
+
+	// With testserver configs for 25.4 and 26.1, the old logic would
+	// only produce [26.1.2, 26.2.0-rc.1], missing 25.4.8. The new
+	// logic walks back far enough to cover both.
+	requiredSeries := map[string]bool{"25.4": true, "26.1": true}
+	versions, err := collectPredecessorVersions(data, currentVersion, requiredSeries)
+	require.NoError(t, err)
+	require.Equal(t, []string{"25.4.8", "26.1.2", "26.2.0-rc.1"}, versions)
+}
+
+func Test_collectPredecessorVersions(t *testing.T) {
+	data := map[string]release.Series{
+		"25.3": {Latest: "25.3.7", Predecessor: "25.2"},
+		"25.4": {Latest: "25.4.8", Predecessor: "25.3"},
+		"26.1": {Latest: "26.1.2", Predecessor: "25.4"},
+		"26.2": {Latest: "26.2.0-rc.1", Predecessor: "26.1"},
+		"26.3": {Predecessor: "26.2"},
+	}
+
+	testCases := []struct {
+		name           string
+		currentVersion string
+		requiredSeries map[string]bool
+		expected       []string
+		expectedErr    string
+	}{
+		{
+			name:           "two predecessors without gap",
+			currentVersion: "v26.3.0",
+			requiredSeries: map[string]bool{"26.1": true, "25.4": true},
+			// Even though 26.2 is released, we still walk past it to
+			// find 25.4 because the testserver configs require it.
+			expected: []string{"25.4.8", "26.1.2", "26.2.0-rc.1"},
+		},
+		{
+			name:           "single predecessor",
+			currentVersion: "v26.3.0",
+			requiredSeries: map[string]bool{"26.1": true},
+			// Stops after collecting 26.2 and 26.1.
+			expected: []string{"26.1.2", "26.2.0-rc.1"},
+		},
+		{
+			name:           "unreachable series",
+			currentVersion: "v26.3.0",
+			requiredSeries: map[string]bool{"24.0": true},
+			expectedErr:    "could not find released versions for required testserver series",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := collectPredecessorVersions(
+				data, version.MustParse(tc.currentVersion), tc.requiredSeries,
+			)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
 func Test_validateReleaseData(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/pkg/cmd/release/update_releases_test.go
+++ b/pkg/cmd/release/update_releases_test.go
@@ -373,6 +373,84 @@ func Test_simulatePR167081(t *testing.T) {
 		"pre-predecessor should be 25.4.5")
 }
 
+// Test_collectPredecessorVersions_PR168432 reproduces the scenario from
+// PR #168432 where 26.2 gets an RC release, causing the old
+// two-predecessor logic to drop the 25.4 binary that
+// cockroach-go-testserver-25.4 tests need.
+func Test_collectPredecessorVersions_PR168432(t *testing.T) {
+	data := map[string]release.Series{
+		"25.3": {Latest: "25.3.7", Predecessor: "25.2"},
+		"25.4": {Latest: "25.4.8", Predecessor: "25.3"},
+		"26.1": {Latest: "26.1.2", Predecessor: "25.4"},
+		"26.2": {Latest: "26.2.0-rc.1", Predecessor: "26.1"},
+		"26.3": {Predecessor: "26.2"},
+	}
+	currentVersion := version.MustParse("v26.3.0")
+
+	// With testserver configs for 25.4 and 26.1, the old logic would
+	// only produce [26.1.2, 26.2.0-rc.1], missing 25.4.8. The new
+	// logic walks back far enough to cover 25.4 and skips 26.2 since
+	// no testserver config requires it.
+	requiredSeries := map[string]bool{"25.4": true, "26.1": true}
+	versions, err := collectPredecessorVersions(data, currentVersion, requiredSeries)
+	require.NoError(t, err)
+	require.Equal(t, []string{"25.4.8", "26.1.2"}, versions)
+}
+
+func Test_collectPredecessorVersions(t *testing.T) {
+	data := map[string]release.Series{
+		"25.3": {Latest: "25.3.7", Predecessor: "25.2"},
+		"25.4": {Latest: "25.4.8", Predecessor: "25.3"},
+		"26.1": {Latest: "26.1.2", Predecessor: "25.4"},
+		"26.2": {Latest: "26.2.0-rc.1", Predecessor: "26.1"},
+		"26.3": {Predecessor: "26.2"},
+	}
+
+	testCases := []struct {
+		name           string
+		currentVersion string
+		requiredSeries map[string]bool
+		expected       []string
+		expectedErr    string
+	}{
+		{
+			name:           "two predecessors without gap",
+			currentVersion: "v26.3.0",
+			requiredSeries: map[string]bool{"26.1": true, "25.4": true},
+			// We walk past 26.2 to find 25.4, but 26.2 is not
+			// included because no testserver config requires it.
+			expected: []string{"25.4.8", "26.1.2"},
+		},
+		{
+			name:           "single predecessor",
+			currentVersion: "v26.3.0",
+			requiredSeries: map[string]bool{"26.1": true},
+			// Walks past 26.2 (not required) and stops at 26.1.
+			expected: []string{"26.1.2"},
+		},
+		{
+			name:           "unreachable series",
+			currentVersion: "v26.3.0",
+			requiredSeries: map[string]bool{"24.0": true},
+			expectedErr:    "could not find released versions for required testserver series",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := collectPredecessorVersions(
+				data, version.MustParse(tc.currentVersion), tc.requiredSeries,
+			)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
 func Test_validateReleaseData(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Previously, `release update-releases-file` hardcoded exactly two predecessor versions (predecessor and pre-predecessor) in REPOSITORIES.bzl. When 26.2 got an RC release, the two-version window shifted to [26.1, 26.2], dropping 25.4 — but the
cockroach-go-testserver-25.4 tests still need the 25.4.8 binary, causing all 11 shards to fail (cockroachdb#168432).

Instead of hardcoding two levels, the tool now scans for cockroach-go-testserver-* directories to discover which series need binaries, then walks the predecessor chain until all required series are covered. This makes the version selection resilient to new releases without requiring manual coordination between the releases YAML and the testserver configs.

The core logic is split into collectPredecessorVersions (pure, testable) and findTestserverSeries (filesystem I/O) for testability.

Epic: none
Release note: None