### PR TITLE
release-26.1: conflict: diff the clusters when there is a row mismatch

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -320,6 +320,7 @@ go_library(
         "//pkg/workload/debug",
         "//pkg/workload/histogram",
         "//pkg/workload/histogram/exporter",
+        "//pkg/workload/rand",
         "//pkg/workload/schemachange",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpcds",

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	workloadrand "github.com/cockroachdb/cockroach/pkg/workload/rand"
 	"github.com/stretchr/testify/require"
 )
 
@@ -468,11 +469,65 @@ func TestLDRConflict(
 		leftURL)
 
 	t.Status("verifying results")
-	VerifyCorrectness(ctx, c, t, setup, leftJobID, rightJobID, 2*time.Minute, LDRWorkload{
-		dbName:            "conflict",
-		tableNames:        []string{"conflict"},
-		manualSchemaSetup: true,
-	})
+	verifyConflictCorrectness(ctx, t, setup, leftJobID, rightJobID)
+}
+
+// verifyConflictCorrectness waits for replication to catch up, checks DLQs,
+// and compares table fingerprints. If fingerprints diverge, it runs a row-level
+// diff. There is a known bug where the conflict workload can produce two
+// conflict rows with the same origin timestamp, causing LDR to resolve them
+// nondeterministically. If all differing rows have identical origin timestamps
+// on both sides, the test passes. Otherwise, the test fails and prints the
+// diffs.
+func verifyConflictCorrectness(
+	ctx context.Context, t test.Test, setup multiClusterSetup, leftJobID, rightJobID int,
+) {
+	now := timeutil.Now()
+	t.Status("waiting for replicated times to catchup")
+	waitForReplicatedTimeToReachTimestamp(t, leftJobID, setup.left.db, getLogicalDataReplicationJobInfo, 2*time.Minute, now)
+	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.left.db, "conflict"))
+	waitForReplicatedTimeToReachTimestamp(t, rightJobID, setup.right.db, getLogicalDataReplicationJobInfo, 2*time.Minute, now)
+	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.right.db, "conflict"))
+
+	t.Status("comparing fingerprints")
+	fpQuery := "SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE conflict.conflict"
+	fpLeft := setup.left.sysSQL.QueryStr(t, fpQuery)
+	fpRight := setup.right.sysSQL.QueryStr(t, fpQuery)
+
+	if fmt.Sprint(fpLeft) == fmt.Sprint(fpRight) {
+		t.L().Printf("fingerprints match")
+		return
+	}
+
+	t.Status("running row-level diff")
+
+	// Limit to 100 diffs: without a limit, the worst case reports the entire
+	// database which is millions of rows. In practice we expect only 1-2 rows
+	// with matching origin timestamps, so if there are 100 or more something
+	// else is wrong.
+	const diffLimit = 100
+	diffs, err := workloadrand.Diff(setup.left.db, "conflict.conflict", setup.right.db, "conflict.conflict", diffLimit)
+	require.NoError(t, err)
+	require.NotEmpty(t, diffs, "fingerprints differ but no row diffs found")
+	require.Less(t, len(diffs), diffLimit, "too many diffs; likely a real divergence, not a timestamp tie")
+
+	// Check if all diffs are caused by the known bug: two conflict rows with
+	// the same origin timestamp cause nondeterministic resolution.
+	for _, diff := range diffs {
+		if diff.RowA == nil || diff.RowB == nil {
+			// TODO(jeffswenson): this case is a little sad because we don't
+			// currently have a way to get the origin timestamp for a tombstone, so
+			// we can't assert the only time we see this is on origin timestamp
+			// conflicts.
+			continue
+		}
+		if diff.OriginTimestampA == diff.OriginTimestampB {
+			// TODO(#168541): if the origin timestamps are the same, lww conflict
+			// resolution will tie and the clusters may diverge.
+			continue
+		}
+		t.Errorf("fingerprints differ with mismatched origin timestamps: %s", diff)
+	}
 }
 
 // TestLDRCreateTablesTPCC inits the left cluster with 1000 warehouse tpcc,

