### PR TITLE
[dnm] kvserver: replace StoreWriteBytes plumbing with unified plumbing that…

### DIFF
--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -226,8 +226,7 @@ func sendProbe(ctx context.Context, r replicaInCircuitBreaker) error {
 	}
 	// Pass empty AdmissionInfo since this is an internal probe request that
 	// bypasses admission control.
-	_, writeBytes, pErr := r.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
-	writeBytes.Release()
+	_, pErr := r.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{}, nil)
 	if err := pErr.GoError(); err != nil {
 		return r.replicaUnavailableError(err)
 	}

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -209,6 +209,7 @@ func evaluateBatch(
 	ui uncertainty.Interval,
 	evalPath batchEvalPath,
 	omitInRangefeeds bool, // only relevant for transactional writes
+	ss *kvpb.ScanStats,
 ) (_ *kvpb.BatchResponse, _ result.Result, retErr *kvpb.Error) {
 	tenantID, _ := roachpb.ClientTenantFromContext(ctx)
 	cleanup := ash.SetWorkState(
@@ -290,19 +291,20 @@ func evaluateBatch(
 	// retries.
 	var deferredWriteTooOldErr *kvpb.WriteTooOldError
 
-	// Only collect the scan stats if the tracing is enabled.
-	var ss *kvpb.ScanStats
-	if sp := tracing.SpanFromContext(ctx); sp.RecordingType() != tracingpb.RecordingOff {
-		ss = &kvpb.ScanStats{}
-		defer func() {
-			if ss.NumGets != 0 || ss.NumScans != 0 || ss.NumReverseScans != 0 {
-				// Only record non-empty ScanStats.
-				ss.NodeID = rec.NodeID()
-				locality := rec.GetNodeLocality()
-				ss.Region, _ = locality.Find("region")
-				sp.RecordStructured(ss)
-			}
-		}()
+	// Only record the scan stats if the tracing is enabled.
+	// NB: ss should always be non-nil on any meaningful production path.
+	if ss != nil {
+		if sp := tracing.SpanFromContext(ctx); sp.RecordingType() != tracingpb.RecordingOff {
+			defer func() {
+				if ss.NumGets != 0 || ss.NumScans != 0 || ss.NumReverseScans != 0 {
+					// Only record non-empty ScanStats.
+					ss.NodeID = rec.NodeID()
+					locality := rec.GetNodeLocality()
+					ss.Region, _ = locality.Find("region")
+					sp.RecordStructured(ss)
+				}
+			}()
+		}
 	}
 
 	// TODO(tbg): if we introduced an "executor" helper here that could carry state

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -98,7 +98,7 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 	br, result, pErr :=
 		evaluateBatch(
 			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, &ba,
-			nil /* g */, nil /* st */, uncertainty.Interval{}, readOnlyDefault, false, /* omitInRangefeeds */
+			nil /* g */, nil /* st */, uncertainty.Interval{}, readOnlyDefault, false /* omitInRangefeeds */, nil, /* ss */
 		)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -981,6 +981,7 @@ func (r *Replica) evaluateProposal(
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
+	ss *kvpb.ScanStats,
 ) (*kvpb.BatchRequest, *result.Result, bool, *kvpb.Error) {
 	if ba.Timestamp.IsEmpty() {
 		return ba, nil, false, kvpb.NewErrorf("can't propose Raft command with zero timestamp")
@@ -996,7 +997,7 @@ func (r *Replica) evaluateProposal(
 	//
 	// TODO(tschottdorf): absorb all returned values in `res` below this point
 	// in the call stack as well.
-	ba, batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, g, st, ui)
+	ba, batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, g, st, ui, ss)
 
 	// Note: reusing the proposer's batch when applying the command on the
 	// proposer was explored as an optimization but resulted in no performance
@@ -1087,8 +1088,9 @@ func (r *Replica) requestToProposal(
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
+	ss *kvpb.ScanStats,
 ) (*ProposalData, *kvpb.Error) {
-	ba, res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, g, st, ui)
+	ba, res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, g, st, ui, ss)
 
 	// Fill out the results even if pErr != nil; we'll return the error below.
 	proposal := &ProposalData{

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -119,16 +119,15 @@ func (r *Replica) evalAndPropose(
 	ui uncertainty.Interval,
 	tok TrackedRequestToken,
 	admissionInfo kvadmission.AdmissionInfo,
-) (
-	chan proposalResult,
-	abandonToken,
-	kvserverbase.CmdIDKey,
-	*kvadmission.StoreWriteBytes,
-	*kvpb.Error,
-) {
+	stats *SomethingStats,
+) (chan proposalResult, abandonToken, kvserverbase.CmdIDKey, *kvpb.Error) {
 	defer tok.DoneIfNotMoved(ctx)
+	var ss *kvpb.ScanStats
+	if stats != nil {
+		ss = &stats.ScanStats
+	}
 	idKey := raftlog.MakeCmdIDKey()
-	proposal, pErr := r.requestToProposal(ctx, idKey, ba, g, st, ui)
+	proposal, pErr := r.requestToProposal(ctx, idKey, ba, g, st, ui, ss)
 	ba = proposal.Request // may have been updated
 	log.Event(proposal.Context(), "evaluated request")
 
@@ -136,7 +135,7 @@ func (r *Replica) evalAndPropose(
 	// propagate the error. Don't assume ownership of the concurrency guard.
 	if isConcurrencyRetryError(pErr) {
 		pErr = maybeAttachLease(pErr, &st.Lease)
-		return nil, nil, "", nil, pErr
+		return nil, nil, "", pErr
 	}
 
 	// Pull out proposal channel to return. proposal.doneCh may be set to
@@ -151,7 +150,7 @@ func (r *Replica) evalAndPropose(
 	//    in an error.
 	if proposal.command == nil {
 		if proposal.Local.RequiresRaft() {
-			return nil, nil, "", nil, kvpb.NewError(errors.AssertionFailedf(
+			return nil, nil, "", kvpb.NewError(errors.AssertionFailedf(
 				"proposal resulting from batch %s erroneously bypassed Raft", ba))
 		}
 		intents := proposal.Local.DetachEncounteredIntents()
@@ -170,7 +169,7 @@ func (r *Replica) evalAndPropose(
 		proposal.ec = makeUnreplicatedEndCmds(r, g, *st)
 		pr := makeProposalResult(proposal.Local.Reply, pErr, intents, endTxns)
 		proposal.finishApplication(ctx, pr)
-		return proposalCh, nil, "", nil, nil
+		return proposalCh, nil, "", nil
 	}
 
 	// Make it a truly replicated proposal. We measure the replication latency
@@ -193,12 +192,13 @@ func (r *Replica) evalAndPropose(
 	// typical lag in consensus is expected to be small compared to the time
 	// granularity of admission control doing token and size estimation (which
 	// is 15s). Also, admission control corrects for gaps in reporting.
-	writeBytes := kvadmission.NewStoreWriteBytes()
-	if proposal.command.WriteBatch != nil {
-		writeBytes.WriteBytes = int64(len(proposal.command.WriteBatch.Data))
-	}
-	if proposal.command.ReplicatedEvalResult.AddSSTable != nil {
-		writeBytes.IngestedBytes = int64(len(proposal.command.ReplicatedEvalResult.AddSSTable.Data))
+	if stats != nil {
+		if proposal.command.WriteBatch != nil {
+			stats.StoreWriteBytes.WriteBytes = int64(len(proposal.command.WriteBatch.Data))
+		}
+		if proposal.command.ReplicatedEvalResult.AddSSTable != nil {
+			stats.StoreWriteBytes.IngestedBytes = int64(len(proposal.command.ReplicatedEvalResult.AddSSTable.Data))
+		}
 	}
 	// If the request requested that Raft consensus be performed asynchronously,
 	// return a proposal result immediately on the proposal's done channel.
@@ -210,7 +210,7 @@ func (r *Replica) evalAndPropose(
 			// Disallow async consensus for commands with EndTxnIntents because
 			// any !Always EndTxnIntent can't be cleaned up until after the
 			// command succeeds.
-			return nil, nil, "", writeBytes, kvpb.NewErrorf("cannot perform consensus asynchronously for "+
+			return nil, nil, "", kvpb.NewErrorf("cannot perform consensus asynchronously for "+
 				"proposal with EndTxnIntents=%v; %v", ets, ba)
 		}
 
@@ -289,7 +289,7 @@ func (r *Replica) evalAndPropose(
 	// behavior.
 	quotaSize := uint64(proposal.command.Size())
 	if maxSize := uint64(kvserverbase.MaxCommandSize.Get(&r.store.cfg.Settings.SV)); quotaSize > maxSize {
-		return nil, nil, "", nil, kvpb.NewError(errors.Errorf(
+		return nil, nil, "", kvpb.NewError(errors.Errorf(
 			"command is too large: %d bytes (max: %d)", quotaSize, maxSize,
 		))
 	}
@@ -300,7 +300,7 @@ func (r *Replica) evalAndPropose(
 	var err error
 	proposal.quotaAlloc, err = r.maybeAcquireProposalQuota(ctx, ba, quotaSize)
 	if err != nil {
-		return nil, nil, "", nil, kvpb.NewError(err)
+		return nil, nil, "", kvpb.NewError(err)
 	}
 	// Make sure we clean up the proposal if we fail to insert it into the
 	// proposal buffer successfully. This ensures that we always release any
@@ -324,13 +324,13 @@ func (r *Replica) evalAndPropose(
 			// SeedID not set, since this is not a reproposal.
 		}
 		if pErr = filter(filterArgs); pErr != nil {
-			return nil, nil, "", nil, pErr
+			return nil, nil, "", pErr
 		}
 	}
 
 	pErr = r.propose(ctx, proposal, tok.Move(ctx))
 	if pErr != nil {
-		return nil, nil, "", nil, pErr
+		return nil, nil, "", pErr
 	}
 	// We've successfully handed the proposal to the replication layer, so this
 	// method should not finish the trace span if we forked one off above.
@@ -342,7 +342,7 @@ func (r *Replica) evalAndPropose(
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
 
-	return proposalCh, abandonToken(proposal), idKey, writeBytes, nil
+	return proposalCh, abandonToken(proposal), idKey, nil
 }
 
 // abandonToken is an interface used for allowing callers to "abandon" an

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -699,8 +699,7 @@ func (p *pendingLeaseRequest) requestLease(
 		Source:     kvpb.AdmissionHeader_OTHER,
 	}
 	// Pass empty AdmissionInfo since lease acquisition bypasses admission control.
-	_, writeBytes, pErr := p.repl.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
-	writeBytes.Release()
+	_, pErr := p.repl.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{}, nil)
 	return pErr.GoError()
 }
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -39,20 +39,19 @@ import (
 // iterator to evaluate the batch and then updates the timestamp cache to
 // reflect the key spans that it read.
 func (r *Replica) executeReadOnlyBatch(
-	ctx context.Context, ba *kvpb.BatchRequest, g concurrency.Guard, _ kvadmission.AdmissionInfo,
-) (
-	br *kvpb.BatchResponse,
-	_ concurrency.Guard,
-	_ *kvadmission.StoreWriteBytes,
-	pErr *kvpb.Error,
-) {
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	g concurrency.Guard,
+	_ kvadmission.AdmissionInfo,
+	stats *SomethingStats,
+) (br *kvpb.BatchResponse, _ concurrency.Guard, pErr *kvpb.Error) {
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
 
 	// Verify that the batch can be executed.
 	st, err := r.checkExecutionCanProceedBeforeStorageSnapshot(ctx, ba, g)
 	if err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	if fn := r.store.TestingKnobs().PreStorageSnapshotButChecksCompleteInterceptor; fn != nil {
@@ -161,13 +160,17 @@ func (r *Replica) executeReadOnlyBatch(
 				reply = &kvpb.ResolveIntentResponse{}
 				r.store.metrics.VirtualResolveIntentCount.Inc(1)
 			}
+			var ss *kvpb.ScanStats
+			if stats != nil {
+				ss = &stats.ScanStats
+			}
 			_, err = evaluateCommand(
-				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, req,
+				ctx, rwNoAssert, rec, nil /* ms */, ss, h, req,
 				reply, g, &st, ui, readWrite, false, /* omitInRangefeeds */
 			)
 			if err != nil {
 				r.store.metrics.VirtualResolveBatchErrors.Inc(1)
-				return nil, g, nil, kvpb.NewError(err)
+				return nil, g, kvpb.NewError(err)
 			}
 		}
 	}
@@ -185,15 +188,15 @@ func (r *Replica) executeReadOnlyBatch(
 		break
 	}
 	if err := rw.PinEngineStateForIterators(readCategory); err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	if err := r.checkExecutionCanProceedAfterStorageSnapshot(ctx, ba, st); err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 	ok, stillNeedsInterleavedIntents, pErr := r.canDropLatchesBeforeEval(ctx, rw, ba, g, st)
 	if pErr != nil {
-		return nil, g, nil, pErr
+		return nil, g, pErr
 	}
 	evalPath := readOnlyDefault
 	if ok {
@@ -218,8 +221,12 @@ func (r *Replica) executeReadOnlyBatch(
 		g = nil
 	}
 
+	var ss *kvpb.ScanStats
+	if stats != nil {
+		ss = &stats.ScanStats
+	}
 	var result result.Result
-	ba, br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ba, g, &st, ui, evalPath)
+	ba, br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ba, g, &st, ui, evalPath, ss)
 
 	// If the request hit a server-side concurrency retry error, immediately
 	// propagate the error. Don't assume ownership of the concurrency guard.
@@ -239,11 +246,11 @@ func (r *Replica) executeReadOnlyBatch(
 			// non-error path.
 			if !g.CheckOptimisticNoLatchConflicts() {
 				log.Eventf(ctx, "optimistic evaluation failed with %s", pErr)
-				return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
+				return nil, g, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 			}
 		}
 		pErr = maybeAttachLease(pErr, &st.Lease)
-		return nil, g, nil, pErr
+		return nil, g, pErr
 	}
 
 	if g != nil && g.EvalKind() == concurrency.OptimisticEval {
@@ -253,19 +260,19 @@ func (r *Replica) executeReadOnlyBatch(
 			// the response.
 			latchSpansRead, lockSpansRead, err := r.collectSpansRead(ba, br)
 			if err != nil {
-				return nil, g, nil, kvpb.NewError(err)
+				return nil, g, kvpb.NewError(err)
 			}
 			defer latchSpansRead.Release()
 			defer lockSpansRead.Release()
 			if ok := g.CheckOptimisticNoConflicts(latchSpansRead, lockSpansRead); !ok {
-				return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
+				return nil, g, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 			}
 		} else {
 			// There was an error, that was not classified as a concurrency retry
 			// error, and this request was not holding latches. This should be rare,
 			// and in the interest of not having subtle correctness bugs, we retry
 			// pessimistically.
-			return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
+			return nil, g, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 		}
 	}
 
@@ -332,7 +339,7 @@ func (r *Replica) executeReadOnlyBatch(
 		r.loadStats.RecordReadBytes(bytesRead)
 		log.Event(ctx, "read completed")
 	}
-	return br, nil, nil, pErr
+	return br, nil, pErr
 }
 
 // updateTimestampCacheAndDropLatches updates the timestamp cache and releases
@@ -523,6 +530,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	evalPath batchEvalPath,
+	ss *kvpb.ScanStats,
 ) (_ *kvpb.BatchRequest, br *kvpb.BatchResponse, res result.Result, pErr *kvpb.Error) {
 	log.Event(ctx, "executing read-only batch")
 
@@ -606,7 +614,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 		now := timeutil.Now()
 		br, res, pErr = evaluateBatch(
 			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, ba, g,
-			st, ui, evalPath, false, /* omitInRangefeeds */
+			st, ui, evalPath, false /* omitInRangefeeds */, ss,
 		)
 		r.store.metrics.ReplicaReadBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 		// Allow only one retry.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -113,8 +113,11 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 //	to commit the command, then signaling proposer and
 //	applying the command)
 func (r *Replica) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error) {
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	admissionInfo kvadmission.AdmissionInfo,
+	stats *SomethingStats,
+) (*kvpb.BatchResponse, *kvpb.Error) {
 	tenantIDOrZero, _ := roachpb.ClientTenantFromContext(ctx)
 	cleanup := ash.SetWorkState(
 		tenantIDOrZero, ash.WorkloadInfo{
@@ -162,43 +165,42 @@ func (r *Replica) SendWithWriteBytes(
 
 	isReadOnly := ba.IsReadOnly()
 	if err := r.checkBatchRequest(ba, isReadOnly); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	if err := r.maybeBackpressureBatch(ctx, ba); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 	if err := r.maybeRateLimitBatch(ctx, ba, tenantIDOrZero); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 	if err := r.maybeCommitWaitBeforeCommitTrigger(ctx, ba); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	// NB: must be performed before collecting request spans.
 	ba, err := maybeStripInFlightWrites(ba)
 	if err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	if filter := r.store.cfg.TestingKnobs.TestingRequestFilter; filter != nil {
 		if pErr := filter(ctx, ba); pErr != nil {
-			return nil, nil, pErr
+			return nil, pErr
 		}
 	}
 
 	// Differentiate between read-write, read-only, and admin.
 	var br *kvpb.BatchResponse
 	var pErr *kvpb.Error
-	var writeBytes *kvadmission.StoreWriteBytes
 	if isReadOnly {
 		log.Event(ctx, "read-only path")
 		fn := (*Replica).executeReadOnlyBatch
-		br, _, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, admissionInfo)
+		br, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, admissionInfo, stats)
 	} else if ba.IsWrite() {
 		log.Event(ctx, "read-write path")
 		fn := (*Replica).executeWriteBatch
-		br, writeBytes, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, admissionInfo)
+		br, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, admissionInfo, stats)
 	} else if ba.IsAdmin() {
 		log.Event(ctx, "admin path")
 		br, pErr = r.executeAdminBatch(ctx, ba)
@@ -235,11 +237,12 @@ func (r *Replica) SendWithWriteBytes(
 	// Record summary throughput information about the batch request for
 	// accounting.
 	r.recordBatchRequestLoad(ctx, ba)
-	if writeBytes != nil {
+	if stats != nil {
+		writeBytes := &stats.StoreWriteBytes
 		r.recordRequestWriteBytes(writeBytes.WriteBytes + writeBytes.IngestedBytes)
 	}
 	r.recordImpactOnRateLimiter(ctx, br, isReadOnly)
-	return br, writeBytes, pErr
+	return br, pErr
 }
 
 // maybeCommitWaitBeforeCommitTrigger detects batches that are attempting to
@@ -426,8 +429,8 @@ func (r *Replica) maybeAddRangeInfoToResponse(
 // the function returns one of these errors, it must also pass ownership of the
 // concurrency guard back to the caller.
 type batchExecutionFn func(
-	*Replica, context.Context, *kvpb.BatchRequest, concurrency.Guard, kvadmission.AdmissionInfo,
-) (*kvpb.BatchResponse, concurrency.Guard, *kvadmission.StoreWriteBytes, *kvpb.Error)
+	*Replica, context.Context, *kvpb.BatchRequest, concurrency.Guard, kvadmission.AdmissionInfo, *SomethingStats,
+) (*kvpb.BatchResponse, concurrency.Guard, *kvpb.Error)
 
 var _ batchExecutionFn = (*Replica).executeWriteBatch
 var _ batchExecutionFn = (*Replica).executeReadOnlyBatch
@@ -451,7 +454,8 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 	ba *kvpb.BatchRequest,
 	fn batchExecutionFn,
 	admissionInfo kvadmission.AdmissionInfo,
-) (br *kvpb.BatchResponse, writeBytes *kvadmission.StoreWriteBytes, pErr *kvpb.Error) {
+	stats *SomethingStats,
+) (br *kvpb.BatchResponse, pErr *kvpb.Error) {
 	// Try to execute command; exit retry loop on success.
 	var latchSpans *spanset.SpanSet
 	var lockSpans *lockspanset.LockSpanSet
@@ -472,7 +476,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 	for {
 		// Exit loop if context has been canceled or timed out.
 		if err := ctx.Err(); err != nil {
-			return nil, nil, kvpb.NewError(err)
+			return nil, kvpb.NewError(err)
 		}
 
 		// Determine the maximal set of key spans that the batch will operate on.
@@ -485,7 +489,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			var err error
 			latchSpans, lockSpans, requestEvalKind, err = r.collectSpans(ba)
 			if err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 		}
 
@@ -531,21 +535,21 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 					)))
 				}
 			}
-			return nil, nil, pErr
+			return nil, pErr
 		} else if resp != nil {
 			br = new(kvpb.BatchResponse)
 			br.Responses = resp
-			return br, nil, nil
+			return br, nil
 		}
 		latchSpans, lockSpans = nil, nil // ownership released
 
-		br, g, writeBytes, pErr = fn(r, ctx, ba, g, admissionInfo)
+		br, g, pErr = fn(r, ctx, ba, g, admissionInfo, stats)
 		if pErr == nil {
 			// Success.
-			return br, writeBytes, nil
+			return br, nil
 		} else if !isConcurrencyRetryError(pErr) {
 			// Propagate error.
-			return nil, nil, pErr
+			return nil, pErr
 		}
 
 		log.VErrEventf(ctx, 2, "concurrency retry error: %s", pErr)
@@ -582,13 +586,13 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// Drop latches, but retain lock wait-queues.
 			g.AssertLatches()
 			if g, pErr = r.handleLockConflictError(ctx, ba, g, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.TransactionPushError:
 			// Drop latches, but retain lock wait-queues.
 			g.AssertLatches()
 			if g, pErr = r.handleTransactionPushError(ctx, ba, g, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.IndeterminateCommitError:
 			dropLatchesAndLockWaitQueues(true /* reuseLatchAndLockSpans */)
@@ -596,7 +600,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// is returned if the transaction is recovered successfully to either a
 			// COMMITTED or ABORTED state.
 			if pErr = r.handleIndeterminateCommitError(ctx, ba, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.ReadWithinUncertaintyIntervalError:
 			// If the batch is able to perform a server-side retry in order to avoid
@@ -612,7 +616,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// propagate it.
 			ba, pErr = r.handleReadWithinUncertaintyIntervalError(ctx, ba, pErr, t)
 			if pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.InvalidLeaseError:
 			dropLatchesAndLockWaitQueues(true /* reuseLatchAndLockSpans */)
@@ -620,13 +624,13 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// replica or redirect to the current leaseholder if currently held
 			// by a different replica.
 			if pErr = r.handleInvalidLeaseError(ctx, ba); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.MergeInProgressError:
 			dropLatchesAndLockWaitQueues(true /* reuseLatchAndLockSpans */)
 			// Then listen for the merge to complete.
 			if pErr = r.handleMergeInProgressError(ctx, ba, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.OptimisticEvalConflictsError:
 			// We are deliberately not dropping latches. Note that the latches are

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -80,12 +80,8 @@ func (r *Replica) executeWriteBatch(
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	admissionInfo kvadmission.AdmissionInfo,
-) (
-	br *kvpb.BatchResponse,
-	_ concurrency.Guard,
-	_ *kvadmission.StoreWriteBytes,
-	pErr *kvpb.Error,
-) {
+	stats *SomethingStats,
+) (br *kvpb.BatchResponse, _ concurrency.Guard, pErr *kvpb.Error) {
 	startTime := timeutil.Now()
 
 	spanName := "executeWriteBatch"
@@ -120,14 +116,14 @@ func (r *Replica) executeWriteBatch(
 	// Verify that the batch can be executed.
 	st, err := r.checkExecutionCanProceedRWOrAdmin(ctx, ba, g)
 	if err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	// Check the breaker. Note that we do this after
 	// checkExecutionCanProceedBeforeStorageSnapshot, so that NotLeaseholderError
 	// has precedence.
 	if err := r.signallerForBatch(ba).Err(); err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	// Compute the transaction's local uncertainty limit using observed
@@ -182,16 +178,16 @@ func (r *Replica) executeWriteBatch(
 	// Checking the context just before proposing can help avoid ambiguous errors.
 	if err := ctx.Err(); err != nil {
 		log.VEventf(ctx, 2, "%s before proposing: %s", err, ba.Summary())
-		return nil, g, nil, kvpb.NewError(errors.Wrapf(err, "aborted before proposing"))
+		return nil, g, kvpb.NewError(errors.Wrapf(err, "aborted before proposing"))
 	}
 
 	// If the command is proposed to Raft, ownership of and responsibility for
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose. If we return with an error from executeWriteBatch, we
 	// also return the guard which the caller reassumes ownership of.
-	ch, abandonTok, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx), admissionInfo)
+	ch, abandonTok, _, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx), admissionInfo, stats)
 	if pErr != nil {
-		return nil, g, nil, pErr
+		return nil, g, pErr
 	}
 	g = nil // ownership passed to Raft, prevent misuse
 
@@ -309,7 +305,7 @@ func (r *Replica) executeWriteBatch(
 				propResult.Reply, propResult.Err = ba.CreateReply(), nil
 			}
 
-			return propResult.Reply, nil, writeBytes, propResult.Err
+			return propResult.Reply, nil, propResult.Err
 
 		case <-ctxDone:
 			// If our context was canceled, return an AmbiguousResultError,
@@ -349,7 +345,7 @@ func (r *Replica) executeWriteBatch(
 			dur := timeutil.Since(startTime)
 			log.VEventf(ctx, 2, "context cancellation after %.2fs of attempting command %s",
 				dur.Seconds(), ba)
-			return nil, nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultError(
+			return nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultError(
 				errors.Wrapf(ctx.Err(), "after %.2fs of attempting command", dur.Seconds()),
 			))
 
@@ -359,7 +355,7 @@ func (r *Replica) executeWriteBatch(
 			r.abandon(abandonTok)
 			log.VEventf(ctx, 2, "shutdown cancellation after %0.1fs of attempting command %s",
 				timeutil.Since(startTime).Seconds(), ba)
-			return nil, nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultErrorf(
+			return nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultErrorf(
 				"server shutdown"))
 		}
 	}
@@ -426,6 +422,7 @@ func (r *Replica) evaluateWriteBatch(
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
+	ss *kvpb.ScanStats,
 ) (
 	*kvpb.BatchRequest,
 	storage.Batch,
@@ -482,7 +479,7 @@ func (r *Replica) evaluateWriteBatch(
 	// For transactional writes, we propagate the flag from the txn.
 	omitInRangefeeds := ba.Txn != nil && ba.Txn.OmitInRangefeeds
 	ba, batch, br, res, pErr := r.evaluateWriteBatchWithServersideRefreshes(
-		ctx, idKey, rec, ms, ba, g, st, ui, hlc.Timestamp{} /* deadline */, omitInRangefeeds)
+		ctx, idKey, rec, ms, ba, g, st, ui, hlc.Timestamp{} /* deadline */, omitInRangefeeds, ss)
 	return ba, batch, *ms, br, res, pErr
 }
 
@@ -567,10 +564,10 @@ func (r *Replica) evaluate1PC(
 	defer releaseMVCCStats(ms)
 	if ba.CanForwardReadTimestamp {
 		_, batch, br, res, pErr = r.evaluateWriteBatchWithServersideRefreshes(
-			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline, ba.Txn.OmitInRangefeeds)
+			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline, ba.Txn.OmitInRangefeeds, nil /* ss */)
 	} else {
 		batch, br, res, pErr = r.evaluateWriteBatchWrapper(
-			ctx, idKey, rec, ms, &strippedBa, g, st, ui, ba.Txn.OmitInRangefeeds)
+			ctx, idKey, rec, ms, &strippedBa, g, st, ui, ba.Txn.OmitInRangefeeds, nil /* ss */)
 	}
 
 	if pErr != nil || (!ba.CanForwardReadTimestamp && ba.Timestamp != br.Timestamp) {
@@ -700,6 +697,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 	ui uncertainty.Interval,
 	deadline hlc.Timestamp,
 	omitInRangefeeds bool,
+	ss *kvpb.ScanStats,
 ) (
 	_ *kvpb.BatchRequest,
 	batch storage.Batch,
@@ -718,7 +716,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 			batch.Close()
 		}
 
-		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui, omitInRangefeeds)
+		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui, omitInRangefeeds, ss)
 
 		// Allow one retry only; a non-txn batch containing overlapping
 		// spans will always experience WriteTooOldError.
@@ -750,10 +748,11 @@ func (r *Replica) evaluateWriteBatchWrapper(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	omitInRangefeeds bool,
+	ss *kvpb.ScanStats,
 ) (storage.Batch, *kvpb.BatchResponse, result.Result, *kvpb.Error) {
 	batch, opLogger := r.newBatchedEngine(g)
 	now := timeutil.Now()
-	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, readWrite, omitInRangefeeds)
+	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, readWrite, omitInRangefeeds, ss)
 	r.store.metrics.ReplicaWriteBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 	if pErr == nil {
 		if opLogger != nil {

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -25,17 +25,23 @@ import (
 // extends the kv.Sender.Send signature with an additional StoreWriteBytes
 // return value for admission control integration.
 type SenderWithWriteBytes interface {
+	// stats can be nil.
+	// TODO: rename to SendWithStats.
 	SendWithWriteBytes(
-		ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-	) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error)
+		ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo, stats *SomethingStats,
+	) (*kvpb.BatchResponse, *kvpb.Error)
+}
+
+type SomethingStats struct {
+	ScanStats       kvpb.ScanStats
+	StoreWriteBytes kvadmission.StoreWriteBytes
 }
 
 // ToSenderForTesting wraps a SenderWithWriteBytes as a kv.Sender. It releases
 // the StoreWriteBytes after each call.
 func ToSenderForTesting(swb SenderWithWriteBytes) kv.Sender {
 	return kv.SenderFunc(func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-		br, writeBytes, pErr := swb.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
-		writeBytes.Release()
+		br, pErr := swb.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{}, nil)
 		return br, pErr
 	})
 }
@@ -59,8 +65,11 @@ func ToSenderForTesting(swb SenderWithWriteBytes) kv.Sender {
 // of one of its writes), the response will have a transaction set which should
 // be used to update the client transaction object.
 func (s *Store) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-) (br *kvpb.BatchResponse, writeBytes *kvadmission.StoreWriteBytes, pErr *kvpb.Error) {
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	admissionInfo kvadmission.AdmissionInfo,
+	stats *SomethingStats,
+) (br *kvpb.BatchResponse, pErr *kvpb.Error) {
 	// Attach any log tags from the store to the context (which normally
 	// comes from gRPC).
 	ctx = s.AnnotateCtx(ctx)
@@ -68,13 +77,14 @@ func (s *Store) SendWithWriteBytes(
 		arg := union.GetInner()
 		header := arg.Header()
 		if err := verifyKeys(header.Key, header.EndKey, kvpb.IsRange(arg)); err != nil {
-			return nil, nil, kvpb.NewError(errors.Wrapf(err,
+			return nil, kvpb.NewError(errors.Wrapf(err,
 				"failed to verify keys for %s", arg.Method()))
 		}
 	}
 
+	// TODO: use stats.ScanStats to accurately deduct tokens after execution.
 	if res, err := s.maybeThrottleBatch(ctx, ba); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	} else if res != nil {
 		defer res.Release()
 	}
@@ -82,13 +92,13 @@ func (s *Store) SendWithWriteBytes(
 	if ba.BoundedStaleness != nil {
 		newBa, pErr := s.executeServerSideBoundedStalenessNegotiation(ctx, ba)
 		if pErr != nil {
-			return nil, nil, pErr
+			return nil, pErr
 		}
 		ba = newBa
 	}
 
 	if err := ba.SetActiveTimestamp(s.Clock()); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	// Update our clock with the incoming request timestamp. This advances the
@@ -101,7 +111,7 @@ func (s *Store) SendWithWriteBytes(
 			// If the command appears to come from a node with a bad clock,
 			// reject it instead of updating the local clock and proceeding.
 			if err := s.cfg.Clock.UpdateAndCheckMaxOffset(ctx, ba.Now); err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 		}
 	}
@@ -172,7 +182,7 @@ func (s *Store) SendWithWriteBytes(
 		// Get range and add command to the range for execution.
 		repl, err := s.GetReplica(ba.RangeID)
 		if err != nil {
-			return nil, nil, kvpb.NewError(err)
+			return nil, kvpb.NewError(err)
 		}
 		if !repl.IsInitialized() {
 			// If we have an uninitialized copy of the range, then we are probably a
@@ -182,7 +192,7 @@ func (s *Store) SendWithWriteBytes(
 			// the client that it should move on and try the next replica. Very
 			// likely, the next replica the client tries will be initialized and will
 			// have useful leaseholder information for the client.
-			return nil, nil, kvpb.NewError(&kvpb.NotLeaseHolderError{
+			return nil, kvpb.NewError(&kvpb.NotLeaseHolderError{
 				RangeID: ba.RangeID,
 				// The replica doesn't have a range descriptor yet, so we have to build
 				// a ReplicaDescriptor manually.
@@ -194,7 +204,7 @@ func (s *Store) SendWithWriteBytes(
 			})
 		}
 
-		br, writeBytes, pErr = repl.SendWithWriteBytes(ctx, ba, admissionInfo)
+		br, pErr = repl.SendWithWriteBytes(ctx, ba, admissionInfo, stats)
 		if pErr == nil {
 			// If any retries occurred, we should include the RangeInfos accumulated
 			// and pass these to the client, to invalidate their cache. This is
@@ -204,7 +214,7 @@ func (s *Store) SendWithWriteBytes(
 				br.RangeInfos = append(rangeInfos, br.RangeInfos...)
 			}
 
-			return br, writeBytes, nil
+			return br, nil
 		}
 
 		// Augment error if necessary and return.
@@ -222,7 +232,7 @@ func (s *Store) SendWithWriteBytes(
 			// Range from this Store.
 			rSpan, err := keys.Range(ba.Requests)
 			if err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 
 			// The kvclient thought that a particular range id covers rSpans. It was
@@ -233,7 +243,7 @@ func (s *Store) SendWithWriteBytes(
 			// that the client requested, and all the ranges in between.
 			ri, err := t.MismatchedRange()
 			if err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 			skipRID := ri.Desc.RangeID // We already have info on one range, so don't add it again below.
 			startKey := ri.Desc.StartKey
@@ -310,7 +320,7 @@ func (s *Store) SendWithWriteBytes(
 		// Unable to retry, exit the retry loop and return an error.
 		break
 	}
-	return nil, nil, pErr
+	return nil, pErr
 }
 
 // maybeThrottleBatch inspects the provided batch and determines whether
@@ -445,8 +455,7 @@ func (s *Store) executeServerSideBoundedStalenessNegotiation(
 
 	// Pass empty AdmissionInfo since this is an internal request that bypasses
 	// admission control.
-	br, writeBytes, pErr := s.SendWithWriteBytes(ctx, queryResBa, kvadmission.AdmissionInfo{})
-	writeBytes.Release()
+	br, pErr := s.SendWithWriteBytes(ctx, queryResBa, kvadmission.AdmissionInfo{}, nil)
 	if pErr != nil {
 		return ba, pErr
 	}

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -178,22 +178,25 @@ func (ls *Stores) GetReplicaForRangeID(
 // SendWithWriteBytes sends a batch request. The store is looked up from the
 // store map using the ID specified in the request.
 func (ls *Stores) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error) {
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	admissionInfo kvadmission.AdmissionInfo,
+	stats *SomethingStats,
+) (*kvpb.BatchResponse, *kvpb.Error) {
 	if err := ba.ValidateForEvaluation(); err != nil {
-		return nil, nil, kvpb.NewError(errors.Wrapf(err, "invalid batch (%s)", ba))
+		return nil, kvpb.NewError(errors.Wrapf(err, "invalid batch (%s)", ba))
 	}
 
 	store, err := ls.GetStore(ba.Replica.StoreID)
 	if err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
-	br, writeBytes, pErr := store.SendWithWriteBytes(ctx, ba, admissionInfo)
+	br, pErr := store.SendWithWriteBytes(ctx, ba, admissionInfo, stats)
 	if br != nil && br.Error != nil {
 		panic(kvpb.ErrorUnexpectedlySet(store, br))
 	}
-	return br, writeBytes, pErr
+	return br, pErr
 }
 
 // RangeFeed registers a rangefeed over the specified span. It sends

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1697,6 +1697,7 @@ func (n *Node) batchInternal(
 		defer log.Event(ctx, "node sending response")
 	}
 
+	var stats kvserver.SomethingStats
 	var rangeTenantIDForAC roachpb.TenantID
 	// The computation of rangeTenantIDForAC fails open in case of error.
 	if len(args.Requests) > 0 {
@@ -1720,10 +1721,8 @@ func (n *Node) batchInternal(
 	// for replication flow control.
 	admissionInfo := handle.AdmissionInfo()
 
-	var writeBytes *kvadmission.StoreWriteBytes
 	defer func() {
-		n.storeCfg.KVAdmissionController.AdmittedKVWorkDone(handle, writeBytes)
-		writeBytes.Release()
+		n.storeCfg.KVAdmissionController.AdmittedKVWorkDone(handle, &stats.StoreWriteBytes)
 	}()
 
 	// If a proxy attempt is requested, we copy the request to prevent evaluation
@@ -1743,7 +1742,7 @@ func (n *Node) batchInternal(
 		originalRequest = args.ShallowCopy()
 	}
 	var pErr *kvpb.Error
-	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, args, admissionInfo)
+	br, pErr = n.stores.SendWithWriteBytes(ctx, args, admissionInfo, &stats)
 	if pErr != nil {
 		if originalRequest != nil {
 			if proxyResponse := n.maybeProxyRequest(ctx, originalRequest, pErr); proxyResponse != nil {


### PR DESCRIPTION
… includes ScanStats

Previously, StoreWriteBytes was returned as a separate value from SendWithWriteBytes and threaded back up through multiple layers. The allocation of StoreWriteBytes happened at a lower layer and the higher layer needed to return it to the sync.Pool.

Previously, ScanStats was allocated locally inside evaluateBatchi for tracing only.

The StoreWriteBytes plumbing was smelly. And with the need for ScanStats in all cases (ScanStats are cheap to collect), we need unified plumbing.

This commit introduces SomethingStats (aggregating ScanStats and StoreWriteBytes) and plumbs it top-down from Node.batchInternal through the entire Send path. The caller provides the struct and the lower layers populate it: evalAndPropose fills StoreWriteBytes, and evaluateBatch receives a *kvpb.ScanStats pointer that is populated during evaluation.

There is no sync.Pool so the smelly plumbing of StoreWriteBytes is no more. The SomethingStats allows future addition of more stats.

Todos:
- SomethingStats needs a real name.
- The paths that use nil need some scrutiny.
- This is a POC — tests are not updated.

Epic: none
Release note: None