### PR TITLE
sql: check trigger/policy deps in ALTER FUNCTION RENAME

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -1414,7 +1414,7 @@ statement ok
 ALTER TYPE typ RENAME TO typ2;
 
 # Routines are referenced by name, so renaming is not allowed.
-statement ok
+statement error cannot rename function "g" because other functions or views \(.*\) still depend on it
 ALTER FUNCTION g RENAME TO g2;
 
 statement ok
@@ -1422,7 +1422,7 @@ DROP TRIGGER foo ON xy;
 
 statement ok
 DROP FUNCTION trigger_func;
-DROP FUNCTION g2;
+DROP FUNCTION g;
 DROP TYPE typ2;
 DROP SEQUENCE s2;
 DROP TABLE t;
@@ -6467,6 +6467,58 @@ DROP POLICY my_policy ON t_tr_policy;
 DROP TABLE t_tr_policy;
 DROP FUNCTION trigger_fn_policy;
 DROP SEQUENCE seq_tr_policy;
+
+subtest end
+
+# Regression test: ALTER FUNCTION RENAME/SET SCHEMA should be blocked when the
+# function is referenced in a trigger function body. The trigger body stores
+# fully-qualified function names, so renaming or moving the function breaks the
+# trigger at DML time.
+subtest regression_trigger_udf_rename_dep
+
+statement ok
+CREATE TABLE t_tr_udf_dep (k INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE FUNCTION udf_dep_helper() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement ok
+CREATE FUNCTION trigger_fn_udf_dep() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+BEGIN
+  SELECT public.udf_dep_helper();
+  RETURN NEW;
+END
+$$;
+
+statement ok
+CREATE TRIGGER tr_udf_dep BEFORE INSERT ON t_tr_udf_dep
+FOR EACH ROW EXECUTE FUNCTION trigger_fn_udf_dep();
+
+# INSERT should work before any rename.
+statement ok
+INSERT INTO t_tr_udf_dep VALUES (1, 1);
+
+# Renaming the UDF referenced by the trigger body should be blocked.
+statement error cannot rename function "udf_dep_helper" because other functions or views \(\[trigger "tr_udf_dep" on .*t_tr_udf_dep\]\) still depend on it
+ALTER FUNCTION udf_dep_helper() RENAME TO udf_dep_helper_renamed;
+
+# Moving the UDF to another schema should also be blocked.
+statement ok
+CREATE SCHEMA sc_tr_dep;
+
+statement error cannot set schema for function "udf_dep_helper" because other functions or views \(\[trigger "tr_udf_dep" on .*t_tr_udf_dep\]\) still depend on it
+ALTER FUNCTION udf_dep_helper() SET SCHEMA sc_tr_dep;
+
+# INSERT should still work after the blocked operations.
+statement ok
+INSERT INTO t_tr_udf_dep VALUES (2, 2);
+
+statement ok
+DROP TRIGGER tr_udf_dep ON t_tr_udf_dep;
+DROP TABLE t_tr_udf_dep;
+DROP FUNCTION trigger_fn_udf_dep;
+DROP FUNCTION udf_dep_helper;
+DROP SCHEMA sc_tr_dep;
 
 subtest end
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -1414,7 +1414,7 @@ statement ok
 ALTER TYPE typ RENAME TO typ2;
 
 # Routines are referenced by name, so renaming is not allowed.
-statement ok
+statement error cannot rename function "g" because other objects \(.*\) still depend on it
 ALTER FUNCTION g RENAME TO g2;
 
 statement ok
@@ -1422,7 +1422,7 @@ DROP TRIGGER foo ON xy;
 
 statement ok
 DROP FUNCTION trigger_func;
-DROP FUNCTION g2;
+DROP FUNCTION g;
 DROP TYPE typ2;
 DROP SEQUENCE s2;
 DROP TABLE t;
@@ -6467,6 +6467,58 @@ DROP POLICY my_policy ON t_tr_policy;
 DROP TABLE t_tr_policy;
 DROP FUNCTION trigger_fn_policy;
 DROP SEQUENCE seq_tr_policy;
+
+subtest end
+
+# Regression test: ALTER FUNCTION RENAME/SET SCHEMA should be blocked when the
+# function is referenced in a trigger function body. The trigger body stores
+# fully-qualified function names, so renaming or moving the function breaks the
+# trigger at DML time.
+subtest regression_trigger_udf_rename_dep
+
+statement ok
+CREATE TABLE t_tr_udf_dep (k INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE FUNCTION udf_dep_helper() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement ok
+CREATE FUNCTION trigger_fn_udf_dep() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+BEGIN
+  SELECT public.udf_dep_helper();
+  RETURN NEW;
+END
+$$;
+
+statement ok
+CREATE TRIGGER tr_udf_dep BEFORE INSERT ON t_tr_udf_dep
+FOR EACH ROW EXECUTE FUNCTION trigger_fn_udf_dep();
+
+# INSERT should work before any rename.
+statement ok
+INSERT INTO t_tr_udf_dep VALUES (1, 1);
+
+# Renaming the UDF referenced by the trigger body should be blocked.
+statement error cannot rename function "udf_dep_helper" because other objects \(\[trigger "tr_udf_dep" on .*t_tr_udf_dep\]\) still depend on it
+ALTER FUNCTION udf_dep_helper() RENAME TO udf_dep_helper_renamed;
+
+# Moving the UDF to another schema should also be blocked.
+statement ok
+CREATE SCHEMA sc_tr_dep;
+
+statement error cannot set schema for function "udf_dep_helper" because other objects \(\[trigger "tr_udf_dep" on .*t_tr_udf_dep\]\) still depend on it
+ALTER FUNCTION udf_dep_helper() SET SCHEMA sc_tr_dep;
+
+# INSERT should still work after the blocked operations.
+statement ok
+INSERT INTO t_tr_udf_dep VALUES (2, 2);
+
+statement ok
+DROP TRIGGER tr_udf_dep ON t_tr_udf_dep;
+DROP TABLE t_tr_udf_dep;
+DROP FUNCTION trigger_fn_udf_dep;
+DROP FUNCTION udf_dep_helper;
+DROP SCHEMA sc_tr_dep;
 
 subtest end
 

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -7,7 +7,6 @@ package sql
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -25,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type alterFunctionOptionsNode struct {
@@ -221,13 +221,9 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	if len(dependentObjects) > 0 {
 		// TODO(#146475): once functions are rewritten to use ID references, we can
 		// allow renames for views.
-		return errors.UnimplementedErrorf(
-			errors.IssueLink{
-				IssueURL: build.MakeIssueURL(83233),
-				Detail:   "renames are disallowed because references are by name",
-			},
-			"cannot rename function %q because other functions or views ([%v]) still depend on it",
-			fnDesc.Name, strings.Join(dependentObjects, ", "))
+		return newAlterFunctionDependentObjectsError(
+			"rename", "renames are disallowed because references are by name",
+			fnDesc, dependentObjects)
 	}
 
 	scDesc.RemoveFunction(fnDesc.GetName(), fnDesc.GetID())
@@ -382,14 +378,10 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 		return err
 	}
 	if len(dependentObjects) > 0 {
-		return errors.UnimplementedErrorf(
-			errors.IssueLink{
-				IssueURL: build.MakeIssueURL(83233),
-				Detail: "set schema is disallowed because there are references from " +
-					"other objects by name",
-			},
-			"cannot set schema for function %q because other functions or views ([%v]) still depend on it",
-			fnDesc.Name, strings.Join(dependentObjects, ", "))
+		return newAlterFunctionDependentObjectsError(
+			"set schema for",
+			"set schema is disallowed because there are references from other objects by name",
+			fnDesc, dependentObjects)
 	}
 
 	switch sc.SchemaKind() {
@@ -529,9 +521,34 @@ func toSchemaOverloadSignature(fnDesc *funcdesc.Mutable) descpb.SchemaDescriptor
 	return ret
 }
 
+// newAlterFunctionDependentObjectsError builds the error returned when an
+// ALTER FUNCTION operation is blocked by name-based references from other
+// objects. The user-visible message has redaction markers stripped; the
+// redactable form is attached as safe details so logs and Sentry retain the
+// structural words ("trigger", "policy", "view") while user-supplied names
+// get redacted.
+func newAlterFunctionDependentObjectsError(
+	operation, detail string, fnDesc *funcdesc.Mutable, dependentObjects []redact.RedactableString,
+) error {
+	joined := redact.Join(", ", dependentObjects)
+	err := errors.UnimplementedErrorf(
+		errors.IssueLink{
+			IssueURL: build.MakeIssueURL(83233),
+			Detail:   detail,
+		},
+		"cannot %s function %q because other objects ([%s]) still depend on it",
+		operation, fnDesc.Name, joined.StripMarkers())
+	return errors.WithSafeDetails(err, "dependents: %s", joined)
+}
+
+// getFuncRefsDisallowingAlter returns descriptions of objects that reference
+// fnDesc by name and would therefore be broken by a rename or schema change.
+// Each entry is a redact.RedactableString so that object kinds (e.g. "trigger",
+// "policy") remain visible in redacted logs and Sentry reports while
+// user-supplied names get redacted.
 func getFuncRefsDisallowingAlter(
 	params runParams, fnDesc *funcdesc.Mutable,
-) (dependentObjects []string, err error) {
+) (dependentObjects []redact.RedactableString, err error) {
 	for _, dep := range fnDesc.GetDependedOnBy() {
 		desc, err := params.p.Descriptors().ByIDWithoutLeased(params.p.Txn()).Get().Desc(params.ctx, dep.ID)
 		if err != nil {
@@ -539,7 +556,7 @@ func getFuncRefsDisallowingAlter(
 		}
 		switch t := desc.(type) {
 		case catalog.TableDescriptor:
-			if !t.IsView() {
+			if !t.IsView() && len(dep.TriggerIDs) == 0 && len(dep.PolicyIDs) == 0 {
 				continue
 			}
 			fullyResolvedName, err := params.p.GetQualifiedTableNameByID(
@@ -547,13 +564,38 @@ func getFuncRefsDisallowingAlter(
 			if err != nil {
 				return nil, err
 			}
-			dependentObjects = append(dependentObjects, fullyResolvedName.FQString())
+			if t.IsView() {
+				dependentObjects = append(dependentObjects,
+					redact.Sprintf("%s", fullyResolvedName.FQString()))
+				continue
+			}
+			for _, triggerID := range dep.TriggerIDs {
+				trigger := catalog.FindTriggerByID(t, triggerID)
+				if trigger == nil {
+					return nil, errors.AssertionFailedf(
+						"trigger %d not found on relation %q (%d) referenced by function %q (%d)",
+						triggerID, t.GetName(), t.GetID(), fnDesc.GetName(), fnDesc.GetID())
+				}
+				dependentObjects = append(dependentObjects,
+					redact.Sprintf("trigger %q on %s", trigger.Name, fullyResolvedName.FQString()))
+			}
+			for _, policyID := range dep.PolicyIDs {
+				policy := catalog.FindPolicyByID(t, policyID)
+				if policy == nil {
+					return nil, errors.AssertionFailedf(
+						"policy %d not found on relation %q (%d) referenced by function %q (%d)",
+						policyID, t.GetName(), t.GetID(), fnDesc.GetName(), fnDesc.GetID())
+				}
+				dependentObjects = append(dependentObjects,
+					redact.Sprintf("policy %q on %s", policy.Name, fullyResolvedName.FQString()))
+			}
 		case catalog.FunctionDescriptor:
 			fullyResolvedName, err := params.p.GetQualifiedFunctionNameByID(params.ctx, int64(dep.ID))
 			if err != nil {
 				return nil, err
 			}
-			dependentObjects = append(dependentObjects, fullyResolvedName.FQString())
+			dependentObjects = append(dependentObjects,
+				redact.Sprintf("%s", fullyResolvedName.FQString()))
 		default:
 			continue
 		}

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -7,6 +7,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
@@ -539,7 +540,7 @@ func getFuncRefsDisallowingAlter(
 		}
 		switch t := desc.(type) {
 		case catalog.TableDescriptor:
-			if !t.IsView() {
+			if !t.IsView() && len(dep.TriggerIDs) == 0 && len(dep.PolicyIDs) == 0 {
 				continue
 			}
 			fullyResolvedName, err := params.p.GetQualifiedTableNameByID(
@@ -547,7 +548,24 @@ func getFuncRefsDisallowingAlter(
 			if err != nil {
 				return nil, err
 			}
-			dependentObjects = append(dependentObjects, fullyResolvedName.FQString())
+			if t.IsView() {
+				dependentObjects = append(dependentObjects, fullyResolvedName.FQString())
+				continue
+			}
+			for _, triggerID := range dep.TriggerIDs {
+				trigger := catalog.FindTriggerByID(t, triggerID)
+				if trigger != nil {
+					dependentObjects = append(dependentObjects,
+						fmt.Sprintf("trigger %q on %s", trigger.Name, fullyResolvedName.FQString()))
+				}
+			}
+			for _, policyID := range dep.PolicyIDs {
+				policy := catalog.FindPolicyByID(t, policyID)
+				if policy != nil {
+					dependentObjects = append(dependentObjects,
+						fmt.Sprintf("policy %q on %s", policy.Name, fullyResolvedName.FQString()))
+				}
+			}
 		case catalog.FunctionDescriptor:
 			fullyResolvedName, err := params.p.GetQualifiedFunctionNameByID(params.ctx, int64(dep.ID))
 			if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -303,7 +303,7 @@ CREATE FUNCTION altSchema.f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 
 statement disable-cf-mutator ok
 CREATE TABLE t1_with_b_2_ref(j int default altSchema.f_called_by_b() CHECK (altSchema.f_called_by_b() > 0));
 
-statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions or views \(\[test.public.f_called_by_b2\]\) still depend on it
+statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
 ALTER FUNCTION f_called_by_b SET SCHEMA altSchema;
 
 skipif config local-legacy-schema-changer

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -6414,3 +6414,38 @@ statement ok
 DROP USER cascade_test_user;
 
 subtest end
+
+# Regression test: ALTER FUNCTION RENAME/SET SCHEMA should be blocked when the
+# function is referenced in a policy expression.
+subtest regression_policy_udf_rename_dep
+
+statement ok
+CREATE TABLE t_rls_dep (k INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE FUNCTION rls_dep_fn(v INT) RETURNS BOOL LANGUAGE SQL AS $$ SELECT v > 0 $$;
+
+statement ok
+ALTER TABLE t_rls_dep ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p_rls_dep ON t_rls_dep USING (public.rls_dep_fn(v));
+
+# Renaming the function referenced by the policy should be blocked.
+statement error cannot rename function "rls_dep_fn" because other objects \(\[policy "p_rls_dep" on .*t_rls_dep\]\) still depend on it
+ALTER FUNCTION rls_dep_fn(INT) RENAME TO rls_dep_fn_renamed;
+
+# Moving the function to another schema should also be blocked.
+statement ok
+CREATE SCHEMA sc_rls_dep;
+
+statement error cannot set schema for function "rls_dep_fn" because other objects \(\[policy "p_rls_dep" on .*t_rls_dep\]\) still depend on it
+ALTER FUNCTION rls_dep_fn(INT) SET SCHEMA sc_rls_dep;
+
+statement ok
+DROP POLICY p_rls_dep ON t_rls_dep;
+DROP TABLE t_rls_dep;
+DROP FUNCTION rls_dep_fn;
+DROP SCHEMA sc_rls_dep;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -6414,3 +6414,38 @@ statement ok
 DROP USER cascade_test_user;
 
 subtest end
+
+# Regression test: ALTER FUNCTION RENAME/SET SCHEMA should be blocked when the
+# function is referenced in a policy expression.
+subtest regression_policy_udf_rename_dep
+
+statement ok
+CREATE TABLE t_rls_dep (k INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE FUNCTION rls_dep_fn(v INT) RETURNS BOOL LANGUAGE SQL AS $$ SELECT v > 0 $$;
+
+statement ok
+ALTER TABLE t_rls_dep ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p_rls_dep ON t_rls_dep USING (public.rls_dep_fn(v));
+
+# Renaming the function referenced by the policy should be blocked.
+statement error cannot rename function "rls_dep_fn" because other functions or views \(\[policy "p_rls_dep" on .*t_rls_dep\]\) still depend on it
+ALTER FUNCTION rls_dep_fn(INT) RENAME TO rls_dep_fn_renamed;
+
+# Moving the function to another schema should also be blocked.
+statement ok
+CREATE SCHEMA sc_rls_dep;
+
+statement error cannot set schema for function "rls_dep_fn" because other functions or views \(\[policy "p_rls_dep" on .*t_rls_dep\]\) still depend on it
+ALTER FUNCTION rls_dep_fn(INT) SET SCHEMA sc_rls_dep;
+
+statement ok
+DROP POLICY p_rls_dep ON t_rls_dep;
+DROP TABLE t_rls_dep;
+DROP FUNCTION rls_dep_fn;
+DROP SCHEMA sc_rls_dep;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1174,10 +1174,10 @@ SET ROLE root;
 statement ok
 REVOKE SELECT ON xy FROM bob;
 
-statement error pgcode 0A000 cannot rename function "f_scalar" because other functions or views \(\[test.public.v, test.public.mv\]\) still depend on it
+statement error pgcode 0A000 cannot rename function "f_scalar" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
 ALTER FUNCTION f_scalar RENAME TO f_scalar_renamed;
 
-statement error pgcode 0A000 cannot rename function "f_setof" because other functions or views \(\[test.public.v, test.public.mv\]\) still depend on it
+statement error pgcode 0A000 cannot rename function "f_setof" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
 ALTER FUNCTION f_setof RENAME TO f_setof_renamed;
 
 statement error pgcode 2BP01 pq: cannot drop function "f_scalar" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -55,14 +55,14 @@ statement error pgcode 42883 unknown function: recursion_check\(\)
 CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;
 
 # Validate that function renaming is blocked.
-statement error pgcode 0A000 cannot rename function \"lower_hello\" because other functions or views \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+statement error pgcode 0A000 cannot rename function \"lower_hello\" because other objects \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
 ALTER FUNCTION lower_hello rename to lower_hello_new
 
 statement ok
 CREATE SCHEMA sc2;
 
 # Validate that function schema changes are blocked.
-statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other functions or views \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other objects \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
 ALTER FUNCTION lower_hello SET SCHEMA sc2;
 
 statement ok

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4920,9 +4920,22 @@ func (og *operationGenerator) alterFunctionRename(ctx context.Context, tx pgx.Tx
 		return nil, err
 	}
 
+	triggerPolicyDeps, err := Collect(ctx, og, tx, pgx.RowToMap,
+		With([]CTE{
+			{"descriptors", descJSONQuery},
+		},
+			functionTriggerPolicyDepsQuery,
+		))
+	if err != nil {
+		return nil, err
+	}
+
 	functionDepsMap := make(map[int64]struct{})
 	for _, f := range functionDeps {
 		functionDepsMap[f["to_oid"].(int64)] = struct{}{}
+	}
+	for _, f := range triggerPolicyDeps {
+		functionDepsMap[f["func_oid"].(int64)] = struct{}{}
 	}
 
 	functionWithDeps := make([]map[string]any, 0, len(functions))
@@ -5017,9 +5030,22 @@ func (og *operationGenerator) alterFunctionSetSchema(
 		return nil, err
 	}
 
+	triggerPolicyDeps, err := Collect(ctx, og, tx, pgx.RowToMap,
+		With([]CTE{
+			{"descriptors", descJSONQuery},
+		},
+			functionTriggerPolicyDepsQuery,
+		))
+	if err != nil {
+		return nil, err
+	}
+
 	functionDepsMap := make(map[int64]struct{})
 	for _, f := range functionDeps {
 		functionDepsMap[f["to_oid"].(int64)] = struct{}{}
+	}
+	for _, f := range triggerPolicyDeps {
+		functionDepsMap[f["func_oid"].(int64)] = struct{}{}
 	}
 
 	functionWithDeps := make([]map[string]any, 0, len(functions))
@@ -5834,6 +5860,8 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 		{code: pgcode.UndefinedObject, condition: true},
 		{code: pgcode.InvalidParameterValue, condition: true},
 		{code: pgcode.InvalidTextRepresentation, condition: true},
+		{code: pgcode.InvalidSchemaName, condition: true},
+		{code: pgcode.InvalidFunctionDefinition, condition: true},
 	})
 
 	return opStmt, nil

--- a/pkg/workload/schemachange/query_util.go
+++ b/pkg/workload/schemachange/query_util.go
@@ -103,6 +103,23 @@ FROM
 WHERE
 	d.classid = 'pg_catalog.pg_proc'::REGCLASS::INT8
 	AND d.refclassid = 'pg_catalog.pg_proc'::REGCLASS::INT8`
+
+	// functionTriggerPolicyDepsQuery finds functions that have trigger or policy
+	// back-references in their descriptors. These functions cannot be renamed or
+	// have their schema changed. Mirrors the check in getFuncRefsDisallowingAlter.
+	//
+	// [descJSONQuery] must be bound to the name "descriptors".
+	functionTriggerPolicyDepsQuery = `SELECT (id + 100000) AS func_oid
+FROM descriptors
+WHERE descriptor ? 'function'
+AND EXISTS (
+	SELECT 1
+	FROM jsonb_array_elements(
+		COALESCE(descriptor->'function'->'dependedOnBy', '[]'::JSONB)
+	) AS dep
+	WHERE jsonb_array_length(COALESCE(dep->'triggerIds', '[]'::JSONB)) > 0
+		OR jsonb_array_length(COALESCE(dep->'policyIds', '[]'::JSONB)) > 0
+)`
 )
 
 func regionsFromDatabaseQuery(database string) string {


### PR DESCRIPTION
ALTER FUNCTION RENAME and SET SCHEMA did not check whether the function was referenced by a trigger body or policy expression. These objects store fully-qualified function names, so renaming or moving the function left stale references that caused DML failures with "unknown function" at runtime.

Include trigger and policy back-references in the dependency check so the rename is blocked when such references exist.

Fixes: #168612
Epic: none
Release note (bug fix): ALTER FUNCTION RENAME and ALTER FUNCTION SET SCHEMA now correctly detect dependencies from triggers and row-level security policies, preventing renames that would break those objects.