### PR TITLE
sql: add KVSavepoint to isql.Session

### DIFF
--- a/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
@@ -75,7 +75,10 @@ func TestSQLRowWriter(t *testing.T) {
 	// Test InsertRow
 	insertRow := makeTestRow(t, desc, 1, "test")
 	insertTimestamp := s.Clock().Now()
-	require.NoError(t, writer.InsertRow(ctx, insertTimestamp, insertRow))
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, insertTimestamp, insertRow)
+	})
+	require.NoError(t, err)
 	require.Equal(t,
 		[][]string{{"1", "test", "NULL", hlcToString(insertTimestamp), "1"}},
 		sqlDB.QueryStr(t, "SELECT id, name, is_always_null, crdb_internal_origin_timestamp, crdb_internal_origin_id FROM test_table WHERE id = 1"))
@@ -96,7 +99,10 @@ func TestSQLRowWriter(t *testing.T) {
 	// Test DeleteRow - first insert a test row to verify origin data before delete
 	insertRow2 := makeTestRow(t, desc, 2, "to_delete")
 	insertTimestamp2 := s.Clock().Now()
-	require.NoError(t, writer.InsertRow(ctx, insertTimestamp2, insertRow2))
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, insertTimestamp2, insertRow2)
+	})
+	require.NoError(t, err)
 
 	// Verify the row exists with correct data and origin metadata
 	require.Equal(t,
@@ -123,7 +129,10 @@ func TestSQLRowWriter(t *testing.T) {
 	// timestamp than the existing row should return a ConditionFailedError.
 	existingRow := makeTestRow(t, desc, 10, "existing")
 	newerTimestamp := s.Clock().Now()
-	require.NoError(t, writer.InsertRow(ctx, newerTimestamp, existingRow))
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, newerTimestamp, existingRow)
+	})
+	require.NoError(t, err)
 	err = session.Txn(ctx, func(ctx context.Context) error {
 		return writer.InsertRow(ctx, newerTimestamp.Prev(), makeTestRow(t, desc, 10, "duplicate"))
 	})

