### PR TITLE
clusterversion: default auto_upgrade.initiate_from_meta1leaseholder to true

### DIFF
--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -266,7 +266,7 @@ var AutoUpgradeSystemClusterFromMeta1Leaseholder = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"cluster.auto_upgrade.initiate_from_meta1leaseholder.enabled",
 	"only initiate automatic cluster version upgrade from the Meta1 leaseholder (system-cluster only)",
-	false,
+	true,
 )
 
 var metaPreserveDowngradeLastUpdated = metric.Metadata{


### PR DESCRIPTION
Default `cluster.auto_upgrade.initiate_from_meta1leaseholder.enabled` to `true`.

Epic: none

release justification: low risk change.