### PR TITLE
sql/bulksst: include SQL instance ID in SST filenames

### DIFF
--- a/pkg/sql/bulkmerge/doc.go
+++ b/pkg/sql/bulkmerge/doc.go
@@ -154,13 +154,17 @@
 // easy cleanup:
 //
 //	nodelocal://{nodeID}/job/{jobID}/
-//	├── map/                           # Map phase output
-//	│   ├── {walltime}-{logical}.sst   # One SST per flush
+//	├── map/                                       # Map phase output
+//	│   ├── n{instanceID}-{walltime}-{logical}.sst # One SST per flush; the
+//	│   │                                          # n{instanceID} prefix
+//	│   │                                          # disambiguates writers
+//	│   │                                          # when nodelocal:// URIs
+//	│   │                                          # share a physical dir.
 //	│   └── ...
-//	├── merge/iter-1/                  # Local merge output
-//	│   ├── {taskID}-{fileIdx}.sst
+//	├── merge/iter-1/                              # Local merge output
+//	│   ├── n{instanceID}-{walltime}-{logical}.sst
 //	│   └── ...
-//	└── merge/iter-2/                  # (not used: final writes to KV)
+//	└── merge/iter-2/                              # (not used: final writes to KV)
 //
 // The /job/{jobID}/ prefix enables prefix-based cleanup on job
 // completion, cancellation, or failure. Intermediate SSTs from the map

--- a/pkg/sql/bulkmerge/merge_processor.go
+++ b/pkg/sql/bulkmerge/merge_processor.go
@@ -366,7 +366,7 @@ func (m *bulkMergeProcessor) mergeSSTs(
 	}
 	defer destStore.Close()
 	destFileAllocator := bulksst.NewExternalFileAllocator(destStore, m.spec.OutputStorage.URI,
-		m.flowCtx.Cfg.DB.KV().Clock())
+		m.flowCtx.Cfg.DB.KV().Clock(), m.flowCtx.NodeID.SQLInstanceID())
 
 	writer, err := newExternalStorageWriter(
 		ctx,

--- a/pkg/sql/bulkmerge/merge_test.go
+++ b/pkg/sql/bulkmerge/merge_test.go
@@ -67,19 +67,7 @@ func TestDistributedMergeThreeNodes(t *testing.T) {
 	ctx := context.Background()
 	instanceCount := 3
 
-	dir, cleanup := testutils.TempDir(t)
-	defer cleanup()
-
-	args := base.TestClusterArgs{
-		ServerArgsPerNode: map[int]base.TestServerArgs{},
-	}
-	for i := 0; i < 3; i++ {
-		args.ServerArgsPerNode[i] = base.TestServerArgs{
-			ExternalIODir: fmt.Sprintf("%s/node-%d", dir, i),
-		}
-	}
-
-	tc := serverutils.StartCluster(t, instanceCount, args)
+	tc := serverutils.StartCluster(t, instanceCount, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
 	// Pick a random node to connect to
@@ -121,7 +109,7 @@ func TestDistributedMergeProcessorFailurePropagates(t *testing.T) {
 	defer cleanupJob()
 
 	tsa := newTestServerAllocator(t, ctx, execCfg)
-	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, srv.Clock())
+	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, srv.Clock(), base.SQLInstanceID(1))
 	batcher := bulksst.NewUnsortedSSTBatcher(srv.ClusterSettings(), fileAllocator)
 	writeSSTs(t, ctx, batcher, 3)
 	ssts := importToMerge(fileAllocator.GetFileList())
@@ -160,7 +148,7 @@ func TestDistributedMergeMultiPassIngestsIntoKV(t *testing.T) {
 	defer jobCleanup()
 
 	targetFileSize.Override(ctx, &s.ClusterSettings().SV, 1<<20)
-	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock())
+	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock(), base.SQLInstanceID(1))
 	batcher := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator)
 
 	prefix := "merge-multi/"
@@ -316,7 +304,7 @@ func testMergeProcessors(
 	// Override the target size of our merged SSTs to ensure we are flushing
 	// correctly.
 	targetFileSize.Override(ctx, &s.ClusterSettings().SV, 30)
-	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock())
+	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock(), base.SQLInstanceID(1))
 	batcher := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator)
 	ls := writeSSTs(t, ctx, batcher, 13)
 
@@ -513,7 +501,7 @@ func TestMergeSSTsSplitsAtRowBoundaries(t *testing.T) {
 	targetFileSize.Override(ctx, &srv.ClusterSettings().SV, 150)
 
 	tsa := newTestServerAllocator(t, ctx, execCfg)
-	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, srv.Clock())
+	fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, srv.Clock(), base.SQLInstanceID(1))
 	batcher := bulksst.NewUnsortedSSTBatcher(srv.ClusterSettings(), fileAllocator)
 
 	ts := hlc.Timestamp{WallTime: 1}
