### PR TITLE
admission: add modeStrategy interface with serverlessStrategy

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -7,7 +7,6 @@ package admission
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"time"
 
@@ -246,6 +245,9 @@ var _ cpuTimeTokenAllocatorI = &cpuTimeTokenAllocator{}
 // responsibility of cpuTimeTokenAllocator is to gradually allocate tokens
 // every interval, while respecting the bucket capacities. The computation
 // of the rate of tokens to add every interval is left to cpuTimeModel.
+//
+// Mode-specific behavior (target computation and burst bucket refill)
+// is delegated to a modeStrategy, which is swapped on mode transitions.
 type cpuTimeTokenAllocator struct {
 	granter *cpuTimeTokenGranter
 	// queues holds references to WorkQueues for each resource tier. Used to
@@ -255,6 +257,10 @@ type cpuTimeTokenAllocator struct {
 	settings *cluster.Settings
 	model    cpuTimeModel
 	metrics  *cpuTimeTokenMetrics
+	// strategy is only accessed by the filler goroutine (via
+	// allocateTokens and resetInterval), so no synchronization is
+	// needed.
+	strategy modeStrategy
 
 	// refillRates stores the number of CPU time tokens to add to each bucket
 	// per interval (1s).
@@ -263,6 +269,64 @@ type cpuTimeTokenAllocator struct {
 	// cpuTimeTokenAllocator. No mutex, since only a single goroutine will call
 	// the allocator.
 	allocated tokenCounts
+}
+
+// modeStrategy encapsulates the mode-specific behavior of the
+// cpuTimeTokenAllocator. serverlessStrategy implements it for
+// Serverless mode; rmStrategy will be added for resource manager mode.
+type modeStrategy interface {
+	mode() cpuTimeTokenMode
+	// computeTargets reads mode-specific cluster settings and returns
+	// the target utilizations for model fitting.
+	computeTargets(sv *settings.Values) targetUtilizations
+	// refillBurst refills per-tenant burst buckets. tokens is the
+	// per-tick allocation (from allocateTokens) or per-interval delta
+	// (from resetInterval). refillRates is the current refill rates.
+	refillBurst(tokens tokenCounts, refillRates rates)
+}
+
+// serverlessStrategy implements modeStrategy for Serverless mode,
+// which uses 2 WorkQueues (systemTenant, appTenant) with per-tier
+// utilization targets. Each tier's burst bucket gets noBurst/4 of
+// that tier's allocation and rate.
+type serverlessStrategy struct {
+	queues [numResourceTiers]workQueueIForAllocator
+}
+
+func (s *serverlessStrategy) mode() cpuTimeTokenMode {
+	return serverlessMode
+}
+
+func (s *serverlessStrategy) computeTargets(sv *settings.Values) targetUtilizations {
+	if numResourceTiers != 2 || numBurstQualifications != 2 {
+		panic(errors.AssertionFailedf(
+			"computeTargets requires numResourceTiers=2 and "+
+				"numBurstQualifications=2 but got %d, %d",
+			numResourceTiers, numBurstQualifications))
+	}
+	// Compute target utilizations from cluster settings. The noBurst targets are
+	// configurable by cluster settings. A canBurst target adds a delta to the
+	// corresponding noBurst target, and the delta is also configurable by a
+	// cluster setting. The code here is not general with respect to
+	// numResourceTiers & numBurstQualifications. This isn't necessary for the
+	// Serverless use case on which we will first introduce CPU time token AC.
+	burstDelta := KVCPUTimeUtilBurstDelta.Get(sv)
+	var targets targetUtilizations
+	appTarget := KVCPUTimeAppUtilGoal.Get(sv)
+	targets[appTenant][noBurst] = appTarget
+	targets[appTenant][canBurst] = appTarget + burstDelta
+	systemTarget := KVCPUTimeSystemUtilGoal.Get(sv)
+	targets[systemTenant][noBurst] = systemTarget
+	targets[systemTenant][canBurst] = systemTarget + burstDelta
+	return targets
+}
+
+func (s *serverlessStrategy) refillBurst(tokens tokenCounts, refillRates rates) {
+	for tier := range s.queues {
+		toAdd := tokens[tier][noBurst] / 4
+		burstCapacity := refillRates[tier][noBurst] / 4
+		s.queues[tier].refillBurstBuckets(toAdd, burstCapacity)
+	}
 }
 
 // rates stores a token count per second, for example, the refill
@@ -410,35 +474,13 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	// default values, this implies that an application tenant can burst,
 	// if they are using roughly less than 20% of the CPU on a CRDB node
 	// (0.8 * 0.25 = 0.2).
-	for resourceTier := range numResourceTiers {
-		toAdd := allocations[resourceTier][noBurst] / 4
-		burstCapacity := a.refillRates[resourceTier][noBurst] / 4
-		a.queues[resourceTier].refillBurstBuckets(toAdd, burstCapacity)
-	}
+	a.strategy.refillBurst(allocations, a.refillRates)
 }
 
-// resetInterval is called to signal the beginning of a new interval.
-// allocateTokens adds the desired number of tokens every interval.
+// resetInterval recomputes refill rates and applies the delta to the
+// granter and burst buckets.
 func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
-	// Compute target utilizations from cluster settings. The noBurst targets are
-	// configurable by cluster settings. A canBurst target adds a delta to the
-	// corresponding noBurst target, and the delta is also configurable by a
-	// cluster setting. The code here is not general with respect to
-	// numResourceTiers & numBurstQualifications. This isn't necessary for the
-	// Serverless use case on which we will first introduce CPU time token AC.
-	var targets targetUtilizations
-	if numResourceTiers != 2 || numBurstQualifications != 2 {
-		panic(fmt.Sprintf(
-			"resetInterval requires that numResourceTiers = 2 and numBurstQualifications = 2 but got %d, %d", numResourceTiers, numBurstQualifications))
-	}
-	burstDelta := KVCPUTimeUtilBurstDelta.Get(&a.settings.SV)
-	appTarget := KVCPUTimeAppUtilGoal.Get(&a.settings.SV)
-	targets[appTenant][noBurst] = appTarget
-	targets[appTenant][canBurst] = appTarget + burstDelta
-	systemTarget := KVCPUTimeSystemUtilGoal.Get(&a.settings.SV)
-	targets[systemTenant][noBurst] = systemTarget
-	targets[systemTenant][canBurst] = systemTarget + burstDelta
-
+	targets := a.strategy.computeTargets(&a.settings.SV)
 	newRefillRates := a.model.fit(ctx, targets)
 
 	// deltaRefillRates is the difference in tokens to add per interval (1s)
@@ -465,13 +507,8 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 	refillGranter(a.granter, a.metrics, deltaRefillRates,
 		bucketCapacities, bucketMinimums, true /* updateMetrics */)
 	a.refillRates = newRefillRates
-
 	// Apply the delta to the per-group burst buckets also.
-	for resourceTier := range numResourceTiers {
-		toAdd := deltaRefillRates[resourceTier][noBurst] / 4
-		burstCapacity := bucketCapacities[resourceTier][noBurst] / 4
-		a.queues[resourceTier].refillBurstBuckets(toAdd, burstCapacity)
-	}
+	a.strategy.refillBurst(deltaRefillRates, a.refillRates)
 
 	// Reset allocated.
 	for wc := range a.allocated {
@@ -479,6 +516,40 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 			a.allocated[wc][kind] = 0
 		}
 	}