--- a/pkg/crosscluster/ldrrandgen/logical.go
+++ b/pkg/crosscluster/ldrrandgen/logical.go
@@ -21,6 +21,14 @@ func isSupportedType(t *types.T) bool {
 		// We don't support RefCursor columns in LDR tables because they do not
 		// support equality.
 		return false
+	case types.TSVectorFamily,
+		types.TSQueryFamily,
+		types.JsonpathFamily,
+		types.PGVectorFamily:
+		// These type families do not support keyside encoding, which means they
+		// cannot be used with crdb_internal.datums_to_bytes. This prevents
+		// fingerprinting and diff hashing from working.
+		return false
 	case types.ArrayFamily:
 		// We don't allow Arrays of bits because rand.LoadTable doesn't correctly identify their bit width.
 		if t.ArrayContents().Family() == types.BitFamily {
@@ -59,6 +67,9 @@ func GenerateLDRTable(
 		}),
 		randgen.WithPrimaryIndexFilter(func(indexDef *tree.IndexTableDef, columnDefs []*tree.ColumnTableDef) bool {
 			for _, col := range indexDef.Columns {
+				if col.Expr != nil {
+					continue
+				}
 				columnDef := columnByName(col.Column, columnDefs)
 				// TODO(127315): types with composite encoding are not supported in the
 				// primary key by LDR.
@@ -89,12 +100,15 @@ func GenerateLDRTable(
 				return false
 			case *tree.IndexTableDef:
 				for _, col := range indexDef.Columns {
-					if supportKVWriter && col.Expr != nil {
-						// Do not allow expression indexes. These cause SQL to generate a hidden computed column, which is not
-						// supported by the kv writer.
-						if col.Expr != nil {
+					if col.Expr != nil {
+						if supportKVWriter {
+							// Expression indexes generate hidden computed
+							// columns not supported by the KV writer.
 							return false
 						}
+						// Expression columns don't map to a column def;
+						// skip column-level checks.
+						continue
 					}
 					columnDef := columnByName(col.Column, columnDefs)
 					if columnDef.IsVirtual() {

--- a/pkg/workload/conflict/BUILD.bazel
+++ b/pkg/workload/conflict/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = [
         "conflict.go",
         "conflict_worker.go",
-        "writer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/conflict",
     visibility = ["//visibility:public"],
@@ -17,7 +16,6 @@ go_library(
         "//pkg/workload",
         "//pkg/workload/histogram",
         "//pkg/workload/rand",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgx_v5//stdlib",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",
@@ -26,28 +24,15 @@ go_library(
 
 go_test(
     name = "conflict_test",
-    srcs = [
-        "main_test.go",
-        "writer_test.go",
-    ],
+    srcs = ["main_test.go"],
     data = ["//c-deps:libgeos"],
-    embed = [":conflict"],
     deps = [
-        "//pkg/base",
         "//pkg/ccl",
-        "//pkg/crosscluster/ldrrandgen",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql/sem/tree",
-        "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
-        "//pkg/util/leaktest",
-        "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/workload/rand",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/workload/conflict/conflict.go
+++ b/pkg/workload/conflict/conflict.go
@@ -102,7 +102,7 @@ func (w *conflict) Ops(
 		poolA := clusterA.Get()
 		poolB := clusterB.Get()
 		dbs := []*gosql.DB{stdlib.OpenDBFromPool(poolA), stdlib.OpenDBFromPool(poolB)}
-		worker, err := newConflictWorker(ctx, dbs, w.tableName)
+		worker, err := newConflictWorker(dbs, w.tableName)
 		if err != nil {
 			return workload.QueryLoad{}, err
 		}

--- a/pkg/workload/conflict/conflict_worker.go
+++ b/pkg/workload/conflict/conflict_worker.go
@@ -19,24 +19,19 @@ import (
 type conflictWorker struct {
 	table   workloadrand.Table
 	rng     *rand.Rand
-	writers []*writer
+	writers []*workloadrand.TableWriter
 	nullPct int
 }
 
-func newConflictWorker(
-	ctx context.Context, connections []*gosql.DB, tableName string,
-) (*conflictWorker, error) {
+func newConflictWorker(connections []*gosql.DB, tableName string) (*conflictWorker, error) {
 	table, err := workloadrand.LoadTable(connections[0], tableName)
 	if err != nil {
 		return nil, err
 	}
 
-	writers := make([]*writer, len(connections))
+	writers := make([]*workloadrand.TableWriter, len(connections))
 	for i := range writers {
-		writers[i], err = newWriter(ctx, connections[i], table)
-		if err != nil {
-			return nil, err
-		}
+		writers[i] = workloadrand.NewTableWriter(connections[i], table)
 	}
 
 	return &conflictWorker{
@@ -71,7 +66,7 @@ func (w *conflictWorker) RunOp(ctx context.Context) (err error) {
 }
 
 func (w *conflictWorker) runOpOnCluster(
-	ctx context.Context, writer *writer, row []any, rng *rand.Rand,
+	ctx context.Context, writer *workloadrand.TableWriter, row []any, rng *rand.Rand,
 ) error {
 	var err error
 	// run between 0, 1, or 2 mutations on each cluster. This way we get coverage of:
@@ -86,11 +81,11 @@ func (w *conflictWorker) runOpOnCluster(
 					return err
 				}
 			}
-			if err := writer.upsertRow(ctx, row); err != nil {
+			if err := writer.UpsertRow(ctx, row); err != nil {
 				return err
 			}
 		} else {
-			if err := writer.deleteRow(ctx, row); err != nil {
+			if err := writer.DeleteRow(ctx, row); err != nil {
 				return err
 			}
 		}

--- a/pkg/workload/rand/BUILD.bazel
+++ b/pkg/workload/rand/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "rand",
     srcs = [
+        "diff.go",
         "rand.go",
         "schema.go",
         "writer.go",
@@ -15,6 +16,7 @@ go_library(
         "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/hlc",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",
@@ -29,6 +31,7 @@ go_test(
     name = "rand_test",
     size = "small",
     srcs = [
+        "diff_test.go",
         "rand_test.go",
         "writer_test.go",
     ],
@@ -47,6 +50,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/workload/rand/BUILD.bazel
+++ b/pkg/workload/rand/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "rand.go",
         "schema.go",
+        "writer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/rand",
     visibility = ["//visibility:public"],
@@ -27,16 +28,22 @@ go_library(
 go_test(
     name = "rand_test",
     size = "small",
-    srcs = ["rand_test.go"],
+    srcs = [
+        "rand_test.go",
+        "writer_test.go",
+    ],
+    data = ["//c-deps:libgeos"],
     embed = [":rand"],
     deps = [
         "//pkg/base",
+        "//pkg/crosscluster/ldrrandgen",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/workload/rand/diff.go
+++ b/pkg/workload/rand/diff.go
@@ -1,0 +1,329 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rand
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// RowDiff represents a difference between two tables. If RowA is nil, the row
+// exists only in table B. If RowB is nil, the row exists only in table A. If
+// both are non-nil, the rows have the same primary key but different column
+// values. The MVCC and origin timestamps are included to help diagnose
+// replication convergence issues.
+type RowDiff struct {
+	ColNames         []string
+	RowA             []any
+	MVCCTimestampA   hlc.Timestamp // crdb_internal_mvcc_timestamp from table A
+	OriginTimestampA hlc.Timestamp // crdb_internal_origin_timestamp from table A
+	RowB             []any
+	MVCCTimestampB   hlc.Timestamp // crdb_internal_mvcc_timestamp from table B
+	OriginTimestampB hlc.Timestamp // crdb_internal_origin_timestamp from table B
+}
+
+// formatRow returns a pretty-printed representation of a row as
+// {col1: 'val1', col2: 'val2', ...}.
+func (d RowDiff) formatRow(row []any) string {
+	if row == nil {
+		return "<nil>"
+	}
+	var b strings.Builder
+	b.WriteByte('{')
+
+	for i := range row {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s: '%v'", d.ColNames[i], row[i])
+	}
+
+	b.WriteByte('}')
+	return b.String()
+}
+
+func (d RowDiff) String() string {
+	return fmt.Sprintf(
+		"RowA=%s (mvcc=%s, origin=%s) RowB=%s (mvcc=%s, origin=%s)",
+		d.formatRow(d.RowA), d.MVCCTimestampA, d.OriginTimestampA,
+		d.formatRow(d.RowB), d.MVCCTimestampB, d.OriginTimestampB,
+	)
+}
+
+// fetchedRow holds the data for a single row fetched during diff phase 2.
+type fetchedRow struct {
+	row             []any
+	mvccTimestamp   hlc.Timestamp
+	originTimestamp hlc.Timestamp
+}
+
+// buildPKHashExpr returns the SQL expression for the primary key hash, using
+// fnv64 to produce a compact int64 instead of raw bytes.
+func buildPKHashExpr(schema *Table) string {
+	var b strings.Builder
+	b.WriteString("fnv64(crdb_internal.datums_to_bytes(")
+	for i, pkIdx := range schema.PrimaryKey {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(tree.NameString(schema.Cols[pkIdx].Name))
+	}
+	b.WriteString("))")
+	return b.String()
+}
+
+// buildOrderByClause returns an ORDER BY clause using the primary key columns,
+// ensuring deterministic row ordering for hash and fetch queries.
+func buildOrderByClause(schema *Table) string {
+	var b strings.Builder
+	b.WriteString(" ORDER BY ")
+	for i, pkIdx := range schema.PrimaryKey {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(tree.NameString(schema.Cols[pkIdx].Name))
+	}
+	return b.String()
+}
+
+// buildHashQuery returns a lightweight query that computes only pk_hash and
+// row_hash for every row as int64 values using fnv64.
+//
+// Example for a table with PK (id) and columns (id, name, value):
+//
+//	SELECT fnv64(crdb_internal.datums_to_bytes(id)) AS pk_hash,
+//	  fnv64(crdb_internal.datums_to_bytes(id, name, value)) AS row_hash
+//	FROM my_table
+func buildHashQuery(schema *Table, tableName string) string {
+	var b strings.Builder
+	b.WriteString("SELECT ")
+	b.WriteString(buildPKHashExpr(schema))
+	b.WriteString(" AS pk_hash, fnv64(crdb_internal.datums_to_bytes(")
+	for i, colIdx := range schema.IndexableColumns() {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(tree.NameString(schema.Cols[colIdx].Name))
+	}
+	b.WriteString(")) AS row_hash FROM ")
+	b.WriteString(tableName)
+	b.WriteString(buildOrderByClause(schema))
+	return b.String()
+}
+
+// queryHashes executes the hash query and returns a map from pk_hash to
+// row_hash. Both are int64 values produced by fnv64.
+func queryHashes(conn *gosql.DB, query string) (map[int64]int64, error) {
+	rows, err := conn.Query(query)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading hashes")
+	}
+	defer rows.Close()
+
+	result := make(map[int64]int64)
+	for rows.Next() {
+		var pkHash, rowHash int64
+		if err := rows.Scan(&pkHash, &rowHash); err != nil {
+			return nil, errors.Wrap(err, "scanning hash row")
+		}
+		result[pkHash] = rowHash
+	}
+	return result, errors.Wrap(rows.Err(), "iterating hash rows")
+}
+
+// buildFetchQuery returns a query that retrieves all columns plus MVCC/origin
+// timestamps and the pk_hash for every row.
+//
+// Example for a table with PK (id) and columns (id, name, value):
+//
+//	SELECT id, name, value,
+//	  crdb_internal_mvcc_timestamp, crdb_internal_origin_timestamp,
+//	  fnv64(crdb_internal.datums_to_bytes(id)) AS pk_hash
+//	FROM my_table
+func buildFetchQuery(schema *Table, pkHashExpr string, tableName string) string {
+	var b strings.Builder
+	b.WriteString("SELECT ")
+	for i, col := range schema.Cols {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(tree.NameString(col.Name))
+	}
+	b.WriteString(", crdb_internal_mvcc_timestamp, crdb_internal_origin_timestamp, ")
+	b.WriteString(pkHashExpr)
+	b.WriteString(" AS pk_hash FROM ")
+	b.WriteString(tableName)
+	b.WriteString(buildOrderByClause(schema))
+	return b.String()
+}
+
+// fetchDiffRows executes a full table scan but only retains rows whose
+// pk_hash is in the diffPKs set, returning a map from pk_hash to the
+// fetched row data.
+func fetchDiffRows(
+	conn *gosql.DB, query string, numCols int, diffPKs map[int64]struct{},
+) (map[int64]fetchedRow, error) {
+	rows, err := conn.Query(query)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching diff rows")
+	}
+	defer rows.Close()
+
+	result := make(map[int64]fetchedRow)
+	for rows.Next() {
+		// The fetch query (see buildFetchQuery) appends three columns after the
+		// table's own columns: dest[numCols] is crdb_internal_mvcc_timestamp,
+		// dest[numCols+1] is crdb_internal_origin_timestamp, and dest[numCols+2]
+		// is pk_hash.
+		dest := make([]any, numCols+3)
+		ptrs := make([]any, numCols+3)
+		for i := range dest {
+			ptrs[i] = &dest[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, errors.Wrap(err, "scanning diff row")
+		}
+		pk, ok := dest[numCols+2].(int64)
+		if !ok {
+			return nil, errors.Newf(
+				"expected int64 for pk_hash, got %T", dest[numCols+2],
+			)
+		}
+		if _, needed := diffPKs[pk]; !needed {
+			continue
+		}
+		fr := fetchedRow{
+			row: dest[:numCols],
+		}
+		if fr.mvccTimestamp, err = decimalToHLC(dest[numCols]); err != nil {
+			return nil, errors.Wrap(err, "parsing mvcc timestamp")
+		}
+		if fr.originTimestamp, err = decimalToHLC(dest[numCols+1]); err != nil {
+			return nil, errors.Wrap(err, "parsing origin timestamp")
+		}
+		result[pk] = fr
+	}
+	return result, errors.Wrap(rows.Err(), "iterating diff rows")
+}
+
+// Diff compares the contents of two tables across two database connections and
+// returns up to resultLimit differences. Both tables must have the same schema.
+// The schema is loaded from connA/tableA and used for both sides.
+//
+// The comparison uses two queries per table. The first is a lightweight hash
+// query that computes pk_hash and row_hash server-side using
+// crdb_internal.datums_to_bytes, minimizing data sent over pgwire. The second
+// query fetches full row data (all columns plus MVCC/origin timestamps) only
+// for rows whose pk_hash appeared in the diff set.
+//
+// Limitations:
+//   - Columns with types that cannot be keyside-encoded (e.g. TSVECTOR,
+//     PGVECTOR) are excluded from the row hash. Differences in only those
+//     columns will not be detected.
+//   - Primary key hashes use FNV64, so hash collisions would cause rows to be
+//     silently dropped. This is negligible for reasonable table sizes.
+func Diff(
+	connA *gosql.DB, tableA string, connB *gosql.DB, tableB string, resultLimit int,
+) ([]RowDiff, error) {
+	schema, err := LoadTable(connA, tableA)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading table schema")
+	}
+
+	if len(schema.PrimaryKey) == 0 {
+		return nil, errors.Newf("table %s has no primary key", tableA)
+	}
+
+	pkHashExpr := buildPKHashExpr(&schema)
+
+	// Phase 1: load hashes from both tables.
+	hashesA, err := queryHashes(connA, buildHashQuery(&schema, tableA))
+	if err != nil {
+		return nil, err
+	}
+	hashesB, err := queryHashes(connB, buildHashQuery(&schema, tableB))
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute the set of pk_hashes that differ between the two tables.
+	diffPKs := make(map[int64]struct{})
+	for pk, hashA := range hashesA {
+		hashB, ok := hashesB[pk]
+		if !ok || hashA != hashB {
+			diffPKs[pk] = struct{}{}
+		}
+	}
+	for pk := range hashesB {
+		if _, ok := hashesA[pk]; !ok {
+			diffPKs[pk] = struct{}{}
+		}
+	}
+
+	if len(diffPKs) == 0 {
+		return nil, nil
+	}
+
+	// Phase 2: fetch full row data only for differing rows.
+	numCols := len(schema.Cols)
+	fetchQueryA := buildFetchQuery(&schema, pkHashExpr, tableA)
+	dataA, err := fetchDiffRows(connA, fetchQueryA, numCols, diffPKs)
+	if err != nil {
+		return nil, err
+	}
+	fetchQueryB := buildFetchQuery(&schema, pkHashExpr, tableB)
+	dataB, err := fetchDiffRows(connB, fetchQueryB, numCols, diffPKs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build diff results from the fetched rows.
+	colNames := make([]string, len(schema.Cols))
+	for i, col := range schema.Cols {
+		colNames[i] = col.Name
+	}
+
+	var results []RowDiff
+	for pk := range diffPKs {
+		if len(results) >= resultLimit {
+			break
+		}
+		diff := RowDiff{ColNames: colNames}
+		if entryA, inA := dataA[pk]; inA {
+			diff.RowA = entryA.row
+			diff.MVCCTimestampA = entryA.mvccTimestamp
+			diff.OriginTimestampA = entryA.originTimestamp
+		}
+		if entryB, inB := dataB[pk]; inB {
+			diff.RowB = entryB.row
+			diff.MVCCTimestampB = entryB.mvccTimestamp
+			diff.OriginTimestampB = entryB.originTimestamp
+		}
+		results = append(results, diff)
+	}
+
+	return results, nil
+}
+
+// decimalToHLC converts a scanned crdb_internal_mvcc_timestamp or
+// crdb_internal_origin_timestamp value (a DECIMAL) into an hlc.Timestamp.
+// Returns the zero timestamp if the value is nil (e.g. origin timestamp for
+// locally-written data).
+func decimalToHLC(v any) (hlc.Timestamp, error) {
+	if v == nil {
+		return hlc.Timestamp{}, nil
+	}
+	s, ok := v.([]byte)
+	if !ok {
+		return hlc.Timestamp{}, errors.Newf("expected []byte for timestamp, got %T", v)
+	}
+	return hlc.ParseHLC(string(s))
+}

--- a/pkg/workload/rand/diff_test.go
+++ b/pkg/workload/rand/diff_test.go
@@ -1,0 +1,320 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rand
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/ldrrandgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowDiffFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	d := RowDiff{
+		ColNames:         []string{"id", "name", "value"},
+		RowA:             []any{1, "alice", 10},
+		MVCCTimestampA:   hlc.Timestamp{WallTime: 1e9, Logical: 1},
+		OriginTimestampA: hlc.Timestamp{WallTime: 5e8},
+		RowB:             nil,
+	}
+	require.Equal(t,
+		"RowA={id: '1', name: 'alice', value: '10'} (mvcc=1.000000000,1, origin=0.500000000,0) "+
+			"RowB=<nil> (mvcc=0,0, origin=0,0)",
+		d.String(),
+	)
+}
+
+func TestDiff(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// Create tables used by most subtests. Fully qualified names exercise the
+	// schema.table path in diff queries (ensures we don't accidentally quote
+	// the whole name as a single identifier).
+	sqlDB.Exec(t, `CREATE TABLE diff_a (id INT PRIMARY KEY, name STRING, value INT)`)
+	sqlDB.Exec(t, `CREATE TABLE diff_b (id INT PRIMARY KEY, name STRING, value INT)`)
+	const diffA = "defaultdb.public.diff_a"
+	const diffB = "defaultdb.public.diff_b"
+
+	// BIT column tables for the qualified-name regression test.
+	sqlDB.Exec(t, `CREATE TABLE bit_a (id INT PRIMARY KEY, bits BIT(15))`)
+	sqlDB.Exec(t, `CREATE TABLE bit_b (id INT PRIMARY KEY, bits BIT(15))`)
+	const bitA = "defaultdb.public.bit_a"
+	const bitB = "defaultdb.public.bit_b"
+
+	type diffCheck struct {
+		name     string
+		tableA   string // fully qualified table A name
+		tableB   string // fully qualified table B name
+		setup    []string
+		limit    int
+		wantLen  int
+		validate func(t *testing.T, diffs []RowDiff)
+	}
+
+	tests := []diffCheck{
+		{
+			name:   "identical",
+			tableA: diffA, tableB: diffB,
+			setup: []string{
+				"DELETE FROM diff_a", "DELETE FROM diff_b",
+				"INSERT INTO diff_a VALUES (1, 'alice', 10), (2, 'bob', 20)",
+				"INSERT INTO diff_b VALUES (1, 'alice', 10), (2, 'bob', 20)",
+			},
+			limit:   100,
+			wantLen: 0,
+		},
+		{
+			name:   "only-in-a",
+			tableA: diffA, tableB: diffB,
+			setup: []string{
+				"DELETE FROM diff_a", "DELETE FROM diff_b",
+				"INSERT INTO diff_a VALUES (1, 'alice', 10), (2, 'bob', 20)",
+				"INSERT INTO diff_b VALUES (1, 'alice', 10)",
+			},
+			limit:   100,
+			wantLen: 1,
+			validate: func(t *testing.T, diffs []RowDiff) {
+				require.NotNil(t, diffs[0].RowA)
+				require.Nil(t, diffs[0].RowB)
+				require.True(t, diffs[0].MVCCTimestampA.IsSet())
+				require.True(t, diffs[0].OriginTimestampA.IsEmpty())
+				require.True(t, diffs[0].MVCCTimestampB.IsEmpty())
+				require.True(t, diffs[0].OriginTimestampB.IsEmpty())
+			},
+		},
+		{
+			name:   "only-in-b",
+			tableA: diffA, tableB: diffB,
+			setup: []string{
+				"DELETE FROM diff_a", "DELETE FROM diff_b",
+				"INSERT INTO diff_a VALUES (1, 'alice', 10)",
+				"INSERT INTO diff_b VALUES (1, 'alice', 10), (2, 'bob', 20)",
+			},
+			limit:   100,
+			wantLen: 1,
+			validate: func(t *testing.T, diffs []RowDiff) {
+				require.Nil(t, diffs[0].RowA)
+				require.NotNil(t, diffs[0].RowB)
+			},
+		},
+		{
+			name:   "value-mismatch",
+			tableA: diffA, tableB: diffB,
+			setup: []string{
+				"DELETE FROM diff_a", "DELETE FROM diff_b",
+				"INSERT INTO diff_a VALUES (1, 'alice', 10)",
+				"INSERT INTO diff_b VALUES (1, 'alice', 99)",
+			},
+			limit:   100,
+			wantLen: 1,
+			validate: func(t *testing.T, diffs []RowDiff) {
+				require.NotNil(t, diffs[0].RowA)
+				require.NotNil(t, diffs[0].RowB)
+				require.True(t, diffs[0].MVCCTimestampA.IsSet())
+				require.True(t, diffs[0].MVCCTimestampB.IsSet())
+			},
+		},
+		{
+			name:   "result-limit",
+			tableA: diffA, tableB: diffB,
+			setup: []string{
+				"DELETE FROM diff_a", "DELETE FROM diff_b",
+				"INSERT INTO diff_a VALUES (1, 'a', 1), (2, 'b', 2), (3, 'c', 3)",
+			},
+			limit:   2,
+			wantLen: 2,
+		},
+		{
+			name:   "empty-tables",
+			tableA: diffA, tableB: diffB,
+			setup: []string{
+				"DELETE FROM diff_a", "DELETE FROM diff_b",
+			},
+			limit:   100,
+			wantLen: 0,
+		},
+		{
+			// Regression test: LoadTable previously failed to resolve BIT column
+			// widths when using a fully qualified table name because typeForOid
+			// queried information_schema.columns with the raw (qualified) name.
+			name:   "qualified-bit-column",
+			tableA: bitA, tableB: bitB,
+			setup: []string{
+				"DELETE FROM bit_a", "DELETE FROM bit_b",
+				"INSERT INTO bit_a VALUES (1, B'100000000000000')",
+				"INSERT INTO bit_b VALUES (1, B'100000000000000')",
+			},
+			limit:   100,
+			wantLen: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, stmt := range tc.setup {
+				sqlDB.Exec(t, stmt)
+			}
+			diffs, err := Diff(db, tc.tableA, db, tc.tableB, tc.limit)
+			require.NoError(t, err)
+			require.Len(t, diffs, tc.wantLen)
+			if tc.validate != nil {
+				tc.validate(t, diffs)
+			}
+		})
+	}
+}
+
+// TestDiffRandomSchema generates two tables with the same random schema using
+// the LDR table generator, inserts different random data into each, and
+// validates that Diff correctly reports no differences when comparing a table
+// to itself and detects differences when the tables have divergent content.
+func TestDiffRandomSchema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	rng, seed := randutil.NewTestRand()
+	t.Logf("random seed: %v", seed)
+
+	const numTables = 2
+	created := 0
+	for attempt := 0; created < numTables; attempt++ {
+		createTable := ldrrandgen.GenerateLDRTable(ctx, rng, "diff_rand", true)
+
+		shortNameA := fmt.Sprintf("diff_rand_a_%d", attempt)
+		shortNameB := fmt.Sprintf("diff_rand_b_%d", attempt)
+		// Use fully qualified names to exercise the schema.table path in diff
+		// queries.
+		tableNameA := fmt.Sprintf("defaultdb.public.%s", shortNameA)
+		tableNameB := fmt.Sprintf("defaultdb.public.%s", shortNameB)
+
+		// Extract the table body and create both tables with the same schema.
+		// The random schema generator can produce features (e.g. partitions)
+		// that require a CCL binary. Skip these schemas and retry.
+		fmtCtx := tree.NewFmtCtx(tree.FmtParsable)
+		createTable.FormatBody(fmtCtx)
+		body := fmtCtx.CloseAndGetString()
+		t.Logf("attempt %d schema: CREATE TABLE t %s", attempt, body)
+
+		createA := fmt.Sprintf("CREATE TABLE %s %s", shortNameA, body)
+		if _, err := db.Exec(createA); err != nil {
+			t.Logf("skipping schema (attempt %d): %v", attempt, err)
+			continue
+		}
+		createB := fmt.Sprintf("CREATE TABLE %s %s", shortNameB, body)
+		if _, err := db.Exec(createB); err != nil {
+			t.Logf("skipping schema (attempt %d): %v", attempt, err)
+			continue
+		}
+
+		tableA, err := LoadTable(db, tableNameA)
+		require.NoError(t, err)
+		require.NotEmpty(t, tableA.PrimaryKey, "table %s has no primary key", tableNameA)
+
+		// Insert random rows into both tables.
+		insertRows(t, ctx, db, rng, &tableA, tableNameA, 10)
+		insertRows(t, ctx, db, rng, &tableA, tableNameB, 10)
+
+		// Verify both tables have rows. Some random schemas have constraints
+		// that cause all inserts to fail silently. Skip these.
+		var countA, countB int
+		require.NoError(t, db.QueryRow(
+			fmt.Sprintf("SELECT count(*) FROM %s", tableNameA),
+		).Scan(&countA))
+		require.NoError(t, db.QueryRow(
+			fmt.Sprintf("SELECT count(*) FROM %s", tableNameB),
+		).Scan(&countB))
+		if countA == 0 || countB == 0 {
+			t.Logf("skipping schema (attempt %d): tables have %d and %d rows", attempt, countA, countB)
+			continue
+		}
+
+		t.Run(fmt.Sprintf("self-diff-%d", created), func(t *testing.T) {
+			diffs, err := Diff(db, tableNameA, db, tableNameA, 100)
+			require.NoError(t, err)
+			require.Empty(t, diffs, "diffing table against itself should produce no differences")
+		})
+
+		t.Run(fmt.Sprintf("fingerprint-diff-%d", created), func(t *testing.T) {
+			fpA := fingerprint(t, sqlDB, tableNameA)
+			fpB := fingerprint(t, sqlDB, tableNameB)
+
+			diffs, err := Diff(db, tableNameA, db, tableNameB, 100)
+			require.NoError(t, err)
+			if fpA != fpB {
+				require.NotEmpty(t, diffs,
+					"fingerprints differ (a=%s, b=%s) but Diff returned no differences", fpA, fpB)
+			}
+		})
+		created++
+	}
+}
+
+// insertRows inserts n random rows into the given table using the TableWriter.
+// Rows that fail to insert (e.g. due to unique constraint violations on
+// secondary indexes) are silently skipped.
+func insertRows(
+	t *testing.T,
+	ctx context.Context,
+	db *gosql.DB,
+	rng *rand.Rand,
+	table *Table,
+	tableName string,
+	n int,
+) {
+	t.Helper()
+	// The TableWriter needs the table name to match, so override it.
+	writerTable := *table
+	writerTable.Name = tableName
+	w := NewTableWriter(db, writerTable)
+	for i := 0; i < n; i++ {
+		row, err := table.RandomRow(rng, 0 /* nullPct */)
+		require.NoError(t, err)
+		// Ignore execution errors from unique constraint violations on
+		// secondary indexes or other schema-level constraints.
+		_ = w.UpsertRow(ctx, row)
+	}
+}
+
+// fingerprint returns the primary index fingerprint for a table.
+func fingerprint(t *testing.T, sqlDB *sqlutils.SQLRunner, tableName string) string {
+	t.Helper()
+	var fp string
+	sqlDB.QueryRow(t,
+		fmt.Sprintf(
+			`SELECT fingerprint FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s] LIMIT 1`,
+			tableName,
+		),
+	).Scan(&fp)
+	return fp
+}

--- a/pkg/workload/rand/schema.go
+++ b/pkg/workload/rand/schema.go
@@ -59,6 +59,25 @@ func (t *Table) RandomRow(rng *rand.Rand, nullPct int) ([]any, error) {
 	return row, nil
 }
 
+// IndexableColumns returns the indices of columns with a type that can be
+// stored in an index. This is useful for things like fingerprinting, where we
+// can only tolerate types with a canonical encoding.
+func (t *Table) IndexableColumns() []int {
+	var columns []int
+	for i := range t.Cols {
+		switch t.Cols[i].DataType.Family() {
+		case types.TSVectorFamily,
+			types.TSQueryFamily,
+			types.JsonpathFamily,
+			types.PGVectorFamily,
+			types.RefCursorFamily:
+			continue
+		}
+		columns = append(columns, i)
+	}
+	return columns
+}
+
 func (t *Table) randomColumn(rng *rand.Rand, columnIndex int, nullPct int) (any, error) {
 	col := t.Cols[columnIndex]
 	nullChance := 0
@@ -99,15 +118,16 @@ func (t *Table) MutateRow(rng *rand.Rand, nullPct int, prevRow []any) ([]any, er
 // `character_maximum_length` column is NULL, it means the column has
 // variable width and we set the width of the type to 0, which will
 // cause the random data generator to generate data with random width.
-func typeForOid(db *gosql.DB, typeOid oid.Oid, tableName, columnName string) (*types.T, error) {
+func typeForOid(db *gosql.DB, typeOid oid.Oid, relid int, columnName string) (*types.T, error) {
 	datumType := *types.OidToType[typeOid]
 	if typeOid == oid.T_bit || typeOid == oid.T_char {
 		var width int32
 		if err := db.QueryRow(
 			`SELECT IFNULL(character_maximum_length, 0)
 			FROM information_schema.columns
-			WHERE table_name = $1 AND column_name = $2`,
-			tableName, columnName).Scan(&width); err != nil {
+			JOIN pg_catalog.pg_class ON pg_class.relname = table_name
+			WHERE pg_class.oid = $1 AND column_name = $2`,
+			relid, columnName).Scan(&width); err != nil {
 			return nil, err
 		}
 
@@ -120,8 +140,7 @@ func typeForOid(db *gosql.DB, typeOid oid.Oid, tableName, columnName string) (*t
 // LoadTable loads a table's schema from the database.
 func LoadTable(conn *gosql.DB, tableName string) (_ Table, retErr error) {
 	var relid int
-	sqlName := tree.Name(tableName)
-	if err := conn.QueryRow("SELECT $1::REGCLASS::OID", sqlName.String()).Scan(&relid); err != nil {
+	if err := conn.QueryRow("SELECT $1::REGCLASS::OID", tableName).Scan(&relid); err != nil {
 		return Table{}, err
 	}
 
@@ -147,7 +166,7 @@ WHERE attrelid=$1 AND NOT attisdropped`, relid)
 		if err := rows.Scan(&c.Name, &typOid, &c.CDefault, &c.IsNullable, &c.IsComputed, &c.Expression); err != nil {
 			return Table{}, err
 		}
-		c.DataType, err = typeForOid(conn, oid.Oid(typOid), tableName, c.Name)
+		c.DataType, err = typeForOid(conn, oid.Oid(typOid), relid, c.Name)
 		if err != nil {
 			return Table{}, err
 		}

--- a/pkg/workload/rand/writer.go
+++ b/pkg/workload/rand/writer.go
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-package conflict
+package rand
 
 import (
 	"context"
@@ -11,22 +11,22 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/workload/rand"
 	"github.com/cockroachdb/errors"
 )
 
-type writer struct {
+// TableWriter provides upsert and delete operations for a Table.
+type TableWriter struct {
 	conn  *gosql.DB
-	table rand.Table
+	table Table
 
 	upsertStmt string
 	deleteStmt string
 }
 
-func newWriter(ctx context.Context, conn *gosql.DB, table rand.Table) (*writer, error) {
+// NewTableWriter creates a TableWriter for the given table and connection.
+func NewTableWriter(conn *gosql.DB, table Table) *TableWriter {
 	var columns, params, updates []string
 	for _, col := range table.Cols {
-		// Can't update a computed column, so skip it
 		if col.IsComputed {
 			continue
 		}
@@ -41,12 +41,8 @@ func newWriter(ctx context.Context, conn *gosql.DB, table rand.Table) (*writer, 
 		pkColumns = append(pkColumns, fmt.Sprintf(`"%s"`, table.Cols[col].Name))
 	}
 
-	upsertStmt := fmt.Sprintf(`
-			INSERT INTO %s (%s)
-			VALUES (%s)
-			ON CONFLICT (%s) DO UPDATE
-			SET %s
-		`,
+	upsertStmt := fmt.Sprintf(
+		`INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s`,
 		table.Name,
 		strings.Join(columns, ", "),
 		strings.Join(params, ", "),
@@ -64,20 +60,28 @@ func newWriter(ctx context.Context, conn *gosql.DB, table rand.Table) (*writer, 
 				fmt.Sprintf(`"%s" = $%d::%s`, col.Name, len(pkComponents)+1, col.DataType.SQLString()))
 		}
 	}
-	deleteStmt := fmt.Sprintf(`
-		DELETE FROM %s
-		WHERE %s
-	`, table.Name, strings.Join(pkComponents, " AND "))
+	deleteStmt := fmt.Sprintf(
+		`DELETE FROM %s WHERE %s`,
+		table.Name, strings.Join(pkComponents, " AND "),
+	)
 
-	return &writer{conn: conn, upsertStmt: upsertStmt, deleteStmt: deleteStmt, table: table}, nil
+	return &TableWriter{
+		conn:       conn,
+		table:      table,
+		upsertStmt: upsertStmt,
+		deleteStmt: deleteStmt,
+	}
 }
 
-func (w *writer) upsertRow(ctx context.Context, row []any) error {
+// UpsertRow inserts or updates a row. The row values must correspond to
+// the non-computed columns of the table.
+func (w *TableWriter) UpsertRow(ctx context.Context, row []any) error {
 	_, err := w.conn.ExecContext(ctx, w.upsertStmt, row...)
-	return errors.Wrapf(err, "upsertRow '%s'", w.upsertStmt)
+	return errors.Wrapf(err, "UpsertRow '%s'", w.upsertStmt)
 }
 
-func (w *writer) deleteRow(ctx context.Context, row []any) error {
+// DeleteRow deletes the row identified by the primary key values in row.
+func (w *TableWriter) DeleteRow(ctx context.Context, row []any) error {
 	pkValues := []any{}
 	valIndex := 0
 	for schemaIndex, col := range w.table.Cols {
@@ -90,5 +94,5 @@ func (w *writer) deleteRow(ctx context.Context, row []any) error {
 		valIndex++
 	}
 	_, err := w.conn.ExecContext(ctx, w.deleteStmt, pkValues...)
-	return errors.Wrapf(err, "deleteRow '%s'", w.deleteStmt)
+	return errors.Wrapf(err, "DeleteRow '%s'", w.deleteStmt)
 }

--- a/pkg/workload/rand/writer_test.go
+++ b/pkg/workload/rand/writer_test.go
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-package conflict
+package rand
 
 import (
 	"context"
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	workloadrand "github.com/cockroachdb/cockroach/pkg/workload/rand"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,14 +36,13 @@ func TestWriter(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE test`)
 	sqlDB.Exec(t, `CREATE TABLE test_writer (id INT PRIMARY KEY, data TEXT NOT NULL)`)
 
-	table, err := workloadrand.LoadTable(db, "test_writer")
+	table, err := LoadTable(db, "test_writer")
 	require.NoError(t, err)
 
-	writer, err := newWriter(ctx, db, table)
-	require.NoError(t, err)
+	writer := NewTableWriter(db, table)
 
 	row := []any{1, "test data"}
-	err = writer.upsertRow(ctx, row)
+	err = writer.UpsertRow(ctx, row)
 	require.NoError(t, err)
 
 	sqlDB.CheckQueryResults(t,
@@ -52,7 +50,7 @@ func TestWriter(t *testing.T) {
 		[][]string{{"1", "test data"}},
 	)
 
-	err = writer.deleteRow(ctx, row)
+	err = writer.DeleteRow(ctx, row)
 	require.NoError(t, err)
 
 	sqlDB.CheckQueryResults(t,
@@ -73,11 +71,10 @@ func runWriterTest(
 
 	t.Logf("stmt: %s\n", createStmt)
 
-	table, err := workloadrand.LoadTable(db, tableName)
+	table, err := LoadTable(db, tableName)
 	require.NoError(t, err)
 
-	writer, err := newWriter(ctx, db, table)
-	require.NoError(t, err)
+	writer := NewTableWriter(db, table)
 
 	t.Logf("upsert: %s\n", writer.upsertStmt)
 	t.Logf("delete: %s\n", writer.deleteStmt)
@@ -88,7 +85,7 @@ func runWriterTest(
 	// possible the table contains computed columns that combine to overflow
 	// (e.g. a + b). It's tricky to fix randgen so that it only generates values
 	// that do not overflow.
-	shouldRetryUpdate := func(err error, table workloadrand.Table) bool {
+	shouldRetryUpdate := func(err error, table Table) bool {
 		hasComputedColumns := false
 		for _, col := range table.Cols {
 			if col.IsComputed {
@@ -114,7 +111,7 @@ func runWriterTest(
 			return err
 		}
 		t.Logf("inserting row: %+v", row)
-		err = writer.upsertRow(ctx, row)
+		err = writer.UpsertRow(ctx, row)
 		if err != nil && shouldRetryUpdate(err, table) {
 			return err
 		}
@@ -131,7 +128,7 @@ func runWriterTest(
 			return err
 		}
 		t.Logf("mutating row: %+v", row)
-		err = writer.upsertRow(ctx, row)
+		err = writer.UpsertRow(ctx, row)
 		if err != nil && shouldRetryUpdate(err, table) {
 			return err
 		}
@@ -148,7 +145,7 @@ func runWriterTest(
 	)
 
 	t.Logf("deleting row: %+v", row)
-	require.NoError(t, writer.deleteRow(ctx, row))
+	require.NoError(t, writer.DeleteRow(ctx, row))
 
 	rows := sqlDB.QueryStr(t, fmt.Sprintf("SELECT * FROM %s", tableName))
 	if len(rows) != 0 {


### PR DESCRIPTION
Backport 2/2 commits from #166626.

/cc @cockroachdb/release

Release justification: test only change.

---

## conflict: diff the clusters when there is a row mismatch
There is a known unlikely bug in LDR, if conflicting rows with the same
primary key are written at the same mvcc timestamp in both clusters,
then they tie LWW and the clusters do not converge. Since timestamps are
nanosecond precision and LWW is intended for low conflict workloads,
this is believed to be very rare in production, but the conflict
workload reproduces it every few runs.

For now, we will check for this known form of non-convergence.

Fixes: #156714
Release note: none

## rand: move TableWriter from conflict to rand package
Move the table writer infrastructure from `pkg/workload/conflict` to
`pkg/workload/rand` as an exported `TableWriter` type. The writer
operates on `rand.Table` and naturally belongs in the same package.

This makes the writer available to other packages (e.g. for use in
diff tests) without creating cross-package dependencies.

Release note: none
