### PR TITLE
dbconsole: add feature flag infrastructure for DB Console pages

### DIFF
--- a/.claude/skills/db-console-feature/SKILL.md
+++ b/.claude/skills/db-console-feature/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: db-console-feature
+description: Add a new feature-flagged page to the DB Console. Use when creating a new DB Console page that should be gated behind a cluster setting toggle.
+---
+
+# Adding a DB Console Feature
+
+New DB Console pages can be added behind a `dbconsole.feature_flag.<name>`
+cluster setting. When enabled, the page appears in the sidebar; when disabled,
+it's hidden and its backend endpoints return 403.
+
+## How it works
+
+Read `pkg/server/dbconsole/features.go` for the `Feature` struct and registry.
+The `jobs_manager.go` file in the same package is a working example.
+
+## Steps to add a new feature
+
+### 1. Backend: create a feature file
+
+Create `pkg/server/dbconsole/<feature_name>.go`:
+
+```go
+package dbconsole
+
+func init() {
+	RegisterFeature(&Feature{
+		Name:        "my_feature",      // cluster setting key suffix
+		Title:       "My Feature",      // sidebar display text
+		Description: "Does something",  // shown on the feature flags debug page
+		RoutePath:   "/feature/my-feature", // frontend route path
+	})
+}
+```
+
+`RegisterFeature` automatically creates the cluster setting
+`dbconsole.feature_flag.my_feature` (default: false).
+
+### 2. Backend: add BFF endpoints
+
+Add handler methods on `ApiV2DBConsole` in the same file. Guard each with:
+
+```go
+if !requireFeatureEnabled(ctx, "my_feature", &api.Settings.SV, w) {
+    return
+}
+```
+
+### 3. Backend: register routes
+
+Add your routes to the `Handler()` method in `dbconsole.go`:
+
+```go
+mux.HandleFunc("/my-feature/data", api.GetMyFeatureData)
+```
+
+### 4. Frontend: create the page component
+
+Create `pkg/ui/workspaces/db-console/src/views/myFeature/index.tsx` as a
+functional component. Use SWR hooks for data fetching (see `useHotRanges.ts`
+for the pattern). API paths must not have a leading `/`.
+
+### 5. Frontend: register the component
+
+In `app.tsx`, add your component to the `featureComponents` map:
+
+```typescript
+import MyFeaturePage from "src/views/myFeature";
+
+const featureComponents: Record<string, React.ComponentType> = {
+  "my-feature": MyFeaturePage,
+  // ...
+};
+```
+
+The slug key (`"my-feature"`) must match the last segment of `RoutePath`.
+
+### 6. Build
+
+```bash
+./dev generate bazel
+./dev build pkg/server/dbconsole
+./dev test pkg/server/dbconsole -v --count=1
+```
+
+## Toggling features
+
+- **SQL:** `SET CLUSTER SETTING dbconsole.feature_flag.my_feature = true`
+- **UI:** Advanced Debug > Feature Flags page (`/debug/feature-flags`)
+
+## Key files
+
+- `pkg/server/dbconsole/features.go` — registry, guard, list/toggle endpoints
+- `pkg/server/dbconsole/jobs_manager.go` — example feature implementation
+- `pkg/ui/workspaces/db-console/src/hooks/useFeatures.ts` — frontend SWR hook
+- `pkg/ui/workspaces/db-console/src/views/featureFlags/index.tsx` — debug page
+- `pkg/ui/workspaces/db-console/src/app.tsx` — `featureComponents` map

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/server/srverrors",
         "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/sql/isql",
     ],
 )

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dbconsole.go",
         "features.go",
+        "jobs_manager.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/dbconsole",
     visibility = ["//visibility:public"],
@@ -17,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/isql",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
     ],
 )

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/isql",
+        "//pkg/sql/sessiondata",
     ],
 )
 

