### PR TITLE
rpc: validate cluster identity on every drpc dial

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -186,6 +186,7 @@ go_test(
         "@io_storj_drpc//:drpc",
         "@io_storj_drpc//drpcclient",
         "@io_storj_drpc//drpcctx",
+        "@io_storj_drpc//drpcmigrate",
         "@io_storj_drpc//drpcmux",
         "@io_storj_drpc//drpcserver",
         "@org_golang_google_grpc//:grpc",

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -25,9 +26,11 @@ type rpcConn io.Closer
 
 // dialFunc is a generic function type used to establish an RPC connection.
 // It takes a context for cancellation/timeouts, a target string (e.g., address),
-// and a ConnectionClass to categorize the connection's purpose or priority.
-// It returns the established connection (of type Conn) or an error if dialing fails.
-type dialFunc[Conn rpcConn] func(ctx context.Context, target string, class rpcbase.ConnectionClass) (Conn, error)
+// the expected NodeID at the target (used by transports that perform a
+// dial-time identity handshake), and a ConnectionClass to categorize the
+// connection's purpose or priority. It returns the established connection
+// (of type Conn) or an error if dialing fails.
+type dialFunc[Conn rpcConn] func(ctx context.Context, target string, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (Conn, error)
 
 // heartbeatClientConstructor is a function type that creates a HeartbeatClient
 // for a given rpc connection. This allows us to use different implementations of

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/VividCortex/ewma"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
@@ -44,8 +45,8 @@ func (d *drpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
 // TODO(server): unexport this once dial methods are added in rpccontext.
 func DialDRPC(
 	rpcCtx *Context, cm *drpcmetrics.ClientMetrics,
-) func(ctx context.Context, target string, class rpcbase.ConnectionClass) (drpc.Conn, error) {
-	return func(ctx context.Context, target string, class rpcbase.ConnectionClass) (drpc.Conn, error) {
+) func(ctx context.Context, target string, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (drpc.Conn, error) {
+	return func(ctx context.Context, target string, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (drpc.Conn, error) {
 		transport := tcpTransport
 		if rpcCtx.ContextOptions.AdvertiseAddr == target && rpcCtx.canLoopbackDial() {
 			transport = loopbackTransport
@@ -73,9 +74,24 @@ func DialDRPC(
 			ShouldRecord: shouldRecordFunc,
 		})
 
+		// drpcpool transparently re-dials when a cached conn dies, so we
+		// cannot rely on a one-time peer-level handshake the way gRPC does
+		// (via onlyOnceDialer + initial heartbeat in pkg/rpc/context.go).
+		// Identity must be checked on every fresh conn entering the pool;
+		// conns that fail validation are closed and never cached.
 		pooledConn := pool.Get(ctx /* unused */, struct{}{}, func(ctx context.Context,
 			_ struct{}) (drpcpool.Conn, error) {
-			return drpcclient.DialContext(ctx, target, drpcDialOptions...)
+			conn, err := drpcclient.DialContext(ctx, target, drpcDialOptions...)
+			if err != nil {
+				return nil, err
+			}
+			if err := validateOnDial(
+				ctx, rpcCtx, conn, target, nodeID, class, drpcDialOptions,
+			); err != nil {
+				_ = conn.Close()
+				return nil, errors.Wrap(err, "dial-time validation")
+			}
+			return conn, nil
 		})
 
 		// The passed in drpc connection can be either a concrete connection or
@@ -91,6 +107,51 @@ func DialDRPC(
 			pool: pool,
 		}, nil
 	}
+}
+
+// validateOnDial issues a Ping over the freshly-dialed bare drpc conn to
+// verify the remote endpoint's cluster identity (cluster ID, node ID,
+// cluster name, and version). It mirrors the checks runSingleHeartbeat
+// performs at peer setup. The Ping flows through the same interceptors and
+// per-RPC metadata as production traffic so server-side authorization
+// behaves identically.
+//
+// On error the caller must close conn — the pool must not cache an
+// unvalidated conn.
+//
+// drpc cannot use the gRPC strategy of "one TCP conn per peer lifetime"
+// (enforced for gRPC by onlyOnceDialer in pkg/rpc/context.go): drpcpool
+// transparently re-dials when a cached conn dies, and drpc currently
+// runs one stream per conn so blocking re-dials would either thrash or
+// serialize all traffic. Identity is therefore enforced per-dial here,
+// not once per peer.
+func validateOnDial(
+	ctx context.Context,
+	rpcCtx *Context,
+	conn drpc.Conn,
+	target string,
+	nodeID roachpb.NodeID,
+	class rpcbase.ConnectionClass,
+	drpcDialOptions []drpcclient.DialOption,
+) error {
+	// Wrap the bare conn so interceptors and per-RPC metadata apply to the
+	// Ping. The wrapper is single-shot and intentionally not Closed on
+	// success: ClientConn embeds drpc.Conn, so wrapper.Close would close
+	// the underlying conn we are about to hand back to the pool.
+	validationCC, err := drpcclient.NewClientConnWithOptions(ctx, conn, drpcDialOptions...)
+	if err != nil {
+		return errors.Wrap(err, "wrapping conn")
+	}
+	return runSingleHeartbeat(
+		ctx,
+		NewDRPCHeartbeatClientAdapter(validationCC),
+		peerKey{TargetAddr: target, NodeID: nodeID, Class: class},
+		ewma.NewMovingAverage(), // throwaway; latency is tracked by the peer heartbeat loop
+		nil,                     // skip clock-offset tracking at dial time
+		&rpcCtx.ContextOptions,
+		rpcCtx.RPCHeartbeatTimeout,
+		PingRequest_NONE, // dialback negotiation is owned by the peer layer
+	)
 }
 
 // drpcDialOptionsInternal is similar to grpcDialOptionsInternal but for
@@ -191,7 +252,11 @@ func (rpcCtx *Context) drpcDialOptsNetwork(
 ) ([]drpcclient.DialOption, error) {
 	// TODO(server): add compression support to drpc.
 	// TODO(server): add support for dial timeout.
-	// TODO(server): check if onlyOnceDialer is needed for drpc.
+	//
+	// We deliberately do not install an onlyOnceDialer-equivalent here;
+	// drpc enforces the cluster-identity invariant per-dial via
+	// validateOnDial instead. See validateOnDial for why drpc cannot use
+	// the gRPC strategy.
 
 	drpcDialOpts, err := rpcCtx.drpcDialOptsNetworkCredentials()
 	if err != nil {

--- a/pkg/rpc/drpc_test.go
+++ b/pkg/rpc/drpc_test.go
@@ -8,12 +8,19 @@ package rpc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -25,6 +32,9 @@ import (
 	"google.golang.org/grpc/metadata"
 	"storj.io/drpc"
 	"storj.io/drpc/drpcclient"
+	"storj.io/drpc/drpcmigrate"
+	"storj.io/drpc/drpcmux"
+	"storj.io/drpc/drpcserver"
 )
 
 // dummyStream is a minimal implementation of drpc.Stream used for testing the
@@ -284,4 +294,157 @@ func TestDRPCValidateOnDial(t *testing.T) {
 			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
+}
+
+// dropDRPCHeaderListener strips the DRPC migration header from accepted
+// connections. Production servers strip the header inside cmux; raw
+// drpcserver instances used in tests do not, so connections from a real
+// drpc client (which prefixes the header via drpcmigrate.DialWithHeader)
+// would otherwise fail at the protocol layer.
+type dropDRPCHeaderListener struct {
+	net.Listener
+}
+
+func (ln *dropDRPCHeaderListener) Accept() (net.Conn, error) {
+	conn, err := ln.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, len(drpcmigrate.DRPCHeader))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// fakeHeartbeatServer is a minimal HeartbeatServer that lets a test
+// pin a remote identity (cluster name) and an echoed Pong value
+// without standing up a full HeartbeatService.
+type fakeHeartbeatServer struct {
+	pong        string
+	clusterName string
+}
+
+func (f *fakeHeartbeatServer) Ping(_ context.Context, req *PingRequest) (*PingResponse, error) {
+	return &PingResponse{
+		Pong:          f.pong,
+		ServerTime:    timeutil.Now().UnixNano(),
+		ServerVersion: clusterversion.Latest.Version(),
+		ClusterName:   f.clusterName,
+	}, nil
+}
+
+// startFakeDRPCServer starts a minimal insecure dRPC server with a fake
+// heartbeat service on the given TCP address. Returns the listener and a
+// cleanup function that stops the server and waits for it to exit.
+func startFakeDRPCServer(
+	t *testing.T, addr string, pong string, clusterName string,
+) (net.Listener, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	mux := drpcmux.New()
+	require.NoError(t, DRPCRegisterHeartbeat(mux, &fakeHeartbeatServer{
+		pong: pong, clusterName: clusterName,
+	}))
+	srv := drpcserver.New(mux)
+
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = srv.Serve(context.Background(), &dropDRPCHeaderListener{Listener: ln})
+	}()
+	return ln, func() {
+		_ = ln.Close()
+		<-serveDone
+	}
+}
+
+// TestDRPCPoolConnRevalidatesAfterPortReuse is the regression test for
+// #168792. It exercises the exact race that produced "phantom" raft
+// messages in CI: a peer connection is established to server A; A is
+// killed; another process binds to the same TCP port; the next RPC on
+// the existing peer conn forces drpcpool to re-dial. With dial-time
+// validation, the new conn fails its identity handshake against the
+// expected cluster and is rejected before any RPC can ride it.
+//
+// Adapted from the reproducer in #169068. The original test asserted
+// the buggy behavior (silent re-dial succeeding); this version asserts
+// the fix (re-dial blocked at the cluster-identity handshake).
+func TestDRPCPoolConnRevalidatesAfterPortReuse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const clusterA = "cluster-A"
+	const clusterB = "cluster-B"
+
+	// Server A listens on a random port. The client expects to be
+	// talking to clusterA throughout the test.
+	lnA, cleanupA := startFakeDRPCServer(t, "127.0.0.1:0", "server-A", clusterA)
+	addr := lnA.Addr().String()
+	port := lnA.Addr().(*net.TCPAddr).Port
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	// The very long heartbeat interval ensures no peer-level Ping fires
+	// between the server swap and the next RPC on the cached conn,
+	// isolating the test to dial-time validation.
+	opts := DefaultContextOptions()
+	opts.Insecure = true
+	opts.Clock = &timeutil.DefaultTimeSource{}
+	opts.ToleratedOffset = time.Nanosecond
+	opts.Stopper = stopper
+	opts.Settings = cluster.MakeTestingClusterSettings()
+	opts.RPCHeartbeatInterval = time.Hour
+	opts.RPCHeartbeatTimeout = 10 * time.Second
+	opts.ClusterName = clusterA
+	clientCtx := NewContext(ctx, opts)
+	clientCtx.StorageClusterID.Set(ctx, uuid.MakeV4())
+	clientCtx.NodeID.Set(ctx, 99)
+
+	// Connect to server A. The peer-level initial heartbeat validates
+	// identity once.
+	conn, err := clientCtx.DRPCDialNode(
+		addr, 1, roachpb.Locality{}, rpcbase.DefaultClass,
+	).Connect(ctx)
+	require.NoError(t, err)
+
+	client := NewDRPCHeartbeatClient(conn)
+	resp, err := client.Ping(ctx, &PingRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "server-A", resp.Pong)
+
+	// Kill server A. The underlying TCP conn dies but drpcpool's wrapper
+	// stays "open" from the peer layer's point of view, so connClosedCh
+	// (peer.go:556) does not fire.
+	cleanupA()
+
+	// Bind server B to the freed port. This is the production hazard:
+	// some other process grabs the IP:port the original peer was using.
+	_, cleanupB := startFakeDRPCServer(
+		t, fmt.Sprintf("127.0.0.1:%d", port), "server-B", clusterB,
+	)
+	defer cleanupB()
+
+	// The next Ping on the existing peer conn forces drpcpool to evict
+	// the dead cached conn and dial fresh. validateOnDial runs against
+	// server B, sees the cluster name does not match clusterA, and
+	// rejects the conn. The Ping surfaces that error rather than
+	// silently returning "server-B".
+	testutils.SucceedsSoon(t, func() error {
+		resp, err := client.Ping(ctx, &PingRequest{})
+		if err == nil {
+			return errors.Newf("expected dial-time validation to reject the re-dial, got pong %q", resp.Pong)
+		}
+		if !strings.Contains(err.Error(), "cluster name") {
+			return errors.Wrapf(err, "unexpected error shape; want cluster-name rejection")
+		}
+		return nil
+	})
 }

--- a/pkg/rpc/drpc_test.go
+++ b/pkg/rpc/drpc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 	"storj.io/drpc"
+	"storj.io/drpc/drpcclient"
 )
 
 // dummyStream is a minimal implementation of drpc.Stream used for testing the
@@ -190,4 +191,97 @@ func TestDRPCServerWithInterceptor(t *testing.T) {
 	shouldBlock.Store(true)
 	_, err = client.Ping(ctx, &PingRequest{})
 	require.Contains(t, err.Error(), "RPC blocked by interceptor")
+}
+
+// TestDRPCValidateOnDial verifies that validateOnDial rejects freshly
+// dialed drpc conns whose remote cluster identity (cluster ID, node ID)
+// does not match what the client expects, and accepts conns that match.
+func TestDRPCValidateOnDial(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	const serverNodeID roachpb.NodeID = 7
+	const advertiseAddr = "127.0.0.1:1"
+	serverClusterID := uuid.MakeV4()
+	clock := timeutil.NewManualTime(timeutil.Unix(0, 1))
+
+	loopbackL := netutil.NewLoopbackListener(ctx, stopper)
+	serverCtx := newTestContext(serverClusterID, clock, 0, stopper)
+	serverCtx.NodeID.Set(ctx, serverNodeID)
+	serverCtx.SetLoopbackDRPCDialer(loopbackL.Connect)
+	serverCtx.AdvertiseAddr = advertiseAddr
+
+	drpcServer, err := NewDRPCServer(ctx, serverCtx)
+	require.NoError(t, err)
+	require.NoError(t, DRPCRegisterHeartbeat(drpcServer, serverCtx.NewHeartbeatService()))
+
+	tlsConfig, err := serverCtx.GetServerTLSConfig()
+	require.NoError(t, err)
+	tlsListener := tls.NewListener(loopbackL, tlsConfig)
+	require.NoError(t, stopper.RunAsyncTask(ctx, "drpc-server", func(ctx context.Context) {
+		netutil.FatalIfUnexpected(drpcServer.Serve(ctx, tlsListener))
+	}))
+
+	// newClientCtx returns an rpcCtx that dials the test server via the
+	// shared loopback listener. clusterID controls which cluster identity
+	// the client claims, allowing tests to exercise mismatched-identity
+	// cases.
+	newClientCtx := func(clusterID uuid.UUID) *Context {
+		c := newTestContext(clusterID, clock, 0, stopper)
+		c.SetLoopbackDRPCDialer(loopbackL.Connect)
+		c.AdvertiseAddr = advertiseAddr
+		return c
+	}
+
+	// dialAndValidate bare-dials the server through the loopback listener
+	// and runs validateOnDial with the provided expected NodeID, returning
+	// the validation error.
+	dialAndValidate := func(t *testing.T, clientCtx *Context, expectedNodeID roachpb.NodeID) error {
+		opts, err := clientCtx.drpcDialOptionsInternal(ctx, advertiseAddr, rpcbase.DefaultClass, loopbackTransport)
+		require.NoError(t, err)
+		conn, err := drpcclient.DialContext(ctx, advertiseAddr, opts...)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		return validateOnDial(ctx, clientCtx, conn, advertiseAddr, expectedNodeID, rpcbase.DefaultClass, opts)
+	}
+
+	tests := []struct {
+		name        string
+		clientUUID  uuid.UUID
+		nodeID      roachpb.NodeID
+		expectedErr string
+	}{
+		{
+			name:       "matching identity",
+			clientUUID: serverClusterID,
+			nodeID:     serverNodeID,
+		},
+		{
+			name:        "mismatched node ID",
+			clientUUID:  serverClusterID,
+			nodeID:      serverNodeID + 1,
+			expectedErr: "node ID",
+		},
+		{
+			name:        "mismatched cluster ID",
+			clientUUID:  uuid.MakeV4(),
+			nodeID:      serverNodeID,
+			expectedErr: "cluster ID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := dialAndValidate(t, newClientCtx(tc.clientUUID), tc.nodeID)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
 }

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -102,7 +102,12 @@ func newGRPCPeerOptions(
 		locality: locality,
 		peers:    &rpcCtx.peers,
 		connOptions: &ConnectionOptions[*grpc.ClientConn]{
-			dial: func(ctx context.Context, target string, class rpcbase.ConnectionClass) (*grpc.ClientConn, error) {
+			// nodeID is unused on the gRPC path: the cluster-identity
+			// invariant is enforced once per *ClientConn lifetime via
+			// onlyOnceDialer + the initial heartbeat (see onlyOnceDialer in
+			// context.go). drpc uses the same parameter to drive per-dial
+			// validation in validateOnDial.
+			dial: func(ctx context.Context, target string, _ roachpb.NodeID, class rpcbase.ConnectionClass) (*grpc.ClientConn, error) {
 				additionalDialOpts := []grpc.DialOption{grpc.WithStatsHandler(&statsTracker{lm})}
 				additionalDialOpts = append(additionalDialOpts, rpcCtx.testingDialOpts...)
 				// onNetworkDial is a callback that is called after we dial a TCP connection.

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -391,7 +391,7 @@ func (p *peer[Conn]) run(ctx context.Context, report func(error), done func()) {
 }
 
 func (p *peer[Conn]) runOnce(ctx context.Context, report func(error)) error {
-	cc, err := p.connOptions.dial(ctx, p.k.TargetAddr, p.k.Class)
+	cc, err := p.connOptions.dial(ctx, p.k.TargetAddr, p.k.NodeID, p.k.Class)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/drpc_test.go
+++ b/pkg/server/drpc_test.go
@@ -245,7 +245,10 @@ func TestDialDRPC_InterceptorsAreSet(t *testing.T) {
 		},
 	}
 	getConn := rpc.DialDRPC(rpcCtx, nil)
-	conn, err := getConn(ctx, rpcAddr, rpcbase.DefaultClass)
+	// nodeID 0 disables the server-side node-ID check in the dial-time
+	// identity handshake, since this minimal client setup does not bind
+	// to a specific peer node.
+	conn, err := getConn(ctx, rpcAddr, 0 /* nodeID */, rpcbase.DefaultClass)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, conn.Close()) }()
 	desc := c.LookupRangeOrFatal(t, c.ScratchRange(t))


### PR DESCRIPTION
drpc connections use a per-peer drpcpool that transparently re-dials when a cached conn dies. Without explicit validation, this lets a peer's RPCs flow over a TCP conn that was never identity-checked against the expected remote. The failure surfaces as a panic when a fresh TCP conn lands on a different cluster's node at the same host:port (e.g. via port reuse during test teardown).

The gRPC transport prevents this class of bug structurally: onlyOnceDialer (pkg/rpc/context.go:1885-1961) refuses any second dial, so the first failure of the underlying TCP conn kills the entire *ClientConn. The peer is torn down, a new probe runs, and the initial heartbeat re-validates cluster ID, node ID, cluster name, and version against whatever is now at host:port. One TCP conn per peer lifetime collapses the per-conn validation problem into a per-peer one.

drpc cannot use the same strategy. drpc currently runs one stream per TCP conn (no multiplexing), and drpcpool grows the conn count under concurrent load. A 'first dial succeeds, all others fail' model would either thrash on every transient blip or serialize all peer traffic through a single conn. The invariant we want, that every TCP conn is identity-validated before traffic flows, has to be enforced per-dial, not once per peer.

Move the cluster-identity handshake from the peer layer down into the drpcpool dial closure. Every fresh conn pays one Ping RTT before entering the pool; conns that fail validation are closed and never cached. The Ping is wrapped in a single-shot *ClientConn so all production interceptors and per-RPC metadata apply, so that server-side authorization (e.g. tenant ID) behaves identically to real traffic. The check itself reuses runSingleHeartbeat, so the dial gate runs the same cluster ID, node ID, cluster name, and version checks the peer-level heartbeat already runs.

validateOnDial needs the expected NodeID, which requires a small expansion of the dialFunc signature. The gRPC dial absorbs the parameter as unused, since its onlyOnceDialer path already enforces the invariant and does not need a per-dial gate.

Scenarios worth checking:

- Cross-cluster port reuse (the original bug). A different cluster's node grabs the same host:port. Cluster ID and cluster name mismatch on the dial-time Ping; the conn is closed and discarded before any other RPC can ride it.

- Same-cluster peer rotated. The node at host:port goes down and is replaced by a different node of the same cluster (e.g. decommission + new node grabs the IP). Old cached conns die at the TCP layer and are evicted by the pool on next use; fresh dials fail the NodeID check and are rejected. Without the NodeID arg in the dial path this case would slip through.

- Concurrent dialing. drpcpool grows on demand under concurrent RPCs. Each fresh dial runs its own validation; an in-flight conn that passes can coexist with a fresh dial that fails. The pool simply does not cache the failing one. Pre-existing in-pool conns remain valid because they were validated when dialed.

- Single conn dies, peer identity unchanged. Validation passes on the re-dial, the new conn enters the pool, and the peer is undisturbed. This is the routine case the pool exists to handle.

- Bad re-dial detection latency. We deliberately do not propagate the underlying conn's close up through the pool wrapper to fast-fail the peer's connClosedCh path (peer.go:556). With validate-on-dial, fast detection is not a safety property; the pool cannot serve any RPC over an unvalidated conn. The periodic heartbeat still catches identity changes via Pings that route through the pool and trigger fresh (validating) dials, so the breaker trips within at most one heartbeat interval. The trade of detection latency for the pool's transparent-redial contract is the right call: a single dropped TCP conn is not a peer-fatal event in the drpc model.

Resolves: #168792
Epic: none

Release note: None