### PR TITLE
roachtestutil: write perf summary stats to local artifacts dir

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -68,7 +68,11 @@ go_test(
     ],
     embed = [":roachtestutil"],
     deps = [
+        "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/spec",
+        "//pkg/cmd/roachtest/test",
+        "//pkg/roachprod/logger",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/cmd/roachtest/roachtestutil/metric_utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -576,24 +577,17 @@ func GetOpenmetricsLabelsFromString(labelString string) (map[string]string, erro
 	return labels, nil
 }
 
-// UploadPerfSummaryStats serializes the given metrics to both JSON
-// (for human readability) and openmetrics format, then uploads both
-// files to the perf artifacts directory on the specified node.
-func UploadPerfSummaryStats(
-	ctx context.Context,
-	t test.Test,
-	c cluster.Cluster,
-	stats AggregatedPerfMetrics,
-	node option.NodeListOption,
-) error {
+// WritePerfSummaryStats serializes the given metrics to both JSON
+// (for human readability) and openmetrics format, then writes both
+// files to a summary.perf directory under the test's local artifacts
+// directory.
+func WritePerfSummaryStats(t test.Test, c cluster.Cluster, stats AggregatedPerfMetrics) error {
 	if len(stats) == 0 {
 		return errors.New("no summary stats provided")
 	}
 
-	perfDir := t.PerfArtifactsDir()
-	if err := c.RunE(
-		ctx, option.WithNodes(node), "mkdir -p "+perfDir,
-	); err != nil {
+	destDir := filepath.Join(t.ArtifactsDir(), "summary.perf")
+	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return err
 	}
 
@@ -601,9 +595,8 @@ func UploadPerfSummaryStats(
 	if err != nil {
 		return err
 	}
-	jsonDest := filepath.Join(perfDir, "summary_stats.json")
-	if err := c.PutString(
-		ctx, jsonBuf.String(), jsonDest, 0755, node,
+	if err := os.WriteFile(
+		filepath.Join(destDir, "summary_stats.json"), jsonBuf.Bytes(), 0644,
 	); err != nil {
 		return err
 	}
@@ -612,8 +605,9 @@ func UploadPerfSummaryStats(
 	if err != nil {
 		return err
 	}
-	omDest := filepath.Join(perfDir, "summary_stats.om")
-	return c.PutString(ctx, omBuf.String(), omDest, 0755, node)
+	return os.WriteFile(
+		filepath.Join(destDir, "summary_stats.om"), omBuf.Bytes(), 0644,
+	)
 }
 
 type summaryStatJSON struct {

--- a/pkg/cmd/roachtest/roachtestutil/metric_utils_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils_test.go
@@ -7,10 +7,38 @@ package roachtestutil
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/stretchr/testify/require"
 )
+
+type stubTest struct {
+	test.Test
+	name         string
+	artifactsDir string
+	l            *logger.Logger
+}
+
+func (s stubTest) Name() string            { return s.name }
+func (s stubTest) ArtifactsDir() string    { return s.artifactsDir }
+func (s stubTest) GetRunId() string        { return "test-run-id" }
+func (s stubTest) Owner() string           { return "test-owner" }
+func (s stubTest) L() *logger.Logger       { return s.l }
+func (s stubTest) ExportOpenmetrics() bool { return false }
+
+type stubCluster struct {
+	cluster.Cluster
+	cloud spec.Cloud
+}
+
+func (s stubCluster) Cloud() spec.Cloud { return s.cloud }
 
 func TestSummaryStatsToJSON(t *testing.T) {
 	tests := []struct {
@@ -59,4 +87,51 @@ func TestSummaryStatsToJSONEmpty(t *testing.T) {
 	var got []summaryStatJSON
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
 	require.Empty(t, got)
+}
+
+func TestWritePerfSummaryStats(t *testing.T) {
+	artifactsDir := t.TempDir()
+	l, err := logger.RootLogger(filepath.Join(artifactsDir, "test.log"), false /* tee */)
+	require.NoError(t, err)
+
+	st := stubTest{
+		name:         "test/perf-summary",
+		artifactsDir: artifactsDir,
+		l:            l,
+	}
+	sc := stubCluster{cloud: spec.GCE}
+
+	stats := AggregatedPerfMetrics{
+		{Name: "restore_runtime", Value: 5.5, Unit: "minutes", IsHigherBetter: false},
+	}
+
+	require.NoError(t, WritePerfSummaryStats(st, sc, stats))
+
+	summaryDir := filepath.Join(artifactsDir, "summary.perf")
+
+	// Verify the JSON file.
+	jsonBytes, err := os.ReadFile(filepath.Join(summaryDir, "summary_stats.json"))
+	require.NoError(t, err)
+	var jsonStats []summaryStatJSON
+	require.NoError(t, json.Unmarshal(jsonBytes, &jsonStats))
+	require.Len(t, jsonStats, 1)
+	require.Equal(t, "restore_runtime", jsonStats[0].Name)
+	require.Equal(t, 5.5, jsonStats[0].Value)
+	require.Equal(t, "minutes", jsonStats[0].Unit)
+
+	// Verify the OpenMetrics file.
+	omBytes, err := os.ReadFile(filepath.Join(summaryDir, "summary_stats.om"))
+	require.NoError(t, err)
+	omContent := string(omBytes)
+	require.Contains(t, omContent, "restore_runtime")
+	require.Contains(t, omContent, "# EOF")
+	require.True(t, strings.Contains(omContent, `owner="test-owner"`))
+}
+
+func TestWritePerfSummaryStatsEmpty(t *testing.T) {
+	st := stubTest{artifactsDir: t.TempDir()}
+	sc := stubCluster{cloud: spec.GCE}
+
+	err := WritePerfSummaryStats(st, sc, AggregatedPerfMetrics{})
+	require.ErrorContains(t, err, "no summary stats provided")
 }

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -446,7 +446,7 @@ func registerFastRestorePerf(r registry.Registry) {
 					throughput := float64(endDu-startDu) / (float64(sp.hardware.nodes) * restoreDuration.Seconds())
 					t.L().Printf("Usage %d, Nodes %d, Duration %f; Throughput: %f MB/s/node",
 						endDu-startDu, sp.hardware.nodes, restoreDuration.Seconds(), throughput)
-					uploadRestoreSummaryStats(ctx, t, c, restoreDuration.Seconds(), throughput)
+					uploadRestoreSummaryStats(t, c, restoreDuration.Seconds(), throughput)
 				},
 			})
 		}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -929,7 +929,7 @@ func (rd *restoreDriver) initRestorePerfMetrics(
 			testDuration,
 			throughput)
 		exportToRoachperf(ctx, rd.t, rd.c, rd.sp.testName, int64(throughput))
-		uploadRestoreSummaryStats(ctx, rd.t, rd.c, testDuration, throughput)
+		uploadRestoreSummaryStats(rd.t, rd.c, testDuration, throughput)
 	}
 }
 
@@ -1002,11 +1002,7 @@ func exportToRoachperf(
 }
 
 func uploadRestoreSummaryStats(
-	ctx context.Context,
-	t test.Test,
-	c cluster.Cluster,
-	durationSeconds float64,
-	throughputMBPerSPerNode float64,
+	t test.Test, c cluster.Cluster, durationSeconds float64, throughputMBPerSPerNode float64,
 ) {
 	stats := roachtestutil.AggregatedPerfMetrics{
 		{
@@ -1022,7 +1018,7 @@ func uploadRestoreSummaryStats(
 			IsHigherBetter: true,
 		},
 	}
-	if err := roachtestutil.UploadPerfSummaryStats(ctx, t, c, stats, c.Node(1)); err != nil {
+	if err := roachtestutil.WritePerfSummaryStats(t, c, stats); err != nil {
 		t.L().Printf("failed to upload perf summary stats: %v", err)
 	}
 }


### PR DESCRIPTION
Summary stats don't need to be uploaded to a cluster node only to be copied back later. Write directly to a local summary.perf directory under the test's artifacts dir instead.

Epic: none

Release note: none