### PR TITLE
kvserver: plumb ScanStats to obtain pebble iterator statistics during request evaluation

### DIFF
--- a/pkg/kv/kvserver/kv_snapshot_strategy_test.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy_test.go
@@ -60,7 +60,7 @@ func (m *mockKVAdmissionController) AdmitKVWork(
 }
 
 func (m *mockKVAdmissionController) AdmittedKVWorkDone(
-	kvadmission.Handle, *kvadmission.StoreWriteBytes,
+	kvadmission.Handle, admission.StoreWorkDoneInfo,
 ) {
 }
 

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -9,7 +9,6 @@ package kvadmission
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -163,7 +162,7 @@ type Controller interface {
 	) (Handle, error)
 	// AdmittedKVWorkDone is called after the admitted KV work is done
 	// executing.
-	AdmittedKVWorkDone(Handle, *StoreWriteBytes)
+	AdmittedKVWorkDone(Handle, admission.StoreWorkDoneInfo)
 	// AdmitRangefeedRequest must be called before serving rangefeed requests.
 	// If enabled, it returns a non-nil Pacer that's to be used within rangefeed
 	// catchup scans (typically CPU-intensive and affecting scheduling
@@ -457,7 +456,7 @@ func (n *controllerImpl) AdmitKVWork(
 }
 
 // AdmittedKVWorkDone implements the Controller interface.
