### PR TITLE
sql/stats: fix slice aliasing in TestAddMisestimateRandomized

### DIFF
--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -1429,6 +1430,6 @@ func TestAddMisestimateRandomized(t *testing.T) {
 			indexInfo: id,
 			Spans:     new,
 		})
-		require.Equal(t, dedupAndMerge(append(old, new...)), r.misestimateSpans[id])
+		require.Equal(t, dedupAndMerge(append(slices.Clone(old), new...)), r.misestimateSpans[id])
 	}
 }


### PR DESCRIPTION
The test assertion `dedupAndMerge(append(old, new...))` could corrupt `r.misestimateSpans[id]` when `old` and the map entry shared the same backing array. This happened when `addMisestimate` took the `allDups` early-return path (no reassignment) and `old` had spare capacity so `append` didn't allocate. The subsequent `sort.Sort` inside `dedupAndMerge` then reordered elements visible through the map entry.

Fix by cloning `old` before appending to break the aliasing.

Fixes: #168676

Release note: None