### PR TITLE
opt: prevent rule cycle with very large limit values

### DIFF
--- a/pkg/sql/opt/norm/limit_funcs.go
+++ b/pkg/sql/opt/norm/limit_funcs.go
@@ -19,3 +19,11 @@ func (c *CustomFuncs) LimitGeMaxRows(limit tree.Datum, input memo.RelExpr) bool 
 	maxRows := input.Relational().Cardinality.Max
 	return limitVal >= 0 && maxRows < math.MaxUint32 && limitVal >= int64(maxRows)
 }
+
+// CanRepresentMaxRows returns true if the given limit value is small enough to
+// be tracked by the cardinality system (which uses uint32). Limits >= MaxUint32
+// can't be represented, so rules that rely on cardinality tracking to detect
+// already-pushed limits should not fire.
+func (c *CustomFuncs) CanRepresentMaxRows(limit tree.Datum) bool {
+	return int64(*limit.(*tree.DInt)) < math.MaxUint32
+}

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -159,6 +159,7 @@ $input
         (JoinPreservesLeftRows $input)
     $limitExpr:(Const $limit:*) &
         (IsPositiveInt $limit) &
+        (CanRepresentMaxRows $limit) &
         ^(LimitGeMaxRows $limit $left)
     $ordering:* &
         (OrderingCanProjectCols
@@ -190,6 +191,7 @@ $input
         (JoinPreservesRightRows $input)
     $limitExpr:(Const $limit:*) &
         (IsPositiveInt $limit) &
+        (CanRepresentMaxRows $limit) &
         ^(LimitGeMaxRows $limit $right)
     $ordering:* &
         (OrderingCanProjectCols

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1161,6 +1161,34 @@ limit
  │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── -1
 
+# Don't push limits larger than MaxUint32 into a join input, since the
+# cardinality system can't track them, which would lead to a rule cycle.
+# Regression test for #168718.
+norm expect-not=(PushLimitIntoJoinLeft,PushLimitIntoJoinRight)
+SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT 4611686018427387903
+----
+limit
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── left-join (hash)
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │    ├── limit hint: 4611686018427387904.00
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan uv
+ │    │    ├── columns: u:5!null v:6
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 4611686018427387903
+
 # Don't push limits into an inner join that may not preserve rows.
 norm expect-not=(PushLimitIntoJoinLeft,PushLimitIntoJoinRight)
 SELECT * FROM ab INNER JOIN uv ON a = u LIMIT 10


### PR DESCRIPTION
PushLimitIntoJoinLeft and PushLimitIntoJoinRight could cycle infinitely when the limit value exceeded MaxUint32, because the cardinality system (uint32) couldn't represent the pushed-down limit, so LimitGeMaxRows never detected it had already been pushed. Skip these rules when the limit can't be tracked by the cardinality system.

Fixes: #168718
Release note (bug fix): Fixed a bug that could cause an infinite loop in the optimizer when a query used a LIMIT value larger than 4294967295 with a join.