### PR TITLE
workload/schemachange: tolerate OutOfMemory errors during op generation

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -588,10 +588,16 @@ func (w *schemaChangeWorker) runInTxn(
 		}
 
 		op, err := w.opGen.randOp(ctx, tx, useDeclarativeSchemaChanger, numOps)
-		if pgErr := new(pgconn.PgError); errors.As(err, &pgErr) &&
-			pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
-			return errors.Mark(err, errRunInTxnRbkSentinel)
-		} else if err != nil && errors.Is(err, errRunInTxnRbkSentinel) {
+		if pgErr := new(pgconn.PgError); errors.As(err, &pgErr) {
+			// OutOfMemory (53200) is rollback-worthy: the workload's
+			// introspection queries can exhaust the server's per-query
+			// memory budget under load, which is not a workload bug.
+			switch pgcode.MakeCode(pgErr.Code) {
+			case pgcode.SerializationFailure, pgcode.OutOfMemory:
+				return errors.Mark(err, errRunInTxnRbkSentinel)
+			}
+		}
+		if err != nil && errors.Is(err, errRunInTxnRbkSentinel) {
 			// Error was already marked for us.
 			return err
 		} else if errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
The random schema-change workload's introspection queries (notably
`alterTableAlterPrimaryKey`'s `information_schema` joins) can exhaust the
server's per-query memory budget under load and return a 53200
(OutOfMemory) error. Previously `runInTxn` treated any non-serialization
error from `randOp` as a fatal test failure.

Mark `OutOfMemory` with `errRunInTxnRbkSentinel` so the in-flight
transaction rolls back and the worker continues, matching the existing
handling for `SerializationFailure`.

Resolves #169072

Release note: none
Epic: none