### PR TITLE
logictest: fix `builtins` test under high --vmodule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtins
+++ b/pkg/sql/logictest/testdata/logic_test/builtins
@@ -66,8 +66,9 @@ statement ok
 SET TRACING = "off";
 
 # The first execution should miss the query cache.
+# Strip suffix after "query cache ..." because nightly tests with high vmodule setting appends the SQL stmt.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT regexp_replace(message, ':.*', '') FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache miss
 query cache add
@@ -83,7 +84,7 @@ SET TRACING = "off";
 
 # The second execution should hit the query cache.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT regexp_replace(message, ':.*', '') FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache hit
 
@@ -101,7 +102,7 @@ SET TRACING = "off";
 
 # After running the builtin, the query cache should be cleared.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT regexp_replace(message, ':.*', '') FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache miss
 query cache add


### PR DESCRIPTION
74b2da00d5 moved this test from `pkg/ccl/logictestccl/` into `pkg/sql/logictest/`, exposing it to the SqlLogicTestHighVModuleNightlyBazel nightly. Under `--vmodule=*=10`, `opc.log()` appends the SQL statement to trace messages (e.g. "query cache miss: SELECT * FROM xy"), causing the expected output to mismatch.

Strip the suffix with regexp_replace so the test passes in both modes.

Fixes #169054

Release note: None