### PR TITLE
release-26.2: descs: evict stale SystemDatabaseCache entries on descriptor-not-found

### DIFF
--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -1396,6 +1397,90 @@ func TestForceStorageLookupIDs(t *testing.T) {
 			})
 		}
 
+		return nil
+	}))
+}
+
+// TestSystemDatabaseCacheEvictionOnDescriptorNotFound verifies that when
+// getDescriptorByName resolves a system table name to a stale ID via the
+// SystemDatabaseCache and the descriptor at that ID doesn't exist, the stale
+// cache entry is evicted so the next lookup self-heals through KV.
+func TestSystemDatabaseCacheEvictionOnDescriptorNotFound(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	codec := execCfg.Codec
+
+	const fakeName = "_test_evict_stale_cache"
+	const bogusID descpb.ID = 999999
+	nameKey := descpb.NameInfo{
+		ParentID:       keys.SystemDatabaseID,
+		ParentSchemaID: keys.SystemPublicSchemaID,
+		Name:           fakeName,
+	}
+
+	// Write a namespace entry pointing to an ID with no descriptor.
+	require.NoError(t, execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		return txn.Put(ctx, catalogkeys.EncodeNameKey(codec, &nameKey), int64(bogusID))
+	}))
+	defer func() {
+		require.NoError(t, execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			_, err := txn.Del(ctx, catalogkeys.EncodeNameKey(codec, &nameKey))
+			return err
+		}))
+	}()
+
+	// First lookup: the cached catalog reader reads the bogus namespace entry
+	// from KV and caches it in the SystemDatabaseCache. getDescriptorsByID then
+	// fails with ErrDescriptorNotFound, which triggers eviction of the stale
+	// cache entry.
+	err := sql.DescsTxn(ctx, &execCfg, func(
+		ctx context.Context, txn isql.Txn, col *descs.Collection,
+	) error {
+		db, err := col.ByName(txn.KV()).Get().Database(ctx, "system")
+		if err != nil {
+			return err
+		}
+		sc, err := col.ByName(txn.KV()).Get().Schema(ctx, db, "public")
+		if err != nil {
+			return err
+		}
+		_, err = col.ByName(txn.KV()).Get().Table(ctx, db, sc, fakeName)
+		return err
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, catalog.ErrDescriptorNotFound))
+
+	// Fix the namespace entry to point to a real system table descriptor.
+	realID := descpb.ID(keys.CommentsTableID)
+	require.NoError(t, execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		return txn.Put(ctx, catalogkeys.EncodeNameKey(codec, &nameKey), int64(realID))
+	}))
+
+	// Second lookup: succeeds because the eviction cleared the stale
+	// SystemDatabaseCache entry. Without eviction, the cache would still
+	// return bogusID and this lookup would fail with ErrDescriptorNotFound.
+	require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+		ctx context.Context, txn isql.Txn, col *descs.Collection,
+	) error {
+		db, err := col.ByName(txn.KV()).Get().Database(ctx, "system")
+		if err != nil {
+			return err
+		}
+		sc, err := col.ByName(txn.KV()).Get().Schema(ctx, db, "public")
+		if err != nil {
+			return err
+		}
+		desc, err := col.ByName(txn.KV()).Get().Table(ctx, db, sc, fakeName)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, realID, desc.GetID())
 		return nil
 	}))
 }

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -553,6 +553,19 @@ func getDescriptorByName(
 		if flags.layerFilters.withoutStorage {
 			return nil, err
 		}
+		// Evict the stale name→ID mapping from the SystemDatabaseCache so
+		// that the next lookup goes to KV and self-heals. This handles PCR
+		// reader tenants where SetupOrAdvanceStandbyReaderCatalog rewrites
+		// the namespace but the cache still holds the bootstrap ID. While this
+		// request will still fail, we expect the next request will hydrate the
+		// cache correctly and succeed.
+		if db != nil && db.GetID() == keys.SystemDatabaseID && sc != nil {
+			tc.cr.InvalidateSystemCacheEntry(descpb.NameInfo{
+				ParentID:       db.GetID(),
+				ParentSchemaID: sc.GetID(),
+				Name:           name,
+			})
+		}
 		// In all other cases, having an ID should imply having a descriptor.
 		return nil, errors.Wrapf(
 			err,

--- a/pkg/sql/catalog/internal/catkv/catalog_reader.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader.go
@@ -114,6 +114,10 @@ type CatalogReader interface {
 	ScanAllTableIDsInDatabase(
 		ctx context.Context, txn *kv.Txn, parentDBID descpb.ID,
 	) ([]descpb.ID, error)
+
+	// InvalidateSystemCacheEntry removes a name→ID mapping from the
+	// SystemDatabaseCache, if one is present.
+	InvalidateSystemCacheEntry(key descpb.NameInfo)
 }
 
 // NewUncachedCatalogReader is the constructor for the default
@@ -282,6 +286,9 @@ func (cr catalogReader) ScanAllTableIDsInDatabase(
 
 	return ids, nil
 }
+
+// InvalidateSystemCacheEntry is part of the CatalogReader interface.
+func (cr catalogReader) InvalidateSystemCacheEntry(descpb.NameInfo) {}
 
 // getDescriptorIDFromExclusiveKey translates an exclusive upper bound roach key
 // into an upper bound descriptor ID. It does this by turning the key into a

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
@@ -492,6 +492,11 @@ func (c *cachedCatalogReader) ensure(ctx context.Context, read nstree.Catalog) e
 
 }
 
+// InvalidateSystemCacheEntry is part of the CatalogReader interface.
+func (c *cachedCatalogReader) InvalidateSystemCacheEntry(key descpb.NameInfo) {
+	c.systemDatabaseCache.removeNameEntry(c.version, key)
+}
+
 func (c *cachedCatalogReader) setByIDState(id descpb.ID, s byIDStateValue) {
 	if c.byIDState == nil {
 		c.byIDState = make(map[descpb.ID]byIDStateValue)

--- a/pkg/sql/catalog/internal/catkv/system_database_cache.go
+++ b/pkg/sql/catalog/internal/catkv/system_database_cache.go
@@ -155,6 +155,23 @@ func (c *SystemDatabaseCache) update(version clusterversion.ClusterVersion, in n
 	}
 }
 
+// removeNameEntry removes a single namespace entry from the cache. This is
+// used to evict a stale name→ID mapping when the ID is discovered to not
+// correspond to a live descriptor (e.g. after SetupOrAdvanceStandbyReaderCatalog
+// rewrites the namespace on a PCR reader tenant).
+func (c *SystemDatabaseCache) removeNameEntry(
+	version clusterversion.ClusterVersion, key descpb.NameInfo,
+) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached := c.mu.m[version.Version]; cached != nil {
+		cached.DeleteByName(key)
+	}
+}
+
 // nameCandidatesForUpdate is a helper function for update which returns a
 // subset of namespace entries in the given nstree.Catalog which could
 // potentially be upserted into the cache.

--- a/pkg/sql/catalog/internal/catkv/system_database_cache_internal_test.go
+++ b/pkg/sql/catalog/internal/catkv/system_database_cache_internal_test.go
@@ -86,3 +86,54 @@ func TestSystemDatabaseCacheUpdate(t *testing.T) {
 		require.Equal(t, tsNew, gotTS)
 	})
 }
