### PR TITLE
ts: include metric name in childMetricNameCache key

### DIFF
--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -172,6 +172,7 @@ go_test(
         "//pkg/util/log/eventpb",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
+        "//pkg/util/syncutil",
         "//pkg/util/system",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -1162,59 +1162,89 @@ func (rr registryRecorder) recordChild(
 	})
 }
 
-func hashLabels(labels []*prometheusgo.LabelPair) uint64 {
+// hashSep is the field separator written between hashed components in
+// hashLabeledName. Hoisted to package scope to avoid per-call allocation on
+// the recording hot path.
+var hashSep = []byte{0}
+
+// hashLabeledName computes a stable hash that uniquely identifies a (metric
+// name, label-set) pair. The metric name must be part of the key because two
+// distinct allowlisted changefeed metrics can share an identical label set
+// (e.g. both built via aggmetric.MakeBuilder("scope") with the same scope
+// value); without it, the cache would return one metric's encoded name when
+// queried for the other, corrupting downstream TSDB writes. The zero-byte
+// separators close a secondary collision where adjacent fields could be
+// reassociated (e.g. {name="ab", value="c"} vs {name="a", value="bc"}).
+func hashLabeledName(metricName string, labels []*prometheusgo.LabelPair) uint64 {
 	h := fnv.New64a()
+	h.Write([]byte(metricName))
+	h.Write(hashSep)
 	for _, label := range labels {
 		h.Write([]byte(label.GetName()))
+		h.Write(hashSep)
 		h.Write([]byte(label.GetValue()))
+		h.Write(hashSep)
 	}
 	return h.Sum64()
 }
 
-// cacheEntry holds a cached metric name along with the labels that produced it,
-// used for verification when hash collisions occur.
+// cacheEntry records the inputs that produced an encoded metric name, so that
+// hash collisions and same-label/different-metric scenarios are caught on
+// lookup.
 type cacheEntry struct {
+	// metricName is the unlabeled metric name (e.g. "changefeed.error_retries").
+	// Stored alongside labels so that distinct metrics sharing a label set are
+	// distinguished on lookup.
+	metricName string
+	// labels is the label set for this child. Captured by reference; callers
+	// must not mutate the slice (or the underlying LabelPair values) after
+	// passing it to getOrComputeMetricName.
 	labels []*prometheusgo.LabelPair
-	name   string
+	// encoded is the cached fully-encoded metric name produced by computeFn
+	// (typically metricName + metric.EncodeLabeledName(...)).
+	encoded string
 }
 
-// labelsEqual returns true if two label slices are equal.
-func labelsEqual(a, b []*prometheusgo.LabelPair) bool {
-	if len(a) != len(b) {
+// matches reports whether the cached entry was produced from the given metric
+// name and label set.
+func (c *cacheEntry) matches(metricName string, labels []*prometheusgo.LabelPair) bool {
+	if c.metricName != metricName || len(c.labels) != len(labels) {
 		return false
 	}
-	for i := range a {
-		if a[i].GetName() != b[i].GetName() || a[i].GetValue() != b[i].GetValue() {
+	for i := range c.labels {
+		if c.labels[i].GetName() != labels[i].GetName() ||
+			c.labels[i].GetValue() != labels[i].GetValue() {
 			return false
 		}
 	}
 	return true
 }
 
-// getOrComputeMetricName looks up the encoded metric name in the cache,
-// or computes it using the provided computeFn if not found.
-// Verifies labels on cache hit to detect hash collisions.
+// getOrComputeMetricName looks up the encoded metric name in the cache, or
+// computes and stores it using computeFn if not found. metricName is the
+// unlabeled prefix of the encoded name (e.g. "changefeed.error_retries"); it
+// must match what computeFn produces, since it is used both as part of the
+// cache key and to verify cache hits.
 func getOrComputeMetricName(
 	cache *syncutil.Map[uint64, cacheEntry],
+	metricName string,
 	labels []*prometheusgo.LabelPair,
 	computeFn func() string,
 ) string {
 	if cache == nil {
 		return computeFn()
 	}
-	labelHash := hashLabels(labels)
-	if cached, ok := cache.Load(labelHash); ok {
-		if labelsEqual(cached.labels, labels) {
-			return cached.name
-		}
-		// Hash collision detected - proceed to compute
+	key := hashLabeledName(metricName, labels)
+	if cached, ok := cache.Load(key); ok && cached.matches(metricName, labels) {
+		return cached.encoded
 	}
-	name := computeFn()
-	cache.Store(labelHash, &cacheEntry{
-		labels: labels,
-		name:   name,
+	encoded := computeFn()
+	cache.Store(key, &cacheEntry{
+		metricName: metricName,
+		labels:     labels,
+		encoded:    encoded,
 	})
-	return name
+	return encoded
 }
 
 // recordChangefeedChildMetrics iterates through changefeed metrics in the registry and processes child metrics
@@ -1262,7 +1292,7 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 				}
 
 				// Check cache for encoded name
-				baseName := getOrComputeMetricName(rr.childMetricNameCache, childLabels, func() string {
+				baseName := getOrComputeMetricName(rr.childMetricNameCache, metadata.Name, childLabels, func() string {
 					return metadata.Name + metric.EncodeLabeledName(&prometheusgo.Metric{Label: childLabels})
 				})
 				// Record all histogram computed metrics using child-specific snapshots
@@ -1323,8 +1353,9 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 			}
 
 			// Check cache for encoded name
-			metricName := getOrComputeMetricName(rr.childMetricNameCache, childMetric.Label, func() string {
-				return prom.GetName(false /* useStaticLabels */) + metric.EncodeLabeledName(childMetric)
+			promName := prom.GetName(false /* useStaticLabels */)
+			metricName := getOrComputeMetricName(rr.childMetricNameCache, promName, childMetric.Label, func() string {
+				return promName + metric.EncodeLabeledName(childMetric)
 			})
 
 			*dest = append(*dest, tspb.TimeSeriesData{

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/kr/pretty"
@@ -1347,6 +1348,61 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 		}
 
 		require.Equal(t, len(expectedSuffixes), len(foundSuffixes), "Expected to find histogram metric suffixes")
+	})
+
+	// Regression test: the childMetricNameCache must not return one metric's
+	// name when serving another metric that happens to have an identical label
+	// set. In production, most allowlisted changefeed agg-metrics are built
+	// via aggmetric.MakeBuilder("scope") and share the same single-label
+	// structure, so this collision is reachable for any non-trivial cluster.
+	t.Run("cache does not collide across different metrics with identical labels", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		counter := aggmetric.NewCounter(metric.Metadata{
+			Name:     "changefeed.error_retries",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "scope")
+		counter.AddChild("default").Inc(7)
+		reg.AddMetric(counter)
+
+		gauge := aggmetric.NewGauge(metric.Metadata{
+			Name:     "changefeed.lagging_ranges",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "scope")
+		gauge.AddChild("default").Update(99)
+		reg.AddMetric(gauge)
+
+		// Wire up a real cache, matching how MetricsRecorder shares one
+		// cache across all of its registryRecorder instances.
+		var cache syncutil.Map[uint64, cacheEntry]
+		recorder := registryRecorder{
+			registry:             reg,
+			format:               nodeTimeSeriesPrefix,
+			source:               "test-source",
+			timestampNanos:       manual.Now().UnixNano(),
+			childMetricNameCache: &cache,
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		seen := make(map[string]float64, len(dest))
+		for _, ts := range dest {
+			require.Len(t, ts.Datapoints, 1)
+			seen[ts.Name] = ts.Datapoints[0].Value
+		}
+
+		wantErrorRetries := fmt.Sprintf(nodeTimeSeriesPrefix,
+			`changefeed.error_retries{scope="default"}`)
+		wantLaggingRanges := fmt.Sprintf(nodeTimeSeriesPrefix,
+			`changefeed.lagging_ranges{scope="default"}`)
+
+		require.Contains(t, seen, wantErrorRetries,
+			"counter should be recorded under its own name; got %v", seen)
+		require.Contains(t, seen, wantLaggingRanges,
+			"gauge should be recorded under its own name; got %v", seen)
+		require.Equal(t, float64(7), seen[wantErrorRetries])
+		require.Equal(t, float64(99), seen[wantLaggingRanges])
 	})
 }
 


### PR DESCRIPTION
childMetricNameCache previously keyed entries on a hash of the Prometheus label set alone, on the assumption that the label set was sufficient to identify the encoded TSDB metric name. That assumption does not hold: most allowlisted changefeed agg-metrics are constructed via aggmetric.MakeBuilder("scope"), so distinct metrics (e.g. changefeed.error_retries and changefeed.lagging_ranges) routinely share an identical {scope="..."} label set. The first metric to populate the cache for a given label hash would win, and any subsequent metric with the same labels was recorded into TSDB under the first metric's encoded name -- producing wrong values in the affected time series and dropping the displaced metric entirely.

Fix this by including the unlabeled metric name in both the cache key (hashLabeledName) and the cache-hit verification (cacheEntry.matches). hashLabeledName also writes zero-byte separators between fields to close a secondary collision class where adjacent name/value bytes could be reassociated (e.g. {name="ab", value="c"} vs {name="a", value="bc"} hashing to the same value).

Cache footprint grows by roughly the number of allowlisted metrics that share a label set; it remains bounded by the existing per-metric 1024-child cap.

Fixes: https://github.com/cockroachdb/cockroach/issues/169172
Epic: none
Release note: None