### PR TITLE
release-26.2: changefeedccl: persist frontier for checkpointing test

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1711,9 +1711,16 @@ func runCDCFineGrainedCheckpointingBenchmark(
 	t.L().Printf("setting up test data...")
 	setupStmts := []string{
 		`CREATE TABLE foo (id INT PRIMARY KEY, val INT)`,
+		// Configure frequent checkpointing in the form of frontier persistence.
+		// Span level checkpointing is now deprecated, so we use frontier persistence
+		// instead.
+		//
+		// NB: We set changefeed.span_checkpoint.interval because in addition
+		// to controlling how often we saved the now-deprecated legacy span-level
+		// checkpoint, it also controls how often a change aggregator will flush
+		// its frontier to the coordinator during a backfill.
 		`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '1s'`,
-		`SET CLUSTER SETTING changefeed.frontier_highwater_lag_checkpoint_threshold = '100ms'`,
-		`SET CLUSTER SETTING changefeed.frontier_checkpoint_frequency = '1s'`,
+		`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '5s'`,
 		// We do not set timestamp quantization here since it is off by default
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
 	}


### PR DESCRIPTION
Backport 1/1 commits from #168975 on behalf of @aerfrei.

----

Previously, this test verified that we saw fewer duplicate changefeed messages when span level checkpointing was enabled. Once we deprecated span level checkpoints in 26.2, we saw in roachperf that the number of duplicates was increasing.

This change enables more aggressive frontier persistence in this test, which should give us a new baseline for this test.

Epic: none

Release note: None

----

Release justification: Test only.