### PR TITLE
serverutils: remove UseDRPC from TestServerArgs

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -168,13 +168,10 @@ type TestServerArgs struct {
 
 	// DefaultDRPCOption specifies the DRPC enablement mode for a test
 	// server. This controls whether inter-node connectivity uses DRPC, just
-	// gRPC, or is chosen randomly.
+	// gRPC, or is chosen randomly. It is resolved by the test framework
+	// (via ShouldEnableDRPC) into a concrete TestDRPCEnabled or
+	// TestDRPCDisabled value before the server starts.
 	DefaultDRPCOption DefaultTestDRPCOption
-
-	// UseDRPC is the resolved DRPC enablement decision, set by the test
-	// framework after evaluating DefaultDRPCOption. It's a framework-internal
-	// arg and tests should not set this directly; use DefaultDRPCOption instead.
-	UseDRPC bool
 
 	// DefaultTenantName is the name of the tenant created implicitly according
 	// to DefaultTestTenant. It is typically `test-tenant` for unit tests and

--- a/pkg/cli/democluster/context.go
+++ b/pkg/cli/democluster/context.go
@@ -8,6 +8,7 @@ package democluster
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/clicfg"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
@@ -109,6 +110,13 @@ type Context struct {
 	// UseDRPC indicates whether to use DRPC instead of gRPC for
 	// inter-node RPC communication in the demo cluster.
 	UseDRPC bool
+}
+
+func (demoCtx *Context) defaultDRPCOption() base.DefaultTestDRPCOption {
+	if demoCtx.UseDRPC {
+		return base.TestDRPCEnabled
+	}
+	return base.TestDRPCDisabled
 }
 
 // IsInteractive returns true if the demo cluster configuration

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -944,7 +944,7 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		CacheSize:               demoCtx.CacheSize,
 		NoAutoInitializeCluster: true,
 		EnableDemoLoginEndpoint: true,
-		UseDRPC:                 demoCtx.UseDRPC,
+		DefaultDRPCOption:       demoCtx.defaultDRPCOption(),
 		// Demo clusters by default will create their own tenants, so we
 		// don't need to create them here.
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -55,7 +55,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 		joinAddr          string
 		sqlPoolMemorySize int64
 		cacheSize         int64
-		useDRPC           bool
+		useDRPC           bool // sets demoCtx.UseDRPC
 
 		expected base.TestServerArgs
 	}{
@@ -79,6 +79,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				CacheSize:                     1 << 10,
 				NoAutoInitializeCluster:       true,
 				EnableDemoLoginEndpoint:       true,
+				DefaultDRPCOption:             base.TestDRPCDisabled,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						StickyVFSRegistry: stickyVFSRegistry,
@@ -107,6 +108,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				CacheSize:                     4 << 10,
 				NoAutoInitializeCluster:       true,
 				EnableDemoLoginEndpoint:       true,
+				DefaultDRPCOption:             base.TestDRPCDisabled,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						StickyVFSRegistry: stickyVFSRegistry,
@@ -136,7 +138,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				CacheSize:                     1 << 10,
 				NoAutoInitializeCluster:       true,
 				EnableDemoLoginEndpoint:       true,
-				UseDRPC:                       true,
+				DefaultDRPCOption:             base.TestDRPCEnabled,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						StickyVFSRegistry: stickyVFSRegistry,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -334,7 +334,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.TestingKnobs.AdmissionControlOptions = &admission.Options{}
 	}
 