--- a/pkg/server/dbconsole/BUILD.bazel
+++ b/pkg/server/dbconsole/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "dbconsole",
-    srcs = ["dbconsole.go"],
+    srcs = [
+        "dbconsole.go",
+        "features.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/dbconsole",
     visibility = ["//visibility:public"],
     deps = [
@@ -11,19 +14,25 @@ go_library(
         "//pkg/server/authserver",
         "//pkg/server/serverpb",
         "//pkg/server/srverrors",
+        "//pkg/settings",
         "//pkg/sql/isql",
     ],
 )
 
 go_test(
     name = "dbconsole_test",
-    srcs = ["dbconsole_test.go"],
+    srcs = [
+        "dbconsole_test.go",
+        "features_test.go",
+    ],
     embed = [":dbconsole"],
     deps = [
         "//pkg/build",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/server/serverpb",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/server/dbconsole/dbconsole.go
+++ b/pkg/server/dbconsole/dbconsole.go
@@ -90,6 +90,8 @@ func (api *ApiV2DBConsole) Handler() http.Handler {
 	mux.HandleFunc("/nodes", api.GetNodes)
 	mux.HandleFunc("/features", api.ListFeatures)
 	mux.HandleFunc("/features/", api.handleFeatureToggle)
+	mux.HandleFunc("/jobs-manager/jobs", api.GetJobsManagerJobs)
+	mux.HandleFunc("/jobs-manager/jobs/", api.HandleJobsManagerControl)
 	return mux
 }
 

--- a/pkg/server/dbconsole/dbconsole.go
+++ b/pkg/server/dbconsole/dbconsole.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 )
 
@@ -42,6 +43,7 @@ type ApiV2DBConsole struct {
 	Status     StatusAPI
 	Admin      AdminAPI
 	InternalDB isql.DB
+	Settings   *cluster.Settings
 }
 
 // NodeInfo contains summarized node information for the UI.

--- a/pkg/server/dbconsole/dbconsole.go
+++ b/pkg/server/dbconsole/dbconsole.go
@@ -82,6 +82,17 @@ type ErrorResponse struct {
 	Error string `json:"error"`
 }
 
+// Handler returns an http.Handler that routes requests to the appropriate
+// BFF endpoint. The caller should wrap this with http.StripPrefix to strip
+// the /api/v2/dbconsole prefix before dispatching.
+func (api *ApiV2DBConsole) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/nodes", api.GetNodes)
+	mux.HandleFunc("/features", api.ListFeatures)
+	mux.HandleFunc("/features/", api.handleFeatureToggle)
+	return mux
+}
+
 // GetNodes returns node information for the cluster overview page.
 // @Summary Get cluster nodes
 // @Description Returns status information for all nodes in the cluster.

--- a/pkg/server/dbconsole/features.go
+++ b/pkg/server/dbconsole/features.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+)
+
+// Feature represents a feature-flagged DB Console page. Each feature gets a
+// dedicated cluster setting (dbconsole.feature_flag.<name>) that acts as a
+// toggle. When enabled, the feature appears in the sidebar and its BFF
+// endpoints accept requests. When disabled, the sidebar entry is hidden and
+// endpoints return 403.
+type Feature struct {
+	Name        string
+	Title       string
+	Description string
+	RoutePath   string
+	Setting     *settings.BoolSetting
+}
+
+var features []*Feature
+
+// RegisterFeature adds a feature to the registry and creates its backing
+// cluster setting. Call this from init() in each feature's Go file.
+func RegisterFeature(f *Feature) {
+	f.Setting = settings.RegisterBoolSetting(
+		settings.ApplicationLevel,
+		settings.InternalKey("dbconsole.feature_flag."+f.Name),
+		f.Description,
+		false,
+		settings.WithPublic,
+	)
+	features = append(features, f)
+}
+
+// GetFeatures returns all registered features.
+func GetFeatures() []*Feature {
+	return features
+}
+
+// LookupFeature finds a feature by name, or returns nil.
+func LookupFeature(name string) *Feature {
+	for _, f := range features {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// requireFeatureEnabled checks whether the named feature is enabled. If not,
+// it writes a 403 JSON response and returns false. Handlers should return
+// immediately when this returns false.
+func requireFeatureEnabled(
+	ctx context.Context, name string, sv *settings.Values, w http.ResponseWriter,
+) bool {
+	f := LookupFeature(name)
+	if f == nil || !f.Setting.Get(sv) {
+		apiutil.WriteJSONResponse(
+			ctx, w, http.StatusForbidden,
+			ErrorResponse{Error: "feature " + name + " is not enabled"},
+		)
+		return false
+	}
+	return true
+}

--- a/pkg/server/dbconsole/features.go
+++ b/pkg/server/dbconsole/features.go
@@ -7,10 +7,15 @@ package dbconsole
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // Feature represents a feature-flagged DB Console page. Each feature gets a
@@ -110,4 +115,63 @@ func (api *ApiV2DBConsole) ListFeatures(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, result)
+}
+
+// handleFeatureToggle handles POST /features/{name}/enable and
+// POST /features/{name}/disable. It parses the feature name and action from
+// the URL path and executes SET CLUSTER SETTING via InternalDB.
+func (api *ApiV2DBConsole) handleFeatureToggle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Path is /features/{name}/{action} after StripPrefix.
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) != 3 || parts[0] != "features" {
+		http.NotFound(w, r)
+		return
+	}
+	name := parts[1]
+	action := parts[2]
+
+	f := LookupFeature(name)
+	if f == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var enabled bool
+	switch action {
+	case "enable":
+		enabled = true
+	case "disable":
+		enabled = false
+	default:
+		http.NotFound(w, r)
+		return
+	}
+
+	ctx := r.Context()
+	ctx = authserver.ForwardHTTPAuthInfoToRPCCalls(ctx, r)
+
+	settingKey := string(f.Setting.InternalKey())
+	value := "false"
+	if enabled {
+		value = "true"
+	}
+	stmt := fmt.Sprintf(
+		"SET CLUSTER SETTING \"%s\" = %s", settingKey, value,
+	)
+	ie := api.InternalDB.Executor()
+	_, err := ie.ExecEx(
+		ctx, "toggle-feature-flag", nil,
+		sessiondata.NodeUserSessionDataOverride, stmt,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/server/dbconsole/features.go
+++ b/pkg/server/dbconsole/features.go
@@ -72,3 +72,42 @@ func requireFeatureEnabled(
 	}
 	return true
 }
