### PR TITLE
release-26.1: sql/catalog/lease: fix deadlock in TestLeaseManagerLockedTimestampConcurrent

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3851,7 +3851,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 				sql := fmt.Sprintf("CREATE TABLE %s(n int PRIMARY KEY)\n", objectName)
 				if _, err := conn.ExecContext(ctx, sql); err != nil {
 					if isCancellationError(err) {
-						return nil
+						return err
 					}
 					panic(err)
 				}
@@ -3873,7 +3873,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 				sql := fmt.Sprintf("SELECT * FROM %s", objectName)
 				if _, err := conn.ExecContext(ctx, sql); err != nil {
 					if isCancellationError(err) {
-						return nil
+						return err
 					}
 					panic(err)
 				}
@@ -3888,7 +3888,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 					sql := fmt.Sprintf("SELECT * FROM %s", objectName)
 					if _, err := conn.ExecContext(ctx, sql); err != nil {
 						if isCancellationError(err) {
-							return nil
+							return err
 						}
 						panic(err)
 					}
@@ -3905,7 +3905,7 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 				sql := fmt.Sprintf("ALTER TABLE %s ADD COLUMN n2 int", objectName)
 				if _, err := conn.ExecContext(ctx, sql); err != nil {
 					if isCancellationError(err) {
-						return nil
+						return err
 					}
 					panic(err)
 				}
@@ -3917,7 +3917,9 @@ func TestLeaseManagerLockedTimestampConcurrent(t *testing.T) {
 		grp.GoCtx(createThreads)
 		grp.GoCtx(readThreads)
 		grp.GoCtx(modifyThreads)
-		require.NoError(t, grp.Wait())
+		if err := grp.Wait(); err != nil && !isCancellationError(err) {
+			t.Fatalf("unexpected error from ctxgroup: %v", err)
+		}
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #168891 on behalf of @spilchen.

----

Prior deflake fixes caught cancellation errors and returned nil from errgroup goroutines. However, returning nil does not cancel the errgroup's derived context, so when readThreads or modifyThreads exited early, createThreads would block forever trying to send on nextObjectToRead with no receiver and no ctx.Done() signal.

Return the cancellation error instead of nil so the errgroup context gets cancelled, unblocking other goroutines. Tolerate cancellation errors at grp.Wait().

Resolves: #168505
Epic: none

Release note: None

----

Release justification: test only fix