### PR TITLE
revlogjob: checkpoint frontier directly instead of via stringified copy

### DIFF
--- a/pkg/revlog/revlogjob/checkpoint_internal_test.go
+++ b/pkg/revlog/revlogjob/checkpoint_internal_test.go
@@ -18,36 +18,62 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
 // countingPersister is a small in-memory Persister that counts
-// Store invocations and snapshots the most recent state. The
-// counter is read from the test goroutine while Store runs on the
-// checkpointer goroutine, so accesses are guarded by a mutex (the
-// synctest bubble enforces ordering but not memory model
-// synchronization).
+// Store invocations and snapshots the most recent (highWater,
+// frontier-as-resolved-spans, openTicks). Frontier entries are
+// captured by walking Entries() during the Store call (the
+// frontier itself is owned by the caller and may move after Store
+// returns). The counter is read from the test goroutine while
+// Store runs on the checkpointer goroutine, so accesses are
+// guarded by a mutex (the synctest bubble enforces ordering but
+// not memory model synchronization).
 type countingPersister struct {
 	mu     syncutil.Mutex
 	stores int
-	last   State
+	last   recordedStore
+}
+
+type recordedStore struct {
+	highWater hlc.Timestamp
+	frontier  []frontierEntry
+	openTicks map[hlc.Timestamp][]revlogpb.File
+}
+
+type frontierEntry struct {
+	span roachpb.Span
+	ts   hlc.Timestamp
 }
 
 func (p *countingPersister) Load(context.Context) (State, bool, error) {
 	return State{}, false, nil
 }
 