-	cfg.UseDRPC = params.UseDRPC
+	cfg.UseDRPC = params.DefaultDRPCOption == base.TestDRPCEnabled
 
 	return cfg
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -284,7 +284,7 @@ func StartServerOnlyE(t TestLogger, params base.TestServerArgs) (TestServerInter
 	// Priority of these Should* functions:
 	// Test explicit value > env vars > factory defaults > metamorphic.
 	params.DefaultTestTenant = ShouldStartDefaultTestTenant(t, params.DefaultTestTenant)
-	params.UseDRPC = ShouldEnableDRPC(ctx, t, params.DefaultDRPCOption)
+	params.DefaultDRPCOption = ShouldEnableDRPC(ctx, t, params.DefaultDRPCOption)
 
 	s, err := NewServer(params)
 	if err != nil {
@@ -596,13 +596,16 @@ func parseDefaultTestDRPCOptionFromEnv() base.DefaultTestDRPCOption {
 }
 
 // ShouldEnableDRPC determines the final DRPC enablement decision based on the
-// input option, resolving random choices to a concrete bool.
-func ShouldEnableDRPC(ctx context.Context, t TestLogger, option base.DefaultTestDRPCOption) bool {
+// input option, resolving random choices to a concrete TestDRPCEnabled or
+// TestDRPCDisabled value.
+func ShouldEnableDRPC(
+	ctx context.Context, t TestLogger, option base.DefaultTestDRPCOption,
+) base.DefaultTestDRPCOption {
 	if skip.UnderBench() {
 		// Microbenchmarks exercise specific parts of the database and we
 		// want to remove any non-deterministic factors that could affect the
 		// numbers, so we disable the dRPC option until it becomes the default.
-		return false
+		return base.TestDRPCDisabled
 	}
 	var logSuffix string
 
@@ -614,7 +617,7 @@ func ShouldEnableDRPC(ctx context.Context, t TestLogger, option base.DefaultTest
 			option = *factoryDefaultDRPC
 			logSuffix = " (via testserver factory defaults)"
 		} else {
-			return false
+			return base.TestDRPCDisabled
 		}
 	} else {
 		logSuffix = " (via test explicit setting)"
@@ -628,13 +631,16 @@ func ShouldEnableDRPC(ctx context.Context, t TestLogger, option base.DefaultTest
 		rng, _ := randutil.NewTestRand()
 		enableDRPC = rng.Intn(2) == 0
 	case base.TestDRPCUnset:
-		return false
+		return base.TestDRPCDisabled
 	}
 
-	if enableDRPC && t != nil {
-		t.Log("DRPC is enabled" + logSuffix)
+	if enableDRPC {
+		if t != nil {
+			t.Log("DRPC is enabled" + logSuffix)
+		}
+		return base.TestDRPCEnabled
 	}
-	return enableDRPC
+	return base.TestDRPCDisabled
 }
 
 // SetUnsafeOverride sets an unsafe override for eval.TestingKnobs.UnsafeOverride on

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -89,7 +89,7 @@ type TestCluster struct {
 	clusterArgs base.TestClusterArgs
 
 	defaultTestTenantOptions base.DefaultTestTenantOptions
-	drpcEnabled              bool
+	defaultDRPCOption        base.DefaultTestDRPCOption
 
 	t serverutils.TestFataler
 }
@@ -149,7 +149,7 @@ func (tc *TestCluster) StartedDefaultTestTenant() bool {
 // IsDRPCEnabled returns whether DRPC is enabled for inter-node communication
 // in this cluster.
 func (tc *TestCluster) IsDRPCEnabled() bool {
-	return tc.drpcEnabled
+	return tc.defaultDRPCOption == base.TestDRPCEnabled
 }
 
 // ApplicationLayer calls .ApplicationLayer() on the ith server in
@@ -403,7 +403,7 @@ func NewTestCluster(
 	// by the top-level ServerArgs.
 	defaultDRPCOption := tc.clusterArgs.ServerArgs.DefaultDRPCOption
 	tc.validateDefaultDRPCOption(t, nodes, defaultDRPCOption)
-	tc.drpcEnabled = serverutils.ShouldEnableDRPC(context.Background(), t, defaultDRPCOption)
+	tc.defaultDRPCOption = serverutils.ShouldEnableDRPC(context.Background(), t, defaultDRPCOption)
 
 	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {
@@ -760,7 +760,7 @@ func (tc *TestCluster) AddServer(
 	// Inject the decisions that were made about test configuration
 	// into this new server's configuration.
 	serverArgs.DefaultTestTenant = tc.defaultTestTenantOptions
-	serverArgs.UseDRPC = tc.drpcEnabled
+	serverArgs.DefaultDRPCOption = tc.defaultDRPCOption
 
 	s, err := serverutils.NewServer(serverArgs)
 	if err != nil {


### PR DESCRIPTION
Remove the `UseDRPC` bool from `TestServerArgs` to avoid having two overlapping fields for DRPC enablement. `ShouldEnableDRPC` now resolves `DefaultDRPCOption` into a concrete `TestDRPCEnabled` or `TestDRPCDisabled` value (mirroring how `ShouldStartDefaultTestTenant` resolves `DefaultTestTenant`), and `makeTestConfigFromParams` reads `DefaultDRPCOption` directly.

Epic: CRDB-55382
Release note: None