@@ -708,7 +696,7 @@ func TestKVWritePreexistingKeyConflictDetection(t *testing.T) {
 	// Step 1: First merge to populate KV with some keys.
 	// Write keys [key-0, key-1, key-2] to an SST and ingest into KV.
 	writeTS1 := hlc.Timestamp{WallTime: 1}
-	fileAllocator1 := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock())
+	fileAllocator1 := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock(), base.SQLInstanceID(1))
 	batcher1 := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator1)
 	writeSpecificKeys(t, ctx, batcher1, []int{0, 1, 2}, writeTS1, s.Codec())
 
@@ -737,7 +725,7 @@ func TestKVWritePreexistingKeyConflictDetection(t *testing.T) {
 	// Step 2: Second merge with overlapping keys and EnforceUniqueness=true.
 	// Write keys [key-2, key-3, key-4] to an SST - key-2 overlaps with existing data.
 	writeTS2 := hlc.Timestamp{WallTime: 2}
-	fileAllocator2 := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock())
+	fileAllocator2 := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock(), base.SQLInstanceID(1))
 	batcher2 := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator2)
 	writeSpecificKeys(t, ctx, batcher2, []int{2, 3, 4}, writeTS2, s.Codec())
 
@@ -873,7 +861,7 @@ func TestCrossSSTDuplicateHandling(t *testing.T) {
 			prefixURI1 := "nodelocal://1/merge/sst1/"
 			store1, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, prefixURI1, username.RootUserName())
 			require.NoError(t, err)
-			fileAllocator1 := bulksst.NewExternalFileAllocator(store1, prefixURI1, s.Clock())
+			fileAllocator1 := bulksst.NewExternalFileAllocator(store1, prefixURI1, s.Clock(), base.SQLInstanceID(1))
 			batcher1 := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator1)
 			writeSpecificKeys(t, ctx, batcher1, []int{0, 1, 2}, writeTS, s.Codec())
 
@@ -881,7 +869,7 @@ func TestCrossSSTDuplicateHandling(t *testing.T) {
 			prefixURI2 := "nodelocal://1/merge/sst2/"
 			store2, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, prefixURI2, username.RootUserName())
 			require.NoError(t, err)
