### PR TITLE
schemachanger: add error-on-fallthrough guards on vistors

### DIFF
--- a/pkg/sql/schemachanger/scexec/scmutationexec/create.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/create.go
@@ -65,6 +65,10 @@ func (i *immediateVisitor) AddDescriptorName(ctx context.Context, op scop.AddDes
 	switch t := desc.(type) {
 	case *tabledesc.Mutable:
 		t.ParentID = op.Namespace.DatabaseID
+	case *dbdesc.Mutable, *schemadesc.Mutable, *typedesc.Mutable:
+		// These descriptor types have their parent IDs set through other ops.
+	default:
+		return errors.AssertionFailedf("unexpected descriptor type %T for AddDescriptorName", desc)
 	}
 
 	return nil
@@ -90,6 +94,8 @@ func (i *immediateVisitor) SetNameInDescriptor(
 		// functions do not have a namespace entry and their name field is handled
 		// by FunctionName element.
 		return errors.AssertionFailedf("Incorrect descriptor type %v", mut.DescriptorType())
+	default:
+		return errors.AssertionFailedf("unexpected descriptor type %v for SetNameInDescriptor", mut.DescriptorType())
 	}
 	return nil
 }

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -644,6 +644,10 @@ func (i *immediateVisitor) RemoveObjectParent(
 			return err
 		}
 		sc.RemoveFunction(obj.GetName(), obj.GetID())
+	case catalog.Table, catalog.Type:
+		// Schemas don't maintain back-references to tables or types.
+	default:
+		return errors.AssertionFailedf("unexpected descriptor type %v for RemoveObjectParent", obj.DescriptorType())
 	}
 	return nil
 }


### PR DESCRIPTION
The issue in #169345 demonstrated the risk of switch statements on types
if an unexpected type is passed to the vistor function. This change
guards against future bugs by adding errors-on-default that trip on
unexpected types.

Epic: CRDB-31325

Informed by: #169345

Release note: None