### PR TITLE
sctestbackupmrccl: skip TestBackupSuccess_multiregion_alter_table_locality_global_to_rbt_secondary_region

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_global_to_rbt_secondary_region/alter_table_locality_global_to_rbt_secondary_region.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_global_to_rbt_secondary_region/alter_table_locality_global_to_rbt_secondary_region.definition
@@ -1,3 +1,6 @@
+skip issue-num=168350
+----
+
 setup
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
 CREATE TABLE multiregion_db.public.t (  


### PR DESCRIPTION
sctestbackupmrccl: skip TestBackupSuccess_multiregion_alter_table_locality_global_to_rbt_secondary_region

The fix is to use nodelocal instead of userfile, which will be
implemented in a separate commit.

Informs: #168350
Epic: none
Release note: None