### PR TITLE
opt: extend test catalog to support temporary backfill indexes

### DIFF
--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -140,7 +140,11 @@ func formatCatalogIndex(tab Table, ord int, tp treeprinter.Node, redactableValue
 	}
 	mutation := ""
 	if IsMutationIndex(tab, ord) {
-		mutation = " (mutation)"
+		if tab.Index(ord).IsTemporaryIndexForBackfill() {
+			mutation = " (mutation, temp)"
+		} else {
+			mutation = " (mutation)"
+		}
 	}
 
 	idxVisibililty := ""

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -343,6 +343,122 @@ update t106663
            ├── false [as=partial_index_put2:14]
            └── false [as=partial_index_del2:15]
 
+# --------------------------------------------------
+# Regression test for #166122. SimplifyPartialIndexProjections must not simplify
+# partial index projections for temporary backfill indexes, even when the update
+# does not touch any columns referenced by the index or its predicate. During a
+# backfill, the execution layer unconditionally writes to temporary indexes for
+# all concurrent mutations.
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE t166122 (
+  k INT PRIMARY KEY,
+  a INT,
+  b STRING,
+  c INT,
+  FAMILY (k, a, b),
+  FAMILY (c),
+  INDEX (a) WHERE b IS NOT NULL,
+  INDEX "idx_temp:write-only+temp" (a) WHERE b IS NOT NULL
+)
+----
+
+# The update does not touch columns a or b, but since idx_temp is a temporary
+# backfill index, its partial index put/del columns must NOT be simplified to
+# false.
+norm expect-not=SimplifyPartialIndexProjections
+UPDATE t166122 SET c = 1 WHERE k = 1
+----
+update t166122
+ ├── columns: <none>
+ ├── fetch columns: k:7 a:8 c:10
+ ├── update-mapping:
+ │    └── c_new:13 => c:4
+ ├── partial index put columns: partial_index_put1:14 partial_index_put1:14
+ ├── partial index del columns: partial_index_put1:14 partial_index_put1:14
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:14!null c_new:13!null k:7!null a:8 c:10
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,8,10,13,14)
+      ├── select
+      │    ├── columns: k:7!null a:8 b:9 c:10
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7-10)
+      │    ├── scan t166122
+      │    │    ├── columns: k:7!null a:8 b:9 c:10
+      │    │    ├── partial index predicates
+      │    │    │    ├── t166122_a_idx: filters
+      │    │    │    │    └── b:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    │    └── idx_temp: filters
+      │    │    │         └── b:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(8-10)
+      │    └── filters
+      │         └── k:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── projections
+           ├── b:9 IS NOT NULL [as=partial_index_put1:14, outer=(9)]
+           └── 1 [as=c_new:13]
+
+# When the non-temp partial index on the same predicate is the only one, the
+# simplification SHOULD fire because the update doesn't touch relevant columns.
+exec-ddl
+DROP TABLE t166122
+----
+
+exec-ddl
+CREATE TABLE t166122_nobackfill (
+  k INT PRIMARY KEY,
+  a INT,
+  b STRING,
+  c INT,
+  FAMILY (k, a, b),
+  FAMILY (c),
+  INDEX (a) WHERE b IS NOT NULL
+)
+----
+
+norm expect=SimplifyPartialIndexProjections
+UPDATE t166122_nobackfill SET c = 1 WHERE k = 1
+----
+update t166122_nobackfill
+ ├── columns: <none>
+ ├── fetch columns: k:7 c:10
+ ├── update-mapping:
+ │    └── c_new:13 => c:4
+ ├── partial index put columns: partial_index_put1:14
+ ├── partial index del columns: partial_index_put1:14
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:14!null c_new:13!null k:7!null c:10
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,10,13,14)
+      ├── select
+      │    ├── columns: k:7!null c:10
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7,10)
+      │    ├── scan t166122_nobackfill
+      │    │    ├── columns: k:7!null c:10
+      │    │    ├── partial index predicates
+      │    │    │    └── t166122_nobackfill_a_idx: filters
+      │    │    │         └── b:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(10)
+      │    └── filters
+      │         └── k:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── projections
+           ├── false [as=partial_index_put1:14]
+           └── 1 [as=c_new:13]
+
 norm set=optimizer_use_lock_op_for_serializable=true expect=RemoveZeroCardLock
 SELECT a FROM t WHERE a = 1 AND a = 2 FOR UPDATE;
 ----
