### PR TITLE
sql: add PostgreSQL-parity math builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -530,9 +530,9 @@
 a convenience function to display HLCs in a print-friendly form. Use the decimal
 value if you rely on the HLC for accuracy.</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="min_scale"></a><code>min_scale(val: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the minimum scale (number of fractional decimal digits) needed to represent <code>val</code> exactly.</p>
+<tr><td><a name="min_scale"></a><code>min_scale(val: <a href="decimal.html">decimal</a>) &rarr; int4</code></td><td><span class="funcdesc"><p>Returns the minimum scale (number of fractional decimal digits) needed to represent <code>val</code> exactly.</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="scale"></a><code>scale(val: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the scale (number of fractional decimal digits) of <code>val</code>.</p>
+<tr><td><a name="scale"></a><code>scale(val: <a href="decimal.html">decimal</a>) &rarr; int4</code></td><td><span class="funcdesc"><p>Returns the scale (number of fractional decimal digits) of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="to_number"></a><code>to_number(value: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Convert a string to a numeric using the given format.</p>
 </span></td><td>Stable</td></tr>
@@ -1223,7 +1223,11 @@ available replica will error.</p>
 </span></td><td>Leakproof</td></tr>
 <tr><td><a name="fnv64a"></a><code>fnv64a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1a hash value of a set of values.</p>
 </span></td><td>Leakproof</td></tr>
+<tr><td><a name="gcd"></a><code>gcd(a: <a href="decimal.html">decimal</a>, b: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the greatest common divisor of <code>a</code> and <code>b</code>. Returns 0 if both inputs are 0; otherwise returns a positive value. Returns NaN if either input is NaN or Infinity.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="gcd"></a><code>gcd(a: <a href="int.html">int</a>, b: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the greatest common divisor of <code>a</code> and <code>b</code>. Returns 0 if both inputs are 0; otherwise returns a positive value.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="lcm"></a><code>lcm(a: <a href="decimal.html">decimal</a>, b: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the least common multiple of <code>a</code> and <code>b</code>. Returns 0 if either input is 0. Returns NaN if either input is NaN or Infinity.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="lcm"></a><code>lcm(a: <a href="int.html">int</a>, b: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the least common multiple of <code>a</code> and <code>b</code>. Returns 0 if either input is 0.</p>
 </span></td><td>Immutable</td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -530,8 +530,14 @@
 a convenience function to display HLCs in a print-friendly form. Use the decimal
 value if you rely on the HLC for accuracy.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="min_scale"></a><code>min_scale(val: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the minimum scale (number of fractional decimal digits) needed to represent <code>val</code> exactly.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="scale"></a><code>scale(val: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the scale (number of fractional decimal digits) of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="to_number"></a><code>to_number(value: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Convert a string to a numeric using the given format.</p>
-</span></td><td>Stable</td></tr></tbody>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="trim_scale"></a><code>trim_scale(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Returns <code>val</code> with any trailing zeros after the decimal point removed.</p>
+</span></td><td>Immutable</td></tr></tbody>
 </table>
 
 ### Date and time functions
@@ -948,6 +954,10 @@ available replica will error.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="div"></a><code>div(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the integer quotient of <code>x</code>/<code>y</code>.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="erf"></a><code>erf(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the error function of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="erfc"></a><code>erfc(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the complementary error function: <code>1 - erf(val)</code>.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="exp"></a><code>exp(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates <em>e</em> ^ <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="exp"></a><code>exp(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates <em>e</em> ^ <code>val</code>.</p>
@@ -966,13 +976,25 @@ available replica will error.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="ln"></a><code>ln(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the natural log of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="ln"></a><code>ln(val: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the natural log of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="log"></a><code>log(b: <a href="decimal.html">decimal</a>, x: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base <code>b</code> log of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="log"></a><code>log(b: <a href="float.html">float</a>, x: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the base <code>b</code> log of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="log"></a><code>log(b: <a href="int.html">int</a>, x: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base <code>b</code> log of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="log"></a><code>log(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="log"></a><code>log(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="log"></a><code>log(val: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="log10"></a><code>log10(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="log10"></a><code>log10(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="log10"></a><code>log10(val: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="mod"></a><code>mod(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>%<code>y</code>.</p>
 </span></td><td>Immutable</td></tr>
@@ -997,6 +1019,10 @@ available replica will error.</p>
 <tr><td><a name="radians"></a><code>radians(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> as a degree value to a radians value.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="random"></a><code>random() &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns a random floating-point number between 0 (inclusive) and 1 (exclusive). Note that the value contains at most 53 bits of randomness.</p>
+</span></td><td>Volatile</td></tr>
+<tr><td><a name="random_normal"></a><code>random_normal() &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns a random floating-point value drawn from the standard normal distribution (mean 0, standard deviation 1).</p>
+</span></td><td>Volatile</td></tr>
+<tr><td><a name="random_normal"></a><code>random_normal(mean: <a href="float.html">float</a>, stddev: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns a random floating-point value drawn from a normal distribution with the given <code>mean</code> and <code>stddev</code>.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="round"></a><code>round(input: <a href="decimal.html">decimal</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Keeps <code>decimal_accuracy</code> number of figures to the right of the zero position in <code>input</code> using half away from zero rounding. If <code>decimal_accuracy</code> is not in the range -2^31…(2^31-1), the results are undefined.</p>
 </span></td><td>Immutable</td></tr>
@@ -1179,6 +1205,8 @@ available replica will error.</p>
 </span></td><td>Leakproof</td></tr>
 <tr><td><a name="crc32ieee"></a><code>crc32ieee(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the CRC-32 hash using the IEEE polynomial.</p>
 </span></td><td>Leakproof</td></tr>
+<tr><td><a name="factorial"></a><code>factorial(val: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the factorial of <code>val</code>. <code>val</code> must be between 0 and 32177 inclusive.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="fnv32"></a><code>fnv32(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1 hash value of a set of values.</p>
 </span></td><td>Leakproof</td></tr>
 <tr><td><a name="fnv32"></a><code>fnv32(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1 hash value of a set of values.</p>
@@ -1195,6 +1223,10 @@ available replica will error.</p>
 </span></td><td>Leakproof</td></tr>
 <tr><td><a name="fnv64a"></a><code>fnv64a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1a hash value of a set of values.</p>
 </span></td><td>Leakproof</td></tr>
+<tr><td><a name="gcd"></a><code>gcd(a: <a href="int.html">int</a>, b: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the greatest common divisor of <code>a</code> and <code>b</code>. Returns 0 if both inputs are 0; otherwise returns a positive value.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="lcm"></a><code>lcm(a: <a href="int.html">int</a>, b: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the least common multiple of <code>a</code> and <code>b</code>. Returns 0 if either input is 0.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="width_bucket"></a><code>width_bucket(operand: <a href="decimal.html">decimal</a>, b1: <a href="decimal.html">decimal</a>, b2: <a href="decimal.html">decimal</a>, count: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>return the bucket number to which operand would be assigned in a histogram having count equal-width buckets spanning the range b1 to b2. Returns 0 or count+1 for an input outside that range.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="width_bucket"></a><code>width_bucket(operand: <a href="int.html">int</a>, b1: <a href="int.html">int</a>, b2: <a href="int.html">int</a>, count: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>return the bucket number to which operand would be assigned in a histogram having count equal-width buckets spanning the range b1 to b2.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4846,3 +4846,128 @@ statement ok
 RESET search_path;
 
 subtest end
+
+subtest factorial
+
+query RRRR
+SELECT factorial(0), factorial(1), factorial(5), factorial(20)
+----
+1  1  120  2432902008176640000
+
+query R
+SELECT factorial(25)
+----
+15511210043330985984000000
+
+statement error pgcode 22003 factorial of a negative number is undefined
+SELECT factorial(-1)
+
+statement error pgcode 22003 value overflows numeric format
+SELECT factorial(32178)
+
+subtest end
+
+subtest gcd_lcm
+
+query IIII
+SELECT gcd(12, 18), gcd(0, 0), gcd(0, 7), gcd(-12, 18)
+----
+6  0  7  6
+
+query IIII
+SELECT lcm(4, 6), lcm(0, 7), lcm(7, 0), lcm(-4, 6)
+----
+12  0  0  12
+
+query II
+SELECT gcd(9223372036854775807, 3), lcm(9223372036854775807, 1)
+----
+1  9223372036854775807
+
+# gcd(MinInt64, 0) = 2^63 which overflows int64.
+statement error pgcode 22003 bigint out of range
+SELECT gcd(-9223372036854775808, 0)
+
+statement error pgcode 22003 bigint out of range
+SELECT lcm(9223372036854775807, 2)
+
+subtest end
+
+subtest scale_min_scale_trim_scale
+
+query IIII
+SELECT scale(1.234), scale(1.2300), scale(0), scale(100)
+----
+3  4  0  0
+
+query IIII
+SELECT min_scale(1.234), min_scale(1.2300), min_scale(0), min_scale(100.000)
+----
+3  2  0  0
+
+query RRRR
+SELECT trim_scale(1.23000), trim_scale(0.0), trim_scale(100.00), trim_scale(1.234)
+----
+1.23  0  100  1.234
+
+# NaN and Infinity return NULL for scale/min_scale.
+query II
+SELECT scale('NaN'::decimal), min_scale('Infinity'::decimal)
+----
+NULL  NULL
+
+# trim_scale passes NaN/Infinity through unchanged.
+query RR
+SELECT trim_scale('NaN'::decimal), trim_scale('Infinity'::decimal)
+----
+NaN  Infinity
+
+subtest end
+
+subtest log10
+
+query RR
+SELECT log10(1000::float), log10(1000::decimal)
+----
+3  3.0000000000000000000
+
+statement error pgcode 2201E cannot take logarithm of a negative number
+SELECT log10(-1::decimal)
+
+statement error pgcode 2201E cannot take logarithm of zero
+SELECT log10(0::decimal)
+
+subtest end
+
+subtest erf
+
+query RR
+SELECT round(erf(1)::numeric, 4), round(erfc(1)::numeric, 4)
+----
+0.8427  0.1573
+
+query RR
+SELECT erf(0::float), erfc(0::float)
+----
+0  1
+
+subtest end
+
+subtest random_normal
+
+# Non-deterministic; just check that the calls succeed and return floats.
+query BB
+SELECT random_normal() IS NOT NULL, random_normal(0, 1) IS NOT NULL
+----
+true  true
+
+# stddev=0 collapses to mean.
+query R
+SELECT random_normal(5, 0)
+----
+5
+
+statement error pgcode 22023 stddev cannot be negative
+SELECT random_normal(0, -1)
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4939,6 +4939,34 @@ SELECT log10(0::decimal)
 
 subtest end
 
+subtest log_int_args
+
+# PostgreSQL implicitly casts int to numeric for log/log10/ln; CRDB matches via
+# explicit int overloads.
+query RRR
+SELECT log(1000), log10(1000), ln(1)
+----
+3.0000000000000000000  3.0000000000000000000  0
+
+query R
+SELECT log(2, 64)
+----
+6.0000000000000000000
+
+statement error pgcode 2201E cannot take logarithm of zero
+SELECT log(0)
+
+statement error pgcode 2201E cannot take logarithm of a negative number
+SELECT log(-1)
+
+statement error pgcode 2201E cannot take logarithm of zero
+SELECT log(2, 0)
+
+statement error pgcode 2201E cannot take logarithm of a negative number
+SELECT log(-2, 8)
+
+subtest end
+
 subtest erf
 
 query RR

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4891,6 +4891,72 @@ SELECT gcd(-9223372036854775808, 0)
 statement error pgcode 22003 bigint out of range
 SELECT lcm(9223372036854775807, 2)
 
+# Decimal overloads. Cases mirror PostgreSQL's regression tests for numeric
+# gcd/lcm in src/test/regress/expected/numeric.out.
+query RRRRRRR
+SELECT a, b, gcd(a, b), gcd(a, -b), gcd(-b, a), gcd(-b, -a), gcd(b, a)
+FROM (VALUES (0::decimal, 0::decimal),
+             (0::decimal, 46375::decimal),
+             (433125::decimal, 46375::decimal),
+             (43312.5, 4637.5),
+             (4331.250, 463.75000)) AS v(a, b)
+ORDER BY a, b
+----
+0         0          0        0        0        0        0
+0         46375      46375    46375    46375    46375    46375
+4331.250  463.75000  8.75000  8.75000  8.75000  8.75000  8.75000
+43312.5   4637.5     87.5     87.5     87.5     87.5     87.5
+433125    46375      875      875      875      875      875
+
+# NaN/Infinity inputs yield NaN, regardless of position.
+query RRRRRR
+SELECT a, b, gcd(a, b), gcd(b, a), gcd(-a, b), gcd(a, -b)
+FROM (VALUES (0::decimal, 'NaN'::decimal),
+             ('Infinity'::decimal, 0::decimal),
+             ('Infinity'::decimal, 42::decimal),
+             ('Infinity'::decimal, 'Infinity'::decimal)) AS v(a, b)
+ORDER BY a, b
+----
+0         NaN       NaN  NaN  NaN  NaN
+Infinity  0         NaN  NaN  NaN  NaN
+Infinity  42        NaN  NaN  NaN  NaN
+Infinity  Infinity  NaN  NaN  NaN  NaN
+
+query RRRRRRR
+SELECT a, b, lcm(a, b), lcm(a, -b), lcm(-b, a), lcm(-b, -a), lcm(b, a)
+FROM (VALUES (0::decimal, 0::decimal),
+             (0::decimal, 13272::decimal),
+             (13272::decimal, 13272::decimal),
+             (423282::decimal, 13272::decimal),
+             (42328.2, 1327.2),
+             (4232.820, 132.72000)) AS v(a, b)
+ORDER BY a, b
+----
+0         0          0             0             0             0             0
+0         13272      0             0             0             0             0
+4232.820  132.72000  118518.96000  118518.96000  118518.96000  118518.96000  118518.96000
+13272     13272      13272         13272         13272         13272         13272
+42328.2   1327.2     1185189.6     1185189.6     1185189.6     1185189.6     1185189.6
+423282    13272      11851896      11851896      11851896      11851896      11851896
+
+query RRRRRR
+SELECT a, b, lcm(a, b), lcm(b, a), lcm(-a, b), lcm(a, -b)
+FROM (VALUES (0::decimal, 'NaN'::decimal),
+             ('Infinity'::decimal, 0::decimal),
+             ('Infinity'::decimal, 42::decimal),
+             ('Infinity'::decimal, 'Infinity'::decimal)) AS v(a, b)
+ORDER BY a, b
+----
+0         NaN       NaN  NaN  NaN  NaN
+Infinity  0         NaN  NaN  NaN  NaN
+Infinity  42        NaN  NaN  NaN  NaN
+Infinity  Infinity  NaN  NaN  NaN  NaN
+
+# Decimal lcm overflow. CockroachDB hits the limit earlier than PostgreSQL
+# because the high-precision context caps at 2000 digits.
+statement error pgcode 22003 value overflows numeric format
+SELECT lcm(1e2000::decimal, 3::decimal)
+
 subtest end
 
 subtest scale_min_scale_trim_scale

--- a/pkg/sql/pgwire/testdata/pgtest/procedure
+++ b/pkg/sql/pgwire/testdata/pgtest/procedure
@@ -66,9 +66,9 @@ Query {"String": "CALL p()"}
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func401","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func401","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func401","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -84,8 +84,8 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func399","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func401","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func401","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func401","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2175,6 +2175,36 @@ var regularBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	"random_normal": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDFloat(tree.DFloat(evalCtx.GetRNG().NormFloat64())), nil
+			},
+			Info:       "Returns a random floating-point value drawn from the standard normal distribution (mean 0, standard deviation 1).",
+			Volatility: volatility.Volatile,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "mean", Typ: types.Float},
+				{Name: "stddev", Typ: types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Float),
+			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				mean := float64(tree.MustBeDFloat(args[0]))
+				stddev := float64(tree.MustBeDFloat(args[1]))
+				if stddev < 0 {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "stddev cannot be negative")
+				}
+				return tree.NewDFloat(tree.DFloat(stddev*evalCtx.GetRNG().NormFloat64() + mean)), nil
+			},
+			Info:       "Returns a random floating-point value drawn from a normal distribution with the given `mean` and `stddev`.",
+			Volatility: volatility.Volatile,
+		},
+	),
+
 	"setseed": makeBuiltin(
 		defProps(),
 		tree.Overload{

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2913,6 +2913,18 @@ var builtinOidsArray = []string{
 	2958: `pg_try_advisory_xact_lock(key1: int4, key2: int4) -> bool`,
 	2959: `pg_try_advisory_xact_lock_shared(key: int) -> bool`,
 	2960: `pg_try_advisory_xact_lock_shared(key1: int4, key2: int4) -> bool`,
+	2961: `random_normal() -> float`,
+	2962: `random_normal(mean: float, stddev: float) -> float`,
+	2963: `factorial(val: int) -> decimal`,
+	2964: `gcd(a: int, b: int) -> int`,
+	2965: `lcm(a: int, b: int) -> int`,
+	2966: `scale(val: decimal) -> int4`,
+	2967: `min_scale(val: decimal) -> int4`,
+	2968: `trim_scale(val: decimal) -> decimal`,
+	2969: `log10(val: float) -> float`,
+	2970: `log10(val: decimal) -> decimal`,
+	2971: `erf(val: float) -> float`,
+	2972: `erfc(val: float) -> float`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2929,6 +2929,8 @@ var builtinOidsArray = []string{
 	2974: `log(val: int) -> decimal`,
 	2975: `log(b: int, x: int) -> decimal`,
 	2976: `log10(val: int) -> decimal`,
+	2977: `gcd(a: decimal, b: decimal) -> decimal`,
+	2978: `lcm(a: decimal, b: decimal) -> decimal`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2925,6 +2925,10 @@ var builtinOidsArray = []string{
 	2970: `log10(val: decimal) -> decimal`,
 	2971: `erf(val: float) -> float`,
 	2972: `erfc(val: float) -> float`,
+	2973: `ln(val: int) -> decimal`,
+	2974: `log(val: int) -> decimal`,
+	2975: `log(b: int, x: int) -> decimal`,
+	2976: `log10(val: int) -> decimal`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -291,6 +291,11 @@ var mathBuiltins = map[string]builtinDefinition{
 				"Returns 0 if both inputs are 0; otherwise returns a positive value.",
 			Volatility: volatility.Immutable,
 		},
+		decimalOverload2("a", "b", decimalGCD,
+			"Calculates the greatest common divisor of `a` and `b`. "+
+				"Returns 0 if both inputs are 0; otherwise returns a positive value. "+
+				"Returns NaN if either input is NaN or Infinity.",
+			volatility.Immutable),
 	),
 
 	"isnan": makeBuiltin(defProps(),
@@ -328,6 +333,10 @@ var mathBuiltins = map[string]builtinDefinition{
 				"Returns 0 if either input is 0.",
 			Volatility: volatility.Immutable,
 		},
+		decimalOverload2("a", "b", decimalLCM,
+			"Calculates the least common multiple of `a` and `b`. "+
+				"Returns 0 if either input is 0. Returns NaN if either input is NaN or Infinity.",
+			volatility.Immutable),
 	),
 
 	"ln": makeBuiltin(defProps(),
@@ -1006,6 +1015,139 @@ func intLCM(a, b int64) (tree.Datum, error) {
 		return nil, errIntOutOfRange
 	}
 	return tree.NewDInt(tree.DInt(res.Int64())), nil
+}
+
+// decimalGCD returns the greatest common divisor of x and y as a non-negative
+// DDecimal, matching PostgreSQL's numeric_gcd semantics:
+//   - If either input is NaN or Infinity, the result is NaN.
+//   - The result is always non-negative.
+//   - The display scale of the result is max(scale(x), scale(y)), so e.g.
+//     gcd(1.0, 2) returns 1.0 rather than 1.
+//
+// Errors with "value overflows numeric format" if an intermediate computation
+// exceeds the supported decimal range.
+func decimalGCD(x, y *apd.Decimal) (tree.Datum, error) {
+	if x.Form != apd.Finite || y.Form != apd.Finite {
+		return &tree.DDecimal{Decimal: apd.Decimal{Form: apd.NaN}}, nil
+	}
+	resScale := decimalScale(x)
+	if s := decimalScale(y); s > resScale {
+		resScale = s
+	}
+	dd := &tree.DDecimal{}
+	if err := decimalGCDExact(&dd.Decimal, x, y); err != nil {
+		return nil, err
+	}
+	dd.Negative = false
+	if err := expandDecimalScale(&dd.Decimal, resScale); err != nil {
+		return nil, err
+	}
+	return dd, nil
+}
+
+// decimalLCM returns the least common multiple of x and y, computed in
+// arbitrary-precision decimal space. Matches PostgreSQL's numeric_lcm:
+//   - If either input is NaN or Infinity, the result is NaN.
+//   - If either input is 0, the result is 0.
+//   - Otherwise, the result is |x / gcd(x, y) * y|.
+//   - The display scale of the result is max(scale(x), scale(y)).
+//
+// Errors with "value overflows numeric format" if the result exceeds the
+// supported decimal range.
+func decimalLCM(x, y *apd.Decimal) (tree.Datum, error) {
+	if x.Form != apd.Finite || y.Form != apd.Finite {
+		return &tree.DDecimal{Decimal: apd.Decimal{Form: apd.NaN}}, nil
+	}
+	resScale := decimalScale(x)
+	if s := decimalScale(y); s > resScale {
+		resScale = s
+	}
+	dd := &tree.DDecimal{}
+	if x.IsZero() || y.IsZero() {
+		if err := expandDecimalScale(&dd.Decimal, resScale); err != nil {
+			return nil, err
+		}
+		return dd, nil
+	}
+	var g apd.Decimal
+	if err := decimalGCDExact(&g, x, y); err != nil {
+		return nil, err
+	}
+	g.Negative = false
+	// |x / gcd(x, y) * y|. The division is exact since g divides x; using
+	// QuoInteger gives a clean integer result without trailing-zero padding
+	// from precision-driven rounding.
+	var quo apd.Decimal
+	if cond, err := tree.HighPrecisionCtx.QuoInteger(&quo, x, &g); err != nil {
+		if isDecimalOverflow(cond) {
+			return nil, errFactorialOverflow
+		}
+		return nil, err
+	}
+	if cond, err := tree.HighPrecisionCtx.Mul(&dd.Decimal, &quo, y); err != nil {
+		if isDecimalOverflow(cond) {
+			return nil, errFactorialOverflow
+		}
+		return nil, err
+	}
+	dd.Negative = false
+	if err := expandDecimalScale(&dd.Decimal, resScale); err != nil {
+		return nil, err
+	}
+	return dd, nil
+}
+
+// decimalGCDExact runs the Euclidean algorithm on |x| and |y|, writing the
+// result to g. Both inputs must be finite. The result is always non-negative.
+func decimalGCDExact(g, x, y *apd.Decimal) error {
+	var a, b apd.Decimal
+	a.Set(x)
+	a.Negative = false
+	b.Set(y)
+	b.Negative = false
+	// Arrange for |a| >= |b| so the first Rem isn't a no-op.
+	if a.Cmp(&b) < 0 {
+		a, b = b, a
+	}
+	var mod apd.Decimal
+	for b.Sign() != 0 {
+		if cond, err := tree.HighPrecisionCtx.Rem(&mod, &a, &b); err != nil {
+			if isDecimalOverflow(cond) {
+				return errFactorialOverflow
+			}
+			return err
+		}
+		a.Set(&b)
+		b.Set(&mod)
+	}
+	g.Set(&a)
+	return nil
+}
+
+// isDecimalOverflow reports whether cond signals that an arithmetic result
+// exceeded the supported decimal range. DivisionImpossible is included
+// because QuoInteger raises it when the integer quotient does not fit in
+// the configured precision, which for our purposes is also an overflow.
+func isDecimalOverflow(cond apd.Condition) bool {
+	return cond.Overflow() || cond.SystemOverflow() || cond.DivisionImpossible()
+}
+
+// expandDecimalScale grows d in-place so that its display scale is at least
+// resScale (i.e. it has at least resScale fractional digits). If d already
+// has a smaller exponent (more fractional digits), it is left unchanged. The
+// numeric value is preserved.
+func expandDecimalScale(d *apd.Decimal, resScale int32) error {
+	target := -resScale
+	if d.Exponent <= target {
+		return nil
+	}
+	if int64(d.Exponent-target) > int64(tree.DecimalCtx.MaxExponent) {
+		return errFactorialOverflow
+	}
+	pow := apd.NewBigInt(0).Exp(bigTen, apd.NewBigInt(int64(d.Exponent-target)), nil)
+	d.Coeff.Mul(&d.Coeff, pow)
+	d.Exponent = target
+	return nil
 }
 
 // decimalScale returns the number of fractional digits in d, mirroring the

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -335,6 +335,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Log(x))), nil
 		}, "Calculates the natural log of `val`.", volatility.Immutable),
 		decimalLogFn(tree.DecimalCtx.Ln, "Calculates the natural log of `val`."),
+		intLogFn(tree.DecimalCtx.Ln, "Calculates the natural log of `val`."),
 	),
 
 	"log": makeBuiltin(defProps(),
@@ -357,36 +358,9 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Log10(x) / math.Log10(b))), nil
 		}, "Calculates the base `b` log of `val`.", volatility.Immutable),
 		decimalLogFn(tree.DecimalCtx.Log10, "Calculates the base 10 log of `val`."),
-		decimalOverload2("b", "x", func(b, x *apd.Decimal) (tree.Datum, error) {
-			switch x.Sign() {
-			case -1:
-				return nil, errLogOfNegNumber
-			case 0:
-				return nil, errLogOfZero
-			}
-			switch b.Sign() {
-			case -1:
-				return nil, errLogOfNegNumber
-			case 0:
-				return nil, errLogOfZero
-			}
-			if isInf(b) {
-				return &tree.DDecimal{Decimal: *decimalZero}, nil
-			}
-
-			top := new(apd.Decimal)
-			if _, err := tree.IntermediateCtx.Ln(top, x); err != nil {
-				return nil, err
-			}
-			bot := new(apd.Decimal)
-			if _, err := tree.IntermediateCtx.Ln(bot, b); err != nil {
-				return nil, err
-			}
-
-			dd := &tree.DDecimal{}
-			_, err := tree.DecimalCtx.Quo(&dd.Decimal, top, bot)
-			return dd, err
-		}, "Calculates the base `b` log of `val`.", volatility.Immutable),
+		decimalOverload2("b", "x", decimalLogBaseB, "Calculates the base `b` log of `val`.", volatility.Immutable),
+		intLogFn(tree.DecimalCtx.Log10, "Calculates the base 10 log of `val`."),
+		intLogBaseBOverload(),
 	),
 
 	"log10": makeBuiltin(defProps(),
@@ -394,6 +368,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Log10(x))), nil
 		}, "Calculates the base 10 log of `val`.", volatility.Immutable),
 		decimalLogFn(tree.DecimalCtx.Log10, "Calculates the base 10 log of `val`."),
+		intLogFn(tree.DecimalCtx.Log10, "Calculates the base 10 log of `val`."),
 	),
 
 	"min_scale": makeBuiltin(defProps(),
@@ -833,6 +808,84 @@ func decimalLogFn(
 		_, err := logFn(&dd.Decimal, x)
 		return dd, err
 	}, info, volatility.Immutable)
+}
+
+// intLogFn returns a log overload for an int argument that mirrors the
+// PostgreSQL behavior of implicitly casting int to numeric and dispatching
+// to the numeric log implementation.
+func intLogFn(
+	logFn func(*apd.Decimal, *apd.Decimal) (apd.Condition, error), info string,
+) tree.Overload {
+	return tree.Overload{
+		Types:      tree.ParamTypes{{Name: "val", Typ: types.Int}},
+		ReturnType: tree.FixedReturnType(types.Decimal),
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			x := int64(tree.MustBeDInt(args[0]))
+			switch {
+			case x < 0:
+				return nil, errLogOfNegNumber
+			case x == 0:
+				return nil, errLogOfZero
+			}
+			var d apd.Decimal
+			d.SetInt64(x)
+			dd := &tree.DDecimal{}
+			_, err := logFn(&dd.Decimal, &d)
+			return dd, err
+		},
+		Info:       info,
+		Volatility: volatility.Immutable,
+	}
+}
+
+// decimalLogBaseB computes the base-`b` logarithm of `x` as a decimal,
+// shared between the decimal and int two-argument log overloads.
+func decimalLogBaseB(b, x *apd.Decimal) (tree.Datum, error) {
+	switch x.Sign() {
+	case -1:
+		return nil, errLogOfNegNumber
+	case 0:
+		return nil, errLogOfZero
+	}
+	switch b.Sign() {
+	case -1:
+		return nil, errLogOfNegNumber
+	case 0:
+		return nil, errLogOfZero
+	}
+	if isInf(b) {
+		return &tree.DDecimal{Decimal: *decimalZero}, nil
+	}
+
+	top := new(apd.Decimal)
+	if _, err := tree.IntermediateCtx.Ln(top, x); err != nil {
+		return nil, err
+	}
+	bot := new(apd.Decimal)
+	if _, err := tree.IntermediateCtx.Ln(bot, b); err != nil {
+		return nil, err
+	}
+
+	dd := &tree.DDecimal{}
+	_, err := tree.DecimalCtx.Quo(&dd.Decimal, top, bot)
+	return dd, err
+}
+
+// intLogBaseBOverload returns the log(b: int, x: int) -> decimal overload,
+// mirroring PostgreSQL's implicit cast of int args to numeric for log/2.
+func intLogBaseBOverload() tree.Overload {
+	return tree.Overload{
+		Types:      tree.ParamTypes{{Name: "b", Typ: types.Int}, {Name: "x", Typ: types.Int}},
+		ReturnType: tree.FixedReturnType(types.Decimal),
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			var b, x apd.Decimal
+			b.SetInt64(int64(tree.MustBeDInt(args[0])))
+			x.SetInt64(int64(tree.MustBeDInt(args[1])))
+			return decimalLogBaseB(&b, &x)
+		},
+		Info:       "Calculates the base `b` log of `val`.",
+		Volatility: volatility.Immutable,
+	}
 }
 
 func floatOverload1(

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -27,9 +27,12 @@ func init() {
 }
 
 var (
-	errAbsOfMinInt64  = pgerror.New(pgcode.NumericValueOutOfRange, "abs of min integer value (-9223372036854775808) not defined")
-	errLogOfNegNumber = pgerror.New(pgcode.InvalidArgumentForLogarithm, "cannot take logarithm of a negative number")
-	errLogOfZero      = pgerror.New(pgcode.InvalidArgumentForLogarithm, "cannot take logarithm of zero")
+	errAbsOfMinInt64       = pgerror.New(pgcode.NumericValueOutOfRange, "abs of min integer value (-9223372036854775808) not defined")
+	errLogOfNegNumber      = pgerror.New(pgcode.InvalidArgumentForLogarithm, "cannot take logarithm of a negative number")
+	errLogOfZero           = pgerror.New(pgcode.InvalidArgumentForLogarithm, "cannot take logarithm of zero")
+	errFactorialOfNegative = pgerror.New(pgcode.NumericValueOutOfRange, "factorial of a negative number is undefined")
+	errFactorialOverflow   = pgerror.New(pgcode.NumericValueOutOfRange, "value overflows numeric format")
+	errIntOutOfRange       = pgerror.New(pgcode.NumericValueOutOfRange, "bigint out of range")
 
 	bigTen = apd.NewBigInt(10)
 )
@@ -212,6 +215,18 @@ var mathBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	"erf": makeBuiltin(defProps(),
+		floatOverload1(func(x float64) (tree.Datum, error) {
+			return tree.NewDFloat(tree.DFloat(math.Erf(x))), nil
+		}, "Calculates the error function of `val`.", volatility.Immutable),
+	),
+
+	"erfc": makeBuiltin(defProps(),
+		floatOverload1(func(x float64) (tree.Datum, error) {
+			return tree.NewDFloat(tree.DFloat(math.Erfc(x))), nil
+		}, "Calculates the complementary error function: `1 - erf(val)`.", volatility.Immutable),
+	),
+
 	"exp": makeBuiltin(defProps(),
 		floatOverload1(func(x float64) (tree.Datum, error) {
 			return tree.NewDFloat(tree.DFloat(math.Exp(x))), nil
@@ -221,6 +236,28 @@ var mathBuiltins = map[string]builtinDefinition{
 			_, err := tree.DecimalCtx.Exp(&dd.Decimal, x)
 			return dd, err
 		}, "Calculates *e* ^ `val`.", volatility.Immutable),
+	),
+
+	"factorial": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.Int}},
+			ReturnType: tree.FixedReturnType(types.Decimal),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				n := int64(tree.MustBeDInt(args[0]))
+				switch {
+				case n < 0:
+					return nil, errFactorialOfNegative
+				case n > 32177:
+					// PostgreSQL's numeric type cannot represent 32178! or larger.
+					return nil, errFactorialOverflow
+				}
+				dd := &tree.DDecimal{}
+				dd.Coeff.MulRange(1, n)
+				return dd, nil
+			},
+			Info:       "Calculates the factorial of `val`. `val` must be between 0 and 32177 inclusive.",
+			Volatility: volatility.Immutable,
+		},
 	),
 
 	"floor": makeBuiltin(defProps(),
@@ -239,6 +276,19 @@ var mathBuiltins = map[string]builtinDefinition{
 				return tree.NewDFloat(tree.DFloat(float64(*args[0].(*tree.DInt)))), nil
 			},
 			Info:       "Calculates the largest integer not greater than `val`.",
+			Volatility: volatility.Immutable,
+		},
+	),
+
+	"gcd": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "a", Typ: types.Int}, {Name: "b", Typ: types.Int}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return intGCD(int64(tree.MustBeDInt(args[0])), int64(tree.MustBeDInt(args[1])))
+			},
+			Info: "Calculates the greatest common divisor of `a` and `b`. " +
+				"Returns 0 if both inputs are 0; otherwise returns a positive value.",
 			Volatility: volatility.Immutable,
 		},
 	),
@@ -263,6 +313,19 @@ var mathBuiltins = map[string]builtinDefinition{
 				return tree.MakeDBool(tree.DBool(isNaN)), nil
 			},
 			Info:       "Returns true if `val` is NaN, false otherwise.",
+			Volatility: volatility.Immutable,
+		},
+	),
+
+	"lcm": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "a", Typ: types.Int}, {Name: "b", Typ: types.Int}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return intLCM(int64(tree.MustBeDInt(args[0])), int64(tree.MustBeDInt(args[1])))
+			},
+			Info: "Calculates the least common multiple of `a` and `b`. " +
+				"Returns 0 if either input is 0.",
 			Volatility: volatility.Immutable,
 		},
 	),
@@ -324,6 +387,31 @@ var mathBuiltins = map[string]builtinDefinition{
 			_, err := tree.DecimalCtx.Quo(&dd.Decimal, top, bot)
 			return dd, err
 		}, "Calculates the base `b` log of `val`.", volatility.Immutable),
+	),
+
+	"log10": makeBuiltin(defProps(),
+		floatOverload1(func(x float64) (tree.Datum, error) {
+			return tree.NewDFloat(tree.DFloat(math.Log10(x))), nil
+		}, "Calculates the base 10 log of `val`.", volatility.Immutable),
+		decimalLogFn(tree.DecimalCtx.Log10, "Calculates the base 10 log of `val`."),
+	),
+
+	"min_scale": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.Decimal}},
+			ReturnType: tree.FixedReturnType(types.Int4),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				d := &args[0].(*tree.DDecimal).Decimal
+				if d.Form != apd.Finite {
+					return tree.DNull, nil
+				}
+				var reduced apd.Decimal
+				reduced.Reduce(d)
+				return tree.NewDInt(tree.DInt(decimalScale(&reduced))), nil
+			},
+			Info:       "Returns the minimum scale (number of fractional decimal digits) needed to represent `val` exactly.",
+			Volatility: volatility.Immutable,
+		},
 	),
 
 	"mod": makeBuiltin(defProps(),
@@ -430,6 +518,22 @@ var mathBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	"scale": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.Decimal}},
+			ReturnType: tree.FixedReturnType(types.Int4),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				d := &args[0].(*tree.DDecimal).Decimal
+				if d.Form != apd.Finite {
+					return tree.DNull, nil
+				}
+				return tree.NewDInt(tree.DInt(decimalScale(d))), nil
+			},
+			Info:       "Returns the scale (number of fractional decimal digits) of `val`.",
+			Volatility: volatility.Immutable,
+		},
+	),
+
 	"sin": makeBuiltin(defProps(),
 		floatOverload1(func(x float64) (tree.Datum, error) {
 			return tree.NewDFloat(tree.DFloat(math.Sin(x))), nil
@@ -509,6 +613,27 @@ var mathBuiltins = map[string]builtinDefinition{
 		floatOverload1(func(x float64) (tree.Datum, error) {
 			return tree.NewDFloat(tree.DFloat(math.Tanh(x))), nil
 		}, "Calculates the hyperbolic tangent of `val`.", volatility.Immutable),
+	),
+
+	"trim_scale": makeBuiltin(defProps(),
+		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
+			dd := &tree.DDecimal{}
+			if x.Form != apd.Finite {
+				dd.Decimal.Set(x)
+				return dd, nil
+			}
+			dd.Decimal.Reduce(x)
+			// Reduce strips trailing zeros from the coefficient including those
+			// to the left of the decimal point (e.g. 100 -> 1E+2). PostgreSQL's
+			// trim_scale only trims zeros in the fractional part, so restore any
+			// positive exponent by scaling the coefficient back to exponent 0.
+			if dd.Exponent > 0 {
+				scale := apd.NewBigInt(0).Exp(bigTen, apd.NewBigInt(int64(dd.Exponent)), nil)
+				dd.Coeff.Mul(&dd.Coeff, scale)
+				dd.Exponent = 0
+			}
+			return dd, nil
+		}, "Returns `val` with any trailing zeros after the decimal point removed.", volatility.Immutable),
 	),
 
 	"trunc": makeBuiltin(defProps(),
@@ -791,6 +916,53 @@ func roundDecimal(x *apd.Decimal, scale int32) (tree.Datum, error) {
 		dd.Negative = false
 	}
 	return dd, err
+}
+
+// intGCD returns the greatest common divisor of a and b as a non-negative
+// DInt, matching PostgreSQL semantics: gcd(0, 0) = 0, and otherwise the
+// result is positive. Errors with bigint-out-of-range when the result does
+// not fit in an int64 (only possible for gcd(MinInt64, 0)).
+func intGCD(a, b int64) (tree.Datum, error) {
+	var ba, bb, g apd.BigInt
+	ba.SetInt64(a)
+	bb.SetInt64(b)
+	g.GCD(nil, nil, &ba, &bb) // lint: uppercase function OK
+	if !g.IsInt64() {
+		return nil, errIntOutOfRange
+	}
+	return tree.NewDInt(tree.DInt(g.Int64())), nil
+}
+
+// intLCM returns the least common multiple of a and b, computed in
+// arbitrary-precision integer space to avoid intermediate overflow. Returns
+// 0 if either input is 0. Errors with bigint-out-of-range when the result
+// does not fit in an int64.
+func intLCM(a, b int64) (tree.Datum, error) {
+	if a == 0 || b == 0 {
+		return tree.DZero, nil
+	}
+	var ba, bb, g, res apd.BigInt
+	ba.SetInt64(a)
+	bb.SetInt64(b)
+	g.GCD(nil, nil, &ba, &bb) // lint: uppercase function OK
+	// |a / gcd(a, b) * b|.
+	res.Quo(&ba, &g)
+	res.Mul(&res, &bb)
+	res.Abs(&res)
+	if !res.IsInt64() {
+		return nil, errIntOutOfRange
+	}
+	return tree.NewDInt(tree.DInt(res.Int64())), nil
+}
+
+// decimalScale returns the number of fractional digits in d, mirroring the
+// PostgreSQL scale() semantics. The caller is responsible for handling the
+// non-finite forms (NaN, Infinity).
+func decimalScale(d *apd.Decimal) int32 {
+	if d.Exponent >= 0 {
+		return 0
+	}
+	return -d.Exponent
 }
 
 // widthBucket returns the bucket number to which operand would be assigned in a histogram having count


### PR DESCRIPTION
Adds a set of math built-in functions that PostgreSQL exposes but CockroachDB was missing, for users porting from PG:

- factorial(int) -> decimal: matches PG's numeric_fac, including the 32177 upper bound and the "factorial of a negative number is undefined" error introduced in PG13.
- gcd(int, int) and lcm(int, int): computed in arbitrary-precision integer space to avoid intermediate overflow; gcd(MinInt64, 0) and overflowing lcm results error with "bigint out of range".
- scale(decimal), min_scale(decimal), trim_scale(decimal): inspect or trim the fractional scale of a decimal. NaN/Infinity return NULL for scale/min_scale and pass through unchanged for trim_scale. trim_scale clamps a positive exponent back to 0 so that e.g. trim_scale(100.00) renders as 100, not 1E+2.
- log10(float) and log10(decimal): base-10 log overloads, reusing the existing decimalLogFn helper.
- erf(float) and erfc(float): error function and complementary error function, wrapping math.Erf and math.Erfc.
- random_normal() and random_normal(mean, stddev): floats drawn from a normal distribution, sharing the session-scoped RNG with the existing random()/setseed() builtins. A negative stddev errors with "stddev cannot be negative".

PostgreSQL removed the postfix ! and prefix !! factorial operators in v14, so this change does not introduce them.

resolves https://github.com/cockroachdb/cockroach/issues/160055
Epic: CRDB-60811

Release note (sql change): Added PostgreSQL-compatible built-in functions factorial, gcd, lcm, scale, min_scale, trim_scale, log10, erf, erfc, and random_normal.