### PR TITLE
sql/backfill: fix CREATE VECTOR INDEX panic with virtual computed columns

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -530,8 +530,10 @@ func (vihb *VectorIndexHelperBase) initBase(
 // that are replaced at write time.
 type VectorIndexHelper struct {
 	VectorIndexHelperBase
-	// vectorOrd is the ordinal of the vector column in the table.
-	vectorOrd int
+	// rowValsIdx is the index into the IndexBackfiller's rowVals slice
+	// (equivalently, into ib.cols) at which this vector column's value
+	// lives.
+	rowValsIdx int
 	// centroid is an all zeros centroid of the appropriate dimension for the
 	// vector column. It's used to encode the vector in the reader. The writer
 	// will re-encode the vector with the centroid for the partition selected.
@@ -555,13 +557,9 @@ func NewVectorIndexHelper(
 	sourceIndexID catid.IndexID,
 	vecIndexManager *vecindex.Manager,
 ) (*VectorIndexHelper, error) {
-	vectorCol, err := catalog.MustFindColumnByID(desc, idx.VectorColumnID())
-	if err != nil {
-		return nil, err
-	}
-
 	var sourceIndex catalog.Index
 	if sourceIndexID != 0 {
+		var err error
 		sourceIndex, err = catalog.MustFindIndexByID(desc, sourceIndexID)
 		if err != nil {
 			return nil, err
@@ -571,7 +569,6 @@ func NewVectorIndexHelper(
 	}
 
 	vih := &VectorIndexHelper{
-		vectorOrd:   vectorCol.Ordinal(),
 		centroid:    make(vector.T, idx.GetVecConfig().Dims),
 		indexPrefix: rowenc.MakeIndexKeyPrefix(evalCtx.Codec, desc.GetID(), idx.GetID()),
 		evalCtx:     evalCtx,
@@ -1023,8 +1020,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 		ib.valNeededForCol.Add(ib.colIdxMap.GetDefault(col))
 	})
 
-	ib.init(evalCtx, predicates, colExprs, mon)
-	return nil
+	return ib.init(evalCtx, predicates, colExprs, mon)
 }
 
 // constructExprs is a helper to construct the index and column expressions
@@ -1209,8 +1205,7 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 		ib.valNeededForCol.Add(ib.colIdxMap.GetDefault(col))
 	})
 
-	ib.init(evalCtx, predicates, colExprs, mon)
-	return nil
+	return ib.init(evalCtx, predicates, colExprs, mon)
 }
 
 // Close releases the resources used by the IndexBackfiller. It can be called
@@ -1325,7 +1320,9 @@ func (ib *IndexBackfiller) initIndexes(
 	return nil
 }
 
-// init completes the initialization of an IndexBackfiller.
+// init completes the initialization of an IndexBackfiller. It must be
+// called after both initIndexes and initCols have run, since it resolves
+// each VectorIndexHelper's rowValsIdx from colIdxMap.
 //
 // The IndexBackfiller takes ownership of the monitor which must be non-nil.
 // It'll be closed when the backfiller is closed.
@@ -1334,7 +1331,7 @@ func (ib *IndexBackfiller) init(
 	predicateExprs map[descpb.IndexID]tree.TypedExpr,
 	colExprs map[descpb.ColumnID]tree.TypedExpr,
 	mon *mon.BytesMonitor,
-) {
+) error {
 	ib.evalCtx = evalCtx
 	ib.predicates = predicateExprs
 	ib.colExprs = colExprs
@@ -1354,9 +1351,24 @@ func (ib *IndexBackfiller) init(
 		ib.types[i] = ib.cols[i].GetType()
 	}
 
+	// Resolve each vector helper's index into rowVals. The helpers are
+	// constructed during initIndexes, before colIdxMap exists; the lookup
+	// has to happen here.
+	for indexID, helper := range ib.VectorIndexes {
+		colID := helper.vectorIndex.VectorColumnID()
+		idx, ok := ib.colIdxMap.Get(colID)
+		if !ok {
+			return errors.AssertionFailedf(
+				"vector column %d for index %d not present in backfill column set",
+				colID, indexID)
+		}
+		helper.rowValsIdx = idx
+	}
+
 	// Create a bound account associated with the index backfiller monitor.
 	ib.mon = mon
 	ib.muBoundAccount.boundAccount = mon.MakeBoundAccount()
+	return nil
 }
 
 // BuildIndexEntriesChunk reads a chunk of rows from a table using the span sp
@@ -1555,13 +1567,13 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 				firstVectorIndex = false
 			}
 
