### PR TITLE
kvserver/allocator/mmaprototype: lock advisor methods

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go
@@ -77,6 +77,11 @@ func NoopMMARebalanceAdvisor() *MMARebalanceAdvisor {
 func (a *allocatorState) BuildMMARebalanceAdvisor(
 	existing roachpb.StoreID, cands []roachpb.StoreID,
 ) *MMARebalanceAdvisor {
+	// a.cs is mutated by gossip-driven callbacks (e.g. ProcessStoreLoadMsg) and
+	// must only be accessed under a.mu. The other public methods on
+	// allocatorState follow this discipline.
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	// TODO(wenyihu6): for simplicity, we create a new scratchNodes every call.
 	// We should reuse the scratchNodes instead.
 	scratchNodes := map[roachpb.NodeID]*NodeLoad{}
@@ -105,6 +110,11 @@ func (a *allocatorState) IsInConflictWithMMA(
 	if advisor.disabled {
 		return false
 	}
+	// a.cs is mutated by gossip-driven callbacks (e.g. ProcessStoreLoadMsg) and
+	// must only be accessed under a.mu. The other public methods on
+	// allocatorState follow this discipline.
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	// Lazily compute and cache the load summary for the existing store.
 	if advisor.existingStoreSLS == nil {
 		summary := a.cs.computeLoadSummary(ctx, advisor.existingStoreID, &advisor.means.storeLoad, &advisor.means.nodeLoad, makeMMALogger(false /* verboseToInfof */))


### PR DESCRIPTION
`(*allocatorState).BuildMMARebalanceAdvisor` and `IsInConflictWithMMA` read `a.cs` (the `clusterState`) without holding `a.mu`. Every other public method on `allocatorState` (`SetStore`, `ProcessStoreLoadMsg`, `UpdateStoresStatuses`, etc.) takes `a.mu` before touching `a.cs`; these two were missed.

The race is exposed once MMA runs in the lease-queue path (gossip-driven `ProcessStoreLoadMsg` writes concurrently with `TransferLeaseTarget` reads), which happens by default starting with the v26.3 default flip in #169430. It went unnoticed because MMA was not the default and no existing race-test configuration exercised both call paths concurrently.

Fix: take `a.mu` in both methods. `MMARebalanceAdvisor` returned by `Build...` carries `means` by value; `existingStoreSLS` is filled lazily inside `IsInConflict...` (also under the lock now), so no reference to `a.cs` escapes the locked region.

Epic: CRDB-56265