### PR TITLE
roachtest: increase job wait to 90 minutes in backup-restore tests

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -478,7 +478,7 @@ func (u *CommonTestUtils) waitForJobSuccessWithNode(
 	r := retry.StartWithCtx(ctx, retry.Options{
 		InitialBackoff: time.Second,
 		MaxBackoff:     time.Second,
-		MaxDuration:    80 * time.Minute,
+		MaxDuration:    90 * time.Minute,
 	})
 	for r.Next() {
 		var status string


### PR DESCRIPTION
Even with the changes introduced in #168610, we are seeing backups take 84 minutes near the end of tests. This bumps up the job wait from 80 minutes to 90 minutes in an effort to deflake the tests.

Epic: None

Release note: None