### PR TITLE
sql/schemachanger: install PTS during enum value drop validation

### DIFF
--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1256,6 +1256,7 @@ func (s *TestState) ValidateConstraint(
 // ValidateEnumTypeValueRemoval implements the validator interface.
 func (s *TestState) ValidateEnumTypeValueRemoval(
 	ctx context.Context,
+	job *jobs.Job,
 	typeDesc catalog.TypeDescriptor,
 	physicalRep []byte,
 	logicalRep string,

--- a/pkg/sql/schemachanger/scdeps/validator.go
+++ b/pkg/sql/schemachanger/scdeps/validator.go
@@ -64,12 +64,14 @@ type ValidateConstraintFn func(
 // that an enum value is safe to remove.
 type ValidateEnumTypeValueRemovalFn func(
 	ctx context.Context,
+	job *jobs.Job,
 	codec keys.SQLCodec,
 	typeDesc catalog.TypeDescriptor,
 	physicalRep []byte,
 	logicalRep string,
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
+	protectedTSManager scexec.ProtectedTimestampManager,
 ) error
 
 // NewFakeSessionDataFn callback function used to create session data
@@ -137,14 +139,15 @@ func (vd validator) ValidateConstraint(
 // with no table rows referencing it.
 func (vd validator) ValidateEnumTypeValueRemoval(
 	ctx context.Context,
+	job *jobs.Job,
 	typeDesc catalog.TypeDescriptor,
 	physicalRep []byte,
 	logicalRep string,
 	override sessiondata.InternalExecutorOverride,
 ) error {
 	return vd.validateEnumTypeValueRemoval(
-		ctx, vd.codec, typeDesc, physicalRep, logicalRep,
-		vd.makeHistoricalInternalExecTxnRunner(), override,
+		ctx, job, vd.codec, typeDesc, physicalRep, logicalRep,
+		vd.makeHistoricalInternalExecTxnRunner(), override, vd.protectedTimestampProvider,
 	)
 }
 

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -249,6 +249,7 @@ type Validator interface {
 
 	ValidateEnumTypeValueRemoval(
 		ctx context.Context,
+		job *jobs.Job,
 		typeDesc catalog.TypeDescriptor,
 		physicalRep []byte,
 		logicalRep string,

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -147,7 +147,8 @@ func executeValidateEnumTypeValueRemoval(
 	// Execute the validation operation as a node user.
 	execOverride := sessiondata.NodeUserSessionDataOverride
 	err = deps.Validator().ValidateEnumTypeValueRemoval(
-		ctx, typeDesc, op.PhysicalRepresentation, op.LogicalRepresentation, execOverride,
+		ctx, deps.TransactionalJobRegistry().CurrentJob(), typeDesc,
+		op.PhysicalRepresentation, op.LogicalRepresentation, execOverride,
 	)
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -509,6 +509,7 @@ func (noopValidator) ValidateConstraint(
 
 func (noopValidator) ValidateEnumTypeValueRemoval(
 	ctx context.Context,
+	job *jobs.Job,
 	typeDesc catalog.TypeDescriptor,
 	physicalRep []byte,
 	logicalRep string,

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/regions"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -1181,16 +1183,21 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 	return t.canRemoveEnumValueFromArrayUsages(ctx, arrayTypeDesc, member, txn, descsCol)
 }
 
-// ValidateEnumValueRemoval checks that the given enum value is unused and safe to remove.
+// ValidateEnumValueRemoval checks that the given enum value is unused and safe
+// to remove. It installs a protected timestamp over the enum's referencing
+// descriptors for the duration of the historical scans so that GC cannot
+// invalidate the read timestamp on large tables (see #161636).
 func ValidateEnumValueRemoval(
 	ctx context.Context,
+	job *jobs.Job,
 	codec keys.SQLCodec,
 	typeDesc catalog.TypeDescriptor,
 	physicalRep []byte,
 	logicalRep string,
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	override sessiondata.InternalExecutorOverride,
-) error {
+	protectedTSManager scexec.ProtectedTimestampManager,
+) (retErr error) {
 	// If this removal is part of a rename (another member with the same physical
 	// representation exists and is not being removed), skip validation. The value
 	// is being renamed, not deleted, so data referencing it remains valid.
@@ -1203,6 +1210,29 @@ func ValidateEnumValueRemoval(
 		Capability:             descpb.TypeDescriptor_EnumMember_READ_ONLY,
 		Direction:              descpb.TypeDescriptor_EnumMember_REMOVE,
 	}
+
+	// Install a protected timestamp over the enum's referencing descriptors so
+	// the historical scans below cannot fail due to GC catching up with the
+	// read timestamp. Backreferences for T[] columns are installed on both the
+	// enum descriptor and its array alias, so iterating typeDesc's referencing
+	// IDs covers both the direct and array-aliased usages.
+	if n := typeDesc.NumReferencingDescriptors(); n > 0 && protectedTSManager != nil && job != nil {
+		ids := make(descpb.IDs, n)
+		for i := 0; i < n; i++ {
+			ids[i] = typeDesc.GetReferencingDescriptorID(i)
+		}
+		target := ptpb.MakeSchemaObjectsTarget(ids)
+		cleaner, err := protectedTSManager.Protect(ctx, job, target, runHistoricalTxn.ReadAsOf())
+		if err != nil {
+			return err
+		}
+		if cleaner != nil {
+			defer func() {
+				retErr = errors.CombineErrors(retErr, cleaner(ctx))
+			}()
+		}
+	}
+
 	return runHistoricalTxn.Exec(ctx, func(ctx context.Context, txn descs.Txn) error {
 		mutableType, err := txn.Descriptors().MutableByID(txn.KV()).Type(ctx, typeDesc.GetID())
 		if err != nil {


### PR DESCRIPTION
Dropping an enum value requires the schema changer to scan every relation that references the enum to confirm the value is not in use. On large tables these scans can take long enough that GC catches up with the historical read timestamp and the validation fails, rolling back the schema change.

This commit installs a protected timestamp over the enum's referencing descriptors for the duration of the validation scans in the declarative schema changer. The DSC validator already holds the ProtectedTimestampManager that index validation uses; this hooks it into ValidateEnumValueRemoval and reuses Manager.Protect with a multi-table SchemaObjectsTarget. A defer releases the record on completion (and the job-level cleanup machinery handles the failure case).

Backreferences for T[] columns are installed on both the enum descriptor and its array alias, so iterating typeDesc's referencing IDs covers both the direct and array-aliased usages without an extra descriptor read.

Chunked / span-incremental validation (the longer-term half of the issue) and the legacy schema changer path are not addressed. The latter is on its way out for ALTER TYPE per the migration to DSC.

Resolves: #161636
Epic: CRDB-31325

Release note (bug fix): Fixed an issue where ALTER TYPE ... DROP VALUE could fail on enums referenced by very large tables when the validation scan ran long enough for GC to invalidate its read timestamp. The schema changer now installs a
protected timestamp over referencing tables for the duration of the scan.