### PR TITLE
changefeedccl: register changefeed.bare_table_names.enabled setting (25.3 backport)

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -360,3 +360,12 @@ var KafkaV2ErrorDetailsEnabled = settings.RegisterBoolSetting(
 	true,
 	settings.WithPublic,
 )
+
+// UseBareTableNames is used to enable and disable the use of bare table names
+// in changefeed topics.
+// Off by default so users can turn off before upgrade.
+var UseBareTableNames = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.bare_table_names.enabled",
+	"set to true to use bare table names in changefeed topics, false to use quoted table names; default is false",
+	false)


### PR DESCRIPTION
Backport-only PR for the [25.3 release branch].

Registers the \`changefeed.bare_table_names.enabled\` cluster setting introduced
in #149438 (which shipped in 25.4) so that operators on 25.3 can explicitly set
the value before upgrading. The setting is **not consulted** by any code path
in this release.

Default is \`false\` here so that an explicit value an operator sets is what
persists across the upgrade — clusters that have actively opted out keep their
opt-out, while clusters that never touched it pick up the post-upgrade default
(\`true\`) on 25.4.

Companion backport for 25.2 will follow with an identical diff.

Refs: #149438
Refs: #148181

Epic: none

Release note (cli change): The \`changefeed.bare_table_names.enabled\` cluster
setting is now available on 25.3. It has no effect in this release; operators
may set it to opt out of the bare-table-name behavior that becomes the default
in 25.4.

release justification: This change does not have any functionality impacts and helps users avoid breaking changes when upgrading. 