+}
+
+// newStrategy constructs the modeStrategy for the given mode. Queue
+// side effects are not applied here; resetInterval applies them
+// after the refill is complete.
+//
+// No explicit bucket reset is needed on mode switch. The granter's
+// tier-1 buckets stay alive across transitions, and the delta
+// mechanism in resetInterval (deltaRefillRates) adjusts all bucket
+// token counts to converge to the new mode's rates within one
+// interval (1s). In-flight work in queue[1] during a serverless-to-RM
+// switch may stall (no new refill routed there), but will time out
+// via the WorkQueue's normal deadline handling.
+func (a *cpuTimeTokenAllocator) newStrategy(mode cpuTimeTokenMode) modeStrategy {
+	switch mode {
+	case offMode:
+		panic(errors.AssertionFailedf("offMode is not a valid strategy; callers must guard against it"))
+	case serverlessMode:
+		return &serverlessStrategy{queues: a.queues}
+	case resourceManagerMode:
+		// TODO(wenyihu6): implement this
+		panic(errors.AssertionFailedf("resourceManagerMode not implemented yet"))
+	default:
+		panic(errors.AssertionFailedf("unknown cpuTimeTokenMode: %d", mode))
+	}
+}
+
+// configureQueue applies mode-specific settings to the WorkQueue.
+// Called at the end of resetInterval after refill is complete.
+//
+// TODO(wenyihu6): This will become unnecessary once serverless
+// tenants are modeled as resource groups in a single WorkQueue.
+func (a *cpuTimeTokenAllocator) configureQueue() {
+	a.queues[0].setUseResourceGroup(a.strategy.mode() == resourceManagerMode)
 }
 
 // refillGranter increments per-bucket refill metrics, then delegates to
@@ -506,10 +577,11 @@ func refillGranter(
 	granter.refill(toAdd, bucketCapacities, bucketMinimums, updateMetrics)
 }
 
-// workQueueIForAllocator abstracts the burst bucket refill method in WorkQueue,
-// to enable unit testing.
+// workQueueIForAllocator abstracts the burst bucket refill methods in
+// WorkQueue, to enable unit testing.
 type workQueueIForAllocator interface {
 	refillBurstBuckets(toAdd int64, capacity int64)
+	setUseResourceGroup(enabled bool)
 }
 
 // cpuTimeModel abstracts cpuTimeLinearModel for testing.

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -346,13 +346,11 @@ func computeMinimums(r rates) minimums {
 	return m
 }
 
-// allocateTokens allocates tokens to a cpuTimeTokenGranter. allocateTokens
-// adds the desired number of tokens every interval, while respecting the bucket
-// capacities. allocateTokens adds tokens evenly among the expected remaining
-// ticks in the interval.
-// INVARIANT: remainingTicks >= 1.
-// TODO(josh): Expand to cover group-specific token buckets too.
-func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval int64) {
+// allocateTokensFn distributes refillRates across remaining ticks in
+// the interval, returning the per-tick allocations. Extracted as a
+// standalone function so it can be reused by future strategy
+// implementations (e.g. resource manager mode).
+func allocateTokensFn(refillRates rates, allocated *tokenCounts, remainingTicks int64) tokenCounts {
 	allocateFunc := func(total int64, allocated int64, remainingTicks int64) (toAllocate int64) {
 		remainingTokens := total - allocated
 		// ceil(a / b) == (a + b - 1) / b, when using integer division.
@@ -368,18 +366,29 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 		return toAllocate
 	}
 
-	// a.refillRates must be added every 1s, but allocateTokens is called more than once
-	// every 1s (typically). The amount we need to allocate this call to allocateTokens
-	// is stored in allocations.
+	// refillRates must be added every 1s, but allocateTokens is called more
+	// than once every 1s (typically). The amount we need to allocate this call
+	// to allocateTokens is stored in allocations.
 	var allocations tokenCounts
-	for wc := range a.refillRates {
-		for kind := range a.refillRates[wc] {
+	for wc := range refillRates {
+		for kind := range refillRates[wc] {
 			toAllocate := allocateFunc(
-				a.refillRates[wc][kind], a.allocated[wc][kind], expectedRemainingTicksInInterval)
-			a.allocated[wc][kind] += toAllocate
+				refillRates[wc][kind], allocated[wc][kind], remainingTicks)
+			allocated[wc][kind] += toAllocate
 			allocations[wc][kind] = toAllocate
 		}
 	}
+	return allocations
+}
+
+// allocateTokens allocates tokens to a cpuTimeTokenGranter. allocateTokens
+// adds the desired number of tokens every interval, while respecting the bucket
+// capacities. allocateTokens adds tokens evenly among the expected remaining
+// ticks in the interval.
+// INVARIANT: remainingTicks >= 1.
+// TODO(josh): Expand to cover group-specific token buckets too.
+func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval int64) {
+	allocations := allocateTokensFn(a.refillRates, &a.allocated, expectedRemainingTicksInInterval)
 	// Each bucket has a max capacity. The max capacity for each bucket is
 	// one second worth of tokens at the current refill rate. This is a fairly
 	// arbitrary decision.
@@ -390,7 +399,8 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	bucketMinimums := computeMinimums(a.refillRates)
 	// Metrics don't need higher fidelity than one update per second. For example,
 	// in CC, we scrape metrics once every 10s.
-	a.refill(allocations, bucketCapacities, bucketMinimums, false /* updateMetrics */)
+	refillGranter(a.granter, a.metrics, allocations,
+		bucketCapacities, bucketMinimums, false /* updateMetrics */)
 
 	// Refill per-group burst buckets in the WorkQueues. The burst bucket
 	// refill rate and capacity should be 1/4th of the noBurst refill rate
@@ -452,7 +462,8 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 	bucketMinimums := computeMinimums(newRefillRates)
 	// Metrics don't need higher fidelity than one update per second. For example,
 	// in CC, we scrape metrics once every 10s.
-	a.refill(deltaRefillRates, bucketCapacities, bucketMinimums, true /* updateMetrics */)
+	refillGranter(a.granter, a.metrics, deltaRefillRates,
+		bucketCapacities, bucketMinimums, true /* updateMetrics */)
 	a.refillRates = newRefillRates
 
 	// Apply the delta to the per-group burst buckets also.
@@ -470,24 +481,29 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 	}
 }
 
-// refill increments per-bucket refill metrics, then delegates to
+// refillGranter increments per-bucket refill metrics, then delegates to
 // granter.refill. Positive toAdd values are tracked as tokens added;
 // negative values (which occur when refill rates decrease between
 // intervals) are tracked as tokens removed.
