### PR TITLE
roachprod/install: use detected architecture for opentelemetry install

### DIFF
--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -93,7 +93,8 @@ sudo apt-get install -y fluent-bit;
 	"opentelemetry": `
 sudo apt-get update;
 sudo apt-get install -y curl;
-curl -L -o /tmp/otelcol-contrib.deb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.101.0/otelcol-contrib_0.101.0_linux_amd64.deb;
+arch="$(dpkg --print-architecture)";
+curl -L -o /tmp/otelcol-contrib.deb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.101.0/otelcol-contrib_0.101.0_linux_${arch}.deb;
 sudo apt-get install -y /tmp/otelcol-contrib.deb;
 rm /tmp/otelcol-contrib.deb;
 `,


### PR DESCRIPTION
## Summary
- The opentelemetry install snippet hardcoded `amd64`, causing installation
  to fail on `arm64` or other architectures like `s390x` machines.
- Use `dpkg --print-architecture` to detect the correct architecture at
  runtime.
- Also works for `s390x` architecture.

Epic: None
Release note: None