### PR TITLE
release-24.3: roachtest: add exit code 13 for storage invariant violations

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -46,6 +46,11 @@ const (
 	// created due to errors during cloud hardware allocation.
 	ExitCodeClusterProvisioningFailed = 11
 
+	// ExitCodeStorageInvariantViolation is the exit code indicating that a
+	// storage invariant violation (e.g., raft log corruption, Pebble checksum
+	// mismatch) was detected during a roachtest run.
+	ExitCodeStorageInvariantViolation = 13
+
 	// runnerLogsDir is the dir under the artifacts root where the test runner log
 	// and other runner-related logs (i.e. cluster creation logs) will be written.
 	runnerLogsDir = "_runner-logs"
@@ -222,7 +227,9 @@ this command does no setup/teardown of clusters.`,
 
 	if err := rootCmd.Execute(); err != nil {
 		code := 1
-		if errors.Is(err, errTestsFailed) {
+		if errors.Is(err, errStorageInvariantViolation) {
+			code = ExitCodeStorageInvariantViolation
+		} else if errors.Is(err, errTestsFailed) {
 			code = ExitCodeTestsFailed
 		}
 		if errors.Is(err, errSomeClusterProvisioningFailed) {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -62,6 +62,10 @@ var (
 	// reference error used by main.go at the end of a run of tests
 	errSomeClusterProvisioningFailed = fmt.Errorf("some clusters could not be created")
 
+	// errStorageInvariantViolation error sent after a run in [testRunner.Run]
+	// if any worker detected a storage invariant violation.
+	errStorageInvariantViolation = fmt.Errorf("potential data corruption: storage invariant violation detected")
+
 	prometheusNameSpace = "roachtest"
 	// prometheusScrapeInterval should be consistent with the scrape interval defined in
 	// https://grafana.testeng.crdb.io/prometheus/config
@@ -167,6 +171,10 @@ type testRunner struct {
 
 	// Counts cluster creation errors across all workers.
 	numClusterErrs int32
+
+	// storageInvariantViolation is set when a storage invariant violation
+	// is detected by maybeSaveClusterDueToInvariantProblems.
+	storageInvariantViolation atomic.Bool
 }
 
 // newTestRunner constructs a testRunner.
@@ -431,6 +439,10 @@ func (r *testRunner) Run(
 	passFailLine := r.generateReport()
 	shout(ctx, l, lopt.stdout, passFailLine)
 
+	if r.storageInvariantViolation.Load() {
+		shout(ctx, l, lopt.stdout, "potential data corruption: invariant violation detected")
+		return errStorageInvariantViolation
+	}
 	if r.numClusterErrs > 0 {
 		shout(ctx, l, lopt.stdout, "%d clusters could not be created", r.numClusterErrs)
 		return errSomeClusterProvisioningFailed
@@ -1588,6 +1600,7 @@ func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 				snapName = "<failed>"
 			}
 			c.Save(ctx, "invariant problem - snap name "+snapName, t.L())
+			r.storageInvariantViolation.Store(true)
 			t.Error("invariant problem - snap name " + snapName + ":\n" + det.Stdout)
 			return
 		}

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"math/rand"
 	"path/filepath"
@@ -717,4 +718,45 @@ func TestVMPreemptionPolling(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+}
+
+func TestRunnerInvariantViolation(t *testing.T) {
+	for _, testFailed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("failed=%t", testFailed), func(t *testing.T) {
+			ctx := context.Background()
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+			cr := newClusterRegistry()
+			runner := newUnitTestRunner(cr, stopper)
+
+			var buf syncedBuffer
+			copt := defaultClusterOpt()
+			lopt := defaultLoggingOpt(&buf)
+			test := registry.TestSpec{
+				Name:             `invariant`,
+				Owner:            OwnerUnitTest,
+				Timeout:          10 * time.Second,
+				Cluster:          spec.MakeClusterSpec(0),
+				CompatibleClouds: registry.AllClouds,
+				Suites:           registry.Suites(registry.Nightly),
+				CockroachBinary:  registry.StandardCockroach,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					if testFailed {
+						t.Fatal("boom")
+					}
+				},
+			}
+
+			// Simulate an invariant violation detected during teardown.
+			runner.storageInvariantViolation.Store(true)
+
+			err := runner.Run(ctx, []registry.TestSpec{test}, 1, /* count */
+				defaultParallelism, copt, testOpts{}, lopt)
+
+			// The storage invariant violation takes precedence over test
+			// failures, so we expect errStorageInvariantViolation regardless
+			// of whether the test itself passed or failed.
+			require.ErrorIs(t, err, errStorageInvariantViolation)
+		})
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #167798 on behalf of @williamchoe3.

----

When `maybeSaveClusterDueToInvariantProblems` detects storage corruption
(raft log corruption, Pebble checksum mismatch), roachtest now exits
with code 13 (`ExitCodeStorageInvariantViolation`) instead of the generic
code 10 (test failure). This lets TeamCity fire a dedicated alert for
potential data corruption.

Epic: none

----

Release justification: test only