-func (a *cpuTimeTokenAllocator) refill(
-	toAdd tokenCounts, bucketCapacities capacities, bucketMinimums minimums, updateMetrics bool,
+func refillGranter(
+	granter *cpuTimeTokenGranter,
+	metrics *cpuTimeTokenMetrics,
+	toAdd tokenCounts,
+	bucketCapacities capacities,
+	bucketMinimums minimums,
+	updateMetrics bool,
 ) {
 	for tier := range toAdd {
 		for qual := range toAdd[tier] {
 			idx := perBucketIdx(resourceTier(tier), burstQualification(qual))
 			if v := toAdd[tier][qual]; v > 0 {
-				a.metrics.RefillAdded[idx].Inc(v)
+				metrics.RefillAdded[idx].Inc(v)
 			} else if v < 0 {
-				a.metrics.RefillRemoved[idx].Inc(-v)
+				metrics.RefillRemoved[idx].Inc(-v)
 			}
 		}
 	}
-	a.granter.refill(toAdd, bucketCapacities, bucketMinimums, updateMetrics)
+	granter.refill(toAdd, bucketCapacities, bucketMinimums, updateMetrics)
 }
 
 // workQueueIForAllocator abstracts the burst bucket refill method in WorkQueue,

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -8,6 +8,7 @@ package admission
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -155,12 +156,39 @@ type cpuTimeTokenFiller struct {
 	closeCh    chan struct{}
 	// Used only in unit tests.
 	tickCh *chan struct{}
+	// activeMode is the cpuTimeTokenMode after the most recent
+	// resetInterval. Written by the filler goroutine, read by
+	// GetKVWorkQueue via cpuTimeTokenGrantCoordinator.
+	//
+	// On a mode transition, resetInterval coordinates several state
+	// changes so they take effect together at the interval boundary:
+	//  1. strategy (cpuTimeTokenAllocator.strategy) - swapped to the new
+	//     modeStrategy, which controls target computation and burst
+	//     bucket refill routing.
+	//  2. refill rates and granter buckets - the delta between old and
+	//     new rates is applied to the granter, so token levels converge
+	//     to the new mode within one interval.
+	//  3. WorkQueue.useResourceGroup - set via configureQueue, which
+	//     switches group ID derivation between TenantID (serverless)
+	//     and Priority (resource manager).
+	//  4. activeMode (this field) - stored last, after refill and queue
+	//     configuration are complete, so that GetKVWorkQueue routes to
+	//     the correct queue only after the queues are ready.
+	//
+	// TODO(wenyihu6): All four steps can be simplified once
+	// serverless mode is mapped to a single WorkQueue with resource
+	// groups. Serverless tenants would just be resource groups with
+	// specific configs (e.g. system tenant = maxCPU group), so the
+	// rmStrategy handles both modes and the strategy swap (step 1),
+	// queue config toggle (step 3), and routing via activeMode
+	// (step 4) all become unnecessary.
+	activeMode atomic.Int64
 }
 
 func (f *cpuTimeTokenFiller) start(ctx context.Context) {
 	// The token buckets should start full. The first call to resetInterval will
 	// fill the buckets.
-	f.allocator.resetInterval(ctx)
+	f.activeMode.Store(int64(f.allocator.resetInterval(ctx)))
 
 	ticker := f.timeSource.NewTicker(timePerTick)
 	intervalStart := f.timeSource.Now()
@@ -202,7 +230,7 @@ func (f *cpuTimeTokenFiller) start(ctx context.Context) {
 						f.allocator.allocateTokens(1)
 					}
 					intervalStart = t
-					f.allocator.resetInterval(ctx)
+					f.activeMode.Store(int64(f.allocator.resetInterval(ctx)))
 					remainingTicks = int64(time.Second / timePerTick)
 				} else {
 					remainingSinceIntervalStart := time.Second - elapsedSinceIntervalStart
@@ -235,7 +263,7 @@ func (f *cpuTimeTokenFiller) close() {
 // cpuTimeTokenAllocatorI abstracts cpuTimeTokenAllocator for testing.
 type cpuTimeTokenAllocatorI interface {
 	allocateTokens(expectedRemainingTicksInInterval int64)
-	resetInterval(context.Context)
+	resetInterval(context.Context) cpuTimeTokenMode
 }
 
 var _ cpuTimeTokenAllocatorI = &cpuTimeTokenAllocator{}
@@ -259,7 +287,8 @@ type cpuTimeTokenAllocator struct {
 	metrics  *cpuTimeTokenMetrics
 	// strategy is only accessed by the filler goroutine (via
 	// allocateTokens and resetInterval), so no synchronization is
-	// needed.
+	// needed. Contrast with filler.activeMode, which is atomic because
+	// GetKVWorkQueue reads it from arbitrary goroutines.
 	strategy modeStrategy
 
 	// refillRates stores the number of CPU time tokens to add to each bucket
@@ -478,8 +507,21 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 }
 
 // resetInterval recomputes refill rates and applies the delta to the
-// granter and burst buckets.
-func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
+// granter and burst buckets. If the mode cluster setting has changed,
+// the strategy is swapped before computing targets.
+func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenMode {
+	// Check for mode transition. a.strategy is only accessed by the
+	// filler goroutine, so we can update it immediately. offMode is
+	// skipped because it is not a real strategy - the constructor
+	// defaults offMode to serverlessMode, and GetKVWorkQueue handles
+	// the off case before reaching activeMode routing.
+	modeChanged := false
+	newMode := cpuTimeTokenACMode.Get(&a.settings.SV)
+	if newMode != offMode && newMode != a.strategy.mode() {
+		a.strategy = a.newStrategy(newMode)
+		modeChanged = true
+	}
+
 	targets := a.strategy.computeTargets(&a.settings.SV)
 	newRefillRates := a.model.fit(ctx, targets)
 
@@ -492,6 +534,8 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 	// TODO(josh): This is missing logic to prevent token counts from becoming
 	// negative. Also, the above comment needs to be beefed up.
 	// https://github.com/cockroachdb/cockroach/issues/158539
+	// TODO(wenyihu6): we should do something here for per group burst bucket as
+	// well
 	var deltaRefillRates tokenCounts
 	for tier := range newRefillRates {
 		for qual := range newRefillRates[tier] {
@@ -516,11 +560,26 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) {
 			a.allocated[wc][kind] = 0
 		}
 	}
+
+	// Apply queue configuration after refill is complete, so admission
+	// behavior only changes once tokens are in place. The returned mode
+	// is stored into filler.activeMode by the caller, which is what
+	// GetKVWorkQueue reads to route work. If activeMode were updated
+	// before tokens and queue config, callers could route work into a
+	// CTT queue that has stale token levels or wrong group derivation
+	// (e.g. TenantID instead of Priority), breaking fair-sharing until
+	// the next interval.
+	if modeChanged {
+		a.configureQueue()
+	}
+	return a.strategy.mode()
 }
 
-// newStrategy constructs the modeStrategy for the given mode. Queue
-// side effects are not applied here; resetInterval applies them
-// after the refill is complete.
+// newStrategy constructs the modeStrategy for the given mode.
+// offMode is not a valid argument - callers must guard against it
+// (resetInterval skips the swap, the constructor maps off to
+// serverless). Queue side effects are not applied here;
+// resetInterval applies them after the refill is complete.
 //
 // No explicit bucket reset is needed on mode switch. The granter's
 // tier-1 buckets stay alive across transitions, and the delta
@@ -552,10 +611,10 @@ func (a *cpuTimeTokenAllocator) configureQueue() {
 	a.queues[0].setUseResourceGroup(a.strategy.mode() == resourceManagerMode)
 }
 
-// refillGranter increments per-bucket refill metrics, then delegates to
-// granter.refill. Positive toAdd values are tracked as tokens added;
-// negative values (which occur when refill rates decrease between
-// intervals) are tracked as tokens removed.
+// refillGranter increments per-bucket refill metrics, then delegates
+// to granter.refill. Positive toAdd values are tracked as tokens
+// added; negative values (which occur when refill rates decrease
+// between intervals) are tracked as tokens removed.
 func refillGranter(
 	granter *cpuTimeTokenGranter,
 	metrics *cpuTimeTokenMetrics,

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -109,6 +109,8 @@ func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
 	}
 }
 
+func (m *testBurstManager) setUseResourceGroup(_ bool) {}
+
 func (m *testModel) init() {}
 
 func (m *testModel) fit(_ context.Context, targets targetUtilizations) rates {
@@ -174,15 +176,17 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 		testTier0: {},
 		testTier1: {},
 	}
+	queues := [numResourceTiers]workQueueIForAllocator{
+		testTier0: burstMgrs[testTier0],
+		testTier1: burstMgrs[testTier1],
+	}
 	allocator := cpuTimeTokenAllocator{
 		granter:  granter,
 		settings: cluster.MakeClusterSettings(),
 		model:    model,
 		metrics:  metrics,
-		queues: [numResourceTiers]workQueueIForAllocator{
-			testTier0: burstMgrs[testTier0],
-			testTier1: burstMgrs[testTier1],
-		},
+		queues:   queues,
+		strategy: &serverlessStrategy{queues: queues},
 	}
 	printBurstMgrs = func() string {
 		var b strings.Builder
@@ -485,4 +489,91 @@ func (p *testCPUMetricsProvider) append(dur time.Duration, count int) {
 	for i := 0; i < count; i++ {
 		p.durations = append(p.durations, dur)
 	}
+}
+
+// TestServerlessStrategyComputeTargets verifies that computeTargets
+// reads the per-tier cluster settings (app and system utilization
+// goals) and adds the burst delta setting to each to produce the
+// canBurst targets.
+func TestServerlessStrategyComputeTargets(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeClusterSettings()
+	ctx := context.Background()
+	KVCPUTimeAppUtilGoal.Override(ctx, &st.SV, 0.75)
+	KVCPUTimeSystemUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.25)
+
+	s := &serverlessStrategy{}
+	targets := s.computeTargets(&st.SV)
+
+	// noBurst targets come directly from the cluster settings.
+	require.Equal(t, 0.75, targets[appTenant][noBurst])
+	require.Equal(t, 0.5, targets[systemTenant][noBurst])
+	// canBurst targets are noBurst + burstDelta.
+	require.Equal(t, 1.0, targets[appTenant][canBurst])
+	require.Equal(t, 0.75, targets[systemTenant][canBurst])
+}
+
+// TestServerlessStrategyRefillBurst verifies that refillBurst
+// distributes noBurst/4 of each tier's tokens and capacity to the
+// per-group burst buckets. The canBurst token counts should be
+// ignored since burst bucket refill is derived solely from the
+// noBurst allocation.
+func TestServerlessStrategyRefillBurst(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	burstMgrs := [numResourceTiers]*testBurstManager{
+		testTier0: {},
+		testTier1: {},
+	}
+	queues := [numResourceTiers]workQueueIForAllocator{
+		testTier0: burstMgrs[testTier0],
+		testTier1: burstMgrs[testTier1],
+	}
+	s := &serverlessStrategy{queues: queues}
+
+	// Set up token counts and refill rates. refillBurst should pass
+	// tokens[tier][noBurst]/4 as toAdd and refillRates[tier][noBurst]/4
+	// as capacity to each tier's burst manager.
+	var tokens tokenCounts
+	tokens[testTier0][noBurst] = 400
+	tokens[testTier0][canBurst] = 500 // ignored by refillBurst
+	tokens[testTier1][noBurst] = 200
+	tokens[testTier1][canBurst] = 300 // ignored by refillBurst
+
+	var refillRates rates
+	refillRates[testTier0][noBurst] = 4000
+	refillRates[testTier1][noBurst] = 2000
+
+	s.refillBurst(tokens, refillRates)
+
+	// Each tier gets noBurst/4 tokens, capped at noBurst/4 capacity.
+	require.Equal(t, int64(100), burstMgrs[testTier0].tokens) // 400/4
+	require.Equal(t, int64(50), burstMgrs[testTier1].tokens)  // 200/4
+}
+
+// TestNewStrategy verifies that newStrategy returns the correct
+// strategy for serverlessMode and panics for offMode (not a real
+// strategy), resourceManagerMode (not yet implemented), and unknown
+// modes.
+func TestNewStrategy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	allocator := cpuTimeTokenAllocator{}
+	s := allocator.newStrategy(serverlessMode)
+	require.Equal(t, serverlessMode, s.mode())
+
+	require.Panics(t, func() {
+		allocator.newStrategy(offMode)
+	})
+	require.Panics(t, func() {
+		allocator.newStrategy(resourceManagerMode)
+	})
+	require.Panics(t, func() {
+		allocator.newStrategy(cpuTimeTokenMode(99))
+	})
 }

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -82,8 +82,9 @@ type testTokenAllocator struct {
 
 func (m *testTokenAllocator) init() {}
 
-func (a *testTokenAllocator) resetInterval(context.Context) {
+func (a *testTokenAllocator) resetInterval(context.Context) cpuTimeTokenMode {
 	fmt.Fprintf(a.buf, "resetInterval()\n")
+	return serverlessMode
 }
 
 func (a *testTokenAllocator) allocateTokens(remainingTicks int64) {
@@ -96,7 +97,8 @@ type testModel struct {
 }
 
 type testBurstManager struct {
-	tokens int64
+	tokens           int64
+	useResourceGroup bool
 }
 
 func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
@@ -109,7 +111,9 @@ func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
 	}
 }
 
-func (m *testBurstManager) setUseResourceGroup(_ bool) {}
+func (m *testBurstManager) setUseResourceGroup(enabled bool) {
+	m.useResourceGroup = enabled
+}
 
 func (m *testModel) init() {}
 
@@ -576,4 +580,60 @@ func TestNewStrategy(t *testing.T) {
 	require.Panics(t, func() {
 		allocator.newStrategy(cpuTimeTokenMode(99))
 	})
+}
+
+// TestResetIntervalReturnsMode verifies that resetInterval returns
+// the current strategy's mode and skips strategy swap when the
+// cluster setting is offMode.
+func TestResetIntervalReturnsMode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	metrics := makeCPUTimeTokenMetrics()
+	granter := newCPUTimeTokenGranter(metrics, timeutil.DefaultTimeSource{})
+	burstMgrs := [numResourceTiers]*testBurstManager{{}, {}}
+	queues := [numResourceTiers]workQueueIForAllocator{
+		testTier0: burstMgrs[testTier0],
+		testTier1: burstMgrs[testTier1],
+	}
+	// Use default settings where cpuTimeTokenACMode is offMode.
+	// resetInterval should not attempt to swap strategy.
+	st := cluster.MakeClusterSettings()
+	require.Equal(t, offMode, cpuTimeTokenACMode.Get(&st.SV))
+	allocator := cpuTimeTokenAllocator{
+		granter:  granter,
+		settings: st,
+		model:    &testModel{buf: &strings.Builder{}, rates: rates{}},
+		metrics:  metrics,
+		queues:   queues,
+		strategy: &serverlessStrategy{queues: queues},
+	}
+
+	ctx := context.Background()
+	mode := allocator.resetInterval(ctx)
+	require.Equal(t, serverlessMode, mode)
+}
+
+// TestConfigureQueue verifies that configureQueue calls
+// setUseResourceGroup with the correct value based on the
+// current strategy's mode.
+func TestConfigureQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	mgr := &testBurstManager{}
+	queues := [numResourceTiers]workQueueIForAllocator{
+		testTier0: mgr,
+		testTier1: &testBurstManager{},
+	}
+	allocator := cpuTimeTokenAllocator{
+		queues:   queues,
+		strategy: &serverlessStrategy{queues: queues},
+	}
+
+	// In serverless mode, useResourceGroup should be false. The RM
+	// direction (useResourceGroup=true) will be tested when rmStrategy
+	// is implemented.
+	allocator.configureQueue()
+	require.False(t, mgr.useResourceGroup)
 }

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -250,6 +250,7 @@ func makeCPUTimeTokenGrantCoordinator(
 		// returns a *WorkQueue.
 		allocator.queues[tier] = requesters[tier].(*WorkQueue)
 	}
