### PR TITLE
sql: stop auto-retry from masking advisory-lock deadlocks

### DIFF
--- a/pkg/sql/advisorylock/advisory_lock_test.go
+++ b/pkg/sql/advisorylock/advisory_lock_test.go
@@ -32,6 +32,22 @@ func assertLockCycleBrokenError(t *testing.T, err error) {
 		"expected lock-cycle resolution to surface as a transaction retry error, got: %v", err)
 }
 
+// finishAdvisoryDeadlockTxn captures the error surfaced when the deadlock
+// cycle is broken. The losing side's failure can show up either on the
+// second pg_advisory_xact_lock call or at COMMIT — KV deadlock detection
+// force-aborts the victim, but the abort may only become visible to the
+// client at commit time if the lock acquisition slips past the abort (e.g.
+// because the lock holder released the lock before the abort propagated).
+// This helper tries COMMIT when the lock acquire returned nil so either
+// failure mode is captured on errCh.
+func finishAdvisoryDeadlockTxn(ctx context.Context, conn *gosql.Conn, lockErr error) error {
+	if lockErr != nil {
+		return lockErr
+	}
+	_, err := conn.ExecContext(ctx, `COMMIT`)
+	return err
+}
+
 // TestAdvisoryLockSQLAcquireRelease verifies locks are released on commit so a
 // later transaction can acquire the same key.
 func TestAdvisoryLockSQLAcquireRelease(t *testing.T) {
@@ -220,7 +236,7 @@ func TestAdvisoryLockSQLDeadlock(t *testing.T) {
 		select {
 		case start2 <- struct{}{}:
 		case <-ctx.Done():
-			return err
+			return ctx.Err()
 		}
 		select {
 		case <-proceed1:
@@ -230,7 +246,7 @@ func TestAdvisoryLockSQLDeadlock(t *testing.T) {
 		_, err := conn1.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, k2)
 		// Note: The final error cannot be returned here, since it will cancel the context
 		// if something failed.
-		errCh <- err
+		errCh <- finishAdvisoryDeadlockTxn(ctx, conn1, err)
 		return nil
 	})
 
@@ -254,7 +270,7 @@ func TestAdvisoryLockSQLDeadlock(t *testing.T) {
 			return ctx.Err()
 		}
 		_, err := conn2.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, k1)
-		errCh <- err
+		errCh <- finishAdvisoryDeadlockTxn(ctx, conn2, err)
 		return nil
 	})
 
@@ -270,7 +286,7 @@ func TestAdvisoryLockSQLDeadlock(t *testing.T) {
 		assertLockCycleBrokenError(t, err)
 	}
 	require.True(t, sawBreakingErr,
-		"expected at least one failing statement when breaking a lock cycle, got %#v", errs)
+		"expected at least one failing statement or commit when breaking a lock cycle, got %#v", errs)
 }
 
 // TestAdvisoryLockSQLDeadlockForUpdateCrossAdvisory builds a wait cycle between a
@@ -337,12 +353,6 @@ func TestAdvisoryLockSQLDeadlockForUpdateCrossAdvisory(t *testing.T) {
 			return err
 		}
 		defer func() { _, _ = conn1.ExecContext(context.Background(), `ROLLBACK`) }()
-		// Return at least one row so results are flushed to the client before the
-		// statements that participate in the deadlock. Otherwise explicit-txn
-		// auto-retry can rewind transparently and both Exec calls may return nil.
-		if _, err := conn1.ExecContext(ctx, `SELECT 1`); err != nil {
-			return err
-		}
 		if _, err := conn1.ExecContext(ctx,
 			`SELECT * FROM dead_adv_row WHERE id = 1 FOR UPDATE`); err != nil {
 			return err
@@ -356,7 +366,7 @@ func TestAdvisoryLockSQLDeadlockForUpdateCrossAdvisory(t *testing.T) {
 		_, err := conn1.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, advKey)
 		// Note: The final error cannot be returned here, since it will cancel the context
 		// if something failed.
-		errCh <- err
+		errCh <- finishAdvisoryDeadlockTxn(ctx, conn1, err)
 		return nil
 	})
 
@@ -370,15 +380,12 @@ func TestAdvisoryLockSQLDeadlockForUpdateCrossAdvisory(t *testing.T) {
 			return err
 		}
 		defer func() { _, _ = conn2.ExecContext(context.Background(), `ROLLBACK`) }()
