### PR TITLE
importer: address overcounting of rows brought in

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -248,6 +248,7 @@ go_test(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "//pkg/workload",
+        "//pkg/workload/bank",
         "//pkg/workload/tpcc",
         "@com_github_apache_arrow_go_v11//arrow",
         "@com_github_apache_arrow_go_v11//arrow/array",

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -633,11 +633,7 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 // mid-processing. The duringDistImport knob injects an error after the first
 // batch is persisted, so distImport fails with intermediate ResumePos values.
 // On retry the import should complete and INSPECT should confirm the correct
-// row count.
-//
-// This currently fails because the workload reader ignores resumePos (#168396),
-// re-reading all rows from scratch, while bulkSummary accumulates across
-// retries — inflating the expected count.
+// row count. This is a regression test for #168396.
 func TestImportIntoWorkloadURIRowCountCheckAfterRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	// Register the bank workload generator for workload:// URI tests.
+	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -624,4 +626,77 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 				[][]string{{fmt.Sprintf("%d", tc.totalRows)}})
 		})
 	}
+}
+
+// TestImportIntoWorkloadURIRowCountCheckAfterRetry verifies that INSPECT row
+// count validation passes after an import using a workload:// URI is retried
+// mid-processing. The duringDistImport knob injects an error after the first
+// batch is persisted, so distImport fails with intermediate ResumePos values.
+// On retry the import should complete and INSPECT should confirm the correct
+// row count.
+//
+// This currently fails because the workload reader ignores resumePos (#168396),
+// re-reading all rows from scratch, while bulkSummary accumulates across
+// retries — inflating the expected count.
+func TestImportIntoWorkloadURIRowCountCheckAfterRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "uses short job adoption intervals that don't work well in slow test configurations")
+
+	ctx := context.Background()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				BulkAdderFlushesEveryBatch: true,
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(db)
+
+	// Use sync mode so the import blocks until the inspect job completes. If
+	// the row count is wrong the import statement itself will fail.
+	runner.Exec(t, `SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'sync'`)
+
+	s := srv.ApplicationLayer()
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	var once sync.Once
+	var retryTriggered atomic.Bool
+	registry.TestingWrapResumerConstructor(
+		jobspb.TypeImport,
+		func(resumer jobs.Resumer) jobs.Resumer {
+			r := resumer.(interface {
+				TestingSetAlwaysFlushJobProgress()
+				TestingSetDuringDistImportKnob(func() error)
+			})
+			// Flush progress after every batch so that intermediate
+			// ResumePos and partial Summary are persisted to the job
+			// record before we inject the error.
+			r.TestingSetAlwaysFlushJobProgress()
+			r.TestingSetDuringDistImportKnob(func() error {
+				var err error
+				once.Do(func() {
+					retryTriggered.Store(true)
+					// The "rpc error" substring makes this retryable
+					// per sqlerrors.IsDistSQLRetryableError.
+					err = errors.New("rpc error: injected test retry")
+				})
+				return err
+			})
+			return resumer
+		})
+
+	runner.Exec(t, `CREATE TABLE bank (id INT PRIMARY KEY, balance INT, payload STRING)`)
+
+	runner.Exec(t,
+		`IMPORT INTO bank (id, balance, payload) CSV DATA ('workload:///csv/bank/bank?rows=100&row-start=0&row-end=1&version=1.0.0')`)
+
+	require.True(t, retryTriggered.Load(), "expected injected error to trigger a retry")
+
+	runner.CheckQueryResults(t,
+		`SELECT count(*) FROM bank`, [][]string{{"100"}})
 }

--- a/pkg/sql/importer/import_into_test.go
+++ b/pkg/sql/importer/import_into_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	// Register the bank workload generator for workload:// URI tests.
+	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -624,4 +626,73 @@ func TestImportIntoRowCountCheckAfterIngestRetry(t *testing.T) {
 				[][]string{{fmt.Sprintf("%d", tc.totalRows)}})
 		})
 	}