@@ -2006,7 +2122,7 @@ update trig
       │         │    │              ├── ((id:6, name:7, val:8) AS id, name, val) [as=old:12, outer=(6-8)]
       │         │    │              └── 2 [as=val_new:11]
       │         │    └── projections
-      │         │         └── clamp_val_before_update(new:13, old:12, 'before_trig_update', 'BEFORE', 'ROW', 'UPDATE', 66, 'trig', 'trig', 'public', 0, ARRAY[]) [as=clamp_val_before_update:43, outer=(12,13), volatile, udf]
+      │         │         └── clamp_val_before_update(new:13, old:12, 'before_trig_update', 'BEFORE', 'ROW', 'UPDATE', 68, 'trig', 'trig', 'public', 0, ARRAY[]) [as=clamp_val_before_update:43, outer=(12,13), volatile, udf]
       │         └── filters
       │              └── clamp_val_before_update:43 IS DISTINCT FROM NULL [outer=(43), immutable, constraints=(/43: (/NULL - ]; tight)]
       └── projections

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2500,6 +2500,58 @@ upsert partial_indexes
            ├── upsert_b:20 > 1 [as=partial_index_put1:23, outer=(20)]
            └── b:12 > 1 [as=partial_index_del1:24, outer=(12)]
 
+# Regression test for #166122. When a temporary backfill index exists, columns
+# needed by the index and its predicate must be fetched even when the update does
+# not touch those columns. Here, the scan fetches a (index key) and b (predicate)
+# despite only updating c. Without the temp index, a and b would be pruned.
+exec-ddl
+CREATE TABLE prune_temp_idx (
+  k INT PRIMARY KEY,
+  a INT,
+  b STRING,
+  c INT,
+  FAMILY (k, a, b),
+  FAMILY (c),
+  INDEX "idx_temp:write-only+temp" (a) WHERE b IS NOT NULL
+)
+----
+
+norm
+UPDATE prune_temp_idx SET c = 1 WHERE k = 1
+----
+update prune_temp_idx
+ ├── columns: <none>
+ ├── fetch columns: k:7 a:8 c:10
+ ├── update-mapping:
+ │    └── c_new:13 => c:4
+ ├── partial index put columns: partial_index_put1:14
+ ├── partial index del columns: partial_index_put1:14
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:14!null c_new:13!null k:7!null a:8 c:10
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,8,10,13,14)
+      ├── select
+      │    ├── columns: k:7!null a:8 b:9 c:10
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7-10)
+      │    ├── scan prune_temp_idx
+      │    │    ├── columns: k:7!null a:8 b:9 c:10
+      │    │    ├── partial index predicates
+      │    │    │    └── idx_temp: filters
+      │    │    │         └── b:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(8-10)
+      │    └── filters
+      │         └── k:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      └── projections
+           ├── b:9 IS NOT NULL [as=partial_index_put1:14, outer=(9)]
+           └── 1 [as=c_new:13]
+
 # Do not prune DELETE fetch columns.
 norm
 DELETE FROM partial_indexes WHERE a = 1

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -937,12 +937,14 @@ func (tt *Table) addIndexWithVersion(
 	}
 
 	// Look for name suffixes indicating this is a mutation index.
