### PR TITLE
ccl/multiregionccl: use correct default policy in global table tests

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -359,7 +359,7 @@ SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled 
 				s := ds.tc.ApplicationLayer(idx)
 				cache := s.DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
 				tablePrefix := keys.MustAddr(s.Codec().TablePrefix(tableID))
-				entry, err := cache.TestingGetCached(ctx, tablePrefix, false, roachpb.LAG_BY_CLUSTER_SETTING)
+				entry, err := cache.TestingGetCached(ctx, tablePrefix, false, roachpb.LEAD_FOR_GLOBAL_READS)
 				if err != nil {
 					return err.Error()
 				}

--- a/pkg/ccl/multiregionccl/roundtrips_test.go
+++ b/pkg/ccl/multiregionccl/roundtrips_test.go
@@ -121,7 +121,7 @@ func TestEnsureLocalReadsOnGlobalTables(t *testing.T) {
 			// Check that the cache was indeed populated.
 			cache := tc.Server(i).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
 			entry, err := cache.TestingGetCached(
-				context.Background(), tablePrefix, false /* inverted */, roachpb.LAG_BY_CLUSTER_SETTING,
+				context.Background(), tablePrefix, false /* inverted */, roachpb.LEAD_FOR_GLOBAL_READS,
 			)
 			require.NoError(t, err)
 			require.False(t, entry.Lease.Empty())


### PR DESCRIPTION
The tests TestMultiRegionDataDriven_global_tables and TestEnsureLocalReadsOnGlobalTables were flaky because they checked the RangeDescriptorCache for the closed timestamp policy but provided LAG_BY_CLUSTER_SETTING as the fallback policy.

In CockroachDB, DistSender defaults to LEAD_FOR_GLOBAL_READS when the policy in a cached range descriptor is unknown (the -1 sentinel). For GLOBAL tables, the server often omits returning the range descriptor if the client-sent policy already matches the server's state, leaving the client cache in an unknown state.

By providing LEAD_FOR_GLOBAL_READS as the fallback in these test verifications, we correctly account for this default behavior and prevent false-positive failures where the test expected a specific policy but saw the fallback instead.

Fixes: #167544

Epic: none
Release note: none