### PR TITLE
sql: fix DeleteTableWithPredicate hang on producer send

### DIFF
--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -77,11 +77,11 @@ func DeleteTableWithPredicate(
 
 	spansToDo := make(chan *roachpb.Span, 1)
 
-	// Create a cancellable context to prevent the worker goroutines below from
-	// leaking once the parent goroutine returns.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
+	// Producer and workers run inside the same ctxgroup so they share its
+	// derived context. Either a parent-ctx cancellation (e.g. PAUSE on a
+	// reverting IMPORT) or a worker error then propagates to the other side
+	// via ctx.Done(); without this sharing the producer would block on send
+	// into a channel with no readers. See #168754.
 	grp := ctxgroup.WithContext(ctx)
 	grp.GoCtx(func(ctx context.Context) error {
 		return ctxgroup.GroupWorkers(ctx, numWorkers, func(ctx context.Context, _ int) error {
@@ -142,27 +142,38 @@ func DeleteTableWithPredicate(
 		})
 	})
 
-	var n int64
-	lastKey := tableSpan.Key
-	ri := kvcoord.MakeRangeIterator(distSender)
-	for ri.Seek(ctx, tableSpan.Key, kvcoord.Ascending); ; ri.Next(ctx) {
-		if !ri.Valid() {
-			return ri.Error()
-		}
-		if n++; n >= rangesPerBatch || !ri.NeedAnother(tableSpan) {
-			endKey := ri.Desc().EndKey
-			if tableSpan.EndKey.Less(endKey) {
-				endKey = tableSpan.EndKey
+	grp.GoCtx(func(ctx context.Context) error {
+		defer close(spansToDo)
+		var n int64
+		lastKey := tableSpan.Key
+		ri := kvcoord.MakeRangeIterator(distSender)
+		for ri.Seek(ctx, tableSpan.Key, kvcoord.Ascending); ; ri.Next(ctx) {
+			if !ri.Valid() {
+				return ri.Error()
 			}
-			spansToDo <- &roachpb.Span{Key: lastKey.AsRawKey(), EndKey: endKey.AsRawKey()}
-			n = 0
-			lastKey = endKey
+			if n++; n >= rangesPerBatch || !ri.NeedAnother(tableSpan) {
+				endKey := ri.Desc().EndKey
+				if tableSpan.EndKey.Less(endKey) {
+					endKey = tableSpan.EndKey
+				}
+				select {
+				case <-ctx.Done():
+					// Return nil so grp.Wait surfaces the originating error
+					// (a worker's wrapped KV error, or a worker's ctx.Err on
+					// parent cancellation) rather than this producer's
+					// downstream context.Canceled. ctxgroup.Wait falls back
+					// to ctx.Err when no goroutine returned an error.
+					return nil
+				case spansToDo <- &roachpb.Span{Key: lastKey.AsRawKey(), EndKey: endKey.AsRawKey()}:
+				}
+				n = 0
+				lastKey = endKey
+			}
+			if !ri.NeedAnother(tableSpan) {
+				return nil
+			}
 		}
+	})
 
-		if !ri.NeedAnother(tableSpan) {
-			break
-		}
-	}
-	close(spansToDo)
 	return grp.Wait()
 }

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -6,12 +6,18 @@
 package sql_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -24,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -121,4 +128,153 @@ func TestRollbackRandomTable(t *testing.T) {
 
 	afterFingerprint := db.QueryStr(t, fmt.Sprintf("SHOW FINGERPRINTS FROM TABLE test.%s", tableName))
 	require.Equal(t, fingerprint, afterFingerprint)
+}
+
+// TestDeleteTableWithPredicateNoHang covers two regressions in
+// DeleteTableWithPredicate's producer/worker pipeline (#168754): when the
+// parent ctx is canceled (e.g. PAUSE on a reverting IMPORT) and when a worker
+// returns an error, the producer must observe the cancellation rather than
+// block forever on send into a channel whose readers have exited. The cluster
+// settings pin parallelism=1 and rangesPerBatch=1 so the producer must
+// traverse multiple ranges before the lone worker drains its first request,
+// keeping the producer mid-loop when the injected filter fires.
+func TestDeleteTableWithPredicateNoHang(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	noopFilter := kvserverbase.ReplicaRequestFilter(
+		func(context.Context, *kvpb.BatchRequest) *kvpb.Error { return nil })
+
+	var filterFn atomic.Value
+	filterFn.Store(noopFilter)
+
+	s, sqlDB, kv := serverutils.StartServer(t, base.TestServerArgs{
+		UseDatabase: "test",
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				TestingRequestFilter: func(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+					return filterFn.Load().(kvserverbase.ReplicaRequestFilter)(ctx, ba)
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+	tt := s.ApplicationLayer()
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `CREATE DATABASE IF NOT EXISTS test`)
+	db.Exec(t, `SET CLUSTER SETTING bulkio.import.predicate_delete_range_batch_size = 1`)
+	db.Exec(t, `SET CLUSTER SETTING bulkio.import.predicate_delete_range_parallelism = 1`)
+
+	for _, tc := range []struct {
+		name string
+		// run installs the per-subtest filter behavior, drives
+		// DeleteTableWithPredicate via invoke, and asserts the outcome.
+		// tablePrefix scopes the filter to predicate DeleteRanges targeting
+		// the test's table, ignoring any unrelated traffic.
+		run func(t *testing.T, tablePrefix roachpb.Key, invoke func(context.Context) error)
+	}{
+		{
+			name: "parent_context_cancellation",
+			run: func(t *testing.T, tablePrefix roachpb.Key, invoke func(context.Context) error) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				var triggered atomic.Bool
+				filterFn.Store(kvserverbase.ReplicaRequestFilter(
+					func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+						for _, ru := range ba.Requests {
+							if dr, ok := ru.GetInner().(*kvpb.DeleteRangeRequest); ok &&
+								dr.Predicates.StartTime.IsSet() &&
+								bytes.HasPrefix(dr.Key, tablePrefix) {
+								if triggered.CompareAndSwap(false, true) {
+									cancel()
+								}
+								break
+							}
+						}
+						return nil
+					}))
+				err := runWithHangWatchdog(t, ctx, invoke)
+				require.True(t, triggered.Load(), "filter never saw a predicate DeleteRange")
+				require.True(t, errors.Is(err, context.Canceled), "want context.Canceled, got: %v", err)
+			},
+		},
+		{
+			name: "worker_error_propagation",
+			run: func(t *testing.T, tablePrefix roachpb.Key, invoke func(context.Context) error) {
+				var triggered atomic.Bool
+				filterFn.Store(kvserverbase.ReplicaRequestFilter(
+					func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+						for _, ru := range ba.Requests {
+							if dr, ok := ru.GetInner().(*kvpb.DeleteRangeRequest); ok &&
+								dr.Predicates.StartTime.IsSet() &&
+								bytes.HasPrefix(dr.Key, tablePrefix) {
+								triggered.Store(true)
+								return kvpb.NewError(errors.New("injected delete range error"))
+							}
+						}
+						return nil
+					}))
+				// Background ctx so any hang can only stem from the worker error.
+				err := runWithHangWatchdog(t, context.Background(), invoke)
+				require.True(t, triggered.Load(), "filter never saw a predicate DeleteRange")
+				require.ErrorContains(t, err, "injected delete range error")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset filter in case a prior subtest left its closure installed
+			// (matters under -shuffle, where source order isn't guaranteed).
+			filterFn.Store(noopFilter)
+
+			// Reseed: rows on both sides of a captured timestamp, with the
+			// post-targetTime writes giving the predicate something to match.
+			db.Exec(t, `DROP TABLE IF EXISTS test`)
+			db.Exec(t, `CREATE TABLE test (k INT PRIMARY KEY)`)
+			db.Exec(t, `INSERT INTO test SELECT generate_series(1, 200)`)
+			db.Exec(t, `ALTER TABLE test SPLIT AT SELECT i*10 FROM generate_series(1, 19) AS g(i)`)
+
+			var ts string
+			db.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts)
+			targetTime, err := hlc.ParseHLC(ts)
+			require.NoError(t, err)
+
+			db.Exec(t, `INSERT INTO test SELECT generate_series(201, 400)`)
+
+			desc := desctestutils.TestingGetPublicTableDescriptor(kv, tt.Codec(), "test", "test")
+			predicates := kvpb.DeleteRangePredicates{StartTime: targetTime}
+			tablePrefix := tt.Codec().TablePrefix(uint32(desc.GetID()))
+
+			tc.run(t, tablePrefix, func(ctx context.Context) error {
+				return sql.DeleteTableWithPredicate(ctx, kv, tt.Codec(), tt.ClusterSettings(),
+					tt.ExecutorConfig().(sql.ExecutorConfig).DistSender, desc.GetID(), predicates, 10)
+			})
+		})
+	}
+}
+
+// runWithHangWatchdog runs do(ctx) in a goroutine and fails the test if it
+// doesn't return within 15s. On timeout the ctx is canceled and the goroutine
+// is given a brief grace period so a non-buggy call can unwind cleanly,
+// avoiding a noisy secondary leaktest failure on top of the t.Fatal.
+func runWithHangWatchdog(
+	t *testing.T, parent context.Context, do func(context.Context) error,
+) error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- do(ctx) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(15 * time.Second):
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+		}
+		t.Fatal("DeleteTableWithPredicate hung; producer likely blocked on send")
+	}
+	panic("unreachable") // t.Fatal aborts the goroutine
 }


### PR DESCRIPTION
DeleteTableWithPredicate's producer goroutine and worker pool ran on separate contexts, so neither parent-ctx cancellation (e.g. PAUSE of a reverting IMPORT, #168754) nor a worker error would unblock the producer's send into a channel whose readers had exited. The job slot was pinned indefinitely; RESUME was a no-op until node restart.

Run the producer alongside the workers under a single ctxgroup so both observe the same derived context and either side's exit propagates to the other.

Resolves: #168754
Epic: none

Release note (bug fix): Fixed a hang in IMPORT INTO rollback where the revert could wedge the job indefinitely until the node was restarted.