### PR TITLE
admission: preserve non-tenant groupWeights across SetTenantWeights swap

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1618,6 +1618,8 @@ func (q *WorkQueue) SetOverrideAllToBypassAdmission(override bool) {
 
 // SetTenantWeights sets the weight of tenants, using the provided tenant ID
 // => weight map. A nil map will result in all tenants having the same weight.
+// Only tenantKind entries in groupWeights.active are written; any non-tenant
+// entries already in active are preserved across the swap.
 //
 // TODO(wenyihu): rename to SetGroupWeights.
 func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
@@ -1650,10 +1652,17 @@ func (q *WorkQueue) SetTenantWeights(groupWeights map[uint64]uint32) {
 		}
 		q.mu.groupWeights.inactive[tenantGroupKey(k)] = w
 	}
-	// Establish the new active map.
+	// Establish the new active map. Before swapping, copy any
+	// non-tenant entries from active into inactive so that the swap
+	// does not lose them.
 	func() {
 		q.mu.Lock()
 		defer q.mu.Unlock()
+		for k, v := range q.mu.groupWeights.active {
+			if k.kind != tenantKind {
+				q.mu.groupWeights.inactive[k] = v
+			}
+		}
 		q.mu.groupWeights.active, q.mu.groupWeights.inactive =
 			q.mu.groupWeights.inactive, q.mu.groupWeights.active
 	}()


### PR DESCRIPTION
`SetTenantWeights` repopulates `q.mu.groupWeights.inactive` with the
supplied tenant weights and then swaps it with `q.mu.groupWeights.active`
under `q.mu`. With `groupWeights` now keyed by composite `groupKey`
(`id`, `kind`), `active` may hold non-tenant entries — for example,
`rgKind` weights written by a future resource-group writer — but
`SetTenantWeights` writes only `tenantKind` entries into `inactive`,
so the swap drops everything else.

This change copies any non-tenant entries from `active` into `inactive`
immediately before the swap, so they survive. The current writer set
is tenant-only, so the copy is a no-op today; it future-proofs the
swap for an `rgKind` writer to be introduced in a follow-up commit.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>