### PR TITLE
roachtest: avoid requesting local-SSD machine types when unnecessary

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -592,12 +592,9 @@ func (s *ClusterSpec) RoachprodOpts(
 			var err error
 			switch cloud {
 			case AWS:
-				// We always pass true for shouldSupportLocalSSD here because the machine type selection
-				// logic should not depend on the user's preference for local SSDs.
-				// The actual decision to use provisioned local SSDs is handled in the disk configuration logic
-				// at the provider level, and EBS volume have priority over local SSDs.
-				// This means that if both EBS and local SSDs are available, EBS will be used.
-				machineType, selectedArch, err = SelectAWSMachineType(s.CPUs, s.Mem, true, requestedArch)
+				machineType, selectedArch, err = SelectAWSMachineType(
+					s.CPUs, s.Mem, s.mayUseLocalSSD(params.Defaults.PreferLocalSSD), requestedArch,
+				)
 			case GCE:
 				machineType, selectedArch = SelectGCEMachineType(s.CPUs, s.Mem, requestedArch)
 			case Azure:
@@ -794,6 +791,27 @@ func (s *ClusterSpec) RoachprodOpts(
 	}
 
 	return createVMOpts, providerOpts, workloadProviderOpts, selectedArch, nil
+}
+
+// mayUseLocalSSD returns whether this spec could end up using local SSDs.
+// This is used to determine whether to select a machine type that supports
+// local SSDs (e.g. on AWS, machine families with a "d" suffix). When local
+// SSDs definitely won't be used, selecting a non-local-SSD machine type
+// avoids unnecessary capacity constraints.
+func (s *ClusterSpec) mayUseLocalSSD(defaultPreferLocalSSD bool) bool {
+	if s.VolumeType != "" && s.VolumeType != "local-ssd" {
+		return false
+	}
+	if s.LocalSSD == LocalSSDDisable {
+		return false
+	}
+	if s.VolumeSize != 0 {
+		return false
+	}
+	return s.VolumeType == "local-ssd" ||
+		s.LocalSSD == LocalSSDPreferOn ||
+		s.RandomizeVolumeType ||
+		defaultPreferLocalSSD
 }
 
 func (s *ClusterSpec) isLocalSSDAvailable(

--- a/pkg/cmd/roachtest/spec/cluster_spec_test.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec_test.go
@@ -45,6 +45,75 @@ func TestClustersCompatible(t *testing.T) {
 	})
 }
 
+func TestMayUseLocalSSD(t *testing.T) {
+	tests := []struct {
+		name                  string
+		spec                  ClusterSpec
+		defaultPreferLocalSSD bool
+		expected              bool
+	}{
+		{
+			name:                  "default spec with PreferLocalSSD=true",
+			defaultPreferLocalSSD: true,
+			expected:              true,
+		},
+		{
+			name:                  "default spec with PreferLocalSSD=false",
+			defaultPreferLocalSSD: false,
+			expected:              false,
+		},
+		{
+			name:                  "explicit non-local-ssd volume type",
+			spec:                  ClusterSpec{VolumeType: "gp3"},
+			defaultPreferLocalSSD: true,
+			expected:              false,
+		},
+		{
+			name:                  "explicit local-ssd volume type",
+			spec:                  ClusterSpec{VolumeType: "local-ssd"},
+			defaultPreferLocalSSD: false,
+			expected:              true,
+		},
+		{
+			name:                  "LocalSSD disabled",
+			spec:                  ClusterSpec{LocalSSD: LocalSSDDisable},
+			defaultPreferLocalSSD: true,
+			expected:              false,
+		},
+		{
+			name:                  "LocalSSD preferred",
+			spec:                  ClusterSpec{LocalSSD: LocalSSDPreferOn},
+			defaultPreferLocalSSD: false,
+			expected:              true,
+		},
+		{
+			name:                  "RandomizeVolumeType enabled",
+			spec:                  ClusterSpec{RandomizeVolumeType: true},
+			defaultPreferLocalSSD: false,
+			expected:              true,
+		},
+		{
+			name:                  "VolumeSize set overrides PreferLocalSSD",
+			spec:                  ClusterSpec{VolumeSize: 100},
+			defaultPreferLocalSSD: true,
+			expected:              false,
+		},
+		{
+			name:                  "VolumeSize set overrides LocalSSDPreferOn",
+			spec:                  ClusterSpec{VolumeSize: 100, LocalSSD: LocalSSDPreferOn},
+			defaultPreferLocalSSD: true,
+			expected:              false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.spec.mayUseLocalSSD(tc.defaultPreferLocalSSD)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestClustersRetainClearedInfo(t *testing.T) {
 	// Adding a test in case we switch the ClustersCompatible signature to take
 	// pointers to ClusterSpec in the future.


### PR DESCRIPTION
We've been seeing a number of `InsufficientInstanceCapacity` errors on AWS in nightly roachtests. One possible contributing factor is that `SelectAWSMachineType` was always called with `shouldSupportLocalSSD=true`, which appends the `d` suffix to the instance family — even when the test spec makes it clear that local SSDs won't be used (e.g. explicit EBS volume type, `DisableLocalSSD()`, or a non-zero `VolumeSize`).

The original intent of always passing `true` was to maximize cluster reuse: if all clusters are provisioned with local-SSD-capable machine types, they can be reused by subsequent tests regardless of whether those tests need local SSDs. However, this also means we always request `d`-suffix instance families, which may have more constrained availability in certain AZs.

This patch adds a `mayUseLocalSSD` helper that inspects the cluster spec to determine whether local SSDs could actually end up being used, and passes its result to `SelectAWSMachineType` instead of the hardcoded `true`. When local SSDs are ruled out, this allows the machine type selection to pick non-`d` families, which may have better availability.

It's unclear how much of the capacity pressure is attributable to the `d`-suffix constraint specifically, but broadening the set of eligible instance types should help in general.

Epic: none
Release note: None
Informs: #169373