### PR TITLE
release-26.1: sql/backfill: report panics in backfill goroutines

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",
+        "//pkg/util/log/logcrash",
         "//pkg/util/mon",
         "//pkg/util/syncutil",
         "//pkg/util/vector",

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -285,7 +286,16 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context, output execinfra.RowRec
 	})
 
 	workersDoneCh := make(chan error)
-	go func() { workersDoneCh <- g.Wait() }()
+	go func() {
+		// Without this defer, a panic re-thrown from a ctxgroup worker via Wait
+		// would tear down the SQL pod with no Sentry report. We can't switch
+		// this goroutine to stop.Stopper.RunAsyncTask because Run blocks on
+		// g.Wait to satisfy the invariant that the deferred memory monitor
+		// cleanup above runs only after the workers in g have exited; a refused
+		// stopper task would force a return with workers still running.
+		defer logcrash.RecoverAndReportPanic(ctx, &ibm.flowCtx.Cfg.Settings.SV)
+		workersDoneCh <- g.Wait()
+	}()
 
 	tick := time.NewTicker(indexBackfillMergeProgressReportInterval)
 	defer tick.Stop()

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -115,6 +115,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/stop",
         "//pkg/util/stringarena",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -578,12 +579,21 @@ func (ib *indexBackfiller) Run(ctx context.Context, output execinfra.RowReceiver
 
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 	var err error
-	// We don't have to worry about this go routine leaking because next we loop
-	// over progCh which is closed only after the go routine returns.
-	go func() {
+	// Launch via the stopper so that any panic in runBackfill (or a panic
+	// re-thrown from a ctxgroup worker via Wait) is recovered and reported to
+	// Sentry by the stopper's recover wrapper before it tears down the
+	// process. We don't have to worry about the goroutine leaking because next
+	// we loop over progCh, which is closed only after the goroutine returns.
+	if startErr := ib.flowCtx.Stopper().RunAsyncTaskEx(ctx, stop.TaskOpts{
+		TaskName: "indexBackfiller-runBackfill",
+		SpanOpt:  stop.ChildSpan,
+	}, func(ctx context.Context) {
 		defer close(progCh)
 		err = ib.runBackfill(ctx, progCh)
-	}()
+	}); startErr != nil {
+		close(progCh)
+		err = startErr
+	}
 
 	for prog := range progCh {
 		// Take a copy so that we can send the progress address to the output processor.


### PR DESCRIPTION
Backport 1/1 commits from #169062 on behalf of @rafiss.

----

The index backfiller and the MVCC index merger each spawn goroutines that, until now, had no panic recovery. A panic inside the goroutine spawned by indexBackfiller.Run (or one re-thrown from a ctxgroup worker by g.Wait) would tear down the SQL pod with no Sentry report and no CRDB-formatted log entry — only the Go runtime's bare stderr dump.

Switch the indexBackfiller goroutine to stopper.RunAsyncTaskEx so that the stopper's recover wrapper reports the panic to Sentry before re-panicking. The MVCC index merger keeps its bare goroutine because Run depends on g.Wait returning before the deferred memory monitor cleanup runs (a refused stopper task would force an early return with workers still using the bound account); instead it gets a
defer logcrash.RecoverAndReportPanic so the same Sentry visibility applies.

Both changes are defense in depth: the SQL pod still crashes after a panic in either path, but now the crash is observable instead of silent.

Informs: #169059
Epic: none

Release note: None

----

Release justification: Observability for production crashes: defense-in-depth fix that enables Sentry reporting for otherwise-silent SQL pod crashes during index backfill/merge.