### PR TITLE
inspect: expose invalid counts from the row counter interface

### DIFF
--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -87,8 +87,9 @@ type indexConsistencyCheck struct {
 	// lastQueryPlaceholders stores the placeholder values used in lastQuery.
 	lastQueryPlaceholders []interface{}
 
-	// rowCount stores the number of rows processed by the check.
-	rowCount uint64
+	// rowCount stores the number of rows processed by the check. It is nil
+	// when the check cannot provide a reliable row count for the span.
+	rowCount *uint64
 }
 
 var _ inspectCheck = (*indexConsistencyCheck)(nil)
@@ -183,7 +184,6 @@ func (c *indexConsistencyCheck) Start(
 				c.secIndex.GetName())
 		} else {
 			match, rowCount, hashErr := c.hashesMatch(ctx, allColNames, predicate, queryArgs)
-			c.rowCount = uint64(rowCount)
 			if hashErr != nil {
 				if isQueryConstructionError(hashErr) {
 					// If hashing fails and the error stems from query construction,
@@ -192,6 +192,8 @@ func (c *indexConsistencyCheck) Start(
 				}
 				// For all other hash errors, log and fall back.
 				log.Dev.Infof(ctx, "hash precheck failed; falling back to full check: %v", hashErr)
+			} else {
+				c.rowCount = &rowCount
 			}
 			if match {
 				// Hashes match, no corruption detected - skip the full check.
@@ -353,8 +355,8 @@ func (c *indexConsistencyCheck) Close(context.Context) error {
 	return nil
 }
 
-// Rows implements the inspectCheckRowCount interface.
-func (c *indexConsistencyCheck) RowCount() uint64 {
+// RowCount implements the inspectCheckRowCount interface.
+func (c *indexConsistencyCheck) RowCount() *uint64 {
 	return c.rowCount
 }
 
@@ -635,7 +637,7 @@ func (c *indexConsistencyCheck) createIndexCheckQuery(
 }
 
 type hashResult struct {
-	rowCount int64
+	rowCount uint64
 	hash     string
 }
 
@@ -645,7 +647,7 @@ type hashResult struct {
 // row count from the primary index.
 func (c *indexConsistencyCheck) hashesMatch(
 	ctx context.Context, columnNames []string, predicate string, queryArgs []interface{},
-) (match bool, rowCount int64, err error) {
+) (match bool, rowCount uint64, err error) {
 	primary, err := c.computeHashAndRowCount(ctx, c.priIndex, columnNames, predicate, queryArgs)
 	if err != nil {
 		return false, 0, errors.Wrapf(err, "computing hash for primary index %s", c.priIndex.GetName())
@@ -687,7 +689,7 @@ func (c *indexConsistencyCheck) computeHashAndRowCount(
 		return hashResult{}, errors.AssertionFailedf("hash query returned unexpected column count: %d", len(row))
 	}
 	return hashResult{
-		rowCount: int64(tree.MustBeDInt(row[0])),
+		rowCount: uint64(tree.MustBeDInt(row[0])),
 		hash:     string(tree.MustBeDBytes(row[1])),
 	}, nil
 }

--- a/pkg/sql/inspect/index_consistency_check_test.go
+++ b/pkg/sql/inspect/index_consistency_check_test.go
@@ -174,7 +174,9 @@ func runIndexConsistencyCheckTestCases(t *testing.T, testCases []indexConsistenc
 					InspectIssueLogger: issueLogger,
 					OnCheckComplete: func(check interface{}) error {
 						if rowCountCheck, ok := check.(inspectCheckRowCount); ok {
-							issueLogger.recordRowCount(rowCountCheck.RowCount())
+							if rc := rowCountCheck.RowCount(); rc != nil {
+								issueLogger.recordRowCount(*rc)
+							}
 						}
 						return nil
 					},

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -27,8 +27,9 @@ import (
 // inspectCheckRowCount extends an inspectCheck that counts rows in addition to
 // its primary validation.
 type inspectCheckRowCount interface {
-	// Rows returns the number of rows counted by the check.
-	RowCount() uint64
+	// RowCount returns nil when the check cannot provide a reliable row count
+	// for the span.
+	RowCount() *uint64
 }
 
 // rowCountCheck verifies a table's row count matches the expected count.
@@ -127,8 +128,10 @@ func (c *rowCountCheck) CheckSpan(
 	for _, check := range checks {
 		// TODO(#160989): Handle inconsistency btwn checks on the same span.
 		if check, ok := check.(inspectCheckRowCount); ok {
-			data.SpanRowCount = check.RowCount()
-			return nil
+			if rowCount := check.RowCount(); rowCount != nil {
+				data.SpanRowCount = *rowCount
+				return nil
+			}
 		}
 	}
 

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -13,9 +13,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -325,4 +328,102 @@ func TestRowCountCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockCheck is a minimal (noop) inspectCheck.
+type mockCheck struct{}
+
+var _ inspectCheck = (*mockCheck)(nil)
+
+func (*mockCheck) AppliesTo(keys.SQLCodec, roachpb.Span) (bool, error) { return true, nil }
+func (*mockCheck) IsSpanLevel() bool                                   { return false }
+func (*mockCheck) Started() bool                                       { return true }
+
+func (*mockCheck) Start(context.Context, *execinfra.ServerConfig, roachpb.Span, int) error {
+	return nil
+}
+
+func (*mockCheck) Next(context.Context, *execinfra.ServerConfig) (*inspectIssue, error) {
+	return nil, nil
+}
+
+func (*mockCheck) Done(context.Context) bool   { return true }
+func (*mockCheck) Close(context.Context) error { return nil }
+
+// mockCheckWithRowCount is a minimal inspectCheck that implements
+// inspectCheckRowCount.
+type mockCheckWithRowCount struct {
+	mockCheck
+	rowCount *uint64
+}
+
+var _ inspectCheckRowCount = (*mockCheckWithRowCount)(nil)
+
+func (m *mockCheckWithRowCount) RowCount() *uint64 { return m.rowCount }
+
+// TestRowCountCheckSpanFallback verifies the row count interface dispatch in
+// CheckSpan: When checks implement inspectCheckRowCount but return nil, the
+// rowCountCheck falls back to counting rows itself; when one of several checks
+// returns a non-nil count, that count is used directly.
+func TestRowCountCheckSpanFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	codec := s.ApplicationLayer().Codec()
+	execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
+	r := sqlutils.MakeSQLRunner(db)
+
+	r.Exec(t, `CREATE DATABASE test`)
+	r.Exec(t, `CREATE TABLE test.t (id INT PRIMARY KEY)`)
+	defer r.Exec(t, `DROP TABLE test.t`)
+	r.Exec(t, `INSERT INTO test.t SELECT * FROM generate_series(1, 50)`)
+
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", "t")
+	pkSpan := tableDesc.PrimaryIndexSpan(codec)
+
+	var timestampStr string
+	r.QueryRow(t, "SELECT cluster_logical_timestamp()::STRING").Scan(&timestampStr)
+	asOf, err := hlc.ParseHLC(timestampStr)
+	require.NoError(t, err)
+
+	newRowCountCheck := func() *rowCountCheck {
+		return &rowCountCheck{
+			rowCountCheckApplicability: rowCountCheckApplicability{
+				tableID: tableDesc.GetID(),
+			},
+			execCfg:      &execCfg,
+			tableVersion: tableDesc.GetVersion(),
+			asOf:         asOf,
+		}
+	}
+
+	t.Run("nil_row_count_falls_back_to_query", func(t *testing.T) {
+		rc := newRowCountCheck()
+		data := &inspectpb.InspectProcessorSpanCheckData{}
+		checks := inspectChecks{&mockCheckWithRowCount{rowCount: nil}}
+		err := rc.CheckSpan(ctx, checks, pkSpan, nil /* logger */, data)
+		require.NoError(t, err)
+		require.Equal(t, uint64(50), data.SpanRowCount)
+	})
+
+	t.Run("second_check_provides_row_count", func(t *testing.T) {
+		rc := newRowCountCheck()
+		data := &inspectpb.InspectProcessorSpanCheckData{}
+		count := uint64(42)
+		checks := inspectChecks{
+			&mockCheckWithRowCount{rowCount: nil},
+			&mockCheckWithRowCount{rowCount: &count},
+		}
+		err := rc.CheckSpan(ctx, checks, pkSpan, nil /* logger */, data)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), data.SpanRowCount)
+	})
 }


### PR DESCRIPTION
The row count check opportunistically uses other
checks to get row counts; the index consistency
check has been reporting bad counts on empty spans
so the row counter does an empty span check
validation and discards the bad count if it finds
one. This change updates the row counter interface
to allow checks to report invalid counts so the
row count check can trust the other checks rather
than having to do its own validations.

Epic: none
Part of: #168001
Informs: #168158
Part of: #168396

Release note: None
