### PR TITLE
*: introduce tenant branching (PoC)

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -329,8 +329,20 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 	tcf *TxnCoordSenderFactory, txn *roachpb.Transaction, typ kv.TxnType,
 ) {
 	var riGen rangeIteratorFactory
-	if ds, ok := tcf.wrapped.(*DistSender); ok {
-		riGen.ds = ds
+	// Walk through any wrapping senders (e.g. a branch tenant's BranchSender)
+	// to find the underlying DistSender. The condensableSpanSet uses this
+	// factory to walk ranges when the txn's tracked span set grows large
+	// enough to need condensing; if it isn't wired up, condensing panics.
+	for s := tcf.wrapped; s != nil; {
+		if ds, ok := s.(*DistSender); ok {
+			riGen.ds = ds
+			break
+		}
+		u, ok := s.(interface{ Unwrap() kv.Sender })
+		if !ok {
+			break
+		}
+		s = u.Unwrap()
 	}
 	tc.interceptorAlloc.txnWriteBuffer = txnWriteBuffer{
 		st:         tcf.st,

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "kvtenant",
     srcs = [
+        "branch_sender.go",
         "connector.go",
         "connector_factory.go",
         "setting_overrides.go",
@@ -30,6 +31,7 @@ go_library(
         "//pkg/settings",
         "//pkg/spanconfig",
         "//pkg/sql/isql",
+        "//pkg/storage/mvccencoding",
         "//pkg/ts/tspb",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/kv/kvclient/kvtenant/branch_sender.go
+++ b/pkg/kv/kvclient/kvtenant/branch_sender.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // BranchSender wraps an inner kv.Sender (typically a DistSender) for a branch
@@ -74,6 +75,25 @@ func NewBranchSender(
 func (b *BranchSender) Send(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, *kvpb.Error) {
+	// Two write-side fixups for CoW semantics, applied to every batch (read or
+	// write) since either kind can carry an Increment or CPut on a key the
+	// branch has never written.
+	//
+	// Increment: MVCCIncrement starts from 0 if the key is missing, so the
+	// branch would allocate ID sequence values that collide with the parent's.
+	// We seed the branch with the parent's current value before the Increment
+	// is dispatched.
+	//
+	// CPut: a CPut whose expected bytes came from a parent-fallback read will
+	// fail against the branch (which has nil for that key). Setting
+	// AllowIfDoesNotExist=true makes the CPut succeed when the branch is empty
+	// — i.e. the branch's first write of a key it previously only saw via the
+	// parent.
+	if err := b.seedIncrements(ctx, ba); err != nil {
+		return nil, kvpb.NewError(err)
+	}
+	ba = rewriteCPutsForBranch(ba)
+
 	if !batchHasReads(ba) {
 		log.Dev.Infof(ctx, "[BRANCH] passthrough write batch (%d reqs)", len(ba.Requests))
 		return b.inner.Send(ctx, ba)
@@ -382,6 +402,101 @@ func encodeBatchResponse(rows []roachpb.KeyValue) [][]byte {
 	return [][]byte{buf}
 }
 
+// seedIncrements ensures every IncrementRequest in ba targets a key that
+// already has a value in the branch's keyspace. For each Increment whose key
+// is unwritten on the branch, it copies the parent's current value at
+// branch_ts into the branch. The Increment then proceeds normally and
+// produces the same value the parent would have, plus the requested delta.
+//
+// This is the CoW fix for sequence keys: descriptor IDs, role IDs, etc. live
+// at fixed sequence keys in the tenant keyspace, are mutated via Increment,
+// and need to start from the parent's current value rather than 0 on a fresh
+// branch.
+//
+// The seeding Get/Put are non-transactional: they're idempotent (repeated
+// seeding writes the same value) and must be visible to all subsequent
+// readers, not just the calling txn. A racing seeder writes the same value,
+// so concurrent CREATE TABLE statements on a branch converge.
+func (b *BranchSender) seedIncrements(ctx context.Context, ba *kvpb.BatchRequest) error {
+	for _, ru := range ba.Requests {
+		inc, ok := ru.GetInner().(*kvpb.IncrementRequest)
+		if !ok {
+			continue
+		}
+		if err := b.maybeSeedIncrement(ctx, inc.Key); err != nil {
+			return errors.Wrapf(err, "seeding increment key %s", inc.Key)
+		}
+	}
+	return nil
+}
+
+// maybeSeedIncrement seeds branchKey with the parent's current value at
+// branch_ts if the branch has no value there yet. A no-op if the branch
+// already has a value, or if the parent has none either (in which case
+// MVCCIncrement starting from zero is the correct behavior).
+func (b *BranchSender) maybeSeedIncrement(ctx context.Context, branchKey roachpb.Key) error {
+	branchKV, err := b.fallbackDB.Get(ctx, branchKey)
+	if err != nil {
+		return errors.Wrap(err, "reading branch key")
+	}
+	if branchKV.Value != nil && branchKV.Value.IsPresent() {
+		return nil
+	}
+
+	parentBa := newFallbackBatch(b.branchTS)
+	parentKey := rewriteKey(branchKey, b.branchCodec, b.parentCodec)
+	var u kvpb.RequestUnion
+	u.MustSetInner(&kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: parentKey}})
+	parentBa.Requests = append(parentBa.Requests, u)
+	parentBr, pErr := b.fallbackDB.NonTransactionalSender().Send(ctx, parentBa)
+	if pErr != nil {
+		return errors.Wrap(pErr.GoError(), "reading parent key")
+	}
+	parentResp := parentBr.Responses[0].GetInner().(*kvpb.GetResponse)
+	if parentResp.Value == nil || !parentResp.Value.IsPresent() {
+		return nil
+	}
+	parentInt, err := parentResp.Value.GetInt()
+	if err != nil {
+		return errors.Wrap(err, "decoding parent value as int")
+	}
+	log.Dev.Infof(ctx, "[BRANCH] seeding increment key %s with parent value %d", branchKey, parentInt)
+	if err := b.fallbackDB.Put(ctx, branchKey, parentInt); err != nil {
+		return errors.Wrap(err, "writing seed value")
+	}
+	return nil
+}
+
+// rewriteCPutsForBranch returns a batch in which every ConditionalPutRequest
+// with non-nil ExpBytes has AllowIfDoesNotExist set to true. On a branch the
+// expected bytes of any CPut came from a read that fell through to the
+// parent, so the branch keyspace is necessarily empty for that key on the
+// first write — exactly the case AllowIfDoesNotExist was designed for.
+//
+// Returns ba unchanged if there are no CPuts to rewrite.
+func rewriteCPutsForBranch(ba *kvpb.BatchRequest) *kvpb.BatchRequest {
+	var modified *kvpb.BatchRequest
+	for i, ru := range ba.Requests {
+		cput, ok := ru.GetInner().(*kvpb.ConditionalPutRequest)
+		if !ok || len(cput.ExpBytes) == 0 || cput.AllowIfDoesNotExist {
+			continue
+		}
+		if modified == nil {
+			modified = ba.ShallowCopy()
+			modified.Requests = append([]kvpb.RequestUnion(nil), ba.Requests...)
+		}
+		clone := *cput
+		clone.AllowIfDoesNotExist = true
+		var out kvpb.RequestUnion
+		out.MustSetInner(&clone)
+		modified.Requests[i] = out
+	}
+	if modified == nil {
+		return ba
+	}
+	return modified
+}
+
 // rewriteKey strips fromCodec's tenant prefix from key and prepends
 // toCodec's. Returns nil if key is nil.
 func rewriteKey(key roachpb.Key, fromCodec, toCodec keys.SQLCodec) roachpb.Key {
@@ -401,4 +516,3 @@ func rewriteKey(key roachpb.Key, fromCodec, toCodec keys.SQLCodec) roachpb.Key {
 	out = append(out, suffix...)
 	return out
 }
-

--- a/pkg/kv/kvclient/kvtenant/branch_sender.go
+++ b/pkg/kv/kvclient/kvtenant/branch_sender.go
@@ -1,0 +1,404 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvtenant
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// BranchSender wraps an inner kv.Sender (typically a DistSender) for a branch
+// tenant. It implements copy-on-write semantics at the request level:
+//
+//   - Writes pass through to the branch's keyspace.
+//   - Reads (Get/Scan) first hit the branch's keyspace with IncludeTombstones
+//     set. Any keys the branch has not written are then fetched from the
+//     parent tenant at the branch's fork timestamp via a separate, non-
+//     transactional batch and merged into the response.
+//
+// The fallback batch is non-transactional because the parent's keyspace is
+// outside the branch txn's scope; refreshes/locks across tenants are not
+// supported in this PoC. See .memory/WHITEBOARD.md.
+type BranchSender struct {
+	inner       kv.Sender
+	fallbackDB  *kv.DB
+	parentCodec keys.SQLCodec
+	branchCodec keys.SQLCodec
+	branchTS    hlc.Timestamp
+}
+
+var _ kv.Sender = (*BranchSender)(nil)
+
+// Unwrap returns the inner sender. This lets callers that need direct access
+// to the underlying DistSender (e.g. the rangefeed dbAdapter) bypass the
+// CoW layer. Rangefeeds operate on raw KV state and have no notion of
+// branching; the parent's data is reachable directly via its keyspace.
+func (b *BranchSender) Unwrap() kv.Sender {
+	return b.inner
+}
+
+// NewBranchSender constructs a BranchSender. The inner sender should be the
+// raw DistSender (not a TxnCoordSender) so write batches pass through directly.
+// fallbackDB is a kv.DB rooted on the same DistSender; its non-transactional
+// sender is used to issue fallback reads against the parent (which may need
+// to be auto-wrapped in a txn when they span multiple ranges).
+func NewBranchSender(
+	inner kv.Sender,
+	fallbackDB *kv.DB,
+	parentCodec, branchCodec keys.SQLCodec,
+	branchTS hlc.Timestamp,
+) *BranchSender {
+	return &BranchSender{
+		inner:       inner,
+		fallbackDB:  fallbackDB,
+		parentCodec: parentCodec,
+		branchCodec: branchCodec,
+		branchTS:    branchTS,
+	}
+}
+
+// Send implements the kv.Sender interface.
+func (b *BranchSender) Send(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (*kvpb.BatchResponse, *kvpb.Error) {
+	if !batchHasReads(ba) {
+		log.Dev.Infof(ctx, "[BRANCH] passthrough write batch (%d reqs)", len(ba.Requests))
+		return b.inner.Send(ctx, ba)
+	}
+
+	log.Dev.Infof(ctx, "[BRANCH] read batch (%d reqs) at branch_ts=%s", len(ba.Requests), b.branchTS)
+
+	// Mark every Get/Scan in the branch read with IncludeTombstones so we can
+	// distinguish "branch deleted this key" from "branch never wrote it". The
+	// caller's original ScanFormat is recorded so we can re-encode the merged
+	// result before returning (the merge step needs KEY_VALUES, but the caller
+	// may have asked for BATCH_RESPONSE / COL_BATCH_RESPONSE).
+	branchBa := ba.ShallowCopy()
+	branchBa.Requests = make([]kvpb.RequestUnion, len(ba.Requests))
+	origFormats := make([]kvpb.ScanFormat, len(ba.Requests))
+	for i, ru := range ba.Requests {
+		branchBa.Requests[i], origFormats[i] = withTombstones(ru)
+	}
+
+	br, pErr := b.inner.Send(ctx, branchBa)
+	if pErr != nil {
+		log.Dev.Infof(ctx, "[BRANCH] branch read errored: %s", pErr)
+		return nil, pErr
+	}
+
+	// For every read that returned no value (and no tombstone), build a parallel
+	// fallback request against the parent's keyspace at branch_ts. If nothing
+	// needs fallback, we can return the branch's response as-is.
+	fallbackIdx, fallbackBa := b.buildFallback(ba, br)
+	if fallbackBa == nil {
+		log.Dev.Infof(ctx, "[BRANCH] no fallback needed (%d reqs all satisfied by branch)", len(ba.Requests))
+		stripTombstones(br)
+		restoreScanFormat(br, origFormats)
+		return br, nil
+	}
+
+	log.Dev.Infof(ctx, "[BRANCH] dispatching fallback to parent (%d of %d reqs)", len(fallbackIdx), len(ba.Requests))
+	// Use the fallbackDB's non-transactional sender so multi-range Gets/Scans
+	// get auto-wrapped in a txn. The CrossRangeTxnWrapperSender drops the
+	// AOST timestamp when it auto-wraps, so the fallback observes the
+	// parent's current state rather than branch_ts; the protected timestamp
+	// merely guarantees the data is reachable. This is acceptable for the
+	// PoC. See .memory/WHITEBOARD.md.
+	fbResp, pErr := b.fallbackDB.NonTransactionalSender().Send(ctx, fallbackBa)
+	if pErr != nil {
+		log.Dev.Infof(ctx, "[BRANCH] fallback errored: %s", pErr)
+		return nil, pErr
+	}
+
+	b.mergeFallback(br, fbResp, fallbackIdx)
+	stripTombstones(br)
+	restoreScanFormat(br, origFormats)
+	log.Dev.Infof(ctx, "[BRANCH] merged response ready")
+	return br, nil
+}
+
+// batchHasReads reports whether ba contains any read requests we need to apply
+// CoW semantics to.
+func batchHasReads(ba *kvpb.BatchRequest) bool {
+	for _, ru := range ba.Requests {
+		switch ru.GetInner().(type) {
+		case *kvpb.GetRequest, *kvpb.ScanRequest:
+			return true
+		}
+	}
+	return false
+}
+
+// withTombstones returns a RequestUnion that, for read requests, has the
+// IncludeTombstones flag set. Scans are also forced into KEY_VALUES format so
+// that the BranchSender's row-level merge has access to the per-row keys
+// (BATCH_RESPONSE and COL_BATCH_RESPONSE bury the keys inside opaque bytes,
+// which we cannot rewrite without a table descriptor). The caller's original
+// ScanFormat is returned so the response can be re-encoded after the merge.
+func withTombstones(ru kvpb.RequestUnion) (kvpb.RequestUnion, kvpb.ScanFormat) {
+	switch r := ru.GetInner().(type) {
+	case *kvpb.GetRequest:
+		clone := *r
+		clone.IncludeTombstones = true
+		var out kvpb.RequestUnion
+		out.MustSetInner(&clone)
+		return out, kvpb.KEY_VALUES
+	case *kvpb.ScanRequest:
+		clone := *r
+		clone.IncludeTombstones = true
+		orig := clone.ScanFormat
+		clone.ScanFormat = kvpb.KEY_VALUES
+		var out kvpb.RequestUnion
+		out.MustSetInner(&clone)
+		return out, orig
+	default:
+		return ru, kvpb.KEY_VALUES
+	}
+}
+
+// buildFallback constructs a non-transactional BatchRequest against the
+// parent's keyspace at branch_ts for the subset of reads in ba that returned
+// no value and no tombstone in br. It returns the fallback batch and a
+// parallel slice mapping fallback request index -> original request index.
+// If no requests need a fallback, it returns (nil, nil).
+func (b *BranchSender) buildFallback(
+	ba *kvpb.BatchRequest, br *kvpb.BatchResponse,
+) (origIdx []int, fallbackBa *kvpb.BatchRequest) {
+	for i, ru := range ba.Requests {
+		switch r := ru.GetInner().(type) {
+		case *kvpb.GetRequest:
+			resp := br.Responses[i].GetInner().(*kvpb.GetResponse)
+			if resp.Value != nil {
+				// Either a value or a tombstone (empty bytes with timestamp).
+				// Either way the branch has a definitive answer for this key.
+				continue
+			}
+			fbReq := &kvpb.GetRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key: rewriteKey(r.Key, b.branchCodec, b.parentCodec),
+				},
+			}
+			if fallbackBa == nil {
+				fallbackBa = newFallbackBatch(b.branchTS)
+			}
+			origIdx = append(origIdx, i)
+			var out kvpb.RequestUnion
+			out.MustSetInner(fbReq)
+			fallbackBa.Requests = append(fallbackBa.Requests, out)
+
+		case *kvpb.ScanRequest:
+			// Scans always need a fallback: the branch may have only some of
+			// the rows in the range, and the parent may have additional rows.
+			// We let mergeFallback dedupe and respect tombstones on overlap.
+			fbReq := &kvpb.ScanRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:    rewriteKey(r.Key, b.branchCodec, b.parentCodec),
+					EndKey: rewriteKey(r.EndKey, b.branchCodec, b.parentCodec),
+				},
+				ScanFormat: kvpb.KEY_VALUES,
+			}
+			if fallbackBa == nil {
+				fallbackBa = newFallbackBatch(b.branchTS)
+			}
+			origIdx = append(origIdx, i)
+			var out kvpb.RequestUnion
+			out.MustSetInner(fbReq)
+			fallbackBa.Requests = append(fallbackBa.Requests, out)
+		}
+	}
+	return origIdx, fallbackBa
+}
+
+// newFallbackBatch returns a BatchRequest with no transaction, pinned to
+// branch_ts, suitable as a non-transactional AOST read against the parent
+// tenant's keyspace.
+func newFallbackBatch(branchTS hlc.Timestamp) *kvpb.BatchRequest {
+	return &kvpb.BatchRequest{
+		Header: kvpb.Header{
+			Timestamp:       branchTS,
+			ReadConsistency: kvpb.CONSISTENT,
+		},
+	}
+}
+
+// mergeFallback merges the fallback responses (against the parent) back into
+// the branch's response br. fallbackIdx[i] gives the original request index
+// in br corresponding to fbResp.Responses[i].
+//
+// For Get: if the branch returned no value, plug in the parent's value
+// (rewriting the key prefix back to the branch).
+// For Scan: take the union of parent rows and branch rows, prefer the
+// branch row on key collision, drop any parent row whose key has a branch
+// tombstone.
+func (b *BranchSender) mergeFallback(
+	br *kvpb.BatchResponse, fbResp *kvpb.BatchResponse, fallbackIdx []int,
+) {
+	// fbResp may contain extra trailing responses (e.g. an EndTxn appended
+	// when the CrossRangeTxnWrapperSender auto-wrapped the batch in a txn).
+	// Only the first len(fallbackIdx) responses correspond to our requests.
+	for j := range fallbackIdx {
+		i := fallbackIdx[j]
+		switch fb := fbResp.Responses[j].GetInner().(type) {
+		case *kvpb.GetResponse:
+			if fb.Value == nil {
+				continue
+			}
+			// Rewrite parent's value into branch's response slot. The Get
+			// response carries no key, so we just plug the value in.
+			origGet := br.Responses[i].GetInner().(*kvpb.GetResponse)
+			origGet.Value = fb.Value
+
+		case *kvpb.ScanResponse:
+			origScan := br.Responses[i].GetInner().(*kvpb.ScanResponse)
+			merged := mergeScanRows(origScan.Rows, fb.Rows, b.branchCodec, b.parentCodec)
+			origScan.Rows = merged
+		}
+	}
+}
+
+// mergeScanRows merges branch and parent rows into a single key-sorted slice.
+// Branch rows whose value is nil are tombstones: the row is dropped from the
+// output, but the key still suppresses any matching parent row. Parent row
+// keys are rewritten from the parent prefix into the branch prefix.
+func mergeScanRows(
+	branchRows, parentRows []roachpb.KeyValue, branchCodec, parentCodec keys.SQLCodec,
+) []roachpb.KeyValue {
+	// Build the set of branch keys (including tombstoned ones) so we know
+	// which parent rows to suppress.
+	branchKeys := make(map[string]struct{}, len(branchRows))
+	for _, r := range branchRows {
+		branchKeys[string(r.Key)] = struct{}{}
+	}
+
+	out := make([]roachpb.KeyValue, 0, len(branchRows)+len(parentRows))
+	for _, r := range branchRows {
+		if r.Value.IsPresent() && len(r.Value.RawBytes) > 0 {
+			out = append(out, r)
+		}
+		// else: tombstone. Drop from output, but the key remains in
+		// branchKeys to suppress parent.
+	}
+	for _, r := range parentRows {
+		bk := rewriteKey(r.Key, parentCodec, branchCodec)
+		if _, ok := branchKeys[string(bk)]; ok {
+			continue
+		}
+		out = append(out, roachpb.KeyValue{Key: bk, Value: r.Value})
+	}
+	sort.Slice(out, func(i, j int) bool { return bytes.Compare(out[i].Key, out[j].Key) < 0 })
+	return out
+}
+
+// stripTombstones removes tombstone entries from Get and Scan responses so
+// the caller (above the branchSender) sees the standard "missing key" /
+// "row absent" semantics.
+func stripTombstones(br *kvpb.BatchResponse) {
+	for _, ru := range br.Responses {
+		switch r := ru.GetInner().(type) {
+		case *kvpb.GetResponse:
+			if r.Value != nil && len(r.Value.RawBytes) == 0 {
+				r.Value = nil
+			}
+		case *kvpb.ScanResponse:
+			out := r.Rows[:0]
+			for _, row := range r.Rows {
+				if row.Value.IsPresent() && len(row.Value.RawBytes) > 0 {
+					out = append(out, row)
+				}
+			}
+			r.Rows = out
+		}
+	}
+}
+
+// restoreScanFormat re-encodes Scan responses whose original ScanFormat was
+// not KEY_VALUES back into the format the caller asked for. The branch and
+// fallback paths are forced to KEY_VALUES so the merge can dedupe by key;
+// without this step the SQL pod's KV fetcher would error with "unexpectedly
+// got a ScanResponse using KEY_VALUES response format".
+//
+// COL_BATCH_RESPONSE is also collapsed into BATCH_RESPONSE: the columnar
+// format requires an IndexFetchSpec-driven encoder, which would entail
+// rewriting the spec's tenant prefix and re-running the cfetcher in this
+// package. The KV fetcher accepts BatchResponses regardless of which format
+// was originally requested (popBatch in pkg/sql/row/kv_batch_fetcher.go
+// prefers the BatchResponses path), so this is sufficient for the PoC.
+func restoreScanFormat(br *kvpb.BatchResponse, origFormats []kvpb.ScanFormat) {
+	for i, ru := range br.Responses {
+		scan, ok := ru.GetInner().(*kvpb.ScanResponse)
+		if !ok {
+			continue
+		}
+		if origFormats[i] == kvpb.KEY_VALUES {
+			continue
+		}
+		scan.BatchResponses = encodeBatchResponse(scan.Rows)
+		scan.Rows = nil
+	}
+}
+
+// encodeBatchResponse encodes a slice of KeyValues into the BATCH_RESPONSE
+// wire format expected by MVCCScanDecodeKeyValues: a single []byte buffer of
+// repeated <valueLen:u32 LE><keyLen:u32 LE><MVCCKey><Value>. Returns nil for
+// an empty input so an empty Scan stays empty (BatchResponses=nil rather
+// than [[]byte{}], which the fetcher treats the same).
+func encodeBatchResponse(rows []roachpb.KeyValue) [][]byte {
+	if len(rows) == 0 {
+		return nil
+	}
+	// Pre-size the output buffer.
+	totalSize := 0
+	keyLens := make([]int, len(rows))
+	for i, kv := range rows {
+		keyLens[i] = mvccencoding.EncodedMVCCKeyLength(kv.Key, kv.Value.Timestamp)
+		totalSize += 8 + keyLens[i] + len(kv.Value.RawBytes)
+	}
+	buf := make([]byte, totalSize)
+	pos := 0
+	for i, kv := range rows {
+		valLen := len(kv.Value.RawBytes)
+		keyLen := keyLens[i]
+		binary.LittleEndian.PutUint32(buf[pos:], uint32(valLen))
+		binary.LittleEndian.PutUint32(buf[pos+4:], uint32(keyLen))
+		pos += 8
+		mvccencoding.EncodeMVCCKeyToBufSized(buf[pos:pos+keyLen], kv.Key, kv.Value.Timestamp, keyLen)
+		pos += keyLen
+		copy(buf[pos:], kv.Value.RawBytes)
+		pos += valLen
+	}
+	return [][]byte{buf}
+}
+
+// rewriteKey strips fromCodec's tenant prefix from key and prepends
+// toCodec's. Returns nil if key is nil.
+func rewriteKey(key roachpb.Key, fromCodec, toCodec keys.SQLCodec) roachpb.Key {
+	if len(key) == 0 {
+		return key
+	}
+	fromPrefix := fromCodec.TenantPrefix()
+	if !bytes.HasPrefix(key, fromPrefix) {
+		// Defensive: if the key isn't in fromCodec's tenant, return as-is
+		// rather than panic. Non-tenant-prefixed keys (e.g. range-local)
+		// land here.
+		return key
+	}
+	suffix := key[len(fromPrefix):]
+	out := make(roachpb.Key, 0, len(toCodec.TenantPrefix())+len(suffix))
+	out = append(out, toCodec.TenantPrefix()...)
+	out = append(out, suffix...)
+	return out
+}
+

--- a/pkg/kv/kvclient/kvtenant/branch_sender.go
+++ b/pkg/kv/kvclient/kvtenant/branch_sender.go
@@ -93,6 +93,9 @@ func (b *BranchSender) Send(
 		return nil, kvpb.NewError(err)
 	}
 	ba = rewriteCPutsForBranch(ba)
+	if pErr := b.checkParentForCPuts(ctx, ba); pErr != nil {
+		return nil, pErr
+	}
 
 	if !batchHasReads(ba) {
 		log.Dev.Infof(ctx, "[BRANCH] passthrough write batch (%d reqs)", len(ba.Requests))
@@ -495,6 +498,104 @@ func rewriteCPutsForBranch(ba *kvpb.BatchRequest) *kvpb.BatchRequest {
 		return ba
 	}
 	return modified
+}
+
+// checkParentForCPuts enforces CPut(nil-expected) semantics — "the key must
+// not have a value" — across both the branch's and the parent's keyspaces.
+//
+// CPut(nil-expected) is the storage-level mechanism behind primary key and
+// unique-secondary-index uniqueness. Without intervention a CPut on a key the
+// branch has never written succeeds against the empty branch keyspace even
+// when the parent has a value at the same key, silently allowing a duplicate
+// row that violates the constraint.
+//
+// For each candidate CPut we first look the key up on the branch with
+// IncludeTombstones. If the branch has any state (live value or tombstone)
+// the storage CPut already produces the right answer — fail on a live value,
+// succeed on a tombstone (the tombstone records an explicit branch-side
+// DELETE, so re-inserting at that key is legitimate). Otherwise we look the
+// key up on the parent at branch_ts; a value there means the CPut would
+// violate uniqueness, and we synthesize the ConditionFailedError the storage
+// layer would have produced if the value lived on the branch so the SQL
+// layer's ConvertBatchError can surface it as a duplicate-key error.
+//
+// CPut(non-nil-expected) is the "update from old to new" shape and is
+// handled separately by rewriteCPutsForBranch; it does not need a parent
+// check because the expected bytes already came from a parent-fallback read.
+func (b *BranchSender) checkParentForCPuts(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+	type cputPos struct {
+		origIdx int
+		key     roachpb.Key
+	}
+	var positions []cputPos
+	for i, ru := range ba.Requests {
+		cput, ok := ru.GetInner().(*kvpb.ConditionalPutRequest)
+		if !ok || len(cput.ExpBytes) > 0 {
+			continue
+		}
+		positions = append(positions, cputPos{origIdx: i, key: cput.Key})
+	}
+	if len(positions) == 0 {
+		return nil
+	}
+
+	branchBa := &kvpb.BatchRequest{Header: kvpb.Header{ReadConsistency: kvpb.CONSISTENT}}
+	for _, p := range positions {
+		var u kvpb.RequestUnion
+		u.MustSetInner(&kvpb.GetRequest{
+			RequestHeader:     kvpb.RequestHeader{Key: p.key},
+			IncludeTombstones: true,
+		})
+		branchBa.Requests = append(branchBa.Requests, u)
+	}
+	branchBr, pErr := b.fallbackDB.NonTransactionalSender().Send(ctx, branchBa)
+	if pErr != nil {
+		return pErr
+	}
+
+	var parentBa *kvpb.BatchRequest
+	var parentToPos []int // index in parentBa.Requests -> index in positions
+	for j, p := range positions {
+		gr := branchBr.Responses[j].GetInner().(*kvpb.GetResponse)
+		if gr.Value != nil {
+			// Branch has a live value or a tombstone — the storage CPut
+			// will give the correct answer without involving the parent.
+			continue
+		}
+		if parentBa == nil {
+			parentBa = newFallbackBatch(b.branchTS)
+		}
+		var u kvpb.RequestUnion
+		u.MustSetInner(&kvpb.GetRequest{
+			RequestHeader: kvpb.RequestHeader{
+				Key: rewriteKey(p.key, b.branchCodec, b.parentCodec),
+			},
+		})
+		parentBa.Requests = append(parentBa.Requests, u)
+		parentToPos = append(parentToPos, j)
+	}
+	if parentBa == nil {
+		return nil
+	}
+	parentBr, pErr := b.fallbackDB.NonTransactionalSender().Send(ctx, parentBa)
+	if pErr != nil {
+		return pErr
+	}
+	for k, j := range parentToPos {
+		gr := parentBr.Responses[k].GetInner().(*kvpb.GetResponse)
+		if gr.Value == nil || !gr.Value.IsPresent() {
+			continue
+		}
+		log.Dev.Infof(ctx,
+			"[BRANCH] CPut(nil-expected) on inherited key %s blocked by parent value",
+			positions[j].key)
+		pe := kvpb.NewErrorWithTxn(
+			&kvpb.ConditionFailedError{ActualValue: gr.Value}, ba.Txn,
+		)
+		pe.SetErrorIndex(int32(positions[j].origIdx))
+		return pe
+	}
+	return nil
 }
 
 // rewriteKey strips fromCodec's tenant prefix from key and prepends

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -51,10 +51,21 @@ func newDBAdapter(db *kv.DB, st *cluster.Settings) (*dbAdapter, error) {
 			return nil, errors.Errorf("failed to extract a %T from %T",
 				(*kv.CrossRangeTxnWrapperSender)(nil), db.NonTransactionalSender())
 		}
-		distSender, ok = txnWrapperSender.Wrapped().(*kvcoord.DistSender)
-		if !ok {
-			return nil, errors.Errorf("failed to extract a %T from %T",
-				(*kvcoord.DistSender)(nil), txnWrapperSender.Wrapped())
+		// Walk through any wrapping senders (e.g. branch tenant's BranchSender)
+		// to find the underlying DistSender. Rangefeeds operate on raw KV
+		// state below the CoW layer.
+		s := txnWrapperSender.Wrapped()
+		for {
+			if ds, ok := s.(*kvcoord.DistSender); ok {
+				distSender = ds
+				break
+			}
+			u, ok := s.(interface{ Unwrap() kv.Sender })
+			if !ok {
+				return nil, errors.Errorf("failed to extract a %T from %T",
+					(*kvcoord.DistSender)(nil), txnWrapperSender.Wrapped())
+			}
+			s = u.Unwrap()
 		}
 	}
 	return &dbAdapter{

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -232,6 +232,14 @@ message GetRequest {
   // lock should have prevented. If such a write is found an
   // ExclusionViolationError is returned.
   util.hlc.Timestamp expect_exclusion_since = 6 [(gogoproto.nullable) = false];
+
+  // IncludeTombstones, if true, instructs the read to surface MVCC deletion
+  // tombstones to the caller (as a value with empty bytes) rather than
+  // suppressing them. This is used by branch tenants to distinguish a
+  // "branch deleted this key" from "branch never wrote this key", so that
+  // the branchSender can avoid falling through to the parent for keys the
+  // branch has tombstoned. See pkg/kv/kvclient/kvtenant/branch_sender.go.
+  bool include_tombstones = 7;
 }
 
 // A GetResponse is the return value from the Get() method.
@@ -678,6 +686,11 @@ message ScanRequest {
   // This option is not compatible for reads over inline values (see
   // https://github.com/cockroachdb/cockroach/issues/131667)
   bool return_raw_mvcc_values = 7 [(gogoproto.customname) = "ReturnRawMVCCValues"];
+
+  // IncludeTombstones, if true, instructs the scan to surface MVCC deletion
+  // tombstones to the caller (as rows with empty values) rather than
+  // suppressing them. See the IncludeTombstones field on GetRequest.
+  bool include_tombstones = 8;
 }
 
 // A ScanResponse is the return value from the Scan() method.

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -70,6 +70,7 @@ func Get(
 		AllowEmpty:            cArgs.Header.AllowEmpty,
 		ReadCategory:          fs.BatchEvalReadCategory,
 		ReturnRawMVCCValues:   args.ReturnRawMVCCValues,
+		Tombstones:            args.IncludeTombstones,
 		WorkloadID:            h.WorkloadID,
 	})
 	if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -64,6 +64,7 @@ func Scan(
 		DontInterleaveIntents:   cArgs.DontInterleaveIntents,
 		ReadCategory:            readCategory,
 		ReturnRawMVCCValues:     args.ReturnRawMVCCValues,
+		Tombstones:              args.IncludeTombstones,
 		WorkloadID:              h.WorkloadID,
 	}
 

--- a/pkg/multitenant/mtinfopb/info.go
+++ b/pkg/multitenant/mtinfopb/info.go
@@ -110,6 +110,11 @@ type TenantInfo struct {
 	SQLInfo
 }
 
+// IsBranch reports whether this tenant is a branch of another tenant.
+func (m *ProtoInfo) IsBranch() bool {
+	return m.BranchParentID != nil
+}
+
 // ToInfo converts a TenantInfoWithUsage to an TenantInfo.
 func (m *TenantInfoWithUsage) ToInfo() *TenantInfo {
 	return &TenantInfo{

--- a/pkg/multitenant/mtinfopb/info.proto
+++ b/pkg/multitenant/mtinfopb/info.proto
@@ -83,7 +83,22 @@ message ProtoInfo {
   // maintaining its catalog accordingly).
   optional roachpb.TenantID read_from_tenant = 9 ;
 
-  // Next ID: 10.
+  // BranchParentID, if set, identifies the parent tenant that this tenant was
+  // branched from. A branch tenant has its own keyspace, but reads of keys
+  // unmodified since the fork point fall through to the parent at
+  // BranchTimestamp via a SQL-pod-level Sender wrapper. See
+  // pkg/kv/kvclient/kvtenant/branch_sender.go.
+  optional roachpb.TenantID branch_parent_id = 10 [(gogoproto.customname) = "BranchParentID"];
+
+  // BranchTimestamp is the fork point of a branch tenant. Reads on the branch
+  // that miss in the branch's keyspace fall through to the parent at this
+  // timestamp; the parent's data at this timestamp is held by a protected
+  // timestamp record for the lifetime of the branch.
+  //
+  // Only meaningful when BranchParentID is set.
+  optional util.hlc.Timestamp branch_timestamp = 11 [(gogoproto.nullable) = false];
+
+  // Next ID: 12.
 }
 
 message PreviousSourceTenant {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -504,6 +505,12 @@ type SQLConfig struct {
 	// TenantReadOnly indicates if this tenant is read-only (PCR reader tenant).
 	TenantReadOnly bool
 
+	// BranchInfo is set if this tenant is a branch of another tenant. When
+	// non-nil, the SQL pod's KV client wraps DistSender with a BranchSender
+	// that falls through to the parent tenant at BranchTimestamp for keys
+	// the branch has not written. See pkg/kv/kvclient/kvtenant/branch_sender.go.
+	BranchInfo *TenantBranchInfo
+
 	// If set, will to be called at server startup to obtain the tenant id and
 	// locality.
 	DelayedSetTenantID func(context.Context) (roachpb.TenantID, roachpb.Locality, error)
@@ -551,6 +558,14 @@ type SQLConfig struct {
 
 	// LicenseEnforcer is used to enforce license policies.
 	LicenseEnforcer *license.Enforcer
+}
+
+// TenantBranchInfo identifies the parent tenant and fork point of a branch
+// tenant. It is consumed by the SQL pod startup path to wire BranchSender
+// in front of DistSender.
+type TenantBranchInfo struct {
+	ParentID  roachpb.TenantID
+	Timestamp hlc.Timestamp
 }
 
 // LocalKVServerInfo is used to group information about the local KV server

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -66,7 +66,7 @@ func (s *topLevelServer) newTenantServer(
 	portStartHint int,
 	testArgs base.TestSharedProcessTenantArgs,
 ) (onDemandServer, error) {
-	tenantID, tenantReadOnly, err := s.getTenantID(ctx, tenantNameContainer.Get())
+	tenantID, tenantReadOnly, branchInfo, err := s.getTenantID(ctx, tenantNameContainer.Get())
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (s *topLevelServer) newTenantServer(
 	}
 
 	baseCfg, sqlCfg, err := s.makeSharedProcessTenantConfig(ctx, tenantID, tenantNameContainer.Get(), portStartHint,
-		tenantStopper, testArgs.Settings, tenantReadOnly)
+		tenantStopper, testArgs.Settings, tenantReadOnly, branchInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -119,19 +119,19 @@ var ErrInvalidTenant error = errInvalidTenantMarker{}
 
 func (s *topLevelServer) getTenantID(
 	ctx context.Context, tenantName roachpb.TenantName,
-) (roachpb.TenantID, bool, error) {
+) (roachpb.TenantID, bool, *TenantBranchInfo, error) {
 	var rec *mtinfopb.TenantInfo
 	if err := s.sqlServer.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		var err error
 		rec, err = sql.GetTenantRecordByName(ctx, s.cfg.Settings, txn, tenantName)
 		return err
 	}); err != nil {
-		return roachpb.TenantID{}, false, errors.Mark(err, ErrInvalidTenant)
+		return roachpb.TenantID{}, false, nil, errors.Mark(err, ErrInvalidTenant)
 	}
 
 	tenantID, err := roachpb.MakeTenantID(rec.ID)
 	if err != nil {
-		return roachpb.TenantID{}, false, errors.Mark(
+		return roachpb.TenantID{}, false, nil, errors.Mark(
 			errors.NewAssertionErrorWithWrappedErrf(err, "stored tenant ID %d does not convert to TenantID", rec.ID),
 			ErrInvalidTenant)
 	}
@@ -139,7 +139,15 @@ func (s *topLevelServer) getTenantID(
 	// Check if tenant is read-only (PCR reader tenant).
 	readOnlyTenant := rec.ReadFromTenant != nil
 
-	return tenantID, readOnlyTenant, nil
+	var branchInfo *TenantBranchInfo
+	if rec.IsBranch() {
+		branchInfo = &TenantBranchInfo{
+			ParentID:  *rec.BranchParentID,
+			Timestamp: rec.BranchTimestamp,
+		}
+	}
+
+	return tenantID, readOnlyTenant, branchInfo, nil
 }
 
 // newTenantServerInternal instantiates a server for the given target
@@ -178,6 +186,7 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
 	stopper *stop.Stopper,
 	testSettings *cluster.Settings,
 	tenantReadOnly bool,
+	branchInfo *TenantBranchInfo,
 ) (BaseConfig, SQLConfig, error) {
 	// Create a configuration for the new tenant.
 	parentCfg := s.cfg
@@ -194,7 +203,7 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
 	}
 
 	baseCfg, sqlCfg, err := makeSharedProcessTenantServerConfig(ctx, tenantID, tenantName, portStartHint, parentCfg,
-		localServerInfo, st, stopper, s.recorder, tenantReadOnly)
+		localServerInfo, st, stopper, s.recorder, tenantReadOnly, branchInfo)
 	if err != nil {
 		return BaseConfig{}, SQLConfig{}, err
 	}
@@ -214,6 +223,7 @@ func makeSharedProcessTenantServerConfig(
 	stopper *stop.Stopper,
 	nodeMetricsRecorder *status.MetricsRecorder,
 	tenantReadOnly bool,
+	branchInfo *TenantBranchInfo,
 ) (baseCfg BaseConfig, sqlCfg SQLConfig, err error) {
 	tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
 
@@ -368,6 +378,7 @@ func makeSharedProcessTenantServerConfig(
 
 	sqlCfg = MakeSQLConfig(tenantID, tenantName, tempStorageCfg)
 	sqlCfg.TenantReadOnly = tenantReadOnly
+	sqlCfg.BranchInfo = branchInfo
 	baseCfg.ExternalIODirConfig = kvServerCfg.BaseConfig.ExternalIODirConfig
 
 	baseCfg.ExternalIODir = kvServerCfg.BaseConfig.ExternalIODir

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1324,6 +1324,37 @@ func makeTenantSQLServerArgs(
 
 	txnMetrics := kvcoord.MakeTxnMetrics(baseCfg.HistogramWindowInterval())
 	registry.AddMetricStruct(txnMetrics)
+
+	// If this tenant is a branch, wrap the DistSender so reads of keys the
+	// branch has not written fall through to the parent tenant at the
+	// branch's fork timestamp. The fallback uses a separate kv.DB rooted on
+	// the raw DistSender so multi-range Gets/Scans get auto-wrapped in a
+	// transaction. See pkg/kv/kvclient/kvtenant/branch_sender.go.
+	var rootSender kv.Sender = ds
+	if bi := sqlCfg.BranchInfo; bi != nil {
+		parentCodec := keys.MakeSQLCodec(bi.ParentID)
+		branchCodec := keys.MakeSQLCodec(sqlCfg.TenantID)
+		log.Dev.Infof(startupCtx, "[BRANCH] wiring BranchSender: branch=%s parent=%s branch_ts=%s",
+			sqlCfg.TenantID, bi.ParentID, bi.Timestamp)
+		fallbackTCS := kvcoord.NewTxnCoordSenderFactory(
+			kvcoord.TxnCoordSenderFactoryConfig{
+				AmbientCtx:        baseCfg.AmbientCtx,
+				Settings:          st,
+				Clock:             clock,
+				Stopper:           stopper,
+				HeartbeatInterval: base.DefaultTxnHeartbeatInterval,
+				Linearizable:      sqlCfg.Linearizable,
+				Metrics:           txnMetrics,
+				TestingKnobs:      clientKnobs,
+			},
+			ds,
+		)
+		fallbackDBCtx := kv.DefaultDBContext(st, stopper)
+		fallbackDBCtx.NodeID = deps.instanceIDContainer
+		fallbackDB := kv.NewDBWithContext(baseCfg.AmbientCtx, fallbackTCS, clock, fallbackDBCtx)
+		rootSender = kvtenant.NewBranchSender(ds, fallbackDB, parentCodec, branchCodec, bi.Timestamp)
+	}
+
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(
 		kvcoord.TxnCoordSenderFactoryConfig{
 			AmbientCtx:        baseCfg.AmbientCtx,
@@ -1335,7 +1366,7 @@ func makeTenantSQLServerArgs(
 			Metrics:           txnMetrics,
 			TestingKnobs:      clientKnobs,
 		},
-		ds,
+		rootSender,
 	)
 
 	dbCtx := kv.DefaultDBContext(st, stopper)

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -263,6 +263,7 @@ go_library(
         "telemetry_logging.go",
         "temporary_schema.go",
         "tenant_accessors.go",
+        "tenant_branch.go",
         "tenant_capability.go",
         "tenant_creation.go",
         "tenant_deletion.go",

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -199,6 +199,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.CreateExternalConnection(ctx, n)
 	case *tree.CreateTenant:
 		return p.CreateTenantNode(ctx, n)
+	case *tree.CreateTenantAsBranch:
+		return p.CreateTenantAsBranchNode(ctx, n)
 	case *tree.CheckExternalConnection:
 		return p.CheckExternalConnection(ctx, n)
 	case *tree.DropExternalConnection:
@@ -394,6 +396,7 @@ func init() {
 		&tree.CreateExternalConnection{},
 		&tree.AlterExternalConnection{},
 		&tree.CreateTenant{},
+		&tree.CreateTenantAsBranch{},
 		&tree.CreateIndex{},
 		&tree.CreatePolicy{},
 		&tree.CreateSchema{},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1008,6 +1008,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %token <str> ASENSITIVE ASYMMETRIC AT ATOMIC ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY AVOID_FULL_SCAN
 
 %token <str> BACKUP BACKUPS BACKWARD BATCH BEFORE BEGIN BETWEEN BIDIRECTIONAL BIGINT BIGSERIAL BINARY BIT
+%token <str> BRANCH
 %token <str> BUCKET_COUNT
 %token <str> BOOLEAN BOTH BOX2D BY BYPASSRLS
 
@@ -5111,6 +5112,23 @@ create_virtual_cluster_stmt:
       ReplicationSourceTenantName: &tree.TenantSpec{IsName: true, Expr: $10.expr()},
       ReplicationSourceConnUri: $12.expr(),
       Options: *$13.tenantReplicationOptions(),
+    }
+  }
+| CREATE virtual_cluster virtual_cluster_spec BRANCH FROM d_expr
+  {
+    /* SKIP DOC */
+    $$.val = &tree.CreateTenantAsBranch{
+      TenantSpec: $3.tenantSpec(),
+      ParentTenantName: &tree.TenantSpec{IsName: true, Expr: $6.expr()},
+    }
+  }
+| CREATE virtual_cluster IF NOT EXISTS virtual_cluster_spec BRANCH FROM d_expr
+  {
+    /* SKIP DOC */
+    $$.val = &tree.CreateTenantAsBranch{
+      IfNotExists: true,
+      TenantSpec: $6.tenantSpec(),
+      ParentTenantName: &tree.TenantSpec{IsName: true, Expr: $9.expr()},
     }
   }
 | CREATE virtual_cluster error // SHOW HELP: CREATE VIRTUAL CLUSTER
@@ -18931,6 +18949,7 @@ unreserved_keyword:
 | BEGIN
 | BIDIRECTIONAL
 | BINARY
+| BRANCH
 | BUCKET_COUNT
 | BY
 | BYPASSRLS

--- a/pkg/sql/plan_names.go
+++ b/pkg/sql/plan_names.go
@@ -109,6 +109,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&createStatsNode{}):                               "create statistics",
 	reflect.TypeOf(&createTableNode{}):                               "create table",
 	reflect.TypeOf(&createTenantNode{}):                              "create tenant",
+	reflect.TypeOf(&createTenantAsBranchNode{}):                      "create tenant as branch",
 	reflect.TypeOf(&createTypeNode{}):                                "create type",
 	reflect.TypeOf(&CreateRoleNode{}):                                "create user/role",
 	reflect.TypeOf(&createViewNode{}):                                "create view",

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2278,6 +2278,31 @@ func (node *CreateTenant) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.TenantSpec)
 }
 
+// CreateTenantAsBranch represents a CREATE VIRTUAL CLUSTER ... BRANCH FROM
+// statement: it creates a new tenant as a copy-on-write branch of an existing
+// tenant. The branch shares the parent's data at its creation time and
+// diverges via writes to its own keyspace.
+type CreateTenantAsBranch struct {
+	IfNotExists bool
+	TenantSpec  *TenantSpec
+
+	// ParentTenantName names the tenant being branched from. As with
+	// ReplicationSourceTenantName, parsing guarantees this is a name, but we
+	// reuse TenantSpec for consistent identifier auto-promotion.
+	ParentTenantName *TenantSpec
+}
+
+// Format implements the NodeFormatter interface.
+func (node *CreateTenantAsBranch) Format(ctx *FmtCtx) {
+	ctx.WriteString("CREATE VIRTUAL CLUSTER ")
+	if node.IfNotExists {
+		ctx.WriteString("IF NOT EXISTS ")
+	}
+	ctx.FormatNode(node.TenantSpec)
+	ctx.WriteString(" BRANCH FROM ")
+	ctx.FormatNode(node.ParentTenantName)
+}
+
 // CreateTenantFromReplication represents a CREATE VIRTUAL CLUSTER...FROM REPLICATION
 // statement.
 type CreateTenantFromReplication struct {

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1075,6 +1075,15 @@ func (*CreateTenant) StatementType() StatementType { return TypeDCL }
 func (*CreateTenant) StatementTag() string { return "CREATE VIRTUAL CLUSTER" }
 
 // StatementReturnType implements the Statement interface.
+func (*CreateTenantAsBranch) StatementReturnType() StatementReturnType { return Ack }
+
+// StatementType implements the Statement interface.
+func (*CreateTenantAsBranch) StatementType() StatementType { return TypeDCL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CreateTenantAsBranch) StatementTag() string { return "CREATE VIRTUAL CLUSTER BRANCH" }
+
+// StatementReturnType implements the Statement interface.
 func (*CreateTenantFromReplication) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.
@@ -2701,6 +2710,7 @@ func (n *CreatePolicy) String() string                        { return AsString(
 func (n *CreateRole) String() string                          { return AsString(n) }
 func (n *CreateTable) String() string                         { return AsString(n) }
 func (n *CreateTenant) String() string                        { return AsString(n) }
+func (n *CreateTenantAsBranch) String() string                { return AsString(n) }
 func (n *CreateTenantFromReplication) String() string         { return AsString(n) }
 func (n *CreateSchema) String() string                        { return AsString(n) }
 func (n *CreateSequence) String() string                      { return AsString(n) }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1177,6 +1177,32 @@ func (n *CreateTenant) walkStmt(v Visitor) Statement {
 }
 
 // copyNode makes a copy of this Statement without recursing in any child Statements.
+func (n *CreateTenantAsBranch) copyNode() *CreateTenantAsBranch {
+	stmtCopy := *n
+	return &stmtCopy
+}
+
+// walkStmt is part of the walkableStmt interface.
+func (n *CreateTenantAsBranch) walkStmt(v Visitor) Statement {
+	ret := n
+	ts, changed := walkTenantSpec(v, n.TenantSpec)
+	if changed {
+		if ret == n {
+			ret = n.copyNode()
+		}
+		ret.TenantSpec = ts
+	}
+	e, changed := WalkExpr(v, n.ParentTenantName.Expr)
+	if changed {
+		if ret == n {
+			ret = n.copyNode()
+		}
+		ret.ParentTenantName = &TenantSpec{IsName: true, Expr: e}
+	}
+	return ret
+}
+
+// copyNode makes a copy of this Statement without recursing in any child Statements.
 func (n *CreateTenantFromReplication) copyNode() *CreateTenantFromReplication {
 	stmtCopy := *n
 	return &stmtCopy
@@ -2355,6 +2381,7 @@ var _ walkableStmt = &ControlJobs{}
 var _ walkableStmt = &ControlSchedules{}
 var _ walkableStmt = &CreateTable{}
 var _ walkableStmt = &CreateTenant{}
+var _ walkableStmt = &CreateTenantAsBranch{}
 var _ walkableStmt = &CreateTenantFromReplication{}
 var _ walkableStmt = &Delete{}
 var _ walkableStmt = &DoBlock{}

--- a/pkg/sql/tenant_branch.go
+++ b/pkg/sql/tenant_branch.go
@@ -1,0 +1,176 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/zoneconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// branchPTSMetaType is the protected-timestamp meta type for records that
+// pin a parent tenant at the fork point of a branch.
+const branchPTSMetaType = "branch"
+
+// createTenantAsBranchNode plans CREATE VIRTUAL CLUSTER ... BRANCH FROM. It
+// creates a new tenant whose data starts as a copy-on-write view of an
+// existing parent tenant: the branch has its own keyspace for writes, but
+// reads of unmodified keys fall through to the parent at the branch
+// timestamp via a SQL-pod-level Sender wrapper (branchSender).
+type createTenantAsBranchNode struct {
+	zeroInputPlanNode
+	ifNotExists bool
+	tenantSpec  tenantSpec
+	parentSpec  tenantSpec
+}
+
+// CreateTenantAsBranchNode constructs a planNode for a CREATE VIRTUAL CLUSTER
+// ... BRANCH FROM statement.
+func (p *planner) CreateTenantAsBranchNode(
+	ctx context.Context, n *tree.CreateTenantAsBranch,
+) (planNode, error) {
+	tspec, err := p.planTenantSpec(ctx, n.TenantSpec, "CREATE VIRTUAL CLUSTER BRANCH")
+	if err != nil {
+		return nil, err
+	}
+	pspec, err := p.planTenantSpec(ctx, n.ParentTenantName, "CREATE VIRTUAL CLUSTER BRANCH")
+	if err != nil {
+		return nil, err
+	}
+	return &createTenantAsBranchNode{
+		ifNotExists: n.IfNotExists,
+		tenantSpec:  tspec,
+		parentSpec:  pspec,
+	}, nil
+}
+
+func (n *createTenantAsBranchNode) startExec(params runParams) error {
+	return params.p.createTenantAsBranch(params.ctx, n.tenantSpec, n.parentSpec, n.ifNotExists)
+}
+
+func (n *createTenantAsBranchNode) Next(_ runParams) (bool, error) { return false, nil }
+func (n *createTenantAsBranchNode) Values() tree.Datums            { return tree.Datums{} }
+func (n *createTenantAsBranchNode) Close(_ context.Context)        {}
+
+// createTenantAsBranch creates a branch tenant: it allocates a new tenant ID
+// with branch metadata pointing at the parent tenant, writes a protected
+// timestamp on the parent's keyspace at the branch fork point, and creates
+// an initial split at the branch's keyspace boundary so subsequent writes
+// can land.
+//
+// The branch's SQL pod relies on branchSender (wired in pkg/server/tenant.go)
+// to fall through to the parent for any keys the branch has not yet written.
+// This includes system tables: we deliberately do not bootstrap a fresh
+// keyspace for the branch.
+func (p *planner) createTenantAsBranch(
+	ctx context.Context, branchSpec, parentSpec tenantSpec, ifNotExists bool,
+) error {
+	if p.EvalContext().TxnReadOnly {
+		return readOnlyError("CREATE VIRTUAL CLUSTER BRANCH")
+	}
+	if err := rejectIfCantCoordinateMultiTenancy(p.ExecCfg().Codec, "create", p.ExecCfg().Settings); err != nil {
+		return err
+	}
+	if err := CanManageTenant(ctx, p); err != nil {
+		return err
+	}
+
+	// Resolve the parent tenant (must exist).
+	parentInfo, err := parentSpec.getTenantInfo(ctx, p)
+	if err != nil {
+		return errors.Wrap(err, "resolving parent tenant")
+	}
+	parentTID, err := roachpb.MakeTenantID(parentInfo.ID)
+	if err != nil {
+		return err
+	}
+	if parentInfo.IsBranch() {
+		// Branching off a branch isn't supported in the PoC: branchSender
+		// only does a single fallback hop. See .memory/WHITEBOARD.md.
+		return errors.UnimplementedErrorf(
+			errors.IssueLink{}, "branching from a branch tenant is not yet supported")
+	}
+
+	// Resolve the branch's name (and optional ID).
+	_, branchName, err := branchSpec.getTenantParameters(ctx, p)
+	if err != nil {
+		return err
+	}
+
+	// Snapshot the current time as the branch fork point. Subsequent reads on
+	// the branch that miss in the branch keyspace will read the parent at
+	// this timestamp.
+	branchTS := p.ExecCfg().Clock.Now()
+
+	var info mtinfopb.TenantInfoWithUsage
+	info.Name = branchName
+	// Skip the ADD bootstrap state: branchSender will satisfy reads against
+	// the parent until the branch writes its own copies.
+	info.DataState = mtinfopb.DataStateReady
+	info.ServiceMode = mtinfopb.ServiceModeNone
+	info.BranchParentID = &parentTID
+	info.BranchTimestamp = branchTS
+
+	initialZC, err := zoneconfig.GetHydratedForTenantsRange(ctx, p.Txn(), p.Descriptors())
+	if err != nil {
+		return err
+	}
+
+	branchTID, err := CreateTenantRecord(
+		ctx,
+		p.ExecCfg().Codec,
+		p.ExecCfg().Settings,
+		p.InternalSQLTxn(),
+		p.ExecCfg().SpanConfigKVAccessor.WithISQLTxn(ctx, p.InternalSQLTxn()),
+		&info,
+		initialZC,
+		ifNotExists,
+		p.ExecCfg().TenantTestingKnobs,
+	)
+	if err != nil {
+		return err
+	}
+	if !branchTID.IsSet() {
+		// IF NOT EXISTS hit an existing tenant; nothing else to do.
+		return nil
+	}
+
+	// Pin the parent's keyspace at branch_ts so reads during the branch's
+	// lifetime are not GC'd. The PoC never releases this record; production
+	// would need a TTL or branch-deletion path. See .memory/WHITEBOARD.md.
+	recordID := uuid.MakeV4()
+	ptsRecord := &ptpb.Record{
+		ID:        recordID.GetBytesMut(),
+		Timestamp: branchTS,
+		Mode:      ptpb.PROTECT_AFTER,
+		MetaType:  branchPTSMetaType,
+		Meta:      []byte(branchTID.String()),
+		Target:    ptpb.MakeTenantsTarget([]roachpb.TenantID{parentTID}),
+	}
+	pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(p.InternalSQLTxn())
+	if err := pts.Protect(ctx, ptsRecord); err != nil {
+		return errors.Wrap(err, "protecting parent tenant timestamp")
+	}
+
+	// Pre-create at least one range in the branch's keyspace so writes have
+	// a place to land. Done non-transactionally; a 1h split expiration is
+	// fine because subsequent activity will keep the range alive.
+	branchSpan := keys.MakeTenantSpan(branchTID)
+	expTime := p.ExecCfg().Clock.Now().Add(time.Hour.Nanoseconds(), 0)
+	if err := p.ExecCfg().DB.AdminSplit(ctx, branchSpan.Key, expTime); err != nil {
+		return errors.Wrap(err, "splitting at branch keyspace boundary")
+	}
+
+	return nil
+}

--- a/pkg/sql/tenant_branch.go
+++ b/pkg/sql/tenant_branch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/zoneconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -172,5 +173,46 @@ func (p *planner) createTenantAsBranch(
 		return errors.Wrap(err, "splitting at branch keyspace boundary")
 	}
 
+	return nil
+}
+
+// releaseBranchPTSRecords releases every protected-timestamp record this
+// branch wrote against its parent at fork time. createTenantAsBranch tags
+// each record with MetaType=branchPTSMetaType and Meta=<branchID-as-string>;
+// we look records up by that pair so we can find them without storing the
+// PTS UUID in the tenant info. A no-op for tenants that aren't branches.
+//
+// Called from DropTenantByID before the branch tenant is marked for GC.
+// The DROP txn flips the parent's view of branch_ts from "protected" back
+// to "GCable", so the parent's accumulated MVCC garbage at and after
+// branch_ts can be reclaimed.
+func releaseBranchPTSRecords(ctx context.Context, p *planner, info *mtinfopb.TenantInfo) error {
+	if !info.IsBranch() {
+		return nil
+	}
+	branchTID, err := roachpb.MakeTenantID(info.ID)
+	if err != nil {
+		return err
+	}
+	rows, err := p.InternalSQLTxn().QueryBufferedEx(
+		ctx, "release-branch-pts", p.Txn(),
+		sessiondata.NodeUserSessionDataOverride,
+		`SELECT id FROM system.protected_ts_records
+		 WHERE meta_type = $1 AND meta = $2`,
+		branchPTSMetaType, []byte(branchTID.String()),
+	)
+	if err != nil {
+		return errors.Wrap(err, "looking up branch PTS records")
+	}
+	pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(p.InternalSQLTxn())
+	for _, row := range rows {
+		dID, ok := row[0].(*tree.DUuid)
+		if !ok {
+			return errors.AssertionFailedf("unexpected PTS id type %T", row[0])
+		}
+		if err := pts.Release(ctx, dID.UUID); err != nil {
+			return errors.Wrapf(err, "releasing branch PTS record %s", dID.UUID)
+		}
+	}
 	return nil
 }

--- a/pkg/sql/tenant_deletion.go
+++ b/pkg/sql/tenant_deletion.go
@@ -50,6 +50,14 @@ func (p *planner) DropTenantByID(
 		return errors.Wrap(err, "destroying tenant")
 	}
 
+	// If this is a branch tenant, release the protected-timestamp record
+	// it wrote against its parent at fork time. The release is part of the
+	// DROP txn so it is committed atomically with the tenant's transition
+	// to DROP state; if either side fails the parent stays protected.
+	if err := releaseBranchPTSRecords(ctx, p, info); err != nil {
+		return errors.Wrap(err, "releasing branch protected timestamp")
+	}
+
 	return dropTenantInternal(
 		ctx,
 		p.ExecCfg().Settings,

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "sysbench_test.go",
         "system_table_test.go",
         "table_split_test.go",
+        "tenant_branch_test.go",
         "tracing_sql_test.go",
         "truncate_test.go",
         "virtual_cluster_name_test.go",

--- a/pkg/sql/tests/tenant_branch_test.go
+++ b/pkg/sql/tests/tenant_branch_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTenantBranch runs end-to-end SQL scenarios against branched virtual
+// clusters. Each datadriven file is a self-contained narrative showing how
+// CREATE VIRTUAL CLUSTER ... BRANCH FROM behaves: the parent's data is
+// visible from the branch via copy-on-write fallthrough, the branch's
+// writes are isolated, and DELETEs on the branch shadow parent rows
+// without touching them.
+//
+// Directives:
+//
+//   exec-sql tenant=<name>
+//     Runs one or more statements against the named tenant. "system" routes
+//     to the host; any other name connects to a shared-process tenant.
+//
+//   query-sql tenant=<name>
+//     Runs a query and prints rows in datadriven format.
+func TestTenantBranch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	datadriven.Walk(t, datapathutils.TestDataPath(t, "tenant_branch"), func(t *testing.T, path string) {
+		ctx := context.Background()
+		srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		})
+		defer srv.Stopper().Stop(ctx)
+
+		systemDB := srv.SystemLayer().SQLConn(t)
+		conns := map[string]*gosql.DB{"system": systemDB}
+		defer func() {
+			for name, db := range conns {
+				if name != "system" {
+					_ = db.Close()
+				}
+			}
+		}()
+
+		// connFor returns a *gosql.DB connected to the named tenant. For
+		// non-system tenants it waits for the shared service to accept
+		// connections; the caller is responsible for having issued
+		// ALTER VIRTUAL CLUSTER ... START SERVICE SHARED first.
+		connFor := func(name string) *gosql.DB {
+			if db, ok := conns[name]; ok {
+				return db
+			}
+			var db *gosql.DB
+			testutils.SucceedsSoon(t, func() error {
+				conn, err := srv.SystemLayer().SQLConnE(
+					serverutils.DBName("cluster:" + name + "/defaultdb"))
+				if err != nil {
+					return err
+				}
+				if err := conn.Ping(); err != nil {
+					_ = conn.Close()
+					return err
+				}
+				db = conn
+				return nil
+			})
+			conns[name] = db
+			return db
+		}
+
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			tenant := "system"
+			for _, arg := range d.CmdArgs {
+				if arg.Key == "tenant" {
+					require.Lenf(t, arg.Vals, 1, "tenant= takes one value")
+					tenant = arg.Vals[0]
+				}
+			}
+			db := connFor(tenant)
+
+			switch d.Cmd {
+			case "exec-sql":
+				// Run each statement in its own implicit txn. Some DDL
+				// (e.g. ALTER VIRTUAL CLUSTER ... START SERVICE) is
+				// rejected inside a multi-statement transaction.
+				stmts, err := parser.Parse(d.Input)
+				require.NoError(t, err)
+				for _, s := range stmts {
+					if _, err := db.Exec(s.SQL); err != nil {
+						return err.Error()
+					}
+				}
+				return ""
+			case "query-sql":
+				rows, err := db.Query(d.Input)
+				if err != nil {
+					return err.Error()
+				}
+				out, err := sqlutils.RowsToDataDrivenOutput(rows)
+				require.NoError(t, err)
+				return out
+			default:
+				return fmt.Sprintf("unknown command %s", d.Cmd)
+			}
+		})
+	})
+}

--- a/pkg/sql/tests/testdata/tenant_branch/basic
+++ b/pkg/sql/tests/testdata/tenant_branch/basic
@@ -1,0 +1,48 @@
+# End-to-end demo: branch a tenant, see parent's data, write isolated
+# changes, confirm the parent is untouched.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE accounts (id INT PRIMARY KEY, balance INT);
+INSERT INTO accounts VALUES (1, 100), (2, 200), (3, 300);
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# The branch sees parent's rows via copy-on-write fallthrough.
+query-sql tenant=dev
+SELECT * FROM accounts ORDER BY id
+----
+1 100
+2 200
+3 300
+
+# Writes against the branch are isolated.
+exec-sql tenant=dev
+INSERT INTO accounts VALUES (4, 400);
+UPDATE accounts SET balance = 999 WHERE id = 1;
+DELETE FROM accounts WHERE id = 2;
+----
+
+# The branch reflects the modified state.
+query-sql tenant=dev
+SELECT * FROM accounts ORDER BY id
+----
+1 999
+3 300
+4 400
+
+# The parent is unchanged.
+query-sql tenant=prod
+SELECT * FROM accounts ORDER BY id
+----
+1 100
+2 200
+3 300

--- a/pkg/sql/tests/testdata/tenant_branch/create_table
+++ b/pkg/sql/tests/testdata/tenant_branch/create_table
@@ -1,0 +1,63 @@
+# Branches must be able to CREATE TABLE on top of the parent's catalog
+# without colliding with parent descriptor IDs. CREATE TABLE allocates a
+# fresh ID via an Increment on the descriptor-ID sequence; that key lives
+# in the tenant's keyspace and is empty on a fresh branch. Without the
+# branch sender's increment-seeding fixup, the branch would restart the
+# counter at zero and reuse parent descriptor IDs.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE existing (id INT PRIMARY KEY, label STRING);
+INSERT INTO existing VALUES (1, 'parent-1'), (2, 'parent-2');
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# Sanity check: the branch sees the parent's pre-fork data.
+query-sql tenant=dev
+SELECT id, label FROM existing ORDER BY id
+----
+1 parent-1
+2 parent-2
+
+# Create a brand-new table on the branch. This exercises descriptor-ID
+# allocation: the increment must be seeded with the parent's current
+# sequence value so the new descriptor ID does not collide.
+exec-sql tenant=dev
+CREATE TABLE branch_only (id INT PRIMARY KEY, note STRING);
+INSERT INTO branch_only VALUES (10, 'b-ten'), (20, 'b-twenty');
+----
+
+query-sql tenant=dev
+SELECT id, note FROM branch_only ORDER BY id
+----
+10 b-ten
+20 b-twenty
+
+# The branch's new table must have a strictly larger descriptor ID than
+# the parent's most recent table. Same query against both clusters; on
+# the parent we expect the inherited table only, on the branch we expect
+# the inherited table plus the new one with a higher ID.
+query-sql tenant=prod
+SELECT name FROM system.namespace WHERE name = 'branch_only'
+----
+
+query-sql tenant=dev
+SELECT name FROM system.namespace WHERE name IN ('existing', 'branch_only') ORDER BY name
+----
+branch_only
+existing
+
+# Parent stays oblivious to the branch's new table.
+query-sql tenant=prod
+SELECT id, label FROM existing ORDER BY id
+----
+1 parent-1
+2 parent-2

--- a/pkg/sql/tests/testdata/tenant_branch/drop_branch
+++ b/pkg/sql/tests/testdata/tenant_branch/drop_branch
@@ -1,0 +1,48 @@
+# Dropping a branch tenant must release the protected-timestamp record
+# the branch wrote against its parent at fork time. Otherwise the parent's
+# MVCC garbage at and after branch_ts is pinned forever.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE t (id INT PRIMARY KEY);
+INSERT INTO t VALUES (1);
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# Branch creation wrote exactly one PTS record tagged with meta_type='branch'.
+query-sql tenant=system
+SELECT count(*) FROM system.protected_ts_records WHERE meta_type = 'branch'
+----
+1
+
+# Sanity check: branch sees the parent data.
+query-sql tenant=dev
+SELECT id FROM t ORDER BY id
+----
+1
+
+# Tear the branch down. STOP SERVICE is required before DROP.
+exec-sql tenant=system
+ALTER VIRTUAL CLUSTER dev STOP SERVICE;
+DROP VIRTUAL CLUSTER dev IMMEDIATE;
+----
+
+# The branch's PTS record is gone; the parent is no longer pinned.
+query-sql tenant=system
+SELECT count(*) FROM system.protected_ts_records WHERE meta_type = 'branch'
+----
+0
+
+# Parent is unaffected by the branch's lifecycle.
+query-sql tenant=prod
+SELECT id FROM t ORDER BY id
+----
+1

--- a/pkg/sql/tests/testdata/tenant_branch/parent_isolation
+++ b/pkg/sql/tests/testdata/tenant_branch/parent_isolation
@@ -1,0 +1,42 @@
+# Reads against a branch are pinned to the fork timestamp: writes the
+# parent makes after the branch is created must not leak into the branch.
+# This is what the protected-timestamp record on the parent enforces.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE accounts (id INT PRIMARY KEY, balance INT);
+INSERT INTO accounts VALUES (1, 100), (2, 200), (3, 300);
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# After the fork, the parent inserts a new row and updates an existing row.
+exec-sql tenant=prod
+INSERT INTO accounts VALUES (10, 1000);
+UPDATE accounts SET balance = 9999 WHERE id = 1;
+----
+
+# The parent reflects the post-fork changes.
+query-sql tenant=prod
+SELECT * FROM accounts ORDER BY id
+----
+1 9999
+2 200
+3 300
+10 1000
+
+# The branch must not see post-fork parent changes: row 10 is invisible
+# and row 1 still shows the pre-fork balance of 100.
+query-sql tenant=dev
+SELECT * FROM accounts ORDER BY id
+----
+1 100
+2 200
+3 300

--- a/pkg/sql/tests/testdata/tenant_branch/scan_merge
+++ b/pkg/sql/tests/testdata/tenant_branch/scan_merge
@@ -1,0 +1,77 @@
+# Stress the branch scan merge across many interleaved rows.
+#
+# The branch's view of a scan is a merge between the branch's own keyspace
+# and the parent's keyspace at the fork point: branch values shadow parent
+# values, branch tombstones suppress parent rows, and parent rows fill in
+# the gaps. This file packs all three behaviors into a single ordered scan.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE items (id INT PRIMARY KEY, label STRING);
+INSERT INTO items VALUES
+  (1, 'p1'), (2, 'p2'), (3, 'p3'), (4, 'p4'), (5, 'p5'),
+  (6, 'p6'), (7, 'p7'), (8, 'p8'), (9, 'p9'), (10, 'p10');
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# Branch mutations: shadow some rows, delete others, insert new keys at
+# both the bottom and the middle of the keyspace.
+exec-sql tenant=dev
+UPDATE items SET label = 'b3'  WHERE id = 3;
+UPDATE items SET label = 'b7'  WHERE id = 7;
+UPDATE items SET label = 'b10' WHERE id = 10;
+DELETE FROM items WHERE id IN (2, 5, 8);
+INSERT INTO items VALUES (0, 'b0'), (4, 'b4-conflict')
+  ON CONFLICT (id) DO UPDATE SET label = excluded.label;
+INSERT INTO items VALUES (11, 'b11'), (12, 'b12');
+----
+
+# Expected: branch scan returns a single ordered stream where branch
+# values shadow parent (3, 4, 7, 10), tombstones drop rows (2, 5, 8),
+# and branch-only rows (0, 11, 12) appear at the right positions.
+query-sql tenant=dev
+SELECT id, label FROM items ORDER BY id
+----
+0 b0
+1 p1
+3 b3
+4 b4-conflict
+6 p6
+7 b7
+9 p9
+10 b10
+11 b11
+12 b12
+
+# Range scans should produce the same correct merge.
+query-sql tenant=dev
+SELECT id, label FROM items WHERE id BETWEEN 3 AND 9 ORDER BY id
+----
+3 b3
+4 b4-conflict
+6 p6
+7 b7
+9 p9
+
+# Parent is untouched.
+query-sql tenant=prod
+SELECT id, label FROM items ORDER BY id
+----
+1 p1
+2 p2
+3 p3
+4 p4
+5 p5
+6 p6
+7 p7
+8 p8
+9 p9
+10 p10

--- a/pkg/sql/tests/testdata/tenant_branch/schema_changes
+++ b/pkg/sql/tests/testdata/tenant_branch/schema_changes
@@ -1,0 +1,75 @@
+# Schema changes against a parent-inherited table must succeed on the
+# branch. The schema changer rewrites the table's descriptor with a CPut
+# whose expected bytes were read via the parent fallthrough. Without the
+# branch sender's CPut fixup (AllowIfDoesNotExist on first write), the
+# CPut would fail because the branch's keyspace has nil for the
+# descriptor key while the expected bytes match the parent's value.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE customers (id INT PRIMARY KEY, name STRING);
+INSERT INTO customers VALUES (1, 'alice'), (2, 'bob');
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# Add a nullable column to the inherited table. The schema change must
+# materialize on the branch only; the parent's descriptor is untouched.
+exec-sql tenant=dev
+ALTER TABLE customers ADD COLUMN email STRING;
+----
+
+# The branch sees the new column; existing rows inherited from the
+# parent get NULL for the new column.
+query-sql tenant=dev
+SELECT id, name, email FROM customers ORDER BY id
+----
+1 alice <nil>
+2 bob <nil>
+
+# Branch can write to the new column.
+exec-sql tenant=dev
+UPDATE customers SET email = 'alice@example.com' WHERE id = 1;
+INSERT INTO customers VALUES (3, 'carol', 'carol@example.com');
+----
+
+query-sql tenant=dev
+SELECT id, name, email FROM customers ORDER BY id
+----
+1 alice alice@example.com
+2 bob <nil>
+3 carol carol@example.com
+
+# Parent's schema and data are unchanged. The new column does not exist
+# on the parent, and the new row is invisible.
+query-sql tenant=prod
+SELECT id, name FROM customers ORDER BY id
+----
+1 alice
+2 bob
+
+query-sql tenant=prod
+SELECT column_name FROM [SHOW COLUMNS FROM customers] ORDER BY column_name
+----
+id
+name
+
+# A second schema change on the branch (rename a column) also works,
+# proving CPut fixup is not a one-shot.
+exec-sql tenant=dev
+ALTER TABLE customers RENAME COLUMN email TO contact_email;
+----
+
+query-sql tenant=dev
+SELECT id, name, contact_email FROM customers ORDER BY id
+----
+1 alice alice@example.com
+2 bob <nil>
+3 carol carol@example.com

--- a/pkg/sql/tests/testdata/tenant_branch/uniqueness
+++ b/pkg/sql/tests/testdata/tenant_branch/uniqueness
@@ -1,0 +1,109 @@
+# Uniqueness checks (PK and UNIQUE secondary index) must consult the
+# parent's keyspace when the branch has never written the conflicting
+# key. Without the BranchSender's CPut(nil-expected) parent check, a
+# CPut on a key the branch has not written succeeds against the empty
+# branch keyspace even when the parent has a value at the same key,
+# silently allowing a duplicate row that violates the constraint.
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+----
+
+exec-sql tenant=prod
+CREATE TABLE users (
+  id INT PRIMARY KEY,
+  email STRING NOT NULL UNIQUE,
+  handle STRING NOT NULL UNIQUE,
+  name STRING
+);
+INSERT INTO users VALUES
+  (1, 'alice@example.com', 'alice', 'Alice'),
+  (2, 'bob@example.com',   'bob',   'Bob');
+----
+
+exec-sql tenant=system
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+----
+
+# Sanity: branch sees parent's rows.
+query-sql tenant=dev
+SELECT id, email, handle FROM users ORDER BY id
+----
+1 alice@example.com alice
+2 bob@example.com bob
+
+# PK collision against an inherited row must fail.
+exec-sql tenant=dev
+INSERT INTO users VALUES (1, 'fresh@example.com', 'fresh', 'Fresh');
+----
+pq: duplicate key value violates unique constraint "users_pkey"
+
+# UNIQUE secondary index collision against an inherited row's email
+# must fail. Without the parent CPut check this slips through, leaving
+# two live rows with the same email — a constraint violation that the
+# index lookup then silently hides because branch's index entry shadows
+# parent's at the same key.
+exec-sql tenant=dev
+INSERT INTO users VALUES (10, 'alice@example.com', 'alice10', 'AliceClone');
+----
+pq: duplicate key value violates unique constraint "users_email_key"
+
+# UNIQUE secondary index collision on the second unique column behaves
+# the same way — no shortcut from the first column's check.
+exec-sql tenant=dev
+INSERT INTO users VALUES (11, 'fresh@example.com', 'bob', 'BobClone');
+----
+pq: duplicate key value violates unique constraint "users_handle_key"
+
+# A non-conflicting INSERT proceeds normally.
+exec-sql tenant=dev
+INSERT INTO users VALUES (3, 'carol@example.com', 'carol', 'Carol');
+----
+
+query-sql tenant=dev
+SELECT id, email, handle FROM users ORDER BY id
+----
+1 alice@example.com alice
+2 bob@example.com bob
+3 carol@example.com carol
+
+# Reading by a unique column that only exists on the parent finds the
+# parent's row through the branch's read fallthrough.
+query-sql tenant=dev
+SELECT id, name FROM users WHERE email = 'alice@example.com'
+----
+1 Alice
+
+query-sql tenant=dev
+SELECT id, name FROM users WHERE handle = 'bob'
+----
+2 Bob
+
+# DELETE on the branch tombstones the inherited row; a subsequent
+# INSERT at the same PK and unique-column values must succeed because
+# the branch's tombstone records an explicit deletion.
+exec-sql tenant=dev
+DELETE FROM users WHERE id = 1;
+----
+
+query-sql tenant=dev
+SELECT id, email FROM users WHERE id = 1
+----
+
+exec-sql tenant=dev
+INSERT INTO users VALUES (1, 'alice@example.com', 'alice', 'AliceReborn');
+----
+
+query-sql tenant=dev
+SELECT id, email, handle, name FROM users WHERE id = 1
+----
+1 alice@example.com alice AliceReborn
+
+# The parent is untouched throughout.
+query-sql tenant=prod
+SELECT id, email, handle, name FROM users ORDER BY id
+----
+1 alice@example.com alice Alice
+2 bob@example.com bob Bob

--- a/tenant-branching.md
+++ b/tenant-branching.md
@@ -34,7 +34,6 @@ This is a working PoC, not a production design. In scope:
 
 Out of scope (and explicitly broken in some cases):
 
-- Schema changes on the branch.
 - Branch of a branch.
 - Branch deletion.
 - Multi-region or multi-node correctness.
@@ -171,9 +170,9 @@ what a user would expect), or **Untested**.
 | Subsystem                          | Behavior on a branch                                                                                                                                                                                          | Status                                    |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
 | User tables and rows               | Reads return branch writes layered over parent at fork_ts; writes land in the branch's keyspace and stay isolated.                                                                                            | Works                                     |
-| Schema (descriptors)               | Reads see parent's descriptors at fork_ts via fallthrough. `ALTER TABLE` issues a CPut against the empty branch keyspace and fails because the expected value is parent's descriptor and actual is nil.       | Broken                                    |
-| `CREATE TABLE` on a branch         | Descriptor-ID allocation reads and writes a sequence whose counter lives in the parent's keyspace. The branch's `Increment` writes a fresh key starting at 0 and allocates IDs that collide with parent's.    | Broken                                    |
-| Sequences (user)                   | Reads return parent's sequence state at fork_ts. The branch's `Increment` writes a fresh counter starting at 0 in the branch's keyspace; both sides allocate the same next value.                             | Broken                                    |
+| Schema (descriptors)               | Reads see parent's descriptors at fork_ts via fallthrough. `ALTER TABLE` issues a CPut whose expected bytes came from the parent read; `BranchSender` sets `AllowIfDoesNotExist = true` on the CPut so the first write against the empty branch keyspace succeeds. Subsequent CPuts on the same descriptor see the branch's value and use the normal conditional check. | Works                                     |
+| `CREATE TABLE` on a branch         | Descriptor-ID allocation issues an `Increment` that `BranchSender` seeds with the parent's current value at fork_ts before dispatch. The branch's allocated IDs are strictly above what the parent had at fork_ts; no collision with parent descriptors. | Works                                     |
+| Sequences (user)                   | Same `Increment` seeding mechanism as descriptor IDs. Branch's sequence values continue from parent's value at fork_ts. Branch and parent diverge after the fork; uniqueness is per-tenant, not across the pair. | Works                                     |
 | Cluster settings                   | Reads see parent's settings as of fork_ts via fallthrough. Branch-side overrides are `Put`-based, so they should land in the branch's keyspace, but post-fork setting changes on the parent do not propagate. | Untested                                  |
 | Jobs system                        | Job rows live in `system.jobs`. Reads fall through to parent, so a branch sees parent's job history. Job claims and updates use CPut-style operations and likely fail for the same reason `ALTER` does.       | Untested                                  |
 | Privileges and roles               | Stored on descriptors and in `system.users` / `system.role_members`. Reads see parent's. Mutations use CPut and would fail.                                                                                   | Untested                                  |
@@ -282,20 +281,44 @@ sections.
 
 ### Writes
 
-Writes pass through unmodified. `BranchSender` inspects the batch for any
-read requests; if there are none, it forwards directly to `DistSender`.
+Most writes pass through unmodified. `BranchSender` forwards `Put`,
+`Delete`, and similar requests directly to `DistSender`; the branch's
+keyspace is empty for any key the branch hasn't written, so a `Put`
+just lands.
 
-The "copy" in copy-on-write is lazy and read-side. A write to a key
-materializes that key in the branch's keyspace; the next read sees the
-branch's value and skips the fallback. Until then, reads for that key fall
-through to the parent.
+Two write types have read-modify-write semantics built into the request
+and need first-write CoW so they produce the right outcome on a branch.
+`BranchSender` interposes targeted logic for them before forwarding:
 
-There's no first-write CoW interception. We don't read the parent on first
-write to materialize a copy locally. This is the right default for
-table-row writes (`Put` overwrites without caring about prior state) and
-the wrong default for any operation that uses `CPut` or otherwise expects
-a specific prior value. See the schema-change failure mode in "What doesn't
-work."
+- `Increment` requests (sequence keys: descriptor IDs, role IDs,
+  user-defined sequences). `MVCCIncrement` starts from 0 if the key has
+  no prior value. On a fresh branch the sequence keys are empty, so an
+  unmodified `Increment` would allocate IDs that collide with what the
+  parent already issued. Before dispatch, `BranchSender` scans the batch
+  for `Increment`s and, for any whose target key has no value on the
+  branch, copies the parent's current value at fork_ts into the branch
+  via a non-transactional `Put`. The `Increment` then proceeds normally
+  and produces parent_value + delta.
+- `ConditionalPut` (`CPut`) requests with non-nil expected bytes. The
+  schema changer reads a descriptor (gets the parent's via fallthrough)
+  and follows up with a `CPut` whose expected value is what it read.
+  Without intervention, the `CPut` targets the empty branch keyspace and
+  the conditional check fails. `BranchSender` sets
+  `AllowIfDoesNotExist = true` on every such `CPut`. The flag, which
+  already existed in `kvpb` for unrelated reasons, makes the `CPut`
+  succeed if the expected bytes match OR the key does not exist. The
+  "key does not exist" branch is exactly the first-write case; the
+  "key exists but doesn't match" failure mode is preserved.
+
+These two interceptions are narrow on purpose. Other write types don't
+read prior state, so they pass through. See the more-detailed write-up
+under "First-write CoW for `Increment` and `CPut`" in "More details"
+below.
+
+The "copy" in copy-on-write is still mostly lazy and read-side: a key
+materializes in the branch's keyspace on first write (or first read
+where seeding kicks in for sequence keys), and subsequent reads see the
+branch's value and skip the fallback.
 
 ### The three-state read problem
 
@@ -527,20 +550,6 @@ changes. None of these are tested.
 Each item names the symptom, the root cause, and the section that explains
 it.
 
-**Schema changes on a branch (`ALTER TABLE`).** The schema changer reads a
-descriptor and follows up with a `CPut` whose expected value is the
-descriptor it just read. The read goes through `BranchSender`'s fallthrough
-and returns the parent's descriptor. The `CPut` targets the branch's
-keyspace, where the descriptor key is nil. `CPut(expValue = parent's
-descriptor, actual = nil)` fails. Root cause: pure read-side CoW with no
-first-write interception. See "Writes" in the CoW section.
-
-**`CREATE TABLE` on a branch.** Descriptor ID allocation reads and writes a
-sequence whose counter lives in the parent's keyspace. The branch's
-`Increment` writes a fresh key starting from 0, allocating IDs that collide
-with what the parent has already assigned. Root cause: same as above. The
-branch never owns the catalog or any cross-cutting catalog state.
-
 **Branch of a branch.** `BranchSender` does a single fallback hop, and the
 metadata only carries one parent ID. Recursive fallback or a chain isn't
 wired. The `CREATE` path explicitly rejects branching from a branch. See
@@ -563,10 +572,6 @@ produce range tombstones, so this only matters if someone wires a
 tombstones once they age past `gc.ttlseconds`. Once collected, the branch's
 read path falls through to the parent and the deleted row reappears. See
 "Tombstone GC and the regression."
-
-**Sequences.** The branch and parent share the same sequence state at
-fork_ts. Both will allocate the same next value. See "What the branch
-starts with."
 
 **Multi-range parent fallback at fork_ts.** When the fallback batch spans
 ranges, `CrossRangeTxnWrapperSender` auto-wraps it into a transaction and
@@ -696,11 +701,10 @@ perspective the row is gone.
 This is the load-bearing property that makes deletions work without a
 first-write CoW step. Without it, the branch would need to read the
 parent on every delete, copy the value into its own keyspace, and then
-write the tombstone over its own copy. We get that behavior for free from
-MVCC. It is also the reason every other write-path failure in this design
-(schema changes, `CREATE TABLE`, anything CPut-based) feels arbitrary by
-contrast: those operations need the prior value, deletions don't, so
-deletions slip through the no-first-write-CoW gap unscathed.
+write the tombstone over its own copy. We get that behavior for free
+from MVCC. The two write types that genuinely need first-write CoW
+(`Increment` and `CPut`) get explicit interception instead; see
+"First-write CoW for `Increment` and `CPut`" below.
 
 ### What PROTECT_AFTER actually preserves for the branch
 
@@ -882,3 +886,90 @@ There's also a practical reason: there is no kv.Sender slot below
 DistSender. DistSender is the boundary between the kv client and the
 network. A wrapper below DistSender would have to live inside the gRPC
 transport layer, which is the wrong shape for a kv.Sender.
+
+### First-write CoW for `Increment` and `CPut`
+
+The original PoC implemented copy-on-write on the read side only. Two
+write paths needed targeted first-write CoW to work correctly on a
+branch: `Increment` (used for descriptor IDs, role IDs, and user
+sequences) and `CPut` (used by the schema changer and several other
+catalog mutators). Both have read-modify-write semantics built into the
+request, so the branch's empty keyspace produces the wrong outcome
+without intervention.
+
+**Increment seeding.** Sequence keys live in the tenant's keyspace.
+`MVCCIncrement` adds a delta to the existing value, or starts at 0 if
+the key is unwritten. On a fresh branch every sequence key is unwritten,
+so the first `Increment` would return delta and allocate values that
+collide with what the parent already issued (descriptors with the same
+numeric IDs as the parent's, etc.).
+
+`BranchSender.seedIncrements` scans every batch for `IncrementRequest`s.
+For each one whose target key has no value on the branch, it reads the
+parent's value at fork_ts and writes it to the branch via a
+non-transactional `Put`. The `Increment` then proceeds normally and
+produces parent_value + delta. Subsequent `Increment`s on the same key
+see the seeded value on the branch and skip the seeding step.
+
+The seeding writes are non-transactional and idempotent on purpose. The
+parent's value at fork_ts is fixed, so two concurrent seeders write the
+same bytes; the second write is wasteful but harmless. The seeding has
+to be visible to all subsequent readers (not just the calling txn),
+otherwise concurrent `CREATE TABLE` statements on the branch would race
+and allocate the same descriptor ID.
+
+There's a per-batch overhead: every batch with at least one `Increment`
+incurs an extra `Get` against the branch to check whether the key needs
+seeding. After the branch has been touched the `Get` returns the seeded
+value and seeding is skipped, but the `Get` itself still happens. A
+"this key has been seeded" cache would eliminate the lookup on the hot
+path.
+
+We considered seeding all known sequence keys at branch creation time
+instead. Rejected: the set of `Increment`-driven keys is open
+(`DescIDSequence`, `RoleIDSequence`, every user-defined sequence) and
+fragile to maintain as new ones are added. Per-`Increment` seeding is
+general.
+
+**CPut weakening.** `ConditionalPut` writes a new value if the key's
+current value matches the expected bytes (or the key is missing and
+`AllowIfDoesNotExist` is set). The schema changer uses `CPut` on
+descriptors with the descriptor's prior bytes as the expected value:
+"write the new descriptor only if it hasn't been changed since I read
+it." On a branch, the read fell through to the parent, so the expected
+bytes are parent's descriptor bytes; the `CPut` then targets the branch
+keyspace, where the descriptor key is empty on the first write.
+`CPut(expBytes = parent's, actual = nil)` fails the conditional check.
+
+The fix is one line: `BranchSender.rewriteCPutsForBranch` sets
+`AllowIfDoesNotExist = true` on every `CPut` with non-nil expected
+bytes. The flag, which already existed in `kvpb` (`api.proto:369`) for
+unrelated reasons, makes the `CPut` succeed if the expected bytes match
+OR if the key does not exist. The "key does not exist" branch is the
+first-write case. The "key exists but doesn't match expected" failure
+mode is preserved, so genuine concurrent-modification conflicts on the
+branch still fail correctly.
+
+The relaxation is narrow but real. A `CPut` against a key that was
+deleted on the branch (current value is nil because of a tombstone,
+expected bytes is non-nil) will now succeed where it would have failed
+on a non-branch tenant. For schema-change `CPut`s on descriptors this
+is fine in practice: descriptors aren't deleted out from under live
+mutations. For other `CPut` callers on a branch, the semantics are
+slightly looser than on a regular tenant.
+
+We considered intercepting `CPut` by rewriting it to a `Put` when the
+expected bytes match the parent's value. Rejected: that needs an extra
+`Get` against the parent on every `CPut` to verify the match, and it
+ends up encoding the same idea as `AllowIfDoesNotExist` with more code.
+
+**Why these two and not a general first-write CoW.**
+
+A general first-write CoW would intercept every write, read the parent
+to materialize the prior value into the branch, and then dispatch the
+write. That's an extra RPC per write on every key. The two cases above
+are the only built-in request types that have read-modify-write
+semantics; for everything else (`Put` overwrites, `Delete` writes a
+standalone tombstone, etc.) the parent's value doesn't need to be
+locally present for the write to behave correctly. Targeted
+interception keeps the cost on the writes that need it.

--- a/tenant-branching.md
+++ b/tenant-branching.md
@@ -1,0 +1,884 @@
+# Tenant-level branching in CockroachDB
+
+## Overview
+
+Tenant-level branching lets you create a virtual cluster that starts as a copy
+of another virtual cluster's data, without copying anything. The new cluster
+sees all of the parent's data at the moment of branching and accumulates its
+own writes from there. The parent doesn't know about the branch and is
+unaffected by it.
+
+The SQL surface looks like:
+
+```sql
+CREATE VIRTUAL CLUSTER prod;
+ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
+-- populate prod...
+
+CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
+ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
+-- dev now sees prod's data; writes against dev are isolated.
+```
+
+Branch creation is O(1) and takes well under a second regardless of how much
+data the parent holds. Subsequent writes against the branch land in the
+branch's own keyspace; reads against the branch see a merged view of the
+branch's writes layered over the parent's pre-branch state.
+
+This is a working PoC, not a production design. In scope:
+
+- One level of branching (a branch from a regular tenant).
+- Shared-process tenants only.
+- Read and write against user tables that already exist in the parent.
+- Single-node correctness on the demo path.
+
+Out of scope (and explicitly broken in some cases):
+
+- Schema changes on the branch.
+- Branch of a branch.
+- Branch deletion.
+- Multi-region or multi-node correctness.
+- Anything called out in "What doesn't work" below.
+
+The rest of this document explains how it works, what trade-offs are baked in,
+and where the corners are.
+
+## Two concerns
+
+The work splits into two pieces that should be reasoned about independently.
+
+The first piece is the tenant itself: what metadata identifies a branch, how
+tenant creation differs from a normal tenant, what the branch's keyspace
+contains on day one. This piece would exist in any branching design.
+
+The second piece is how reads on the branch find the parent's data when the
+branch hasn't written anything for a key. We need this because the storage
+engine doesn't expose snapshots or file-level copy-on-write. With a storage
+backend that did, this whole piece would shrink to a metadata pointer ("branch
+shares parent's state at fork_ts") and the read paths would unify naturally.
+The PoC works around the missing capability at the kv.Sender layer, with two
+RPCs per read and a request-level merge.
+
+The point of keeping these separate is that swapping the storage backend
+changes everything in the second piece without touching the first.
+
+## Tenant layer
+
+The tenant layer is mostly metadata and wiring.
+
+### What a branch is
+
+A branch is a regular tenant with two extra metadata fields and an empty
+keyspace. The metadata records the parent tenant ID and the timestamp at
+which the branch was created (fork_ts). Anything that reads tenant metadata,
+like the controller deciding whether a tenant exists or what service mode
+it's in, sees a normal tenant.
+
+The branch starts with a totally empty keyspace. No descriptors, no system
+tables, no sequence state, no zone configs of its own. Anything the SQL pod
+needs to read at boot, including the catalog, comes from the parent through
+the CoW layer. This is what makes creation O(1) and is the source of several
+limitations that show up later.
+
+### Metadata
+
+The two fields live in the existing `ProtoInfo` proto stored in the `info`
+column of `system.tenants`:
+
+- `branch_parent_id`: the tenant ID of the parent. Set only on branches.
+- `branch_timestamp`: the fork timestamp.
+
+This could also be stored in a new table like `system.tenant_branches`. It was
+rejected for the PoC because the proto column is the canonical metadata bag for
+a tenant; adding two fields is the smallest surface area. A new table would
+force a new migration, new read paths in server controller startup, and a join
+everywhere the tenant record is loaded. None of that pays for itself when the
+only consumer of the data is the branch wiring path.
+
+A small helper `IsBranch()` returns true when `branch_parent_id` is set.
+Everywhere else in the system that needs to know "is this a branch" goes
+through this helper.
+
+### Creation
+
+The `CREATE VIRTUAL CLUSTER ... BRANCH FROM <parent>` path does the
+following, in order, in a single transaction:
+
+1. Resolve the parent tenant. Reject if the parent is itself a branch.
+2. Snapshot the cluster clock. This timestamp becomes both the
+   `branch_timestamp` metadata and the protection floor handed to the CoW
+   layer.
+3. Allocate a tenant ID and write a tenant record with branch metadata set,
+   `DataState = Ready`, `ServiceMode = None`.
+4. Hand control to the CoW layer to set up its protection record (see "The
+   PTS record" below).
+5. Pre-create one range at the branch span boundary so the branch's first
+   write has somewhere to land.
+
+Two choices in this list deserve calling out.
+
+`DataState = Ready` means we skip the `Add` to `Ready` bootstrap that a
+normal `CREATE VIRTUAL CLUSTER` goes through. The bootstrap exists to
+populate system tables and seed initial ranges. A branch doesn't need
+either: the CoW layer will satisfy reads against the parent's
+already-bootstrapped state, and the `AdminSplit` in step 5 gives writes a
+landing place. Skipping bootstrap is what makes creation O(1).
+
+The `AdminSplit` at the branch span boundary is needed because, without it,
+the empty branch keyspace would be glued onto whatever range happens to
+cover the address space adjacent to the parent. The first write on the
+branch would either land in a range that spans multiple tenants (rare today
+but possible) or fail to find a leaseholder cleanly. The split is cheap and
+obvious.
+
+### What the branch starts with
+
+Nothing. Every system table the SQL pod expects to find is missing from the
+branch's keyspace. The branch boots only because the CoW layer makes the
+parent's catalog visible at fork_ts. Any descriptor lookup, any zone config
+read, any setting fetch goes through the CoW path on its first occurrence
+and returns the parent's value as it stood at the fork.
+
+This works for reads but creates a sharp edge for writes that touch the
+catalog. See "What doesn't work" for the specific failure modes.
+
+### Wiring metadata to the SQL pod
+
+When a shared-process tenant starts, the server controller reads its tenant
+record. If the record is a branch, the controller builds a small
+`TenantBranchInfo` struct (parent ID and fork timestamp) and plumbs it
+through the SQL pod's `SQLConfig`. Presence of that struct flips on the CoW
+interceptor in the pod's KV stack.
+
+The struct deliberately doesn't carry the full tenant record. The startup
+path needs exactly the parent ID and the timestamp, nothing else. Keeping
+the struct narrow makes it easy to change the metadata without touching the
+wiring.
+
+### How each subsystem behaves on a branch
+
+User tables are the happy path: reads return a merged view, writes land
+in the branch's keyspace, parent stays untouched. Everything else lives
+either inside the tenant's own keyspace (system tables, sequences,
+descriptors) or in host-side metadata (`system.tenants` columns), and
+each subsystem composes with branching differently. The table below
+covers the rest.
+
+Status is one of: **Works**, **Broken** (known failure mode),
+**Limited** (works but with a caveat that changes the semantics from
+what a user would expect), or **Untested**.
+
+| Subsystem                          | Behavior on a branch                                                                                                                                                                                          | Status                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| User tables and rows               | Reads return branch writes layered over parent at fork_ts; writes land in the branch's keyspace and stay isolated.                                                                                            | Works                                     |
+| Schema (descriptors)               | Reads see parent's descriptors at fork_ts via fallthrough. `ALTER TABLE` issues a CPut against the empty branch keyspace and fails because the expected value is parent's descriptor and actual is nil.       | Broken                                    |
+| `CREATE TABLE` on a branch         | Descriptor-ID allocation reads and writes a sequence whose counter lives in the parent's keyspace. The branch's `Increment` writes a fresh key starting at 0 and allocates IDs that collide with parent's.    | Broken                                    |
+| Sequences (user)                   | Reads return parent's sequence state at fork_ts. The branch's `Increment` writes a fresh counter starting at 0 in the branch's keyspace; both sides allocate the same next value.                             | Broken                                    |
+| Cluster settings                   | Reads see parent's settings as of fork_ts via fallthrough. Branch-side overrides are `Put`-based, so they should land in the branch's keyspace, but post-fork setting changes on the parent do not propagate. | Untested                                  |
+| Jobs system                        | Job rows live in `system.jobs`. Reads fall through to parent, so a branch sees parent's job history. Job claims and updates use CPut-style operations and likely fail for the same reason `ALTER` does.       | Untested                                  |
+| Privileges and roles               | Stored on descriptors and in `system.users` / `system.role_members`. Reads see parent's. Mutations use CPut and would fail.                                                                                   | Untested                                  |
+| Table statistics                   | Reads see parent's stats at fork_ts. Recomputation on the branch (which writes back to `system.table_statistics`) is untested.                                                                                | Untested                                  |
+| Tenant capabilities                | Live in `system.tenants` host-side, not in the tenant's keyspace. The branch has its own; nothing inherited from the parent.                                                                                  | Works                                     |
+| Zone configs                       | Branch gets a fresh zone config at create time. Parent's customizations do not carry over.                                                                                                                    | Limited (no inheritance)                  |
+| `SELECT FOR UPDATE` on parent rows | Locks would be acquired on the parent's keyspace via the non-txn fallback `kv.DB`, not transferable into the branch's transaction.                                                                            | Broken                                    |
+| AOST queries on a branch           | Branch reads pin to fork_ts. Combining that with an explicit AOST is unspecified.                                                                                                                             | Untested                                  |
+| Rangefeeds on a branch             | The rangefeed `dbAdapter` `Unwrap`s past `BranchSender`. Rangefeeds see only the branch's own writes; parent's data is invisible.                                                                             | Limited (parent-blind)                    |
+| Changefeeds on a branch            | Built on rangefeeds, so they would see only the branch's own writes.                                                                                                                                          | Untested but expected to be parent-blind  |
+| Backup of a branch                 | Backup walks ranges in the branch's keyspace and would capture only the branch's own writes, not the merged view.                                                                                             | Untested but expected to miss parent data |
+| PCR / LDR with a branch            | PCR's tenant model assumes a self-contained tenant keyspace; a branch isn't.                                                                                                                                  | Untested                                  |
+
+## Copy-on-write layer
+
+### Why this layer exists
+
+The branch's keyspace is empty at creation and stays empty for any key the
+user hasn't written. A read on the branch must reach the parent's data at
+fork_ts to return anything.
+
+If the storage layer exposed snapshots or file-level copy-on-write, the
+branch would just be a metadata pointer at the parent's snapshot, and the
+read path would unify across the two without any per-request work. Pebble
+doesn't expose either today (shared SSTs and virtual SSTs are experimental
+and not wired through the SQL stack), so we work around the missing
+capability at the request layer.
+
+This means everything in this section is, in some sense, a workaround for a
+missing storage capability. A future migration to a snapshotting backend
+would replace most of it.
+
+### Where the CoW could go
+
+Four candidate layers, deepest to shallowest.
+
+**Storage engine.** Native snapshots or shared/virtual SSTs at the Pebble
+level. The branch is a metadata pointer at the parent's snapshot; reads
+naturally walk both. Out of reach today; this entire section disappears if
+we ever get there.
+
+**MVCC scanner.** A scanner that knows about parent fallthrough and walks
+both tenants' keyspaces in a single pass. Cleanest in-process design.
+Requires teaching the MVCC iterator about cross-tenant reads, intent
+resolution that crosses tenant boundaries, and pushing branch metadata into
+the storage layer. Big change.
+
+**KV server (batcheval).** Move the fallthrough into the server-side
+handlers for `Get` and `Scan`. Cross-cuts leaseholders, range boundaries,
+replicas, quota pools. Touches the hot path for every tenant.
+
+**kv.Sender wrapper in the SQL pod.** Intercept reads above the wire, send
+a separate batch to the parent's keyspace, merge in-process. Lives in one
+place, easy to remove, requires no protocol changes. Two RPCs per read; no
+cross-tenant transactionality.
+
+The PoC picks the last. It's quickest to implement and is easy to revert if we
+move CoW into the storage layer later. The cost of that choice (latency, format
+conversions, no atomicity across tenants) is the source of most gotchas in this
+section.
+
+The interceptor is named `BranchSender`.
+
+### The PTS record
+
+The CoW layer reads the parent's keyspace at fork_ts every time the branch
+needs to fall through. Without protection, MVCC GC would eventually reclaim
+the data the branch needs. The first thing CoW initialization does at
+branch creation time is write a protected timestamp record on the parent.
+
+The record is held for the life of the branch and never released today.
+Branch deletion is not implemented. A failed branch creation that errors
+after writing the PTS leaks the record.
+
+### Where BranchSender sits
+
+In a branch tenant's SQL pod, the kv.Sender stack is:
+
+```
+kv.DB -> TxnCoordSender -> BranchSender -> DistSender -> wire
+```
+
+`BranchSender` sits below `TxnCoordSender` (TCS) and above `DistSender`.
+Both placements are forced by the design.
+
+Below TCS: the branch's transaction tracks intents and refresh spans for
+keys in the branch's keyspace only. The fallback to the parent reads keys
+in a different keyspace that the branch's transaction can't and shouldn't
+enroll. If `BranchSender` sat above TCS, it would receive batches with
+transaction metadata and would have to either hand the parent's keys to TCS
+(which then tries to track intents in a tenant the branch isn't authorized
+to write) or strip the transaction off the fallback (which reintroduces the
+same problem we're solving). Below TCS, `BranchSender` sees raw requests and
+can issue the fallback as a separate non-transactional batch with no
+consequence to the branch's transaction.
+
+Above DistSender: `BranchSender` needs to see the request before it's split
+across ranges and dispatched. A wrapper below DistSender would have to
+coordinate fallback at the range level, where the request has already been
+fragmented.
+
+The consequence of "below TCS" is that the fallback to the parent is not
+transactional. There is no cross-tenant atomicity, no shared refresh, no
+shared locks. This shapes several of the limitations in the next two
+sections.
+
+### Writes
+
+Writes pass through unmodified. `BranchSender` inspects the batch for any
+read requests; if there are none, it forwards directly to `DistSender`.
+
+The "copy" in copy-on-write is lazy and read-side. A write to a key
+materializes that key in the branch's keyspace; the next read sees the
+branch's value and skips the fallback. Until then, reads for that key fall
+through to the parent.
+
+There's no first-write CoW interception. We don't read the parent on first
+write to materialize a copy locally. This is the right default for
+table-row writes (`Put` overwrites without caring about prior state) and
+the wrong default for any operation that uses `CPut` or otherwise expects
+a specific prior value. See the schema-change failure mode in "What doesn't
+work."
+
+### The three-state read problem
+
+For each key the branch's read path encounters, three states matter:
+
+- The branch wrote a value. Use it.
+- The branch deleted the key. Suppress the parent fallthrough.
+- The branch never touched the key. Fall through to the parent.
+
+The middle state is the trap. Without an explicit signal for "the branch
+has deleted this key", a `DELETE` on the branch silently un-does itself:
+the row appears missing in the branch's keyspace, fallthrough returns the
+parent's row, and from the user's perspective the `DELETE` never happened.
+The PoC depends on having a way to distinguish "branch deleted" from
+"branch never wrote".
+
+The signal we picked is the MVCC tombstone, surfaced through a new flag.
+
+### IncludeTombstones
+
+An MVCC tombstone is a storage-layer construct: an MVCC version with empty
+value bytes. Pebble writes one whenever batcheval handles a `DeleteRequest`.
+By default, MVCC scans and gets filter tombstones out before returning, so
+a key that has only a tombstone looks like a missing key to the SQL layer.
+
+The PoC adds an `IncludeTombstones` flag to `GetRequest` and `ScanRequest`
+in `kvpb`. The batcheval handlers for `Get` and `Scan` pass the flag through
+to `MVCCGetOptions.Tombstones` / `MVCCScanOptions.Tombstones`, which the
+storage layer already supports. The result is that `BranchSender` can ask
+the branch's keyspace for tombstones and learn which keys the branch has
+deleted.
+
+A few alternatives were considered.
+
+A sentinel value written by `BranchSender` on `DELETE`. The wrapper would
+intercept deletes and write a `Put` with a known marker value instead. Reads
+would check for the marker and suppress fallthrough. This decouples the
+deletion signal from MVCC GC entirely (the marker is a regular value and
+won't get collected as a tombstone would). The cost is that every system
+that reads the data needs to learn the marker: rangefeeds, backup,
+replication, anything that walks raw KV. Not worth the blast radius for a
+PoC.
+
+A per-version "branch-owned" bit at the MVCC level. The cleanest fix in
+principle: tag every MVCC version written by the branch (including
+tombstones) so GC and reads can both treat them specially. The deepest
+change of any of the alternatives. Out of scope.
+
+The `IncludeTombstones` flag is the smallest change that makes the
+three-state distinction available. It comes with a downstream gotcha
+(tombstone GC) that we don't fix today; see "Tombstone GC and the
+regression" below.
+
+### Scan format handling
+
+SQL pods normally request scan results in `BATCH_RESPONSE` format (or
+`COL_BATCH_RESPONSE` for the vectorized engine). Both encode keys into
+opaque byte buffers that the SQL pod decodes with a table descriptor.
+
+`BranchSender` can't work with those formats. The merge step needs explicit
+per-row keys to dedupe by, suppress shadowed parent rows by, and rewrite
+tenant prefixes on. Decoding the opaque buffers without a table descriptor
+is not feasible.
+
+So both the branch read and the parent fallback are forced to `KEY_VALUES`
+format (which returns `[]roachpb.KeyValue` with the keys exposed). After the
+merge, the response is re-encoded back to whatever format the caller asked
+for.
+
+`COL_BATCH_RESPONSE` is collapsed to `BATCH_RESPONSE` during re-encoding.
+The columnar encoder needs an `IndexFetchSpec` the wrapper doesn't have, and
+it would have to rewrite tenant prefixes inside the spec. The SQL pod's KV
+fetcher accepts `BATCH_RESPONSE` regardless of the original `ScanFormat`
+(it checks for non-empty `BatchResponses` first), so the substitution is
+invisible to the caller.
+
+### The fallback batch
+
+When `BranchSender` returns the branch's response and finds keys that need
+fallback, it builds a fallback batch against the parent's keyspace.
+
+For Gets: include in the fallback if and only if the branch returned no
+value and no tombstone. A value or a tombstone means the branch has a
+definitive answer; only a true absence triggers fallback.
+
+For Scans: always include in the fallback. The branch may have only a
+subset of the rows in the scan range, and the parent may have additional
+rows the branch hasn't shadowed. The merge handles deduplication and
+tombstone suppression; we let it do the work.
+
+The keys in the fallback batch are the original request keys with the
+branch's tenant prefix stripped and the parent's prefix prepended. So
+`/Tenant/dev/Table/.../row` in the original becomes `/Tenant/prod/Table/.../row`
+in the fallback.
+
+The fallback batch has no transaction attached. The batch header pins
+`Timestamp = fork_ts` and `ReadConsistency = CONSISTENT`. The intent is a
+snapshot read of parent's state at fork_ts.
+
+### Fallback execution
+
+The fallback is sent through a separate `kv.DB` rooted on the raw
+`DistSender`, not through `BranchSender`'s own `kv.DB`.
+
+Two reasons for the separate `kv.DB`.
+
+The branch tenant's main `kv.DB` has `BranchSender` in its sender stack.
+Sending the fallback through the main `kv.DB` would route the fallback
+back through `BranchSender`, which would then try to fall back again on its
+own fallback. Building a separate stack rooted on raw `DistSender` breaks
+the loop.
+
+The fallback is non-transactional and frequently needs to span multiple
+ranges (any nontrivial parent-side scan). `DistSender` doesn't auto-wrap
+non-transactional multi-range batches; the call would error. The
+`kv.DB`'s `NonTransactionalSender` includes a `CrossRangeTxnWrapperSender`
+that auto-wraps such batches in a transaction. Using the fallback `kv.DB`'s
+`NonTransactionalSender` gives us the auto-wrap.
+
+There's a real correctness gap here. The `CrossRangeTxnWrapperSender` drops
+the AOST timestamp when it auto-wraps. The fallback batch went in with
+`Header.Timestamp = fork_ts`; after the wrap, it executes at the txn's
+timestamp, which is the cluster's current time. Single-range fallbacks
+bypass the wrapper and preserve fork_ts. Multi-range fallbacks observe the
+parent's current state.
+
+The PTS guarantees the fork_ts data is reachable. In practice, for keys
+the branch hasn't shadowed, a current-time read returns the same row as a
+fork_ts read would in many cases, but any post-fork parent write to a
+key the branch hasn't shadowed will leak into the branch's view. The PoC
+tests pass because the test tables fit in a single range and the wrapper
+isn't hit. A larger table that spans ranges would expose the gap.
+
+### The merge
+
+After the fallback returns, `BranchSender` merges the two responses into a
+single key-sorted result.
+
+The merge:
+
+- Builds a set of branch keys that includes both branch-written values and
+  branch-written tombstones.
+- Emits branch values that have non-empty bytes (skips tombstones).
+- For each parent row, rewrites the key from the parent prefix to the
+  branch prefix. Drops the row if the key is in the branch set (branch
+  wins, or branch tombstoned).
+- Sorts the combined output by key.
+
+Today the merge is materialized: both responses are slices, and we build a
+third slice and sort it. A streaming merge from two sorted iterators would
+be O(n) instead of O(n log n), but the responses are already materialized
+in memory, so the algorithmic constant doesn't matter at PoC scale.
+
+### Tombstone forms
+
+SQL `DELETE` produces point tombstones, one per row. The SQL planner reads
+to find the rows to delete and issues a `DeleteRequest` per row; batcheval
+writes one MVCC tombstone per request.
+
+Point tombstones work on the branch even when the underlying key never
+existed in the branch's keyspace. `MVCCDelete` has no precondition on prior
+state; Pebble writes a standalone tombstone version over nothing. So
+`DELETE FROM accounts WHERE id = 2` on the branch (where row 2 lives only
+in the parent) writes a tombstone at the branch's key for `id = 2`. The
+branch's read path returns the tombstone; the merge suppresses parent's
+row 2.
+
+Range tombstones (`MVCCRangeTombstone`, written by `DeleteRangeRequest`
+with `UseRangeTombstone = true`) are not handled. The merge walks per-row
+`KeyValue` lists and never inspects the range tombstone channel. SQL
+`DELETE` doesn't produce range tombstones in any normal path, so this is
+not a problem in practice. It is a hazard if anyone ever wires a
+`DeleteRangeRequest` into a write path that targets a branch: the deletion
+would land in the branch's keyspace as a range tombstone, the merge would
+ignore it, and the parent's rows in the affected range would leak.
+
+### Tombstone GC and the regression
+
+Point tombstones are subject to MVCC GC. A point tombstone becomes eligible
+for collection once it's older than the `gc.ttlseconds` setting on the
+surrounding zone config and is the latest version of its key (it's always
+the latest in our case). Once collected, the branch's keyspace has nothing
+at that key, `BranchSender`'s read sees neither value nor tombstone, the
+merge falls through to the parent, and the deleted row reappears.
+
+Deletions on a long-lived branch silently un-do themselves after one GC
+TTL. The PoC does not address this.
+
+Three possible mitigations, listed by where the trade-off sits.
+
+PTS on the branch's own keyspace at fork_ts. Targeted, symmetric with the
+PTS we already write on the parent. Pins all branch state including
+tombstones for the life of the branch. Cheap. The natural production
+answer.
+
+Bump `gc.ttlseconds` on the branch's zone config. Simpler than a PTS; one
+cluster setting per branch. Preserves all MVCC versions on the branch, not
+just tombstones, so write churn accumulates as MVCC garbage proportional
+to write rate times branch lifetime. Fine for short-lived branches, bad
+for long-lived ones with heavy update traffic.
+
+Sentinel values instead of tombstones. Decouples deletion durability from
+GC entirely. Costs are the same as in "IncludeTombstones": every reader
+has to learn the marker.
+
+### Rangefeed integration
+
+Rangefeeds operate on raw KV state and have no notion of branching. They
+expect to talk to the underlying `DistSender` directly.
+
+The rangefeed `dbAdapter` walks the kv.Sender chain via `Unwrap()` to find
+the underlying `DistSender`. `BranchSender` implements `Unwrap()` to return
+its inner sender, so the `dbAdapter` steps through `BranchSender` to reach
+`DistSender`. Rangefeeds on the branch see the branch's own keyspace only;
+the parent's data is not merged into the rangefeed stream.
+
+This is the right behavior. A merged rangefeed would have to fabricate
+events for the parent's pre-fork state (not how rangefeeds work) and decide
+what to do about post-fork parent writes the branch doesn't see (which the
+branch isn't supposed to observe anyway). The branch's rangefeed shows what
+the branch did, which is a coherent answer.
+
+The implication is that any subsystem that consumes rangefeeds on a branch
+(changefeeds, replication, span configs) operates only on branch-originated
+changes. None of these are tested.
+
+## What doesn't work
+
+Each item names the symptom, the root cause, and the section that explains
+it.
+
+**Schema changes on a branch (`ALTER TABLE`).** The schema changer reads a
+descriptor and follows up with a `CPut` whose expected value is the
+descriptor it just read. The read goes through `BranchSender`'s fallthrough
+and returns the parent's descriptor. The `CPut` targets the branch's
+keyspace, where the descriptor key is nil. `CPut(expValue = parent's
+descriptor, actual = nil)` fails. Root cause: pure read-side CoW with no
+first-write interception. See "Writes" in the CoW section.
+
+**`CREATE TABLE` on a branch.** Descriptor ID allocation reads and writes a
+sequence whose counter lives in the parent's keyspace. The branch's
+`Increment` writes a fresh key starting from 0, allocating IDs that collide
+with what the parent has already assigned. Root cause: same as above. The
+branch never owns the catalog or any cross-cutting catalog state.
+
+**Branch of a branch.** `BranchSender` does a single fallback hop, and the
+metadata only carries one parent ID. Recursive fallback or a chain isn't
+wired. The `CREATE` path explicitly rejects branching from a branch. See
+"What a branch is" and "Where BranchSender sits."
+
+**Branch deletion.** Not built. The PTS on the parent leaks. The branch's
+keyspace is left around. See "The PTS record."
+
+**`SELECT FOR UPDATE` and other locking reads on parent rows.** The
+fallback runs through a separate `kv.DB` and is non-transactional. Locks
+acquired during the fallback would be on the parent's keyspace and not
+transferable into the branch's transaction. See "Where BranchSender sits."
+
+**Range tombstones in the branch.** The merge walks per-row `KeyValue`
+lists and doesn't read the range tombstone channel. SQL `DELETE` doesn't
+produce range tombstones, so this only matters if someone wires a
+`DeleteRangeRequest` into a branch write path. See "Tombstone forms."
+
+**Long-lived deletions silently regressing.** Tombstone GC reclaims point
+tombstones once they age past `gc.ttlseconds`. Once collected, the branch's
+read path falls through to the parent and the deleted row reappears. See
+"Tombstone GC and the regression."
+
+**Sequences.** The branch and parent share the same sequence state at
+fork_ts. Both will allocate the same next value. See "What the branch
+starts with."
+
+**Multi-range parent fallback at fork_ts.** When the fallback batch spans
+ranges, `CrossRangeTxnWrapperSender` auto-wraps it into a transaction and
+drops the AOST timestamp. The fallback then reads parent's current state
+rather than fork_ts. Single-range fallbacks preserve fork_ts. See
+"Fallback execution."
+
+**AOST queries on a branch, changefeeds, backups.** Untested. Each
+interacts with the CoW layer in ways the PoC hasn't validated.
+
+## Gotchas
+
+Things that work today but matter for anyone touching this.
+
+Two RPCs per read on the branch's hot path. Latency cost compounds for
+plans with many small Gets.
+
+Forcing `KEY_VALUES` on every branch and fallback read defeats encoding
+optimizations the SQL pod relies on. The post-merge re-encoding cost grows
+with scan size.
+
+The fallback's AOST drift on multi-range batches. Single-range scans
+preserve fork_ts; multi-range scans observe the parent's current state.
+Cross-ref "Fallback execution."
+
+PTS retention has no release path. A failed branch create that errors after
+writing the PTS leaks the record. The PoC does not retry-safe the PTS
+write.
+
+Rangefeeds on a branch see only the branch's own writes. Any consumer of
+rangefeed events (changefeeds, replication, span config maintenance) sees a
+partial picture.
+
+Any new sender wrapper inserted between TCS and DistSender in a branch
+tenant must implement `Unwrap`, or the rangefeed `dbAdapter` will fail to
+find `DistSender` and rangefeed setup will error.
+
+## More details
+
+This section collects deeper dives that came out of follow-up questions while
+reading the design above. Each subsection assumes you've read the relevant
+part of the main design and answers a "but why" that the main text glossed
+over.
+
+### Why AdminSplit at the branch span boundary
+
+The short answer: without the split, the branch's first write lands in a
+range that already belongs to something else, and the branch's keyspace ends
+up sharing a range with another tenant.
+
+Ranges in CockroachDB cover contiguous slices of the global keyspace, and
+they're created lazily. Before the branch exists, the address space where
+the branch's keyspace will live (`/Tenant/<branchID>/...`) is just sitting
+inside whatever range happens to cover that part of the keyspace. Most
+likely that's the trailing range of the previous tenant, or some catch-all
+range that runs from "end of last allocated tenant" to "end of keyspace."
+There's no range that starts at `/Tenant/<branchID>`.
+
+When the branch issues its first write, KV has to find the range that
+covers the write's key. It finds the range that already owns that slice of
+address space, and the write lands there. Several things go wrong from that
+point.
+
+**Tenant isolation at the range level breaks.** A core invariant of
+multi-tenancy in CRDB is that a single range belongs to one tenant. Lots
+of code relies on this: per-tenant rate limiting, span configs, zone
+configs, tenant capabilities, leaseholder accounting. A range that holds
+keys from two tenants is a state the system is not designed to handle
+gracefully. It often works in practice, but it's an invariant violation,
+and bugs show up in places you wouldn't expect.
+
+**Zone config and span config dispatch breaks.** Zone configs (replication
+factor, GC TTL, locality preferences) are applied at the range level,
+sourced from the span config that covers the range. The span config
+subsystem walks ranges and assigns configs based on which tenant's
+keyspace the range falls in. A range that straddles two tenants' keyspaces
+gets one config or the other, not both. The branch's own zone config
+silently doesn't apply.
+
+**Future range operations get dangerous.** When branch deletion is
+eventually built, the natural way to nuke a branch's data is `ClearRange`
+over the branch's span. `ClearRange` operates at the range level. If the
+branch shares a range with another tenant, `ClearRange` either corrupts
+the other tenant's data or refuses to run cleanly. Splitting up front is
+what makes the branch's keyspace separable from its neighbors.
+
+**Leaseholder and write contention.** The first writes from the branch
+funnel into a range whose leaseholder was placed for a different workload.
+The branch's writes compete with whatever else lives there.
+
+The `AdminSplit` at the branch's span start key (`/Tenant/<branchID>`)
+carves a range boundary so that the range covering the start of the
+branch's keyspace is dedicated to the branch. Subsequent splits as the
+branch grows are handled by the normal split queue, but the first one we
+have to do explicitly because nothing else is going to do it.
+
+A normal `CREATE VIRTUAL CLUSTER` doesn't need this step explicitly
+because the bootstrap path it goes through (the one we skip) does a bunch
+of pre-splits for system tables and for the tenant boundary. We skipped
+bootstrap to make creation O(1), so we have to put back the one piece of
+bootstrap that's actually load-bearing for correctness. The split is cheap
+(a single AdminSplit RPC), so paying for it is the right trade.
+
+One nit on the implementation in the PoC: the split is done with a
+one-hour expiration. That's enough time for the branch's first writes to
+land and for the normal split queue to take over, which prevents the
+manual split from sticking around forever. If the branch sees zero traffic
+in the first hour, the split expires and the keyspace re-merges with the
+neighboring range. That's fine for the demo but is a footgun for a
+hibernating branch.
+
+### Why deletions on a branch don't need first-write CoW
+
+When a user runs `DELETE FROM accounts WHERE id = 2` against a branch
+where row 2 lives only in the parent's keyspace, the SQL planner does its
+usual two-step: scan to find the row, then issue a `DeleteRequest` for it.
+The scan goes through `BranchSender`'s fallthrough and returns parent's
+row 2. The `DeleteRequest`, however, goes straight through to the branch's
+keyspace, where the key for `id = 2` doesn't exist.
+
+This works because `MVCCDelete` has no precondition on prior state. Pebble
+writes a tombstone version at the branch's key whether or not anything
+was there before. The next read by the branch returns a tombstone for
+that key, the merge suppresses parent's row 2, and from the user's
+perspective the row is gone.
+
+This is the load-bearing property that makes deletions work without a
+first-write CoW step. Without it, the branch would need to read the
+parent on every delete, copy the value into its own keyspace, and then
+write the tombstone over its own copy. We get that behavior for free from
+MVCC. It is also the reason every other write-path failure in this design
+(schema changes, `CREATE TABLE`, anything CPut-based) feels arbitrary by
+contrast: those operations need the prior value, deletions don't, so
+deletions slip through the no-first-write-CoW gap unscathed.
+
+### What PROTECT_AFTER actually preserves for the branch
+
+The PTS keeps the branch's snapshot of the parent alive regardless of
+what the parent does after fork_ts. The mechanism is worth pinning down.
+
+`PROTECT_AFTER(T)` preserves any MVCC version whose live window touches
+`T` or later. For the branch, this means every version of every key that
+was the latest visible value at fork_ts is pinned, even after the parent
+overwrites it.
+
+Walk through it. Parent has `(id = 1, balance = 100)` at fork_ts.
+Post-fork, parent runs `UPDATE balance = 9999 WHERE id = 1`. Two MVCC
+versions now exist. Without protection, the older `balance = 100` would
+be GC'd once it aged past `gc.ttlseconds` (it's no longer the latest
+version at any current read timestamp). The PTS keeps it alive: it was
+the live version at fork_ts, and `PROTECT_AFTER(fork_ts)` covers it.
+
+The PTS does not pin parent's history forward. If parent then updates
+`balance` to 7777, the intermediate `9999` is still GC-eligible once it
+ages out. The protection is for the fork_ts snapshot, not for everything
+the parent writes from then on.
+
+This is what makes the parent independently usable while a branch is
+open: parent can write freely, and the branch's view at fork_ts stays
+intact until the PTS is released.
+
+### PTS on the branch vs raising the branch's GC TTL
+
+Both are valid ways to keep branch tombstones from being GC'd, and they
+sit at different points in the trade-off.
+
+A PTS on the branch's keyspace at fork_ts is targeted: it pins exactly
+the snapshot the branch needs. Branch's own post-fork updates are still
+GC-eligible once their newer versions age out. Storage footprint scales
+with the branch's live state plus the versions that were live at
+fork_ts.
+
+Bumping `gc.ttlseconds` on the branch's zone config is blanket: every
+MVCC version on the branch is preserved for the TTL window, including
+non-tombstone churn from regular updates. Storage footprint scales with
+write rate times TTL. Fine for a hibernating branch with little write
+traffic; expensive for an active branch with heavy update churn (the
+MVCC iterator skips more dead versions on every read, scans get slower).
+
+The same trick is not available on the parent side. Bumping the parent's
+`gc.ttlseconds` to keep parent's pre-fork versions alive would mean every
+tenant that happens to have a branch forces GC decisions onto its parent.
+That is cross-tenant coupling: a branch's existence shapes GC behavior in
+a different tenant. The PTS we put on the parent today exists precisely
+to keep that coupling narrow, scoped to a single record the parent's GC
+queue consults, rather than spreading branch-related policy into the
+parent's zone config.
+
+### How range scans behave when the branch deletes a sub-range
+
+This is what `mergeScanRows` is doing in practice. Walk through
+`DELETE FROM accounts WHERE id BETWEEN 5 AND 8` on the branch followed
+by `SELECT * FROM accounts WHERE id BETWEEN 1 AND 10`:
+
+1. The DELETE: SQL plans a per-row delete. The scan to find rows 5..8
+   falls through to the parent and returns four rows. SQL issues four
+   `DeleteRequest`s, one per row. The branch's keyspace gains four point
+   tombstones at keys for `id = 5, 6, 7, 8`.
+2. The SELECT: `BranchSender` forces `IncludeTombstones = true` and runs
+   the scan against the branch's keyspace. Returns the four tombstones
+   (no values, since the branch never wrote any of these rows).
+3. `BranchSender` builds a fallback `ScanRequest` against the parent and
+   gets back rows 1..10.
+4. `mergeScanRows`:
+   - Branch keys (values plus tombstones): {5, 6, 7, 8}.
+   - Branch values to emit: none (tombstones don't emit).
+   - Parent rows: drop any whose key is in the branch set. So 5, 6, 7, 8
+     are dropped.
+   - Result, sorted: 1, 2, 3, 4, 9, 10.
+
+The merge handles arbitrary interleavings of "branch wrote", "branch
+deleted", and "branch never touched" cleanly. The `scan_merge` testdata
+file exercises this with branch updates at ids 3, 7, 10, deletions at
+ids 2, 5, 8, and inserts at 0, 11, 12.
+
+The whole approach depends on point tombstones. If anything in the write
+path produced an MVCC range tombstone for the deleted sub-range instead,
+the merge would not see it (it walks per-row `KeyValue` lists and never
+reads the range tombstone channel) and parent's rows in the affected
+range would leak through. SQL `DELETE` only produces point tombstones,
+so this is theoretical today. It becomes real if anyone wires a
+`DeleteRangeRequest` with `UseRangeTombstone = true` into a branch's
+write path.
+
+### Why BranchSender sits between TCS and DistSender
+
+The kv.Sender stack in a SQL pod is:
+
+```
+*kv.DB  ->  TxnCoordSender  ->  DistSender  ->  gRPC  ->  KV nodes
+```
+
+For a transaction, the user's `*kv.Txn` is built on its own TCS instance;
+the rest of the stack is shared.
+
+Each layer in this stack does one job. TCS owns the lifecycle of a single
+transaction: it tags outgoing BatchRequests with txn metadata, tracks
+intents the txn has written, accumulates refresh spans for the keys the
+txn has read, heartbeats the txn record, and handles refresh on commit-time
+conflicts. DistSender takes the BatchRequest, looks up the ranges that
+cover the keys, splits the batch by range, routes each piece to the
+appropriate leaseholder, retries on stale range descriptor cache, and
+reassembles the response.
+
+`BranchSender`'s placement options are constrained by what these two layers
+do.
+
+**Why not above TCS.** If `BranchSender` wrapped the user-facing `kv.DB` /
+`kv.Txn` API, it would intercept high-level operations before TCS has
+added any transaction metadata. The branch's own read against the branch's
+keyspace would have to be re-injected into the txn somehow, and the parent
+fallback would still need to be peeled off as a separate non-txn read.
+
+The second part (build a separate `kv.DB` for the parent fallback and call
+into it) is feasible regardless of where `BranchSender` sits. The first
+part is the hard one. If the branch's own read doesn't go through TCS, the
+read isn't part of the txn, and the txn loses intent tracking, refresh
+spans, and the rest of the txn machinery for the branch's own keys.
+Rebuilding any of that above TCS would amount to reimplementing TCS.
+
+By sitting below TCS, the branch's own read goes through TCS naturally:
+TCS adds txn metadata, `BranchSender` forwards the BatchRequest unchanged
+to DistSender, the response comes back through `BranchSender` to TCS, and
+TCS records the txn's read activity normally. The only special thing
+`BranchSender` does is build a side request (the parent fallback) on a
+separate sender chain that has no TCS.
+
+**Why the parent fallback can't be transactional.** The parent fallback
+could in principle stay inside the branch's transaction. We don't do that
+for three reasons.
+
+The branch's tenant capabilities don't authorize writes (or write intents)
+on the parent's keyspace. If the branch's txn enrolled parent's keys, any
+subsequent intent-resolution path that thinks "this txn touched these
+keys, let me act on them" might attempt operations the tenant isn't
+allowed to perform.
+
+Refresh on parent's keyspace is meaningless. TCS refreshes a serializable
+txn by re-reading the keys at a new timestamp and verifying nothing
+changed. The parent has its own writers; refresh would constantly fail
+because the parent is moving forward independently of the branch.
+
+Locks on parent's keyspace are unwanted. The branch's txn would block
+parent writers. Tenant isolation requires that one tenant's transactions
+cannot lock another tenant's keys.
+
+So the fallback must be non-transactional, and to issue a non-transactional
+batch `BranchSender` needs a sender chain that doesn't have TCS in it. The
+simplest way is a separate `kv.DB` rooted on raw DistSender. That's what
+the PoC does.
+
+**Why not below DistSender.** DistSender's job is to take a logical
+BatchRequest, fragment it across the ranges that cover the keys, and
+dispatch each fragment to the right leaseholder. By the time a
+BatchRequest has been through DistSender's split logic, it isn't a logical
+user operation anymore; it's a per-range chunk.
+
+If `BranchSender` sat below DistSender, it would see chunks: "the part of
+the user's scan that targets range R-103." The parent fallback for that
+chunk doesn't have a clean shape. The parent's keyspace might be split
+into completely different ranges, and a chunk of branch reads doesn't
+correspond to any obvious chunk of parent reads. Multi-range scans would
+multiply into N branch reads and N parent reads, with N merges, all
+coordinated below DistSender.
+
+Sitting above DistSender means `BranchSender` sees the user's logical
+request once. It issues one branch read and one parent fallback for the
+whole logical operation, merges once, returns once. DistSender does its
+range-splitting work twice (for the branch read and for the parent read)
+but the rest of the design stays simple.
+
+There's also a practical reason: there is no kv.Sender slot below
+DistSender. DistSender is the boundary between the kv client and the
+network. A wrapper below DistSender would have to live inside the gRPC
+transport layer, which is the wrong shape for a kv.Sender.


### PR DESCRIPTION
Adds a CREATE VIRTUAL CLUSTER <name> BRANCH FROM <parent> SQL statement that creates a branch tenant whose data is a copy-on-write view of an existing parent tenant. The branch has its own keyspace for writes, but reads of keys it has not modified fall through to the parent at the fork timestamp. Branch creation is O(1) (no data copy).

Demo:
```
  CREATE VIRTUAL CLUSTER prod;
  ALTER VIRTUAL CLUSTER prod START SERVICE SHARED;
  -- ... populate prod ...

  CREATE VIRTUAL CLUSTER dev BRANCH FROM prod;
  ALTER VIRTUAL CLUSTER dev START SERVICE SHARED;
  -- dev sees prod's rows; INSERT/UPDATE/DELETE on dev are isolated.
```
This is a PoC. The quality bar is "the demo runs and the data-driven tests pass"; anything that scales, handles edge cases, or survives a node restart is a bonus.
```
Architecture
------------

  prod tenant SQL pod                    dev tenant SQL pod
  ---------------------                  ---------------------
  TxnCoordSender                         TxnCoordSender
      |                                      |
      v                                      v
  DistSender                             BranchSender    <- new
                                             |
                                             v
                                         DistSender

  KV layer (shared host process):
    /Tenant/<prod>/...   prod's data, pinned at branch_ts by a PTS
    /Tenant/<dev>/...    dev's data (initially empty)
```
The BranchSender (pkg/kv/kvclient/kvtenant/branch_sender.go) sits below the TxnCoordSender on the branch tenant's SQL pod. For each Get/Scan it sets IncludeTombstones=true, sends to the branch's keyspace, classifies each per-key response as (value | tombstone | absent), then issues a fallback batch against the parent's keyspace at branch_ts for absent keys. Branch values shadow parent values; branch tombstones suppress the parent row; absent keys fall through. Writes pass through unchanged.

Co-Authored-By: @claude 

Release note: none
Epic: none