### PR TITLE
release-26.2: roachtest: retry gcloud disk creation on transient GCE errors

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
 // CopySnapshotDataToNodes copies CockroachDB data from GCE disk snapshots to
@@ -100,15 +101,36 @@ func copySnapshotDataToNode(
 	tempDiskName := fmt.Sprintf("%s-temp-snapshot-%04d", c.Name(), nodeID)
 	deviceName := fmt.Sprintf("snapshot-disk-%04d", nodeID)
 
-	// Create a temporary disk from the snapshot.
+	// Create a temporary disk from the snapshot. Retry transient GCE API
+	// errors (e.g. HTTP 502) which can occur when many nodes create disks
+	// in parallel against the same zone.
 	l.Printf("n%d: creating temp disk %s from snapshot in zone %s",
 		nodeID, tempDiskName, zone)
 	createDiskCmd := fmt.Sprintf(
 		`gcloud compute disks create %s --source-snapshot=%s --zone=%s --type=pd-ssd --quiet`,
 		tempDiskName, snap.ID, zone,
 	)
-	if err := c.RunE(ctx, option.WithNodes(node), createDiskCmd); err != nil {
+	var createDiskErr error
+	if err := retry.ForDuration(2*time.Minute, func() error {
+		result, err := c.RunWithDetailsSingleNode(
+			ctx, l, option.WithNodes(node), createDiskCmd,
+		)
+		if err == nil {
+			return nil
+		}
+		if isGCETransientError(result.Stderr) {
+			l.Printf("n%d: transient GCE error creating disk, retrying: %v", nodeID, err)
+			return err
+		}
+		// Non-transient error; stop retrying.
+		createDiskErr = err
+		return nil
+	}); err != nil {
+		// Transient errors exhausted the retry duration.
 		return fmt.Errorf("n%d: failed to create disk from snapshot: %w", nodeID, err)
+	}
+	if createDiskErr != nil {
+		return fmt.Errorf("n%d: failed to create disk from snapshot: %w", nodeID, createDiskErr)
 	}
 
 	// Clean up the temp disk when we're done, regardless of success or
@@ -170,4 +192,24 @@ func copySnapshotDataToNode(
 	l.Printf("n%d: data copy complete", nodeID)
 
 	return nil
+}
+
+// isGCETransientError checks whether stderr from a gcloud command
+// indicates a transient server-side error worth retrying.
+func isGCETransientError(stderr string) bool {
+	transientPatterns := []string{
+		"502",
+		"503",
+		"Server Error",
+		"try again",
+		"Rate Limit",
+		"RATE_LIMIT",
+		"rate limit",
+	}
+	for _, p := range transientPatterns {
+		if strings.Contains(stderr, p) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Backport 1/1 commits from #168526 on behalf of @angeladietz.

----

CopySnapshotDataToNodes creates temporary GCE disks from snapshots in
parallel, and transient GCE API errors (e.g. HTTP 502) can fail the
test before any CockroachDB code runs. Wrap the disk creation call in
retry.ForDuration with a 2-minute window and exponential backoff.

Fixes #168296

Release note: None
Epic: none

----

Release justification: