### PR TITLE
sqlinstance: deduplicate live rows by rpcAddr

### DIFF
--- a/pkg/sql/sqlinstance/instancestorage/instancereader.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader.go
@@ -263,8 +263,15 @@ func (r *Reader) GetAllInstances(ctx context.Context) ([]sqlinstance.InstanceInf
 	return makeInstanceInfos(liveInstances), nil
 }
 
-// selectDistinctLiveRows modifies the given slice in-place and returns
-// the selected rows.
+// selectDistinctLiveRows returns the subset of rows whose sqlliveness session
+// is live, deduplicated by rpcAddr. When multiple live rows share an rpcAddr,
+// the row with the highest timestamp is kept.
+//
+// Deduplication handles the transient overlap in external-process multi-tenant
+// deployments where a SQL pod crashes and a new pod starts at the same rpcAddr
+// with a fresh instance ID before the dead pod's session expires.
+//
+// The input slice is mutated in place and is no longer valid after the call.
 func selectDistinctLiveRows(
 	ctx context.Context, slReader sqlliveness.Reader, rows []instancerow,
 ) ([]instancerow, error) {
@@ -287,16 +294,18 @@ func selectDistinctLiveRows(
 		rows = truncated
 	}
 	sort.Slice(rows, func(idx1, idx2 int) bool {
-		if rows[idx1].sqlAddr == rows[idx2].sqlAddr {
+		if rows[idx1].rpcAddr == rows[idx2].rpcAddr {
 			return !rows[idx1].timestamp.Less(rows[idx2].timestamp) // decreasing timestamp order
 		}
-		return rows[idx1].sqlAddr < rows[idx2].sqlAddr
+		return rows[idx1].rpcAddr < rows[idx2].rpcAddr
 	})
-	// Only provide the latest entry for a given address.
+	// Keep only the newest row per rpcAddr. Older rows for the same rpcAddr
+	// are stale entries from a previous instance that crashed and was
+	// restarted at the same address with a new instance ID.
 	{
 		truncated := rows[:0]
 		for i := 0; i < len(rows); i++ {
-			if i == 0 || rows[i].sqlAddr != rows[i-1].sqlAddr {
+			if i == 0 || rows[i].rpcAddr != rows[i-1].rpcAddr {
 				truncated = append(truncated, rows[i])
 			}
 		}

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage_internal_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage_internal_test.go
@@ -40,6 +40,86 @@ func makeSession() sqlliveness.SessionID {
 	return session
 }
 
+func TestSelectDistinctLiveRows(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	type rowSpec struct {
+		instanceID base.SQLInstanceID
+		rpcAddr    string
+		sqlAddr    string
+		// live registers the row's session in slstorage so IsAlive returns
+		// true. Rows with live=false have an unregistered session and are
+		// dropped by the liveness filter.
+		live      bool
+		timestamp int64
+	}
+
+	tests := []struct {
+		name string
+		rows []rowSpec
+		// expectedIDs are the surviving instance IDs, order-independent.
+		expectedIDs []base.SQLInstanceID
+	}{
+		{
+			name: "shared sqlAddr keeps distinct rpcAddr rows",
+			rows: []rowSpec{
+				{instanceID: 1, rpcAddr: "rpc1", sqlAddr: "regional:26257", live: true, timestamp: 1},
+				{instanceID: 2, rpcAddr: "rpc2", sqlAddr: "regional:26257", live: true, timestamp: 2},
+			},
+			expectedIDs: []base.SQLInstanceID{1, 2},
+		},
+		{
+			name: "shared rpcAddr keeps newest by timestamp",
+			rows: []rowSpec{
+				{instanceID: 1, rpcAddr: "rpc1", sqlAddr: "sql1", live: true, timestamp: 1},
+				{instanceID: 2, rpcAddr: "rpc1", sqlAddr: "sql2", live: true, timestamp: 2},
+			},
+			expectedIDs: []base.SQLInstanceID{2},
+		},
+		{
+			name: "dead newer row does not displace live older row at same rpcAddr",
+			rows: []rowSpec{
+				{instanceID: 1, rpcAddr: "rpc1", sqlAddr: "sql1", live: true, timestamp: 1},
+				{instanceID: 2, rpcAddr: "rpc1", sqlAddr: "sql2", live: false, timestamp: 2},
+			},
+			expectedIDs: []base.SQLInstanceID{1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			slStorage := slstorage.NewFakeStorage()
+			instanceRows := make([]instancerow, len(tc.rows))
+			for i, r := range tc.rows {
+				sessionID := makeSession()
+				if r.live {
+					require.NoError(t, slStorage.Insert(ctx, sessionID,
+						hlc.Timestamp{WallTime: int64(time.Hour)}))
+				}
+				instanceRows[i] = instancerow{
+					instanceID: r.instanceID,
+					rpcAddr:    r.rpcAddr,
+					sqlAddr:    r.sqlAddr,
+					sessionID:  sessionID,
+					timestamp:  hlc.Timestamp{WallTime: r.timestamp},
+				}
+			}
+
+			result, err := selectDistinctLiveRows(ctx, slStorage, instanceRows)
+			require.NoError(t, err)
+
+			gotIDs := make([]base.SQLInstanceID, len(result))
+			for i, r := range result {
+				gotIDs[i] = r.instanceID
+			}
+			require.ElementsMatch(t, tc.expectedIDs, gotIDs)
+		})
+	}
+}
+
 func TestGetAvailableInstanceIDForRegion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
selectDistinctLiveRows was deduplicating live SQL instance rows by sqlAddr (the SQL advertise address). This was the wrong key: the SQL advertise address (--sql-advertise-addr) is allowed to be non-unique across nodes — Kubernetes deployments commonly point it at a regional service DNS shared by all pods in the region. Deduplication on sqlAddr silently collapsed distinct live instances down to one entry, breaking downstream consumers like DistSQL placement and execution-locality filtering.

Switch the dedup key to rpcAddr. RPC advertise addresses must be node-unique among live instances — gossip and KV peer dialing depend on this — so rpcAddr is the correct identity for the pod-restart race that motivates dedup in the first place (a SQL pod crashes and a new pod starts at the same rpcAddr with a fresh instance ID before the dead pod's session expires).

The wrong key was introduced when the RPC and SQL listen ports were split; before the split there was a single advertise address and the choice was unambiguous.

Resolves: #168991
Epic: CRDB-63207

Release note (bug fix): Fixed a bug where setting `--advertise-sql-addr` to the same value across multiple SQL instances could cause changefeeds with execution_locality filters to fail with "no instances found matching locality filter".
