### PR TITLE
serverutils: allow DRPC in benchmarks when explicitly enabled

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -601,12 +601,6 @@ func parseDefaultTestDRPCOptionFromEnv() base.DefaultTestDRPCOption {
 func ShouldEnableDRPC(
 	ctx context.Context, t TestLogger, option base.DefaultTestDRPCOption,
 ) base.DefaultTestDRPCOption {
-	if skip.UnderBench() {
-		// Microbenchmarks exercise specific parts of the database and we
-		// want to remove any non-deterministic factors that could affect the
-		// numbers, so we disable the dRPC option until it becomes the default.
-		return base.TestDRPCDisabled
-	}
 	var logSuffix string
 
 	if option == base.TestDRPCUnset {
@@ -628,6 +622,10 @@ func ShouldEnableDRPC(
 	case base.TestDRPCEnabled:
 		enableDRPC = true
 	case base.TestDRPCEnabledRandomly:
+		if skip.UnderBench() {
+			// Benchmarks need deterministic behavior; skip random DRPC selection.
+			return base.TestDRPCDisabled
+		}
 		rng, _ := randutil.NewTestRand()
 		enableDRPC = rng.Intn(2) == 0
 	case base.TestDRPCUnset:


### PR DESCRIPTION
Previously, `ShouldEnableDRPC` unconditionally disabled DRPC for all benchmarks, even when explicitly enabled via test args, the `COCKROACH_TEST_DRPC` environment variable, or factory defaults. The intent was to avoid non-determinism from `TestDRPCEnabledRandomly`, but this also blocked deterministic `TestDRPCEnabled`.

Move the `skip.UnderBench()` guard into the `TestDRPCEnabledRandomly` case so that only the random selection is skipped in benchmarks.

Release note: None
Epic: none