### PR TITLE
roachprod: bump gc image

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:da76d9d091d
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:e7748732f34
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
This patch updates the k8s configuration to reflect the newly depoyed roachprod gc image. This new version includes #168893.

Epic: none
Release note: none