--- a/pkg/sql/internal_session.go
+++ b/pkg/sql/internal_session.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -111,6 +112,20 @@ func (c *ConnectionStateMachine) Close(ctx context.Context) {
 // Push adds a command to the state machines buffer.
 func (c *ConnectionStateMachine) Push(ctx context.Context, cmd Command) error {
 	return c.buffer.Push(ctx, cmd)
+}
+
+// Txn returns the current KV transaction if the session is in an open
+// transaction, along with true. Returns (nil, false) if the session is not in
+// a transaction.
+//
+// This method must only be called from the session's main goroutine. No lock
+// is needed because that goroutine is the only writer of mu.txn; the mutex
+// exists for readers on other goroutines (e.g. SHOW SESSIONS).
+func (c *ConnectionStateMachine) Txn() (*kv.Txn, bool) {
+	if _, ok := c.executor.machine.CurState().(stateOpen); !ok {
+		return nil, false
+	}
+	return c.executor.state.mu.txn, true
 }
 
 // SessionDataMutatorIterator returns the session data mutator iterator for this connection.

--- a/pkg/sql/isession/BUILD.bazel
+++ b/pkg/sql/isession/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/col/coldata",
+        "//pkg/kv",
         "//pkg/sql",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/isql",
@@ -38,10 +39,12 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/kv",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/isql",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/isession/internal_session.go
+++ b/pkg/sql/isession/internal_session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
@@ -140,6 +141,10 @@ func (i *InternalSession) Savepoint(ctx context.Context, do func(ctx context.Con
 		return i.poison
 	}
 
+	if _, ok := i.csm.Txn(); !ok {
+		return errors.AssertionFailedf("Savepoint requires an active transaction")
+	}
+
 	if err := i.executeStatement(ctx, savepointBegin); err != nil {
 		return errors.Wrap(err, "failed to create savepoint")
 	}
@@ -167,6 +172,23 @@ func (i *InternalSession) Savepoint(ctx context.Context, do func(ctx context.Con
 	}
 
 	return nil
+}
+
+func (i *InternalSession) KVSavepoint(
+	ctx context.Context, do func(ctx context.Context, txn *kv.Txn) error,
+) error {
+	return i.Savepoint(ctx, func(ctx context.Context) error {
+		txn, ok := i.csm.Txn()
+		if !ok {
+			return errors.AssertionFailedf("KVSavepoint requires an active transaction")
+		}
+		// Step the txn to ensure we are reading all writes that are present on
+		// the transaction. The SQL SAVEPOINT path does not step automatically.
+		if err := txn.Step(ctx, false /* allowReadTimestampStep */); err != nil {
+			return err
+		}
+		return do(ctx, txn)
+	})
 }
 
 func (i *InternalSession) Prepare(

--- a/pkg/sql/isession/internal_session_test.go
+++ b/pkg/sql/isession/internal_session_test.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -580,6 +582,12 @@ func TestSavepoint(t *testing.T) {
 	selectPrepared, err := session.Prepare(ctx, "select", selectStmt, nil)
 	require.NoError(t, err)
 
+	// Savepoint outside a transaction should fail.
+	err = session.Savepoint(ctx, func(ctx context.Context) error {
+		return nil
+	})
+	require.ErrorContains(t, err, "requires an active transaction")
+
 	// Create a a three deep savepoint and rollback the inner two savepoints.
 	err = session.Txn(ctx, func(ctx context.Context) error {
 		return session.Savepoint(ctx, func(ctx context.Context) error {
@@ -655,4 +663,105 @@ func TestModifySession(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, "my_test_app", string(tree.MustBeDString(rows[0][0])))
+}
+
+func TestKVSavepoint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	codec := s.ApplicationLayer().Codec()
+	kvDB := s.ApplicationLayer().DB()
+
+	idb := s.InternalDB().(descs.DB)
+	session, err := idb.Session(ctx, "test-session")
+	require.NoError(t, err)
+	defer session.Close(ctx)
+
+	// KVSavepoint outside a transaction should fail.
+	err = session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		return nil
+	})
+	require.ErrorContains(t, err, "requires an active transaction")
+
+	db := s.SQLConn(t)
+	_, err = db.Exec("CREATE TABLE defaultdb.kv_sp_test (id INT PRIMARY KEY, val INT)")
+	require.NoError(t, err)
+
+	insertStmt, err := parser.ParseOne("INSERT INTO defaultdb.kv_sp_test VALUES ($1, $2)")
+	require.NoError(t, err)
+	insert, err := session.Prepare(ctx, "insert", insertStmt, []*types.T{types.Int, types.Int})
+	require.NoError(t, err)
+
+	// Use high table ID prefixes as scratch keys within the tenant's keyspace.
+	rolledBackKey := codec.TablePrefix(0xFFFF00)
+	committedKey := codec.TablePrefix(0xFFFF01)
+
+	// Open a transaction, do a SQL write, then exercise two KVSavepoints: one
+	// that rolls back and one that commits. The first savepoint also verifies
+	// that prior SQL writes are visible inside the callback (i.e. the Step
+	// before the callback is working).
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		_, err := session.ExecutePrepared(ctx, insert, tree.Datums{
+			tree.NewDInt(1), tree.NewDInt(10),
+		})
+		if err != nil {
+			return err
+		}
+
+		// First savepoint: write to KV, verify the earlier SQL row is visible
+		// via a raw KV scan, then roll back.
+		spErr := session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if err := txn.Put(ctx, rolledBackKey, []byte("nope")); err != nil {
+				return err
+			}
+			// The SQL INSERT above should be visible here because KVSavepoint
+			// steps the read sequence before invoking the callback.
+			td := desctestutils.TestingGetPublicTableDescriptor(
+				kvDB, codec, "defaultdb", "kv_sp_test",
+			)
+			start := codec.TablePrefix(uint32(td.GetID()))
+			kvs, err := txn.Scan(ctx, start, start.PrefixEnd(), 0)
+			if err != nil {
+				return err
+			}
+			require.NotEmpty(t, kvs)
+			return errors.New("rollback")
+		})
+		require.ErrorContains(t, spErr, "rollback")
+
+		// Second savepoint: write to KV and succeed.
+		if err := session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			return txn.Put(ctx, committedKey, []byte("yes"))
+		}); err != nil {
+			return err
+		}
+
+		// One more SQL write to confirm the txn is still healthy.
+		_, err = session.ExecutePrepared(ctx, insert, tree.Datums{
+			tree.NewDInt(2), tree.NewDInt(20),
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	// The rolled-back KV write should not exist.
+	val, err := kvDB.Get(ctx, rolledBackKey)
+	require.NoError(t, err)
+	require.Nil(t, val.Value)
+
+	// The committed KV write should exist.
+	val, err = kvDB.Get(ctx, committedKey)
+	require.NoError(t, err)
+	require.Equal(t, []byte("yes"), val.ValueBytes())
+
+	// Both SQL rows should be present.
+	runner := sqlutils.MakeSQLRunner(db)
+	runner.CheckQueryResults(t,
+		"SELECT id, val FROM defaultdb.kv_sp_test ORDER BY id",
+		[][]string{{"1", "10"}, {"2", "20"}},
+	)
 }

--- a/pkg/sql/isql/isql_session.go
+++ b/pkg/sql/isql/isql_session.go
@@ -8,6 +8,7 @@ package isql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionmutator"
@@ -68,14 +69,10 @@ type Session interface {
 	// Savepoint creates a savepoint within an existing transaction and executes
 	// the given function. If the function returns an error, the savepoint is
 	// rolled back. If the function succeeds, the savepoint is released.
-	// Savepoints must be used within a transaction.
 	//
-	// TODO(jeffswenson): we should have Savepoint return an error if it is called
-	// outside of a transaction or transparently open a transaction. Right now,
-	// using a savepoint outside of a transaction returns an error, but after the
-	// `do` function is executed. For some reason Postgres does not produce an
-	// error if you create a savepoint outside of a transaction, but it does not
-	// remember the savepoint and returns an error when you attempt to release it.
+	// Savepoint must be called within an active transaction (i.e. inside a Txn
+	// callback). It returns an error if the session is not currently in a
+	// transaction.
 	//
 	// Example:
 	// err := session.Txn(ctx, func(ctx context.Context) error {
@@ -87,6 +84,22 @@ type Session interface {
 	// 	return err
 	// }
 	Savepoint(ctx context.Context, do func(context.Context) error) error
+
+	// KVSavepoint provides direct access to the KV transaction owned by the
+	// session. The txn is exposed in the context of a savepoint. The savepoint
+	// is reverted if the handler returns an error and released if the handler
+	// returns nil.
+	//
+	// The txn should only be used for the duration of the handler call and must
+	// not be stored or used after the handler returns.
+	//
+	// Example:
+	//	err := session.Txn(ctx, func(ctx context.Context) error {
+	//		return session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
+	//			return txn.Put(ctx, key, value)
+	//		})
+	//	})
+	KVSavepoint(ctx context.Context, do func(ctx context.Context, txn *kv.Txn) error) error
 
 	// ModifySession executes a function that mutates the session using the
 	// sessionmutator.SessionDataMutator argument.


### PR DESCRIPTION
Add a KVSavepoint method to isql.Session that provides direct access to the KV transaction owned by the underlying conn_executor. The method exposes the KV transaction in the context of a savepoint. This will be used by LDR to interact with tombstones.

Part of: #169239
Epic: CRDB-60163
Release note: None