### PR TITLE
roachtest: introduce testCluster interface for pluggable cluster backends

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -411,52 +411,52 @@ func initBinariesAndLibraries() {
 type clusterRegistry struct {
 	mu struct {
 		syncutil.Mutex
-		clusters map[string]*clusterImpl
+		clusters map[string]testCluster
 		tagCount map[string]int
 		// savedClusters keeps track of clusters that have been saved for further
 		// debugging. Each cluster comes with a message about the test failure
 		// causing it to be saved for debugging.
-		savedClusters map[*clusterImpl]string
+		savedClusters map[testCluster]string
 	}
 }
 
 func newClusterRegistry() *clusterRegistry {
 	cr := &clusterRegistry{}
-	cr.mu.clusters = make(map[string]*clusterImpl)
-	cr.mu.savedClusters = make(map[*clusterImpl]string)
+	cr.mu.clusters = make(map[string]testCluster)
+	cr.mu.savedClusters = make(map[testCluster]string)
 	return cr
 }
 
-func (r *clusterRegistry) registerCluster(c *clusterImpl) error {
+func (r *clusterRegistry) registerCluster(c testCluster) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.mu.clusters[c.name] != nil {
-		return fmt.Errorf("cluster named %q already exists in registry", c.name)
+	if r.mu.clusters[c.Name()] != nil {
+		return fmt.Errorf("cluster named %q already exists in registry", c.Name())
 	}
-	r.mu.clusters[c.name] = c
-	if err := c.addLabels(map[string]string{VmLabelTestRunID: runID}); err != nil && c.l != nil {
-		c.l.Printf("failed to add label to cluster [%s] - %s", c.name, err)
+	r.mu.clusters[c.Name()] = c
+	if err := c.addLabels(map[string]string{VmLabelTestRunID: runID}); err != nil && c.Logger() != nil {
+		c.Logger().Printf("failed to add label to cluster [%s] - %s", c.Name(), err)
 	}
 	return nil
 }
 
-func (r *clusterRegistry) unregisterCluster(c *clusterImpl) bool {
+func (r *clusterRegistry) unregisterCluster(c testCluster) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.mu.clusters[c.name]; !ok {
+	if _, ok := r.mu.clusters[c.Name()]; !ok {
 		// If the cluster is not registered, no-op. This allows the
 		// method to be called defensively.
 		return false
 	}
-	if err := c.removeLabels([]string{VmLabelTestRunID}); err != nil && c.l != nil {
-		c.l.Printf("failed to remove label from cluster [%s] - %s", c.name, err)
+	if err := c.removeLabels([]string{VmLabelTestRunID}); err != nil && c.Logger() != nil {
+		c.Logger().Printf("failed to remove label from cluster [%s] - %s", c.Name(), err)
 	}
-	delete(r.mu.clusters, c.name)
-	if c.tag != "" {
-		if _, ok := r.mu.tagCount[c.tag]; !ok {
+	delete(r.mu.clusters, c.Name())
+	if c.clusterTag() != "" {
+		if _, ok := r.mu.tagCount[c.clusterTag()]; !ok {
 			panic(fmt.Sprintf("tagged cluster not accounted for: %s", c))
 		}
-		r.mu.tagCount[c.tag]--
+		r.mu.tagCount[c.clusterTag()]--
 	}
 	return true
 }
@@ -471,14 +471,14 @@ func (r *clusterRegistry) countForTag(tag string) int {
 // destroyAllClusters.
 // msg is a message recording the reason why the cluster is being saved (i.e.
 // generally a test failure error).
-func (r *clusterRegistry) markClusterAsSaved(c *clusterImpl, msg string) {
+func (r *clusterRegistry) markClusterAsSaved(c testCluster, msg string) {
 	r.mu.Lock()
 	r.mu.savedClusters[c] = msg
 	r.mu.Unlock()
 }
 
 type clusterWithMsg struct {
-	*clusterImpl
+	testCluster
 	savedMsg string
 }
 
@@ -491,13 +491,13 @@ func (r *clusterRegistry) savedClusters() []clusterWithMsg {
 	i := 0
 	for c, msg := range r.mu.savedClusters {
 		res[i] = clusterWithMsg{
-			clusterImpl: c,
+			testCluster: c,
 			savedMsg:    msg,
 		}
 		i++
 	}
 	sort.Slice(res, func(i, j int) bool {
-		return strings.Compare(res[i].name, res[j].name) < 0
+		return strings.Compare(res[i].Name(), res[j].Name()) < 0
 	})
 	return res
 }
@@ -512,8 +512,8 @@ func (r *clusterRegistry) destroyAllClusters(ctx context.Context, l *logger.Logg
 	go func() {
 		defer close(done)
 
-		var clusters []*clusterImpl
-		savedClusters := make(map[*clusterImpl]struct{})
+		var clusters []testCluster
+		savedClusters := make(map[testCluster]struct{})
 		r.mu.Lock()
 		for _, c := range r.mu.clusters {
 			clusters = append(clusters, c)
@@ -526,7 +526,7 @@ func (r *clusterRegistry) destroyAllClusters(ctx context.Context, l *logger.Logg
 		var wg sync.WaitGroup
 		wg.Add(len(clusters))
 		for _, c := range clusters {
-			go func(c *clusterImpl) {
+			go func(c testCluster) {
 				defer wg.Done()
 				if _, ok := savedClusters[c]; !ok {
 					// We don't close the logger here since the cluster may be still in use
@@ -653,8 +653,55 @@ type nodeSelector interface {
 	Merge(option.NodeListOption) option.NodeListOption
 }
 
-// clusterImpl implements cluster.Cluster.
+// testCluster is the roachtest runner's internal view of a cluster. Test
+// bodies continue to receive the public cluster.Cluster interface.
+type testCluster interface {
+	cluster.Cluster
+	fmt.Stringer
 
+	setTest(test.Test)
+	status(...interface{})
+
+	Destroy(context.Context, closeLoggerOpt, *logger.Logger)
+	Save(context.Context, string, *logger.Logger)
+	WipeForReuse(context.Context, *logger.Logger, spec.ClusterSpec) error
+	MaybeExtendCluster(context.Context, *logger.Logger, *registry.TestSpec) error
+
+	PutCockroach(context.Context, *logger.Logger, *testImpl) error
+	PutDeprecatedWorkload(context.Context, *logger.Logger, *testImpl) error
+
+	FetchLogs(context.Context, *logger.Logger) error
+	FetchDmesg(context.Context, *logger.Logger) error
+	FetchJournalctl(context.Context, *logger.Logger) error
+	FetchCores(context.Context, *logger.Logger) error
+	FetchPebbleCheckpoints(context.Context, *logger.Logger) error
+	FetchVMSpecs(context.Context, *logger.Logger) error
+	CopyRoachprodState(context.Context) error
+
+	HealthStatus(context.Context, *logger.Logger, option.NodeListOption) ([]*HealthStatusResult, error)
+	GetHostErrorVMs(context.Context, *logger.Logger) ([]string, error)
+	GetLiveMigrationVMs(*logger.Logger) ([]string, error)
+	Extend(context.Context, time.Duration, *logger.Logger) error
+
+	addLabels(map[string]string) error
+	removeLabels([]string) error
+	clusterTag() string
+
+	SetArchitecture(vm.CPUArch)
+	OS() string
+	SetEncryptedAtRest(bool)
+	EncryptedAtRest() bool
+	SetUseDRPC(bool)
+	SetGoCoverDir(string)
+	Logger() *logger.Logger
+	SetLogger(*logger.Logger)
+	ResetClusterSettings()
+	SetClusterSetting(string, string)
+	SetGrafanaTags([]string)
+	Saved() (bool, string)
+}
+
+// clusterImpl implements cluster.Cluster.
 // It is safe for concurrent use by multiple goroutines.
 type clusterImpl struct {
 	name  string
@@ -712,6 +759,13 @@ type clusterImpl struct {
 	preStartVirtualClusterHooks []install.PreStartHook
 }
 
+type roachprodCluster = clusterImpl
+
+var (
+	_ cluster.Cluster = (*roachprodCluster)(nil)
+	_ testCluster     = (*roachprodCluster)(nil)
+)
+
 // Name returns the cluster name, i.e. something like `teamcity-....`
 func (c *clusterImpl) Name() string {
 	return c.name
@@ -720,6 +774,64 @@ func (c *clusterImpl) Name() string {
 // Spec returns the spec underlying the cluster.
 func (c *clusterImpl) Spec() spec.ClusterSpec {
 	return c.spec
+}
+
+func (c *clusterImpl) clusterTag() string {
+	return c.tag
+}
+
+func (c *clusterImpl) SetArchitecture(arch vm.CPUArch) {
+	c.arch = arch
+}
+
+func (c *clusterImpl) OS() string {
+	return c.os
+}
+
+func (c *clusterImpl) SetEncryptedAtRest(enabled bool) {
+	c.encAtRest = enabled
+}
+
+func (c *clusterImpl) EncryptedAtRest() bool {
+	return c.encAtRest
+}
+
+func (c *clusterImpl) SetUseDRPC(enabled bool) {
+	c.useDRPC = enabled
+}
+
+func (c *clusterImpl) SetGoCoverDir(dir string) {
+	c.goCoverDir = dir
+}
+
+func (c *clusterImpl) Logger() *logger.Logger {
+	return c.l
+}
+
+func (c *clusterImpl) SetLogger(l *logger.Logger) {
+	c.l = l
+}
+
+func (c *clusterImpl) ResetClusterSettings() {
+	c.clusterSettings = map[string]string{}
+	c.virtualClusterSettings = map[string]string{}
+}
+
+func (c *clusterImpl) SetClusterSetting(name, value string) {
+	if c.clusterSettings == nil {
+		c.clusterSettings = map[string]string{}
+	}
+	c.clusterSettings[name] = value
+}
+
+func (c *clusterImpl) SetGrafanaTags(tags []string) {
+	c.grafanaTags = tags
+}
+
+func (c *clusterImpl) Saved() (bool, string) {
+	c.destroyState.mu.Lock()
+	defer c.destroyState.mu.Unlock()
+	return c.destroyState.mu.saved, c.destroyState.mu.savedMsg
 }
 
 // status is used to communicate the test's status. It's a no-op until the
@@ -885,7 +997,7 @@ func (f *clusterFactory) clusterMock(cfg clusterConfig) *clusterImpl {
 // i.e. unit tests that don't want to actually access a provider.
 var create = roachprod.Create
 
-// newCluster creates a new roachprod cluster.
+// newCluster creates a new cluster for the roachtest runner.
 //
 // setStatus is called with status messages indicating the stage of cluster
 // creation.
@@ -893,7 +1005,14 @@ var create = roachprod.Create
 // NOTE: setTest() needs to be called before a test can use this cluster.
 func (f *clusterFactory) newCluster(
 	ctx context.Context, cfg clusterConfig, setStatus func(string),
-) (*clusterImpl, *vm.CreateOpts, error) {
+) (testCluster, *vm.CreateOpts, error) {
+	return f.newRoachprodCluster(ctx, cfg, setStatus)
+}
+
+// newRoachprodCluster creates a new roachprod-backed cluster.
+func (f *clusterFactory) newRoachprodCluster(
+	ctx context.Context, cfg clusterConfig, setStatus func(string),
+) (testCluster, *vm.CreateOpts, error) {
 	if ctx.Err() != nil {
 		return nil, nil, errors.Wrap(ctx.Err(), "newCluster")
 	}
@@ -1117,12 +1236,6 @@ func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	c.destroyState.mu.saved = true
 	c.destroyState.mu.savedMsg = msg
 	c.destroyState.mu.Unlock()
-}
-
-func (c *clusterImpl) saved() bool {
-	c.destroyState.mu.Lock()
-	defer c.destroyState.mu.Unlock()
-	return c.destroyState.mu.saved
 }
 
 var errClusterNotFound = errors.New("cluster not found")
@@ -1578,21 +1691,6 @@ func (c *clusterImpl) HealthStatus(
 	})
 
 	return results, nil
-}
-
-// assertConsistentReplicas fails the test if
-// crdb_internal.check_consistency(false, ”, ”) indicates that any ranges'
-// replicas are inconsistent with each other.
-func (c *clusterImpl) assertConsistentReplicas(
-	ctx context.Context, db *gosql.DB, t *testImpl,
-) error {
-	t.L().Printf("checking for replica divergence")
-	return timeutil.RunWithTimeout(
-		ctx, "consistency check", 20*time.Minute,
-		func(ctx context.Context) error {
-			return roachtestutil.CheckReplicaDivergenceOnDB(ctx, t.L(), db)
-		},
-	)
 }
 
 // FetchDmesg grabs the dmesg logs if possible. This requires being able to run

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -48,12 +48,12 @@ type githubIssues struct {
 // worker / test
 // separate from githubIssues because githubIssues is shared amongst all workers
 type githubIssueInfo struct {
-	cluster      *clusterImpl
+	cluster      testCluster
 	vmCreateOpts *vm.CreateOpts
 }
 
 // newGithubIssueInfo constructor for newGithubIssueInfo
-func newGithubIssueInfo(cluster *clusterImpl, vmCreateOpts *vm.CreateOpts) *githubIssueInfo {
+func newGithubIssueInfo(cluster testCluster, vmCreateOpts *vm.CreateOpts) *githubIssueInfo {
 	return &githubIssueInfo{
 		cluster:      cluster,
 		vmCreateOpts: vmCreateOpts,
@@ -302,7 +302,7 @@ func (g *githubIssues) createPostRequest(
 	artifacts := fmt.Sprintf("/%s", testName)
 
 	if issueInfo.cluster != nil {
-		issueClusterName = issueInfo.cluster.name
+		issueClusterName = issueInfo.cluster.Name()
 	}
 
 	issueMessage := messagePrefix + message

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -151,7 +151,7 @@ func TestCreatePostRequest(t *testing.T) {
 		}
 		ti.ReplaceL(nilLogger())
 
-		testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64, name: "foo"}
+		var testClusterImpl testCluster = &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64, name: "foo"}
 		vo := vm.DefaultCreateOpts()
 		vmOpts := &vo
 		teamLoadFn := validTeamsFn

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -89,7 +89,7 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	defer stopper.Stop(context.Background())
 	runner := newTestRunner(cr, stopper)
 
-	clusterType := roachprodCluster
+	clusterType := roachprodClusterType
 	bindTo := ""
 	parallelism := roachtestflags.Parallelism
 	if roachtestflags.Cloud == spec.Local {

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -828,7 +828,7 @@ type clusterType int
 
 const (
 	localCluster clusterType = iota
-	roachprodCluster
+	roachprodClusterType
 )
 
 type loggingOpt struct {
@@ -864,7 +864,7 @@ type workerStatus struct {
 		// The cluster that the worker is currently operating on. If the worker is
 		// currently running a test, the test is using this cluster. Nil if the
 		// worker does not currently have a cluster.
-		c *clusterImpl
+		c testCluster
 	}
 }
 
@@ -880,13 +880,13 @@ func (w *workerStatus) SetStatus(status string) {
 	w.mu.Unlock()
 }
 
-func (w *workerStatus) Cluster() *clusterImpl {
+func (w *workerStatus) Cluster() testCluster {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.mu.c
 }
 
-func (w *workerStatus) SetCluster(c *clusterImpl) {
+func (w *workerStatus) SetCluster(c testCluster) {
 	w.mu.Lock()
 	w.mu.c = c
 	w.mu.Unlock()

--- a/pkg/cmd/roachtest/test_monitor.go
+++ b/pkg/cmd/roachtest/test_monitor.go
@@ -21,7 +21,7 @@ type testMonitorImpl struct {
 
 // newTestMonitor is a function that creates a new test monitor. It can be used for testing
 // purposes to replace the default monitor with a custom implementation.
-var newTestMonitor = func(ctx context.Context, t test.Test, c *clusterImpl) *testMonitorImpl {
+var newTestMonitor = func(ctx context.Context, t test.Test, c testCluster) *testMonitorImpl {
 	return &testMonitorImpl{
 		monitor: newMonitor(ctx, t, c, true /* expectExactProcessDeath */),
 		t:       t,

--- a/pkg/cmd/roachtest/test_monitor_test.go
+++ b/pkg/cmd/roachtest/test_monitor_test.go
@@ -40,7 +40,7 @@ func (s *stubTestMonitorError) WaitForNodeDeath() error {
 }
 
 func TestGlobalMonitorError(t *testing.T) {
-	newTestMonitor = func(_ context.Context, t test.Test, c *clusterImpl) *testMonitorImpl {
+	newTestMonitor = func(_ context.Context, t test.Test, c testCluster) *testMonitorImpl {
 		return &testMonitorImpl{
 			monitor: &stubTestMonitorError{},
 			t:       t,

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -657,7 +657,7 @@ func (r *testRunner) allocateOrAttachToCluster(
 	t registry.TestSpec,
 	arch vm.CPUArch,
 	wStatus *workerStatus,
-) (*clusterImpl, *vm.CreateOpts, error) {
+) (testCluster, *vm.CreateOpts, error) {
 	wStatus.SetStatus(fmt.Sprintf("creating cluster (arch=%q)", arch))
 	defer wStatus.SetStatus("")
 
@@ -694,7 +694,7 @@ func (r *testRunner) allocateOrAttachToCluster(
 			}
 		} else {
 			// Pretend pre-existing's cluster architecture matches the desired one; see the above TODO wrt validation.
-			c.arch = arch
+			c.SetArchitecture(arch)
 			return c, nil, nil
 		}
 		// Fall through to create new cluster with name override.
@@ -766,7 +766,7 @@ func (r *testRunner) runWorker(
 		r.removeWorker(ctx, name)
 	}()
 
-	var c *clusterImpl // The cluster currently being used.
+	var c testCluster // The cluster currently being used.
 	// When this method returns we'll destroy the cluster we had at the time.
 	// Note that, if debug was set, c has been set to nil.
 	defer func() {
@@ -830,7 +830,7 @@ func (r *testRunner) runWorker(
 		testToRun := testToRunRes{noWork: true}
 		if c != nil {
 			// Try to reuse cluster.
-			testToRun = work.selectTestForCluster(ctx, workerL, c.spec, r.cr, roachtestflags.Cloud)
+			testToRun = work.selectTestForCluster(ctx, workerL, c.Spec(), r.cr, roachtestflags.Cloud)
 			if !testToRun.noWork {
 				// We found a test to run on this cluster. Wipe the cluster.
 				if err := c.WipeForReuse(ctx, workerL, testToRun.spec.Cluster); err != nil {
@@ -896,12 +896,12 @@ func (r *testRunner) runWorker(
 			// Apple M1/M2) it can run multiple architectures.
 			// TODO(radu): this is not true of Intel and/or linux hosts, we should
 			// somehow determine the capabilities at runtime.
-			arch = c.arch
+			arch = c.Architecture()
 		} else {
 			arch = archForTest(ctx, workerL, testToRun.spec)
 			if c != nil {
 				// Switch architecture of local cluster (see above).
-				c.arch = arch
+				c.SetArchitecture(arch)
 			}
 		}
 
@@ -939,11 +939,11 @@ func (r *testRunner) runWorker(
 					shout(ctx, workerL, stdout, "Cluster logs: %s", filepath.Join(runnerLogsDir, clusterCreateDir, c.Name()+".log"))
 				}
 			} else {
-				if c.arch != arch {
+				if c.Architecture() != arch {
 					// N.B. this can happen if requested machine type is not feasible/available.
 					workerL.PrintfCtx(ctx, "WARN: cluster arch for test differs %s: %s (cluster arch=%q, specified arch=%q)",
-						testToRun.spec.Name, c.Name(), c.arch, arch)
-					arch = c.arch
+						testToRun.spec.Name, c.Name(), c.Architecture(), arch)
+					arch = c.Architecture()
 				}
 				shout(ctx, workerL, stdout, "Cluster %s created for test %s (arch=%q, logs: %s)",
 					c.Name(), testToRun.spec.Name, arch,
@@ -968,10 +968,10 @@ func (r *testRunner) runWorker(
 		}
 		testName := testToRun.spec.Name
 		// N.B. c may be nil owing to clusterCreateErr
-		if c != nil && c.arch != vm.ArchAMD64 {
+		if c != nil && c.Architecture() != vm.ArchAMD64 {
 			// N.B. For non-default cpu architecture, encode it in the test name. This helps to differentiate test
 			// artifacts/results by cpu architecture.
-			testName = fmt.Sprintf("%s/cpu_arch=%s", testName, c.arch)
+			testName = fmt.Sprintf("%s/cpu_arch=%s", testName, c.Architecture())
 		}
 		escapedTestName := teamCityNameEscape(testName)
 		runSuffix := "run_" + strconv.Itoa(testToRun.runNum)
@@ -1015,10 +1015,8 @@ func (r *testRunner) runWorker(
 		handleClusterCreationFailure := func(clusterCreateErr error) {
 			t.Error(errClusterProvisioningFailed(clusterCreateErr))
 
-			// Technically don't need the issueInfo struct here because we have access
-			// to the clusterImpl and vm.CreateOpts in runWorker()
-			// but not in runTests() so keeping the invocation of getTestParameters()
-			// the same in both spots
+			// Keep the invocation of getTestParameters() the same here and in
+			// runTests(), where only the issue info is available.
 			params := getTestParameters(t, issueInfo.cluster, issueInfo.vmCreateOpts)
 			logTestParameters(workerL, params)
 			if _, githubErr := github.MaybePost(t, issueInfo, workerL, t.failureMsg(), params); githubErr != nil {
@@ -1050,7 +1048,7 @@ func (r *testRunner) runWorker(
 			shout(ctx, workerL, stdout, "Setting up cluster %s for test %s", c.Name(), testToRun.spec.Name)
 
 			var setupErr error
-			if c.spec.NodeCount > 0 { // skip during tests
+			if c.Spec().NodeCount > 0 { // skip during tests
 				setupErr = c.PutCockroach(ctx, clusterSetupL, t)
 			}
 			if setupErr == nil {
@@ -1080,19 +1078,18 @@ func (r *testRunner) runWorker(
 				testSpec := t.Spec().(*registry.TestSpec)
 				switch testSpec.EncryptionSupport {
 				case registry.EncryptionAlwaysEnabled:
-					c.encAtRest = true
+					c.SetEncryptedAtRest(true)
 				case registry.EncryptionAlwaysDisabled:
-					c.encAtRest = false
+					c.SetEncryptedAtRest(false)
 				case registry.EncryptionMetamorphic:
 					// when tests opted-in to metamorphic testing, encryption will
 					// be enabled according to the probability passed to
 					// --metamorphic-encryption-probability
-					c.encAtRest = prng.Float64() < roachtestflags.EncryptionProbability
+					c.SetEncryptedAtRest(prng.Float64() < roachtestflags.EncryptionProbability)
 				}
 
 				// Set initial cluster settings for this test.
-				c.clusterSettings = map[string]string{}
-				c.virtualClusterSettings = map[string]string{}
+				c.ResetClusterSettings()
 
 				leases := testSpec.Leases
 				if leases == registry.MetamorphicLeases {
@@ -1109,13 +1106,13 @@ func (r *testRunner) runWorker(
 				switch leases {
 				case registry.DefaultLeases:
 				case registry.EpochLeases:
-					c.clusterSettings["kv.expiration_leases_only.enabled"] = "false"
-					c.clusterSettings["kv.raft.leader_fortification.fraction_enabled"] = "0.0"
+					c.SetClusterSetting("kv.expiration_leases_only.enabled", "false")
+					c.SetClusterSetting("kv.raft.leader_fortification.fraction_enabled", "0.0")
 				case registry.ExpirationLeases:
-					c.clusterSettings["kv.expiration_leases_only.enabled"] = "true"
+					c.SetClusterSetting("kv.expiration_leases_only.enabled", "true")
 				case registry.LeaderLeases:
-					c.clusterSettings["kv.expiration_leases_only.enabled"] = "false"
-					c.clusterSettings["kv.raft.leader_fortification.fraction_enabled"] = "1.0"
+					c.SetClusterSetting("kv.expiration_leases_only.enabled", "false")
+					c.SetClusterSetting("kv.raft.leader_fortification.fraction_enabled", "1.0")
 				case registry.MetamorphicLeases:
 					t.Fatalf("metamorphic leases handled above")
 				default:
@@ -1128,11 +1125,11 @@ func (r *testRunner) runWorker(
 				switch testSpec.WriteOptimization {
 				case registry.DefaultWriteOptimization:
 				case registry.Pipelining:
-					c.clusterSettings["kv.transaction.write_pipelining.enabled"] = "true"
-					c.clusterSettings["kv.transaction.write_buffering.enabled"] = "false"
+					c.SetClusterSetting("kv.transaction.write_pipelining.enabled", "true")
+					c.SetClusterSetting("kv.transaction.write_buffering.enabled", "false")
 				case registry.Buffering:
-					c.clusterSettings["kv.transaction.write_buffering.enabled"] = "true"
-					c.clusterSettings["kv.transaction.write_pipelining.enabled"] = "false"
+					c.SetClusterSetting("kv.transaction.write_buffering.enabled", "true")
+					c.SetClusterSetting("kv.transaction.write_pipelining.enabled", "false")
 				}
 
 				// Apply metamorphic settings not explicitly defined by the test.
@@ -1152,7 +1149,7 @@ func (r *testRunner) runWorker(
 					} {
 						enable := prng.Intn(2) == 0
 						if !t.spec.Suites.Contains(registry.MixedVersion) && enable {
-							c.clusterSettings[tc.setting] = "true"
+							c.SetClusterSetting(tc.setting, "true")
 							c.status(fmt.Sprintf("metamorphically setting %q to 'true'", tc.setting))
 							t.AddParam(tc.label, fmt.Sprint(enable))
 						}
@@ -1176,18 +1173,18 @@ func (r *testRunner) runWorker(
 						t.L().Printf("WARN: --force-drpc is set for mixed-version suite %s",
 							t.Name())
 					}
-					c.useDRPC = true
+					c.SetUseDRPC(true)
 					c.status("Enabling DRPC")
 					t.AddParam("forceDRPC", "true")
 				} else if !testSpec.Benchmark && !isMixedVersion && prng.Intn(2) == 0 {
-					c.useDRPC = true
+					c.SetUseDRPC(true)
 					c.status("Enabling DRPC")
 					t.AddParam("metamorphicDRPC", "true")
 				} else {
-					c.useDRPC = false
+					c.SetUseDRPC(false)
 				}
 
-				c.goCoverDir = t.GoCoverArtifactsDir()
+				c.SetGoCoverDir(t.GoCoverArtifactsDir())
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")
 
@@ -1219,7 +1216,7 @@ func (r *testRunner) runWorker(
 					// Continue with a fresh cluster.
 					c = nil
 				case NoDebug:
-					if !c.saved() {
+					if saved, _ := c.Saved(); !saved {
 						// On any test failure or error, we destroy the cluster. We could be
 						// more selective, but this sounds safer.
 						workerL.PrintfCtx(ctx, "destroying cluster %s because: %s", c, failureMsg)
@@ -1252,7 +1249,7 @@ func (r *testRunner) runWorker(
 // destroyClusterAsync runs cluster destroy in a goroutine and adds 1 to the wait group.
 // if the cluster is local, the cluster destroy is sequential.
 func (r *testRunner) destroyClusterAsync(
-	clusterDestroyWg *sync.WaitGroup, c *clusterImpl, l *logger.Logger,
+	clusterDestroyWg *sync.WaitGroup, c testCluster, l *logger.Logger,
 ) {
 	if c.IsLocal() {
 		// N.B. multiple local clusters aren't supported, hence we must use a blocking call.
@@ -1260,7 +1257,7 @@ func (r *testRunner) destroyClusterAsync(
 		return
 	}
 	clusterDestroyWg.Add(1)
-	go func(ci *clusterImpl) {
+	go func(ci testCluster) {
 		defer clusterDestroyWg.Done()
 		// We use a context that can't be canceled for the Destroy().
 		ci.Destroy(context.Background(), closeLogger, l)
@@ -1277,7 +1274,7 @@ func (r *testRunner) runTest(
 	t *testImpl,
 	runNum int,
 	runCount int,
-	c *clusterImpl,
+	c testCluster,
 	stdout io.Writer,
 	l *logger.Logger,
 	github GithubPoster,
@@ -1314,7 +1311,7 @@ func (r *testRunner) runTest(
 	if grafanaAvailable {
 		// Add the runID, testRunID, and cluster name to grafanaTags. These are the three
 		// template variables grafana uses to filter tests by.
-		c.grafanaTags = []string{vm.SanitizeLabel(runID), vm.SanitizeLabel(testRunID), vm.SanitizeLabel(c.Name())}
+		c.SetGrafanaTags([]string{vm.SanitizeLabel(runID), vm.SanitizeLabel(testRunID), vm.SanitizeLabel(c.Name())})
 	}
 
 	defer func() {
@@ -1430,8 +1427,8 @@ func (r *testRunner) runTest(
 		// Upload test logs to Datadog for failed tests on master/release branches (configurable via flags)
 		if datadog.ShouldUploadTestLogsToDatadog(t.Failed()) {
 			m := datadog.NewLogMetadata(
-				t.L(), t.spec, !t.Failed(), fmt.Sprintf("%.2f", timeutil.Since(t.start).Seconds()), c.cloud, c.os, c.arch,
-				c.name)
+				t.L(), t.spec, !t.Failed(), fmt.Sprintf("%.2f", timeutil.Since(t.start).Seconds()), c.Cloud(), c.OS(), c.Architecture(),
+				c.Name())
 			uploadStart := timeutil.Now()
 			if err := datadog.MaybeUploadTestLogs(ctx, t.L(), t.artifactsDir, m); err != nil {
 				// Best effort
@@ -1592,12 +1589,17 @@ func (r *testRunner) runTest(
 
 	// Replacing the logger is best effort.
 	replaceLogger := func(name string) {
-		logger, err := c.l.ChildLogger(name, logger.QuietStderr, logger.QuietStdout)
+		clusterLogger := c.Logger()
+		if clusterLogger == nil {
+			l.Printf("unable to create logger %s: cluster logger is nil", name)
+			return
+		}
+		logger, err := clusterLogger.ChildLogger(name, logger.QuietStderr, logger.QuietStdout)
 		if err != nil {
 			l.Printf("unable to create logger %s: %s", name, err)
 			return
 		}
-		c.l = logger
+		c.SetLogger(logger)
 		t.ReplaceL(logger)
 	}
 
@@ -1662,7 +1664,7 @@ func getVMNames(fullVMNames []string) string {
 
 // getPreemptedVMNames returns a comma separated list of preempted VM
 // names, or an empty string if no VM was preempted or an error was found.
-func getPreemptedVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) string {
+func getPreemptedVMNames(ctx context.Context, c testCluster, l *logger.Logger) string {
 	preemptedVMs, err := getPreemptedVMsHook(c, ctx, l)
 	if err != nil {
 		l.Printf("failed to check preempted VMs:\n%+v", err)
@@ -1679,7 +1681,7 @@ func getPreemptedVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) 
 
 // getHostErrorVMNames returns a comma separated list of host error VM
 // names, or an empty string if no VM had a host error.
-func getHostErrorVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) string {
+func getHostErrorVMNames(ctx context.Context, c testCluster, l *logger.Logger) string {
 	hostErrorVMs, err := c.GetHostErrorVMs(ctx, l)
 	if err != nil {
 		l.Printf("failed to check hostError VMs:\n%+v", err)
@@ -1691,7 +1693,7 @@ func getHostErrorVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) 
 
 // getLiveMigrationVMNames returns a comma separated list of VMs that
 // experienced a live migration over the duration of the test.
-func getLiveMigrationVMNames(c *clusterImpl, l *logger.Logger) string {
+func getLiveMigrationVMNames(c testCluster, l *logger.Logger) string {
 	liveMigrationVMs, err := c.GetLiveMigrationVMs(l)
 	if err != nil {
 		l.Printf("failed to check live migrations:\n%+v", err)
@@ -1705,7 +1707,7 @@ func getLiveMigrationVMNames(c *clusterImpl, l *logger.Logger) string {
 // may opt out of these assertions by setting the relevant `SkipPostValidations` flag in the test spec.
 // An error caused by a timeout will not result in a failure.
 func (r *testRunner) postTestAssertions(
-	ctx context.Context, t *testImpl, c *clusterImpl, timeout time.Duration,
+	ctx context.Context, t *testImpl, c testCluster, timeout time.Duration,
 ) error {
 	assertionFailed := false
 	postAssertionErr := func(err error) {
@@ -1791,7 +1793,13 @@ func (r *testRunner) postTestAssertions(
 				// NB: the consistency checks should run at the system tenant level.
 				db := c.Conn(ctx, t.L(), validationNode, option.VirtualClusterName(install.SystemInterfaceName))
 				defer db.Close()
-				if err := c.assertConsistentReplicas(ctx, db, t); err != nil {
+				t.L().Printf("checking for replica divergence")
+				if err := timeutil.RunWithTimeout(
+					ctx, "consistency check", 20*time.Minute,
+					func(ctx context.Context) error {
+						return roachtestutil.CheckReplicaDivergenceOnDB(ctx, t.L(), db)
+					},
+				); err != nil {
 					postAssertionErr(errors.WithDetail(err, "consistency check failed"))
 				}
 			}()
@@ -1835,7 +1843,7 @@ func (r *testRunner) postTestAssertions(
 // teardownTest is best effort and should not fail a test.
 // Errors during artifact collection will be propagated up.
 func (r *testRunner) teardownTest(
-	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool,
+	ctx context.Context, t *testImpl, c testCluster, timedOut bool,
 ) error {
 	// Check for rare conditions (such as storage durability crashes) at this
 	// point. This may still mark the test as failed (so that we enter artifacts
@@ -1905,7 +1913,7 @@ func (r *testRunner) teardownTest(
 // t.L() which is test-teardown.log since inspectArtifacts is called after
 // teardownTest
 func (r *testRunner) inspectArtifacts(
-	ctx context.Context, t *testImpl, c *clusterImpl, testLogger *logger.Logger,
+	ctx context.Context, t *testImpl, c testCluster, testLogger *logger.Logger,
 ) (inspectArtifactsErr error) {
 
 	if t.Failed() || roachtestflags.AlwaysCollectArtifacts {
@@ -1934,9 +1942,9 @@ func (r *testRunner) inspectArtifacts(
 }
 
 // gatherNodeIpMapping attempts to gather cluster node ip information for debug
-func gatherNodeIpMapping(t *testImpl, c *clusterImpl) (string, error) {
+func gatherNodeIpMapping(t *testImpl, c testCluster) (string, error) {
 	var table [][]string
-	cachedCluster, err := getCachedCluster(c.name)
+	cachedCluster, err := getCachedCluster(c.Name())
 	if err != nil {
 		return "", err
 	}
@@ -1951,7 +1959,12 @@ func gatherNodeIpMapping(t *testImpl, c *clusterImpl) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	testClusterLogger, err := c.l.ChildLogger("node-ips", logger.QuietStderr, logger.QuietStdout)
+	clusterLogger := c.Logger()
+	if clusterLogger == nil {
+		t.L().Printf("unable to create logger %s: cluster logger is nil", "node-ips")
+		return nodeIpTable, nil
+	}
+	testClusterLogger, err := clusterLogger.ChildLogger("node-ips", logger.QuietStderr, logger.QuietStdout)
 	if err != nil {
 		// Best effort, swallowing error
 		t.L().Printf("unable to create logger %s: %s", "node-ips", err)
@@ -2008,7 +2021,7 @@ func gatherFatalNodeLogs(t *testImpl, testLogger *logger.Logger) (string, error)
 // volume snapshots so that the durable state close to the incident is
 // preserved.
 func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
-	ctx context.Context, t *testImpl, c *clusterImpl,
+	ctx context.Context, t *testImpl, c testCluster,
 ) {
 	if len(c.All()) == 0 {
 		return // test only
@@ -2048,7 +2061,7 @@ func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 }
 
 func (r *testRunner) collectArtifacts(
-	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool, timeout time.Duration,
+	ctx context.Context, t *testImpl, c testCluster, timedOut bool, timeout time.Duration,
 ) error {
 	// Collecting artifacts may hang, so we run it in a goroutine which is abandoned
 	// after a timeout.
@@ -2133,7 +2146,7 @@ func (r *testRunner) collectArtifacts(
 			t.L().Printf("failed to fetch Pebble checkpoints: %s", err)
 		}
 		// Bypass the collection of timeseries data for "large" clusters.
-		if c.spec.NodeCount < 30 {
+		if c.Spec().NodeCount < 30 {
 			if err := c.FetchTimeseriesData(ctx, t.L()); err != nil {
 				t.L().Printf("failed to fetch timeseries data: %s", err)
 			}
@@ -2280,9 +2293,9 @@ func (r *testRunner) serveHTTP(wr http.ResponseWriter, req *http.Request) {
 			}
 		}
 		var clusterBuilder strings.Builder
-		if w.Cluster() != nil {
-			clusterName := w.Cluster().name
-			adminUIAddrs, err := w.Cluster().ExternalAdminUIAddr(req.Context(), w.Cluster().l, w.Cluster().Node(1))
+		if cluster := w.Cluster(); cluster != nil {
+			clusterName := cluster.Name()
+			adminUIAddrs, err := cluster.ExternalAdminUIAddr(req.Context(), cluster.Logger(), cluster.Node(1))
 			if err == nil {
 				clusterAdminUIAddr := adminUIAddrs[0]
 				clusterBuilder.WriteString(fmt.Sprintf("<a href='//%s'>%s</a>", clusterAdminUIAddr, clusterName))
@@ -2329,7 +2342,7 @@ func (r *testRunner) serveHTTP(wr http.ResponseWriter, req *http.Request) {
 	<th>Test</th>
 	</tr>`)
 	for _, c := range r.cr.savedClusters() {
-		fmt.Fprintf(wr, "<tr><td>%s</td><td>%s</td><tr/>", c.name, c.savedMsg)
+		fmt.Fprintf(wr, "<tr><td>%s</td><td>%s</td><tr/>", c.Name(), c.savedMsg)
 	}
 	fmt.Fprintf(wr, "</table>")
 
@@ -2363,7 +2376,7 @@ func (r *testRunner) getCompletedTests() []completedTestInfo {
 }
 
 func (r *testRunner) postProcessPerfMetrics(
-	ctx context.Context, t *testImpl, c *clusterImpl, dstDirFn func(nodeIdx int) string,
+	ctx context.Context, t *testImpl, c testCluster, dstDirFn func(nodeIdx int) string,
 ) {
 	// Initialize metrics collector
 	metrics := &perfMetricsCollector{
@@ -2385,7 +2398,7 @@ func (r *testRunner) postProcessPerfMetrics(
 }
 
 func (m *perfMetricsCollector) collectFromNodes(
-	c *clusterImpl, dstDirFn func(nodeIdx int) string, log *logger.Logger,
+	c testCluster, dstDirFn func(nodeIdx int) string, log *logger.Logger,
 ) error {
 	for _, node := range getPerfArtifactsNode(c) {
 		files, err := m.findMetricsFiles(dstDirFn(node))
@@ -2605,7 +2618,7 @@ func logTestParameters(l *logger.Logger, params map[string]string) {
 	}
 }
 
-func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) map[string]string {
+func getTestParameters(t *testImpl, c testCluster, createOpts *vm.CreateOpts) map[string]string {
 	spec := t.spec
 
 	clusterParams := map[string]string{
@@ -2629,13 +2642,10 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 	}
 
 	if c != nil {
-		clusterParams["encrypted"] = fmt.Sprintf("%v", c.encAtRest)
-		clusterParams["arch"] = string(c.arch)
+		clusterParams["encrypted"] = fmt.Sprintf("%v", c.EncryptedAtRest())
+		clusterParams["arch"] = string(c.Architecture())
 
-		c.destroyState.mu.Lock()
-		saved, savedMsg := c.destroyState.mu.saved, c.destroyState.mu.savedMsg
-		c.destroyState.mu.Unlock()
-		if saved {
+		if saved, savedMsg := c.Saved(); saved {
 			clusterParams["saved"] = savedMsg
 		}
 	}

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -67,7 +67,7 @@ func nilLogger() *logger.Logger {
 
 func defaultClusterOpt() clustersOpt {
 	return clustersOpt{
-		typ:       roachprodCluster,
+		typ:       roachprodClusterType,
 		user:      "test_user",
 		cpuQuota:  1000,
 		debugMode: NoDebug,
@@ -79,7 +79,7 @@ func defaultClusterOpt() clustersOpt {
 // cluster provisioning error.
 func clusterOptWithProvisioningError() clustersOpt {
 	return clustersOpt{
-		typ:       roachprodCluster,
+		typ:       roachprodClusterType,
 		user:      "test_user",
 		cpuQuota:  1000,
 		debugMode: NoDebug,
@@ -288,7 +288,7 @@ func TestRunnerEncryptionAtRest(t *testing.T) {
 		Owner:             OwnerUnitTest,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			encAtRest := c.(*clusterImpl).encAtRest
+			encAtRest := c.(testCluster).EncryptedAtRest()
 			t.L().Printf("encryption-at-rest=%t", encAtRest)
 			if encAtRest {
 				atomic.StoreInt32(&sawEncrypted, 1)


### PR DESCRIPTION
Previously, the roachtest runner was tightly coupled to `*clusterImpl` (the roachprod-backed cluster implementation). The runner, cluster registry, github reporter, and test monitor all accessed `clusterImpl` fields directly, making it impossible to plug in an alternative cluster backend without modifying runner internals.

This was inadequate because upcoming work to support managed-service clusters (e.g. CockroachDB Cloud) requires the runner to operate against clusters it does not provision via roachprod.

This patch introduces `testCluster`, an internal interface that captures the runner's view of a cluster, and threads it through all runner plumbing in order to decouple the runner from the concrete roachprod implementation. The early commits define the interface and mechanically replace `*clusterImpl` with `testCluster` across the runner, registry, github reporter, and test monitor. Later commits clean up remaining concrete dependencies: the post-validation consistency check is inlined in the runner, the cluster factory is split into a public entry point and a roachprod-specific implementation, and the last type assertion against `*clusterImpl` in test helpers is replaced with an interface-based accessor. `clusterImpl` continues to be the only implementation; no behavior changes.

Epic: none
Release note: None