+
+// FeatureInfo is the JSON representation of a feature for the API response.
+type FeatureInfo struct {
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	RoutePath   string `json:"route_path"`
+	Enabled     bool   `json:"enabled"`
+}
+
+// FeaturesResponse is the response body for GET /features.
+type FeaturesResponse struct {
+	Features []FeatureInfo `json:"features"`
+}
+
+// ListFeatures returns all registered features with their current
+// enabled/disabled state.
+func (api *ApiV2DBConsole) ListFeatures(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ctx := r.Context()
+	sv := &api.Settings.SV
+
+	result := FeaturesResponse{
+		Features: make([]FeatureInfo, 0, len(features)),
+	}
+	for _, f := range features {
+		result.Features = append(result.Features, FeatureInfo{
+			Name:        f.Name,
+			Title:       f.Title,
+			Description: f.Description,
+			RoutePath:   f.RoutePath,
+			Enabled:     f.Setting.Get(sv),
+		})
+	}
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, result)
+}

--- a/pkg/server/dbconsole/features_test.go
+++ b/pkg/server/dbconsole/features_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/stretchr/testify/require"
+)
+
+// Test features registered once per test binary. Use unique names to avoid
+// duplicate setting registration panics.
+var (
+	testFeatureA = makeTestFeature("test_a")
+	testFeatureB = makeTestFeature("test_b")
+)
+
+func makeTestFeature(name string) *Feature {
+	return &Feature{
+		Name:        name,
+		Title:       "Test " + name,
+		Description: "test feature " + name,
+		RoutePath:   "/feature/" + name,
+		Setting: settings.RegisterBoolSetting(
+			settings.ApplicationLevel,
+			settings.InternalKey("dbconsole.feature_flag.test_"+name),
+			"test feature "+name,
+			false,
+		),
+	}
+}
+
+// withTestFeatures replaces the global features slice for the duration of the
+// test, restoring it on cleanup.
+func withTestFeatures(t *testing.T, ff ...*Feature) {
+	saved := features
+	features = ff
+	t.Cleanup(func() { features = saved })
+}
+
+func TestLookupFeature(t *testing.T) {
+	withTestFeatures(t, testFeatureA, testFeatureB)
+
+	require.Equal(t, testFeatureA, LookupFeature("test_a"))
+	require.Equal(t, testFeatureB, LookupFeature("test_b"))
+	require.Nil(t, LookupFeature("nonexistent"))
+}
+
+func TestGetFeatures(t *testing.T) {
+	withTestFeatures(t, testFeatureA, testFeatureB)
+
+	ff := GetFeatures()
+	require.Len(t, ff, 2)
+	require.Equal(t, "test_a", ff[0].Name)
+	require.Equal(t, "test_b", ff[1].Name)
+}
+
+func TestRequireFeatureEnabled(t *testing.T) {
+	withTestFeatures(t, testFeatureA)
+	st := cluster.MakeTestingClusterSettings()
+
+	t.Run("disabled feature returns 403", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ok := requireFeatureEnabled(
+			context.Background(), "test_a", &st.SV, w,
+		)
+		require.False(t, ok)
+		require.Equal(t, http.StatusForbidden, w.Code)
+
+		var resp ErrorResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Contains(t, resp.Error, "not enabled")
+	})
+
+	t.Run("enabled feature passes", func(t *testing.T) {
+		ctx := context.Background()
+		testFeatureA.Setting.Override(ctx, &st.SV, true)
+		t.Cleanup(func() {
+			testFeatureA.Setting.Override(ctx, &st.SV, false)
+		})
+
+		w := httptest.NewRecorder()
+		ok := requireFeatureEnabled(ctx, "test_a", &st.SV, w)
+		require.True(t, ok)
+		require.Empty(t, w.Body.Bytes())
+	})
+
+	t.Run("unknown feature returns 403", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ok := requireFeatureEnabled(
+			context.Background(), "nonexistent", &st.SV, w,
+		)
+		require.False(t, ok)
+		require.Equal(t, http.StatusForbidden, w.Code)
+	})
+}

