### PR TITLE
release-26.2: sql/schemachanger: don't preserve old PK when DROP+ADD in same statement

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -881,7 +881,9 @@ t  CREATE TABLE public.t (
      FAMILY fam_1_y (y)
    );
 
-# The declarative schema changer leaves behind an index on the old primary key column.
+# Regression for #168748: when DROP CONSTRAINT <pk> and ADD PRIMARY KEY appear
+# in the same statement, the DSC must not preserve the old PK as a unique
+# secondary index.
 skipif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
@@ -890,7 +892,6 @@ t  CREATE TABLE public.t (
      x INT8 NOT NULL,
      y INT8 NOT NULL,
      CONSTRAINT t_pkey PRIMARY KEY (y ASC),
-     UNIQUE INDEX t_x_key (x ASC),
      FAMILY fam_0_x (x),
      FAMILY fam_1_y (y)
    );
@@ -1103,8 +1104,7 @@ t  CREATE TABLE public.t (
      x INT8 NOT NULL,
      y INT8 NOT NULL,
      z INT8 NULL AS (x + 1:::INT8) STORED,
-     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
-     UNIQUE INDEX t_x_key (x ASC)
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC)
    );
 
 subtest create_table_change_pk

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key_regressions
@@ -653,4 +653,49 @@ CREATE TABLE public.table_w0_66 (
   FAMILY "fam_0_Abc_ab\f" ("Abc", "ab\f")
 ) WITH (schema_locked = true);
 
+# Regression for #168748: combining DROP CONSTRAINT <pk> with ADD PRIMARY KEY
+# in a single ALTER TABLE must not leave behind a unique secondary index on
+# the old PK columns. The user explicitly asked for the old PK to go away,
+# so the standard "preserve old PK as a unique secondary" behavior of ALTER
+# PRIMARY KEY does not apply.
+statement disable-cf-mutator ok
+CREATE TABLE t168748 (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false)
+
+statement ok
+ALTER TABLE t168748 DROP CONSTRAINT t168748_pkey, ADD PRIMARY KEY (y)
+
+query TT
+SHOW CREATE TABLE t168748
+----
+t168748  CREATE TABLE public.t168748 (
+           x INT8 NOT NULL,
+           y INT8 NOT NULL,
+           CONSTRAINT t168748_pkey PRIMARY KEY (y ASC)
+         );
+
+statement ok
+DROP TABLE t168748
+
+# Same as above but with a composite old PK: covers the shape that originally
+# motivated the "preserve old PK as a unique secondary" behavior, ensuring it
+# is suppressed for composite keys too.
+statement disable-cf-mutator ok
+CREATE TABLE t168748_composite (a INT, b INT, c INT NOT NULL, PRIMARY KEY (a, b)) WITH (schema_locked = false)
+
+statement ok
+ALTER TABLE t168748_composite DROP CONSTRAINT t168748_composite_pkey, ADD PRIMARY KEY (c)
+
+query TT
+SHOW CREATE TABLE t168748_composite
+----
+t168748_composite  CREATE TABLE public.t168748_composite (
+                     a INT8 NOT NULL,
+                     b INT8 NOT NULL,
+                     c INT8 NOT NULL,
+                     CONSTRAINT t168748_composite_pkey PRIMARY KEY (c ASC)
+                   );
+
+statement ok
+DROP TABLE t168748_composite
+
 subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -100,6 +100,10 @@ func alterTableAddPrimaryKey(
 		Sharded:       d.Sharded,
 		Name:          d.Name,
 		StorageParams: d.StorageParams,
+		// If the user did not have a default rowid PK, the only legal way to
+		// reach this point is to have dropped the existing PK constraint by
+		// name in the same statement (the panic above guarantees this).
+		PkConstraintExplicitlyDropped: implicitRowIDPKCol == nil,
 	})
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -55,6 +55,15 @@ type alterPrimaryKeySpec struct {
 	Name          tree.Name
 	StorageParams tree.StorageParams
 	Partitioning  *partitioningSpec
+
+	// PkConstraintExplicitlyDropped is true when the user dropped the existing
+	// primary key constraint by name in the same statement (e.g.
+	// `ALTER TABLE ... DROP CONSTRAINT <pk>, ADD PRIMARY KEY (...)`). In that
+	// case alterPrimaryKey must not preserve the old PK as a unique secondary
+	// index — the user explicitly asked for the uniqueness constraint to go
+	// away. Only set by the ADD CONSTRAINT entry point; ALTER PRIMARY KEY
+	// leaves it false.
+	PkConstraintExplicitlyDropped bool
 }
 
 // partitioningSpec specifies partitioning to apply during ALTER PRIMARY KEY.
