### PR TITLE
workload/pgbench: add pgbench-equivalent workload

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/workload/kv",
         "//pkg/workload/ledger",
         "//pkg/workload/movr",
+        "//pkg/workload/pgbench",
         "//pkg/workload/querybench",
         "//pkg/workload/querylog",
         "//pkg/workload/queue",

--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ledger"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/movr"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/pgbench"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/querybench"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/querylog"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/queue"

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -271,6 +271,7 @@ go_library(
         "//pkg/workload/insights",
         "//pkg/workload/kv",
         "//pkg/workload/movr",
+        "//pkg/workload/pgbench",
         "//pkg/workload/querybench",
         "//pkg/workload/sqlstats",
         "//pkg/workload/tpcc",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/insights"           // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"                 // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/movr"               // registers workloads
+	_ "github.com/cockroachdb/cockroach/pkg/workload/pgbench"            // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/querybench"         // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/sqlstats"           // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"               // registers workloads

--- a/pkg/workload/pgbench/BUILD.bazel
+++ b/pkg/workload/pgbench/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "pgbench",
+    srcs = ["pgbench.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/workload/pgbench",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/col/coldata",
+        "//pkg/sql/types",
+        "//pkg/util/bufalloc",
+        "//pkg/util/timeutil",
+        "//pkg/workload",
+        "//pkg/workload/histogram",
+        "@com_github_cockroachdb_cockroach_go_v2//crdb",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_spf13_pflag//:pflag",
+    ],
+)
+
+go_test(
+    name = "pgbench_test",
+    size = "medium",
+    srcs = [
+        "main_test.go",
+        "pgbench_test.go",
+    ],
+    embed = [":pgbench"],
+    deps = [
+        "//pkg/base",
+        "//pkg/security/securityassets",
+        "//pkg/security/securitytest",
+        "//pkg/security/username",
+        "//pkg/server",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "//pkg/workload",
+        "//pkg/workload/histogram",
+        "//pkg/workload/workloadsql",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/workload/pgbench/main_test.go
+++ b/pkg/workload/pgbench/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package pgbench_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	securityassets.SetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/workload/pgbench/pgbench.go
+++ b/pkg/workload/pgbench/pgbench.go
@@ -1,0 +1,502 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package pgbench implements a CockroachDB workload that mirrors the schema
+// and transactions of PostgreSQL's pgbench tool. It is intended as a
+// bug-hunting and cross-database comparability harness, not as a published
+// benchmark.
+//
+// The default ("tpcb") transaction is the deprecated TPC-B variant that
+// pgbench has shipped since 1996:
+//
+//	BEGIN;
+//	UPDATE pgbench_accounts SET abalance = abalance + :delta WHERE aid = :aid;
+//	SELECT abalance FROM pgbench_accounts WHERE aid = :aid;
+//	UPDATE pgbench_tellers  SET tbalance = tbalance + :delta WHERE tid = :tid;
+//	UPDATE pgbench_branches SET bbalance = bbalance + :delta WHERE bid = :bid;
+//	INSERT INTO pgbench_history (tid, bid, aid, delta, mtime)
+//	  VALUES (:tid, :bid, :aid, :delta, current_timestamp);
+//	END;
+//
+// At scale s the table cardinalities are:
+//
+//	pgbench_branches: s            (extreme heat — all clients update these s rows)
+//	pgbench_tellers:  10*s
+//	pgbench_accounts: 100000*s     (bulk of the working set; cold)
+//	pgbench_history:  starts empty (append-only)
+//
+// The combination of multi-statement transactions, severe heat skew across
+// tables of very different sizes, a read-after-write within the txn, and an
+// append-only history table exercises code paths that single-table workloads
+// like `kv` do not.
+package pgbench
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/pflag"
+)
+
+const (
+	// pgbench multipliers from the upstream tool. Do not change without a
+	// corresponding update to the consistency check.
+	naccountsPerScale = 100000
+	ntellersPerScale  = 10
+	nbranchesPerScale = 1
+
+	// Filler widths chosen to approximate pgbench's row sizes (~100 bytes
+	// for accounts/tellers/branches, ~50 bytes for history). Matching the
+	// upstream filler widths matters for any comparison that touches block
+	// cache footprint or page-fault behavior.
+	accountsFillerWidth = 84
+	tellersFillerWidth  = 84
+	branchesFillerWidth = 88
+	historyFillerWidth  = 22
+
+	// pgbench draws delta uniformly from [-5000, 5000].
+	deltaRange = 5000
+
+	defaultScale     = 1
+	defaultBatchSize = 1000
+	defaultMode      = modeTPCB
+	modeTPCB         = "tpcb"
+	modeSimpleUpdate = "simple-update"
+	modeSelectOnly   = "select-only"
+)
+
+var RandomSeed = workload.NewUint64RandomSeed()
+
+// pgbench is the workload generator. The schema and transaction shapes are
+// chosen to mirror upstream pgbench so that performance pathologies observed
+// against PostgreSQL can be reproduced (or ruled out) against CockroachDB.
+type pgbench struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	// scale controls table cardinalities (see naccountsPerScale et al.).
+	scale int
+	// batchSize controls how many rows are emitted per FillBatch call during
+	// initial data load. It does not affect the running workload.
+	batchSize int
+	// mode selects the transaction template; see the mode* constants.
+	mode string
+}
+
+func init() {
+	workload.Register(pgbenchMeta)
+}
+
+var pgbenchMeta = workload.Meta{
+	Name: `pgbench`,
+	Description: `pgbench mirrors PostgreSQL's pgbench tool (TPC-B-like) for ` +
+		`bug-hunting and cross-database comparability.`,
+	Version:    `1.0.0`,
+	RandomSeed: RandomSeed,
+	New: func() workload.Generator {
+		g := &pgbench{}
+		g.flags.FlagSet = pflag.NewFlagSet(`pgbench`, pflag.ContinueOnError)
+		g.flags.Meta = map[string]workload.FlagMeta{
+			`batch-size`: {RuntimeOnly: true},
+		}
+		g.flags.IntVar(&g.scale, `scale`, defaultScale,
+			`Scale factor; sets accounts=100000*scale, tellers=10*scale, branches=scale.`)
+		g.flags.IntVar(&g.batchSize, `batch-size`, defaultBatchSize,
+			`Rows per batch during initial data load.`)
+		g.flags.StringVar(&g.mode, `mode`, defaultMode,
+			`Transaction mode: tpcb (default 5-statement), simple-update (-N), select-only (-S).`)
+		RandomSeed.AddFlag(&g.flags)
+		g.connFlags = workload.NewConnFlags(&g.flags)
+		return g
+	},
+}
+
+// Meta implements the Generator interface.
+func (*pgbench) Meta() workload.Meta { return pgbenchMeta }
+
+// Flags implements the Flagser interface.
+func (g *pgbench) Flags() workload.Flags { return g.flags }
+
+// ConnFlags implements the ConnFlagser interface.
+func (g *pgbench) ConnFlags() *workload.ConnFlags { return g.connFlags }
+
+// Hooks implements the Hookser interface.
+func (g *pgbench) Hooks() workload.Hooks {
+	return workload.Hooks{
+		Validate: func() error {
+			if g.scale < 1 {
+				return errors.Errorf(`scale must be >= 1; was %d`, g.scale)
+			}
+			if g.batchSize <= 0 {
+				return errors.Errorf(`batch-size must be > 0; was %d`, g.batchSize)
+			}
+			switch g.mode {
+			case modeTPCB, modeSimpleUpdate, modeSelectOnly:
+			default:
+				return errors.Errorf(
+					`invalid mode %q (want one of tpcb, simple-update, select-only)`, g.mode)
+			}
+			return nil
+		},
+		CheckConsistency: g.checkConsistency,
+	}
+}
+
+// checkConsistency verifies the invariants maintained by the workload.
+// Which sums must match depends on the mode the workload was run in, since
+// simple-update and select-only deliberately do not touch every table.
+//
+// Always-true invariants (across all modes, assuming a single mode was run
+// since init):
+//
+//  1. Row counts in accounts/tellers/branches match the scale factor — no
+//     mode inserts or deletes from these tables.
+//  2. sum(abalance) == sum(history.delta) — both are written together by
+//     tpcb and simple-update; both stay zero in select-only.
+//  3. sum(bbalance) == sum(tbalance) — both are written only by tpcb.
+//
+// Mode-specific invariant: under tpcb, the four sums are all equal because
+// every transaction applies the same delta to abalance, bbalance, tbalance,
+// and history.delta.
+//
+// A violation of (1) catches accidental schema or row drops. A violation of
+// (2) or (3) indicates a lost or duplicated write somewhere in the
+// transactional path.
+func (g *pgbench) checkConsistency(ctx context.Context, db *gosql.DB) error {
+	expected := []struct {
+		table string
+		count int64
+	}{
+		{`pgbench_accounts`, int64(naccountsPerScale * g.scale)},
+		{`pgbench_tellers`, int64(ntellersPerScale * g.scale)},
+		{`pgbench_branches`, int64(nbranchesPerScale * g.scale)},
+	}
+	for _, e := range expected {
+		var got int64
+		if err := db.QueryRowContext(ctx,
+			fmt.Sprintf(`SELECT count(*) FROM %s`, e.table)).Scan(&got); err != nil {
+			return errors.Wrapf(err, "row count for %s", e.table)
+		}
+		if got != e.count {
+			return errors.Errorf("row count for %s: expected %d, got %d", e.table, e.count, got)
+		}
+	}
+
+	var aSum, bSum, tSum, hSum int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(sum(abalance), 0) FROM pgbench_accounts`).Scan(&aSum); err != nil {
+		return errors.Wrap(err, "sum(abalance)")
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(sum(bbalance), 0) FROM pgbench_branches`).Scan(&bSum); err != nil {
+		return errors.Wrap(err, "sum(bbalance)")
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(sum(tbalance), 0) FROM pgbench_tellers`).Scan(&tSum); err != nil {
+		return errors.Wrap(err, "sum(tbalance)")
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(sum(delta), 0) FROM pgbench_history`).Scan(&hSum); err != nil {
+		return errors.Wrap(err, "sum(history.delta)")
+	}
+	if aSum != hSum {
+		return errors.Errorf(
+			"balance invariant violated: sum(abalance)=%d != sum(history.delta)=%d", aSum, hSum)
+	}
+	if bSum != tSum {
+		return errors.Errorf(
+			"balance invariant violated: sum(bbalance)=%d != sum(tbalance)=%d", bSum, tSum)
+	}
+	if g.mode == modeTPCB && aSum != bSum {
+		return errors.Errorf(
+			"balance invariant violated under tpcb mode: sum(abalance)=%d != sum(bbalance)=%d",
+			aSum, bSum)
+	}
+	fmt.Printf("pgbench: row counts ok; sum(abalance)=%d sum(bbalance)=%d sum(tbalance)=%d sum(history.delta)=%d\n",
+		aSum, bSum, tSum, hSum)
+	return nil
+}
+
+// Schema definitions. We deliberately match upstream pgbench, including:
+//   - 1-based primary keys (so values from a PG benchmark can be cross-loaded);
+//   - CHAR(N) filler columns of the same widths as upstream;
+//   - no primary key on pgbench_history (it is an append-only log).
+//
+// CockroachDB will assign pgbench_history a hidden unique_rowid PK, which
+// spreads inserts across ranges — a notable behavioral divergence from PG
+// (where the heap appends sequentially). This is a feature for our purposes:
+// we get the same logical workload without an artificial single-range
+// hotspot, and any consumer that explicitly wants the hotspot can add a
+// sequential PK after the fact.
+const (
+	accountsSchema = `(
+		aid      INT NOT NULL PRIMARY KEY,
+		bid      INT,
+		abalance INT,
+		filler   CHAR(84),
+		FAMILY (aid, bid, abalance, filler)
+	)`
+	tellersSchema = `(
+		tid      INT NOT NULL PRIMARY KEY,
+		bid      INT,
+		tbalance INT,
+		filler   CHAR(84),
+		FAMILY (tid, bid, tbalance, filler)
+	)`
+	branchesSchema = `(
+		bid      INT NOT NULL PRIMARY KEY,
+		bbalance INT,
+		filler   CHAR(88),
+		FAMILY (bid, bbalance, filler)
+	)`
+	historySchema = `(
+		tid    INT,
+		bid    INT,
+		aid    INT,
+		delta  INT,
+		mtime  TIMESTAMP,
+		filler CHAR(22)
+	)`
+)
+
+var accountsTypes = []*types.T{types.Int, types.Int, types.Int, types.Bytes}
+
+// Tables implements the Generator interface.
+func (g *pgbench) Tables() []workload.Table {
+	naccounts := naccountsPerScale * g.scale
+	ntellers := ntellersPerScale * g.scale
+	nbranches := nbranchesPerScale * g.scale
+
+	// Accounts is the only table large enough to justify columnar batched
+	// init; the others are tiny and use the simpler Tuples helper.
+	accountsBatches := (naccounts + g.batchSize - 1) / g.batchSize
+	accounts := workload.Table{
+		Name:   `pgbench_accounts`,
+		Schema: accountsSchema,
+		InitialRows: workload.BatchedTuples{
+			NumBatches: accountsBatches,
+			FillBatch: func(batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
+				rowBegin := batchIdx * g.batchSize
+				rowEnd := rowBegin + g.batchSize
+				if rowEnd > naccounts {
+					rowEnd = naccounts
+				}
+				cb.Reset(accountsTypes, rowEnd-rowBegin, coldata.StandardColumnFactory)
+				aidCol := cb.ColVec(0).Int64()
+				bidCol := cb.ColVec(1).Int64()
+				abalCol := cb.ColVec(2).Int64()
+				fillerCol := cb.ColVec(3).Bytes()
+				fillerCol.Reset()
+				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
+					// pgbench is 1-indexed; aid in [1, naccounts].
+					aid := int64(rowIdx + 1)
+					off := rowIdx - rowBegin
+					aidCol[off] = aid
+					// bid = ceil(aid / naccountsPerScale), 1-indexed.
+					bidCol[off] = (aid-1)/naccountsPerScale + 1
+					abalCol[off] = 0
+					var buf []byte
+					*a, buf = a.Alloc(accountsFillerWidth)
+					for i := range buf {
+						buf[i] = ' '
+					}
+					fillerCol.Set(off, buf)
+				}
+			},
+		},
+	}
+
+	branches := workload.Table{
+		Name:   `pgbench_branches`,
+		Schema: branchesSchema,
+		InitialRows: workload.Tuples(nbranches, func(i int) []interface{} {
+			return []interface{}{i + 1, 0, blankFiller(branchesFillerWidth)}
+		}),
+	}
+
+	tellers := workload.Table{
+		Name:   `pgbench_tellers`,
+		Schema: tellersSchema,
+		InitialRows: workload.Tuples(ntellers, func(i int) []interface{} {
+			tid := i + 1
+			bid := (tid-1)/ntellersPerScale + 1
+			return []interface{}{tid, bid, 0, blankFiller(tellersFillerWidth)}
+		}),
+	}
+
+	history := workload.Table{
+		Name:   `pgbench_history`,
+		Schema: historySchema,
+		// Starts empty.
+	}
+
+	return []workload.Table{accounts, branches, tellers, history}
+}
+
+// blankFiller returns a string of n spaces. pgbench uses CHAR(N) defaulted
+// to spaces; we generate the equivalent client-side so the row size on disk
+// matches what PG produces.
+func blankFiller(n int) string {
+	return strings.Repeat(" ", n)
+}
+
+// Ops implements the Opser interface.
+func (g *pgbench) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
+	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	db.SetMaxOpenConns(g.connFlags.Concurrency + 1)
+	db.SetMaxIdleConns(g.connFlags.Concurrency + 1)
+
+	stmts, err := prepareStatements(ctx, db)
+	if err != nil {
+		return workload.QueryLoad{}, errors.CombineErrors(err, db.Close())
+	}
+
+	naccounts := naccountsPerScale * g.scale
+	ntellers := ntellersPerScale * g.scale
+	nbranches := nbranchesPerScale * g.scale
+
+	ql := workload.QueryLoad{
+		Close: func(_ context.Context) error { return db.Close() },
+	}
+	for i := 0; i < g.connFlags.Concurrency; i++ {
+		// Seed each worker independently so a given (seed, worker) pair is
+		// reproducible.
+		rng := rand.New(rand.NewPCG(RandomSeed.Seed(), uint64(i)))
+		hists := reg.GetHandle()
+		mode := g.mode
+
+		workerFn := func(ctx context.Context) error {
+			aid := rng.IntN(naccounts) + 1
+			bid := rng.IntN(nbranches) + 1
+			tid := rng.IntN(ntellers) + 1
+			delta := rng.IntN(2*deltaRange+1) - deltaRange
+
+			start := timeutil.Now()
+			err := runTxn(ctx, db, stmts, mode, aid, bid, tid, delta)
+			hists.Get(mode).Record(timeutil.Since(start))
+			return err
+		}
+		ql.WorkerFns = append(ql.WorkerFns, workerFn)
+	}
+	return ql, nil
+}
+
+// pgbenchStmts holds the prepared statements used by all worker goroutines.
+// Statements are prepared once on the shared *sql.DB; database/sql handles
+// per-connection re-preparation transparently.
+type pgbenchStmts struct {
+	updateAccount *gosql.Stmt
+	selectAccount *gosql.Stmt
+	updateTeller  *gosql.Stmt
+	updateBranch  *gosql.Stmt
+	insertHistory *gosql.Stmt
+}
+
+func prepareStatements(ctx context.Context, db *gosql.DB) (*pgbenchStmts, error) {
+	prep := func(q string) (*gosql.Stmt, error) {
+		s, err := db.PrepareContext(ctx, q)
+		if err != nil {
+			return nil, errors.Wrapf(err, "preparing %q", q)
+		}
+		return s, nil
+	}
+	s := &pgbenchStmts{}
+	var err error
+	if s.updateAccount, err = prep(
+		`UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2`); err != nil {
+		return nil, err
+	}
+	if s.selectAccount, err = prep(
+		`SELECT abalance FROM pgbench_accounts WHERE aid = $1`); err != nil {
+		return nil, err
+	}
+	if s.updateTeller, err = prep(
+		`UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2`); err != nil {
+		return nil, err
+	}
+	if s.updateBranch, err = prep(
+		`UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2`); err != nil {
+		return nil, err
+	}
+	if s.insertHistory, err = prep(
+		`INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) ` +
+			`VALUES ($1, $2, $3, $4, current_timestamp)`); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// runTxn executes one pgbench transaction in the requested mode. It uses
+// crdb.ExecuteTx so serializable conflicts are retried transparently — the
+// same retry loop ledger uses. Bug-hunters who want to observe raw retry
+// behavior should disable retries at the workload-runner layer rather than
+// here, to keep the per-mode SQL identical to upstream pgbench.
+func runTxn(
+	ctx context.Context, db *gosql.DB, stmts *pgbenchStmts, mode string, aid, bid, tid, delta int,
+) error {
+	return crdb.ExecuteTx(ctx, db, nil /* txopts */, func(tx *gosql.Tx) error {
+		switch mode {
+		case modeSelectOnly:
+			var abalance int
+			return tx.StmtContext(ctx, stmts.selectAccount).
+				QueryRowContext(ctx, aid).Scan(&abalance)
+
+		case modeSimpleUpdate:
+			if _, err := tx.StmtContext(ctx, stmts.updateAccount).
+				ExecContext(ctx, delta, aid); err != nil {
+				return err
+			}
+			var abalance int
+			if err := tx.StmtContext(ctx, stmts.selectAccount).
+				QueryRowContext(ctx, aid).Scan(&abalance); err != nil {
+				return err
+			}
+			_, err := tx.StmtContext(ctx, stmts.insertHistory).
+				ExecContext(ctx, tid, bid, aid, delta)
+			return err
+
+		case modeTPCB:
+			if _, err := tx.StmtContext(ctx, stmts.updateAccount).
+				ExecContext(ctx, delta, aid); err != nil {
+				return err
+			}
+			var abalance int
+			if err := tx.StmtContext(ctx, stmts.selectAccount).
+				QueryRowContext(ctx, aid).Scan(&abalance); err != nil {
+				return err
+			}
+			if _, err := tx.StmtContext(ctx, stmts.updateTeller).
+				ExecContext(ctx, delta, tid); err != nil {
+				return err
+			}
+			if _, err := tx.StmtContext(ctx, stmts.updateBranch).
+				ExecContext(ctx, delta, bid); err != nil {
+				return err
+			}
+			_, err := tx.StmtContext(ctx, stmts.insertHistory).
+				ExecContext(ctx, tid, bid, aid, delta)
+			return err
+
+		default:
+			return errors.AssertionFailedf("unknown mode %q", mode)
+		}
+	})
+}

--- a/pkg/workload/pgbench/pgbench_test.go
+++ b/pkg/workload/pgbench/pgbench_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package pgbench
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name        string
+		scale       int
+		batchSize   int
+		mode        string
+		expectedErr string
+	}{
+		{name: "defaults", scale: defaultScale, batchSize: defaultBatchSize, mode: defaultMode},
+		{name: "tpcb mode", scale: 1, batchSize: 1, mode: modeTPCB},
+		{name: "select-only mode", scale: 1, batchSize: 1, mode: modeSelectOnly},
+		{name: "simple-update mode", scale: 1, batchSize: 1, mode: modeSimpleUpdate},
+		{name: "scale zero rejected", scale: 0, batchSize: 1, mode: modeTPCB,
+			expectedErr: "scale must be >= 1"},
+		{name: "negative scale rejected", scale: -1, batchSize: 1, mode: modeTPCB,
+			expectedErr: "scale must be >= 1"},
+		{name: "zero batch rejected", scale: 1, batchSize: 0, mode: modeTPCB,
+			expectedErr: "batch-size must be > 0"},
+		{name: "unknown mode rejected", scale: 1, batchSize: 1, mode: "oltp",
+			expectedErr: "invalid mode"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &pgbench{scale: tc.scale, batchSize: tc.batchSize, mode: tc.mode}
+			err := g.Hooks().Validate()
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCheckConsistency exercises the consistency check directly against a
+// hand-built fixture so the assertion logic can be tested without paying for
+// a full scale=1 init.
+func TestCheckConsistency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE test`)
+
+	// Build a fixture matching scale=1 cardinalities: branches=1, tellers=10,
+	// accounts=100000, history empty.
+	setup := func(t *testing.T) {
+		t.Helper()
+		sqlDB.Exec(t, `DROP TABLE IF EXISTS pgbench_history, pgbench_accounts, pgbench_tellers, pgbench_branches`)
+		sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE pgbench_branches %s`, branchesSchema))
+		sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE pgbench_tellers %s`, tellersSchema))
+		sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE pgbench_accounts %s`, accountsSchema))
+		sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE pgbench_history %s`, historySchema))
+		sqlDB.Exec(t, `INSERT INTO pgbench_branches (bid, bbalance) VALUES (1, 0)`)
+		sqlDB.Exec(t, `INSERT INTO pgbench_tellers (tid, bid, tbalance)
+			SELECT g, (g - 1) // 10 + 1, 0 FROM generate_series(1, 10) AS g`)
+		sqlDB.Exec(t, `INSERT INTO pgbench_accounts (aid, bid, abalance)
+			SELECT g, (g - 1) // 100000 + 1, 0 FROM generate_series(1, 100000) AS g`)
+	}
+
+	gen := &pgbench{scale: 1}
+	hooks := gen.Hooks()
+
+	t.Run("happy path: all sums zero", func(t *testing.T) {
+		setup(t)
+		require.NoError(t, hooks.CheckConsistency(ctx, db))
+	})
+
+	t.Run("balance sums match a non-zero offset", func(t *testing.T) {
+		setup(t)
+		// Apply a +7 to one of each balance and to history so all sums are 7.
+		sqlDB.Exec(t, `UPDATE pgbench_accounts SET abalance = 7 WHERE aid = 1`)
+		sqlDB.Exec(t, `UPDATE pgbench_branches SET bbalance = 7 WHERE bid = 1`)
+		sqlDB.Exec(t, `UPDATE pgbench_tellers SET tbalance = 7 WHERE tid = 1`)
+		sqlDB.Exec(t, `INSERT INTO pgbench_history (tid, bid, aid, delta) VALUES (1, 1, 1, 7)`)
+		require.NoError(t, hooks.CheckConsistency(ctx, db))
+	})
+
+	t.Run("missing history row detected", func(t *testing.T) {
+		setup(t)
+		sqlDB.Exec(t, `UPDATE pgbench_accounts SET abalance = 7 WHERE aid = 1`)
+		sqlDB.Exec(t, `UPDATE pgbench_branches SET bbalance = 7 WHERE bid = 1`)
+		sqlDB.Exec(t, `UPDATE pgbench_tellers SET tbalance = 7 WHERE tid = 1`)
+		// No history insert — history sum (0) won't match the others (7).
+		err := hooks.CheckConsistency(ctx, db)
+		require.ErrorContains(t, err, "balance invariant violated")
+	})
+
+	t.Run("row deletion detected", func(t *testing.T) {
+		setup(t)
+		sqlDB.Exec(t, `DELETE FROM pgbench_tellers WHERE tid = 5`)
+		err := hooks.CheckConsistency(ctx, db)
+		require.ErrorContains(t, err, "row count for pgbench_tellers")
+	})
+}
+
+// TestPgbenchEndToEnd exercises the full workload: schema creation, initial
+// data load via the framework, running a batch of transactions through the
+// worker, and verifying the consistency check still passes.
+func TestPgbenchEndToEnd(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE test`)
+
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "tpcb", mode: modeTPCB},
+		{name: "simple-update", mode: modeSimpleUpdate},
+		{name: "select-only", mode: modeSelectOnly},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlDB.Exec(t, `DROP TABLE IF EXISTS pgbench_history, pgbench_accounts, pgbench_tellers, pgbench_branches`)
+
+			gen := workload.FromFlags(pgbenchMeta,
+				`--scale=1`, `--batch-size=10000`, `--mode=`+tc.mode, `--concurrency=2`)
+			loader := workloadsql.InsertsDataLoader{BatchSize: 1000, Concurrency: 4}
+			_, err := workloadsql.Setup(ctx, db, gen, loader)
+			require.NoError(t, err)
+
+			pgURL, urlCleanup := srv.PGUrl(t,
+				serverutils.User(username.RootUser),
+				serverutils.DBName("test"),
+			)
+			defer urlCleanup()
+
+			reg := histogram.NewRegistry(time.Minute, pgbenchMeta.Name)
+			ql, err := gen.(workload.Opser).Ops(ctx, []string{pgURL.String()}, reg)
+			require.NoError(t, err)
+			defer func() {
+				if ql.Close != nil {
+					require.NoError(t, ql.Close(ctx))
+				}
+			}()
+
+			// Run a small batch of operations across all worker funcs.
+			const opsPerWorker = 25
+			for _, fn := range ql.WorkerFns {
+				for i := 0; i < opsPerWorker; i++ {
+					require.NoError(t, fn(ctx))
+				}
+			}
+
+			require.NoError(t, gen.(workload.Hookser).Hooks().CheckConsistency(ctx, db))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a CockroachDB workload that mirrors PostgreSQL's pgbench: a TPC-B-like
schema (accounts, branches, tellers, history) with the classic five-statement
update transaction, plus the standard `simple-update` and `select-only`
variants.

Motivation is bug hunting, not benchmarking. pgbench is the de-facto
microbenchmark for OLTP databases and shows up frequently in Postgres
regression reports (e.g. the recent Linux 6.x PREEMPT_LAZY /
spinlock-during-page-fault thread). Having a faithful in-tree port lets us
reproduce and triage similar issues against CockroachDB without translating
workloads on the fly, and gives us another well-understood transactional
shape to throw at the storage and KV layers.

Schema and constants match upstream pgbench (1-indexed PKs, CHAR(N) fillers
of widths 84/84/88/22). Transactions are wrapped in `crdb.ExecuteTx` so
serialization conflicts retry transparently. The `history` table
intentionally lacks an explicit PK so the hidden `unique_rowid` spreads
inserts across the keyspace.

A mode-aware consistency check reconciles account/teller/branch balances
against the `history` ledger.

The workload is registered with both the OSS `cockroach workload` CLI and
the `allccl` test harness.

Epic: none