### PR TITLE
admission: add rmStrategy for RM-mode burst refill 

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -358,6 +358,63 @@ func (s *serverlessStrategy) refillBurst(tokens tokenCounts, refillRates rates) 
 	}
 }
 
+// rmStrategy implements modeStrategy for Resource Manager mode, which uses a
+// single WorkQueue with N resource groups and a single utilization target.
+type rmStrategy struct {
+	queue workQueueIForAllocator
+	// canBurstTarget is the canBurst utilization target (e.g. 1.0 when
+	// KVCPUTimeUtilTarget=0.75 + KVCPUTimeUtilBurstDeltaRM=0.25). Set by
+	// computeTargets each interval; used by refillBurst to recover the 100% CPU
+	// rate by dividing the cycle's canBurst allocation by canBurstTarget and
+	// forwards to WorkQueue.refillRMGroupBurstBuckets.
+	canBurstTarget float64
+}
+
+var _ modeStrategy = &rmStrategy{}
+
+func (s *rmStrategy) mode() cpuTimeTokenMode {
+	return resourceManagerMode
+}
+
+func (s *rmStrategy) computeTargets(sv *settings.Values) targetUtilizations {
+	if numResourceTiers != 2 {
+		panic(errors.AssertionFailedf(
+			"rmStrategy.computeTargets requires numResourceTiers=2 but got %d",
+			numResourceTiers))
+	}
+	var targets targetUtilizations
+	noBurstTarget := KVCPUTimeUtilTarget.Get(sv)
+	burstDelta := KVCPUTimeUtilBurstDeltaRM.Get(sv)
+	targets[0][noBurst] = noBurstTarget
+	targets[0][canBurst] = noBurstTarget + burstDelta
+	s.canBurstTarget = targets[0][canBurst]
+	// Mirror tier-0 to tier-1. RM mode does not route KV admission work to
+	// tier-1; SQL CPU work still uses tier-1 via GetCTTWorkQueue, and the
+	// granter deducts every consumed token from both tiers' buckets (see
+	// tookWithoutPermissionLocked). Equal refill rates keep tier-1 in sync
+	// with tier-0 and preserve the granter's invariant that the lower-ordinal
+	// tier holds >= tokens than the higher. Read more in cpuTimeTokenGranter.
+	targets[1] = targets[0]
+	return targets
+}
+
+func (s *rmStrategy) refillBurst(tokens tokenCounts, refillRates rates) {
+	// Cold-start guard: skip if computeTargets has not run yet (canBurstTarget
+	// is the zero value). Setting validators rule out negative values, so
+	// == 0 catches the only reachable bad state.
+	if s.canBurstTarget == 0 {
+		return
+	}
+	// Recover the 100% CPU rate by dividing out canBurstTarget; valid
+	// because cpuTimeTokenLinearModel is linear in target.
+	//
+	// TODO(wenyihu6): instead of computing by division, plumb rate100 from the
+	// model so this division (and canBurstTarget storage) can go away.
+	rate100 := float64(tokens[0][canBurst]) / s.canBurstTarget
+	cap100 := float64(refillRates[0][canBurst]) / s.canBurstTarget
+	s.queue.refillRMGroupBurstBuckets(rate100, cap100)
+}
+
 // rates stores a token count per second, for example, the refill
 // rates at which we add tokens per second, one per bucket in
 // cpuTimeTokenGranter.
