### PR TITLE
roachtestutil: add UploadPerfSummaryStats api

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     srcs = [
         "commandbuilder_test.go",
         "load_group_test.go",
+        "metric_utils_test.go",
         "utils_test.go",
     ],
     embed = [":roachtestutil"],

--- a/pkg/cmd/roachtest/roachtestutil/metric_utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -573,4 +574,85 @@ func GetOpenmetricsLabelsFromString(labelString string) (map[string]string, erro
 	}
 
 	return labels, nil
+}
+
+// UploadPerfSummaryStats serializes the given metrics to both JSON
+// (for human readability) and openmetrics format, then uploads both
+// files to the perf artifacts directory on the specified node.
+func UploadPerfSummaryStats(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	stats AggregatedPerfMetrics,
+	node option.NodeListOption,
+) error {
+	if len(stats) == 0 {
+		return errors.New("no summary stats provided")
+	}
+
+	perfDir := t.PerfArtifactsDir()
+	if err := c.RunE(
+		ctx, option.WithNodes(node), "mkdir -p "+perfDir,
+	); err != nil {
+		return err
+	}
+
+	jsonBuf, err := summaryStatsToJSON(stats)
+	if err != nil {
+		return err
+	}
+	jsonDest := filepath.Join(perfDir, "summary_stats.json")
+	if err := c.PutString(
+		ctx, jsonBuf.String(), jsonDest, 0755, node,
+	); err != nil {
+		return err
+	}
+
+	omBuf, err := summaryStatsToOpenmetrics(t, c, stats)
+	if err != nil {
+		return err
+	}
+	omDest := filepath.Join(perfDir, "summary_stats.om")
+	return c.PutString(ctx, omBuf.String(), omDest, 0755, node)
+}
+
+type summaryStatJSON struct {
+	Name  string  `json:"name"`
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit"`
+}
+
+func summaryStatsToJSON(stats AggregatedPerfMetrics) (*bytes.Buffer, error) {
+	out := make([]summaryStatJSON, len(stats))
+	for i, s := range stats {
+		out[i] = summaryStatJSON{
+			Name:  s.Name,
+			Value: float64(s.Value),
+			Unit:  s.Unit,
+		}
+	}
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return nil, errors.Wrap(err, "encoding summary stats to JSON")
+	}
+	return buf, nil
+}
+
+func summaryStatsToOpenmetrics(
+	t test.Test, c cluster.Cluster, stats AggregatedPerfMetrics,
+) (*bytes.Buffer, error) {
+	labelMap := GetOpenmetricsLabelMap(t, c, nil)
+	labels := make([]*Label, 0, len(labelMap))
+	for k, v := range labelMap {
+		labels = append(labels, &Label{Name: k, Value: v})
+	}
+	buf := &bytes.Buffer{}
+	if err := GetAggregatedMetricBytes(
+		stats, labels, timeutil.Now(), buf,
+	); err != nil {
+		return nil, errors.Wrap(err, "encoding summary stats to openmetrics")
+	}
+	return buf, nil
 }

--- a/pkg/cmd/roachtest/roachtestutil/metric_utils_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummaryStatsToJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		stats    AggregatedPerfMetrics
+		expected []summaryStatJSON
+	}{
+		{
+			name: "single stat",
+			stats: AggregatedPerfMetrics{
+				{Name: "throughput", Value: 1234, Unit: "ops/sec"},
+			},
+			expected: []summaryStatJSON{
+				{Name: "throughput", Value: 1234, Unit: "ops/sec"},
+			},
+		},
+		{
+			name: "multiple stats",
+			stats: AggregatedPerfMetrics{
+				{Name: "copy_row_rate", Value: 5000, Unit: "rows/sec"},
+				{Name: "p99_latency", Value: 12.5, Unit: "ms"},
+			},
+			expected: []summaryStatJSON{
+				{Name: "copy_row_rate", Value: 5000, Unit: "rows/sec"},
+				{Name: "p99_latency", Value: 12.5, Unit: "ms"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := summaryStatsToJSON(tc.stats)
+			require.NoError(t, err)
+
+			var got []summaryStatJSON
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestSummaryStatsToJSONEmpty(t *testing.T) {
+	buf, err := summaryStatsToJSON(AggregatedPerfMetrics{})
+	require.NoError(t, err)
+
+	var got []summaryStatJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Empty(t, got)
+}

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -414,6 +414,10 @@ func registerFastRestorePerf(r registry.Registry) {
 					rd := makeRestoreDriver(ctx, t, c, sp.restoreSpecs)
 					rd.prepareCluster(ctx)
 
+					dut, err := roachtestutil.NewDiskUsageTracker(rd.c, t.L())
+					require.NoError(t, err)
+					startDu := dut.GetDiskUsage(ctx, rd.c.All())
+
 					db, err := rd.c.ConnE(ctx, t.L(), rd.c.Node(1)[0])
 					require.NoError(t, err)
 					defer db.Close()
@@ -437,6 +441,12 @@ func registerFastRestorePerf(r registry.Registry) {
 
 					restoreDuration := restoreEndTime.Sub(restoreStartTime)
 					t.L().Printf("Fast restore completed in %s", restoreDuration)
+
+					endDu := dut.GetDiskUsage(ctx, rd.c.All())
+					throughput := float64(endDu-startDu) / (float64(sp.hardware.nodes) * restoreDuration.Seconds())
+					t.L().Printf("Usage %d, Nodes %d, Duration %f; Throughput: %f MB/s/node",
+						endDu-startDu, sp.hardware.nodes, restoreDuration.Seconds(), throughput)
+					uploadRestoreSummaryStats(ctx, t, c, restoreDuration.Seconds(), throughput)
 				},
 			})
 		}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -929,6 +929,7 @@ func (rd *restoreDriver) initRestorePerfMetrics(
 			testDuration,
 			throughput)
 		exportToRoachperf(ctx, rd.t, rd.c, rd.sp.testName, int64(throughput))
+		uploadRestoreSummaryStats(ctx, rd.t, rd.c, testDuration, throughput)
 	}
 }
 
@@ -997,6 +998,32 @@ func exportToRoachperf(
 
 	if err != nil {
 		return
+	}
+}
+
+func uploadRestoreSummaryStats(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	durationSeconds float64,
+	throughputMBPerSPerNode float64,
+) {
+	stats := roachtestutil.AggregatedPerfMetrics{
+		{
+			Name:           "restore_runtime",
+			Value:          roachtestutil.MetricPoint(durationSeconds / 60.0),
+			Unit:           "minutes",
+			IsHigherBetter: false,
+		},
+		{
+			Name:           "per_node_throughput",
+			Value:          roachtestutil.MetricPoint(throughputMBPerSPerNode),
+			Unit:           "MB/s/node",
+			IsHigherBetter: true,
+		},
+	}
+	if err := roachtestutil.UploadPerfSummaryStats(ctx, t, c, stats, c.Node(1)); err != nil {
+		t.L().Printf("failed to upload perf summary stats: %v", err)
 	}
 }
 


### PR DESCRIPTION
Roachtest writers can now upload custom per roachtest run summary stats (e.g.
restore throughput, pcr cutover time) to a summary_stats.json (and open metrics
file). A seperate PR will build an ETL pipeline which scrapes the
summary_stats.json files into a data warehouse table that teams can easily use
to track perf over runs using a custom UI instead of roachperf.

Epic: none

Release note: none