### PR TITLE
server: use liveness cache for upgradeStatus

### DIFF
--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -269,6 +269,15 @@ var AutoUpgradeSystemClusterFromMeta1Leaseholder = settings.RegisterBoolSetting(
 	true,
 )
 
+var AutoUpgradeUseLivenessCache = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"cluster.auto_upgrade.use_liveness_cache.enabled",
+	"use the liveness cache instead of scanning liveness from KV when "+
+		"checking upgrade status; this avoids a KV read on every iteration "+
+		"of the auto-upgrade loop",
+	true,
+)
+
 var metaPreserveDowngradeLastUpdated = metric.Metadata{
 	Name:        "cluster.preserve-downgrade-option.last-updated",
 	Help:        "Unix timestamp of last updated time for cluster.preserve_downgrade_option",

--- a/pkg/kv/kvserver/asim/state/liveness.go
+++ b/pkg/kv/kvserver/asim/state/liveness.go
@@ -109,3 +109,7 @@ func (m MockNodeLiveness) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap
 	}
 	return isLiveMap
 }
+
+func (m MockNodeLiveness) ScanAllNodeVitalityFromCache() livenesspb.NodeVitalityMap {
+	return m.ScanNodeVitalityFromCache()
+}

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -296,8 +296,8 @@ func (c *Cache) getAllLivenessEntries() []livenesspb.Liveness {
 // ScanNodeVitalityFromCache returns a map of nodeID to boolean liveness status
 // of each node from the cache. This excludes nodes that were decommissioned.
 // Decommissioned nodes are kept in the KV store and the cache forever, but are
-// typically not referenced in normal usage. The method ScanNodeVitalityFromKV
-// does return decommissioned nodes.
+// typically not referenced in normal usage. Use ScanAllNodeVitalityFromCache to
+// include decommissioned nodes.
 func (c *Cache) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
 	entries := c.getAllLivenessEntries()
 	statusMap := make(map[roachpb.NodeID]livenesspb.NodeVitality, len(entries))
@@ -306,6 +306,17 @@ func (c *Cache) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
 			// This is a node that was completely removed. Skip over it.
 			continue
 		}
+		statusMap[l.NodeID] = c.convertToNodeVitality(l)
+	}
+	return statusMap
+}
+
+// ScanAllNodeVitalityFromCache is like ScanNodeVitalityFromCache but includes
+// decommissioned nodes.
+func (c *Cache) ScanAllNodeVitalityFromCache() livenesspb.NodeVitalityMap {
+	entries := c.getAllLivenessEntries()
+	statusMap := make(map[roachpb.NodeID]livenesspb.NodeVitality, len(entries))
+	for _, l := range entries {
 		statusMap[l.NodeID] = c.convertToNodeVitality(l)
 	}
 	return statusMap

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -880,10 +880,16 @@ func (nl *NodeLiveness) GetIsLiveMap() livenesspb.IsLiveMap {
 // ScanNodeVitalityFromCache returns a map of nodeID to boolean liveness status
 // of each node from the cache. This excludes nodes that were decommissioned.
 // Decommissioned nodes are kept in the KV store and the cache forever, but are
-// typically not referenced in normal usage. The method ScanNodeVitalityFromKV
-// does return decommissioned nodes.
+// typically not referenced in normal usage. Use ScanAllNodeVitalityFromCache to
+// include decommissioned nodes.
 func (nl *NodeLiveness) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
 	return nl.cache.ScanNodeVitalityFromCache()
+}
+
+// ScanAllNodeVitalityFromCache is like ScanNodeVitalityFromCache but includes
+// decommissioned nodes.
+func (nl *NodeLiveness) ScanAllNodeVitalityFromCache() livenesspb.NodeVitalityMap {
+	return nl.cache.ScanAllNodeVitalityFromCache()
 }
 
 // ScanNodeVitalityFromKV returns the status for all the nodes from KV including

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.go
@@ -26,6 +26,9 @@ import (
 type NodeVitalityInterface interface {
 	GetNodeVitalityFromCache(roachpb.NodeID) NodeVitality
 	ScanNodeVitalityFromCache() NodeVitalityMap
+	// ScanAllNodeVitalityFromCache is like ScanNodeVitalityFromCache but
+	// includes decommissioned nodes.
+	ScanAllNodeVitalityFromCache() NodeVitalityMap
 	ScanNodeVitalityFromKV(context.Context) (NodeVitalityMap, error)
 }
 

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness_test_helper.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness_test_helper.go
@@ -78,6 +78,10 @@ func (tnv TestNodeVitality) ScanNodeVitalityFromCache() NodeVitalityMap {
 	return nvm
 }
 
+func (tnv TestNodeVitality) ScanAllNodeVitalityFromCache() NodeVitalityMap {
+	return tnv.ScanNodeVitalityFromCache()
+}
+
 func (tnv TestNodeVitality) AddNextNode() {
 	maxNodeID := roachpb.NodeID(0)
 	for id := range tnv.Entry {

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -157,10 +157,7 @@ func (s *topLevelServer) upgradeStatus(
 	if err != nil {
 		return UpgradeBlockedDueToError, err
 	}
-	vitalities, err := s.nodeLiveness.ScanNodeVitalityFromKV(ctx)
-	if err != nil {
-		return UpgradeBlockedDueToError, err
-	}
+	vitalities := s.nodeLiveness.ScanAllNodeVitalityFromCache()
 
 	var newVersion string
 	var notRunningErr error

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -157,7 +157,15 @@ func (s *topLevelServer) upgradeStatus(
 	if err != nil {
 		return UpgradeBlockedDueToError, err
 	}
-	vitalities := s.nodeLiveness.ScanAllNodeVitalityFromCache()
+	var vitalities livenesspb.NodeVitalityMap
+	if clusterversion.AutoUpgradeUseLivenessCache.Get(&s.ClusterSettings().SV) {
+		vitalities = s.nodeLiveness.ScanAllNodeVitalityFromCache()
+	} else {
+		vitalities, err = s.nodeLiveness.ScanNodeVitalityFromKV(ctx)
+		if err != nil {
+			return UpgradeBlockedDueToError, err
+		}
+	}
 
 	var newVersion string
 	var notRunningErr error


### PR DESCRIPTION
Backport of master commits 77e43c31bfb and c31de22cb84.

Switch `upgradeStatus` from `ScanNodeVitalityFromKV` to `ScanAllNodeVitalityFromCache`. This avoids a KV read of all liveness records on every iteration of the auto-upgrade loop (~30s).

Epic: none