### PR TITLE
jobs: rename job updater types and methods to Deprecated

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -751,7 +751,9 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		// Update the job payload (non-volatile job definition) once, with the now
 		// resolved destination, updated description, etc. If we resume again we'll
 		// skip this whole block so this isn't an excessive update of payload.
-		if err := b.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := b.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			if err := md.CheckRunningOrReverting(); err != nil {
 				return err
 			}

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -5998,7 +5998,8 @@ func TestBatchedInsertStats(t *testing.T) {
 			// Reset the job state, for the next iteration of the test.
 			details := job.Details().(jobspb.RestoreDetails)
 			details.StatsInserted = false
-			require.NoError(t, job.NoTxn().SetDetails(ctx, details))
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			require.NoError(t, job.DeprecatedNoTxn().SetDetails(ctx, details))
 			var err error
 			job, err = registry.LoadJob(ctx, job.ID())
 			require.NoError(t, err)

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -355,7 +355,9 @@ func (b *backupResumer) ResumeCompaction(
 		// Update the job payload (non-volatile job definition) once, with the now
 		// resolved destination, updated description, etc. If we resume again we'll
 		// skip this whole block so this isn't an excessive update of payload.
-		if err := b.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := b.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			if err := md.CheckRunningOrReverting(); err != nil {
 				return err
 			}

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2024,7 +2024,9 @@ func createImportingDescriptors(
 		}
 
 		// Update the job once all descs have been prepared for ingestion.
-		err := r.job.WithTxn(txn).SetDetails(ctx, details)
+		//
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		err := r.job.DeprecatedWithTxn(txn).SetDetails(ctx, details)
 
 		// Emit to the event log now that the job has finished preparing descs.
 		emitRestoreJobEvent(ctx, p, jobs.StateRunning, r.job)
@@ -2285,7 +2287,8 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		// Ensure we have the latest copy of the job details.
 		details = r.job.Details().(jobspb.RestoreDetails)
 		details.DownloadSpans = downloadSpans
-		if err := r.job.NoTxn().SetDetails(ctx, details); err != nil {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := r.job.DeprecatedNoTxn().SetDetails(ctx, details); err != nil {
 			return errors.Wrap(err, "updating job details with download spans")
 		}
 	}
@@ -2992,7 +2995,8 @@ func insertStats(
 
 	// Mark the stats insertion complete.
 	details.StatsInserted = true
-	return errors.Wrap(job.NoTxn().SetDetails(ctx, details), "updating job marking stats insertion complete")
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return errors.Wrap(job.DeprecatedNoTxn().SetDetails(ctx, details), "updating job marking stats insertion complete")
 }
 
 // publishDescriptors updates the RESTORED descriptors' status from OFFLINE to
@@ -3249,7 +3253,8 @@ func (r *restoreResumer) publishDescriptors(
 	if details.OnlineImpl() {
 		details.PostDownloadTableAutoStatsSettings = tableAutoStatsSettings
 	}
-	if err := r.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := r.job.DeprecatedWithTxn(txn).SetDetails(ctx, details); err != nil {
 		return errors.Wrap(err,
 			"updating job details after publishing tables")
 	}
@@ -4116,7 +4121,8 @@ func (r *restoreResumer) restoreSystemTables(
 				// restarts don't try to import data over our migrated data. This would
 				// fail since the restored data would shadow the migrated keys.
 				details.SystemTablesMigrated[systemTable.systemTableName] = true
-				return r.job.WithTxn(txn).SetDetails(ctx, details)
+				//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+				return r.job.DeprecatedWithTxn(txn).SetDetails(ctx, details)
 			}); err != nil {
 				return err
 			}

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -595,7 +595,8 @@ func (r *restoreResumer) maybeCalculateTotalDownloadSpans(
 		return total, nil
 	}
 
-	if err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := r.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		md.Progress.GetRestore().TotalDownloadRequired = total
 		ju.UpdateProgress(md.Progress)
 		return nil
@@ -762,7 +763,8 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	// either case we can mark the job as done.
 	if total == 0 {
 		r.downloadJobProg = 1.0
-		return r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return r.job.DeprecatedNoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 			return 1.0
 		})
 	}