+	allocator.strategy = allocator.newStrategy(serverlessMode)
 
 	coordinator := &cpuTimeTokenGrantCoordinator{
 		filler: filler,

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -145,7 +146,24 @@ func (coord *CPUGrantCoordinators) GetKVWorkQueue(isSystemTenant bool) *WorkQueu
 	if !cpuTimeTokenACIsEnabled(&coord.st.SV) {
 		return coord.slotsCoord.GetWorkQueue(KVWork)
 	}
-	return coord.GetCTTWorkQueue(isSystemTenant)
+	mode := cpuTimeTokenMode(coord.cpuTimeCoord.filler.activeMode.Load())
+	switch mode {
+	case offMode:
+		// activeMode should never be offMode in normal operation: the
+		// constructor maps off to serverless, and resetInterval never
+		// returns offMode. This case is a defensive fallback.
+		return coord.slotsCoord.GetWorkQueue(KVWork)
+	case serverlessMode:
+		if isSystemTenant {
+			return coord.cpuTimeCoord.getWorkQueue(systemTenant)
+		}
+		return coord.cpuTimeCoord.getWorkQueue(appTenant)
+	case resourceManagerMode:
+		// RM mode uses a single WorkQueue for all work.
+		return coord.cpuTimeCoord.getWorkQueue(0)
+	default:
+		panic(fmt.Sprintf("unexpected mode %d", mode))
+	}
 }
 
 // GetCTTWorkQueue returns the CPU time token WorkQueue unconditionally,
