### PR TITLE
upgrade/upgrades: add env var to skip nonessential bootstrap steps

### DIFF
--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -20,11 +20,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
+
+// skipNonessentialBootstrap, when true, causes bootstrapSystem and
+// bootstrapCluster to skip the substeps marked skippableInTest, mirroring
+// the SkipSomeUpgradeSteps testing knob. This env var exists to make the
+// same fast path reachable from containerized test setups (e.g.
+// testcontainers, docker-compose) that cannot set Go-level testing knobs.
+// Intended for dev/test clusters only; do not enable in production.
+var skipNonessentialBootstrap = envutil.EnvOrDefaultBool(
+	"COCKROACH_SKIP_NONESSENTIAL_BOOTSTRAP", false)
 
 // bootstrapSystem runs a series of steps required to bootstrap a new cluster's
 // system tenant. These are run before the rest of the initialization steps in
@@ -34,10 +44,8 @@ import (
 func bootstrapSystem(
 	ctx context.Context, cv clusterversion.ClusterVersion, deps upgrade.SystemDeps,
 ) error {
-	var skipSomeSteps bool
-	if deps.TestingKnobs != nil && deps.TestingKnobs.SkipSomeUpgradeSteps {
-		skipSomeSteps = true
-	}
+	skipSomeSteps := (deps.TestingKnobs != nil && deps.TestingKnobs.SkipSomeUpgradeSteps) ||
+		skipNonessentialBootstrap
 	for _, u := range []struct {
 		name            string
 		fn              upgrade.SystemUpgradeFunc
@@ -67,10 +75,8 @@ func bootstrapSystem(
 func bootstrapCluster(
 	ctx context.Context, cv clusterversion.ClusterVersion, deps upgrade.TenantDeps,
 ) error {
-	var skipSomeSteps bool
-	if deps.TestingKnobs != nil && deps.TestingKnobs.SkipSomeUpgradeSteps {
-		skipSomeSteps = true
-	}
+	skipSomeSteps := (deps.TestingKnobs != nil && deps.TestingKnobs.SkipSomeUpgradeSteps) ||
+		skipNonessentialBootstrap
 	for _, u := range []struct {
 		name            string
 		fn              upgrade.TenantUpgradeFunc


### PR DESCRIPTION
Adds `COCKROACH_SKIP_NONESSENTIAL_BOOTSTRAP`, a boolean env var read at
package init. When set, `bootstrapSystem` and `bootstrapCluster` skip
the substeps marked `skippableInTest`, mirroring the existing
`SkipSomeUpgradeSteps` testing knob used by in-process test servers.

The existing knob is reachable only via Go-level `TestingKnobs`, which
containerized test harnesses (testcontainers, docker-compose) cannot
set. Exposing the same fast path through an env var lets those setups
skip the observability scaffolding (scheduled jobs, `cluster.secret`
initialization, diagnostics opt-in, default `system.locations` entries,
key visualizer tables) that isn't needed for short-lived tests, while
still executing the essential steps: cluster version, root user and
admin role, and default databases.

Intended for dev/test clusters only; the env var is not gated by build
tags and will take effect in production binaries if set, consistent
with the convention established by other `COCKROACH_SKIP_*` env vars.

Epic: none

Release note (ops change): Added a new environment variable,
`COCKROACH_SKIP_NONESSENTIAL_BOOTSTRAP`, which when set causes a new
cluster to skip the nonessential steps of its first-time bootstrap
(scheduled observability jobs, `cluster.secret` initialization,
diagnostics opt-in, default `system.locations` data, and the key
visualizer tables). Intended only for dev/test clusters where bootstrap
latency matters; do not enable in production.