### PR TITLE
sql: align `ALTER TYPE ... RENAME VALUE` name conflicts with postgres

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -304,19 +304,13 @@ func (p *planner) renameTypeValue(
 ) error {
 	enumMemberIndex := -1
 
-	// Do one pass to verify that the oldVal exists and there isn't already
-	// a member that is named newVal.
+	// Verify that oldVal exists.
 	for i := range n.desc.EnumMembers {
-		member := n.desc.EnumMembers[i]
-		if member.LogicalRepresentation == oldVal {
+		if n.desc.EnumMembers[i].LogicalRepresentation == oldVal {
 			enumMemberIndex = i
-		} else if member.LogicalRepresentation == newVal {
-			return pgerror.Newf(pgcode.DuplicateObject,
-				"enum value %s already exists", newVal)
+			break
 		}
 	}
-
-	// An enum member with the name oldVal was not found.
 	if enumMemberIndex == -1 {
 		return pgerror.Newf(pgcode.InvalidParameterValue,
 			"%s is not an existing enum value", oldVal)
@@ -329,7 +323,14 @@ func (p *planner) renameTypeValue(
 	if enumMemberIsAdding(&n.desc.EnumMembers[enumMemberIndex]) {
 		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			"enum value %q is being added, try again later", oldVal)
+	}
 
+	// Check that newVal doesn't already exist.
+	for _, member := range n.desc.EnumMembers {
+		if member.LogicalRepresentation == newVal {
+			return pgerror.Newf(pgcode.DuplicateObject,
+				"enum value %s already exists", newVal)
+		}
 	}
 
 	n.desc.EnumMembers[enumMemberIndex].LogicalRepresentation = newVal

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -85,6 +85,14 @@ ALTER TYPE names RENAME VALUE 'james' TO 'johnny'
 statement error jim is not an existing enum value
 ALTER TYPE names RENAME VALUE 'jim' TO 'jimmy'
 
+# When oldVal doesn't exist and newVal does, report the missing old value first.
+statement error nonexistent is not an existing enum value
+ALTER TYPE names RENAME VALUE 'nonexistent' TO 'johnny'
+
+# Renaming a value to itself errors.
+statement error enum value james already exists
+ALTER TYPE names RENAME VALUE 'james' TO 'james'
+
 statement ok
 ALTER TYPE names RENAME VALUE 'james' to 'jimmy'
 


### PR DESCRIPTION
These behaviors in the legacy schemachanger were previously untested and
inconsistent with postgres.

Part of: #164220
Epic: CRDB-31325

Release note (sql change): Conflicting names in `ALTER TYPE ... RENAME
VALUE` error consistently with Postgres.
