### PR TITLE
types: avoid panic in `WithoutTypeModifiers()` for domains

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1614,6 +1614,13 @@ func (t *T) WithoutTypeModifiers() *T {
 		// Enums have no type modifiers.
 		return t
 	}
+	// Domain types share their base type's Family, so check for them before
+	// looking up the OID in OidToType. Domain OIDs are user defined and do not
+	// exist in OidToType, and domains do not have independent type modifiers to
+	// strip beyond the base type information already baked into the type.
+	if t.UserDefined() && t.TypeMeta.DomainData != nil {
+		return t
+	}
 
 	// For types that can be a collated string, we copy the type and set the width
 	// to 0 rather than returning the default OidToType type so that we retain the

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -1014,6 +1014,16 @@ func TestSQLStandardName(t *testing.T) {
 }
 
 func TestWithoutTypeModifiers(t *testing.T) {
+	const userDefinedOID = oidext.CockroachPredefinedOIDMax + 700
+	domain := MakeDomain(MakeString(2), userDefinedOID, userDefinedOID+1)
+	domain.TypeMeta = UserDefinedTypeMetadata{
+		Name: &UserDefinedTypeName{Name: "d"},
+		DomainData: &DomainMetadata{
+			BaseType: MakeString(2),
+		},
+	}
+	domainArray := MakeArray(domain)
+
 	testCases := []struct {
 		t        *T
 		expected *T
@@ -1037,6 +1047,8 @@ func TestWithoutTypeModifiers(t *testing.T) {
 		{MakeInterval(IntervalTypeMetadata{Precision: 3, PrecisionIsSet: true}),
 			Interval},
 		{MakeArray(MakeDecimal(5, 1)), DecimalArray},
+		{domain, domain},
+		{domainArray, domainArray},
 		{MakeTuple([]*T{MakeString(2), Time, MakeDecimal(5, 1)}),
 			MakeTuple([]*T{String, Time, Decimal})},
 		{MakeGeography(geopb.ShapeType_Point, 3857), Geography},


### PR DESCRIPTION
`WithoutTypeModifiers()` assumed that non-composite scalar types could be reconstructed from `OidToType` after removing modifiers. That works for built-in types, but it breaks for hydrated domain types because domains reuse their base type family while carrying user-defined OIDs that are not present in `OidToType`.

This surfaced while type checking `ARRAY[...]` literals. The `typeCheckSameTypedConsts()` path calls `WithoutTypeModifiers()` before assigning a common type to constant elements, which caused domain array expressions to hit an unexpected OID assertion and return an internal error.

Fix this by recognizing hydrated domain types in
`WithoutTypeModifiers()` and returning the type unchanged. Domains do not have independent type modifiers to strip, so preserving the hydrated type avoids the invalid `OidToType` lookup while keeping the domain identity intact.

Also add a regression test covering domain types and arrays of domains in `TestWithoutTypeModifiers`.

Fixes: https://github.com/cockroachdb/cockroach/issues/168036
See also: [CRDB-62766](https://cockroachlabs.atlassian.net/browse/CRDB-62766)
Epic: [CRDB-62146](https://cockroachlabs.atlassian.net/browse/CRDB-62146)