### PR TITLE
sql/sem/tree: roll back desired-type filter when it eliminates all overloads

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4075,7 +4075,8 @@ func (t *logicTest) execQuery(query logicQuery) error {
 				} else if pgErr := (*pq.Error)(nil); errors.As(execErr, &pgErr) &&
 					(pgcode.MakeCode(string(pgErr.Code)) == pgcode.Syntax ||
 						pgcode.MakeCode(string(pgErr.Code)) == pgcode.InvalidParameterValue ||
-						pgcode.MakeCode(string(pgErr.Code)) == pgcode.InvalidTextRepresentation) {
+						pgcode.MakeCode(string(pgErr.Code)) == pgcode.InvalidTextRepresentation ||
+						pgcode.MakeCode(string(pgErr.Code)) == pgcode.DatatypeMismatch) {
 					prep, execErr = t.db.Prepare(p.SQL)
 					args = []interface{}{}
 				}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -5065,3 +5065,24 @@ statement error pgcode 22023 stddev cannot be negative
 SELECT random_normal(0, -1)
 
 subtest end
+
+# Regression tests for desired-type heuristic in overload resolution (#102716).
+# INT / INT returns DECIMAL, not INT. Previously the desired-type filter would
+# eliminate all division overloads, producing confusing errors. Now the error
+# correctly identifies the outer type mismatch.
+subtest division_desired_type
+
+statement error unknown signature: repeat\(string, decimal\)
+SELECT repeat('a', 1/1)
+
+statement error unknown signature: to_english\(decimal\)
+SELECT to_english(1/1)
+
+# BIT_LENGTH returns a scalar, not an array. Previously the desired-type filter
+# would eliminate overloads (since none return INT[]), producing a confusing
+# "unknown signature" error. Now the error correctly identifies the array
+# mismatch.
+query error op ANY <right> requires array, tuple or subquery on right side
+SELECT 1 > ANY(bit_length(''))
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1032,7 +1032,7 @@ ALTER TABLE x ADD COLUMN d INT AS (a + 'a') STORED
 statement error could not parse "a" as type int
 ALTER TABLE x ADD COLUMN d INT AS ('a') STORED
 
-statement error unsupported binary operator
+statement error expected STORED COMPUTED COLUMN expression to have type int, but 'a / 0' has type decimal
 ALTER TABLE x ADD COLUMN d INT AS (a / 0) STORED
 
 # Verify an error during computation fails.

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_assign
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_assign
@@ -272,3 +272,30 @@ statement ok
 DROP FUNCTION f(xy);
 
 subtest end
+
+# Regression test for desired-type heuristic incorrectly eliminating all
+# overloads for division. INT / INT has no overload returning INT (they all
+# return DECIMAL), so the desired-type filter used to eliminate all candidates,
+# causing "unsupported binary operator" errors.
+subtest division_desired_type
+
+statement ok
+CREATE FUNCTION f_div() RETURNS INT AS $$
+  DECLARE
+    x INT := 10;
+    result INT;
+  BEGIN
+    result := x / 5;
+    RETURN result;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query I
+SELECT f_div();
+----
+2
+
+statement ok
+DROP FUNCTION f_div;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -922,7 +922,7 @@ SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy);
 # The outer ROW(ROW(a, b)) is already a tuple, so shouldn't be wrapped in
 # another tuple before comparison. But the comparison should fail due to
 # mismatched types.
-query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(returning <tuple\{int, int\}>\)
+query error pgcode 22023 unsupported comparison operator: <tuple\{tuple\{int, int\}\}> IN <tuple\{int\}>
 SELECT * FROM ab WHERE ROW(ROW(a, b)) IN (SELECT x+1 FROM xy);
 
 # The outer ROW(ROW(a, b)) is already a tuple, so shouldn't be wrapped in
@@ -959,7 +959,7 @@ true
 # The outer ((2, 2), (3, 3)) is already a tuple, so shouldn't be wrapped in
 # another tuple before comparison. But the comparison should fail due to
 # mismatched types.
