### PR TITLE
roachtest: fix restore throughput measurement on clusters with workload nodes

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -416,7 +416,7 @@ func registerFastRestorePerf(r registry.Registry) {
 
 					dut, err := roachtestutil.NewDiskUsageTracker(rd.c, t.L())
 					require.NoError(t, err)
-					startDu := dut.GetDiskUsage(ctx, rd.c.All())
+					startDu := dut.GetDiskUsage(ctx, sp.hardware.getCRDBNodes())
 
 					db, err := rd.c.ConnE(ctx, t.L(), rd.c.Node(1)[0])
 					require.NoError(t, err)
@@ -442,7 +442,7 @@ func registerFastRestorePerf(r registry.Registry) {
 					restoreDuration := restoreEndTime.Sub(restoreStartTime)
 					t.L().Printf("Fast restore completed in %s", restoreDuration)
 
-					endDu := dut.GetDiskUsage(ctx, rd.c.All())
+					endDu := dut.GetDiskUsage(ctx, sp.hardware.getCRDBNodes())
 					throughput := float64(endDu-startDu) / (float64(sp.hardware.nodes) * restoreDuration.Seconds())
 					t.L().Printf("Usage %d, Nodes %d, Duration %f; Throughput: %f MB/s/node",
 						endDu-startDu, sp.hardware.nodes, restoreDuration.Seconds(), throughput)

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -913,7 +913,7 @@ func (rd *restoreDriver) initRestorePerfMetrics(
 	dut, err := roachtestutil.NewDiskUsageTracker(rd.c, rd.t.L())
 	require.NoError(rd.t, err)
 	startTime := timeutil.Now()
-	startDu := dut.GetDiskUsage(ctx, rd.c.All())
+	startDu := dut.GetDiskUsage(ctx, rd.sp.hardware.getCRDBNodes())
 
 	return func() {
 		promLabel := registry.PromSub(strings.Replace(rd.sp.testName, "restore/", "", 1)) + "_seconds"
@@ -921,7 +921,7 @@ func (rd *restoreDriver) initRestorePerfMetrics(
 		durationGauge.WithLabelValues(promLabel).Set(testDuration)
 
 		// compute throughput as MB / node / second.
-		du := dut.GetDiskUsage(ctx, rd.c.All())
+		du := dut.GetDiskUsage(ctx, rd.sp.hardware.getCRDBNodes())
 		throughput := float64(du-startDu) / (float64(rd.sp.hardware.nodes) * testDuration)
 		rd.t.L().Printf("Usage %d , Nodes %d , Duration %f\n; Throughput: %f mb / node / second",
 			du,


### PR DESCRIPTION
GetDiskUsage was called with c.All(), which includes the workload node.
The workload node has no cockroach store directory, so GetDiskUsageInBytes
fails on it, and GetDiskUsage returns 0 for the entire measurement. With
both start and end measurements returning 0, throughput was always reported
as 0. Use getCRDBNodes() to restrict disk usage measurement to nodes
actually running CockroachDB.

This affected registerFastRestorePerf (both specs have workloadNode: true)
and initRestorePerfMetrics (used by the MediumFixture restore spec which
also has workloadNode: true).

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>