### PR TITLE
sql: fix clause ordering in UniqueConstraintTableDef.Format

### DIFF
--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -2664,6 +2664,16 @@ CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING H
 CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH BUCKET_COUNT = _ WITH ('foo' = '_')) -- literals removed
 CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, UNIQUE INDEX (_ NULLS FIRST) USING HASH WITH BUCKET_COUNT = 10 WITH ('foo' = 'bar')) -- identifiers removed
 
+# Regression test for #169278: WITH clause must come before WHERE and visibility
+# clauses in UniqueConstraintTableDef formatting.
+parse
+CREATE TABLE t (a INT8, UNIQUE INDEX idx (a) WITH ('fillfactor' = 100) WHERE a > 5)
+----
+CREATE TABLE t (a INT8, UNIQUE INDEX idx (a) WITH ('fillfactor' = 100) WHERE a > 5)
+CREATE TABLE t (a INT8, UNIQUE INDEX idx (a) WITH ('fillfactor' = (100)) WHERE ((a) > (5))) -- fully parenthesized
+CREATE TABLE t (a INT8, UNIQUE INDEX idx (a) WITH ('fillfactor' = _) WHERE a > _) -- literals removed
+CREATE TABLE _ (_ INT8, UNIQUE INDEX _ (_) WITH ('fillfactor' = 100) WHERE _ > 5) -- identifiers removed
+
 parse
 CREATE TABLE t (a INT PRIMARY KEY, b INT, UNIQUE INDEX (b) USING HASH)
 ----

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1207,6 +1207,11 @@ func (node *UniqueConstraintTableDef) Format(ctx *FmtCtx) {
 	if node.PartitionByIndex != nil {
 		ctx.FormatNode(node.PartitionByIndex)
 	}
+	if node.StorageParams != nil {
+		ctx.WriteString(" WITH (")
+		ctx.FormatNode(&node.StorageParams)
+		ctx.WriteString(")")
+	}
 	if node.Predicate != nil {
 		ctx.WriteString(" WHERE ")
 		ctx.FormatNode(node.Predicate)
@@ -1216,11 +1221,6 @@ func (node *UniqueConstraintTableDef) Format(ctx *FmtCtx) {
 		ctx.WriteString(" VISIBILITY " + fmt.Sprintf("%.2f", 1-node.Invisibility.Value))
 	case node.Invisibility.Value == 1.0:
 		ctx.WriteString(" NOT VISIBLE")
-	}
-	if node.StorageParams != nil {
-		ctx.WriteString(" WITH (")
-		ctx.FormatNode(&node.StorageParams)
-		ctx.WriteString(")")
 	}
 }
 

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1919,6 +1919,12 @@ func (node *UniqueConstraintTableDef) Doc(p *PrettyCfg) pretty.Doc {
 	if node.PartitionByIndex != nil {
 		clauses = append(clauses, p.Doc(node.PartitionByIndex))
 	}
+	if node.StorageParams != nil {
+		clauses = append(clauses, p.bracketKeyword(
+			"WITH", "(",
+			p.Doc(&node.StorageParams),
+			")", ""))
+	}
 	if node.Predicate != nil {
 		clauses = append(clauses, p.nestUnder(pretty.Keyword("WHERE"), p.Doc(node.Predicate)))
 	}
@@ -1928,12 +1934,6 @@ func (node *UniqueConstraintTableDef) Doc(p *PrettyCfg) pretty.Doc {
 			pretty.Keyword(" VISIBILITY "+fmt.Sprintf("%.2f", 1-node.Invisibility.Value)))
 	case node.Invisibility.Value == 1.0:
 		clauses = append(clauses, pretty.Keyword(" NOT VISIBLE"))
-	}
-	if node.StorageParams != nil {
-		clauses = append(clauses, p.bracketKeyword(
-			"WITH", "(",
-			p.Doc(&node.StorageParams),
-			")", ""))
 	}
 
 	if len(clauses) == 0 {


### PR DESCRIPTION
The `UniqueConstraintTableDef.Format` and `Doc` (pretty printer) methods
emitted the `WITH (storage_params)` clause after the visibility clause,
but the SQL grammar requires the ordering:

    ... PARTITION BY ... WITH (...) WHERE ... [NOT VISIBLE | VISIBILITY ...]

Move the `StorageParams` block to its correct position in both methods,
matching the grammar and the sibling `Format` methods
(`IndexTableDef.Format`, `CreateIndex.Format`) and
`catformat.indexForDisplay`.

Fixes: #169278

Release note (bug fix): Fixed a bug where formatting a unique
constraint or primary key with both storage parameters and a WHERE
or visibility clause produced output that didn't match the grammar
and couldn't be re-parsed.