### PR TITLE
chore: clean up creation of FQN

### DIFF
--- a/pkg/sql/catalog/desctestutils/BUILD.bazel
+++ b/pkg/sql/catalog/desctestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/catalog/internal/catkv",
         "//pkg/sql/catalog/internal/validate",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/sem/tree",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/catalog/desctestutils/descriptor_test_utils.go
+++ b/pkg/sql/catalog/desctestutils/descriptor_test_utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/catkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
 
@@ -167,10 +168,12 @@ func TestingGetFunctionDescriptor(
 	sc := TestingGetSchemaDescriptor(kvDB, codec, db.GetID(), schema)
 	f, found := sc.GetFunction(fName)
 	if !found {
-		panic(fmt.Sprintf("function %s.%s.%s does not exist", database, schema, fName))
+		fn := tree.MakeQualifiedRoutineName(database, schema, fName)
+		panic(fmt.Sprintf("function %s does not exist", fn.FQString()))
 	}
 	if len(f.Signatures) != 1 {
-		panic(fmt.Sprintf("expected only 1 function %s.%s.%s, found %d", database, schema, fName, len(f.Signatures)))
+		fn := tree.MakeQualifiedRoutineName(database, schema, fName)
+		panic(fmt.Sprintf("expected only 1 function %s, found %d", fn.FQString(), len(f.Signatures)))
 	}
 	fnID := f.Signatures[0].ID
 	ctx := context.Background()

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -904,8 +904,10 @@ func exerciseBackupRestore(
 		for _, row := range backupContents {
 			switch row[2] {
 			case "table":
-				fqn := fmt.Sprintf("%s.%s.%s", cs.DatabaseName, row[0], row[1])
-				tablesToRestore = append(tablesToRestore, fqn)
+				tn := tree.MakeTableNameWithSchema(
+					tree.Name(cs.DatabaseName), tree.Name(row[0]), tree.Name(row[1]),
+				)
+				tablesToRestore = append(tablesToRestore, tn.FQString())
 			case "schema":
 				if row[1] != "public" {
 					tablesToRestore = nil


### PR DESCRIPTION
These are a couple of uses that don't use the `tree` helper as they
should. Hopefully reducing the use of this in the repo trains claude off
of the bad habit.

Epic: none

Release note: None
