### PR TITLE
opt: implement PlanGram parser

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
@@ -34,6 +34,7 @@ func (g *opsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.genOperatorCamelCaseNames()
 	g.genOperatorSyntaxTags()
 	g.genOperatorsByTag()
+	g.genOperatorByCamelCase()
 }
 
 func (g *opsGen) genOperatorEnum() {
@@ -129,6 +130,20 @@ func (g *opsGen) genOperatorsByTag() {
 		fmt.Fprintf(g.w, "  return false\n")
 		fmt.Fprintf(g.w, "}\n\n")
 	}
+}
+
+func (g *opsGen) genOperatorByCamelCase() {
+	fmt.Fprintf(g.w, "var opByCamelCase = map[string]Operator{\n")
+	for _, define := range g.sorted {
+		fmt.Fprintf(g.w, "  %q: %sOp,\n", define.Name, define.Name)
+	}
+	fmt.Fprintf(g.w, "}\n\n")
+
+	fmt.Fprintf(g.w, "// OperatorByCamelCase returns the Operator for the given CamelCase name.\n")
+	fmt.Fprintf(g.w, "func OperatorByCamelCase(name string) (Operator, bool) {\n")
+	fmt.Fprintf(g.w, "  op, ok := opByCamelCase[name]\n")
+	fmt.Fprintf(g.w, "  return op, ok\n")
+	fmt.Fprintf(g.w, "}\n\n")
 }
 
 // sortDefines returns a copy of the given expression definitions, sorted by

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/ops
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/ops
@@ -134,5 +134,19 @@ func IsEnforcerOp(e Expr) bool {
 	}
 	return false
 }