@@ -203,6 +221,17 @@ func makeCPUTimeTokenGrantCoordinator(
 	registry *metric.Registry,
 	knobs *TestingKnobs,
 ) *cpuTimeTokenGrantCoordinator {
+	// Always create 2 tiers. In RM mode, tier-1 sits idle (no work
+	// routed, zero refill rates). This enables dynamic mode switching
+	// at runtime without rebuilding queues.
+	// Default to serverless when mode is off (legacy bool path or CTT
+	// not yet enabled). The strategy only matters when the filler runs,
+	// and the filler only starts when CTT is enabled. Using serverless
+	// as the default preserves the legacy 2-queue behavior.
+	initialMode := cpuTimeTokenACMode.Get(&settings.SV)
+	if initialMode == offMode {
+		initialMode = serverlessMode
+	}
 	metrics := makeCPUTimeTokenMetrics()
 	registry.AddMetricStruct(metrics)
 	timeSource := timeutil.DefaultTimeSource{}
@@ -250,7 +279,7 @@ func makeCPUTimeTokenGrantCoordinator(
 		// returns a *WorkQueue.
 		allocator.queues[tier] = requesters[tier].(*WorkQueue)
 	}
-	allocator.strategy = allocator.newStrategy(serverlessMode)
+	allocator.strategy = allocator.newStrategy(initialMode)
 
 	coordinator := &cpuTimeTokenGrantCoordinator{
 		filler: filler,
@@ -258,6 +287,10 @@ func makeCPUTimeTokenGrantCoordinator(
 	for tier := resourceTier(0); tier < numResourceTiers; tier++ {
 		coordinator.queues[tier] = requesters[tier]
 	}
+
+	// Initialize the filler's activeMode so GetKVWorkQueue returns the
+	// correct queue before the filler goroutine starts.
+	filler.activeMode.Store(int64(initialMode))
 
 	// The filler ticking appears to have a slight negative impact on perf.
 	// For now, we accept this, since CPU time token AC will be off by
@@ -286,6 +319,16 @@ func makeCPUTimeTokenGrantCoordinator(
 }
 
 func (coord *cpuTimeTokenGrantCoordinator) getWorkQueue(tier resourceTier) *WorkQueue {
+	// TODO(wenyihu6): activeMode is read here and again in the caller
+	// (GetKVWorkQueue / GetCTTWorkQueue). If a mode transition lands
+	// between the two reads, the assertion can fire.
+	if buildutil.CrdbTestBuild {
+		mode := cpuTimeTokenMode(coord.filler.activeMode.Load())
+		if mode == resourceManagerMode && tier != 0 {
+			panic(fmt.Sprintf(
+				"queue[%d] accessed in resource manager mode", tier))
+		}
+	}
 	return coord.queues[tier].(*WorkQueue)
 }
 

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -39,6 +39,9 @@ func TestObsoleteCode(t *testing.T) {
 	}
 }
 
+// TestCPUTimeTokenACEnableAndDisable verifies that GetKVWorkQueue
+// routes work to the correct queue based on cpuTimeTokenACMode,
+// activeMode, the legacy bool, and the kill switch.
 func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -51,6 +54,12 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	coords := NewGrantCoordinators(ambientCtx, settings, opts, registry, &noopOnLogEntryAdmitted{}, knobs)
 	defer coords.Close()
 	cpuCoords := coords.RegularCPU
+	// The filler goroutine is disabled, so activeMode must be set
+	// manually to simulate what the filler would do on each
+	// resetInterval.
+	setActiveMode := func(mode cpuTimeTokenMode) {
+		cpuCoords.cpuTimeCoord.filler.activeMode.Store(int64(mode))
+	}
 
 	ctx := context.Background()
 	defer func(prevMode cpuTimeTokenMode, prevEnabled bool) {
@@ -61,30 +70,47 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	// Both settings off: slot-based AC.
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
 	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
+	setActiveMode(offMode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 	require.Equal(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 
-	// Mode set to serverless: CPU time token AC.
+	// Mode set to serverless: CPU time token AC with separate queues
+	// per tenant.
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, serverlessMode)
 	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
+	setActiveMode(serverlessMode)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 
-	// Mode set to resource_manager: CPU time token AC.
+	// Mode set to resource_manager: CPU time token AC with a single
+	// queue for all work.
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, resourceManagerMode)
 	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
+	setActiveMode(resourceManagerMode)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
+	require.Equal(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
+
+	// Legacy bool fallback: mode is off but enabled=true enables CTT
+	// AC. activeMode stays serverless (the default when mode is off).
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, true)
+	setActiveMode(serverlessMode)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 
-	// Legacy bool fallback: mode is off but enabled=true enables CTT AC.
-	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
-	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, true)
-	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
-	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
-	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
+	// Defensive case: setting says serverless but activeMode is offMode.
+	// This shouldn't occur in production (the constructor and filler
+	// never store offMode), but GetKVWorkQueue handles it by falling
+	// back to slots.
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, serverlessMode)
+	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
+	setActiveMode(offMode)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
+	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 
 	// Kill switch overrides all modes.
 	defer func(prev bool) {
@@ -94,6 +120,7 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	// Kill switch overrides serverlessMode.
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, serverlessMode)
 	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, false)
