### PR TITLE
release-26.2: roachtest: pin system DB replicas across regions in super-region-failover

### DIFF
--- a/pkg/cmd/roachtest/tests/super_region_failover.go
+++ b/pkg/cmd/roachtest/tests/super_region_failover.go
@@ -142,6 +142,17 @@ func setupDatabase(ctx context.Context, t test.Test, conn *gosql.DB) {
 	stmts := []string{
 		`SET CLUSTER SETTING sql.defaults.primary_region = ''`,
 		`SET CLUSTER SETTING server.time_until_store_dead = '30s'`,
+
+		// Pin at least one system-database replica to each region so that no
+		// single region holds a majority of the 5 replicas. Without this,
+		// the allocator may concentrate replicas in 2 regions, causing
+		// permanent quorum loss when one of those regions is killed.
+		`ALTER DATABASE system CONFIGURE ZONE USING num_replicas = 5, constraints = '{` +
+			`"+region=europe-west2": 1, ` +
+			`"+region=us-east1": 1, ` +
+			`"+region=us-central1": 1, ` +
+			`"+region=us-west1": 1}'`,
+
 		`CREATE DATABASE test_sr PRIMARY REGION "europe-west2"
 			REGIONS "us-east1", "us-central1", "us-west1"`,
 		`ALTER DATABASE test_sr ADD SUPER REGION "americas"


### PR DESCRIPTION
Backport 1/1 commits from #168436 on behalf of @shghasemi.

----

Without placement constraints, the allocator may concentrate all 5 system-database replicas in just 2 of the 4 regions (e.g. europe-west2+ us-east1). When the test kills an entire region, system ranges can permanently lose quorum because 3 of 5 replicas were in the killed region.

Add a zone configuration on the system database that pins at least one replica to each region. With 4 pinned and 1 floating, no single region can hold more than 2 of 5 replicas, so quorum (3) is preserved after any single-region kill.

Fixes #168148

Release note: None

----

Release justification: test only fix