### PR TITLE
sql: fix various bad usages of internal executor MultiOverride

### DIFF
--- a/pkg/sql/hints/BUILD.bazel
+++ b/pkg/sql/hints/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/util/buildutil",
         "//pkg/util/cache",

--- a/pkg/sql/hints/hint_table.go
+++ b/pkg/sql/hints/hint_table.go
@@ -18,17 +18,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
+// distSQLOff is used to take the address of sessiondatapb.DistSQLOff.
+var distSQLOff = sessiondatapb.DistSQLOff
+
 // nodeUserLocalOnly is a session data override that forces local (non-DistSQL)
 // execution. Statement hint queries are simple point lookups that should not
 // incur the overhead of distributed execution.
 var nodeUserLocalOnly = sessiondata.InternalExecutorOverride{
-	User:          sessiondata.NodeUserSessionDataOverride.User,
-	MultiOverride: "distsql=off",
+	User:        sessiondata.NodeUserSessionDataOverride.User,
+	DistSQLMode: &distSQLOff,
 }
 
 var (

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
@@ -1161,8 +1162,9 @@ func truncateTable(ctx context.Context, execCfg *sql.ExecutorConfig, id catid.De
 		return err
 	}
 
+	unsafeAlways := sessiondatapb.UseNewSchemaChangerUnsafeAlways
 	override := sessiondata.NodeUserSessionDataOverride
-	override.MultiOverride = "use_declarative_schema_changer=unsafe_always"
+	override.NewSchemaChangerMode = &unsafeAlways
 	_, err = execCfg.InternalDB.Executor().ExecParsed(
 		ctx,
 		redact.RedactableString("import-truncate-table"),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -970,6 +970,9 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.DistSQLMode != nil {
 		sd.DistSQLMode = *o.DistSQLMode
 	}
+	if o.NewSchemaChangerMode != nil {
+		sd.NewSchemaChangerMode = *o.NewSchemaChangerMode
+	}
 	// For 25.2, we're being conservative and explicitly disabling buffered
 	// writes for the internal executor.
 	// TODO(yuzefovich): remove this for 25.3.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -967,6 +967,9 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.PreventPartitioningSoftLimitedScans != nil {
 		sd.DistSQLPreventPartitioningSoftLimitedScans = *o.PreventPartitioningSoftLimitedScans
 	}
+	if o.DistSQLMode != nil {
+		sd.DistSQLMode = *o.DistSQLMode
+	}
 	// For 25.2, we're being conservative and explicitly disabling buffered
 	// writes for the internal executor.
 	// TODO(yuzefovich): remove this for 25.3.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -979,6 +980,11 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	sd.BufferedWritesEnabled = false
 
 	if o.MultiOverride != "" {
+		if buildutil.CrdbTestBuild {
+			if err := sessiondata.ValidateMultiOverride(o.MultiOverride); err != nil {
+				panic(errors.Wrap(err, "invalid MultiOverride"))
+			}
+		}
 		overrides := strings.Split(o.MultiOverride, ",")
 		for _, override := range overrides {
 			parts := strings.Split(override, "=")
@@ -997,17 +1003,7 @@ var ieMultiOverride = settings.RegisterStringSetting(
 		"session variables used by the InternalExecutor (performed on a best-effort basis)",
 	"",
 	settings.WithValidateString(func(_ *settings.Values, val string) error {
-		if val == "" {
-			return nil
-		}
-		overrides := strings.Split(val, ",")
-		for _, override := range overrides {
-			parts := strings.Split(override, "=")
-			if len(parts) != 2 {
-				return errors.Newf("invalid override format: expected 'variable=value', found %q", override)
-			}
-		}
-		return nil
+		return sessiondata.ValidateMultiOverride(val)
 	}),
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -471,3 +471,19 @@ statement ok
 SET CLUSTER SETTING sql.ttl.default_select_rate_limit = 0;
 
 subtest end
+
+subtest internal_executor_session_overrides_validation
+
+statement ok
+SET CLUSTER SETTING sql.internal_executor.session_overrides = 'Database=foo'
+
+statement error unknown or unsupported session variable "bogus"
+SET CLUSTER SETTING sql.internal_executor.session_overrides = 'bogus=bar'
+
+statement error invalid override format
+SET CLUSTER SETTING sql.internal_executor.session_overrides = 'no_equals_sign'
+
+statement ok
+SET CLUSTER SETTING sql.internal_executor.session_overrides = ''
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -211,10 +211,8 @@ SELECT crdb_internal.execute_internally('SELECT session_user;');
 ----
 testuser
 
-query T
-SELECT crdb_internal.execute_internally('SELECT session_user;', 'User=root');
-----
-testuser
+statement error changing "UserProto" via overrides is not allowed
+SELECT crdb_internal.execute_internally('SELECT session_user;', 'UserProto=root');
 
 user root
 
@@ -223,10 +221,8 @@ SELECT crdb_internal.execute_internally('SELECT session_user;');
 ----
 root
 
-query T
-SELECT crdb_internal.execute_internally('SELECT session_user;', 'User=testuser');
-----
-root
+statement error changing "UserProto" via overrides is not allowed
+SELECT crdb_internal.execute_internally('SELECT session_user;', 'UserProto=testuser');
 
 statement ok
 SELECT crdb_internal.execute_internally('EXPLAIN ANALYZE SELECT 1;');

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -4249,6 +4249,21 @@ func makeInternallyExecutedQueryGeneratorOverload(
 					return nil, errors.Newf("expected string argument for 'overrides', got %s", args[overridesIdx].ResolvedType())
 				}
 				overrides = string(*o)
+				if overrides != "" {
+					if err := sessiondata.ValidateMultiOverride(overrides); err != nil {
+						return nil, err
+					}
+					// Disallow changing identity or privilege fields
+					// via the override for security reasons.
+					for _, override := range strings.Split(overrides, ",") {
+						parts := strings.Split(override, "=")
+						if len(parts) == 2 && (parts[0] == "UserProto" || parts[0] == "SessionUserProto" || parts[0] == "SystemIdentityProto" || parts[0] == "IsSuperuser") {
+							return nil, errors.Newf(
+								"changing %q via overrides is not allowed", parts[0],
+							)
+						}
+					}
+				}
 			}
 			var useTxn bool
 			if withTxn {

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -90,6 +90,8 @@ type InternalExecutorOverride struct {
 	// PreventPartitioningSoftLimitedScans, if set, overrides the
 	// distsql_prevent_partitioning_soft_limited_scans session variable.
 	PreventPartitioningSoftLimitedScans *bool
+	// DistSQLMode, if set, overrides the distsql session variable.
+	DistSQLMode *sessiondatapb.DistSQLExecMode
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -92,6 +92,9 @@ type InternalExecutorOverride struct {
 	PreventPartitioningSoftLimitedScans *bool
 	// DistSQLMode, if set, overrides the distsql session variable.
 	DistSQLMode *sessiondatapb.DistSQLExecMode
+	// NewSchemaChangerMode, if set, overrides the use_declarative_schema_changer
+	// session variable.
+	NewSchemaChangerMode *sessiondatapb.NewSchemaChangerMode
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -446,6 +446,9 @@ func getValueToSet(value, typeName string) (_ reflect.Value, ok bool) {
 	case "VectorizeExecMode":
 		v, ok := sessiondatapb.VectorizeExecModeFromString(value)
 		return reflect.ValueOf(v), ok
+	case "DistSQLExecMode":
+		v, ok := sessiondatapb.DistSQLExecModeFromString(value)
+		return reflect.ValueOf(v), ok
 	}
 	return reflect.Value{}, false
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -452,8 +452,35 @@ func getValueToSet(value, typeName string) (_ reflect.Value, ok bool) {
 	case "NewSchemaChangerMode":
 		v, ok := sessiondatapb.NewSchemaChangerModeFromString(value)
 		return reflect.ValueOf(v), ok
+	case "SQLUsernameProto":
+		return reflect.ValueOf(username.SQLUsernameProto(value)), true
 	}
 	return reflect.Value{}, false
+}
+
+// ValidateMultiOverride checks that each "variable=value" pair in a
+// comma-separated override string refers to a real SessionData field and that
+// the value can be parsed for that field's type.
+func ValidateMultiOverride(multiOverride string) error {
+	if multiOverride == "" {
+		return nil
+	}
+	var sd SessionData
+	for _, override := range strings.Split(multiOverride, ",") {
+		parts := strings.Split(override, "=")
+		if len(parts) != 2 {
+			return errors.Newf(
+				"invalid override format: expected 'variable=value', found %q",
+				override,
+			)
+		}
+		if !sd.Update(parts[0], parts[1]) {
+			return errors.Newf(
+				"unknown or unsupported session variable %q", parts[0],
+			)
+		}
+	}
+	return nil
 }
 
 // updateField updates a single field in elem (which must be of Struct kind)

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -449,6 +449,9 @@ func getValueToSet(value, typeName string) (_ reflect.Value, ok bool) {
 	case "DistSQLExecMode":
 		v, ok := sessiondatapb.DistSQLExecModeFromString(value)
 		return reflect.ValueOf(v), ok
+	case "NewSchemaChangerMode":
+		v, ok := sessiondatapb.NewSchemaChangerModeFromString(value)
+		return reflect.ValueOf(v), ok
 	}
 	return reflect.Value{}, false
 }

--- a/pkg/sql/sessiondata/session_data_test.go
+++ b/pkg/sql/sessiondata/session_data_test.go
@@ -172,6 +172,8 @@ func TestUpdateSessionData(t *testing.T) {
 		{variable: "OptSplitScanLimit", value: "123", localOnly: true, expectedSubstring: `opt_split_scan_limit:123`},
 		// DistSQLExecMode custom type.
 		{variable: "DistSQLMode", value: "on", localOnly: true, expectedSubstring: `dist_sql_mode:2`},
+		// NewSchemaChangerMode custom type.
+		{variable: "NewSchemaChangerMode", value: "unsafe_always", localOnly: true, expectedSubstring: `new_schema_changer_mode:3`},
 	} {
 		sd = SessionData{}
 		ok := sd.Update(tc.variable, tc.value)

--- a/pkg/sql/sessiondata/session_data_test.go
+++ b/pkg/sql/sessiondata/session_data_test.go
@@ -170,6 +170,8 @@ func TestUpdateSessionData(t *testing.T) {
 		{variable: "LargeFullScanRows", value: "12.34", localOnly: true, expectedSubstring: `large_full_scan_rows:12.34`},
 		// int32 type.
 		{variable: "OptSplitScanLimit", value: "123", localOnly: true, expectedSubstring: `opt_split_scan_limit:123`},
+		// DistSQLExecMode custom type.
+		{variable: "DistSQLMode", value: "on", localOnly: true, expectedSubstring: `dist_sql_mode:2`},
 	} {
 		sd = SessionData{}
 		ok := sd.Update(tc.variable, tc.value)

--- a/pkg/sql/sessiondata/session_data_test.go
+++ b/pkg/sql/sessiondata/session_data_test.go
@@ -150,9 +150,8 @@ func TestUpdateSessionData(t *testing.T) {
 	}{
 		// string type.
 		{variable: "Database", value: "foo", localOnly: false, expectedSubstring: `database:"foo"`},
-		// This variable uses string type under the hood but has the custom
-		// cast type which isn't handled, so the update should be a no-op.
-		{variable: "UserProto", value: "foo", localOnly: false},
+		// SQLUsernameProto custom type.
+		{variable: "UserProto", value: "foo", localOnly: false, expectedSubstring: `user_proto:"foo"`},
 		// This variable has a custom type that isn't handled, so the update
 		// should be a no-op.
 		{variable: "DataConversionConfig", value: "foo", localOnly: false},
@@ -192,5 +191,49 @@ func TestUpdateSessionData(t *testing.T) {
 			require.Equal(t, unchangedLocal, local)
 			require.Equal(t, unchangedRemote, remote)
 		}
+	}
+}
+
+func TestValidateMultiOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		input       string
+		expectedErr string
+	}{
+		{name: "empty", input: ""},
+		{name: "valid bool", input: "DefaultTxnReadOnly=true"},
+		{name: "valid string", input: "Database=foo"},
+		{name: "valid multiple", input: "Database=foo,DefaultTxnReadOnly=true"},
+		{name: "valid DistSQLMode", input: "DistSQLMode=off"},
+		{name: "valid NewSchemaChangerMode", input: "NewSchemaChangerMode=unsafe_always"},
+		{
+			name:        "bad format",
+			input:       "no_equals_sign",
+			expectedErr: "invalid override format",
+		},
+		{
+			name:        "unknown field name",
+			input:       "distsql=off",
+			expectedErr: `unknown or unsupported session variable "distsql"`,
+		},
+		{
+			name:        "bad value for type",
+			input:       "DefaultTxnReadOnly=notabool",
+			expectedErr: `unknown or unsupported session variable "DefaultTxnReadOnly"`,
+		},
+		{
+			name:        "second override invalid",
+			input:       "Database=foo,bogus=bar",
+			expectedErr: `unknown or unsupported session variable "bogus"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMultiOverride(tc.input)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### sql/hints: fix distsql=off override for statement hints queries

PR #166334 attempted to prevent distributed execution of statement hints
queries by setting `MultiOverride: "distsql=off"` in the internal
executor override. However, this override was silently ineffective due
to two aspects of the MultiOverride mechanism:

1. The `updateField()` function does exact case-sensitive struct field
name matching, so `"distsql"` doesn't match the actual Go struct
field name `"DistSQLMode"`.
2. The `getValueToSet()` function has no case for the `DistSQLExecMode`
type, so even with the correct field name, the value parsing would
fail.

This caused `TestTrace` to flake: when the statement hints cache
rangefeed hasn't initialized on the node running the test, the hints
lookup falls through to a database query. Without the distsql=off
override actually taking effect, that query gets distributed,
producing unexpected `SetupFlow` spans in the session trace.

Fix this by:

- Adding a direct `DistSQLMode` field to `InternalExecutorOverride`,
following the established pattern used by `PlanCacheMode` and other
direct override fields.
- Using the direct field in the hints override instead of
`MultiOverride`.
- Adding `DistSQLExecMode` support to `getValueToSet()` so
`MultiOverride` also works correctly for this type going forward.

Fixes: #168528

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### importer: fix broken schema changer override in import truncate

(Here's another `MultiOverride` bug similar to the previous commit.)

The import truncate code intended to use the declarative schema
changer in `unsafe_always` mode via `MultiOverride`, but the override
string used the SQL session variable name
`"use_declarative_schema_changer"` instead of the Go struct field
name `"NewSchemaChangerMode"`. The `MultiOverride` mechanism matches
against Go struct field names, so this override was silently ignored.

Fix by adding a direct `NewSchemaChangerMode` field to
`InternalExecutorOverride` (following the same pattern as the
`DistSQLMode` field) and using it instead of `MultiOverride`.
Also add `NewSchemaChangerMode` support to `getValueToSet()` so
`MultiOverride` works correctly for this type going forward.

Epic: none

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql: validate MultiOverride strings against SessionData fields

`MultiOverride` strings use Go struct field names to identify session
variables, but there was no validation that the field names were correct
or that the values could be parsed. Invalid overrides were silently
ignored, which led to bugs like #168528.

Add a `ValidateMultiOverride` function that checks each
"variable=value" pair against a scratch `SessionData`, catching both
unknown field names and unparseable values. Use it in:
- The `sql.internal_executor.session_overrides` cluster setting
validator, so `SET CLUSTER SETTING` rejects invalid overrides.
- `applyOverrides`, where invalid overrides panic in test builds.

Epic: none

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>