### PR TITLE
pkg/cli: dump labeled histogram child metrics

### DIFF
--- a/pkg/ts/BUILD.bazel
+++ b/pkg/ts/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/stop",
         "//pkg/util/timeutil",

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -648,15 +648,35 @@ func dumpImpl(
 		}
 	}
 
-	// Dump child metrics only for allowed metrics at 1M resolution
+	// Dump child metrics only for allowed metrics at 1M resolution.
+	//
+	// req.Names contains both unsuffixed series (counters, gauges) and
+	// histogram-expanded series (e.g. "cr.node.foo-count", "cr.node.foo-p99").
+	// Labeled child metrics are stored with the labels appended to the base
+	// metric name -- counters/gauges as "cr.node.foo{labels}", histogram
+	// children as "cr.node.foo{labels}-anysuffix". A scan span keyed on the
+	// suffixed name "cr.node.foo-count" therefore misses every labeled
+	// histogram child: '{' (0x7B) > '-' (0x2D), so "cr.node.foo{...}-count"
+	// sorts after the span's end key "cr.node.foo-count|".
+	//
+	// Strip any histogram suffix to recover the base name and scan once per
+	// unique allowed base. The span [base, base|) covers labeled
+	// counters/gauges ("base{labels}") and labeled histogram children
+	// ("base{labels}-anysuffix") in a single pass, since '{' < '|'.
+	seenBases := make(map[string]struct{})
 	for _, seriesName := range req.Names {
-		if !tsutil.IsAllowedChildMetric(seriesName) {
+		base := stripHistogramSuffix(seriesName)
+		if !tsutil.IsAllowedChildMetric(base) {
 			continue
 		}
+		if _, ok := seenBases[base]; ok {
+			continue
+		}
+		seenBases[base] = struct{}{}
 		if err := dumpTimeseriesAllSources(
 			ctx,
 			db,
-			seriesName,
+			base,
 			Resolution1m,
 			req.StartNanos,
 			req.EndNanos,
@@ -667,6 +687,18 @@ func dumpImpl(
 		}
 	}
 	return nil
+}
+
+// stripHistogramSuffix returns name with any HistogramMetricComputers suffix
+// removed. Used to recover the base metric name from a histogram-expanded name
+// like "cr.node.foo-p99". Returns name unchanged if no suffix matches.
+func stripHistogramSuffix(name string) string {
+	for _, c := range metric.HistogramMetricComputers {
+		if strings.HasSuffix(name, c.Suffix) {
+			return strings.TrimSuffix(name, c.Suffix)
+		}
+	}
+	return name
 }
 
 // DefaultDumper translates *roachpb.KeyValue into TimeSeriesData.

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -1500,16 +1501,24 @@ func TestServerDump(t *testing.T) {
 	}
 }
 
