### PR TITLE
storage: log batch commit stats in periodic Pebble metrics dump

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3838,6 +3838,23 @@ func (s *Store) ComputeMetricsPeriodically(
 	// stats.
 	if tick%logSSTInfoTicks == 1 /* every 10m */ {
 		log.Storage.Infof(ctx, "Pebble metrics:\n%s", m.Metrics)
+		// Log cumulative batch commit stats. These are useful for diagnosing
+		// commit pipeline stalls that fall below Pebble's per-operation
+		// DiskSlow threshold but compound across serialized batches. In
+		// healthy operation, mean commit-wait per batch (delta commit-wait /
+		// delta count between intervals) should be under 50ms. Values above
+		// 1s suggest WAL sync latency issues; sustained values above 5s
+		// indicate the commit pipeline is stalled. See #168664 for a case
+		// where this data would have identified the root cause.
+		log.Storage.Infof(ctx, "batch commit stats: count=%d, total=%s, commit-wait=%s, sem=%s, wal-q=%s, mem-stall=%s, l0-stall=%s, wal-rot=%s",
+			m.BatchCommitStats.Count,
+			m.BatchCommitStats.TotalDuration,
+			m.BatchCommitStats.CommitWaitDuration,
+			m.BatchCommitStats.SemaphoreWaitDuration,
+			m.BatchCommitStats.WALQueueWaitDuration,
+			m.BatchCommitStats.MemTableWriteStallDuration,
+			m.BatchCommitStats.L0ReadAmpWriteStallDuration,
+			m.BatchCommitStats.WALRotationDuration)
 	}
 	// Periodically emit a store stats structured event to the TELEMETRY channel,
 	// if reporting is enabled. These events are intended to be emitted at low


### PR DESCRIPTION
Add cumulative BatchCommitStats to the 10-minute Pebble metrics log. These stats (commit-wait duration, WAL queue wait, memtable/L0 stall durations) are already collected per-batch and exposed via Prometheus metrics (storage.batch-commit.*), but were never logged to disk.

This matters for diagnosing commit pipeline stalls in environments without Prometheus scraping (e.g., unit test CI). Investigation of #168664 revealed that WAL fdatasync calls on s390x CI stayed below Pebble's 5s DiskSlow threshold individually, but compounded through the serialized commit pipeline to produce minutes of total stall. Zero DiskSlow events were logged, making the root cause invisible in build artifacts. With this change, consecutive log entries can be diffed to compute mean commit-wait per batch over 10-minute intervals, directly revealing sub-threshold sync compounding.

Expected output (healthy):
  batch commit stats: count=50000 commit-wait 2.1s total=8.5s
  (mean commit-wait = ~42µs/batch)

Expected output (stalled pipeline):
  batch commit stats: count=200 commit-wait 145s total=180s
  (mean commit-wait = ~725ms/batch)

Informs #168664.

Release note: None