### PR TITLE
release-26.2: roachtest: fetch and check rust

### DIFF
--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -152,8 +152,9 @@ func registerDjango(r registry.Registry) {
 					# s390x doesn't have a prebuilt wheel for bcrypt, so we need
 					# to build it from source. This requires rust.
 					# Install rust and set the default toolchain to stable.
-					curl https://sh.rustup.rs -sSf | sh -s -- -y
+					bash -o pipefail -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y'
 					source $HOME/.cargo/env
+					cargo --version
 
 					# s390x doesn't have a prebuilt wheel for pillow, so we need
 					# to build it from source. This requires libjpeg-dev.

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -78,9 +78,8 @@ func registerRustPostgres(r registry.Registry) {
 			t,
 			c,
 			node,
-			"install rust and cargo",
-			`curl https://sh.rustup.rs -sSf | sh -s -- -y
-`,
+			"install and verify rust and cargo",
+			`bash -o pipefail -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y && $HOME/.cargo/bin/cargo --version'`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +129,7 @@ func registerRustPostgres(r registry.Registry) {
 			ctx,
 			t.L(),
 			option.WithNodes(node),
-			`cd /mnt/data1/rust-postgres && /home/ubuntu/.cargo/bin/cargo test 2>&1 > rustpostgres.stdout --no-fail-fast`)
+			`cd /mnt/data1/rust-postgres && $HOME/.cargo/bin/cargo test 2>&1 > rustpostgres.stdout --no-fail-fast`)
 		if err != nil {
 			t.L().Printf("error during rust postgres run (may be ok): %v\n", err)
 		}

--- a/pkg/cmd/roachtest/tests/rust_sqlx.go
+++ b/pkg/cmd/roachtest/tests/rust_sqlx.go
@@ -63,7 +63,7 @@ func registerRustSqlx(r registry.Registry) {
 
 		// Use /tmp for local runs, /mnt/data1 for remote.
 		sqlxDir := "/mnt/data1/sqlx"
-		cargoPath := "/home/ubuntu/.cargo/bin/cargo"
+		cargoPath := "$HOME/.cargo/bin/cargo"
 		if c.IsLocal() {
 			sqlxDir = "/tmp/sqlx"
 			cargoPath = "cargo"
@@ -92,8 +92,8 @@ func registerRustSqlx(r registry.Registry) {
 		if !c.IsLocal() {
 			if err := repeatRunE(
 				ctx, t, c, node,
-				"install rust and cargo",
-				`curl https://sh.rustup.rs -sSf | sh -s -- -y`,
+				"install and verify rust and cargo",
+				`bash -o pipefail -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y && $HOME/.cargo/bin/cargo --version'`,
 			); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #167437 on behalf of @bghal.

----

Until the RiiR
[project](https://github.com/ansuz/RIIR) is
globally complete, fetching Rust infra will not be
completely reliable.
For our purposes, the `curl` for rust installation
can fail silently and the pipeline proceeds. This
change adds a fetch and check which trips a retry
in the pipeline.

Epic: none
Fixes: #167098

Release note: None


----

Release justification: Covers flakey non-production code, to wit, testing setup.