### PR TITLE
sql: support domain type named constraints

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1781,9 +1781,20 @@ message TypeDescriptor {
       optional string name = 1 [(gogoproto.nullable) = false];
       // Expr is the CHECK expression, serialized as a string.
       optional string expr = 2 [(gogoproto.nullable) = false];
+      // ConstraintID uniquely identifies individual constraints within the domain.
+      optional uint32 constraint_id = 3 [(gogoproto.customname) = "ConstraintID",
+        (gogoproto.casttype) = "ConstraintID", (gogoproto.nullable) = false];
     }
     // CheckConstraints is the list of CHECK constraints on this domain.
     repeated CheckConstraint check_constraints = 4 [(gogoproto.nullable) = false];
+
+    // NotNullConstraintName is the name of the NOT NULL constraint. Empty if
+    // there is no NOT NULL constraint.
+    optional string not_null_constraint_name = 5 [(gogoproto.nullable) = false];
+    // NotNullConstraintID uniquely identifies the NOT NULL constraint within
+    // the domain. Zero if there is no NOT NULL constraint.
+    optional uint32 not_null_constraint_id = 6 [(gogoproto.customname) = "NotNullConstraintID",
+      (gogoproto.casttype) = "ConstraintID", (gogoproto.nullable) = false];
   }
 
   // Domain is the domain definition if this is a domain type.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -1067,6 +1067,12 @@ type DomainTypeDescriptor interface {
 	GetBaseType() *types.T
 	// IsNotNull returns true if the domain has a NOT NULL constraint.
 	IsNotNull() bool
+	// GetNotNullConstraintName returns the name of the NOT NULL constraint, or
+	// an empty string if there is no NOT NULL constraint.
+	GetNotNullConstraintName() string
+	// GetNotNullConstraintID returns the ID of the NOT NULL constraint, or zero
+	// if there is no NOT NULL constraint.
+	GetNotNullConstraintID() descpb.ConstraintID
 	// GetDefaultExpr returns the default expression for the domain, or an
 	// empty string if no default is specified.
 	GetDefaultExpr() string
@@ -1078,6 +1084,9 @@ type DomainTypeDescriptor interface {
 	// GetCheckConstraintExpr returns the expression of the CHECK constraint at
 	// the given ordinal.
 	GetCheckConstraintExpr(idx int) string
+	// GetCheckConstraintID returns the ID of the CHECK constraint at the given
+	// ordinal.
+	GetCheckConstraintID(idx int) descpb.ConstraintID
 }
 
 // TypeDescriptorResolver is an interface used during hydration of type

--- a/pkg/sql/catalog/typedesc/hydrate.go
+++ b/pkg/sql/catalog/typedesc/hydrate.go
@@ -161,8 +161,9 @@ func ensureTypeMetadataIsHydrated(
 		for i := 0; i < n; i++ {
 			exprStr := d.GetCheckConstraintExpr(i)
 			checks[i] = types.DomainCheckConstraint{
-				Name: d.GetCheckConstraintName(i),
-				Expr: exprStr,
+				Name:         d.GetCheckConstraintName(i),
+				Expr:         exprStr,
+				ConstraintID: d.GetCheckConstraintID(i),
 			}
 			// Pre-parse the CHECK expression so that eval-time validation can
 			// skip the parse step. Errors are intentionally ignored; the
@@ -172,10 +173,12 @@ func ensureTypeMetadataIsHydrated(
 			}
 		}
 		tm.DomainData = &types.DomainMetadata{
-			BaseType:         d.GetBaseType(),
-			NotNull:          d.IsNotNull(),
-			DefaultExpr:      d.GetDefaultExpr(),
-			CheckConstraints: checks,
+			BaseType:              d.GetBaseType(),
+			NotNull:               d.IsNotNull(),
+			NotNullConstraintName: d.GetNotNullConstraintName(),
+			NotNullConstraintID:   d.GetNotNullConstraintID(),
+			DefaultExpr:           d.GetDefaultExpr(),
+			CheckConstraints:      checks,
 		}
 	}
 }

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -503,10 +503,91 @@ func (desc *immutable) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 			vea.Report(errors.AssertionFailedf("COMPOSITE type desc has nil composite type"))
 		}
 	case descpb.TypeDescriptor_DOMAIN:
+		if desc.RegionConfig != nil {
+			vea.Report(errors.AssertionFailedf(
+				"found region config on %s type desc", desc.Kind.String(),
+			))
+		}
+		if len(desc.EnumMembers) > 0 {
+			vea.Report(errors.AssertionFailedf(
+				"DOMAIN type desc has enum members",
+			))
+		}
+		if desc.Alias != nil {
+			vea.Report(errors.AssertionFailedf(
+				"DOMAIN type desc has alias type set",
+			))
+		}
+		if desc.Composite != nil {
+			vea.Report(errors.AssertionFailedf(
+				"DOMAIN type desc has composite type set",
+			))
+		}
 		if desc.Domain == nil {
 			vea.Report(errors.AssertionFailedf("DOMAIN type desc has nil domain"))
 		} else if desc.Domain.BaseType == nil {
 			vea.Report(errors.AssertionFailedf("DOMAIN type desc has nil base type"))
+		} else {
+			if desc.Domain.NotNull {
+				if desc.Domain.NotNullConstraintName == "" {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc has NotNull but no NOT NULL constraint name",
+					))
+				}
+				if desc.Domain.NotNullConstraintID == 0 {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc has NotNull but no NOT NULL constraint ID",
+					))
+				}
+			} else {
+				if desc.Domain.NotNullConstraintName != "" {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc has NOT NULL constraint name %q but NotNull is false",
+						desc.Domain.NotNullConstraintName,
+					))
+				}
+				if desc.Domain.NotNullConstraintID != 0 {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc has NOT NULL constraint ID %d but NotNull is false",
+						desc.Domain.NotNullConstraintID,
+					))
+				}
+			}
+			constraintNames := make(map[string]struct{})
+			constraintIDs := make(map[descpb.ConstraintID]struct{})
+			if desc.Domain.NotNull {
+				constraintNames[desc.Domain.NotNullConstraintName] = struct{}{}
+				constraintIDs[desc.Domain.NotNullConstraintID] = struct{}{}
+			}
+			for i, c := range desc.Domain.CheckConstraints {
+				if c.Name == "" {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc CHECK constraint %d has empty name", i,
+					))
+				}
+				if c.Expr == "" {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc CHECK constraint %d has empty expr", i,
+					))
+				}
+				if c.ConstraintID == 0 {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc CHECK constraint %d has unset constraint ID", i,
+					))
+				}
+				if _, exists := constraintNames[c.Name]; exists {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc has duplicated constraint name %q", c.Name,
+					))
+				}
+				constraintNames[c.Name] = struct{}{}
+				if _, exists := constraintIDs[c.ConstraintID]; exists {
+					vea.Report(errors.AssertionFailedf(
+						"DOMAIN type desc has duplicated constraint ID %d", c.ConstraintID,
+					))
+				}
+				constraintIDs[c.ConstraintID] = struct{}{}
+			}
 		}
 	case descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE:
 		vea.Report(errors.AssertionFailedf("invalid type descriptor: kind %s should never be serialized or validated", desc.Kind.String()))
@@ -1091,6 +1172,16 @@ func (desc *immutable) IsNotNull() bool {
 	return desc.Domain.NotNull
 }
 
