### PR TITLE
release-26.1: workloadccl: deflake TestAllRegisteredImportFixture

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -46,7 +46,7 @@ go_test(
         "main_test.go",
     ],
     embed = [":allccl"],
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -84,6 +84,9 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 		}
 
 		t.Run(meta.Name, func(t *testing.T) {
+			if meta.Name == "tpcc" {
+				t.Parallel() // SAFE FOR TESTING
+			}
 			if bigInitialData(meta) {
 				skip.UnderShort(t, fmt.Sprintf(`%s loads a lot of data`, meta.Name))
 			}

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -84,7 +84,7 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 		}
 
 		t.Run(meta.Name, func(t *testing.T) {
-			if meta.Name == "tpcc" {
+			if meta.Name == "tpcc" || meta.Name == "tpccmultidb" {
 				t.Parallel() // SAFE FOR TESTING
 			}
 			if bigInitialData(meta) {


### PR DESCRIPTION
Backports the 3-PR fix stack for the `TestAllRegisteredImportFixture` timeout/race

- #162128 — `roachtest: run tpcc import in parallel to reduce timeouts`
- #164016 — `workloadccl: parallelize tpccmultidb in TestAllRegisteredImportFixture`
- #164279 — `workloadccl: fix log.Scope() race and enable test sharding`

The first two parallelize tpcc/tpccmultidb to fit the 15-min timeout; the third splits the test into `TestImportFixture_TPCC` and `TestImportFixture_Others` so the two TPC variants no longer race on the global `log.Scope()` state, and bumps Bazel `shard_count` from 4 to 5.

Verified locally on this branch: `./dev test pkg/ccl/workloadccl/allccl -f 'TestImportFixture_TPCC|TestImportFixture_Others' --short -v` passes.

Fixes: #168725

Release justification: deflake test failure.

Companion backports: #168761 (26.1), #168763 (25.4), #168765 (25.2), #168768 (24.3).

Epic: none
