### PR TITLE
sql: short-circuit `ALTER TYPE ... OWNER` for noop commands

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -407,6 +407,10 @@ func (p *planner) alterTypeOwner(
 	typeDesc := n.desc
 	oldOwner := typeDesc.GetPrivileges().Owner()
 
+	if newOwner == oldOwner {
+		return nil
+	}
+
 	arrayDesc, err := p.Descriptors().MutableByID(p.txn).Type(ctx, typeDesc.ArrayTypeID)
 	if err != nil {
 		return err
@@ -429,11 +433,6 @@ func (p *planner) alterTypeOwner(
 	if err := p.setNewTypeOwner(ctx, typeDesc, arrayDesc, typeNameWithPrefix,
 		arrayTypeNameWithPrefix, newOwner); err != nil {
 		return err
-	}
-
-	// If the owner we want to set to is the current owner, do a no-op.
-	if newOwner == oldOwner {
-		return nil
 	}
 
 	if err := p.writeTypeSchemaChange(

--- a/pkg/sql/logictest/testdata/logic_test/alter_type_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type_owner
@@ -37,6 +37,20 @@ user root
 statement ok
 ALTER TYPE s.typ OWNER TO testuser
 
+# Setting the owner to the current owner is a no-op.
+statement ok
+REVOKE CREATE ON SCHEMA s FROM testuser
+
+user testuser
+
+statement ok
+ALTER TYPE s.typ OWNER TO testuser
+
+user root
+
+statement ok
+GRANT CREATE ON SCHEMA s TO testuser
+
 user testuser
 
 statement error must be member of role "testuser2"


### PR DESCRIPTION
This change matches Postgres' short-circuit behavior and adds a test to
demonstrate it.

Part of: #164217
Supports: #166601
Epic: CRDB-31325

Release note: None