--- a/pkg/server/dbconsole/features_test.go
+++ b/pkg/server/dbconsole/features_test.go
@@ -103,3 +103,30 @@ func TestRequireFeatureEnabled(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, w.Code)
 	})
 }
+
+func TestListFeatures(t *testing.T) {
+	withTestFeatures(t, testFeatureA, testFeatureB)
+	st := cluster.MakeTestingClusterSettings()
+
+	ctx := context.Background()
+	testFeatureA.Setting.Override(ctx, &st.SV, true)
+
+	api := &ApiV2DBConsole{Settings: st}
+	req := httptest.NewRequest("GET", "/features", nil)
+	w := httptest.NewRecorder()
+	api.ListFeatures(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result FeaturesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result.Features, 2)
+
+	require.Equal(t, "test_a", result.Features[0].Name)
+	require.Equal(t, "Test test_a", result.Features[0].Title)
+	require.Equal(t, "/feature/test_a", result.Features[0].RoutePath)
+	require.True(t, result.Features[0].Enabled)
+
+	require.Equal(t, "test_b", result.Features[1].Name)
+	require.False(t, result.Features[1].Enabled)
+}

--- a/pkg/server/dbconsole/features_test.go
+++ b/pkg/server/dbconsole/features_test.go
@@ -130,3 +130,45 @@ func TestListFeatures(t *testing.T) {
 	require.Equal(t, "test_b", result.Features[1].Name)
 	require.False(t, result.Features[1].Enabled)
 }
