### PR TITLE
release-25.2: workload/schemachanger: reduce contention with object selection

### DIFF
--- a/pkg/workload/schemachange/generate.go
+++ b/pkg/workload/schemachange/generate.go
@@ -69,7 +69,7 @@ func PickBetween[T any](rng *rand.Rand, atLeast, atMost int, options []T) ([]T, 
 	})
 
 	length := atLeast + rng.Intn(atMost-atLeast+1)
-	return options[:length], nil
+	return cloned[:length], nil
 }
 
 // Values is a helper for formatting a list of SQL values within a


### PR DESCRIPTION
Backport 1/1 commits from #168756 on behalf of @fqazi.

----

Previously, the selection of random lists of items would not produce a truly random order and only select a prefix. To address this, this patch makes the selection truly random. This reduces contention that could lead slow downs / timeouts in the workload.

Fixes: #167511

Release note: None

----

Release justification: test only change