### PR TITLE
roachtest: write PCR summary stats to summary_stats.json

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -144,8 +144,11 @@ type c2cMetrics struct {
 	fingerprintingEnd time.Time
 }
 
-// export summarizes all metrics gathered throughout the test.
-func (m c2cMetrics) export(t test.Test, nodeCount int) {
+// export summarizes all metrics gathered throughout the test and returns
+// the per-phase metrics keyed by "<phase>/<metric>" (e.g.
+// "InitialScan/Duration Minutes").
+func (m c2cMetrics) export(t test.Test, nodeCount int) map[string]float64 {
+	allMetrics := make(map[string]float64)
 
 	// aggregate aggregates metric snapshots across two time periods. A non-zero
 	// durationOverride will be used instead of the duration between the two
@@ -182,6 +185,7 @@ func (m c2cMetrics) export(t test.Test, nodeCount int) {
 		t.L().Printf("%s Perf:", label)
 		for _, name := range metricNames {
 			t.L().Printf("\t%s : %.2f", name, metrics[name])
+			allMetrics[label+"/"+name] = metrics[name]
 		}
 	}
 	aggregate(m.initalScanStart, m.initialScanEnd, "InitialScan", 0)
@@ -191,6 +195,49 @@ func (m c2cMetrics) export(t test.Test, nodeCount int) {
 	// The _amount_ of data processed during cutover should be the data ingested between the
 	// timestamp we cut over to and the start of the cutover process.
 	aggregate(m.cutoverTo, m.cutoverStart, "Cutover", m.cutoverEnd.time.Sub(m.cutoverStart.time))
+
+	return allMetrics
+}
+
+func (rd *replicationDriver) writePerfSummaryStats(
+	exportedMetrics map[string]float64, lv *latencyVerifier,
+) {
+	getMetric := func(name string) float64 {
+		v, ok := exportedMetrics[name]
+		if !ok {
+			rd.t.Fatalf("metric %q not found in exported metrics", name)
+		}
+		return v
+	}
+	stats := roachtestutil.AggregatedPerfMetrics{
+		{
+			Name:           "initial_scan_time",
+			Value:          roachtestutil.MetricPoint(getMetric("InitialScan/Duration Minutes")),
+			Unit:           "minutes",
+			IsHigherBetter: false,
+		},
+		{
+			Name:           "initial_scan_throughput",
+			Value:          roachtestutil.MetricPoint(getMetric("InitialScan/Throughput_LogicalMegabytes_MB/S/Node")),
+			Unit:           "MB/s/node",
+			IsHigherBetter: true,
+		},
+		{
+			Name:           "cutover_time",
+			Value:          roachtestutil.MetricPoint(getMetric("Cutover/Duration Minutes")),
+			Unit:           "minutes",
+			IsHigherBetter: false,
+		},
+		{
+			Name:           "max_replication_lag",
+			Value:          roachtestutil.MetricPoint(lv.MaxSeenSteadyLatency().Seconds()),
+			Unit:           "seconds",
+			IsHigherBetter: false,
+		},
+	}
+	if err := roachtestutil.WritePerfSummaryStats(rd.t, rd.c, stats); err != nil {
+		rd.t.L().Printf("failed to write perf summary stats: %v", err)
+	}
 }
 
 type streamingWorkload interface {
@@ -1301,7 +1348,10 @@ func (rd *replicationDriver) main(ctx context.Context) {
 	)
 	rd.c.StartServiceForVirtualCluster(ctx, rd.t.L(), startOpts, install.MakeClusterSettings())
 
-	rd.metrics.export(rd.t, len(rd.setup.src.nodes))
+	exportedMetrics := rd.metrics.export(rd.t, len(rd.setup.src.nodes))
+	if !rd.c.IsLocal() {
+		rd.writePerfSummaryStats(exportedMetrics, lv)
+	}
 
 	rd.t.Status("comparing fingerprints")
 	rd.compareTenantFingerprintsAtTimestamp(

--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -213,6 +213,10 @@ func (lv *latencyVerifier) assertValid(t test.Test) {
 	}
 }
 
+func (lv *latencyVerifier) MaxSeenSteadyLatency() time.Duration {
+	return lv.maxSeenSteadyLatency
+}
+
 func (lv *latencyVerifier) maybeLogLatencyHist() {
 	if lv.latencyHist == nil {
 		return


### PR DESCRIPTION
## Summary

- Write initial scan time, per-node initial scan throughput, cutover time,
  and max replication lag to `summary_stats.json` via `WritePerfSummaryStats`
  in the c2c roachtests.
- These metrics were already computed and logged but not persisted for
  automated analysis.

Epic: none