### PR TITLE
workload/schemachange: version-gate ALTER FUNCTION dep check

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4930,12 +4930,23 @@ func (og *operationGenerator) alterFunctionRename(ctx context.Context, tx pgx.Tx
 		return nil, err
 	}
 
+	// The server only blocks ALTER FUNCTION RENAME on trigger/policy back-refs
+	// starting in v26.3. In a mixed-version cluster the rename succeeds against
+	// older servers, so don't classify those functions as "with deps" or the
+	// workload will incorrectly expect a feature_not_supported error.
+	skipTriggerPolicyDeps, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3.Version())
+	if err != nil {
+		return nil, err
+	}
+
 	functionDepsMap := make(map[int64]struct{})
 	for _, f := range functionDeps {
 		functionDepsMap[f["to_oid"].(int64)] = struct{}{}
 	}
-	for _, f := range triggerPolicyDeps {
-		functionDepsMap[f["func_oid"].(int64)] = struct{}{}
+	if !skipTriggerPolicyDeps {
+		for _, f := range triggerPolicyDeps {
+			functionDepsMap[f["func_oid"].(int64)] = struct{}{}
+		}
 	}
 
 	functionWithDeps := make([]map[string]any, 0, len(functions))
@@ -5040,12 +5051,24 @@ func (og *operationGenerator) alterFunctionSetSchema(
 		return nil, err
 	}
 
+	// The server only blocks ALTER FUNCTION SET SCHEMA on trigger/policy
+	// back-refs starting in v26.3. In a mixed-version cluster the statement
+	// succeeds against older servers, so don't classify those functions as
+	// "with deps" or the workload will incorrectly expect a
+	// feature_not_supported error.
+	skipTriggerPolicyDeps, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3.Version())
+	if err != nil {
+		return nil, err
+	}
+
 	functionDepsMap := make(map[int64]struct{})
 	for _, f := range functionDeps {
 		functionDepsMap[f["to_oid"].(int64)] = struct{}{}
 	}
-	for _, f := range triggerPolicyDeps {
-		functionDepsMap[f["func_oid"].(int64)] = struct{}{}
+	if !skipTriggerPolicyDeps {
+		for _, f := range triggerPolicyDeps {
+			functionDepsMap[f["func_oid"].(int64)] = struct{}{}
+		}
 	}
 
 	functionWithDeps := make([]map[string]any, 0, len(functions))


### PR DESCRIPTION
The schemachange workload's alterFunctionRename and alterFunctionSetSchema ops started expecting feature_not_supported when a function had trigger or policy back-references, matching a recent server-side restriction added in v26.3. In a mixed-version cluster the workload talks to older servers that still allow the rename, so the workload tripped on "Failed to receive an execution error when errors were expected".

Gate the trigger/policy dep classification on the active cluster version. Below v26.3 those functions are treated as having no deps, matching old-server behavior.

Resolves: #168962
Epic: none

Release note: None