### PR TITLE
crosscluster/logical: handle nil previous UDF rows

### DIFF
--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -145,6 +145,7 @@ func (q *queryBuilder) AddRowDefaultNull(row *cdcevent.Row) error {
 		for range q.inputColumns {
 			q.scratchDatums = append(q.scratchDatums, tree.DNull)
 		}
+		return nil
 	}
 
 	for _, n := range q.inputColumns {

--- a/pkg/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/crosscluster/logical/lww_row_processor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -36,6 +37,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
+
+func TestQueryBuilderAddRowDefaultNullNilRow(t *testing.T) {
+	q := queryBuilder{
+		inputColumns: []string{"pk", "v"},
+	}
+
+	require.NoError(t, q.AddRowDefaultNull(nil))
+	require.Equal(t, []interface{}{tree.DNull, tree.DNull}, q.scratchDatums)
+}
 
 func TestLWWInsertQueryGeneration(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
AddRowDefaultNull already treats a nil row as meaningful by appending NULL
datums for the configured input columns. Return after that path so callers
that pass a nil previous row do not fall through and dereference it.

Fixes #166620

Release note: None

Tests:
- `./dev test pkg/crosscluster/logical -f TestQueryBuilderAddRowDefaultNullNilRow -v`
