### PR TITLE
logictest: deflake advisory_lock

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/advisory_lock
+++ b/pkg/sql/logictest/testdata/logic_test/advisory_lock
@@ -111,6 +111,7 @@ COMMIT
 
 user testuser
 
+retry
 query B
 SELECT pg_try_advisory_xact_lock(4242424242)
 ----
@@ -340,6 +341,9 @@ COMMIT
 
 user testuser
 
+# Intent resolution is asynchronous, so after the commit it may be possible
+# that the lock is still held by the other session.
+retry
 query B
 SELECT pg_try_advisory_xact_lock(702345678)
 ----
@@ -377,6 +381,9 @@ COMMIT
 
 user testuser
 
+# Intent resolution is asynchronous, so after the commit it may be possible
+# that the lock is still held by the other session.
+retry
 query B
 SELECT pg_try_advisory_xact_lock_shared(703456789)
 ----
@@ -405,6 +412,7 @@ user testuser
 statement ok
 BEGIN
 
+retry
 query B
 SELECT pg_try_advisory_xact_lock(705678901)
 ----


### PR DESCRIPTION
Previously, the advisory_lock test for pg_try_advisory_xact* could flake, since intent release on COMMIT is asynchronous. To address this, these sub tests now have a retry.

Fixes: #169032
Fixes: #168984
Fixes: #169023
Fixes: #169022
Fixes: #168985
Fixes: #169168
Fixes: #169163
Fixes: #169165
Fixes: #169162
Fixes: #169160

Release note: None