### PR TITLE
backup: rewrite region enum ID in schema change state on table restore

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -119,6 +119,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/schemachanger/scbackup",
+        "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -364,6 +365,7 @@ func remapTables(
 	p sql.PlanHookState,
 	databasesByID map[descpb.ID]*dbdesc.Mutable,
 	tablesByID map[descpb.ID]*tabledesc.Mutable,
+	typesByID map[descpb.ID]*typedesc.Mutable,
 	descriptorCoverage tree.DescriptorCoverage,
 	intoDB string,
 	restoreDBNames map[string]catalog.DatabaseDescriptor,
@@ -452,6 +454,16 @@ func remapTables(
 			return false, pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
 		}
 
+		// Must run before the table's own rewrite is recorded below: any region
+		// enum referenced by an in-flight SET LOCALITY in the table's
+		// declarative schema changer state needs a mapping to the destination
+		// DB's enum (which checkMultiRegionCompatible above guaranteed exists).
+		if err := maybeAddRegionEnumRewriteForSchemaChangeState(
+			ctx, txn, table, parentDB, typesByID, descriptorRewrites,
+		); err != nil {
+			return false, err
+		}
+
 		// Create the table rewrite with the new parent ID. We've done all the
 		// up-front validation that we can.
 		descriptorRewrites[table.ID] = &jobspb.DescriptorRewrite{ParentID: parentID}
@@ -466,6 +478,123 @@ func remapTables(
 		}
 	}
 	return shouldBufferDeprecatedPrivilegeNotice, nil
