### PR TITLE
changefeedccl: unskip distribution strategy tests

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -544,8 +544,6 @@ func TestChangefeedWithNoDistributionStrategy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 120470)
-
 	// The test is slow and will time out under deadlock/race/stress.
 	skip.UnderShort(t)
 	skip.UnderDuress(t)
@@ -576,7 +574,6 @@ func TestChangefeedWithSimpleDistributionStrategy(t *testing.T) {
 	// The test is slow and will time out under deadlock/race/stress.
 	skip.UnderShort(t)
 	skip.UnderDuress(t)
-	skip.WithIssue(t, 121408)
 
 	noLocality := func(i int) []roachpb.Tier {
 		return make([]roachpb.Tier, 0)


### PR DESCRIPTION
## Summary

- Unskip `TestChangefeedWithNoDistributionStrategy` (#120470) and
  `TestChangefeedWithSimpleDistributionStrategy` (#121408).
- Both were skipped in March 2024 due to flaky range distribution
  assertions. The root causes (undefined behavior from `math.Log2(0)`
  and background queues racing with RELOCATE) were fixed in later
  commits but nobody unskipped the tests.
- Verified with 200 local runs: zero assertion failures.

Epic: none
Resolves: #120470
Resolves: #121408