### PR TITLE
obs: make `ASH` settings application-level

### DIFF
--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -28,11 +28,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// Enabled controls whether ASH sampling is active. This is a
-// system-level setting because the sampler is a process-wide
-// singleton.
+// Enabled controls whether ASH sampling is active. This is an
+// application-level setting because ASH sampling is owned by the SQL
+// process rather than the shared KV/storage layer. In shared-process
+// multi-tenancy, the single process-global sampler remains bound to the
+// system tenant's cluster settings.
 var Enabled = settings.RegisterBoolSetting(
-	settings.SystemVisible,
+	settings.ApplicationLevel,
 	"obs.ash.enabled",
 	"enable active session history sampling",
 	false,
@@ -43,11 +45,13 @@ var Enabled = settings.RegisterBoolSetting(
 // that callers of SetWorkState do not need to pass in cluster settings.
 var enabled atomic.Bool
 
-// SampleInterval controls how often ASH samples are taken. This is a
-// system-level setting because the sampler is a process-wide
-// singleton.
+// SampleInterval controls how often ASH samples are taken. This is an
+// application-level setting because ASH sampling is owned by the SQL
+// process rather than the shared KV/storage layer. In shared-process
+// multi-tenancy, the single process-global sampler remains bound to the
+// system tenant's cluster settings.
 var SampleInterval = settings.RegisterDurationSetting(
-	settings.SystemVisible,
+	settings.ApplicationLevel,
 	"obs.ash.sample_interval",
 	"interval between ASH samples",
 	time.Second,
@@ -56,10 +60,12 @@ var SampleInterval = settings.RegisterDurationSetting(
 )
 
 // BufferSize controls the maximum number of ASH samples retained in
-// memory. This is a system-level setting because the sampler is a
-// process-wide singleton.
+// memory. This is an application-level setting because ASH sampling is
+// owned by the SQL process rather than the shared KV/storage layer. In
+// shared-process multi-tenancy, the single process-global sampler
+// remains bound to the system tenant's cluster settings.
 var BufferSize = settings.RegisterIntSetting(
-	settings.SystemVisible,
+	settings.ApplicationLevel,
 	"obs.ash.buffer_size",
 	"number of ASH samples to retain in memory",
 	1_000_000,
@@ -76,7 +82,7 @@ var BufferSize = settings.RegisterIntSetting(
 // profiler when writing reports alongside CPU profiles or goroutine
 // dumps triggered by the env sampler.
 var LogInterval = settings.RegisterDurationSetting(
-	settings.SystemVisible,
+	settings.ApplicationLevel,
 	"obs.ash.log_interval",
 	"interval between periodic ASH top-N workload summary logs; "+
 		"also used as the lookback window for ASH reports written "+
@@ -90,7 +96,7 @@ var LogInterval = settings.RegisterDurationSetting(
 // in each periodic summary. Entries are ranked by sample count
 // (descending), so only the most frequently sampled workloads appear.
 var LogTopN = settings.RegisterIntSetting(
-	settings.SystemVisible,
+	settings.ApplicationLevel,
 	"obs.ash.log_top_n",
 	"maximum number of entries in periodic ASH workload summary, "+
 		"ranked by sample count descending",

--- a/pkg/server/ash_test.go
+++ b/pkg/server/ash_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
@@ -192,4 +193,95 @@ func TestASHVirtualTableAccessControl(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestASHClusterSettingsSeparateProcessTenantCanModify(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	_, tenantDB := serverutils.StartTenant(t, srv, base.TestTenantArgs{
+		TenantName: "ext-ash",
+		TenantID:   serverutils.TestTenantID(),
+	})
+	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
+
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "obs.ash.enabled", value: "true", want: "true"},
+		{name: "obs.ash.sample_interval", value: "'250ms'", want: "00:00:00.25"},
+		{name: "obs.ash.buffer_size", value: "2048", want: "2048"},
+		{name: "obs.ash.log_interval", value: "'2m'", want: "00:02:00"},
+		{name: "obs.ash.log_top_n", value: "7", want: "7"},
+	} {
+		tenantSQL.Exec(t, fmt.Sprintf("SET CLUSTER SETTING %s = %s", tc.name, tc.value))
+		tenantSQL.CheckQueryResults(t,
+			fmt.Sprintf("SHOW CLUSTER SETTING %s", tc.name),
+			[][]string{{tc.want}},
+		)
+	}
+}
+
+func TestASHClusterSettingsSharedProcessTenantDoesNotControlSampler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ash.ResetGlobalSamplerForTesting()
+
+	ctx := context.Background()
+	srv, systemDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	systemSQL := sqlutils.MakeSQLRunner(systemDB)
+	systemSQL.Exec(t, `SET CLUSTER SETTING obs.ash.enabled = true`)
+	systemSQL.Exec(t, `SET CLUSTER SETTING obs.ash.sample_interval = '10ms'`)
+
+	_, tenantDB := serverutils.StartSharedProcessTenant(t, srv, base.TestSharedProcessTenantArgs{
+		TenantName: "shared-ash",
+		TenantID:   serverutils.TestTenantID(),
+	})
+	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
+	tenantSQL.Exec(t, `SET CLUSTER SETTING obs.ash.enabled = false`)
+	tenantSQL.Exec(t, `SET application_name = 'shared_process_app'`)
+	tenantSQL.Exec(t, `CREATE TABLE t (id INT PRIMARY KEY, data STRING)`)
+	tenantSQL.Exec(t, `INSERT INTO t SELECT i, repeat('x', 32) FROM generate_series(1, 2000) AS g(i)`)
+
+	testutils.SucceedsSoon(t, func() error {
+		tenantSQL.Exec(t, `SELECT count(*) FROM t WHERE data LIKE '%x%'`)
+
+		var count int
+		tenantSQL.QueryRow(t,
+			`SELECT count(*) FROM crdb_internal.node_active_session_history WHERE app_name = 'shared_process_app'`,
+		).Scan(&count)
+		if count == 0 {
+			return errors.Newf("expected ASH samples for shared-process tenant despite tenant-local disabled setting")
+		}
+		return nil
+	})
+
+	tenantSQL.CheckQueryResults(t,
+		`SHOW CLUSTER SETTING obs.ash.enabled`,
+		[][]string{{"false"}},
+	)
+
+	// Give the sampler another tick and verify samples continue to appear,
+	// demonstrating that the process-global sampler is still driven by the
+	// system tenant's settings in shared-process mode.
+	time.Sleep(25 * time.Millisecond)
+	tenantSQL.Exec(t, `SELECT count(*) FROM t WHERE data LIKE '%x%'`)
+	var finalCount int
+	tenantSQL.QueryRow(t,
+		`SELECT count(*) FROM crdb_internal.node_active_session_history WHERE app_name = 'shared_process_app'`,
+	).Scan(&finalCount)
+	require.NotZero(t, finalCount)
 }


### PR DESCRIPTION
Change the `ASH` process-local cluster settings from `SystemVisible` to `ApplicationLevel`.

Before this change, separate-process tenants could not modify `obs.ash.enabled`, `obs.ash.sample_interval`, `obs.ash.buffer_size`, `obs.ash.log_interval`, or `obs.ash.log_top_n` because those settings were classified as system-visible. That classification matched shared-process multi-tenancy, where a single process-wide `ASH` sampler is shared across tenants, but it was too restrictive for separate-process deployments where each tenant has its own `SQL` process and its own sampler.

With this change, separate-process tenants can tune their own `ASH` settings. Shared-process behavior is preserved because the process-global sampler still remains bound to the system tenant's cluster settings.

Add regression tests covering both cases: separate-process tenants can set the `ASH` settings, and shared-process tenants do not take control of the shared sampler by changing tenant-local values.

Fixes: https://github.com/cockroachdb/cockroach/issues/168064
Epic: [CRDB-62772](https://cockroachlabs.atlassian.net/browse/CRDB-62772)