### PR TITLE
roachtest: bump tpcc-severe-overload timeout to 6h

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -190,7 +190,7 @@ func registerTPCCSevereOverload(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(7, spec.CPU(8), spec.WorkloadNode(), spec.WorkloadNodeCPU(8)),
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.Suites(registry.Weekly),
-		Timeout:          5 * time.Hour,
+		Timeout:          6 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			warehouseCount := 10000
 			rampTime := 4 * time.Hour
@@ -200,7 +200,7 @@ func registerTPCCSevereOverload(r registry.Registry) {
 			}
 
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
-			t.Status("initializing (~30m)")
+			t.Status("initializing (~1h)")
 			cmd := fmt.Sprintf(
 				"./cockroach workload fixtures import tpcc --checks=false --warehouses=%d {pgurl:1}",
 				warehouseCount,


### PR DESCRIPTION
The 10K warehouse import consistently takes ~1h (not ~30m as the status
message claimed), which combined with the 4h ramp pushes the total past
the 5h timeout. Bump to 6h and fix the status message.

Fixes: #169102

Epic: none