### PR TITLE
sql: skip declarative schema changer for DISCARD

### DIFF
--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -75,6 +75,18 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 		}
 	}
 
+	// Some statements reach this point because tree.CanModifySchema reports
+	// them as schema-modifying (e.g. DISCARD ALL drops temporary tables),
+	// but they do work beyond schema changes (resetting session state,
+	// plan cache, cached sequence values, etc.) that the declarative schema
+	// changer has no vocabulary for. Route them straight to the legacy path:
+	// scbuild.Build would otherwise panic with a NotImplementedError on
+	// every invocation, producing high-volume INFO log spam on busy clusters.
+	switch stmt.(type) {
+	case *tree.Discard:
+		return nil, nil
+	}
+
 	scs := p.extendedEvalCtx.SchemaChangerState
 	scs.stmts = append(scs.stmts, p.stmt.SQL)
 	deps := p.newSchemaChangeBuilderDependencies(scs.stmts)


### PR DESCRIPTION
tree.CanModifySchema reports DISCARD as schema-modifying because DISCARD ALL/TEMP drops temporary tables. As a result, every DISCARD statement is routed through planner.SchemaChange, which calls scbuild.Build, which panics with a NotImplementedError because the declarative schema changer has no case for *tree.Discard and never will: DISCARD does work beyond schema changes (resetting session state, sequences, etc.).

The deferred error handler in scerrors.HandlePanicAndLogError logs this not-implemented case at INFO level unconditionally. On clusters that use connection pooling with DISCARD ALL on every connection checkout, this produced tens of millions of log lines per hour.

Short-circuit DISCARD to the legacy path in planner.SchemaChange before any builder work runs. The legacy planOpaque path handles DISCARD as it always has.

Epic: none

Release note: None