-func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, writeBytes *StoreWriteBytes) {
+func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, doneInfo admission.StoreWorkDoneInfo) {
 	n.elasticCPUGrantCoordinator.ElasticCPUWorkQueue.AdmittedWorkDone(ah.elasticCPUWorkHandle)
 	if ah.cpuKVAdmissionQResp.Enabled {
 		cpuTime := grunning.Time() - ah.cpuStart
@@ -473,10 +472,6 @@ func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, writeBytes *StoreWriteByt
 		ah.cpuAdmissionQueue.AdmittedWorkDone(ah.cpuKVAdmissionQResp, cpuTime)
 	}
 	if ah.storeAdmissionQ != nil {
-		var doneInfo admission.StoreWorkDoneInfo
-		if writeBytes != nil {
-			doneInfo = admission.StoreWorkDoneInfo(*writeBytes)
-		}
 		err := ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle, doneInfo)
 		if err != nil {
 			// This shouldn't be happening.
@@ -660,30 +655,6 @@ func (f *FollowerStoreWriteBytes) Merge(from FollowerStoreWriteBytes) {
 	f.NumEntries += from.NumEntries
 	f.WriteBytes += from.WriteBytes
 	f.IngestedBytes += from.IngestedBytes
-}
-
-// StoreWriteBytes aliases admission.StoreWorkDoneInfo, since the notion of
-// "work is done" is specific to admission control and doesn't need to leak
-// everywhere.
-type StoreWriteBytes admission.StoreWorkDoneInfo
-
-var storeWriteBytesPool = sync.Pool{
-	New: func() interface{} { return &StoreWriteBytes{} },
-}
-
-// NewStoreWriteBytes constructs a new StoreWriteBytes.
-func NewStoreWriteBytes() *StoreWriteBytes {
-	wb := storeWriteBytesPool.Get().(*StoreWriteBytes)
-	*wb = StoreWriteBytes{}
-	return wb
-}
-
-// Release returns the *StoreWriteBytes to the pool.
-func (wb *StoreWriteBytes) Release() {
-	if wb == nil {
-		return
-	}
-	storeWriteBytesPool.Put(wb)
 }
 
 func workInfoForBatch(

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -354,7 +354,7 @@ func (mu *ReplicaMutex) RLocker() sync.Locker {
 	return (*syncutil.RWMutex)(mu).RLocker()
 }
 
-var _ SenderWithWriteBytes = &Replica{}
+var _ SenderWithWorkStats = &Replica{}
 
 // A Replica is a contiguous keyspace with writes managed via an
 // instance of the Raft consensus algorithm. Many ranges may exist

--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -32,7 +32,7 @@ import (
 type replicaInCircuitBreaker interface {
 	Clock() *hlc.Clock
 	Desc() *roachpb.RangeDescriptor
-	SenderWithWriteBytes
+	SenderWithWorkStats
 	slowReplicationThreshold(ba *kvpb.BatchRequest) (time.Duration, bool)
 	replicaUnavailableError(err error) error
 	poisonInflightLatches(err error)
@@ -226,8 +226,7 @@ func sendProbe(ctx context.Context, r replicaInCircuitBreaker) error {
 	}
 	// Pass empty AdmissionInfo since this is an internal probe request that
 	// bypasses admission control.
-	_, writeBytes, pErr := r.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
-	writeBytes.Release()
+	_, pErr := r.SendWithWorkStats(ctx, ba, nil /* stats */, kvadmission.AdmissionInfo{})
 	if err := pErr.GoError(); err != nil {
 		return r.replicaUnavailableError(err)
 	}

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -30,8 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/kr/pretty"
@@ -203,6 +201,7 @@ func evaluateBatch(
 	readWriter storage.ReadWriter,
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -289,21 +288,6 @@ func evaluateBatch(
 	// conflicts and chose the highest timestamp to return for more efficient
 	// retries.
 	var deferredWriteTooOldErr *kvpb.WriteTooOldError
-
-	// Only collect the scan stats if the tracing is enabled.
-	var ss *kvpb.ScanStats
-	if sp := tracing.SpanFromContext(ctx); sp.RecordingType() != tracingpb.RecordingOff {
-		ss = &kvpb.ScanStats{}
-		defer func() {
-			if ss.NumGets != 0 || ss.NumScans != 0 || ss.NumReverseScans != 0 {
-				// Only record non-empty ScanStats.
-				ss.NodeID = rec.NodeID()
-				locality := rec.GetNodeLocality()
-				ss.Region, _ = locality.Find("region")
-				sp.RecordStructured(ss)
-			}
-		}()
-	}
 
 	// TODO(tbg): if we introduced an "executor" helper here that could carry state
 	// across the slots in the batch while we execute them, this code could come

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -939,6 +939,7 @@ func TestEvaluateBatch(t *testing.T) {
 				d.eng,
 				d.MockEvalCtx.EvalContext(),
 				&d.ms,
+				&d.ss,
 				&d.ba,
 				nil,
 				nil,
@@ -958,6 +959,7 @@ type data struct {
 	idKey    kvserverbase.CmdIDKey
 	eng      storage.Engine
 	ms       enginepb.MVCCStats
+	ss       kvpb.ScanStats
 	readOnly bool
 }
 

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -97,7 +97,7 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 
 	br, result, pErr :=
 		evaluateBatch(
-			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, &ba,
+			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, nil /* ss */, &ba,
 			nil /* g */, nil /* st */, uncertainty.Interval{}, readOnlyDefault, false, /* omitInRangefeeds */
 		)
 	if pErr != nil {

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -977,6 +977,7 @@ func makeProposalResultErr(err error) proposalResult {
 func (r *Replica) evaluateProposal(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -996,7 +997,7 @@ func (r *Replica) evaluateProposal(
 	//
 	// TODO(tschottdorf): absorb all returned values in `res` below this point
 	// in the call stack as well.
-	ba, batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, g, st, ui)
+	ba, batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ss, ba, g, st, ui)
 
 	// Note: reusing the proposer's batch when applying the command on the
 	// proposer was explored as an optimization but resulted in no performance
@@ -1083,12 +1084,13 @@ func (r *Replica) evaluateProposal(
 func (r *Replica) requestToProposal(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 ) (*ProposalData, *kvpb.Error) {
-	ba, res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, g, st, ui)
+	ba, res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ss, ba, g, st, ui)
 
 	// Fill out the results even if pErr != nil; we'll return the error below.
 	proposal := &ProposalData{

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -125,7 +125,8 @@ func (r *Replica) evalAndPropose(
 ) (chan proposalResult, abandonToken, kvserverbase.CmdIDKey, *kvpb.Error) {
 	defer tok.DoneIfNotMoved(ctx)
 	idKey := raftlog.MakeCmdIDKey()
-	proposal, pErr := r.requestToProposal(ctx, idKey, ba, g, st, ui)
+	ss := stats.ScanStats()
+	proposal, pErr := r.requestToProposal(ctx, idKey, ss, ba, g, st, ui)
 	ba = proposal.Request // may have been updated
 	log.Event(proposal.Context(), "evaluated request")
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -92,6 +92,10 @@ var ReplicaLeaderlessUnavailableThreshold = settings.RegisterDurationSettingWith
 // caller should relinquish all ownership of it. If it does return an error, the
 // caller retains full ownership over the guard.
 //
+// Any bytes that will be scanned or written by the replica during the
+// application of the Raft command will be accumulated into the *StoreWorkStats
+// parameter.
+//
 // evalAndPropose takes ownership of the supplied token; the caller should
 // tok.Move() it into this method. It will be used to untrack the request once
 // it comes out of the proposal buffer.
@@ -107,8 +111,6 @@ var ReplicaLeaderlessUnavailableThreshold = settings.RegisterDurationSettingWith
 //     terminate execution, although it is given no guarantee that the proposal
 //     won't still go on to commit and apply at some later time.
 //   - the proposal's ID.
-//   - the bytes that will be written by the replica during the application of
-//     the Raft command.
 //   - any error obtained during the creation or proposal of the command, in
 //     which case the other returned values are zero.
 func (r *Replica) evalAndPropose(
@@ -118,14 +120,9 @@ func (r *Replica) evalAndPropose(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	tok TrackedRequestToken,
+	stats *StoreWorkStats,
 	admissionInfo kvadmission.AdmissionInfo,
-) (
-	chan proposalResult,
-	abandonToken,
-	kvserverbase.CmdIDKey,
-	*kvadmission.StoreWriteBytes,
-	*kvpb.Error,
-) {
+) (chan proposalResult, abandonToken, kvserverbase.CmdIDKey, *kvpb.Error) {
 	defer tok.DoneIfNotMoved(ctx)
 	idKey := raftlog.MakeCmdIDKey()
 	proposal, pErr := r.requestToProposal(ctx, idKey, ba, g, st, ui)
@@ -136,7 +133,7 @@ func (r *Replica) evalAndPropose(
 	// propagate the error. Don't assume ownership of the concurrency guard.
 	if isConcurrencyRetryError(pErr) {
 		pErr = maybeAttachLease(pErr, &st.Lease)
-		return nil, nil, "", nil, pErr
+		return nil, nil, "", pErr
 	}
 
 	// Pull out proposal channel to return. proposal.doneCh may be set to
@@ -151,7 +148,7 @@ func (r *Replica) evalAndPropose(
 	//    in an error.
 	if proposal.command == nil {
 		if proposal.Local.RequiresRaft() {
-			return nil, nil, "", nil, kvpb.NewError(errors.AssertionFailedf(
+			return nil, nil, "", kvpb.NewError(errors.AssertionFailedf(
 				"proposal resulting from batch %s erroneously bypassed Raft", ba))
 		}
 		intents := proposal.Local.DetachEncounteredIntents()
@@ -170,7 +167,7 @@ func (r *Replica) evalAndPropose(
 		proposal.ec = makeUnreplicatedEndCmds(r, g, *st)
 		pr := makeProposalResult(proposal.Local.Reply, pErr, intents, endTxns)
 		proposal.finishApplication(ctx, pr)
-		return proposalCh, nil, "", nil, nil
+		return proposalCh, nil, "", nil
 	}
 
 	// Make it a truly replicated proposal. We measure the replication latency
@@ -193,12 +190,13 @@ func (r *Replica) evalAndPropose(
 	// typical lag in consensus is expected to be small compared to the time
 	// granularity of admission control doing token and size estimation (which
 	// is 15s). Also, admission control corrects for gaps in reporting.
-	writeBytes := kvadmission.NewStoreWriteBytes()
-	if proposal.command.WriteBatch != nil {
-		writeBytes.WriteBytes = int64(len(proposal.command.WriteBatch.Data))
-	}
-	if proposal.command.ReplicatedEvalResult.AddSSTable != nil {
-		writeBytes.IngestedBytes = int64(len(proposal.command.ReplicatedEvalResult.AddSSTable.Data))
+	if stats != nil {
+		if proposal.command.WriteBatch != nil {
+			stats.WriteBytes += int64(len(proposal.command.WriteBatch.Data))
+		}
+		if proposal.command.ReplicatedEvalResult.AddSSTable != nil {
+			stats.IngestedBytes += int64(len(proposal.command.ReplicatedEvalResult.AddSSTable.Data))
+		}
 	}
 	// If the request requested that Raft consensus be performed asynchronously,
 	// return a proposal result immediately on the proposal's done channel.
@@ -210,7 +208,7 @@ func (r *Replica) evalAndPropose(
 			// Disallow async consensus for commands with EndTxnIntents because
 			// any !Always EndTxnIntent can't be cleaned up until after the
 			// command succeeds.
-			return nil, nil, "", writeBytes, kvpb.NewErrorf("cannot perform consensus asynchronously for "+
+			return nil, nil, "", kvpb.NewErrorf("cannot perform consensus asynchronously for "+
 				"proposal with EndTxnIntents=%v; %v", ets, ba)
 		}
 
@@ -289,7 +287,7 @@ func (r *Replica) evalAndPropose(
 	// behavior.
 	quotaSize := uint64(proposal.command.Size())
 	if maxSize := uint64(kvserverbase.MaxCommandSize.Get(&r.store.cfg.Settings.SV)); quotaSize > maxSize {
-		return nil, nil, "", nil, kvpb.NewError(errors.Errorf(
+		return nil, nil, "", kvpb.NewError(errors.Errorf(
 			"command is too large: %d bytes (max: %d)", quotaSize, maxSize,
 		))
 	}
@@ -300,7 +298,7 @@ func (r *Replica) evalAndPropose(
 	var err error
 	proposal.quotaAlloc, err = r.maybeAcquireProposalQuota(ctx, ba, quotaSize)
 	if err != nil {
-		return nil, nil, "", nil, kvpb.NewError(err)
+		return nil, nil, "", kvpb.NewError(err)
 	}
 	// Make sure we clean up the proposal if we fail to insert it into the
 	// proposal buffer successfully. This ensures that we always release any
@@ -324,13 +322,13 @@ func (r *Replica) evalAndPropose(
 			// SeedID not set, since this is not a reproposal.
 		}
 		if pErr = filter(filterArgs); pErr != nil {
-			return nil, nil, "", nil, pErr
+			return nil, nil, "", pErr
 		}
 	}
 
 	pErr = r.propose(ctx, proposal, tok.Move(ctx))
 	if pErr != nil {
-		return nil, nil, "", nil, pErr
+		return nil, nil, "", pErr
 	}
 	// We've successfully handed the proposal to the replication layer, so this
 	// method should not finish the trace span if we forked one off above.
@@ -342,7 +340,7 @@ func (r *Replica) evalAndPropose(
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
 
-	return proposalCh, abandonToken(proposal), idKey, writeBytes, nil
+	return proposalCh, abandonToken(proposal), idKey, nil
 }
 
 // abandonToken is an interface used for allowing callers to "abandon" an

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -699,8 +699,7 @@ func (p *pendingLeaseRequest) requestLease(
 		Source:     kvpb.AdmissionHeader_OTHER,
 	}
 	// Pass empty AdmissionInfo since lease acquisition bypasses admission control.
-	_, writeBytes, pErr := p.repl.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
-	writeBytes.Release()
+	_, pErr := p.repl.SendWithWorkStats(ctx, ba, nil /* stats */, kvadmission.AdmissionInfo{})
 	return pErr.GoError()
 }
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -42,11 +42,13 @@ func (r *Replica) executeReadOnlyBatch(
 	ctx context.Context,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
-	_ *StoreWorkStats,
+	stats *StoreWorkStats,
 	_ kvadmission.AdmissionInfo,
 ) (br *kvpb.BatchResponse, _ concurrency.Guard, pErr *kvpb.Error) {
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
+
+	ss := stats.ScanStats()
 
 	// Verify that the batch can be executed.
 	st, err := r.checkExecutionCanProceedBeforeStorageSnapshot(ctx, ba, g)
@@ -161,7 +163,7 @@ func (r *Replica) executeReadOnlyBatch(
 				r.store.metrics.VirtualResolveIntentCount.Inc(1)
 			}
 			_, err = evaluateCommand(
-				ctx, rwNoAssert, rec, nil /* ms */, nil /* ss */, h, req,
+				ctx, rwNoAssert, rec, nil /* ms */, ss, h, req,
 				reply, g, &st, ui, readWrite, false, /* omitInRangefeeds */
 			)
 			if err != nil {
@@ -218,7 +220,7 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 
 	var result result.Result
-	ba, br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ba, g, &st, ui, evalPath)
+	ba, br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ss, ba, g, &st, ui, evalPath)
 
 	// If the request hit a server-side concurrency retry error, immediately
 	// propagate the error. Don't assume ownership of the concurrency guard.
@@ -517,6 +519,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 	ctx context.Context,
 	rw storage.ReadWriter,
 	rec batcheval.EvalContext,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -604,7 +607,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 		}
 		now := timeutil.Now()
 		br, res, pErr = evaluateBatch(
-			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, ba, g,
+			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, ss, ba, g,
 			st, ui, evalPath, false, /* omitInRangefeeds */
 		)
 		r.store.metrics.ReplicaReadBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -39,20 +39,19 @@ import (
 // iterator to evaluate the batch and then updates the timestamp cache to
 // reflect the key spans that it read.
 func (r *Replica) executeReadOnlyBatch(
-	ctx context.Context, ba *kvpb.BatchRequest, g concurrency.Guard, _ kvadmission.AdmissionInfo,
-) (
-	br *kvpb.BatchResponse,
-	_ concurrency.Guard,
-	_ *kvadmission.StoreWriteBytes,
-	pErr *kvpb.Error,
-) {
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	g concurrency.Guard,
+	_ *StoreWorkStats,
+	_ kvadmission.AdmissionInfo,
+) (br *kvpb.BatchResponse, _ concurrency.Guard, pErr *kvpb.Error) {
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
 
 	// Verify that the batch can be executed.
 	st, err := r.checkExecutionCanProceedBeforeStorageSnapshot(ctx, ba, g)
 	if err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	if fn := r.store.TestingKnobs().PreStorageSnapshotButChecksCompleteInterceptor; fn != nil {
@@ -167,7 +166,7 @@ func (r *Replica) executeReadOnlyBatch(
 			)
 			if err != nil {
 				r.store.metrics.VirtualResolveBatchErrors.Inc(1)
-				return nil, g, nil, kvpb.NewError(err)
+				return nil, g, kvpb.NewError(err)
 			}
 		}
 	}
@@ -185,15 +184,15 @@ func (r *Replica) executeReadOnlyBatch(
 		break
 	}
 	if err := rw.PinEngineStateForIterators(readCategory); err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	if err := r.checkExecutionCanProceedAfterStorageSnapshot(ctx, ba, st); err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 	ok, stillNeedsInterleavedIntents, pErr := r.canDropLatchesBeforeEval(ctx, rw, ba, g, st)
 	if pErr != nil {
-		return nil, g, nil, pErr
+		return nil, g, pErr
 	}
 	evalPath := readOnlyDefault
 	if ok {
@@ -239,11 +238,11 @@ func (r *Replica) executeReadOnlyBatch(
 			// non-error path.
 			if !g.CheckOptimisticNoLatchConflicts() {
 				log.Eventf(ctx, "optimistic evaluation failed with %s", pErr)
-				return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
+				return nil, g, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 			}
 		}
 		pErr = maybeAttachLease(pErr, &st.Lease)
-		return nil, g, nil, pErr
+		return nil, g, pErr
 	}
 
 	if g != nil && g.EvalKind() == concurrency.OptimisticEval {
@@ -253,19 +252,19 @@ func (r *Replica) executeReadOnlyBatch(
 			// the response.
 			latchSpansRead, lockSpansRead, err := r.collectSpansRead(ba, br)
 			if err != nil {
-				return nil, g, nil, kvpb.NewError(err)
+				return nil, g, kvpb.NewError(err)
 			}
 			defer latchSpansRead.Release()
 			defer lockSpansRead.Release()
 			if ok := g.CheckOptimisticNoConflicts(latchSpansRead, lockSpansRead); !ok {
-				return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
+				return nil, g, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 			}
 		} else {
 			// There was an error, that was not classified as a concurrency retry
 			// error, and this request was not holding latches. This should be rare,
 			// and in the interest of not having subtle correctness bugs, we retry
 			// pessimistically.
-			return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
+			return nil, g, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 		}
 	}
 
@@ -332,7 +331,7 @@ func (r *Replica) executeReadOnlyBatch(
 		r.loadStats.RecordReadBytes(bytesRead)
 		log.Event(ctx, "read completed")
 	}
-	return br, nil, nil, pErr
+	return br, nil, pErr
 }
 
 // updateTimestampCacheAndDropLatches updates the timestamp cache and releases

--- a/pkg/kv/kvserver/replica_read_test.go
+++ b/pkg/kv/kvserver/replica_read_test.go
@@ -164,7 +164,7 @@ func TestVirtualizedIntentResolution(t *testing.T) {
 				}
 				gArgs := getArgs(k)
 				ba.Add(&gArgs)
-				br, _, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, g, kvadmission.AdmissionInfo{})
+				br, _, pErr := tc.repl.executeReadOnlyBatch(ctx, ba, g, nil /* stats */, kvadmission.AdmissionInfo{})
 
 				if c.exp.error == "" {
 					require.NoError(t, pErr.GoError())

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -47,10 +47,6 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 	true,
 )
 
-// SendWithWriteBytes executes a command on this range, dispatching it to the
-// read-only, read-write, or admin execution path as appropriate. ctx should
-// contain the log tags from the store (and up).
-//
 // A rough schematic for the path requests take through a Replica
 // is presented below, with a focus on where requests may spend
 // most of their time (once they arrive at the Node.Batch endpoint).
@@ -66,7 +62,7 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 //	               Admission control
 //	                       │
 //	                       ▼
-//	              Replica.SendWithWriteBytes
+//	              Replica.SendWithWorkStats
 //	                       │
 //	                 Circuit breaker
 //	                       │
@@ -79,24 +75,18 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 //	                       ▼
 //	  Replica.maybeCommitWaitBeforeCommitTrigger (if committing with commit-trigger)
 //	                       │
-//
-// read-write ◄─────────────────────────┴────────────────────────► read-only
-//
+// read-write ◄────────────┴──────────────────────────────────► read-only
 //	│                                                               │
 //	│                                                               │
 //	├─────────────► executeBatchWithConcurrencyRetries ◄────────────┤
 //	│               (handles leases and txn conflicts)              │
 //	│                                                               │
 //	▼                                                               │
-//
-// executeWriteBatch                                                   │
-//
+// executeWriteBatch                                                │
 //	│                                                               │
 //	▼                                                               ▼
-//
-// evalAndPropose         (turns the BatchRequest        executeReadOnlyBatch
-//
-//	│                   into pebble WriteBatch)
+// evalAndPropose (turns the BatchRequest                executeReadOnlyBatch
+//	│              into pebble WriteBatch)
 //	│
 //	├──────────────────► (writes that can use async consensus do not
 //	│                     wait for replication and are done here)
@@ -107,14 +97,19 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 //	│
 //	│
 //	▼
-//
-// handleRaftReady        (drives the Raft loop, first appending to the log
-//
-//	to commit the command, then signaling proposer and
-//	applying the command)
-func (r *Replica) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error) {
+// handleRaftReady (drives the Raft loop, first appending to the log
+//	                to commit the command, then signaling proposer and
+//	                applying the command)
+
+// SendWithWorkStats executes a command on this range, dispatching it to the
+// read-only, read-write, or admin execution path as appropriate. ctx should
+// contain the log tags from the store (and up).
+func (r *Replica) SendWithWorkStats(
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	stats *StoreWorkStats,
+	admissionInfo kvadmission.AdmissionInfo,
+) (*kvpb.BatchResponse, *kvpb.Error) {
 	tenantIDOrZero, _ := roachpb.ClientTenantFromContext(ctx)
 	cleanup := ash.SetWorkState(
 		tenantIDOrZero, ash.WorkloadInfo{
@@ -162,43 +157,42 @@ func (r *Replica) SendWithWriteBytes(
 
 	isReadOnly := ba.IsReadOnly()
 	if err := r.checkBatchRequest(ba, isReadOnly); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	if err := r.maybeBackpressureBatch(ctx, ba); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 	if err := r.maybeRateLimitBatch(ctx, ba, tenantIDOrZero); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 	if err := r.maybeCommitWaitBeforeCommitTrigger(ctx, ba); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	// NB: must be performed before collecting request spans.
 	ba, err := maybeStripInFlightWrites(ba)
 	if err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	if filter := r.store.cfg.TestingKnobs.TestingRequestFilter; filter != nil {
 		if pErr := filter(ctx, ba); pErr != nil {
-			return nil, nil, pErr
+			return nil, pErr
 		}
 	}
 
 	// Differentiate between read-write, read-only, and admin.
 	var br *kvpb.BatchResponse
 	var pErr *kvpb.Error
-	var writeBytes *kvadmission.StoreWriteBytes
 	if isReadOnly {
 		log.Event(ctx, "read-only path")
 		fn := (*Replica).executeReadOnlyBatch
-		br, _, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, admissionInfo)
+		br, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, stats, admissionInfo)
 	} else if ba.IsWrite() {
 		log.Event(ctx, "read-write path")
 		fn := (*Replica).executeWriteBatch
-		br, writeBytes, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, admissionInfo)
+		br, pErr = r.executeBatchWithConcurrencyRetries(ctx, ba, fn, stats, admissionInfo)
 	} else if ba.IsAdmin() {
 		log.Event(ctx, "admin path")
 		br, pErr = r.executeAdminBatch(ctx, ba)
@@ -235,11 +229,11 @@ func (r *Replica) SendWithWriteBytes(
 	// Record summary throughput information about the batch request for
 	// accounting.
 	r.recordBatchRequestLoad(ctx, ba)
-	if writeBytes != nil {
-		r.recordRequestWriteBytes(writeBytes.WriteBytes + writeBytes.IngestedBytes)
+	if stats != nil {
+		r.recordRequestWriteBytes(stats.WriteBytes + stats.IngestedBytes)
 	}
 	r.recordImpactOnRateLimiter(ctx, br, isReadOnly)
-	return br, writeBytes, pErr
+	return br, pErr
 }
 
 // maybeCommitWaitBeforeCommitTrigger detects batches that are attempting to
@@ -426,8 +420,13 @@ func (r *Replica) maybeAddRangeInfoToResponse(
 // the function returns one of these errors, it must also pass ownership of the
 // concurrency guard back to the caller.
 type batchExecutionFn func(
-	*Replica, context.Context, *kvpb.BatchRequest, concurrency.Guard, kvadmission.AdmissionInfo,
-) (*kvpb.BatchResponse, concurrency.Guard, *kvadmission.StoreWriteBytes, *kvpb.Error)
+	*Replica,
+	context.Context,
+	*kvpb.BatchRequest,
+	concurrency.Guard,
+	*StoreWorkStats,
+	kvadmission.AdmissionInfo,
+) (*kvpb.BatchResponse, concurrency.Guard, *kvpb.Error)
 
 var _ batchExecutionFn = (*Replica).executeWriteBatch
 var _ batchExecutionFn = (*Replica).executeReadOnlyBatch
@@ -450,8 +449,9 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 	ctx context.Context,
 	ba *kvpb.BatchRequest,
 	fn batchExecutionFn,
+	stats *StoreWorkStats,
 	admissionInfo kvadmission.AdmissionInfo,
-) (br *kvpb.BatchResponse, writeBytes *kvadmission.StoreWriteBytes, pErr *kvpb.Error) {
+) (br *kvpb.BatchResponse, pErr *kvpb.Error) {
 	// Try to execute command; exit retry loop on success.
 	var latchSpans *spanset.SpanSet
 	var lockSpans *lockspanset.LockSpanSet
@@ -472,7 +472,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 	for {
 		// Exit loop if context has been canceled or timed out.
 		if err := ctx.Err(); err != nil {
-			return nil, nil, kvpb.NewError(err)
+			return nil, kvpb.NewError(err)
 		}
 
 		// Determine the maximal set of key spans that the batch will operate on.
@@ -485,7 +485,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			var err error
 			latchSpans, lockSpans, requestEvalKind, err = r.collectSpans(ba)
 			if err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 		}
 
@@ -531,21 +531,21 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 					)))
 				}
 			}
-			return nil, nil, pErr
+			return nil, pErr
 		} else if resp != nil {
 			br = new(kvpb.BatchResponse)
 			br.Responses = resp
-			return br, nil, nil
+			return br, nil
 		}
 		latchSpans, lockSpans = nil, nil // ownership released
 
-		br, g, writeBytes, pErr = fn(r, ctx, ba, g, admissionInfo)
+		br, g, pErr = fn(r, ctx, ba, g, stats, admissionInfo)
 		if pErr == nil {
 			// Success.
-			return br, writeBytes, nil
+			return br, nil
 		} else if !isConcurrencyRetryError(pErr) {
 			// Propagate error.
-			return nil, nil, pErr
+			return nil, pErr
 		}
 
 		log.VErrEventf(ctx, 2, "concurrency retry error: %s", pErr)
@@ -582,13 +582,13 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// Drop latches, but retain lock wait-queues.
 			g.AssertLatches()
 			if g, pErr = r.handleLockConflictError(ctx, ba, g, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.TransactionPushError:
 			// Drop latches, but retain lock wait-queues.
 			g.AssertLatches()
 			if g, pErr = r.handleTransactionPushError(ctx, ba, g, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.IndeterminateCommitError:
 			dropLatchesAndLockWaitQueues(true /* reuseLatchAndLockSpans */)
@@ -596,7 +596,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// is returned if the transaction is recovered successfully to either a
 			// COMMITTED or ABORTED state.
 			if pErr = r.handleIndeterminateCommitError(ctx, ba, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.ReadWithinUncertaintyIntervalError:
 			// If the batch is able to perform a server-side retry in order to avoid
@@ -612,7 +612,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// propagate it.
 			ba, pErr = r.handleReadWithinUncertaintyIntervalError(ctx, ba, pErr, t)
 			if pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.InvalidLeaseError:
 			dropLatchesAndLockWaitQueues(true /* reuseLatchAndLockSpans */)
@@ -620,13 +620,13 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			// replica or redirect to the current leaseholder if currently held
 			// by a different replica.
 			if pErr = r.handleInvalidLeaseError(ctx, ba); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.MergeInProgressError:
 			dropLatchesAndLockWaitQueues(true /* reuseLatchAndLockSpans */)
 			// Then listen for the merge to complete.
 			if pErr = r.handleMergeInProgressError(ctx, ba, pErr, t); pErr != nil {
-				return nil, nil, pErr
+				return nil, pErr
 			}
 		case *kvpb.OptimisticEvalConflictsError:
 			// We are deliberately not dropping latches. Note that the latches are

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -572,7 +572,7 @@ func sendLeaseRequest(r *Replica, l *roachpb.Lease) error {
 	}
 	ba.Add(leaseReq)
 	_, tok := r.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := r.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+	ch, _, _, pErr := r.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor this to a more conventional error-handling pattern.
@@ -1339,7 +1339,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 	ba.Timestamp = tc.repl.store.Clock().Now()
 	ba.Add(&kvpb.RequestLeaseRequest{Lease: *lease, PrevLease: st.Lease})
 	_, tok := tc.repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := tc.repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+	ch, _, _, pErr := tc.repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor to a more conventional error-handling pattern.
@@ -7563,7 +7563,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			if err := ba.SetActiveTimestamp(tc.Clock()); err != nil {
 				t.Fatal(err)
 			}
-			_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, ba, (*Replica).executeWriteBatch, kvadmission.AdmissionInfo{})
+			_, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, ba, (*Replica).executeWriteBatch, nil /* stats */, kvadmission.AdmissionInfo{})
 			if cancelEarly {
 				if !testutils.IsPError(pErr, context.Canceled.Error()) {
 					t.Fatalf("expected canceled error; got %v", pErr)
@@ -7619,7 +7619,7 @@ func TestReplicaAbandonProposal(t *testing.T) {
 	ba.Add(&kvpb.PutRequest{
 		RequestHeader: kvpb.RequestHeader{Key: []byte("acdfg")},
 	})
-	_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, ba, (*Replica).executeWriteBatch, kvadmission.AdmissionInfo{})
+	_, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, ba, (*Replica).executeWriteBatch, nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr == nil {
 		t.Fatal("expected failure, but found success")
 	}
@@ -7729,10 +7729,11 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 	iArg := incrementArgs(roachpb.Key("b"), expInc)
 	ba.Add(iArg)
 	{
-		_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(
+		_, pErr := tc.repl.executeBatchWithConcurrencyRetries(
 			context.WithValue(ctx, magicKey{}, "foo"),
 			ba,
 			(*Replica).executeWriteBatch,
+			nil, /* stats */
 			kvadmission.AdmissionInfo{},
 		)
 		if pErr != nil {
@@ -7764,10 +7765,11 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 			Lease:     lease,
 			PrevLease: prevLease,
 		})
-		_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(
+		_, pErr := tc.repl.executeBatchWithConcurrencyRetries(
 			context.WithValue(ctx, magicKey{}, "foo"),
 			ba,
 			(*Replica).executeWriteBatch,
+			nil, /* stats */
 			kvadmission.AdmissionInfo{},
 		)
 		if pErr != nil {
@@ -7817,7 +7819,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 		})
 		st := repl.CurrentLeaseStatus(ctx)
 		_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-		ch, _, id, _, err := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+		ch, _, id, err := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7889,7 +7891,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 		})
 		_, tok := tc.repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
 		st := tc.repl.CurrentLeaseStatus(ctx)
-		ch, _, _, _, err := tc.repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+		ch, _, _, err := tc.repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -8006,7 +8008,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: roachpb.Key(id)}})
 		st := r.CurrentLeaseStatus(ctx)
-		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), ba, allSpansGuard(), &st, uncertainty.Interval{})
+		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), nil /* ss */, ba, allSpansGuard(), &st, uncertainty.Interval{})
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -8775,7 +8777,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 	assignSeqNumsForReqs(txn, &txnPut, &txnPut2)
 	origTxn := txn.Clone()
 
-	_, batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, raftlog.MakeCmdIDKey(), ba, allSpansGuard(), nil, uncertainty.Interval{})
+	_, batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, raftlog.MakeCmdIDKey(), nil /* ss */, ba, allSpansGuard(), nil, uncertainty.Interval{})
 	defer batch.Close()
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -9590,7 +9592,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	exLease, _ := repl.GetLease()
 	st := kvserverpb.LeaseStatus{Lease: exLease, State: kvserverpb.LeaseState_VALID}
 	_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+	ch, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -9638,7 +9640,7 @@ func TestProposeWithAsyncConsensus(t *testing.T) {
 	atomic.StoreInt32(&filterActive, 1)
 	st := tc.repl.CurrentLeaseStatus(ctx)
 	_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+	ch, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -9703,7 +9705,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 	atomic.StoreInt32(&filterActive, 1)
 	st := repl.CurrentLeaseStatus(ctx)
 	_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	_, _, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+	_, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -9722,7 +9724,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 
 		var pErr *kvpb.Error
 		_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-		ch, _, _, _, pErr = repl.evalAndPropose(ctx, ba2, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), kvadmission.AdmissionInfo{})
+		ch, _, _, pErr = repl.evalAndPropose(ctx, ba2, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx), nil /* stats */, kvadmission.AdmissionInfo{})
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -13852,7 +13854,7 @@ func TestContainsEstimatesClampProposal(t *testing.T) {
 		req := putArgs(roachpb.Key("some-key"), []byte("some-value"))
 		ba.Add(&req)
 		st := tc.repl.CurrentLeaseStatus(ctx)
-		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, ba, allSpansGuard(), &st, uncertainty.Interval{})
+		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, nil /* ss */, ba, allSpansGuard(), &st, uncertainty.Interval{})
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -418,6 +418,7 @@ func (r *Replica) canAttempt1PCEvaluation(
 func (r *Replica) evaluateWriteBatch(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -441,7 +442,7 @@ func (r *Replica) evaluateWriteBatch(
 	// Attempt 1PC execution, if applicable. If not transactional or there are
 	// indications that the batch's txn will require retry, execute as normal.
 	if ba, ok = r.canAttempt1PCEvaluation(ctx, ba, g); ok {
-		res := r.evaluate1PC(ctx, idKey, ba, g, st)
+		res := r.evaluate1PC(ctx, idKey, ss, ba, g, st)
 		switch res.success {
 		case onePCSucceeded:
 			return ba, res.batch, res.stats, res.br, res.res, nil
@@ -478,7 +479,7 @@ func (r *Replica) evaluateWriteBatch(
 	// For transactional writes, we propagate the flag from the txn.
 	omitInRangefeeds := ba.Txn != nil && ba.Txn.OmitInRangefeeds
 	ba, batch, br, res, pErr := r.evaluateWriteBatchWithServersideRefreshes(
-		ctx, idKey, rec, ms, ba, g, st, ui, hlc.Timestamp{} /* deadline */, omitInRangefeeds)
+		ctx, idKey, rec, ms, ss, ba, g, st, ui, hlc.Timestamp{} /* deadline */, omitInRangefeeds)
 	return ba, batch, *ms, br, res, pErr
 }
 
@@ -520,6 +521,7 @@ type onePCResult struct {
 func (r *Replica) evaluate1PC(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -563,10 +565,10 @@ func (r *Replica) evaluate1PC(
 	defer releaseMVCCStats(ms)
 	if ba.CanForwardReadTimestamp {
 		_, batch, br, res, pErr = r.evaluateWriteBatchWithServersideRefreshes(
-			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline, ba.Txn.OmitInRangefeeds)
+			ctx, idKey, rec, ms, ss, &strippedBa, g, st, ui, etArg.Deadline, ba.Txn.OmitInRangefeeds)
 	} else {
 		batch, br, res, pErr = r.evaluateWriteBatchWrapper(
-			ctx, idKey, rec, ms, &strippedBa, g, st, ui, ba.Txn.OmitInRangefeeds)
+			ctx, idKey, rec, ms, ss, &strippedBa, g, st, ui, ba.Txn.OmitInRangefeeds)
 	}
 
 	if pErr != nil || (!ba.CanForwardReadTimestamp && ba.Timestamp != br.Timestamp) {
@@ -690,6 +692,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 	idKey kvserverbase.CmdIDKey,
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -714,7 +717,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 			batch.Close()
 		}
 
-		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui, omitInRangefeeds)
+		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ss, ba, g, st, ui, omitInRangefeeds)
 
 		// Allow one retry only; a non-txn batch containing overlapping
 		// spans will always experience WriteTooOldError.
@@ -741,6 +744,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 	idKey kvserverbase.CmdIDKey,
 	rec batcheval.EvalContext,
 	ms *enginepb.MVCCStats,
+	ss *kvpb.ScanStats,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
@@ -749,7 +753,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 ) (storage.Batch, *kvpb.BatchResponse, result.Result, *kvpb.Error) {
 	batch, opLogger := r.newBatchedEngine(g)
 	now := timeutil.Now()
-	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, readWrite, omitInRangefeeds)
+	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ss, ba, g, st, ui, readWrite, omitInRangefeeds)
 	r.store.metrics.ReplicaWriteBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 	if pErr == nil {
 		if opLogger != nil {

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -79,13 +79,9 @@ func (r *Replica) executeWriteBatch(
 	ctx context.Context,
 	ba *kvpb.BatchRequest,
 	g concurrency.Guard,
+	stats *StoreWorkStats,
 	admissionInfo kvadmission.AdmissionInfo,
-) (
-	br *kvpb.BatchResponse,
-	_ concurrency.Guard,
-	_ *kvadmission.StoreWriteBytes,
-	pErr *kvpb.Error,
-) {
+) (br *kvpb.BatchResponse, _ concurrency.Guard, pErr *kvpb.Error) {
 	startTime := timeutil.Now()
 
 	spanName := "executeWriteBatch"
@@ -120,14 +116,14 @@ func (r *Replica) executeWriteBatch(
 	// Verify that the batch can be executed.
 	st, err := r.checkExecutionCanProceedRWOrAdmin(ctx, ba, g)
 	if err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	// Check the breaker. Note that we do this after
 	// checkExecutionCanProceedBeforeStorageSnapshot, so that NotLeaseholderError
 	// has precedence.
 	if err := r.signallerForBatch(ba).Err(); err != nil {
-		return nil, g, nil, kvpb.NewError(err)
+		return nil, g, kvpb.NewError(err)
 	}
 
 	// Compute the transaction's local uncertainty limit using observed
@@ -182,16 +178,16 @@ func (r *Replica) executeWriteBatch(
 	// Checking the context just before proposing can help avoid ambiguous errors.
 	if err := ctx.Err(); err != nil {
 		log.VEventf(ctx, 2, "%s before proposing: %s", err, ba.Summary())
-		return nil, g, nil, kvpb.NewError(errors.Wrapf(err, "aborted before proposing"))
+		return nil, g, kvpb.NewError(errors.Wrapf(err, "aborted before proposing"))
 	}
 
 	// If the command is proposed to Raft, ownership of and responsibility for
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose. If we return with an error from executeWriteBatch, we
 	// also return the guard which the caller reassumes ownership of.
-	ch, abandonTok, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx), admissionInfo)
+	ch, abandonTok, _, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx), stats, admissionInfo)
 	if pErr != nil {
-		return nil, g, nil, pErr
+		return nil, g, pErr
 	}
 	g = nil // ownership passed to Raft, prevent misuse
 
@@ -309,7 +305,7 @@ func (r *Replica) executeWriteBatch(
 				propResult.Reply, propResult.Err = ba.CreateReply(), nil
 			}
 
-			return propResult.Reply, nil, writeBytes, propResult.Err
+			return propResult.Reply, nil, propResult.Err
 
 		case <-ctxDone:
 			// If our context was canceled, return an AmbiguousResultError,
@@ -349,7 +345,7 @@ func (r *Replica) executeWriteBatch(
 			dur := timeutil.Since(startTime)
 			log.VEventf(ctx, 2, "context cancellation after %.2fs of attempting command %s",
 				dur.Seconds(), ba)
-			return nil, nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultError(
+			return nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultError(
 				errors.Wrapf(ctx.Err(), "after %.2fs of attempting command", dur.Seconds()),
 			))
 
@@ -359,7 +355,7 @@ func (r *Replica) executeWriteBatch(
 			r.abandon(abandonTok)
 			log.VEventf(ctx, 2, "shutdown cancellation after %0.1fs of attempting command %s",
 				timeutil.Since(startTime).Seconds(), ba)
-			return nil, nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultErrorf(
+			return nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultErrorf(
 				"server shutdown"))
 		}
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1166,7 +1166,7 @@ type Store struct {
 	diskMonitor *disk.Monitor
 }
 
-var _ SenderWithWriteBytes = &Store{}
+var _ SenderWithWorkStats = &Store{}
 var _ IncomingRaftMessageHandler = &Store{}
 var _ OutgoingRaftMessageHandler = &Store{}
 

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -7,6 +7,7 @@ package kvserver
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -15,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -23,26 +25,53 @@ import (
 	"github.com/cockroachdb/tokenbucket"
 )
 
-// SenderWithWriteBytes is implemented by Store, Stores, and Replica. It
-// extends the kv.Sender.Send signature with an additional StoreWriteBytes
-// return value for admission control integration.
-type SenderWithWriteBytes interface {
-	SendWithWriteBytes(
-		ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-	) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error)
+// StoreWorkStats embeds admission.StoreWorkDoneInfo, since the notion of
+// "work is done" is specific to admission control and doesn't need to leak
+// everywhere.
+type StoreWorkStats struct {
+	admission.StoreWorkDoneInfo
 }
 
-// ToSenderForTesting wraps a SenderWithWriteBytes as a kv.Sender. It releases
-// the StoreWriteBytes after each call.
-func ToSenderForTesting(swb SenderWithWriteBytes) kv.Sender {
+var storeWorkStatsPool = sync.Pool{
+	New: func() any { return &StoreWorkStats{} },
+}
+
+// NewStoreWorkStats returns a new empty StoreWorkStats from the pool.
+func NewStoreWorkStats() *StoreWorkStats {
+	return storeWorkStatsPool.Get().(*StoreWorkStats)
+}
+
+// Release returns the *StoreWorkStats to the pool.
+func (ws *StoreWorkStats) Release() {
+	if ws == nil {
+		return
+	}
+	*ws = StoreWorkStats{}
+	storeWorkStatsPool.Put(ws)
+}
+
+// SenderWithWorkStats is implemented by Store, Stores, and Replica. It extends
+// the kv.Sender.Send signature with an additional StoreWorkStats parameter that
+// tracks statistics during request evaluation that is used to perform admission
+// control and tracing.
+type SenderWithWorkStats interface {
+	SendWithWorkStats(
+		ctx context.Context,
+		ba *kvpb.BatchRequest,
+		stats *StoreWorkStats,
+		admissionInfo kvadmission.AdmissionInfo,
+	) (*kvpb.BatchResponse, *kvpb.Error)
+}
+
+// ToSenderForTesting wraps a SenderWithWorkStats as a kv.Sender.
+func ToSenderForTesting(sws SenderWithWorkStats) kv.Sender {
 	return kv.SenderFunc(func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-		br, writeBytes, pErr := swb.SendWithWriteBytes(ctx, ba, kvadmission.AdmissionInfo{})
-		writeBytes.Release()
+		br, pErr := sws.SendWithWorkStats(ctx, ba, nil /* stats */, kvadmission.AdmissionInfo{})
 		return br, pErr
 	})
 }
 
-// SendWithWriteBytes fetches a range based on the header's replica, assembles
+// SendWithWorkStats fetches a range based on the header's replica, assembles
 // method, args & reply into a Raft Cmd struct and executes the command using
 // the fetched range.
 //
@@ -60,9 +89,12 @@ func ToSenderForTesting(swb SenderWithWriteBytes) kv.Sender {
 // instance due to the timestamp cache or finding a committed value in the path
 // of one of its writes), the response will have a transaction set which should
 // be used to update the client transaction object.
-func (s *Store) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-) (br *kvpb.BatchResponse, writeBytes *kvadmission.StoreWriteBytes, pErr *kvpb.Error) {
+func (s *Store) SendWithWorkStats(
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	stats *StoreWorkStats,
+	admissionInfo kvadmission.AdmissionInfo,
+) (br *kvpb.BatchResponse, pErr *kvpb.Error) {
 	// Attach any log tags from the store to the context (which normally
 	// comes from gRPC).
 	ctx = s.AnnotateCtx(ctx)
@@ -70,13 +102,13 @@ func (s *Store) SendWithWriteBytes(
 		arg := union.GetInner()
 		header := arg.Header()
 		if err := verifyKeys(header.Key, header.EndKey, kvpb.IsRange(arg)); err != nil {
-			return nil, nil, kvpb.NewError(errors.Wrapf(err,
+			return nil, kvpb.NewError(errors.Wrapf(err,
 				"failed to verify keys for %s", arg.Method()))
 		}
 	}
 
 	if throttled, err := s.maybeThrottleBatch(ctx, ba); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	} else {
 		defer func() { throttled.performAccounting(br) }()
 	}
@@ -84,13 +116,13 @@ func (s *Store) SendWithWriteBytes(
 	if ba.BoundedStaleness != nil {
 		newBa, pErr := s.executeServerSideBoundedStalenessNegotiation(ctx, ba)
 		if pErr != nil {
-			return nil, nil, pErr
+			return nil, pErr
 		}
 		ba = newBa
 	}
 
 	if err := ba.SetActiveTimestamp(s.Clock()); err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
 	// Update our clock with the incoming request timestamp. This advances the
@@ -103,7 +135,7 @@ func (s *Store) SendWithWriteBytes(
 			// If the command appears to come from a node with a bad clock,
 			// reject it instead of updating the local clock and proceeding.
 			if err := s.cfg.Clock.UpdateAndCheckMaxOffset(ctx, ba.Now); err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 		}
 	}
@@ -174,7 +206,7 @@ func (s *Store) SendWithWriteBytes(
 		// Get range and add command to the range for execution.
 		repl, err := s.GetReplica(ba.RangeID)
 		if err != nil {
-			return nil, nil, kvpb.NewError(err)
+			return nil, kvpb.NewError(err)
 		}
 		if !repl.IsInitialized() {
 			// If we have an uninitialized copy of the range, then we are probably a
@@ -184,7 +216,7 @@ func (s *Store) SendWithWriteBytes(
 			// the client that it should move on and try the next replica. Very
 			// likely, the next replica the client tries will be initialized and will
 			// have useful leaseholder information for the client.
-			return nil, nil, kvpb.NewError(&kvpb.NotLeaseHolderError{
+			return nil, kvpb.NewError(&kvpb.NotLeaseHolderError{
 				RangeID: ba.RangeID,
 				// The replica doesn't have a range descriptor yet, so we have to build
 				// a ReplicaDescriptor manually.
@@ -196,7 +228,7 @@ func (s *Store) SendWithWriteBytes(
 			})
 		}
 
-		br, writeBytes, pErr = repl.SendWithWriteBytes(ctx, ba, admissionInfo)
+		br, pErr = repl.SendWithWorkStats(ctx, ba, stats, admissionInfo)
 		if pErr == nil {
 			// If any retries occurred, we should include the RangeInfos accumulated
 			// and pass these to the client, to invalidate their cache. This is
@@ -206,7 +238,7 @@ func (s *Store) SendWithWriteBytes(
 				br.RangeInfos = append(rangeInfos, br.RangeInfos...)
 			}
 
-			return br, writeBytes, nil
+			return br, nil
 		}
 
 		// Augment error if necessary and return.
@@ -224,7 +256,7 @@ func (s *Store) SendWithWriteBytes(
 			// Range from this Store.
 			rSpan, err := keys.Range(ba.Requests)
 			if err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 
 			// The kvclient thought that a particular range id covers rSpans. It was
@@ -235,7 +267,7 @@ func (s *Store) SendWithWriteBytes(
 			// that the client requested, and all the ranges in between.
 			ri, err := t.MismatchedRange()
 			if err != nil {
-				return nil, nil, kvpb.NewError(err)
+				return nil, kvpb.NewError(err)
 			}
 			skipRID := ri.Desc.RangeID // We already have info on one range, so don't add it again below.
 			startKey := ri.Desc.StartKey
@@ -312,12 +344,12 @@ func (s *Store) SendWithWriteBytes(
 		// Unable to retry, exit the retry loop and return an error.
 		break
 	}
-	return nil, nil, pErr
+	return nil, pErr
 }
 
 // batchThrottleCallback is returned from the maybeThrottleBatch function and is
 // used to perform accounting and cleanup of any rate limiting related state
-// after a SendWithWriteBytes call completes.
+// after a SendWithWorkStats call completes.
 type batchThrottleCallback struct {
 	// reservation is the reservation from a ConcurrentRequestLimiter.
 	reservation limit.Reservation
@@ -514,8 +546,7 @@ func (s *Store) executeServerSideBoundedStalenessNegotiation(
 
 	// Pass empty AdmissionInfo since this is an internal request that bypasses
 	// admission control.
-	br, writeBytes, pErr := s.SendWithWriteBytes(ctx, queryResBa, kvadmission.AdmissionInfo{})
-	writeBytes.Release()
+	br, pErr := s.SendWithWorkStats(ctx, queryResBa, nil /* stats */, kvadmission.AdmissionInfo{})
 	if pErr != nil {
 		return ba, pErr
 	}

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -116,10 +116,10 @@ func (s *Store) SendWithWorkStats(
 		}
 	}
 
-	if throttled, err := s.maybeThrottleBatch(ctx, ba); err != nil {
+	if throttled, err := s.maybeThrottleBatch(ctx, ba, stats); err != nil {
 		return nil, kvpb.NewError(err)
 	} else {
-		defer func() { throttled.performAccounting(br) }()
+		defer throttled.performAccounting(stats)
 	}
 
 	if ba.BoundedStaleness != nil {
@@ -366,20 +366,24 @@ type batchThrottleCallback struct {
 	// set whenever a request for low-priority bulk reads was throttled and
 	// needs to account for tokens corresponding to actually read data.
 	limiters *batcheval.Limiters
+	// baseline contains the number of bytes accumulated into ScanStats before
+	// request evaluation. This is tracked so we can correctly attribute the
+	// statistics for this instance of evaluation.
+	baseline uint64
 }
 
 // maybeThrottleBatch inspects the provided batch and determines whether
 // throttling should be applied to avoid overloading the Store. If so, the
 // method blocks and returns a struct containing the information needed to
 // perform accounting for rate limiters. The caller must call
-// (batchThrottleCallback).performAccounting with the BatchResponse after the
+// (batchThrottleCallback).performAccounting with the StoreWorkStats after the
 // evaluation completes.
 //
 // Of note is that request throttling is all performed above evaluation and
 // before a request acquires latches on a range. Otherwise, the request could
 // inadvertently block others while being throttled.
 func (s *Store) maybeThrottleBatch(
-	ctx context.Context, ba *kvpb.BatchRequest,
+	ctx context.Context, ba *kvpb.BatchRequest, stats *StoreWorkStats,
 ) (batchThrottleCallback, error) {
 	if !ba.IsSingleRequest() {
 		return batchThrottleCallback{}, nil
@@ -444,15 +448,21 @@ func (s *Store) maybeThrottleBatch(
 			log.KvExec.Infof(ctx, "bulk low-priority read operation was delayed by %v", waited)
 		}
 
-		return batchThrottleCallback{reservation: res, limiters: &s.limiters}, nil
+		// Calculate the baseline stats from the given parameters.
+		var baseline uint64
+		if ss := stats.ScanStats(); ss != nil {
+			baseline = ss.BlockBytes - ss.BlockBytesInCache
+		}
+
+		return batchThrottleCallback{reservation: res, limiters: &s.limiters, baseline: baseline}, nil
 	}
 
 	return batchThrottleCallback{}, nil
 }
 
 // performAccounting must be called after maybeThrottleBatch with the returned
-// batchThrottleCallback and the BatchResponse.
-func (b batchThrottleCallback) performAccounting(br *kvpb.BatchResponse) {
+// batchThrottleCallback and the StoreWorkStats.
+func (b batchThrottleCallback) performAccounting(stats *StoreWorkStats) {
 	if b.reservation != nil {
 		b.reservation.Release()
 	}
@@ -466,11 +476,9 @@ func (b batchThrottleCallback) performAccounting(br *kvpb.BatchResponse) {
 	// token bucket falling too much into -ve, because we have pagination in the
 	// TTL layer and also a ConcurrentRequestLimiter to ensure the bucket
 	// doesn't fall arbitrarily into debt.
-	var bytesRead int64
-	if br != nil {
-		for _, resp := range br.Responses {
-			bytesRead += resp.GetInner().Header().NumBytes
-		}
+	var bytesRead uint64
+	if ss := stats.ScanStats(); ss != nil {
+		bytesRead = (ss.BlockBytes - ss.BlockBytesInCache) - b.baseline
 	}
 
 	b.limiters.BulkIOReadRate.Lock()

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -25,11 +25,12 @@ import (
 	"github.com/cockroachdb/tokenbucket"
 )
 
-// StoreWorkStats embeds admission.StoreWorkDoneInfo, since the notion of
-// "work is done" is specific to admission control and doesn't need to leak
-// everywhere.
+// StoreWorkStats embeds admission.StoreWorkDoneInfo to record information
+// relevant to admission control. It also contains an instance of kvpb.ScanStats
+// to keep track of low-level pebble statistics.
 type StoreWorkStats struct {
 	admission.StoreWorkDoneInfo
+	scanStats kvpb.ScanStats
 }
 
 var storeWorkStatsPool = sync.Pool{
@@ -48,6 +49,14 @@ func (ws *StoreWorkStats) Release() {
 	}
 	*ws = StoreWorkStats{}
 	storeWorkStatsPool.Put(ws)
+}
+
+// ScanStats returns a pointer to the underlying kvpb.ScanStats.
+func (ws *StoreWorkStats) ScanStats() *kvpb.ScanStats {
+	if ws == nil {
+		return nil
+	}
+	return &ws.scanStats
 }
 
 // SenderWithWorkStats is implemented by Store, Stores, and Replica. It extends

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -47,7 +47,7 @@ type Stores struct {
 	sendQueueLogger *rac2.SendQueueLogger
 }
 
-var _ SenderWithWriteBytes = &Stores{}
+var _ SenderWithWorkStats = &Stores{}
 var _ gossip.Storage = &Stores{} // Stores implements the gossip.Storage interface
 
 // NewStores returns a local-only sender which directly accesses
@@ -175,25 +175,28 @@ func (ls *Stores) GetReplicaForRangeID(
 	return replica, store, nil
 }
 
-// SendWithWriteBytes sends a batch request. The store is looked up from the
+// SendWithWorkStats sends a batch request. The store is looked up from the
 // store map using the ID specified in the request.
-func (ls *Stores) SendWithWriteBytes(
-	ctx context.Context, ba *kvpb.BatchRequest, admissionInfo kvadmission.AdmissionInfo,
-) (*kvpb.BatchResponse, *kvadmission.StoreWriteBytes, *kvpb.Error) {
+func (ls *Stores) SendWithWorkStats(
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	stats *StoreWorkStats,
+	admissionInfo kvadmission.AdmissionInfo,
+) (*kvpb.BatchResponse, *kvpb.Error) {
 	if err := ba.ValidateForEvaluation(); err != nil {
-		return nil, nil, kvpb.NewError(errors.Wrapf(err, "invalid batch (%s)", ba))
+		return nil, kvpb.NewError(errors.Wrapf(err, "invalid batch (%s)", ba))
 	}
 
 	store, err := ls.GetStore(ba.Replica.StoreID)
 	if err != nil {
-		return nil, nil, kvpb.NewError(err)
+		return nil, kvpb.NewError(err)
 	}
 
-	br, writeBytes, pErr := store.SendWithWriteBytes(ctx, ba, admissionInfo)
+	br, pErr := store.SendWithWorkStats(ctx, ba, stats, admissionInfo)
 	if br != nil && br.Error != nil {
 		panic(kvpb.ErrorUnexpectedlySet(store, br))
 	}
-	return br, writeBytes, pErr
+	return br, pErr
 }
 
 // RangeFeed registers a rangefeed over the specified span. It sends

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1720,10 +1720,13 @@ func (n *Node) batchInternal(
 	// for replication flow control.
 	admissionInfo := handle.AdmissionInfo()
 
-	var writeBytes *kvadmission.StoreWriteBytes
+	// NB: we allocate a single instance of StoreWorkStats across retries since
+	// we want to accumulate those statistics to better account for all the work
+	// done at this store.
+	stats := kvserver.NewStoreWorkStats()
 	defer func() {
-		n.storeCfg.KVAdmissionController.AdmittedKVWorkDone(handle, writeBytes)
-		writeBytes.Release()
+		n.storeCfg.KVAdmissionController.AdmittedKVWorkDone(handle, stats.StoreWorkDoneInfo)
+		stats.Release()
 	}()
 
 	// If a proxy attempt is requested, we copy the request to prevent evaluation
@@ -1743,7 +1746,7 @@ func (n *Node) batchInternal(
 		originalRequest = args.ShallowCopy()
 	}
 	var pErr *kvpb.Error
-	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, args, admissionInfo)
+	br, pErr = n.stores.SendWithWorkStats(ctx, args, stats, admissionInfo)
 	if pErr != nil {
 		if originalRequest != nil {
 			if proxyResponse := n.maybeProxyRequest(ctx, originalRequest, pErr); proxyResponse != nil {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1720,14 +1720,25 @@ func (n *Node) batchInternal(
 	// for replication flow control.
 	admissionInfo := handle.AdmissionInfo()
 
-	// NB: we allocate a single instance of StoreWorkStats across retries since
-	// we want to accumulate those statistics to better account for all the work
-	// done at this store.
+	// Allocate a StoreWorkStats object that is used to track various statistics
+	// about the work done during the course of processing this request.
 	stats := kvserver.NewStoreWorkStats()
 	defer func() {
 		n.storeCfg.KVAdmissionController.AdmittedKVWorkDone(handle, stats.StoreWorkDoneInfo)
 		stats.Release()
 	}()
+
+	// Record the scan stats if tracing is enabled.
+	if sp := tracing.SpanFromContext(ctx); sp.RecordingType() != tracingpb.RecordingOff {
+		defer func() {
+			if ss := stats.ScanStats(); ss.NumGets != 0 || ss.NumScans != 0 || ss.NumReverseScans != 0 {
+				// Only record non-empty ScanStats.
+				ss.NodeID = n.Descriptor.NodeID
+				ss.Region, _ = n.Descriptor.Locality.Find("region")
+				sp.RecordStructured(ss)
+			}
+		}()
+	}
 
 	// If a proxy attempt is requested, we copy the request to prevent evaluation
 	// from modifying the request. There are places on the server that can modify


### PR DESCRIPTION
At the high-level, this PR restructures the `SenderWithWorkDone` interface in the following ways:

1. Change the API from a returning an instance of `StoreWriteBytes`, to accepting a parameter `*StoreWorkStats` into which all the stats are accumulated.
2. Add an instance of `kvpb.ScanStats` which is passed deep into the `BatchRequest` evaluation call stack so we can obtain low-level Pebble statistics that can be used for tracing and admission control.

---

**kvserver,kvadmission,server: refactor the SendWithWriteBytes API**
    
This is a mechanical change. `StoreWriteBytes` is renamed to `StoreWorkStats` and is moved from the `kvadmission` package into `kvserver` package. The `SenderWithWorkDone` interface is renamed to `SenderWithWorkStats` and the function `SendWithWorkDone` is renamed to `SendWithWorkStats`. Moreover, function `SendWithWorkDone` is modified to accept an `*StoreWorkStats` as an argument as opposed to returning it. We allocate an instance of `*StoreWorkStats` from a pool at the first site where `SenderWithWorkStats` is called (in `batchInternal`).

---

**kvserver,server: plumb ScanStats during request evaluation**
    
In this commit we add a `kvpb.ScanStats` to the `StoreWorkStats` struct that is plumbed into the request evaluation call-stack to obtain pebble iterator stats. Also moved the recording of scan stats from `evaluateBatch` to `batchInternal`, so that these stats are accumulated across retries.

---

**kvserver: use `ScanStats` to perform disk read I/O accounting**
    
Here we change the `maybeThrottleBatch` and `performAccounting` functions in `store_send.go` to actually use `StoreWorkStats`.

---

Reolves: CRDB-63465
Informs: #167041
Release note: None
Epic: None