### PR TITLE
roachtest: set mixed version minimum for ldr/conflict test

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -258,7 +258,12 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 				createTables: true,
 			},
 			requiresDeprecatedWorkload: true,
-			run:                        TestLDRConflict,
+			// The conflict workload generates tables with expression-based
+			// indexes that use virtual computed columns as index keys. Prior
+			// to 26.2, virtual computed columns in secondary indexes were
+			// unconditionally rejected during LDR stream creation.
+			mixedVersionMinimum: clusterversion.V26_2,
+			run:                 TestLDRConflict,
 		},
 		{
 			name: "ldr/kv0/workload=source/single_key_update_benchmark",


### PR DESCRIPTION
The conflict workload generates tables with expression-based indexes that use virtual computed columns as index keys. Support for virtual computed columns in secondary indexes was added in 26.2 (c5a74eaa072). When running against a 26.1 predecessor, the reverse stream creation in bidirectional LDR fails because the older node unconditionally rejects virtual computed columns in secondary index keys.

Fixes: #169053
Epic: none

Release note: None