### PR TITLE
cli: add psql-compatible \restrict and \unrestrict metacommands

### DIFF
--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -80,6 +80,18 @@ type internalContext struct {
 	// Determines whether to perform client-side syntax checking.
 	checkSyntax bool
 
+	// restricted, when true, blocks all backslash metacommands except
+	// \unrestrict. It is set by \restrict KEY and cleared by \unrestrict
+	// with the matching key. The state is shared across \i / \ir file
+	// inclusion because internalContext is reused across child cliState
+	// instances (see runIncludeInternal). This mirrors psql's restricted
+	// mode, which mitigates the dump-injection attack described in
+	// CVE-2025-8714: a hostile server can embed metacommands in plain-text
+	// dump output that would otherwise execute on the operator's machine
+	// when the dump is piped back through the shell.
+	restricted  bool
+	restrictKey string
+
 	// autoTrace, when non-empty, encloses the executed statements
 	// by suitable SET TRACING and SHOW TRACE FOR SESSION statements.
 	autoTrace string

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -112,6 +112,10 @@ Statement diagnostics
   \statement-diag list                               list available bundles.
   \statement-diag download <bundle-id> [<filename>]  download bundle.
 
+Restricted mode
+  \restrict KEY     block all metacommands except \unrestrict KEY.
+  \unrestrict KEY   leave restricted mode (KEY must match).
+
 %s
 More documentation about our SQL dialect and the CLI shell is available online:
 %s
@@ -670,6 +674,38 @@ func (c *cliState) handleUnset(args []string, nextState, errState cliStateEnum) 
 
 func isEndOfStatement(lastTok int) bool {
 	return lastTok == ';' || lastTok == lexbase.HELPTOKEN
+}
+
+// handleRestrict supports the \restrict client-side command. It enters
+// restricted mode, in which all backslash metacommands except \unrestrict are
+// rejected by the dispatcher in doHandleCliCmd.
+func (c *cliState) handleRestrict(args []string, nextState, errState cliStateEnum) cliStateEnum {
+	if len(args) != 1 || args[0] == "" {
+		return c.cliError(errState, errors.New(`\restrict: missing required argument`))
+	}
+	if c.iCtx.restricted {
+		return c.cliError(errState, errors.New(`\restrict: already in restricted mode`))
+	}
+	c.iCtx.restrictKey = args[0]
+	c.iCtx.restricted = true
+	return nextState
+}
+
+// handleUnrestrict supports the \unrestrict client-side command. It exits
+// restricted mode if the supplied key matches the key passed to \restrict.
+func (c *cliState) handleUnrestrict(args []string, nextState, errState cliStateEnum) cliStateEnum {
+	if len(args) != 1 || args[0] == "" {
+		return c.cliError(errState, errors.New(`\unrestrict: missing required argument`))
+	}
+	if !c.iCtx.restricted {
+		return c.cliError(errState, errors.New(`\unrestrict: not currently in restricted mode`))
+	}
+	if args[0] != c.iCtx.restrictKey {
+		return c.cliError(errState, errors.New(`\unrestrict: wrong key`))
+	}
+	c.iCtx.restrictKey = ""
+	c.iCtx.restricted = false
+	return nextState
 }
 
 // handleDemo handles operations on \demo.
@@ -1402,6 +1438,13 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 	if err != nil {
 		return c.cliError(cliStartLine, err)
 	}
+	// In restricted mode, only \unrestrict is permitted. This blocks
+	// metacommands that may have been injected via dump output before they
+	// reach the dispatcher below. See internalContext.restricted.
+	if c.iCtx.restricted && cmd[0] != `\unrestrict` {
+		return c.cliError(errState, errors.New(
+			`backslash commands are restricted; only \unrestrict is allowed`))
+	}
 	if cmd[0] == `\z` {
 		// psql compatibility.
 		cmd[0] = `\dp`
@@ -1563,6 +1606,12 @@ ORDER BY 1`
 
 	case `\statement-diag`:
 		return c.handleStatementDiag(cmd[1:], loopState, errState)
+
+	case `\restrict`:
+		return c.handleRestrict(cmd[1:], loopState, errState)
+
+	case `\unrestrict`:
+		return c.handleUnrestrict(cmd[1:], loopState, errState)
 
 	default:
 		return c.invalidSyntax(errState)

--- a/pkg/cli/clisqlshell/sql_test.go
+++ b/pkg/cli/clisqlshell/sql_test.go
@@ -357,6 +357,53 @@ func Example_includes() {
 	// ERROR: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: testdata/i_maxrecursion.sql: \i: too many recursion levels (max 10)
 }
 
+// Example_sql_restrict tests the \restrict and \unrestrict metacommands,
+// which mirror psql's CVE-2025-8714 mitigation by blocking all backslash
+// metacommands except \unrestrict while restricted mode is active.
+func Example_sql_restrict() {
+	c := cli.NewCLITest(cli.TestCLIParams{})
+	defer c.Cleanup()
+
+	// Missing argument is rejected.
+	c.RunWithArgs([]string{`sql`, `-e`, `\restrict`})
+	c.RunWithArgs([]string{`sql`, `-e`, `\unrestrict`})
+
+	// \unrestrict outside of restricted mode is rejected.
+	c.RunWithArgs([]string{`sql`, `-e`, `\unrestrict somekey`})
+
+	// While restricted, other metacommands are blocked but SQL still runs.
+	c.RunWithArgs([]string{`sql`, `-e`, `\restrict mykey`, `-e`, `select 42 as n`, `-e`, `\echo hi`})
+
+	// Wrong key on \unrestrict is rejected.
+	c.RunWithArgs([]string{`sql`, `-e`, `\restrict mykey`, `-e`, `\unrestrict wrong`})
+
+	// Re-running \restrict while already restricted is rejected by the
+	// pre-dispatch check (the in-handler "already in restricted mode" error
+	// is defense-in-depth and not reachable from this path).
+	c.RunWithArgs([]string{`sql`, `-e`, `\restrict mykey`, `-e`, `\restrict other`})
+
+	// Correct key exits restricted mode and \echo works again.
+	c.RunWithArgs([]string{`sql`, `-e`, `\restrict mykey`, `-e`, `\unrestrict mykey`, `-e`, `\echo hi`})
+
+	// Output:
+	// sql -e \restrict
+	// ERROR: -e: \restrict: missing required argument
+	// sql -e \unrestrict
+	// ERROR: -e: \unrestrict: missing required argument
+	// sql -e \unrestrict somekey
+	// ERROR: -e: \unrestrict: not currently in restricted mode
+	// sql -e \restrict mykey -e select 42 as n -e \echo hi
+	// n
+	// 42
+	// ERROR: -e: backslash commands are restricted; only \unrestrict is allowed
+	// sql -e \restrict mykey -e \unrestrict wrong
+	// ERROR: -e: \unrestrict: wrong key
+	// sql -e \restrict mykey -e \restrict other
+	// ERROR: -e: backslash commands are restricted; only \unrestrict is allowed
+	// sql -e \restrict mykey -e \unrestrict mykey -e \echo hi
+	// hi
+}
+
 // Example_sql_lex tests the usage of the lexer in the sql subcommand.
 func Example_sql_lex() {
 	c := cli.NewCLITest(cli.TestCLIParams{Insecure: true})


### PR DESCRIPTION
Mirror the psql metacommands introduced in PostgreSQL 18 as a mitigation for CVE-2025-8714. A malicious server
can inject backslash metacommands into plain-text dump output (e.g. pg_dump --format=plain); when an operator pipes that dump back through the SQL shell at restore time, those metacommands execute on the operator's machine. The same vector applies to cockroach sql, which accepts the psql-compatible metacommand set (\!, \i, \copy, ...).

\restrict KEY enters restricted mode, in which all backslash metacommands except \unrestrict are rejected before dispatch. SQL statements continue to execute normally. \unrestrict KEY leaves restricted mode if KEY matches the key supplied to \restrict. Restricted state lives on internalContext, which is shared across \i / \ir file inclusion, so a wrapper script can bracket an entire dump (including its includes) between \restrict and \unrestrict.

The error wording matches psql exactly so existing operator runbooks that grep for the message keep working.

resolves https://github.com/cockroachdb/cockroach/issues/168755

Release note (cli change): The cockroach sql shell now supports the \restrict KEY and \unrestrict KEY metacommands, matching the psql commands added in PostgreSQL 18 for CVE-2025-8714. While restricted, all backslash metacommands except \unrestrict are rejected, so metacommands injected into plain-text dump output by a hostile server no longer execute when the dump is piped back through cockroach sql. SQL statements run normally while restricted. The state is preserved across \i / \ir includes.