-func (p *countingPersister) Store(_ context.Context, s State) error {
+func (p *countingPersister) Store(
+	_ context.Context,
+	highWater hlc.Timestamp,
+	frontier span.ReadOnlyFrontier,
+	openTicks map[hlc.Timestamp][]revlogpb.File,
+) error {
+	rec := recordedStore{highWater: highWater, openTicks: openTicks}
+	if frontier != nil {
+		for sp, ts := range frontier.Entries() {
+			rec.frontier = append(rec.frontier, frontierEntry{span: sp, ts: ts})
+		}
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.stores++
-	p.last = s
+	p.last = rec
 	return nil
 }
 
-func (p *countingPersister) snapshot() (int, State) {
+func (p *countingPersister) snapshot() (int, recordedStore) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.stores, p.last
@@ -102,8 +128,8 @@ func TestRunCheckpointerSyncTest(t *testing.T) {
 			require.Equal(t, i, stores, "after %d intervals", i)
 		}
 		_, last := p.snapshot()
-		require.Equal(t, hlc.Timestamp{WallTime: 100 * int64(time.Second)}, last.HighWater)
-		require.Len(t, last.OpenTicks, 1)
+		require.Equal(t, hlc.Timestamp{WallTime: 100 * int64(time.Second)}, last.highWater)
+		require.Len(t, last.openTicks, 1)
 
 		// Cancellation drains the loop without further stores.
 		cancel()

--- a/pkg/revlog/revlogjob/flow.go
+++ b/pkg/revlog/revlogjob/flow.go
@@ -132,7 +132,7 @@ func Run(
 	// of the DistSQL flow and exits when checkpointCtx is cancelled
 	// either by the deferred cleanup below or by parent ctx
 	// cancellation (job pause / cancel / fail). It only reads from
-	// manager (via Snapshot); it never mutates flow state, so it's
+	// manager (via Checkpoint); it never mutates flow state, so it's
 	// safe to run concurrently with the DistSQL flow.
 	checkpointCtx, cancelCheckpoint := context.WithCancel(ctx)
 	checkpointDone := make(chan struct{})
@@ -270,15 +270,13 @@ func runOneFlow(
 			"revlogjob.runOneFlow: span partitioning yielded no producers for %d spans", len(spans))
 	}
 
-	// Snapshot the manager once so every producer in this iteration
-	// sees a consistent ResumeState — and so each iteration after a
-	// widening starts new producers' per-tick flushorder above any
-	// prior incarnation's contributions to the still-open tick.
-	resumeBase, err := manager.Snapshot()
-	if err != nil {
-		return errors.Wrap(err, "snapshotting manager for producer resume")
-	}
-
+	// Each producer in this iteration gets its restart position
+	// derived from the manager under the manager's lock. Per
+	// partition is fine — partition counts are O(nodes), not
+	// O(spans) — and avoids exposing a copy of the live frontier.
+	// On a widening this also gives every new producer a per-tick
+	// starting flushorder above any prior incarnation's
+	// contribution to the still-open tick.
 	plan := planCtx.NewPhysicalPlan()
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(partitions))
 	for i, part := range partitions {
@@ -289,7 +287,7 @@ func runOneFlow(
 			Dest:           dest,
 			TickWidthNanos: int64(tickWidth),
 		}
-		resumeToSpec(spec, ResumeStateForPartition(resumeBase, part.Spans))
+		resumeToSpec(spec, manager.ResumeForPartition(part.Spans))
 		corePlacement[i].SQLInstanceID = part.SQLInstanceID
 		corePlacement[i].Core.Revlog = spec
 	}

--- a/pkg/revlog/revlogjob/persister.go
+++ b/pkg/revlog/revlogjob/persister.go
@@ -13,12 +13,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 )
 
-// State is the snapshot of TickManager state that survives a job
-// restart. It is what the coordinator persists periodically and
-// what it loads on resume to pick up where the prior incarnation
-// left off.
-//
-// Three pieces, none of which can be derived from the other two:
+// State is the persisted checkpoint of TickManager state, returned
+// by Persister.Load and consumed by TickManager.Rehydrate. Three
+// pieces, none of which can be derived from the other two:
 //
 //   - HighWater is the end time of the most-recently-closed tick.
 //     User-visible (system.job_progress.resolved) and used by the
@@ -40,10 +37,17 @@ type State struct {
 }
 
 // Persister loads and stores TickManager checkpoint state. The
-// orchestration code (TickManager, the checkpoint loop in flow.go)
-// uses this interface; concrete implementations live elsewhere
-// (progress_persist.go for the production jobs-backed impl;
-// in-memory variants for tests).
+// orchestration code (TickManager, the checkpoint loop in
+// progress.go) uses this interface; concrete implementations live
+// elsewhere (progress_persist.go for the production jobs-backed
+// impl; in-memory variants for tests).
+//
+// Store takes the three pieces as separate arguments rather than a
+// State value so that the live TickManager frontier flows directly
+// into the persister (and from there into jobfrontier.Store) under
+// the manager's lock — no intermediate copy keyed on
+// stringified-span. The OpenTicks map is owned by the caller; the
+// persister must not retain or mutate it after Store returns.
 //
 // All persistence is expected to be atomic — a partial Store that
 // e.g. writes the frontier but not the open-tick file lists would
@@ -57,5 +61,10 @@ type State struct {
 // run), or (zero, false, err) on a hard error.
 type Persister interface {
 	Load(ctx context.Context) (State, bool, error)
-	Store(ctx context.Context, state State) error
+	Store(
+		ctx context.Context,
+		highWater hlc.Timestamp,
+		frontier span.ReadOnlyFrontier,
+		openTicks map[hlc.Timestamp][]revlogpb.File,
+	) error
 }

--- a/pkg/revlog/revlogjob/persister_test.go
+++ b/pkg/revlog/revlogjob/persister_test.go
@@ -20,13 +20,23 @@ import (
 
 // memPersister is an in-memory revlogjob.Persister for unit tests
 // that exercise the orchestration code without spinning up a job
-// registry.
+// registry. Store walks the live frontier into a flat list of
+// (span, ts) entries; Load rebuilds a fresh frontier from that
+// list so the loaded State doesn't share storage with whatever
+// frontier was passed to Store.
 type memPersister struct {
-	state revlogjob.State
-	found bool
+	highWater    hlc.Timestamp
+	frontierEnts []memFrontierEntry
+	openTicks    map[hlc.Timestamp][]revlogpb.File
+	found        bool
 	// stores counts how many times Store was called. Useful for
 	// driving synctest-bubbled checkpoint-loop tests.
 	stores int
+}
+
+type memFrontierEntry struct {
+	Span     roachpb.Span
+	Resolved hlc.Timestamp
 }
 
 var _ revlogjob.Persister = (*memPersister)(nil)
@@ -35,21 +45,51 @@ func (m *memPersister) Load(_ context.Context) (revlogjob.State, bool, error) {
 	if !m.found {
 		return revlogjob.State{}, false, nil
 	}
-	return m.state, true, nil
+	state := revlogjob.State{
+		HighWater: m.highWater,
+		OpenTicks: m.openTicks,
+	}
+	if len(m.frontierEnts) > 0 {
+		f, err := span.MakeFrontier()
+		if err != nil {
+			return revlogjob.State{}, false, err
+		}
+		for _, e := range m.frontierEnts {
+			if err := f.AddSpansAt(e.Resolved, e.Span); err != nil {
+				return revlogjob.State{}, false, err
+			}
+		}
+		state.Frontier = f
+	}
+	return state, true, nil
 }
 
-func (m *memPersister) Store(_ context.Context, state revlogjob.State) error {
-	m.state = state
+func (m *memPersister) Store(
+	_ context.Context,
+	highWater hlc.Timestamp,
+	frontier span.ReadOnlyFrontier,
+	openTicks map[hlc.Timestamp][]revlogpb.File,
+) error {
+	m.highWater = highWater
+	m.openTicks = openTicks
+	m.frontierEnts = m.frontierEnts[:0]
+	if frontier != nil {
+		for sp, ts := range frontier.Entries() {
+			m.frontierEnts = append(m.frontierEnts,
+				memFrontierEntry{Span: sp, Resolved: ts})
+		}
+	}
 	m.found = true
 	m.stores++
 	return nil
 }
 
-// TestSnapshotRoundTrip verifies that a fresh TickManager rehydrated
-// from another TickManager's Snapshot reproduces the same
+// TestCheckpointRoundTrip verifies that the manager's live state
+// flows through Checkpoint → Persister.Store → Persister.Load →
+// Rehydrate into a fresh manager that reports the same
 // observable state: HighWater (LastClosed), per-tick file lists,
 // and per-span frontier.
-func TestSnapshotRoundTrip(t *testing.T) {
+func TestCheckpointRoundTrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
@@ -58,27 +98,31 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	require.NoError(t, d.OnCheckpoint(ctx, allSpan, ts(115)))
 	d.OnValue(ctx, roachpb.Key("b"), ts(125), []byte("v_b"), nil)
 	// Don't checkpoint past the second tick — leaves it in pending
-	// state on the manager so Snapshot has both a closed tick and
-	// an open tick to capture.
+	// state on the manager so the Checkpoint captures both a
+	// closed tick (HighWater) and an open tick.
 
-	snap, err := d.Manager.Snapshot()
+	p := &memPersister{}
+	require.NoError(t, d.Manager.Checkpoint(ctx, p))
+
+	loaded, found, err := p.Load(ctx)
 	require.NoError(t, err)
-
-	// HighWater = last-closed tick end.
-	require.Equal(t, ts(110), snap.HighWater)
-	// Frontier reached ts(115).
-	require.Equal(t, ts(115), snap.Frontier.Frontier())
+	require.True(t, found)
+	require.Equal(t, ts(110), loaded.HighWater)
+	require.Equal(t, ts(115), loaded.Frontier.Frontier())
 
 	// Build a fresh manager, rehydrate, and verify it reports the
 	// same LastClosed and that the frontier round-trips.
 	d2, _ := newTestDriver(t, ts(100))
-	require.NoError(t, d2.Manager.Rehydrate(snap))
+	require.NoError(t, d2.Manager.Rehydrate(loaded))
 	require.Equal(t, ts(110), d2.Manager.LastClosed())
 
-	snap2, err := d2.Manager.Snapshot()
+	p2 := &memPersister{}
+	require.NoError(t, d2.Manager.Checkpoint(ctx, p2))
+	loaded2, found2, err := p2.Load(ctx)
 	require.NoError(t, err)
-	require.Equal(t, ts(110), snap2.HighWater)
-	require.Equal(t, ts(115), snap2.Frontier.Frontier())
+	require.True(t, found2)
+	require.Equal(t, ts(110), loaded2.HighWater)
+	require.Equal(t, ts(115), loaded2.Frontier.Frontier())
 }
 
 // TestRehydrateOpenTicksAreClosedWithPriorFiles verifies that a
@@ -197,7 +241,7 @@ func TestResumeProducerBumpsFlushOrder(t *testing.T) {
 }
 
 // TestPersisterRoundTrip exercises the in-memory Persister contract:
-// Store followed by Load returns the same state.
+// Store followed by Load returns equivalent state.
 func TestPersisterRoundTrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
@@ -210,19 +254,16 @@ func TestPersisterRoundTrip(t *testing.T) {
 
 	frontier, err := span.MakeFrontierAt(ts(50), allSpan)
 	require.NoError(t, err)
-	want := revlogjob.State{
-		HighWater: ts(40),
-		Frontier:  frontier,
-		OpenTicks: map[hlc.Timestamp][]revlogpb.File{
-			ts(50): {{FileID: 1, FlushOrder: 0}, {FileID: 2, FlushOrder: 1}},
-		},
+	defer frontier.Release()
+	openTicks := map[hlc.Timestamp][]revlogpb.File{
+		ts(50): {{FileID: 1, FlushOrder: 0}, {FileID: 2, FlushOrder: 1}},
 	}
-	require.NoError(t, p.Store(ctx, want))
+	require.NoError(t, p.Store(ctx, ts(40), frontier, openTicks))
 
 	got, found, err = p.Load(ctx)
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Equal(t, want.HighWater, got.HighWater)
-	require.Equal(t, want.OpenTicks, got.OpenTicks)
-	require.Equal(t, want.Frontier.Frontier(), got.Frontier.Frontier())
+	require.Equal(t, ts(40), got.HighWater)
+	require.Equal(t, openTicks, got.OpenTicks)
+	require.Equal(t, ts(50), got.Frontier.Frontier())
 }

--- a/pkg/revlog/revlogjob/progress.go
+++ b/pkg/revlog/revlogjob/progress.go
@@ -20,14 +20,14 @@ import (
 // resume after a crash loses at most one interval of work.
 const checkpointInterval = 30 * time.Second
 
-// runCheckpointer periodically snapshots TickManager state and
-// hands it to the Persister. It returns when ctx is cancelled (job
+// runCheckpointer periodically asks TickManager to checkpoint its
+// state to the Persister. It returns when ctx is cancelled (job
 // pause / cancel / fail / completion).
 //
 // Failures during a single checkpoint are logged and skipped
 // rather than fatal: persistence is best-effort progress
 // reporting, not a correctness gate. The next interval retries
-// from the then-current snapshot.
+// from the then-current state.
 func runCheckpointer(ctx context.Context, persister Persister, manager *TickManager) error {
 	ticker := time.NewTicker(checkpointInterval)
 	defer ticker.Stop()
@@ -36,18 +36,9 @@ func runCheckpointer(ctx context.Context, persister Persister, manager *TickMana
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := checkpointOnce(ctx, persister, manager); err != nil {
+			if err := manager.Checkpoint(ctx, persister); err != nil {
 				log.Dev.Warningf(ctx, "revlogjob: checkpoint persist failed: %v", err)
 			}
 		}
 	}
-}
-
-// checkpointOnce snapshots and persists once. Extracted for tests.
-func checkpointOnce(ctx context.Context, persister Persister, manager *TickManager) error {
-	state, err := manager.Snapshot()
-	if err != nil {
-		return err
-	}
-	return persister.Store(ctx, state)
 }

--- a/pkg/revlog/revlogjob/progress_persist.go
+++ b/pkg/revlog/revlogjob/progress_persist.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/revlog/revlogpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/errors"
 )
 
@@ -114,16 +115,23 @@ func (p *jobPersister) Load(ctx context.Context) (State, bool, error) {
 }
 
 // Store atomically writes the three pieces of checkpoint state
-// under one transaction. Order of writes within the txn doesn't
+// under one transaction. The frontier is iterated by
+// jobfrontier.Store directly inside the txn, so its raw byte
+// keys land in InfoStorage without ever passing through a
+// stringly-keyed Go map. Order of writes within the txn doesn't
 // matter — they all commit or none do — but the Set is last so
 // that a hypothetical caller observing partial commits would never
 // see the user-visible HighWater jump ahead of the actual
-// underlying state. (Today we always commit the whole txn or none,
-// so this is belt-and-suspenders.)
-func (p *jobPersister) Store(ctx context.Context, state State) error {
+// underlying state.
+func (p *jobPersister) Store(
+	ctx context.Context,
+	highWater hlc.Timestamp,
+	frontier span.ReadOnlyFrontier,
+	openTicks map[hlc.Timestamp][]revlogpb.File,
+) error {
 	return p.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		ticks := make([]revlogpb.OpenTick, 0, len(state.OpenTicks))
-		for tickEnd, files := range state.OpenTicks {
+		ticks := make([]revlogpb.OpenTick, 0, len(openTicks))
+		for tickEnd, files := range openTicks {
 			ticks = append(ticks, revlogpb.OpenTick{
 				TickEnd: tickEnd,
 				Files:   files,
@@ -135,9 +143,9 @@ func (p *jobPersister) Store(ctx context.Context, state State) error {
 		); err != nil {
 			return errors.Wrap(err, "writing open-ticks blob")
 		}
-		if state.Frontier != nil {
+		if frontier != nil {
 			if err := jobfrontier.Store(
-				ctx, txn, p.jobID, flushedFrontierKey, state.Frontier,
+				ctx, txn, p.jobID, flushedFrontierKey, frontier,
 			); err != nil {
 				return errors.Wrap(err, "writing flushed frontier")
 			}
@@ -145,7 +153,7 @@ func (p *jobPersister) Store(ctx context.Context, state State) error {
 		// Continuous backup is unbounded, so there's no meaningful
 		// completion fraction to report — pass NaN to leave it null.
 		if err := jobs.ProgressStorage(p.jobID).Set(
-			ctx, txn, math.NaN(), state.HighWater,
+			ctx, txn, math.NaN(), highWater,
 		); err != nil {
 			return errors.Wrap(err, "writing job progress")
 		}

--- a/pkg/revlog/revlogjob/resume.go
+++ b/pkg/revlog/revlogjob/resume.go
@@ -12,8 +12,11 @@ import (
 )
 
 // ResumeStateForPartition derives the per-producer ResumeState for
-// a partition's assigned spans from the rehydrated TickManager
-// state.
+// a partition's assigned spans from a loaded checkpoint State —
+// the post-Rehydrate version of TickManager.ResumeForPartition,
+// suitable for tests that build State by hand. Production code
+// should call manager.ResumeForPartition instead, which reads the
+// live frontier under the manager's lock.
 //
 // The persisted Frontier may have spans that don't line up with the
 // new partition's spans (e.g. partitioning changed across the

--- a/pkg/revlog/revlogjob/tick_manager.go
+++ b/pkg/revlog/revlogjob/tick_manager.go
@@ -38,9 +38,10 @@ import (
 // the boundary.
 //
 // Concurrency: Flush is the only writer of the per-tick state and
-// the frontier, but Snapshot (used by the checkpoint loop) and
-// LastClosed (used by the per-job-info readers) read them from
-// other goroutines. mu serializes all three.
+// the frontier, but Checkpoint and ResumeForPartition (used by the
+// checkpoint loop and the flow planner) and LastClosed (used by
+// the per-job-info readers) read them from other goroutines. mu
+// serializes all of them.
 type TickManager struct {
 	es        cloud.ExternalStorage
 	tickWidth time.Duration
@@ -228,7 +229,7 @@ func (m *TickManager) DataFrontier() hlc.Timestamp {
 // span.Frontier semantics; the merged ts is the supplied ts, so
 // callers must pass spans they know are not already tracked at a
 // higher ts (or accept the conservative reset). Safe to call
-// concurrently with Flush, Snapshot, and the close loop.
+// concurrently with Flush, Checkpoint, and the close loop.
 func (m *TickManager) AddSpansAt(spans []roachpb.Span, ts hlc.Timestamp) error {
 	if len(spans) == 0 {
 		return nil
@@ -241,36 +242,19 @@ func (m *TickManager) AddSpansAt(spans []roachpb.Span, ts hlc.Timestamp) error {
 	return nil
 }
 
-// Snapshot captures the manager's checkpoint state for persistence
-// (see Persister). Holds mu briefly to copy frontier entries and
-// per-tick file lists; the returned State is independent of the
-// manager and may outlive subsequent Flushes.
-func (m *TickManager) Snapshot() (State, error) {
+// Checkpoint hands the manager's live (highWater, frontier,
+// openTicks) to the Persister under the manager's lock. The
+// frontier is passed by reference: the persister iterates
+// frontier.Entries() inside its txn and never retains it past
+// Store's return. The openTicks map is a freshly-copied snapshot
+// so the persister can serialize it without contending with
+// subsequent Flushes. Holds mu for the duration of the
+// persister.Store call (one InternalDB.Txn for the production
+// jobPersister); contention with Flush is bounded by
+// checkpointInterval (see progress.go).
+func (m *TickManager) Checkpoint(ctx context.Context, p Persister) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	// Rebuild the frontier into a fresh one so the caller (and the
-	// persister it hands the snapshot to) doesn't share storage with
-	// the live manager. The walk is bounded by the number of spans,
-	// not the volume of events flushed.
-	spans := make([]roachpb.Span, 0)
-	tsBySpan := make(map[string]hlc.Timestamp)
-	for sp, ts := range m.mu.frontier.Entries() {
-		spans = append(spans, sp)
-		tsBySpan[sp.String()] = ts
-	}
-	snapFrontier, err := span.MakeFrontier(spans...)
-	if err != nil {
-		return State{}, errors.Wrap(err, "snapshotting frontier")
-	}
-	for _, sp := range spans {
-		if ts := tsBySpan[sp.String()]; ts.IsSet() {
-			if _, err := snapFrontier.Forward(sp, ts); err != nil {
-				return State{}, errors.Wrap(err, "snapshotting frontier")
-			}
-		}
-	}
-
 	openTicks := make(map[hlc.Timestamp][]revlogpb.File, len(m.mu.pending))
 	for tickEnd, pt := range m.mu.pending {
 		if len(pt.files) == 0 {
@@ -280,12 +264,61 @@ func (m *TickManager) Snapshot() (State, error) {
 		copy(files, pt.files)
 		openTicks[tickEnd] = files
 	}
+	return p.Store(ctx, m.mu.lastClosed, m.mu.frontier, openTicks)
+}
 
-	return State{
-		HighWater: m.mu.lastClosed,
-		Frontier:  snapFrontier,
-		OpenTicks: openTicks,
-	}, nil
+// ResumeForPartition derives the per-producer ResumeState for a
+// partition's assigned spans from the manager's live frontier and
+// open-tick file lists. Holds mu for the duration of the
+// derivation. Used by runOneFlow to populate each producer's
+// RevlogSpec with a consistent restart position.
+func (m *TickManager) ResumeForPartition(spans []roachpb.Span) ResumeState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return resumeStateForPartitionLocked(m.mu.frontier, m.mu.pending, spans)
+}
+
+// resumeStateForPartitionLocked is the locked-region body of
+// ResumeForPartition. Mirrors the public ResumeStateForPartition
+// (which derives the same info from a loaded State) but reads
+// directly from the live manager state, avoiding any
+// stringly-keyed copy.
+func resumeStateForPartitionLocked(
+	frontier span.ReadOnlyFrontier, pending map[hlc.Timestamp]*pendingTick, spans []roachpb.Span,
+) ResumeState {
+	var resumes []SpanResume
+	for _, sp := range spans {
+		var minTS hlc.Timestamp
+		var found bool
+		for esp, ts := range frontier.Entries() {
+			if !sp.Overlaps(esp) || !ts.IsSet() {
+				continue
+			}
+			if !found || ts.Less(minTS) {
+				minTS = ts
+				found = true
+			}
+		}
+		if found {
+			resumes = append(resumes, SpanResume{Span: sp, Resolved: minTS})
+		}
+	}
+	var flushOrders map[hlc.Timestamp]int32
+	for tickEnd, pt := range pending {
+		var next int32
+		for _, f := range pt.files {
+			if f.FlushOrder >= next {
+				next = f.FlushOrder + 1
+			}
+		}
+		if next > 0 {
+			if flushOrders == nil {
+				flushOrders = make(map[hlc.Timestamp]int32, len(pending))
+			}
+			flushOrders[tickEnd] = next
+		}
+	}
+	return ResumeState{SpanResumes: resumes, StartingFlushOrders: flushOrders}
 }
 
 // Flush applies one producer's flush report (TickSink). Files are
@@ -303,7 +336,7 @@ func (m *TickManager) Flush(ctx context.Context, msg *revlogpb.Flush) error {
 	}
 	// Fire the hook outside the locked region so it observes the
 	// final post-close frontier and so its work doesn't serialize
-	// against Snapshot / LastClosed readers. We deliberately fire
+	// against Checkpoint / LastClosed readers. We deliberately fire
 	// on *any* forward movement (even sub-tick movement that didn't
 	// close any tick) — the PTS hook in particular wants to track
 	// the resolved frontier, not the closed-tick boundary.


### PR DESCRIPTION
The TickManager held a Snapshot step that copied its frontier
into a fresh one keyed on `Span.String()` before handing it to
the persister. `Span.String()` goes through `PrettyPrintRange`,
so two byte-distinct spans can collapse to the same key and
silently lose one entry on rehydrate (the loser resumes at
startHLC and re-streams unbounded history).

Replace `Snapshot` with `TickManager.Checkpoint(ctx, p)`, which
holds the manager's lock and hands the live frontier directly
to `Persister.Store`. The production `jobPersister` forwards it
to `jobfrontier.Store`, which iterates `Entries()` inside the
txn and writes raw bytes — no map, no `Span.String()` anywhere.

Per-flow producer resume derivation moves to the matching
`TickManager.ResumeForPartition(spans)`, one lock acquisition
per partition.

Epic: none
Release note: None