### PR TITLE
chore: typo sweep (occured, recieve, seperate, enviroment)

### DIFF
--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -245,7 +245,7 @@ func (set *localitySet) maybeUpdateTargetInstance() {
 // available nodes, this function has two behaviors, depending on whether strict is set.
 // If strict is true, this function will return an error. If strict is false, we fall back to
 // assigning all available nodes. In that case, compactions may output data to a different URI
-// than they recieved it from. This is an edge case that would occur if the cluster topology has
+// than they received it from. This is an edge case that would occur if the cluster topology has
 // changed between backup time and compaction time such that all nodes matching one of our URIs
 // become unavailable (for example, a region going down).
 func buildLocalitySets(

--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -650,7 +650,7 @@ func runGenerativeSplitAndScatter(
 					}
 
 					if _, ok := flowCtx.NodeID.OptionalNodeID(); !ok {
-						// If a seperate process tenant is running restore, the nodeID
+						// If a separate process tenant is running restore, the nodeID
 						// returned by scatter does not map identically to a sqlInstanceID;
 						// thus, the processor must randomly choose a sqlInstanceID to route
 						// the chunk to.

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2489,7 +2489,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		}
 		// TODO(msbutler): ideally doDownloadFiles would not depend on job details
 		// and is instead passed an execCfg and the download spans and anything else
-		// it needs. If that occured, we would not need to update details above.
+		// it needs. If that occurred, we would not need to update details above.
 		if err := r.doDownloadFilesWithRetry(ctx, p); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -118,7 +118,7 @@ type rowEvent struct {
 }
 
 // Flush implements the Sink interface, returning the first error that has
-// occured in the past EmitRow calls.
+// occurred in the past EmitRow calls.
 func (s *batchingSink) Flush(ctx context.Context) error {
 	defer s.metrics.recordFlushRequestCallback()()
 	flushWaiter := make(chan struct{})

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1054,7 +1054,7 @@ func TestChangefeedSendError(t *testing.T) {
 		retryCounter := sli.ErrorRetries
 		testutils.SucceedsSoon(t, func() error {
 			if retryCounter.Value() < 1 {
-				return fmt.Errorf("no retry has occured")
+				return fmt.Errorf("no retry has occurred")
 			}
 			return nil
 		})

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2347,7 +2347,7 @@ func registerCDC(r registry.Registry) {
 		// change aggregators in the execution_locality region while targeting tables
 		// whose primary region is different. In issue #2955, in that scenario,
 		// a single change aggregator (on the gateway node) would watch all the ranges.
-		// The above scenario occured with the older bin-packing oracle rather than
+		// The above scenario occurred with the older bin-packing oracle rather than
 		// the bulk oracle.
 		Name:             "cdc/multi-region-execution-locality-tpcc",
 		Owner:            registry.OwnerCDC,

--- a/pkg/cmd/roachtest/tests/chaos.go
+++ b/pkg/cmd/roachtest/tests/chaos.go
@@ -51,7 +51,7 @@ type Chaos struct {
 	// Chaos is responsible for closing the channel when the test is over.
 	// This is optional.
 	ChaosEventCh chan ChaosEvent
-	// Env is an array of enviroment variables to set when restarting nodes.
+	// Env is an array of environment variables to set when restarting nodes.
 	// Ex. "COCKROACH_CHANGEFEED_TESTING_FAST_RETRY=true"
 	Env []string
 }

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2721,7 +2721,7 @@ func TestAlterExternalConnection(t *testing.T) {
 	q1.Set(streamclient.RoutingModeKey, string(streamclient.RoutingModeGateway))
 	dbANode1URL.RawQuery = q1.Encode()
 
-	// We want to make sure operations for cluster B is on seperate node from cluster A.
+	// We want to make sure operations for cluster B is on separate node from cluster A.
 	node2 := server.Server(2).ApplicationLayer()
 	dbBNode2 := sqlutils.MakeSQLRunner(node2.SQLConn(t, serverutils.DBName(dbNames[1])))
 

--- a/pkg/crosscluster/replicationtestutils/replication_helpers.go
+++ b/pkg/crosscluster/replicationtestutils/replication_helpers.go
@@ -155,7 +155,7 @@ func (rf *ReplicationFeed) ObserveResolved(ctx context.Context, lo hlc.Timestamp
 	return minResolvedTimestamp(rf.msg.GetCheckpoint().ResolvedSpans)
 }
 
-// ObserveRangeStats consumes the feed until we recieve a checkpoint that
+// ObserveRangeStats consumes the feed until we receive a checkpoint that
 // contains range stats. Returns the stats from the checkpoint.
 func (rf *ReplicationFeed) ObserveRangeStats(ctx context.Context) rangescanstatspb.RangeStats {
 	if !ContainsRangeStats()(rf.msg) {


### PR DESCRIPTION
Nine single-character typo fixes across `pkg/backup/`, `pkg/ccl/changefeedccl/`, `pkg/cmd/roachtest/`, and `pkg/crosscluster/`. All are in comments or test assertion strings — no functional change:

- `pkg/crosscluster/replicationtestutils/replication_helpers.go:158` — comment `until we recieve a checkpoint` -> `until we receive a checkpoint`
- `pkg/cmd/roachtest/tests/chaos.go:54` — doc comment `array of enviroment variables` -> `array of environment variables`
- `pkg/crosscluster/logical/logical_replication_job_test.go:2724` — comment `operations for cluster B is on seperate node` -> `on separate node`
- `pkg/cmd/roachtest/tests/cdc.go:2350` — comment `The above scenario occured` -> `occurred`
- `pkg/backup/compaction_dist.go:248` — comment `than they recieved it from` -> `received`
- `pkg/backup/generative_split_and_scatter_processor.go:653` — comment `If a seperate process tenant` -> `separate`
- `pkg/ccl/changefeedccl/changefeed_test.go:1057` — test error message `no retry has occured` -> `occurred`
- `pkg/ccl/changefeedccl/batching_sink.go:121` — comment `occured in the past EmitRow calls` -> `occurred`
- `pkg/backup/restore_job.go:2492` — comment `If that occured, we would not need to update` -> `occurred`

The test-fixture string `a nonexistant schema` in `pkg/cmd/roachtest/tests/ruby_pg_blocklist.go` was intentionally left alone — it matches an externally-generated Ruby driver error string, changing it would break the blocklist matching.