### PR TITLE
sql/catalog/catformat: emit INCLUDE for covering indexes in pg_catalog

### DIFF
--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -147,7 +147,14 @@ func indexForDisplay(
 	}
 
 	if !isPrimary && len(index.StoreColumnNames) > 0 {
-		f.WriteString(" STORING (")
+		// PostgreSQL spells covering-index columns as INCLUDE; emit that
+		// spelling under FmtPGCatalog so pg_get_indexdef output matches
+		// what real PG would return. CockroachDB's parser accepts both.
+		if f.HasFlags(tree.FmtPGCatalog) {
+			f.WriteString(" INCLUDE (")
+		} else {
+			f.WriteString(" STORING (")
+		}
 		for i := range index.StoreColumnNames {
 			if i > 0 {
 				f.WriteString(", ")

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -222,7 +222,7 @@ func TestIndexForDisplay(t *testing.T) {
 			partition:   "",
 			displayMode: IndexDisplayDefOnly,
 			expected:    "INDEX baz (a ASC, b DESC) STORING (c)",
-			pgExpected:  "INDEX baz USING btree (a ASC, b DESC) STORING (c)",
+			pgExpected:  "INDEX baz USING btree (a ASC, b DESC) INCLUDE (c)",
 		},
 		{
 			index:       storingIndex,
@@ -230,7 +230,7 @@ func TestIndexForDisplay(t *testing.T) {
 			partition:   "",
 			displayMode: IndexDisplayShowCreate,
 			expected:    "CREATE INDEX baz ON foo.public.bar (a ASC, b DESC) STORING (c)",
-			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a ASC, b DESC) STORING (c)",
+			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a ASC, b DESC) INCLUDE (c)",
 		},
 		{
 			index:       partialIndex,
@@ -304,7 +304,7 @@ func TestIndexForDisplay(t *testing.T) {
 			partition:   "",
 			displayMode: IndexDisplayDefOnly,
 			expected:    "INDEX baz (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
-			pgExpected:  "INDEX baz USING btree (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
+			pgExpected:  "INDEX baz USING btree (a DESC) USING HASH INCLUDE (c) WITH (bucket_count=8)",
 		},
 		{
 			index:       shardedStoringIndex,
@@ -312,7 +312,7 @@ func TestIndexForDisplay(t *testing.T) {
 			partition:   "",
 			displayMode: IndexDisplayShowCreate,
 			expected:    "CREATE INDEX baz ON foo.public.bar (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
-			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH STORING (c) WITH (bucket_count=8)",
+			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH INCLUDE (c) WITH (bucket_count=8)",
 		},
 		{
 			index:       vectorIndex,

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -92,7 +92,7 @@ FROM pg_indexes
 WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
 ----
 tablename           indexname  indexdef
-store_columns_test  idx1       CREATE INDEX idx1 ON public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
+store_columns_test  idx1       CREATE INDEX idx1 ON public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH INCLUDE (c3) WITH (bucket_count=16)
 
 # Verify that the CREATE INDEX statement from pg_indexes can be executed.
 # First, save the index definition.
@@ -112,7 +112,7 @@ FROM pg_indexes
 WHERE tablename = 'store_columns_test' AND indexname = 'idx1'
 ----
 tablename           indexname  indexdef
-store_columns_test  idx1       CREATE INDEX idx1 ON public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH STORING (c3) WITH (bucket_count=16)
+store_columns_test  idx1       CREATE INDEX idx1 ON public.store_columns_test USING btree (c1 ASC, c2 ASC) USING HASH INCLUDE (c3) WITH (bucket_count=16)
 
 statement ok
 DROP TABLE store_columns_test

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1135,7 +1135,7 @@ crdb_oid    tablename  indexname          indexdef
 5181036     t1_n_seq   primary            CREATE INDEX "primary" ON public.t1_n_seq USING btree (value ASC)
 2955071325  t2         t2_pkey            CREATE UNIQUE INDEX t2_pkey ON public.t2 USING btree (rowid ASC)
 2955071326  t2         t2_t1_id_idx       CREATE INDEX t2_t1_id_idx ON public.t2 USING btree (t1_id ASC)
-2695335053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON public.t3 USING btree (a ASC, b DESC) STORING (c)
+2695335053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON public.t3 USING btree (a ASC, b DESC) INCLUDE (c)
 2695335054  t3         t3_pkey            CREATE UNIQUE INDEX t3_pkey ON public.t3 USING btree (rowid ASC)
 3214807592  t4         t4_pkey            CREATE UNIQUE INDEX t4_pkey ON public.t4 USING btree (rowid ASC)
 1869730585  t5         t5_pkey            CREATE UNIQUE INDEX t5_pkey ON public.t5 USING btree (rowid ASC)


### PR DESCRIPTION
PostgreSQL spells the columns of a covering index using the INCLUDE keyword, but CockroachDB's pg_get_indexdef and pg_indexes.indexdef output used the CockroachDB-specific STORING spelling. This caused pg_dump output to be non-portable: a covering index emitted as "USING btree (...) STORING (...)" would fail to restore on a real PostgreSQL server, even though the rest of the dump was valid PG SQL.

Emit INCLUDE instead of STORING when the FmtPGCatalog format flag is set. FmtPGCatalog already implies "render like PG would" (it also emits "USING btree" and similar PG-style structure), so this is a natural extension. Other display paths (SHOW CREATE TABLE, error messages, etc.) continue to use STORING.

CockroachDB's parser already accepts INCLUDE as a synonym for STORING, so dumps emitted in the new form still round-trip cleanly back into CockroachDB.

Epic: CRDB-28751

Release note: None