+	setActiveMode(serverlessMode)
 	cpuTimeTokenACKillSwitch = true
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
@@ -101,12 +128,14 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 
 	// Kill switch overrides resourceManagerMode.
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, resourceManagerMode)
+	setActiveMode(resourceManagerMode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 
 	// Kill switch overrides legacy bool fallback.
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, offMode)
 	cpuTimeTokenACEnabled.Override(ctx, &settings.SV, true)
+	setActiveMode(serverlessMode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */).mode)
 	require.Equal(t, usesSlots, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/168382
Epic: none
Release note: none

---
**admission: extract allocateTokensFn and refillGranter**

Pure mechanical extraction - no behavioral changes. The modeStrategy
interface (next commit) needs different strategies to reuse token
allocation and granter refill logic, so these are lifted out of
cpuTimeTokenAllocator into standalone functions.

Epic: CRDB-42544
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: introduce modeStrategy interface with serverlessStrategy**

This commit introduces the modeStrategy interface (mode(),
computeTargets(), refillBurst()) and moves the existing target
computation and burst refill logic into serverlessStrategy. The
allocator delegates to a.strategy for these operations.

This is the extension point for the resource manager: a future
rmStrategy will implement the same interface with different target
computation and per-group burst refill. The next commit wires up
runtime mode switching so the strategy can be swapped without a
restart.

Epic: CRDB-42544
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: add activeMode routing to GetKVWorkQueue**

This commit wires up the mode switching infrastructure that the
modeStrategy interface (previous commit) enables. resetInterval now
checks the cluster setting for mode transitions, swaps the strategy,
and stores the result into filler.activeMode. GetKVWorkQueue reads
activeMode to route work: offMode falls back to slots, serverlessMode
routes by tenant tier, resourceManagerMode routes to queue[0].

The main concern is that GetKVWorkQueue runs on arbitrary goroutines
while the filler goroutine owns strategy, tokens, and queue
configuration. If activeMode were visible before those are updated,
callers could route work into a CTT queue with stale token levels or
wrong group derivation (e.g. TenantID instead of Priority). To avoid
this, activeMode is stored last in resetInterval, after strategy
swap, token refill, and queue configuration are complete.

A secondary concern is the race between the cluster setting check
(cpuTimeTokenACIsEnabled) and the activeMode load: the setting
propagates immediately while activeMode updates at the next 1s
interval boundary. During this window GetKVWorkQueue falls back to
slots, which self-resolves when both values converge.

offMode is not a valid argument to newStrategy. resetInterval guards
against it (skips the swap), and the constructor maps offMode to
serverlessMode at init time so the allocator always has a concrete
strategy.

Epic: CRDB-42544
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

