### PR TITLE
sql/importer: include fully qualified name and job ID in INSPECT description

### DIFF
--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -428,17 +428,28 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 
 		var checks []*jobspb.InspectDetails_Check
-		var tableName string
+		var dbName, schemaName, tableName string
 		if err := p.ExecCfg().InternalDB.DescsTxn(ctx, func(
 			ctx context.Context, txn descs.Txn,
 		) error {
 			// INSPECT requires the latest descriptor. The one cached in the job is
 			// out of date as it has an old table version.
-			tblDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, table.Desc.ID)
+			descriptors := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get()
+			tblDesc, err := descriptors.Table(ctx, table.Desc.ID)
 			if err != nil {
 				return err
 			}
 			tableName = tblDesc.GetName()
+			dbDesc, err := descriptors.Database(ctx, tblDesc.GetParentID())
+			if err != nil {
+				return err
+			}
+			dbName = dbDesc.GetName()
+			scDesc, err := descriptors.Schema(ctx, tblDesc.GetParentSchemaID())
+			if err != nil {
+				return err
+			}
+			schemaName = scDesc.GetName()
 
 			if creationVersion := r.job.Payload().CreationClusterVersion; !details.Table.WasEmpty && creationVersion.Less(clusterversion.V26_2.Version()) {
 				log.Eventf(ctx, "skipping row count on table %q: the table was not empty and the job was started in an unsupported version", tableName)
@@ -460,9 +471,14 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 
 		if len(checks) > 0 {
+			tn := tree.MakeTableNameWithSchema(
+				tree.Name(dbName),
+				tree.Name(schemaName),
+				tree.Name(tableName),
+			)
 			inspectJob, err := inspect.TriggerJob(
 				ctx,
-				fmt.Sprintf("import-validation-%s", tableName),
+				fmt.Sprintf("Validating IMPORT of %s (IMPORT job %d)", tn.FQString(), r.job.ID()),
 				p.ExecCfg(),
 				checks,
 				setPublicTimestamp,

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -913,3 +913,37 @@ DROP TABLE uniqueness_check_complex;
 subtest end
 
 subtest end
+
+subtest import_validation_job_description
+
+statement ok
+SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'async';
+
+statement ok
+CREATE TABLE import_desc_test (k INT PRIMARY KEY, v INT);
+
+let $exp_file
+WITH cte AS (EXPORT INTO CSV 'nodelocal://1/import-desc-test' FROM SELECT i, i*10 FROM generate_series(1, 5) AS g(i)) SELECT filename FROM cte;
+
+statement ok
+IMPORT INTO import_desc_test CSV DATA ('nodelocal://1/import-desc-test/$exp_file');
+
+let $import_job_id
+SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT' ORDER BY created DESC LIMIT 1
+
+query B retry
+SELECT
+  crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload)->>'description'
+  = 'Validating IMPORT of test.public.import_desc_test (IMPORT job ' || $import_job_id::STRING || ')'
+FROM crdb_internal.system_jobs
+WHERE job_type = 'INSPECT' ORDER BY id DESC LIMIT 1
+----
+true
+
+statement ok
+DROP TABLE import_desc_test;
+
+statement ok
+RESET CLUSTER SETTING bulkio.import.row_count_validation.mode;
+
+subtest end


### PR DESCRIPTION
The INSPECT job triggered after IMPORT used a terse slug-style description like "import-validation-order". Update it to include the fully qualified table name (db.schema.table) and the originating IMPORT job ID, making it easier to identify what was validated and trace back to the IMPORT.

The new format is:
```
  Validating IMPORT of defaultdb.public.order (IMPORT job 123456789)
```

Informs: #168396
Release note: None
Epic: none