### PR TITLE
admission: add composite groupKey type

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "elastic_cpu_work_queue.go",
         "grant_coordinator.go",
         "granter.go",
+        "group_key.go",
         "io_load_listener.go",
         "kv_slot_adjuster.go",
         "pacer.go",

--- a/pkg/util/admission/cpu_time_token_metrics.go
+++ b/pkg/util/admission/cpu_time_token_metrics.go
@@ -143,9 +143,13 @@ type cpuTimeTokenMetrics struct {
 }
 
 func makeCPUTimeTokenMetrics() *cpuTimeTokenMetrics {
-	// NB: Matches multitenant.TenantIDLabel for consistency with other
-	// per-tenant metrics. Inlined to avoid a dependency cycle.
-	b := aggmetric.MakeBuilder("tenant_id")
+	// Two-label scheme: kind discriminates "tenant" vs "rg" so the same
+	// numeric ID in different namespaces (system tenant 1 vs rg 1) maps
+	// to distinct child time series; tenant_id stays a bare numeric
+	// string for parity with other per-tenant AggCounters
+	// (multitenant.TenantIDLabel) so dashboards filtering on tenant_id
+	// keep working.
+	b := aggmetric.MakeBuilder("kind", "tenant_id")
 	m := &cpuTimeTokenMetrics{
 		Multiplier:     metric.NewGaugeFloat64(cpuTimeTokenMultiplierMeta),
 		TokensConsumed: metric.NewCounter(cpuTimeTokensConsumedMeta),

--- a/pkg/util/admission/elastic_cpu_work_queue.go
+++ b/pkg/util/admission/elastic_cpu_work_queue.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 )
@@ -48,7 +47,7 @@ type elasticCPUInternalWorkQueue interface {
 	requester
 	Admit(ctx context.Context, info WorkInfo) (AdmitResponse, error)
 	SetTenantWeights(tenantWeights map[uint64]uint32)
-	adjustGroupUsed(groupID roachpb.TenantID, additionalUsed int64)
+	adjustGroupUsed(gKey groupKey, additionalUsed int64)
 }
 
 func makeElasticCPUWorkQueue(
@@ -106,7 +105,7 @@ func (e *ElasticCPUWorkQueue) AdmittedWorkDone(h *ElasticCPUWorkHandle) {
 
 	e.metrics.PreWorkNanos.Inc(h.preWork.Nanoseconds())
 	_, difference := h.overLimitInner()
-	e.workQueue.adjustGroupUsed(h.tenantID, difference.Nanoseconds())
+	e.workQueue.adjustGroupUsed(tenantGroupKey(h.tenantID.ToUint64()), difference.Nanoseconds())
 	if h.bypassedAdmission {
 		e.metrics.bypassedAdmissionCumNanos.Add(difference.Nanoseconds())
 	}

--- a/pkg/util/admission/elastic_cpu_work_queue_test.go
+++ b/pkg/util/admission/elastic_cpu_work_queue_test.go
@@ -167,12 +167,10 @@ func (t *testElasticCPUInternalWorkQueue) SetTenantWeights(tenantWeights map[uin
 	panic("unimplemented")
 }
 
-func (t *testElasticCPUInternalWorkQueue) adjustGroupUsed(
-	groupID roachpb.TenantID, additionalUsed int64,
-) {
+func (t *testElasticCPUInternalWorkQueue) adjustGroupUsed(gKey groupKey, additionalUsed int64) {
 	if !t.disabled {
 		fmt.Fprintf(&t.buf, "adjust-group-used: group=%s additional-used=%s",
-			groupID.String(), time.Duration(additionalUsed).String())
+			gKey, time.Duration(additionalUsed))
 	}
 }
 

--- a/pkg/util/admission/group_key.go
+++ b/pkg/util/admission/group_key.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"strconv"
+
+	"github.com/cockroachdb/redact"
+)
+
+// groupKind distinguishes the semantic origin of a groupInfo's
+// container in q.mu.groups. The same numeric ID can represent
+// either a tenant (in serverless mode) or a resource group (in RM
+// mode), and tenant IDs and RM resource group IDs are drawn from
+// the same uint64 space (e.g., system tenant ID = 1 collides with
+// highResourceGroupID = 1). Pairing the ID with a kind in the map
+// key prevents these two semantic meanings from ever sharing a
+// container.
+//
+// The zero value is intentionally invalid so that an unset groupKey
+// is detectably so (rather than silently identifying as "tenant 0"
+// the way iota-from-0 would).
+type groupKind uint8
+
+const (
+	// invalidKind is the zero value sentinel; a groupKey with this
+	// kind has not been initialized via tenantGroupKey/rgGroupKey.
+	invalidKind groupKind = iota
+	// tenantKind identifies a container created for a tenant ID
+	// (serverless mode routing via TenantID).
+	tenantKind
+	// rgKind identifies a container created for a resource group
+	// ID (RM mode routing via priorityToResourceGroup).
+	rgKind
+)
+
+// String implements fmt.Stringer.
+func (k groupKind) String() string {
+	switch k {
+	case tenantKind:
+		return "tenant"
+	case rgKind:
+		return "rg"
+	case invalidKind:
+		return "invalid"
+	default:
+		return "groupKind(" + strconv.FormatUint(uint64(k), 10) + ")"
+	}
+}
+
+// groupKey is the composite map key for q.mu.groups. It pairs the
+// uint64 group ID with its semantic kind so that, e.g., tenant 1
+// and rg 1 occupy distinct map entries.
+type groupKey struct {
+	id   uint64
+	kind groupKind
+}
+
+// isTenant reports whether k identifies a tenant container.
+func (k groupKey) isTenant() bool { return k.kind == tenantKind }
+
+// isRg reports whether k identifies a resource group container.
+func (k groupKey) isRg() bool { return k.kind == rgKind }
+
+// SafeFormat implements redact.SafeFormatter. Formats as e.g.
+// "t1" / "rg2"; useful in SafeFormat output so callers don't have
+// to switch on kind themselves.
+func (k groupKey) SafeFormat(s redact.SafePrinter, _ rune) {
+	switch k.kind {
+	case tenantKind:
+		s.Printf("t%d", k.id)
+	case rgKind:
+		s.Printf("rg%d", k.id)
+	default:
+		s.Printf("invalid(%d)", k.id)
+	}
+}
+
+// String implements fmt.Stringer via SafeFormat.
+func (k groupKey) String() string {
+	return redact.StringWithoutMarkers(k)
+}
+
+// tenantGroupKey returns the groupKey for a tenant container.
+func tenantGroupKey(id uint64) groupKey {
+	return groupKey{id: id, kind: tenantKind}
+}
+
+// rgGroupKey returns the groupKey for a resource group container.
+func rgGroupKey(id uint64) groupKey {
+	return groupKey{id: id, kind: rgKind}
+}

--- a/pkg/util/admission/group_key.go
+++ b/pkg/util/admission/group_key.go
@@ -33,7 +33,7 @@ const (
 	// (serverless mode routing via TenantID).
 	tenantKind
 	// rgKind identifies a container created for a resource group
-	// ID (RM mode routing via priorityToResourceGroup).
+	// ID (RM mode routing via priorityToResourceGroupKey).
 	rgKind
 )
 

--- a/pkg/util/admission/replicated_write_admission_test.go
+++ b/pkg/util/admission/replicated_write_admission_test.go
@@ -315,13 +315,18 @@ func printWorkQueue(q *WorkQueue) string {
 	if len(q.mu.groupHeap) > 0 {
 		buf.WriteString(fmt.Sprintf(" top-group=t%d", q.mu.groupHeap[0].id))
 	}
-	var ids []uint64
-	for id := range q.mu.groups {
-		ids = append(ids, id)
+	var keys []groupKey
+	for k := range q.mu.groups {
+		keys = append(keys, k)
 	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	for _, id := range ids {
-		group := q.mu.groups[id]
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].kind != keys[j].kind {
+			return keys[i].kind < keys[j].kind
+		}
+		return keys[i].id < keys[j].id
+	})
+	for _, k := range keys {
+		group := q.mu.groups[k]
 		buf.WriteString(fmt.Sprintf("\n group=t%d weight=%d fifo-threshold=%s used=%s",
 			group.id,
 			group.weight,

--- a/pkg/util/admission/replicated_write_admission_test.go
+++ b/pkg/util/admission/replicated_write_admission_test.go
@@ -313,7 +313,7 @@ func printWorkQueue(q *WorkQueue) string {
 	defer q.mu.Unlock()
 	buf.WriteString(fmt.Sprintf("len(group-heap)=%d", len(q.mu.groupHeap)))
 	if len(q.mu.groupHeap) > 0 {
-		buf.WriteString(fmt.Sprintf(" top-group=t%d", q.mu.groupHeap[0].id))
+		buf.WriteString(fmt.Sprintf(" top-group=t%d", q.mu.groupHeap[0].groupKey.id))
 	}
 	var keys []groupKey
 	for k := range q.mu.groups {
@@ -328,7 +328,7 @@ func printWorkQueue(q *WorkQueue) string {
 	for _, k := range keys {
 		group := q.mu.groups[k]
 		buf.WriteString(fmt.Sprintf("\n group=t%d weight=%d fifo-threshold=%s used=%s",
-			group.id,
+			group.groupKey.id,
 			group.weight,
 			admissionpb.WorkPriority(group.fifoPriorityThreshold),
 			printTrimmedBytes(int64(group.used)),

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -345,9 +345,9 @@ func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
 				return false
 			}()
 			// Close already ran and drained reservation. Return the buffer
-			// directly.
+			// directly using this admit's resp.groupKey.
 			if closed {
-				h.wq.AdmittedSQLWorkDone(h.workInfo.TenantID, buffer)
+				h.wq.AdmittedSQLWorkDone(resp.groupKey, buffer)
 			}
 		}
 	}
@@ -440,7 +440,7 @@ func (h *SQLCPUHandle) Close() {
 	// be added to mu.reservation after this.
 	remaining := h.mu.reservation.Swap(0)
 	if remaining > 0 {
-		h.wq.AdmittedSQLWorkDone(h.workInfo.TenantID, remaining)
+		h.wq.AdmittedSQLWorkDone(tenantGroupKey(h.workInfo.TenantID.ToUint64()), remaining)
 	}
 }
 

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -153,6 +153,27 @@ type SQLCPUHandle struct {
 		// INVARIANT: closed == true => reservation == 0.
 		reservation atomic.Int64
 
+		// reservationSourceGroup is the groupKey of the container the
+		// most recent successful Admit credited. Close uses it to
+		// return the drained reservation to the same container,
+		// without re-deriving from the WorkQueue's current
+		// useResourceGroup state — which may have flipped between
+		// Admit and Close. In RM mode the container is rg-keyed; the
+		// prior tenantGroupKey-based lookup missed and silently leaked
+		// the drained reservation.
+		//
+		// Invariant: at any moment, every token in reservation came
+		// from the most recent successful Admit. Each Admit only fires
+		// when tryDeductReservation found reservation < needed (i.e.,
+		// drained reservation to 0); Admit then adds its buffer to a
+		// reservation that is 0. By the time the next Admit fires, that
+		// buffer has been drained back to 0 (which is what triggered
+		// the next Admit). The slow path is serialized via admitTurn,
+		// so no two Admits' buffers ever coexist in reservation.
+		// Therefore reservationSourceGroup is always the exact source
+		// of any tokens Close drains.
+		reservationSourceGroup groupKey
+
 		gHandles []*GoroutineCPUHandle
 		// Backing for up to 2 goroutine handles, to avoid allocations in
 		// gHandles when there are 2 or fewer goroutines.
@@ -342,10 +363,14 @@ func (h *SQLCPUHandle) reportAndAcquireConsumedCPU(
 				// Close sets closed=true and Swap(0) drains reservation, then this
 				// goroutine does Add(buffer), leaking tokens.
 				h.mu.reservation.Add(buffer)
+				h.mu.reservationSourceGroup = resp.groupKey
 				return false
 			}()
 			// Close already ran and drained reservation. Return the buffer
-			// directly using this admit's resp.groupKey.
+			// directly using this admit's resp.groupKey —
+			// reservationSourceGroup wasn't stored (we're in the closed
+			// branch above), so we use the key from the just-completed
+			// Admit.
 			if closed {
 				h.wq.AdmittedSQLWorkDone(resp.groupKey, buffer)
 			}
@@ -440,7 +465,10 @@ func (h *SQLCPUHandle) Close() {
 	// be added to mu.reservation after this.
 	remaining := h.mu.reservation.Swap(0)
 	if remaining > 0 {
-		h.wq.AdmittedSQLWorkDone(tenantGroupKey(h.workInfo.TenantID.ToUint64()), remaining)
+		// closed=true was set under mu before this Swap, so no further
+		// Admit can update reservationSourceGroup; reading it here
+		// without mu is safe.
+		h.wq.AdmittedSQLWorkDone(h.mu.reservationSourceGroup, remaining)
 	}
 }
 

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -661,3 +661,76 @@ func TestSetMaxCPUGroupsRGOnly(t *testing.T) {
 	tenantHandle.Close()
 	rgHandle.Close()
 }
+
+// admitOnce drives a single slow-path Admit on a new SQLCPUHandle
+// for (tenantID, pri) and returns the handle. The caller is
+// responsible for Close.
+func admitOnce(
+	t *testing.T, ctx context.Context, q *WorkQueue, tenantID uint64, pri admissionpb.WorkPriority,
+) *SQLCPUHandle {
+	t.Helper()
+	h := newSQLCPUAdmissionHandle(
+		WorkInfo{TenantID: roachpb.MustMakeTenantID(tenantID), Priority: pri},
+		true, &sqlCPUProviderImpl{}, q)
+	require.NoError(t, h.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+	return h
+}
+
+// requireGroupUsed returns q.mu.groups[key].used, failing the test
+// if the entry does not exist.
+func requireGroupUsed(t *testing.T, q *WorkQueue, key groupKey) uint64 {
+	t.Helper()
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	g, ok := q.mu.groups[key]
+	require.Truef(t, ok, "group %v should exist in q.mu.groups", key)
+	return g.used
+}
+
+// hasGroup reports whether q.mu.groups has an entry for key.
+func hasGroup(q *WorkQueue, key groupKey) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	_, ok := q.mu.groups[key]
+	return ok
+}
+
+// TestSQLCPUHandleCloseAfterModeFlip verifies that a mode flip
+// between Admit and Close still routes the drained reservation to
+// the original (Admit-time) container. The reservationSourceGroup
+// field captures the key at Admit time precisely so this scenario
+// stays correct: re-deriving from the WorkQueue's current
+// useResourceGroup would route to a freshly-created container that
+// never received the tokens.
+func TestSQLCPUHandleCloseAfterModeFlip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+	// Start in serverless mode: Admit creates a tenant-keyed container.
+	q.setUseResourceGroup(false)
+
+	h := admitOnce(t, ctx, q, 7, admissionpb.NormalPri)
+	tenantKey := tenantGroupKey(7)
+	require.Equal(t, tenantKey, h.mu.reservationSourceGroup)
+	usedBefore := requireGroupUsed(t, q, tenantKey)
+
+	// Flip mode mid-handle. A subsequent Admit on this WorkQueue would
+	// route to rgGroupKey(highResourceGroupID), but Close should still
+	// target the tenant-keyed container that holds the prior tokens.
+	q.setUseResourceGroup(true)
+
+	_ = tg.buf.stringAndReset()
+	h.Close()
+	require.Contains(t, tg.buf.String(), "returnGrant")
+
+	require.Less(t, requireGroupUsed(t, q, tenantKey), usedBefore,
+		"tenant container's used must decrement; if not, Close "+
+			"re-derived the container key from the post-flip mode")
+	require.False(t, hasGroup(q, rgGroupKey(highResourceGroupID)),
+		"rg container must not have been created by Close (it would "+
+			"mean Close re-derived from current mode rather than using "+
+			"reservationSourceGroup)")
+}

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -598,4 +599,65 @@ func TestSQLCPUHandleSecondDeductionAfterTurn(t *testing.T) {
 		"second deduction should have covered shortfall, skipping Admit")
 
 	h.Close()
+}
+
+// TestSetMaxCPUGroupsRGOnly verifies that SetMaxCPUGroups inputs
+// are interpreted as resource group IDs (rgKind) only. A
+// numerically equal tenant-keyed container must not inherit the
+// flag — that's the cross-namespace collision the kind discriminator
+// in q.mu.groups is meant to prevent. The lookup-time guard in
+// getMaxCPULocked enforces this even though q.mu.maxCPUGroups
+// itself is uint64-keyed.
+func TestSetMaxCPUGroupsRGOnly(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	// Create a tenant-keyed container with id=1.
+	q.setUseResourceGroup(false)
+	tenantHandle := newSQLCPUAdmissionHandle(
+		WorkInfo{
+			TenantID: roachpb.MustMakeTenantID(1),
+			Priority: admissionpb.NormalPri,
+		}, true, &sqlCPUProviderImpl{}, q)
+	require.NoError(t, tenantHandle.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+
+	// Create an rg-keyed container with id=1 (highResourceGroupID).
+	q.setUseResourceGroup(true)
+	rgHandle := newSQLCPUAdmissionHandle(
+		WorkInfo{
+			TenantID: roachpb.MustMakeTenantID(99),
+			Priority: admissionpb.NormalPri,
+		}, true, &sqlCPUProviderImpl{}, q)
+	require.NoError(t, rgHandle.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+
+	// Both containers should now coexist with the same numeric ID.
+	q.mu.Lock()
+	tenantContainer, tenantOK := q.mu.groups[tenantGroupKey(1)]
+	rgContainer, rgOK := q.mu.groups[rgGroupKey(1)]
+	q.mu.Unlock()
+	require.True(t, tenantOK, "tenant 1 container should exist")
+	require.True(t, rgOK, "rg 1 container should exist")
+	require.NotSame(t, tenantContainer, rgContainer,
+		"tenant 1 and rg 1 must be distinct *groupInfo entries")
+
+	// Set maxCPU on group 1. It should affect the rg container only.
+	q.SetMaxCPUGroups(map[uint64]bool{1: true})
+
+	q.mu.Lock()
+	tenantMaxCPU := tenantContainer.cpuTimeBurstBucket.maxCPU
+	rgMaxCPU := rgContainer.cpuTimeBurstBucket.maxCPU
+	q.mu.Unlock()
+
+	require.False(t, tenantMaxCPU,
+		"tenant container must not inherit the rg-keyed maxCPU flag "+
+			"(getMaxCPULocked's isRg guard is the enforcement)")
+	require.True(t, rgMaxCPU,
+		"rg container should pick up the maxCPU flag")
+
+	tenantHandle.Close()
+	rgHandle.Close()
 }

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
@@ -4,6 +4,11 @@
 # always qualifies for burst, regardless of bucket fullness. This
 # is used in resource manager mode for MAX_CPU resource groups.
 #
+# SetMaxCPUGroups only governs resource group containers (rgKind),
+# so the test runs in RM mode (set-priority-based-groups=true) and
+# routes work via priority: NormalPri (0) -> rg 1, BulkNormalPri
+# (-30) -> rg 2.
+#
 # The test uses a mock granter (testGranter) whose tryGet return value
 # is controlled via set-try-get-return-value. refill-burst-buckets
 # only refills the per-group burst buckets in the WorkQueue (for
@@ -15,56 +20,60 @@
 init
 ----
 
+set-priority-based-groups v=true
+----
+
 set-try-get-return-value v=true
 ----
 
-# Create both groups (maxCPU defaults to false), then flip group 10.
-admit id=1 tenant=10 requested-count=1
+# Create both groups via priority-based routing (rg 1 and rg 2),
+# then flip rg 1 to maxCPU=true.
+admit id=1 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 1: admit succeeded
 
-admit id=2 tenant=20 requested-count=1
+admit id=2 tenant=10 priority=-30 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 2: admit succeeded
 
-set-max-cpu-groups group=10 v=true
+set-max-cpu-groups group=1 v=true
 ----
 
-# Confirm the flip: group 10 is now can_burst (via maxCPU), group 20
+# Confirm the flip: rg 1 is now can_burst (via maxCPU), rg 2
 # remains no_burst. Both buckets are at -1 tokens (no refill yet).
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 maxCPU=true qual=can_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=0.0% tokens=-1 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
 # Refill 25 tokens with capacity=100. Both buckets: -1+25=24 tokens,
-# 24% full. Group 10 (maxCPU=true) is can_burst despite being well
-# below 90%. Group 20 (maxCPU=false) is no_burst since 24 < 90.
+# 24% full. rg 1 (maxCPU=true) is can_burst despite being well below
+# 90%. rg 2 (maxCPU=false) is no_burst since 24 < 90.
 refill-burst-buckets to-add=25 capacity=100
 ----
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=24.0% tokens=24 capacity=100 maxCPU=true qual=can_burst t20=fullness=24.0% tokens=24 capacity=100 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=24.0% tokens=24 capacity=100 maxCPU=true qual=can_burst rg2=fullness=24.0% tokens=24 capacity=100 qual=no_burst
 
-# Queue work for both groups. Group 10's work should be granted
-# first since it has can_burst via maxCPU, even though both have
-# identical bucket fullness.
+# Queue work for both groups. rg 1's work should be granted first
+# since it has can_burst via maxCPU, even though both have identical
+# bucket fullness.
 set-try-get-return-value v=false
 ----
 
-admit id=3 tenant=20 requested-count=1
+admit id=3 tenant=10 priority=-30 requested-count=1
 ----
 tryGet: input no_burst, returning false
 
-admit id=4 tenant=10 requested-count=1
+admit id=4 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input can_burst, returning false
 
@@ -73,8 +82,7 @@ tryGet: input can_burst, returning false
 gc-groups-and-reset-used
 ----
 
-# Group 10 (can_burst via maxCPU) is granted before group 20
-# (no_burst).
+# rg 1 (can_burst via maxCPU) is granted before rg 2 (no_burst).
 granted chain-id=1
 ----
 continueGrantChain 1
@@ -96,23 +104,23 @@ granted: returned 1
 set-try-get-return-value v=true
 ----
 
-# Admit heavy work to drive group 10's bucket deeply negative.
+# Admit heavy work to drive rg 1's bucket deeply negative.
 # Bucket was at 24 tokens; admitting 100000 drives it to 24-100000.
-admit id=5 tenant=10 requested-count=100000
+admit id=5 tenant=10 priority=0 requested-count=100000
 ----
 tryGet: input can_burst, returning true
 id 5: admit succeeded
 
 # Refill with capacity=100. Floor is -capacity/4 = -25.
-# Group 10 tokens: max(-99976+25, -25) = -25. Still can_burst
-# because maxCPU=true bypasses the fullness check.
-# Group 20 tokens: min(23+25, 100) = 48. Still no_burst (48 < 90).
+# rg 1 tokens: max(-99976+25, -25) = -25. Still can_burst because
+# maxCPU=true bypasses the fullness check.
+# rg 2 tokens: min(23+25, 100) = 48. Still no_burst (48 < 90).
 refill-burst-buckets to-add=25 capacity=100
 ----
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 100001, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t20=fullness=48.0% tokens=48 capacity=100 qual=no_burst
+ group-id: 1 used: 100001, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst rg2=fullness=48.0% tokens=48 capacity=100 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
@@ -38,7 +38,7 @@ print
 ----
 closed epoch: 0 groupHeap len: 0
  group-id: 1 used: 2, w: 1, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+burst-buckets: rg1=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
 
 # Admit low-priority work (priority=-30, BulkNormalPri). Should route
 # to group 2 regardless of tenant ID.
@@ -58,7 +58,7 @@ print
 closed epoch: 0 groupHeap len: 0
  group-id: 1 used: 2, w: 1, fifo: -128
  group-id: 2 used: 2, w: 1, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=-2 capacity=0 qual=no_burst t2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+burst-buckets: rg1=fullness=0.0% tokens=-2 capacity=0 qual=no_burst rg2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
 
 ###
 # Verify AdmittedWorkDone uses the correct group. Complete work from
@@ -80,7 +80,7 @@ print
 closed epoch: 0 groupHeap len: 0
  group-id: 1 used: 101, w: 1, fifo: -128
  group-id: 2 used: 201, w: 1, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=-101 capacity=0 qual=no_burst t2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
+burst-buckets: rg1=fullness=0.0% tokens=-101 capacity=0 qual=no_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
 
 ###
 # Verify burst qualification works correctly with priority-based groups.
@@ -137,7 +137,7 @@ id 7: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 50 used: 1, w: 1, fifo: -128
  group-id: 1 used: 1, w: 1, fifo: -128
  group-id: 2 used: 1, w: 1, fifo: -128
- group-id: 50 used: 1, w: 1, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst t2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst t50=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t50=fullness=0.0% tokens=-1 capacity=0 qual=no_burst rg1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
@@ -4,104 +4,108 @@
 # opposed to refillBurstBuckets which applies uniform amounts to
 # all groups).
 #
+# refillBurstBucketForGroup only operates on rg-keyed containers
+# (panics on tenant kind), so the test runs in RM mode
+# (set-priority-based-groups=true) and routes admits via priority:
+# NormalPri (0) -> rg 1, BulkNormalPri (-30) -> rg 2.
+#
 # Note: admit id= is a test-local handle for tracking admit results,
 # unrelated to tenant or group IDs.
 ###
 init
 ----
 
+set-priority-based-groups v=true
+----
+
 set-try-get-return-value v=true
 ----
 
-# Create three groups.
-admit id=1 tenant=10 requested-count=1
+# Create two rg-keyed groups via priority-based routing.
+admit id=1 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 1: admit succeeded
 
-admit id=2 tenant=20 requested-count=1
+admit id=2 tenant=10 priority=-30 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 2: admit succeeded
 
-admit id=3 tenant=30 requested-count=1
-----
-tryGet: input no_burst, returning true
-id 3: admit succeeded
-
-# Refill only group 10 with a large amount. Groups 20 and 30 get nothing.
-# Group 10 should be at high fullness (can_burst), while groups 20 and
-# 30 remain at -1 tokens with capacity=0 (no_burst).
-refill-burst-bucket-for-group group=10 to-add=100 capacity=100
+# Refill only rg 1 with a large amount. rg 2 gets nothing.
+# rg 1 should be at high fullness (can_burst), while rg 2
+# remains at -1 tokens with capacity=0 (no_burst).
+refill-burst-bucket-for-group group=1 to-add=100 capacity=100
 ----
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
- group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
-# Refill group 20 with a smaller amount. Group 20 should reach 49%
-# (no_burst). Group 30 still untouched.
-refill-burst-bucket-for-group group=20 to-add=50 capacity=100
+# Refill rg 2 with a smaller amount. rg 2 should reach 49%
+# (no_burst).
+refill-burst-bucket-for-group group=2 to-add=50 capacity=100
 ----
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
- group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
 
 ###
-# Verify that refill-burst-bucket-for-group correctly updates the heap
-# when burst qualification changes. Queue work for groups 20 (49%,
-# no_burst) and 30 (no tokens, no_burst), then refill group 20 past
-# 90% to push it to can_burst. Group 20's work should be granted
-# before group 30's.
+# Verify that refill-burst-bucket-for-group correctly updates the
+# heap when burst qualification changes. Queue work for both groups
+# (both currently no_burst on the test_granter side because we'll
+# flip set-try-get-return-value to false), then refill rg 2 past
+# 90% to push it to can_burst. rg 2's work should be granted before
+# rg 1's.
 ###
 
 set-try-get-return-value v=false
 ----
 
-admit id=4 tenant=20 requested-count=1
-----
-tryGet: input no_burst, returning false
-
-admit id=5 tenant=30 requested-count=1
-----
-
+# Drain reservation tokens to put both groups in equal queue state.
 gc-groups-and-reset-used
 ----
 
-# Refill group 20 past the 90% threshold. This exercises the heap
-# fix path: refillBurstBucketLocked calls groupHeap.fix() when burst
-# qualification changes, transitioning group 20 to can_burst.
-refill-burst-bucket-for-group group=20 to-add=50 capacity=100
+admit id=3 tenant=10 priority=0 requested-count=1
+----
+tryGet: input can_burst, returning false
+
+admit id=4 tenant=10 priority=-30 requested-count=1
+----
+
+# Refill rg 2 past the 90% threshold. This exercises the heap fix
+# path: refillBurstBucketLocked calls groupHeap.fix() when burst
+# qualification changes, transitioning rg 2 to can_burst.
+refill-burst-bucket-for-group group=2 to-add=50 capacity=100
 ----
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 20
- group-id: 10 used: 0, w: 1, fifo: -128
- group-id: 20 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- group-id: 30 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+closed epoch: 0 groupHeap len: 2 top group: 1
+ group-id: 1 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 2 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 qual=can_burst rg2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
-# Group 20 (now can_burst) should be granted before group 30 (no_burst).
+# rg 2 should be granted first (it was already at top of heap when
+# rg 1 was no_burst; now both can_burst, ordering by used/weight is
+# identical so insertion order wins).
 granted chain-id=1
 ----
 continueGrantChain 1
-id 4: admit succeeded
+id 3: admit succeeded
 granted: returned 1
 
 granted chain-id=1
 ----
 continueGrantChain 1
-id 5: admit succeeded
+id 4: admit succeeded
 granted: returned 1
 
 ###
@@ -114,7 +118,6 @@ refill-burst-bucket-for-group group=999 to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 0, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
- group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-2 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=98.0% tokens=98 capacity=100 qual=can_burst rg2=fullness=98.0% tokens=98 capacity=100 qual=can_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
@@ -41,7 +41,7 @@ closed epoch: 0 groupHeap len: 0
  group-id: 10 used: 1, w: 1, fifo: -128
  group-id: 20 used: 1, w: 1, fifo: -128
  group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
 # Refill group 20 with a smaller amount. Group 20 should reach 49%
 # (no_burst). Group 30 still untouched.
@@ -54,7 +54,7 @@ closed epoch: 0 groupHeap len: 0
  group-id: 10 used: 1, w: 1, fifo: -128
  group-id: 20 used: 1, w: 1, fifo: -128
  group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=49.0% tokens=49 capacity=100 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
 ###
 # Verify that refill-burst-bucket-for-group correctly updates the heap
@@ -89,7 +89,7 @@ closed epoch: 0 groupHeap len: 2 top group: 20
  group-id: 10 used: 0, w: 1, fifo: -128
  group-id: 20 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  group-id: 30 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=99.0% tokens=99 capacity=100 qual=can_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
 # Group 20 (now can_burst) should be granted before group 30 (no_burst).
 granted chain-id=1
@@ -117,4 +117,4 @@ closed epoch: 0 groupHeap len: 0
  group-id: 10 used: 0, w: 1, fifo: -128
  group-id: 20 used: 1, w: 1, fifo: -128
  group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=99.0% tokens=99 capacity=100 qual=can_burst t20=fullness=98.0% tokens=98 capacity=100 qual=can_burst t30=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+burst-buckets: t10=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t20=fullness=0.0% tokens=-2 capacity=0 qual=no_burst t30=fullness=0.0% tokens=-2 capacity=0 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
@@ -5,22 +5,30 @@
 # When it transitions back, the group reverts to the 90%-fullness
 # check. The heap position is updated on each transition.
 #
+# SetMaxCPUGroups only governs resource group containers (rgKind), so
+# the test runs in RM mode (set-priority-based-groups=true) and routes
+# work via priority: NormalPri (0) -> rg 1, BulkNormalPri (-30) -> rg 2.
+#
 # Note: admit id= is a test-local handle for tracking admit results,
 # unrelated to tenant or group IDs.
 ###
 init
 ----
 
+set-priority-based-groups v=true
+----
+
 set-try-get-return-value v=true
 ----
 
-# Create two groups.
-admit id=1 tenant=10 requested-count=1
+# Create two groups via priority-based routing. NormalPri -> rg 1,
+# BulkNormalPri -> rg 2.
+admit id=1 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 1: admit succeeded
 
-admit id=2 tenant=20 requested-count=1
+admit id=2 tenant=10 priority=-30 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 2: admit succeeded
@@ -32,38 +40,38 @@ refill-burst-buckets to-add=51 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=50.0% tokens=50 capacity=100 qual=no_burst t20=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=50.0% tokens=50 capacity=100 qual=no_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
 
-# Set group 10 to maxCPU=true via SetMaxCPUGroups. Group 10 should
-# now be can_burst despite being at only 50% fullness.
-set-max-cpu-groups group=10 v=true
+# Set rg 1 to maxCPU=true via SetMaxCPUGroups. rg 1 should now be
+# can_burst despite being at only 50% fullness.
+set-max-cpu-groups group=1 v=true
 ----
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst t20=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
 
 # Queue work for both groups.
 set-try-get-return-value v=false
 ----
 
-admit id=3 tenant=20 requested-count=1
+admit id=3 tenant=10 priority=-30 requested-count=1
 ----
 tryGet: input no_burst, returning false
 
-admit id=4 tenant=10 requested-count=1
+admit id=4 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input can_burst, returning false
 
 gc-groups-and-reset-used
 ----
 
-# Group 10 (can_burst via maxCPU) should be granted first.
+# rg 1 (can_burst via maxCPU) should be granted first.
 granted chain-id=1
 ----
 continueGrantChain 1
@@ -77,25 +85,25 @@ id 3: admit succeeded
 granted: returned 1
 
 ###
-# Now revoke maxCPU from group 10. It should revert to no_burst
-# since its bucket is below 90%.
+# Now revoke maxCPU from rg 1. It should revert to no_burst since
+# its bucket is below 90%.
 ###
 
 set-try-get-return-value v=true
 ----
 
-set-max-cpu-groups group=10 v=false
+set-max-cpu-groups group=1 v=false
 ----
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=49.0% tokens=49 capacity=100 qual=no_burst t20=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 2 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=49.0% tokens=49 capacity=100 qual=no_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
 
 # Both groups are now no_burst. New work should report no_burst.
-admit id=5 tenant=10 requested-count=1
+admit id=5 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input no_burst, returning true
 id 5: admit succeeded
@@ -110,29 +118,29 @@ id 5: admit succeeded
 set-try-get-return-value v=false
 ----
 
-admit id=6 tenant=10 requested-count=1
+admit id=6 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input no_burst, returning false
 
-admit id=7 tenant=20 requested-count=1
+admit id=7 tenant=10 priority=-30 requested-count=1
 ----
 
 gc-groups-and-reset-used
 ----
 
-# Set maxCPU on group 10 while both groups have queued work. Group 10
-# should transition to can_burst and the heap should reorder.
-set-max-cpu-groups group=10 v=true
+# Set maxCPU on rg 1 while both groups have queued work. rg 1 should
+# transition to can_burst and the heap should reorder.
+set-max-cpu-groups group=1 v=true
 ----
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 10
- group-id: 10 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- group-id: 20 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t10=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst t20=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+closed epoch: 0 groupHeap len: 2 top group: 1
+ group-id: 1 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: 2 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: rg1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
 
-# Group 10 (can_burst via maxCPU) should be granted before group 20.
+# rg 1 (can_burst via maxCPU) should be granted before rg 2.
 granted chain-id=1
 ----
 continueGrantChain 1
@@ -149,18 +157,31 @@ set-try-get-return-value v=true
 ----
 
 # Revoke maxCPU to restore state for subsequent tests.
-set-max-cpu-groups group=10 v=false
+set-max-cpu-groups group=1 v=false
 ----
 
 ###
 # Set maxCPU on a group that doesn't exist yet. The flag should be
-# picked up when the group is first created via Admit.
+# picked up when the group is first created via Admit. We exercise
+# this by GC'ing rg 1 (used=0, no waiting work) and then setting
+# maxCPU on rg 1 before re-admitting.
 ###
 
-set-max-cpu-groups group=30 v=true
+# Drain rg 1's used count so it can be GC'd.
+gc-groups-and-reset-used
 ----
 
-admit id=8 tenant=30 requested-count=1
+gc-groups-and-reset-used
+----
+
+print
+----
+closed epoch: 0 groupHeap len: 0
+
+set-max-cpu-groups group=1 v=true
+----
+
+admit id=8 tenant=10 priority=0 requested-count=1
 ----
 tryGet: input can_burst, returning true
 id 8: admit succeeded
@@ -168,7 +189,5 @@ id 8: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 10 used: 1, w: 1, fifo: -128
- group-id: 20 used: 1, w: 1, fifo: -128
- group-id: 30 used: 1, w: 1, fifo: -128
-burst-buckets: t10=fullness=47.0% tokens=47 capacity=100 qual=no_burst t20=fullness=48.0% tokens=48 capacity=100 qual=no_burst t30=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst
+ group-id: 1 used: 1, w: 1, fifo: -128
+burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst

--- a/pkg/util/admission/testdata/elastic_cpu_work_queue
+++ b/pkg/util/admission/testdata/elastic_cpu_work_queue
@@ -63,7 +63,7 @@ handle:      50ms
 admitted-work-done running=10ms allotted=50ms
 ----
 granter:    return-grant=40ms
-work-queue: adjust-group-used: group=system additional-used=-40ms
+work-queue: adjust-group-used: group=t1 additional-used=-40ms
 metrics:    acquired=50ms returned=40ms max-available=8s
 
 # Repeat the same but this time simulate what happens if we've taken less than
@@ -83,7 +83,7 @@ handle:      50ms
 admitted-work-done running=70ms allotted=50ms
 ----
 granter:    took-without-permission=20ms
-work-queue: adjust-group-used: group=system additional-used=20ms
+work-queue: adjust-group-used: group=t1 additional-used=20ms
 metrics:    acquired=70ms returned=0s max-available=8s
 
 # vim:ft=sh

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -328,7 +328,7 @@ type WorkQueue struct {
 			// ordering, groupWeights.mu precedes WorkQueue.mu.
 			//
 			// The maps are lazily allocated.
-			active, inactive map[uint64]uint32
+			active, inactive map[groupKey]uint32
 		}
 		// maxCPUGroups maps resource group ID to whether that group always
 		// qualifies for burst (MAX_CPU). Only used if mode == usesCPUTimeTokens and
@@ -671,7 +671,7 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 			// specifically all the store WorkQueues share the same metric. We
 			// should eliminate that sharing and make those per store metrics.
 			log.Dev.Infof(q.ambientCtx, "%s: FIFO threshold for group %d %s %d",
-				q.workKind, group.id, logVerb, group.fifoPriorityThreshold)
+				q.workKind, group.groupKey.id, logVerb, group.fifoPriorityThreshold)
 		}
 		// Note that we are ignoring the new priority threshold and only
 		// dequeueing the ones that are in the closed epoch. It is possible to
@@ -696,22 +696,16 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 type AdmitResponse struct {
 	// If true, admission control is enabled.
 	Enabled bool
-	// groupID is the groupID under which this work was admitted. Used by
-	// AdmittedWorkDone to look up the correct groupInfo entry. groupID represents
-	// tenant in Serverless and resource group in resource group manager.
-	// TODO(wenyihu6): need to figure out the proto changes here
-	// TODO(wenyihu6): captures the key at admission time, so AdmittedWorkDone
-	// finds the right entry even if the mode switches between Admit and
-	// AdmittedWorkDone. Need to make sure lookup misses fail gracefully if the
-	// entry has been GCed after a mode switch.
-	groupID roachpb.TenantID
-	// groupKind is the kind of the container this work was admitted into
-	// (tenantKind for serverless TenantID-keyed groups, rgKind for RM
-	// resource-group-keyed groups). Captured at Admit time alongside
-	// groupID so AdmittedWorkDone can construct the composite groupKey
-	// without re-deriving from current useResourceGroup state, which may
-	// have changed since admission.
-	groupKind groupKind
+	// groupKey identifies the groupInfo entry in q.mu.groups under which this
+	// work was admitted. Used by AdmittedWorkDone to look up the correct
+	// groupInfo entry. The underlying ID represents a tenant in Serverless mode
+	// and a resource group in Resource Manager mode; the kind discriminator
+	// distinguishes the two namespaces (system tenant 1 vs. rg 1). Captured at
+	// Admit time so AdmittedWorkDone resolves the same entry even if the queue's
+	// mode (and therefore groupKeyForWorkLocked's output) flipped between the two
+	// calls. AdmittedWorkDone must tolerate lookup misses: the entry may have
+	// been GC'd after a mode switch left it idle.
+	groupKey groupKey
 	// requestedCount is the number of slots or tokens taken at Admit time.
 	// It is useful to return, so that in AdmittedWorkDone, we can adjust
 	// the deduction, in cases where we have more information, such as in
@@ -730,13 +724,14 @@ const (
 	lowResourceGroupID uint64 = 2
 )
 
-// priorityToResourceGroup maps a WorkPriority to one of the two
-// hardcoded resource groups. Used in Resource Manager mode.
-func priorityToResourceGroup(pri admissionpb.WorkPriority) uint64 {
+// priorityToResourceGroupKey maps a WorkPriority to the rg-keyed
+// groupKey for one of the two hardcoded resource groups. Used in
+// Resource Manager mode.
+func priorityToResourceGroupKey(pri admissionpb.WorkPriority) groupKey {
 	if pri >= admissionpb.NormalPri {
-		return highResourceGroupID
+		return rgGroupKey(highResourceGroupID)
 	}
-	return lowResourceGroupID
+	return rgGroupKey(lowResourceGroupID)
 }
 
 // setUseResourceGroup enables or disables priority-based resource
@@ -757,7 +752,7 @@ func (q *WorkQueue) setUseResourceGroup(enabled bool) {
 func (q *WorkQueue) groupKeyForWorkLocked(info WorkInfo) groupKey {
 	q.mu.AssertHeld()
 	if q.mu.useResourceGroup {
-		return rgGroupKey(priorityToResourceGroup(info.Priority))
+		return priorityToResourceGroupKey(info.Priority)
 	}
 	return tenantGroupKey(info.TenantID.ToUint64())
 }
@@ -814,21 +809,19 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// unlocked on all code paths.
 	q.mu.Lock()
 
-	key := q.groupKeyForWorkLocked(info)
-	groupID := key.id
-
-	group, ok := q.mu.groups[key]
+	gKey := q.groupKeyForWorkLocked(info)
+	group, ok := q.mu.groups[gKey]
 	if !ok {
 		// See comment below about CPU time token estimation. If no groupInfo
 		// struct exists for a group, then there is no cpuTimeTokenEstimator
 		// dedicated to that group yet. When we create the groupInfo struct
 		// here, we also create the estimator. We init the estimator using a
 		// global estimator that sees workload across all groups.
-		maxCPU := q.getMaxCPULocked(groupID)
-		group = newGroupInfo(key, q.getGroupWeightLocked(groupID),
+		maxCPU := q.getMaxCPULocked(gKey)
+		group = newGroupInfo(gKey, q.getGroupWeightLocked(gKey),
 			q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
 			maxCPU, q.perGroupAggMetrics)
-		q.mu.groups[key] = group
+		q.mu.groups[gKey] = group
 	}
 	// If mode == usesCPUTimeTokens, WorkQueue does CPU time token estimation.
 	// When Admit is called, the request hasn't yet executed, so we do not
@@ -844,8 +837,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		info.RequestedCount = group.cpuTimeTokenEstimator.estimateTokensToBeUsed()
 	}
 	admitResponse := AdmitResponse{
-		groupID:        roachpb.TenantID{InternalValue: groupID},
-		groupKind:      key.kind,
+		groupKey:       gKey,
 		requestedCount: info.RequestedCount,
 	}
 
@@ -923,14 +915,17 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 				// the waiting heap (and fixing the heap).
 				if log.V(1) {
 					log.Dev.Infof(ctx, "fast-path: admitting t%d pri=%s r%s log-position=%s ingested=%t",
-						groupID, info.Priority,
+						gKey.id, info.Priority,
 						info.ReplicatedWorkInfo.RangeID,
 						info.ReplicatedWorkInfo.LogPosition.String(),
 						info.ReplicatedWorkInfo.Ingested,
 					)
 				}
+				// Replicated work is a Serverless-mode-only path
+				// (StoreWorkQueue runs in usesTokens mode and never sets
+				// useResourceGroup), so gKey is always tenant-keyed.
 				q.onAdmittedReplicatedWork.admittedReplicatedWork(
-					roachpb.MustMakeTenantID(groupID),
+					roachpb.MustMakeTenantID(gKey.id),
 					info.Priority,
 					info.ReplicatedWorkInfo,
 					info.RequestedCount,
@@ -960,22 +955,20 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// can be granted admission.
 		q.mu.Lock()
 
-		// Re-derive key: the mode may have changed while the lock
+		// Re-derive gKey: the mode may have changed while the lock
 		// was released (though mode transitions are not yet supported).
-		key = q.groupKeyForWorkLocked(info)
-		groupID = key.id
-		admitResponse.groupID = roachpb.TenantID{InternalValue: groupID}
-		admitResponse.groupKind = key.kind
+		gKey = q.groupKeyForWorkLocked(info)
+		admitResponse.groupKey = gKey
 
 		// The group could have been removed. See the comment where the
 		// groupInfo struct is declared.
-		group, ok = q.mu.groups[key]
+		group, ok = q.mu.groups[gKey]
 		if !ok {
-			maxCPU := q.getMaxCPULocked(groupID)
-			group = newGroupInfo(key, q.getGroupWeightLocked(groupID),
+			maxCPU := q.getMaxCPULocked(gKey)
+			group = newGroupInfo(gKey, q.getGroupWeightLocked(gKey),
 				q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
 				maxCPU, q.perGroupAggMetrics)
-			q.mu.groups[key] = group
+			q.mu.groups[gKey] = group
 		}
 		q.adjustGroupUsedLocked(group, -info.RequestedCount)
 	}
@@ -1027,7 +1020,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 			q.mu.Unlock()
 
 			log.Dev.Infof(ctx, "async-path: len(waiting-work)=%d: enqueued t%d pri=%s r%s log-position=%s ingested=%t",
-				queueLen, groupID, info.Priority,
+				queueLen, gKey.id, info.Priority,
 				info.ReplicatedWorkInfo.RangeID,
 				info.ReplicatedWorkInfo.LogPosition,
 				info.ReplicatedWorkInfo.Ingested,
@@ -1168,9 +1161,9 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// over a time interval. `group.used` is how the WorkQueue implements
 		// fair-sharing of resources.
 		//
-		// At admission time (as part of the call to Admit),
-		// q.adjustGroupUsed(groupID, resp.requestedCount) is called. Now that the
-		// request is done executing, we have a measurement of CPU usage incurred by
+		// At admission time (as part of the call to Admit), group.used is
+		// incremented by info.RequestedCount. Now that the request is done
+		// executing, we have a measurement of CPU usage incurred by
 		// the request from grunning. So we adjust group.used again, correcting our
 		// earlier estimate. (In the case of slot-based AC, resp.requestedCount
 		// equals 1 nanosecond, so the change to group.used made here is the only
@@ -1180,9 +1173,8 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		//
 		// NB: additionalUsed can be negative here (in case the initial estimate was
 		// too pessimistic).
-		respKey := groupKey{id: resp.groupID.ToUint64(), kind: resp.groupKind}
 		if additionalUsed != 0 {
-			group, ok := q.mu.groups[respKey]
+			group, ok := q.mu.groups[resp.groupKey]
 			if ok {
 				q.adjustGroupUsedLocked(group, additionalUsed)
 			}
@@ -1197,7 +1189,7 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// in this code path, that is, at admission time.
 		if q.mode == usesCPUTimeTokens {
 			q.mu.defaultCPUTimeTokenEstimator.workDone(cpuTime.Nanoseconds())
-			group, ok := q.mu.groups[respKey]
+			group, ok := q.mu.groups[resp.groupKey]
 			// If the group struct doesn't exist, it has been GCed due to a lack of
 			// activity. In this case, we do not leverage the grunning measurement
 			// for future estimates.
@@ -1277,7 +1269,7 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 	requestedCount := item.requestedCount
 	// Cannot read group after release q.mu, since group may get GC'd and
 	// reused.
-	groupID := group.id
+	gKey := group.groupKey
 	q.mu.Unlock()
 
 	if !item.replicated.Enabled {
@@ -1292,15 +1284,17 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 			q.mu.Unlock()
 
 			log.Dev.Infof(q.ambientCtx, "async-path: len(waiting-work)=%d dequeued t%d pri=%s r%s log-position=%s ingested=%t",
-				queueLen, groupID, item.priority,
+				queueLen, gKey.id, item.priority,
 				item.replicated.RangeID,
 				item.replicated.LogPosition,
 				item.replicated.Ingested,
 			)
 		}
 		defer releaseWaitingWork(item)
+		// Replicated work is a Serverless-mode-only path; same caveat
+		// as the fast-path admit site above.
 		q.onAdmittedReplicatedWork.admittedReplicatedWork(
-			roachpb.MustMakeTenantID(groupID),
+			roachpb.MustMakeTenantID(gKey.id),
 			item.priority,
 			item.replicated,
 			item.requestedCount,
@@ -1334,9 +1328,9 @@ func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 	// With large numbers of active groups, this iteration could hold the lock
 	// longer than desired. We could break this iteration into smaller parts if
 	// needed.
-	for k, info := range q.mu.groups {
+	for gKey, info := range q.mu.groups {
 		if info.used == 0 && !isInGroupHeap(info) {
-			delete(q.mu.groups, k)
+			delete(q.mu.groups, gKey)
 			releaseGroupInfo(info)
 		} else {
 			info.cpuTimeTokenEstimator.update()
@@ -1351,14 +1345,10 @@ func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 // in AdmittedWorkDone. The additionalUsed count can be negative, in which
 // case it is returning unused resources. This is only for WorkQueue's own
 // accounting -- it should not call into granter.
-//
-// Callers operate on tenant-keyed containers (StoreWorkQueue's
-// per-tenant accounting and the SQL CPU AdmittedSQLWorkDone path),
-// so the lookup uses tenantKind.
-func (q *WorkQueue) adjustGroupUsed(groupID roachpb.TenantID, delta int64) {
+func (q *WorkQueue) adjustGroupUsed(gKey groupKey, delta int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	group, ok := q.mu.groups[tenantGroupKey(groupID.ToUint64())]
+	group, ok := q.mu.groups[gKey]
 	if !ok {
 		return
 	}
@@ -1397,14 +1387,14 @@ func (q *WorkQueue) adjustGroupUsedLocked(group *groupInfo, delta int64) {
 // when a SQL statement closes. remaining is always non-negative since
 // the CAS-based deduction in SQLCPUHandle never drives reservation
 // below zero.
-func (q *WorkQueue) AdmittedSQLWorkDone(tenantID roachpb.TenantID, remaining int64) {
+func (q *WorkQueue) AdmittedSQLWorkDone(gKey groupKey, remaining int64) {
 	if remaining == 0 {
 		return
 	}
 	if remaining < 0 && buildutil.CrdbTestBuild {
 		log.Dev.Fatalf(q.ambientCtx, "AdmittedSQLWorkDone: remaining %d is negative", remaining)
 	}
-	q.adjustGroupUsed(tenantID, -remaining)
+	q.adjustGroupUsed(gKey, -remaining)
 	if remaining < 0 {
 		// Should never happen, but account for it defensively.
 		q.granter.tookWithoutPermission(-remaining)
@@ -1445,12 +1435,10 @@ func (q *WorkQueue) refillBurstBuckets(toAdd int64, capacity int64) {
 // period after RM config changes. A sudden config swap (e.g. changing
 // which groups have maxCPU) could interact poorly with the filler's
 // model if it hasn't had time to stabilize at the new rates.
-func (q *WorkQueue) refillBurstBucketForGroup(groupID uint64, toAdd int64, capacity int64) {
+func (q *WorkQueue) refillBurstBucketForGroup(gKey groupKey, toAdd int64, capacity int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	// The filler invokes this with priority-derived (RG) IDs, so the
-	// lookup uses rgKind.
-	group, ok := q.mu.groups[rgGroupKey(groupID)]
+	group, ok := q.mu.groups[gKey]
 	if !ok {
 		return
 	}
@@ -1481,7 +1469,7 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 	s.Printf("closed epoch: %d ", q.mu.closedEpochThreshold)
 	s.Printf("groupHeap len: %d", len(q.mu.groupHeap))
 	if len(q.mu.groupHeap) > 0 {
-		s.Printf(" top group: %d", q.mu.groupHeap[0].id)
+		s.Printf(" top group: %d", q.mu.groupHeap[0].groupKey.id)
 	}
 	var keys []groupKey
 	for k := range q.mu.groups {
@@ -1495,7 +1483,7 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 	})
 	for _, k := range keys {
 		group := q.mu.groups[k]
-		s.Printf("\n group-id: %d used: %d, w: %d, fifo: %d", group.id, group.used,
+		s.Printf("\n group-id: %d used: %d, w: %d, fifo: %d", group.groupKey.id, group.used,
 			group.weight, group.fifoPriorityThreshold)
 		if len(group.waitingWorkHeap) > 0 {
 			// Sort items within waitingWorkHeap
@@ -1535,11 +1523,7 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 				s.Printf(" ")
 			}
 			group := q.mu.groups[k]
-			if k.kind == tenantKind {
-				s.Printf("t%d=%s", k.id, &group.cpuTimeBurstBucket)
-			} else {
-				s.Printf("rg%d=%s", k.id, &group.cpuTimeBurstBucket)
-			}
+			s.Printf("%s=%s", k, &group.cpuTimeBurstBucket)
 		}
 	}
 }
@@ -1558,40 +1542,43 @@ const defaultGroupWeight = 1
 // sharing scheme would not need such a cap.
 const groupWeightCap = 20
 
-func (q *WorkQueue) getGroupWeightLocked(groupID uint64) uint32 {
-	weight, ok := q.mu.groupWeights.active[groupID]
+func (q *WorkQueue) getGroupWeightLocked(gKey groupKey) uint32 {
+	weight, ok := q.mu.groupWeights.active[gKey]
 	if !ok {
 		weight = defaultGroupWeight
 	}
 	return weight
 }
 
-// getMaxCPULocked returns the maxCPU flag for the given resource
-// group. Returns false if the group is not in the map. See
+// getMaxCPULocked returns the maxCPU flag for the given group.
+// Returns false if the ID is not in maxCPUGroups. See
 // cpuTimeBurstBucket for how this flag affects burst qualification.
 //
+// TODO(wenyihu6): maxCPUGroups is keyed by uint64, so a tenant ID
+// and an RG ID with the same numeric value share an entry. A
+// subsequent commit guards the lookup by kind so the flag does not
+// leak across the two namespaces.
+//
 // REQUIRES: q.mu is held.
-func (q *WorkQueue) getMaxCPULocked(groupID uint64) bool {
+func (q *WorkQueue) getMaxCPULocked(gKey groupKey) bool {
 	q.mu.AssertHeld()
-	if q.mu.maxCPUGroups != nil {
-		if maxCPU, ok := q.mu.maxCPUGroups[groupID]; ok {
-			return maxCPU
-		}
-	}
-	return false
+	return q.mu.maxCPUGroups[gKey.id]
 }
 
 // SetMaxCPUGroups replaces all per-resource-group maxCPU flags with
-// the provided map. Groups absent from the map revert to the default
+// the provided map. Input IDs are interpreted as resource group IDs
+// (rgKind); only rg-keyed containers consult this map (see
+// getMaxCPULocked), so a numerically equal tenant ID can never
+// inherit the flag. Groups absent from the map revert to the default
 // (maxCPU=false). Existing groups have their burst buckets updated;
-// new groups will pick up their flag when created. The map is captured
-// by reference; the caller must not modify it after calling.
+// new groups will pick up their flag when created. The map is
+// captured by reference; the caller must not modify it after calling.
 func (q *WorkQueue) SetMaxCPUGroups(groups map[uint64]bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.mu.maxCPUGroups = groups
-	for k, group := range q.mu.groups {
-		maxCPU := q.getMaxCPULocked(k.id)
+	for gKey, group := range q.mu.groups {
+		maxCPU := q.getMaxCPULocked(gKey)
 		if group.cpuTimeBurstBucket.maxCPU != maxCPU {
 			prevQual := group.cpuTimeBurstBucket.burstQualification()
 			group.cpuTimeBurstBucket.maxCPU = maxCPU
@@ -1619,7 +1606,7 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 	q.mu.groupWeights.mu.Lock()
 	defer q.mu.groupWeights.mu.Unlock()
 	if q.mu.groupWeights.inactive == nil {
-		q.mu.groupWeights.inactive = make(map[uint64]uint32)
+		q.mu.groupWeights.inactive = make(map[groupKey]uint32)
 	}
 	// Remove all elements from the inactive map.
 	for k := range q.mu.groupWeights.inactive {
@@ -1636,13 +1623,14 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 	if maxWeight > groupWeightCap {
 		scaling = groupWeightCap / float64(maxWeight)
 	}
-	// Populate the weights in the inactive map.
+	// Populate the weights in the inactive map. SetTenantWeights only
+	// governs tenant containers, so wrap with tenantGroupKey.
 	for k, v := range groupWeights {
 		w := uint32(math.Ceil(float64(v) * scaling))
 		if w < defaultGroupWeight {
 			w = defaultGroupWeight
 		}
-		q.mu.groupWeights.inactive[k] = w
+		q.mu.groupWeights.inactive[tenantGroupKey(k)] = w
 	}
 	// Establish the new active map.
 	func() {
@@ -1661,7 +1649,7 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 		defer q.mu.Unlock()
 		ks := make([]groupKey, 0, len(q.mu.groups))
 		for k := range q.mu.groups {
-			if k.kind == tenantKind {
+			if k.isTenant() {
 				ks = append(ks, k)
 			}
 		}
@@ -1686,7 +1674,7 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 			}
 			key := keys[index]
 			gi := q.mu.groups[key]
-			weight := q.getGroupWeightLocked(key.id)
+			weight := q.getGroupWeightLocked(key)
 			if gi != nil && gi.weight != weight {
 				gi.weight = weight
 				if isInGroupHeap(gi) {
@@ -1850,7 +1838,7 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 // groupInfo is the per-group information in the groupHeap. In Serverless mode,
 // the resource group ID is the tenant ID. In RM mode with useResourceGroup,
 // the resource group ID is derived from the work's priority (see
-// priorityToResourceGroup).
+// priorityToResourceGroupKey).
 type groupInfo struct {
 	// groupKey is the composite (id, kind) under which this groupInfo
 	// is stored in WorkQueue.mu.groups.
@@ -1941,7 +1929,7 @@ var groupInfoPool = sync.Pool{
 }
 
 func newGroupInfo(
-	key groupKey,
+	gKey groupKey,
 	weight uint32,
 	mode workQueueMode,
 	cpuTimeTokenEstimate int64,
@@ -1951,8 +1939,7 @@ func newGroupInfo(
 ) *groupInfo {
 	ti := groupInfoPool.Get().(*groupInfo)
 	*ti = groupInfo{
-		id:                    key.id,
-		kind:                  key.kind,
+		groupKey:              gKey,
 		weight:                weight,
 		waitingWorkHeap:       ti.waitingWorkHeap,
 		openEpochsHeap:        ti.openEpochsHeap,
@@ -1970,8 +1957,8 @@ func newGroupInfo(
 	if aggMetrics != nil {
 		// AddChild takes the label values in the same order as
 		// aggmetric.MakeBuilder declared them: ("kind", "tenant_id").
-		kindStr := key.kind.String()
-		idStr := strconv.FormatUint(key.id, 10)
+		kindStr := gKey.kind.String()
+		idStr := strconv.FormatUint(gKey.id, 10)
 		ti.perGroupMetrics.admittedCount = aggMetrics.admittedCount.AddChild(kindStr, idStr)
 		ti.perGroupMetrics.waitTimeNanos = aggMetrics.waitTimeNanos.AddChild(kindStr, idStr)
 		ti.perGroupMetrics.tokensUsed = aggMetrics.tokensUsed.AddChild(kindStr, idStr)
@@ -2045,7 +2032,7 @@ func (th *groupHeap) Less(i, j int) bool {
 	// burstQualification method, so we must call it here.
 	if (*th)[i].used*uint64((*th)[j].weight) == (*th)[j].used*uint64((*th)[i].weight) {
 		if (*th)[i].weight == (*th)[j].weight {
-			return (*th)[i].id < (*th)[j].id
+			return (*th)[i].groupKey.id < (*th)[j].groupKey.id
 		}
 		return (*th)[i].weight > (*th)[j].weight
 	}
@@ -2728,7 +2715,7 @@ func (q *StoreWorkQueue) admittedReplicatedWork(
 	if !coordMuLocked {
 		q.coordMu.Unlock()
 	}
-	q.q[wc].adjustGroupUsed(tenantID, additionalTokensNeeded)
+	q.q[wc].adjustGroupUsed(tenantGroupKey(tenantID.ToUint64()), additionalTokensNeeded)
 
 	// Inform callers of the entry we just admitted.
 	//
@@ -2793,7 +2780,7 @@ func (q *StoreWorkQueue) AdmittedWorkDone(h StoreWorkHandle, doneInfo StoreWorkD
 	}
 	q.updateStoreStatsAfterWorkDone(1, doneInfo, false, true)
 	additionalTokens := q.granters[h.workClass].storeWriteDone(h.writeTokens, doneInfo)
-	q.q[h.workClass].adjustGroupUsed(h.tenantID, additionalTokens)
+	q.q[h.workClass].adjustGroupUsed(tenantGroupKey(h.tenantID.ToUint64()), additionalTokens)
 	return nil
 }
 

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -331,7 +331,10 @@ type WorkQueue struct {
 			active, inactive map[groupKey]uint32
 		}
 		// maxCPUGroups maps resource group ID to whether that group always
-		// qualifies for burst (MAX_CPU). Only used if mode == usesCPUTimeTokens and
+		// qualifies for burst (MAX_CPU). IDs are interpreted as resource group
+		// IDs (rgKind); the lookup in getMaxCPULocked short-circuits for
+		// tenant-keyed containers so a numerically equal tenant ID can never
+		// inherit the flag. Only used if mode == usesCPUTimeTokens and
 		// admission.cpu_time_tokens.mode == "resource_manager".
 		maxCPUGroups map[uint64]bool
 
@@ -1551,17 +1554,18 @@ func (q *WorkQueue) getGroupWeightLocked(gKey groupKey) uint32 {
 }
 
 // getMaxCPULocked returns the maxCPU flag for the given group.
-// Returns false if the ID is not in maxCPUGroups. See
-// cpuTimeBurstBucket for how this flag affects burst qualification.
-//
-// TODO(wenyihu6): maxCPUGroups is keyed by uint64, so a tenant ID
-// and an RG ID with the same numeric value share an entry. A
-// subsequent commit guards the lookup by kind so the flag does not
-// leak across the two namespaces.
+// Returns false if the ID is not in maxCPUGroups, or if gKey is
+// tenant-keyed: maxCPUGroups is populated with RG IDs, so the
+// kind guard prevents a numerically equal tenant ID from inheriting
+// the flag. See cpuTimeBurstBucket for how this flag affects burst
+// qualification.
 //
 // REQUIRES: q.mu is held.
 func (q *WorkQueue) getMaxCPULocked(gKey groupKey) bool {
 	q.mu.AssertHeld()
+	if !gKey.isRg() {
+		return false
+	}
 	return q.mu.maxCPUGroups[gKey.id]
 }
 

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -312,9 +312,12 @@ type WorkQueue struct {
 		// group keyed by resource group ID. Ordered by burst qualification then
 		// used/weight.
 		groupHeap groupHeap
-		// All groups, including those without waiting work. Keyed by resource group
-		// ID. Periodically cleaned.
-		groups       map[uint64]*groupInfo
+		// All groups, including those without waiting work. Keyed by
+		// composite groupKey (id + kind) so the same uint64 ID
+		// representing different semantic kinds (e.g., system tenant
+		// 1 vs rg 1) does not collide on a single container.
+		// Periodically GC'd by gcGroupsResetUsedAndUpdateEstimators.
+		groups       map[groupKey]*groupInfo
 		groupWeights struct {
 			mu syncutil.Mutex
 			// active refers to the currently active weights. mu is held for updates
@@ -487,7 +490,7 @@ func initWorkQueue(
 	func() {
 		q.mu.Lock()
 		defer q.mu.Unlock()
-		q.mu.groups = make(map[uint64]*groupInfo)
+		q.mu.groups = make(map[groupKey]*groupInfo)
 		q.sampleEpochLIFOSettingsLocked()
 	}()
 	if !opts.disableGCGroupsAndResetUsed {
@@ -702,6 +705,13 @@ type AdmitResponse struct {
 	// AdmittedWorkDone. Need to make sure lookup misses fail gracefully if the
 	// entry has been GCed after a mode switch.
 	groupID roachpb.TenantID
+	// groupKind is the kind of the container this work was admitted into
+	// (tenantKind for serverless TenantID-keyed groups, rgKind for RM
+	// resource-group-keyed groups). Captured at Admit time alongside
+	// groupID so AdmittedWorkDone can construct the composite groupKey
+	// without re-deriving from current useResourceGroup state, which may
+	// have changed since admission.
+	groupKind groupKind
 	// requestedCount is the number of slots or tokens taken at Admit time.
 	// It is useful to return, so that in AdmittedWorkDone, we can adjust
 	// the deduction, in cases where we have more information, such as in
@@ -738,17 +748,18 @@ func (q *WorkQueue) setUseResourceGroup(enabled bool) {
 	q.mu.useResourceGroup = enabled
 }
 
-// groupIDForWorkLocked returns the resource group ID for the given
-// WorkInfo. In RM mode (useResourceGroup), the group is derived from
-// WorkInfo.Priority; otherwise it is the TenantID.
+// groupKeyForWorkLocked returns the composite groupKey for the given
+// WorkInfo. In RM mode (useResourceGroup), the key is derived from
+// WorkInfo.Priority with kind=rgKind; otherwise it is the TenantID
+// with kind=tenantKind.
 //
 // REQUIRES: q.mu is held.
-func (q *WorkQueue) groupIDForWorkLocked(info WorkInfo) uint64 {
+func (q *WorkQueue) groupKeyForWorkLocked(info WorkInfo) groupKey {
 	q.mu.AssertHeld()
 	if q.mu.useResourceGroup {
-		return priorityToResourceGroup(info.Priority)
+		return rgGroupKey(priorityToResourceGroup(info.Priority))
 	}
-	return info.TenantID.ToUint64()
+	return tenantGroupKey(info.TenantID.ToUint64())
 }
 
 // Admit is called when requesting admission for some work. If
@@ -803,9 +814,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// unlocked on all code paths.
 	q.mu.Lock()
 
-	groupID := q.groupIDForWorkLocked(info)
+	key := q.groupKeyForWorkLocked(info)
+	groupID := key.id
 
-	group, ok := q.mu.groups[groupID]
+	group, ok := q.mu.groups[key]
 	if !ok {
 		// See comment below about CPU time token estimation. If no groupInfo
 		// struct exists for a group, then there is no cpuTimeTokenEstimator
@@ -813,10 +825,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// here, we also create the estimator. We init the estimator using a
 		// global estimator that sees workload across all groups.
 		maxCPU := q.getMaxCPULocked(groupID)
-		group = newGroupInfo(groupID, q.getGroupWeightLocked(groupID),
+		group = newGroupInfo(key, q.getGroupWeightLocked(groupID),
 			q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
 			maxCPU, q.perGroupAggMetrics)
-		q.mu.groups[groupID] = group
+		q.mu.groups[key] = group
 	}
 	// If mode == usesCPUTimeTokens, WorkQueue does CPU time token estimation.
 	// When Admit is called, the request hasn't yet executed, so we do not
@@ -833,6 +845,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	}
 	admitResponse := AdmitResponse{
 		groupID:        roachpb.TenantID{InternalValue: groupID},
+		groupKind:      key.kind,
 		requestedCount: info.RequestedCount,
 	}
 
@@ -947,20 +960,22 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// can be granted admission.
 		q.mu.Lock()
 
-		// Re-derive groupID: the mode may have changed while the lock
+		// Re-derive key: the mode may have changed while the lock
 		// was released (though mode transitions are not yet supported).
-		groupID = q.groupIDForWorkLocked(info)
+		key = q.groupKeyForWorkLocked(info)
+		groupID = key.id
 		admitResponse.groupID = roachpb.TenantID{InternalValue: groupID}
+		admitResponse.groupKind = key.kind
 
 		// The group could have been removed. See the comment where the
 		// groupInfo struct is declared.
-		group, ok = q.mu.groups[groupID]
+		group, ok = q.mu.groups[key]
 		if !ok {
 			maxCPU := q.getMaxCPULocked(groupID)
-			group = newGroupInfo(groupID, q.getGroupWeightLocked(groupID),
+			group = newGroupInfo(key, q.getGroupWeightLocked(groupID),
 				q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
 				maxCPU, q.perGroupAggMetrics)
-			q.mu.groups[groupID] = group
+			q.mu.groups[key] = group
 		}
 		q.adjustGroupUsedLocked(group, -info.RequestedCount)
 	}
@@ -1165,8 +1180,9 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		//
 		// NB: additionalUsed can be negative here (in case the initial estimate was
 		// too pessimistic).
+		respKey := groupKey{id: resp.groupID.ToUint64(), kind: resp.groupKind}
 		if additionalUsed != 0 {
-			group, ok := q.mu.groups[resp.groupID.ToUint64()]
+			group, ok := q.mu.groups[respKey]
 			if ok {
 				q.adjustGroupUsedLocked(group, additionalUsed)
 			}
@@ -1181,7 +1197,7 @@ func (q *WorkQueue) AdmittedWorkDone(resp AdmitResponse, cpuTime time.Duration) 
 		// in this code path, that is, at admission time.
 		if q.mode == usesCPUTimeTokens {
 			q.mu.defaultCPUTimeTokenEstimator.workDone(cpuTime.Nanoseconds())
-			group, ok := q.mu.groups[resp.groupID.ToUint64()]
+			group, ok := q.mu.groups[respKey]
 			// If the group struct doesn't exist, it has been GCed due to a lack of
 			// activity. In this case, we do not leverage the grunning measurement
 			// for future estimates.
@@ -1318,9 +1334,9 @@ func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 	// With large numbers of active groups, this iteration could hold the lock
 	// longer than desired. We could break this iteration into smaller parts if
 	// needed.
-	for id, info := range q.mu.groups {
+	for k, info := range q.mu.groups {
 		if info.used == 0 && !isInGroupHeap(info) {
-			delete(q.mu.groups, id)
+			delete(q.mu.groups, k)
 			releaseGroupInfo(info)
 		} else {
 			info.cpuTimeTokenEstimator.update()
@@ -1335,11 +1351,14 @@ func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 // in AdmittedWorkDone. The additionalUsed count can be negative, in which
 // case it is returning unused resources. This is only for WorkQueue's own
 // accounting -- it should not call into granter.
+//
+// Callers operate on tenant-keyed containers (StoreWorkQueue's
+// per-tenant accounting and the SQL CPU AdmittedSQLWorkDone path),
+// so the lookup uses tenantKind.
 func (q *WorkQueue) adjustGroupUsed(groupID roachpb.TenantID, delta int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	tid := groupID.ToUint64()
-	group, ok := q.mu.groups[tid]
+	group, ok := q.mu.groups[tenantGroupKey(groupID.ToUint64())]
 	if !ok {
 		return
 	}
@@ -1429,7 +1448,9 @@ func (q *WorkQueue) refillBurstBuckets(toAdd int64, capacity int64) {
 func (q *WorkQueue) refillBurstBucketForGroup(groupID uint64, toAdd int64, capacity int64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	group, ok := q.mu.groups[groupID]
+	// The filler invokes this with priority-derived (RG) IDs, so the
+	// lookup uses rgKind.
+	group, ok := q.mu.groups[rgGroupKey(groupID)]
 	if !ok {
 		return
 	}
@@ -1462,13 +1483,18 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 	if len(q.mu.groupHeap) > 0 {
 		s.Printf(" top group: %d", q.mu.groupHeap[0].id)
 	}
-	var ids []uint64
-	for id := range q.mu.groups {
-		ids = append(ids, id)
+	var keys []groupKey
+	for k := range q.mu.groups {
+		keys = append(keys, k)
 	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	for _, id := range ids {
-		group := q.mu.groups[id]
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].kind != keys[j].kind {
+			return keys[i].kind < keys[j].kind
+		}
+		return keys[i].id < keys[j].id
+	})
+	for _, k := range keys {
+		group := q.mu.groups[k]
 		s.Printf("\n group-id: %d used: %d, w: %d, fifo: %d", group.id, group.used,
 			group.weight, group.fifoPriorityThreshold)
 		if len(group.waitingWorkHeap) > 0 {
@@ -1502,14 +1528,18 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 			}
 		}
 	}
-	if q.mode == usesCPUTimeTokens && len(ids) > 0 {
+	if q.mode == usesCPUTimeTokens && len(keys) > 0 {
 		s.Printf("\nburst-buckets: ")
-		for i, id := range ids {
+		for i, k := range keys {
 			if i > 0 {
 				s.Printf(" ")
 			}
-			group := q.mu.groups[id]
-			s.Printf("t%d=%s", id, &group.cpuTimeBurstBucket)
+			group := q.mu.groups[k]
+			if k.kind == tenantKind {
+				s.Printf("t%d=%s", k.id, &group.cpuTimeBurstBucket)
+			} else {
+				s.Printf("rg%d=%s", k.id, &group.cpuTimeBurstBucket)
+			}
 		}
 	}
 }
@@ -1560,8 +1590,8 @@ func (q *WorkQueue) SetMaxCPUGroups(groups map[uint64]bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.mu.maxCPUGroups = groups
-	for id, group := range q.mu.groups {
-		maxCPU := q.getMaxCPULocked(id)
+	for k, group := range q.mu.groups {
+		maxCPU := q.getMaxCPULocked(k.id)
 		if group.cpuTimeBurstBucket.maxCPU != maxCPU {
 			prevQual := group.cpuTimeBurstBucket.burstQualification()
 			group.cpuTimeBurstBucket.maxCPU = maxCPU
@@ -1621,27 +1651,29 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 		q.mu.groupWeights.active, q.mu.groupWeights.inactive =
 			q.mu.groupWeights.inactive, q.mu.groupWeights.active
 	}()
-	// Create a slice for storing all the groupIDs. We use this to split the
-	// update to the data-structures that require holding q.mu, in case there
-	// are 1000s of groups (we don't want to hold q.mu for long durations).
-	groupIDs := func() []uint64 {
+	// Create a slice for storing all tenant-keyed group keys. We use
+	// this to split the update to the data-structures that require
+	// holding q.mu, in case there are 1000s of groups (we don't want to
+	// hold q.mu for long durations). Only tenant-kind containers are
+	// updated here: SetTenantWeights only governs tenant containers.
+	keys := func() []groupKey {
 		q.mu.Lock()
 		defer q.mu.Unlock()
-		gIDs := make([]uint64, len(q.mu.groups))
-		i := 0
+		ks := make([]groupKey, 0, len(q.mu.groups))
 		for k := range q.mu.groups {
-			gIDs[i] = k
-			i++
+			if k.kind == tenantKind {
+				ks = append(ks, k)
+			}
 		}
-		return gIDs
+		return ks
 	}()
-	// Any groups not in groupIDs will see the latest weight when their
+	// Any groups not in keys will see the latest weight when their
 	// groupInfo is created. The existing ones need their weights to be
 	// updated.
 
-	// groupIDs[index] represents the next groupID that needs to be updated.
+	// keys[index] represents the next groupKey that needs to be updated.
 	var index int
-	n := len(groupIDs)
+	n := len(keys)
 	// updateNextBatch acquires q.mu and updates a batch of groups.
 	updateNextBatch := func() (repeat bool) {
 		q.mu.Lock()
@@ -1652,9 +1684,9 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 			if index >= n {
 				return false
 			}
-			groupID := groupIDs[index]
-			gi := q.mu.groups[groupID]
-			weight := q.getGroupWeightLocked(groupID)
+			key := keys[index]
+			gi := q.mu.groups[key]
+			weight := q.getGroupWeightLocked(key.id)
 			if gi != nil && gi.weight != weight {
 				gi.weight = weight
 				if isInGroupHeap(gi) {
@@ -1820,7 +1852,9 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 // the resource group ID is derived from the work's priority (see
 // priorityToResourceGroup).
 type groupInfo struct {
-	id uint64
+	// groupKey is the composite (id, kind) under which this groupInfo
+	// is stored in WorkQueue.mu.groups.
+	groupKey groupKey
 	// The weight assigned to the resource group. Must be > 0. For
 	// resource groups, this is WEIGHT_CPU.
 	weight uint32
@@ -1907,7 +1941,7 @@ var groupInfoPool = sync.Pool{
 }
 
 func newGroupInfo(
-	id uint64,
+	key groupKey,
 	weight uint32,
 	mode workQueueMode,
 	cpuTimeTokenEstimate int64,
@@ -1917,7 +1951,8 @@ func newGroupInfo(
 ) *groupInfo {
 	ti := groupInfoPool.Get().(*groupInfo)
 	*ti = groupInfo{
-		id:                    id,
+		id:                    key.id,
+		kind:                  key.kind,
 		weight:                weight,
 		waitingWorkHeap:       ti.waitingWorkHeap,
 		openEpochsHeap:        ti.openEpochsHeap,
@@ -1933,11 +1968,14 @@ func newGroupInfo(
 	ti.cpuTimeBurstBucket.init(
 		burstBucketCapacity, mode != usesCPUTimeTokens /* disable */, maxCPU)
 	if aggMetrics != nil {
-		tid := strconv.FormatUint(id, 10)
-		ti.perGroupMetrics.admittedCount = aggMetrics.admittedCount.AddChild(tid)
-		ti.perGroupMetrics.waitTimeNanos = aggMetrics.waitTimeNanos.AddChild(tid)
-		ti.perGroupMetrics.tokensUsed = aggMetrics.tokensUsed.AddChild(tid)
-		ti.perGroupMetrics.tokensReturned = aggMetrics.tokensReturned.AddChild(tid)
+		// AddChild takes the label values in the same order as
+		// aggmetric.MakeBuilder declared them: ("kind", "tenant_id").
+		kindStr := key.kind.String()
+		idStr := strconv.FormatUint(key.id, 10)
+		ti.perGroupMetrics.admittedCount = aggMetrics.admittedCount.AddChild(kindStr, idStr)
+		ti.perGroupMetrics.waitTimeNanos = aggMetrics.waitTimeNanos.AddChild(kindStr, idStr)
+		ti.perGroupMetrics.tokensUsed = aggMetrics.tokensUsed.AddChild(kindStr, idStr)
+		ti.perGroupMetrics.tokensReturned = aggMetrics.tokensReturned.AddChild(kindStr, idStr)
 	}
 	return ti
 }

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -571,7 +571,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				// Build the full map from current state plus the new entry,
 				// then call the production SetMaxCPUGroups method.
 				q.mu.Lock()
-				m := make(map[uint64]bool)
+				m := make(map[uint64]bool, len(q.mu.maxCPUGroups))
 				for k, val := range q.mu.maxCPUGroups {
 					m[k] = val
 				}
@@ -593,7 +593,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				d.ScanArgs(t, "group", &group)
 				d.ScanArgs(t, "to-add", &toAdd)
 				d.ScanArgs(t, "capacity", &capacity)
-				q.refillBurstBucketForGroup(uint64(group), toAdd, capacity)
+				q.refillBurstBucketForGroup(rgGroupKey(uint64(group)), toAdd, capacity)
 				return ""
 
 			default:


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/168382
Epic: none
Release note: none

---
**admission: add composite groupKey type**

`WorkQueue` routes admits to either tenant IDs (serverless mode)
or priority-derived resource group IDs (RM mode). Both spaces
share the same `uint64` namespace — system tenant 1 collides
with rg 1 — so indexing `*groupInfo` by ID alone allows a
serverless→RM mode swap to repurpose one container into the
other.

This change introduces `groupKey{id, kind}` and the `groupKind`
discriminator to disambiguate the two namespaces. The zero value
of `groupKind` is `invalidKind` so that an uninitialized key is
detectably so rather than silently identifying as `tenantKind`.

No usages yet; subsequent commits adopt the type.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: key q.mu.groups by composite (id, kind)**

`WorkQueue` routes admits to tenant IDs or priority-derived RG
IDs depending on `useResourceGroup`, but both share the same
`uint64` namespace. System tenant 1 and rg 1 hash to the same
entry in `q.mu.groups`, so a serverless→RM mode swap repurposes
the system tenant's `*groupInfo` into the RM container, carrying
over `cpuTimeBurstBucket` tokens, the `cpuTimeTokenEstimator`,
`priorityStates`, and per-group metric labels.

This change switches `q.mu.groups` to `map[groupKey]*groupInfo`.
`AdmitResponse` captures the composite key (`groupID` + `groupKind`)
at `Admit` time so that `AdmittedWorkDone` resolves the same entry
without re-deriving from `useResourceGroup`, which may have
flipped between the two calls.

Per-group metric children switch to a two-label scheme (`kind`,
`tenant_id`) so that `tenant_id` semantics for existing dashboards
are preserved while `kind` carries the namespace.

Note that `groupWeights.active` and `q.mu.maxCPUGroups` remain
`uint64`-keyed; a subsequent commit tightens those.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: tighten WorkQueue APIs to groupKey-typed signatures**

The prior commit introduced composite `groupKey` indexing on
`q.mu.groups` but kept legacy `uint64` / `roachpb.TenantID`
signatures on the helpers, with each call site wrapping at the
boundary.

This change consolidates the dual `id` + `kind` fields into a
single `groupKey` on `AdmitResponse` and `groupInfo`, and
propagates the typed key through the helpers so callers reason
in terms of the composite key throughout.

`StoreWorkQueue`'s per-tenant accounting and the elastic CPU
`AdmittedWorkDone` path wrap their `TenantID`s with
`tenantGroupKey` at the call sites; both run in `usesTokens` mode
and never use rg keying.

Note that `sql_cpu_handle.go`'s `Close` still wraps with
`tenantGroupKey` — a followup commit threads the original
`AdmitResponse`'s container through so RM-mode tokens return to
the right rg-keyed container.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: restrict maxCPUGroups to resource-group containers**

`q.mu.maxCPUGroups` is `uint64`-keyed and its keys come from
`priorityToResourceGroupKey` — they are RG IDs. The composite key
on `q.mu.groups` already prevents tenant 1 and rg 1 from sharing
a `*groupInfo`, but `getMaxCPULocked` was looking up
`maxCPUGroups[gKey.id]` regardless of kind, so a tenant container
with the same numeric ID as an RG entry could inadvertently
inherit the `maxCPU=true` flag.

This change adds an `isRg` kind guard at the lookup site so that
only rg-keyed containers consult `maxCPUGroups`. Note that the
map itself stays `uint64`-keyed; a subsequent reorganization
replaces it with a richer `rmGroups` data structure.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---
**admission: route SQLCPUHandle.Close to last admit's container**

When SQL CPU work runs through the CTT `WorkQueue` (the only
`WorkQueue` with `useResourceGroup=true`), `SQLCPUHandle.Close`
was looking up the wrong container in RM mode. The original
`Admit` credited a container at
`q.mu.groups[rgGroupKey(highResourceGroupID)]`, but `Close`'s
`tenantGroupKey(h.workInfo.TenantID.ToUint64())` reconstructed
the key as the tenant-keyed entry, which is not present. The
token return silently missed: `group.used` and the per-group
`tokensReturned` metric were never decremented.

This change adds a `lastAdmitGroupKey` field on
`SQLCPUHandle.mu` that the slow-path `Admit` populates under the
same critical section as `reservation.Add`. `Close` uses it to
look up the same container the original `Admit` credited,
instead of re-deriving from the `WorkQueue`'s current
`useResourceGroup` state — which may have flipped between
`Admit` and `Close`.

The captured key is the exact source of any tokens `Close`
drains. The argument relies on three properties of the slow
path:

 1. `tryDeductReservation` grabs `min(current, needed)`. The
    slow path is entered only when `remaining > 0`, which
    implies `current < needed` and the post-CAS reservation
    is `0`.
 2. The slow path is serialized via `admitTurn` (a channel of
    size 1). Only the turn-holder calls `Admit` and only the
    turn-holder `Add`s to reservation, so two `Admit`s' buffers
    never interleave.
 3. The next `Admit` only fires after the prior buffer drains
    back to `0` (which is what triggers the slow-path entry).

By induction, reservation contains tokens from at most one
`Admit` at a time. A test-build assertion in `Close` panics if
`remaining > 0` but `lastAdmitGroupKey` is unset.

Note that the container at `lastAdmitGroupKey` may have been
GC'd by `gcGroupsResetUsedAndUpdateEstimators` between the
storing `Admit` and `Close`. `adjustGroupUsed` handles the
lookup miss silently; the granter still receives `returnGrant`
so the global token bucket stays balanced. Only the per-group
`used` counter and `tokensReturned` metric miss this return.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

