### PR TITLE
pgwire: validate binary numeric digits

### DIFF
--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/lib/pq/oid"
+	"github.com/stretchr/testify/require"
 )
 
 type encodingTest struct {
@@ -318,6 +321,7 @@ func TestExoticNumericEncodings(t *testing.T) {
 		{apd.New(100000000, 0), []byte{0, 2, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0}},
 		{apd.New(100000000, 0), []byte{0, 3, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0}},
 		{apd.New(100000001, 0), []byte{0, 3, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1}},
+		{apd.New(9999, 0), []byte{0, 1, 0, 0, 0, 0, 0, 0, 0x27, 0x0f}},
 		// Elixir/Postgrex combinations.
 		{apd.New(1234, 0), []byte{0, 2, 0, 0, 0, 0, 0, 0, 0x4, 0xd2, 0, 0}},
 		{apd.New(12340, -1), []byte{0, 2, 0, 0, 0, 0, 0, 1, 0x4, 0xd2, 0, 0}},
@@ -346,6 +350,51 @@ func TestExoticNumericEncodings(t *testing.T) {
 			} else if cmp != 0 {
 				t.Fatalf("%v != %v", d, expected)
 			}
+		})
+	}
+}
+
+func TestInvalidBinaryNumericEncodings(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name     string
+		encoding []byte
+	}{
+		{
+			name: "negative digit count",
+			// Ndigits=-1, Weight=0, Sign=Pos, Dscale=0.
+			encoding: []byte{0xff, 0xff, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "weight inconsistent with digit count",
+			// Ndigits=1, Weight=-3, Sign=Pos, Dscale=0, Digit[0]=1.
+			encoding: []byte{0, 1, 0xff, 0xfd, 0, 0, 0, 0, 0, 1},
+		},
+		{
+			name: "negative digit",
+			// Ndigits=1, Weight=0, Sign=Pos, Dscale=0, Digit[0]=-1.
+			encoding: []byte{0, 1, 0, 0, 0, 0, 0, 0, 0xff, 0xff},
+		},
+		{
+			name: "digit too large",
+			// Ndigits=1, Weight=0, Sign=Pos, Dscale=0, Digit[0]=10000.
+			encoding: []byte{0, 1, 0, 0, 0, 0, 0, 0, 0x27, 0x10},
+		},
+	}
+
+	ctx := context.Background()
+	evalCtx := eval.MakeTestingEvalContext(nil)
+	var da tree.DatumAlloc
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := pgwirebase.DecodeDatum(
+				ctx, &evalCtx, types.Decimal, pgwirebase.FormatBinary, tc.encoding, &da,
+			)
+			require.Error(t, err)
+			code := pgerror.GetPGCode(err)
+			require.Equal(t, pgcode.InvalidBinaryRepresentation, code, "unexpected pgcode for error: %v", err)
 		})
 	}
 }

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -589,6 +589,10 @@ func DecodeDatum(
 				}
 			}
 
+			if alloc.pgNum.Ndigits < 0 {
+				return nil, pgerror.Newf(pgcode.InvalidBinaryRepresentation, "invalid numeric digit count: %d", alloc.pgNum.Ndigits)
+			}
+
 			if alloc.pgNum.Dscale < 0 {
 				return nil, pgerror.Newf(pgcode.InvalidBinaryRepresentation, "invalid decimal scale: %d", alloc.pgNum.Dscale)
 			}
@@ -598,6 +602,9 @@ func DecodeDatum(
 				for i := int16(0); i < alloc.pgNum.Ndigits; i++ {
 					if err := binary.Read(r, binary.BigEndian, &alloc.i16); err != nil {
 						return nil, err
+					}
+					if alloc.i16 < 0 || alloc.i16 >= PGDecBase {
+						return nil, pgerror.Newf(pgcode.InvalidBinaryRepresentation, "invalid numeric digit: %d", alloc.i16)
 					}
 					// Each 16-bit "digit" can represent a 4 digit number.
 					// In the case where each digit is not 4 digits, we must append
@@ -665,11 +672,16 @@ func DecodeDatum(
 				// * if the digits we have in the buffer on the RHS, as calculated above,
 				// is larger or smaller than our calculated dscale, truncate or pad our buffer to
 				// match the desired dscale.
-				overScale := (alloc.pgNum.Ndigits-(alloc.pgNum.Weight+1))*PGDecDigits - alloc.pgNum.Dscale
+				overScale := (int(alloc.pgNum.Ndigits)-(int(alloc.pgNum.Weight)+1))*PGDecDigits - int(alloc.pgNum.Dscale)
 				if overScale > 0 {
-					decDigits = decDigits[:len(decDigits)-int(overScale)]
+					if overScale > len(decDigits) {
+						return nil, pgerror.Newf(pgcode.InvalidBinaryRepresentation,
+							"invalid numeric: weight %d is inconsistent with digit count %d and scale %d",
+							alloc.pgNum.Weight, alloc.pgNum.Ndigits, alloc.pgNum.Dscale)
+					}
+					decDigits = decDigits[:len(decDigits)-overScale]
 				} else {
-					for i := int16(0); i < -overScale; i++ {
+					for i := 0; i < -overScale; i++ {
 						decDigits = append(decDigits, '0')
 					}
 				}
@@ -1024,8 +1036,12 @@ const (
 	// PGNumericNan PGNumericSign = 0xC000
 )
 
-// PGDecDigits represents the number of decimal digits per int16 Postgres "digit".
-const PGDecDigits = 4
+const (
+	// PGDecDigits represents the number of decimal digits per int16 Postgres "digit".
+	PGDecDigits = 4
+	// PGDecBase represents the base of a Postgres numeric digit.
+	PGDecBase = 10000
+)
 
 // PGNumeric represents a numeric.
 type PGNumeric struct {


### PR DESCRIPTION
Validate binary numeric headers and base-10000 digit values before
constructing the decimal string. Malformed inputs now return an
InvalidBinaryRepresentation error instead of panicking or silently
accepting invalid digit values.

The validation covers negative Ndigits, out-of-range digit values
(negative or >= 10000), and weight/digit-count/scale inconsistencies
that would cause a slice bounds panic. The overScale calculation is
also widened from int16 to int to prevent overflow with extreme header
values.

Supersedes #169005.

Fixes: #166641
Epic: none

Release note (bug fix): Fixed a bug where a malformed binary numeric
value sent over the pgwire protocol could cause the server to panic
with a slice bounds error, crashing the connection. These inputs are
now rejected with a proper error.

Co-Authored-By: Asish Kumar <officialasishkumar@gmail.com>