### PR TITLE
workload: add UDF call deps to trigger function bodies

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4534,20 +4534,6 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 		{"descriptors", descJSONQuery},
 	}, `SELECT quote_ident(name) FROM descriptors WHERE descriptor ? 'schema'`)
 
-	functionsQuery := With([]CTE{
-		{"descriptors", descJSONQuery},
-		{"functions", functionDescsQuery},
-	}, `SELECT
-	quote_ident(schema_id::REGNAMESPACE::STRING) AS schema,
-	quote_ident(name) AS name,
-	array_to_string(proargnames, ',') AS args,
-	proargtypes AS argtypes,
-	pronargdefaults as numdefaults
-FROM
-	functions
-	INNER JOIN pg_catalog.pg_proc ON oid = (id + 100000)
-	WHERE COALESCE((descriptor->'state')::STRING, 'PUBLIC') = 'PUBLIC'::STRING
-	AND prorettype != 'trigger'::REGTYPE;`)
 	enums, err := Collect(ctx, og, tx, pgx.RowToMap, enumQuery)
 	if err != nil {
 		return nil, err
@@ -4560,7 +4546,7 @@ FROM
 	if err != nil {
 		return nil, err
 	}
-	functions, err := Collect(ctx, og, tx, pgx.RowToMap, functionsQuery)
+	functions, err := og.findNonTriggerFunctions(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -4642,50 +4628,12 @@ FROM
 		possibleBodyReferences = append(possibleBodyReferences, fmt.Sprintf(`((SELECT count(*) FROM %s LIMIT 0) = 0)`, table))
 	}
 
-	// For each function generate a possible invocation passing in null arguments.
 	for _, function := range functions {
-		args := ""
-		if function["args"] != nil {
-			args = function["args"].(string)
-			argTypesStr := strings.Split(function["argtypes"].(string), " ")
-			argTypes := make([]int, 0, len(argTypesStr))
-			// Determine how many default arguemnts should be used.
-			numDefaultArgs := int(function["numdefaults"].(int16))
-			if numDefaultArgs > 0 {
-				numDefaultArgs = rand.Intn(numDefaultArgs)
-			}
-			// Populate the arguments for this signature, and select some number
-			// of default arguments.
-			for _, oidStr := range argTypesStr {
-				oid, err := strconv.Atoi(oidStr)
-				if err != nil {
-					return nil, err
-				}
-				argTypes = append(argTypes, oid)
-			}
-			argIn := strings.Builder{}
-			for idx := range strings.Split(args, ",") {
-				// We have hit the default arguments that we want to not populate.
-				if idx > len(argTypesStr)-numDefaultArgs {
-					break
-				}
-				if argIn.Len() > 0 {
-					argIn.WriteString(",")
-				}
-				// Resolve the type for each column and if possible generate a random
-				// value via randgen.
-				oidValue := oid.Oid(argTypes[idx])
-				typ, ok := types.OidToType[oidValue]
-				if !ok {
-					argIn.WriteString("NULL")
-				} else {
-					randomDatum := randgen.RandDatum(og.params.rng, typ, true)
-					argIn.WriteString(tree.AsStringWithFlags(randomDatum, tree.FmtParsable))
-				}
-			}
-			args = argIn.String()
+		invocation, err := og.buildFuncInvocation(function)
+		if err != nil {
+			return nil, err
 		}
-		possibleBodyFuncReferences = append(possibleBodyFuncReferences, fmt.Sprintf("(SELECT %s.%s(%s) IS NOT NULL)", function["schema"].(string), function["name"].(string), args))
+		possibleBodyFuncReferences = append(possibleBodyFuncReferences, invocation)
 	}
 
 	hasFuncRefs := false
@@ -5739,11 +5687,34 @@ func (og *operationGenerator) createTriggerFunction(
 		}
 	}
 
+	// Sometimes include a UDF call expression to exercise trigger-UDF
+	// dependency tracking (TriggerDeps.uses_routine_ids).
+	udfSelectStmt := ""
+	hasUdfRef := false
+	if og.randIntn(2) == 0 {
+		udfFunctions, err := og.findNonTriggerFunctions(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+		if len(udfFunctions) > 0 {
+			picked, err := PickOne(og.params.rng, udfFunctions)
+			if err != nil {
+				return nil, err
+			}
+			invocation, err := og.buildFuncInvocation(picked)
+			if err != nil {
+				return nil, err
+			}
+			udfSelectStmt = fmt.Sprintf("SELECT %s;", invocation)
+			hasUdfRef = true
+		}
+	}
+
 	// The trigger function always returns NEW to avoid breaking inserts.
 	opStmt := makeOpStmt(OpStmtDDL)
 	opStmt.sql = fmt.Sprintf(
-		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
-		resolvedName, seqSelectStmt, enumSelectStmt, selectStmt.sql,
+		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s%s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
+		resolvedName, seqSelectStmt, enumSelectStmt, udfSelectStmt, selectStmt.sql,
 	)
 	og.LogMessage(fmt.Sprintf("createTriggerFunction: %s", opStmt.sql))
 
@@ -5755,6 +5726,9 @@ func (og *operationGenerator) createTriggerFunction(
 	opStmt.expectedExecErrors.addAll(codesWithConditions{
 		{code: pgcode.FeatureNotSupported, condition: !og.useDeclarativeSchemaChanger},
 		{code: pgcode.DuplicateFunction, condition: routineAlreadyExists},
+	})
+	opStmt.potentialExecErrors.addAll(codesWithConditions{
+		{code: pgcode.UndefinedFunction, condition: hasUdfRef},
 	})
 
 	return opStmt, nil
@@ -5886,6 +5860,73 @@ func (og *operationGenerator) collectEnumMembers(
 		FROM enum_members
 	`)
 	return Collect(ctx, og, tx, pgx.RowToMap, q)
+}
+
+// findNonTriggerFunctions returns public, non-trigger UDFs with argument
+// metadata (schema, name, args, argtypes, numdefaults) for building
+// invocations.
+func (og *operationGenerator) findNonTriggerFunctions(
+	ctx context.Context, tx pgx.Tx,
+) ([]map[string]any, error) {
+	q := With([]CTE{
+		{"descriptors", descJSONQuery},
+		{"functions", functionDescsQuery},
+	}, `SELECT
+	quote_ident(schema_id::REGNAMESPACE::STRING) AS schema,
+	quote_ident(name) AS name,
+	array_to_string(proargnames, ',') AS args,
+	proargtypes AS argtypes,
+	pronargdefaults as numdefaults
+FROM
+	functions
+	INNER JOIN pg_catalog.pg_proc ON oid = (id + 100000)
+	WHERE COALESCE((descriptor->'state')::STRING, 'PUBLIC') = 'PUBLIC'::STRING
+	AND prorettype != 'trigger'::REGTYPE;`)
+	return Collect(ctx, og, tx, pgx.RowToMap, q)
+}
+
+// buildFuncInvocation constructs a SQL expression that invokes the given UDF
+// with random arguments: (SELECT schema.func(args) IS NOT NULL).
+func (og *operationGenerator) buildFuncInvocation(function map[string]any) (string, error) {
+	args := ""
+	if function["args"] != nil {
+		args = function["args"].(string)
+		argTypesStr := strings.Split(function["argtypes"].(string), " ")
+		argTypes := make([]int, 0, len(argTypesStr))
+		numDefaultArgs := int(function["numdefaults"].(int16))
+		if numDefaultArgs > 0 {
+			numDefaultArgs = og.randIntn(numDefaultArgs)
+		}
+		for _, oidStr := range argTypesStr {
+			oidVal, err := strconv.Atoi(oidStr)
+			if err != nil {
+				return "", err
+			}
+			argTypes = append(argTypes, oidVal)
+		}
+		argIn := strings.Builder{}
+		for idx := range strings.Split(args, ",") {
+			if idx > len(argTypesStr)-numDefaultArgs {
+				break
+			}
+			if argIn.Len() > 0 {
+				argIn.WriteString(",")
+			}
+			oidValue := oid.Oid(argTypes[idx])
+			typ, ok := types.OidToType[oidValue]
+			if !ok {
+				argIn.WriteString("NULL")
+			} else {
+				randomDatum := randgen.RandDatum(og.params.rng, typ, true)
+				argIn.WriteString(tree.AsStringWithFlags(randomDatum, tree.FmtParsable))
+			}
+		}
+		args = argIn.String()
+	}
+	return fmt.Sprintf(
+		"(SELECT %s.%s(%s) IS NOT NULL)",
+		function["schema"].(string), function["name"].(string), args,
+	), nil
 }
 
 // findExistingTriggerFunctions returns existing trigger functions (RETURNS

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4535,20 +4535,6 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 		{"descriptors", descJSONQuery},
 	}, `SELECT quote_ident(name) FROM descriptors WHERE descriptor ? 'schema'`)
 
-	functionsQuery := With([]CTE{
-		{"descriptors", descJSONQuery},
-		{"functions", functionDescsQuery},
-	}, `SELECT
-	quote_ident(schema_id::REGNAMESPACE::STRING) AS schema,
-	quote_ident(name) AS name,
-	array_to_string(proargnames, ',') AS args,
-	proargtypes AS argtypes,
-	pronargdefaults as numdefaults
-FROM
-	functions
-	INNER JOIN pg_catalog.pg_proc ON oid = (id + 100000)
-	WHERE COALESCE((descriptor->'state')::STRING, 'PUBLIC') = 'PUBLIC'::STRING
-	AND prorettype != 'trigger'::REGTYPE;`)
 	enums, err := Collect(ctx, og, tx, pgx.RowToMap, enumQuery)
 	if err != nil {
 		return nil, err
@@ -4561,7 +4547,7 @@ FROM
 	if err != nil {
 		return nil, err
 	}
-	functions, err := Collect(ctx, og, tx, pgx.RowToMap, functionsQuery)
+	functions, err := og.findNonTriggerFunctions(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -4643,50 +4629,12 @@ FROM
 		possibleBodyReferences = append(possibleBodyReferences, fmt.Sprintf(`((SELECT count(*) FROM %s LIMIT 0) = 0)`, table))
 	}
 
-	// For each function generate a possible invocation passing in null arguments.
 	for _, function := range functions {
-		args := ""
-		if function["args"] != nil {
-			args = function["args"].(string)
-			argTypesStr := strings.Split(function["argtypes"].(string), " ")
-			argTypes := make([]int, 0, len(argTypesStr))
-			// Determine how many default arguemnts should be used.
-			numDefaultArgs := int(function["numdefaults"].(int16))
-			if numDefaultArgs > 0 {
-				numDefaultArgs = rand.Intn(numDefaultArgs)
-			}
-			// Populate the arguments for this signature, and select some number
-			// of default arguments.
-			for _, oidStr := range argTypesStr {
-				oid, err := strconv.Atoi(oidStr)
-				if err != nil {
-					return nil, err
-				}
-				argTypes = append(argTypes, oid)
-			}
-			argIn := strings.Builder{}
-			for idx := range strings.Split(args, ",") {
-				// We have hit the default arguments that we want to not populate.
-				if idx > len(argTypesStr)-numDefaultArgs {
-					break
-				}
-				if argIn.Len() > 0 {
-					argIn.WriteString(",")
-				}
-				// Resolve the type for each column and if possible generate a random
-				// value via randgen.
-				oidValue := oid.Oid(argTypes[idx])
-				typ, ok := types.OidToType[oidValue]
-				if !ok {
-					argIn.WriteString("NULL")
-				} else {
-					randomDatum := randgen.RandDatum(og.params.rng, typ, true)
-					argIn.WriteString(tree.AsStringWithFlags(randomDatum, tree.FmtParsable))
-				}
-			}
-			args = argIn.String()
+		invocation, err := og.buildFuncInvocation(function)
+		if err != nil {
+			return nil, err
 		}
-		possibleBodyFuncReferences = append(possibleBodyFuncReferences, fmt.Sprintf("(SELECT %s.%s(%s) IS NOT NULL)", function["schema"].(string), function["name"].(string), args))
+		possibleBodyFuncReferences = append(possibleBodyFuncReferences, invocation)
 	}
 
 	hasFuncRefs := false
@@ -5766,11 +5714,32 @@ func (og *operationGenerator) createTriggerFunction(
 		}
 	}
 
+	// Sometimes include a UDF call expression to exercise trigger-UDF
+	// dependency tracking (TriggerDeps.uses_routine_ids).
+	udfSelectStmt := ""
+	if og.randIntn(2) == 0 {
+		udfFunctions, err := og.findNonTriggerFunctions(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+		if len(udfFunctions) > 0 {
+			picked, err := PickOne(og.params.rng, udfFunctions)
+			if err != nil {
+				return nil, err
+			}
+			invocation, err := og.buildFuncInvocation(picked)
+			if err != nil {
+				return nil, err
+			}
+			udfSelectStmt = fmt.Sprintf("SELECT %s;", invocation)
+		}
+	}
+
 	// The trigger function always returns NEW to avoid breaking inserts.
 	opStmt := makeOpStmt(OpStmtDDL)
 	opStmt.sql = fmt.Sprintf(
-		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
-		resolvedName, seqSelectStmt, enumSelectStmt, selectStmt.sql,
+		`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s%s%s%s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`,
+		resolvedName, seqSelectStmt, enumSelectStmt, udfSelectStmt, selectStmt.sql,
 	)
 	og.LogMessage(fmt.Sprintf("createTriggerFunction: %s", opStmt.sql))
 
@@ -5783,7 +5752,6 @@ func (og *operationGenerator) createTriggerFunction(
 		{code: pgcode.FeatureNotSupported, condition: !og.useDeclarativeSchemaChanger},
 		{code: pgcode.DuplicateFunction, condition: routineAlreadyExists},
 	})
-
 	return opStmt, nil
 }
 
@@ -5916,6 +5884,73 @@ func (og *operationGenerator) collectEnumMembers(
 		FROM enum_members
 	`)
 	return Collect(ctx, og, tx, pgx.RowToMap, q)
+}
+
+// findNonTriggerFunctions returns public, non-trigger UDFs with argument
+// metadata (schema, name, args, argtypes, numdefaults) for building
+// invocations.
+func (og *operationGenerator) findNonTriggerFunctions(
+	ctx context.Context, tx pgx.Tx,
+) ([]map[string]any, error) {
+	q := With([]CTE{
+		{"descriptors", descJSONQuery},
+		{"functions", functionDescsQuery},
+	}, `SELECT
+	quote_ident(schema_id::REGNAMESPACE::STRING) AS schema,
+	quote_ident(name) AS name,
+	array_to_string(proargnames, ',') AS args,
+	proargtypes AS argtypes,
+	pronargdefaults as numdefaults
+FROM
+	functions
+	INNER JOIN pg_catalog.pg_proc ON oid = (id + 100000)
+	WHERE COALESCE((descriptor->'state')::STRING, 'PUBLIC') = 'PUBLIC'::STRING
+	AND prorettype != 'trigger'::REGTYPE;`)
+	return Collect(ctx, og, tx, pgx.RowToMap, q)
+}
+
+// buildFuncInvocation constructs a SQL expression that invokes the given UDF
+// with random arguments: (SELECT schema.func(args) IS NOT NULL).
+func (og *operationGenerator) buildFuncInvocation(function map[string]any) (string, error) {
+	args := ""
+	if function["args"] != nil {
+		args = function["args"].(string)
+		argTypesStr := strings.Split(function["argtypes"].(string), " ")
+		argTypes := make([]int, 0, len(argTypesStr))
+		numDefaultArgs := int(function["numdefaults"].(int16))
+		if numDefaultArgs > 0 {
+			numDefaultArgs = og.randIntn(numDefaultArgs)
+		}
+		for _, oidStr := range argTypesStr {
+			oidVal, err := strconv.Atoi(oidStr)
+			if err != nil {
+				return "", err
+			}
+			argTypes = append(argTypes, oidVal)
+		}
+		argIn := strings.Builder{}
+		for idx := range strings.Split(args, ",") {
+			if idx > len(argTypesStr)-numDefaultArgs {
+				break
+			}
+			if argIn.Len() > 0 {
+				argIn.WriteString(",")
+			}
+			oidValue := oid.Oid(argTypes[idx])
+			typ, ok := types.OidToType[oidValue]
+			if !ok {
+				argIn.WriteString("NULL")
+			} else {
+				randomDatum := randgen.RandDatum(og.params.rng, typ, true)
+				argIn.WriteString(tree.AsStringWithFlags(randomDatum, tree.FmtParsable))
+			}
+		}
+		args = argIn.String()
+	}
+	return fmt.Sprintf(
+		"(SELECT %s.%s(%s) IS NOT NULL)",
+		function["schema"].(string), function["name"].(string), args,
+	), nil
 }
 
 // findExistingTriggerFunctions returns existing trigger functions (RETURNS


### PR DESCRIPTION
The random schema workload's trigger function bodies never called other UDFs, so TriggerDeps.uses_routine_ids was never populated and dropping a UDF referenced by a trigger function body was never exercised.

Extract findNonTriggerFunctions and buildFuncInvocation helpers from createFunction for reuse, then use them in createTriggerFunction to sometimes (50% probability) include a UDF invocation in the trigger function body. Add pgcode.UndefinedFunction as a potential exec error when a UDF reference is present. Also fix a determinism issue by replacing the bare rand.Intn call with og.randIntn.

Informs: #167410

Epic: CRDB-60540
Release note: None