### PR TITLE
physical: improve cutover UX during initial scan

### DIFF
--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -563,11 +563,21 @@ func alterTenantJobCutover(
 	progress := job.Progress()
 
 	replicatedTimeAtCutover := replicationutils.ReplicatedTimeFromProgress(&progress)
-	if replicatedTimeAtCutover.IsEmpty() {
-		replicatedTimeAtCutover = details.ReplicationStartTime
-	}
 
-	if alterTenantStmt.Cutover.Latest {
+	if replicatedTimeAtCutover.IsEmpty() {
+		if alterTenantStmt.Cutover.Latest {
+			return hlc.Timestamp{}, errors.Newf(
+				"replicated tenant %q (%d) has not replicated any data yet; "+
+					"cannot cut over to LATEST",
+				tenantName, tenInfo.ID)
+		}
+		if cutoverTime.Less(details.ReplicationStartTime) {
+			return hlc.Timestamp{}, errors.Newf(
+				"cutover time %s is before the replication start time %s",
+				cutoverTime, details.ReplicationStartTime)
+		}
+		replicatedTimeAtCutover = cutoverTime
+	} else if alterTenantStmt.Cutover.Latest {
 		cutoverTime = replicatedTimeAtCutover
 	}
 

--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -1038,7 +1038,9 @@ func TestProtectedTimestampManagement(t *testing.T) {
 		checkDestinationPTSExists(t, replicationJobID)
 
 		if completeReplication {
-			// Complete replication via cutover.
+			// Wait for the replicated time to advance past the start time
+			// before attempting cutover to LATEST.
+			c.WaitUntilStartTimeReached(jobspb.JobID(replicationJobID))
 			var emptyCutoverTime time.Time
 			c.Cutover(ctx, producerJobID, replicationJobID, emptyCutoverTime, false)
 		} else {

--- a/pkg/crosscluster/physical/testdata/add_early_cutover
+++ b/pkg/crosscluster/physical/testdata/add_early_cutover
@@ -1,5 +1,6 @@
-# This test ensures 1) the user can set a cutover before the initial scan completes; 2) cannot set a
-# cutover time before the replicatedStartTime.
+# This test ensures 1) the user can set a cutover before the initial scan completes with an explicit
+# timestamp >= the replication start time; 2) cannot set a cutover time before the
+# replicationStartTime; 3) cannot cut over to LATEST during the initial scan.
 
 create-replication-clusters
 ----
@@ -18,11 +19,19 @@ start-replication-stream
 job as=destination-system wait-for-state=paused
 ----
 
-query-sql as=destination-system regex-error=(.*before earliest safe cutover.*)
+query-sql as=destination-system regex-error=(.*before the replication start time.*)
 ALTER TENANT "destination" COMPLETE REPLICATION TO SYSTEM TIME '$pre'
 ----
 
-exec-sql as=destination-system
+let $post as=source-system
+SELECT clock_timestamp()::timestamp::string
+----
+
+query-sql as=destination-system regex-error=(.*has not replicated any data yet.*)
 ALTER TENANT "destination" COMPLETE REPLICATION TO LATEST
+----
+
+query-sql as=destination-system
+ALTER TENANT "destination" COMPLETE REPLICATION TO SYSTEM TIME '$post'
 ----
 

--- a/pkg/crosscluster/physical/testdata/add_early_cutover
+++ b/pkg/crosscluster/physical/testdata/add_early_cutover
@@ -1,5 +1,6 @@
-# This test ensures 1) the user can set a cutover before the initial scan completes; 2) cannot set a
-# cutover time before the replicatedStartTime.
+# This test ensures 1) the user can set a cutover before the initial scan completes with an explicit
+# timestamp >= the replication start time; 2) cannot set a cutover time before the
+# replicationStartTime; 3) cannot cut over to LATEST during the initial scan.
 
 create-replication-clusters
 ----
@@ -18,11 +19,19 @@ start-replication-stream
 job as=destination-system wait-for-state=paused
 ----
 
-query-sql as=destination-system regex-error=(.*before earliest safe cutover.*)
+query-sql as=destination-system regex-error=(.*before the replication start time.*)
 ALTER TENANT "destination" COMPLETE REPLICATION TO SYSTEM TIME '$pre'
 ----
 
-exec-sql as=destination-system
+let $post as=source-system
+SELECT clock_timestamp()::timestamp::string
+----
+
+query-sql as=destination-system regex-error=(.*has not replicated any data yet.*)
 ALTER TENANT "destination" COMPLETE REPLICATION TO LATEST
+----
+
+exec-sql as=destination-system
+ALTER TENANT "destination" COMPLETE REPLICATION TO SYSTEM TIME '$post'
 ----
 


### PR DESCRIPTION
Previously, if a user attempted to cut over before the initial scan completed, there were a variety of strange UX papercuts:
- an explicit cutover timestamp would get overriden by the start time
- a LATEST timestamp would get set to start time, even though LATEST implies there exists a start time.

Now, when no data has been replicated yet:
- LATEST cutover returns a clear error.
- Explicit timestamps must be greater than the start time.
- replicatedTimeAtCutover is set to the user-provided cutover time rather than the replication start time.

Informs: #168256

Release note (ops change): Physical cluster replication now returns
clearer error messages when a user attempts to cut over before the
initial scan has replicated any data. Cutting over to LATEST during the
initial scan now returns an explicit error instead of silently using the
replication start time. Cutting over to an explicit timestamp now
validates that the timestamp is not before the replication start time.