### PR TITLE
catalog/lease: fix missing observer notifications on rangefeed updates

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -55,6 +55,10 @@ type descriptorState struct {
 		// of a descriptor.
 		maxVersionSeen descpb.DescriptorVersion
 
+		// maxVersionNotified is the maximum version of the descriptor for
+		// which observers have been notified.
+		maxVersionNotified descpb.DescriptorVersion
+
 		// acquisitionsInProgress indicates that at least one caller is currently
 		// in the process of performing an acquisition. This tracking is critical
 		// to ensure that notifications of new versions which arrive before a lease

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1621,10 +1621,13 @@ func (m *Manager) acquireNodeLease(
 				if err := m.upsertDescriptorIntoState(ctx, id, session, desc); err != nil {
 					return false, err
 				}
+				// If the version of the lease we are acquiring has changed,
+				// then notify any observers.
+				if desc.GetVersion() != currentVersion {
+					m.maybeAddObserverEvent(id, desc.GetVersion(), desc.GetModificationTime(), false /* dropped */)
+				}
+				return true, nil
 			}
-			// If the version of the lease we are acquiring has changed,
-			// then notify any observers.
-			m.maybeAddObserverEvent(id, currentVersion, false /* dropped */)
 			return true, nil
 		})
 	if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
@@ -1725,7 +1728,7 @@ func (m *Manager) purgeOldVersions(
 		}()
 		// Fire a notification for dropped descriptors.
 		if dropped && !wasOffline {
-			m.maybeAddObserverEvent(id, minVersion, true /* dropped */)
+			m.maybeAddObserverEvent(id, minVersion, hlc.Timestamp{}, true /* dropped */)
 		}
 		for _, l := range leases {
 			releaseLease(ctx, l, m)
@@ -2278,29 +2281,44 @@ func (m *Manager) findNewest(id descpb.ID) (state *descriptorVersionState, offli
 
 // maybeAddObserverEvent appends a new observer event if the version has changed.
 func (m *Manager) maybeAddObserverEvent(
-	id descpb.ID, currentVersion descpb.DescriptorVersion, dropped bool,
+	id descpb.ID, version descpb.DescriptorVersion, modificationTime hlc.Timestamp, dropped bool,
 ) {
-	newest, _ := m.findNewest(id)
-	// If the version hasn't changed, then nothing needs to be emitted.
-	if (newest != nil && newest.GetVersion() == currentVersion) || (newest == nil && !dropped) {
+	processEvent := func() bool {
+		t := m.findDescriptorState(id, false /* create */)
+		// If the descriptor does not exist, then there is no event
+		// for a new version.
+		if t == nil {
+			return false
+		}
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		// If the version hasn't changed, then nothing needs to be emitted, unless
+		// it's a drop event.
+		if !dropped && version <= t.mu.maxVersionNotified {
+			return false
+		}
+		if !dropped {
+			t.mu.maxVersionNotified = version
+		}
+		return true
+	}()
+	// Event should be skipped, since we already posted observers.
+	if !processEvent {
 		return
 	}
-	// Append the new observer event.
+	// Append the new event.
 	func() {
 		m.mu.Lock()
 		defer m.mu.Unlock()
-		var ts hlc.Timestamp
-		newVersion := currentVersion
-		if dropped {
-			ts = m.storage.clock.Now()
-		} else {
-			ts = newest.GetModificationTime()
-			newVersion = newest.GetVersion()
-		}
-		m.mu.pendingObserverEvents = append(m.mu.pendingObserverEvents, observerEvent{id: id,
-			version:          newVersion,
-			modificationTime: ts,
+		// Append the new observer event.
+		m.mu.pendingObserverEvents = append(m.mu.pendingObserverEvents, observerEvent{
+			id:               id,
+			version:          version,
+			modificationTime: modificationTime,
 		})
+		if dropped {
+			m.mu.pendingObserverEvents[len(m.mu.pendingObserverEvents)-1].modificationTime = m.storage.clock.Now()
+		}
 	}()
 	// Signal there is an event waiting, unless the channel is already
 	// posted.
@@ -2954,6 +2972,7 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 
 				dropped := desc.Dropped()
 				// Try to refresh the lease to one >= this version.
+
 				log.VEventf(ctx, 2, "purging old version of descriptor %d@%d (dropped %v)",
 					desc.GetID(), desc.GetVersion(), dropped)
 				// purgeOldVersionsOrAcquireInitialVersion will purge older versions of
@@ -2995,6 +3014,9 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 						log.Dev.Warningf(ctx, "error purging leases for descriptor %d(%s): %s",
 							desc.GetID(), desc.GetName(), err)
 					}
+					// Notify any observers that a new version of the descriptor is
+					// available.
+					m.maybeAddObserverEvent(desc.GetID(), desc.GetVersion(), desc.GetModificationTime(), dropped)
 				}
 				// New descriptors may appear in the future if the descriptor table is
 				// global or if the transaction which performed the schema change wrote

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -4578,3 +4578,113 @@ func TestLeaseInternalLookupCtxWithLocked(t *testing.T) {
 	require.NoError(t, grp.Wait())
 
 }
+
+// TestObserverNotificationFromRangefeed validates the range feed will generate a notification
+// even if the version is cached via another method.
+func TestObserverNotificationFromRangefeed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	proceedRangefeed := make(chan struct{})
+	knobs := lease.ManagerTestingKnobs{
+		TestingDescriptorUpdateEvent: func(desc *descpb.Descriptor) error {
+			_, _, name, _, err := descpb.GetDescriptorMetadata(desc)
+			if err != nil {
+				return err
+			}
+			if name == "t" {
+				<-proceedRangefeed
+			}
+			return nil
+		},
+	}
+	// Use 2 nodes.
+	nodes := serverutils.StartCluster(t, 2, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLLeaseManager: &knobs,
+			},
+		},
+	})
+	defer nodes.Stopper().Stop(context.Background())
+
+	db0 := nodes.Server(0).SQLConn(t)
+	sql0 := sqlutils.MakeSQLRunner(db0)
+	lm1 := nodes.Server(1).LeaseManager().(*lease.Manager)
+
+	sql0.Exec(t, "CREATE TABLE t (k INT PRIMARY KEY)")
+	var tableID descpb.ID
+	sql0.QueryRow(t, "SELECT 't'::regclass::int").Scan(&tableID)
+
+	// Acquire a lease on Node 1 and hold it.
+	ctx := context.Background()
+	ld, err := lm1.Acquire(ctx, lm1.GetReadTimestamp(ctx, nodes.Server(1).Clock().Now()), tableID)
+	require.NoError(t, err)
+
+	// Register observer on Node 1.
+	// The observer will release the lease when it sees a new version.
+	obs := &testObserverRelease{
+		notified:  make(chan descpb.DescriptorVersion, 100),
+		targetID:  tableID,
+		lease:     ld,
+		startTime: nodes.Server(1).Clock().Now(),
+	}
+	_ = lm1.RegisterLeaseObserver(obs)
+	// Run schema change on Node 0 in a goroutine because it will block
+	// on the two-version invariant waiting for Node 1 to release version 1.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := db0.Exec("ALTER TABLE t ADD COLUMN v INT")
+		errCh <- err
+	}()
+	// Wait until version 2 is committed on Node 0 and visible to Node 1 via historical read.
+	// This silently pulls version 2 into Node 1's cache.
+	testutils.SucceedsSoon(t, func() error {
+		now := nodes.Server(0).Clock().Now()
+		_, err := nodes.Server(1).SQLConn(t).Query(fmt.Sprintf("SELECT * FROM t AS OF SYSTEM TIME '%s'", now.AsOfSystemTime()))
+		return err
+	})
+	// Release the rangefeed.
+	close(proceedRangefeed)
+	// Wait for rangefeed on Node 1 to see the update and notify the observer.
+	// If the observer is notified, it will release the lease, allowing the
+	// ALTER TABLE to finish.
+	timeout := time.After(30 * time.Second)
+	select {
+	case v := <-obs.notified:
+		t.Logf("Observer notified of version %d", v)
+		if v < 2 {
+			t.Errorf("expected version >= 2, got %d", v)
+		}
+	case <-timeout:
+		t.Fatal("timed out waiting for observer notification on Node 1")
+	}
+	require.NoError(t, <-errCh)
+}
+
+// testObserverRelease is a mock observer similar to schema feed,
+// that will release a version on notification.
+type testObserverRelease struct {
+	notified  chan descpb.DescriptorVersion
+	targetID  descpb.ID
+	lease     lease.LeasedDescriptor
+	once      sync.Once
+	startTime hlc.Timestamp
+}
+
+// OnNewVersion implements Observer.
+func (o *testObserverRelease) OnNewVersion(
+	ctx context.Context, id descpb.ID, version descpb.DescriptorVersion, timestamp hlc.Timestamp,
+) {
+	// Only start emitting after a selected timestamp.
+	if timestamp.Less(o.startTime) {
+		return
+	}
+	if id != o.targetID {
+		return
+	}
+	o.once.Do(func() {
+		if o.lease != nil {
+			o.lease.Release(ctx)
+		}
+	})
+	o.notified <- version
+}


### PR DESCRIPTION
Previously, the lease manager only notified observers of a new version if an acquisition from the store occurred after the range feed event. If the range feed event already saw the new version cached, then the notification was skipped. This could happen due to AOST queries or bulk acquisitions. This would cause events to get lost leading to hangs in schema changes because observers like schema_feed would continue holding onto old leases, violating the two-version invariant and blocking the commitment of version V+2.

This patch updates maybeAddObserverEvent and where its called to make the delivery more reliable for scenarios where the in memory cache already has the new version. It also adds a reproduction similar to the schemafeed hang we observed.

Fixes: #168182
Epic: none
Release note: None