### PR TITLE
release-24.3: roachprod: update gce images

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -37,8 +37,8 @@ import (
 
 const (
 	ProviderName = "gce"
-	DefaultImage = "ubuntu-2204-jammy-v20240319"
-	ARM64Image   = "ubuntu-2204-jammy-arm64-v20240319"
+	DefaultImage = "ubuntu-2204-jammy-v20260414"
+	ARM64Image   = "ubuntu-2204-jammy-arm64-v20260414"
 	// TODO(DarrylWong): Upgrade FIPS to Ubuntu 22 when it is available.
 	FIPSImage           = "ubuntu-pro-fips-2004-focal-v20230811"
 	defaultImageProject = "ubuntu-os-cloud"


### PR DESCRIPTION
Backport 1/1 commits from #168593.

/cc @cockroachdb/release

---

Update GCE images. Same OS, but newer kernel (6.8 instead of 6.5; the
latter has some known Folio-related filesystem bugs).

Release note: None
Epic: none
Informs #168434

Release justification: test infrastructure change.