### PR TITLE
errorutil: stop returning unimplemented errors for virtual cluster features

### DIFF
--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -11,9 +11,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/reports/problemranges... received response...
 [cluster] requesting data for debug/reports/problemranges: last request failed: rpc error: ...
 [cluster] requesting data for debug/reports/problemranges: creating error output: debug/reports/problemranges.json.err.txt... done
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -25,9 +25,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
 [node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
 [node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -51,9 +51,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges... received response...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: last request failed: rpc error: ...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: creating error output: debug/cluster/test-tenant/reports/problemranges.json.err.txt... done
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/cluster/test-tenant/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -65,9 +65,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/cluster/test-tenant/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/cluster/test-tenant/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/gossip.json... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
@@ -51,9 +51,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges... received response...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: last request failed: rpc error: ...
 [cluster] requesting data for debug/cluster/test-tenant/reports/problemranges: creating error output: debug/cluster/test-tenant/reports/problemranges.json.err.txt... done
-[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_node_status: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[cluster] retrieving SQL data for crdb_internal.kv_store_status: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
 [cluster] requesting liveness... received response... writing JSON output: debug/cluster/test-tenant/liveness.json... done
 [cluster] requesting tenant ranges... received response...
@@ -65,9 +65,9 @@ debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /d
 [cluster] profile for node 1... writing binary output: debug/cluster/test-tenant/nodes/1/cpu.pprof... done
 [node 1] node status... writing JSON output: debug/cluster/test-tenant/nodes/1/status.json... done
 [node 1] using SQL connection URL: postgresql://...
-[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
-[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: unimplemented: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes: last request failed: ERROR: operation is unsupported within a virtual cluster (SQLSTATE 0A000)
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/gossip.json... done

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1696,13 +1696,13 @@ type OptionalGossip struct {
 }
 
 // OptionalErr returns the Gossip instance if the wrapper was set up to allow
-// it. Otherwise, it returns an error referring to the optionally passed in
-// issues.
+// it. Otherwise, it returns an error indicating that the operation is
+// unsupported within a virtual cluster.
 //
 // Use of Gossip from within the SQL layer is **deprecated**. Please do not
 // introduce new uses of it.
-func (og OptionalGossip) OptionalErr(issue int) (*Gossip, error) {
-	v, err := og.w.OptionalErr(issue)
+func (og OptionalGossip) OptionalErr() (*Gossip, error) {
+	v, err := og.w.OptionalErr()
 	if err != nil {
 		return nil, err
 	}
@@ -1715,7 +1715,7 @@ func (og OptionalGossip) OptionalErr(issue int) (*Gossip, error) {
 //
 // Use of Gossip from within the SQL layer is **deprecated**. Please do not
 // introduce new uses of it.
-func (og OptionalGossip) Optional(issue int) (*Gossip, bool) {
+func (og OptionalGossip) Optional() (*Gossip, bool) {
 	v, ok := og.w.Optional()
 	if !ok {
 		return nil, false

--- a/pkg/inspectz/unsupported.go
+++ b/pkg/inspectz/unsupported.go
@@ -24,40 +24,40 @@ var _ inspectzpb.InspectzServer = Unsupported{}
 func (u Unsupported) KVFlowController(
 	ctx context.Context, request *kvflowinspectpb.ControllerRequest,
 ) (*kvflowinspectpb.ControllerResponse, error) {
-	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization()
 }
 
 // KVFlowHandles is part of the inspectzpb.InspectzServer interface.
 func (u Unsupported) KVFlowHandles(
 	ctx context.Context, request *kvflowinspectpb.HandlesRequest,
 ) (*kvflowinspectpb.HandlesResponse, error) {
-	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization()
 }
 
 // KVFlowControllerV2 is part of the inspectzpb.InspectzServer interface.
 func (u Unsupported) KVFlowControllerV2(
 	ctx context.Context, request *kvflowinspectpb.ControllerRequest,
 ) (*kvflowinspectpb.ControllerResponse, error) {
-	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization()
 }
 
 // KVFlowHandlesV2 is part of the inspectzpb.InspectzServer interface.
 func (u Unsupported) KVFlowHandlesV2(
 	ctx context.Context, request *kvflowinspectpb.HandlesRequest,
 ) (*kvflowinspectpb.HandlesResponse, error) {
-	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization()
 }
 
 // StoreLivenessSupportFrom is part of the inspectzpb.InspectzServer interface.
 func (u Unsupported) StoreLivenessSupportFrom(
 	_ context.Context, _ *slpb.InspectStoreLivenessRequest,
 ) (*slpb.InspectSupportFromResponse, error) {
-	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization()
 }
 
 // StoreLivenessSupportFor is part of the inspectzpb.InspectzServer interface.
 func (u Unsupported) StoreLivenessSupportFor(
 	_ context.Context, _ *slpb.InspectStoreLivenessRequest,
 ) (*slpb.InspectSupportForResponse, error) {
-	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return nil, errorutil.UnsupportedUnderClusterVirtualization()
 }

--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -48,5 +48,5 @@ var _ StoresIterator = UnsupportedStoresIterator{}
 
 // ForEachStore is part of the StoresIterator interface.
 func (i UnsupportedStoresIterator) ForEachStore(f func(Store) error) error {
-	return errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	return errorutil.UnsupportedUnderClusterVirtualization()
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -934,7 +934,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	}
 
 	var isAvailable func(sqlInstanceID base.SQLInstanceID) bool
-	nodeLiveness, hasNodeLiveness := cfg.nodeLiveness.Optional(47900)
+	nodeLiveness, hasNodeLiveness := cfg.nodeLiveness.Optional()
 	if hasNodeLiveness {
 		isAvailable = func(sqlInstanceID base.SQLInstanceID) bool {
 			return nodeLiveness.GetNodeVitalityFromCache(roachpb.NodeID(sqlInstanceID)).IsLive(livenesspb.DistSQL)

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -100,10 +100,10 @@ type TenantStatusServer interface {
 }
 
 // OptionalNodesStatusServer returns the wrapped NodesStatusServer, if it is
-// available. If it is not, an error referring to the optionally supplied issues
-// is returned.
+// available. If it is not, an error indicating that the feature is not
+// supported under cluster virtualization is returned.
 func (s *OptionalNodesStatusServer) OptionalNodesStatusServer() (NodesStatusServer, error) {
-	v, err := s.w.OptionalErr(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+	v, err := s.w.OptionalErr()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4986,7 +4986,7 @@ CREATE TABLE crdb_internal.zones (
 }
 
 func getAllNodeDescriptors(p *planner) ([]roachpb.NodeDescriptor, error) {
-	g, err := p.ExecCfg().Gossip.OptionalErr(47899)
+	g, err := p.ExecCfg().Gossip.OptionalErr()
 	if err != nil {
 		return nil, err
 	}
@@ -5044,7 +5044,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 			return err
 		}
 
-		g, err := p.ExecCfg().Gossip.OptionalErr(47899)
+		g, err := p.ExecCfg().Gossip.OptionalErr()
 		if err != nil {
 			return err
 		}
@@ -5163,7 +5163,7 @@ CREATE TABLE crdb_internal.kv_node_liveness (
 			return err
 		}
 
-		nl, err := p.ExecCfg().NodeLiveness.OptionalErr(47900)
+		nl, err := p.ExecCfg().NodeLiveness.OptionalErr()
 		if err != nil {
 			return err
 		}
@@ -5229,7 +5229,7 @@ CREATE TABLE crdb_internal.gossip_liveness (
 			return err
 		}
 
-		g, err := p.ExecCfg().Gossip.OptionalErr(47899)
+		g, err := p.ExecCfg().Gossip.OptionalErr()
 		if err != nil {
 			return err
 		}
@@ -5305,7 +5305,7 @@ CREATE TABLE crdb_internal.gossip_alerts (
 			return err
 		}
 
-		g, err := p.ExecCfg().Gossip.OptionalErr(47899)
+		g, err := p.ExecCfg().Gossip.OptionalErr()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -53,12 +53,6 @@ import (
 // nodes.
 const minFlowDrainWait = 1 * time.Second
 
-// MultiTenancyIssueNo is the issue tracking DistSQL's Gossip and
-// NodeID dependencies.
-//
-// See https://github.com/cockroachdb/cockroach/issues/47900.
-const MultiTenancyIssueNo = 47900
-
 // ServerImpl implements the server for the distributed SQL APIs.
 type ServerImpl struct {
 	execinfra.ServerConfig
@@ -138,7 +132,7 @@ func (ds *ServerImpl) Drain(
 	if ds.ServerConfig.TestingKnobs.DrainFast {
 		flowWait = 0
 		minWait = 0
-	} else if g, ok := ds.Gossip.Optional(MultiTenancyIssueNo); !ok || len(g.Outgoing()) == 0 {
+	} else if g, ok := ds.Gossip.Optional(); !ok || len(g.Outgoing()) == 0 {
 		// If there is only one node in the cluster (us), there's no need to
 		// wait a minimum time for the draining state to be gossiped.
 		minWait = 0
@@ -153,10 +147,9 @@ func (ds *ServerImpl) setDraining(drain bool) error {
 	if !ok {
 		// Ignore draining requests when running on behalf of a tenant.
 		// NB: intentionally swallow the error or the server will fatal.
-		_ = MultiTenancyIssueNo // related issue
 		return nil
 	}
-	if g, ok := ds.ServerConfig.Gossip.Optional(MultiTenancyIssueNo); ok {
+	if g, ok := ds.ServerConfig.Gossip.Optional(); ok {
 		return g.AddInfoProto(
 			gossip.MakeDistSQLDrainingKey(base.SQLInstanceID(nodeID)),
 			&execinfrapb.DistSQLDrainingInfo{

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -900,7 +900,7 @@ func (h *distSQLNodeHealth) checkSystem(
 	}
 
 	// Check that the node is not draining.
-	g, ok := h.gossip.Optional(distsql.MultiTenancyIssueNo)
+	g, ok := h.gossip.Optional()
 	if !ok {
 		return errors.AssertionFailedf("gossip is expected to be available for the system tenant")
 	}

--- a/pkg/sql/gossip.go
+++ b/pkg/sql/gossip.go
@@ -14,7 +14,7 @@ import (
 
 // TryClearGossipInfo implements the tree.GossipOperator interface.
 func (p *planner) TryClearGossipInfo(ctx context.Context, key string) (bool, error) {
-	g, err := p.ExecCfg().Gossip.OptionalErr(0 /* issue */)
+	g, err := p.ExecCfg().Gossip.OptionalErr()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/kv_builtin_functions_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/kv_builtin_functions_tenant
@@ -1,7 +1,7 @@
 # LogicTest: 3node-tenant
 
-query error pq: unimplemented: operation is unsupported within a virtual cluster
+query error pq: operation is unsupported within a virtual cluster
 select crdb_internal.kv_set_queue_active('split', true);
 
-query error pq: unimplemented: operation is unsupported within a virtual cluster
+query error pq: operation is unsupported within a virtual cluster
 select crdb_internal.kv_enqueue_replica(42, 'split', true);

--- a/pkg/sql/optionalnodeliveness/node_liveness.go
+++ b/pkg/sql/optionalnodeliveness/node_liveness.go
@@ -30,12 +30,13 @@ func MakeContainer(nl livenesspb.NodeVitalityInterface) Container {
 }
 
 // OptionalErr returns the NodeLiveness instance if available. Otherwise, it
-// returns an error referring to the optionally passed in issues.
+// returns an error indicating that the operation is unsupported within a
+// virtual cluster.
 //
 // Use of NodeLiveness from within the SQL layer is **deprecated**. Please do
 // not introduce new uses of it.
-func (nl *Container) OptionalErr(issue int) (livenesspb.NodeVitalityInterface, error) {
-	v, err := nl.w.OptionalErr(issue)
+func (nl *Container) OptionalErr() (livenesspb.NodeVitalityInterface, error) {
+	v, err := nl.w.OptionalErr()
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +50,7 @@ var _ = (*Container)(nil).OptionalErr // silence unused lint
 //
 // Use of NodeLiveness from within the SQL layer is **deprecated**. Please do
 // not introduce new uses of it.
-func (nl *Container) Optional(issue int) (livenesspb.NodeVitalityInterface, bool) {
+func (nl *Container) Optional() (livenesspb.NodeVitalityInterface, bool) {
 	v, ok := nl.w.Optional()
 	if !ok {
 		return nil, false

--- a/pkg/util/errorutil/BUILD.bazel
+++ b/pkg/util/errorutil/BUILD.bazel
@@ -12,7 +12,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/errorutil",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/errorutil/unimplemented",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/util/errorutil/tenant.go
+++ b/pkg/util/errorutil/tenant.go
@@ -5,7 +5,10 @@
 
 package errorutil
 
-import "github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+)
 
 // UnsupportedUnderClusterVirtualizationMessage is the message used by UnsupportedUnderClusterVirtualization error.
 const UnsupportedUnderClusterVirtualizationMessage = "operation is unsupported within a virtual cluster"
@@ -14,14 +17,6 @@ const UnsupportedUnderClusterVirtualizationMessage = "operation is unsupported w
 // returning when an operation could not be carried out due to the SQL
 // server running inside a virtual cluster. In that mode, Gossip and
 // other components of the KV layer are not available.
-func UnsupportedUnderClusterVirtualization(issue int) error {
-	return unimplemented.NewWithIssue(issue, UnsupportedUnderClusterVirtualizationMessage)
+func UnsupportedUnderClusterVirtualization() error {
+	return pgerror.New(pgcode.FeatureNotSupported, UnsupportedUnderClusterVirtualizationMessage)
 }
-
-// FeatureNotAvailableToNonSystemTenantsIssue is to be used with the
-// Optional and related error interfaces when a feature is simply not
-// available to non-system tenants (i.e. we're not planning to change
-// this).
-// For all other multitenancy errors where there is a plan to
-// improve the situation, a specific issue should be created instead.
-const FeatureNotAvailableToNonSystemTenantsIssue = 54252

--- a/pkg/util/errorutil/tenant_deprecated_wrapper.go
+++ b/pkg/util/errorutil/tenant_deprecated_wrapper.go
@@ -25,21 +25,11 @@ package errorutil
 // to reach into the KV layer as needed while the first category above is
 // being whittled down.
 //
-// This wrapper aids that process by offering two methods corresponding to
-// the categories above:
-//
-// Deprecated() trades in a reference to Github issue (tracking the removal of
-// an essential usage) for the wrapped object; OptionalErr() returns the wrapped
-// object only if the wrapper was set up to allow this.
-//
-// Note that the wrapped object will in fact always have to be present as long
-// as calls to Deprecated() exist. However, when running semi-dedicated SQL
-// tenants, the wrapper should be set up with exposed=false so that it can
-// pretend that the object is in fact not available.
-//
-// Finally, once all Deprecated() calls have been removed, it is possible to
-// treat the wrapper as a pure option type, i.e. wrap a nil value with
-// exposed=false.
+// This wrapper aids that process by offering two methods, Optional() and
+// OptionalErr(), which return the wrapped object only if the wrapper was set
+// up to allow this (i.e. exposed=true). When running in a virtual cluster,
+// the wrapper should be set up with exposed=false so that it can pretend that
+// the object is in fact not available.
 type TenantSQLDeprecatedWrapper struct {
 	v       interface{}
 	exposed bool
@@ -66,12 +56,12 @@ func (w TenantSQLDeprecatedWrapper) Optional() (interface{}, bool) {
 	return w.v, true
 }
 
-// OptionalErr calls Optional and returns an error (referring to the optionally
-// supplied Github issues) if the wrapped object is not available.
-func (w TenantSQLDeprecatedWrapper) OptionalErr(issue int) (interface{}, error) {
+// OptionalErr calls Optional and returns an UnsupportedUnderClusterVirtualization
+// error if the wrapped object is not available.
+func (w TenantSQLDeprecatedWrapper) OptionalErr() (interface{}, error) {
 	v, ok := w.Optional()
 	if !ok {
-		return nil, UnsupportedUnderClusterVirtualization(issue)
+		return nil, UnsupportedUnderClusterVirtualization()
 	}
 	return v, nil
 }


### PR DESCRIPTION
The UnsupportedUnderClusterVirtualization helper wrapped its returned error with unimplemented.NewWithIssue, which annotated the error with a telemetry key like "#47899" and prefixed the message with "unimplemented:". Telemetry showed that clusters in the wild were still hitting unimplemented.#47899 and unimplemented.#47900 even though those issues have been closed since 2023, because these features (Gossip, NodeLiveness, and similar KV-layer dependencies) are by-design unavailable in virtual clusters rather than waiting to be implemented.

Switch the helper to return a plain pgerror with code FeatureNotSupported so these no longer surface in telemetry under the unimplemented bucket or claim to users that the feature is forthcoming. Drop the now-unused issue parameter from the helper and from the OptionalErr/Optional methods on TenantSQLDeprecatedWrapper, OptionalGossip, and optionalnodeliveness.Container, and update all callers. The MultiTenancyIssueNo and FeatureNotAvailableToNonSystemTenantsIssue constants are removed.

Resolves: #54252
Epic: none

Release note: None