### PR TITLE
sql: return user-facing error for duplicates in skip_unique_checks indexes

### DIFF
--- a/pkg/sql/catalog/fetchpb/index_fetch.proto
+++ b/pkg/sql/catalog/fetchpb/index_fetch.proto
@@ -149,5 +149,14 @@ message IndexFetchSpec {
   // it is stored outside the span of the object.
   optional ExternalRowData external  = 17 [(gogoproto.nullable) = true];
 
-  // NEXT ID 18.
+  // HasSkipUniqueChecks is true if the index has the skip_unique_checks storage
+  // parameter set. This is used to produce a user-facing error instead of an
+  // internal assertion failure when duplicate rows are encountered during index
+  // joins or lookup joins.
+  //
+  // This field is only populated on v26.3+. On older nodes the field will be
+  // false, causing the original internal assertion error to be returned instead.
+  optional bool has_skip_unique_checks = 18 [(gogoproto.nullable) = false];
+
+  // NEXT ID 19.
 }

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/rowinfra",
         "//pkg/sql/scrub",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
@@ -141,6 +142,13 @@ type ColIndexJoin struct {
 	// maintainOrdering is true when the index join is required to maintain its
 	// input ordering, in which case the ordering of the spans cannot be changed.
 	maintainOrdering bool
+
+	// hasSkipUniqueChecks, tableName, and indexName are stored from the fetch
+	// spec to produce a user-facing error instead of an internal assertion
+	// failure when duplicate rows are encountered due to skip_unique_checks.
+	hasSkipUniqueChecks bool
+	tableName           string
+	indexName           string
 
 	// usesStreamer indicates whether the ColIndexJoin is using the Streamer
 	// API.
@@ -349,6 +357,10 @@ func (s *ColIndexJoin) getRowSize(idx int) int64 {
 func (s *ColIndexJoin) assertScanRowCounts() {
 	if s.lockingWaitPolicy == descpb.ScanLockingWaitPolicy_SKIP_LOCKED {
 		if s.scanRowCounts.actual > s.scanRowCounts.expected {
+			if s.hasSkipUniqueChecks {
+				colexecerror.ExpectedError(sqlerrors.NewSkipUniqueChecksError(s.tableName, s.indexName))
+				return
+			}
 			colexecerror.InternalError(errors.AssertionFailedf(
 				"expected to fetch no more than %d rows, found %d",
 				s.scanRowCounts.expected, s.scanRowCounts.actual,
@@ -356,6 +368,10 @@ func (s *ColIndexJoin) assertScanRowCounts() {
 		}
 	} else {
 		if s.scanRowCounts.actual != s.scanRowCounts.expected {
+			if s.hasSkipUniqueChecks && s.scanRowCounts.actual > s.scanRowCounts.expected {
+				colexecerror.ExpectedError(sqlerrors.NewSkipUniqueChecksError(s.tableName, s.indexName))
+				return
+			}
 			colexecerror.InternalError(errors.AssertionFailedf(
 				"expected to fetch %d rows, found %d",
 				s.scanRowCounts.expected, s.scanRowCounts.actual,
@@ -687,17 +703,20 @@ func NewColIndexJoin(
 	)
 
 	op := &ColIndexJoin{
-		OneInputNode:      colexecop.NewOneInputNode(input),
-		flowCtx:           flowCtx,
-		processorID:       processorID,
-		cf:                fetcher,
-		spanAssembler:     spanAssembler,
-		ResultTypes:       tableArgs.typs,
-		maintainOrdering:  spec.MaintainOrdering,
-		txn:               txn,
-		usesStreamer:      useStreamer,
-		limitHintHelper:   execinfra.MakeLimitHintHelper(spec.LimitHint, post),
-		lockingWaitPolicy: spec.LockingWaitPolicy,
+		OneInputNode:        colexecop.NewOneInputNode(input),
+		flowCtx:             flowCtx,
+		processorID:         processorID,
+		cf:                  fetcher,
+		spanAssembler:       spanAssembler,
+		ResultTypes:         tableArgs.typs,
+		maintainOrdering:    spec.MaintainOrdering,
+		txn:                 txn,
+		usesStreamer:        useStreamer,
+		limitHintHelper:     execinfra.MakeLimitHintHelper(spec.LimitHint, post),
+		lockingWaitPolicy:   spec.LockingWaitPolicy,
+		hasSkipUniqueChecks: spec.FetchSpec.HasSkipUniqueChecks,
+		tableName:           spec.FetchSpec.TableName,
+		indexName:           spec.FetchSpec.IndexName,
 	}
 	op.mem.inputBatchSizeLimit = getIndexJoinBatchSize(
 		useStreamer, flowCtx.EvalCtx.TestingKnobs.ForceProductionValues, flowCtx.EvalCtx.SessionData(),

--- a/pkg/sql/logictest/testdata/logic_test/regional_by_row_skip_unique_checks
+++ b/pkg/sql/logictest/testdata/logic_test/regional_by_row_skip_unique_checks
@@ -366,3 +366,86 @@ SELECT DISTINCT checked_index(info)
 FROM [EXPLAIN INSERT INTO t2 VALUES (3, 30, 300, 'us-east-1'), (4, 40, 400, 'us-east-1')]
 WHERE info ~ 'table:';
 ----
+
+# ===========================================================================
+# Test that duplicate rows in indexes with skip_unique_checks produce
+# user-facing errors instead of internal assertion failures.
+# ===========================================================================
+
+subtest duplicate_rows_user_facing_error
+
+# Create a parent table with a unique secondary index (skip_unique_checks)
+# and a child table with a FK referencing it, to test lookup join via FK check.
+statement ok
+CREATE TABLE t_parent (
+  id INT PRIMARY KEY,
+  val INT,
+  UNIQUE INDEX idx_val (val)
+) WITH (schema_locked = false) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER INDEX t_parent@idx_val SET (skip_unique_checks = true)
+
+# Insert duplicate val across regions. Because skip_unique_checks is true,
+# the INSERT succeeds even though uniqueness of val is violated.
+statement ok
+INSERT INTO t_parent (id, val, crdb_region) VALUES (1, 42, 'us-east-1')
+
+statement ok
+INSERT INTO t_parent (id, val, crdb_region) VALUES (2, 42, 'ca-central-1')
+
+statement ok
+CREATE TABLE t_child (
+  id INT PRIMARY KEY,
+  parent_val INT REFERENCES t_parent(val)
+) LOCALITY REGIONAL BY ROW
+
+# The FK lookup join hits the unique index with duplicates. Without the fix,
+# this produces an internal assertion error (pgcode XX000). With the fix, it
+# produces a user-facing UniqueViolation error with a helpful hint.
+statement error pgcode 23505 pq: index "idx_val" of table "t_parent" contains duplicate keys\nHINT:.*skip_unique_checks
+INSERT INTO t_child (id, parent_val) VALUES (1, 42)
+
+# Test a direct lookup join against a unique index with duplicates.
+statement ok
+CREATE TABLE t_probe (
+  x INT PRIMARY KEY
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO t_probe VALUES (42)
+
+# An explicit lookup join against the unique index with duplicate values.
+# Without the fix, this produces an internal assertion error (pgcode XX000).
+statement error pgcode 23505 pq: index "idx_val" of table "t_parent" contains duplicate keys\nHINT:.*skip_unique_checks
+SELECT * FROM t_probe INNER LOOKUP JOIN t_parent ON t_probe.x = t_parent.val
+
+# Test the row-based execution engine path (joinReader.assertBatchRowCounts).
+statement ok
+SET vectorize = off
+
+statement error pgcode 23505 pq: index "idx_val" of table "t_parent" contains duplicate keys\nHINT:.*skip_unique_checks
+INSERT INTO t_child (id, parent_val) VALUES (1, 42)
+
+statement error pgcode 23505 pq: index "idx_val" of table "t_parent" contains duplicate keys\nHINT:.*skip_unique_checks
+SELECT * FROM t_probe INNER LOOKUP JOIN t_parent ON t_probe.x = t_parent.val
+
+statement ok
+RESET vectorize
+
+# Verify that the user can recover by deleting the duplicate row. After removing
+# one of the duplicates, queries that previously hit the assertion should work.
+statement count 1
+DELETE FROM t_parent WHERE id = 2
+
+# The FK insert should now succeed since val=42 is unique.
+statement ok
+INSERT INTO t_child (id, parent_val) VALUES (1, 42)
+
+# The lookup join should now return exactly one row.
+query III
+SELECT * FROM t_probe INNER LOOKUP JOIN t_parent ON t_probe.x = t_parent.val
+----
+42  1  42
+
+subtest end

--- a/pkg/sql/rowenc/index_fetch.go
+++ b/pkg/sql/rowenc/index_fetch.go
@@ -39,6 +39,7 @@ func InitIndexFetchSpec(
 		IndexName:           index.GetName(),
 		IsSecondaryIndex:    !index.Primary(),
 		IsUniqueIndex:       index.IsUnique(),
+		HasSkipUniqueChecks: index.SkipUniqueChecks(),
 		EncodingType:        index.GetEncodingType(),
 		NumKeySuffixColumns: uint32(index.NumKeySuffixColumns()),
 		GeoConfig:           index.GetGeoConfig(),

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1119,6 +1119,9 @@ func (jr *joinReader) assertBatchRowCounts() error {
 	nonSkippingIndexJoin := jr.readerType == indexJoinReaderType &&
 		jr.lockingWaitPolicy != descpb.ScanLockingWaitPolicy_SKIP_LOCKED
 	if nonSkippingIndexJoin && jr.curBatchRowsRead != jr.curBatchInputRowCount {
+		if jr.fetchSpec.HasSkipUniqueChecks && jr.curBatchRowsRead > jr.curBatchInputRowCount {
+			return sqlerrors.NewSkipUniqueChecksError(jr.fetchSpec.TableName, jr.fetchSpec.IndexName)
+		}
 		return errors.AssertionFailedf(
 			"expected to fetch %d rows, found %d",
 			jr.curBatchInputRowCount, jr.curBatchRowsRead,
@@ -1130,6 +1133,9 @@ func (jr *joinReader) assertBatchRowCounts() error {
 		jr.lockingWaitPolicy == descpb.ScanLockingWaitPolicy_SKIP_LOCKED
 	if (skippingIndexJoin || jr.lookupColumnsAreKey) &&
 		jr.curBatchRowsRead > jr.curBatchInputRowCount {
+		if jr.fetchSpec.HasSkipUniqueChecks {
+			return sqlerrors.NewSkipUniqueChecksError(jr.fetchSpec.TableName, jr.fetchSpec.IndexName)
+		}
 		return errors.AssertionFailedf(
 			"expected to fetch no more than %d rows, found %d",
 			jr.curBatchInputRowCount, jr.curBatchRowsRead,

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -698,3 +698,19 @@ var (
 )
 
 var ErrNoZoneConfigApplies = errors.New("no zone config applies")
+
+// NewSkipUniqueChecksError returns a user-facing error when duplicate rows are
+// found in an index that has the skip_unique_checks storage parameter set. This
+// is used by both the row-based and vectorized execution engines in place of an
+// internal assertion failure.
+func NewSkipUniqueChecksError(tableName, indexName string) error {
+	return errors.WithHint(
+		pgerror.Newf(pgcode.UniqueViolation,
+			"index %q of table %q contains duplicate keys",
+			indexName, tableName,
+		),
+		"This index has the skip_unique_checks storage parameter set, which "+
+			"allows duplicate values. Resolve the duplicate rows and consider "+
+			"removing skip_unique_checks using ALTER INDEX ... RESET (skip_unique_checks).",
+	)
+}


### PR DESCRIPTION
When an index with the `skip_unique_checks` storage parameter contains duplicate values, lookup joins and index joins that hit the index previously produced an internal assertion error:

  internal error: expected to fetch no more than 1 rows, found 2

This commit detects `skip_unique_checks` at the two assertion sites in the execution layer (row-based joinReader and vectorized ColIndexJoin) and produces a user-facing `UniqueViolation` (23505) error with a hint explaining that the index has `skip_unique_checks` set and how to resolve it.

To propagate the flag to the execution layer, a new `has_skip_unique_checks` field is added to the `IndexFetchSpec` proto and populated during `InitIndexFetchSpec`.

Fixes: #167122

Release note (bug fix): Queries that hit a UNIQUE index with the `skip_unique_checks` storage parameter containing duplicate values now return a user-facing error instead of an internal assertion failure.