### PR TITLE
kvserver: wait for raft leadership in TestLeaseExpirationBelowFutureTimeRequest

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2000,6 +2000,25 @@ func TestLeaseExpirationBelowFutureTimeRequest(t *testing.T) {
 			return lease.Replica.StoreID == l.replica1.StoreID()
 		}, 5*time.Second, 100*time.Millisecond, "timed out waiting for replica 0 to pick up new lease")
 
+		// Wait for raft leadership to transfer to the leaseholder. The lease
+		// extension below goes through verifyLeaseRequestSafetyRLocked which
+		// treats a stasis-period lease as expired (PrevLeaseExpired=true) and
+		// falls through to verifyAcquisition, which rejects if we're not the
+		// raft leader. Without this wait, the raft group can be leaderless
+		// after AdminTransferLease initiates a leadership transfer.
+		require.Eventually(t, func() bool {
+			raftStatus := l.replica1.RaftStatus()
+			if raftStatus == nil {
+				return false
+			}
+			if raftStatus.RaftState == raftpb.StateLeader {
+				return true
+			}
+			t.Logf("replica1 raft state: %s, lead: %d, term: %d",
+				raftStatus.RaftState, raftStatus.Lead, raftStatus.Term)
+			return false
+		}, 5*time.Second, 100*time.Millisecond, "timed out waiting for raft leadership transfer to replica1")
+
 		// Pause the cluster's clocks.
 		l.manualClock.Pause()
 		atPause := l.manualClock.UnixNano()
@@ -2033,8 +2052,8 @@ func TestLeaseExpirationBelowFutureTimeRequest(t *testing.T) {
 			// may end up being extended by some other request. That fact that
 			// our request was rejected is good enough.
 		} else {
-			// The request should have been rejected.
-			require.Nil(t, pErr)
+			// The request should succeed and trigger a lease extension.
+			require.Nil(t, pErr, "expected request to succeed: %s", pErr)
 
 			// The lease should have been extended.
 			l.checkHasLease(t, 1)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2006,18 +2006,17 @@ func TestLeaseExpirationBelowFutureTimeRequest(t *testing.T) {
 		// falls through to verifyAcquisition, which rejects if we're not the
 		// raft leader. Without this wait, the raft group can be leaderless
 		// after AdminTransferLease initiates a leadership transfer.
-		require.Eventually(t, func() bool {
+		testutils.SucceedsSoon(t, func() error {
 			raftStatus := l.replica1.RaftStatus()
 			if raftStatus == nil {
-				return false
+				return errors.New("raft status not available")
 			}
 			if raftStatus.RaftState == raftpb.StateLeader {
-				return true
+				return nil
 			}
-			t.Logf("replica1 raft state: %s, lead: %d, term: %d",
+			return errors.Newf("replica1 raft state: %s, lead: %d, term: %d",
 				raftStatus.RaftState, raftStatus.Lead, raftStatus.Term)
-			return false
-		}, 5*time.Second, 100*time.Millisecond, "timed out waiting for raft leadership transfer to replica1")
+		})
 
 		// Pause the cluster's clocks.
 		l.manualClock.Pause()


### PR DESCRIPTION
kvserver: wait for raft leadership in TestLeaseExpirationBelowFutureTimeRequest

Wait for raft leadership transfer to complete before issuing the lease
extension request. Without this, the raft group can be transiently
leaderless after AdminTransferLease, causing the lease extension to be
rejected by verifyAcquisition.

Fixes: #163750
Epic: none
Release note: None