### PR TITLE
tree: parenthesize CASE in PL/pgSQL pretty-printer output

### DIFF
--- a/pkg/sql/sem/plpgsqltree/pretty.go
+++ b/pkg/sql/sem/plpgsqltree/pretty.go
@@ -350,9 +350,10 @@ func (s *Exception) Doc(p *tree.PrettyCfg) pretty.Doc {
 }
 
 func (s *DoBlock) Doc(p *tree.PrettyCfg) pretty.Doc {
+	p = p.WithInPLpgSQL()
 	// Render the block to a string to find a dollar-quote delimiter that
 	// doesn't collide with the body content.
-	bodyStr := tree.AsStringWithFlags(s.Block, p.FmtFlagsWithDefaults())
+	bodyStr := p.AsString(s.Block)
 	tag := "$" + tree.DollarQuoteDelimiter(bodyStr) + "$"
 	return pretty.Fold(pretty.Concat,
 		pretty.ConcatSpace(pretty.Keyword("DO"), pretty.Text(tag)),

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -268,6 +268,7 @@ go_test(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/normalize",
+        "//pkg/sql/sem/plpgsqltree",
         "//pkg/sql/sem/tree/treebin",
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/sem/volatility",

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -245,7 +245,7 @@ func (node *CreateRoutine) Doc(p *PrettyCfg) pretty.Doc {
 			}
 			// Render the body to find a dollar-quote tag that doesn't
 			// collide with nested dollar quotes (e.g. from DO blocks).
-			fmtCtx := NewFmtCtx(p.FmtFlagsWithDefaults())
+			fmtCtx := p.NewFmtCtx()
 			for _, stmt := range stmts {
 				fmtCtx.FormatNode(stmt)
 			}
@@ -259,13 +259,14 @@ func (node *CreateRoutine) Doc(p *PrettyCfg) pretty.Doc {
 		}
 	} else if isPLpgSQL && ParsePLpgSQLForDoc != nil {
 		if parsed := ParsePLpgSQLForDoc(string(funcBody)); parsed != nil {
+			bodyCfg := p.WithInPLpgSQL()
 			// Use the formatted output to pick a dollar-quote tag that
 			// doesn't collide with nested dollar quotes (e.g. DO blocks).
-			bodyStr := AsStringWithFlags(parsed, p.FmtFlagsWithDefaults())
+			bodyStr := bodyCfg.AsString(parsed)
 			tag := "$" + DollarQuoteDelimiter(bodyStr) + "$"
 			bodyDoc = pretty.Fold(pretty.Concat,
 				pretty.ConcatSpace(pretty.Keyword("AS"), pretty.Text(tag)),
-				pretty.NestT(pretty.Concat(pretty.HardLine, p.Doc(parsed))),
+				pretty.NestT(pretty.Concat(pretty.HardLine, bodyCfg.Doc(parsed))),
 				pretty.HardLine,
 				pretty.Text(tag))
 		}

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -76,6 +76,11 @@ type PrettyCfg struct {
 	ValueRedaction bool
 	// FmtFlags specifies FmtFlags to use when formatting expressions.
 	FmtFlags FmtFlags
+
+	// inPLpgSQL, when set, indicates that the pretty-printer is rendering a
+	// node within a PL/pgSQL body. Set only via WithInPLpgSQL at the
+	// boundary between SQL and PL/pgSQL; do not assign directly.
+	inPLpgSQL bool
 }
 
 // DefaultPrettyCfg returns a PrettyCfg with the default
@@ -88,6 +93,18 @@ func DefaultPrettyCfg() PrettyCfg {
 		UseTabs:   true,
 		Align:     PrettyNoAlign, // TODO(knz): I really want this to be AlignAndDeindent
 	}
+}
+
+// WithInPLpgSQL returns a shallow copy of p marked as rendering a node within
+// a PL/pgSQL body. Use at the boundary between SQL and PL/pgSQL (e.g. DoBlock.Doc,
+// CreateRoutine.Doc for PL/pgSQL bodies) when recursing into a PL/pgSQL body,
+// so that nested expression formatters (e.g. CaseExpr.Doc) emit defensive
+// parens when FmtPLpgSQLParen is set. Returns a copy so the state does not
+// leak to sibling subtrees rendered from the parent cfg.
+func (p *PrettyCfg) WithInPLpgSQL() *PrettyCfg {
+	cp := *p
+	cp.inPLpgSQL = true
+	return &cp
 }
 
 // PrettyAlignMode directs which alignment mode to use.
@@ -191,20 +208,32 @@ func (p *PrettyCfg) Doc(f NodeFormatter) pretty.Doc {
 }
 
 func (p *PrettyCfg) docAsString(f NodeFormatter) pretty.Doc {
-	txt := AsStringWithFlags(f, p.FmtFlagsWithDefaults())
-	return pretty.Text(strings.TrimSpace(txt))
+	return pretty.Text(strings.TrimSpace(p.AsString(f)))
+}
+
+// AsString formats f using the Format path, propagating all relevant PrettyCfg
+// state to the FmtCtx.
+func (p *PrettyCfg) AsString(f NodeFormatter) string {
+	return AsStringWithFlags(f, p.fmtFlagsWithDefaults(), p.fmtCtxOptions()...)
+}
+
+// NewFmtCtx creates a FmtCtx, propagating all relevant PrettyCfg state to the
+// FmtCtx.
+func (p *PrettyCfg) NewFmtCtx() *FmtCtx {
+	return NewFmtCtx(p.fmtFlagsWithDefaults(), p.fmtCtxOptions()...)
 }
 
 // HasFlags returns true if the given flags are set in the pretty-printer's
 // effective FmtFlags (which includes defaults like FmtParsable when no
 // explicit flags are configured).
 func (p *PrettyCfg) HasFlags(f FmtFlags) bool {
-	return p.FmtFlagsWithDefaults().HasFlags(f)
+	return p.fmtFlagsWithDefaults().HasFlags(f)
 }
 
-// FmtFlagsWithDefaults returns the effective FmtFlags for this configuration,
-// applying defaults (FmtParsable, FmtShowPasswords) when no explicit flags are set.
-func (p *PrettyCfg) FmtFlagsWithDefaults() FmtFlags {
+// fmtFlagsWithDefaults returns the effective FmtFlags for this configuration,
+// applying defaults (FmtParsable, FmtShowPasswords) when no explicit flags
+// are set.
+func (p *PrettyCfg) fmtFlagsWithDefaults() FmtFlags {
 	if p.FmtFlags != FmtFlags(0) {
 		return p.FmtFlags
 	}
@@ -214,6 +243,16 @@ func (p *PrettyCfg) FmtFlagsWithDefaults() FmtFlags {
 		prettyFlags |= FmtMarkRedactionNode | FmtOmitNameRedaction
 	}
 	return prettyFlags
+}
+
+// fmtCtxOptions returns FmtCtxOptions that propagate PrettyCfg state to a
+// FmtCtx.
+func (p *PrettyCfg) fmtCtxOptions() []FmtCtxOption {
+	var opts []FmtCtxOption
+	if p.inPLpgSQL {
+		opts = append(opts, FmtInPLpgSQL(true /* inPLpgSQL */))
+	}
+	return opts
 }
 
 func (p *PrettyCfg) nestUnder(a, b pretty.Doc) pretty.Doc {
@@ -1455,7 +1494,11 @@ func (node *CaseExpr) Doc(p *PrettyCfg) pretty.Doc {
 		)))
 	}
 	d = append(d, pretty.Keyword("END"))
-	return pretty.Stack(d...)
+	result := pretty.Stack(d...)
+	if p.HasFlags(FmtPLpgSQLParen) && p.inPLpgSQL {
+		result = p.bracket("(", result, ")")
+	}
+	return result
 }
 
 func (node *When) Doc(p *PrettyCfg) pretty.Doc {
@@ -2157,7 +2200,7 @@ func (node *ColumnTableDef) docRow(p *PrettyCfg) pretty.TableRow {
 // FormatType formats a ResolvableTypeReference as a pretty.Doc, respecting
 // the configured FmtFlags.
 func (p *PrettyCfg) FormatType(typ ResolvableTypeReference) pretty.Doc {
-	ctx := NewFmtCtx(p.FmtFlagsWithDefaults())
+	ctx := p.NewFmtCtx()
 	ctx.FormatTypeReference(typ)
 	return pretty.Text(strings.TrimSpace(ctx.String()))
 }

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -302,5 +303,107 @@ func TestPrettyExprs(t *testing.T) {
 		if pretty != got {
 			t.Fatalf("got: %s\nexpected: %s", got, pretty)
 		}
+	}
+}
+
+// TestPrettyCaseExprInPLpgSQL is a regression test for #168216. It verifies
+// that CASE expressions inside PL/pgSQL IF/ELSIF conditions are wrapped in
+// defensive parentheses when pretty-printed with FmtPLpgSQLParen. Without
+// wrapping, the PL/pgSQL parser confuses the CASE's inner THEN with the
+// IF/ELSIF's THEN, producing a syntax error.
+//
+// ASTs are built directly (not parsed from text) because parsing requires
+// parens around CASE in these positions, which would mask the bug we're
+// testing for.
+func TestPrettyCaseExprInPLpgSQL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	makeCaseExpr := func() *tree.CaseExpr {
+		return &tree.CaseExpr{
+			Whens: []*tree.When{{Cond: tree.MakeDBool(true), Val: tree.NewDInt(1)}},
+			Else:  tree.NewDInt(0),
+		}
+	}
+
+	cfg := tree.DefaultPrettyCfg()
+	cfg.Simplify = false
+	cfg.FmtFlags = tree.FmtPLpgSQLParen
+
+	for name, tc := range map[string]struct {
+		body      []plpgsqltree.Statement
+		unwrapped string
+		wrapped   string
+	}{
+		"if condition": {
+			body: []plpgsqltree.Statement{
+				&plpgsqltree.If{
+					Condition: makeCaseExpr(),
+					ThenBody:  []plpgsqltree.Statement{&plpgsqltree.Null{}},
+				},
+			},
+			unwrapped: `DO $$
+	BEGIN
+		IF CASE WHEN true THEN 1 ELSE 0 END THEN
+			NULL;
+		END IF;
+	END;
+$$;`,
+			wrapped: `DO $$
+	BEGIN
+		IF (CASE WHEN true THEN 1 ELSE 0 END) THEN
+			NULL;
+		END IF;
+	END;
+$$;`,
+		},
+		"elsif condition": {
+			body: []plpgsqltree.Statement{
+				&plpgsqltree.If{
+					Condition: tree.MakeDBool(false),
+					ThenBody:  []plpgsqltree.Statement{&plpgsqltree.Null{}},
+					ElseIfList: []plpgsqltree.ElseIf{{
+						Condition: makeCaseExpr(),
+						Stmts:     []plpgsqltree.Statement{&plpgsqltree.Null{}},
+					}},
+				},
+			},
+			unwrapped: `DO $$
+	BEGIN
+		IF false THEN
+			NULL;
+		ELSIF CASE WHEN true THEN 1 ELSE 0 END THEN
+			NULL;
+		END IF;
+	END;
+$$;`,
+			wrapped: `DO $$
+	BEGIN
+		IF false THEN
+			NULL;
+		ELSIF (CASE WHEN true THEN 1 ELSE 0 END) THEN
+			NULL;
+		END IF;
+	END;
+$$;`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Verify that the unwrapped form (bare CASE without defensive
+			// parens) is indeed unparseable due to THEN keyword ambiguity.
+			_, err := parser.ParseOne(tc.unwrapped)
+			require.ErrorContainsf(t, err, "syntax error",
+				"unwrapped input must not parse:\n%s", tc.unwrapped)
+
+			// Pretty-print the AST and verify it matches the wrapped form
+			// (CASE wrapped in parens) and that the result reparses.
+			block := &plpgsqltree.Block{Body: tc.body}
+			doBlock := &tree.DoBlock{Code: &plpgsqltree.DoBlock{Block: block}}
+			out, err := cfg.Pretty(doBlock)
+			require.NoError(t, err)
+			require.Equal(t, tc.wrapped, out)
+			_, err = parser.ParseOne(out)
+			require.NoError(t, err, "pretty-printed output must reparse:\n%s", out)
+		})
 	}
 }


### PR DESCRIPTION
`FmtCtx`, which is used by the basic node formatter contains a flag
for whether it's currently inside a PL/pgSQL subtree so that it can
determine if it needs to add extra parentheses to prevent a parse error.
`PrettyCfg`, which is used by the pretty-printer will now also propagate
and use such a flag. New public helpers `AsString` and `NewFmtCtx` have
also been added to `PrettyCfg` to ensure consistent flag and option
application when falling back to the basic node formatter.

Fixes #168216

Release note: None