### PR TITLE
importer: accept unsigned PGCOPY byte escapes

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -1093,6 +1093,33 @@ var importDataTests = []importDataTest{
 		},
 	},
 	{
+		name:   "unsigned byte escapes",
+		create: `b bytes`,
+		typ:    "PGCOPY",
+		data:   `\200\377\x80\xFF`,
+		query: map[string][][]string{
+			`SELECT encode(b, 'hex') from t`: {{"80ff80ff"}},
+		},
+	},
+	{
+		name:   "utf8 text escapes",
+		create: `s string`,
+		typ:    "PGCOPY",
+		data:   `\xC3\xA9`,
+		query: map[string][][]string{
+			`SELECT encode(s::BYTES, 'hex') from t`: {{"c3a9"}},
+		},
+	},
+	{
+		name:   "copy done marker",
+		create: `i int8, s string`,
+		typ:    "PGCOPY",
+		data:   "1\tSTR\n\\.\n2\tignored",
+		query: map[string][][]string{
+			`SELECT * from t`: {{"1", "STR"}},
+		},
+	},
+	{
 		name:   "normal",
 		create: `i int8, s string`,
 		typ:    "PGCOPY",

--- a/pkg/sql/importer/read_import_pgcopy.go
+++ b/pkg/sql/importer/read_import_pgcopy.go
@@ -148,7 +148,7 @@ func (p *postgreStreamCopy) Next() (copyData, error) {
 								base = 16
 								idx = 1
 							}
-							v, err := strconv.ParseInt(string(field[i+idx:i+3]), base, 8)
+							v, err := strconv.ParseUint(string(field[i+idx:i+3]), base, 8)
 							if err != nil {
 								return err
 							}
@@ -276,7 +276,7 @@ var _ importRowProducer = &pgCopyProducer{}
 // Scan implements importRowProducer
 func (p *pgCopyProducer) Scan() bool {
 	p.row, p.err = p.copyStream.Next()
-	if p.err == io.EOF {
+	if p.err == io.EOF || errors.Is(p.err, errCopyDone) {
 		p.err = nil
 		return false
 	}


### PR DESCRIPTION
PGCOPY text data accepts octal and hexadecimal byte escapes in the full unsigned byte range. Decode those escapes with unsigned parsing so values from 128 through 255 import correctly, and treat the standard `\\.` marker as end-of-data when scanning rows.

Fixes #166618

Release note (bug fix): Fixed a bug that caused PGCOPY imports to reject valid octal and hexadecimal byte escapes for values greater than 127. PGCOPY imports now also treat the standard `\\.` marker as the end of input.

Tests:
- `git diff --check`
- `go run github.com/cockroachdb/crlfmt -w -tab 2 pkg/sql/importer/read_import_pgcopy.go pkg/sql/importer/import_stmt_test.go`
- Not run: `./dev test pkg/sql/importer -f TestImportDataPgCopy -v` (local Bazel setup ran out of disk space before test execution)
