### PR TITLE
sctest: switch backup tests from userfile to nodelocal storage

### DIFF
--- a/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
+++ b/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
@@ -84,7 +84,10 @@ func (f MultiRegionTestClusterFactory) Start(ctx context.Context, t *testing.T) 
 	sql.CreateTableWithSchemaLocked.Override(ctx, &st.SV, !f.schemaLockedDisabled)
 	closedts.TargetDuration.Override(ctx, &st.SV, 20*time.Millisecond)
 	closedts.SideTransportCloseInterval.Override(ctx, &st.SV, 20*time.Millisecond)
-	c, db, _ := multiregionccltestutils.TestingCreateMultiRegionCluster(t, numServers, knobs, multiregionccltestutils.WithSettings(st))
+	c, db, _ := multiregionccltestutils.TestingCreateMultiRegionCluster(t, numServers, knobs,
+		multiregionccltestutils.WithSettings(st),
+		multiregionccltestutils.WithBaseDirectory(t.TempDir()),
+	)
 	return sctest.TestServer{
 		Server: c.Server(0),
 		DB:     db,

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_global_to_rbt_secondary_region/alter_table_locality_global_to_rbt_secondary_region.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_locality_global_to_rbt_secondary_region/alter_table_locality_global_to_rbt_secondary_region.definition
@@ -1,6 +1,3 @@
-skip issue-num=168350
-----
-
 setup
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
 CREATE TABLE multiregion_db.public.t (  

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -44,8 +44,6 @@ func BackupSuccess(t *testing.T, path string, factory TestServerFactory) {
 			backupArgs.server.Stopper(t)
 		}
 	}()
-	// Disable schema_locked in backup and restore tests, since the userfiles table
-	// cannot be created with schema_locked by default yet.
 	cumulativeTestForEachPostCommitStage(t, path, factory,
 		func(t *testing.T, spec CumulativeTestSpec) PrepResult[backupSuccessTestArgs] {
 			result := backupSuccessPrepare(t, factory, spec)
@@ -67,8 +65,6 @@ func BackupRollbacks(t *testing.T, path string, factory TestServerFactory) {
 	// These tests are only marginally more useful than BackupSuccess
 	// and at least as expensive to run.
 	skip.UnderShort(t)
-	// Disable schema_locked in backup and restore tests, since the userfiles table
-	// cannot be created with schema_locked by default yet.
 	factory = factory.WithSchemaLockDisabled()
 	var rollbackArgs backupRollbacksTestArgs
 	defer func() {
@@ -104,8 +100,6 @@ func BackupSuccessMixedVersion(t *testing.T, path string, factory TestServerFact
 			backupArgs.server.Stopper(t)
 		}
 	}()
-	// Disable schema_locked in backup and restore tests, since the userfiles table
-	// cannot be created with schema_locked by default yet.
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, spec CumulativeTestSpec) PrepResult[backupSuccessTestArgs] {
 		result := backupSuccessPrepare(t, factory, spec)
 		backupArgs = result.PrepData
@@ -295,7 +289,7 @@ func backupSuccessPrepare(
 				Ordinal: p.Stages[stageIdx].Ordinal,
 			}
 
-			url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d",
+			url := fmt.Sprintf("nodelocal://1/data_%s_%d",
 				key.Phase, key.Ordinal)
 			backupStmt := fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s'",
 				dbName,
@@ -334,8 +328,6 @@ func backupSuccessPrepare(
 	db.SetMaxOpenConns(1)
 	dbForBackup.Store(db)
 	tdb := sqlutils.MakeSQLRunner(db)
-	// Setup the test cluster.
-	tdb.Exec(t, "CREATE DATABASE backups")
 	require.NoError(t, setupSchemaChange(ctx, t, spec, db))
 
 	// Skip test if it requires system tenant operations and we're running under a secondary tenant.
@@ -343,7 +335,7 @@ func backupSuccessPrepare(
 
 	// Determine which database contains the schema change before enabling knobs.
 	// Some tests create a separate database (e.g. "db"), others use defaultdb.
-	rows := tdb.QueryStr(t, "SELECT database_name FROM [SHOW DATABASES] WHERE database_name NOT IN ('system', 'postgres', 'defaultdb', 'backups')")
+	rows := tdb.QueryStr(t, "SELECT database_name FROM [SHOW DATABASES] WHERE database_name NOT IN ('system', 'postgres', 'defaultdb')")
 	if len(rows) > 0 {
 		dbName = rows[0][0]
 	} else {
@@ -524,7 +516,7 @@ func backupRollbacksPrepare(
 				// is identical to pre-rollback state due to how rollback initialization works.
 				// Restoring this backup wouldn't test anything meaningful.
 				if p.InRollback && stageIdx > 0 {
-					url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d_%d",
+					url := fmt.Sprintf("nodelocal://1/data_%s_%d_%d",
 						activeKey.Phase, activeKey.Ordinal, stageIdx)
 					if _, ok := scenario.urlsSamples[url]; !ok {
 						scenario.urlsSamples[url] = struct{}{}
@@ -565,9 +557,6 @@ func backupRollbacksPrepare(
 	db.SetMaxOpenConns(1)
 	tdb := sqlutils.MakeSQLRunner(db)
 
-	// Create backups database for userfile before discovery.
-	tdb.Exec(t, "CREATE DATABASE backups")
-
 	// Phase 1: Discovery — run the schema change to completion to discover stages.
 	require.NoError(t, setupSchemaChange(ctx, t, spec, db))
 
@@ -589,7 +578,7 @@ func backupRollbacksPrepare(
 
 	// Discover the database name and CREATE DATABASE statement.
 	// Some tests create a separate database (e.g. "db"), others use defaultdb.
-	rows := tdb.QueryStr(t, "SELECT database_name FROM [SHOW DATABASES] WHERE database_name NOT IN ('system', 'postgres', 'defaultdb', 'backups')")
+	rows := tdb.QueryStr(t, "SELECT database_name FROM [SHOW DATABASES] WHERE database_name NOT IN ('system', 'postgres', 'defaultdb')")
 	dbName := "defaultdb"
 	var createDatabaseStmt string
 	if len(rows) > 0 {

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -110,6 +110,7 @@ func (f SingleNodeTestClusterFactory) Run(
 // Start implements the TestServerFactory interface.
 func (f SingleNodeTestClusterFactory) Start(ctx context.Context, t *testing.T) TestServer {
 	args := base.TestServerArgs{
+		ExternalIODir: t.TempDir(),
 		Knobs: base.TestingKnobs{
 			SQLEvalContext: &eval.TestingKnobs{
 				ForceProductionValues: true,


### PR DESCRIPTION
Backup tests were using userfile:// URLs, which store backup data in SQL
tables. This created unnecessary coupling between the backup under test
and the userfile system tables, which could cause flaky failures in
multi-region clusters. Switch to nodelocal://1/ which writes directly to
the filesystem and avoids this interaction.

This requires configuring ExternalIODir on both SingleNodeTestClusterFactory
and MultiRegionTestClusterFactory.

Informs: https://github.com/cockroachdb/cockroach/issues/168350

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>