+}
+
+// maybeAddRegionEnumRewriteForSchemaChangeState records ToExisting rewrites
+// from the source database's region enum and array type IDs to the
+// destination database's existing enum and array type IDs.
+//
+// Without these rewrites, table-level RESTORE of a multi-region table whose
+// in-flight schema change references the region enum (via
+// TableLocalitySecondaryRegion or via the crdb_region column's type closure)
+// would fail downstream with "missing rewrite for ..." because remapTypes
+// does not visit type descriptors not in the restore set.
+//
+// The destination database is required to be multi-region (enforced by
+// checkMultiRegionCompatible upstream).
+func maybeAddRegionEnumRewriteForSchemaChangeState(
+	ctx context.Context,
+	txn descs.Txn,
+	table *tabledesc.Mutable,
+	parentDB catalog.DatabaseDescriptor,
+	typesByID map[descpb.ID]*typedesc.Mutable,
+	descriptorRewrites jobspb.DescRewriteMap,
+) error {
+	if !parentDB.IsMultiRegion() {
+		return nil
+	}
+	srcEnum, srcEnumID, srcArrayID := findSourceRegionEnumIDs(table, typesByID)
+	needRewrite := func(srcID descpb.ID) bool {
+		if srcID == descpb.InvalidID {
+			return false
+		}
+		_, ok := descriptorRewrites[srcID]
+		return !ok
+	}
+	if !needRewrite(srcEnumID) && !needRewrite(srcArrayID) {
+		return nil
+	}
+
+	destEnumID, err := parentDB.MultiRegionEnumID()
+	if err != nil {
+		// Unreachable: parentDB.IsMultiRegion() is checked above.
+		return errors.NewAssertionErrorWithWrappedErrf(err,
+			"MultiRegionEnumID after IsMultiRegion check")
+	}
+	destEnumDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Type(ctx, destEnumID)
+	if err != nil {
+		return errors.Wrapf(err,
+			"fetching destination region enum descriptor (id %d) for table-level restore of %q",
+			destEnumID, table.GetName())
+	}
+	// When the source enum descriptor is in scope, verify that every value it
+	// contains is also present in the destination. Otherwise rows whose
+	// crdb_region values exist only in the source would be silently mismapped
+	// after the rewrite. The fallback branch in findSourceRegionEnumIDs (where
+	// srcEnum is nil) has no source descriptor to compare against and skips
+	// this check.
+	if srcEnum != nil {
+		if err := srcEnum.IsCompatibleWith(destEnumDesc); err != nil {
+			return errors.Wrapf(err,
+				"table-level restore of %q into database %q",
+				table.GetName(), parentDB.GetName())
+		}
+	}
+	destArrayID := destEnumDesc.TypeDesc().ArrayTypeID
+
+	addRewrite := func(srcID, destID descpb.ID) {
+		if !needRewrite(srcID) {
+			return
+		}
+		descriptorRewrites[srcID] = &jobspb.DescriptorRewrite{
+			ParentID:   parentDB.GetID(),
+			ID:         destID,
+			ToExisting: true,
+		}
+	}
+	addRewrite(srcEnumID, destEnumID)
+	addRewrite(srcArrayID, destArrayID)
+	return nil
+}
+
+// findSourceRegionEnumIDs returns the source database's region enum descriptor
+// (when in scope), enum ID, and array type ID referenced by the table. Either
+// or both IDs may be descpb.InvalidID and srcEnum may be nil if the
+// corresponding reference is not present.
+//
+// The enum and array IDs come from two sources, in order of preference:
+//   - The first MULTIREGION_ENUM type descriptor in typesByID whose parent
+//     matches the table's parent (covers RBR tables and any case where the
+//     enum descriptor itself is in the restore set). srcEnum is non-nil here.
+//   - Any TableLocalitySecondaryRegion element in the table's declarative
+//     schema changer state (covers RBT-IN-region tables whose enum descriptor
+//     is not in the restore set). srcEnum is nil here, srcArrayID is
+//     InvalidID, and no enum compatibility check can be run against the
+//     destination because the source descriptor is not available.
+func findSourceRegionEnumIDs(
+	table *tabledesc.Mutable, typesByID map[descpb.ID]*typedesc.Mutable,
+) (srcEnum catalog.TypeDescriptor, srcEnumID, srcArrayID descpb.ID) {
+	for _, typ := range typesByID {
+		if typ.GetKind() != descpb.TypeDescriptor_MULTIREGION_ENUM {
+			continue
+		}
+		if typ.GetParentID() != table.GetParentID() {
+			continue
+		}
+		return typ, typ.GetID(), typ.ArrayTypeID
+	}
+	if state := table.GetDeclarativeSchemaChangerState(); state != nil {
+		for _, target := range state.Targets {
+			sec, ok := target.Element().(*scpb.TableLocalitySecondaryRegion)
+			if !ok {
+				continue
+			}
+			if sec.RegionEnumTypeID != descpb.InvalidID {
+				return nil, sec.RegionEnumTypeID, descpb.InvalidID
+			}
+		}
+	}
+	return nil, descpb.InvalidID, descpb.InvalidID
 }
 
 func remapTypes(
@@ -1002,7 +1131,7 @@ func allocateDescriptorRewrites(
 	}
 
 	if b, err := remapTables(
-		ctx, p, databasesByID, tablesByID, descriptorCoverage, intoDB, restoreDBNames,
+		ctx, p, databasesByID, tablesByID, typesByID, descriptorCoverage, intoDB, restoreDBNames,
 		databasesWithDeprecatedPrivileges, descriptorRewrites,
 	); err != nil {
 		return nil, 0, err

--- a/pkg/backup/testdata/backup-restore/restore-table-incompatible-region-enum
+++ b/pkg/backup/testdata/backup-restore/restore-table-incompatible-region-enum
@@ -1,0 +1,37 @@
+# Regression test for the IsCompatibleWith check in
+# maybeAddRegionEnumRewriteForSchemaChangeState. Without it, table-level
+# RESTORE of an RBR table whose source enum has values not present in
+# the destination DB's enum would silently rewrite the source enum ID to
+# the destination's, leaving crdb_region values that no longer map to
+# any region in the destination.
+
+skip-under-duress
+----
+
+new-cluster name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
+----
+
+exec-sql
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+USE d;
+CREATE TABLE t (pk INT PRIMARY KEY, v INT) LOCALITY REGIONAL BY ROW;
+INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://1/test-backup';
+----
+
+# Same node localities but the destination database deliberately has
+# fewer regions than the source.
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
+----
+
+exec-sql
+CREATE DATABASE narrow PRIMARY REGION "us-east-1";
+----
+
+exec-sql expect-error-regex=(table-level restore of "t" into database "narrow".*could not find enum value)
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test-backup' WITH into_db = 'narrow', skip_missing_sequences, skip_missing_udfs;
+----
+regex matches error

--- a/pkg/backup/testdata/backup-restore/restore-table-mid-locality-change
+++ b/pkg/backup/testdata/backup-restore/restore-table-mid-locality-change
@@ -1,0 +1,62 @@
+# Regression test for #169128.
+#
+# When a multi-region table is backed up mid-ALTER TABLE ... SET LOCALITY
+# and restored at the table level, rewriteSchemaChangerState used to fail
+# with "missing rewrite for id N in TableLocalitySecondaryRegion" because
+# the source DB's region enum has no entry in descriptorRewrites for a
+# table-level restore. The fix in remapTables records a ToExisting rewrite
+# from the source enum ID to the destination DB's existing region enum.
+
+skip-under-duress
+----
+
+new-cluster name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
+----
+
+exec-sql
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+CREATE TABLE d.t (pk INT PRIMARY KEY, v INT) LOCALITY REGIONAL BY TABLE IN "us-west-1";
+INSERT INTO d.t VALUES (1, 10), (2, 20), (3, 30);
+----
+
+set-cluster-setting setting=jobs.debug.pausepoints value=newschemachanger.before.exec
+----
+
+# Start the locality change. The pausepoint halts execution while
+# TableLocalitySecondaryRegion is still in the table's declarative schema
+# changer state (target ABSENT).
+new-schema-change expect-pausepoint
+ALTER TABLE d.t SET LOCALITY REGIONAL BY TABLE;
+----
+job paused at pausepoint
+
+# Clear the pausepoint setting (the paused job stays paused).
+set-cluster-setting setting=jobs.debug.pausepoints value=
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://1/test-backup';
+----
+
+# Fresh destination cluster with the same regions.
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
+----
+
+exec-sql
+CREATE DATABASE d2 PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+----
+
+# Before the fix this failed with:
+#   pq: table descriptor rewrite failed: rewriting declarative schema
+#   changer state: rewriting descriptor ids: missing rewrite for id N in
+#   TableLocalitySecondaryRegion:{...}
+exec-sql
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test-backup' WITH into_db = 'd2', skip_missing_sequences, skip_missing_udfs;
+----
+
+query-sql
+SELECT pk, v FROM d2.t ORDER BY pk;
+----
+1 10
+2 20
+3 30

--- a/pkg/sql/logictest/testdata/logic_test/multi_region_backup
+++ b/pkg/sql/logictest/testdata/logic_test/multi_region_backup
@@ -1401,12 +1401,12 @@ ap-southeast-2  {ap-az1,ap-az2,ap-az3}  {mr-backup-1,mr-backup-2,mr-restore-1}  
 ca-central-1    {ca-az1,ca-az2,ca-az3}  {mr-backup-1,mr-backup-2}               {mr-backup-1}               {}
 us-east-1       {us-az1,us-az2,us-az3}  {mr-backup-1,mr-backup-2,mr-restore-1}  {}                          {}
 
-statement error "crdb_internal_region" is not compatible with type "crdb_internal_region" existing in cluster: could not find enum value "ca-central-1" in "crdb_internal_region"
+statement error table-level restore of "regional_by_table_in_ap_southeast_2" into database "mr-restore-1": could not find enum value "ca-central-1" in "crdb_internal_region"
 RESTORE TABLE "mr-backup-2".regional_by_table_in_ap_southeast_2 FROM LATEST IN 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1';
 
 # Cannot restore a REGIONAL BY TABLE table that has different regions.
 statement error cannot restore REGIONAL BY TABLE regional_by_table_in_ca_central_1 IN REGION "ca-central-1" \(table ID: [0-9]+\) into database "mr-restore-1"; region "ca-central-1" not found in database regions "ap-southeast-2", "us-east-1"
 RESTORE TABLE "mr-backup-2".regional_by_table_in_ca_central_1 FROM LATEST IN 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1'
 
-statement error "crdb_internal_region" is not compatible with type "crdb_internal_region" existing in cluster: could not find enum value "ca-central-1" in "crdb_internal_region"
+statement error table-level restore of "regional_by_row_table" into database "mr-restore-1": could not find enum value "ca-central-1" in "crdb_internal_region"
 RESTORE TABLE "mr-backup-2".regional_by_row_table FROM LATEST IN 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1'


### PR DESCRIPTION
When a multi-region table is backed up mid-`ALTER TABLE ... SET LOCALITY` and restored at the table level, the table's declarative schema changer state may reference the source database's region enum and array type IDs. Only table descriptors get entries in `descriptorRewrites` during table-level restore, so the rewrite passes failed with one of:

- `missing rewrite for type N` (in `TypeDescs`)
- `missing rewrite for id N in TableLocalitySecondaryRegion` (in `rewriteSchemaChangerState`, RBT-IN-region case)
- `missing rewrite for id N in ColumnType` (in `rewriteSchemaChangerState`, RBR variants where the `crdb_region` column type closure references both the enum and its array type)

`remapTables` now records `ToExisting` rewrites for both the source enum and array type IDs to the destination database's existing enum and array type (`parentDB.MultiRegionEnumID` and the enum descriptor's `ArrayTypeID`) before the rewrite passes run. The source IDs are discovered from `typesByID` when the enum descriptor is in scope (RBR and other UDT-referencing cases), or from `TableLocalitySecondaryRegion` in the schema changer state otherwise (RBT-IN-region case).

Resolves: #169128
Resolves: #168804 
Resolves: #168884
Resolves: #169008 
Resolves: #169088
Resolves: #169089
Resolves: #169090

Epic: none

Release note (bug fix): Fixed a bug where RESTORE TABLE of a multi-region table backed up mid-ALTER TABLE ... SET LOCALITY would fail with a descriptor rewrite error.