### PR TITLE
sql/row: revert per-query txn reuse for external row data fetches

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -310,69 +310,53 @@ func makeExternalSpanSendFunc(
 	batchRequestsIssued *int64,
 	kvCPUTime *int64,
 ) sendFunc {
-	// Use a background context for the txn lifetime since it outlives any
-	// single request context.
-	bgCtx := context.Background()
-
-	// Lazily create a single read-only transaction with a fixed timestamp for
-	// all batch requests. The txn is initialized on the first batch request so
-	// that we can use the priority from that batch's AdmissionHeader. A
-	// read-only txn at a fixed timestamp is safe to reuse. The txn does not need
-	// explicit cleanup via Commit or Rollback — read-only transactions hold no
-	// server-side resources (no transaction record, no intents), so they can
-	// simply be garbage collected.
-	var txn *kv.Txn
-
-	nodeID, _ := db.Context().NodeID.OptionalNodeID()
-
-	sf := func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
-		if txn == nil {
-			txn = kv.NewTxnWithAdmissionControl(
-				bgCtx, db, nodeID,
-				kvpb.AdmissionHeader_FROM_SQL,
-				admissionpb.WorkPriority(ba.AdmissionHeader.Priority),
-			)
-			if err := txn.SetFixedTimestamp(bgCtx, ext.AsOf); err != nil {
-				return nil, err
-			}
-		}
-
+	return func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
 		for _, req := range ba.Requests {
+			// We only allow external row data for a few known types of request.
 			switch r := req.GetInner().(type) {
 			case *kvpb.GetRequest:
 			case *kvpb.ScanRequest:
 			case *kvpb.ReverseScanRequest:
 			default:
-				return nil, errors.AssertionFailedf(
-					"request type %T unsupported for external row data", r,
-				)
+				return nil, errors.AssertionFailedf("request type %T unsupported for external row data", r)
 			}
 		}
+		log.VEventf(ctx, 2, "kv external fetcher: sending a batch with %d requests", len(ba.Requests))
 
-		if log.V(2) {
-			log.VEventf(
-				ctx, 2,
-				"kv external fetcher: sending a batch with %d requests",
-				len(ba.Requests),
-			)
-		}
-
-		res, pErr := txn.Send(ctx, ba)
-		// Note that in some code paths there is no concurrency when using
-		// the sendFunc, but we choose to unconditionally use atomics here
-		// since its overhead should be negligible in the grand scheme of
-		// things anyway.
+		// Open a new transaction with fixed timestamp set to the external
+		// timestamp. We must do this with txn.Send rather than using
+		// db.NonTransactionalSender to get the 1-to-1 request-response guarantee
+		// required by txnKVFetcher.
+		// TODO(michae2): Explore whether we should keep this transaction open for
+		// the duration of the surrounding transaction.
+		var res *kvpb.BatchResponse
+		err := db.TxnWithAdmissionControl(
+			ctx, ba.AdmissionHeader.Source, admissionpb.WorkPriority(ba.AdmissionHeader.Priority),
+			kv.SteppingDisabled,
+			func(ctx context.Context, txn *kv.Txn) error {
+				if err := txn.SetFixedTimestamp(ctx, ext.AsOf); err != nil {
+					return err
+				}
+				var err *kvpb.Error
+				res, err = txn.Send(ctx, ba)
+				if err != nil {
+					return err.GoError()
+				}
+				return nil
+			})
+		// Note that in some code paths there is no concurrency when using the
+		// sendFunc, but we choose to unconditionally use atomics here since its
+		// overhead should be negligible in the grand scheme of things anyway.
 		atomic.AddInt64(batchRequestsIssued, 1)
-		if pErr != nil {
-			return nil, pErr.GoError()
+		if err != nil {
+			return nil, err
 		}
+
 		if res.CPUTime > 0 {
 			atomic.AddInt64(kvCPUTime, res.CPUTime)
 		}
 		return res, nil
 	}
-
-	return sf
 }
 
 type newTxnKVFetcherArgs struct {


### PR DESCRIPTION
This reverts commit 93748d78377 (#164857), which changed
`makeExternalSpanSendFunc` to lazily create a single `kv.Txn` and reuse
it across all batch requests instead of creating a new txn per batch via
`db.TxnWithAdmissionControl`.

The reused txn was a RootTxn, which has `allowConcurrentRequests = false`
in the `txnLockGatekeeper`. When the `sendFunc` is used via the
kvstreamer (e.g. for lookup joins or index joins on standby tables), the
Streamer launches multiple goroutines that call `sendFn` concurrently
(`workerCoordinator.performRequestAsync`). Those concurrent calls to
`txn.Send` on the shared RootTxn trigger `concurrent txn use detected`.

Before the reverted PR, each `sendFn` invocation created its own
independent txn, so concurrent Streamer goroutines were safe.

As a follow-up on master, we could re-land the optimization by using a
single LeafTxn (which allows concurrent requests) instead of a RootTxn.

Epic: none
Release note: None