@@ -955,7 +964,8 @@ func maybeAddUniqueIndexForOldPrimaryKey(
 ) {
 	overrideIndexPartitioning := t.Partitioning != nil
 	if !shouldCreateUniqueIndexOnOldPrimaryKeyColumns(
-		b, t.n, tbl, oldPrimaryIndex.IndexID, newPrimaryIndex.IndexID, rowidToDrop, overrideIndexPartitioning,
+		b, t.n, tbl, oldPrimaryIndex.IndexID, newPrimaryIndex.IndexID, rowidToDrop,
+		overrideIndexPartitioning, t.PkConstraintExplicitlyDropped,
 	) {
 		return
 	}
@@ -1116,6 +1126,9 @@ func addIndexNameForNewUniqueSecondaryIndex(b BuildCtx, tbl *scpb.Table, indexID
 
 // We only recreate the old primary key of the table as a unique secondary
 // index if:
+//   - The user did not explicitly drop the old PK constraint in the same
+//     statement (e.g. `ALTER TABLE ... DROP CONSTRAINT <pk>, ADD PRIMARY
+//     KEY (...)`).
 //   - The table has a primary key (no DROP PRIMARY KEY statements have
 //     been executed).
 //   - The primary key is not the default rowid primary key.
@@ -1130,7 +1143,11 @@ func shouldCreateUniqueIndexOnOldPrimaryKeyColumns(
 	oldPrimaryIndexID, newPrimaryIndexID catid.IndexID,
 	rowidToDrop *scpb.Column,
 	overrideIndexPartitioning bool,
+	pkConstraintExplicitlyDropped bool,
 ) bool {
+	if pkConstraintExplicitlyDropped {
+		return false
+	}
 	// A function that retrieves all KEY columns of this index.
 	// If excludeShardedCol, sharded column is excluded, if any.
 	keyColumnIDsAndDirsOfIndex := func(

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_add_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_add_primary_key
@@ -8,106 +8,106 @@ ALTER TABLE t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i);
 ----
 StatementPhase stage 1 of 1 with 6 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexData:{DescID: 104, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexData:{DescID: 104, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.MakeAbsentIndexBackfilling
       Index:
-        ConstraintID: 4
-        IndexID: 4
+        ConstraintID: 2
+        IndexID: 2
         IsUnique: true
         SourceIndexID: 1
         TableID: 104
-        TemporaryIndexID: 5
+        TemporaryIndexID: 3
     *scop.AddColumnToIndex
       ColumnID: 2
-      IndexID: 4
+      IndexID: 2
       TableID: 104
     *scop.MakeAbsentTempIndexDeleteOnly
       Index:
-        ConstraintID: 5
-        IndexID: 5
+        ConstraintID: 3
+        IndexID: 3
         IsUnique: true
         SourceIndexID: 1
         TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 2
-      IndexID: 5
+      IndexID: 3
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 1
-      IndexID: 4
+      IndexID: 2
       Ordinal: 1
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 1
-      IndexID: 5
+      IndexID: 3
       Ordinal: 1
       TableID: 104
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
-    [[IndexData:{DescID: 104, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[IndexData:{DescID: 104, IndexID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
 PreCommitPhase stage 2 of 2 with 10 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexData:{DescID: 104, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexData:{DescID: 104, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.MakeAbsentIndexBackfilling
       Index:
-        ConstraintID: 4
-        IndexID: 4
+        ConstraintID: 2
+        IndexID: 2
         IsUnique: true
         SourceIndexID: 1
         TableID: 104
-        TemporaryIndexID: 5
+        TemporaryIndexID: 3
     *scop.MaybeAddSplitForIndex
-      IndexID: 4
+      IndexID: 2
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 2
-      IndexID: 4
+      IndexID: 2
       TableID: 104
     *scop.MakeAbsentTempIndexDeleteOnly
       Index:
-        ConstraintID: 5
-        IndexID: 5
+        ConstraintID: 3
+        IndexID: 3
         IsUnique: true
         SourceIndexID: 1
         TableID: 104
     *scop.MaybeAddSplitForIndex
-      IndexID: 5
+      IndexID: 3
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 2
-      IndexID: 5
+      IndexID: 3
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 1
-      IndexID: 4
+      IndexID: 2
       Ordinal: 1
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 1
-      IndexID: 5
+      IndexID: 3
       Ordinal: 1
       TableID: 104
     *scop.SetJobStateOnDescriptor
@@ -120,146 +120,14 @@ PreCommitPhase stage 2 of 2 with 10 MutationType ops
       DescriptorIDs:
       - 104
       JobID: 1
-      RunningStatus: 'Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 1 of 15).'
+      RunningStatus: 'Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 1 of 7).'
       Statements:
       - statement: ALTER TABLE t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
         redactedstatement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
         statementtag: ALTER TABLE
-PostCommitPhase stage 1 of 15 with 3 MutationType ops
+PostCommitPhase stage 1 of 7 with 3 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
-    [[IndexData:{DescID: 104, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-  ops:
-    *scop.MakeDeleteOnlyIndexWriteOnly
-      IndexID: 5
-      TableID: 104
-    *scop.SetJobStateOnDescriptor
-      DescriptorID: 104
-    *scop.UpdateSchemaChangerJob
-      JobID: 1
-PostCommitPhase stage 2 of 15 with 1 BackfillType op
-  transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
-  ops:
-    *scop.BackfillIndex
-      IndexID: 4
-      SourceIndexID: 1
-      TableID: 104
-PostCommitPhase stage 3 of 15 with 3 MutationType ops
-  transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
-  ops:
-    *scop.MakeBackfillingIndexDeleteOnly
-      IndexID: 4
-      TableID: 104
-    *scop.SetJobStateOnDescriptor
-      DescriptorID: 104
-    *scop.UpdateSchemaChangerJob
-      JobID: 1
-PostCommitPhase stage 4 of 15 with 3 MutationType ops
-  transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
-  ops:
-    *scop.MakeBackfilledIndexMerging
-      IndexID: 4
-      TableID: 104
-    *scop.SetJobStateOnDescriptor
-      DescriptorID: 104
-    *scop.UpdateSchemaChangerJob
-      JobID: 1
-PostCommitPhase stage 5 of 15 with 1 BackfillType op
-  transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
-  ops:
-    *scop.MergeIndex
-      BackfilledIndexID: 4
-      TableID: 104
-      TemporaryIndexID: 5
-PostCommitPhase stage 6 of 15 with 4 MutationType ops
-  transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
-  ops:
-    *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 5
-      TableID: 104
-    *scop.MakeMergedIndexWriteOnly
-      IndexID: 4
-      TableID: 104
-    *scop.SetJobStateOnDescriptor
-      DescriptorID: 104
-    *scop.UpdateSchemaChangerJob
-      JobID: 1
-PostCommitPhase stage 7 of 15 with 1 ValidationType op
-  transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
-  ops:
-    *scop.ValidateIndex
-      IndexID: 4
-      TableID: 104
-PostCommitPhase stage 8 of 15 with 11 MutationType ops
-  transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[IndexData:{DescID: 104, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexName:{DescID: 104, Name: t_i_key, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-  ops:
-    *scop.MakeAbsentIndexBackfilling
-      Index:
-        ConstraintID: 2
-        IndexID: 2
-        IsUnique: true
-        SourceIndexID: 4
-        TableID: 104
-        TemporaryIndexID: 3
-      IsSecondaryIndex: true
-    *scop.MaybeAddSplitForIndex
-      IndexID: 2
-      TableID: 104
-    *scop.MakeAbsentTempIndexDeleteOnly
-      Index:
-        ConstraintID: 3
-        IndexID: 3
-        IsUnique: true
-        SourceIndexID: 4
-        TableID: 104
-      IsSecondaryIndex: true
-    *scop.MaybeAddSplitForIndex
-      IndexID: 3
-      TableID: 104
-    *scop.AddColumnToIndex
-      ColumnID: 1
-      IndexID: 2
-      TableID: 104
-    *scop.AddColumnToIndex
-      ColumnID: 1
-      IndexID: 3
-      TableID: 104
-    *scop.AddColumnToIndex
-      ColumnID: 2
-      IndexID: 2
-      Kind: 1
-      TableID: 104
-    *scop.AddColumnToIndex
-      ColumnID: 2
-      IndexID: 3
-      Kind: 1
-      TableID: 104
-    *scop.SetIndexName
-      IndexID: 2
-      Name: t_i_key
-      TableID: 104
-    *scop.SetJobStateOnDescriptor
-      DescriptorID: 104
-    *scop.UpdateSchemaChangerJob
-      JobID: 1
-PostCommitPhase stage 9 of 15 with 3 MutationType ops
-  transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
     [[IndexData:{DescID: 104, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.MakeDeleteOnlyIndexWriteOnly
@@ -269,17 +137,17 @@ PostCommitPhase stage 9 of 15 with 3 MutationType ops
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 10 of 15 with 1 BackfillType op
+PostCommitPhase stage 2 of 7 with 1 BackfillType op
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
-      SourceIndexID: 4
+      SourceIndexID: 1
       TableID: 104
-PostCommitPhase stage 11 of 15 with 3 MutationType ops
+PostCommitPhase stage 3 of 7 with 3 MutationType ops
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
   ops:
     *scop.MakeBackfillingIndexDeleteOnly
       IndexID: 2
@@ -288,9 +156,9 @@ PostCommitPhase stage 11 of 15 with 3 MutationType ops
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 12 of 15 with 3 MutationType ops
+PostCommitPhase stage 4 of 7 with 3 MutationType ops
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
   ops:
     *scop.MakeBackfilledIndexMerging
       IndexID: 2
@@ -299,18 +167,18 @@ PostCommitPhase stage 12 of 15 with 3 MutationType ops
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 13 of 15 with 1 BackfillType op
+PostCommitPhase stage 5 of 7 with 1 BackfillType op
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], MERGE_ONLY] -> MERGED
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
   ops:
     *scop.MergeIndex
       BackfilledIndexID: 2
       TableID: 104
       TemporaryIndexID: 3
-PostCommitPhase stage 14 of 15 with 4 MutationType ops
+PostCommitPhase stage 6 of 7 with 4 MutationType ops
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], MERGED] -> WRITE_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 3
@@ -322,24 +190,20 @@ PostCommitPhase stage 14 of 15 with 4 MutationType ops
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 15 of 15 with 1 ValidationType op
+PostCommitPhase stage 7 of 7 with 1 ValidationType op
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], WRITE_ONLY] -> VALIDATED
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
   ops:
     *scop.ValidateIndex
       IndexID: 2
       TableID: 104
-PostCommitNonRevertiblePhase stage 1 of 3 with 14 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 9 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
     [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, PUBLIC], VALIDATED] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
   ops:
@@ -351,37 +215,20 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 14 MutationType ops
       Name: crdb_internal_index_1_name_placeholder
       TableID: 104
     *scop.SetIndexName
-      IndexID: 4
+      IndexID: 2
       Name: t_pkey
       TableID: 104
     *scop.RemoveColumnFromIndex
       ColumnID: 1
-      IndexID: 5
+      IndexID: 3
       Ordinal: 1
       TableID: 104
     *scop.RemoveColumnFromIndex
       ColumnID: 2
-      IndexID: 5
-      TableID: 104
-    *scop.MakeValidatedSecondaryIndexPublic
-      IndexID: 2
-      TableID: 104
-    *scop.RefreshStats
-      TableID: 104
-    *scop.RemoveColumnFromIndex
-      ColumnID: 1
       IndexID: 3
-      TableID: 104
-    *scop.RemoveColumnFromIndex
-      ColumnID: 2
-      IndexID: 3
-      Kind: 1
       TableID: 104
     *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 4
-      TableID: 104
-    *scop.MakeIndexAbsent
-      IndexID: 5
+      IndexID: 2
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -414,11 +261,10 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 3 of 3 with 5 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[IndexData:{DescID: 104, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[IndexData:{DescID: 104, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexData:{DescID: 104, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
   ops:
     *scop.MakeIndexAbsent
@@ -431,11 +277,6 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
       TableID: 104
     *scop.CreateGCJobForIndex
       IndexID: 3
-      StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
-      TableID: 104
-    *scop.CreateGCJobForIndex
-      IndexID: 5
       StatementForDropJob:
         Statement: ALTER TABLE defaultdb.public.t DROP CONSTRAINT t_pkey, ADD PRIMARY KEY (j, i)
       TableID: 104


### PR DESCRIPTION
Backport 1/1 commits from #168911 on behalf of @spilchen.

----

When `ALTER TABLE ... DROP CONSTRAINT <pk>, ADD PRIMARY KEY (...)` ran under the declarative schema changer, the old primary key was preserved as a unique secondary index on the original PK columns. This is the "perf preservation" behavior of `ALTER PRIMARY KEY`, but it is wrong when the user has explicitly asked to drop the PK constraint in the same statement. This applies only to the declarative schema changer as the legacy schema changer already does this flow correctly.

Teach the ADD PRIMARY KEY build path to recognize when it is the second half of a same-statement DROP+ADD pair and propagate that signal to the decision that would otherwise preserve the old PK as a unique secondary index. The standalone ALTER PRIMARY KEY path is unaffected and continues to preserve the old PK as a unique secondary.

Closes #168748

Epic: none

Release note (bug fix): Fixed a bug under the declarative schema changer where `ALTER TABLE ... DROP CONSTRAINT <pk>, ADD PRIMARY KEY (...)` would leave behind an unwanted unique secondary index on the old primary key columns.

----

Release justification: low risk bug fix that addresses a recent regression