### PR TITLE
build: add slim docker image variant for CI pull-time sensitive workloads

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -103,6 +103,8 @@ jobs:
       - run: ./build/github/prepare-summarize-build.sh
       - name: run docker tests
         run: ./build/github/docker-image.sh amd64
+      - name: run slim docker tests
+        run: ./build/github/docker-image-slim.sh amd64
       - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/deploy-slim/.gitignore
+++ b/build/deploy-slim/.gitignore
@@ -1,0 +1,4 @@
+# Ignore the per-arch staging directories populated by
+# build/github/docker-image-slim.sh.
+amd64/
+arm64/

--- a/build/deploy-slim/Dockerfile
+++ b/build/deploy-slim/Dockerfile
@@ -1,0 +1,39 @@
+# Slim CockroachDB image for CI use cases. Parallel to build/deploy/Dockerfile;
+# it is NOT a replacement. The standard image remains the canonical release
+# artifact.
+#
+# Optimized for fast pulls in CI. Drops the interactive/bash entrypoint,
+# kubectl-cp helpers (tar/gzip/xz), and the embedded DB Console UI. Uses a
+# distroless base so the image contains only glibc + CA certs + tzdata +
+# /etc/passwd alongside the cockroach binary and GEOS libraries.
+#
+# Consumers invoke the binary directly:
+#   docker run --rm cockroachdb/cockroach-slim:latest version
+#   docker run --rm cockroachdb/cockroach-slim:latest \
+#       start-single-node --insecure --store=/tmp/data
+#
+# There is no cockroach.sh wrapper, so the auto-cert-generation and
+# /docker-entrypoint-initdb.d processing from the standard image are not
+# available here. CI harnesses must bring their own cert and init flow.
+#
+# The distroless base is pulled directly from gcr.io rather than a CRL
+# mirror. Follow-up work (tracked in the PR body) may mirror it into
+# us-east1-docker.pkg.dev for reliability parity with the standard image's
+# UBI base.
+FROM gcr.io/distroless/base-debian12:latest
+
+# TARGETARCH is set automatically by `docker buildx build --platform`.
+# The build context must place per-arch files under ${TARGETARCH}/ subdirectories
+# (e.g. amd64/cockroach, amd64/libgeos.so, etc.).
+ARG TARGETARCH
+COPY ${TARGETARCH}/cockroach /cockroach/cockroach
+COPY ${TARGETARCH}/libgeos.so ${TARGETARCH}/libgeos_c.so /usr/local/lib/cockroach/
+COPY ${TARGETARCH}/LICENSE ${TARGETARCH}/THIRD-PARTY-NOTICES.txt /licenses/
+
+WORKDIR /cockroach/
+
+ENV PATH=/cockroach:$PATH
+ENV COCKROACH_CHANNEL=official-docker-slim
+
+EXPOSE 26257 8080
+ENTRYPOINT ["/cockroach/cockroach"]

