### PR TITLE
kvserver: deflake flow control integration tests

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -716,6 +716,9 @@ func TestFlowControlRaftSnapshotV2(t *testing.T) {
 							return disableWorkQueueGranting.Load()
 						},
 					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
+					},
 					RaftTransport: &kvserver.RaftTransportTestingKnobs{
 						OverrideIdleTimeout: func() time.Duration {
 							// Effectively disable token returns due to underlying
@@ -949,6 +952,9 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 						DisableWorkQueueGranting: func() bool {
 							return disableWorkQueueGranting.Load()
 						},
+					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
 					},
 					Server: &server.TestingKnobs{
 						WallClock: manualClock,
@@ -1337,6 +1343,9 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 						DisableWorkQueueGranting: func() bool {
 							return disableWorkQueueGranting.Load()
 						},
+					},
+					KVClient: &kvcoord.ClientTestingKnobs{
+						DontRandomizeLeaseholderOnCtxError: true,
 					},
 					RaftTransport: &kvserver.RaftTransportTestingKnobs{
 						DisableFallbackFlowTokenDispatch: func() bool {
@@ -2925,6 +2934,9 @@ func TestFlowControlSendQueueRangeMigrate(t *testing.T) {
 						idx := i
 						return disableWorkQueueGrantingServers[idx].Load()
 					},
+				},
+				KVClient: &kvcoord.ClientTestingKnobs{
+					DontRandomizeLeaseholderOnCtxError: true,
 				},
 			},
 		}


### PR DESCRIPTION
Add the DontRandomizeLeaseholderOnCtxError testing knob to four flow
control integration tests that were missing it:

- TestFlowControlSendQueueRangeMigrate
- TestFlowControlRaftSnapshotV2
- TestFlowControlRaftMembershipV2
- TestFlowControlUnquiescedRangeV2

Without this knob, the DistSender may randomize the cached leaseholder
on context errors (common in stress mode), routing requests to a node
where admission granting is disabled. This causes the request to block
indefinitely in WorkQueue.Admit, leading to a test timeout.

This is the same fix applied to 12 other flow control tests in recent
deflaking efforts.

Resolves: #168560

Release note: None