+// GetNotNullConstraintName implements the catalog.DomainTypeDescriptor interface.
+func (desc *immutable) GetNotNullConstraintName() string {
+	return desc.Domain.NotNullConstraintName
+}
+
+// GetNotNullConstraintID implements the catalog.DomainTypeDescriptor interface.
+func (desc *immutable) GetNotNullConstraintID() descpb.ConstraintID {
+	return desc.Domain.NotNullConstraintID
+}
+
 // GetDefaultExpr implements the catalog.DomainTypeDescriptor interface.
 func (desc *immutable) GetDefaultExpr() string {
 	return desc.Domain.DefaultExpr
@@ -1109,6 +1200,11 @@ func (desc *immutable) GetCheckConstraintName(idx int) string {
 // GetCheckConstraintExpr implements the catalog.DomainTypeDescriptor interface.
 func (desc *immutable) GetCheckConstraintExpr(idx int) string {
 	return desc.Domain.CheckConstraints[idx].Expr
+}
+
+// GetCheckConstraintID implements the catalog.DomainTypeDescriptor interface.
+func (desc *immutable) GetCheckConstraintID(idx int) descpb.ConstraintID {
+	return desc.Domain.CheckConstraints[idx].ConstraintID
 }
 
 // Aliased implements the catalog.AliasTypeDescriptor interface.

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -575,6 +576,8 @@ func (p *planner) createDomainWithID(
 	// VALUE with a typed null of the base type and type-checking as boolean.
 	// This catches invalid expressions (e.g., referencing nonexistent
 	// functions) at CREATE DOMAIN time rather than at INSERT/UPDATE time.
+	var nextConstraintID descpb.ConstraintID = 1
+	var usedNames []string
 	checks := make(
 		[]descpb.TypeDescriptor_Domain_CheckConstraint, len(n.DomainConstraints),
 	)
@@ -597,15 +600,30 @@ func (p *planner) createDomainWithID(
 
 		name := string(c.Name)
 		if name == "" {
-			name = fmt.Sprintf("%s_check", typeName.Type())
-			if i > 0 {
-				name = fmt.Sprintf("%s_check%d", typeName.Type(), i+1)
-			}
+			name = chooseDomainConstraintName(
+				typeName.Type(), "check", usedNames,
+			)
+		} else if slices.Contains(usedNames, name) {
+			return pgerror.Newf(pgcode.DuplicateObject,
+				"constraint %q for domain %s already exists", name, typeName.Type())
 		}
+		usedNames = append(usedNames, name)
 		checks[i] = descpb.TypeDescriptor_Domain_CheckConstraint{
-			Name: name,
-			Expr: tree.Serialize(c.Expr),
+			Name:         name,
+			Expr:         tree.Serialize(c.Expr),
+			ConstraintID: nextConstraintID,
 		}
+		nextConstraintID++
+	}
+
+	// Assign a constraint ID and auto-generated name for the NOT NULL constraint.
+	var notNullConstraintName string
+	var notNullConstraintID descpb.ConstraintID
+	if n.DomainNotNull {
+		notNullConstraintName = chooseDomainConstraintName(
+			typeName.Type(), "not_null", usedNames,
+		)
+		notNullConstraintID = nextConstraintID
 	}
 
 	// Serialize default expression if present.
@@ -632,10 +650,12 @@ func (p *planner) createDomainWithID(
 		ParentSchemaID: schema.GetID(),
 		Kind:           descpb.TypeDescriptor_DOMAIN,
 		Domain: &descpb.TypeDescriptor_Domain{
-			BaseType:         baseType,
-			NotNull:          n.DomainNotNull,
-			DefaultExpr:      defaultExpr,
-			CheckConstraints: checks,
+			BaseType:              baseType,
+			NotNull:               n.DomainNotNull,
+			NotNullConstraintName: notNullConstraintName,
+			NotNullConstraintID:   notNullConstraintID,
+			DefaultExpr:           defaultExpr,
+			CheckConstraints:      checks,
 		},
 		Version:    1,
 		Privileges: privs,
@@ -647,6 +667,20 @@ func (p *planner) createDomainWithID(
 	// Install back references to types used by this domain (e.g., if the base
 	// type is a user-defined type like an enum).
 	return p.addBackRefsFromAllTypesInType(params.ctx, typeDesc)
+}
+
+// chooseDomainConstraintName generates a unique constraint name for a domain
+// constraint.
+func chooseDomainConstraintName(domainName string, label string, usedNames []string) string {
+	candidate := fmt.Sprintf("%s_%s", domainName, label)
+	for pass := 0; ; pass++ {
+		if pass > 0 {
+			candidate = fmt.Sprintf("%s_%s%d", domainName, label, pass)
+		}
+		if !slices.Contains(usedNames, candidate) {
+			return candidate
+		}
+	}
 }
 
 func (p *planner) finishCreateType(

--- a/pkg/sql/logictest/testdata/logic_test/domain
+++ b/pkg/sql/logictest/testdata/logic_test/domain
@@ -752,3 +752,96 @@ statement ok
 DROP DOMAIN d_atom
 
 subtest end
+
+subtest domain_constraint_names
+
+# Test that constraint naming behaves like PG18.
+
+statement error pgcode 42710 constraint "upper_bound" for domain d_constraint_names already exists
+CREATE DOMAIN d_constraint_names AS INT
+  CONSTRAINT upper_bound CHECK (VALUE < 100)
+  CONSTRAINT upper_bound CHECK (VALUE < 500);
+
+statement ok
+CREATE DOMAIN d_constraint_names AS INT 
+  CONSTRAINT d_constraint_names_not_null CHECK (VALUE > 0)
+  NOT NULL
+  CONSTRAINT d_constraint_names_check1 CHECK (VALUE < 13)
+  CHECK (VALUE < 17)
+  CHECK (VALUE < 19)
+  CHECK (VALUE != 23);
+
+query TTT colnames
+SELECT conname, contype, pg_get_constraintdef(oid) AS condef
+FROM pg_constraint
+WHERE contypid = 'd_constraint_names'::regtype
+ORDER BY conname
+----
+conname                       contype  condef
+d_constraint_names_check      c        CHECK ((value < 17))
+d_constraint_names_check1     c        CHECK ((value < 13))
+d_constraint_names_check2     c        CHECK ((value < 19))
+d_constraint_names_check3     c        CHECK ((value != 23))
+d_constraint_names_not_null   c        CHECK ((value > 0))
+d_constraint_names_not_null1  n        NOT NULL
+
+statement ok
+DROP DOMAIN d_constraint_names;
+
+# Domain with only NOT NULL and no CHECK constraints.
+statement ok
+CREATE DOMAIN d_not_null_only AS INT NOT NULL;
+
+query TTT colnames
+SELECT conname, contype, pg_get_constraintdef(oid) AS condef
+FROM pg_constraint
+WHERE contypid = 'd_not_null_only'::regtype
+ORDER BY conname
+----
+conname               contype  condef
+d_not_null_only_not_null  n        NOT NULL
+
+statement ok
+DROP DOMAIN d_not_null_only;
+
+# Test a not null constraint name-colliding with a check constraint.
+statement ok
+CREATE DOMAIN d_nn_collision AS INT
+  CONSTRAINT d_nn_collision_not_null CHECK (VALUE > 0)
+  NOT NULL;
+
+query TTT colnames
+SELECT conname, contype, pg_get_constraintdef(oid) AS condef
+FROM pg_constraint
+WHERE contypid = 'd_nn_collision'::regtype
+ORDER BY conname
+----
+conname                   contype  condef
+d_nn_collision_not_null   c        CHECK ((value > 0))
+d_nn_collision_not_null1  n        NOT NULL
+
+statement ok
+DROP DOMAIN d_nn_collision;
+
+
+# TODO(166932): name this constraint when there's grammar support
+# Test a check constraint name-colliding with a not null constraint.
+statement ok
+CREATE DOMAIN d_c_collision AS INT
+  NOT NULL 
+  CHECK (VALUE > 0);
+
+query TTT colnames
+SELECT conname, contype, pg_get_constraintdef(oid) AS condef
+FROM pg_constraint
+WHERE contypid = 'd_c_collision'::regtype
+ORDER BY conname
+----
+conname                 contype  condef
+d_c_collision_check     c        CHECK ((value > 0))
+d_c_collision_not_null  n        NOT NULL
+
+statement ok
+DROP DOMAIN d_c_collision;
+
+subtest end

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1148,6 +1148,7 @@ https://www.postgresql.org/docs/18/catalog-pg-collation.html`,
 var (
 	conTypeCheck     = tree.NewDString("c")
 	conTypeFK        = tree.NewDString("f")
+	conTypeNotNull   = tree.NewDString("n")
 	conTypePKey      = tree.NewDString("p")
 	conTypeUnique    = tree.NewDString("u")
 	conTypeTrigger   = tree.NewDString("t")
@@ -1397,6 +1398,104 @@ func populateTableConstraints(
 	return nil
 }
 
+func populateDomainConstraints(
+	h oidHasher, nspOid tree.Datum, _ tree.Datum, typ *types.T, addRow func(...tree.Datum) error,
+) error {
+	d := typ.TypeMeta.DomainData
+	if d == nil {
+		return nil
+	}
+
+	typOid := typ.Oid()
+
+	for _, ck := range d.CheckConstraints {
+		conoid := h.DomainConstraintOid(typOid, ck.ConstraintID)
+		displayExpr := ck.Expr
+		if parsedExpr, err := parser.ParseExpr(ck.Expr); err == nil {
+			f := tree.NewFmtCtx(tree.FmtPGCatalog)
+			f.FormatNode(parsedExpr)
+			displayExpr = f.CloseAndGetString()
+		}
+		consrc := tree.NewDString(fmt.Sprintf("(%s)", displayExpr))
+		condef := tree.NewDString(fmt.Sprintf("CHECK ((%s))", displayExpr))
+		if err := addRow(
+			conoid,               // oid
+			dNameOrNull(ck.Name), // conname
+			nspOid,               // connamespace
+			conTypeCheck,         // contype
+			tree.DBoolFalse,      // condeferrable
+			tree.DBoolFalse,      // condeferred
+			tree.DBoolTrue,       // convalidated
+			oidZero,              // conrelid
+			tree.NewDOid(typOid), // contypid
+			oidZero,              // conindid
+			oidZero,              // conparentid
+			oidZero,              // confrelid
+			tree.DNull,           // confupdtype
+			tree.DNull,           // confdeltype
+			tree.DNull,           // confmatchtype
+			tree.DBoolTrue,       // conislocal
+			zeroVal,              // coninhcount
+			tree.DBoolTrue,       // connoinherit
+			tree.DNull,           // conkey
+			tree.DNull,           // confkey
+			tree.DNull,           // conpfeqop
+			tree.DNull,           // conppeqop
+			tree.DNull,           // conffeqop
+			tree.DNull,           // confdelsetcols
+			tree.DNull,           // conexclop
+			consrc,               // conbin
+			consrc,               // consrc
+			condef,               // condef
+			tree.DBoolTrue,       // conenforced
+			tree.DBoolFalse,      // conperiod
+		); err != nil {
+			return err
+		}
+	}
+
+	if d.NotNull {
+		conoid := h.DomainConstraintOid(typOid, d.NotNullConstraintID)
+		condef := tree.NewDString("NOT NULL")
+		if err := addRow(
+			conoid,                               // oid
+			dNameOrNull(d.NotNullConstraintName), // conname
+			nspOid,                               // connamespace
+			conTypeNotNull,                       // contype
+			tree.DBoolFalse,                      // condeferrable
+			tree.DBoolFalse,                      // condeferred
+			tree.DBoolTrue,                       // convalidated
+			oidZero,                              // conrelid
+			tree.NewDOid(typOid),                 // contypid
+			oidZero,                              // conindid
+			oidZero,                              // conparentid
+			oidZero,                              // confrelid
+			tree.DNull,                           // confupdtype
+			tree.DNull,                           // confdeltype
+			tree.DNull,                           // confmatchtype
+			tree.DBoolTrue,                       // conislocal
+			zeroVal,                              // coninhcount
+			tree.DBoolTrue,                       // connoinherit
+			tree.DNull,                           // conkey
+			tree.DNull,                           // confkey
+			tree.DNull,                           // conpfeqop
+			tree.DNull,                           // conppeqop
+			tree.DNull,                           // conffeqop
+			tree.DNull,                           // confdelsetcols
+			tree.DNull,                           // conexclop
+			tree.DNull,                           // conbin
+			tree.DNull,                           // consrc
+			condef,                               // condef
+			tree.DBoolTrue,                       // conenforced
+			tree.DBoolFalse,                      // conperiod
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type oneAtATimeSchemaResolver struct {
 	ctx context.Context
 	p   *planner
@@ -1561,7 +1660,8 @@ https://www.postgresql.org/docs/18/catalog-pg-constraint.html`,
 	hideVirtual, /* Virtual tables have no constraints */
 	false,       /* includesIndexEntries */
 	populateTableConstraints,
-	nil)
+	populateDomainConstraints,
+)
 
 // colIDArrayToDatum returns an int[] containing the ColumnIDs, or NULL if there
 // are no ColumnIDs.
@@ -6072,6 +6172,7 @@ const (
 	triggerTypeTag
 	policyTypeTag
 	roleMembershipTypeTag
+	domainConstraintTypeTag
 )
 
 func (h oidHasher) writeTypeTag(tag oidTypeTag) {
@@ -6185,6 +6286,15 @@ func (h oidHasher) UniqueConstraintOid(
 	h.writeSchema(scID)
 	h.writeTable(tableID)
 	h.writeIndex(uwi.GetID())
+	return h.getOid()
+}
+
+func (h oidHasher) DomainConstraintOid(
+	typeOid oid.Oid, constraintID descpb.ConstraintID,
+) *tree.DOid {
+	h.writeTypeTag(domainConstraintTypeTag)
+	h.writeUInt32(uint32(typeOid))
+	h.writeUInt32(uint32(constraintID))
 	return h.getOid()
 }
 

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -349,6 +349,12 @@ type DomainMetadata struct {
 	BaseType *T
 	// NotNull is true if the domain has a NOT NULL constraint.
 	NotNull bool
+	// NotNullConstraintName is the name of the NOT NULL constraint.
+	// Empty if the domain has no NOT NULL constraint.
+	NotNullConstraintName string
+	// NotNullConstraintID uniquely identifies the NOT NULL constraint.
+	// Zero if the domain has no NOT NULL constraint.
+	NotNullConstraintID catid.ConstraintID
 	// DefaultExpr is the default expression for the domain, serialized as
 	// a string. Empty if no default is specified.
 	DefaultExpr string
@@ -362,6 +368,8 @@ type DomainCheckConstraint struct {
 	Name string
 	// Expr is the CHECK expression, serialized as a string.
 	Expr string
+	// ConstraintID uniquely identifies this constraint within the domain.
+	ConstraintID catid.ConstraintID
 	// ParsedExpr is the cached parsed expression tree from hydration.
 	// Typed as any to avoid an import cycle with tree. At runtime this
 	// holds a tree.Expr obtained via parserutils.ParseExpr. It may be nil


### PR DESCRIPTION
This change adds support for naming not null constraints on domain types and
revises the default name generation/validation of constraints. Testing
based on PG18 behavior is added; the pg catalog `pg_constraint` is
populated with domain constraints to support that testing.

Epic: CRDB-62146
Part of: #166933
Part of: #27796
Supports: #166916

Release note: None
