### PR TITLE
roachtest: don't fatal in withIncreasedStmtTimeout

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -220,7 +220,9 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 				})
 				defer m.Wait()
 				select {
-				case <-time.After(timeout * 2):
+				case <-time.After(timeout * 6):
+					// Use 6x the statement timeout to account for DDL statements
+					// which have their session statement_timeout increased by 3x.
 					// SQLSmith generates queries that either perform full table scans of
 					// large tables or backup/restore operations that timeout. These
 					// should not cause an issue to be raised, as they most likely are

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -376,19 +376,19 @@ func withIncreasedStmtTimeout(
 	t.Helper()
 	var stmtTimeout int
 	if err := conn.QueryRow("SHOW statement_timeout").Scan(&stmtTimeout); err != nil {
-		t.Fatal(err)
+		return func() {}
 	}
 	if stmtTimeout == 0 {
 		return func() {}
 	}
 	setTimeout := func(v int) {
 		stmt := fmt.Sprintf("SET statement_timeout = %d", v)
-		logStmt(stmt)
 		if _, err := conn.Exec(stmt); err != nil {
-			t.Fatal(err)
+			t.L().Printf("failed to set statement_timeout to %d: %v", v, err)
+			return
 		}
+		logStmt(stmt)
 	}
-	t.L().Printf("temporarily increasing the statement timeout")
 	setTimeout(factor * stmtTimeout)
 	return func() { setTimeout(stmtTimeout) }
 }

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -193,13 +193,15 @@ func runMutationStatement(
 	}()
 
 	stmt, stmtType := smither.GenerateWithTag()
+	timeout := statementTimeout
 	if stmtType == tree.TypeDDL {
 		defer withIncreasedStmtTimeout(t, conn, logStmt, 3)()
+		timeout *= 3
 	}
 
 	// Ignore timeouts.
 	var err error
-	_ = runWithTimeout(t, func() error {
+	_ = runWithTimeout(t, timeout, func() error {
 		// Ignore errors. Log successful statements.
 		if _, err = conn.Exec(stmt); err == nil {
 			logStmt(connInfo + stmt)
@@ -240,7 +242,7 @@ func runTLPQuery(
 	unpartitioned, partitioned, args := smither.GenerateTLP()
 	combined := sqlsmith.CombinedTLP(unpartitioned, partitioned)
 
-	return runWithTimeout(t, func() error {
+	return runWithTimeout(t, statementTimeout, func() error {
 		counts := conn.QueryRow(combined, args...)
 		var undiffCount, diffCount int
 		if err := counts.Scan(&undiffCount, &diffCount); err != nil {
@@ -293,7 +295,7 @@ func runTLPQuery(
 	})
 }
 
-func runWithTimeout(t task.Tasker, f func() error) error {
+func runWithTimeout(t task.Tasker, timeout time.Duration, f func() error) error {
 	done := make(chan error, 1)
 	t.Go(func(context.Context, *logger.Logger) error {
 		err := f()
@@ -301,7 +303,7 @@ func runWithTimeout(t task.Tasker, f func() error) error {
 		return nil
 	})
 	select {
-	case <-time.After(statementTimeout + time.Second*5):
+	case <-time.After(timeout + time.Second*5):
 		// Ignore timeouts.
 		return nil
 	case err := <-done:


### PR DESCRIPTION
### roachtest: don't fatal in withIncreasedStmtTimeout

withIncreasedStmtTimeout called t.Fatal when SHOW or SET
statement_timeout failed. After #168775 started calling this for every
DDL statement in the main smithing loops, a broken connection would kill
the entire test even though callers handle DDL execution errors
gracefully.

Replace t.Fatal with a log-and-continue approach: if SHOW fails, return
a no-op cleanup; if SET fails, log the error and skip logging the
statement.

Fixes: #168847

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### roachtest: pass timeout to runWithTimeout for DDL statements

runWithTimeout used the hardcoded statementTimeout (1 minute) constant,
so even though withIncreasedStmtTimeout bumped the session's
statement_timeout to 3x for DDL, the Go-level timeout would still
abandon the goroutine after ~65 seconds.

Add a timeout parameter to runWithTimeout so the caller can keep the
Go-level and session-level timeouts in sync. runMutationStatement now
passes 3x the timeout for DDL statements.

Informs: #168847

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### roachtest: increase Go-level watchdog timeout for sqlsmith DDL

The Go-level watchdog in the sqlsmith main loop used timeout*2 (2
minutes), but DDL statements have their session statement_timeout
increased to 3x (3 minutes) via withIncreasedStmtTimeout. This meant
the Go watchdog would abandon the goroutine before the session timeout
fired. Increase the watchdog to timeout*6 to accommodate DDL.

Informs: #168847

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>