### PR TITLE
sctest: lower closed timestamp settings to speed up tests

### DIFF
--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/clusterversion",
         "//pkg/jobs",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql",

--- a/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
+++ b/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -80,6 +82,8 @@ func (f MultiRegionTestClusterFactory) Start(ctx context.Context, t *testing.T) 
 		st = cluster.MakeClusterSettingsWithVersions(clusterversion.Latest.Version(), f.server.ClusterVersionOverride)
 	}
 	sql.CreateTableWithSchemaLocked.Override(ctx, &st.SV, !f.schemaLockedDisabled)
+	closedts.TargetDuration.Override(ctx, &st.SV, 20*time.Millisecond)
+	closedts.SideTransportCloseInterval.Override(ctx, &st.SV, 20*time.Millisecond)
 	c, db, _ := multiregionccltestutils.TestingCreateMultiRegionCluster(t, numServers, knobs, multiregionccltestutils.WithSettings(st))
 	return sctest.TestServer{
 		Server: c.Server(0),

--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/settings/cluster",

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -130,6 +132,8 @@ func (f SingleNodeTestClusterFactory) Start(ctx context.Context, t *testing.T) T
 		args.Settings = cluster.MakeClusterSettingsWithVersions(clusterversion.Latest.Version(), f.server.ClusterVersionOverride)
 	}
 	sql.CreateTableWithSchemaLocked.Override(ctx, &args.Settings.SV, !f.schemaLockedDisabled)
+	closedts.TargetDuration.Override(ctx, &args.Settings.SV, 20*time.Millisecond)
+	closedts.SideTransportCloseInterval.Override(ctx, &args.Settings.SV, 20*time.Millisecond)
 	s, db, _ := serverutils.StartServer(t, args)
 
 	return TestServer{


### PR DESCRIPTION
The TestingEnsureLatestLeaseIsAvailable retry loop added in #167844 waits for the lease manager's closed timestamp to catch up before each BeforeStage hook. With default settings (kv.closed_timestamp.target_duration=3s, kv.closed_timestamp.side_transport_interval=200ms), this adds significant latency per post-commit stage in backup, rollback, and pause tests.

Override both settings to 20ms in SingleNodeTestClusterFactory and MultiRegionTestClusterFactory so all schemachanger end-to-end tests benefit. Measured improvements:
- TestBackupSuccess_base_create_index: 97s → 64s (~34%)
- TestBackupSuccess_multiregion_add_column_regional_by_row: 56s → 41s (~26%)

Epic: none
Release note: None