### PR TITLE
sql: strip _unfinished tag in SHOW TRACE test assertions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -25,7 +25,7 @@ SELECT
   CASE WHEN message LIKE '=== operation:%'
     THEN regexp_replace(
       regexp_replace(message, ' statement:.*?( _| $)', '\1'),
-      ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+      ' (gid|node|client|user|txn|cockroach\.\w+|implicit|_unfinished):\S*| hostssl:\S*',
       '', 'g')
     ELSE regexp_replace(message, 'pos:[0-9]*', 'pos:?')
   END,
@@ -33,7 +33,7 @@ SELECT
 FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%=== operation:%' OR message LIKE '%pos%executing%';
 ----
-0   === operation:session recording _unfinished:1 _verbose:1  session recording
+0   === operation:session recording _verbose:1                session recording
 1   === operation:session tracing _verbose:1                  session tracing
 1   [Open pos:?] executing Sync                               session tracing
 2   === operation:commit sql txn _verbose:1                   commit sql txn
@@ -1951,7 +1951,7 @@ query T
 SELECT CASE WHEN message LIKE '=== operation:%'
     THEN regexp_replace(
       message,
-      ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+      ' (gid|node|client|user|txn|cockroach\.\w+|implicit|_unfinished):\S*| hostssl:\S*',
       '', 'g')
     ELSE message
   END

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -258,7 +258,7 @@ query T rowsort
 SELECT DISTINCT CASE WHEN message LIKE '=== operation:%'
     THEN regexp_replace(
       message,
-      ' (gid|node|client|user|txn|cockroach\.\w+|implicit):\S*| hostssl:\S*',
+      ' (gid|node|client|user|txn|cockroach\.\w+|implicit|_unfinished):\S*| hostssl:\S*',
       '', 'g')
     ELSE message
   END


### PR DESCRIPTION
The DistSender "sending partial batch" span can be recorded before Finish() is called, causing a non-deterministic `_unfinished:1` tag in SHOW TRACE output. This is a timing race exacerbated by the race detector. Add `_unfinished` to the regexp_replace alternation that already strips other non-deterministic span tags.

Fixes: #168869

Release note: None