### PR TITLE
obs,sql: address review feedback on statement fingerprint store

### DIFF
--- a/pkg/obs/statementstore/statement_store.go
+++ b/pkg/obs/statementstore/statement_store.go
@@ -162,14 +162,14 @@ func (ss *StatementStore) addToCacheIfAbsent(
 	if _, ok := ss.cacheMu.cache.Get(id); ok {
 		return false
 	}
-	// Add may trigger eviction, which shrinks the account via OnEvicted.
-	ss.cacheMu.cache.Add(id, struct{}{})
 	if ss.memAcc != nil {
 		if err := ss.memAcc.Grow(ctx, cacheEntrySize); err != nil {
 			log.Ops.Warningf(ctx,
 				"statement store cache memory accounting error: %s", err)
+			return false
 		}
 	}
+	ss.cacheMu.cache.Add(id, struct{}{})
 	return true
 }
 
@@ -185,13 +185,17 @@ func (ss *StatementStore) appendPending(ctx context.Context, info StatementInfo)
 	if len(ss.flushMu.pending) >= maxPendingSize {
 		// Buffer full — evict from cache so we retry on the next
 		// occurrence rather than silently dropping the fingerprint.
+		log.Ops.Warningf(ctx, "statement store pending buffer full, skipping fingerprint. ID: %d", info.FingerprintID)
 		ss.evictFromCacheByID(info.FingerprintID)
 		return
 	}
-	ss.flushMu.pending = append(ss.flushMu.pending, info)
 	if ss.memAcc != nil {
-		_ = ss.memAcc.Grow(ctx, statementInfoSize(info))
+		if err := ss.memAcc.Grow(ctx, statementInfoSize(info)); err != nil {
+			ss.evictFromCacheByID(info.FingerprintID)
+			return
+		}
 	}
+	ss.flushMu.pending = append(ss.flushMu.pending, info)
 }
 
 var logEvery = log.Every(10 * time.Second)
@@ -203,7 +207,7 @@ func (ss *StatementStore) Start(ctx context.Context, stopper *stop.Stopper) {
 			panic(errors.AssertionFailedf(
 				"StatementStore.Start called before SetInternalExecutor"))
 		}
-		log.Dev.Error(ctx,
+		log.Ops.Errorf(ctx,
 			"StatementStore.Start called before SetInternalExecutor")
 		return
 	}

--- a/pkg/obs/statementstore/statement_store.go
+++ b/pkg/obs/statementstore/statement_store.go
@@ -162,14 +162,14 @@ func (ss *StatementStore) addToCacheIfAbsent(
 	if _, ok := ss.cacheMu.cache.Get(id); ok {
 		return false
 	}
-	// Add may trigger eviction, which shrinks the account via OnEvicted.
-	ss.cacheMu.cache.Add(id, struct{}{})
 	if ss.memAcc != nil {
 		if err := ss.memAcc.Grow(ctx, cacheEntrySize); err != nil {
 			log.Ops.Warningf(ctx,
 				"statement store cache memory accounting error: %s", err)
+			return false
 		}
 	}
+	ss.cacheMu.cache.Add(id, struct{}{})
 	return true
 }
 
@@ -179,19 +179,29 @@ func (ss *StatementStore) evictFromCacheByID(id appstatspb.StmtFingerprintID) {
 	ss.cacheMu.cache.Del(id)
 }
 
