### PR TITLE
release-26.2: sql/catalog/lease: accept ABORT_REASON_CLIENT_REJECT in deadline test

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3029,9 +3029,16 @@ SELECT * FROM t1;
 			_, err = conn.ExecContext(ctx, `
 COMMIT;`,
 			)
+			// The commit deadline can be detected at two layers:
+			//   - RETRY_COMMIT_DEADLINE_EXCEEDED: server-side EndTxn deadline check.
+			//   - ABORT_REASON_CLIENT_REJECT: txnCoordSender heartbeat observed the
+			//     txn record was aborted before EndTxn was sent (see #168540).
+			// Both outcomes prove the txn was correctly prevented from committing.
 			if err == nil {
 				err = errors.New("Failing did not get expected error")
-			} else if !testutils.IsError(err, "pq: restart transaction: TransactionRetryWithProtoRefreshError: TransactionRetryError: retry txn \\(RETRY_COMMIT_DEADLINE_EXCEEDED -.*") {
+			} else if !testutils.IsError(err, "pq: restart transaction: TransactionRetryWithProtoRefreshError: "+
+				"(TransactionRetryError: retry txn \\(RETRY_COMMIT_DEADLINE_EXCEEDED -.*"+
+				"|TransactionAbortedError\\(ABORT_REASON_CLIENT_REJECT\\).*)") {
 				err = errors.Wrap(err, "Failed unexpected error")
 			} else {
 				err = nil


### PR DESCRIPTION
Backport 1/1 commits from #168973 on behalf of @spilchen.

----

TestLeaseTxnDeadlineExtensionWithSession expects COMMIT to fail with RETRY_COMMIT_DEADLINE_EXCEEDED, but the txnCoordSender heartbeat can race ahead and surface ABORT_REASON_CLIENT_REJECT instead. Both prove the txn was correctly prevented from committing, so accept either.

Closes #168540

Epic: none

Release note: None

----

Release justification: test only fix