### PR TITLE
roachtest: disable generic kafka tests on Azure

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2519,7 +2519,7 @@ CONFIGURE ZONE USING
 		Cluster:   r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
 		Leases:    registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
-		CompatibleClouds: registry.AllClouds.NoIBM(),
+		CompatibleClouds: registry.AllClouds.NoIBM().NoAzure(),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -2729,7 +2729,7 @@ CONFIGURE ZONE USING
 		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		Leases:    registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
-		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM().NoAzure(),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -2839,7 +2839,7 @@ CONFIGURE ZONE USING
 		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		Leases:    registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
-		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM().NoAzure(),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -2878,7 +2878,7 @@ CONFIGURE ZONE USING
 		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		Leases:    registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
-		CompatibleClouds:           registry.AllClouds.NoAWS().NoIBM(),
+		CompatibleClouds:           registry.AllClouds.NoAWS().NoIBM().NoAzure(),
 		Suites:                     registry.Suites(registry.Nightly),
 		RequiresDeprecatedWorkload: true, // uses ledger
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -3385,7 +3385,7 @@ CONFIGURE ZONE USING
 		Cluster:   r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
 		Leases:    registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
-		CompatibleClouds: registry.AllClouds.NoIBM(),
+		CompatibleClouds: registry.AllClouds.NoIBM().NoAzure(),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)


### PR DESCRIPTION
We saw a few failures for three of these tests that failed
on azure when cluster setup was slow there, causing the
changefeed to have less time to run and complete.

Since these tests exercise generic CDC behavior with an
in-cluster Kafka sink, none of them are testing anything
Azure-specific.

Azure-specific CDC coverage continues to live in cdc/kafka-azure
(Event Hub).

Affected tests:
- cdc/tpcc-1000/sink=kafka
- cdc/kafka-chaos
- cdc/crdb-chaos
- cdc/ledger
- cdc/tpcc-100/10min/sink=kafka/envelope=enriched

Epic: none
Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/168858
Fixes: https://github.com/cockroachdb/cockroach/issues/168867
Fixes: https://github.com/cockroachdb/cockroach/issues/168235