### PR TITLE
kvserver: force loose-coupled truncations with separate engine

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -343,6 +343,7 @@ go_test(
         "raft_transport_unit_test.go",
         "range_log_test.go",
         "rebalance_objective_test.go",
+        "replica_app_batch_test.go",
         "replica_application_cmd_buf_test.go",
         "replica_application_result_test.go",
         "replica_application_state_machine_test.go",

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -117,7 +117,8 @@ import (
 var looselyCoupledTruncationEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.raft_log.loosely_coupled_truncation.enabled",
-	"set to true to loosely couple the raft log truncation",
+	"set to true to loosely couple the raft log truncation. Loosely coupled truncations are "+
+		"automatically enabled if engines are separated",
 	metamorphic.ConstantWithTestBool("kv.raft_log.loosely_coupled_truncation.enabled", false),
 	settings.WithVisibility(settings.Reserved),
 )

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -498,7 +498,14 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 // useLooselyCoupledTruncation returns true if the truncation must be enacted
 // via the loosely-coupled path (raftLogTruncator). Otherwise, it should be
 // applied synchronously using the tightly-coupled path.
-func useLooselyCoupledTruncation(sv *settings.Values, raftExpectedFirstIndex kvpb.RaftIndex) bool {
+func useLooselyCoupledTruncation(
+	sv *settings.Values, raftExpectedFirstIndex kvpb.RaftIndex, enginesSeparated bool,
+) bool {
+	if enginesSeparated {
+		// With separated engines, loosely-coupled truncation is mandatory: the
+		// synchronous path cannot atomically truncate across two engines.
+		return true
+	}
 	// Use loosely-coupled truncations if configured by the setting. Otherwise,
 	// perform a tightly-coupled truncation, i.e. apply it immediately.
 	//
@@ -517,7 +524,7 @@ func (b *replicaAppBatch) stageTruncation(
 ) error {
 	truncatedState := res.GetRaftTruncatedState() // NB: not nil
 	useLooselyCoupled := useLooselyCoupledTruncation(
-		&b.r.ClusterSettings().SV, res.RaftExpectedFirstIndex,
+		&b.r.ClusterSettings().SV, res.RaftExpectedFirstIndex, b.r.store.EnginesSeparated(),
 	)
 
 	if useLooselyCoupled {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -494,13 +495,10 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	return nil
 }
 
-// stageTruncation stages the raft log truncation command. It prepares the
-// truncation to happen immediately if tightly coupled truncations are used, or
-// queues the truncation into the loosely coupled machinery otherwise.
-func (b *replicaAppBatch) stageTruncation(
-	ctx context.Context, res *kvserverpb.ReplicatedEvalResult,
-) error {
-	truncatedState := res.GetRaftTruncatedState() // NB: not nil
+// useLooselyCoupledTruncation returns true if the truncation must be enacted
+// via the loosely-coupled path (raftLogTruncator). Otherwise, it should be
+// applied synchronously using the tightly-coupled path.
+func useLooselyCoupledTruncation(sv *settings.Values, raftExpectedFirstIndex kvpb.RaftIndex) bool {
 	// Use loosely-coupled truncations if configured by the setting. Otherwise,
 	// perform a tightly-coupled truncation, i.e. apply it immediately.
 	//
@@ -508,8 +506,19 @@ func (b *replicaAppBatch) stageTruncation(
 	// comment in that proto). It is possible that a replica still has a
 	// truncation sitting in the raft log that never populated this field.
 	// TODO(pav-kv): remove the zero check after any below-raft migration.
-	useLooselyCoupled := res.RaftExpectedFirstIndex != 0 &&
-		looselyCoupledTruncationEnabled.Get(&b.r.ClusterSettings().SV)
+	return raftExpectedFirstIndex != 0 && looselyCoupledTruncationEnabled.Get(sv)
+}
+
+// stageTruncation stages the raft log truncation command. It prepares the
+// truncation to happen immediately if tightly coupled truncations are used, or
+// queues the truncation into the loosely coupled machinery otherwise.
+func (b *replicaAppBatch) stageTruncation(
+	ctx context.Context, res *kvserverpb.ReplicatedEvalResult,
+) error {
+	truncatedState := res.GetRaftTruncatedState() // NB: not nil
+	useLooselyCoupled := useLooselyCoupledTruncation(
+		&b.r.ClusterSettings().SV, res.RaftExpectedFirstIndex,
+	)
 
 	if useLooselyCoupled {
 		b.r.store.raftTruncator.addPendingTruncation(

--- a/pkg/kv/kvserver/replica_app_batch_test.go
+++ b/pkg/kv/kvserver/replica_app_batch_test.go
@@ -16,16 +16,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldUseLooselyCoupledTruncation(t *testing.T) {
+func TestUseLooselyCoupledTruncation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	tests := []struct {
+		enginesSeparated       bool
 		settingEnabled         bool
 		raftExpectedFirstIndex kvpb.RaftIndex
 		wantLoose              bool
 	}{
+		// Separated engines use loosely coupled truncations unconditionally.
+		{enginesSeparated: true, settingEnabled: false, raftExpectedFirstIndex: 0, wantLoose: true},
+		{enginesSeparated: true, settingEnabled: false, raftExpectedFirstIndex: 5, wantLoose: true},
+		{enginesSeparated: true, settingEnabled: true, raftExpectedFirstIndex: 0, wantLoose: true},
+		{enginesSeparated: true, settingEnabled: true, raftExpectedFirstIndex: 5, wantLoose: true},
+		// Other tests assume single engine.
 		{settingEnabled: false, raftExpectedFirstIndex: 0, wantLoose: false},
 		{settingEnabled: false, raftExpectedFirstIndex: 5, wantLoose: false},
 		{settingEnabled: true, raftExpectedFirstIndex: 0, wantLoose: false},
@@ -35,8 +42,9 @@ func TestShouldUseLooselyCoupledTruncation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 			looselyCoupledTruncationEnabled.Override(ctx, &st.SV, tc.settingEnabled)
-			got := useLooselyCoupledTruncation(&st.SV, tc.raftExpectedFirstIndex)
-			require.Equal(t, tc.wantLoose, got)
+			require.Equal(t, tc.wantLoose, useLooselyCoupledTruncation(
+				&st.SV, tc.raftExpectedFirstIndex, tc.enginesSeparated,
+			))
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_app_batch_test.go
+++ b/pkg/kv/kvserver/replica_app_batch_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldUseLooselyCoupledTruncation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	tests := []struct {
+		settingEnabled         bool
+		raftExpectedFirstIndex kvpb.RaftIndex
+		wantLoose              bool
+	}{
+		{settingEnabled: false, raftExpectedFirstIndex: 0, wantLoose: false},
+		{settingEnabled: false, raftExpectedFirstIndex: 5, wantLoose: false},
+		{settingEnabled: true, raftExpectedFirstIndex: 0, wantLoose: false},
+		{settingEnabled: true, raftExpectedFirstIndex: 5, wantLoose: true},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			looselyCoupledTruncationEnabled.Override(ctx, &st.SV, tc.settingEnabled)
+			got := useLooselyCoupledTruncation(&st.SV, tc.raftExpectedFirstIndex)
+			require.Equal(t, tc.wantLoose, got)
+		})
+	}
+}


### PR DESCRIPTION
When we have separated engines, the apply path forces loosely-coupled truncation regardless of the
kv.raft_log.loosely_coupled_truncation.enabled cluster setting because loosely-coupled truncations are mandatory in separate engines world.

References: #93248

Release note: None