### PR TITLE
kvserver: enable loosely coupled truncations metamorphically

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -61,6 +61,9 @@ func registerKV(r registry.Registry) {
 		jemallocReleaseFaster bool
 		// Set to true to reduce the Pebble block cache from 25% to 20%.
 		smallBlockCache bool
+		// TODO(ibrahim): Remove this flag once looselyCoupled truncation is enabled
+		// by default.
+		looselyCoupledTrunc bool
 	}
 	computeConcurrency := func(opts kvOptions) int {
 		// Scale the workload concurrency with the number of nodes in the cluster to
@@ -117,6 +120,11 @@ func registerKV(r registry.Registry) {
 		if opts.tracing {
 			if _, err := db.ExecContext(ctx, "SET CLUSTER SETTING trace.debug.enable = true"); err != nil {
 				t.Fatalf("failed to enable tracing: %v", err)
+			}
+		}
+		if opts.looselyCoupledTrunc {
+			if _, err := db.ExecContext(ctx, "SET CLUSTER SETTING kv.raft_log.loosely_coupled_truncation.enabled = true"); err != nil {
+				t.Fatalf("failed to enable loosely coupled raft log truncation: %v", err)
 			}
 		}
 		if opts.sharedProcessMT {
@@ -231,6 +239,7 @@ func registerKV(r registry.Registry) {
 		{nodes: 3, cpus: 8, readPercent: 0, blockSize: 1 << 12 /* 4 KB */},
 		{nodes: 3, cpus: 8, readPercent: 95, blockSize: 1 << 12 /* 4 KB */},
 		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 12 /* 4 KB */},
+		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 12 /* 4 KB */, looselyCoupledTrunc: true},
 		{nodes: 3, cpus: 32, readPercent: 95, blockSize: 1 << 12 /* 4 KB */},
 		{nodes: 3, cpus: 8, readPercent: 0, blockSize: 1 << 16 /* 64 KB */},
 		{nodes: 3, cpus: 8, readPercent: 95, blockSize: 1 << 16 /* 64 KB */},
@@ -243,7 +252,13 @@ func registerKV(r registry.Registry) {
 		{nodes: 3, cpus: 8, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 100},
 		{nodes: 3, cpus: 8, readPercent: 95, blockSize: 1 << 16 /* 64 KB */, splits: 100},
 		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 100},
+		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 100, looselyCoupledTrunc: true},
 		{nodes: 3, cpus: 32, readPercent: 95, blockSize: 1 << 16 /* 64 KB */, splits: 100},
+
+		// TODO(ibrahim): Remove these two tests after loosely coupled truncations
+		// are enabled by default, and we are confident about their performance.
+		{nodes: 5, cpus: 8, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 10000},
+		{nodes: 5, cpus: 8, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 10000, looselyCoupledTrunc: true},
 
 		// Configs with large batch sizes.
 		{nodes: 3, cpus: 8, readPercent: 0, batchSize: 16},
@@ -328,6 +343,9 @@ func registerKV(r registry.Registry) {
 		}
 		if opts.sharedProcessMT {
 			nameParts = append(nameParts, "mt-shared-process")
+		}
+		if opts.looselyCoupledTrunc {
+			nameParts = append(nameParts, "loosely-coupled")
 		}
 		owner := registry.OwnerTestEng
 		if opts.owner != "" {

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3507,6 +3507,11 @@ func TestLeaseTransferRejectedIfTargetNeedsSnapshot(t *testing.T) {
 		_, pErr = kv.SendWrapped(ctx, store0.TestSender(), truncArgs)
 		require.Nil(t, pErr)
 
+		// Wait for the truncation to be enacted. Under loosely coupled
+		// truncations, the truncation is applied asynchronously after the state
+		// machine engine flushes, so we poll until GetCompactedIndex catches up.
+		waitForTruncationForTesting(t, repl0, index)
+
 		// Complete or initiate the lease transfer attempt to node 2, which must not
 		// succeed because node 2 now needs a snapshot.
 		var transferErr error

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
@@ -117,7 +118,7 @@ var looselyCoupledTruncationEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.raft_log.loosely_coupled_truncation.enabled",
 	"set to true to loosely couple the raft log truncation",
-	false,
+	metamorphic.ConstantWithTestBool("kv.raft_log.loosely_coupled_truncation.enabled", false),
 	settings.WithVisibility(settings.Reserved),
 )
 


### PR DESCRIPTION
This PR does the following:

1) Enables loosely coupled truncations metamorphically (in unit tests, non-benchmark roachtests).
2) Create a couple of benchmark roachtests that run tightly and loosely coupled truncations to compare the two over  time.

References: #93248

Release note: None