### PR TITLE
generate-import-fixtures: add Parquet output format

### DIFF
--- a/pkg/cmd/generate-import-fixtures/BUILD.bazel
+++ b/pkg/cmd/generate-import-fixtures/BUILD.bazel
@@ -5,12 +5,19 @@ go_library(
     srcs = [
         "format.go",
         "format_avro.go",
+        "format_parquet.go",
         "main.go",
         "tpch.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/generate-import-fixtures",
     visibility = ["//visibility:private"],
-    deps = ["@com_github_linkedin_goavro_v2//:goavro"],
+    deps = [
+        "@com_github_apache_arrow_go_v11//parquet",
+        "@com_github_apache_arrow_go_v11//parquet/compress",
+        "@com_github_apache_arrow_go_v11//parquet/file",
+        "@com_github_apache_arrow_go_v11//parquet/schema",
+        "@com_github_linkedin_goavro_v2//:goavro",
+    ],
 )
 
 go_binary(
@@ -23,11 +30,13 @@ go_test(
     name = "generate-import-fixtures_test",
     srcs = [
         "format_avro_test.go",
+        "format_parquet_test.go",
         "main_test.go",
         "tpch_test.go",
     ],
     embed = [":generate-import-fixtures_lib"],
     deps = [
+        "@com_github_apache_arrow_go_v11//parquet/file",
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/cmd/generate-import-fixtures/format_parquet.go
+++ b/pkg/cmd/generate-import-fixtures/format_parquet.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/apache/arrow/go/v11/parquet"
+	"github.com/apache/arrow/go/v11/parquet/compress"
+	"github.com/apache/arrow/go/v11/parquet/file"
+	"github.com/apache/arrow/go/v11/parquet/schema"
+)
+
+// parquetFormat implements OutputFormat for Parquet. It produces Parquet files
+// with Snappy compression. Date columns are stored as INT32 with DATE logical
+// type (days since Unix epoch).
+type parquetFormat struct{}
+
+var _ OutputFormat = (*parquetFormat)(nil)
+
+func (p *parquetFormat) Name() string { return "parquet" }
+
+// defaultSchemaFieldID lets the parquet library auto-assign field IDs.
+const defaultSchemaFieldID = int32(-1)
+
+// defaultTypeLength signals no fixed type length for variable-length types.
+const defaultTypeLength = -1
+
+// buildParquetSchema constructs a Parquet schema from a TPC-H TableDef. All
+// columns are Required (non-nullable), matching the TPC-H specification.
+func buildParquetSchema(table TableDef) (*schema.Schema, error) {
+	fields := make([]schema.Node, len(table.Columns))
+	for i, col := range table.Columns {
+		var err error
+		switch col.Type {
+		case Long:
+			fields[i], err = schema.NewPrimitiveNodeLogical(col.Name,
+				parquet.Repetitions.Required, schema.NewIntLogicalType(64, true),
+				parquet.Types.Int64, defaultTypeLength, defaultSchemaFieldID)
+		case Double:
+			fields[i] = schema.NewFloat64Node(col.Name,
+				parquet.Repetitions.Required, defaultSchemaFieldID)
+		case Text:
+			fields[i], err = schema.NewPrimitiveNodeLogical(col.Name,
+				parquet.Repetitions.Required, schema.StringLogicalType{},
+				parquet.Types.ByteArray, defaultTypeLength, defaultSchemaFieldID)
+		case Date:
+			fields[i], err = schema.NewPrimitiveNodeLogical(col.Name,
+				parquet.Repetitions.Required, schema.DateLogicalType{},
+				parquet.Types.Int32, defaultTypeLength, defaultSchemaFieldID)
+		default:
+			return nil, fmt.Errorf("unsupported column type %s for column %s", col.Type, col.Name)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("creating schema node for %s: %w", col.Name, err)
+		}
+	}
+	root, err := schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, defaultSchemaFieldID)
+	if err != nil {
+		return nil, fmt.Errorf("creating schema root: %w", err)
+	}
+	return schema.NewSchema(root), nil
+}
+
+// parquetWriter streams batches of rows to a Parquet file. Each call to
+// WriteBatch creates a new row group.
+type parquetWriter struct {
+	table   TableDef
+	outPath string
+	writer  *file.Writer
+	count   int
+}
+
+var _ FormatWriter = (*parquetWriter)(nil)
+
+// NewWriter creates a parquetWriter that writes to a Parquet file with Snappy
+// compression.
+func (p *parquetFormat) NewWriter(
+	table TableDef, outputDir string, shardIdx int,
+) (FormatWriter, error) {
+	sch, err := buildParquetSchema(table)
+	if err != nil {
+		return nil, err
+	}
+
+	outPath := filepath.Join(outputDir, fmt.Sprintf("%s.parquet.%d", table.Name, shardIdx))
+	f, err := os.Create(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("creating %s: %w", outPath, err)
+	}
+
+	props := parquet.NewWriterProperties(
+		parquet.WithCreatedBy("cockroachdb"),
+		parquet.WithCompression(compress.Codecs.Snappy),
+	)
+	writer := file.NewParquetWriter(f, sch.Root(), file.WithWriterProps(props))
+
+	return &parquetWriter{
+		table:   table,
+		outPath: outPath,
+		writer:  writer,
+	}, nil
+}
+
+// WriteBatch writes a batch of rows as a single Parquet row group.
+func (w *parquetWriter) WriteBatch(rows [][]any) error {
+	rowGroup := w.writer.AppendBufferedRowGroup()
+	numRows := len(rows)
+
+	for colIdx, col := range w.table.Columns {
+		cw, err := rowGroup.Column(colIdx)
+		if err != nil {
+			return fmt.Errorf("getting column writer for %s: %w", col.Name, err)
+		}
+
+		switch col.Type {
+		case Long:
+			values := make([]int64, numRows)
+			for i, row := range rows {
+				v, ok := row[colIdx].(int64)
+				if !ok {
+					return fmt.Errorf("column %s row %d: expected int64, got %T", col.Name, i, row[colIdx])
+				}
+				values[i] = v
+			}
+			chunkWriter := cw.(*file.Int64ColumnChunkWriter)
+			if _, err := chunkWriter.WriteBatch(values, nil, nil); err != nil {
+				return fmt.Errorf("writing int64 column %s: %w", col.Name, err)
+			}
+		case Double:
+			values := make([]float64, numRows)
+			for i, row := range rows {
+				v, ok := row[colIdx].(float64)
+				if !ok {
+					return fmt.Errorf("column %s row %d: expected float64, got %T", col.Name, i, row[colIdx])
+				}
+				values[i] = v
+			}
+			chunkWriter := cw.(*file.Float64ColumnChunkWriter)
+			if _, err := chunkWriter.WriteBatch(values, nil, nil); err != nil {
+				return fmt.Errorf("writing float64 column %s: %w", col.Name, err)
+			}
+		case Text:
+			values := make([]parquet.ByteArray, numRows)
+			for i, row := range rows {
+				v, ok := row[colIdx].(string)
+				if !ok {
+					return fmt.Errorf("column %s row %d: expected string, got %T", col.Name, i, row[colIdx])
+				}
+				values[i] = parquet.ByteArray(v)
+			}
+			chunkWriter := cw.(*file.ByteArrayColumnChunkWriter)
+			if _, err := chunkWriter.WriteBatch(values, nil, nil); err != nil {
+				return fmt.Errorf("writing string column %s: %w", col.Name, err)
+			}
+		case Date:
+			values := make([]int32, numRows)
+			for i, row := range rows {
+				t, ok := row[colIdx].(time.Time)
+				if !ok {
+					return fmt.Errorf("column %s row %d: expected time.Time, got %T", col.Name, i, row[colIdx])
+				}
+				values[i] = int32(t.Unix() / 86400)
+			}
+			chunkWriter := cw.(*file.Int32ColumnChunkWriter)
+			if _, err := chunkWriter.WriteBatch(values, nil, nil); err != nil {
+				return fmt.Errorf("writing date column %s: %w", col.Name, err)
+			}
+		default:
+			return fmt.Errorf("unsupported column type %s for column %s", col.Type, col.Name)
+		}
+	}
+
+	if err := rowGroup.Close(); err != nil {
+		return fmt.Errorf("closing row group for %s: %w", w.table.Name, err)
+	}
+
+	w.count += numRows
+	return nil
+}
+
+// Close closes the Parquet writer and underlying file, printing a summary.
+// The parquet writer's Close method closes the underlying sink (os.File), so
+// we must not close it again ourselves.
+func (w *parquetWriter) Close() error {
+	if err := w.writer.Close(); err != nil {
+		return fmt.Errorf("closing parquet writer for %s: %w", w.table.Name, err)
+	}
+	fmt.Printf("  wrote %s (%d records)\n", w.outPath, w.count)
+	return nil
+}
+
+// WriteSchema is a no-op for Parquet because the schema is embedded in the
+// file footer.
+func (p *parquetFormat) WriteSchema(table TableDef, outputDir string) error {
+	return nil
+}

--- a/pkg/cmd/generate-import-fixtures/format_parquet_test.go
+++ b/pkg/cmd/generate-import-fixtures/format_parquet_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v11/parquet/file"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParquetRoundTrip(t *testing.T) {
+	table := TableDef{
+		Name: "roundtrip",
+		Columns: []ColumnDef{
+			longCol("id"),
+			doubleCol("price"),
+			stringCol("label"),
+			dateCol("dt"),
+		},
+	}
+
+	dir := t.TempDir()
+	format := &parquetFormat{}
+	w, err := format.NewWriter(table, dir, 1)
+	require.NoError(t, err)
+
+	date1 := time.Date(1995, 3, 15, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	rows := [][]any{
+		{int64(1), 9.99, "hello", date1},
+		{int64(2), 0.0, "world", date2},
+	}
+	require.NoError(t, w.WriteBatch(rows))
+	require.NoError(t, w.Close())
+
+	// Read back and verify.
+	outPath := filepath.Join(dir, "roundtrip.parquet.1")
+	reader, err := file.OpenParquetFile(outPath, false)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reader.Close()) }()
+
+	require.Equal(t, 4, reader.MetaData().Schema.NumColumns())
+	require.Equal(t, 1, reader.NumRowGroups())
+
+	rg := reader.RowGroup(0)
+	require.Equal(t, int64(2), rg.NumRows())
+
+	// Verify int64 column.
+	int64Reader, err := rg.Column(0)
+	require.NoError(t, err)
+	int64Chunk := int64Reader.(*file.Int64ColumnChunkReader)
+	int64Vals := make([]int64, 2)
+	n, _, err := int64Chunk.ReadBatch(2, int64Vals, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+	require.Equal(t, []int64{1, 2}, int64Vals)
+
+	// Verify float64 column.
+	float64Reader, err := rg.Column(1)
+	require.NoError(t, err)
+	float64Chunk := float64Reader.(*file.Float64ColumnChunkReader)
+	float64Vals := make([]float64, 2)
+	n, _, err = float64Chunk.ReadBatch(2, float64Vals, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+	require.InDelta(t, 9.99, float64Vals[0], 0.001)
+	require.InDelta(t, 0.0, float64Vals[1], 0.001)
+
+	// Verify date column (days since epoch).
+	dateReader, err := rg.Column(3)
+	require.NoError(t, err)
+	dateChunk := dateReader.(*file.Int32ColumnChunkReader)
+	dateVals := make([]int32, 2)
+	n, _, err = dateChunk.ReadBatch(2, dateVals, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+	// 1995-03-15 is 9204 days since epoch.
+	require.Equal(t, int32(9204), dateVals[0])
+	// 1970-01-01 is day 0.
+	require.Equal(t, int32(0), dateVals[1])
+}
+
+func TestParquetWriteBatchTypeMismatch(t *testing.T) {
+	table := TableDef{
+		Name:    "mismatch",
+		Columns: []ColumnDef{longCol("id")},
+	}
+
+	dir := t.TempDir()
+	format := &parquetFormat{}
+	w, err := format.NewWriter(table, dir, 1)
+	require.NoError(t, err)
+	defer func() {
+		// Close may fail since we wrote bad data; that's fine.
+		_ = w.Close()
+		require.NoError(t, os.Remove(filepath.Join(dir, "mismatch.parquet.1")))
+	}()
+
+	// Pass a string where int64 is expected.
+	rows := [][]any{{"not-a-number"}}
+	err = w.WriteBatch(rows)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected int64")
+}
+
+func TestParquetWriteBatchUnknownType(t *testing.T) {
+	table := TableDef{
+		Name: "unknown",
+		Columns: []ColumnDef{
+			{Name: "col", Type: ColumnType(99), Parse: parseString},
+		},
+	}
+
+	dir := t.TempDir()
+	format := &parquetFormat{}
+	// buildParquetSchema should fail on unknown type.
+	_, err := format.NewWriter(table, dir, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported column type")
+}
+
+func TestBuildParquetSchema(t *testing.T) {
+	table := TableDef{
+		Name: "test",
+		Columns: []ColumnDef{
+			longCol("a"),
+			doubleCol("b"),
+			stringCol("c"),
+			dateCol("d"),
+		},
+	}
+
+	sch, err := buildParquetSchema(table)
+	require.NoError(t, err)
+	require.Equal(t, 4, sch.NumColumns())
+	require.Equal(t, "a", sch.Column(0).Name())
+	require.Equal(t, "b", sch.Column(1).Name())
+	require.Equal(t, "c", sch.Column(2).Name())
+	require.Equal(t, "d", sch.Column(3).Name())
+}

--- a/pkg/cmd/generate-import-fixtures/main.go
+++ b/pkg/cmd/generate-import-fixtures/main.go
@@ -33,7 +33,8 @@ import (
 const batchSize = 10000
 
 var formats = map[string]OutputFormat{
-	"avro": &avroFormat{},
+	"avro":    &avroFormat{},
+	"parquet": &parquetFormat{},
 }
 
 func main() {

--- a/pkg/cmd/generate-import-fixtures/main_test.go
+++ b/pkg/cmd/generate-import-fixtures/main_test.go
@@ -113,5 +113,5 @@ func TestShardFiles(t *testing.T) {
 
 func TestAvailableFormats(t *testing.T) {
 	result := availableFormats()
-	require.Equal(t, "avro", result)
+	require.Equal(t, "avro, parquet", result)
 }


### PR DESCRIPTION
Add the Parquet format implementation using Apache Arrow. Date columns are stored as INT32 with DATE logical type (days since Unix epoch), and files use Snappy compression. Each WriteBatch call creates a new row group.

Part of: #168589
Release note: None
Epic: CRDB-62435