### PR TITLE
release-26.2.0-rc: roachtest: fix db-console/mixed-version-endpoints flake

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -303,16 +303,29 @@ func withRetries(ctx context.Context, opts retry.Options, f func() error) error 
 func initializeSchemaAndIDs(
 	ctx context.Context, c cluster.Cluster, l *logger.Logger, binaryPath string,
 ) error {
-	// Initialize some schema objects.
-	initTpcc := fmt.Sprintf("%s workload init tpcc --drop {pgurl:1}", binaryPath)
-	c.Run(ctx, option.WithNodes([]int{1}), initTpcc)
-
 	// Get SQL connection to query for a tableID, databaseID and fingerprintID.
 	conn, err := c.ConnE(ctx, l, 1)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
+
+	// Check if TPCC is already initialized. In mixed-version testing this
+	// function is called many times across upgrade steps. We only run
+	// `workload init` once to avoid both key-collision errors (without --drop)
+	// and races with background schema operations (with --drop).
+	var exists bool
+	err = conn.QueryRowContext(ctx,
+		"SELECT count(*) > 0 FROM system.namespace WHERE name='warehouse'").Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		initTpcc := fmt.Sprintf("%s workload init tpcc {pgurl:1}", binaryPath)
+		c.Run(ctx, option.WithNodes([]int{1}), initTpcc)
+	} else {
+		l.Printf("TPCC already initialized, skipping workload init")
+	}
 
 	err = conn.QueryRowContext(ctx, "select id, \"parentID\" from system.namespace where name='warehouse'").Scan(&tableID, &databaseID)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #166591.

/cc @cockroachdb/release

---

`initializeSchemaAndIDs` is called many times during mixed-version testing due to the randomized test plan. Each call re-ran `workload init tpcc`, causing flakes:
With `--drop`: DROP races with background schema ops from a prior invocation
Without `--drop`: AddSSTable key collisions with older binary versions

Fix: check if TPCC is already initialized via `system.namespace` and skip init on subsequent calls.

Fixes #168632

Release note: None

release justification: test only fix

Epic: none