### PR TITLE
roachtest: fix cdc/initial-scan-only/parquet/metamorphic auth on GCE

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2625,7 +2625,6 @@ CONFIGURE ZONE USING
 	})
 	r.Add(registry.TestSpec{
 		Name:             "cdc/initial-scan-only/parquet/metamorphic",
-		Skip:             "#119295",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),

--- a/pkg/cmd/roachtest/tests/cdc_helper.go
+++ b/pkg/cmd/roachtest/tests/cdc_helper.go
@@ -7,8 +7,10 @@ package tests
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"os"
 	"strings"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -26,6 +29,39 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
+
+// gceCredentialsEnv is the env var the roachtest CI runner exposes with a
+// JSON service-account key that has read/write access to roachtest GCS
+// buckets. Other roachtests (e.g. query_comparison_util.go) rely on the
+// same convention.
+const gceCredentialsEnv = "GOOGLE_EPHEMERAL_CREDENTIALS"
+
+// rewriteGCSAuthForLocalRead swaps AUTH=implicit on a gs:// URI for
+// AUTH=specified using credentials from gceCredentialsEnv. The sink URI uses
+// AUTH=implicit so the cluster nodes — which have a service account with the
+// devstorage.read_write scope attached — can write to GCS. The roachtest
+// process itself runs on a TeamCity GCE worker without that scope, so when it
+// needs to read the sink output back (to fingerprint it) it must authenticate
+// explicitly. URIs with other schemes or auth modes are returned unchanged.
+// See #119295.
+func rewriteGCSAuthForLocalRead(sinkURI string) (string, error) {
+	u, err := url.Parse(sinkURI)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing sink URI")
+	}
+	if u.Scheme != "gs" || u.Query().Get("AUTH") != "implicit" {
+		return sinkURI, nil
+	}
+	credKey, ok := os.LookupEnv(gceCredentialsEnv)
+	if !ok {
+		return "", errors.Newf("%s not set", gceCredentialsEnv)
+	}
+	q := u.Query()
+	q.Set("AUTH", "specified")
+	q.Set("CREDENTIALS", b64.StdEncoding.EncodeToString([]byte(credKey)))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
 
 // createTargetTableStmt returns two statements - one to create a new table with
 // name newTableName and with same schema as the targetTableName table and
@@ -235,7 +271,11 @@ func (m *metamorphicTestHelper) loadOpsToTableAndShowFingerprint(
 	newTableName string,
 ) string {
 	// Grab a handler to the cloud storage for the given sinks.
-	cs, err := cloud.ExternalStorageFromURI(ctx, strings.TrimPrefix(sinkURI, `experimental-`),
+	readURI, err := rewriteGCSAuthForLocalRead(strings.TrimPrefix(sinkURI, `experimental-`))
+	if err != nil {
+		t.Fatal(rperrors.TransientFailure(err, "GCE credentials issue"))
+	}
+	cs, err := cloud.ExternalStorageFromURI(ctx, readURI,
 		base.ExternalIODirConfig{},
 		cluster.MakeTestingClusterSettings(),
 		blobs.TestEmptyBlobClientFactory,


### PR DESCRIPTION
The test was skipped because it failed on the GCE nightly worker with:

  unable to list files in gcs bucket: ... metadata: GCE metadata
  "instance/service-accounts/default/token?scopes=.../devstorage.read_write"
  not defined

The test creates a cloud storage sink with AUTH=implicit, which works for the cluster nodes (their attached service account has the right scope), but not for the roachtest process itself, which runs on a TeamCity GCE worker without devstorage.read_write. The test process needs to read the sink output back to fingerprint it, which is what triggers the failure.

Switch the URI used by the local read path to AUTH=specified, populating CREDENTIALS from the GOOGLE_EPHEMERAL_CREDENTIALS env var (the same convention already used by query_comparison_util.go). The cluster-side sink URI is left untouched. If the env var is missing, fail with TransientFailure so CI surfaces it as an infra issue rather than a real test regression.

Fixes: #119295
Fixes: #127940
Epic: none
Release note: None