### PR TITLE
ci/ai: fix investigate.md prompt to use

### DIFF
--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -193,8 +193,12 @@ artifact is `failure-logs.tbz` — a bzip2-compressed tar archive bundled
 
 ```bash
 unzip -j "$DEST/artifacts.zip" "failure-logs.tbz" -d "$DEST"
-tar -xjf "$DEST/failure-logs.tbz" -C "$DEST"
+tar --extract -f "$DEST/failure-logs.tbz" -C "$DEST"
 ```
+
+(GNU tar auto-detects bzip2 compression on extract, so no `-j` flag
+is needed. Use the long-form `--extract` because that's the form
+allowed by the workflow's tool permissions; `tar -xjf` is sandboxed.)
 
 The archive contains:
 


### PR DESCRIPTION
`tar -xjf` is sandboxed, so we use
`tar --extract -f` instead.

Epic: none
Release note: None