-	if name, ok := extractWriteOnlyIndex(def); ok {
+	if name, writeOnly, deleteOnly, temp := extractIndexMutationState(def); writeOnly || deleteOnly {
 		idx.IdxName = name
-		tt.writeOnlyIdxCount++
-	} else if name, ok := extractDeleteOnlyIndex(def); ok {
-		idx.IdxName = name
-		tt.deleteOnlyIdxCount++
+		idx.isTemporaryIndexForBackfill = temp
+		if writeOnly {
+			tt.writeOnlyIdxCount++
+		} else {
+			tt.deleteOnlyIdxCount++
+		}
 	}
 
 	// Add explicit columns. Primary key columns definitions have already been
@@ -1496,18 +1498,30 @@ func isMutationColumn(def *tree.ColumnTableDef) bool {
 	return false
 }
 
-func extractWriteOnlyIndex(def *tree.IndexTableDef) (name string, ok bool) {
-	if !strings.HasSuffix(string(def.Name), ":write-only") {
-		return "", false
+// extractIndexMutationState parses the index name for mutation state suffixes.
+// It returns the clean name and flags for the mutation state. Supported
+// suffixes:
+//   - ":write-only"       — write-only mutation index
+//   - ":delete-only"      — delete-only mutation index
+//   - ":write-only+temp"  — write-only temporary backfill index
+//   - ":delete-only+temp" — delete-only temporary backfill index
+func extractIndexMutationState(
+	def *tree.IndexTableDef,
+) (name string, writeOnly, deleteOnly, temp bool) {
+	n := string(def.Name)
+	// Check compound suffixes first to avoid ambiguity.
+	switch {
+	case strings.HasSuffix(n, ":write-only+temp"):
+		return strings.TrimSuffix(n, ":write-only+temp"), true, false, true
+	case strings.HasSuffix(n, ":delete-only+temp"):
+		return strings.TrimSuffix(n, ":delete-only+temp"), false, true, true
+	case strings.HasSuffix(n, ":write-only"):
+		return strings.TrimSuffix(n, ":write-only"), true, false, false
+	case strings.HasSuffix(n, ":delete-only"):
+		return strings.TrimSuffix(n, ":delete-only"), false, true, false
+	default:
+		return n, false, false, false
 	}
-	return strings.TrimSuffix(string(def.Name), ":write-only"), true
-}
-
-func extractDeleteOnlyIndex(def *tree.IndexTableDef) (name string, ok bool) {
-	if !strings.HasSuffix(string(def.Name), ":delete-only") {
-		return "", false
-	}
-	return strings.TrimSuffix(string(def.Name), ":delete-only"), true
 }
 
 func validatedCheckConstraint(def *tree.CheckConstraintTableDef) bool {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1373,6 +1373,11 @@ type Index struct {
 	// numImplicitPartitioningColumns is the number of implicit partitioning
 	// columns defined in this index.
 	numImplicitPartitioningColumns int
+
+	// isTemporaryIndexForBackfill indicates that this is a temporary index
+	// used during an in-progress index backfill (UseDeletePreservingEncoding
+	// in the real catalog).
+	isTemporaryIndexForBackfill bool
 }
 
 // ID is part of the cat.Index interface.
@@ -1515,8 +1520,9 @@ func (ti *Index) Partition(i int) cat.Partition {
 	return &ti.partitions[i]
 }
 
+// IsTemporaryIndexForBackfill is part of the cat.Index interface.
 func (ti *Index) IsTemporaryIndexForBackfill() bool {
-	return false
+	return ti.isTemporaryIndexForBackfill
 }
 
 // SetPartitions manually sets the partitions.

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -322,6 +322,37 @@ TABLE mutations
       ├── b int [inaccessible]
       └── rowid int not null default (unique_rowid()) [hidden]
 
+# Table with temporary backfill mutation indexes. The +temp suffix marks an
+# index as a temporary index used during an in-progress index backfill.
+exec-ddl
+CREATE TABLE temp_mutations (
+  a INT PRIMARY KEY,
+  b INT,
+  c STRING,
+  INDEX "idx_partial:write-only+temp" (b) WHERE c IS NOT NULL,
+  INDEX "idx_regular:delete-only+temp" (c)
+)
+----
+
+exec-ddl
+SHOW CREATE temp_mutations
+----
+TABLE temp_mutations
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── PRIMARY INDEX temp_mutations_pkey
+ │    └── a int not null
+ ├── INDEX idx_partial (mutation, temp)
+ │    ├── b int
+ │    ├── a int not null
+ │    └── WHERE c IS NOT NULL
+ └── INDEX idx_regular (mutation, temp)
+      ├── c string
+      └── a int not null
+
 # Table with generated_as_identity constraints.
 exec-ddl
 CREATE TABLE generated_as_identity (


### PR DESCRIPTION
The opt-tester test catalog uses name suffixes to simulate schema elements in mutation states, but IsTemporaryIndexForBackfill() always returned false, making it impossible to test the fix for #166122 (partial index data loss during backfill) via opt-tester.

This commit adds:

- Index suffixes `:write-only+temp` and `:delete-only+temp` to mark temporary backfill indexes, displayed as `(mutation, temp)` in formatted output.

- Regression tests for #166122 exercising both SimplifyPartialIndexProjections and PruneMutationFetchCols with temporary partial indexes.

Epic: none
Release note: None