### PR TITLE
release-26.2: backup: fix drop `exclude_data_from_backup` GC PTS bug

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -2035,6 +2035,10 @@ func maybeWriteBackupLock(
 
 // getCompletedSpans inspects a backup manifest and returns all spans and
 // introduced spans that have already been backed up.
+//
+// NB: This function is currently only used for the purposes of filtering.
+// There are circumstances where spans will be added to both completedSpans and completedIntroducedSpans,
+// in order to direct filtering correctly, as these spans overlap both span groups.
 func getCompletedSpans(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
@@ -2070,6 +2074,7 @@ func getCompletedSpans(
 
 	// Add the spans for any tables that are excluded from backup to the set of
 	// already-completed spans, as there is nothing to do for them.
+	excludedTableIDs := make(map[descpb.ID]struct{})
 	descs := iterFactory.NewDescIter(ctx)
 	defer descs.Close()
 	for ; ; descs.Next() {
@@ -2079,11 +2084,44 @@ func getCompletedSpans(
 			break
 		}
 
-		if tbl, _, _, _, _ := descpb.GetDescriptors(descs.Value()); tbl != nil && tbl.ExcludeDataFromBackup {
+		tbl, _, _, _, _ := descpb.GetDescriptors(descs.Value())
+		if tbl != nil && tbl.ExcludeDataFromBackup {
+			excludedTableIDs[tbl.ID] = struct{}{}
 			prefix := execCtx.ExecCfg().Codec.TablePrefix(uint32(tbl.ID))
-			completedSpans = append(completedSpans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+			span := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+			completedSpans = append(completedSpans, span)
+			completedIntroducedSpans = append(completedIntroducedSpans, span)
 		}
 	}
+
+	// If this is a revision history backup, also check revisions to exclude from export requests.
+	if backupManifest.MVCCFilter == backuppb.MVCCFilter_All {
+		descRevs := iterFactory.NewDescriptorChangesIter(ctx)
+		defer descRevs.Close()
+		for ; ; descRevs.Next() {
+			if ok, err := descRevs.Valid(); err != nil {
+				return nil, nil, err
+			} else if !ok {
+				break
+			}
+
+			rev := descRevs.Value()
+			if rev.Desc == nil {
+				continue
+			}
+			tbl, _, _, _, _ := descpb.GetDescriptors(rev.Desc)
+			if tbl != nil && tbl.ExcludeDataFromBackup {
+				if _, ok := excludedTableIDs[tbl.ID]; !ok {
+					excludedTableIDs[tbl.ID] = struct{}{}
+					prefix := execCtx.ExecCfg().Codec.TablePrefix(uint32(tbl.ID))
+					span := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+					completedSpans = append(completedSpans, span)
+					completedIntroducedSpans = append(completedIntroducedSpans, span)
+				}
+			}
+		}
+	}
+
 	return completedSpans, completedIntroducedSpans, nil
 }
 

--- a/pkg/backup/schedule_pts_chaining_test.go
+++ b/pkg/backup/schedule_pts_chaining_test.go
@@ -7,6 +7,7 @@ package backup
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -517,4 +518,85 @@ func TestScheduleChainingWithDatabaseExpansion(t *testing.T) {
 	// We should be able to run an incremental backup.
 	incSchedule = th.loadSchedule(t, incID)
 	runSchedule(t, incSchedule)
+}
+
+// TestSchedulePTSChainingExcludeFromBackupDrop tests that a scheduled
+// incremental backup with revision_history succeeds when a table with
+// exclude_data_from_backup=true is dropped between full and incremental.
+func TestSchedulePTSChainingExcludeFromBackupDrop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	th, cleanup := newTestHelper(t)
+	defer cleanup()
+
+	th.sqlDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'`)
+	th.sqlDB.Exec(t, `SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s'`)
+	th.sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 1`)
+
+	th.sqlDB.Exec(t, `CREATE DATABASE db`)
+	th.sqlDB.Exec(t, `USE db`)
+	th.sqlDB.Exec(t, `CREATE TABLE t (k INT PRIMARY KEY, v STRING)`)
+	th.sqlDB.Exec(t, `ALTER TABLE t SET (exclude_data_from_backup = true)`)
+	th.sqlDB.Exec(t, `INSERT INTO t SELECT generate_series(1, 100), 'initial'`)
+
+	var tableID int
+	th.sqlDB.QueryRow(t,
+		`SELECT table_id FROM crdb_internal.tables WHERE name = 't' AND database_name = 'db'`,
+	).Scan(&tableID)
+
+	// The table needs its own range so GC respects ExcludeDataFromBackup
+	// and ignores the schedule's PTS.
+	waitForTableSplit(t, th.sqlDB.DB.(*gosql.DB), "t", "db")
+
+	th.cfg.TestingKnobs.(*jobs.TestingKnobs).OverrideAsOfClause = func(
+		clause *tree.AsOfClause, statementTime time.Time,
+	) {
+		backupAsOfTime := th.cfg.DB.KV().Clock().PhysicalTime()
+		if backupAsOfTime.After(statementTime) {
+			backupAsOfTime = statementTime
+		}
+		expr, err := tree.MakeDTimestampTZ(backupAsOfTime, time.Microsecond)
+		require.NoError(t, err)
+		clause.Expr = expr
+	}
+
+	fullID, incID, cleanupSchedules := th.createSchedules(t,
+		`BACKUP INTO 'nodelocal://1/exclude_test'`, "revision_history")
+	defer cleanupSchedules()
+
+	fullSchedule := th.loadSchedule(t, fullID)
+	th.env.SetTime(fullSchedule.NextRun().Add(time.Second))
+	require.NoError(t, th.executeSchedules())
+	th.waitForSuccessfulScheduledJob(t, fullSchedule.ScheduleID())
+
+	// Advance GC past the backup's AOST while the span config still has the
+	// flag (so the PTS is ignored).
+	var rangeID int
+	th.sqlDB.QueryRow(t, `SELECT range_id FROM [SHOW RANGES FROM TABLE db.t]`).Scan(&rangeID)
+	th.sqlDB.Exec(t,
+		fmt.Sprintf(`SELECT crdb_internal.kv_enqueue_replica(%d, 'mvccGC', true, true)`, rangeID))
+
+	// Drop the table and wait for the span config to be fully cleaned up.
+	th.sqlDB.Exec(t, `DROP TABLE db.t`)
+	testutils.SucceedsSoon(t, func() error {
+		th.sqlDB.Exec(t,
+			fmt.Sprintf(`SELECT crdb_internal.kv_enqueue_replica(%d, 'mvccGC', true, true)`, rangeID))
+		var count int
+		if err := th.sqlDB.DB.QueryRowContext(context.Background(),
+			`SELECT count(*) FROM system.span_configurations
+			 WHERE start_key = crdb_internal.table_span($1)[1]`, tableID,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count != 0 {
+			return errors.Newf("waiting for span config removal (still %d entries)", count)
+		}
+		return nil
+	})
+
+	incSchedule := th.loadSchedule(t, incID)
+	th.env.SetTime(incSchedule.NextRun().Add(time.Second))
+	require.NoError(t, th.executeSchedules())
+	th.waitForSuccessfulScheduledJob(t, incSchedule.ScheduleID())
 }


### PR DESCRIPTION
Backport 1/1 commits from #169087 on behalf of @andrew-r-thomas.

----

This patch fixes a bug where dropped tables with the `exclude_data_from_backup` flag could cause us to fail incremental revision-history backups due to kv failing to set
`BatchTimestampBeforeGCError.DataExcludedFromBackup` when exporting the dropped table's span. This fix simply extends `getCompletedSpans` to refrain from sending export requests for additional spans, namely it adds checks for both descriptor revisions, and introduced spans.

Epic: None

Release note: None

----

Release justification: Low risk bug fix.