### PR TITLE
release-25.4: sql: deflake TestIndexBackfillAfterGC

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4201,6 +4201,17 @@ func TestIndexBackfillAfterGC(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'))`)
 		sqlDB.Exec(t, `INSERT INTO t.test VALUES (1, 1)`)
 
+		// Split t.test off into its own range. Without this, t.test shares a
+		// range with system tables (notably system.jobs), and the GCRequest
+		// injected below would advance the GC threshold on that shared range.
+		// The schema changer recovers from BatchTimestampBeforeGCError on the
+		// backfill, but the parallel poll-show-jobs query in jobs.WaitForJobs
+		// would race with the threshold bump and fail the CREATE INDEX.
+		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "test")
+		if err := kvDB.AdminSplit(ctx, codec.TablePrefix(uint32(tableDesc.GetID())), hlc.MaxTimestamp); err != nil {
+			t.Fatal(err)
+		}
+
 		shouldRunGC.Store(true)
 		if _, err := db.Exec(
 			fmt.Sprintf(`CREATE UNIQUE INDEX %s ON t.test (v)`, indexName),


### PR DESCRIPTION
Backport 1/1 commits from #168904 on behalf of @spilchen.

----

TestIndexBackfillAfterGC injects a GCRequest during an index backfill to verify that the schema changer recovers from BatchTimestampBeforeGCError. The GCRequest is sent on the chunk span passed to the RunBeforeBackfillChunk knob, which falls within t.test's keyspace.

t.test was sharing a range with system tables (notably system.jobs), so the GC threshold bump on that shared range caused the parallel poll-show-jobs query in jobs.WaitForJobs to race with the threshold and fail the CREATE INDEX.

Split t.test off into its own range before issuing the CREATE INDEX so the GCRequest only affects t.test data.

Resolves: #168738
Epic: none

Release note: None

----

Release justification: test only fix