### PR TITLE
roachprod-microbench: stage tarball to /mnt/data1

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -59,6 +59,16 @@ get_latest_patch_tag() {
   echo "$latest_tag"
 }
 
+# Best-effort disk-usage snapshotter
+log_disk_usage() {
+  echo "=== disk usage: $1 ($(date -u +%H:%M:%SZ)) ===" \
+    | tee -a "$output_dir/disk_usage.log"
+  ./bin/roachprod run "$ROACHPROD_CLUSTER":1-2 -- df -h /mnt/data1 / 2>&1 \
+    | tee -a "$output_dir/disk_usage.log" \
+    || echo "warn: log_disk_usage failed (exit $?)" \
+       | tee -a "$output_dir/disk_usage.log"
+}
+
 # Create arrays for the revisions and their corresponding SHAs.
 revisions=("${BENCH_REVISION}" "${BENCH_COMPARE_REVISION}")
 declare -a sha_arr
@@ -139,12 +149,16 @@ log_into_gcloud
   --gce-pd-volume-size=384 \
   --os-volume-size=50
 
+log_disk_usage "before-stage"
+
 # Stage binaries on the cluster
 for sha in "${build_sha_arr[@]}"; do
   archive_name=${BENCH_PACKAGE//\//-}
   archive_name="$sha-${archive_name/.../all}.tar.gz"
   ./bin/roachprod-microbench stage --quiet "$ROACHPROD_CLUSTER" "gs://$BENCH_BUCKET/builds/$archive_name" "$remote_dir/$sha"
 done
+
+log_disk_usage "after-stage"
 
 # Post issues to github for triggered builds (triggered builds are always on master)
 if [ -n "${TRIGGERED_BUILD:-}" ]; then
@@ -168,6 +182,8 @@ fi
   --quiet \
   -- "$TEST_ARGS" \
   || exit_status=$?
+
+log_disk_usage "after-run"
 
 # Write metadata to a file for each set of benchmarks
 declare -A metadata

--- a/pkg/cmd/roachprod-microbench/stage.go
+++ b/pkg/cmd/roachprod-microbench/stage.go
@@ -46,7 +46,11 @@ func stage(cluster, archivePath, remoteDest string, longRetries bool) (err error
 	}
 
 	archiveName := path.Base(archivePath)
-	archiveRemotePath := path.Join("/tmp", archiveName)
+	// Stage to /mnt/data1 (the persistent disk preserved by the MIG's stateful
+	// policy and not subject to systemd-tmpfiles cleanup on boot) rather than
+	// /tmp. On a spot-MIG cluster, /tmp is wiped on every boot even if the
+	// boot disk itself is preserved across recreation.
+	archiveRemotePath := path.Join("/mnt/data1", archiveName)
 
 	defer func() {
 		// Remove the remote archive after we're done.


### PR DESCRIPTION
Move the staged tarball location in stage() from /tmp to /mnt/data1.

The weekly microbench job creates a 12-node MIG of spot VMs
(--gce-managed --gce-use-spot). The MIG's stateful policy preserves
both the boot disk (persistent-disk-0) and the data PD
(persistent-disk-1) on instance recreation. However, /tmp on the boot
disk's root filesystem is wiped on every boot by systemd-tmpfiles
(per `D /tmp 1777 root root -` in /usr/lib/tmpfiles.d/tmp.conf),
including the boot that follows MIG instance recreation after a spot
preemption. As a result, a tarball that gsutil cp wrote to /tmp
disappears by the time the subsequent tar -xzf runs on the recreated
VM, even though the boot disk content was technically preserved.
/mnt/data1 is on the separate stateful PD and is not subject to any
tmpfiles cleanup rule, so a tarball written there survives both the
recreation and the subsequent boot.

Also added logging for volume usage in CI script.