### PR TITLE
sql: enforce statement_timeout on pre-commit two-version wait

### DIFF
--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -125,15 +125,20 @@ func CheckTwoVersionInvariant(
 			return err
 		}
 		if count == 0 {
-			break
+			return &twoVersionInvariantViolationError{ids: withNewVersion}
 		}
 		if onRetryBackoff != nil {
 			onRetryBackoff()
 		}
 	}
-	return &twoVersionInvariantViolationError{
-		ids: withNewVersion,
+	// The retry loop has no max retries or duration, so exiting it implies
+	// ctx was cancelled. Surface ctx.Err() so a statement_timeout is visible
+	// as a timeout rather than the retryable violation sentinel; fall
+	// through to the sentinel defensively.
+	if err := ctx.Err(); err != nil {
+		return err
 	}
+	return &twoVersionInvariantViolationError{ids: withNewVersion}
 }
 
 // CheckSpanCountLimit checks whether committing the set of uncommitted tables

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4293,7 +4293,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// acquired.
 		if ex.extraTxnState.descCollection.HasUncommittedDescriptors() {
 			// Apply statement timeout on any waiting logic.
-			err = ex.runWithStatementTimeout(func(ctx context.Context) error {
+			err = ex.runWithStatementTimeout(ex.Ctx(), func(ctx context.Context) error {
 				cachedRegions, err := regions.NewCachedDatabaseRegions(ctx, ex.server.cfg.DB, ex.server.cfg.LeaseManager)
 				if err != nil {
 					return err
@@ -4395,15 +4395,16 @@ func (ex *connExecutor) onTxnStart(txnID uuid.UUID) error {
 	return ex.maybeSetSQLLivenessSessionAndGeneration()
 }
 
-// runWithStatementTimeout runs the given function with a context that has
-// the statement timeout applied. If the statement timeout is exceeded,
-// the onTimeoutError function is called and the return value of the function
-// is returned.
+// runWithStatementTimeout runs the given function with a context derived from
+// ctx that has the statement timeout applied. The caller passes the ctx it
+// wants threaded into execFn (e.g. a per-statement ctx so tracing spans and
+// other scope-bound state propagate to downstream KV calls). If the statement
+// timeout is exceeded, the onTimeoutError function is called and
+// QueryTimeoutError is returned.
 func (ex *connExecutor) runWithStatementTimeout(
-	execFn func(ctx context.Context) error, onTimeoutError func() error,
+	ctx context.Context, execFn func(ctx context.Context) error, onTimeoutError func() error,
 ) error {
-	// Set up a context that can be cancelled when the statement timeout is exceeded.
-	waitCtx := ex.ctxHolder.ctx()
+	waitCtx := ctx
 	var queryTimedout atomic.Bool
 	if ex.sessionData().StmtTimeout > 0 {
 		timePassed := ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived).Elapsed()
@@ -4453,7 +4454,7 @@ func (ex *connExecutor) waitForTxnJobs() error {
 		ex.ctxHolder.connCtx, ex.extraTxnState.jobs.created...,
 	)
 
-	return ex.runWithStatementTimeout(func(ctx context.Context) error {
+	return ex.runWithStatementTimeout(ex.Ctx(), func(ctx context.Context) error {
 		if !ex.sessionData().DisableWaitForJobsNotice {
 			jobIDs := strings.Builder{}
 			for i, jobID := range ex.extraTxnState.jobs.created {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/prep"
 	"github.com/cockroachdb/cockroach/pkg/sql/regions"
@@ -2639,7 +2640,20 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retEr
 			return err
 		}
 
-		if err := ex.checkDescriptorTwoVersionInvariant(ctx); err != nil {
+		// Apply the statement timeout so the wait for older descriptor leases
+		// to drain (inside CheckTwoVersionInvariant's retry loop) cannot hang
+		// indefinitely. The schema-change KV writes are rolled back inside
+		// CheckTwoVersionInvariant before the wait begins, so timing out here
+		// does not leave anything in flight; the user can simply retry.
+		err := ex.runWithStatementTimeout(ctx, func(ctx context.Context) error {
+			return ex.checkDescriptorTwoVersionInvariant(ctx)
+		}, func() error {
+			return ex.planner.noticeSender.SendNotice(ex.Ctx(), pgnotice.Newf(
+				"The statement has timed out while waiting for older descriptor "+
+					"leases to be released. The schema change was not applied."),
+				true /* immediateFlush */)
+		})
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/conn_executor_jobs.go
+++ b/pkg/sql/conn_executor_jobs.go
@@ -161,6 +161,13 @@ func (ex *connExecutor) descIDsInSchemaChangeJobs() (catalog.DescriptorIDSet, er
 			}
 			descIDsInJobs.Add(t.DroppedDatabaseID)
 			descIDsInJobs.Add(t.DescID)
+		case jobspb.TypeSchemaChangeDetails:
+			// The type schema-change job drains old leases on the type
+			// descriptor itself (via refreshTypeDescriptorLeases). Register
+			// the type ID here so waitOneVersionForNewVersionDescriptorsWithoutJobs
+			// skips it and the user session does not redundantly wait for the
+			// same leases to converge.
+			descIDsInJobs.Add(t.TypeID)
 		}
 		return nil
 	}); err != nil {

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -1266,3 +1266,118 @@ func TestStatementTimeoutForSchemaChangeWaitForOneVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestStatementTimeoutForCheckTwoVersionInvariant confirms that the pre-commit
+// two-version invariant check (descs.CheckTwoVersionInvariant) honours
+// statement_timeout. The check runs inside commitSQLTransactionInternal and
+// waits for stale (V-2) descriptor leases to drain before the schema-change
+// txn can commit. To enter the wait loop deterministically we disable the
+// post-commit schema-changer job (via *SchemaChangeJobNoOp), which prevents
+// the usual WaitForOneVersion from dropping old leases between successive
+// schema changes; this leaves a V-2 lease lingering when the second schema
+// change tries to commit. ALTER TYPE ADD VALUE is the original symptom from
+// #168767; ALTER TABLE ADD COLUMN exercises the same pre-commit code path.
+func TestStatementTimeoutForCheckTwoVersionInvariant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	skip.UnderDuress(t, "sets a long timeout")
+
+	for _, tc := range []struct {
+		name string
+		// knobs disables the post-commit schema-changer job that would
+		// normally drop the lingering V-2 lease via WaitForOneVersion.
+		knobs base.TestingKnobs
+		// setup creates the descriptor under test.
+		setup string
+		// pinDescriptor runs in an open txn on a separate session to hold a
+		// lease on the descriptor at its initial version.
+		pinDescriptor string
+		// bumpVersion bumps the descriptor (v=1 -> v=2). The held lease
+		// lingers at v=1.
+		bumpVersion string
+		// bumpVersionAgain triggers the second pre-commit two-version check
+		// (v=2 -> v=3) under the tight statement_timeout.
+		bumpVersionAgain string
+	}{
+		{
+			name: "alter table add column",
+			knobs: base.TestingKnobs{
+				SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+					SchemaChangeJobNoOp: func() bool { return true },
+				},
+			},
+			setup:            "CREATE TABLE t (n INT) WITH (schema_locked=false)",
+			pinDescriptor:    "INSERT INTO t VALUES (1)",
+			bumpVersion:      "ALTER TABLE t ADD COLUMN c1 INT",
+			bumpVersionAgain: "ALTER TABLE t ADD COLUMN c2 INT",
+		},
+		{
+			name: "alter type add value",
+			knobs: base.TestingKnobs{
+				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+					TypeSchemaChangeJobNoOp: func() bool { return true },
+				},
+			},
+			setup:            "CREATE TYPE et AS ENUM ('a')",
+			pinDescriptor:    "SELECT 'a'::et",
+			bumpVersion:      "ALTER TYPE et ADD VALUE 'b'",
+			bumpVersionAgain: "ALTER TYPE et ADD VALUE 'c'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := serverutils.StartServerOnly(t, base.TestServerArgs{Knobs: tc.knobs})
+			defer srv.Stopper().Stop(ctx)
+
+			url, cleanup := srv.ApplicationLayer().PGUrl(t)
+			defer cleanup()
+			baseConn, err := pq.NewConnector(url.String())
+			require.NoError(t, err)
+			var actualNotices []string
+			connector := pq.ConnectorWithNoticeHandler(baseConn, func(n *pq.Error) {
+				actualNotices = append(actualNotices, n.Message)
+			})
+			dbWithHandler := gosql.OpenDB(connector)
+			defer dbWithHandler.Close()
+			conn := sqlutils.MakeSQLRunner(dbWithHandler)
+
+			// CheckTwoVersionInvariant only runs in the user's commit when the
+			// txn has uncommitted descriptors, which the legacy schema changer
+			// arranges for here.
+			conn.Exec(t, "SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off'")
+			conn.Exec(t, "SET use_declarative_schema_changer = 'off'")
+			conn.Exec(t, tc.setup)
+
+			// Open a separate session and pin a lease on the descriptor at its
+			// initial version. With the post-commit job no-op, the usual
+			// WaitForOneVersion does not drop this lease after the first bump,
+			// so it persists as the V-2 lease for the second bump's pre-commit
+			// check.
+			leaseHolder, err := dbWithHandler.Conn(ctx)
+			require.NoError(t, err)
+			defer func() { _ = leaseHolder.Close() }()
+			leaseTxn, err := leaseHolder.BeginTx(ctx, nil)
+			require.NoError(t, err)
+			_, err = leaseTxn.ExecContext(ctx, tc.pinDescriptor)
+			require.NoError(t, err)
+			defer func() { _ = leaseTxn.Rollback() }()
+
+			// First bump moves the descriptor to v=2; the held lease stays at
+			// v=1.
+			conn.Exec(t, tc.bumpVersion)
+
+			// Second bump (v=2 -> v=3) under a tight statement_timeout. Its
+			// pre-commit CheckTwoVersionInvariant finds the lingering v=1
+			// lease and enters the wait loop. Without the fix the loop would
+			// block indefinitely; with the fix it exits when the timeout
+			// cancels the context.
+			conn.Exec(t, "SET statement_timeout = '1s'")
+			conn.ExpectErr(t, "pq: query execution canceled due to statement timeout",
+				tc.bumpVersionAgain)
+
+			const expected = "The statement has timed out while waiting for older descriptor " +
+				"leases to be released. The schema change was not applied."
+			require.Contains(t, actualNotices, expected)
+		})
+	}
+}


### PR DESCRIPTION
Schema-change DDLs (such as `ALTER TYPE ADD VALUE`) could ignore `statement_timeout` and hang for up to the descriptor lease duration (~5 min) when an older descriptor lease lingered. The pre-commit wait for those leases to drain did not honour the timeout, so the statement exceeded its configured limit by minutes.

This patch enforces `statement_timeout` on that wait. On timeout the txn is rolled back and no schema change is left in flight; the user can simply retry.

A redundant post-commit lease wait for type descriptors is also removed. The type schema-change job already drains those leases, so the user session does not need to repeat the wait. Mirroring how table changes work, the type descriptor is now registered as covered by its job, which causes the post-commit wait in the user session to skip it.

Resolves: #168767

Epic: none