### PR TITLE
sql: reject creation of domains over arrays and tuples

### DIFF
--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -566,6 +566,10 @@ func (p *planner) createDomainWithID(
 	if baseType.TypeMeta.DomainData != nil {
 		return unimplemented.NewWithIssue(165347, "domain of domain is not yet supported")
 	}
+	// Reject domain of arrays and tuples types as well.
+	if baseType.Family() == types.ArrayFamily || baseType.Family() == types.TupleFamily {
+		return unimplemented.NewWithIssue(32552, "domain of arrays and tuples is not yet supported")
+	}
 
 	// Build CHECK constraints. Each expression is validated by substituting
 	// VALUE with a typed null of the base type and type-checking as boolean.

--- a/pkg/sql/logictest/testdata/logic_test/domain
+++ b/pkg/sql/logictest/testdata/logic_test/domain
@@ -422,6 +422,21 @@ CREATE DOMAIN d_nested AS d_base_for_nested
 
 subtest end
 
+subtest domain_of_array_and_tuple
+
+# Test that CREATE DOMAIN with an array base type is rejected (#32552).
+statement error pgcode 0A000 unimplemented: domain of arrays and tuples is not yet supported
+CREATE DOMAIN d_array AS INT[]
+
+# Test that CREATE DOMAIN with a tuple base type is rejected (#32552).
+statement ok
+CREATE TYPE my_tuple AS (a INT, b INT)
+
+statement error pgcode 0A000 unimplemented: domain of arrays and tuples is not yet supported
+CREATE DOMAIN d_tuple AS my_tuple
+
+subtest end
+
 subtest domain_drop_syntax
 
 # Test DROP DOMAIN syntax variants.

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1442,6 +1442,9 @@ func MakeDomain(baseType *T, typeOID, arrayTypeOID oid.Oid) *T {
 	it.UDTMetadata = &PersistentUserDefinedTypeMetadata{
 		ArrayTypeOID: arrayTypeOID,
 	}
+	if baseType.Family() == ArrayFamily || baseType.Family() == TupleFamily {
+		panic(errors.AssertionFailedf("cannot make domain of array or tuple"))
+	}
 	return &T{InternalType: it}
 }
 


### PR DESCRIPTION
Previously, CockroachDB did not explicitly reject creating domains over array or tuple types, which could lead to unsupported states or assertions failures. This commit adds a check during domain creation to reject these base types with a clear unimplemented error, matching the existing restriction on domain-of-domain.

Fixes: #167545
Epic: none
Release note: None