### PR TITLE
crosscluster/physical: add telemetry for reader tenant creation

### DIFF
--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -341,6 +341,7 @@ func createReaderTenant(
 		if err != nil {
 			return readerID, err
 		}
+		telemetry.Count("physical_replication.reader_tenant.created")
 	}
 	return readerID, nil
 }


### PR DESCRIPTION
Add a telemetry counter that fires when a PCR reader virtual cluster is
created, covering both CREATE VIRTUAL CLUSTER ... WITH READ VIRTUAL CLUSTER
and ALTER VIRTUAL CLUSTER ... SET REPLICATION READ VIRTUAL CLUSTER paths.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>