### PR TITLE
sql: update PG read-only server version from 13.0.0 to 18.0.0

### DIFF
--- a/docs/generated/sql/session_vars.md
+++ b/docs/generated/sql/session_vars.md
@@ -214,8 +214,8 @@ SHOW application_name;
 <tr><td><code>search_path</code></td><td>Sets the list of namespaces to search when resolving unqualified names.</td><td><code>"$user", public</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>serial_normalization</code></td><td>Controls how `SERIAL` columns are normalized.</td><td><code>rowid</code></td><td>No</td><td><code>sql.defaults.serial_normalization</code></td></tr>
 <tr><td><code>server_encoding</code></td><td>Reports the database encoding (always UTF8). This cannot be changed.</td><td><code>UTF8</code></td><td>Yes</td><td>-</td></tr>
-<tr><td><code>server_version</code></td><td>Reports the server version string.</td><td><code>13.0.0</code></td><td>Yes</td><td>-</td></tr>
-<tr><td><code>server_version_num</code></td><td>Reports the server version as an integer.</td><td><code>130000</code></td><td>Yes</td><td>-</td></tr>
+<tr><td><code>server_version</code></td><td>Reports the server version string.</td><td><code>18.0.0</code></td><td>Yes</td><td>-</td></tr>
+<tr><td><code>server_version_num</code></td><td>Reports the server version as an integer.</td><td><code>180000</code></td><td>Yes</td><td>-</td></tr>
 <tr><td><code>session_id</code></td><td>The unique identifier for the current session.</td><td><code>-</code></td><td>Yes</td><td>-</td></tr>
 <tr><td><code>show_primary_key_constraint_on_not_visible_columns</code></td><td>Controls whether SHOW CONSTRAINTS and pg_catalog.pg_constraint include primary key constraints with only hidden columns.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>sql_safe_updates</code></td><td>When enabled, disallows potentially unsafe SQL statements: `DROP DATABASE` of a non-empty database, `DELETE` and `UPDATE` without a `WHERE` clause (unless a `LIMIT` clause is included), `SELECT ... FOR UPDATE`/`FOR SHARE` without a `WHERE` or `LIMIT` clause, `ALTER TABLE ... DROP COLUMN`, and converting an existing table to `REGIONAL BY ROW` unless a region column has already been added.</td><td><code>off</code></td><td>No</td><td>-</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4047,8 +4047,8 @@ row_security                                                     on
 search_path                                                      "$user", public
 serial_normalization                                             rowid
 server_encoding                                                  UTF8
-server_version                                                   13.0.0
-server_version_num                                               130000
+server_version                                                   18.0.0
+server_version_num                                               180000
 show_primary_key_constraint_on_not_visible_columns               on
 sql_safe_updates                                                 off
 ssl                                                              on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3444,8 +3444,8 @@ row_security                                                     on             
 search_path                                                      "$user", public     NULL      NULL        NULL        string
 serial_normalization                                             rowid               NULL      NULL        NULL        string
 server_encoding                                                  UTF8                NULL      NULL        NULL        string
-server_version                                                   13.0.0              NULL      NULL        NULL        string
-server_version_num                                               130000              NULL      NULL        NULL        string
+server_version                                                   18.0.0              NULL      NULL        NULL        string
+server_version_num                                               180000              NULL      NULL        NULL        string
 show_primary_key_constraint_on_not_visible_columns               on                  NULL      NULL        NULL        string
 sql_safe_updates                                                 off                 NULL      NULL        NULL        string
 ssl                                                              on                  NULL      NULL        NULL        string
@@ -3704,8 +3704,8 @@ row_security                                                     on             
 search_path                                                      "$user", public     NULL  user     NULL      "$user", public     "$user", public
 serial_normalization                                             rowid               NULL  user     NULL      rowid               rowid
 server_encoding                                                  UTF8                NULL  user     NULL      UTF8                UTF8
-server_version                                                   13.0.0              NULL  user     NULL      13.0.0              13.0.0
-server_version_num                                               130000              NULL  user     NULL      130000              130000
+server_version                                                   18.0.0              NULL  user     NULL      18.0.0              18.0.0
+server_version_num                                               180000              NULL  user     NULL      180000              180000
 show_primary_key_constraint_on_not_visible_columns               on                  NULL  user     NULL      on                  on
 sql_safe_updates                                                 off                 NULL  user     NULL      off                 off
 ssl                                                              on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -285,13 +285,13 @@ query T colnames
 SHOW server_version
 ----
 server_version
-13.0.0
+18.0.0
 
 query T colnames
 SHOW server_version_num
 ----
 server_version_num
-130000
+180000
 
 query T
 SHOW log_timezone

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -221,8 +221,8 @@ row_security                                                     on             
 search_path                                                      "$user", public     Sets the list of namespaces to search when resolving unqualified names.
 serial_normalization                                             rowid               Controls how `SERIAL` columns are normalized.
 server_encoding                                                  UTF8                Reports the database encoding (always UTF8). This cannot be changed.
-server_version                                                   13.0.0              Reports the server version string.
-server_version_num                                               130000              Reports the server version as an integer.
+server_version                                                   18.0.0              Reports the server version string.
+server_version_num                                               180000              Reports the server version as an integer.
 show_primary_key_constraint_on_not_visible_columns               on                  Controls whether SHOW CONSTRAINTS and pg_catalog.pg_constraint include primary key constraints with only hidden columns.
 sql_safe_updates                                                 off                 When enabled, disallows potentially unsafe SQL statements: `DROP DATABASE` of a non-empty database, `DELETE` and `UPDATE` without a `WHERE` clause (unless a `LIMIT` clause is included), `SELECT ... FOR UPDATE`/`FOR SHARE` without a `WHERE` or `LIMIT` clause, `ALTER TABLE ... DROP COLUMN`, and converting an existing table to `REGIONAL BY ROW` unless a region column has already been added.
 ssl                                                              on                  Controls whether SSL is enabled.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -54,9 +54,9 @@ import (
 
 const (
 	// PgServerVersion is the latest version of postgres that we claim to support.
-	PgServerVersion = "13.0.0"
+	PgServerVersion = "18.0.0"
 	// PgServerVersionNum is the latest version of postgres that we claim to support in the numeric format of "server_version_num".
-	PgServerVersionNum = "130000"
+	PgServerVersionNum = "180000"
 	// PgCompatLocale is the locale string we advertise in `LC_*` session
 	// variables. C.UTF-8 is the only locale that is allowed in CREATE DATABASE
 	// at the time of writing.


### PR DESCRIPTION
Stacked on https://github.com/cockroachdb/cockroach/pull/168705.

This is the fifth and final commit of the series to address https://github.com/cockroachdb/cockroach/issues/133677.

-----------------------------------------------------------------------------

Update PgServerVersion and PgServerVersionNum to reflect
the completed Postgres 18 catalog alignment work.

Fixes https://github.com/cockroachdb/cockroach/issues/133677

Release note (sql change): CockroachDB now reports PostgreSQL
version 18.0.0 in the `server_version` and `server_version_num`
read-only configuration parameters. pg_catalog virtual tables are
now aligned with the PostgreSQL 18 schema. Changes include:
- Updated schemas for pg_attribute, pg_auth_members, pg_class,
  pg_collation, pg_constraint, pg_database, pg_prepared_statements,
  pg_statistic_ext, and pg_type with new and corrected columns.
- Fixed 14 pre-existing column type mismatches across pg_am,
  pg_conversion, pg_enum, pg_extension, pg_operator, pg_range,
  pg_seclabel, pg_settings, and pg_stat_activity.
- Updated 35 unimplemented and stub table schemas to match
  PostgreSQL 18: pg_group, pg_hba_file_rules, pg_indexes,
  pg_inherits, pg_language, pg_locks, pg_proc, pg_publication,
  pg_publication_rel, pg_publication_tables, pg_range,
  pg_replication_slots, pg_stat_activity, pg_stat_all_indexes,
  pg_stat_all_tables, pg_stat_database, pg_stat_database_conflicts,
  pg_stat_gssapi, pg_stat_progress_analyze, pg_stat_progress_vacuum,
  pg_stat_subscription, pg_stat_sys_indexes, pg_stat_sys_tables,
  pg_stat_user_indexes, pg_stat_user_tables, pg_stat_xact_all_tables,
  pg_stat_xact_sys_tables, pg_stat_xact_user_tables,
  pg_statio_user_sequences, pg_statistic_ext_data, pg_stats,
  pg_stats_ext, pg_subscription, pg_ts_parser, and pg_user_mapping.
- Added 15 new stub tables: pg_aios, pg_backend_memory_contexts,
  pg_ident_file_mappings, pg_parameter_acl, pg_publication_namespace,
  pg_shmem_allocations_numa, pg_stat_checkpointer, pg_stat_io,
  pg_stat_progress_copy, pg_stat_recovery_prefetch,
  pg_stat_replication_slots, pg_stat_subscription_stats,
  pg_stat_wal, pg_stats_ext_exprs, and pg_wait_events.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>