-		if _, err := conn2.ExecContext(ctx, `SELECT 1`); err != nil {
-			return err
-		}
 		if _, err := conn2.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, advKey); err != nil {
 			return err
 		}
 		close(g2HasAdv)
 		_, err := conn2.ExecContext(ctx, `SELECT * FROM dead_adv_row WHERE id = 1 FOR UPDATE`)
-		errCh <- err
+		errCh <- finishAdvisoryDeadlockTxn(ctx, conn2, err)
 		return nil
 	})
 
@@ -394,5 +401,5 @@ func TestAdvisoryLockSQLDeadlockForUpdateCrossAdvisory(t *testing.T) {
 		assertLockCycleBrokenError(t, err)
 	}
 	require.True(t, sawBreakingErr,
-		"expected at least one failing statement when breaking FOR UPDATE vs advisory cycle, got %#v", errs)
+		"expected at least one failing statement or commit when breaking FOR UPDATE vs advisory cycle, got %#v", errs)
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4092,6 +4092,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	p.statsCollector = ex.statsCollector
 	p.sessionDataMutatorIterator = ex.dataMutatorIterator
 	p.noticeSender = nil
+	p.stmtResultBuffering = nil
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 	p.sqlCursors = ex.getCursorAccessor()
 	p.routineMetadataForwarder = nil

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -518,6 +518,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	ex.resetPlanner(ctx, p, ex.state.mu.txn, stmtTS)
 	p.sessionDataMutatorIterator.ParamStatusUpdater = res
 	p.noticeSender = res
+	p.stmtResultBuffering = res
 	ih := &p.instrumentation
 
 	if ex.executorType != executorTypeInternal {
@@ -1455,6 +1456,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	ex.resetPlanner(ctx, p, ex.state.mu.txn, stmtTS)
 	p.sessionDataMutatorIterator.ParamStatusUpdater = res
 	p.noticeSender = res
+	p.stmtResultBuffering = res
 	ih := &p.instrumentation
 
 	if ex.executorType != executorTypeInternal {

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -933,6 +933,12 @@ type RestrictedCommandResult interface {
 	RevokePortalPausability() error
 }
 
+// resultBufferingDisabler is the subset of RestrictedCommandResult used to
+// flush a statement's result writer mid-execution (see DisableBuffering).
+type resultBufferingDisabler interface {
+	DisableBuffering()
+}
+
 // DescribeResult represents the result of a Describe command (for either
 // describing a prepared statement or a portal).
 type DescribeResult interface {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -298,6 +298,13 @@ type planner struct {
 	// instead.
 	noticeSender noticeSender
 
+	// stmtResultBuffering exposes the current statement's result writer so a
+	// side-effecting builtin can flush its results immediately and prevent
+	// transparent connExecutor rewind across the side effect. Set in
+	// execStmtInOpenState after resetPlanner; nil between statements and for
+	// the internal executor.
+	stmtResultBuffering resultBufferingDisabler
+
 	queryCacheSession querycache.Session
 
 	// evalCatalogBuiltins is used as part of the eval.Context.
@@ -1350,6 +1357,13 @@ func (p *planner) advisoryXactLockImpl(
 			return false, nil
 		}
 		return false, err
+	}
+	// The acquire is a visible side effect; flush the statement's result so
+	// the connExecutor cannot transparently rewind past it on a subsequent
+	// serializable push (e.g. a deadlock break would otherwise be masked by
+	// auto-retry and the losing client would see no error).
+	if w := p.stmtResultBuffering; w != nil {
+		w.DisableBuffering()
 	}
 	return true, nil
 }


### PR DESCRIPTION
When two transactions deadlocked on advisory locks, the SQL conn executor could transparently rewind and replay the txn, masking the cycle break. Both clients ended up seeing nil errors instead of the expected retry error.

A successful advisory-lock acquire is now treated as a visible side effect that flushes the statement's result. The flush blocks the silent rewind, so the deadlock surfaces as a retry error to the losing client, matching PostgreSQL.

The deadlock tests also COMMIT after a successful acquire to catch the case where the victim's KV-level abort only becomes visible at commit time.

Resolves: #168825
Epic: CRDB-49583
Release note: None