--- a/build/github/docker-image-slim.sh
+++ b/build/github/docker-image-slim.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Builds the slim CockroachDB Docker image (see build/deploy-slim/Dockerfile).
+# Parallel to build/github/docker-image.sh; does not replace it.
+#
+# The slim image is intended for CI use cases that want fast pulls and do not
+# need the DB Console UI, interactive shell entrypoint, or kubectl-cp
+# helpers. It uses a distroless base and a stripped cockroach-short binary.
+
+set -euxo pipefail
+
+# The first and only parameter is the name of the architecture the image is
+# being built for, either amd64 or arm64.
+case $1 in
+    amd64)
+        CROSSCONFIG=crosslinux
+        ARCHIVEDIR=archived_cdep_libgeos_linux
+    ;;
+    arm64)
+        CROSSCONFIG=crosslinuxarm
+        ARCHIVEDIR=archived_cdep_libgeos_linuxarm
+    ;;
+    *)
+        echo 'expected one argument, either amd64 or arm64'
+        exit 1
+    ;;
+esac
+
+build_arch=${1:-amd64}
+
+bazel build //pkg/cmd/cockroach-short //c-deps:libgeos \
+  --config $CROSSCONFIG --jobs 50 $(./build/github/engflow-args.sh)
+
+# The Dockerfile expects per-arch files under ${TARGETARCH}/ subdirectories.
+# The binary is renamed from cockroach-short to cockroach so that the in-image
+# command matches the standard image (docker run ... cockroach start-...).
+mkdir -p "build/deploy-slim/${build_arch}"
+cp _bazel/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short \
+   "build/deploy-slim/${build_arch}/cockroach"
+LIBDIR=$(bazel info execution_root --config $CROSSCONFIG)/external/$ARCHIVEDIR/lib
+cp $LIBDIR/libgeos.so "build/deploy-slim/${build_arch}/"
+cp $LIBDIR/libgeos_c.so "build/deploy-slim/${build_arch}/"
+cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-slim/${build_arch}/"
+
+chmod 755 "build/deploy-slim/${build_arch}/cockroach"
+
+docker_tag="cockroachdb/cockroach-slim"
+
+# --no-cache + --pull mirrors docker-image.sh: the runner may have been used
+# for a different architecture's build, and the cache can serve the wrong-arch
+# base image.
+docker build \
+  --no-cache \
+  --platform=linux/${build_arch} \
+  --tag="$docker_tag" \
+  --memory 30g \
+  --memory-swap -1 \
+  --pull \
+  build/deploy-slim
+
+bazel test \
+  //pkg/testutils/docker-slim:docker-slim_test \
+  --config=crosslinux \
+  --test_timeout=3000 \
+  --remote_download_minimal \
+  --jobs 50 $(./build/github/engflow-args.sh) --build_event_binary_file=bes.bin

--- a/pkg/testutils/docker-slim/BUILD.bazel
+++ b/pkg/testutils/docker-slim/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+# docker-slim_test exercises the slim CockroachDB Docker image built by
+# build/deploy-slim/Dockerfile. It is the slim-image counterpart to
+# //pkg/testutils/docker:docker_test. Unlike the standard image, the slim
+# image has no cockroach.sh wrapper — no cert auto-generation, no
+# /docker-entrypoint-initdb.d processing, no shell modes — so this test
+# drives the container by starting cockroach directly and polling via SQL.
+#
+# The target name preserves the directory's hyphen to match the convention
+# used by ci-stress (pkg/cmd/ci-stress), which derives Bazel target names
+# from directory names and does not strip hyphens.
+go_test(
+    name = "docker-slim_test",
+    srcs = ["single_node_slim_docker_test.go"],
+    tags = [
+        "integration",
+        "no-remote-exec",
+    ],
+    deps = [
+        "//pkg/build/bazel",
+        "//pkg/testutils/skip",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_docker_docker//api/types",
+        "@com_github_docker_docker//api/types/container",
+        "@com_github_docker_docker//api/types/filters",
+        "@com_github_docker_docker//client",
+        "@com_github_docker_docker//pkg/stdcopy",
+        "@com_github_docker_go_connections//nat",
+    ],
+)