-query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(returning \<tuple\{int\, int\}>\)
+query error pgcode 22023 unsupported comparison operator: <tuple\{tuple\{int.*\}.*tuple\{int.*\}.*\}> IN <tuple\{tuple\{int.*\}\}>
 SELECT (SELECT (2, 2), (3, 3)) IN (SELECT x+1, y+1 FROM xy)
 
 # Outer scalar is a tuple with 2 elements. Subquery has only 1 column.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -259,7 +259,6 @@ func TestPGPrepareFail(t *testing.T) {
 		"SELECT CASE WHEN TRUE THEN $1 ELSE $2 END": "pq: could not determine data type of placeholder $2",
 		"SELECT $1 > 0 AND NOT $1":                  "pq: placeholder $1 already has type int, cannot assign bool",
 		"CREATE TABLE $1 (id INT)":                  "pq: at or near \"1\": syntax error",
-		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <anyelement> (returning <string>)",
 		"SELECT $0 > 0":                             "pq: lexical error: placeholder index must be between 1 and 65536",
 		"SELECT $2 > 0":                             "pq: could not determine data type of placeholder $1",
 		"SELECT 3 + CASE (4) WHEN 4 THEN $1 END":    "pq: could not determine data type of placeholder $1",

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1206,8 +1206,11 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 	}
 
 	// The first heuristic is to prefer candidates that return the desired type,
-	// if a desired type was provided.
+	// if a desired type was provided. If the filter eliminates all candidates
+	// (e.g., int division has no overload returning int), we roll back so that
+	// subsequent heuristics still have candidates to work with.
 	if desired.Family() != types.AnyFamily {
+		before := s.overloadIdxs
 		s.overloadIdxs = filterOverloads(s.overloadIdxs, s.overloads, func(
 			o overloadImpl,
 		) bool {
@@ -1220,6 +1223,9 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 			}
 			return true
 		})
+		if len(s.overloadIdxs) == 0 {
+			s.overloadIdxs = before
+		}
 		if ok, err := checkReturn(ctx, semaCtx, s); ok {
 			return err
 		}

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -254,7 +254,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{decConst("1.1"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
 		{nil, []Expr{NewDFloat(1.1), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn, binaryFloatFn}, binaryFloatFn, false},
 		{types.Decimal, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn, false},              // Limitation.
-		{nil, []Expr{plus(intConst("1"), intConst("2")), plus(decConst("1.1"), decConst("2.2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false}, // Limitation.
+		{nil, []Expr{plus(intConst("1"), intConst("2")), plus(decConst("1.1"), decConst("2.2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, unsupported, false}, // Limitation.
 		{nil, []Expr{plus(decConst("1.1"), decConst("2.2")), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
 		{nil, []Expr{plus(NewDFloat(1.1), NewDFloat(2.2)), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
 		// Homogenous preference.


### PR DESCRIPTION
Previously, the desired-type heuristic in overload resolution would filter out all overload candidates when none matched the desired return type. With 0 candidates remaining, `checkReturn` would call `defaultTypeCheck` and exit overload resolution immediately, preventing subsequent heuristics (like the binary operator heuristic) from ever running.

Now, when the desired-type filter eliminates all candidates, we roll back to the pre-filter candidate set so that later heuristics can still operate.

This matches what some later heuristics do with `filterAttempt`.

The logictest local-prepared fallback now also catches DatatypeMismatch errors during scalar-replaced PREPARE. The scalar replacer wraps fractional literals like 0.0 in CAST(... AS DECIMAL), which can force overload resolution to pick a decimal-returning overload where the original SQL would have picked an int-returning one. Previously this surfaced as an InvalidParameterValue error (which was already caught); with the rollback change it surfaces as DatatypeMismatch instead.

Fixes: #102716

Release note (bug fix): Fix a bug where some scalar expressions would incorrectly fail type checking with "unsupported binary operator" errors. These scalar expressions now make it further in type checking, which either leads to success or more accurate error messages.