+
+var opByCamelCase = map[string]Operator{
+	"ColPrivate":      ColPrivateOp,
+	"Project":         ProjectOp,
+	"Projections":     ProjectionsOp,
+	"ProjectionsItem": ProjectionsItemOp,
+	"Sort":            SortOp,
+}
+
+// OperatorByCamelCase returns the Operator for the given CamelCase name.
+func OperatorByCamelCase(name string) (Operator, bool) {
+	op, ok := opByCamelCase[name]
+	return op, ok
+}
 ----
 ----

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -6,8 +6,13 @@
 package physical
 
 import (
+	"bufio"
 	"bytes"
+	"io"
 	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -48,8 +53,8 @@ import (
 //	scan: (Scan Index="abc_b_idx") | (Scan Index="abc_c_idx");
 //
 // The grammar is stored as a linked graph of terms, starting with the "root"
-// term. The graph could contain cycles (for example to match a plan with a FK
-// cascade cycle).
+// nonterminal. The graph could contain cycles (for example to match a plan with
+// a FK cascade cycle or a recursive UDF).
 //
 // PlanGrams are equivalent to top-down non-deterministic finite tree
 // automatons. We could compile the PlanGram into a state-table-based NFTA, but
@@ -58,10 +63,10 @@ import (
 // For some background see https://en.wikipedia.org/wiki/Regular_tree_grammar
 // and https://en.wikipedia.org/wiki/Tree_automaton.
 type PlanGram struct {
-	// root is the starting term, and can also be considered a "pseudo
-	// nonterminal" in the grammar consisting of a single production rule. But
-	// because of its construction this "root" nonterminal cannot be referenced
-	// from any other production rule.
+	// root is the starting term. "root" can also be considered a "pseudo
+	// nonterminal" in the grammar with a single production rule, but because of
+	// its construction, this "root" nonterminal cannot be referenced from any
+	// other production rule.
 	root planGramTerm
 }
 
@@ -81,11 +86,11 @@ type planGramTerm interface {
 // nonterminal matches the current optimizer sub-tree if any of its production
 // rules match the current sub-tree.
 type planGramProduction struct {
-	// name is the symbol identifying the nonterminal in the grammar, which must
-	// be unique in the grammar, and must not be "root", "any", or "none". It must
-	// not contain any of the characters "'\:=()|; or whitespace. For clarity it
-	// is recommended that the name not match any optimizer operator name, but
-	// syntactically there's no problem with re-using an operator name.
+	// name is the nonterminal symbol in the grammar, which must be unique.
+	// "any" and "none" are reserved; "root" is the required entry-point
+	// production and cannot be referenced from other productions. The name
+	// must not contain any of the characters "'\,():;=| or whitespace, and
+	// must not start with a digit.
 	name string
 	// rules are the set of production rules for this nonterminal. There must be
 	// at least one rule (which could be anyPlanGramTerm or nonePlanGramTerm if
@@ -94,11 +99,10 @@ type planGramProduction struct {
 	rules []planGramTerm
 }
 
-// planGramExpr represents a right-hand-side expression in the grammar, matching
-// an optimizer expression. If the optimizer expression has children
-// (e.g. InnerJoin) then those children are each represented by a term, and the
-// planGramExpr is a nonterminal. If the optimizer expression is nullary / a
-// leaf (e.g. Scan) then the planGramExpr is a terminal.
+// planGramExpr represents a right-hand-side expression in the grammar matching
+// an optimizer expression. The optimizer expression could have children, in
+// which case those children are each represented by a term (e.g. InnerJoin), or
+// the optimizer expression could be nullary / a leaf (e.g. Scan).
 type planGramExpr struct {
 	op       opt.Operator
 	fields   []planGramExprField
@@ -131,6 +135,8 @@ var AnyPlanGram = PlanGram{anyPlanGramTerm}
 
 // NonePlanGram is the PlanGram: "root: none;". It matches no optimizer plans.
 var NonePlanGram = PlanGram{nonePlanGramTerm}
+
+var errInvalidUTF8 = errors.New("invalid UTF-8")
 
 // Any is true if this PlanGram matches any optimizer sub-tree.
 func (p PlanGram) Any() bool {
@@ -226,6 +232,342 @@ func (p PlanGram) String() string {
 	var b bytes.Buffer
 	p.FormatPretty(&b, false /* newlines */)
 	return b.String()
+}
+
+// ParsePlanGram parses a PlanGram grammar from the given io.Reader, or returns
+// an error if it cannot.
+func ParsePlanGram(r io.Reader) (PlanGram, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(tokenizePlanGram)
+
+	p := planGramParser{
+		scanner:     scanner,
+		productions: make(map[string]*planGramProduction),
+	}
+
+	// Parse all productions, including "root".
+	for {
+		if _, ok := p.peek(); !ok {
+			break
+		}
+		if err := p.parseProduction(); err != nil {
+			return PlanGram{}, err
+		}
+	}
+
+	if err := p.scanner.Err(); err != nil {
+		return PlanGram{}, err
+	}
+
+	// Validate that root exists and has exactly one term (no alternates).
+	root, ok := p.productions["root"]
+	if !ok {
+		return PlanGram{}, errors.New("missing \"root\" production")
+	}
+	if len(root.rules) != 1 {
+		return PlanGram{}, errors.New("root must have exactly one term, not alternates")
+	}
+
+	// Validate all forward references were resolved (i.e. every production has
+	// at least one rule).
+	for name, pp := range p.productions {
+		if len(pp.rules) == 0 {
+			return PlanGram{}, errors.Newf("undefined nonterminal %q", name)
+		}
+	}
+
+	return PlanGram{root: root.rules[0]}, nil
+}
+
+// planGramParser is a recursive-descent parser for plangram grammars with
+// 1-token lookahead.
+type planGramParser struct {
+	scanner     *bufio.Scanner
+	tok         string
+	hasTok      bool
+	productions map[string]*planGramProduction
+}
+
+// next consumes and returns the next token.
+func (p *planGramParser) next() (string, error) {
+	if p.hasTok {
+		p.hasTok = false
+		return p.tok, nil
+	}
+	if !p.scanner.Scan() {
+		if err := p.scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", errors.New("unexpected end of input")
+	}
+	return p.scanner.Text(), nil
+}
+
+// peek returns the next token without consuming it.
+func (p *planGramParser) peek() (string, bool) {
+	if p.hasTok {
+		return p.tok, true
+	}
+	if !p.scanner.Scan() {
+		return "", false
+	}
+	p.tok = p.scanner.Text()
+	p.hasTok = true
+	return p.tok, true
+}
+
+// expect consumes the next token and asserts it equals want.
+func (p *planGramParser) expect(want string) error {
+	got, err := p.next()
+	if err != nil {
+		return errors.Wrapf(err, "expected %q", want)
+	}
+	if got != want {
+		return errors.Newf("expected %q, got %q", want, got)
+	}
+	return nil
+}
+
+// getOrCreateProduction returns the production for the given name, creating a
+// forward-reference stub if one does not yet exist. The name must not be empty,
+// punctuation, or a quoted string.
+func (p *planGramParser) getOrCreateProduction(name string) (*planGramProduction, error) {
+	if len(name) == 0 {
+		return nil, errors.New("name cannot be empty")
+	}
+	if name[0] >= '0' && name[0] <= '9' {
+		return nil, errors.Newf("name %q must not start with a digit", name)
+	}
+	if strings.ContainsAny(name, `"'\,():;=|`) {
+		return nil, errors.Newf("name %q contains invalid character", name)
+	}
+	pp, ok := p.productions[name]
+	if !ok {
+		pp = &planGramProduction{name: name}
+		p.productions[name] = pp
+	}
+	return pp, nil
+}
+
+// resolveNonterminal maps a nonterminal name to its term. "any" and "none" are
+// resolved to their special terms; "root" is an error (root cannot be
+// referenced from other productions).
+func (p *planGramParser) resolveNonterminal(name string) (planGramTerm, error) {
+	switch name {
+	case "any":
+		return anyPlanGramTerm, nil
+	case "none":
+		return nonePlanGramTerm, nil
+	case "root":
+		return nil, errors.New("\"root\" cannot be used as a nonterminal reference")
+	default:
+		pp, err := p.getOrCreateProduction(name)
+		if err != nil {
+			return nil, err
+		}
+		return pp, nil
+	}
+}
+
+// parseProduction parses: NAME ":" term { "|" term } ";".
+func (p *planGramParser) parseProduction() error {
+	name, err := p.next()
+	if err != nil {
+		return err
+	}
+	if name == "any" || name == "none" {
+		return errors.Newf("%q cannot be used as a production name", name)
+	}
+	pp, err := p.getOrCreateProduction(name)
+	if err != nil {
+		return err
+	}
+	if len(pp.rules) > 0 {
+		return errors.Newf("duplicate production %q", name)
+	}
+	if err := p.expect(":"); err != nil {
+		return err
+	}
+	for {
+		term, err := p.parseTerm()
+		if err != nil {
+			return err
+		}
+		pp.rules = append(pp.rules, term)
+		tok, ok := p.peek()
+		if !ok || tok != "|" {
+			break
+		}
+		if _, err = p.next(); err != nil { // consume "|"
+			return err
+		}
+	}
+	return p.expect(";")
+}
+
+// parseTerm parses a single term: either an expression (starting with "(") or
+// a nonterminal name.
+func (p *planGramParser) parseTerm() (planGramTerm, error) {
+	tok, ok := p.peek()
+	if !ok {
+		if err := p.scanner.Err(); err != nil {
+			return nil, err
+		}
+		return nil, errors.New("unexpected end of input: expected term")
+	}
+	if tok == "(" {
+		return p.parseExpr()
+	}
+	// Must be a nonterminal name.
+	name, err := p.next()
+	if err != nil {
+		return nil, err
+	}
+	return p.resolveNonterminal(name)
+}
+
+// parseExpr parses: "(" OP_NAME { field } { child } ")".
+func (p *planGramParser) parseExpr() (planGramTerm, error) {
+	if err := p.expect("("); err != nil {
+		return nil, err
+	}
+	opName, err := p.next()
+	if err != nil {
+		return nil, err
+	}
+	op, ok := opt.OperatorByCamelCase(opName)
+	if !ok {
+		return nil, errors.Newf("unknown operator %q", opName)
+	}
+	expr := &planGramExpr{op: op}
+
+	for {
+		tok, ok := p.peek()
+		if !ok {
+			if err := p.scanner.Err(); err != nil {
+				return nil, err
+			}
+			return nil, errors.New("unexpected end of input: expected \")\"")
+		}
+		if tok == ")" {
+			if _, err := p.next(); err != nil { // consume ")"
+				return nil, err
+			}
+			break
+		}
+		if tok == "(" {
+			// Inline child expression.
+			child, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			expr.children = append(expr.children, child)
+			continue
+		}
+		if len(tok) == 1 && strings.IndexByte(`":;=|`, tok[0]) >= 0 {
+			return nil, errors.Newf("unexpected %q in expression", tok)
+		}
+		// Consume the name. Then peek to decide if it's a field (followed by "=")
+		// or a nonterminal child.
+		name, err := p.next()
+		if err != nil {
+			return nil, err
+		}
+		if next, ok := p.peek(); !ok || next != "=" {
+			// Nonterminal child.
+			term, err := p.resolveNonterminal(name)
+			if err != nil {
+				return nil, err
+			}
+			expr.children = append(expr.children, term)
+			continue
+		}
+		// Field: Name="value".
+		if len(expr.children) > 0 {
+			return nil, errors.New("fields must come before children in expression")
+		}
+		if _, err = p.next(); err != nil { // consume "="
+			return nil, err
+		}
+		val, err := p.next()
+		if err != nil {
+			return nil, err
+		}
+		if len(val) == 0 || val[0] != '"' {
+			return nil, errors.Newf("expected quoted string for field value, got %q", val)
+		}
+		unquoted, err := strconv.Unquote(val)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid field value %s", val)
+		}
+		expr.fields = append(expr.fields, planGramExprField{key: name, val: unquoted})
+	}
+	return expr, nil
+}
+
+// tokenizePlanGram is a bufio.SplitFunc that tokenizes a byte stream for
+// parsing as a PlanGram.
+func tokenizePlanGram(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// Skip leading whitespace.
+	i := 0
+	for i < len(data) {
+		r, size := utf8.DecodeRune(data[i:])
+		if r == utf8.RuneError && size <= 1 {
+			if !atEOF && len(data)-i < utf8.UTFMax {
+				// Might need more data to complete the UTF-8 character.
+				return 0, nil, nil
+			}
+			return 0, nil, errInvalidUTF8
+		}
+		if !unicode.IsSpace(r) {
+			break
+		}
+		i += size
+	}
+	if i == len(data) {
+		if atEOF {
+			return i, nil, nil
+		}
+		return 0, nil, nil
+	}
+
+	switch data[i] {
+	case '"':
+		// Quoted string: use strconv.QuotedPrefix to find the end.
+		quoted, err := strconv.QuotedPrefix(string(data[i:]))
+		if err != nil {
+			if atEOF {
+				return 0, nil, err
+			}
+			// Might need more data to complete the quoted string.
+			return 0, nil, nil
+		}
+		return i + len(quoted), data[i : i+len(quoted)], nil
+	case '(', ')', ':', ';', '=', '|':
+		// Single-character punctuation token.
+		return i + 1, data[i : i+1], nil
+	default:
+		// Word token: scan until whitespace or punctuation.
+		j := i
+		for j < len(data) {
+			r, size := utf8.DecodeRune(data[j:])
+			if r == utf8.RuneError && size <= 1 {
+				if !atEOF && len(data)-j < utf8.UTFMax {
+					// Might need more data to complete the UTF-8 character.
+					return 0, nil, nil
+				}
+				return 0, nil, errInvalidUTF8
+			}
+			if unicode.IsSpace(r) || strings.IndexByte(`"():;=|`, data[j]) >= 0 {
+				break
+			}
+			j += size
+		}
+		if j == len(data) && !atEOF {
+			return 0, nil, nil
+		}
+		return j, data[i:j], nil
+	}
 }
 
 // visitProductions implements the planGramTerm interface.

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -6,7 +6,9 @@
 package physical
 
 import (
+	"bufio"
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -14,6 +16,71 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPlanGramAny(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	require.True(t, AnyPlanGram.Any())
+	require.True(t, PlanGram{}.Any())
+	require.False(t, NonePlanGram.Any())
+}
+
+func TestPlanGramStringAndFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pg, err := ParsePlanGram(strings.NewReader(`root: (Scan Index="abc_a_idx");`))
+	require.NoError(t, err)
+
+	require.Equal(t, `root: (Scan Index="abc_a_idx");`, pg.String())
+
+	var b bytes.Buffer
+	pg.Format(&b)
+	require.Equal(t, `root: (Scan Index="abc_a_idx");`, b.String())
+}
+
+func TestTokenizePlanGramSmallBuffer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "short tokens",
+			input:    `root: (Scan Index="abc_a_idx");`,
+			expected: []string{"root", ":", "(", "Scan", "Index", "=", `"abc_a_idx"`, ")", ";"},
+		},
+		{
+			name:     "word longer than buffer",
+			input:    "root: (InnerJoin (Scan) (Scan));",
+			expected: []string{"root", ":", "(", "InnerJoin", "(", "Scan", ")", "(", "Scan", ")", ")", ";"},
+		},
+		{
+			name:     "whitespace spanning buffer boundary",
+			input:    "root:          (Scan);",
+			expected: []string{"root", ":", "(", "Scan", ")", ";"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(tc.input))
+			scanner.Buffer(make([]byte, 8), 64)
+			scanner.Split(tokenizePlanGram)
+
+			var tokens []string
+			for scanner.Scan() {
+				tokens = append(tokens, scanner.Text())
+			}
+			require.NoError(t, scanner.Err())
+			require.Equal(t, tc.expected, tokens)
+		})
+	}
+}
 
 func TestPlanGramFormatPretty(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -176,6 +243,343 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			b.Reset()
 			tc.plangram.FormatPretty(&b, true /* newlines */)
 			require.Equal(t, tc.expectedNewlines, b.String())
+		})
+	}
+}
+
+func TestPlanGramParse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Round-trip tests: parse the input, format it, parse again, and re-format.
+	// The two formatted strings should be identical.
+	roundTripTests := []struct {
+		name  string
+		input string
+	}{
+		// Simple root-only grammars.
+		{
+			name:  "any",
+			input: "root: any;",
+		},
+		{
+			name:  "none",
+			input: "root: none;",
+		},
+		{
+			name:  "nullary expression",
+			input: "root: (Scan);",
+		},
+		// Expressions with fields.
+		{
+			name:  "one field",
+			input: `root: (Scan Index="abc_a_idx");`,
+		},
+		{
+			name:  "multiple fields",
+			input: `root: (Scan Table="abc" Index="abc_b_idx");`,
+		},
+		{
+			name:  "field value with special characters",
+			input: `root: (Scan Index="has \"quotes\" and spaces");`,
+		},
+		// Expressions with children.
+		{
+			name:  "child referencing any",
+			input: "root: (Select any);",
+		},
+		{
+			name:  "child referencing none",
+			input: "root: (Select none);",
+		},
+		{
+			name:  "inline child expression",
+			input: "root: (Select (Scan));",
+		},
+		{
+			name:  "multiple children",
+			input: "root: (InnerJoin (Scan) (Scan));",
+		},
+		{
+			name:  "fields and children",
+			input: `root: (IndexJoin Table="abc" (Scan));`,
+		},
+		// Productions with nonterminal references.
+		{
+			name:  "root referencing nonterminal",
+			input: `root: scan; scan: (Scan Index="abc_a_idx");`,
+		},
+		{
+			name:  "single rule production",
+			input: "root: (Select scan); scan: (Scan);",
+		},
+		{
+			name:  "production with alternates",
+			input: `root: (Select (IndexJoin scan)); scan: (Scan Index="abc_b_idx") | (Scan Index="abc_c_idx");`,
+		},
+		// Productions with any and none.
+		{
+			name:  "production rule is any",
+			input: "root: (Select s); s: any;",
+		},
+		{
+			name:  "production rule is none",
+			input: "root: (Select s); s: none;",
+		},
+		{
+			name:  "any as alternate",
+			input: "root: (Select s); s: (Scan) | any;",
+		},
+		{
+			name:  "none as alternate",
+			input: "root: (Select s); s: (Scan) | none;",
+		},
+		// Production ordering and references.
+		{
+			name:  "productions in non-root-first order",
+			input: `scan: (Scan Index="abc_a_idx"); root: (Select scan);`,
+		},
+		{
+			name:  "forward and back references",
+			input: "a: (Scan); root: (InnerJoin a b); b: (Scan);",
+		},
+		// Cycles.
+		{
+			name:  "mutual cycle",
+			input: "root: a; a: (Select b); b: (Select a) | (Scan);",
+		},
+		{
+			name:  "self-referencing cycle",
+			input: `root: cycle; cycle: (InnerJoin cycle cycle) | scan; scan: (Scan Index="abc_b_idx") | (Scan Index="abc_c_idx");`,
+		},
+	}
+
+	for _, tc := range roundTripTests {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed1, err := ParsePlanGram(strings.NewReader(tc.input))
+			require.NoError(t, err)
+
+			var b bytes.Buffer
+			parsed1.FormatPretty(&b, false /* newlines */)
+			formatted1 := b.String()
+
+			parsed2, err := ParsePlanGram(strings.NewReader(formatted1))
+			require.NoError(t, err)
+
+			b.Reset()
+			parsed2.FormatPretty(&b, false /* newlines */)
+			require.Equal(t, formatted1, b.String())
+		})
+	}
+
+	// Also test parsing from multi-line format.
+	for _, tc := range roundTripTests {
+		t.Run(tc.name+"/newlines", func(t *testing.T) {
+			// Parse multi-line version.
+			parsed1, err := ParsePlanGram(strings.NewReader(tc.input))
+			require.NoError(t, err)
+
+			var b bytes.Buffer
+			parsed1.FormatPretty(&b, true /* newlines */)
+			multiLine := b.String()
+
+			parsed2, err := ParsePlanGram(strings.NewReader(multiLine))
+			require.NoError(t, err)
+
+			// Compare with single-line format (canonical).
+			b.Reset()
+			parsed1.FormatPretty(&b, false /* newlines */)
+			expected := b.String()
+
+			b.Reset()
+			parsed2.FormatPretty(&b, false /* newlines */)
+			require.Equal(t, expected, b.String())
+		})
+	}
+
+	// Extra whitespace: parse input with extra whitespace and verify it produces
+	// the expected canonical output.
+	whitespaceTests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "extra spaces around tokens",
+			input:    `root :  ( Scan  Index = "abc_a_idx" ) ;`,
+			expected: `root: (Scan Index="abc_a_idx");`,
+		},
+		{
+			name:     "tabs and newlines",
+			input:    "root:\n\t(\n\t\tScan\n\t);\n",
+			expected: "root: (Scan);",
+		},
+		{
+			name:     "leading and trailing whitespace",
+			input:    "   root: (Scan);   ",
+			expected: "root: (Scan);",
+		},
+		{
+			name:     "whitespace around alternates",
+			input:    `root: (Select scan) ; scan: ( Scan Index="b" )  |  ( Scan Index="c" ) ;`,
+			expected: `root: (Select scan); scan: (Scan Index="b") | (Scan Index="c");`,
+		},
+	}
+
+	for _, tc := range whitespaceTests {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := ParsePlanGram(strings.NewReader(tc.input))
+			require.NoError(t, err)
+
+			var b bytes.Buffer
+			parsed.FormatPretty(&b, false /* newlines */)
+			require.Equal(t, tc.expected, b.String())
+		})
+	}
+
+	// Error cases.
+	errorTests := []struct {
+		name        string
+		input       string
+		expectedErr string
+	}{
+		{
+			name:        "empty input",
+			input:       "",
+			expectedErr: `missing "root" production`,
+		},
+		{
+			name:        "missing root",
+			input:       "scan: (Scan);",
+			expectedErr: `missing "root" production`,
+		},
+		{
+			name:        "root alternates",
+			input:       "root: (Scan) | (Select);",
+			expectedErr: "root must have exactly one term",
+		},
+		{
+			name:        "undefined nonterminal",
+			input:       "root: (Select missing);",
+			expectedErr: `undefined nonterminal "missing"`,
+		},
+		{
+			name:        "duplicate production",
+			input:       "root: s; s: (Scan); s: (Select);",
+			expectedErr: `duplicate production "s"`,
+		},
+		{
+			name:        "unknown operator",
+			input:       "root: (Bogus);",
+			expectedErr: `unknown operator "Bogus"`,
+		},
+		{
+			name:        "root as nonterminal",
+			input:       "root: (Select root);",
+			expectedErr: `"root" cannot be used as a nonterminal reference`,
+		},
+		{
+			name:        "any as production name",
+			input:       "root: (Select any); any: (Scan);",
+			expectedErr: `cannot be used as a production name`,
+		},
+		{
+			name:        "none as production name",
+			input:       "root: (Select none); none: (Scan);",
+			expectedErr: `cannot be used as a production name`,
+		},
+		{
+			name:        "missing semicolon",
+			input:       "root: (Scan)",
+			expectedErr: `expected ";"`,
+		},
+		{
+			name:        "fields after children",
+			input:       `root: (IndexJoin (Scan) Table="abc");`,
+			expectedErr: "fields must come before children",
+		},
+		{
+			name:        "apostrophe in production name",
+			input:       "root: s; s'bad: (Scan);",
+			expectedErr: `contains invalid character`,
+		},
+		{
+			name:        "backslash in production name",
+			input:       `root: s; s\bad: (Scan);`,
+			expectedErr: `contains invalid character`,
+		},
+		{
+			name:        "apostrophe in nonterminal reference",
+			input:       `root: (Select s'bad); s'bad: (Scan);`,
+			expectedErr: `contains invalid character`,
+		},
+		{
+			name:        "backslash in nonterminal reference",
+			input:       `root: (Select s\bad); s\bad: (Scan);`,
+			expectedErr: `contains invalid character`,
+		},
+		{
+			name:        "punctuation as production name",
+			input:       "root: (Select ;);",
+			expectedErr: `unexpected ";" in expression`,
+		},
+		{
+			name:        "punctuation as nonterminal reference",
+			input:       `root: (Select =);`,
+			expectedErr: `unexpected "=" in expression`,
+		},
+		{
+			name:        "missing closing paren",
+			input:       "root: (Select (Scan);",
+			expectedErr: `unexpected ";" in expression`,
+		},
+		{
+			name:        "invalid field value",
+			input:       "root: (Scan Index=unquoted);",
+			expectedErr: "expected quoted string for field value",
+		},
+		{
+			name:        "missing field value",
+			input:       `root: (Scan Index=);`,
+			expectedErr: "expected quoted string for field value",
+		},
+		{
+			name:        "truncated input after colon",
+			input:       "root:",
+			expectedErr: "unexpected end of input: expected term",
+		},
+		{
+			name:        "unclosed paren at EOF",
+			input:       "root: (Scan",
+			expectedErr: `unexpected end of input: expected ")"`,
+		},
+		{
+			name:        "production name starts with digit",
+			input:       "root: s; 1scan: (Scan);",
+			expectedErr: "must not start with a digit",
+		},
+		{
+			name:        "comma between children",
+			input:       "root: (InnerJoin (Scan), (Scan));",
+			expectedErr: "contains invalid character",
+		},
+		{
+			name:        "comma in production name",
+			input:       "root: s; s,bad: (Scan);",
+			expectedErr: "contains invalid character",
+		},
+		{
+			name:        "invalid UTF-8",
+			input:       string([]byte{0xff}),
+			expectedErr: "invalid UTF-8",
+		},
+	}
+
+	for _, tc := range errorTests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParsePlanGram(strings.NewReader(tc.input))
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
Implement ParsePlanGram, a recursive-descent parser with 1-token lookahead for plangram grammars. The parser reads from an io.Reader using bufio.Scanner with a custom SplitFunc.

A reverse-lookup function OperatorByCamelCase is added to the optgen code generator to map camel-case operator names (e.g. "InnerJoin") back to opt.Operator values during parsing.

Informs: #152053

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>