### PR TITLE
storage: bump Pebble format major version

### DIFF
--- a/pkg/cli/testdata/ear-list
+++ b/pkg/cli/testdata/ear-list
@@ -8,13 +8,13 @@ list
 000004.log:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: d0 b1 31 4b 08 b9 f6 08 7e e6 af 40
-  counter: 2167389540
+  nonce: 81 b2 be d7 46 6d f3 7b 42 e4 01 5b
+  counter: 2486216603
 000005.sst:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: 13 78 ef e7 4f 95 15 83 24 d8 1a 9d
-  counter: 1330556971
+  nonce: 0f 54 d8 a0 62 63 48 7a 95 0b f6 6f
+  counter: 786839136
 COCKROACHDB_DATA_KEYS_000001_monolith:
   env type: Store, AES128_CTR
   keyID: f594229216d81add7811c4360212eb7629b578ef4eab6e5d05679b3c5de48867
@@ -35,11 +35,11 @@ marker.datakeys.000001.COCKROACHDB_DATA_KEYS_000001_monolith:
   keyID: f594229216d81add7811c4360212eb7629b578ef4eab6e5d05679b3c5de48867
   nonce: 55 d7 d4 27 6c 97 9b dd f1 5d 40 c8
   counter: 467030050
-marker.format-version.000015.028:
+marker.format-version.000017.030:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: d1 05 79 53 68 35 a0 f1 44 01 22 79
-  counter: 1497766936
+  nonce: 13 78 ef e7 4f 95 15 83 24 d8 1a 9d
+  counter: 1330556971
 marker.manifest.000001.MANIFEST-000001:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2581,6 +2581,7 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 // named version, it can be assumed all *nodes* have ratcheted to the pebble
 // version associated with it, since they did so during the fence version.
 var pebbleFormatVersionMap = map[clusterversion.Key]pebble.FormatMajorVersion{
+	clusterversion.V26_3: pebble.FormatRowblkMarkedForCompaction,
 	clusterversion.V26_1: pebble.FormatMarkForCompactionInVersionEdit,
 	clusterversion.V25_4: pebble.FormatV2BlobFiles,
 }


### PR DESCRIPTION
This will ensure compaction of old rowblk tables.

Epic: none
Release note: None