### PR TITLE
release-25.2: sql/opt: treat privilege errors as stale memos during dependency checks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/udf_privileges
@@ -805,3 +805,78 @@ statement ok
 SET ROLE root
 
 subtest end
+
+# Regression test for #168992. Unqualified function calls should not leak
+# descriptors across database boundaries via the query cache. When two databases
+# have identically-named functions in custom schemas, the memo cached from one
+# database context must be treated as stale when accessed from another, rather
+# than producing a privilege error referencing schemas from the wrong database.
+subtest cross_database_function_resolution
+
+statement ok
+CREATE DATABASE db_a;
+CREATE DATABASE db_b;
+CREATE ROLE role_a;
+CREATE ROLE role_b;
+GRANT role_a TO testuser;
+GRANT role_b TO testuser;
+GRANT CONNECT ON DATABASE db_a TO role_a;
+GRANT CONNECT ON DATABASE db_b TO role_b;
+
+statement ok
+USE db_a;
+CREATE SCHEMA sch_a;
+GRANT USAGE ON SCHEMA sch_a TO role_a;
+CREATE TABLE sch_a.records (id INT PRIMARY KEY, label TEXT NOT NULL);
+GRANT SELECT ON TABLE sch_a.records TO role_a;
+CREATE FUNCTION sch_a.get_records(p_id INT) RETURNS TABLE(id INT, label TEXT) LANGUAGE SQL AS $$
+  SELECT id, label FROM db_a.sch_a.records WHERE id >= p_id ORDER BY id
+$$;
+GRANT EXECUTE ON FUNCTION sch_a.get_records TO role_a;
+INSERT INTO sch_a.records VALUES (1, 'alpha');
+
+statement ok
+USE db_b;
+CREATE SCHEMA sch_b;
+GRANT USAGE ON SCHEMA sch_b TO role_b;
+CREATE TABLE sch_b.records (id INT PRIMARY KEY, label TEXT NOT NULL);
+GRANT SELECT ON TABLE sch_b.records TO role_b;
+CREATE FUNCTION sch_b.get_records(p_id INT) RETURNS TABLE(id INT, label TEXT) LANGUAGE SQL AS $$
+  SELECT id, label FROM db_b.sch_b.records WHERE id >= p_id ORDER BY id
+$$;
+GRANT EXECUTE ON FUNCTION sch_b.get_records TO role_b;
+INSERT INTO sch_b.records VALUES (1, 'beta');
+
+# Populate the query cache for get_records via role_a in db_a.
+statement ok
+USE db_a;
+SET ROLE role_a;
+SET search_path = sch_a;
+
+query I
+SELECT count(*) FROM get_records(1)
+----
+1
+
+# Switch to role_b in db_b. The cached memo references db_a.sch_a, but that
+# should be detected as stale rather than producing a privilege error.
+statement ok
+SET ROLE role_b;
+USE db_b;
+SET search_path = sch_b;
+
+query I
+SELECT count(*) FROM get_records(1)
+----
+1
+
+statement ok
+SET ROLE root;
+USE test;
+SET search_path = public;
+DROP DATABASE db_a CASCADE;
+DROP DATABASE db_b CASCADE;
+DROP ROLE role_a;
+DROP ROLE role_b;
+
+subtest end

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -626,18 +626,24 @@ func (md *Metadata) CheckDependencies(
 	return true, nil
 }
 
-// handleMetadataResolveErr swallows errors that are thrown when a database
-// object is dropped, since such an error potentially only means that the
-// metadata is stale and should be re-resolved.
+// maybeSwallowMetadataResolveErr swallows errors that are thrown when a
+// database object cannot be resolved during a metadata staleness check, since
+// such an error potentially only means that the metadata is stale and should be
+// re-resolved. This includes cases where the object no longer exists, or where
+// the current user lacks privileges to access it (e.g. because the cached memo
+// references objects in a different database context). In both cases, the memo
+// is treated as stale and will be replanned in the correct context, which will
+// surface genuine privilege errors during planning if applicable.
 func maybeSwallowMetadataResolveErr(err error) error {
 	if err == nil {
 		return nil
 	}
-	// Handle when the object no longer exists.
+	// Handle when the object no longer exists or is inaccessible.
 	switch pgerror.GetPGCode(err) {
 	case pgcode.UndefinedObject, pgcode.UndefinedTable, pgcode.UndefinedDatabase,
 		pgcode.UndefinedSchema, pgcode.UndefinedFunction, pgcode.InvalidName,
-		pgcode.InvalidSchemaName, pgcode.InvalidCatalogName:
+		pgcode.InvalidSchemaName, pgcode.InvalidCatalogName,
+		pgcode.InsufficientPrivilege:
 		return nil
 	}
 	if errors.Is(err, catalog.ErrDescriptorDropped) {


### PR DESCRIPTION
Backport 1/1 commits from #169190.

/cc @cockroachdb/release

---

Previously, when the query cache's `CheckDependencies` re-resolved data sources from a cached memo and encountered a privilege error (e.g. because the memo referenced objects in a different database context), the error was propagated to the user. This caused unqualified function calls to fail with USAGE privilege errors referencing schemas from the wrong database when two databases had identically-named functions in custom schemas.

Now, `maybeSwallowMetadataResolveErr` also swallows `pgcode.InsufficientPrivilege` errors, treating them as indicators that the memo is stale. The memo is evicted and replanned in the correct user/database context, where genuine privilege errors will surface during planning.

Fixes: #168992

Release note (bug fix): Fixed a bug where unqualified function calls could fail with incorrect privilege errors when two databases on the same cluster had identically-named functions in custom schemas. The query cache could serve a memo from one database context to another, causing USAGE privilege errors referencing schemas from the wrong database.

---

Release justification: one-line low-risk fix for customer incident.