-			if ib.rowVals[vectorIndexHelper.vectorOrd] == tree.DNull {
+			if ib.rowVals[vectorIndexHelper.rowValsIdx] == tree.DNull {
 				ib.vectorEncodingHelper.QuantizedVecs[indexID] = tree.DNull
 				ib.vectorEncodingHelper.PartitionKeys[indexID] = tree.DNull
 				continue
 			}
 
-			vectorValue := tree.MustBeDPGVector(ib.rowVals[vectorIndexHelper.vectorOrd]).T
+			vectorValue := tree.MustBeDPGVector(ib.rowVals[vectorIndexHelper.rowValsIdx]).T
 			encodedVector := vector.Encode([]byte{}, vectorValue)
 			ib.vectorEncodingHelper.QuantizedVecs[indexID] = tree.NewDBytes(tree.DBytes(encodedVector))
 			ib.vectorEncodingHelper.PartitionKeys[indexID] = tree.NewDInt(tree.DInt(cspann.RootKey))

--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -481,3 +481,59 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 		require.Equal(t, row.pk, pk)
 	}
 }
+
+// TestVectorIndexBackfillWithUnreferencedVirtualColumn is a regression test
+// for a panic in IndexBackfiller.BuildIndexEntriesChunk when a virtual
+// computed column appears in the table at an ordinal before the vector
+// column.
+//
+// The backfiller's rowVals slice is sized by the filtered set of columns
+// produced by makeIndexBackfillColumns, which drops public columns that
+// aren't stored in the source primary index and aren't referenced by any
+// added index. A virtual computed column not referenced by the vector
+// index falls into that bucket. The vector code path was indexing rowVals
+// using the vector column's table-wide ordinal, which sits past the end
+// of rowVals once any earlier column has been filtered out.
+func TestVectorIndexBackfillWithUnreferencedVirtualColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DisableElasticCPUAdmission: true,
+	})
+	defer srv.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// Column ordinals:
+	//   0: id          (primary key, in primary index → kept)
+	//   1: name        (public, in primary index → kept)
+	//   2: upper_name  (public, virtual computed, not in primary index,
+	//                   not referenced by the vector index → filtered out)
+	//   3: vec         (vector column → kept)
+	//
+	// After filtering, ib.cols has length 3 but vec.Ordinal() == 3, so the
+	// previous ib.rowVals[vectorOrd] access went out of bounds.
+	sqlDB.Exec(t, `
+		CREATE TABLE t (
+			id INT PRIMARY KEY,
+			name STRING NOT NULL,
+			upper_name STRING AS (upper(name)) VIRTUAL,
+			vec VECTOR(3)
+		)
+	`)
+	sqlDB.Exec(t, `
+		INSERT INTO t (id, name, vec) VALUES
+		(1, 'a', '[1, 2, 3]'),
+		(2, 'b', '[4, 5, 6]'),
+		(3, 'c', '[7, 8, 9]')
+	`)
+
+	sqlDB.Exec(t, `CREATE VECTOR INDEX vec_idx ON t (vec)`)
+
+	var id int
+	sqlDB.QueryRow(t,
+		`SELECT id FROM t@vec_idx ORDER BY vec <-> '[1, 2, 3]' LIMIT 1`,
+	).Scan(&id)
+	require.Equal(t, 1, id)
+}


### PR DESCRIPTION
`VectorIndexHelper.vectorOrd` was set to `vectorCol.Ordinal()`, the
column's position in `desc.AllColumns()`. The backfiller's `rowVals`
slice, however, is sized by the filtered set of columns produced by
`makeIndexBackfillColumns`: public columns that aren't stored in the
source primary index and aren't referenced by any added index get
dropped. When such a column (e.g. an unreferenced virtual computed
column) sits at an ordinal before the vector column, the vector
column's table-wide ordinal points past the end of `rowVals` and
`BuildIndexEntriesChunk` panics with `index out of range`.

Resolve the `rowVals` index from `ib.colIdxMap`, which maps `ColumnID`
to position in `ib.cols`. Compute it once in `IndexBackfiller.init()`,
after both `initIndexes` (which builds the helpers) and `initCols`
(which builds `colIdxMap`) have run, and store it on the helper. Rename
the field to `rowValsIdx` so the index space is unambiguous. `init()`
now returns an error so the impossible-but-asserted "vector column
missing from backfill column set" case can be reported instead of
crashing.

Resolves: #169059
Epic: none

Release note (bug fix): Fixed a panic during CREATE VECTOR INDEX
backfill when the table contained a public column ordered before the
vector column that was not stored in the source primary index and was
not referenced by the new index. In practice this was triggered by
virtual computed columns. The schema change crashed the SQL node
processing the backfill instead of completing.