+
+func TestSystemDatabaseCacheRemoveNameEntry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	st := cluster.MakeTestingClusterSettings()
+	v := clusterversion.ClusterVersion{Version: st.Version.LatestVersion()}
+
+	privKey := descpb.NameInfo{
+		ParentID:       keys.SystemDatabaseID,
+		ParentSchemaID: keys.SystemPublicSchemaID,
+		Name:           "privileges",
+	}
+
+	const staleID = descpb.ID(1000000052)
+	const correctID = descpb.ID(52)
+	tsStale := hlc.Timestamp{WallTime: 100}
+	tsCorrect := hlc.Timestamp{WallTime: 200}
+
+	upsert := func(c *SystemDatabaseCache, id descpb.ID, ts hlc.Timestamp) {
+		var mc nstree.MutableCatalog
+		mc.UpsertNamespaceEntry(privKey, id, ts)
+		c.update(v, mc.Catalog)
+	}
+
+	t.Run("remove stale entry allows re-population", func(t *testing.T) {
+		c := NewSystemDatabaseCache(keys.SystemSQLCodec, st)
+		upsert(c, staleID, tsStale)
+		gotID, _ := c.lookupDescriptorID(v, privKey)
+		require.Equal(t, staleID, gotID)
+
+		c.removeNameEntry(v, privKey)
+		gotID, _ = c.lookupDescriptorID(v, privKey)
+		require.Equal(t, descpb.InvalidID, gotID)
+
+		upsert(c, correctID, tsCorrect)
+		gotID, _ = c.lookupDescriptorID(v, privKey)
+		require.Equal(t, correctID, gotID)
+	})
+
+	t.Run("remove non-existent entry is a no-op", func(t *testing.T) {
+		c := NewSystemDatabaseCache(keys.SystemSQLCodec, st)
+		c.removeNameEntry(v, privKey)
+		gotID, _ := c.lookupDescriptorID(v, privKey)
+		require.Equal(t, descpb.InvalidID, gotID)
+	})
+
+	t.Run("remove on nil cache is safe", func(t *testing.T) {
+		var c *SystemDatabaseCache
+		c.removeNameEntry(v, privKey)
+	})
+}


### PR DESCRIPTION
Backport 1/1 commits from #169351 on behalf of @msbutler.

----

## Summary

PR #169044 allowed `SystemDatabaseCache` to accept updated name→ID mappings,
but the update path was never triggered because the stale cache hit in
`lookupDescriptorID` prevented the KV read that would have provided the
corrected mapping — a self-reinforcing cycle.

When `getDescriptorByName` resolves a system table name to an ID but the
descriptor at that ID doesn't exist, evict the entry from the
`SystemDatabaseCache`. The next lookup misses the cache, reads from KV, and
self-heals. This works across all nodes since the corrected namespace entry
is in shared KV storage.

Fixes #169316

Epic: none

Release note (bug fix): Fixed a bug where PCR reader tenants could
permanently fail authentication after `SetupOrAdvanceStandbyReaderCatalog`
rewrote the `system.privileges` namespace entry. A stale cached name→ID
mapping was never refreshed, causing every SQL connection to fail with
"descriptor not found".

----

Release justification: