### PR TITLE
kvserver: add raft log truncator total time spent metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -19755,6 +19755,15 @@ layers:
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
       owner: cockroachdb/kv
+    - name: raftlog.truncator.busy_nanos
+      exported_name: raftlog_truncator_busy_nanos
+      description: Cumulative wall-clock nanoseconds the per-store loosely-coupled raft log truncator goroutine has spent running.
+      y_axis_label: Processing Time
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      owner: cockroachdb/kv
     - name: range.adds
       exported_name: range_adds
       description: Number of range additions

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -732,6 +732,7 @@ owners:
   raftlog_size_max: cockroachdb/kv
   raftlog_size_total: cockroachdb/kv
   raftlog_truncated: cockroachdb/kv
+  raftlog_truncator_busy_nanos: cockroachdb/kv
   range_adds: cockroachdb/kv
   range_merges: cockroachdb/kv
   range_raftleaderremovals: cockroachdb/kv

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2267,6 +2267,15 @@ var (
 		Measurement: "Log Entries",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRaftLogTruncatorBusyNanos = metric.Metadata{
+		Name: "raftlog.truncator.busy_nanos",
+		Help: crstrings.UnwrapText(`
+			Cumulative wall-clock nanoseconds the per-store loosely-coupled raft
+			log truncator goroutine has spent running.
+		`),
+		Measurement: "Processing Time",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 
 	metaRaftLogTotalSize = metric.Metadata{
 		Name:        "raftlog.size.total",
@@ -3647,6 +3656,7 @@ type StoreMetrics struct {
 	// Raft log metrics.
 	RaftLogFollowerBehindCount *metric.Gauge
 	RaftLogTruncated           *metric.Counter
+	RaftLogTruncatorBusyNanos  *metric.Counter
 	RaftLogTotalSize           *metric.Gauge
 	RaftLogMaxSize             *metric.Gauge
 
@@ -4474,6 +4484,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		// Raft log metrics.
 		RaftLogFollowerBehindCount: metric.NewGauge(metaRaftLogFollowerBehindCount),
 		RaftLogTruncated:           metric.NewCounter(metaRaftLogTruncated),
+		RaftLogTruncatorBusyNanos:  metric.NewCounter(metaRaftLogTruncatorBusyNanos),
 		RaftLogTotalSize:           metric.NewGauge(metaRaftLogTotalSize),
 		RaftLogMaxSize:             metric.NewGauge(metaRaftLogMaxSize),
 

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -15,8 +15,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/crlib/crtime"
 )
 
 // pendingLogTruncations tracks proposed truncations for a replica that have
@@ -189,6 +191,7 @@ type raftLogTruncator struct {
 	ambientCtx context.Context
 	store      storeForTruncator
 	stopper    *stop.Stopper
+	busyNanos  *metric.Counter // maybe nil in tests
 	mu         struct {
 		syncutil.Mutex
 		// Ranges are queued into addRanges and batch dequeued by swapping with
@@ -203,12 +206,16 @@ type raftLogTruncator struct {
 }
 
 func makeRaftLogTruncator(
-	ambientCtx log.AmbientContext, store storeForTruncator, stopper *stop.Stopper,
+	ambientCtx log.AmbientContext,
+	store storeForTruncator,
+	stopper *stop.Stopper,
+	busyNanos *metric.Counter,
 ) *raftLogTruncator {
 	t := &raftLogTruncator{
 		ambientCtx: ambientCtx.AnnotateCtx(context.Background()),
 		store:      store,
 		stopper:    stopper,
+		busyNanos:  busyNanos,
 	}
 	t.mu.addRanges = make(map[roachpb.RangeID]struct{})
 	t.mu.drainRanges = make(map[roachpb.RangeID]struct{})
@@ -388,6 +395,13 @@ func (t *raftLogTruncator) durabilityAdvancedCallback() {
 	}
 	if err := t.stopper.RunAsyncTask(t.ambientCtx, "raft-log-truncation",
 		func(ctx context.Context) {
+			if t.busyNanos != nil {
+				start := crtime.NowMono()
+				defer func() {
+					t.busyNanos.Inc(start.Elapsed().Nanoseconds())
+				}()
+			}
+
 			for {
 				t.durabilityAdvanced(ctx)
 				shouldReturn := false

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -287,7 +287,7 @@ func TestRaftLogTruncator(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	truncator := makeRaftLogTruncator(
-		log.MakeTestingAmbientContext(tracing.NewTracer()), store, stopper)
+		log.MakeTestingAmbientContext(tracing.NewTracer()), store, stopper, nil /* runningNanos */)
 
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "raft_log_truncator"),
 		func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2226,7 +2226,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	s.metrics.registry.AddMetricStruct(s.intentResolver.Metrics)
 
 	// Create the raft log truncator and register the callback.
-	s.raftTruncator = makeRaftLogTruncator(s.cfg.AmbientCtx, (*storeForTruncatorImpl)(s), stopper)
+	s.raftTruncator = makeRaftLogTruncator(
+		s.cfg.AmbientCtx, (*storeForTruncatorImpl)(s), stopper, s.metrics.RaftLogTruncatorBusyNanos)
 
 	if s.EnginesSeparated() {
 		// Initialize the WAG sequencer from the last persisted node index so

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -2065,6 +2065,7 @@ raftlog_behind: raftlog.behind
 raftlog_size_max: raftlog.size.max
 raftlog_size_total: raftlog.size.total
 raftlog_truncated: raftlog.truncated
+raftlog_truncator_busy_nanos: raftlog.truncator.busy_nanos
 range_adds: range.adds
 range_merges: range.merges
 range_raftleaderremovals: range.raftleaderremovals


### PR DESCRIPTION
When we enable loosely-coupled truncations, it might be useful to see if the goroutine responsible for doing the truncations is running behind or not. This commit introduces the metric: `raftlog.truncator.busy_nanos` which serves this purpose. If the rate of this metric is reporting close to 1s per second, then the goroutine is running all the time which likely means that it's running behind.

References: #93248

Release note: None