@@ -796,7 +798,8 @@ func (r *restoreResumer) waitForDownloadToComplete(
 		}
 
 		if timeutil.Since(lastProgressUpdate) > time.Minute {
-			if err := r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if err := r.job.DeprecatedNoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 				return fractionComplete
 			}); err != nil {
 				return err

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -404,8 +404,9 @@ func finalizeAlterChangefeed(
 	if err != nil {
 		return err
 	}
-	if err := j.WithTxn(p.InternalSQLTxn()).Update(ctx, func(
-		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := j.DeprecatedWithTxn(p.InternalSQLTxn()).Update(ctx, func(
+		txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 	) error {
 		ju.UpdatePayload(&newPayload)
 		if newProgress != nil {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1831,8 +1831,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 	cf.metrics.FrontierUpdates.Inc(1)
 	if cf.js.job != nil {
 		var ptsUpdated bool
-		if err := cf.js.job.DebugNameNoTxn(changefeedJobProgressTxnName).Update(cf.Ctx(), func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := cf.js.job.DeprecatedDebugNameNoTxn(changefeedJobProgressTxnName).Update(cf.Ctx(), func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			var err error
 			if err = md.CheckRunningOrReverting(); err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1638,7 +1638,8 @@ func (b *changefeedResumer) setJobStatusMessage(
 	}
 
 	status := jobs.StatusMessage(fmt.Sprintf(fmtOrMsg, args...))
-	if err := b.job.NoTxn().UpdateStatusMessage(ctx, status); err != nil {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := b.job.DeprecatedNoTxn().UpdateStatusMessage(ctx, status); err != nil {
 		log.Changefeed.Warningf(ctx, "failed to set status: %v", err)
 	}
 
@@ -1675,7 +1676,9 @@ func (b *changefeedResumer) ensureClusterIDMatches(ctx context.Context, clusterI
 	if createdBy := b.job.Payload().CreationClusterID; createdBy == uuid.Nil {
 		// This cluster was upgraded from a version that did not set clusterID
 		// in the job record -- rectify this issue.
-		if err := b.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := b.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			md.Payload.CreationClusterID = clusterID
 			ju.UpdatePayload(md.Payload)
 			return nil
@@ -1758,7 +1761,8 @@ func (b *changefeedResumer) handleChangefeedError(
 		const errorFmt = "job failed (%v) but is being paused because of %s=%s"
 		errorMessage := fmt.Sprintf(errorFmt, changefeedErr,
 			changefeedbase.OptOnError, changefeedbase.OptOnErrorPause)
-		return b.job.NoTxn().PauseRequestedWithFunc(ctx, func(ctx context.Context, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return b.job.DeprecatedNoTxn().PauseRequestedWithFunc(ctx, func(ctx context.Context, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			// directly update running status to avoid the running/reverted job status check
 			md.Progress.StatusMessage = errorMessage
 			ju.UpdateProgress(md.Progress)
@@ -2468,8 +2472,9 @@ func maybeUpgradePreProductionReadyExpression(
 	}
 	details.Select = cdceval.AsStringUnredacted(newExpression)
 
-	if err := jobExec.ExecCfg().JobRegistry.UpdateJobWithTxn(ctx, jobID, nil, /* txn */
-		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := jobExec.ExecCfg().JobRegistry.DeprecatedUpdateJobWithTxn(ctx, jobID, nil, /* txn */
+		func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			payload := md.Payload
 			payload.Details = jobspb.WrapPayloadDetails(details)
 			ju.UpdatePayload(payload)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2423,7 +2423,8 @@ func TestChangefeedCanResumeWhenClusterIDMissing(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			return job.NoTxn().Update(context.Background(), func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			return job.DeprecatedNoTxn().Update(context.Background(), func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 				md.Payload.CreationClusterID = uuid.Nil
 				ju.UpdatePayload(md.Payload)
 				return nil

--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -340,7 +340,7 @@ SELECT id, status, payload, progress FROM system.jobs
 	jobsTable = make(doctor.JobsTable, 0)
 
 	if err := selectRowsMap(sqlConn, stmt, make([]driver.Value, 4), func(vals []driver.Value) error {
-		md := jobs.JobMetadata{}
+		md := jobs.DeprecatedJobMetadata{}
 		md.ID = jobspb.JobID(vals[0].(int64))
 		md.State = jobs.State(vals[1].(string))
 		md.Payload = &jobspb.Payload{}
@@ -517,7 +517,7 @@ func fromZipDir(
 			if len(fields) < 6 {
 				return errors.Errorf("expected at least 6 fields, got %d in crdb_internal.system_jobs.txt", len(fields))
 			}
-			md := jobs.JobMetadata{}
+			md := jobs.DeprecatedJobMetadata{}
 			md.State = jobs.State(fields[1])
 
 			id, err := strconv.Atoi(fields[0])
@@ -565,7 +565,7 @@ func fromZipDir(
 			return nil, nil, nil, errors.Wrapf(err, "failed to parse crdb_internal.system_jobs.json")
 		}
 		for _, job := range jobsTableJSON {
-			row := jobs.JobMetadata{
+			row := jobs.DeprecatedJobMetadata{
 				State: jobs.State(job.Status),
 			}
 			id, err := strconv.ParseInt(job.ID, 10, 64)

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -135,7 +135,8 @@ func (r *logicalReplicationResumer) updateStatusMessage(
 	ctx context.Context, status redact.RedactableString,
 ) {
 	log.Dev.Infof(ctx, "%s", status)
-	err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err := r.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		md.Progress.StatusMessage = string(status.Redact())
 		ju.UpdateProgress(md.Progress)
 		return nil
@@ -194,7 +195,8 @@ func (r *logicalReplicationResumer) checkpointPartitionURIs(
 	if uris[0].RoutingMode() == streamclient.RoutingModeGateway {
 		return nil
 	}
-	return r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return r.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		ldrProg := md.Progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
 		ldrProg.PartitionConnUris = partitionPgUrls
 		ju.UpdateProgress(md.Progress)
@@ -383,8 +385,9 @@ func (rh *rowHandler) handleRow(ctx context.Context, row tree.Datums) error {
 
 	rh.lastPartitionUpdate = timeutil.Now()
 	log.Dev.VInfof(ctx, 2, "persisting replicated time of %s", replicatedTime.GoTime())
-	if err := rh.job.NoTxn().Update(ctx,
-		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := rh.job.DeprecatedNoTxn().Update(ctx,
+		func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			if err := md.CheckRunningOrReverting(); err != nil {
 				return err
 			}

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2200,7 +2200,8 @@ func TestLogicalReplicationPlanner(t *testing.T) {
 	})
 	t.Run("generatePlan uses the latest replicated time for planning", func(t *testing.T) {
 		replicatedTime := hlc.Timestamp{WallTime: 142}
-		require.NoError(t, sj.Job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		require.NoError(t, sj.Job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			prog := md.Progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
 			prog.ReplicatedTime = replicatedTime
 			ju.UpdateProgress(md.Progress)

--- a/pkg/crosscluster/logical/resume_create_table.go
+++ b/pkg/crosscluster/logical/resume_create_table.go
@@ -214,7 +214,8 @@ func (r *logicalReplicationResumer) maybeStartReverseStream(
 		return errors.Wrapf(err, "failed to start reverse stream")
 	}
 
-	if err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := r.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		md.Progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication.StartedReverseStream = true
 		ju.UpdateProgress(md.Progress)
 		return nil
@@ -259,7 +260,8 @@ func (r *logicalReplicationResumer) maybePublishCreatedTables(
 		if err := txn.KV().Run(ctx, b); err != nil {
 			return err
 		}
-		return r.job.WithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return r.job.DeprecatedWithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			md.Progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication.PublishedNewTables = true
 			ju.UpdateProgress(md.Progress)
 			return nil

--- a/pkg/crosscluster/logical/txnmode/txnmode.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode.go
@@ -407,7 +407,8 @@ func (p *TxnLdrCoordinator) stageCheckpoint(ctx context.Context, applier *txnapp
 }
 
 func (p *TxnLdrCoordinator) checkpoint(ctx context.Context, frontier hlc.Timestamp) error {
-	return p.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return p.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}

--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -609,7 +609,8 @@ func applyCutoverTime(
 	replicatedTimeAtCutover hlc.Timestamp,
 ) error {
 	log.Dev.Infof(ctx, "adding cutover time %s to job record", cutoverTimestamp)
-	return job.WithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return job.DeprecatedWithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		progress := md.Progress.GetStreamIngest()
 		details := md.Payload.GetStreamIngestion()
 		if progress.ReplicationStatus == jobspb.ReplicationFailingOver {
@@ -641,8 +642,9 @@ func alterTenantExpirationWindow(
 	tenInfo *mtinfopb.TenantInfo,
 ) error {
 	for _, producerJobID := range tenInfo.PhysicalReplicationProducerJobIDs {
-		if err := jobRegistry.UpdateJobWithTxn(ctx, producerJobID, txn,
-			func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := jobRegistry.DeprecatedUpdateJobWithTxn(ctx, producerJobID, txn,
+			func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 
 				streamProducerDetails := md.Payload.GetStreamReplication()
 				previousExpirationWindow := streamProducerDetails.ExpirationWindow
@@ -671,8 +673,9 @@ func alterTenantConsumerOptions(
 	tenInfo *mtinfopb.TenantInfo,
 ) error {
 
-	return jobRegistry.UpdateJobWithTxn(ctx, tenInfo.PhysicalReplicationConsumerJobID, txn,
-		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return jobRegistry.DeprecatedUpdateJobWithTxn(ctx, tenInfo.PhysicalReplicationConsumerJobID, txn,
+		func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			var readerID roachpb.TenantID
 			if options.enableReaderTenant {
 				// If the replicating tenant already has a resolved tiemstamp, we can

--- a/pkg/crosscluster/physical/stream_ingestion_dist.go
+++ b/pkg/crosscluster/physical/stream_ingestion_dist.go
@@ -84,7 +84,8 @@ func startDistIngestion(
 			return err
 		}
 
-		if err := ingestionJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := ingestionJob.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			md.Progress.GetStreamIngest().InitialRevertRequired = false
 			ju.UpdateProgress(md.Progress)
 			updateStatusInternal(md, ju, jobspb.InitializingReplication, string(msg))
@@ -129,7 +130,8 @@ func startDistIngestion(
 	}
 
 	if planner.initialPartitionPgUrls[0].RoutingMode() != streamclient.RoutingModeGateway {
-		err = ingestionJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		err = ingestionJob.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			// Persist the initial Stream Addresses to the jobs table before execution begins.
 			if len(planner.initialPartitionPgUrls) == 0 {
 				return jobs.MarkAsPermanentJobError(errors.AssertionFailedf(
@@ -279,7 +281,8 @@ func startDistIngestion(
 		replicationStatusForFlow = jobspb.InitialScan
 	}
 
-	if err := ingestionJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := ingestionJob.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		md.Progress.GetStreamIngest().ReplicationStatus = replicationStatusForFlow
 		md.Progress.GetStreamIngest().InitialSplitComplete = true
 		md.Progress.StatusMessage = replicationStatusForFlow.String()

--- a/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -346,8 +346,9 @@ func (sf *streamIngestionFrontier) maybeUpdateProgress() error {
 
 	sf.aggregateAndUpdateRangeMetrics()
 
-	if err := registry.UpdateJobWithTxn(ctx, jobID, nil /* txn */, func(
-		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := registry.DeprecatedUpdateJobWithTxn(ctx, jobID, nil /* txn */, func(
+		txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 	) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err

--- a/pkg/crosscluster/physical/stream_ingestion_job.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job.go
@@ -257,7 +257,8 @@ func updateStatus(
 	replicationStatus jobspb.ReplicationStatus,
 	status redact.RedactableString,
 ) {
-	err := ingestionJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err := ingestionJob.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		updateStatusInternal(md, ju, replicationStatus, string(status.Redact()))
 		return nil
 	})
@@ -271,8 +272,8 @@ func updateStatus(
 }
 
 func updateStatusInternal(
-	md jobs.JobMetadata,
-	ju *jobs.JobUpdater,
+	md jobs.DeprecatedJobMetadata,
+	ju *jobs.DeprecatedJobUpdater,
 	replicationStatus jobspb.ReplicationStatus,
 	status string,
 ) {
@@ -637,8 +638,9 @@ func (s *streamIngestionResumer) protectDestinationTenant(
 		if err := ptp.Protect(ctx, pts); err != nil {
 			return err
 		}
-		return s.job.WithTxn(txn).Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return s.job.DeprecatedWithTxn(txn).Update(ctx, func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			if err := md.CheckRunningOrReverting(); err != nil {
 				return err
@@ -695,8 +697,9 @@ func maybeRevertToCutoverTimestamp(
 		remainingSpansToRevert roachpb.Spans
 		readerTenantID         roachpb.TenantID
 	)
-	if err := ingestionJob.NoTxn().Update(ctx,
-		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := ingestionJob.DeprecatedNoTxn().Update(ctx,
+		func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			streamIngestionDetails := md.Payload.GetStreamIngestion()
 			if streamIngestionDetails == nil {
 				return errors.AssertionFailedf("unknown payload %v in stream ingestion job %d",
@@ -1020,7 +1023,8 @@ func (c *cutoverProgressTracker) updateJobProgress(
 		return fractionRangesFinished
 	}
 
-	if err := c.job.NoTxn().FractionProgressed(ctx, persistProgress); err != nil {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := c.job.DeprecatedNoTxn().FractionProgressed(ctx, persistProgress); err != nil {
 		return jobs.SimplifyInvalidStateError(err)
 	}
 	if c.onJobProgressUpdate != nil {

--- a/pkg/crosscluster/physical/stream_ingestion_job_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job_test.go
@@ -494,7 +494,8 @@ func TestCutoverFractionProgressed(t *testing.T) {
 	jobID := registry.MakeJobID()
 	replicationJob, err := registry.CreateJobWithTxn(ctx, mockReplicationJobRecord, jobID, nil)
 	require.NoError(t, err)
-	require.NoError(t, replicationJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	require.NoError(t, replicationJob.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}

--- a/pkg/crosscluster/producer/stream_lifetime.go
+++ b/pkg/crosscluster/producer/stream_lifetime.go
@@ -183,8 +183,9 @@ func updateReplicationStreamProgress(
 			return status, notAReplicationJobError(jobspb.JobID(streamID))
 		}
 		expiration := updateBegin.Add(details.ExpirationWindow)
-		if err := j.WithTxn(txn).Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := j.DeprecatedWithTxn(txn).Update(ctx, func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			status = streampb.StreamReplicationStatus{}
 			pts := ptsProvider.WithTxn(txn)
@@ -354,8 +355,9 @@ func completeReplicationStream(
 	if _, ok := j.Details().(jobspb.StreamReplicationDetails); !ok {
 		return notAReplicationJobError(jobspb.JobID(streamID))
 	}
-	return j.WithTxn(txn).Update(ctx, func(
-		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return j.DeprecatedWithTxn(txn).Update(ctx, func(
+		txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 	) error {
 		// Updates the stream ingestion status, make the job resumer exit running
 		// when picking up the new status.

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -628,8 +628,8 @@ func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqllivenes
 				})
 				log.Dev.Infof(ctx, "job %d, session %s: paused", id, s.ID())
 			case StateReverting:
-				if err := job.WithTxn(txn).Update(ctx, func(
-					txn isql.Txn, md JobMetadata, ju *JobUpdater,
+				if err := job.DeprecatedWithTxn(txn).Update(ctx, func(
+					txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater,
 				) error {
 					if !r.cancelRegisteredJobContext(id) {
 						// If we didn't already have a running job for this

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -24,24 +24,24 @@ func (r *Registry) CancelRequested(ctx context.Context, txn isql.Txn, id jobspb.
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).CancelRequested(ctx)
+	return job.DeprecatedWithTxn(txn).CancelRequested(ctx)
 }
 
 // Started is a wrapper around the internal function that moves a job to the
 // started state.
 func (j *Job) Started(ctx context.Context) error {
-	return j.NoTxn().started(ctx)
+	return j.DeprecatedNoTxn().started(ctx)
 }
 
 // Reverted is a wrapper around the internal function that moves a job to the
 // reverting state.
 func (j *Job) Reverted(ctx context.Context, err error) error {
-	return j.NoTxn().reverted(ctx, err, nil)
+	return j.DeprecatedNoTxn().reverted(ctx, err, nil)
 }
 
 // Paused is a helper to the paused state.
 func (j *Job) Paused(ctx context.Context) error {
-	return j.NoTxn().Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return j.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if md.State == StatePaused {
 			// Already paused - do nothing.
 			return nil
@@ -57,13 +57,13 @@ func (j *Job) Paused(ctx context.Context) error {
 // Failed is a wrapper around the internal function that moves a job to the
 // failed state.
 func (j *Job) Failed(ctx context.Context, causingErr error) error {
-	return j.NoTxn().failed(ctx, causingErr)
+	return j.DeprecatedNoTxn().failed(ctx, causingErr)
 }
 
 // Succeeded is a wrapper around the internal function that moves a job to the
 // succeeded state.
 func (j *Job) Succeeded(ctx context.Context) error {
-	return j.NoTxn().succeeded(ctx, nil /* fn */)
+	return j.DeprecatedNoTxn().succeeded(ctx, nil /* fn */)
 }
 
 // TestingCurrentState returns the current job state from the jobs table or error.

--- a/pkg/jobs/ingeststopped/ingesting_checker.go
+++ b/pkg/jobs/ingeststopped/ingesting_checker.go
@@ -55,7 +55,8 @@ func WaitForNoIngestingNodes(
 
 		if timeutil.Since(lastStatusUpdate) > statusUpdateFrequency {
 			status := jobs.StatusMessage(fmt.Sprintf("waiting for all nodes to finish ingesting writing before proceeding: %s", err))
-			if statusErr := job.NoTxn().UpdateStatusMessage(ctx, status); statusErr != nil {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if statusErr := job.DeprecatedNoTxn().UpdateStatusMessage(ctx, status); statusErr != nil {
 				log.Dev.Warningf(ctx, "failed to update running status of job %d: %s", job.ID(), statusErr)
 			} else {
 				lastStatusUpdate = timeutil.Now()

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -240,13 +240,13 @@ func (j *Job) taskName() redact.SafeString {
 
 // Started marks the tracked job as started by updating state to running in
 // jobs table.
-func (u Updater) started(ctx context.Context) error {
+func (u DeprecatedUpdater) started(ctx context.Context) error {
 	sp := tracing.SpanFromContext(ctx)
 	traceID := tracingpb.TraceID(0)
 	if sp != nil {
 		traceID = sp.TraceID()
 	}
-	return u.Update(ctx, func(_ isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return u.Update(ctx, func(_ isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if md.State != StatePending && md.State != StateRunning {
 			return errors.Errorf("job with state %s cannot be marked started", md.State)
 		}
@@ -265,15 +265,15 @@ func (u Updater) started(ctx context.Context) error {
 
 // CheckState verifies the state of the job and returns an error if the job's
 // state isn't Running or Reverting.
-func (u Updater) CheckState(ctx context.Context) error {
-	return u.Update(ctx, func(_ isql.Txn, md JobMetadata, _ *JobUpdater) error {
+func (u DeprecatedUpdater) CheckState(ctx context.Context) error {
+	return u.Update(ctx, func(_ isql.Txn, md DeprecatedJobMetadata, _ *DeprecatedJobUpdater) error {
 		return md.CheckRunningOrReverting()
 	})
 }
 
 // UpdateStatusMessage updates the detailed status of a job currently in progress.
-func (u Updater) UpdateStatusMessage(ctx context.Context, status StatusMessage) error {
-	return u.Update(ctx, func(_ isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) UpdateStatusMessage(ctx context.Context, status StatusMessage) error {
+	return u.Update(ctx, func(_ isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}
@@ -305,8 +305,10 @@ func FractionUpdater(f float32) FractionProgressedFn {
 //
 // Jobs for which progress computations do not depend on their details can
 // use the FractionUpdater helper to construct a ProgressedFn.
-func (u Updater) FractionProgressed(ctx context.Context, progressedFn FractionProgressedFn) error {
-	return u.Update(ctx, func(_ isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) FractionProgressed(
+	ctx context.Context, progressedFn FractionProgressedFn,
+) error {
+	return u.Update(ctx, func(_ isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}
@@ -349,15 +351,15 @@ func (u Updater) FractionProgressed(ctx context.Context, progressedFn FractionPr
 // Further the node the runs the job will actively cancel it when it notices
 // that it is in state StateCancelRequested and will move it to state
 // StateReverting.
-func (u Updater) CancelRequested(ctx context.Context) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) CancelRequested(ctx context.Context) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		return ju.CancelRequestedWithReason(ctx, md, errJobCanceled)
 	})
 }
 
 // onPauseRequestFunc is a function used to perform action on behalf of a job
 // implementation when a pause is requested.
-type onPauseRequestFunc func(ctx context.Context, md JobMetadata, ju *JobUpdater) error
+type onPauseRequestFunc func(ctx context.Context, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error
 
 // PauseRequestedWithFunc sets the state of the tracked job to pause-requested.
 // It does not directly pause the job; it expects the node that runs the job will
@@ -365,16 +367,16 @@ type onPauseRequestFunc func(ctx context.Context, md JobMetadata, ju *JobUpdater
 // and will move it to state StatePaused. If a function is passed, it will be
 // used to update the job state. If the job has builtin logic to run upon
 // pausing, it will be ignored; use PauseRequested if you want that logic to run.
-func (u Updater) PauseRequestedWithFunc(
+func (u DeprecatedUpdater) PauseRequestedWithFunc(
 	ctx context.Context, fn onPauseRequestFunc, reason string,
 ) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		return ju.PauseRequestedWithFunc(ctx, txn, md, fn, reason)
 	})
 }
 
 // reverted sets the state of the tracked job to reverted.
-func (u Updater) reverted(
+func (u DeprecatedUpdater) reverted(
 	ctx context.Context, err error, fn func(context.Context, isql.Txn) error,
 ) error {
 	sp := tracing.SpanFromContext(ctx)
@@ -383,7 +385,7 @@ func (u Updater) reverted(
 		traceID = sp.TraceID()
 	}
 
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if md.State != StateReverting &&
 			md.State != StateCancelRequested &&
 			md.State != StateRunning &&
@@ -418,8 +420,8 @@ func (u Updater) reverted(
 }
 
 // Canceled sets the state of the tracked job to cancel.
-func (u Updater) canceled(ctx context.Context) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) canceled(ctx context.Context) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if md.State == StateCanceled {
 			return nil
 		}
@@ -440,8 +442,8 @@ func (u Updater) canceled(ctx context.Context) error {
 }
 
 // Failed marks the tracked job as having failed with the given error.
-func (u Updater) failed(ctx context.Context, err error) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) failed(ctx context.Context, err error) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		// TODO(spaskob): should we fail if the terminal state is not StateFailed?
 		if md.State.Terminal() {
 			// Already done - do nothing.
@@ -482,10 +484,10 @@ func (u Updater) failed(ctx context.Context, err error) error {
 
 // RevertFailed marks the tracked job as having failed during revert with the
 // given error. Manual cleanup is required when the job is in this state.
-func (u Updater) revertFailed(
+func (u DeprecatedUpdater) revertFailed(
 	ctx context.Context, err error, fn func(context.Context, isql.Txn) error,
 ) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if md.State != StateReverting {
 			return fmt.Errorf("job with state %s cannot fail during a revert", md.State)
 		}
@@ -504,8 +506,10 @@ func (u Updater) revertFailed(
 
 // succeeded marks the tracked job as having succeeded and sets its fraction
 // completed to 1.0.
-func (u Updater) succeeded(ctx context.Context, fn func(context.Context, isql.Txn) error) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) succeeded(
+	ctx context.Context, fn func(context.Context, isql.Txn) error,
+) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if md.State == StateSucceeded {
 			return nil
 		}
@@ -529,8 +533,8 @@ func (u Updater) succeeded(ctx context.Context, fn func(context.Context, isql.Tx
 }
 
 // SetDetails sets the details field of the currently running tracked job.
-func (u Updater) SetDetails(ctx context.Context, details interface{}) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) SetDetails(ctx context.Context, details interface{}) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}
@@ -541,8 +545,8 @@ func (u Updater) SetDetails(ctx context.Context, details interface{}) error {
 }
 
 // SetProgress sets the details field of the currently running tracked job.
-func (u Updater) SetProgress(ctx context.Context, details interface{}) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+func (u DeprecatedUpdater) SetProgress(ctx context.Context, details interface{}) error {
+	return u.Update(ctx, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}
@@ -660,7 +664,7 @@ func (j *Job) loadJobPayloadAndProgress(
 	return payload, progress, nil
 }
 
-func (u Updater) load(ctx context.Context) (retErr error) {
+func (u DeprecatedUpdater) load(ctx context.Context) (retErr error) {
 	if u.txn == nil {
 		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
@@ -887,7 +891,7 @@ func (sj *StartableJob) Cancel(ctx context.Context) error {
 			sj.registry.unregister(sj.ID())
 		}
 	}()
-	return sj.Job.NoTxn().CancelRequested(ctx)
+	return sj.Job.DeprecatedNoTxn().CancelRequested(ctx)
 }
 
 func (sj *StartableJob) recordStart() (alreadyStarted bool) {

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -171,7 +171,7 @@ type registryTestSuite struct {
 	failOrCancelCheckCh chan struct{}
 
 	// beforeUpdate is invoked in the BeforeUpdate testing knob if non-nil.
-	beforeUpdate func(orig, updated jobs.JobMetadata) error
+	beforeUpdate func(orig, updated jobs.DeprecatedJobMetadata) error
 
 	// afterJobStateMachine is invoked in the AfterJobStateMachine testing knob if
 	// non-nil.
@@ -193,7 +193,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) func() {
 	var args base.TestServerArgs
 	{
 		knobs := jobs.NewTestingKnobsWithShortIntervals()
-		knobs.BeforeUpdate = func(orig, updated jobs.JobMetadata) error {
+		knobs.BeforeUpdate = func(orig, updated jobs.DeprecatedJobMetadata) error {
 			if rts.beforeUpdate != nil {
 				return rts.beforeUpdate(orig, updated)
 			}
@@ -284,7 +284,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) func() {
 					case err := <-rts.resumeCh:
 						return err
 					case <-rts.progressCh:
-						err := job.NoTxn().FractionProgressed(rts.ctx, jobs.FractionUpdater(0))
+						err := job.DeprecatedNoTxn().FractionProgressed(rts.ctx, jobs.FractionUpdater(0))
 						if err != nil {
 							return err
 						}
@@ -795,7 +795,7 @@ func TestRegistryLifecycle(t *testing.T) {
 	t.Run("fail marking success and fail OnFailOrCancel", func(t *testing.T) {
 		var triedToMarkSucceeded atomic.Bool
 		var injectFailures atomic.Bool
-		rts := registryTestSuite{beforeUpdate: func(orig, updated jobs.JobMetadata) error {
+		rts := registryTestSuite{beforeUpdate: func(orig, updated jobs.DeprecatedJobMetadata) error {
 			// Fail marking succeeded.
 			if updated.State == jobs.StateSucceeded && injectFailures.Load() {
 				triedToMarkSucceeded.Store(true)
@@ -876,7 +876,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		// Inject an error in the update to move the job to "succeeded" one time.
 		var failed atomic.Value
 		failed.Store(false)
-		rts.beforeUpdate = func(orig, updated jobs.JobMetadata) error {
+		rts.beforeUpdate = func(orig, updated jobs.DeprecatedJobMetadata) error {
 			if orig.ID != id {
 				return nil
 			}
@@ -920,7 +920,7 @@ func TestRegistryLifecycle(t *testing.T) {
 	t.Run("fail marking failed", func(t *testing.T) {
 		var triedToMarkFailed atomic.Value
 		triedToMarkFailed.Store(false)
-		rts := registryTestSuite{beforeUpdate: func(orig, updated jobs.JobMetadata) error {
+		rts := registryTestSuite{beforeUpdate: func(orig, updated jobs.DeprecatedJobMetadata) error {
 			if triedToMarkFailed.Load().(bool) == true {
 				return nil
 			}
@@ -1250,7 +1250,7 @@ func TestJobLifecycle(t *testing.T) {
 			{0.0, 0.0}, {0.5, 0.5}, {0.5, 0.5}, {0.4, 0.4}, {0.8, 0.8}, {1.0, 1.0},
 		}
 		for _, f := range progresses {
-			if err := woodyJob.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(f.actual)); err != nil {
+			if err := woodyJob.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(f.actual)); err != nil {
 				t.Fatal(err)
 			}
 			woodyExp.FractionCompleted = f.expected
@@ -1260,7 +1260,7 @@ func TestJobLifecycle(t *testing.T) {
 		}
 
 		// Test Progressed callbacks.
-		if err := woodyJob.NoTxn().FractionProgressed(ctx, func(_ context.Context, details jobspb.ProgressDetails) float32 {
+		if err := woodyJob.DeprecatedNoTxn().FractionProgressed(ctx, func(_ context.Context, details jobspb.ProgressDetails) float32 {
 			details.(*jobspb.Progress_Restore).Restore.HighWater = roachpb.Key("mariana")
 			return 1.0
 		}); err != nil {
@@ -1307,7 +1307,7 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := buzzJob.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(.42)); err != nil {
+		if err := buzzJob.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(.42)); err != nil {
 			t.Fatal(err)
 		}
 		buzzExp.FractionCompleted = .42
@@ -1461,7 +1461,7 @@ func TestJobLifecycle(t *testing.T) {
 	t.Run("cancelable jobs can be canceled until finished", func(t *testing.T) {
 		{
 			job, exp := createDefaultJob()
-			if err := job.NoTxn().CancelRequested(ctx); err != nil {
+			if err := job.DeprecatedNoTxn().CancelRequested(ctx); err != nil {
 				t.Fatal(err)
 			}
 			if err := exp.verify(job.ID(), jobs.StateCancelRequested); err != nil {
@@ -1584,10 +1584,10 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(-0.1)); !testutils.IsError(err, "outside allowable range") {
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(-0.1)); !testutils.IsError(err, "outside allowable range") {
 			t.Fatalf("expected 'outside allowable range' error, but got %v", err)
 		}
-		if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(1.1)); !testutils.IsError(err, "outside allowable range") {
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(1.1)); !testutils.IsError(err, "outside allowable range") {
 			t.Fatalf("expected 'outside allowable range' error, but got %v", err)
 		}
 	})
@@ -1597,7 +1597,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.NoTxn().Update(ctx, func(_ isql.Txn, _ jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		if err := job.DeprecatedNoTxn().Update(ctx, func(_ isql.Txn, _ jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			return errors.Errorf("boom")
 		}); !testutils.IsError(err, "boom") {
 			t.Fatalf("expected 'boom' error, but got %v", err)
@@ -1612,7 +1612,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
 			err, `cannot update progress on succeeded job \(id \d+\)`,
 		) {
 			t.Fatalf("expected 'cannot update progress' error, but got %v", err)
@@ -1624,7 +1624,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := registry.PauseRequested(ctx, nil, job.ID(), ""); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
 			err, `cannot update progress on pause-requested job`,
 		) {
 			t.Fatalf("expected progress error, but got %v", err)
@@ -1636,7 +1636,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := registry.CancelRequested(ctx, nil, job.ID()); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.5)); !testutils.IsError(
 			err, `cannot update progress on cancel-requested job \(id \d+\)`,
 		) {
 			t.Fatalf("expected progress error, but got %v", err)
@@ -1648,7 +1648,7 @@ func TestJobLifecycle(t *testing.T) {
 		if err := job.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.2)); err != nil {
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.2)); err != nil {
 			t.Fatal(err)
 		}
 		if err := job.Succeeded(ctx); err != nil {
@@ -1668,14 +1668,14 @@ func TestJobLifecycle(t *testing.T) {
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 		newDetails := jobspb.ImportDetails{URIs: []string{"new"}}
 		exp.Record.Details = newDetails
-		require.NoError(t, job.NoTxn().SetDetails(ctx, newDetails))
+		require.NoError(t, job.DeprecatedNoTxn().SetDetails(ctx, newDetails))
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
-		require.NoError(t, job.NoTxn().SetDetails(ctx, newDetails))
+		require.NoError(t, job.DeprecatedNoTxn().SetDetails(ctx, newDetails))
 
 		// Now change job's session id and check that updates are rejected.
 		_, err := exp.DB.Exec(updateClaimStmt, "!@#!@$!$@#", job.ID())
 		require.NoError(t, err)
-		require.Error(t, job.NoTxn().SetDetails(ctx, newDetails))
+		require.Error(t, job.DeprecatedNoTxn().SetDetails(ctx, newDetails))
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 	})
 
@@ -1684,7 +1684,7 @@ func TestJobLifecycle(t *testing.T) {
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 		_, err := exp.DB.Exec(updateStateStmt, jobs.StateCancelRequested, job.ID())
 		require.NoError(t, err)
-		require.Error(t, job.NoTxn().SetDetails(ctx, jobspb.ImportDetails{URIs: []string{"new"}}))
+		require.Error(t, job.DeprecatedNoTxn().SetDetails(ctx, jobspb.ImportDetails{URIs: []string{"new"}}))
 		require.NoError(t, exp.verify(job.ID(), jobs.StateCancelRequested))
 	})
 
@@ -1693,13 +1693,13 @@ func TestJobLifecycle(t *testing.T) {
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 		newProgress := jobspb.ImportProgress{ResumePos: []int64{42}}
 		exp.Record.Progress = newProgress
-		require.NoError(t, job.NoTxn().SetProgress(ctx, newProgress))
+		require.NoError(t, job.DeprecatedNoTxn().SetProgress(ctx, newProgress))
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 
 		// Now change job's session id and check that updates are rejected.
 		_, err := exp.DB.Exec(updateClaimStmt, "!@#!@$!$@#", job.ID())
 		require.NoError(t, err)
-		require.Error(t, job.NoTxn().SetDetails(ctx, newProgress))
+		require.Error(t, job.DeprecatedNoTxn().SetDetails(ctx, newProgress))
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 	})
 
@@ -1708,7 +1708,7 @@ func TestJobLifecycle(t *testing.T) {
 		require.NoError(t, exp.verify(job.ID(), jobs.StateRunning))
 		_, err := exp.DB.Exec(updateStateStmt, jobs.StatePauseRequested, job.ID())
 		require.NoError(t, err)
-		require.Error(t, job.NoTxn().SetProgress(ctx, jobspb.ImportProgress{ResumePos: []int64{42}}))
+		require.Error(t, job.DeprecatedNoTxn().SetProgress(ctx, jobspb.ImportProgress{ResumePos: []int64{42}}))
 		require.NoError(t, exp.verify(job.ID(), jobs.StatePauseRequested))
 	})
 }
@@ -2936,7 +2936,7 @@ func TestLoseLeaseDuringExecution(t *testing.T) {
 					`UPDATE system.jobs SET claim_session_id = NULL WHERE id = $1`,
 					j.ID())
 				assert.NoError(t, err)
-				err = j.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+				err = j.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 					return nil
 				})
 				resumed <- err

--- a/pkg/jobs/jobsprotectedts/jobs_protected_ts_manager.go
+++ b/pkg/jobs/jobsprotectedts/jobs_protected_ts_manager.go
@@ -176,7 +176,9 @@ func (p *Manager) Protect(
 		return nil, nil
 	}
 	// Set up a new protected timestamp ID and install it on the job.
-	err := job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err := job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		// Check if the protected timestamp is visible in the txn.
 		protectedtsID := getProtectedTSOnJob(md.Payload.UnwrapDetails())
 		// If it's been removed lets create a new one.
@@ -214,7 +216,9 @@ func (p *Manager) Unprotect(ctx context.Context, job *jobs.Job) error {
 	}
 	// If we do find one then we need to clean up the protected timestamp,
 	// and remove it from the job.
-	return job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		// The job will get refreshed, so check one more time the protected
 		// timestamp still exists. The callback returned from Protect works
 		// on a previously cached copy.

--- a/pkg/jobs/metricspoller/job_statistics.go
+++ b/pkg/jobs/metricspoller/job_statistics.go
@@ -267,8 +267,9 @@ func processJobPTSRecord(
 		return nil
 	}
 
-	err = execCfg.JobRegistry.UpdateJobWithTxn(ctx, jobspb.JobID(jobID), txn,
-		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err = execCfg.JobRegistry.DeprecatedUpdateJobWithTxn(ctx, jobspb.JobID(jobID), txn,
+		func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			p := md.Payload
 			jobType, err := p.CheckType()
 			if err != nil {

--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -82,7 +82,7 @@ func DeprecatedNewChunkProgressLoggerForJob(
 ) *ChunkProgressLogger {
 	return NewChunkProgressLogger(
 		func(ctx context.Context, fraction float64) error {
-			return j.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
+			return j.DeprecatedNoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 				if progressedFn != nil {
 					progressedFn(ctx, details)
 				}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -176,14 +176,16 @@ type Registry struct {
 	creationKnobs syncutil.Map[jobspb.Type, func(Resumer) Resumer]
 }
 
-// UpdateJobWithTxn calls the Update method on an existing job with
+// DeprecatedUpdateJobWithTxn calls the Update method on an existing job with
 // jobID, using a transaction passed in the txn argument. Passing a
 // nil transaction means that a txn will be automatically created.
-func (r *Registry) UpdateJobWithTxn(
-	ctx context.Context, jobID jobspb.JobID, txn isql.Txn, updateFunc UpdateFn,
+//
+// Deprecated: See comment on DeprecatedUpdater for more information.
+func (r *Registry) DeprecatedUpdateJobWithTxn(
+	ctx context.Context, jobID jobspb.JobID, txn isql.Txn, updateFunc DeprecatedUpdateFn,
 ) error {
 	job := Job{registry: r, id: jobID}
-	return job.WithTxn(txn).Update(ctx, updateFunc)
+	return job.DeprecatedWithTxn(txn).Update(ctx, updateFunc)
 }
 
 // jobExecCtxMaker is a wrapper around sql.NewInternalPlanner. It returns an
@@ -870,7 +872,7 @@ func (r *Registry) LoadJobWithTxn(
 		id:       jobID,
 		registry: r,
 	}
-	if err := j.WithTxn(txn).load(ctx); err != nil {
+	if err := j.DeprecatedWithTxn(txn).load(ctx); err != nil {
 		return nil, err
 	}
 	return j, nil
@@ -893,7 +895,7 @@ func (r *Registry) LoadClaimedJobWithTxn(
 	if err != nil {
 		return nil, err
 	}
-	if err := j.WithTxn(txn).load(ctx); err != nil {
+	if err := j.DeprecatedWithTxn(txn).load(ctx); err != nil {
 		return nil, err
 	}
 	return j, nil
@@ -1311,7 +1313,7 @@ func (r *Registry) deleteJob(ctx context.Context, txn isql.Txn, id jobspb.JobID)
 func (r *Registry) PauseRequested(
 	ctx context.Context, txn isql.Txn, id jobspb.JobID, reason string,
 ) error {
-	return r.UpdateJobWithTxn(ctx, id, txn, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return r.DeprecatedUpdateJobWithTxn(ctx, id, txn, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		return ju.PauseRequestedWithFunc(ctx, txn, md, nil /* fn */, reason)
 	})
 }
@@ -1319,7 +1321,7 @@ func (r *Registry) PauseRequested(
 // Unpause changes the paused job with id to running or reverting using the
 // specified txn (may be nil).
 func (r *Registry) Unpause(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
-	return r.UpdateJobWithTxn(ctx, id, txn, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
+	return r.DeprecatedUpdateJobWithTxn(ctx, id, txn, func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error {
 		return ju.Unpaused(ctx, md)
 	})
 }
@@ -1335,7 +1337,7 @@ func (r *Registry) UnsafeFailed(
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).failed(ctx, causingError)
+	return job.DeprecatedWithTxn(txn).failed(ctx, causingError)
 }
 
 // Succeeded marks the job with id as succeeded.
@@ -1346,7 +1348,7 @@ func (r *Registry) Succeeded(ctx context.Context, txn isql.Txn, id jobspb.JobID)
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).succeeded(ctx, nil)
+	return job.DeprecatedWithTxn(txn).succeeded(ctx, nil)
 }
 
 // Resumer is a resumable job, and is associated with a Job object. Jobs can be
@@ -1646,7 +1648,7 @@ func (r *Registry) stepThroughStateMachine(
 		resumeCtx, undo := pprofutil.SetProfilerLabelsFromCtxTags(resumeCtx)
 		defer undo()
 
-		if err := job.NoTxn().started(ctx); err != nil {
+		if err := job.DeprecatedNoTxn().started(ctx); err != nil {
 			return err
 		}
 
@@ -1718,7 +1720,7 @@ func (r *Registry) stepThroughStateMachine(
 		return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 			"job %d: unexpected state %s provided to state machine", job.ID(), state)
 	case StateCanceled:
-		if err := job.NoTxn().canceled(ctx); err != nil {
+		if err := job.DeprecatedNoTxn().canceled(ctx); err != nil {
 			// If we can't transactionally mark the job as canceled then it will be
 			// restarted during the next adopt loop and reverting will be retried.
 			return errors.WithSecondaryError(
@@ -1734,7 +1736,7 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 				"job %d: successful but unexpected error provided", job.ID())
 		}
-		err := job.NoTxn().succeeded(ctx, nil /* fn */)
+		err := job.DeprecatedNoTxn().succeeded(ctx, nil /* fn */)
 		switch {
 		case err == nil:
 			telemetry.Inc(TelemetryMetrics[jobType].Successful)
@@ -1746,7 +1748,7 @@ func (r *Registry) stepThroughStateMachine(
 		}
 		return err
 	case StateReverting:
-		if err := job.NoTxn().reverted(ctx, jobErr, nil /* fn */); err != nil {
+		if err := job.DeprecatedNoTxn().reverted(ctx, jobErr, nil /* fn */); err != nil {
 			// If we can't transactionally mark the job as reverting then it will be
 			// restarted during the next adopt loop and it will be retried.
 			return errors.WithSecondaryError(
@@ -1786,7 +1788,7 @@ func (r *Registry) stepThroughStateMachine(
 		if jobErr == nil {
 			return errors.AssertionFailedf("job %d: has StateFailed but no error was provided", job.ID())
 		}
-		if err := job.NoTxn().failed(ctx, jobErr); err != nil {
+		if err := job.DeprecatedNoTxn().failed(ctx, jobErr); err != nil {
 			// If we can't transactionally mark the job as failed then it will be
 			// restarted during the next adopt loop and reverting will be retried.
 			return errors.WithSecondaryError(
@@ -1805,7 +1807,7 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.AssertionFailedf("job %d: has StateRevertFailed but no error was provided",
 				job.ID())
 		}
-		if err := job.NoTxn().revertFailed(ctx, jobErr, nil /* fn */); err != nil {
+		if err := job.DeprecatedNoTxn().revertFailed(ctx, jobErr, nil /* fn */); err != nil {
 			// If we can't transactionally mark the job as failed then it will be
 			// restarted during the next adopt loop and reverting will be retried.
 			return errors.WithSecondaryError(

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -52,7 +52,7 @@ type TestingKnobs struct {
 	// BeforeUpdate is called in the update transaction after the update function
 	// has run. If an error is returned, it will be propagated and the update will
 	// not be committed.
-	BeforeUpdate func(orig, updated JobMetadata) error
+	BeforeUpdate func(orig, updated DeprecatedJobMetadata) error
 
 	// IntervalOverrides consists of override knobs for job intervals.
 	IntervalOverrides TestingIntervalOverrides

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -25,34 +25,55 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// UpdateFn is the callback passed to Job.Update. It is called from the context
+// DeprecatedUpdateFn is the callback passed to Job.Update. It is called from the context
 // of a transaction and is passed the current metadata for the job. The callback
 // can modify metadata using the JobUpdater and the changes will be persisted
 // within the same transaction.
 //
 // The function is free to modify contents of JobMetadata in place (but the
 // changes will be ignored unless JobUpdater is used).
-type UpdateFn func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error
+//
+// Deprecated: See comment on DeprecatedUpdater for more information.
+type DeprecatedUpdateFn func(txn isql.Txn, md DeprecatedJobMetadata, ju *DeprecatedJobUpdater) error
 
-type Updater struct {
+// DeprecatedUpdater implements methods for updating job metadata.
+//
+// Deprecated: The job updater api is deprecated in favor of the api in job_info_storage.go.
+// This api has been a source of bugs and edge cases in the jobs system, and is, in general,
+// overly complex for the problem it solves. The api in job_info_storage.go provides a more simple
+// and direct interface. Specifically, ProgressStorage.Set can be used for reporting human readable
+// progress, and InfoStorage can be used to fetch and store machine readable resumption state.
+// Additionally, for those migrating to the new api, jobs.LoadLegacyPayload, jobs.LoadLegacyProgress
+// and jobs.StoreLegacyProgress can be used for interacting with legacy protobuf schemes from the
+// new api.
+type DeprecatedUpdater struct {
 	j            *Job
 	txn          isql.Txn
 	txnDebugName string
 }
 
-func (j *Job) NoTxn() Updater {
-	return Updater{j: j}
+// DeprecatedNoTxn returns a DeprecatedUpdater with no txn set.
+//
+// Deprecated: See comment on DeprecatedUpdater for more information.
+func (j *Job) DeprecatedNoTxn() DeprecatedUpdater {
+	return DeprecatedUpdater{j: j}
 }
 
-func (j *Job) DebugNameNoTxn(txnDebugName string) Updater {
-	return Updater{j: j, txnDebugName: txnDebugName}
+// DeprecatedDebugNameNoTxn returns a DeprecatedUpdater with txnDebugName set to the passed string.
+//
+// Deprecated: See comment on DeprecatedUpdater for more information.
+func (j *Job) DeprecatedDebugNameNoTxn(txnDebugName string) DeprecatedUpdater {
+	return DeprecatedUpdater{j: j, txnDebugName: txnDebugName}
 }
 
-func (j *Job) WithTxn(txn isql.Txn) Updater {
-	return Updater{j: j, txn: txn}
+// DeprecatedWithTxn returns a DeprecatedUpdater with txn set to the passed isql.Txn.
+//
+// Deprecated: See comment on DeprecatedUpdater for more information.
+func (j *Job) DeprecatedWithTxn(txn isql.Txn) DeprecatedUpdater {
+	return DeprecatedUpdater{j: j, txn: txn}
 }
 
-func (u Updater) update(ctx context.Context, updateFn UpdateFn) (retErr error) {
+func (u DeprecatedUpdater) update(ctx context.Context, updateFn DeprecatedUpdateFn) (retErr error) {
 	if u.txn == nil {
 		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
@@ -158,14 +179,14 @@ WHERE id = $1
 		return errors.AssertionFailedf("expected int num_runs, but got %T", numRuns)
 	}
 
-	md := JobMetadata{
+	md := DeprecatedJobMetadata{
 		ID:       j.ID(),
 		State:    state,
 		Payload:  payload,
 		Progress: progress,
 	}
 
-	var ju JobUpdater
+	var ju DeprecatedJobUpdater
 	if err := updateFn(u.txn, md, &ju); err != nil {
 		return err
 	}
@@ -343,8 +364,10 @@ WHERE id = $1
 	return nil
 }
 
-// JobMetadata groups the job metadata values passed to UpdateFn.
-type JobMetadata struct {
+// DeprecatedJobMetadata groups the job metadata values passed to UpdateFn.
+//
+// This api is deprecated. See job_info_storage.go for better alternatives.
+type DeprecatedJobMetadata struct {
 	ID       jobspb.JobID
 	State    State
 	Payload  *jobspb.Payload
@@ -353,20 +376,22 @@ type JobMetadata struct {
 
 // CheckRunningOrReverting returns an InvalidStatusError if md.Status is not
 // StatusRunning or StatusReverting.
-func (md *JobMetadata) CheckRunningOrReverting() error {
+func (md *DeprecatedJobMetadata) CheckRunningOrReverting() error {
 	if md.State != StateRunning && md.State != StateReverting {
 		return &InvalidStateError{md.ID, md.State, "update progress on", md.Payload.Error}
 	}
 	return nil
 }
 
-// JobUpdater accumulates changes to job metadata that are to be persisted.
-type JobUpdater struct {
-	md JobMetadata
+// DeprecatedJobUpdater accumulates changes to job metadata that are to be persisted.
+//
+// This api is deprecated. See job_info_storage.go for better alternatives.
+type DeprecatedJobUpdater struct {
+	md DeprecatedJobMetadata
 }
 
 // UpdateState sets a new status (to be persisted).
-func (ju *JobUpdater) UpdateState(state State) {
+func (ju *DeprecatedJobUpdater) UpdateState(state State) {
 	ju.md.State = state
 }
 
@@ -374,27 +399,27 @@ func (ju *JobUpdater) UpdateState(state State) {
 //
 // WARNING: the payload can be large (resulting in a large KV for each version);
 // it shouldn't be updated frequently.
-func (ju *JobUpdater) UpdatePayload(payload *jobspb.Payload) {
+func (ju *DeprecatedJobUpdater) UpdatePayload(payload *jobspb.Payload) {
 	ju.md.Payload = payload
 }
 
 // UpdateProgress sets a new Progress (to be persisted).
-func (ju *JobUpdater) UpdateProgress(progress *jobspb.Progress) {
+func (ju *DeprecatedJobUpdater) UpdateProgress(progress *jobspb.Progress) {
 	ju.md.Progress = progress
 }
 
-func (ju *JobUpdater) hasUpdates() bool {
-	return ju.md != JobMetadata{}
+func (ju *DeprecatedJobUpdater) hasUpdates() bool {
+	return ju.md != DeprecatedJobMetadata{}
 }
 
-func (ju *JobUpdater) PauseRequested(
-	ctx context.Context, txn isql.Txn, md JobMetadata, reason string,
+func (ju *DeprecatedJobUpdater) PauseRequested(
+	ctx context.Context, txn isql.Txn, md DeprecatedJobMetadata, reason string,
 ) error {
 	return ju.PauseRequestedWithFunc(ctx, txn, md, nil /* fn */, reason)
 }
 
-func (ju *JobUpdater) PauseRequestedWithFunc(
-	ctx context.Context, txn isql.Txn, md JobMetadata, fn onPauseRequestFunc, reason string,
+func (ju *DeprecatedJobUpdater) PauseRequestedWithFunc(
+	ctx context.Context, txn isql.Txn, md DeprecatedJobMetadata, fn onPauseRequestFunc, reason string,
 ) error {
 	if md.State == StatePauseRequested || md.State == StatePaused {
 		return nil
@@ -421,7 +446,7 @@ func (ju *JobUpdater) PauseRequestedWithFunc(
 
 // Unpaused sets the state of the tracked job to running or reverting iff the
 // job is currently paused. It does not directly resume the job.
-func (ju *JobUpdater) Unpaused(_ context.Context, md JobMetadata) error {
+func (ju *DeprecatedJobUpdater) Unpaused(_ context.Context, md DeprecatedJobMetadata) error {
 	if md.State == StateRunning || md.State == StateReverting {
 		// Already resumed - do nothing.
 		return nil
@@ -439,12 +464,14 @@ func (ju *JobUpdater) Unpaused(_ context.Context, md JobMetadata) error {
 	return nil
 }
 
-func (ju *JobUpdater) CancelRequested(ctx context.Context, md JobMetadata) error {
+func (ju *DeprecatedJobUpdater) CancelRequested(
+	ctx context.Context, md DeprecatedJobMetadata,
+) error {
 	return ju.CancelRequestedWithReason(ctx, md, errJobCanceled)
 }
 
-func (ju *JobUpdater) CancelRequestedWithReason(
-	ctx context.Context, md JobMetadata, reason error,
+func (ju *DeprecatedJobUpdater) CancelRequestedWithReason(
+	ctx context.Context, md DeprecatedJobMetadata, reason error,
 ) error {
 	if md.Payload.Noncancelable {
 		return errors.Newf("job %d: not cancelable", md.ID)
@@ -487,10 +514,10 @@ func (ju *JobUpdater) CancelRequestedWithReason(
 //
 // Note that there are various convenience wrappers (like FractionProgressed)
 // defined in jobs.go.
-func (u Updater) Update(ctx context.Context, updateFn UpdateFn) error {
+func (u DeprecatedUpdater) Update(ctx context.Context, updateFn DeprecatedUpdateFn) error {
 	return u.update(ctx, updateFn)
 }
 
-func (u Updater) now() time.Time {
+func (u DeprecatedUpdater) now() time.Time {
 	return u.j.registry.clock.Now().GoTime()
 }

--- a/pkg/jobs/update_test.go
+++ b/pkg/jobs/update_test.go
@@ -130,18 +130,18 @@ func TestUpdaterUpdatesJobInfo(t *testing.T) {
 	j := createJob(defaultRecord)
 	t.Run("SetDetails", func(t *testing.T) {
 		newDetails := jobspb.ImportDetails{URIs: []string{"new"}}
-		require.NoError(t, j.NoTxn().SetDetails(ctx, newDetails))
+		require.NoError(t, j.DeprecatedNoTxn().SetDetails(ctx, newDetails))
 		runTests(t, j)
 	})
 
 	t.Run("SetProgress", func(t *testing.T) {
 		newProgress := jobspb.ImportProgress{WriteProgress: []float32{1.0}}
-		require.NoError(t, j.NoTxn().SetProgress(ctx, newProgress))
+		require.NoError(t, j.DeprecatedNoTxn().SetProgress(ctx, newProgress))
 		runTests(t, j)
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		require.NoError(t, j.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		require.NoError(t, j.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			md.Payload.StartedMicros = timeutil.Now().UnixNano()
 			md.Progress.TraceID = tracingpb.TraceID(123)
 			ju.UpdateProgress(md.Progress)
@@ -152,7 +152,7 @@ func TestUpdaterUpdatesJobInfo(t *testing.T) {
 	})
 
 	t.Run("FractionProgressed", func(t *testing.T) {
-		require.NoError(t, j.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.9)))
+		require.NoError(t, j.DeprecatedNoTxn().FractionProgressed(ctx, jobs.FractionUpdater(0.9)))
 		runTests(t, j)
 	})
 }

--- a/pkg/jobs/validate.go
+++ b/pkg/jobs/validate.go
@@ -17,7 +17,7 @@ import (
 // JobMetadataGetter is an interface used during job validation.
 // It is similar in principle to validate.ValidationDereferencer.
 type JobMetadataGetter interface {
-	GetJobMetadata(jobspb.JobID) (*JobMetadata, error)
+	GetJobMetadata(jobspb.JobID) (*DeprecatedJobMetadata, error)
 }
 
 // ValidateJobReferencesInDescriptor checks a catalog.Descriptor for
@@ -56,7 +56,7 @@ func ValidateJobReferencesInDescriptor(
 // to an accumulator function. We also have a second accumulator function for
 // keeping track of INFO level details that do not need to fail validation.
 func ValidateDescriptorReferencesInJob(
-	j JobMetadata,
+	j DeprecatedJobMetadata,
 	descLookupFn func(id descpb.ID) catalog.Descriptor,
 	errorAccFn func(error),
 	infoAccFn func(string),
@@ -94,7 +94,7 @@ func ValidateDescriptorReferencesInJob(
 	}
 }
 
-func collectDescriptorReferences(j JobMetadata) (ids catalog.DescriptorIDSet) {
+func collectDescriptorReferences(j DeprecatedJobMetadata) (ids catalog.DescriptorIDSet) {
 	switch j.Payload.Type() {
 	case jobspb.TypeSchemaChange:
 		sc := j.Payload.GetSchemaChange()

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -165,7 +165,8 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 			}
 
 			lastCheckpoint = rc.Checkpoint()
-			return r.job.NoTxn().SetProgress(ctx, jobspb.AutoSpanConfigReconciliationProgress{
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			return r.job.DeprecatedNoTxn().SetProgress(ctx, jobspb.AutoSpanConfigReconciliationProgress{
 				Checkpoint: rc.Checkpoint(),
 			})
 		}); err != nil {

--- a/pkg/sql/alter_job_owner.go
+++ b/pkg/sql/alter_job_owner.go
@@ -100,7 +100,8 @@ func (n *alterJobOwnerNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
-	return legacyJob.WithTxn(p.InternalSQLTxn()).Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return legacyJob.DeprecatedWithTxn(p.InternalSQLTxn()).Update(ctx, func(_ isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		md.Payload.UsernameProto = newOwner.EncodeProto()
 		ju.UpdatePayload(md.Payload)
 		return nil

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -975,7 +975,8 @@ func (sc *SchemaChanger) distIndexBackfill(
 	writeAsOf := jobDetails.WriteTimestamp
 	if writeAsOf.IsEmpty() {
 		status := jobs.StatusMessage("scanning target index for in-progress transactions")
-		if err := sc.job.NoTxn().UpdateStatusMessage(ctx, status); err != nil {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := sc.job.DeprecatedNoTxn().UpdateStatusMessage(ctx, status); err != nil {
 			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(sc.job.ID()))
 		}
 		writeAsOf = sc.clock.Now()
@@ -1010,11 +1011,13 @@ func (sc *SchemaChanger) distIndexBackfill(
 		) error {
 			details := sc.job.Details().(jobspb.SchemaChangeDetails)
 			details.WriteTimestamp = writeAsOf
-			return sc.job.WithTxn(txn).SetDetails(ctx, details)
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			return sc.job.DeprecatedWithTxn(txn).SetDetails(ctx, details)
 		}, metadataOnlyTxn); err != nil {
 			return err
 		}
-		if err := sc.job.NoTxn().UpdateStatusMessage(ctx, StatusBackfill); err != nil {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := sc.job.DeprecatedNoTxn().UpdateStatusMessage(ctx, StatusBackfill); err != nil {
 			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(sc.job.ID()))
 		}
 	} else {
@@ -1458,7 +1461,8 @@ func (sc *SchemaChanger) updateJobStatusMessage(
 			}
 		}
 		if updateJobRunningProgress && !tableDesc.Dropped() {
-			if err := sc.job.WithTxn(txn).UpdateStatusMessage(ctx, status); err != nil {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if err := sc.job.DeprecatedWithTxn(txn).UpdateStatusMessage(ctx, status); err != nil {
 				return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(sc.job.ID()))
 			}
 		}
@@ -2468,7 +2472,8 @@ func (sc *SchemaChanger) runStateMachineAfterTempIndexMerge(ctx context.Context)
 			return err
 		}
 		if sc.job != nil {
-			if err := sc.job.WithTxn(txn).UpdateStatusMessage(ctx, runStatus); err != nil {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if err := sc.job.DeprecatedWithTxn(txn).UpdateStatusMessage(ctx, runStatus); err != nil {
 				return errors.Wrap(err, "failed to update job status")
 			}
 		}

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -62,8 +62,9 @@ func (n *controlJobsNode) startExec(params runParams) error {
 			return errors.AssertionFailedf("%q: expected *DInt, found %T", jobIDDatum, jobIDDatum)
 		}
 
-		if err := reg.UpdateJobWithTxn(params.ctx, jobspb.JobID(*jobID), params.p.InternalSQLTxn(),
-			func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := reg.DeprecatedUpdateJobWithTxn(params.ctx, jobspb.JobID(*jobID), params.p.InternalSQLTxn(),
+			func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 				if err := jobsauth.Authorize(params.ctx, params.p,
 					md.ID, md.Payload.UsernameProto.Decode(), jobsauth.ControlAccess, globalPrivileges); err != nil {
 					return err

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6058,12 +6058,12 @@ type marshaledJobMetadataMap map[jobspb.JobID]marshaledJobMetadata
 // GetJobMetadata implements the jobs.JobMetadataGetter interface.
 func (m marshaledJobMetadataMap) GetJobMetadata(
 	jobID jobspb.JobID,
-) (md *jobs.JobMetadata, err error) {
+) (md *jobs.DeprecatedJobMetadata, err error) {
 	ujm, found := m[jobID]
 	if !found {
 		return nil, errors.New("job not found")
 	}
-	md = &jobs.JobMetadata{ID: jobID}
+	md = &jobs.DeprecatedJobMetadata{ID: jobID}
 	if ujm.status == nil {
 		return nil, errors.New("missing status")
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -1131,7 +1131,9 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) (r
 			// job progress to coerce out the correct error type. If the update succeeds
 			// then return the original error, otherwise return this error instead so
 			// it can be cleaned up at a higher level.
-			if jobErr := r.job.NoTxn().FractionProgressed(ctx, func(
+			//
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if jobErr := r.job.DeprecatedNoTxn().FractionProgressed(ctx, func(
 				ctx context.Context, _ jobspb.ProgressDetails,
 			) float32 {
 				// The job failed so the progress value here doesn't really matter.

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -58,10 +58,10 @@ func (nsr *NamespaceTableRow) GetID() descpb.ID {
 type NamespaceTable []NamespaceTableRow
 
 // JobsTable represents data read from `system.jobs`.
-type JobsTable []jobs.JobMetadata
+type JobsTable []jobs.DeprecatedJobMetadata
 
 // GetJobMetadata implements the jobs.JobMetadataGetter interface.
-func (jt JobsTable) GetJobMetadata(jobID jobspb.JobID) (*jobs.JobMetadata, error) {
+func (jt JobsTable) GetJobMetadata(jobID jobspb.JobID) (*jobs.DeprecatedJobMetadata, error) {
 	for i := range jt {
 		md := &jt[i]
 		if md.ID == jobID {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -463,8 +463,9 @@ func (p *planner) markTableMutationJobsSuccessful(
 			}
 			return err
 		}
-		if err := mutationJob.WithTxn(p.InternalSQLTxn()).Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := mutationJob.DeprecatedWithTxn(p.InternalSQLTxn()).Update(ctx, func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			status := md.State
 			switch status {

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -63,7 +63,8 @@ func initDetailsAndProgress(
 	var details jobspb.SchemaChangeGCDetails
 	var progress *jobspb.SchemaChangeGCProgress
 	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return job.WithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return job.DeprecatedWithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			details = *md.Payload.GetSchemaChangeGC()
 			progress = md.Progress.GetSchemaChangeGC()
 			if err := validateDetails(&details); err != nil {
@@ -258,7 +259,8 @@ func persistProgress(
 	status jobs.StatusMessage,
 ) {
 	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return job.WithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return job.DeprecatedWithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			if err := md.CheckRunningOrReverting(); err != nil {
 				return err
 			}

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -211,8 +211,9 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	format := details.Format
 
 	updateDetails := func(txn isql.Txn, details jobspb.ImportDetails) error {
-		return r.job.WithTxn(txn).Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return r.job.DeprecatedWithTxn(txn).Update(ctx, func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			pl := md.Payload
 			*pl.GetImport() = details
@@ -362,7 +363,8 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			); err != nil {
 				return err
 			}
-			return r.job.WithTxn(txn).SetDetails(ctx, details)
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			return r.job.DeprecatedWithTxn(txn).SetDetails(ctx, details)
 		}); err != nil {
 			return err
 		}
@@ -724,7 +726,8 @@ func (r *importResumer) publishTable(
 
 		// Update job record to mark table published state as complete.
 		details.TablePublished = true
-		err = r.job.WithTxn(txn).SetDetails(ctx, details)
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		err = r.job.DeprecatedWithTxn(txn).SetDetails(ctx, details)
 		if err != nil {
 			return errors.Wrap(err, "updating job details after publishing the table")
 		}
@@ -765,7 +768,8 @@ func (r *importResumer) checkVirtualConstraints(
 
 	if sql.HasVirtualUniqueConstraints(desc) {
 		status := jobs.StatusMessage(fmt.Sprintf("re-validating %s", desc.GetName()))
-		if err := job.NoTxn().UpdateStatusMessage(ctx, status); err != nil {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := job.DeprecatedNoTxn().UpdateStatusMessage(ctx, status); err != nil {
 			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(job.ID()))
 		}
 	}
@@ -1216,8 +1220,9 @@ func (r *importResumer) markOnline(
 			return errors.Wrap(err, "bringing IMPORT INTO table back online")
 		}
 
-		err = r.job.WithTxn(txn).Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		err = r.job.DeprecatedWithTxn(txn).Update(ctx, func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			// Mark the table as published to avoid running cleanup again.
 			details := md.Payload.GetImport()

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -91,8 +91,9 @@ func distImport(
 	// addStoragePrefix records a storage prefix before any SST is written to that
 	// location, ensuring cleanup can occur even if the job fails mid-import.
 	addStoragePrefix := func(ctx context.Context, prefix string) error {
-		return job.NoTxn().Update(ctx, func(
-			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return job.DeprecatedNoTxn().Update(ctx, func(
+			txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 		) error {
 			prog := md.Progress.GetImport()
 			if prog == nil {
@@ -169,7 +170,9 @@ func distImport(
 	importDetails := job.Progress().Details.(*jobspb.Progress_Import).Import
 	if importDetails.ReadProgress == nil {
 		// Initialize the progress metrics on the first attempt.
-		if err := job.NoTxn().FractionProgressed(ctx, func(
+		//
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := job.DeprecatedNoTxn().FractionProgressed(ctx, func(
 			ctx context.Context, details jobspb.ProgressDetails,
 		) float32 {
 			prog := details.(*jobspb.Progress_Import).Import

--- a/pkg/sql/importer/import_progress_tracker.go
+++ b/pkg/sql/importer/import_progress_tracker.go
@@ -185,8 +185,9 @@ func (t *importCheckpointTracker) Persist(ctx context.Context, job *jobs.Job) er
 	}
 
 	numFiles := t.numFiles
-	err = job.DebugNameNoTxn(importProgressDebugName).Update(ctx, func(
-		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err = job.DeprecatedDebugNameNoTxn(importProgressDebugName).Update(ctx, func(
+		txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 	) error {
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err

--- a/pkg/sql/inspect/progress.go
+++ b/pkg/sql/inspect/progress.go
@@ -642,7 +642,8 @@ func (t *inspectProgressTracker) flushProgress(ctx context.Context) error {
 		cachedInspectProgress = t.mu.cachedProgress.GetInspect()
 	}()
 
-	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return t.job.DeprecatedNoTxn().Update(ctx, func(_ isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		// Only write if any part of the inspect progress has changed.
 		currentInspectProgress := md.Progress.GetInspect()
 		if currentInspectProgress != nil &&

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -289,7 +289,8 @@ func (imt *IndexMergeTracker) FlushCheckpoint(ctx context.Context) error {
 		details.ResumeSpanList[progress.MutationIdx[idx]].ResumeSpans = progress.TodoSpans[idx]
 	}
 
-	return imt.jobMu.job.NoTxn().SetDetails(ctx, details)
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return imt.jobMu.job.DeprecatedNoTxn().SetDetails(ctx, details)
 }
 
 // FlushFractionCompleted writes out the fraction completed based on the number of total

--- a/pkg/sql/row/expr_walker.go
+++ b/pkg/sql/row/expr_walker.go
@@ -296,7 +296,7 @@ func (j *SeqChunkProvider) RequestChunk(
 	var hasAllocatedChunk bool
 	return j.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		var foundFromPreviouslyAllocatedChunk bool
-		resolveChunkFunc := func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		resolveChunkFunc := func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 			progress := md.Progress
 
 			// Check if we have already reserved a chunk corresponding to this row in a
@@ -355,7 +355,8 @@ func (j *SeqChunkProvider) RequestChunk(
 		if err != nil {
 			return err
 		}
-		if err := job.WithTxn(txn).Update(ctx, resolveChunkFunc); err != nil {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := job.DeprecatedWithTxn(txn).Update(ctx, resolveChunkFunc); err != nil {
 			return err
 		}
 

--- a/pkg/sql/rowexec/backfiller_test.go
+++ b/pkg/sql/rowexec/backfiller_test.go
@@ -141,14 +141,16 @@ func TestWriteResumeSpan(t *testing.T) {
 		t.Fatal(errors.Wrapf(err, "can't find job %d", jobID))
 	}
 
-	require.NoError(t, job.NoTxn().Update(ctx, func(
-		_ isql.Txn, _ jobs.JobMetadata, ju *jobs.JobUpdater,
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	require.NoError(t, job.DeprecatedNoTxn().Update(ctx, func(
+		_ isql.Txn, _ jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 	) error {
 		ju.UpdateState(jobs.StateRunning)
 		return nil
 	}))
 
-	err = job.NoTxn().SetDetails(ctx, details)
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err = job.DeprecatedNoTxn().SetDetails(ctx, details)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -299,7 +299,8 @@ func SetResumeSpansAndSSTManifestsInJob(
 		return errors.Errorf("expected SchemaChangeDetails job type, got %T", job.Details())
 	}
 	details.ResumeSpanList[mutationIdx].ResumeSpans = spans
-	return job.WithTxn(txn).SetDetails(ctx, details)
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return job.DeprecatedWithTxn(txn).SetDetails(ctx, details)
 }
 
 // SetResumeSpansInJob is a helper for legacy callers that only need to persist

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -245,7 +245,8 @@ func (s *sampleAggregator) mainLoop(
 		// If it changed by less than 1%, just check for cancellation (which is more
 		// efficient).
 		if fractionCompleted < 1.0 && fractionCompleted < lastReportedFractionCompleted+0.01 {
-			return job.NoTxn().CheckState(ctx)
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			return job.DeprecatedNoTxn().CheckState(ctx)
 		}
 		lastReportedFractionCompleted = fractionCompleted
 		return s.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1176,7 +1176,8 @@ func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 			}
 		}
 		if statusMessage != "" && !desc.Dropped() {
-			if err := sc.job.WithTxn(txn).UpdateStatusMessage(ctx, statusMessage); err != nil {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if err := sc.job.DeprecatedWithTxn(txn).UpdateStatusMessage(ctx, statusMessage); err != nil {
 				return errors.Wrapf(err, "failed to update job status")
 			}
 		}
@@ -1537,7 +1538,8 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 			return err
 		}
 		if sc.job != nil {
-			if err := sc.job.WithTxn(txn).UpdateStatusMessage(ctx, runStatus); err != nil {
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			if err := sc.job.DeprecatedWithTxn(txn).UpdateStatusMessage(ctx, runStatus); err != nil {
 				return errors.Wrap(err, "failed to update job status")
 			}
 		}
@@ -2670,7 +2672,8 @@ func (sc *SchemaChanger) updateJobForRollback(
 		}
 	}
 	oldDetails := sc.job.Details().(jobspb.SchemaChangeDetails)
-	u := sc.job.WithTxn(txn)
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	u := sc.job.DeprecatedWithTxn(txn)
 	if err := u.SetDetails(
 		ctx, jobspb.SchemaChangeDetails{
 			DescID:               sc.descID,

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6173,7 +6173,7 @@ func TestFailureToMarkCanceledReversalLeadsToCanceledStatus(t *testing.T) {
 		f(jobCancellationsToFail.jobs)
 	}
 	jobKnobs := jobs.NewTestingKnobsWithShortIntervals()
-	jobKnobs.BeforeUpdate = func(orig, updated jobs.JobMetadata) (err error) {
+	jobKnobs.BeforeUpdate = func(orig, updated jobs.DeprecatedJobMetadata) (err error) {
 		withJobsToFail(func(m map[jobspb.JobID]struct{}) {
 			if _, ok := m[orig.ID]; ok && updated.State == jobs.StateCanceled {
 				delete(m, orig.ID)

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -55,8 +55,9 @@ var batchFlushThresholdSize = settings.RegisterByteSizeSetting(
 type JobRegistry interface {
 	MakeJobID() jobspb.JobID
 	CreateJobWithTxn(ctx context.Context, record jobs.Record, jobID jobspb.JobID, txn isql.Txn) (*jobs.Job, error)
-	UpdateJobWithTxn(
-		ctx context.Context, jobID jobspb.JobID, txn isql.Txn, updateFunc jobs.UpdateFn,
+	DeprecatedUpdateJobWithTxn(
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		ctx context.Context, jobID jobspb.JobID, txn isql.Txn, updateFunc jobs.DeprecatedUpdateFn,
 	) error
 	CheckPausepoint(name string) error
 }
@@ -148,8 +149,8 @@ func (t nameEntry) GetID() descpb.ID {
 func (d *txnDeps) UpdateSchemaChangeJob(
 	ctx context.Context, id jobspb.JobID, callback scexec.JobUpdateCallback,
 ) error {
-	return d.jobRegistry.UpdateJobWithTxn(ctx, id, d.txn, func(
-		txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+	return d.jobRegistry.DeprecatedUpdateJobWithTxn(ctx, id, d.txn, func(
+		txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 	) error {
 		return callback(md, ju.UpdateProgress, ju.UpdatePayload)
 	})

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1130,7 +1130,7 @@ func (s *TestState) UpdateSchemaChangeJob(
 		Details:          jobspb.WrapPayloadDetails(scJob.Details),
 		PauseReason:      "",
 	}
-	oldJobMetadata := jobs.JobMetadata{
+	oldJobMetadata := jobs.DeprecatedJobMetadata{
 		ID:       scJob.JobID,
 		State:    jobs.StateRunning,
 		Payload:  &oldPayload,

--- a/pkg/sql/schemachanger/scexec/backfiller/tracker.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/tracker.go
@@ -149,8 +149,9 @@ func newTrackerConfig(
 			return nil
 		},
 		writeCheckpoint: func(ctx context.Context, bps []scexec.BackfillProgress, mps []scexec.MergeProgress) error {
-			return job.NoTxn().Update(ctx, func(
-				txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+			//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+			return job.DeprecatedNoTxn().Update(ctx, func(
+				txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 			) error {
 				pl := md.Payload
 				backfillJobProgress, err := convertToJobBackfillProgress(codec, bps)

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -178,7 +178,7 @@ type TransactionalJobRegistry interface {
 
 // JobUpdateCallback is for updating a job.
 type JobUpdateCallback = func(
-	md jobs.JobMetadata,
+	md jobs.DeprecatedJobMetadata,
 	updateProgress func(*jobspb.Progress),
 	updatePayload func(*jobspb.Payload),
 ) error

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -332,7 +332,7 @@ func manageJobs(
 	}
 	for id, update := range scJobUpdates {
 		if err := jr.UpdateSchemaChangeJob(ctx, id, func(
-			md jobs.JobMetadata, updateProgress func(*jobspb.Progress), updatePayload func(*jobspb.Payload),
+			md jobs.DeprecatedJobMetadata, updateProgress func(*jobspb.Progress), updatePayload func(*jobspb.Payload),
 		) error {
 			s := schemaChangeJobUpdateState{md: md}
 			defer s.doUpdate(updateProgress, updatePayload)
@@ -357,7 +357,7 @@ func manageJobs(
 // callback passed to TransactionalJobRegistry.UpdateSchemaChangeJob in
 // manageJobs.
 type schemaChangeJobUpdateState struct {
-	md                   jobs.JobMetadata
+	md                   jobs.DeprecatedJobMetadata
 	maybeUpdatedPayload  *jobspb.Payload
 	maybeUpdatedProgress *jobspb.Progress
 }

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -396,8 +396,12 @@ func (n noopJobRegistry) CheckPausepoint(name string) error {
 	return nil
 }
 
-func (n noopJobRegistry) UpdateJobWithTxn(
-	ctx context.Context, jobID jobspb.JobID, txn isql.Txn, updateFunc jobs.UpdateFn,
+func (n noopJobRegistry) DeprecatedUpdateJobWithTxn(
+	ctx context.Context,
+	jobID jobspb.JobID,
+	txn isql.Txn,
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	updateFunc jobs.DeprecatedUpdateFn,
 ) error {
 	return nil
 }

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -105,7 +105,8 @@ func (n *newSchemaChangeResumer) CollectProfile(ctx context.Context, execCtx int
 func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) error {
 	execCtx := execCtxI.(sql.JobExecContext)
 	execCfg := execCtx.ExecCfg()
-	if err := n.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := n.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		return nil
 	}); err != nil {
 		// TODO(ajwerner): Detect transient errors and classify as retriable here or

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -162,7 +162,7 @@ func newJobsKnobs() *jobs.TestingKnobs {
 	}{
 		m: make(map[jobspb.JobID]struct{}),
 	}
-	jobKnobs.BeforeUpdate = func(orig, updated jobs.JobMetadata) error {
+	jobKnobs.BeforeUpdate = func(orig, updated jobs.DeprecatedJobMetadata) error {
 		sc := orig.Payload.GetNewSchemaChange()
 		if sc == nil {
 			return nil

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -140,7 +140,8 @@ func (j *tableMetadataUpdateJobResumer) updateProgress(
 // markAsRunning updates the last_start_time and status fields in the job's progress
 // details and writes the job progress as a JSON string to the running status.
 func (j *tableMetadataUpdateJobResumer) markAsRunning(ctx context.Context) {
-	if err := j.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := j.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		progress := md.Progress
 		details := progress.Details.(*jobspb.Progress_TableMetadataCache).TableMetadataCache
 		now := timeutil.Now()
@@ -160,7 +161,8 @@ func (j *tableMetadataUpdateJobResumer) markAsRunning(ctx context.Context) {
 // markAsCompleted updates the last_completed_time and status fields in the job's progress
 // details and writes the job progress as a JSON string to the running status.
 func (j *tableMetadataUpdateJobResumer) markAsCompleted(ctx context.Context) {
-	if err := j.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	if err := j.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		progress := md.Progress
 		details := progress.Details.(*jobspb.Progress_TableMetadataCache).TableMetadataCache
 		now := timeutil.Now()

--- a/pkg/sql/tenant_deletion.go
+++ b/pkg/sql/tenant_deletion.go
@@ -108,7 +108,8 @@ func dropTenantInternal(
 		if err != nil {
 			return errors.Wrap(err, "loading tenant replication job for cancelation")
 		}
-		if err := job.WithTxn(txn).CancelRequested(ctx); err != nil {
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		if err := job.DeprecatedWithTxn(txn).CancelRequested(ctx); err != nil {
 			return errors.Wrapf(err, "canceling tenant replication job %d", info.PhysicalReplicationConsumerJobID)
 		}
 	}

--- a/pkg/sql/ttl/ttljob/progress.go
+++ b/pkg/sql/ttl/ttljob/progress.go
@@ -120,7 +120,9 @@ func (t *legacyProgressTracker) initJobProgress(ctx context.Context, jobSpanCoun
 	t.setupUpdateFrequency(jobSpanCount)
 
 	// Write initial progress to job record
-	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return t.job.DeprecatedNoTxn().Update(ctx, func(_ isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		rowLevelTTL := &jobspb.RowLevelTTLProgress{
 			JobTotalSpanCount:     jobSpanCount,
 			JobProcessedSpanCount: 0,
@@ -140,7 +142,7 @@ func (t *legacyProgressTracker) initJobProgress(ctx context.Context, jobSpanCoun
 // refreshJobProgress computes updated job progress from processor metadata.
 // It may return nil to skip immediate persistence, or a Progress to trigger an update.
 func (t *legacyProgressTracker) refreshJobProgress(
-	_ context.Context, md *jobs.JobMetadata, meta *execinfrapb.ProducerMetadata,
+	_ context.Context, md *jobs.DeprecatedJobMetadata, meta *execinfrapb.ProducerMetadata,
 ) (*jobspb.Progress, error) {
 	if meta.BulkProcessorProgress == nil {
 		return nil, nil
@@ -218,7 +220,8 @@ func (t *legacyProgressTracker) refreshJobProgress(
 func (t *legacyProgressTracker) handleProgressUpdate(
 	ctx context.Context, meta *execinfrapb.ProducerMetadata,
 ) error {
-	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return t.job.DeprecatedNoTxn().Update(ctx, func(_ isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		progress, err := t.refreshJobProgress(ctx, &md, meta)
 		if err != nil {
 			return err
@@ -546,7 +549,8 @@ func (t *checkpointProgressTracker) flushProgress(ctx context.Context) error {
 		cachedRowLevelTTL = t.mu.cachedProgress.GetRowLevelTTL()
 	}()
 
-	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	return t.job.DeprecatedNoTxn().Update(ctx, func(_ isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		newProgress := &jobspb.Progress{
 			Details: &jobspb.Progress_RowLevelTTL{
 				RowLevelTTL: cachedRowLevelTTL,

--- a/pkg/sql/ttl/ttljob/progress_test.go
+++ b/pkg/sql/ttl/ttljob/progress_test.go
@@ -170,7 +170,7 @@ func TestLegacyProgressTrackerRefreshJobProgress(t *testing.T) {
 					FractionCompleted: 0,
 				},
 			}
-			md := jobs.JobMetadata{Progress: initialProgress}
+			md := jobs.DeprecatedJobMetadata{Progress: initialProgress}
 
 			var finalProgress *jobspb.Progress
 			var err error

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -409,7 +409,8 @@ func (t *rowLevelTTLResumer) setupProgressTracking(
 	ctx context.Context, sv *settings.Values, execCfg *sql.ExecutorConfig, entirePKSpan roachpb.Span,
 ) ([]roachpb.Span, error) {
 	var completedSpans []roachpb.Span
-	err := t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+	err := t.job.DeprecatedNoTxn().Update(ctx, func(_ isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
 		ttlProg := md.Progress.GetRowLevelTTL()
 		if ttlProg == nil {
 			return errors.AssertionFailedf("no TTL job progress")

--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -287,7 +287,7 @@ func testMigrationWithFailures(
 			defer scope.Close(t)
 
 			type updateEvent struct {
-				orig, updated jobs.JobMetadata
+				orig, updated jobs.DeprecatedJobMetadata
 				errChan       chan error
 			}
 
@@ -296,7 +296,7 @@ func testMigrationWithFailures(
 			// To intercept the schema-change and the migration job.
 			updateEventChan := make(chan updateEvent)
 			var enableUpdateEventCh atomic.Bool
-			beforeUpdate := func(orig, updated jobs.JobMetadata) error {
+			beforeUpdate := func(orig, updated jobs.DeprecatedJobMetadata) error {
 				if !enableUpdateEventCh.Load() {
 					return nil
 				}
@@ -525,9 +525,11 @@ func cancelJob(
 	err := s.InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		// Using this way of canceling because the migration job us non-cancelable.
 		// Canceling in this way skips the check.
-		return s.JobRegistry().(*jobs.Registry).UpdateJobWithTxn(
+		//
+		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
+		return s.JobRegistry().(*jobs.Registry).DeprecatedUpdateJobWithTxn(
 			ctx, jobID, txn, func(
-				txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+				txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater,
 			) error {
 				ju.UpdateState(jobs.StateCancelRequested)
 				return nil


### PR DESCRIPTION
This patch renames various job updater types and methods to indicate that they are deprecated, in order to discourage their future use by humans or agents. See pkg/jobs/job_info_storage.go for the preferred api
for interacting with job metadata.

**renames**:
`Job.NoTxn` -> `Job.DeprecatedNoTxn`
`Job.DebugNameNoTxn` -> `Job.DeprecatedDebugNameNoTxn`
`Job.WithTxn` -> `Job.DeprecatedWIthTxn`

`UpdateFn` -> `DeprecatedUpdateFn`
`Updater` -> `DeprecatedUpdater`
`JobMetadata` -> `DeprecatedJobMetadata`
`JobUpdater` -> `DeprecatedJobUpdater`

`Registry.UpdateJobWithTxn` -> `Registry.DeprecatedUpdateJobWithTxn`

Informs: #169169

Release note: None