### PR TITLE
importer: add test reproducing workload:// row count mismatch on retry

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -248,6 +248,7 @@ go_test(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "//pkg/workload",
+        "//pkg/workload/bank",
         "//pkg/workload/tpcc",
         "@com_github_apache_arrow_go_v11//arrow",
         "@com_github_apache_arrow_go_v11//arrow/array",

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	// Register the bank workload generator for workload:// URI tests.
+	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -624,4 +626,77 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 				[][]string{{fmt.Sprintf("%d", tc.totalRows)}})
 		})
 	}
+}
+
+// TestImportIntoWorkloadURIRowCountCheckAfterRetry verifies that INSPECT row
+// count validation passes after an import using a workload:// URI is retried
+// mid-processing. The duringDistImport knob injects an error after the first
+// batch is persisted, so distImport fails with intermediate ResumePos values.
+// On retry the import should complete and INSPECT should confirm the correct
+// row count.
+//
+// This currently fails because the workload reader ignores resumePos (#168396),
+// re-reading all rows from scratch, while bulkSummary accumulates across
+// retries — inflating the expected count.
+func TestImportIntoWorkloadURIRowCountCheckAfterRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "uses short job adoption intervals that don't work well in slow test configurations")
+
+	ctx := context.Background()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				BulkAdderFlushesEveryBatch: true,
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(db)
+
+	// Use sync mode so the import blocks until the inspect job completes. If
+	// the row count is wrong the import statement itself will fail.
+	runner.Exec(t, `SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'sync'`)
+
+	s := srv.ApplicationLayer()
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	var once sync.Once
+	var retryTriggered atomic.Bool
+	registry.TestingWrapResumerConstructor(
+		jobspb.TypeImport,
+		func(resumer jobs.Resumer) jobs.Resumer {
+			r := resumer.(interface {
+				TestingSetAlwaysFlushJobProgress()
+				TestingSetDuringDistImportKnob(func() error)
+			})
+			// Flush progress after every batch so that intermediate
+			// ResumePos and partial Summary are persisted to the job
+			// record before we inject the error.
+			r.TestingSetAlwaysFlushJobProgress()
+			r.TestingSetDuringDistImportKnob(func() error {
+				var err error
+				once.Do(func() {
+					retryTriggered.Store(true)
+					// The "rpc error" substring makes this retryable
+					// per sqlerrors.IsDistSQLRetryableError.
+					err = errors.New("rpc error: injected test retry")
+				})
+				return err
+			})
+			return resumer
+		})
+
+	runner.Exec(t, `CREATE TABLE bank (id INT PRIMARY KEY, balance INT, payload STRING)`)
+
+	runner.Exec(t,
+		`IMPORT INTO bank (id, balance, payload) CSV DATA ('workload:///csv/bank/bank?rows=100&row-start=0&row-end=1&version=1.0.0')`)
+
+	require.True(t, retryTriggered.Load(), "expected injected error to trigger a retry")
+
+	runner.CheckQueryResults(t,
+		`SELECT count(*) FROM bank`, [][]string{{"100"}})
 }

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -69,6 +69,11 @@ type importTestingKnobs struct {
 	// call inside ingestWithRetry. If it returns an error, that error
 	// replaces the nil err and triggers a retry.
 	afterDistImport func() error
+	// duringDistImport, if set, is called during distImport processing
+	// after each batch's progress has been recorded (and persisted, if
+	// alwaysFlushJobProgress is true). If it returns a non-nil error,
+	// distImport fails with that error.
+	duringDistImport func() error
 }
 
 type importResumer struct {
@@ -101,6 +106,10 @@ func (r *importResumer) TestingSetAlwaysFlushJobProgress() {
 
 func (r *importResumer) TestingSetAfterDistImportKnob(fn func() error) {
 	r.testingKnobs.afterDistImport = fn
+}
+
+func (r *importResumer) TestingSetDuringDistImportKnob(fn func() error) {
+	r.testingKnobs.duringDistImport = fn
 }
 
 var _ jobs.TraceableJob = &importResumer{}

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -239,6 +239,10 @@ func distImport(
 		checkpoint.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
 
+	// hookFired is set when duringDistImport returns an error. After that,
+	// we skip progress persistence to preserve intermediate ResumePos in
+	// the job record. Safe without a mutex: metaFn runs on a single goroutine.
+	var hookFired bool
 	metaFn := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {
 			// Decode map progress outside the lock since it doesn't touch
@@ -268,8 +272,16 @@ func distImport(
 				}
 			}
 
-			if testingKnobs.alwaysFlushJobProgress {
-				return checkpoint.Persist(ctx, job)
+			if testingKnobs.alwaysFlushJobProgress && !hookFired {
+				if err := checkpoint.Persist(ctx, job); err != nil {
+					return err
+				}
+			}
+			if !hookFired && testingKnobs.duringDistImport != nil {
+				if err := testingKnobs.duringDistImport(); err != nil {
+					hookFired = true
+					return err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Add TestImportIntoWorkloadURIRowCountCheckAfterRetry which demonstrates that INSPECT row count validation fails when an IMPORT INTO using a workload:// URI is retried mid-processing. The workload reader ignores resumePos, so on retry all rows are re-read from scratch, while bulkSummary accumulates across retries — inflating the expected row count. INSPECT catches this mismatch.

To support this, add a duringDistImport testing knob that fires inside distImport's metaFn callback after each batch's progress is recorded. This allows injecting an error mid-processing (unlike afterDistImport which fires after distImport completes fully). After the hook fires, further progress persistence is skipped so intermediate ResumePos values are preserved in the job record.

The test currently fails, demonstrating the bug described in #168396.

Epic: none
Release note: None