### PR TITLE
backup: only show revision_start_time column with REVISION START TIME

### DIFF
--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -751,7 +751,7 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 			for rows.Next() {
 				var id string
 				var unused any
-				require.NoError(t, rows.Scan(&id, &unused, &unused))
+				require.NoError(t, rows.Scan(&id, &unused))
 				ids = append([]string{id}, ids...)
 			}
 			backupIDsByColl[coll] = ids

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -1381,10 +1381,13 @@ func showBackupsInCollectionTypeCheck(
 	}
 
 	if p.SessionData().UseBackupsWithIDs {
+		header := showBackupsWithIDsHeader
 		if backup.Options.Debug {
-			return true, showBackupsWithIDsDebugHeader, nil
+			header = showBackupsWithIDsDebugHeader
+		} else if backup.Options.RevisionStartTime {
+			header = showBackupsWithIDsRevisionHeader
 		}
-		return true, showBackupsWithIDsHeader, nil
+		return true, header, nil
 	}
 	return true, showBackupsInCollectionHeader, nil
 }
@@ -1394,6 +1397,11 @@ var showBackupsInCollectionHeader = colinfo.ResultColumns{
 }
 
 var showBackupsWithIDsHeader = colinfo.ResultColumns{
+	{Name: "id", Typ: types.String},
+	{Name: "backup_time", Typ: types.TimestampTZ},
+}
+
+var showBackupsWithIDsRevisionHeader = colinfo.ResultColumns{
 	{Name: "id", Typ: types.String},
 	{Name: "backup_time", Typ: types.TimestampTZ},
 	{Name: "revision_start_time", Typ: types.TimestampTZ},
@@ -1466,6 +1474,7 @@ func showBackupsInCollectionPlanHook(
 
 	useIDs := p.SessionData().UseBackupsWithIDs
 	debug := showStmt.Options.Debug
+	revisionStartTime := showStmt.Options.RevisionStartTime
 	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, showStmt.StatementTag())
 		defer span.Finish()
@@ -1481,7 +1490,7 @@ func showBackupsInCollectionPlanHook(
 			if err != nil {
 				return err
 			}
-			openIndex := showStmt.Options.RevisionStartTime || debug
+			openIndex := revisionStartTime || debug
 			res, exceededMax, err := backupinfo.ListRestorableBackups(
 				ctx, store, newerThan, olderThan, maxCount, openIndex,
 			)
@@ -1505,16 +1514,19 @@ func showBackupsInCollectionPlanHook(
 				if err != nil {
 					return err
 				}
-				revStartTime := tree.DNull
-				if i.OpenedIndex() && i.MVCCFilter(ctx, p.ExecCfg().SV()) == backuppb.MVCCFilter_All {
-					revStartTime, err = tree.MakeDTimestampTZ(
-						timeutil.Unix(0, i.RevisionStartTime(ctx, p.ExecCfg().SV()).WallTime), time.Second,
-					)
-					if err != nil {
-						return err
+				row := tree.Datums{tree.NewDString(i.ID), backupTime}
+				if revisionStartTime || debug {
+					revStartTime := tree.DNull
+					if i.OpenedIndex() && i.MVCCFilter(ctx, p.ExecCfg().SV()) == backuppb.MVCCFilter_All {
+						revStartTime, err = tree.MakeDTimestampTZ(
+							timeutil.Unix(0, i.RevisionStartTime(ctx, p.ExecCfg().SV()).WallTime), time.Second,
+						)
+						if err != nil {
+							return err
+						}
 					}
+					row = append(row, revStartTime)
 				}
-				row := tree.Datums{tree.NewDString(i.ID), backupTime, revStartTime}
 				if debug {
 					sv := p.ExecCfg().SV()
 					startTime := tree.DNull
@@ -1555,6 +1567,8 @@ func showBackupsInCollectionPlanHook(
 		header = showBackupsWithIDsHeader
 		if debug {
 			header = showBackupsWithIDsDebugHeader
+		} else if revisionStartTime {
+			header = showBackupsWithIDsRevisionHeader
 		}
 	}
 	return fn, header, false, nil

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -1038,14 +1038,10 @@ func TestShowBackupsWithIDsAndRevisionHistory(t *testing.T) {
 	})
 
 	t.Run("WITHOUT REVISION START TIME", func(t *testing.T) {
-		revStartTimes := sqlDB.QueryStr(
-			t,
-			`SELECT revision_start_time FROM [SHOW BACKUPS IN $1]`,
-			collectionURI,
-		)
-		require.Len(t, revStartTimes, 3, "expected 3 backups")
-		for idx, row := range revStartTimes {
-			require.Equal(t, "NULL", row[0], "expected empty revision start time (row %d)", idx)
+		rows := sqlDB.QueryStr(t, `SHOW BACKUPS IN $1`, collectionURI)
+		require.Len(t, rows, 3, "expected 3 backups")
+		for _, row := range rows {
+			require.Len(t, row, 2, "expected 2 columns (id, backup_time)")
 		}
 	})
 }
@@ -1234,7 +1230,7 @@ func TestShowBackupWithIDs(t *testing.T) {
 	for idRows.Next() {
 		var id string
 		var unused any
-		if err := idRows.Scan(&id, &unused, &unused); err != nil {
+		if err := idRows.Scan(&id, &unused); err != nil {
 			t.Fatal(err)
 		}
 		ids = append([]string{id}, ids...)


### PR DESCRIPTION
Previously, `SHOW BACKUPS IN` with `use_backups_with_ids` always included
the `revision_start_time` column, even when the `REVISION START TIME`
option was not specified. This makes the column conditional on the option
being set, consistent with how `WITH DEBUG` conditionally adds its columns.

Epic: none

Release note: None