--- a/pkg/testutils/docker-slim/single_node_slim_docker_test.go
+++ b/pkg/testutils/docker-slim/single_node_slim_docker_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package dockerslim contains an integration test for the slim CockroachDB
+// Docker image defined in build/deploy-slim/Dockerfile. The slim image has
+// no cockroach.sh entrypoint wrapper — no cert auto-generation, no
+// /docker-entrypoint-initdb.d processing, no shell-mode commands — so this
+// test drives the container by invoking `cockroach start-single-node`
+// directly and using `docker exec ./cockroach sql` to issue SQL.
+package dockerslim
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
+)
+
+const (
+	// imageName is the tag produced by build/github/docker-image-slim.sh.
+	imageName = "cockroachdb/cockroach-slim:latest"
+	// containerName is fixed so leftover containers from earlier runs are
+	// easy to locate and remove.
+	containerName = "roach-slim"
+	// cockroachEntrypoint is the path to the binary inside the image.
+	// `docker exec` can run it even though distroless has no shell.
+	cockroachEntrypoint = "/cockroach/cockroach"
+
+	httpPort      = "8080"
+	cockroachPort = "26257"
+	hostIP        = "127.0.0.1"
+
+	// memstoreSize must exceed cockroach's 640 MiB minimum for in-memory stores.
+	memstoreSize = "1GiB"
+
+	execTimeout = 30 * time.Second
+	// readyTimeout is generous because the first SQL probe happens shortly
+	// after container start; cockroach needs a few seconds to accept conns.
+	readyTimeout = 90 * time.Second
+	// readyPollInterval controls how often we re-issue SELECT 1 until the
+	// server accepts SQL traffic.
+	readyPollInterval = 500 * time.Millisecond
+)
+
+// TestSingleNodeSlimDocker verifies that the slim image boots a
+// single-node cluster in insecure mode and serves SQL. It is intentionally
+// minimal: the slim image has no init-file machinery to exercise, and
+// running extended scenarios belongs in the standard-image test.
+func TestSingleNodeSlimDocker(t *testing.T) {
+	if !bazel.BuiltWithBazel() {
+		skip.IgnoreLint(t)
+	}
+
+	ctx := context.Background()
+
+	cl, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl.NegotiateAPIVersion(ctx)
+
+	dn := dockerNode{cl: cl}
+
+	// Remove any leftover containers from previous runs before we start a new
+	// one — leftover state from a crashed run would break container creation
+	// under the fixed name.
+	if err := timeutil.RunWithTimeout(ctx, "remove pre-existing containers", execTimeout,
+		dn.removeAllContainers,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := timeutil.RunWithTimeout(ctx, "start container", execTimeout,
+		func(ctx context.Context) error {
+			return dn.startContainer(ctx)
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := dn.rmContainer(context.Background()); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	}()
+
+	if err := timeutil.RunWithTimeout(ctx, "wait for SQL readiness", readyTimeout,
+		dn.waitForSQLReady,
+	); err != nil {
+		logErr := dn.showContainerLog(context.Background())
+		if logErr != nil {
+			t.Logf("additionally, cannot read container logs: %v", logErr)
+		}
+		t.Fatal(err)
+	}
+
+	// A short script of CRUD-style statements confirms the database accepts
+	// DDL and DML end-to-end. Output is compared with Contains so that
+	// incidental formatting (column widths, blank lines) doesn't cause churn.
+	queries := []struct {
+		query    string
+		contains string
+	}{
+		{"SELECT 1", "1"},
+		{"CREATE DATABASE slimtest", "CREATE DATABASE"},
+		{"CREATE TABLE slimtest.t (x INT)", "CREATE TABLE"},
+		{"INSERT INTO slimtest.t VALUES (1), (2), (3)", "INSERT 0 3"},
+		{"SELECT sum(x) FROM slimtest.t", "6"},
+	}
+	for _, q := range queries {
+		q := q
+		t.Run(q.query, func(t *testing.T) {
+			out, err := dn.execSQL(ctx, q.query)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			if !strings.Contains(out, q.contains) {
+				t.Fatalf("%q: output %q does not contain %q", q.query, out, q.contains)
+			}
+		})
+	}
+}
+
+// dockerNode wraps a Docker API client along with the id of the container
+// the test is currently driving.
+type dockerNode struct {
+	cl     client.APIClient
+	contID string
+}
+
+// startContainer creates and starts a slim-image container running
+// `start-single-node` in insecure mode with an in-memory store.
+func (dn *dockerNode) startContainer(ctx context.Context) error {
+	config := container.Config{
+		Hostname:     containerName,
+		Image:        imageName,
+		ExposedPorts: nat.PortSet{httpPort: struct{}{}, cockroachPort: struct{}{}},
+		Cmd: []string{
+			"start-single-node",
+			"--insecure",
+			"--store=type=mem,size=" + memstoreSize,
+			"--listen-addr=:" + cockroachPort,
+			"--http-addr=:" + httpPort,
+		},
+	}
+	hostConfig := container.HostConfig{
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			nat.Port(httpPort):      {{HostIP: hostIP, HostPort: httpPort}},
+			nat.Port(cockroachPort): {{HostIP: hostIP, HostPort: cockroachPort}},
+		},
+	}
+	resp, err := dn.cl.ContainerCreate(ctx, &config, &hostConfig, nil, nil, containerName)
+	if err != nil {
+		return errors.Wrap(err, "create container")
+	}
+	dn.contID = resp.ID
+	if err := dn.cl.ContainerStart(ctx, dn.contID, types.ContainerStartOptions{}); err != nil {
+		return errors.Wrap(err, "start container")
+	}
+	return nil
+}
+
+// waitForSQLReady polls `SELECT 1` until the server responds or the context
+// deadline fires. This replaces the fsnotify-on-init_success readiness
+// signal used by the standard-image test, which depends on cockroach.sh —
+// the slim image has no such wrapper.
+func (dn *dockerNode) waitForSQLReady(ctx context.Context) error {
+	var lastErr error
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.CombineErrors(ctx.Err(), lastErr)
+		default:
+		}
+		out, err := dn.execSQL(ctx, "SELECT 1")
+		if err == nil && strings.Contains(out, "1") {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return errors.CombineErrors(ctx.Err(), lastErr)
+		case <-time.After(readyPollInterval):
+		}
+	}
+}
+
+// execSQL runs `cockroach sql --insecure -e <query>` inside the running
+// container via `docker exec`, returning the combined stdout output.
+func (dn *dockerNode) execSQL(ctx context.Context, query string) (string, error) {
+	cmd := []string{
+		cockroachEntrypoint, "sql",
+		"--insecure",
+		"--host=localhost:" + cockroachPort,
+		"-e", query,
+	}
+	execID, err := dn.cl.ContainerExecCreate(ctx, dn.contID, types.ExecConfig{
+		AttachStderr: true,
+		AttachStdout: true,
+		Cmd:          cmd,
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "exec create for query %q", query)
+	}
+	resp, err := dn.cl.ContainerExecAttach(ctx, execID.ID, types.ExecStartCheck{})
+	if err != nil {
+		return "", errors.Wrapf(err, "exec attach for query %q", query)
+	}
+	defer resp.Close()
+
+	var outBuf, errBuf bytes.Buffer
+	if _, err := stdcopy.StdCopy(&outBuf, &errBuf, resp.Reader); err != nil {
+		return "", errors.Wrap(err, "exec stdcopy")
+	}
+	inspect, err := dn.cl.ContainerExecInspect(ctx, execID.ID)
+	if err != nil {
+		return "", errors.Wrap(err, "exec inspect")
+	}
+	if inspect.ExitCode != 0 {
+		return outBuf.String(), errors.Newf(
+			"query %q exited %d; stderr: %s",
+			query, inspect.ExitCode, errBuf.String(),
+		)
+	}
+	return outBuf.String(), nil
+}
+
+// showContainerLog streams the container's logs to the test's stderr via
+// t.Logf. Used on failure to make diagnosis possible without re-running.
+func (dn *dockerNode) showContainerLog(ctx context.Context) error {
+	rc, err := dn.cl.ContainerLogs(ctx, dn.contID, types.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	})
+	if err != nil {
+		return errors.Wrap(err, "container logs")
+	}
+	defer rc.Close()
+
+	// Docker's log stream framing: [1 byte fd][3 bytes pad][4 bytes length][payload].
+	for {
+		var header uint64
+		if err := binary.Read(rc, binary.BigEndian, &header); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		size := header & math.MaxUint32
+		if _, err := io.CopyN(io.Discard, rc, int64(size)); err != nil {
+			return err
+		}
+	}
+}
+
+// removeAllContainers force-removes every container derived from the slim
+// image. The test uses a fixed container name, so leftover state from a
+// crashed run would block a fresh start.
+func (dn *dockerNode) removeAllContainers(ctx context.Context) error {
+	filter := filters.NewArgs(filters.Arg("ancestor", imageName))
+	conts, err := dn.cl.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return errors.Wrapf(err, "list containers on image %s", imageName)
+	}
+	for _, c := range conts {
+		if err := dn.cl.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{Force: true}); err != nil {
+			return errors.Wrapf(err, "remove container %v", c.Names)
+		}
+	}
+	return nil
+}
+
+// rmContainer force-removes the container the test is currently driving.
+func (dn *dockerNode) rmContainer(ctx context.Context) error {
+	if dn.contID == "" {
+		return nil
+	}
+	if err := dn.cl.ContainerRemove(ctx, dn.contID, types.ContainerRemoveOptions{Force: true}); err != nil {
+		return errors.Wrapf(err, "remove container %s", dn.contID)
+	}
+	dn.contID = ""
+	return nil
+}