+// TestServerDumpChildMetrics covers the dump path's handling of labeled child
+// metrics. For each base in tsutil.AllowedChildMetrics, the server runs a
+// 1m-resolution scan keyed on the base after stripping any histogram suffix
+// from the requested names. The span [base, base|) covers labeled
+// counters/gauges ("base{labels}") and labeled histogram children
+// ("base{labels}-anysuffix") in a single pass, since '{' (0x7B) > '-' (0x2D).
+//
+// Cases exercise non-histogram counters, histogram-suffixed names (which the
+// CLI expands per quantile), allow-list misses (no scan should occur), and
+// dedup across multiple suffixes that share a base (the scan must run once).
 func TestServerDumpChildMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		// For now, direct access to the tsdb is reserved to the storage layer.
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableTimeSeriesMaintenanceQueue: true,
@@ -1519,115 +1528,171 @@ func TestServerDumpChildMetrics(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	tsdb := s.TsDB().(*ts.DB)
-
-	// Store parent metric (without labels)
-	parentMetric := "cr.node.changefeed.emitted_messages"
-	if err := tsdb.StoreData(ctx, ts.Resolution10s, []tspb.TimeSeriesData{
-		{
-			Name:   parentMetric,
-			Source: "1",
-			Datapoints: []tspb.TimeSeriesDatapoint{
-				{TimestampNanos: 100 * 1e9, Value: 1000.0},
-				{TimestampNanos: 200 * 1e9, Value: 2000.0},
-			},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Store child metrics (with labels encoded in name)
-	childMetric1 := fmt.Sprintf(`%s{feed_id="123",scope="default"}`, parentMetric)
-	childMetric2 := fmt.Sprintf(`%s{feed_id="456",scope="system"}`, parentMetric)
-	if err := tsdb.StoreData(ctx, ts.Resolution1m, []tspb.TimeSeriesData{
-		{
-			Name:   childMetric1,
-			Source: "1",
-			Datapoints: []tspb.TimeSeriesDatapoint{
-				{TimestampNanos: 100 * 1e9, Value: 500.0},
-				{TimestampNanos: 200 * 1e9, Value: 1500.0},
-			},
-		},
-		{
-			Name:   childMetric2,
-			Source: "1",
-			Datapoints: []tspb.TimeSeriesDatapoint{
-				{TimestampNanos: 100 * 1e9, Value: 300.0},
-				{TimestampNanos: 200 * 1e9, Value: 800.0},
-			},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
 	conn := s.RPCClientConn(t, username.RootUserName())
 	client := conn.NewTimeSeriesClient()
 
-	t.Run("includes child metrics", func(t *testing.T) {
-		dumpClient, err := client.Dump(ctx, &tspb.DumpRequest{
-			Names:      []string{parentMetric},
+	// store writes a single-datapoint series at the given resolution.
+	store := func(name string, res ts.Resolution) {
+		require.NoError(t, tsdb.StoreData(ctx, res, []tspb.TimeSeriesData{{
+			Name:   name,
+			Source: "1",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{TimestampNanos: 100 * 1e9, Value: 1.0},
+			},
+		}}))
+	}
+
+	// suffixed returns base appended with each HistogramMetricComputers suffix
+	// -- the shape the CLI sends for histogram metrics.
+	suffixed := func(base string) []string {
+		out := make([]string, 0, len(metric.HistogramMetricComputers))
+		for _, c := range metric.HistogramMetricComputers {
+			out = append(out, base+c.Suffix)
+		}
+		return out
+	}
+
+	// labeledSuffixed returns one "base{labels}suffix" per histogram suffix --
+	// labels appear before the suffix, matching how labeled histogram children
+	// are stored in production.
+	labeledSuffixed := func(base, labels string) []string {
+		out := make([]string, 0, len(metric.HistogramMetricComputers))
+		for _, c := range metric.HistogramMetricComputers {
+			out = append(out, base+labels+c.Suffix)
+		}
+		return out
+	}
+
+	// counterBase and histogramBase must be in tsutil.AllowedChildMetrics;
+	// nonAllowedBase must not.
+	const (
+		counterBase    = "cr.node.changefeed.emitted_messages"
+		histogramBase  = "cr.node.changefeed.sink_backpressure_nanos"
+		nonAllowedBase = "cr.node.sql.bytesin"
+	)
+
+	tests := []struct {
+		name string
+		// setup populates tsdb with the series this case needs.
+		setup func()
+		// requestNames is sent in DumpRequest.Names.
+		requestNames []string
+		// expectedPresent must each appear exactly once in the dump output.
+		// More than once indicates a missing dedup or repeated scan.
+		expectedPresent []string
+		// expectedAbsent must not appear in the dump output.
+		expectedAbsent []string
+	}{
+		{
+			name: "non-histogram counter with labeled children",
+			setup: func() {
+				store(counterBase, ts.Resolution10s)
+				store(counterBase+`{feed_id="123",scope="default"}`, ts.Resolution1m)
+				store(counterBase+`{feed_id="456",scope="system"}`, ts.Resolution1m)
+			},
+			requestNames: []string{counterBase},
+			expectedPresent: []string{
+				counterBase,
+				counterBase + `{feed_id="123",scope="default"}`,
+				counterBase + `{feed_id="456",scope="system"}`,
+			},
+		},
+		{
+			name: "histogram with labeled children at every suffix",
+			setup: func() {
+				for _, n := range suffixed(histogramBase) {
+					store(n, ts.Resolution10s)
+				}
+				for _, n := range labeledSuffixed(histogramBase, `{scope="default"}`) {
+					store(n, ts.Resolution1m)
+				}
+			},
+			requestNames:    suffixed(histogramBase),
+			expectedPresent: labeledSuffixed(histogramBase, `{scope="default"}`),
+		},
+		{
+			name: "non-allow-listed metric: labeled children are not scanned",
+			setup: func() {
+				store(nonAllowedBase, ts.Resolution10s)
+				store(nonAllowedBase+`{app="foo"}`, ts.Resolution1m)
+			},
+			requestNames:    []string{nonAllowedBase},
+			expectedPresent: []string{nonAllowedBase},
+			expectedAbsent:  []string{nonAllowedBase + `{app="foo"}`},
+		},
+		{
+			name: "dedup: multiple suffixes sharing a base scan once",
+			setup: func() {
+				// Distinct labels from the histogram case so we can attribute
+				// any duplicates to this case's request shape rather than to
+				// data left over from earlier subtests.
+				for _, n := range labeledSuffixed(histogramBase, `{scope="dedup"}`) {
+					store(n, ts.Resolution1m)
+				}
+			},
+			// One request per histogram suffix, all sharing histogramBase.
+			// Each labeled child must appear exactly once -- a count > 1 means
+			// the seenBases dedup is broken and the 1m scan ran multiple times.
+			requestNames:    suffixed(histogramBase),
+			expectedPresent: labeledSuffixed(histogramBase, `{scope="dedup"}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			stream, err := client.Dump(ctx, &tspb.DumpRequest{
+				Names:      tc.requestNames,
+				StartNanos: 100 * 1e9,
+				EndNanos:   300 * 1e9,
+			})
+			require.NoError(t, err)
+
+			counts := make(map[string]int)
+			for {
+				msg, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				counts[msg.Name]++
+			}
+
+			for _, name := range tc.expectedPresent {
+				require.Equalf(t, 1, counts[name],
+					"expected %q exactly once, got %d", name, counts[name])
+			}
+			for _, name := range tc.expectedAbsent {
+				require.Zerof(t, counts[name],
+					"did not expect %q in dump output", name)
+			}
+		})
+	}
+
+	// Smoke-test the DumpRaw streaming path. Both Dump and DumpRaw share
+	// dumpImpl, so the table above already exercises the lookup logic; this
+	// subtest only confirms that labeled child KVs survive the raw RPC path.
+	t.Run("DumpRaw streams labeled child KVs", func(t *testing.T) {
+		stream, err := client.DumpRaw(ctx, &tspb.DumpRequest{
+			Names:      []string{counterBase},
 			StartNanos: 100 * 1e9,
 			EndNanos:   300 * 1e9,
 		})
 		require.NoError(t, err)
 
-		resultMap := make(map[string][]tspb.TimeSeriesDatapoint)
+		var sawLabeled bool
 		for {
-			msg, err := dumpClient.Recv()
+			kv, err := stream.Recv()
 			if err == io.EOF {
 				break
 			}
 			require.NoError(t, err)
-			resultMap[msg.Name] = append(resultMap[msg.Name], msg.Datapoints...)
-		}
-
-		// Should have parent metric AND both child metrics
-		require.Contains(t, resultMap, parentMetric, "parent metric should be included")
-		require.Contains(t, resultMap, childMetric1, "child metric 1 should be included")
-		require.Contains(t, resultMap, childMetric2, "child metric 2 should be included")
-		require.Equal(t, 3, len(resultMap), "should have parent and both child metrics")
-
-		// Verify data correctness for parent metric
-		require.Len(t, resultMap[parentMetric], 2, "parent metric should have 2 datapoints")
-		require.Equal(t, 1000.0, resultMap[parentMetric][0].Value)
-		require.Equal(t, 2000.0, resultMap[parentMetric][1].Value)
-
-		// Verify data correctness for child metrics
-		require.Len(t, resultMap[childMetric1], 2, "child metric 1 should have 2 datapoints")
-		require.Equal(t, 500.0, resultMap[childMetric1][0].Value)
-		require.Equal(t, 1500.0, resultMap[childMetric1][1].Value)
-
-		require.Len(t, resultMap[childMetric2], 2, "child metric 2 should have 2 datapoints")
-		require.Equal(t, 300.0, resultMap[childMetric2][0].Value)
-		require.Equal(t, 800.0, resultMap[childMetric2][1].Value)
-	})
-
-	t.Run("DumpRaw sees child metrics", func(t *testing.T) {
-		dumpRawClient, err := client.DumpRaw(ctx, &tspb.DumpRequest{
-			Names:      []string{parentMetric},
-			StartNanos: 100 * 1e9,
-			EndNanos:   300 * 1e9,
-		})
-		require.NoError(t, err)
-
-		var kvCount int
-		seenMetrics := make(map[string]bool)
-		for {
-			kv, err := dumpRawClient.Recv()
-			if err == io.EOF {
-				break
-			}
-			require.NoError(t, err)
-			kvCount++
-			// Decode the key to verify it contains child metrics
-			// The key contains the encoded metric name
-			keyStr := string(kv.Key)
-			if strings.Contains(keyStr, "{") {
-				seenMetrics["child"] = true
+			if strings.Contains(string(kv.Key), "{") {
+				sawLabeled = true
 			}
 		}
-
-		require.Greater(t, kvCount, 0, "should have raw KVs")
-		require.True(t, seenMetrics["child"], "should have seen child metrics in raw dump")
+		require.True(t, sawLabeled, "DumpRaw should stream labeled child KVs")
 	})
 }
 


### PR DESCRIPTION
The dump server returned no labeled histogram child series. The CLI's name list contains bare names for counters and gauges ("cr.node.foo") plus histogram-expanded names with one quantile suffix per HistogramMetricComputers entry ("cr.node.foo-count", "cr.node.foo-p99", ...). Labeled child series are stored as "cr.node.foo{labels}" for counters/gauges and
"cr.node.foo{labels}-anysuffix" for histograms -- labels go before the histogram suffix. A scan span keyed on the suffixed name "cr.node.foo-count" therefore misses every labeled histogram child: '{' (0x7B) sorts after '-' (0x2D), so "cr.node.foo{...}-count" sorts past the span's end key "cr.node.foo-count|". IsAllowedChildMetric additionally rejected the suffixed names because the allowlist holds bare metric names.

Strip any histogram suffix to recover the base name, look it up in the allowlist, and scan once per unique allowed base. The span [base, base|) covers labeled counters/gauges ("base{labels}") and labeled histogram children ("base{labels}-anysuffix") in a single pass. Deduplicating by base also collapses the eleven scans that each histogram previously implied into one.

Fixes: https://github.com/cockroachdb/cockroach/issues/169378
Epic: None
Release note (bug fix): Fixed a bug in `cockroach debug tsdump` where labeled per-changefeed histogram child series (e.g. `changefeed.sink_backpressure_nanos{scope="default"}-count`, `-p99`, etc.) were absent from the dump output even with the `timeseries.persist_child_metrics.enabled` cluster setting on. The recorder writes these series correctly; the dump path's child-metric scan was missing them due to the wrong scan prefix and an allowlist lookup mismatch.