### PR TITLE
sqlsmith: no system cols in ORDER BY, increase timeout for DDL

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -185,8 +185,9 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 						}
 					}()
 
+					var stmtType tree.StatementType
 					for {
-						stmt = smither.Generate()
+						stmt, stmtType = smither.GenerateWithTag()
 						if stmt == "" {
 							// If an empty statement is generated, then ignore it.
 							done <- errors.Newf("Empty statement returned by generate")
@@ -195,6 +196,12 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 						if !expectedToTimeout(t, stmt) {
 							break
 						}
+					}
+
+					// DDL statements can take longer than the normal
+					// statement timeout, so temporarily increase it.
+					if stmtType == tree.TypeDDL {
+						defer withIncreasedStmtTimeout(t, conn, logStmt, 3)()
 					}
 
 					// TODO(yuzefovich): investigate why using the context with

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -179,10 +180,10 @@ func runOneTLP(
 	}
 }
 
-// runMutationsStatement runs a random INSERT, UPDATE, or DELETE statement that
-// potentially modifies the state of the database.
+// runMutationStatement runs a random INSERT, UPDATE, DELETE, or DDL statement
+// that potentially modifies the state of the database.
 func runMutationStatement(
-	t task.Tasker, conn *gosql.DB, connInfo string, smither *sqlsmith.Smither, logStmt func(string),
+	t test.Test, conn *gosql.DB, connInfo string, smither *sqlsmith.Smither, logStmt func(string),
 ) {
 	// Ignore panics from Generate.
 	defer func() {
@@ -191,7 +192,10 @@ func runMutationStatement(
 		}
 	}()
 
-	stmt := smither.Generate()
+	stmt, stmtType := smither.GenerateWithTag()
+	if stmtType == tree.TypeDDL {
+		defer withIncreasedStmtTimeout(t, conn, logStmt, 3)()
+	}
 
 	// Ignore timeouts.
 	var err error

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1855,6 +1855,10 @@ func (s *Smither) makeOrderByWithAllCols(refs colRefs) (_ tree.OrderBy, ok bool)
 	}
 	var ob tree.OrderBy
 	for _, ref := range refs {
+		// Skip system columns (crdb_internal_mvcc_timestamp, tableoid, etc.).
+		if colinfo.IsSystemColumnName(string(ref.item.ColumnName)) {
+			continue
+		}
 		if !s.isOrderable(ref.typ) {
 			return nil, false
 		}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -205,6 +205,14 @@ var TestingPrettyCfg = prettyCfg
 
 // Generate returns a random SQL string.
 func (s *Smither) Generate() string {
+	stmt, _ := s.GenerateWithTag()
+	return stmt
+}
+
+// GenerateWithTag returns a random SQL string along with the statement's
+// StatementType (e.g. TypeDDL, TypeDML). Callers can use the type to
+// adjust behavior, for example increasing the statement timeout for DDL.
+func (s *Smither) GenerateWithTag() (string, tree.StatementType) {
 	i := 0
 	for {
 		stmt, ok := s.makeStmt()
@@ -228,7 +236,7 @@ func (s *Smither) Generate() string {
 			// Use simple printing if pretty-printing fails.
 			p = tree.AsStringWithFlags(stmt, fl)
 		}
-		return p
+		return p, stmt.StatementType()
 	}
 }
 


### PR DESCRIPTION
### sqlsmith: don't use system columns in ORDER BY

Using system columns in ORDER BY can produce different query results
depending on index, concurrent schema changes, and other environmental
factors. Prevent them from being used in ORDER BY to reduce flakes of
randomized tests trying to validate query results.

Fixes: #168643

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sqlsmith: add GenerateWithTag and increase stmt timeout for DDL

Add a GenerateWithTag method to the Smither that returns the generated
SQL string along with its tree.StatementType (DDL, DML, DCL, TCL). This
lets callers distinguish DDL from other statements without parsing.

Use this in the costfuzz, tlp, unoptimized-query-oracle, and sqlsmith
roachtests to temporarily increase the statement timeout (3x) when
executing DDL, which can legitimately take longer than the default
1-minute timeout. This uses the existing withIncreasedStmtTimeout helper
introduced in #168414.

Fixes: #168643

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>