@@ -510,11 +567,11 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 // granter and burst buckets. If the mode cluster setting has changed,
 // the strategy is swapped before computing targets.
 func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenMode {
-	// Check for mode transition. a.strategy is only accessed by the
-	// filler goroutine, so we can update it immediately. offMode is
-	// skipped because it is not a real strategy - the constructor
-	// defaults offMode to serverlessMode, and GetKVWorkQueue handles
-	// the off case before reaching activeMode routing.
+	// a.strategy is only accessed by the filler goroutine, so we can
+	// update it immediately. offMode is skipped because it is not a
+	// real strategy - the constructor defaults offMode to
+	// serverlessMode, and GetKVWorkQueue handles the off case before
+	// reaching activeMode routing.
 	modeChanged := false
 	newMode := cpuTimeTokenACMode.Get(&a.settings.SV)
 	if newMode != offMode && newMode != a.strategy.mode() {
@@ -575,19 +632,14 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 	return a.strategy.mode()
 }
 
-// newStrategy constructs the modeStrategy for the given mode.
-// offMode is not a valid argument - callers must guard against it
-// (resetInterval skips the swap, the constructor maps off to
-// serverless). Queue side effects are not applied here;
-// resetInterval applies them after the refill is complete.
+// newStrategy constructs the modeStrategy for the given mode. offMode is not a
+// valid argument - callers must guard against it (resetInterval skips the swap,
+// the constructor maps off to serverless). Queue side effects are not applied
+// here; resetInterval applies them after the refill is complete.
 //
-// No explicit bucket reset is needed on mode switch. The granter's
-// tier-1 buckets stay alive across transitions, and the delta
-// mechanism in resetInterval (deltaRefillRates) adjusts all bucket
-// token counts to converge to the new mode's rates within one
-// interval (1s). In-flight work in queue[1] during a serverless-to-RM
-// switch may stall (no new refill routed there), but will time out
-// via the WorkQueue's normal deadline handling.
+// No bucket reset is needed on a mode switch. The granter's tier-1 buckets stay
+// alive across transitions, and resetInterval's delta mechanism converges all
+// bucket counts to the new mode's rates within one interval (1s).
 func (a *cpuTimeTokenAllocator) newStrategy(mode cpuTimeTokenMode) modeStrategy {
 	switch mode {
 	case offMode:
@@ -595,18 +647,22 @@ func (a *cpuTimeTokenAllocator) newStrategy(mode cpuTimeTokenMode) modeStrategy 
 	case serverlessMode:
 		return &serverlessStrategy{queues: a.queues}
 	case resourceManagerMode:
-		// TODO(wenyihu6): implement this
-		panic(errors.AssertionFailedf("resourceManagerMode not implemented yet"))
+		return &rmStrategy{queue: a.queues[0]}
 	default:
 		panic(errors.AssertionFailedf("unknown cpuTimeTokenMode: %d", mode))
 	}
 }
 
 // configureQueue applies mode-specific settings to the WorkQueue.
-// Called at the end of resetInterval after refill is complete.
+// Called from the constructor after the initial strategy is installed and from
+// resetInterval on a strategy swap.
 //
-// TODO(wenyihu6): This will become unnecessary once serverless
-// tenants are modeled as resource groups in a single WorkQueue.
+// TODO(wenyihu6): in a follow-on change, this should also trigger an apply of
+// the configHolder snapshot to groupInfo so that derived per-group state
+// (weight, MaxCPU, burstFrac) lands before the cycle's refill runs.
+//
+// TODO(wenyihu6): becomes unnecessary once serverless tenants are
+// modeled as resource groups in a single WorkQueue.
 func (a *cpuTimeTokenAllocator) configureQueue() {
 	a.queues[0].setUseResourceGroup(a.strategy.mode() == resourceManagerMode)
 }
@@ -636,10 +692,31 @@ func refillGranter(
 	granter.refill(toAdd, bucketCapacities, bucketMinimums, updateMetrics)
 }
 
-// workQueueIForAllocator abstracts the burst bucket refill methods in
-// WorkQueue, to enable unit testing.
+// workQueueIForAllocator abstracts the WorkQueue methods called from
+// the allocator/strategy layer, to enable unit testing.
+//
+// TODO(wenyihu6): the two refill methods exist because the modes have
+// different per-tick semantics (serverless: uniform per-tenant +
+// burstBucketCapacity update; RM: per-group scaled, no capacity
+// update). Folding them into a single method would force WorkQueue to
+// dispatch internally on q.mu.useResourceGroup, which can race with the
+// strategy during a mode swap. Two methods keep the dispatch on the
+// strategy side, where the active mode is the source of truth.
+// Stop-gap; should go away when we unify serverless and RM.
 type workQueueIForAllocator interface {
 	refillBurstBuckets(toAdd int64, capacity int64)
+	// refillRMGroupBurstBuckets is the future per-group RM-mode refill
+	// entry point: the implementation will refill every configured RM
+	// group's burst bucket under q.mu, using per-group burstFracs scaled
+	// against rate100/cap100. rate100 may be negative when resetInterval
+	// forwards a delta and refill rates have decreased since the previous
+	// interval; cap100 is the current rate and should be non-negative.
+	// Currently a no-op stub on WorkQueue; safe because RM mode is off
+	// by default.
+	refillRMGroupBurstBuckets(rate100, cap100 float64)
+	// setUseResourceGroup toggles RM-style group derivation.
+	// TODO(wenyihu6): on false -> true, snapshot the configHolder and
+	// apply derived state to groupInfo (see WorkQueue.setUseResourceGroup).
 	setUseResourceGroup(enabled bool)
 }
 

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -99,6 +99,11 @@ type testModel struct {
 type testBurstManager struct {
 	tokens           int64
 	useResourceGroup bool
+	// rmCalls counts calls to refillRMGroupBurstBuckets; rmRate100 and
+	// rmCap100 record the args from the most recent call.
+	rmCalls   int
+	rmRate100 float64
+	rmCap100  float64
 }
 
 func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
@@ -109,6 +114,12 @@ func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
 	if m.tokens < -capacity/4 {
 		m.tokens = -capacity / 4
 	}
+}
+
+func (m *testBurstManager) refillRMGroupBurstBuckets(rate100, cap100 float64) {
+	m.rmCalls++
+	m.rmRate100 = rate100
+	m.rmCap100 = cap100
 }
 
 func (m *testBurstManager) setUseResourceGroup(enabled bool) {
@@ -560,22 +571,26 @@ func TestServerlessStrategyRefillBurst(t *testing.T) {
 }
 
 // TestNewStrategy verifies that newStrategy returns the correct
-// strategy for serverlessMode and panics for offMode (not a real
-// strategy), resourceManagerMode (not yet implemented), and unknown
-// modes.
+// strategy for serverlessMode and resourceManagerMode and panics
+// for offMode (not a real strategy) and unknown modes.
 func TestNewStrategy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	allocator := cpuTimeTokenAllocator{}
+	queues := [numResourceTiers]workQueueIForAllocator{
+		testTier0: &testBurstManager{},
+		testTier1: &testBurstManager{},
+	}
+	allocator := cpuTimeTokenAllocator{queues: queues}
+
 	s := allocator.newStrategy(serverlessMode)
 	require.Equal(t, serverlessMode, s.mode())
 
+	rm := allocator.newStrategy(resourceManagerMode)
+	require.Equal(t, resourceManagerMode, rm.mode())
+
 	require.Panics(t, func() {
 		allocator.newStrategy(offMode)
-	})
-	require.Panics(t, func() {
-		allocator.newStrategy(resourceManagerMode)
 	})
 	require.Panics(t, func() {
 		allocator.newStrategy(cpuTimeTokenMode(99))
@@ -631,9 +646,83 @@ func TestConfigureQueue(t *testing.T) {
 		strategy: &serverlessStrategy{queues: queues},
 	}
 
-	// In serverless mode, useResourceGroup should be false. The RM
-	// direction (useResourceGroup=true) will be tested when rmStrategy
-	// is implemented.
+	// Serverless mode -> useResourceGroup=false.
 	allocator.configureQueue()
 	require.False(t, mgr.useResourceGroup)
+
+	// RM mode -> useResourceGroup=true.
+	allocator.strategy = &rmStrategy{queue: mgr}
+	allocator.configureQueue()
+	require.True(t, mgr.useResourceGroup)
+}
+
+// TestRMStrategyComputeTargets verifies that computeTargets reads the
+// RM cluster settings, populates tier-0, mirrors to tier-1, and caches
+// canBurstTarget for refillBurst.
+func TestRMStrategyComputeTargets(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeClusterSettings()
+	ctx := context.Background()
+	KVCPUTimeUtilTarget.Override(ctx, &st.SV, 0.75)
+	KVCPUTimeUtilBurstDeltaRM.Override(ctx, &st.SV, 0.25)
+
+	s := &rmStrategy{}
+	targets := s.computeTargets(&st.SV)
+
+	require.Equal(t, 0.75, targets[0][noBurst])
+	require.Equal(t, 1.0, targets[0][canBurst])
+	// Tier-1 mirrors tier-0.
+	require.Equal(t, targets[0], targets[1])
+	// canBurstTarget is cached for refillBurst's rate100 recovery.
+	require.Equal(t, 1.0, s.canBurstTarget)
+}
+
+// TestRMStrategyRefillBurst verifies the cold-start guard, the
+// rate100/cap100 recovery from canBurstTarget, and that only the
+// strategy's bound queue receives the call.
+func TestRMStrategyRefillBurst(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	mgr := &testBurstManager{}
+	other := &testBurstManager{}
+	s := &rmStrategy{queue: mgr}
+
+	// Cold-start guard: canBurstTarget=0 -> no call.
+	s.refillBurst(tokenCounts{}, rates{})
+	require.Zero(t, mgr.rmCalls)
+
+	// canBurstTarget=1.0 recovers tokens/rates as-is.
+	s.canBurstTarget = 1.0
+	var tokens tokenCounts
+	tokens[0][canBurst] = 1000
+	var rr rates
+	rr[0][canBurst] = 4000
+	s.refillBurst(tokens, rr)
+	require.Equal(t, 1, mgr.rmCalls)
+	require.Equal(t, 1000.0, mgr.rmRate100)
+	require.Equal(t, 4000.0, mgr.rmCap100)
+
+	// canBurstTarget=0.5 doubles both.
+	s.canBurstTarget = 0.5
+	s.refillBurst(tokens, rr)
+	require.Equal(t, 2, mgr.rmCalls)
+	require.Equal(t, 2000.0, mgr.rmRate100)
+	require.Equal(t, 8000.0, mgr.rmCap100)
+
+	// Delta path: tokens (rate100) may be negative when refill rates
+	// decrease between intervals. cap100 stays non-negative because
+	// refillRates is the current rate, which is bounded >= 0 by the model.
+	tokens[0][canBurst] = -500
+	rr[0][canBurst] = 4000
+	s.canBurstTarget = 1.0
+	s.refillBurst(tokens, rr)
+	require.Equal(t, 3, mgr.rmCalls)
+	require.Equal(t, -500.0, mgr.rmRate100)
+	require.Equal(t, 4000.0, mgr.rmCap100)
+
+	// Only the bound queue receives the call.
+	require.Zero(t, other.rmCalls)
 }

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -280,6 +280,12 @@ func makeCPUTimeTokenGrantCoordinator(
 		allocator.queues[tier] = requesters[tier].(*WorkQueue)
 	}
 	allocator.strategy = allocator.newStrategy(initialMode)
+	// Sync the queue's useResourceGroup with the initial strategy.
+	// Without this, a node that starts in resourceManagerMode would never
+	// have configureQueue called: resetInterval only invokes it on a
+	// strategy swap (modeChanged), and the first resetInterval sees
+	// newMode == a.strategy.mode() so modeChanged is false.
+	allocator.configureQueue()
 
 	coordinator := &cpuTimeTokenGrantCoordinator{
 		filler: filler,

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1449,6 +1449,20 @@ func (q *WorkQueue) refillBurstBucketForGroup(gKey groupKey, toAdd int64, capaci
 	q.refillBurstBucketLocked(group, toAdd, capacity)
 }
 
+// refillRMGroupBurstBuckets is the per-group RM-mode refill entry point
+// called by rmStrategy.refillBurst. rate100 may be negative when
+// resetInterval forwards a delta; cap100 is the current rate and should
+// be non-negative.
+//
+// No-op stub today; RM mode is off by default, so the stub has no production
+// effect. Per-group refill cannot be implemented yet because per-resource-group
+// configuration (weight, MaxCPU, burstFrac) is not yet plumbed onto groupInfo.
+//
+// TODO(wenyihu6): once that storage lands, wire this to iterate groupInfos
+// and refill each bucket scaled by burstFrac.
+func (q *WorkQueue) refillRMGroupBurstBuckets(rate100, cap100 float64) {
+}
+
 // refillBurstBucketLocked refills a group's burst bucket and fixes its
 // heap position if the burst qualification changed. q.mu must be held.
 func (q *WorkQueue) refillBurstBucketLocked(group *groupInfo, toAdd int64, capacity int64) {


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/168382

---

This change adds `rmStrategy`, the `modeStrategy` implementation
that drives per-tick burst refill when the queue runs in RM mode.
`rmStrategy.refillBurst` recovers the 100% CPU rate by dividing the
cycle's `canBurst` allocation by `canBurstTarget` and forwards to
`WorkQueue.refillRMGroupBurstBuckets`; per-group state is owned by
`WorkQueue`, so `rmStrategy` caches only `canBurstTarget`.

`computeTargets` mirrors tier-0 to tier-1 because the granter
deducts every consumed token from both tiers' buckets (see
`tookWithoutPermissionLocked`); equal refill rates preserve the
invariant that the lower-ordinal tier holds at least as many tokens
as the higher.

`WorkQueue.refillRMGroupBurstBuckets` is added as a no-op stub.
Per-group refill cannot yet be implemented because resource group
configuration (weight, MaxCPU, derived burstFrac) is not yet
plumbed onto `groupInfo`; once that storage lands, follow-on work
will fill in the iteration and per-group scaling. The same
follow-on work is expected to unify the serverless and RM refill
paths into a single per-group refill once serverless tenants are
modeled as resource groups.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>