### PR TITLE
sql/row: fix TestJobBackedSeqChunkProvider race with job adoption

### DIFF
--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -146,6 +146,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/upgrade/upgradebase",
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/sql/row/expr_walker_test.go
+++ b/pkg/sql/row/expr_walker_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -76,7 +77,20 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			// Prevent the registry from adopting the mock import job, which has
+			// empty ImportDetails and would crash in prepareTableForIngestion.
+			JobsTestingKnobs: &jobs.TestingKnobs{
+				DisableAdoptions: true,
+			},
+			// DisableAdoptions needs this.
+			UpgradeManager: &upgradebase.TestingKnobs{
+				DontUseJobs:                       true,
+				SkipJobMetricsPollingJobBootstrap: true,
+			},
+		},
+	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 


### PR DESCRIPTION
The test creates a mock import job with empty ImportDetails to test sequence chunk allocation. The job registry's adoption loop could race with the test, adopt this job, and crash in prepareTableForIngestion when dereferencing the nil table descriptor.

Disable job adoptions via testing knobs to prevent the registry from resuming the mock job.

Fixes #168691

Release note: None