### PR TITLE
release-26.2: roachtest: increase job wait to 90 minutes in backup-restore tests

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -465,7 +465,7 @@ func (u *CommonTestUtils) waitForJobSuccess(
 	r := retry.StartWithCtx(ctx, retry.Options{
 		InitialBackoff: time.Second,
 		MaxBackoff:     time.Second,
-		MaxDuration:    80 * time.Minute,
+		MaxDuration:    90 * time.Minute,
 	})
 	for r.Next() {
 		var status string


### PR DESCRIPTION
Backport 1/1 commits from #168628 on behalf of @kev-cao.

----

Even with the changes introduced in #168610, we are seeing backups take 84 minutes near the end of tests. This bumps up the job wait from 80 minutes to 90 minutes in an effort to deflake the tests.

Epic: None

Release note: None

----

Release justification: