### PR TITLE
rpc: add test reproducing drpcpool transparent re-dial bug

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -186,6 +186,7 @@ go_test(
         "@io_storj_drpc//:drpc",
         "@io_storj_drpc//drpcclient",
         "@io_storj_drpc//drpcctx",
+        "@io_storj_drpc//drpcmigrate",
         "@io_storj_drpc//drpcmux",
         "@io_storj_drpc//drpcserver",
         "@org_golang_google_grpc//:grpc",

--- a/pkg/rpc/drpc_test.go
+++ b/pkg/rpc/drpc_test.go
@@ -8,12 +8,18 @@ package rpc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -24,6 +30,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 	"storj.io/drpc"
+	"storj.io/drpc/drpcmigrate"
+	"storj.io/drpc/drpcmux"
+	"storj.io/drpc/drpcserver"
 )
 
 // dummyStream is a minimal implementation of drpc.Stream used for testing the
@@ -190,4 +199,143 @@ func TestDRPCServerWithInterceptor(t *testing.T) {
 	shouldBlock.Store(true)
 	_, err = client.Ping(ctx, &PingRequest{})
 	require.Contains(t, err.Error(), "RPC blocked by interceptor")
+}
+
+// dropDRPCHeaderListener strips the DRPC migration header from accepted
+// connections. This is needed for raw drpcserver instances that don't use
+// CockroachDB's multiplexed listener.
+type dropDRPCHeaderListener struct {
+	net.Listener
+}
+
+func (ln *dropDRPCHeaderListener) Accept() (net.Conn, error) {
+	conn, err := ln.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, len(drpcmigrate.DRPCHeader))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// fakeHeartbeatServer implements DRPCHeartbeatServer with a configurable Pong
+// value, allowing tests to identify which server handled a request.
+type fakeHeartbeatServer struct {
+	pong string
+}
+
+func (f *fakeHeartbeatServer) Ping(_ context.Context, req *PingRequest) (*PingResponse, error) {
+	return &PingResponse{
+		Pong:          f.pong,
+		ServerTime:    timeutil.Now().UnixNano(),
+		ServerVersion: clusterversion.Latest.Version(),
+	}, nil
+}
+
+// startFakeDRPCServer starts a minimal dRPC server with a fake heartbeat
+// service on the given TCP address. Returns the listener and a cleanup
+// function that stops the server and waits for it to finish.
+func startFakeDRPCServer(t *testing.T, addr string, pong string) (net.Listener, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	drpcL := &dropDRPCHeaderListener{Listener: ln}
+	mux := drpcmux.New()
+	srv := drpcserver.New(mux)
+	require.NoError(t, DRPCRegisterHeartbeat(mux, &fakeHeartbeatServer{pong: pong}))
+
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = srv.Serve(context.Background(), drpcL)
+	}()
+
+	return ln, func() {
+		_ = ln.Close()
+		<-serveDone
+	}
+}
+
+// TestDRPCPoolConnTransparentRedial demonstrates that the drpcpool underneath a
+// peer connection can transparently re-dial to a different server after TCP port
+// reuse, bypassing CockroachDB's heartbeat-based connection validation.
+//
+// This is the root cause of flakes like #168792: when a TestCluster tears down
+// and another test's node binds to the same port, the surviving node's poolConn
+// silently connects to the new node and delivers phantom raft messages.
+func TestDRPCPoolConnTransparentRedial(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Start server A on a random port.
+	lnA, cleanupA := startFakeDRPCServer(t, "127.0.0.1:0", "server-A")
+	addr := lnA.Addr().String()
+	port := lnA.Addr().(*net.TCPAddr).Port
+
+	// Create a client rpc.Context with a very long heartbeat interval. This
+	// ensures no subsequent heartbeat fires between the server swap, isolating
+	// the test to show that the poolConn re-dials without any re-validation.
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	opts := DefaultContextOptions()
+	opts.Insecure = true
+	opts.Clock = &timeutil.DefaultTimeSource{}
+	opts.ToleratedOffset = time.Nanosecond
+	opts.Stopper = stopper
+	opts.Settings = cluster.MakeTestingClusterSettings()
+	opts.RPCHeartbeatInterval = time.Hour
+	opts.RPCHeartbeatTimeout = 10 * time.Second
+	clientCtx := NewContext(ctx, opts)
+	clientCtx.StorageClusterID.Set(ctx, uuid.MakeV4())
+	clientCtx.NodeID.Set(ctx, 99)
+
+	// Establish a peer connection. Connect() blocks until the initial heartbeat
+	// succeeds, which validates the remote server's identity.
+	conn, err := clientCtx.DRPCDialNode(
+		addr, 1, roachpb.Locality{}, rpcbase.DefaultClass,
+	).Connect(ctx)
+	require.NoError(t, err)
+
+	// Confirm we can reach server A.
+	client := NewDRPCHeartbeatClient(conn)
+	resp, err := client.Ping(ctx, &PingRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "server-A", resp.Pong)
+
+	// Kill server A. The underlying TCP connection will receive a FIN/RST.
+	// The poolConn's Closed() channel does NOT fire (it only fires on explicit
+	// Close), so the heartbeat loop remains blissfully unaware — it's waiting
+	// on the 1-hour timer.
+	cleanupA()
+
+	// Start server B on the SAME port. This simulates another test's node
+	// binding to a recently freed port.
+	lnB, cleanupB := startFakeDRPCServer(
+		t, fmt.Sprintf("127.0.0.1:%d", port), "server-B",
+	)
+	_ = lnB
+	defer cleanupB()
+
+	// Ping again on the SAME conn. The poolConn detects the cached TCP
+	// connection is dead (via Closed() on the underlying drpcconn.Conn) and
+	// transparently re-dials to port P — which is now server B. No heartbeat
+	// validates this new connection.
+	testutils.SucceedsSoon(t, func() error {
+		resp, err := client.Ping(ctx, &PingRequest{})
+		if err != nil {
+			return err
+		}
+		if resp.Pong != "server-B" {
+			return errors.Newf("got pong %q, want %q", resp.Pong, "server-B")
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Add `TestDRPCPoolConnTransparentRedial` which demonstrates that the `drpcpool` underneath a peer connection can transparently re-dial to a completely different server after TCP port reuse, bypassing CockroachDB's heartbeat-based connection validation.

The test establishes a peer connection to server A (with heartbeat validation), then kills server A and starts server B on the same port. It shows that RPCs on the original `drpc.Conn` silently reach server B without any new heartbeat validating the connection.

This reproduces the root cause of flakes like #168792: when a `TestCluster` tears down and another test's node binds to the same port, the surviving node's `poolConn` transparently reconnects and can deliver phantom raft messages to the wrong cluster.

Key findings:
- `poolConn.Closed()` only fires on explicit `Close()`, not on TCP death, so the heartbeat loop's `connClosedCh` never triggers.
- With gRPC, `onlyOnceDialer` prevents internal reconnection. dRPC's pool has no equivalent guard.

Epic: none
Release note: None