### PR TITLE
release-26.1: rand: add ccl link to test

### DIFF
--- a/pkg/workload/rand/BUILD.bazel
+++ b/pkg/workload/rand/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     embed = [":rand"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/crosscluster/ldrrandgen",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/workload/rand/rand_test.go
+++ b/pkg/workload/rand/rand_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -29,6 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer ccl.TestingEnableEnterprise()()
 	randutil.SeedForTests()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)


### PR DESCRIPTION
The backport #169259 is causing test flakes because it does not link the ccl package into the test. This works on master because 26.2 and beyond do not need to explicitly link the ccl package.

Fixes: #169399
Informs: #169402

Release note: none
Release justification: test only change