### PR TITLE
kvstorage: use ReplicaMark in WAG replay decision logic

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag_replay.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay.go
@@ -18,23 +18,8 @@ import (
 // persistedRangeState describes the applied state of a range in the state
 // machine, as needed by the WAG replay decision logic.
 type persistedRangeState struct {
-	replicaID              roachpb.ReplicaID
-	tombstoneNextReplicaID roachpb.ReplicaID
-	appliedIndex           kvpb.RaftIndex
-}
-
-// validate checks persistedRangeState invariants.
-func (s persistedRangeState) validate() error {
-	// When a replica exists (ReplicaID > 0), the tombstone must not exceed the
-	// replica ID. The tombstone is only bumped above a replica's ID when that
-	// replica is destroyed.
-	if s.replicaID > 0 && s.tombstoneNextReplicaID > s.replicaID {
-		return errors.AssertionFailedf(
-			"tombstone (NextReplicaID=%d) is above current ReplicaID=%d",
-			s.tombstoneNextReplicaID, s.replicaID,
-		)
-	}
-	return nil
+	mark         ReplicaMark
+	appliedIndex kvpb.RaftIndex
 }
 
 // loadPersistedRangeState loads the replay-relevant state for a range from the
@@ -51,12 +36,10 @@ func loadPersistedRangeState(
 	if err != nil {
 		return persistedRangeState{}, err
 	}
-	state := persistedRangeState{
-		replicaID:              mark.ReplicaID,
-		tombstoneNextReplicaID: mark.NextReplicaID,
-		appliedIndex:           as.RaftAppliedIndex,
-	}
-	return state, state.validate()
+	return persistedRangeState{
+		mark:         mark,
+		appliedIndex: as.RaftAppliedIndex,
+	}, nil
 }
 
 // replayAction describes what the replay loop must do for a WAG node.
@@ -82,43 +65,38 @@ type raftCatchUpTarget struct {
 // event against the state machine's current position for this range. See
 // canApplyWAGNode for the node-level wrapper.
 //
-// The decision is based on where event replica ID falls relative to
-// state.replicaID on the number line, giving three regions:
+// The decision is based on where the event's replica ID falls relative to
+// the current ReplicaMark, giving three cases:
 //
-//	[0, state.replicaID)   → old (destroyed or never existed); skip
-//	state.replicaID        → current replica; compare raft indices
-//	(state.replicaID, ∞)   → new replica; apply
-//
-// TODO(mira): Refactor to use ReplicaMark (#156696) which will encapsulate
-// the replicaID/tombstone comparison logic.
+//   - Destroyed: the replica ID is below the mark's tombstone or current
+//     replica ID, meaning it can never (re-)appear. Skip.
+//   - Current: the replica ID matches the mark's current replica. Compare
+//     raft indices to determine whether the event has already been applied.
+//   - New: the replica ID is above the mark's current replica and not
+//     destroyed. Apply.
 //
 // TODO(mira): Some of the cases below are not possible for all event types.
-// E.g. For a new replica with event.Addr.ReplicaID > state.replicaID, we'd
-// expect an EventCreate, not another type of event. Assert on these.
+// E.g. For a new replica with event.Addr.ReplicaID > state.mark.ReplicaID,
+// we'd expect an EventCreate, not another type of event. Assert on these.
 func (state persistedRangeState) canApply(event wagpb.Event) bool {
 	// The WAG protocol ensures that any WAG node event has a non-zero ReplicaID.
 	if event.Addr.ReplicaID == 0 {
 		panic(errors.AssertionFailedf("WAG event for r%d has zero ReplicaID", event.Addr.RangeID))
 	}
 	switch {
-	case event.Addr.ReplicaID < state.tombstoneNextReplicaID ||
-		event.Addr.ReplicaID < state.replicaID:
-		// Old replica (destroyed or never existed); skip. The persistedRangeState
-		// validation guarantees state.tombstoneNextReplicaID <= state.replicaID
-		// when a replica exists, but we can't rely on the state.replicaID
-		// comparison alone because when no current replica exists
-		// (state.replicaID == 0), only the tombstone can identify stale events.
+	case state.mark.Destroyed(event.Addr.ReplicaID):
+		// Old replica (destroyed or never existed); skip.
 		return false
-	case event.Addr.ReplicaID == state.replicaID:
+	case state.mark.Is(event.Addr.ReplicaID):
 		// Current replica. Destroy/Subsume events always need applying here —
 		// if their mutation had already been applied, the tombstone would have
-		// been bumped and the first case would have matched.
+		// been bumped and the Destroyed case would have matched.
 		if event.Type == wagpb.EventDestroy || event.Type == wagpb.EventSubsume {
 			return true
 		}
 		// For other events, compare raft indices.
 		return event.Addr.Index > state.appliedIndex
-	case event.Addr.ReplicaID > state.replicaID:
+	case event.Addr.ReplicaID > state.mark.ReplicaID:
 		// New replica not yet seen on this store; apply.
 		return true
 	default:

--- a/pkg/kv/kvserver/kvstorage/wag_replay_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay_test.go
@@ -20,6 +20,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// replicaMark is a test helper that constructs a ReplicaMark.
+func replicaMark(replicaID, nextReplicaID roachpb.ReplicaID) ReplicaMark {
+	return ReplicaMark{
+		RaftReplicaID:  kvserverpb.RaftReplicaID{ReplicaID: replicaID},
+		RangeTombstone: kvserverpb.RangeTombstone{NextReplicaID: nextReplicaID},
+	}
+}
+
 // TestCanApply exercises the per-event replay decision logic, verifying that
 // canApply correctly classifies events as needing application or not, and that
 // raftCatchUp returns the right catch-up index for applicable events.
@@ -42,12 +50,12 @@ func TestCanApply(t *testing.T) {
 		{
 			name:        "event below tombstone",
 			event:       event(3, 10, wagpb.EventApply),
-			state:       persistedRangeState{tombstoneNextReplicaID: 5},
+			state:       persistedRangeState{mark: replicaMark(0, 5)},
 			shouldApply: false,
 		}, {
 			name:        "old replica, superseded by current replica",
 			event:       event(3, 10, wagpb.EventApply),
-			state:       persistedRangeState{replicaID: 5, appliedIndex: 10},
+			state:       persistedRangeState{mark: replicaMark(5, 0), appliedIndex: 10},
 			shouldApply: false,
 		},
 
@@ -56,44 +64,44 @@ func TestCanApply(t *testing.T) {
 		{
 			name:        "apply below applied index",
 			event:       event(3, 49, wagpb.EventApply),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: false,
 		}, {
 			name:        "apply at applied index",
 			event:       event(3, 50, wagpb.EventApply),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: false,
 		}, {
 			name:        "apply above applied index",
 			event:       event(3, 51, wagpb.EventApply),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: true, shouldCatchUp: 51,
 		}, {
 			name:        "split above applied index",
 			event:       event(3, 100, wagpb.EventSplit),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: true, shouldCatchUp: 99,
 		}, {
 			name:        "merge above applied index",
 			event:       event(3, 100, wagpb.EventMerge),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: true, shouldCatchUp: 99,
 		}, {
 			name:        "destroy above applied index",
 			event:       event(3, 100, wagpb.EventDestroy),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: true, shouldCatchUp: 100,
 		}, {
 			// Destroy/Subsume at the applied index still need applying — if they
 			// had already been applied, the tombstone would have been bumped.
 			name:        "destroy at applied index",
 			event:       event(3, 50, wagpb.EventDestroy),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: true, shouldCatchUp: 50,
 		}, {
 			name:        "subsume at applied index",
 			event:       event(3, 50, wagpb.EventSubsume),
-			state:       persistedRangeState{replicaID: 3, appliedIndex: 50},
+			state:       persistedRangeState{mark: replicaMark(3, 0), appliedIndex: 50},
 			shouldApply: true, shouldCatchUp: 50,
 		},
 
@@ -105,12 +113,12 @@ func TestCanApply(t *testing.T) {
 		}, {
 			name:        "create at tombstone boundary",
 			event:       event(5, 0, wagpb.EventCreate),
-			state:       persistedRangeState{tombstoneNextReplicaID: 5},
+			state:       persistedRangeState{mark: replicaMark(0, 5)},
 			shouldApply: true,
 		}, {
 			name:        "create above tombstone",
 			event:       event(10, 0, wagpb.EventCreate),
-			state:       persistedRangeState{tombstoneNextReplicaID: 5},
+			state:       persistedRangeState{mark: replicaMark(0, 5)},
 			shouldApply: true,
 		},
 	} {
@@ -132,10 +140,9 @@ func writePersistedRangeState(
 	t.Helper()
 	ctx := context.Background()
 	sl := MakeStateLoader(rangeID)
-	ts := kvserverpb.RangeTombstone{NextReplicaID: state.tombstoneNextReplicaID}
 	as := &kvserverpb.RangeAppliedState{RaftAppliedIndex: state.appliedIndex}
-	require.NoError(t, sl.SetRaftReplicaID(ctx, stateRW, state.replicaID))
-	require.NoError(t, sl.SetRangeTombstone(ctx, stateRW, ts))
+	require.NoError(t, sl.SetRaftReplicaID(ctx, stateRW, state.mark.ReplicaID))
+	require.NoError(t, sl.SetRangeTombstone(ctx, stateRW, state.mark.RangeTombstone))
 	require.NoError(t, sl.SetRangeAppliedState(ctx, stateRW, as))
 }
 
@@ -158,7 +165,7 @@ func TestCanApplyWAGNode(t *testing.T) {
 		{
 			name: "single event, needs apply",
 			states: map[roachpb.RangeID]persistedRangeState{
-				1: {replicaID: 3, appliedIndex: 50},
+				1: {mark: replicaMark(3, 0), appliedIndex: 50},
 			},
 			node: wagpb.Node{Events: []wagpb.Event{
 				{Addr: wagpb.Addr{RangeID: 1, ReplicaID: 3, Index: 51}, Type: wagpb.EventApply},
@@ -168,7 +175,7 @@ func TestCanApplyWAGNode(t *testing.T) {
 		}, {
 			name: "single event, already applied",
 			states: map[roachpb.RangeID]persistedRangeState{
-				1: {replicaID: 3, appliedIndex: 50},
+				1: {mark: replicaMark(3, 0), appliedIndex: 50},
 			},
 			node: wagpb.Node{Events: []wagpb.Event{
 				{Addr: wagpb.Addr{RangeID: 1, ReplicaID: 3, Index: 50}, Type: wagpb.EventApply},
@@ -177,7 +184,7 @@ func TestCanApplyWAGNode(t *testing.T) {
 		}, {
 			name: "multi-event split, needs apply with per-range catch-ups",
 			states: map[roachpb.RangeID]persistedRangeState{
-				1: {replicaID: 3, appliedIndex: 99},
+				1: {mark: replicaMark(3, 0), appliedIndex: 99},
 			},
 			node: wagpb.Node{Events: []wagpb.Event{
 				// EventSplit for LHS (catch-up to index 99).
@@ -190,8 +197,8 @@ func TestCanApplyWAGNode(t *testing.T) {
 		}, {
 			name: "multi-event split, already applied",
 			states: map[roachpb.RangeID]persistedRangeState{
-				1: {replicaID: 3, appliedIndex: 100},
-				2: {replicaID: 1, tombstoneNextReplicaID: 1, appliedIndex: 10},
+				1: {mark: replicaMark(3, 0), appliedIndex: 100},
+				2: {mark: replicaMark(1, 1), appliedIndex: 10},
 			},
 			node: wagpb.Node{Events: []wagpb.Event{
 				{Addr: wagpb.Addr{RangeID: 1, ReplicaID: 3, Index: 100}, Type: wagpb.EventSplit},
@@ -201,7 +208,7 @@ func TestCanApplyWAGNode(t *testing.T) {
 		}, {
 			name: "multi-event disagreement returns error",
 			states: map[roachpb.RangeID]persistedRangeState{
-				1: {replicaID: 3, appliedIndex: 100},
+				1: {mark: replicaMark(3, 0), appliedIndex: 100},
 			},
 			// LHS already applied but RHS not yet — should not happen.
 			node: wagpb.Node{Events: []wagpb.Event{


### PR DESCRIPTION
Refactor canApply to use ReplicaMark.Destroyed and ReplicaMark.Is
instead of manual replicaID/tombstone comparisons. This removes the
persistedRangeState.validate method (subsumed by ReplicaMark.check,
already called by LoadReplicaMark) and the separate replicaID /
tombstoneNextReplicaID fields (replaced by a single ReplicaMark).

Part of: #167278

Release note: None