+}
+
+// TestImportIntoWorkloadURIRowCountCheckAfterRetry verifies that INSPECT row
+// count validation passes after an import using a workload:// URI is retried
+// mid-processing. The duringDistImport knob injects an error after the first
+// batch is persisted, so distImport fails with intermediate ResumePos values.
+// On retry the import should complete and INSPECT should confirm the correct
+// row count. This is a regression test for #168396.
+func TestImportIntoWorkloadURIRowCountCheckAfterRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "uses short job adoption intervals that don't work well in slow test configurations")
+
+	ctx := context.Background()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				BulkAdderFlushesEveryBatch: true,
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(db)
+
+	// Use sync mode so the import blocks until the inspect job completes. If
+	// the row count is wrong the import statement itself will fail.
+	runner.Exec(t, `SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'sync'`)
+
+	s := srv.ApplicationLayer()
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	var once sync.Once
+	var retryTriggered atomic.Bool
+	registry.TestingWrapResumerConstructor(
+		jobspb.TypeImport,
+		func(resumer jobs.Resumer) jobs.Resumer {
+			r := resumer.(interface {
+				TestingSetAlwaysFlushJobProgress()
+				TestingSetDuringDistImportKnob(func() error)
+			})
+			// Flush progress after every batch so that intermediate
+			// ResumePos and partial Summary are persisted to the job
+			// record before we inject the error.
+			r.TestingSetAlwaysFlushJobProgress()
+			r.TestingSetDuringDistImportKnob(func() error {
+				var err error
+				once.Do(func() {
+					retryTriggered.Store(true)
+					// The "rpc error" substring makes this retryable
+					// per sqlerrors.IsDistSQLRetryableError.
+					err = errors.New("rpc error: injected test retry")
+				})
+				return err
+			})
+			return resumer
+		})
+
+	runner.Exec(t, `CREATE TABLE bank (id INT PRIMARY KEY, balance INT, payload STRING)`)
+
+	runner.Exec(t,
+		`IMPORT INTO bank (id, balance, payload) CSV DATA ('workload:///csv/bank/bank?rows=100&row-start=0&row-end=1&version=1.0.0')`)
+
+	require.True(t, retryTriggered.Load(), "expected injected error to trigger a retry")
+
+	runner.CheckQueryResults(t,
+		`SELECT count(*) FROM bank`, [][]string{{"100"}})
 }

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -69,6 +69,11 @@ type importTestingKnobs struct {
 	// call inside ingestWithRetry. If it returns an error, that error
 	// replaces the nil err and triggers a retry.
 	afterDistImport func() error
+	// duringDistImport, if set, is called during distImport processing
+	// after each batch's progress has been recorded (and persisted, if
+	// alwaysFlushJobProgress is true). If it returns a non-nil error,
+	// distImport fails with that error.
+	duringDistImport func() error
 }
 
 type importResumer struct {
@@ -101,6 +106,10 @@ func (r *importResumer) TestingSetAlwaysFlushJobProgress() {
 
 func (r *importResumer) TestingSetAfterDistImportKnob(fn func() error) {
 	r.testingKnobs.afterDistImport = fn
+}
+
+func (r *importResumer) TestingSetDuringDistImportKnob(fn func() error) {
+	r.testingKnobs.duringDistImport = fn
 }
 
 var _ jobs.TraceableJob = &importResumer{}

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -254,6 +254,10 @@ func distImport(
 		checkpoint.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
 
+	// hookFired is set when duringDistImport returns an error. After that,
+	// we skip progress persistence to preserve intermediate ResumePos in
+	// the job record. Safe without a mutex: metaFn runs on a single goroutine.
+	var hookFired bool
 	metaFn := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {
 			// Decode map progress outside the lock since it doesn't touch
@@ -283,8 +287,16 @@ func distImport(
 				}
 			}
 
-			if testingKnobs.alwaysFlushJobProgress {
-				return checkpoint.Persist(ctx, job)
+			if testingKnobs.alwaysFlushJobProgress && !hookFired {
+				if err := checkpoint.Persist(ctx, job); err != nil {
+					return err
+				}
+			}
+			if !hookFired && testingKnobs.duringDistImport != nil {
+				if err := testingKnobs.duringDistImport(); err != nil {
+					hookFired = true
+					return err
+				}
 			}
 		}
 		return nil

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -239,6 +239,10 @@ func distImport(
 		checkpoint.manifestBuf = backfill.NewSSTManifestBuffer(resumeManifests)
 	}
 
+	// hookFired is set when duringDistImport returns an error. After that,
+	// we skip progress persistence to preserve intermediate ResumePos in
+	// the job record. Safe without a mutex: metaFn runs on a single goroutine.
+	var hookFired bool
 	metaFn := func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {
 			// Decode map progress outside the lock since it doesn't touch
@@ -268,8 +272,16 @@ func distImport(
 				}
 			}
 
-			if testingKnobs.alwaysFlushJobProgress {
-				return checkpoint.Persist(ctx, job)
+			if testingKnobs.alwaysFlushJobProgress && !hookFired {
+				if err := checkpoint.Persist(ctx, job); err != nil {
+					return err
+				}
+			}
+			if !hookFired && testingKnobs.duringDistImport != nil {
+				if err := testingKnobs.duringDistImport(); err != nil {
+					hookFired = true
+					return err
+				}
 			}
 		}
 		return nil

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -190,6 +190,21 @@ func distImport(
 	}
 
 	lastSummary := getLastImportSummary(job)
+	// If no file has made progress, reset the summary to prevent readers that
+	// re-read everything on retry from double counting and inflating the
+	// summary.
+	if importDetails.ResumePos != nil {
+		allFromStart := true
+		for _, pos := range importDetails.ResumePos {
+			if pos > 0 {
+				allFromStart = false
+				break
+			}
+		}
+		if allFromStart {
+			lastSummary = kvpb.BulkOpSummary{}
+		}
+	}
 	checkpoint := newImportCheckpointTracker(
 		len(from), lastSummary, nil, /* manifestBuf */
 	)

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -141,7 +141,7 @@ func makeDatumFromColOffset(
 func (w *workloadReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
-	_ map[int32]int64,
+	resumePos map[int32]int64,
 	_ roachpb.IOFileFormat,
 	_ cloud.ExternalStorageFactory,
 	_ username.SQLUsername,
@@ -181,8 +181,15 @@ func (w *workloadReader) readFiles(
 			return errors.Errorf(`unknown table %s for generator %s`, conf.Table, meta.Name)
 		}
 
+		batchBegin := int(conf.BatchBegin)
+		if resumePos != nil {
+			if pos, ok := resumePos[fileID]; ok && pos > int64(batchBegin) {
+				batchBegin = int(pos)
+			}
+		}
+
 		wc := NewWorkloadKVConverter(
-			fileID, w.table, t.InitialRows, int(conf.BatchBegin), int(conf.BatchEnd), w.kvCh, w.db)
+			fileID, w.table, t.InitialRows, batchBegin, int(conf.BatchEnd), w.kvCh, w.db)
 		wcs = append(wcs, wc)
 	}
 
@@ -204,17 +211,19 @@ func (w *workloadReader) readFiles(
 
 // WorkloadKVConverter converts workload.BatchedTuples to []roachpb.KeyValues.
 type WorkloadKVConverter struct {
-	tableDesc      catalog.TableDescriptor
-	rows           workload.BatchedTuples
-	batchIdxAtomic int64
-	batchEnd       int
-	kvCh           chan row.KVBatch
-	db             *kv.DB
+	tableDesc  catalog.TableDescriptor
+	rows       workload.BatchedTuples
+	batchIdx   atomic.Int64
+	batchStart int
+	batchEnd   int
+	kvCh       chan row.KVBatch
+	db         *kv.DB
 
 	// For progress reporting
-	fileID                int32
-	totalBatches          float32
-	finishedBatchesAtomic int64
+	fileID               int32
+	totalBatches         float32
+	finishedBatchesCount atomic.Int64
+	batchesDone          []atomic.Bool
 }
 
 // NewWorkloadKVConverter returns a WorkloadKVConverter for the given table and
@@ -227,16 +236,34 @@ func NewWorkloadKVConverter(
 	kvCh chan row.KVBatch,
 	db *kv.DB,
 ) *WorkloadKVConverter {
-	return &WorkloadKVConverter{
-		tableDesc:      tableDesc,
-		rows:           rows,
-		batchIdxAtomic: int64(batchStart) - 1,
-		batchEnd:       batchEnd,
-		kvCh:           kvCh,
-		totalBatches:   float32(batchEnd - batchStart),
-		fileID:         fileID,
-		db:             db,
+	numBatches := batchEnd - batchStart
+	if numBatches < 0 {
+		numBatches = 0
 	}
+	wc := &WorkloadKVConverter{
+		tableDesc:  tableDesc,
+		rows:       rows,
+		batchStart: batchStart,
+		batchEnd:   batchEnd,
+		kvCh:       kvCh,
+		db:         db,
+
+		fileID:       fileID,
+		totalBatches: float32(numBatches),
+		batchesDone:  make([]atomic.Bool, numBatches),
+	}
+	wc.batchIdx.Store(int64(batchStart) - 1)
+	return wc
+}
+
+// lowWatermarkBatch returns the batch index of the first incomplete batch.
+func (w *WorkloadKVConverter) lowWatermarkBatch() int64 {
+	for i := range w.batchesDone {
+		if !w.batchesDone[i].Load() {
+			return int64(w.batchStart + i)
+		}
+	}
+	return int64(w.batchEnd)
 }
 
 // Worker can be called concurrently to create multiple workers to process
@@ -267,14 +294,17 @@ func (w *WorkloadKVConverter) Worker(
 	}
 	conv.KvBatch.Source = w.fileID
 	conv.FractionFn = func() float32 {
-		return float32(atomic.LoadInt64(&w.finishedBatchesAtomic)) / w.totalBatches
+		return float32(w.finishedBatchesCount.Load()) / w.totalBatches
+	}
+	conv.CompletedRowFn = func() int64 {
+		return w.lowWatermarkBatch()
 	}
 	var alloc tree.DatumAlloc
 	var a bufalloc.ByteAllocator
 	cb := coldata.NewMemBatchWithCapacity(nil /* typs */, 0 /* capacity */, coldata.StandardColumnFactory)
 
 	for {
-		batchIdx := int(atomic.AddInt64(&w.batchIdxAtomic, 1))
+		batchIdx := int(w.batchIdx.Add(1))
 		if batchIdx >= w.batchEnd {
 			break
 		}
@@ -308,7 +338,8 @@ func (w *WorkloadKVConverter) Worker(
 				return err
 			}
 		}
-		atomic.AddInt64(&w.finishedBatchesAtomic, 1)
+		w.batchesDone[batchIdx-w.batchStart].Store(true)
+		w.finishedBatchesCount.Add(1)
 	}
 	return conv.SendBatch(ctx)
 }

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -141,7 +141,7 @@ func makeDatumFromColOffset(
 func (w *workloadReader) readFiles(
 	ctx context.Context,
 	dataFiles map[int32]string,
-	_ map[int32]int64,
+	resumePos map[int32]int64,
 	_ roachpb.IOFileFormat,
 	_ cloud.ExternalStorageFactory,
 	_ username.SQLUsername,
@@ -181,8 +181,15 @@ func (w *workloadReader) readFiles(
 			return errors.Errorf(`unknown table %s for generator %s`, conf.Table, meta.Name)
 		}
 
+		batchBegin := int(conf.BatchBegin)
+		if resumePos != nil {
+			if pos, ok := resumePos[fileID]; ok && pos > int64(batchBegin) {
+				batchBegin = int(pos)
+			}
+		}
+
 		wc := NewWorkloadKVConverter(
-			fileID, w.table, t.InitialRows, int(conf.BatchBegin), int(conf.BatchEnd), w.kvCh, w.db)
+			fileID, w.table, t.InitialRows, batchBegin, int(conf.BatchEnd), w.kvCh, w.db)
 		wcs = append(wcs, wc)
 	}
 
@@ -204,17 +211,19 @@ func (w *workloadReader) readFiles(
 
 // WorkloadKVConverter converts workload.BatchedTuples to []roachpb.KeyValues.
 type WorkloadKVConverter struct {
-	tableDesc      catalog.TableDescriptor
-	rows           workload.BatchedTuples
-	batchIdxAtomic int64
-	batchEnd       int
-	kvCh           chan row.KVBatch
-	db             *kv.DB
+	tableDesc  catalog.TableDescriptor
+	rows       workload.BatchedTuples
+	batchIdx   atomic.Int64
+	batchStart int
+	batchEnd   int
+	kvCh       chan row.KVBatch
+	db         *kv.DB
 
 	// For progress reporting
-	fileID                int32
-	totalBatches          float32
-	finishedBatchesAtomic int64
+	fileID               int32
+	totalBatches         float32
+	finishedBatchesCount atomic.Int64
+	batchesDone          []atomic.Bool
 }
 
 // NewWorkloadKVConverter returns a WorkloadKVConverter for the given table and
@@ -227,16 +236,34 @@ func NewWorkloadKVConverter(
 	kvCh chan row.KVBatch,
 	db *kv.DB,
 ) *WorkloadKVConverter {
-	return &WorkloadKVConverter{
-		tableDesc:      tableDesc,
-		rows:           rows,
-		batchIdxAtomic: int64(batchStart) - 1,
-		batchEnd:       batchEnd,
-		kvCh:           kvCh,
-		totalBatches:   float32(batchEnd - batchStart),
-		fileID:         fileID,
-		db:             db,
+	numBatches := batchEnd - batchStart
+	if numBatches < 0 {
+		numBatches = 0
 	}
+	wc := &WorkloadKVConverter{
+		tableDesc:  tableDesc,
+		rows:       rows,
+		batchStart: batchStart,
+		batchEnd:   batchEnd,
+		kvCh:       kvCh,
+		db:         db,
+
+		fileID:       fileID,
+		totalBatches: float32(numBatches),
+		batchesDone:  make([]atomic.Bool, numBatches),
+	}
+	wc.batchIdx.Store(int64(batchStart) - 1)
+	return wc
+}
+
+// lowWatermarkBatch returns the batch index of the first incomplete batch.
+func (w *WorkloadKVConverter) lowWatermarkBatch() int64 {
+	for i := range w.batchesDone {
+		if !w.batchesDone[i].Load() {
+			return int64(w.batchStart + i)
+		}
+	}
+	return int64(w.batchEnd)
 }
 
 // Worker can be called concurrently to create multiple workers to process
@@ -267,14 +294,18 @@ func (w *WorkloadKVConverter) Worker(
 	}
 	conv.KvBatch.Source = w.fileID
 	conv.FractionFn = func() float32 {
-		return float32(atomic.LoadInt64(&w.finishedBatchesAtomic)) / w.totalBatches
+		return float32(w.finishedBatchesCount.Load()) / w.totalBatches
+	}
+	// The callback supplies a batch number rather than a row index.
+	conv.CompletedRowFn = func() int64 {
+		return w.lowWatermarkBatch()
 	}
 	var alloc tree.DatumAlloc
 	var a bufalloc.ByteAllocator
 	cb := coldata.NewMemBatchWithCapacity(nil /* typs */, 0 /* capacity */, coldata.StandardColumnFactory)
 
 	for {
-		batchIdx := int(atomic.AddInt64(&w.batchIdxAtomic, 1))
+		batchIdx := int(w.batchIdx.Add(1))
 		if batchIdx >= w.batchEnd {
 			break
 		}
@@ -308,7 +339,8 @@ func (w *WorkloadKVConverter) Worker(
 				return err
 			}
 		}
-		atomic.AddInt64(&w.finishedBatchesAtomic, 1)
+		w.batchesDone[batchIdx-w.batchStart].Store(true)
+		w.finishedBatchesCount.Add(1)
 	}
 	return conv.SendBatch(ctx)
 }

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -209,7 +209,9 @@ func GenerateInsertRow(
 type KVBatch struct {
 	// Source is where the row data in the batch came from.
 	Source int32
-	// LastRow is the index of the last converted row in source in this batch.
+	// LastRow is a progress marker used as the resume position on retry.
+	// Its meaning is opaque: File-based imports set it to a row index while
+	// workload-based imports set it to a batch sequence number.
 	LastRow int64
 	// Progress represents the fraction of the input that generated this row.
 	Progress float32
@@ -249,10 +251,14 @@ type DatumRowConverter struct {
 	computedIVarContainer     schemaexpr.RowIndexedVarContainer
 	partialIndexIVarContainer schemaexpr.RowIndexedVarContainer
 
-	// FractionFn is used to set the progress header in KVBatches.
+	// CompletedRowFn is an opaque callback that returns a progress indicator
+	// stamped onto each KV batch as LastRow. The meaning of the returned value
+	// depends on the caller: File-based imports use it as a row index while
+	// workload-based imports use it as a batch sequence number.
 	CompletedRowFn func() int64
-	FractionFn     func() float32
-	kvInserter     KVInserter
+	// FractionFn is used to set the progress header in KVBatches.
+	FractionFn func() float32
+	kvInserter KVInserter
 
 	db *kv.DB
 }


### PR DESCRIPTION
This change addresses an issue where a retry of an import job causes
rows imported to be double-counted in the import summary. The `INSPECT`
job that is used to validate the import job is then mis-specced with an
inflated expected row count and consequently fails.

Fixes: #168602
Part of: #168396

Release note: None