### PR TITLE
roachtest: add sysbench-drpc variant to isolate DRPC performance impact

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -396,6 +396,21 @@ func registerSysbench(r registry.Registry) {
 				return true
 			},
 		},
+		// DRPC-only variant: default cluster settings with DRPC enabled,
+		// to isolate DRPC's performance impact. The baseline for comparison
+		// is sysbench/*/nodes=3/cpu=8 (default settings, no DRPC).
+		{n: 3, cpus: 8,
+			transform: func(opts *sysbenchOptions) bool {
+				if !coreThree(opts.workload) {
+					return false
+				}
+				opts.extra = extraSetup{
+					nameSuffix: "-drpc",
+					useDRPC:    true,
+				}
+				return true
+			},
+		},
 	} {
 		for w := sysbenchWorkload(0); w < numSysbenchWorkloads; w++ {
 			concPerCPU := d.n*3 - 1


### PR DESCRIPTION
Add a sysbench-drpc benchmark variant that runs the three core sysbench
workloads (oltp_read_only, oltp_read_write, oltp_write_only) with DRPC
enabled but otherwise default cluster settings. The existing
sysbench-settings variant bundles DRPC with other optimizations (stats
flush disabled, write buffering, etc.), making it impossible to attribute
performance differences to DRPC alone. This variant provides a clean A/B
comparison against the baseline sysbench tests (gRPC, default settings).
No regressions observed.

## Sysbench: gRPC (baseline) vs DRPC — 3 nodes, 8 vCPU, 64 threads, 10 tables x 10M rows

### oltp_read_only

| Metric | gRPC (baseline) | DRPC | Delta |
|--------|-----------------|------|-------|
| QPS | 49,589.66 | 57,838.25 | +16.6% |
| TPS | 3,099.35 | 3,614.89 | +16.6% |
| Avg latency | 20.65 ms | 17.70 ms | -14.3% |
| P95 latency | 33.72 ms | 25.74 ms | -23.7% |
| Max latency | 124.26 ms | 105.71 ms | -14.9% |

### oltp_read_write

| Metric | gRPC (baseline) | DRPC | Delta |
|--------|-----------------|------|-------|
| QPS | 25,355.64 | 28,336.70 | +11.7% |
| TPS | 1,267.78 | 1,416.84 | +11.8% |
| Avg latency | 50.48 ms | 45.17 ms | -10.5% |
| P95 latency | 82.96 ms | 68.05 ms | -18.0% |
| Max latency | 404.21 ms | 270.39 ms | -33.1% |

### oltp_write_only

| Metric | gRPC (baseline) | DRPC | Delta |
|--------|-----------------|------|-------|
| QPS | 17,724.29 | 17,981.74 | +1.5% |
| TPS | 2,954.05 | 2,996.96 | +1.5% |
| Avg latency | 21.66 ms | 21.35 ms | -1.4% |
| P95 latency | 34.95 ms | 33.72 ms | -3.5% |
| Max latency | 223.02 ms | 190.13 ms | -14.7% |

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/168322
Release note: None