### PR TITLE
set a max height to the sorted table module to support sticky header …

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
@@ -113,6 +113,7 @@
   padding: 9.55px 20px 17px;
   background-color: $colors--white;
   width: fit-content;
+  max-height: 400px;
 }
 
 .cl-table-statistic {

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -21,6 +21,9 @@
   &__row--header {
     border-bottom: 1px solid $colors--neutral-3;
     height: $line-height--x-large;
+    position: sticky;
+    top: 0;
+    z-index: 1;
     .column-title {
       border-bottom: 1px dashed $colors--neutral-5;
     }


### PR DESCRIPTION
When scrolling tables on pages such as sql-activity or top ranges, the column headers are not sticky and lost with the scroll. This should resolve that.