-			fileAllocator2 := bulksst.NewExternalFileAllocator(store2, prefixURI2, s.Clock())
+			fileAllocator2 := bulksst.NewExternalFileAllocator(store2, prefixURI2, s.Clock(), base.SQLInstanceID(1))
 			batcher2 := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator2)
 			if tc.useDifferentValues {
 				writeSpecificKeysWithValuePrefix(
@@ -980,7 +968,7 @@ func TestMergeMemoryMonitorSelection(t *testing.T) {
 			execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 
 			tsa := newTestServerAllocator(t, ctx, execCfg)
-			fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock())
+			fileAllocator := bulksst.NewExternalFileAllocator(tsa.es, tsa.prefixUri, s.Clock(), base.SQLInstanceID(1))
 			batcher := bulksst.NewUnsortedSSTBatcher(s.ClusterSettings(), fileAllocator)
 			writeTS := hlc.Timestamp{WallTime: 1}
 			writeSpecificKeys(t, ctx, batcher, []int{0, 1, 2}, writeTS, s.Codec())

--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulksst",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/cloud",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/bulksst/sink.go
+++ b/pkg/sql/bulksst/sink.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -110,6 +111,9 @@ var _ BulkSink = (*SSTSink)(nil)
 // Parameters:
 //   - distributedMergeFilePrefix: Base URI for SST files (e.g., "nodelocal://1/job/123/map")
 //   - processorID: Unique ID for this processor, used to create per-processor subdirectories
+//   - instanceID: SQL instance ID of the writer, embedded in SST filenames so
+//     two instances cannot collide on the same path when their nodelocal://
+//     prefixes happen to map to a shared physical directory (see #168559).
 //   - writeAsOf: Timestamp to write on all KV pairs
 //   - checkDuplicates: Whether to detect and reject duplicate keys during flush
 func NewSSTSink(
@@ -118,6 +122,7 @@ func NewSSTSink(
 	externalStorageFromURI cloud.ExternalStorageFromURIFactory,
 	clock *hlc.Clock,
 	distributedMergeFilePrefix string,
+	instanceID base.SQLInstanceID,
 	writeAsOf hlc.Timestamp,
 	processorID int32,
 	checkDuplicates bool,
@@ -136,7 +141,7 @@ func NewSSTSink(
 		return nil, err
 	}
 
-	fileAllocator := NewExternalFileAllocator(es, prefix, clock)
+	fileAllocator := NewExternalFileAllocator(es, prefix, clock, instanceID)
 	writer := NewUnsortedSSTBatcher(settings, fileAllocator)
 	writer.SetWriteTS(writeAsOf)
 	writer.SetCheckDuplicates(checkDuplicates)

--- a/pkg/sql/bulksst/sst_file_allocator.go
+++ b/pkg/sql/bulksst/sst_file_allocator.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -86,28 +87,34 @@ func (f *fileAllocatorBase) recordRowSample(rowSample roachpb.Key) {
 
 // ExternalFileAllocator allocates external files for SSTs.
 type ExternalFileAllocator struct {
-	es      cloud.ExternalStorage
-	baseURI string
-	clock   *hlc.Clock
+	es         cloud.ExternalStorage
+	baseURI    string
+	clock      *hlc.Clock
+	instanceID base.SQLInstanceID
 	fileAllocatorBase
 }
 
+// NewExternalFileAllocator constructs an ExternalFileAllocator. The instanceID
+// is embedded in generated filenames so that writers on different SQL
+// instances do not collide on the same path when their baseURIs happen to
+// resolve to the same physical directory. See #168559.
 func NewExternalFileAllocator(
-	es cloud.ExternalStorage, baseURI string, clock *hlc.Clock,
+	es cloud.ExternalStorage, baseURI string, clock *hlc.Clock, instanceID base.SQLInstanceID,
 ) FileAllocator {
 	return &ExternalFileAllocator{
 		es:                es,
 		baseURI:           baseURI,
 		clock:             clock,
+		instanceID:        instanceID,
 		fileAllocatorBase: fileAllocatorBase{},
 	}
 }
 
-// AddFile creates a new file with an HLC timestamp-based unique name.
+// AddFile creates a new file with a unique name composed of the writer's SQL
+// instance ID and the current HLC timestamp.
 func (e *ExternalFileAllocator) AddFile(ctx context.Context) (objstorage.Writable, string, error) {
-	// Use HLC timestamp for unique filename generation.
 	ts := e.clock.Now()
-	fileName := fmt.Sprintf("%d-%d.sst", ts.WallTime, ts.Logical)
+	fileName := fmt.Sprintf("n%d-%d-%d.sst", e.instanceID, ts.WallTime, ts.Logical)
 	writer, err := e.es.Writer(ctx, fileName)
 	if err != nil {
 		return nil, "", err

--- a/pkg/sql/bulksst/sst_writer_test.go
+++ b/pkg/sql/bulksst/sst_writer_test.go
@@ -55,7 +55,7 @@ func createLocalBatcher(
 	)
 	t.Cleanup(func() { externalStorage.Close() })
 
-	fileAllocator := bulksst.NewExternalFileAllocator(externalStorage, "", s.Clock())
+	fileAllocator := bulksst.NewExternalFileAllocator(externalStorage, "", s.Clock(), base.SQLInstanceID(1))
 	if batchSize > 0 {
 		bulksst.BatchSize.Override(ctx, &s.ClusterSettings().SV, batchSize)
 	}
@@ -79,7 +79,7 @@ func createExternalBatcher(
 	)
 	t.Cleanup(func() { externalStorage.Close() })
 
-	allocator := bulksst.NewExternalFileAllocator(externalStorage, baseURI, s.Clock())
+	allocator := bulksst.NewExternalFileAllocator(externalStorage, baseURI, s.Clock(), base.SQLInstanceID(1))
 	if batchSize > 0 {
 		bulksst.BatchSize.Override(ctx, &s.ClusterSettings().SV, batchSize)
 	}
@@ -426,6 +426,34 @@ func TestExternalFileAllocator(t *testing.T) {
 		require.Greater(t, fileList2.TotalSize, size1)
 
 		require.NoError(t, batcher.CloseWithError(ctx))
+	})
+
+	// Regression test for #168559: two allocators sharing the same external
+	// storage, baseURI, and clock must produce non-colliding filenames when
+	// they belong to different SQL instances. Without the instance-ID prefix,
+	// concurrent writers on the same HLC tick would overwrite each other.
+	t.Run("Instance ID disambiguates filenames", func(t *testing.T) {
+		tempDir := t.TempDir()
+		es := nodelocal.TestingMakeNodelocalStorage(
+			tempDir, s.ClusterSettings(), cloudpb.ExternalStorage{},
+		)
+		t.Cleanup(func() { es.Close() })
+
+		baseURI := "shared/"
+		a1 := bulksst.NewExternalFileAllocator(es, baseURI, s.Clock(), base.SQLInstanceID(1))
+		a2 := bulksst.NewExternalFileAllocator(es, baseURI, s.Clock(), base.SQLInstanceID(2))
+
+		w1, uri1, err := a1.AddFile(ctx)
+		require.NoError(t, err)
+		require.NoError(t, w1.Finish())
+
+		w2, uri2, err := a2.AddFile(ctx)
+		require.NoError(t, err)
+		require.NoError(t, w2.Finish())
+
+		require.NotEqual(t, uri1, uri2, "different instance IDs must yield different URIs")
+		require.Contains(t, uri1, "n1-", "instance 1 filename should contain n1- prefix")
+		require.Contains(t, uri2, "n2-", "instance 2 filename should contain n2- prefix")
 	})
 }
 

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -371,6 +371,7 @@ func ingestKvs(
 			flowCtx.Cfg.ExternalStorageFromURI,
 			flowCtx.Cfg.DB.KV().Clock(),
 			prefix,
+			nodeID,
 			writeTS,
 			processorID,
 			true, /*checkDuplicates */

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -296,6 +296,7 @@ func (ib *indexBackfiller) makeIndexBackfillSink(ctx context.Context) (bulksst.B
 			ib.flowCtx.Cfg.ExternalStorageFromURI,
 			ib.flowCtx.Cfg.DB.KV().Clock(),
 			prefix,
+			nodeID,
 			ib.spec.WriteAsOf,
 			ib.processorID,
 			checkDuplicates,

--- a/pkg/sql/rowexec/indexbackfiller_test.go
+++ b/pkg/sql/rowexec/indexbackfiller_test.go
@@ -140,6 +140,7 @@ func TestSSTFileNamingConvention(t *testing.T) {
 		flowCtx.Cfg.ExternalStorageFromURI,
 		flowCtx.Cfg.DB.KV().Clock(),
 		prefix,
+		nodeID,
 		writeTS,
 		processorID,
 		false, /* checkDuplicates */
@@ -171,7 +172,7 @@ func TestSSTFileNamingConvention(t *testing.T) {
 		t.Logf("SST file URI: %s", uri)
 
 		// Verify the URI follows the naming convention:
-		// nodelocal://<nodeID>/job/<jobID>/map/proc-<procID>/<hlc-walltime>-<hlc-logical>.sst
+		// nodelocal://<nodeID>/job/<jobID>/map/proc-<procID>/n<instanceID>-<hlc-walltime>-<hlc-logical>.sst
 		expectedPrefix := fmt.Sprintf("nodelocal://%d/job/%d/map/proc-%d/", nodeID, jobID, processorID)
 		require.True(t, strings.HasPrefix(uri, expectedPrefix),
 			"URI %q does not have expected prefix %q", uri, expectedPrefix)
@@ -183,17 +184,19 @@ func TestSSTFileNamingConvention(t *testing.T) {
 		require.True(t, strings.HasSuffix(filename, ".sst"),
 			"filename %q does not end with .sst", filename)
 
-		// Verify the format is <walltime>-<logical>.sst.
+		// Verify the format is n<instanceID>-<walltime>-<logical>.sst.
 		filenameWithoutExt := strings.TrimSuffix(filename, ".sst")
 		parts := strings.Split(filenameWithoutExt, "-")
-		require.Equal(t, 2, len(parts),
-			"filename %q should have format <walltime>-<logical>.sst", filename)
+		require.Equal(t, 3, len(parts),
+			"filename %q should have format n<instanceID>-<walltime>-<logical>.sst", filename)
+		require.Equal(t, fmt.Sprintf("n%d", nodeID), parts[0],
+			"filename %q should start with the instance ID prefix", filename)
 
-		// Verify both parts are numeric (HLC timestamp components).
-		for i, part := range parts {
+		// Verify the timestamp parts are numeric (HLC timestamp components).
+		for i, part := range parts[1:] {
 			for _, ch := range part {
 				require.True(t, ch >= '0' && ch <= '9',
-					"part %d of filename %q contains non-numeric character: %c", i, filename, ch)
+					"part %d of filename %q contains non-numeric character: %c", i+1, filename, ch)
 			}
 		}
 	}


### PR DESCRIPTION
`ExternalFileAllocator` named SSTs by HLC timestamp alone, so two writers on
different SQL instances that picked the same HLC value collided when their
`nodelocal://` URIs resolved to the same on-disk directory (as in
`TestServer`/`TestCluster`). The second writer overwrote the first with an
empty SST and the merger silently dropped index entries.

Embed the writer's instance ID in the filename so the path stays unique. A
new `TestExternalFileAllocator` subtest pins the invariant deterministically.

Resolves: #168559
Epic: none

Release note: None