### PR TITLE
sql: implement pg_lock table for monitoring advisory locks

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2321,6 +2321,7 @@ Session represents one SQL session.
 | goroutine_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | The ID of the session's goroutine. | [reserved](#support-status) |
 | authentication_method | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
 | default_isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The session's default transaction isolation level. | [reserved](#support-status) |
+| held_advisory_locks | [HeldAdvisoryLock](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.HeldAdvisoryLock) | repeated | Transaction-scoped advisory locks currently held by this session. | [reserved](#support-status) |
 
 
 
@@ -2377,6 +2378,22 @@ TxnInfo represents an in flight user transaction on some Session.
 | last_auto_retry_reason | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message describing the cause for the txn's last automatic retry. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this transaction started execution. | [reserved](#support-status) |
 | isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The isolation level of the transaction. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.HeldAdvisoryLock"></a>
+#### HeldAdvisoryLock
+
+HeldAdvisoryLock is one transaction-scoped advisory lock held by a session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| lock_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  |  | [reserved](#support-status) |
+| lock_database_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  |  | [reserved](#support-status) |
+| isSingeValue | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
+| lock_mode | [HeldAdvisoryLock.AdvisoryLockMode](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.HeldAdvisoryLock.AdvisoryLockMode) |  |  | [reserved](#support-status) |
 
 
 
@@ -2473,6 +2490,7 @@ Session represents one SQL session.
 | goroutine_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | The ID of the session's goroutine. | [reserved](#support-status) |
 | authentication_method | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
 | default_isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The session's default transaction isolation level. | [reserved](#support-status) |
+| held_advisory_locks | [HeldAdvisoryLock](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.HeldAdvisoryLock) | repeated | Transaction-scoped advisory locks currently held by this session. | [reserved](#support-status) |
 
 
 
@@ -2529,6 +2547,22 @@ TxnInfo represents an in flight user transaction on some Session.
 | last_auto_retry_reason | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | Error message describing the cause for the txn's last automatic retry. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this transaction started execution. | [reserved](#support-status) |
 | isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The isolation level of the transaction. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.HeldAdvisoryLock"></a>
+#### HeldAdvisoryLock
+
+HeldAdvisoryLock is one transaction-scoped advisory lock held by a session.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| lock_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  |  | [reserved](#support-status) |
+| lock_database_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  |  | [reserved](#support-status) |
+| isSingeValue | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  |  | [reserved](#support-status) |
+| lock_mode | [HeldAdvisoryLock.AdvisoryLockMode](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.HeldAdvisoryLock.AdvisoryLockMode) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -574,8 +574,8 @@ pg_catalog,pg_language,table,node,permanent,prefix,"available languages
 https://www.postgresql.org/docs/9.5/catalog-pg-language.html"
 pg_catalog,pg_largeobject,table,node,permanent,prefix,pg_largeobject was created for compatibility and is currently unimplemented
 pg_catalog,pg_largeobject_metadata,table,node,permanent,prefix,pg_largeobject_metadata was created for compatibility and is currently unimplemented
-pg_catalog,pg_locks,table,node,permanent,prefix,"locks held by active processes (empty - feature does not exist)
-https://www.postgresql.org/docs/9.6/view-pg-locks.html"
+pg_catalog,pg_locks,table,node,permanent,prefix,"advisory locks: granted and waiting advisory locks
+https://www.postgresql.org/docs/18/view-pg-locks.html"
 pg_catalog,pg_matviews,table,node,permanent,prefix,"available materialized views
 https://www.postgresql.org/docs/9.6/view-pg-matviews.html"
 pg_catalog,pg_namespace,table,node,permanent,prefix,"available namespaces

--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -5,6 +5,7 @@ debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
+debug/crdb_internal.cluster_held_advisory_locks.txt
 debug/crdb_internal.cluster_inspect_errors.txt
 debug/crdb_internal.cluster_locks.txt
 debug/crdb_internal.cluster_queries.txt
@@ -162,6 +163,7 @@ debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
+debug/crdb_internal.cluster_held_advisory_locks.txt
 debug/crdb_internal.cluster_inspect_errors.txt
 debug/crdb_internal.cluster_locks.txt
 debug/crdb_internal.cluster_queries.txt
@@ -325,6 +327,7 @@ debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
+debug/crdb_internal.cluster_held_advisory_locks.txt
 debug/crdb_internal.cluster_inspect_errors.txt
 debug/crdb_internal.cluster_locks.txt
 debug/crdb_internal.cluster_queries.txt
@@ -484,6 +487,7 @@ debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
+debug/crdb_internal.cluster_held_advisory_locks.txt
 debug/crdb_internal.cluster_inspect_errors.txt
 debug/crdb_internal.cluster_locks.txt
 debug/crdb_internal.cluster_queries.txt
@@ -610,6 +614,7 @@ debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
+debug/crdb_internal.cluster_held_advisory_locks.txt
 debug/crdb_internal.cluster_inspect_errors.txt
 debug/crdb_internal.cluster_locks.txt
 debug/crdb_internal.cluster_queries.txt

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -234,6 +234,14 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"goroutine_id",
 		},
 	},
+	"crdb_internal.cluster_held_advisory_locks": {
+		nonSensitiveCols: NonSensitiveColumns{
+			"session_id",
+			"database_id",
+			"is_single_value",
+			"lock_id",
+		},
+	},
 	"crdb_internal.cluster_settings": {
 		customQueryUnredacted: `SELECT
 			variable,

--- a/pkg/cli/zip_upload_table_dumps.go
+++ b/pkg/cli/zip_upload_table_dumps.go
@@ -67,6 +67,7 @@ var clusterWideTableDumps = map[string]columnParserMap{
 	"crdb_internal.cluster_settings.txt":            {},
 	"system.role_id_seq.txt":                        {},
 	"crdb_internal.cluster_sessions.txt":            {},
+	"crdb_internal.cluster_held_advisory_locks.txt": {},
 	"system.migrations.txt":                         {},
 	"crdb_internal.kv_store_status.txt":             {},
 	"system.locations.txt":                          {},

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1055,6 +1055,20 @@ message ListSessionsRequest {
   bool include_internal = 3;
 }
 
+// HeldAdvisoryLock is one transaction-scoped advisory lock held by a session.
+message HeldAdvisoryLock {
+  int64 lock_id = 1;
+  int64 lock_database_id = 2;
+  bool isSingeValue  = 3;
+  enum AdvisoryLockMode {
+    ADVISORY_LOCK_MODE_UNKNOWN = 0;
+    ADVISORY_LOCK_MODE_SHARED = 1;
+    ADVISORY_LOCK_MODE_EXCLUSIVE = 2;
+  }
+  AdvisoryLockMode lock_mode = 4;
+
+}
+
 // Session represents one SQL session.
 message Session {
   // ID of node where this session exists.
@@ -1135,6 +1149,10 @@ message Session {
 
   // The session's default transaction isolation level.
   string default_isolation_level = 23;
+
+  // Transaction-scoped advisory locks currently held by this session.
+  repeated HeldAdvisoryLock held_advisory_locks = 24
+      [ (gogoproto.nullable) = false ];
 }
 
 // An error wrapper object for ListSessionsResponse.

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -733,6 +733,7 @@ go_test(
         "mvcc_backfiller_test.go",
         "mvcc_statistics_update_job_test.go",
         "normalization_test.go",
+        "pg_locks_test.go",
         "pg_metadata_test.go",
         "pg_oid_test.go",
         "pgwire_internal_test.go",

--- a/pkg/sql/advisorylock/BUILD.bazel
+++ b/pkg/sql/advisorylock/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/util/encoding",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -27,11 +28,14 @@ go_test(
     srcs = [
         "advisory_lock_test.go",
         "main_test.go",
+        "manager_savepoint_test.go",
     ],
+    embed = [":advisorylock"],
     exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",
+        "//pkg/keys",
         "//pkg/kv/kvserver/concurrency",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/advisorylock/manager.go
+++ b/pkg/sql/advisorylock/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -66,6 +67,12 @@ func (k LockKey) Encode(baseKey roachpb.Key) ([]byte, error) {
 	return keys.MakeFamilyKey(baseKey, 0), nil
 }
 
+// Extract returns the components of the key.
+func (k LockKey) Extract() (databaseID descpb.ID, isSingleValue bool, lockKey int64) {
+	isSingleValue = k.lockType == lockKeyTypeSingle
+	return k.databaseID, isSingleValue, k.lockKey
+}
+
 func (k LockKey) String() string {
 	return fmt.Sprintf("(%d, %d, %d)", k.databaseID, k.lockType, k.lockKey)
 }
@@ -103,12 +110,49 @@ const (
 	LockModeExclusive
 )
 
+// String returns a stable display name for the lock mode.
+func (m LockMode) String() string {
+	switch m {
+	case LockModeShare:
+		return "SHARED"
+	case LockModeExclusive:
+		return "EXCLUSIVE"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", m)
+	}
+}
+
+// SafeValue is part of the redact.SafeValue interface.
+func (LockMode) SafeValue() {}
+
+type acquisition struct {
+	key  LockKey
+	mode LockMode
+}
+
+// RewindSnapshot captures advisory lock manager state at a txn rewind position.
+type RewindSnapshot struct {
+	markers []int
+	acqLen  int
+}
+
 // Manager is responsible for acquiring and releasing advisory locks, depending
 // on the scope of the lock.
 type Manager struct {
 	descs   *descs.Collection
 	codec   keys.SQLCodec
 	baseKey roachpb.Key
+
+	mu struct {
+		syncutil.Mutex
+		// stack is ordered acquisition attempts in the current SQL txn (suffix
+		// truncated on savepoint rollback / stmt rewind).
+		stack []acquisition
+		// savepointMarkers[i] is len(stack) when SQL savepoint i was created.
+		// Invariant (when driven by conn_executor_savepoints): len(savepointMarkers)
+		// equals the SQL savepoint stack depth.
+		savepointMarkers []int
+	}
 }
 
 // NewManager creates a new advisory lock manager.
@@ -190,6 +234,9 @@ func (m *Manager) AcquireInTxn(
 		}
 		return errors.Wrap(resErr, "failed to acquire advisory lock in transaction")
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.stack = append(m.mu.stack, acquisition{key: key, mode: mode})
 	return nil
 }
 
@@ -201,4 +248,111 @@ func isWaitPolicyLockConflict(err error) bool {
 		return false
 	}
 	return wi.Reason == kvpb.WriteIntentError_REASON_WAIT_POLICY
+}
+
+// HeldLockInfo represents information about a held advisory lock.
+type HeldLockInfo struct {
+	Key  LockKey
+	Mode LockMode
+}
+
+// GetHeldLocks returns a copy of the effective per-key lock modes derived from
+// the acquisition stack (max strength per key). Safe for concurrent callers.
+func (m *Manager) GetHeldLocks() []HeldLockInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Gather all the modes that locks are uniquely held in.
+	sharedLocks := make(map[LockKey]struct{})
+	exclusiveLocks := make(map[LockKey]struct{})
+	for _, acq := range m.mu.stack {
+		switch acq.mode {
+		case LockModeShare:
+			sharedLocks[acq.key] = struct{}{}
+		case LockModeExclusive:
+			exclusiveLocks[acq.key] = struct{}{}
+		}
+	}
+	heldInfo := make([]HeldLockInfo, 0, len(sharedLocks)+len(exclusiveLocks))
+	for key := range sharedLocks {
+		heldInfo = append(heldInfo, HeldLockInfo{key, LockModeShare})
+	}
+	for key := range exclusiveLocks {
+		heldInfo = append(heldInfo, HeldLockInfo{key, LockModeExclusive})
+	}
+	return heldInfo
+}
+
+// OnSQLSavepointCreated records the current acquisition stack depth for a new
+// SQL savepoint. Call after pushing the SQL savepoint.
+func (m *Manager) OnSQLSavepointCreated() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.savepointMarkers = append(m.mu.savepointMarkers, len(m.mu.stack))
+}
+
+// OnSQLRollbackToSavepoint rolls back the acquisition stack to the depth at
+// SQL savepoint index targetIdx. Call only after txn.RollbackToSavepoint succeeds.
+func (m *Manager) OnSQLRollbackToSavepoint(targetIdx int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if targetIdx < 0 || targetIdx >= len(m.mu.savepointMarkers) {
+		return errors.AssertionFailedf("invalid savepoint index %d", targetIdx)
+	}
+	prefix := m.mu.savepointMarkers[targetIdx]
+	if prefix > len(m.mu.stack) {
+		prefix = len(m.mu.stack)
+	}
+	m.mu.stack = m.mu.stack[:prefix]
+	m.mu.savepointMarkers = m.mu.savepointMarkers[:targetIdx+1]
+	return nil
+}
+
+// OnSQLSavepointStackTruncated shrinks the savepoint marker stack after RELEASE
+// SAVEPOINT (acquisitions unchanged).
+func (m *Manager) OnSQLSavepointStackTruncated(newLen int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if newLen < 0 {
+		newLen = 0
+	}
+	if newLen > len(m.mu.savepointMarkers) {
+		return
+	}
+	m.mu.savepointMarkers = m.mu.savepointMarkers[:newLen]
+}
+
+// OnSQLSavepointsCleared clears savepoint markers (e.g. when SQL savepoints are
+// cleared without replacing the manager).
+func (m *Manager) OnSQLSavepointsCleared() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.savepointMarkers = nil
+}
+
+// ExportRewindSnapshot returns a copy of marker stack and acquisition depth for
+// stmt rewind positions.
+func (m *Manager) ExportRewindSnapshot() RewindSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var snap RewindSnapshot
+	if len(m.mu.savepointMarkers) > 0 {
+		snap.markers = append([]int(nil), m.mu.savepointMarkers...)
+	}
+	snap.acqLen = len(m.mu.stack)
+	return snap
+}
+
+// ApplyRewindSnapshot restores acquisition prefix and marker stack from a prior
+// ExportRewindSnapshot.
+func (m *Manager) ApplyRewindSnapshot(s RewindSnapshot) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s.acqLen < len(m.mu.stack) {
+		m.mu.stack = m.mu.stack[:s.acqLen]
+	}
+	if s.markers != nil {
+		m.mu.savepointMarkers = append([]int(nil), s.markers...)
+	} else {
+		m.mu.savepointMarkers = nil
+	}
 }

--- a/pkg/sql/advisorylock/manager_savepoint_test.go
+++ b/pkg/sql/advisorylock/manager_savepoint_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package advisorylock
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHeldLocksEmptyStack(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	m := NewManager(nil, keys.SystemSQLCodec)
+	locks := m.GetHeldLocks()
+	require.Empty(t, locks)
+}
+
+func TestSavepointCallbacksMarkerStack(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	m := NewManager(nil, keys.SystemSQLCodec)
+	m.OnSQLSavepointCreated()
+	m.OnSQLSavepointCreated()
+	s := m.ExportRewindSnapshot()
+	require.Len(t, s.markers, 2)
+	require.Zero(t, s.acqLen)
+
+	require.NoError(t, m.OnSQLRollbackToSavepoint(0))
+	s2 := m.ExportRewindSnapshot()
+	require.Len(t, s2.markers, 1)
+
+	m.OnSQLSavepointStackTruncated(0)
+	s3 := m.ExportRewindSnapshot()
+	require.Empty(t, s3.markers)
+}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -6,11 +6,13 @@
 package sql
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"math"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -1368,7 +1370,8 @@ func (s *Server) newConnExecutor(
 	ex.extraTxnState.descCollection = s.cfg.CollectionFactory.NewCollection(
 		ctx, descs.WithDescriptorSessionDataProvider(dsdp), descs.WithMonitor(ex.sessionMon),
 	)
-	ex.extraTxnState.advisoryLockManager = advisorylock.NewManager(ex.extraTxnState.descCollection, ex.server.cfg.Codec)
+	ex.extraTxnState.advisoryLockManager = &atomic.Pointer[advisorylock.Manager]{}
+	ex.extraTxnState.advisoryLockManager.Store(advisorylock.NewManager(ex.extraTxnState.descCollection, ex.server.cfg.Codec))
 	ex.extraTxnState.jobs = newTxnJobsCollection()
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangerState = &SchemaChangerState{
@@ -1659,8 +1662,9 @@ type connExecutor struct {
 		// descCollection collects descriptors used by the current transaction.
 		descCollection *descs.Collection
 
-		// advisoryLockManager is the manager for advisory locks.
-		advisoryLockManager *advisorylock.Manager
+		// advisoryLockManager is an atomic pointer that refers to
+		//  the current advisory lock manager.
+		advisoryLockManager *atomic.Pointer[advisorylock.Manager]
 
 		jobs *txnJobsCollection
 
@@ -1793,6 +1797,7 @@ type connExecutor struct {
 		rewindPosSnapshot struct {
 			savepoints       savepointStack
 			sessionDataStack *sessiondata.Stack
+			advisoryRewind   advisorylock.RewindSnapshot
 		}
 		// transactionStatementFingerprintIDs tracks all statement IDs that make up the current
 		// transaction. It's length is bound by the TxnStatsNumStmtFingerprintIDsToRecord
@@ -2237,7 +2242,18 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, pay
 		}
 	} else {
 		ex.extraTxnState.descCollection.ReleaseAll(ctx)
-		ex.extraTxnState.advisoryLockManager = advisorylock.NewManager(ex.extraTxnState.descCollection, ex.server.cfg.Codec)
+		// Advisory lock acquisitions are stored both in KV (where they are
+		// held by the txn record and survive refresh/restart) and in the
+		// in-memory advisoryLockManager. On txnRestart the KV intents
+		// persist, so we must preserve the manager too; replacing it would
+		// silently desync the in-memory stack from KV for the rest of the
+		// txn, surfacing as wrong rows in pg_locks /
+		// crdb_internal.cluster_held_advisory_locks.
+		if ev.eventType != txnRestart {
+			ex.extraTxnState.advisoryLockManager.Store(advisorylock.NewManager(
+				ex.extraTxnState.descCollection, ex.server.cfg.Codec,
+			))
+		}
 		ex.extraTxnState.jobs.reset()
 		ex.extraTxnState.validateDbZoneConfig = false
 		ex.extraTxnState.schemaChangerState.memAcc.Clear(ctx)
@@ -2846,6 +2862,9 @@ func (ex *connExecutor) execCmd() (retErr error) {
 		// Note we use the Replace function instead of reassigning, as there are
 		// copies of the ex.sessionDataStack in the iterators and extendedEvalContext.
 		ex.sessionDataStack.Replace(ex.extraTxnState.rewindPosSnapshot.sessionDataStack)
+		if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+			mgr.ApplyRewindSnapshot(ex.extraTxnState.rewindPosSnapshot.advisoryRewind)
+		}
 		advInfo.rewCap.rewindAndUnlock(ctx)
 	case stayInPlace:
 		// Nothing to do. The same statement will be executed again.
@@ -3022,6 +3041,11 @@ func (ex *connExecutor) setTxnRewindPos(ctx context.Context, pos CmdPos) error {
 	ex.stmtBuf.Ltrim(ctx, pos)
 	ex.extraTxnState.rewindPosSnapshot.savepoints = ex.extraTxnState.savepoints.clone()
 	ex.extraTxnState.rewindPosSnapshot.sessionDataStack = ex.sessionDataStack.Clone()
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		ex.extraTxnState.rewindPosSnapshot.advisoryRewind = mgr.ExportRewindSnapshot()
+	} else {
+		ex.extraTxnState.rewindPosSnapshot.advisoryRewind = advisorylock.RewindSnapshot{}
+	}
 	return ex.commitPrepStmtNamespace(ctx)
 }
 
@@ -3978,8 +4002,8 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		localSQLStats:        ex.server.localSqlStats,
 		indexUsageStats:      ex.indexUsageStats,
 		statementPreparer:    ex,
-		advisoryLockManager:  ex.extraTxnState.advisoryLockManager,
 	}
+	evalCtx.advisoryLockManager = ex.extraTxnState.advisoryLockManager
 	evalCtx.copyFromExecCfg(ex.server.cfg)
 }
 
@@ -4744,6 +4768,40 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		sessionActiveTime = time.Duration(sessionActiveTime.Nanoseconds() + elapsed.Nanoseconds())
 	}
 
+	var heldAdvisoryLocks []serverpb.HeldAdvisoryLock
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		if locks := mgr.GetHeldLocks(); len(locks) > 0 {
+			heldAdvisoryLocks = make([]serverpb.HeldAdvisoryLock, 0, len(locks))
+			for _, lock := range locks {
+				convertedMode := serverpb.HeldAdvisoryLock_ADVISORY_LOCK_MODE_UNKNOWN
+				switch lock.Mode {
+				case advisorylock.LockModeExclusive:
+					convertedMode = serverpb.HeldAdvisoryLock_ADVISORY_LOCK_MODE_EXCLUSIVE
+				case advisorylock.LockModeShare:
+					convertedMode = serverpb.HeldAdvisoryLock_ADVISORY_LOCK_MODE_SHARED
+				default:
+					log.Dev.Warningf(ex.Ctx(), "unknown advisory lock mode: %d", lock.Mode)
+				}
+				db, isSingleValue, id := lock.Key.Extract()
+				heldAdvisoryLocks = append(heldAdvisoryLocks, serverpb.HeldAdvisoryLock{
+					LockDatabaseId: int64(db),
+					LockId:         id,
+					IsSingeValue:   isSingleValue,
+					LockMode:       convertedMode,
+				})
+			}
+			slices.SortFunc(heldAdvisoryLocks, func(a, b serverpb.HeldAdvisoryLock) int {
+				if c := cmp.Compare(a.LockDatabaseId, b.LockDatabaseId); c != 0 {
+					return c
+				}
+				if c := cmp.Compare(a.LockId, b.LockId); c != 0 {
+					return c
+				}
+				return cmp.Compare(a.LockMode, b.LockMode)
+			})
+		}
+	}
+
 	return serverpb.Session{
 		Username:          sd.SessionUser().Normalized(),
 		ClientAddress:     remoteStr,
@@ -4766,6 +4824,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		GoroutineID:                ex.ctxHolder.goroutineID,
 		AuthenticationMethod:       sd.AuthenticationMethod,
 		DefaultIsolationLevel:      tree.IsolationLevel(sd.DefaultTxnIsolationLevel).String(),
+		HeldAdvisoryLocks:          heldAdvisoryLocks,
 	}
 }
 

--- a/pkg/sql/conn_executor_savepoints.go
+++ b/pkg/sql/conn_executor_savepoints.go
@@ -104,6 +104,9 @@ func (ex *connExecutor) execSavepointInOpenState(
 	}
 	savepoints.push(sp)
 	ex.sessionDataStack.PushTopClone()
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		mgr.OnSQLSavepointCreated()
+	}
 
 	return nil, nil, nil
 }
@@ -158,6 +161,9 @@ func (ex *connExecutor) execRelease(
 			// cockroach_restart (that's the whole point of commitOnRelease).
 			env.push(*entry)
 			ex.sessionDataStack.PushTopClone()
+			if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+				mgr.OnSQLSavepointCreated()
+			}
 
 			rc, canAutoRetry := ex.getRewindTxnCapability()
 			ev := eventRetryableErr{
@@ -180,6 +186,10 @@ func (ex *connExecutor) execRelease(
 	if err := ex.state.mu.txn.ReleaseSavepoint(ctx, entry.kvToken); err != nil {
 		ev, payload := ex.makeErrEvent(err, s)
 		return ev, payload
+	}
+
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		mgr.OnSQLSavepointStackTruncated(len(ex.extraTxnState.savepoints))
 	}
 
 	if len(ex.extraTxnState.savepoints) == 0 {
@@ -214,6 +224,12 @@ func (ex *connExecutor) execRollbackToSavepointInOpenState(
 
 	if err := ex.popSavepointsToIdx(s, idx); err != nil {
 		return ex.makeErrEvent(err, s)
+	}
+
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		if err := mgr.OnSQLRollbackToSavepoint(idx); err != nil {
+			return ex.makeErrEvent(err, s)
+		}
 	}
 
 	if entry.kvToken.Initial() {
@@ -295,6 +311,12 @@ func (ex *connExecutor) execRollbackToSavepointInAbortedState(
 
 	if err := ex.state.mu.txn.RollbackToSavepoint(ctx, entry.kvToken); err != nil {
 		return ex.makeErrEvent(err, s)
+	}
+
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		if err := mgr.OnSQLRollbackToSavepoint(idx); err != nil {
+			return ex.makeErrEvent(err, s)
+		}
 	}
 
 	if entry.kvToken.Initial() {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -142,6 +142,7 @@ var crdbInternal = virtualSchema{
 		catconstants.CrdbInternalClusterQueriesTableID:              crdbInternalClusterQueriesTable,
 		catconstants.CrdbInternalClusterTransactionsTableID:         crdbInternalClusterTxnsTable,
 		catconstants.CrdbInternalClusterSessionsTableID:             crdbInternalClusterSessionsTable,
+		catconstants.CrdbInternalClusterHeldAdvisoryLocksTableID:    crdbInternalClusterHeldAdvisoryLocksTable,
 		catconstants.CrdbInternalClusterSettingsTableID:             crdbInternalClusterSettingsTable,
 		catconstants.CrdbInternalClusterStmtStatsTableID:            crdbInternalClusterStmtStatsTable,
 		catconstants.CrdbInternalCreateFunctionStmtsTableID:         crdbInternalCreateFunctionStmtsTable,
@@ -2572,6 +2573,84 @@ var crdbInternalClusterSessionsTable = virtualSchemaTable{
 		}
 		return populateSessionsTable(ctx, p, addRow, response)
 	},
+}
+
+// crdbInternalClusterHeldAdvisoryLocksTable exposes transaction-scoped advisory
+// locks held on sessions across the cluster (cluster RPC; expensive).
+var crdbInternalClusterHeldAdvisoryLocksTable = virtualSchemaTable{
+	comment: "advisory locks held by open sessions visible to current user (cluster RPC; expensive!)",
+	schema: `
+CREATE TABLE crdb_internal.cluster_held_advisory_locks (
+  session_id STRING NOT NULL,
+	database_id int8 NOT NULL,
+	lock_id int8 NOT NULL,
+	is_single_value BOOL,
+  lock_mode   STRING NOT NULL
+)`,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		req, err := p.makeSessionsRequest(ctx, true /* excludeClosed */)
+		if err != nil {
+			return err
+		}
+		response, err := p.extendedEvalCtx.SQLStatusServer.ListSessions(ctx, &req)
+		if err != nil {
+			return err
+		}
+		return populateClusterHeldAdvisoryLocksTable(ctx, p, addRow, response)
+	},
+}
+
+func populateClusterHeldAdvisoryLocksTable(
+	ctx context.Context,
+	p *planner,
+	addRow func(...tree.Datum) error,
+	response *serverpb.ListSessionsResponse,
+) error {
+	canViewOtherUser := false
+	if isAdmin, err := p.HasAdminRole(ctx); err != nil {
+		return err
+	} else if isAdmin {
+		canViewOtherUser = true
+	} else {
+		if hasPriv, _, err := p.HasViewActivityOrViewActivityRedactedRole(ctx); err != nil {
+			return err
+		} else if hasPriv {
+			canViewOtherUser = true
+		}
+	}
+	for _, session := range response.Sessions {
+		normalizedUser, err := username.MakeSQLUsernameFromUserInput(session.Username, username.PurposeValidation)
+		if err != nil {
+			return err
+		}
+		if !canViewOtherUser && normalizedUser != p.User() {
+			continue
+		}
+		sessionID := getSessionID(session)
+		for i := range session.HeldAdvisoryLocks {
+			h := &session.HeldAdvisoryLocks[i]
+			lockMode := "UNKNOWN"
+			switch h.LockMode {
+			case serverpb.HeldAdvisoryLock_ADVISORY_LOCK_MODE_EXCLUSIVE:
+				lockMode = "ExclusiveLock"
+			case serverpb.HeldAdvisoryLock_ADVISORY_LOCK_MODE_SHARED:
+				lockMode = "ShareLock"
+			}
+			if err := addRow(
+				sessionID,
+				tree.NewDInt(tree.DInt(h.LockDatabaseId)),
+				tree.NewDInt(tree.DInt(h.LockId)),
+				tree.MakeDBool(tree.DBool(h.IsSingeValue)),
+				tree.NewDString(lockMode),
+			); err != nil {
+				return err
+			}
+		}
+	}
+	for _, rpcErr := range response.Errors {
+		log.Dev.Warningf(ctx, "%v", rpcErr.Message)
+	}
+	return nil
 }
 
 func populateSessionsTable(

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/advisorylock"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -406,6 +408,15 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 			ex.extraTxnState.jobs = ie.extraTxnState.jobs
 			ex.extraTxnState.schemaChangerState = ie.extraTxnState.schemaChangerState
 			ex.extraTxnState.shouldResetSyntheticDescriptors = shouldResetSyntheticDescriptors
+			// We inherit the parent's advisory lock manager here. This is safe
+			// because internal executors on this path do not issue SQL
+			// SAVEPOINT/RELEASE statements; savepoint hooks still fire from the
+			// parent's conn_executor_savepoints. If that changes, using this
+			// inherited manager could desynchronize advisory-lock savepoint markers
+			// from the parent's savepoint stack.
+			if ie.extraTxnState.advisoryLockManager != nil {
+				ex.extraTxnState.advisoryLockManager = ie.extraTxnState.advisoryLockManager
+			}
 		}
 	}
 
@@ -1743,10 +1754,11 @@ func (icc *internalClientComm) RTrim(_ context.Context, pos CmdPos) {
 // executor in that it may lead to surprising bugs whereby we forget to add
 // fields here and keep them in sync.
 type extraTxnState struct {
-	txn                *kv.Txn
-	descCollection     *descs.Collection
-	jobs               *txnJobsCollection
-	schemaChangerState *SchemaChangerState
+	txn                 *kv.Txn
+	descCollection      *descs.Collection
+	jobs                *txnJobsCollection
+	schemaChangerState  *SchemaChangerState
+	advisoryLockManager *atomic.Pointer[advisorylock.Manager]
 
 	// regionsProvider is populated lazily.
 	regionsProvider *regions.Provider

--- a/pkg/sql/logictest/testdata/logic_test/advisory_lock
+++ b/pkg/sql/logictest/testdata/logic_test/advisory_lock
@@ -930,4 +930,161 @@ COMMIT
 
 user root
 
+subtest cluster_held_advisory_locks
+
+# Begin and the xact lock must be one statement. Separate *sql.DB Execs can use
+# different connections; a lone lock call on autocommit releases before cluster_held.
+statement ok
+BEGIN; SELECT pg_advisory_xact_lock(8877665544); SELECT pg_advisory_xact_lock_shared(8877665544);
+
+query B
+SELECT count(*) >= 1
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE session_id = (SELECT session_id FROM [SHOW session_id])
+  AND lock_id = 8877665544
+  AND lock_mode = 'ExclusiveLock'
+----
+true
+
+query B
+SELECT count(*) >= 1
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE session_id = (SELECT session_id FROM [SHOW session_id])
+  AND lock_id = 8877665544
+  AND lock_mode = 'ShareLock'
+----
+true
+
+statement ok
+COMMIT
+
+query B
+SELECT count(*) = 0
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 8877665544
+----
+true
+
+subtest advisory_max_mode_cluster_held
+
+statement ok
+BEGIN;
+SELECT pg_advisory_xact_lock_shared(9123456789);
+SELECT pg_advisory_xact_lock(9123456789);
+SELECT pg_advisory_xact_lock_shared(9123456789)
+
+query B
+SELECT bool_or(lock_mode = 'ExclusiveLock')
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE session_id = (SELECT session_id FROM [SHOW session_id]) AND lock_id = 9123456789
+----
+true
+
+statement ok
+COMMIT
+
+subtest advisory_savepoint_rollback_cluster_held
+
+statement ok
+BEGIN; SAVEPOINT sp; SELECT pg_advisory_xact_lock(8123456788)
+
+query B
+SELECT count(*) >= 1
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 8123456788
+----
+true
+
+statement ok
+ROLLBACK TO SAVEPOINT sp
+
+query B
+SELECT count(*) = 0
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 8123456788
+----
+true
+
+statement ok
+ROLLBACK
+
 subtest end
+
+subtest advisory_savepoint_release
+statement ok
+BEGIN;
+SAVEPOINT sp1;
+SELECT pg_advisory_xact_lock(1111);
+SAVEPOINT sp2;
+SELECT pg_advisory_xact_lock(2222);
+RELEASE SAVEPOINT sp2;
+
+# Both locks should still be held after RELEASE
+query B
+SELECT count(*) = 2
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 1111 OR lock_id = 2222
+----
+true
+
+statement ok
+ROLLBACK TO SAVEPOINT sp1;
+
+# Both should be gone after rollback to sp1
+query B
+SELECT count(*) = 0
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 1111 OR lock_id = 2222
+----
+true
+
+statement ok
+COMMIT
+
+subtest advisory_nested_savepoint_rollback
+statement ok
+BEGIN;
+SELECT pg_advisory_xact_lock(3333);
+SAVEPOINT sp1;
+SELECT pg_advisory_xact_lock(4444);
+SAVEPOINT sp2;
+SELECT pg_advisory_xact_lock(5555);
+ROLLBACK TO SAVEPOINT sp2;
+
+# 3333 and 4444 should still be held
+query B
+SELECT count(*) = 2
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 3333 OR lock_id = 4444
+----
+true
+
+# 5555 should be gone
+query B
+SELECT count(*) = 0
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 5555
+----
+true
+
+statement ok
+ROLLBACK TO SAVEPOINT sp1;
+
+# Only 3333 should remain
+query B
+SELECT count(*) = 1
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 3333
+----
+true
+
+query B
+SELECT count(*) = 0
+FROM crdb_internal.cluster_held_advisory_locks
+WHERE lock_id = 4444
+----
+true
+
+statement ok
+COMMIT
+

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -119,7 +119,7 @@ pg_init_privs                    true
 pg_language                      false
 pg_largeobject                   true
 pg_largeobject_metadata          true
-pg_locks                         true
+pg_locks                         false
 pg_matviews                      false
 pg_namespace                     false
 pg_opclass                       true

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -60,7 +60,7 @@ pg_catalog  pg_init_privs                    table  node  NULL  NULL
 pg_catalog  pg_language                      table  node  NULL  NULL
 pg_catalog  pg_largeobject                   table  node  NULL  NULL
 pg_catalog  pg_largeobject_metadata          table  node  NULL  NULL
-pg_catalog  pg_locks                         view   node  NULL  NULL
+pg_catalog  pg_locks                         table  node  NULL  NULL
 pg_catalog  pg_matviews                      table  node  NULL  NULL
 pg_catalog  pg_namespace                     table  node  NULL  NULL
 pg_catalog  pg_opclass                       table  node  NULL  NULL
@@ -230,7 +230,7 @@ pg_catalog  pg_init_privs                    table  node  NULL  NULL
 pg_catalog  pg_language                      table  node  NULL  NULL
 pg_catalog  pg_largeobject                   table  node  NULL  NULL
 pg_catalog  pg_largeobject_metadata          table  node  NULL  NULL
-pg_catalog  pg_locks                         view   node  NULL  NULL
+pg_catalog  pg_locks                         table  node  NULL  NULL
 pg_catalog  pg_matviews                      table  node  NULL  NULL
 pg_catalog  pg_namespace                     table  node  NULL  NULL
 pg_catalog  pg_opclass                       table  node  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -60,7 +60,7 @@ pg_catalog  pg_init_privs                    table  node  NULL  NULL
 pg_catalog  pg_language                      table  node  NULL  NULL
 pg_catalog  pg_largeobject                   table  node  NULL  NULL
 pg_catalog  pg_largeobject_metadata          table  node  NULL  NULL
-pg_catalog  pg_locks                         table  node  NULL  NULL
+pg_catalog  pg_locks                         view   node  NULL  NULL
 pg_catalog  pg_matviews                      table  node  NULL  NULL
 pg_catalog  pg_namespace                     table  node  NULL  NULL
 pg_catalog  pg_opclass                       table  node  NULL  NULL
@@ -230,7 +230,7 @@ pg_catalog  pg_init_privs                    table  node  NULL  NULL
 pg_catalog  pg_language                      table  node  NULL  NULL
 pg_catalog  pg_largeobject                   table  node  NULL  NULL
 pg_catalog  pg_largeobject_metadata          table  node  NULL  NULL
-pg_catalog  pg_locks                         table  node  NULL  NULL
+pg_catalog  pg_locks                         view   node  NULL  NULL
 pg_catalog  pg_matviews                      table  node  NULL  NULL
 pg_catalog  pg_namespace                     table  node  NULL  NULL
 pg_catalog  pg_opclass                       table  node  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_locks
+++ b/pkg/sql/logictest/testdata/logic_test/pg_locks
@@ -1,0 +1,23 @@
+# LogicTest: !local-mixed-25.4 !local-mixed-26.1 !local-mixed-26.2
+
+# End-to-end smoke: pg_locks (advisory-only) is a queryable view. Detailed row
+# shape is covered in pkg/sql/pg_locks_test.go (TestPGLocksAdvisory*).
+
+statement ok
+SET database = test
+
+# Idle session: no advisory lock rows
+query I
+SELECT count(*)::INT FROM pg_catalog.pg_locks
+----
+0
+
+# Root can read the optional cluster_locks branch (no waiters in an idle cluster)
+subtest non_granted_smoke
+
+query I
+SELECT count(*)::INT FROM pg_catalog.pg_locks WHERE locktype = 'advisory' AND NOT granted
+----
+0
+
+subtest end

--- a/pkg/sql/logictest/tests/3node-tenant/generated_test.go
+++ b/pkg/sql/logictest/tests/3node-tenant/generated_test.go
@@ -1514,6 +1514,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1492,6 +1492,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1499,6 +1499,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1527,6 +1527,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1499,6 +1499,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -1247,6 +1247,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_plpgsql_assign(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-read-committed/generated_test.go
+++ b/pkg/sql/logictest/tests/local-read-committed/generated_test.go
@@ -1506,6 +1506,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-repeatable-read/generated_test.go
+++ b/pkg/sql/logictest/tests/local-repeatable-read/generated_test.go
@@ -1492,6 +1492,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1520,6 +1520,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1807,6 +1807,13 @@ func TestLogic_pg_extension(
 	runLogicTest(t, "pg_extension")
 }
 
+func TestLogic_pg_locks(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "pg_locks")
+}
+
 func TestLogic_pg_lsn(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -54,7 +54,6 @@ var pgCatalogTables = []string{
 	vtable.PGCatalogIndexes,
 	vtable.PGCatalogInherits,
 	vtable.PGCatalogLanguage,
-	vtable.PGCatalogLocks,
 	vtable.PGCatalogMatViews,
 	vtable.PGCatalogNamespace,
 	vtable.PGCatalogOperator,

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2755,13 +2755,134 @@ https://www.postgresql.org/docs/9.5/catalog-pg-language.html`,
 }
 
 var pgCatalogLocksTable = virtualSchemaTable{
-	comment: `locks held by active processes (empty - feature does not exist)
-https://www.postgresql.org/docs/9.6/view-pg-locks.html`,
+	comment: `advisory locks: granted and waiting advisory locks
+https://www.postgresql.org/docs/18/view-pg-locks.html`,
 	schema: vtable.PGCatalogLocks,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		heldRows, err := p.InternalSQLTxn().QueryBufferedEx(
+			ctx,
+			"read-held-advisory-locks",
+			p.Txn(),
+			sessiondata.NodeUserSessionDataOverride,
+			`
+SELECT
+  h.database_id::OID AS database,
+  (((h.lock_id >> 32)::INT8)::INT4)::OID AS classid,
+  ((h.lock_id & (((1::INT8 << 32) - 1)::INT8))::INT8)::OID AS objid,
+  CASE h.is_single_value
+    WHEN true THEN 1:::INT2
+    ELSE 2:::INT2
+  END AS objsubid,
+  ('0/' || s.pg_backend_pid::STRING)::STRING AS virtualtransaction,
+  s.pg_backend_pid AS pid,
+  h.lock_mode
+FROM crdb_internal.cluster_held_advisory_locks AS h
+INNER JOIN crdb_internal.cluster_sessions AS s ON s.session_id = h.session_id
+WHERE s.session_id <> (SELECT * FROM [SHOW SESSION_ID])
+`,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, row := range heldRows {
+			if err := addRow(
+				tree.NewDString("advisory"), // locktype
+				row[0],                      // database
+				tree.DNull,                  // relation
+				tree.DNull,                  // page
+				tree.DNull,                  // tuple
+				tree.DNull,                  // virtualxid
+				tree.DNull,                  // transactionid
+				row[1],                      // classid
+				row[2],                      // objid
+				row[3],                      // objsubid
+				row[4],                      // virtualtransaction
+				row[5],                      // pid
+				row[6],                      // mode
+				tree.DBoolTrue,              // granted
+				tree.DBoolFalse,             // fastpath
+				tree.DNull,                  // waitstart
+			); err != nil {
+				return err
+			}
+		}
+		// If no advisory locks are held, then no one should be waiting on them.
+		if len(heldRows) == 0 {
+			return nil
+		}
+
+		waiterRows, err := p.InternalSQLTxn().QueryBufferedEx(
+			ctx,
+			"read-waiting-advisory-locks",
+			p.Txn(),
+			sessiondata.NodeUserSessionDataOverride,
+			`
+SELECT
+  pk.db_id::OID AS database,
+  (((pk.packed_key >> 32)::INT8)::INT4)::OID AS classid,
+  ((pk.packed_key & (((1::INT8 << 32) - 1)::INT8))::INT8)::OID AS objid,
+  CASE pk.lock_type
+    WHEN 1:::INT8 THEN 1:::INT2
+    ELSE 2:::INT2
+  END AS objsubid,
+  ('0/' || s.pg_backend_pid::STRING)::STRING AS virtualtransaction,
+  s.pg_backend_pid AS pid,
+  CASE l.lock_strength
+    WHEN 'Exclusive':::STRING THEN 'ExclusiveLock':::STRING
+    WHEN 'Shared':::STRING THEN 'ShareLock':::STRING
+    ELSE l.lock_strength
+  END AS mode,
+  l.ts::TIMESTAMPTZ AS waitstart
+FROM crdb_internal.cluster_locks AS l
+INNER JOIN LATERAL (
+  SELECT
+    CAST(segs[cardinality(segs) - 3] AS INT8) AS db_id,
+    CAST(segs[cardinality(segs) - 2] AS INT8) AS lock_type,
+    CAST(segs[cardinality(segs) - 1] AS INT8) AS packed_key
+  FROM (SELECT string_to_array(btrim(l.lock_key_pretty, ' /'), '/') AS segs) AS x
+  WHERE cardinality(segs) >= 4
+    AND (segs[cardinality(segs) - 3] ~ '^[0-9]+$')
+    AND (segs[cardinality(segs) - 2] ~ '^[0-9]+$')
+    AND (segs[cardinality(segs) - 1] ~ '^-?[0-9]+$')
+    AND segs[cardinality(segs)] = '0'
+) AS pk ON true
+INNER JOIN crdb_internal.cluster_sessions AS s ON l.txn_id::STRING = s.kv_txn
+WHERE l.database_name = 'system'
+  AND l.table_name = 'advisory_locks'
+  AND l.granted = false
+  AND l.txn_id IS NOT NULL
+`,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, row := range waiterRows {
+			if err := addRow(
+				tree.NewDString("advisory"), // locktype
+				row[0],                      // database
+				tree.DNull,                  // relation
+				tree.DNull,                  // page
+				tree.DNull,                  // tuple
+				tree.DNull,                  // virtualxid
+				tree.DNull,                  // transactionid
+				row[1],                      // classid
+				row[2],                      // objid
+				row[3],                      // objsubid
+				row[4],                      // virtualtransaction
+				row[5],                      // pid
+				row[6],                      // mode
+				tree.DBoolFalse,             // granted
+				tree.DBoolFalse,             // fastpath
+				row[7],                      // waitstart
+			); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	},
-	unimplemented: true,
 }
 
 var pgCatalogMatViewsTable = virtualSchemaTable{

--- a/pkg/sql/pg_locks_test.go
+++ b/pkg/sql/pg_locks_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPGLocksAdvisorySingleKeyExclusive validates pg_locks for a single-int8
+// transaction advisory key (classid=0, objid=key, objsubid=1) and that the
+// row clears after commit.
+func TestPGLocksAdvisorySingleKeyExclusive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	_, err := db.ExecContext(ctx, `SET database = defaultdb`)
+	require.NoError(t, err)
+
+	const k = 10001
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, k)
+	require.NoError(t, err)
+
+	var n int
+	err = tx.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_catalog.pg_locks
+		WHERE locktype = 'advisory' AND granted AND classid = 0 AND objid = $1::oid AND objsubid = 1
+		AND relation IS NULL AND page IS NULL AND NOT fastpath
+	`, k).Scan(&n)
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "expected one granted advisory row for the held lock")
+
+	var mode string
+	var fast bool
+	var rel, vxid gosql.NullString
+	var vtxn string
+	err = tx.QueryRowContext(ctx, `
+		SELECT mode, fastpath, relation, virtualxid, virtualtransaction
+		FROM pg_catalog.pg_locks
+		WHERE locktype = 'advisory' AND granted AND objid = $1::oid
+	`, k).Scan(&mode, &fast, &rel, &vxid, &vtxn)
+	require.NoError(t, err)
+	require.Equal(t, "ExclusiveLock", mode)
+	require.False(t, fast)
+	require.False(t, rel.Valid) // NULL relation for advisory
+	require.False(t, vxid.Valid) // no virtual xid
+	require.Greater(t, len(vtxn), 2)
+	require.Equal(t, "0/", vtxn[0:2], "virtualtransaction is like PostgreSQL '0/pid'")
+
+	require.NoError(t, tx.Commit())
+
+	err = db.QueryRowContext(ctx, `SELECT count(*)::int FROM pg_catalog.pg_locks WHERE objid = $1`, k).Scan(&n)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+}
+
+// TestPGLocksAdvisorySingleKeyShared matches ShareLock and objsubid 1.
+func TestPGLocksAdvisorySingleKeyShared(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	_, err := db.ExecContext(ctx, `SET database = defaultdb`)
+	require.NoError(t, err)
+
+	const k = 10002
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock_shared($1)`, k)
+	require.NoError(t, err)
+
+	var mode string
+	err = tx.QueryRowContext(ctx, `SELECT mode FROM pg_catalog.pg_locks WHERE locktype = 'advisory' AND granted AND objid = $1`, k).Scan(&mode)
+	require.NoError(t, err)
+	require.Equal(t, "ShareLock", mode)
+	require.NoError(t, tx.Commit())
+}
+
+// TestPGLocksAdvisoryTwoInt4 maps to objsubid=2 with classid/objid as the two int4 parts.
+func TestPGLocksAdvisoryTwoInt4(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	_, err := db.ExecContext(ctx, `SET database = defaultdb`)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(7::int4, 8::int4)`)
+	require.NoError(t, err)
+
+	var classid, objid int
+	var subid int16
+	err = tx.QueryRowContext(ctx, `
+		SELECT classid::int, objid::int, objsubid::int
+		FROM pg_catalog.pg_locks
+		WHERE locktype = 'advisory' AND granted AND objsubid = 2
+	`).Scan(&classid, &objid, &subid)
+	require.NoError(t, err)
+	require.Equal(t, 7, classid)
+	require.Equal(t, 8, objid)
+	require.Equal(t, int16(2), subid)
+	require.NoError(t, tx.Commit())
+}

--- a/pkg/sql/pg_locks_test.go
+++ b/pkg/sql/pg_locks_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -60,7 +61,7 @@ func TestPGLocksAdvisorySingleKeyExclusive(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "ExclusiveLock", mode)
 	require.False(t, fast)
-	require.False(t, rel.Valid) // NULL relation for advisory
+	require.False(t, rel.Valid)  // NULL relation for advisory
 	require.False(t, vxid.Valid) // no virtual xid
 	require.Greater(t, len(vtxn), 2)
 	require.Equal(t, "0/", vtxn[0:2], "virtualtransaction is like PostgreSQL '0/pid'")
@@ -127,4 +128,106 @@ func TestPGLocksAdvisoryTwoInt4(t *testing.T) {
 	require.Equal(t, 8, objid)
 	require.Equal(t, int16(2), subid)
 	require.NoError(t, tx.Commit())
+}
+
+// TestPGLocksAdvisoryNotGrantedWaiting asserts pg_locks exposes a non-granted
+// row for a second transaction blocked on pg_advisory_xact_lock, using the
+// crdb_internal.cluster_locks leg of the view (granted = false, joined to
+// cluster_sessions for the waiting session).
+func TestPGLocksAdvisoryNotGrantedWaiting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant})
+	defer s.Stopper().Stop(ctx)
+
+	_, err := db.ExecContext(ctx, `SET database = defaultdb`)
+	require.NoError(t, err)
+
+	conn1, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn1.Close()) }()
+	conn2, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn2.Close()) }()
+	_, err = conn1.ExecContext(ctx, `SET database = defaultdb`)
+	require.NoError(t, err)
+	_, err = conn2.ExecContext(ctx, `SET database = defaultdb`)
+	require.NoError(t, err)
+
+	const k = 888777666
+	tx1, err := conn1.BeginTx(ctx, &gosql.TxOptions{})
+	require.NoError(t, err)
+	_, err = tx1.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, k)
+	require.NoError(t, err)
+	defer func() {
+		if tx1 == nil {
+			return
+		}
+		_ = tx1.Rollback()
+	}()
+
+	// Conn2 blocks on the same exclusive transaction lock until conn1 rolls back.
+	errCh := make(chan error, 1)
+	go func() {
+		tx2, werr := conn2.BeginTx(ctx, &gosql.TxOptions{})
+		if werr != nil {
+			errCh <- werr
+			return
+		}
+		defer func() {
+			_ = tx2.Rollback()
+		}()
+		// Blocks while conn1 holds the lock.
+		_, werr = tx2.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, k)
+		errCh <- werr
+	}()
+	// Give the waiter time to start blocking before we poll.
+	time.Sleep(50 * time.Millisecond)
+
+	// Wait for a non-granted advisory row visible from pg_locks.
+	var n int
+	deadline := time.After(30 * time.Second)
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+waitLoop:
+	for {
+		select {
+		case <-deadline:
+			require.FailNowf(t, "timed out waiting for a non-granted pg_locks row for the blocked session", "")
+		case <-tick.C:
+			err = db.QueryRowContext(ctx, `
+				SELECT count(*)
+				FROM pg_catalog.pg_locks
+				WHERE locktype = 'advisory'
+				  AND NOT granted
+				  AND classid::int8 = 0
+				  AND objid::int8 = $1
+				  AND objsubid = 1
+				  AND mode = 'ExclusiveLock'
+			`, k).Scan(&n)
+			if err == nil && n >= 1 {
+				break waitLoop
+			}
+			tick.Reset(20 * time.Millisecond)
+		}
+	}
+	require.NoError(t, tx1.Rollback())
+	tx1 = nil
+	require.GreaterOrEqual(t, n, 1, "expected at least one waiting (non-granted) advisory row")
+
+	select {
+	case werr := <-errCh:
+		require.NoError(t, werr, "second session should have acquired the lock after release")
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out waiting for conn2 to finish after holder released")
+	}
+
+	// Unblock path should have cleared waiters; allow a short settle.
+	err = db.QueryRowContext(ctx, `SELECT count(*)::int FROM pg_catalog.pg_locks WHERE NOT granted`).Scan(&n)
+	require.NoError(t, err)
+	require.Equal(t, 0, n, "no non-granted rows once transactions complete")
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -123,7 +123,7 @@ type extendedEvalContext struct {
 	validateDbZoneConfig *bool
 
 	// advisoryLockManager is the manager for advisory locks.
-	advisoryLockManager *advisorylock.Manager
+	advisoryLockManager *atomic.Pointer[advisorylock.Manager]
 }
 
 // copyFromExecCfg copies relevant fields from an ExecutorConfig.
@@ -745,10 +745,11 @@ func (p *planner) InternalSQLTxn() descs.Txn {
 		ie := MakeInternalExecutor(ief.server, ief.memMetrics, ief.monitor)
 		ie.SetSessionData(p.SessionData())
 		ie.extraTxnState = &extraTxnState{
-			txn:                p.Txn(),
-			descCollection:     p.Descriptors(),
-			jobs:               p.extendedEvalCtx.jobs,
-			schemaChangerState: p.extendedEvalCtx.SchemaChangerState,
+			txn:                 p.Txn(),
+			descCollection:      p.Descriptors(),
+			jobs:                p.extendedEvalCtx.jobs,
+			schemaChangerState:  p.extendedEvalCtx.SchemaChangerState,
+			advisoryLockManager: p.extendedEvalCtx.advisoryLockManager,
 		}
 		p.internalSQLTxn.init(p.txn, ie)
 	}
@@ -1334,7 +1335,7 @@ func (p *planner) advisoryXactLockImpl(
 		return false, pgerror.New(pgcode.NoActiveSQLTransaction,
 			"advisory locks are only available in a transaction")
 	}
-	mgr := p.extendedEvalCtx.advisoryLockManager
+	mgr := p.extendedEvalCtx.advisoryLockManager.Load()
 	if mgr == nil {
 		return false, errors.AssertionFailedf("advisory lock manager not initialized")
 	}

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -478,7 +478,8 @@ const (
 	PgExtensionSpatialRefSysTableID
 	InformationSchemaCrdbNodeActiveSessionHistoryTableID
 	InformationSchemaCrdbClusterActiveSessionHistoryTableID
-	MinVirtualID = InformationSchemaCrdbClusterActiveSessionHistoryTableID
+	CrdbInternalClusterHeldAdvisoryLocksTableID
+	MinVirtualID = CrdbInternalClusterHeldAdvisoryLocksTableID
 )
 
 // ConstraintType is used to identify the type of a constraint.

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -58,10 +58,11 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 			ie := MakeInternalExecutor(ief.server, ief.memMetrics, ief.monitor)
 			ie.SetSessionData(sd)
 			ie.extraTxnState = &extraTxnState{
-				txn:                p.Txn(),
-				descCollection:     p.Descriptors(),
-				jobs:               p.extendedEvalCtx.jobs,
-				schemaChangerState: p.extendedEvalCtx.SchemaChangerState,
+				txn:                 p.Txn(),
+				descCollection:      p.Descriptors(),
+				jobs:                p.extendedEvalCtx.jobs,
+				schemaChangerState:  p.extendedEvalCtx.SchemaChangerState,
+				advisoryLockManager: p.extendedEvalCtx.advisoryLockManager,
 			}
 			if err := p.checkIfCursorExists(s.Name); err != nil {
 				return nil, err

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -307,7 +307,8 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"SafeStack": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/advisorylock": {
-						"LockKey": {},
+						"LockKey":  {},
+						"LockMode": {},
 					},
 				}
 				ty := recv[0].Type


### PR DESCRIPTION

This PR implements the `pg_catalog.pg_locks` view for advisory locks, providing PostgreSQL-compatible visibility into granted and waiting advisory locks. To support this, it introduces in-memory tracking of transaction-scoped advisory locks and exposes them via new virtual tables and RPCs.

### Summary of Changes

1.  **Advisory Lock Tracking**:
    *   Enhanced `advisorylock.Manager` to maintain an acquisition stack for transaction-scoped locks.
    *   Integrated tracking with SQL savepoints (`SAVEPOINT`, `ROLLBACK TO`, `RELEASE`) and statement-level rewinds.
    *   Ensured lock state persists across transaction restarts and refreshes, mirroring the underlying KV intent behavior.

2.  **Cluster-Wide Visibility**:
    *   Updated the `ListSessions` RPC and `serverpb.Session` protobuf to include held advisory locks.
    *   Added `crdb_internal.cluster_held_advisory_locks` (with `session_id`, `lock_key`, and `lock_mode` columns) to expose session-local lock state cluster-wide.

3.  **PostgreSQL Compatibility**:
    *   Replaced the placeholder `pg_catalog.pg_locks` table with a functional view.
    *   The view unions granted locks (via `cluster_held_advisory_locks`) and waiting locks (via `cluster_locks` joined on `system.advisory_locks`).
    *   Implemented parsing logic to map CockroachDB's internal lock keys back to PostgreSQL-compatible `classid`, `objid`, and `objsubid` columns.

### Testing Details

*   **Logic Tests**: Expanded `pkg/sql/logictest/testdata/logic_test/advisory_lock` to cover complex nested savepoints and `RELEASE SAVEPOINT` scenarios.
*   **Unit Tests**: Added `pkg/sql/pg_locks_test.go` to verify `pg_locks` visibility for both granted and waiting (blocked) transactions.


Fixes: #169164
Release note (sql): Added support for the pg_locks table, which only supports the monitoring of advisory locks.