### PR TITLE
sqlwriter: return ErrStalePreviousValue for insert LWW winners

### DIFF
--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -92,6 +92,17 @@ func isLwwLoser(err error) bool {
 	return false
 }
 
+// isInsertWinnerWithConflict returns true if the error is a
+// ConditionFailedError with HadNewerOriginTimestamp set, meaning the insert
+// won the LWW comparison but conflicts with an existing row. The caller
+// should fall through to the upsert path.
+func isInsertWinnerWithConflict(err error) bool {
+	if condErr := (*kvpb.ConditionFailedError)(nil); errors.As(err, &condErr) {
+		return condErr.HadNewerOriginTimestamp
+	}
+	return false
+}
+
 type queryBuilder struct {
 	// stmts are parsed SQL statements. They should have the same number
 	// of inputs.
@@ -651,10 +662,10 @@ func (lww *lwwQuerier) InsertRow(
 			if isLwwLoser(err) {
 				return batchStats{}, nil
 			}
-			// If the optimistic insert failed with unique violation, we have to
-			// fall back to the pessimistic path. If we got a different error,
-			// then we bail completely.
-			if pgerror.GetPGCode(err) != pgcode.UniqueViolation {
+			// If the optimistic insert failed with a unique violation or because
+			// the insert won LWW but conflicts with an existing row, fall back
+			// to the pessimistic upsert path. For any other error, bail.
+			if pgerror.GetPGCode(err) != pgcode.UniqueViolation && !isInsertWinnerWithConflict(err) {
 				log.Dev.Warningf(ctx, "replicated optimistic insert failed (query: %s): %s", stmt.SQL, err.Error())
 				return batchStats{}, err
 			}

--- a/pkg/crosscluster/logical/sqlwriter/sql_row_writer.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_writer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -64,8 +65,10 @@ func (s *RowWriter) DeleteRow(
 	return nil
 }
 
-// InsertRow inserts a row into the table. It will return an error if the row
-// already exists.
+// InsertRow inserts a row into the table. It returns a ConditionFailedError
+// with OriginTimestampOlderThan set if the row lost a LWW comparison, or
+// ErrStalePreviousValue if the insert's origin timestamp is newer but the row
+// already exists (requiring a read refresh to convert the insert to an update).
 func (s *RowWriter) InsertRow(
 	ctx context.Context, originTimestamp hlc.Timestamp, row tree.Datums,
 ) error {
@@ -93,6 +96,15 @@ func (s *RowWriter) InsertRow(
 		}
 		return nil
 	})
+	// When the insert has a newer origin timestamp but conflicts with an
+	// existing row, the CPUT returns a ConditionFailedError with
+	// HadNewerOriginTimestamp. Return ErrStalePreviousValue so the caller
+	// triggers a read refresh and retries the write as an update.
+	if condErr := (*kvpb.ConditionFailedError)(nil); errors.As(err, &condErr) {
+		if condErr.HadNewerOriginTimestamp {
+			return ErrStalePreviousValue
+		}
+	}
 	return err
 }
 

--- a/pkg/crosscluster/logical/txnmode/txnmode_test.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_test.go
@@ -7,6 +7,7 @@ package txnmode_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -153,6 +154,201 @@ func TestTxnModeUniqueConstraintUpdate(t *testing.T) {
 	destDB.QueryRow(t, "SELECT count(*) FROM test_table WHERE unique_value = 1337").Scan(&count)
 	if count != 1 {
 		t.Fatalf("expected 1 row with unique_value = 1337, got %d", count)
+	}
+}
+
+// TestTxnModeLWW exercises every combination of incoming replication action
+// (insert, update, delete) against every possible local state at the
+// destination (nothing, tombstone losing lww, tombstone winning lww, value
+// losing lww, value winning lww). The table uses (tc, cluster, version) where
+// tc encodes the test case, cluster records who wrote the row, and version
+// describes the row's state.
+func TestTxnModeLWW(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlock(t)
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(134857),
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(conn)
+
+	sysRunner := sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t))
+	ldrtestutils.ApplyLowLatencyReplicationSettings(t, sysRunner, runner)
+
+	// execPhase runs a list of SQL statements either individually or grouped
+	// in a single transaction, depending on the useTxn flag.
+	execPhase := func(t *testing.T, db *sqlutils.SQLRunner, useTxn bool, stmts []string) {
+		if useTxn {
+			db.Exec(t, "BEGIN")
+			for _, stmt := range stmts {
+				db.Exec(t, stmt)
+			}
+			db.Exec(t, "COMMIT")
+		} else {
+			for _, stmt := range stmts {
+				db.Exec(t, stmt)
+			}
+		}
+	}
+
+	tests := []struct {
+		name   string
+		useTxn bool
+	}{
+		{name: "individual_statements", useTxn: false},
+		{name: "transactional", useTxn: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dbName := fmt.Sprintf("%s_db", tc.name)
+			sourceDBName := fmt.Sprintf("source_%s", dbName)
+			destDBName := fmt.Sprintf("dest_%s", dbName)
+			runner.Exec(t, fmt.Sprintf("CREATE DATABASE %s", sourceDBName))
+			runner.Exec(t, fmt.Sprintf("CREATE DATABASE %s", destDBName))
+
+			sourceDB := sqlutils.MakeSQLRunner(
+				s.SQLConn(t, serverutils.DBName(sourceDBName)))
+			destDB := sqlutils.MakeSQLRunner(
+				s.SQLConn(t, serverutils.DBName(destDBName)))
+
+			for _, db := range []*sqlutils.SQLRunner{sourceDB, destDB} {
+				db.Exec(t,
+					"CREATE TABLE lww (tc STRING PRIMARY KEY, cluster STRING, version STRING)")
+			}
+
+			// Phase 0: Insert source rows that will later be updated or
+			// deleted. These are written before the cursor so the initial
+			// inserts are not replicated.
+			execPhase(t, sourceDB, tc.useTxn, []string{
+				"INSERT INTO lww VALUES ('upd_nothing',   'source', 'pre-update')",
+				"INSERT INTO lww VALUES ('upd_tomb_lose', 'source', 'pre-update')",
+				"INSERT INTO lww VALUES ('upd_tomb_win',  'source', 'pre-update')",
+				"INSERT INTO lww VALUES ('upd_val_lose',  'source', 'pre-update')",
+				"INSERT INTO lww VALUES ('upd_val_win',   'source', 'pre-update')",
+				"INSERT INTO lww VALUES ('del_nothing',   'source', 'pre-delete')",
+				"INSERT INTO lww VALUES ('del_tomb_lose', 'source', 'pre-delete')",
+				"INSERT INTO lww VALUES ('del_tomb_win',  'source', 'pre-delete')",
+				"INSERT INTO lww VALUES ('del_val_lose',  'source', 'pre-delete')",
+				"INSERT INTO lww VALUES ('del_val_win',   'source', 'pre-delete')",
+			})
+
+			// Capture cursor timestamp. All changes after this point will be
+			// replicated when the LDR stream starts.
+			cursorTS := s.Clock().Now()
+
+			// Phase 2a: Insert destination data that will lose LWW. This
+			// includes values that will be overwritten and seeds for
+			// tombstones.
+			execPhase(t, destDB, tc.useTxn, []string{
+				"INSERT INTO lww VALUES ('ins_val_lose',  'dest', 'losing-value')",
+				"INSERT INTO lww VALUES ('upd_val_lose',  'dest', 'losing-value')",
+				"INSERT INTO lww VALUES ('del_val_lose',  'dest', 'losing-value')",
+				"INSERT INTO lww VALUES ('ins_tomb_lose', 'dest', 'tombstone-seed')",
+				"INSERT INTO lww VALUES ('upd_tomb_lose', 'dest', 'tombstone-seed')",
+				"INSERT INTO lww VALUES ('del_tomb_lose', 'dest', 'tombstone-seed')",
+			})
+
+			// Phase 2b: Delete the tombstone seeds to create losing
+			// tombstones.
+			execPhase(t, destDB, tc.useTxn, []string{
+				"DELETE FROM lww WHERE tc = 'ins_tomb_lose'",
+				"DELETE FROM lww WHERE tc = 'upd_tomb_lose'",
+				"DELETE FROM lww WHERE tc = 'del_tomb_lose'",
+			})
+
+			// Phase 3: Source writes that will be replicated. Inserts,
+			// updates to pre-existing rows, and deletes of pre-existing
+			// rows.
+			execPhase(t, sourceDB, tc.useTxn, []string{
+				"INSERT INTO lww VALUES ('ins_nothing',   'source', 'inserted')",
+				"INSERT INTO lww VALUES ('ins_tomb_lose', 'source', 'inserted')",
+				"INSERT INTO lww VALUES ('ins_tomb_win',  'source', 'inserted')",
+				"INSERT INTO lww VALUES ('ins_val_lose',  'source', 'inserted')",
+				"INSERT INTO lww VALUES ('ins_val_win',   'source', 'inserted')",
+				"UPDATE lww SET cluster = 'source', version = 'updated' WHERE tc = 'upd_nothing'",
+				"UPDATE lww SET cluster = 'source', version = 'updated' WHERE tc = 'upd_tomb_lose'",
+				"UPDATE lww SET cluster = 'source', version = 'updated' WHERE tc = 'upd_tomb_win'",
+				"UPDATE lww SET cluster = 'source', version = 'updated' WHERE tc = 'upd_val_lose'",
+				"UPDATE lww SET cluster = 'source', version = 'updated' WHERE tc = 'upd_val_win'",
+				"DELETE FROM lww WHERE tc = 'del_nothing'",
+				"DELETE FROM lww WHERE tc = 'del_tomb_lose'",
+				"DELETE FROM lww WHERE tc = 'del_tomb_win'",
+				"DELETE FROM lww WHERE tc = 'del_val_lose'",
+				"DELETE FROM lww WHERE tc = 'del_val_win'",
+			})
+
+			// Phase 4a: Insert destination data that will win LWW. These
+			// have the newest timestamps so they survive conflict
+			// resolution.
+			execPhase(t, destDB, tc.useTxn, []string{
+				"INSERT INTO lww VALUES ('ins_val_win',  'dest', 'winning-value')",
+				"INSERT INTO lww VALUES ('upd_val_win',  'dest', 'winning-value')",
+				"INSERT INTO lww VALUES ('del_val_win',  'dest', 'winning-value')",
+				"INSERT INTO lww VALUES ('ins_tomb_win', 'dest', 'tombstone-seed')",
+				"INSERT INTO lww VALUES ('upd_tomb_win', 'dest', 'tombstone-seed')",
+				"INSERT INTO lww VALUES ('del_tomb_win', 'dest', 'tombstone-seed')",
+			})
+
+			// Phase 4b: Delete the tombstone seeds to create winning
+			// tombstones.
+			execPhase(t, destDB, tc.useTxn, []string{
+				"DELETE FROM lww WHERE tc = 'ins_tomb_win'",
+				"DELETE FROM lww WHERE tc = 'upd_tomb_win'",
+				"DELETE FROM lww WHERE tc = 'del_tomb_win'",
+			})
+
+			// Start transactional LDR with cursor set before all the
+			// write traffic.
+			sourceURL := replicationtestutils.GetExternalConnectionURI(
+				t, s, s, serverutils.DBName(sourceDBName))
+
+			var jobID jobspb.JobID
+			destDB.QueryRow(t,
+				"CREATE LOGICAL REPLICATION STREAM FROM TABLE lww ON $1 INTO TABLE lww WITH MODE = 'transactional', CURSOR = $2",
+				sourceURL.String(),
+				cursorTS.AsOfSystemTime(),
+			).Scan(&jobID)
+
+			now := s.Clock().Now()
+			ldrtestutils.WaitUntilReplicatedTime(t, now, destDB, jobID)
+
+			// Assert the final state. Rows where the source wins or there
+			// is no conflict appear with source data. Rows where the
+			// destination wins appear with destination data. Rows deleted
+			// by a winning action are absent.
+			//
+			// Absent rows:
+			//   del_nothing   - delete against nothing produces no row
+			//   del_tomb_lose - source delete wins over older tombstone
+			//   del_tomb_win  - source delete loses to winning tombstone
+			//   del_val_lose  - source delete wins over older value
+			//   ins_tomb_win  - source insert loses to winning tombstone
+			//   upd_tomb_win  - source update loses to winning tombstone
+			destDB.CheckQueryResults(t,
+				"SELECT * FROM lww ORDER BY tc",
+				[][]string{
+					{"del_val_win", "dest", "winning-value"},
+					{"ins_nothing", "source", "inserted"},
+					{"ins_tomb_lose", "source", "inserted"},
+					{"ins_val_lose", "source", "inserted"},
+					{"ins_val_win", "dest", "winning-value"},
+					{"upd_nothing", "source", "updated"},
+					{"upd_tomb_lose", "source", "updated"},
+					{"upd_val_lose", "source", "updated"},
+					{"upd_val_win", "dest", "winning-value"},
+				},
+			)
+		})
 	}
 }
 

