### PR TITLE
sql: add LRU eviction for descriptor leases under memory pressure

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/catalog/lease",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgurlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -65,7 +66,12 @@ func runSchemaChangeWorkload(t *testing.T, createDBStmt string) {
 	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		t,
 		3, /* numServers */
-		base.TestingKnobs{},
+		base.TestingKnobs{
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				MemoryLimit:                 80000, // 80 KB
+				DisallowBytesMonitorCaching: true,
+			},
+		},
 		multiregionccltestutils.WithBaseDirectory(dir),
 	)
 	defer cleanup()
@@ -83,6 +89,7 @@ func runSchemaChangeWorkload(t *testing.T, createDBStmt string) {
 	tdb.Exec(t, createDBStmt)
 	tdb.Exec(t, "GRANT admin TO testuser")
 	tdb.Exec(t, "SET CLUSTER SETTING sql.log.all_statements.enabled = true")
+	tdb.Exec(t, "SET CLUSTER SETTING sql.catalog.descriptor_lease.eviction.enabled = true")
 
 	dumpRows := func(name string, rows *gosql.Rows) {
 		t.Helper()

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "count.go",
         "descriptor_set.go",
         "descriptor_state.go",
+        "descriptor_state_lru.go",
         "descriptor_version_state.go",
         "doc.go",
         "kv_writer.go",

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -25,6 +25,11 @@ type descriptorState struct {
 	id      descpb.ID
 	stopper *stop.Stopper
 
+	// lruEntry holds the intrusive doubly-linked list pointers for
+	// LRU-based memory eviction. Protected by Manager.mu, not
+	// descriptorState.mu.
+	lruEntry
+
 	mu struct {
 		syncutil.Mutex
 

--- a/pkg/sql/catalog/lease/descriptor_state_lru.go
+++ b/pkg/sql/catalog/lease/descriptor_state_lru.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package lease
+
+// lruEntry holds the prev/next pointers for the LRU
+// doubly-linked list embedded in each descriptorState.
+type lruEntry struct {
+	prev *descriptorState
+	next *descriptorState
+}
+
+// descriptorStateLRU is a doubly-linked list of descriptorState objects.
+// The list is ordered from most recently used (head) to least recently used (tail).
+// All operations are O(1). The list is protected by Manager.mu.
+type descriptorStateLRU struct {
+	root descriptorState
+}
+
+// init initializes the LRU list.
+func (l *descriptorStateLRU) init() {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+}
+
+// tail returns the least recently used entry, or nil if empty.
+func (l *descriptorStateLRU) tail() *descriptorState {
+	if l.root.prev == &l.root {
+		return nil
+	}
+	return l.root.prev
+}
+
+// prev returns the entry before e, or nil if e is the tail.
+func (l *descriptorStateLRU) prev(e *descriptorState) *descriptorState {
+	if e.prev == &l.root {
+		return nil
+	}
+	return e.prev
+}
+
+// pushFront moves or inserts e to the front (most recently used)
+// of the list. If e is already in the list, it is moved; otherwise
+// it is inserted.
+func (l *descriptorStateLRU) pushFront(e *descriptorState) {
+	if e == l.root.next {
+		return // already at front
+	}
+	if e.next != nil {
+		// Already in the list; remove first.
+		l.remove(e)
+	}
+	h := l.root.next
+	e.next = h
+	e.prev = &l.root
+	h.prev = e
+	l.root.next = e
+}
+
+// remove removes e from the list. e must be in the list.
+func (l *descriptorStateLRU) remove(e *descriptorState) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil
+	e.prev = nil
+}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -36,6 +36,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/regionliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -141,6 +143,27 @@ var MaxBatchLeaseCount = settings.RegisterIntSetting(settings.ApplicationLevel,
 	"sql.catalog.descriptor_lease.max_batch_lease_count",
 	"the maximum number of descriptors to lease in a single batch",
 	1000)
+
+// LeaseEvictionEnabled controls whether the lease manager evicts unused
+// descriptor leases (refcount == 0) using an LRU policy when memory
+// budget is exceeded. When disabled, memory budget errors are returned
+// to callers without attempting eviction.
+var LeaseEvictionEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.catalog.descriptor_lease.eviction.enabled",
+	"enables LRU eviction of unused descriptor leases when the lease manager "+
+		"runs out of memory budget",
+	false,
+)
+
+var maxEvictionCandidates = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"sql.catalog.descriptor_lease.eviction.batch_size",
+	"maximum number of descriptor leases to consider for eviction in a single pass",
+	100,
+	settings.WithVisibility(settings.Reserved),
+	settings.IntInRange(1, 10000),
+)
 
 // GetLockedLeaseTimestampEnabled returns if locked leasing timestamps are enabled.
 func GetLockedLeaseTimestampEnabled(ctx context.Context, settings *cluster.Settings) bool {
@@ -1270,6 +1293,81 @@ func wrapMemoryError(err error) error {
 	return errors.WithHint(err, "Consider increasing --max-sql-memory startup parameter.")
 }
 
+// isMemoryError returns true if the error is a memory budget exceeded error.
+func isMemoryError(err error) bool {
+	return pgerror.GetPGCode(err) == pgcode.OutOfMemory
+}
+
+// evictLeastRecentlyUsed attempts to free memory by evicting
+// descriptor leases with refcount == 0, walking from the least
+// recently used end of the LRU list. It skips the descriptor with
+// the given skipID to avoid deadlocks (the caller may hold that
+// descriptor's lock). Returns true if any memory was freed.
+func (m *Manager) evictLeastRecentlyUsed(ctx context.Context, skipID descpb.ID) bool {
+	if !LeaseEvictionEnabled.Get(&m.settings.SV) {
+		return false
+	}
+
+	usedBefore := m.boundAccount.Used()
+	log.Dev.Warningf(ctx,
+		"lru eviction: sql memory almost full (%d bytes used for descriptor leases), "+
+			"evicting unused leases (skip descriptor: %d)",
+		usedBefore, skipID)
+
+	batchSize := int(maxEvictionCandidates.Get(&m.settings.SV))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var candidates []*descriptorState
+	for e := m.mu.lru.tail(); e != nil && len(candidates) < batchSize; e = m.mu.lru.prev(e) {
+		if e.id != skipID {
+			candidates = append(candidates, e)
+		}
+	}
+
+	var numFreed int
+	for _, t := range candidates {
+		leases := func() []*storedLease {
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			return t.removeInactiveVersions(ctx)
+		}()
+		for _, l := range leases {
+			releaseLease(ctx, l, m)
+			numFreed++
+		}
+	}
+
+	// Remove descriptors that have no active versions left.
+	for _, t := range candidates {
+		empty := func() bool {
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			return len(t.mu.active.data) == 0 && t.mu.acquisitionsInProgress == 0
+		}()
+		if empty {
+			m.removeDescriptorState(t.id)
+		}
+	}
+
+	log.Dev.Warningf(ctx,
+		"lru eviction: freed %d leases from %d candidates, memory used: %d bytes (was %d bytes)",
+		numFreed, len(candidates), m.boundAccount.Used(), usedBefore)
+	return numFreed > 0
+}
+
+// retryWithEviction calls fn. If fn returns a memory budget error,
+// it evicts unused leases in batches and retries until fn succeeds
+// or no more memory can be freed.
+func (m *Manager) retryWithEviction(ctx context.Context, skipID descpb.ID, fn func() error) error {
+	err := fn()
+	for err != nil && isMemoryError(err) && m.evictLeastRecentlyUsed(ctx, skipID) {
+		err = fn()
+	}
+	return err
+}
+
 // Insert descriptor versions. The versions provided are not in
 // any particular order.
 func (m *Manager) insertDescriptorVersions(
@@ -1478,7 +1576,9 @@ func (m *Manager) EnsureBatch(ctx context.Context, ids []descpb.ID) error {
 				if batch.errs[idx] != nil {
 					continue
 				}
-				if err := m.upsertDescriptorIntoState(ctx, id, session, batch.descs[idx]); err != nil {
+				if err := m.retryWithEviction(ctx, id, func() error {
+					return m.upsertDescriptorIntoState(ctx, id, session, batch.descs[idx])
+				}); err != nil {
 					return err
 				}
 			}
@@ -1586,7 +1686,9 @@ func (m *Manager) acquireNodeLease(
 				if err != nil {
 					return false, err
 				}
-				if err := m.upsertDescriptorIntoState(ctx, id, session, desc); err != nil {
+				if err := m.retryWithEviction(ctx, id, func() error {
+					return m.upsertDescriptorIntoState(ctx, id, session, desc)
+				}); err != nil {
 					return false, err
 				}
 				// Descriptor versions for these tables participate directly in memo
@@ -1618,7 +1720,9 @@ func (m *Manager) acquireNodeLease(
 					}
 					return true, nil
 				}
-				if err := m.upsertDescriptorIntoState(ctx, id, session, desc); err != nil {
+				if err := m.retryWithEviction(ctx, id, func() error {
+					return m.upsertDescriptorIntoState(ctx, id, session, desc)
+				}); err != nil {
 					return false, err
 				}
 			}
@@ -2033,6 +2137,12 @@ type Manager struct {
 
 		// pendingObserverEvents is a list of observer events.
 		pendingObserverEvents []observerEvent
+
+		// lru is a doubly-linked list of descriptorState objects ordered
+		// from most recently used (head) to least recently used (tail).
+		// Used by the eviction policy to free leases with refcount == 0
+		// under memory pressure.
+		lru descriptorStateLRU
 	}
 
 	// closeTimeStamp is the most recent closeTimeStamp handle, for
@@ -2201,6 +2311,7 @@ func NewLeaseManager(
 	lm.stopper.AddCloser(lm.sem.Closer("stopper"))
 	lm.stopper.AddCloser(stop.CloserFn(lm.AssertAllLeasesAreReleasedAfterDrain))
 	lm.mu.descriptors = make(map[descpb.ID]*descriptorState)
+	lm.mu.lru.init()
 	lm.mu.descriptorTxnUpdatesToProcess = btree.NewG(2, func(a, b *descriptorTxnUpdate) bool {
 		return a.timestamp.Less(b.timestamp)
 	})
@@ -2224,7 +2335,7 @@ func NewLeaseManager(
 	if lm.testingKnobs.DisallowBytesMonitorCaching {
 		bytesMonitorIncrement = 1
 	}
-	lm.bytesMonitor = mon.NewMonitor(mon.Options{
+	monOpts := mon.Options{
 		Name:       mon.MakeName("leased-descriptors"),
 		CurCount:   lm.storage.leasingMetrics.leaseCurBytesCount,
 		MaxHist:    lm.storage.leasingMetrics.leaseMaxBytesHist,
@@ -2232,7 +2343,11 @@ func NewLeaseManager(
 		Settings:   settings,
 		LongLiving: true,
 		Increment:  bytesMonitorIncrement,
-	})
+	}
+	if lm.testingKnobs.MemoryLimit > 0 {
+		monOpts.Limit = lm.testingKnobs.MemoryLimit
+	}
+	lm.bytesMonitor = mon.NewMonitor(monOpts)
 	lm.bytesMonitor.StartNoReserved(context.Background(), rootBytesMonitor)
 	lm.boundAccount = lm.bytesMonitor.MakeConcurrentBoundAccount()
 	// Add a stopper for the bound account that we are using to
@@ -2572,8 +2687,9 @@ func (m *Manager) Acquire(
 			if errRead != nil {
 				return nil, errRead
 			}
-			errRead = m.insertDescriptorVersions(ctx, id, versions)
-			if errRead != nil {
+			if errRead = m.retryWithEviction(ctx, id, func() error {
+				return m.insertDescriptorVersions(ctx, id, versions)
+			}); errRead != nil {
 				return nil, errRead
 			}
 		default:
@@ -2691,6 +2807,15 @@ func (m *Manager) maybeWaitForInit() {
 	}
 }
 
+// removeDescriptorState removes the descriptorState for the given ID
+// from the LRU list and the descriptors map. m.mu must be held.
+func (m *Manager) removeDescriptorState(id descpb.ID) {
+	if t := m.mu.descriptors[id]; t != nil {
+		m.mu.lru.remove(t)
+	}
+	delete(m.mu.descriptors, id)
+}
+
 // If create is set, cache and stopper need to be set as well.
 func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorState {
 	m.maybeWaitForInit()
@@ -2700,6 +2825,9 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 	if t == nil && create {
 		t = &descriptorState{m: m, id: id, stopper: m.stopper}
 		m.mu.descriptors[id] = t
+	}
+	if t != nil {
+		m.mu.lru.pushFront(t)
 	}
 	return t
 }
@@ -3545,7 +3673,7 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, refreshAndPurgeAllDescr
 						func() {
 							m.mu.Lock()
 							defer m.mu.Unlock()
-							delete(m.mu.descriptors, id)
+							m.removeDescriptorState(id)
 						}()
 					}
 				}

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -4585,3 +4585,153 @@ func TestLeaseInternalLookupCtxWithLocked(t *testing.T) {
 	require.NoError(t, grp.Wait())
 
 }
+
+// TestLeaseManagerLRUEviction verifies that the lease manager evicts
+// unused leases (refcount == 0) under memory pressure using an LRU
+// policy. It first demonstrates that queries fail with a memory budget
+// error when eviction is disabled, then enables eviction and shows
+// that the same queries succeed.
+func TestLeaseManagerLRUEviction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	// Use a memory limit that is large enough to hold system
+	// descriptors plus a handful of user descriptors, but small
+	// enough that leasing many user tables forces eviction.
+	const memoryLimit = 50000 // 50 KB
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				MemoryLimit:                 memoryLimit,
+				DisallowBytesMonitorCaching: true,
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create enough tables that accessing all of them would exceed
+	// the memory limit.
+	const numTables = 100
+	for i := 0; i < numTables; i++ {
+		runner.Exec(t, fmt.Sprintf(
+			"CREATE TABLE defaultdb.evict_%d (k INT PRIMARY KEY)", i))
+	}
+
+	// Disable eviction. Accessing tables should eventually fail with
+	// a memory budget exceeded error.
+	runner.Exec(t, "SET CLUSTER SETTING sql.catalog.descriptor_lease.eviction.enabled = false")
+
+	var sawMemoryError bool
+	for i := 0; i < numTables; i++ {
+		_, err := sqlDB.ExecContext(ctx,
+			fmt.Sprintf("SELECT * FROM defaultdb.evict_%d", i))
+		if err != nil {
+			require.ErrorContains(t, err, "memory budget exceeded")
+			sawMemoryError = true
+			t.Logf("memory error after accessing table %d", i)
+			break
+		}
+	}
+	require.True(t, sawMemoryError,
+		"expected a memory budget exceeded error with eviction disabled")
+
+	// Enable eviction. Now the same queries should succeed because
+	// unused leases are evicted under memory pressure.
+	runner.Exec(t, "SET CLUSTER SETTING sql.catalog.descriptor_lease.eviction.enabled = true")
+
+	for i := 0; i < numTables; i++ {
+		runner.Exec(t, fmt.Sprintf("SELECT * FROM defaultdb.evict_%d", i))
+	}
+
+	// Memory usage must stay within the configured limit.
+	lm := srv.ApplicationLayer().LeaseManager().(*lease.Manager)
+	used := lm.TestingBoundAccountUsed()
+	t.Logf("memory used after accessing %d tables with eviction: %d bytes (limit %d)",
+		numTables, used, memoryLimit)
+	require.LessOrEqual(t, used, int64(memoryLimit),
+		"memory usage should not exceed the configured limit")
+}
+
+// TestLeaseManagerLRUEvictionSkipsInUse verifies that the LRU eviction
+// policy does not evict descriptor leases that are held by an open
+// transaction (refcount > 0).
+func TestLeaseManagerLRUEvictionSkipsInUse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	const memoryLimit = 50000 // 50 KB
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				MemoryLimit:                 memoryLimit,
+				DisallowBytesMonitorCaching: true,
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	runner.Exec(t, "SET CLUSTER SETTING sql.catalog.descriptor_lease.eviction.enabled = true")
+
+	const numTables = 100
+	const numHeld = 10
+	for i := 0; i < numTables; i++ {
+		runner.Exec(t, fmt.Sprintf(
+			"CREATE TABLE defaultdb.hold_%d (k INT PRIMARY KEY)", i))
+	}
+
+	// Collect descriptor IDs for the held tables.
+	heldIDs := make(map[int64]bool, numHeld)
+	for i := 0; i < numHeld; i++ {
+		var id int64
+		runner.QueryRow(t,
+			fmt.Sprintf("SELECT id FROM system.namespace WHERE name = 'hold_%d'", i),
+		).Scan(&id)
+		heldIDs[id] = true
+	}
+
+	// Open a transaction that holds leases on the first numHeld tables.
+	// This keeps their refcount > 0 for the duration of the transaction.
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	for i := 0; i < numHeld; i++ {
+		_, err := tx.ExecContext(ctx,
+			fmt.Sprintf("SELECT * FROM defaultdb.hold_%d", i))
+		require.NoError(t, err)
+	}
+
+	// Access all tables from the main connection to trigger eviction.
+	// The held tables' leases must survive because refcount > 0.
+	for i := 0; i < numTables; i++ {
+		runner.Exec(t, fmt.Sprintf("SELECT * FROM defaultdb.hold_%d", i))
+	}
+
+	// Use VisitLeases to verify that the held descriptors still have
+	// refcount > 0 in the lease manager — proving they were not evicted.
+	lm := srv.ApplicationLayer().LeaseManager().(*lease.Manager)
+	seen := make(map[int64]bool, numHeld)
+	lm.VisitLeases(func(
+		desc catalog.Descriptor, _ bool, refCount int, _ tree.DTimestamp,
+	) bool {
+		if heldIDs[int64(desc.GetID())] {
+			require.Greater(t, refCount, 0,
+				"held descriptor %d should have refcount > 0", desc.GetID())
+			seen[int64(desc.GetID())] = true
+		}
+		return true
+	})
+	require.Equal(t, len(heldIDs), len(seen),
+		"all held descriptors should still be present in the lease manager")
+
+	require.NoError(t, tx.Commit())
+
+	used := lm.TestingBoundAccountUsed()
+	t.Logf("memory used: %d bytes (limit %d)", used, memoryLimit)
+	require.LessOrEqual(t, used, int64(memoryLimit))
+}

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -71,6 +71,10 @@ type ManagerTestingKnobs struct {
 	// is allow to allocate extra memory.
 	DisallowBytesMonitorCaching bool
 
+	// MemoryLimit, if positive, sets a local memory limit on the lease
+	// manager's bytesMonitor. Used in tests to trigger LRU eviction.
+	MemoryLimit int64
+
 	// TestingLeaseUpsertEventForID, if set, is called on every lease upsert
 	// attempt for the specified descriptor. The msg argument describes what
 	// happened (e.g. "attempting", "skipping", "already leased"). This knob
@@ -113,6 +117,12 @@ func (m *Manager) TestingOutstandingLeasesGauge() *metric.Gauge {
 // expired gauge that is used by this lease manager.
 func (m *Manager) TestingSessionBasedLeasesExpiredGauge() *metric.Gauge {
 	return m.storage.sessionBasedLeasesExpired
+}
+
+// TestingBoundAccountUsed returns the current memory usage of the lease
+// manager's bound account.
+func (m *Manager) TestingBoundAccountUsed() int64 {
+	return m.boundAccount.Used()
 }
 
 // TestingSessionBasedLeasesWaitingToExpireGauge returns the session based leases


### PR DESCRIPTION
When the lease manager's memory budget is exceeded during lease acquisition, evict cached leases with refcount == 0 starting from the least recently used. This prevents OutOfMemory errors when many descriptors are leased concurrently.

The eviction is gated by the cluster setting
sql.catalog.descriptor_lease.eviction.enabled (default false).

Release note (sql change): Added cluster setting
sql.catalog.descriptor_lease.eviction.enabled which enables LRU eviction of unused descriptor leases when memory budget is exceeded.

Epic: none