### PR TITLE
changefeedccl: register changefeed.bare_table_names.enabled setting (25.2 backport)

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -438,3 +438,12 @@ var PartitionAlgEnabled = settings.RegisterBoolSetting(
 	false,
 	settings.WithPublic,
 )
+
+// UseBareTableNames is used to enable and disable the use of bare table names
+// in changefeed topics.
+// Off by default so users can turn off before upgrade.
+var UseBareTableNames = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.bare_table_names.enabled",
+	"set to true to use bare table names in changefeed topics, false to use quoted table names; default is false",
+	false)


### PR DESCRIPTION
Backport-only PR for the 25.2 release branch. Companion to #169180 (25.3).

Registers the \`changefeed.bare_table_names.enabled\` cluster setting introduced
in #149438 (which shipped in 25.4) so that operators on 25.2 can explicitly set
the value before upgrading. The setting is **not consulted** by any code path
in this release.

Default is \`false\` here so that an explicit value an operator sets is what
persists across the upgrade — clusters that have actively opted out keep their
opt-out, while clusters that never touched it pick up the post-upgrade default
(\`true\`) on 25.4.

Refs: #149438
Refs: #148181

Epic: none

Release note (cli change): The \`changefeed.bare_table_names.enabled\` cluster
setting is now available on 25.2. It has no effect in this release; operators
may set it to opt out of the bare-table-name behavior that becomes the default
in 25.4 upon upgrade.

release justification: This change does not have any functionality impacts and helps users avoid breaking changes when upgrading. 