### PR TITLE
geo: implement ST_3DMaxDistance, ST_3DDFullyWithin, ST_3DIntersects, ST_3DShortestLine, ST_3DLongestLine, ST_3DClosestPoint, ST_3DPerimeter

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1721,7 +1721,11 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
+<tr><td><a name="_st_3ddfullywithin"></a><code>_st_3ddfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every point in geometry_a is within distance units of geometry_b, using 3D Euclidean distance. This variant does not utilize any spatial index.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="_st_3ddwithin"></a><code>_st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, using 3D Euclidean distance. This variant does not utilize any spatial index.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="_st_3dintersects"></a><code>_st_3dintersects(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a shares any portion of space with geometry_b, using 3D Euclidean distance. This variant does not utilize any spatial index.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="_st_contains"></a><code>_st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>
 <p>This function utilizes the GEOS module.</p>
@@ -1869,14 +1873,28 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="postgis_wagyu_version"></a><code>postgis_wagyu_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3dclosestpoint"></a><code>st_3dclosestpoint(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the 3-dimensional point on geometry_a that is closest to geometry_b.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3ddfullywithin"></a><code>st_3ddfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every point in geometry_a is within distance units of geometry_b, using 3D Euclidean distance.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="st_3ddistance"></a><code>st_3ddistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional minimum Cartesian distance between two geometries. If either geometry has no Z component, this is equivalent to ST_Distance.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="st_3ddwithin"></a><code>st_3ddwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b, using 3D Euclidean distance.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3dintersects"></a><code>st_3dintersects(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a shares any portion of space with geometry_b, using 3D Euclidean distance.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="st_3dlength"></a><code>st_3dlength(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional or 2-dimensional length of the geometry.</p>
 <p>Note ST_3DLength is only valid for LineString or MultiLineString.
 For 2-D lines it will return the 2-D length (same as ST_Length and ST_Length2D)</p>
 <p>This function utilizes the GEOS module.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3dlongestline"></a><code>st_3dlongestline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the 3-dimensional longest line between two geometries.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3dmaxdistance"></a><code>st_3dmaxdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional maximum Cartesian distance between two geometries. If either geometry has no Z component, this is equivalent to ST_MaxDistance.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3dperimeter"></a><code>st_3dperimeter(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the 3-dimensional perimeter of the geometry. Note ST_3DPerimeter is only valid for Polygon or MultiPolygon. For 2D geometries it returns the 2D perimeter.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="st_3dshortestline"></a><code>st_3dshortestline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the 3-dimensional shortest line between two geometries.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="st_addmeasure"></a><code>st_addmeasure(geometry: geometry, start: <a href="float.html">float</a>, end: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a copy of a LineString or MultiLineString with measure coordinates linearly interpolated between the specified start and end values. Any existing M coordinates will be overwritten.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/geo/geodist/geodist.go
+++ b/pkg/geo/geodist/geodist.go
@@ -310,6 +310,19 @@ func projectVertexToEdge(c DistanceCalculator, vertex Point, edge Edge) bool {
 	return false
 }
 
+// linePolygonInteriorCrosser is an optional interface a DistanceCalculator
+// may implement to short-circuit line-to-polygon distance when the line
+// passes through the polygon's interior. Required for 3D distance: a
+// line may cross a tilted polygon's plane at a point inside the polygon
+// (distance 0) without sharing a 2D-projected boundary edge, so the
+// generic onShapeEdgesToShapeEdges path cannot detect it. 2D
+// calculators do not need this: 2D edge crossing already finds such
+// intersections via NewEdgeCrosser. Implementations must update the
+// DistanceUpdater accordingly when they return true.
+type linePolygonInteriorCrosser interface {
+	LineCrossesPolygonInterior(line LineString, polygon Polygon) bool
+}
+
 // onLineStringToPolygon updates the distance between a polyline and a polygon.
 // Returns true if the calling function should early exit.
 func onLineStringToPolygon(c DistanceCalculator, a LineString, b Polygon) bool {
@@ -325,6 +338,18 @@ func onLineStringToPolygon(c DistanceCalculator, a LineString, b Polygon) bool {
 	//   check each point in the LineString.
 	// BoundingBoxIntersects: if the bounding box of the two shapes do not intersect,
 	//   then the distance is always from the LineString to the exterior ring.
+
+	// 3D-only: detect line edges that cross the polygon's plane at a
+	// point inside the polygon. This produces distance 0 even when no
+	// polygon boundary edge is touched.
+	if !c.DistanceUpdater().IsMaxDistance() {
+		if lpc, ok := c.(linePolygonInteriorCrosser); ok {
+			if lpc.LineCrossesPolygonInterior(a, b) {
+				return true
+			}
+		}
+	}
+
 	if c.DistanceUpdater().IsMaxDistance() ||
 		!c.BoundingBoxIntersects() ||
 		!c.PointIntersectsLinearRing(a.Vertex(0), b.LinearRing(0)) {

--- a/pkg/geo/geodist/geodist.go
+++ b/pkg/geo/geodist/geodist.go
@@ -422,7 +422,16 @@ func onPolygonToPolygon(c DistanceCalculator, a Polygon, b Polygon) bool {
 	// Now we know either a point of the exterior ring A is definitely inside polygon B
 	// or vice versa. This is an intersection.
 	if c.PointIntersectsLinearRing(aFirstPoint, b.LinearRing(0)) {
-		return c.DistanceUpdater().OnIntersects(aFirstPoint)
+		// aFirstPoint is from original A, but FlipGeometries is active so the
+		// updater thinks "a" is original B. Un-flip so OnIntersects correctly
+		// maps p=aFirstPoint to coordA (the original A side), then re-flip so
+		// the deferred FlipGeometries restores the caller's state.
+		c.DistanceUpdater().FlipGeometries()
+		result := c.DistanceUpdater().OnIntersects(aFirstPoint)
+		c.DistanceUpdater().FlipGeometries()
+		return result
 	}
+	// bFirstPoint is from original B, which after the flip is geodist "a",
+	// matching OnIntersects' assumption that p is on the "a" side.
 	return c.DistanceUpdater().OnIntersects(bFirstPoint)
 }

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -556,8 +556,9 @@ func (u *geomMaxDistanceUpdater) FlipGeometries() {
 }
 
 // MinDistance3D returns the 3D minimum distance between geometries A and B.
-// For 2D geometries, Z is treated as 0, so this degrades to 2D distance.
-// This returns a geo.EmptyGeometryError if either A or B is EMPTY.
+// If either input lacks a Z dimension this falls back to 2D distance,
+// matching PostGIS's lwgeom_mindistance3d_tolerance.
+// Returns a geo.EmptyGeometryError if either A or B is EMPTY.
 func MinDistance3D(a geo.Geometry, b geo.Geometry) (float64, error) {
 	if a.SRID() != b.SRID() {
 		return 0, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
@@ -566,12 +567,16 @@ func MinDistance3D(a geo.Geometry, b geo.Geometry) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if !hasZ(a) || !hasZ(b) {
+		return MinDistance(a, b)
+	}
 	return minDistance3DInternal(a, b, 0, geo.EmptyBehaviorOmit)
 }
 
 // DWithin3D determines if any part of geometry A is within D units of
 // geometry B using 3D Euclidean distance.
-// DWithin3D is equivalent to ST_3DDistance(a, b) <= d.
+// DWithin3D is equivalent to ST_3DDistance(a, b) <= d. If either input
+// lacks a Z dimension this falls back to 2D, matching PostGIS.
 func DWithin3D(a geo.Geometry, b geo.Geometry, d float64) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
@@ -581,15 +586,18 @@ func DWithin3D(a geo.Geometry, b geo.Geometry, d float64) (bool, error) {
 			pgcode.InvalidParameterValue, "dwithin distance cannot be less than zero",
 		)
 	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return false, err
+	}
+	if !hasZ(a) || !hasZ(b) {
+		return DWithin(a, b, d, geo.FnInclusive)
+	}
 	// Use the 2D bounding box as a conservative fast-reject filter.
 	// If 2D bounding boxes don't overlap by d, the 3D distance is at
 	// least as large.
 	if !a.CartesianBoundingBox().Buffer(d, d).Intersects(b.CartesianBoundingBox()) {
 		return false, nil
-	}
-	a, b, err := normalizeFor3D(a, b)
-	if err != nil {
-		return false, err
 	}
 	dist, err := minDistance3DInternal(a, b, d, geo.EmptyBehaviorError)
 	if err != nil {
@@ -602,9 +610,8 @@ func DWithin3D(a geo.Geometry, b geo.Geometry, d float64) (bool, error) {
 }
 
 // normalizeFor3D drops the M dimension from inputs so that coord[2] is
-// always Z (or the coord has no Z at all). This matches PostGIS semantics:
-// M is not used in 3D distance calculations, and missing Z is treated as
-// "any value" (effectively 2D distance, since both sides degrade together).
+// always Z (or the coord has no Z at all). After normalization each
+// geometry has layout XY or XYZ.
 func normalizeFor3D(a, b geo.Geometry) (geo.Geometry, geo.Geometry, error) {
 	a, err := stripMDimension(a)
 	if err != nil {
@@ -631,6 +638,15 @@ func stripMDimension(g geo.Geometry) (geo.Geometry, error) {
 		return ForceLayout(g, geom.XYZ)
 	}
 	return g, nil
+}
+
+// hasZ returns whether the geometry has a Z dimension.
+func hasZ(g geo.Geometry) bool {
+	t, err := g.AsGeomT()
+	if err != nil {
+		return false
+	}
+	return t.Layout().ZIndex() != -1
 }
 
 // minDistance3DInternal finds the 3D minimum distance between two geometries.

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -649,6 +649,66 @@ func hasZ(g geo.Geometry) bool {
 	return t.Layout().ZIndex() != -1
 }
 
+// MaxDistance3D returns the maximum 3D distance across every pair of points
+// comprising geometries A and B. If either input lacks a Z dimension this
+// falls back to 2D, matching PostGIS's lwgeom_maxdistance3d_tolerance.
+// Returns a geo.EmptyGeometryError if either A or B is EMPTY.
+func MaxDistance3D(a geo.Geometry, b geo.Geometry) (float64, error) {
+	if a.SRID() != b.SRID() {
+		return 0, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return 0, err
+	}
+	if !hasZ(a) || !hasZ(b) {
+		return MaxDistance(a, b)
+	}
+	return maxDistance3DInternal(a, b, math.MaxFloat64, geo.EmptyBehaviorOmit)
+}
+
+// DFullyWithin3D determines whether the maximum 3D distance across every
+// pair of points comprising geometries A and B is within D units.
+// DFullyWithin3D is equivalent to ST_3DMaxDistance(a, b) <= d. If either
+// input lacks a Z dimension this falls back to 2D, matching PostGIS.
+func DFullyWithin3D(a geo.Geometry, b geo.Geometry, d float64) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	if d < 0 {
+		return false, pgerror.Newf(
+			pgcode.InvalidParameterValue, "dwithin distance cannot be less than zero",
+		)
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return false, err
+	}
+	if !hasZ(a) || !hasZ(b) {
+		return DFullyWithin(a, b, d, geo.FnInclusive)
+	}
+	dist, err := maxDistance3DInternal(a, b, d, geo.EmptyBehaviorError)
+	if err != nil {
+		if geo.IsEmptyGeometryError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return dist <= d, nil
+}
+
+// maxDistance3DInternal finds the 3D maximum distance between two geometries.
+func maxDistance3DInternal(
+	a geo.Geometry, b geo.Geometry, stopAfter float64, emptyBehavior geo.EmptyBehavior,
+) (float64, error) {
+	u := newGeomMaxDistance3DUpdater(stopAfter)
+	c := &geomDistance3DCalculator{
+		updater:               u,
+		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
+	}
+	return distanceInternal(a, b, c, emptyBehavior)
+}
+
 // minDistance3DInternal finds the 3D minimum distance between two geometries.
 func minDistance3DInternal(
 	a geo.Geometry, b geo.Geometry, stopAfter float64, emptyBehavior geo.EmptyBehavior,
@@ -754,6 +814,68 @@ func (u *geomMinDistance3DUpdater) IsMaxDistance() bool {
 
 // FlipGeometries implements the geodist.DistanceUpdater interface.
 func (u *geomMinDistance3DUpdater) FlipGeometries() {
+	u.geometricalObjOrder = -u.geometricalObjOrder
+}
+
+// geomMaxDistance3DUpdater finds the maximum distance using 3D geom
+// calculations. Methods return early if the maximum distance found is
+// >= stopAfter.
+type geomMaxDistance3DUpdater struct {
+	currentValue float64
+	stopAfter    float64
+	coordA       geom.Coord
+	coordB       geom.Coord
+
+	geometricalObjOrder geometricalObjectsOrder
+}
+
+var _ geodist.DistanceUpdater = (*geomMaxDistance3DUpdater)(nil)
+
+func newGeomMaxDistance3DUpdater(stopAfter float64) *geomMaxDistance3DUpdater {
+	return &geomMaxDistance3DUpdater{
+		currentValue:        -math.MaxFloat64,
+		stopAfter:           stopAfter,
+		geometricalObjOrder: geometricalObjectsNotFlipped,
+	}
+}
+
+// Distance implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistance3DUpdater) Distance() float64 {
+	return u.currentValue
+}
+
+// Update implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistance3DUpdater) Update(aPoint geodist.Point, bPoint geodist.Point) bool {
+	a := aPoint.GeomPoint
+	b := bPoint.GeomPoint
+
+	dist := coordNorm3D(coordSub3D(a, b))
+	if dist > u.currentValue || u.coordA == nil {
+		u.currentValue = dist
+		if u.geometricalObjOrder == geometricalObjectsFlipped {
+			u.coordA = b
+			u.coordB = a
+		} else {
+			u.coordA = a
+			u.coordB = b
+		}
+		return dist >= u.stopAfter
+	}
+	return false
+}
+
+// OnIntersects implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistance3DUpdater) OnIntersects(p geodist.Point) bool {
+	return false
+}
+
+// IsMaxDistance implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistance3DUpdater) IsMaxDistance() bool {
+	return true
+}
+
+// FlipGeometries implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistance3DUpdater) FlipGeometries() {
 	u.geometricalObjOrder = -u.geometricalObjOrder
 }
 

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -555,6 +555,183 @@ func (u *geomMaxDistanceUpdater) FlipGeometries() {
 	u.geometricalObjOrder = -u.geometricalObjOrder
 }
 
+// ShortestLineString3D returns a LineString between the closest points
+// of geometries A and B using 3D Euclidean distance. If either input
+// lacks a Z dimension, behavior matches PostGIS's
+// lw_dist3d_distanceline: both 2D falls back to the 2D shortest line
+// (returning a 2D LineString); mixed 2D/3D treats the missing Z as
+// "any value" via the vertical-line trick.
+func ShortestLineString3D(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
+	if a.SRID() != b.SRID() {
+		return geo.Geometry{}, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	aHasZ, bHasZ := hasZ(a), hasZ(b)
+	if !aHasZ && !bHasZ {
+		return ShortestLineString(a, b)
+	}
+	if !aHasZ || !bHasZ {
+		return distanceLineString3DMixedZ(a, b, aHasZ, bHasZ, false /* maxDistance */)
+	}
+	u := newGeomMinDistance3DUpdater(0)
+	return distanceLineString3DInternal(a, b, u, geo.EmptyBehaviorOmit)
+}
+
+// LongestLineString3D returns a LineString between the farthest points
+// of geometries A and B using 3D Euclidean distance. Mixed-Z behavior
+// matches ShortestLineString3D and PostGIS.
+func LongestLineString3D(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
+	if a.SRID() != b.SRID() {
+		return geo.Geometry{}, geo.NewMismatchingSRIDsError(a.SpatialObject(), b.SpatialObject())
+	}
+	a, b, err := normalizeFor3D(a, b)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	aHasZ, bHasZ := hasZ(a), hasZ(b)
+	if !aHasZ && !bHasZ {
+		return LongestLineString(a, b)
+	}
+	if !aHasZ || !bHasZ {
+		return distanceLineString3DMixedZ(a, b, aHasZ, bHasZ, true /* maxDistance */)
+	}
+	u := newGeomMaxDistance3DUpdater(math.MaxFloat64)
+	return distanceLineString3DInternal(a, b, u, geo.EmptyBehaviorOmit)
+}
+
+// ClosestPoint3D returns the point on geometry A that is closest to
+// geometry B using 3D Euclidean distance. The result has the same
+// dimensionality as the LineString returned by ShortestLineString3D
+// (2D when both inputs lack Z, 3D otherwise).
+func ClosestPoint3D(a geo.Geometry, b geo.Geometry) (geo.Geometry, error) {
+	shortestLine, err := ShortestLineString3D(a, b)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	lineT, err := shortestLine.AsGeomT()
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	ls, ok := lineT.(*geom.LineString)
+	if !ok {
+		return geo.Geometry{}, errors.AssertionFailedf(
+			"expected *geom.LineString, got %T", lineT)
+	}
+	coord := ls.Coord(0)
+	layout := ls.Layout()
+	pointCoords := []float64{coord.X(), coord.Y()}
+	if layout.ZIndex() != -1 {
+		pointCoords = append(pointCoords, coord[layout.ZIndex()])
+	}
+	point := geom.NewPointFlat(layout, pointCoords).SetSRID(int(a.SRID()))
+	return geo.MakeGeometryFromGeomT(point)
+}
+
+// distanceLineString3DMixedZ implements PostGIS's vertical-line trick
+// for the case where exactly one of the inputs has a Z dimension. A 2D
+// distance pass identifies the closest XY pair; the 2D side is then
+// substituted with a vertical line at that XY spanning the 3D side's Z
+// range, and a 3D distance pass picks the optimal Z. The result line
+// preserves (a, b) order.
+func distanceLineString3DMixedZ(
+	a, b geo.Geometry, aHasZ, bHasZ bool, maxDistance bool,
+) (geo.Geometry, error) {
+	var u2D geodist.DistanceUpdater
+	if maxDistance {
+		u2D = newGeomMaxDistanceUpdater(math.MaxFloat64, geo.FnInclusive)
+	} else {
+		u2D = newGeomMinDistanceUpdater(0, geo.FnInclusive)
+	}
+	line2D, err := distanceLineStringInternal(a, b, u2D, geo.EmptyBehaviorOmit)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	line2DT, err := line2D.AsGeomT()
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	line2DLS, ok := line2DT.(*geom.LineString)
+	if !ok {
+		return geo.Geometry{}, errors.AssertionFailedf(
+			"expected *geom.LineString, got %T", line2DT)
+	}
+	coords := line2DLS.Coords()
+	coordA, coordB := coords[0], coords[1]
+
+	srid := int(a.SRID())
+	newA, newB := a, b
+	if !aHasZ {
+		zMin, zMax, err := geomZRange(b)
+		if err != nil {
+			return geo.Geometry{}, err
+		}
+		vline := geom.NewLineStringFlat(geom.XYZ, []float64{
+			coordA.X(), coordA.Y(), zMin,
+			coordA.X(), coordA.Y(), zMax,
+		}).SetSRID(srid)
+		newA, err = geo.MakeGeometryFromGeomT(vline)
+		if err != nil {
+			return geo.Geometry{}, err
+		}
+	} else {
+		zMin, zMax, err := geomZRange(a)
+		if err != nil {
+			return geo.Geometry{}, err
+		}
+		vline := geom.NewLineStringFlat(geom.XYZ, []float64{
+			coordB.X(), coordB.Y(), zMin,
+			coordB.X(), coordB.Y(), zMax,
+		}).SetSRID(srid)
+		newB, err = geo.MakeGeometryFromGeomT(vline)
+		if err != nil {
+			return geo.Geometry{}, err
+		}
+	}
+
+	var u geodist.DistanceUpdater
+	if maxDistance {
+		u = newGeomMaxDistance3DUpdater(math.MaxFloat64)
+	} else {
+		u = newGeomMinDistance3DUpdater(0)
+	}
+	return distanceLineString3DInternal(newA, newB, u, geo.EmptyBehaviorOmit)
+}
+
+// distanceLineString3DInternal calculates the 3D LineString between two
+// geometries using the 3D distance calculator.
+func distanceLineString3DInternal(
+	a geo.Geometry, b geo.Geometry, u geodist.DistanceUpdater, emptyBehavior geo.EmptyBehavior,
+) (geo.Geometry, error) {
+	c := &geomDistance3DCalculator{
+		updater:               u,
+		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
+	}
+	_, err := distanceInternal(a, b, c, emptyBehavior)
+	if err != nil {
+		return geo.Geometry{}, err
+	}
+	var coordA, coordB geom.Coord
+	switch u := u.(type) {
+	case *geomMinDistance3DUpdater:
+		coordA = u.coordA
+		coordB = u.coordB
+	case *geomMaxDistance3DUpdater:
+		coordA = u.coordA
+		coordB = u.coordB
+	default:
+		return geo.Geometry{}, errors.AssertionFailedf("unknown updater type")
+	}
+	lineCoords := []float64{
+		coordA.X(), coordA.Y(), coordGetZ(coordA),
+		coordB.X(), coordB.Y(), coordGetZ(coordB),
+	}
+	lineString := geom.NewLineStringFlat(geom.XYZ, lineCoords).SetSRID(int(a.SRID()))
+	return geo.MakeGeometryFromGeomT(lineString)
+}
+
 // MinDistance3D returns the 3D minimum distance between geometries A and B.
 // If either input lacks a Z dimension this falls back to 2D distance,
 // matching PostGIS's lwgeom_mindistance3d_tolerance.
@@ -647,6 +824,48 @@ func hasZ(g geo.Geometry) bool {
 		return false
 	}
 	return t.Layout().ZIndex() != -1
+}
+
+// geomZRange returns the [zMin, zMax] across all coordinates of g. The
+// caller must ensure g has a Z dimension. Empty geometries return
+// (0, 0).
+func geomZRange(g geo.Geometry) (zMin, zMax float64, _ error) {
+	t, err := g.AsGeomT()
+	if err != nil {
+		return 0, 0, err
+	}
+	zIdx := t.Layout().ZIndex()
+	if zIdx < 0 {
+		return 0, 0, errors.AssertionFailedf("geomZRange called on geometry without Z")
+	}
+	found := false
+	var walk func(g geom.T)
+	walk = func(g geom.T) {
+		if gc, ok := g.(*geom.GeometryCollection); ok {
+			for _, sub := range gc.Geoms() {
+				walk(sub)
+			}
+			return
+		}
+		coords := g.FlatCoords()
+		stride := g.Stride()
+		for i := zIdx; i < len(coords); i += stride {
+			z := coords[i]
+			if !found {
+				zMin, zMax = z, z
+				found = true
+				continue
+			}
+			if z < zMin {
+				zMin = z
+			}
+			if z > zMax {
+				zMax = z
+			}
+		}
+	}
+	walk(t)
+	return zMin, zMax, nil
 }
 
 // MaxDistance3D returns the maximum 3D distance across every pair of points
@@ -1372,9 +1591,14 @@ func ClosestPoint(a, b geo.Geometry) (geo.Geometry, error) {
 	if err != nil {
 		return geo.Geometry{}, err
 	}
+	shortestLineLS, ok := shortestLineT.(*geom.LineString)
+	if !ok {
+		return geo.Geometry{}, errors.AssertionFailedf(
+			"expected *geom.LineString, got %T", shortestLineT)
+	}
 	closestPoint, err := geo.MakeGeometryFromPointCoords(
-		shortestLineT.(*geom.LineString).Coord(0).X(),
-		shortestLineT.(*geom.LineString).Coord(0).Y(),
+		shortestLineLS.Coord(0).X(),
+		shortestLineLS.Coord(0).Y(),
 	)
 	if err != nil {
 		return geo.Geometry{}, err

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -705,10 +705,7 @@ func distanceLineString3DMixedZ(
 func distanceLineString3DInternal(
 	a geo.Geometry, b geo.Geometry, u geodist.DistanceUpdater, emptyBehavior geo.EmptyBehavior,
 ) (geo.Geometry, error) {
-	c := &geomDistance3DCalculator{
-		updater:               u,
-		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
-	}
+	c := &geomDistance3DCalculator{updater: u}
 	_, err := distanceInternal(a, b, c, emptyBehavior)
 	if err != nil {
 		return geo.Geometry{}, err
@@ -921,10 +918,7 @@ func maxDistance3DInternal(
 	a geo.Geometry, b geo.Geometry, stopAfter float64, emptyBehavior geo.EmptyBehavior,
 ) (float64, error) {
 	u := newGeomMaxDistance3DUpdater(stopAfter)
-	c := &geomDistance3DCalculator{
-		updater:               u,
-		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
-	}
+	c := &geomDistance3DCalculator{updater: u}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
 
@@ -933,10 +927,7 @@ func minDistance3DInternal(
 	a geo.Geometry, b geo.Geometry, stopAfter float64, emptyBehavior geo.EmptyBehavior,
 ) (float64, error) {
 	u := newGeomMinDistance3DUpdater(stopAfter)
-	c := &geomDistance3DCalculator{
-		updater:               u,
-		boundingBoxIntersects: a.CartesianBoundingBox().Intersects(b.CartesianBoundingBox()),
-	}
+	c := &geomDistance3DCalculator{updater: u}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
 
@@ -952,10 +943,15 @@ type geomMinDistance3DUpdater struct {
 	geometricalObjOrder geometricalObjectsOrder
 
 	// planeDistance is set by the 3D calculator's PointIntersectsLinearRing
-	// when a point is inside a polygon's XY projection. It holds the
-	// perpendicular distance from the point to the polygon's plane.
-	// A negative value means no plane distance is pending.
+	// when a point's perpendicular foot on the polygon's plane lies inside
+	// the polygon. It holds the perpendicular distance from the point to
+	// the plane. A negative value means no plane distance is pending.
 	planeDistance float64
+	// planeFoot is the perpendicular foot on the polygon's plane,
+	// captured alongside planeDistance so OnIntersects can construct a
+	// shortest-line endpoint that lies on the polygon rather than at the
+	// query point.
+	planeFoot geom.Coord
 }
 
 var _ geodist.DistanceUpdater = (*geomMinDistance3DUpdater)(nil)
@@ -1005,23 +1001,36 @@ func (u *geomMinDistance3DUpdater) Update(aPoint geodist.Point, bPoint geodist.P
 // geodist (onPointToPolygon, onLineStringToPolygon, onPolygonToPolygon),
 // each of which calls PointIntersectsLinearRing on a polygon ring
 // immediately before. That call sets planeDistance to the perpendicular
-// distance from the point to the polygon's plane. We use that as the 3D
-// distance rather than treating containment as zero distance. Edge
-// crossings are handled separately by the 3D edge crosser, which never
-// triggers OnIntersects.
+// distance from the point to the polygon's plane and planeFoot to the
+// foot itself. We use the distance as the 3D distance rather than
+// treating containment as zero, and we record the (point, foot) pair as
+// the shortest-line endpoints (matching PostGIS's lw_dist3d_pt_pt(p,
+// projp, dl)). Edge crossings are handled separately by the 3D edge
+// crosser, which never triggers OnIntersects.
 func (u *geomMinDistance3DUpdater) OnIntersects(p geodist.Point) bool {
 	dist := u.planeDistance
+	foot := u.planeFoot
 	u.planeDistance = -1
+	u.planeFoot = nil
 	if dist < 0 {
 		// Should not happen: a polygon-containment path always sets
 		// planeDistance via PointIntersectsLinearRing first. Treat as
 		// zero distance so we still produce a sensible answer.
 		dist = 0
+		foot = p.GeomPoint
 	}
 	if dist < u.currentValue || u.coordA == nil {
 		u.currentValue = dist
-		u.coordA = p.GeomPoint
-		u.coordB = p.GeomPoint
+		// p is on the geodist "a" side; foot is on the polygon ("b") side.
+		// Honor the geometricalObjOrder so the line endpoints come back
+		// out in the caller's original (a, b) order.
+		if u.geometricalObjOrder == geometricalObjectsFlipped {
+			u.coordA = foot
+			u.coordB = p.GeomPoint
+		} else {
+			u.coordA = p.GeomPoint
+			u.coordB = foot
+		}
 	}
 	return u.currentValue <= u.stopAfter
 }
@@ -1102,8 +1111,7 @@ func (u *geomMaxDistance3DUpdater) FlipGeometries() {
 // 3D coordinate math. Point-in-polygon and edge crossing tests remain
 // 2D (XY projection), matching PostGIS behavior for 3D geometries.
 type geomDistance3DCalculator struct {
-	updater               geodist.DistanceUpdater
-	boundingBoxIntersects bool
+	updater geodist.DistanceUpdater
 }
 
 var _ geodist.DistanceCalculator = (*geomDistance3DCalculator)(nil)
@@ -1113,9 +1121,16 @@ func (c *geomDistance3DCalculator) DistanceUpdater() geodist.DistanceUpdater {
 	return c.updater
 }
 
-// BoundingBoxIntersects implements geodist.DistanceCalculator.
+// BoundingBoxIntersects implements geodist.DistanceCalculator. The 2D
+// Cartesian bounding box is unsound as a fast-reject filter for 3D
+// distance: a polygon whose 2D footprint collapses to a line (e.g. a
+// polygon lying in the YZ plane) can have a query point whose
+// perpendicular foot on the polygon's plane lies inside the polygon
+// even when the 2D bboxes do not overlap. PostGIS does not use a
+// bounding-box short-circuit in lw_dist3d_recursive for this reason,
+// so we always run the full 3D comparison.
 func (c *geomDistance3DCalculator) BoundingBoxIntersects() bool {
-	return c.boundingBoxIntersects
+	return true
 }
 
 // NewEdgeCrosser implements geodist.DistanceCalculator.
@@ -1174,17 +1189,95 @@ func (c *geomDistance3DCalculator) PointIntersectsLinearRing(
 	// foot = p - t*n, where t = ((p - v0) · n) / (n · n).
 	p := point.GeomPoint
 	d := coordSub3D(p, v0)
+	dotN := d[0]*nx + d[1]*ny + d[2]*nz
 	norm2 := nx*nx + ny*ny + nz*nz
-	t := (d[0]*nx + d[1]*ny + d[2]*nz) / norm2
+	t := dotN / norm2
 	foot := geom.Coord{p[0] - t*nx, p[1] - t*ny, coordGetZ(p) - t*nz}
 	if !pointInRingProjected(foot, linearRing, dominantNormalAxis(nx, ny, nz)) {
 		return false
 	}
 	if u, ok := c.updater.(*geomMinDistance3DUpdater); ok {
-		// Perpendicular distance from p to the plane: |t| * |n|.
-		u.planeDistance = math.Abs(t) * math.Sqrt(norm2)
+		// Perpendicular distance from p to the plane: |(p - v0) · n| / |n|.
+		// Computing as |dotN| / sqrt(norm2) rather than |t| * sqrt(norm2)
+		// avoids a round-trip through the division by norm2 that loses
+		// precision for axis-aligned polygons (e.g. 0.07 * 100 != 7.0).
+		u.planeDistance = math.Abs(dotN) / math.Sqrt(norm2)
+		u.planeFoot = foot
 	}
 	return true
+}
+
+// LineCrossesPolygonInterior implements geodist's optional
+// linePolygonInteriorCrosser interface. It mirrors PostGIS's
+// lw_dist3d_ptarray_poly: for each edge of the line, if its endpoints
+// lie on opposite sides of the polygon's plane, compute the
+// segment-plane intersection and check whether it falls inside the
+// outer ring and outside any holes. When such a crossing is found, the
+// distance is 0 and both shortest-line endpoints are the intersection
+// point.
+//
+// Returns false when the polygon does not define a usable plane (in
+// which case the standard edge-to-edge fallback handles the geometry)
+// or when no edge of the line crosses the polygon's interior.
+func (c *geomDistance3DCalculator) LineCrossesPolygonInterior(
+	line geodist.LineString, polygon geodist.Polygon,
+) bool {
+	outer := polygon.LinearRing(0)
+	nx, ny, nz, v0, ok := ringPlaneNormal(outer)
+	if !ok {
+		return false
+	}
+	dropAxis := dominantNormalAxis(nx, ny, nz)
+
+	// signedDistanceFromPlane returns a value whose sign indicates which
+	// side of the polygon's plane p lies on. Magnitude is unscaled
+	// (proportional to true perpendicular distance), but only the sign
+	// is used here.
+	signedDistanceFromPlane := func(p geom.Coord) float64 {
+		d := coordSub3D(p, v0)
+		return d[0]*nx + d[1]*ny + d[2]*nz
+	}
+
+	numVerts := line.NumVertexes()
+	if numVerts < 2 {
+		return false
+	}
+	prev := line.Vertex(0).GeomPoint
+	sPrev := signedDistanceFromPlane(prev)
+	for i := 1; i < numVerts; i++ {
+		cur := line.Vertex(i).GeomPoint
+		sCur := signedDistanceFromPlane(cur)
+		if sPrev*sCur < 0 {
+			// Linear interpolation parameter at which the segment
+			// crosses the plane.
+			f := math.Abs(sPrev) / (math.Abs(sPrev) + math.Abs(sCur))
+			isect := geom.Coord{
+				prev[0] + f*(cur[0]-prev[0]),
+				prev[1] + f*(cur[1]-prev[1]),
+				coordGetZ(prev) + f*(coordGetZ(cur)-coordGetZ(prev)),
+			}
+			if pointInRingProjected(isect, outer, dropAxis) {
+				inHole := false
+				for ringIdx := 1; ringIdx < polygon.NumLinearRings(); ringIdx++ {
+					if pointInRingProjected(isect, polygon.LinearRing(ringIdx), dropAxis) {
+						inHole = true
+						break
+					}
+				}
+				if !inHole {
+					if u, ok := c.updater.(*geomMinDistance3DUpdater); ok {
+						u.currentValue = 0
+						u.coordA = isect
+						u.coordB = isect
+					}
+					return true
+				}
+			}
+		}
+		prev = cur
+		sPrev = sCur
+	}
+	return false
 }
 
 // ClosestPointToEdge implements geodist.DistanceCalculator using 3D

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -1040,6 +1040,138 @@ func TestDFullyWithin3D(t *testing.T) {
 	})
 }
 
+func TestShortestLineString3D(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		a        string
+		b        string
+		expected string
+	}{
+		{
+			"3D POINT above LINESTRING",
+			"POINT Z(0 0 5)",
+			"LINESTRING Z(0 0 0, 10 0 0)",
+			"LINESTRING Z(0 0 5, 0 0 0)",
+		},
+		{
+			"3D POINT offset from LINESTRING",
+			"POINT Z(5 3 4)",
+			"LINESTRING Z(0 0 0, 10 0 0)",
+			"LINESTRING Z(5 3 4, 5 0 0)",
+		},
+		{
+			"Same 3D POINTs",
+			"POINT Z(1 2 3)",
+			"POINT Z(1 2 3)",
+			"LINESTRING Z(1 2 3, 1 2 3)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a := geo.MustParseGeometry(tc.a)
+			b := geo.MustParseGeometry(tc.b)
+			expected := geo.MustParseGeometry(tc.expected)
+
+			ret, err := ShortestLineString3D(a, b)
+			require.NoError(t, err)
+			require.Equal(t, expected, ret)
+		})
+	}
+
+	t.Run("errors for EMPTY geometries", func(t *testing.T) {
+		_, err := ShortestLineString3D(
+			geo.MustParseGeometry("POINT EMPTY"),
+			geo.MustParseGeometry("POINT Z(1 1 1)"),
+		)
+		require.Error(t, err)
+		require.True(t, geo.IsEmptyGeometryError(err))
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := ShortestLineString3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestLongestLineString3D(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		a        string
+		b        string
+		expected string
+	}{
+		{
+			"3D POINT above LINESTRING",
+			"POINT Z(0 0 5)",
+			"LINESTRING Z(0 0 0, 10 0 0)",
+			"LINESTRING Z(0 0 5, 10 0 0)",
+		},
+		{
+			"3D POINT offset from LINESTRING",
+			"POINT Z(5 3 4)",
+			"LINESTRING Z(0 0 0, 10 0 0)",
+			"LINESTRING Z(5 3 4, 0 0 0)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a := geo.MustParseGeometry(tc.a)
+			b := geo.MustParseGeometry(tc.b)
+			expected := geo.MustParseGeometry(tc.expected)
+
+			ret, err := LongestLineString3D(a, b)
+			require.NoError(t, err)
+			require.Equal(t, expected, ret)
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := LongestLineString3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestClosestPoint3D(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		a        string
+		b        string
+		expected string
+	}{
+		{
+			"ClosestPoint3D on line to point",
+			"LINESTRING Z(0 0 0, 10 0 0)",
+			"POINT Z(5 3 4)",
+			"POINT Z(5 0 0)",
+		},
+		{
+			"ClosestPoint3D from point to line",
+			"POINT Z(0 0 5)",
+			"LINESTRING Z(0 0 0, 10 0 0)",
+			"POINT Z(0 0 5)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a := geo.MustParseGeometry(tc.a)
+			b := geo.MustParseGeometry(tc.b)
+			expected := geo.MustParseGeometry(tc.expected)
+
+			ret, err := ClosestPoint3D(a, b)
+			require.NoError(t, err)
+			require.Equal(t, expected, ret)
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := ClosestPoint3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
 func TestLongestLineString(t *testing.T) {
 	for _, tc := range distanceTestCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -637,11 +637,13 @@ var distance3DTestCases = []struct {
 	a                   string
 	b                   string
 	expectedMinDistance float64
+	expectedMaxDistance float64
 }{
 	{
 		"Same 3D POINTs",
 		"POINT Z(1 2 3)",
 		"POINT Z(1 2 3)",
+		0,
 		0,
 	},
 	{
@@ -649,11 +651,13 @@ var distance3DTestCases = []struct {
 		"POINT Z(0 0 0)",
 		"POINT Z(1 1 1)",
 		1.7320508075688772,
+		1.7320508075688772,
 	},
 	{
 		"3D POINTs differ only in Z",
 		"POINT Z(0 0 0)",
 		"POINT Z(0 0 5)",
+		5,
 		5,
 	},
 	{
@@ -661,11 +665,13 @@ var distance3DTestCases = []struct {
 		"POINT(0 0)",
 		"POINT(3 4)",
 		5,
+		5,
 	},
 	{
 		"2D POINTs (no Z) different",
 		"POINT(1 1)",
 		"POINT(2 1)",
+		1,
 		1,
 	},
 	{
@@ -673,30 +679,35 @@ var distance3DTestCases = []struct {
 		"POINT Z(5 3 4)",
 		"LINESTRING Z(0 0 0, 10 0 0)",
 		5,
+		7.0710678118654755,
 	},
 	{
 		"3D POINT above 3D LINESTRING",
 		"POINT Z(0 0 10)",
 		"LINESTRING Z(0 0 0, 10 0 0)",
 		10,
+		14.142135623730951,
 	},
 	{
 		"3D parallel LINESTRINGs",
 		"LINESTRING Z(0 0 0, 10 0 0)",
 		"LINESTRING Z(0 5 0, 10 5 0)",
 		5,
+		11.180339887498949,
 	},
 	{
 		"3D skew LINESTRINGs",
 		"LINESTRING Z(0 0 0, 10 0 0)",
 		"LINESTRING Z(5 5 5, 5 5 10)",
 		7.0710678118654755,
+		12.24744871391589,
 	},
 	{
 		"3D POINT to 3D POLYGON",
 		"POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0))",
 		"POINT Z(5 5 3)",
 		3,
+		7.6811457478686078,
 	},
 	{
 		// Regression test: with a 2D point inside the polygon's XY footprint,
@@ -706,18 +717,21 @@ var distance3DTestCases = []struct {
 		"POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
 		"POINT(5 5)",
 		0,
+		7.0710678118654755,
 	},
 	{
 		"2D POINT outside 2D POLYGON",
 		"POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
 		"POINT(15 5)",
 		5,
+		15.811388300841896,
 	},
 	{
 		"3D MULTIPOINTs",
 		"MULTIPOINT Z((0 0 0), (10 10 10))",
 		"MULTIPOINT Z((1 0 0), (0 1 0))",
 		1,
+		16.76305461424021,
 	},
 	{
 		// 2D-projected lines cross at (5,5) but are 10 apart in Z.
@@ -725,6 +739,7 @@ var distance3DTestCases = []struct {
 		"LINESTRING Z(0 0 0, 10 10 0)",
 		"LINESTRING Z(10 0 10, 0 10 10)",
 		10,
+		14.142135623730951,
 	},
 	{
 		// 3D segments truly cross at (5,5,5).
@@ -732,12 +747,15 @@ var distance3DTestCases = []struct {
 		"LINESTRING Z(0 0 0, 10 10 10)",
 		"LINESTRING Z(10 0 0, 0 10 10)",
 		0,
+		14.142135623730951,
 	},
 	{
-		// XYM coordinates: M is not Z; PostGIS treats both as 2D.
+		// XYM coordinates: M is not Z. After stripMDimension both are XY,
+		// so the comparison falls back to 2D and the M values are ignored.
 		"XYM POINTs degrade to 2D",
 		"POINT M(0 0 100)",
 		"POINT M(0 0 0)",
+		0,
 		0,
 	},
 	{
@@ -746,12 +764,14 @@ var distance3DTestCases = []struct {
 		"POINT ZM(0 0 5 100)",
 		"POINT ZM(0 0 0 0)",
 		5,
+		5,
 	},
 	{
 		// Mixed XYM and XY degrades to 2D distance.
 		"XYM POINT vs XY POINT degrades to 2D",
 		"POINT M(0 0 5)",
 		"POINT(3 4)",
+		5,
 		5,
 	},
 	{
@@ -762,6 +782,7 @@ var distance3DTestCases = []struct {
 		"POLYGON Z((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 0), (3 3 0, 7 3 0, 7 7 0, 3 7 0, 3 3 0))",
 		"LINESTRING Z(2 5 100, 8 5 100)",
 		100,
+		100.44401425669923,
 	},
 	{
 		// Two disjoint LINESTRINGs in the XY plane.
@@ -769,6 +790,7 @@ var distance3DTestCases = []struct {
 		"LINESTRING Z(0 0 0, 10 0 0)",
 		"LINESTRING Z(20 0 0, 30 0 0)",
 		10,
+		30,
 	},
 	{
 		// Parallel vertical LINESTRINGs offset in X.
@@ -776,6 +798,7 @@ var distance3DTestCases = []struct {
 		"LINESTRING Z(0 0 0, 0 0 10)",
 		"LINESTRING Z(5 0 0, 5 0 10)",
 		5,
+		11.180339887498949,
 	},
 }
 
@@ -894,6 +917,121 @@ func TestDWithin3D(t *testing.T) {
 
 	t.Run("errors if distance < 0", func(t *testing.T) {
 		_, err := DWithin3D(
+			geo.MustParseGeometry("POINT Z(1 2 3)"),
+			geo.MustParseGeometry("POINT Z(4 5 6)"),
+			-0.01,
+		)
+		require.Error(t, err)
+	})
+}
+
+func TestMaxDistance3D(t *testing.T) {
+	for _, tc := range distance3DTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			ret, err := MaxDistance3D(a, b)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expectedMaxDistance, ret, 1e-10)
+
+			// Verify symmetry.
+			ret, err = MaxDistance3D(b, a)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expectedMaxDistance, ret, 1e-10)
+		})
+	}
+
+	t.Run("errors for EMPTY geometries", func(t *testing.T) {
+		for _, tc := range emptyDistanceTestCases {
+			t.Run(fmt.Sprintf("%s to %s", tc.a, tc.b), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+				_, err = MaxDistance3D(a, b)
+				require.Error(t, err)
+				require.True(t, geo.IsEmptyGeometryError(err))
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := MaxDistance3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestDFullyWithin3D(t *testing.T) {
+	for _, tc := range distance3DTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			// At exact max distance and above, should be fully within.
+			for _, val := range []float64{
+				tc.expectedMaxDistance,
+				tc.expectedMaxDistance + 0.1,
+				tc.expectedMaxDistance + 1,
+				tc.expectedMaxDistance * 2,
+			} {
+				t.Run(fmt.Sprintf("fully_within:%f", val), func(t *testing.T) {
+					dwithin, err := DFullyWithin3D(a, b, val)
+					require.NoError(t, err)
+					require.True(t, dwithin)
+
+					dwithin, err = DFullyWithin3D(b, a, val)
+					require.NoError(t, err)
+					require.True(t, dwithin)
+				})
+			}
+
+			// Below the max distance, should not be fully within.
+			for _, val := range []float64{
+				tc.expectedMaxDistance - 0.1,
+				tc.expectedMaxDistance - 1,
+				tc.expectedMaxDistance / 2,
+			} {
+				if val > 0 {
+					t.Run(fmt.Sprintf("not_fully_within:%f", val), func(t *testing.T) {
+						dwithin, err := DFullyWithin3D(a, b, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+
+						dwithin, err = DFullyWithin3D(b, a, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+					})
+				}
+			}
+		})
+	}
+
+	t.Run("returns false for EMPTY geometries", func(t *testing.T) {
+		for _, tc := range emptyDistanceTestCases {
+			t.Run(fmt.Sprintf("%s to %s", tc.a, tc.b), func(t *testing.T) {
+				a, err := geo.ParseGeometry(tc.a)
+				require.NoError(t, err)
+				b, err := geo.ParseGeometry(tc.b)
+				require.NoError(t, err)
+				dwithin, err := DFullyWithin3D(a, b, 0)
+				require.NoError(t, err)
+				require.False(t, dwithin)
+			})
+		}
+	})
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := DFullyWithin3D(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB, 1)
+		requireMismatchingSRIDError(t, err)
+	})
+
+	t.Run("errors if distance < 0", func(t *testing.T) {
+		_, err := DFullyWithin3D(
 			geo.MustParseGeometry("POINT Z(1 2 3)"),
 			geo.MustParseGeometry("POINT Z(4 5 6)"),
 			-0.01,

--- a/pkg/geo/geomfn/unary_operators.go
+++ b/pkg/geo/geomfn/unary_operators.go
@@ -245,6 +245,76 @@ func CountVertices(t geom.T) int {
 	}
 }
 
+// Perimeter3D returns the 3D perimeter of a given Geometry.
+// For 2D geometries, this falls back to the 2D perimeter.
+// Note only (MULTI)POLYGON objects have a perimeter.
+func Perimeter3D(g geo.Geometry) (float64, error) {
+	geomRepr, err := g.AsGeomT()
+	if err != nil {
+		return 0, err
+	}
+	switch geomRepr.Layout() {
+	case geom.XYZ, geom.XYZM:
+		return perimeter3DFromGeomT(geomRepr)
+	}
+	return perimeterFromGeomT(geomRepr)
+}
+
+// perimeter3DFromGeomT returns the 3D perimeter from a geom.T.
+func perimeter3DFromGeomT(geomRepr geom.T) (float64, error) {
+	switch geomRepr := geomRepr.(type) {
+	case *geom.Point, *geom.MultiPoint, *geom.LineString, *geom.MultiLineString:
+		return 0, nil
+	case *geom.Polygon:
+		return perimeter3DPolygon(geomRepr)
+	case *geom.MultiPolygon:
+		total := float64(0)
+		for i := 0; i < geomRepr.NumPolygons(); i++ {
+			p, err := perimeter3DPolygon(geomRepr.Polygon(i))
+			if err != nil {
+				return 0, err
+			}
+			total += p
+		}
+		return total, nil
+	case *geom.GeometryCollection:
+		total := float64(0)
+		for _, subG := range geomRepr.Geoms() {
+			sub, err := perimeter3DFromGeomT(subG)
+			if err != nil {
+				return 0, err
+			}
+			total += sub
+		}
+		return total, nil
+	default:
+		return 0, errors.AssertionFailedf("unknown geometry type: %T", geomRepr)
+	}
+}
+
+// perimeter3DPolygon returns the 3D perimeter of a polygon by summing the
+// 3D lengths of all its rings (exterior + holes).
+func perimeter3DPolygon(p *geom.Polygon) (float64, error) {
+	zIndex := p.Layout().ZIndex()
+	if zIndex < 0 || zIndex >= p.Stride() {
+		return 0, errors.AssertionFailedf(
+			"Z-Index for Polygon is out-of-bounds: zIndex=%d, stride=%d", zIndex, p.Stride())
+	}
+	total := float64(0)
+	for ringIdx := 0; ringIdx < p.NumLinearRings(); ringIdx++ {
+		ring := p.LinearRing(ringIdx)
+		coords := ring.Coords()
+		for i := 1; i < len(coords); i++ {
+			prev, cur := coords[i-1], coords[i]
+			dx := cur.X() - prev.X()
+			dy := cur.Y() - prev.Y()
+			dz := cur[zIndex] - prev[zIndex]
+			total += math.Sqrt(dx*dx + dy*dy + dz*dz)
+		}
+	}
+	return total, nil
+}
+
 // length3DLineString returns the length of a
 // given 3D LINESTRING. Returns an error if
 // lineString does not have a z-coordinate.

--- a/pkg/geo/geomfn/unary_operators_test.go
+++ b/pkg/geo/geomfn/unary_operators_test.go
@@ -253,6 +253,32 @@ func TestMinimumClearanceLine(t *testing.T) {
 	}
 }
 
+func TestPerimeter3D(t *testing.T) {
+	testCases := []struct {
+		wkt      string
+		expected float64
+	}{
+		{"POLYGON Z((0 0 0, 10 0 0, 10 10 5, 0 10 5, 0 0 0))", 42.3606797749979},
+		{"POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", 40},
+		{"LINESTRING Z(0 0 0, 10 0 0)", 0},
+		{"POINT Z(0 0 0)", 0},
+		{"MULTIPOLYGON Z(((0 0 0, 1 0 0, 1 1 0, 0 1 0, 0 0 0)),((2 2 0, 3 2 0, 3 3 1, 2 3 1, 2 2 0)))", 8.82842712474619},
+	}
+
+	// Get reference value for multipolygon from PostGIS.
+	// Calculate manually: first polygon is flat (perimeter=4), second has Z offsets.
+	// For now, just test against PostGIS output.
+
+	for _, tc := range testCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g := geo.MustParseGeometry(tc.wkt)
+			ret, err := Perimeter3D(g)
+			require.NoError(t, err)
+			require.InDelta(t, tc.expected, ret, 1e-10)
+		})
+	}
+}
+
 func TestLength3D(t *testing.T) {
 	testCases := []struct {
 		wkt      string

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -556,6 +556,69 @@ SELECT ST_3DDistance(
   ST_SetSRID('POINT Z(1 1 1)'::geometry, 3857)
 )
 
+# Vertical polygon whose 2D footprint collapses to a line in XY.
+# Distance is the perpendicular drop to the polygon's plane (5), and the
+# shortest line endpoint on the polygon side is the perpendicular foot.
+# The 2D bounding box of the polygon has zero y-extent and does not
+# overlap the point's bbox, so a 2D fast-reject would incorrectly skip
+# the perpendicular-foot check; the 3D calculator's BoundingBoxIntersects
+# always returns true to avoid this.
+query R
+SELECT ST_3DDistance(
+  'POLYGON Z((0 0 0, 10 0 0, 10 0 10, 0 0 10, 0 0 0))'::geometry,
+  'POINT Z(5 5 5)'::geometry
+)
+----
+5
+
+query R
+SELECT ST_3DDistance(
+  'POINT Z(5 5 5)'::geometry,
+  'POLYGON Z((0 0 0, 10 0 0, 10 0 10, 0 0 10, 0 0 0))'::geometry
+)
+----
+5
+
+# The shortest-line endpoint on the polygon side is the perpendicular
+# foot, not the query point.
+query T
+SELECT ST_AsText(ST_3DShortestLine(
+  'POLYGON Z((0 2 0, 10 2 0, 10 2 10, 0 2 10, 0 2 0))'::geometry,
+  'POINT Z(5 5 5)'::geometry
+))
+----
+LINESTRING Z (5 2 5, 5 5 5)
+
+# Line crosses through the polygon's interior at (5, 0, 5). Distance is
+# 0 even though no boundary edge is touched; the line-plane intersection
+# point lies inside the outer ring.
+query R
+SELECT ST_3DDistance(
+  'POLYGON Z((0 0 0, 10 0 0, 10 0 10, 0 0 10, 0 0 0))'::geometry,
+  'LINESTRING Z(5 -3 5, 5 3 5)'::geometry
+)
+----
+0
+
+# Line crosses the polygon's plane outside the outer ring: not zero.
+query R
+SELECT ST_3DDistance(
+  'POLYGON Z((0 0 0, 10 0 0, 10 0 10, 0 0 10, 0 0 0))'::geometry,
+  'LINESTRING Z(50 -3 5, 50 3 5)'::geometry
+)
+----
+40
+
+# Line crosses the polygon's plane inside a hole: distance is to the
+# hole boundary, not zero.
+query R
+SELECT ST_3DDistance(
+  'POLYGON Z((0 0 0, 10 0 0, 10 0 10, 0 0 10, 0 0 0), (3 0 3, 7 0 3, 7 0 7, 3 0 7, 3 0 3))'::geometry,
+  'LINESTRING Z(5 -3 5, 5 3 5)'::geometry
+)
+----
+2
+
 subtest end
 
 subtest st_3ddwithin

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -444,9 +444,34 @@ SELECT ST_3DDistance('POINT Z(1 2 3)'::geometry, 'POINT Z(1 2 3)'::geometry)
 ----
 0
 
-# 2D geometry fallback (no Z means Z=0).
+# When either input lacks a Z dimension, ST_3DDistance falls back to 2D
+# distance (matching PostGIS's lwgeom_mindistance3d_tolerance).
 query R
 SELECT ST_3DDistance('POINT(0 0)'::geometry, 'POINT(3 4)'::geometry)
+----
+5
+
+# Mixed 2D/3D: PostGIS treats the missing Z as "any value" and degrades
+# the comparison to 2D, so the Z difference is not counted.
+query R
+SELECT ST_3DDistance('POINT(0 0)'::geometry, 'POINT Z(0 0 5)'::geometry)
+----
+0
+
+query B
+SELECT ST_3DDWithin('POINT(0 0)'::geometry, 'POINT Z(0 0 5)'::geometry, 0)
+----
+true
+
+# XYM input has its M dimension stripped, leaving an XY geometry, so the
+# comparison falls back to 2D and the M value is ignored.
+query R
+SELECT ST_3DDistance('POINT M(0 0 5)'::geometry, 'POINT M(0 0 0)'::geometry)
+----
+0
+
+query R
+SELECT ST_3DDistance('POINT M(0 0 5)'::geometry, 'POINT(3 4)'::geometry)
 ----
 5
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -696,6 +696,96 @@ SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 
 
 subtest end
 
+subtest st_3dshortestline
+
+query T
+SELECT ST_AsText(ST_3DShortestLine('POINT Z(0 0 5)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry))
+----
+LINESTRING Z (0 0 5, 0 0 0)
+
+query T
+SELECT ST_AsText(ST_3DShortestLine('POINT Z(5 3 4)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry))
+----
+LINESTRING Z (5 3 4, 5 0 0)
+
+# Both inputs lack Z: falls back to the 2D shortest line (returning a 2D
+# LineString), matching PostGIS's lw_dist3d_distanceline.
+query T
+SELECT ST_AsText(ST_3DShortestLine('POINT(5 0)'::geometry, 'LINESTRING(0 0, 10 0)'::geometry))
+----
+LINESTRING (5 0, 5 0)
+
+# Mixed 2D/3D: PostGIS treats the missing Z as "any value" via the
+# vertical-line trick. The 2D side's Z is chosen to optimize the metric
+# at the closest 2D XY pair.
+query T
+SELECT ST_AsText(ST_3DShortestLine('POINT(5 0)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry))
+----
+LINESTRING Z (5 0 0, 5 0 0)
+
+query T
+SELECT ST_AsText(ST_3DShortestLine('POINT(5 5)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry))
+----
+LINESTRING Z (5 5 0, 5 0 0)
+
+query T
+SELECT ST_AsText(ST_3DShortestLine('LINESTRING Z(0 0 0, 10 0 0)'::geometry, 'POINT(5 5)'::geometry))
+----
+LINESTRING Z (5 0 0, 5 5 0)
+
+subtest end
+
+subtest st_3dlongestline
+
+query T
+SELECT ST_AsText(ST_3DLongestLine('POINT Z(0 0 5)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry))
+----
+LINESTRING Z (0 0 5, 10 0 0)
+
+query T
+SELECT ST_AsText(ST_3DLongestLine('POINT(5 0)'::geometry, 'LINESTRING(0 0, 10 0)'::geometry))
+----
+LINESTRING (5 0, 0 0)
+
+query T
+SELECT ST_AsText(ST_3DLongestLine('POINT(0 0)'::geometry, 'LINESTRING Z(0 0 0, 10 0 100)'::geometry))
+----
+LINESTRING Z (0 0 0, 10 0 100)
+
+subtest end
+
+subtest st_3dclosestpoint
+
+query T
+SELECT ST_AsText(ST_3DClosestPoint('LINESTRING Z(0 0 0, 10 0 0)'::geometry, 'POINT Z(5 3 4)'::geometry))
+----
+POINT Z (5 0 0)
+
+query T
+SELECT ST_AsText(ST_3DClosestPoint('POINT Z(0 0 5)'::geometry, 'LINESTRING Z(0 0 0, 10 0 0)'::geometry))
+----
+POINT Z (0 0 5)
+
+# Both 2D: returns a 2D point.
+query T
+SELECT ST_AsText(ST_3DClosestPoint('POINT(5 0)'::geometry, 'LINESTRING(0 0, 10 0)'::geometry))
+----
+POINT (5 0)
+
+# Mixed 2D/3D: the vertical-line trick assigns the missing Z to match
+# the 3D side at the closest XY.
+query T
+SELECT ST_AsText(ST_3DClosestPoint('POINT(5 0)'::geometry, 'LINESTRING Z(0 0 0, 10 0 100)'::geometry))
+----
+POINT Z (5 0 50)
+
+query T
+SELECT ST_AsText(ST_3DClosestPoint('LINESTRING Z(0 0 0, 10 0 100)'::geometry, 'POINT(5 0)'::geometry))
+----
+POINT Z (5 0 50)
+
+subtest end
+
 subtest st_3dmaxdistance
 
 query R

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -696,6 +696,27 @@ SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 
 
 subtest end
 
+subtest st_3dperimeter
+
+query R
+SELECT ST_3DPerimeter('POLYGON Z((0 0 0, 10 0 0, 10 10 5, 0 10 5, 0 0 0))'::geometry)
+----
+42.3606797749979
+
+# 2D polygon returns 2D perimeter.
+query R
+SELECT ST_3DPerimeter('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))'::geometry)
+----
+40
+
+# Non-polygon types return 0.
+query R
+SELECT ST_3DPerimeter('LINESTRING Z(0 0 0, 10 0 0)'::geometry)
+----
+0
+
+subtest end
+
 subtest st_3dshortestline
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -695,3 +695,100 @@ SELECT id FROM geo_dwithin_zero WHERE st_dwithin(geog, 'POINT(1 1)'::geography, 
 4
 
 subtest end
+
+subtest st_3dmaxdistance
+
+query R
+SELECT ST_3DMaxDistance('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry)
+----
+1.7320508075688772
+
+query R
+SELECT ST_3DMaxDistance('LINESTRING Z(0 0 0, 10 0 0)'::geometry, 'POINT Z(5 5 5)'::geometry)
+----
+8.660254037844387
+
+query R
+SELECT ST_3DMaxDistance('POINT EMPTY'::geometry, 'POINT Z(1 1 1)'::geometry)
+----
+NULL
+
+# When either input lacks Z, ST_3DMaxDistance falls back to 2D distance,
+# matching PostGIS. The missing Z is not implicitly treated as 0.
+query R
+SELECT ST_3DMaxDistance('POINT(0 0)'::geometry, 'POINT Z(0 0 5)'::geometry)
+----
+0
+
+# XYM input has its M dimension stripped, leaving an XY geometry, so the
+# comparison falls back to 2D.
+query R
+SELECT ST_3DMaxDistance('POINT M(0 0 100)'::geometry, 'POINT M(0 0 0)'::geometry)
+----
+0
+
+query R
+SELECT ST_3DMaxDistance('POINT M(0 0 5)'::geometry, 'POINT(3 4)'::geometry)
+----
+5
+
+subtest end
+
+subtest st_3ddfullywithin
+
+query B
+SELECT ST_3DDFullyWithin('LINESTRING Z(0 0 0, 1 0 0)'::geometry, 'POINT Z(0 0 0)'::geometry, 1)
+----
+true
+
+query B
+SELECT ST_3DDFullyWithin('LINESTRING Z(0 0 0, 1 0 0)'::geometry, 'POINT Z(0 0 0)'::geometry, 0.5::float)
+----
+false
+
+query B
+SELECT _ST_3DDFullyWithin('LINESTRING Z(0 0 0, 1 0 0)'::geometry, 'POINT Z(0 0 0)'::geometry, 1)
+----
+true
+
+query error dwithin distance cannot be less than zero
+SELECT ST_3DDFullyWithin('POINT Z(0 0 0)'::geometry, 'POINT Z(1 1 1)'::geometry, -1)
+
+# Mixed 2D/3D falls back to 2D ST_DFullyWithin.
+query B
+SELECT ST_3DDFullyWithin('POINT(0 0)'::geometry, 'POINT Z(0 0 5)'::geometry, 0)
+----
+true
+
+subtest end
+
+subtest st_3dintersects
+
+query B
+SELECT ST_3DIntersects('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 0)'::geometry)
+----
+true
+
+query B
+SELECT ST_3DIntersects('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 1)'::geometry)
+----
+false
+
+query B
+SELECT ST_3DIntersects('LINESTRING Z(0 0 0, 10 0 0)'::geometry, 'POINT Z(5 0 0)'::geometry)
+----
+true
+
+query B
+SELECT _ST_3DIntersects('POINT Z(0 0 0)'::geometry, 'POINT Z(0 0 0)'::geometry)
+----
+true
+
+# ST_3DIntersects delegates to DWithin3D and inherits its 2D fallback:
+# when either input lacks Z, the comparison happens in 2D.
+query B
+SELECT ST_3DIntersects('POINT(0 0)'::geometry, 'POINT Z(0 0 5)'::geometry)
+----
+true
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2940,6 +2940,11 @@ var builtinOidsArray = []string{
 	2985: `crdb_internal.revlog_show_changes(collection: string, tick_time: timestamptz) -> tuple{string AS key, timestamptz AS mvcc_ts, string AS value, string AS prev_value}`,
 	2986: `crdb_internal.revlog_show_changes(collection: string, tick_time: timestamptz, start_key: bytes, end_key: bytes) -> tuple{string AS key, timestamptz AS mvcc_ts, string AS value, string AS prev_value}`,
 	2987: `crdb_internal.revlog_show_changes(collection: string, tick_time: timestamptz, raw_values: bool) -> tuple{string AS key, timestamptz AS mvcc_ts, bytes AS value, bytes AS prev_value}`,
+	2988: `_st_3dintersects(geometry_a: geometry, geometry_b: geometry) -> bool`,
+	2989: `st_3ddfullywithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
+	2990: `_st_3ddfullywithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
+	2991: `st_3dintersects(geometry_a: geometry, geometry_b: geometry) -> bool`,
+	2992: `st_3dmaxdistance(geometry_a: geometry, geometry_b: geometry) -> float`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2948,6 +2948,7 @@ var builtinOidsArray = []string{
 	2993: `st_3dclosestpoint(geometry_a: geometry, geometry_b: geometry) -> geometry`,
 	2994: `st_3dlongestline(geometry_a: geometry, geometry_b: geometry) -> geometry`,
 	2995: `st_3dshortestline(geometry_a: geometry, geometry_b: geometry) -> geometry`,
+	2996: `st_3dperimeter(geometry: geometry) -> float`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2945,6 +2945,9 @@ var builtinOidsArray = []string{
 	2990: `_st_3ddfullywithin(geometry_a: geometry, geometry_b: geometry, distance: float) -> bool`,
 	2991: `st_3dintersects(geometry_a: geometry, geometry_b: geometry) -> bool`,
 	2992: `st_3dmaxdistance(geometry_a: geometry, geometry_b: geometry) -> float`,
+	2993: `st_3dclosestpoint(geometry_a: geometry, geometry_b: geometry) -> geometry`,
+	2994: `st_3dlongestline(geometry_a: geometry, geometry_b: geometry) -> geometry`,
+	2995: `st_3dshortestline(geometry_a: geometry, geometry_b: geometry) -> geometry`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3324,9 +3324,69 @@ The requested number of points must be not larger than 65336.`,
 			volatility.Immutable,
 		),
 	),
+	"st_3dclosestpoint": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ClosestPoint3D(a.Geometry, b.Geometry)
+				if err != nil {
+					if geo.IsEmptyGeometryError(err) {
+						return tree.DNull, nil
+					}
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns the 3-dimensional point on geometry_a that is closest to geometry_b.",
+			},
+			volatility.Immutable,
+		),
+	),
 	"st_3dlength": makeBuiltin(
 		defProps(),
 		length3DOverloadGeometry1,
+	),
+	"st_3dlongestline": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.LongestLineString3D(a.Geometry, b.Geometry)
+				if err != nil {
+					if geo.IsEmptyGeometryError(err) {
+						return tree.DNull, nil
+					}
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns the 3-dimensional longest line between two geometries.",
+			},
+			volatility.Immutable,
+		),
+	),
+	"st_3dshortestline": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ShortestLineString3D(a.Geometry, b.Geometry)
+				if err != nil {
+					if geo.IsEmptyGeometryError(err) {
+						return tree.DNull, nil
+					}
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns the 3-dimensional shortest line between two geometries.",
+			},
+			volatility.Immutable,
+		),
 	),
 	"st_perimeter": makeBuiltin(
 		defProps(),

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3223,6 +3223,107 @@ The requested number of points must be not larger than 65336.`,
 			Volatility: volatility.Immutable,
 		},
 	),
+	"st_3ddfullywithin": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "geometry_a", Typ: types.Geometry},
+				{Name: "geometry_b", Typ: types.Geometry},
+				{Name: "distance", Typ: types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(
+				_ context.Context, _ *eval.Context, args tree.Datums,
+			) (tree.Datum, error) {
+				a := tree.MustBeDGeometry(args[0])
+				b := tree.MustBeDGeometry(args[1])
+				dist := tree.MustBeDFloat(args[2])
+				ret, err := geomfn.DFullyWithin3D(a.Geometry, b.Geometry, float64(dist))
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if every point in geometry_a is within distance units of geometry_b, " +
+					"using 3D Euclidean distance.",
+			}.String(),
+			Volatility: volatility.Immutable,
+		},
+	),
+	"_st_3ddfullywithin": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "geometry_a", Typ: types.Geometry},
+				{Name: "geometry_b", Typ: types.Geometry},
+				{Name: "distance", Typ: types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(
+				_ context.Context, _ *eval.Context, args tree.Datums,
+			) (tree.Datum, error) {
+				a := tree.MustBeDGeometry(args[0])
+				b := tree.MustBeDGeometry(args[1])
+				dist := tree.MustBeDFloat(args[2])
+				ret, err := geomfn.DFullyWithin3D(a.Geometry, b.Geometry, float64(dist))
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if every point in geometry_a is within distance units of geometry_b, " +
+					"using 3D Euclidean distance. This variant does not utilize any spatial index.",
+			}.String(),
+			Volatility: volatility.Immutable,
+		},
+	),
+	"st_3dintersects": makeBuiltin(
+		defProps(),
+		geometryOverload2BinaryPredicate(
+			func(a geo.Geometry, b geo.Geometry) (bool, error) {
+				return geomfn.DWithin3D(a, b, 0)
+			},
+			infoBuilder{
+				info: "Returns true if geometry_a shares any portion of space with geometry_b, " +
+					"using 3D Euclidean distance.",
+			},
+		),
+	),
+	"_st_3dintersects": makeBuiltin(
+		defProps(),
+		geometryOverload2BinaryPredicate(
+			func(a geo.Geometry, b geo.Geometry) (bool, error) {
+				return geomfn.DWithin3D(a, b, 0)
+			},
+			infoBuilder{
+				info: "Returns true if geometry_a shares any portion of space with geometry_b, " +
+					"using 3D Euclidean distance. This variant does not utilize any spatial index.",
+			},
+		),
+	),
+	"st_3dmaxdistance": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MaxDistance3D(a.Geometry, b.Geometry)
+				if err != nil {
+					if geo.IsEmptyGeometryError(err) {
+						return tree.DNull, nil
+					}
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the 3-dimensional maximum Cartesian distance between two geometries. " +
+					"If either geometry has no Z component, this is equivalent to ST_MaxDistance.",
+			},
+			volatility.Immutable,
+		),
+	),
 	"st_3dlength": makeBuiltin(
 		defProps(),
 		length3DOverloadGeometry1,

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -3368,6 +3368,25 @@ The requested number of points must be not larger than 65336.`,
 			volatility.Immutable,
 		),
 	),
+	"st_3dperimeter": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.Perimeter3D(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the 3-dimensional perimeter of the geometry. " +
+					"Note ST_3DPerimeter is only valid for Polygon or MultiPolygon. " +
+					"For 2D geometries it returns the 2D perimeter.",
+			},
+			volatility.Immutable,
+		),
+	),
 	"st_3dshortestline": makeBuiltin(
 		defProps(),
 		geometryOverload2(


### PR DESCRIPTION
This PR adds seven 3D geospatial functions and fixes several
pre-existing bugs in the 3D distance algorithm that the new functions
exposed.

The math was checked against PostGIS 3.6.2 across many edge cases
(skew lines, tilted polygons, polygons with holes, mixed 2D/3D inputs,
polygons in vertical planes, GeometryCollection inputs, etc.). Where
PostGIS itself has bugs (the centroid-of-flat-polygon case, see PostGIS
trac #4246 and the still-incomplete fix in changeset 17053), the
CockroachDB implementation produces the correct answer.

### Commits

1. **`geo: fall back to 2D distance when 3D inputs lack a Z dimension`**
   Pre-existing fix. `ST_3DDistance` and `ST_3DDWithin` previously
   treated missing Z as Z=0; PostGIS instead falls back fully to the 2D
   variant whenever either input lacks Z (per PostGIS's
   `lwgeom_mindistance3d_tolerance`). Adds a `hasZ` helper and routes
   `MinDistance3D`/`DWithin3D` through their 2D counterparts when
   either input lacks Z (after stripping M).

2. **`geo: implement ST_3DMaxDistance, ST_3DDFullyWithin, and ST_3DIntersects`**
   Adds three new 3D functions reusing the existing 3D distance
   infrastructure. Mixed-Z behavior matches PostGIS (fall back to 2D
   when either input lacks Z, after stripping M). `ST_3DIntersects` is
   `DWithin3D(a, b, 0)` and inherits the 2D fallback automatically.

3. **`geo: implement ST_3DShortestLine, ST_3DLongestLine, and ST_3DClosestPoint`**
   Adds three 3D functions that return geometry results. For mixed
   2D/3D inputs, ports PostGIS's "vertical-line trick" from
   `lw_dist3d_distanceline`: run 2D distance to find the closest XY
   pair, replace the 2D side with a vertical 3D segment at that XY
   spanning the other side's Z range, then run 3D distance against the
   augmented pair. When both inputs lack Z, falls back to the 2D
   variants and returns a 2D LineString/Point.

4. **`geo: implement ST_3DPerimeter`**
   Adds `ST_3DPerimeter`, returning the 3D perimeter of polygon
   geometries (sum of 3D segment lengths around each ring, accounting
   for Z differences). Falls back to the 2D perimeter for geometries
   without Z. Matches PostGIS's `lwpoly_perimeter`/`ptarray_length`.

5. **`geo: fix 3D distance for vertical polygons and lines through interior`**
   Pre-existing fixes uncovered while validating the new functions:
   - Replaces the 2D Cartesian bbox short-circuit in the 3D calculator
     with `BoundingBoxIntersects() = true`. The 2D bbox is unsound for
     3D polygons whose footprint collapses to a line in one axis.
   - `ST_3DShortestLine` now records the perpendicular foot on the
     polygon (not the query point) as the line's polygon-side endpoint,
     matching PostGIS's `lw_dist3d_pt_pt(p, projp, dl)`.
   - Adds an optional `linePolygonInteriorCrosser` interface in geodist
     so the 3D calculator can detect line edges that cross the
     polygon's plane at an interior point (zero distance), per
     PostGIS's `lw_dist3d_ptarray_poly`.
   - Improves numerical stability of the perpendicular-distance
     computation so axis-aligned cases return exact float results.

Resolves: #60860
Resolves: #60861
Resolves: #60865
Resolves: #60868
Resolves: #60870
Resolves: #60871
Resolves: #60872

Epic: none