### PR DESCRIPTION
## Summary

Introduces a parallel `cockroachdb/cockroach-slim` Docker image optimized for
CI use cases that care about pull time but not about the interactive shell
entrypoint, kubectl-cp helpers, or the embedded DB Console UI. The standard
`cockroachdb/cockroach` image is unchanged.

The slim image:

- Uses `gcr.io/distroless/base-debian12` as its base (glibc + ca-certs +
  tzdata + `/etc/passwd`) rather than UBI10 minimal plus `tar`/`gzip`/`xz`/`hostname`.
- Packages the existing `cockroach-short` binary, which already omits the
  embedded UI and is production-exercised by roachtest.
- Has no `cockroach.sh` wrapper: `docker run ... cockroach start-...` invokes
  the binary directly. Auto-cert-generation and `/docker-entrypoint-initdb.d`
  processing are intentionally not supported; CI harnesses bring their own
  certs and init flow.

## Size comparison

Against `cockroachdb/cockroach:v25.3.3` (linux/arm64), with the binary and
libgeos extracted from that image and repackaged under the new Dockerfile:

| | Standard | Slim | Delta |
|---|---|---|---|
| Uncompressed | 472 MB | 344 MB | **−128 MB (−27%)** |
| Compressed | 166 MB | 128 MB | **−38 MB (−23%)** |

The compressed number is what matters for CI pull time on fresh runners.

## CI wiring

A new `run slim docker tests` step in
`.github/workflows/github-actions-essential-ci.yml` builds and smoke-tests
the image on every PR via `build/github/docker-image-slim.sh`. The smoke
test lives in `pkg/testutils/docker-slim:docker_slim_test` and is the
slim-image counterpart to the existing `pkg/testutils/docker:docker_test`;
it polls the SQL port for readiness rather than relying on the
`init_success` file written by `cockroach.sh`.

## Follow-up work (not in this PR)

- **Mirror the distroless base into CRL's docker registry.** The current
  Dockerfile pulls `gcr.io/distroless/base-debian12` directly. The standard
  image uses `us-east1-docker.pkg.dev/crl-docker-sync/...` for reliability
  parity — the slim image should follow suit once dev-inf sets up the mirror.
- **Wire the slim tag into the release publishing pipeline.** Currently
  `cockroachdb/cockroach-slim` is only produced by CI; it is not published
  alongside `cockroachdb/cockroach:vX.Y.Z` by
  `build/teamcity/internal/release/process/*`. If the CI-only variant proves
  valuable, a parallel publish path can be added.

Epic: none

Release note: None