+var logEveryAppend = log.Every(10 * time.Second)
+
 func (ss *StatementStore) appendPending(ctx context.Context, info StatementInfo) {
 	ss.flushMu.Lock()
 	defer ss.flushMu.Unlock()
 	if len(ss.flushMu.pending) >= maxPendingSize {
 		// Buffer full — evict from cache so we retry on the next
 		// occurrence rather than silently dropping the fingerprint.
+		if logEveryAppend.ShouldLog() {
+			log.Ops.Warningf(ctx, "statement store pending buffer full, skipping fingerprint. ID: %d", info.FingerprintID)
+		}
 		ss.evictFromCacheByID(info.FingerprintID)
 		return
 	}
-	ss.flushMu.pending = append(ss.flushMu.pending, info)
 	if ss.memAcc != nil {
-		_ = ss.memAcc.Grow(ctx, statementInfoSize(info))
+		if err := ss.memAcc.Grow(ctx, statementInfoSize(info)); err != nil {
+			log.Ops.Warningf(ctx,
+				"statement store cache memory accounting error: %s", err)
+			ss.evictFromCacheByID(info.FingerprintID)
+			return
+		}
 	}
+	ss.flushMu.pending = append(ss.flushMu.pending, info)
 }
 
 var logEvery = log.Every(10 * time.Second)
@@ -203,7 +213,7 @@ func (ss *StatementStore) Start(ctx context.Context, stopper *stop.Stopper) {
 			panic(errors.AssertionFailedf(
 				"StatementStore.Start called before SetInternalExecutor"))
 		}
-		log.Dev.Error(ctx,
+		log.Ops.Errorf(ctx,
 			"StatementStore.Start called before SetInternalExecutor")
 		return
 	}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -569,7 +569,11 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	)
 	s.indexUsageStatsController = idxusage.NewController(cfg.SQLStatusServer)
 
-	statementStoreIEMonitor := MakeInternalExecutorMemMonitor(MemoryMetrics{}, s.GetExecutorConfig().Settings)
+	statementStoreIEMonitor := mon.NewMonitor(mon.Options{
+		Name:       mon.MakeName("statement store"),
+		Settings:   s.GetExecutorConfig().Settings,
+		LongLiving: true,
+	})
 	statementStoreIEMonitor.StartNoReserved(context.Background(), s.GetBytesMonitor())
 	s.statementsStore.SetInternalExecutor(
 		NewInternalDB(s, MemoryMetrics{}, statementStoreIEMonitor),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -568,7 +568,11 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	)
 	s.indexUsageStatsController = idxusage.NewController(cfg.SQLStatusServer)
 
-	statementStoreIEMonitor := MakeInternalExecutorMemMonitor(MemoryMetrics{}, s.GetExecutorConfig().Settings)
+	statementStoreIEMonitor := mon.NewMonitor(mon.Options{
+		Name:       mon.MakeName("statement store"),
+		Settings:   s.GetExecutorConfig().Settings,
+		LongLiving: true,
+	})
 	statementStoreIEMonitor.StartNoReserved(context.Background(), s.GetBytesMonitor())
 	s.statementsStore.SetInternalExecutor(
 		NewInternalDB(s, MemoryMetrics{}, statementStoreIEMonitor),

--- a/pkg/sql/sqlstats/sslocal/sql_stats_ingestor.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_ingestor.go
@@ -529,6 +529,10 @@ func (i *SQLStatsIngester) flushBuffer(
 			}
 			i.storeStatementFingerprint(ctx, s)
 		}
+	} else {
+		for _, s := range *statements {
+			i.storeStatementFingerprint(ctx, s)
+		}
 	}
 
 	for _, sink := range i.sinks {


### PR DESCRIPTION
## Summary

Address post-merge review feedback from #167502:

- Fix `flushBuffer` to store fingerprints for `UnderOuterTxn` statements. When the transaction is nil (internal executor under an outer txn), `storeStatementFingerprint` was never called, silently skipping persistence for these statements.
- Fix grow-before-add memory accounting in `addToCacheIfAbsent` and `appendPending`. Previously entries were added before growing the memory account, risking underreporting on failure. Now `Grow` is called first, and on failure the operation is skipped so the fingerprint retries on its next occurrence.
- Change `log.Dev.Error` to `log.Ops.Errorf` for the "Start called before SetInternalExecutor" error to ensure visibility in operator logs.
- Give the statement store memory monitor a distinct name ("statement store") instead of the generic "internal SQL executor" name.

Epic: none

Release note: None