+
+func TestHandleFeatureToggle(t *testing.T) {
+	withTestFeatures(t, testFeatureA)
+
+	t.Run("unknown feature returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(
+			"POST", "/features/nonexistent/enable", nil,
+		)
+		w := httptest.NewRecorder()
+		api := &ApiV2DBConsole{}
+		api.handleFeatureToggle(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("invalid action returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(
+			"POST", "/features/test_a/invalid", nil,
+		)
+		w := httptest.NewRecorder()
+		api := &ApiV2DBConsole{}
+		api.handleFeatureToggle(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("wrong method returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(
+			"GET", "/features/test_a/enable", nil,
+		)
+		w := httptest.NewRecorder()
+		api := &ApiV2DBConsole{}
+		api.handleFeatureToggle(w, req)
+		require.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("malformed path returns 404", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/features/", nil)
+		w := httptest.NewRecorder()
+		api := &ApiV2DBConsole{}
+		api.handleFeatureToggle(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+}

--- a/pkg/server/dbconsole/jobs_manager.go
+++ b/pkg/server/dbconsole/jobs_manager.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
+
+func init() {
+	RegisterFeature(&Feature{
+		Name:        "jobs_manager",
+		Title:       "Jobs Manager",
+		Description: "Pause and resume active jobs",
+		RoutePath:   "/feature/jobs-manager",
+	})
+}
+
+// JobManagerJob represents a single job in the jobs manager response.
+type JobManagerJob struct {
+	JobID       int64  `json:"job_id"`
+	JobType     string `json:"job_type"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Created     string `json:"created"`
+}
+
+// JobsManagerJobsResponse is the response body for GET /jobs-manager/jobs.
+type JobsManagerJobsResponse struct {
+	Jobs []JobManagerJob `json:"jobs"`
+}
+
+// GetJobsManagerJobs lists running and paused jobs.
+func (api *ApiV2DBConsole) GetJobsManagerJobs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ctx := r.Context()
+	ctx = authserver.ForwardHTTPAuthInfoToRPCCalls(ctx, r)
+
+	if !requireFeatureEnabled(ctx, "jobs_manager", &api.Settings.SV, w) {
+		return
+	}
+
+	ie := api.InternalDB.Executor()
+	rows, err := ie.QueryBufferedEx(
+		ctx, "jobs-manager-list", nil,
+		sessiondata.NodeUserSessionDataOverride,
+		`SELECT job_id, job_type, description, status, created
+		 FROM crdb_internal.jobs
+		 WHERE status IN ('running', 'paused', 'pause-requested', 'resume-requested')
+		 ORDER BY created DESC
+		 LIMIT 50`,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	result := JobsManagerJobsResponse{
+		Jobs: make([]JobManagerJob, 0, len(rows)),
+	}
+	for _, row := range rows {
+		job := JobManagerJob{
+			JobID:       int64(tree.MustBeDInt(row[0])),
+			JobType:     string(tree.MustBeDString(row[1])),
+			Description: string(tree.MustBeDString(row[2])),
+			Status:      string(tree.MustBeDString(row[3])),
+			Created: tree.AsStringWithFlags(
+				row[4], tree.FmtBareStrings,
+			),
+		}
+		result.Jobs = append(result.Jobs, job)
+	}
+
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, result)
+}
+
+// JobControlRequest is the request body for POST /jobs-manager/jobs/{id}.
+type JobControlRequest struct {
+	Action string `json:"action"` // "pause" or "resume"
+}
+
+// HandleJobsManagerControl pauses or resumes a job by ID.
+func (api *ApiV2DBConsole) HandleJobsManagerControl(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ctx := r.Context()
+	ctx = authserver.ForwardHTTPAuthInfoToRPCCalls(ctx, r)
+
+	if !requireFeatureEnabled(ctx, "jobs_manager", &api.Settings.SV, w) {
+		return
+	}
+
+	// Parse job ID from path: /jobs-manager/jobs/{id}
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) != 3 || parts[0] != "jobs-manager" || parts[1] != "jobs" {
+		http.NotFound(w, r)
+		return
+	}
+	jobID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		http.Error(w, "invalid job ID", http.StatusBadRequest)
+		return
+	}
+
+	var req JobControlRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	var stmt string
+	switch req.Action {
+	case "pause":
+		stmt = fmt.Sprintf("PAUSE JOB %d", jobID)
+	case "resume":
+		stmt = fmt.Sprintf("RESUME JOB %d", jobID)
+	default:
+		http.Error(
+			w, `action must be "pause" or "resume"`,
+			http.StatusBadRequest,
+		)
+		return
+	}
+
+	ie := api.InternalDB.Executor()
+	_, err = ie.ExecEx(
+		ctx, "jobs-manager-control", nil,
+		sessiondata.NodeUserSessionDataOverride, stmt,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/oidcauth"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/dbconsole"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -277,6 +278,21 @@ func (s *httpServer) setupRoutes(
 	}
 	s.mux.Handle(debug.Endpoint, handleDebugAuthenticated)
 	s.mux.Handle(inspectz.URLPrefix, handleInspectzAuthenticated)
+
+	// DB Console BFF endpoints.
+	dbconsoleAPI := &dbconsole.ApiV2DBConsole{
+		InternalDB: execCfg.InternalDB,
+		Settings:   s.cfg.Settings,
+	}
+	var dbconsoleHandler http.Handler = http.StripPrefix(
+		"/api/v2/dbconsole", dbconsoleAPI.Handler(),
+	)
+	if !s.cfg.InsecureWebAccess() {
+		dbconsoleHandler = authserver.NewMux(
+			authnServer, dbconsoleHandler, false, /* allowAnonymous */
+		)
+	}
+	s.mux.Handle("/api/v2/dbconsole/", dbconsoleHandler)
 
 	log.Event(ctx, "added http endpoints")
 

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -70,6 +70,7 @@ import CustomChart from "src/views/reports/containers/customChart";
 import Debug from "src/views/reports/containers/debug";
 import DiagnosticsHistoryPage from "src/views/reports/containers/diagnosticsHistoryPage";
 import EnqueueRange from "src/views/reports/containers/enqueueRange";
+import FeatureFlagsPage from "src/views/featureFlags";
 import HotRanges from "src/views/reports/containers/hotranges";
 import Localities from "src/views/reports/containers/localities";
 import Network from "src/views/reports/containers/network";
@@ -348,6 +349,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
 
                           {/* debug pages */}
                           <Route exact path="/debug" component={Debug} />
+                          <Route
+                            exact
+                            path="/debug/feature-flags"
+                            component={FeatureFlagsPage}
+                          />
                           <Route
                             path="/debug/tracez"
                             component={SnapshotRouter}

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -64,6 +64,7 @@ import ClusterExplorerPage from "src/views/explorer/explorer";
 import HotRangesPage from "src/views/hotRanges/index";
 import JobDetails from "src/views/jobs/jobDetails";
 import JobsPage from "src/views/jobs/jobsPage";
+import JobsManagerPage from "src/views/jobsManager";
 import KeyVisualizerPage from "src/views/keyVisualizer";
 import { ConnectedDecommissionedNodeHistory } from "src/views/reports";
 import Certificates from "src/views/reports/containers/certificates";
@@ -110,7 +111,7 @@ import ActiveTransactionDetails from "./views/transactions/activeTransactionDeta
 // Map of feature slugs to their React components. Each feature PR adds its
 // entry here.
 const featureComponents: Record<string, React.ComponentType> = {
-  // "jobs-manager": JobsManagerPage,
+  "jobs-manager": JobsManagerPage,
 };
 
 function FeatureRoute(): React.ReactElement {

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -17,12 +17,13 @@ import { ConnectedRouter } from "connected-react-router";
 import { History } from "history";
 import React from "react";
 import { Provider, ReactReduxContext } from "react-redux";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch, useParams } from "react-router-dom";
 import "react-select/dist/react-select.css";
 import { Action, Store } from "redux";
 import { SWRConfig } from "swr";
 
 import { TimezoneProvider } from "src/contexts/timezoneProvider";
+import { useFeatures } from "src/hooks/useFeatures";
 import { AdminUIState } from "src/redux/state";
 import { createLoginRoute, createLogoutRoute } from "src/routes/login";
 import { RedirectToStatementDetails } from "src/routes/RedirectToStatementDetails";
@@ -105,6 +106,33 @@ import ActiveTransactionDetails from "./views/transactions/activeTransactionDeta
 //
 // Serial numeric values, such as NodeIDs or Descriptor IDs, are not PII and do
 // not need to be redacted.
+
+// Map of feature slugs to their React components. Each feature PR adds its
+// entry here.
+const featureComponents: Record<string, React.ComponentType> = {
+  // "jobs-manager": JobsManagerPage,
+};
+
+function FeatureRoute(): React.ReactElement {
+  const { slug } = useParams<{ slug: string }>();
+  const { features, isLoading } = useFeatures();
+
+  const Component = featureComponents[slug];
+  if (!Component) {
+    return <Redirect to="/" />;
+  }
+
+  const feature = features.find(f => f.route_path === `/feature/${slug}`);
+  if (!isLoading && (!feature || !feature.enabled)) {
+    return <Redirect to="/" />;
+  }
+
+  if (isLoading) {
+    return null;
+  }
+
+  return <Component />;
+}
 
 export interface AppProps {
   history: History;
@@ -527,6 +555,12 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                           <Redirect from="/cluster/events" to="/events" />
 
                           <Redirect exact from="/nodes" to="/overview/list" />
+
+                          {/* feature-flagged pages */}
+                          <Route
+                            path="/feature/:slug"
+                            component={FeatureRoute}
+                          />
 
                           {/* 404 */}
                           <Route path="*" component={NotFound} />

--- a/pkg/ui/workspaces/db-console/src/hooks/useFeatures.ts
+++ b/pkg/ui/workspaces/db-console/src/hooks/useFeatures.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { util } from "@cockroachlabs/cluster-ui";
+
+export interface FeatureInfo {
+  name: string;
+  title: string;
+  description: string;
+  route_path: string;
+  enabled: boolean;
+}
+
+interface FeaturesResponse {
+  features: FeatureInfo[];
+}
+
+const FEATURES_API_PATH = "api/v2/dbconsole/features";
+
+async function fetchFeatures(): Promise<FeatureInfo[]> {
+  const response = await fetch(FEATURES_API_PATH, {
+    headers: {
+      Accept: "application/json",
+      "X-Cockroach-API-Session": "cookie",
+    },
+    credentials: "same-origin",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch features: ${response.status} ${response.statusText}`,
+    );
+  }
+  const data: FeaturesResponse = await response.json();
+  return data.features ?? [];
+}
+
+async function toggleFeature(
+  name: string,
+  action: "enable" | "disable",
+): Promise<void> {
+  const response = await fetch(
+    `${FEATURES_API_PATH}/${name}/${action}`,
+    {
+      method: "POST",
+      headers: { "X-Cockroach-API-Session": "cookie" },
+      credentials: "same-origin",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to ${action} feature ${name}: ${response.status}`,
+    );
+  }
+}
+
+export function useFeatures() {
+  const { data, error, isLoading, mutate } =
+    util.useSwrWithClusterId<FeatureInfo[]>(
+      "dbconsole-features",
+      fetchFeatures,
+      {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      },
+    );
+
+  const enableFeature = async (name: string) => {
+    await toggleFeature(name, "enable");
+    await mutate();
+  };
+
+  const disableFeature = async (name: string) => {
+    await toggleFeature(name, "disable");
+    await mutate();
+  };
+
+  return {
+    features: data ?? [],
+    error,
+    isLoading,
+    enableFeature,
+    disableFeature,
+    refresh: mutate,
+  };
+}

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 
 import { SideNavigation } from "src/components";
+import { useFeatures } from "src/hooks/useFeatures";
 import "./navigation-bar.scss";
 
 interface RouteParam {
@@ -66,8 +67,18 @@ function Sidebar(): React.ReactElement {
     },
   ];
 
+  const { features } = useFeatures();
+  const featureRoutes: RouteParam[] = (features ?? [])
+    .filter(f => f.enabled)
+    .map(f => ({
+      path: f.route_path,
+      text: f.title,
+      activeFor: [f.route_path],
+    }));
+  const allRoutes = [...routes, ...featureRoutes];
+
   const isActiveNavigationItem = (path: string): boolean => {
-    const { activeFor, ignoreFor = [] } = routes.find(
+    const { activeFor, ignoreFor = [] } = allRoutes.find(
       route => route.path === path,
     );
     return [...activeFor, path].some(p => {
@@ -79,7 +90,7 @@ function Sidebar(): React.ReactElement {
     });
   };
 
-  const navigationItems = routes
+  const navigationItems = allRoutes
     .filter(route => !route.isHidden)
     .map(({ path, text }, idx) => (
       <SideNavigation.Item isActive={isActiveNavigationItem(path)} key={idx}>

--- a/pkg/ui/workspaces/db-console/src/views/featureFlags/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/featureFlags/index.tsx
@@ -1,0 +1,72 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import React from "react";
+import { Helmet } from "react-helmet";
+import { Link } from "react-router-dom";
+
+import { useFeatures } from "src/hooks/useFeatures";
+
+function FeatureFlagsPage(): React.ReactElement {
+  const { features, isLoading, enableFeature, disableFeature } = useFeatures();
+
+  return (
+    <div className="section">
+      <Helmet title="Feature Flags" />
+      <section className="section">
+        <h3 className="base-heading">Feature Flags</h3>
+        <p>
+          Toggle experimental DB Console features. Enabled features appear in
+          the sidebar. Changes take effect cluster-wide via{" "}
+          <code>dbconsole.feature_flag.*</code> cluster settings.
+        </p>
+      </section>
+      <section className="section">
+        {isLoading ? (
+          <p>Loading features...</p>
+        ) : features.length === 0 ? (
+          <p>No features registered.</p>
+        ) : (
+          <table className="sort-table">
+            <thead>
+              <tr className="sort-table__row sort-table__row--header">
+                <th className="sort-table__cell">Feature</th>
+                <th className="sort-table__cell">Description</th>
+                <th className="sort-table__cell">Status</th>
+                <th className="sort-table__cell">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {features.map(f => (
+                <tr className="sort-table__row" key={f.name}>
+                  <td className="sort-table__cell">
+                    <Link to={f.route_path}>{f.title}</Link>
+                  </td>
+                  <td className="sort-table__cell">{f.description}</td>
+                  <td className="sort-table__cell">
+                    {f.enabled ? "Enabled" : "Disabled"}
+                  </td>
+                  <td className="sort-table__cell">
+                    <button
+                      onClick={() =>
+                        f.enabled
+                          ? disableFeature(f.name)
+                          : enableFeature(f.name)
+                      }
+                    >
+                      {f.enabled ? "Disable" : "Enable"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default FeatureFlagsPage;

--- a/pkg/ui/workspaces/db-console/src/views/jobsManager/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobsManager/index.tsx
@@ -1,0 +1,146 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { util } from "@cockroachlabs/cluster-ui";
+import React from "react";
+import { Helmet } from "react-helmet";
+
+interface JobInfo {
+  job_id: number;
+  job_type: string;
+  description: string;
+  status: string;
+  created: string;
+}
+
+interface JobsResponse {
+  jobs: JobInfo[];
+}
+
+const JOBS_API_PATH = "api/v2/dbconsole/jobs-manager/jobs";
+
+async function fetchJobs(): Promise<JobInfo[]> {
+  const response = await fetch(JOBS_API_PATH, {
+    headers: {
+      Accept: "application/json",
+      "X-Cockroach-API-Session": "cookie",
+    },
+    credentials: "same-origin",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch jobs: ${response.status}`);
+  }
+  const data: JobsResponse = await response.json();
+  return data.jobs ?? [];
+}
+
+async function controlJob(
+  jobId: number,
+  action: "pause" | "resume",
+): Promise<void> {
+  const response = await fetch(`${JOBS_API_PATH}/${jobId}`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Cockroach-API-Session": "cookie",
+    },
+    credentials: "same-origin",
+    body: JSON.stringify({ action }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to ${action} job ${jobId}: ${response.status}`);
+  }
+}
+
+function useJobs() {
+  const { data, error, isLoading, mutate } =
+    util.useSwrWithClusterId<JobInfo[]>("jobs-manager-jobs", fetchJobs, {
+      revalidateOnFocus: false,
+      refreshInterval: 5000,
+    });
+
+  const pauseJob = async (jobId: number) => {
+    await controlJob(jobId, "pause");
+    await mutate();
+  };
+
+  const resumeJob = async (jobId: number) => {
+    await controlJob(jobId, "resume");
+    await mutate();
+  };
+
+  return {
+    jobs: data ?? [],
+    error,
+    isLoading,
+    pauseJob,
+    resumeJob,
+    refresh: mutate,
+  };
+}
+
+function JobsManagerPage(): React.ReactElement {
+  const { jobs, isLoading, error, pauseJob, resumeJob } = useJobs();
+
+  return (
+    <div className="section">
+      <Helmet title="Jobs Manager" />
+      <section className="section">
+        <h3 className="base-heading">Jobs Manager</h3>
+        <p>
+          View and control running and paused jobs. This page auto-refreshes
+          every 5 seconds.
+        </p>
+      </section>
+      <section className="section">
+        {error ? (
+          <p>Error loading jobs: {error.message}</p>
+        ) : isLoading ? (
+          <p>Loading jobs...</p>
+        ) : jobs.length === 0 ? (
+          <p>No running or paused jobs.</p>
+        ) : (
+          <table className="sort-table">
+            <thead>
+              <tr className="sort-table__row sort-table__row--header">
+                <th className="sort-table__cell">Job ID</th>
+                <th className="sort-table__cell">Type</th>
+                <th className="sort-table__cell">Description</th>
+                <th className="sort-table__cell">Status</th>
+                <th className="sort-table__cell">Created</th>
+                <th className="sort-table__cell">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map(job => (
+                <tr className="sort-table__row" key={job.job_id}>
+                  <td className="sort-table__cell">{job.job_id}</td>
+                  <td className="sort-table__cell">{job.job_type}</td>
+                  <td className="sort-table__cell">{job.description}</td>
+                  <td className="sort-table__cell">{job.status}</td>
+                  <td className="sort-table__cell">{job.created}</td>
+                  <td className="sort-table__cell">
+                    {job.status === "running" ? (
+                      <button onClick={() => pauseJob(job.job_id)}>
+                        Pause
+                      </button>
+                    ) : (
+                      <button onClick={() => resumeJob(job.job_id)}>
+                        Resume
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default JobsManagerPage;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -310,6 +310,11 @@ export default function Debug() {
           note="View all cluster settings."
         />
         <DebugPanelLink
+          name="Feature Flags"
+          url="#/debug/feature-flags"
+          note="View and toggle experimental DB Console features."
+        />
+        <DebugPanelLink
           name="Localities"
           url="#/reports/localities"
           note="Check node localities and locations for your cluster."


### PR DESCRIPTION
## Summary

- Adds a feature flag registry in `pkg/server/dbconsole/` that lets new
  DB Console pages be gated behind `dbconsole.feature_flag.<name>` cluster
  settings. Each feature registers itself via `init()` and gets a sidebar
  entry, dedicated BFF endpoints, and a 403 guard when disabled.
- Adds a Feature Flags debug page at `/debug/feature-flags` for toggling
  flags via the UI.
- Includes a sample "Jobs Manager" page that lists running/paused jobs
  with pause/resume controls to demonstrate the system end-to-end.

The first 8 commits are the infrastructure; the last 2 add the Jobs Manager
as the first consumer.

Epic: none