--- a/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
@@ -360,6 +360,29 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 			)
 		},
 	}, {
+		name: "refresh_converts_insert_to_update",
+		setup: func(t *testing.T, baseID int) {
+			sqlDB.Exec(t, fmt.Sprintf(
+				`INSERT INTO parent (id, payload) VALUES (%d, 'existing')`, baseID+1))
+		},
+		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
+			return ldrdecoder.Transaction{
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
+				WriteSet: []ldrdecoder.DecodedRow{{
+					Row:     parentRow(baseID+1, "insert-winner"),
+					PrevRow: nil, // INSERT: no previous row known on source
+					TableID: parentID,
+				}},
+			}
+		},
+		validate: func(t *testing.T, baseID int, result ApplyResult) {
+			require.Equal(t, ApplyResult{AppliedRows: 1}, result)
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT payload FROM parent WHERE id = %d`, baseID+1),
+				[][]string{{"insert-winner"}},
+			)
+		},
+	}, {
 		name: "refresh_converts_update_to_insert",
 		setup: func(t *testing.T, baseID int) {
 		},

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -48,7 +48,7 @@ func ConvertBatchError(
 		)
 
 	case *kvpb.ConditionFailedError:
-		if !v.OriginTimestampOlderThan.IsEmpty() {
+		if !v.OriginTimestampOlderThan.IsEmpty() || v.HadNewerOriginTimestamp {
 			// NOTE: we return the go error here because this error should never be
 			// communicated to pgwire. It's exposed for the LDR writer.
 			return origPErr.GoError()


### PR DESCRIPTION
When a replicated INSERT had a newer origin timestamp than an existing local row, the CPUT produced a ConditionFailedError with HadNewerOriginTimestamp. ConvertBatchError converted this into a uniqueness violation, which the transaction writer then DLQ'd instead of triggering a read refresh.

Fix by preserving the ConditionFailedError in ConvertBatchError when HadNewerOriginTimestamp is set, and detecting it in InsertRow to return ErrStalePreviousValue. This triggers the existing refresh mechanism which reads the local row, converts the INSERT to an UPDATE, and retries successfully.

Epic: CRDB-60163
Release note: none