### PR TITLE
release-26.1: changefeedccl: log on kafka sink v2 internal retry

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -157,6 +157,12 @@ func (k *kafkaSinkClientV2) Flush(ctx context.Context, payload SinkPayload) (ret
 		if err := k.client.ProduceSync(ctx, msgs...).FirstErr(); err != nil {
 			if k.shouldTryResizing(err, msgs) {
 				a, b := msgs[0:len(msgs)/2], msgs[len(msgs)/2:]
+				log.Changefeed.Infof(ctx,
+					"resizing kafka batch from %d messages to halves of %d and %d due to error: %v",
+					redact.SafeInt(int64(len(msgs))),
+					redact.SafeInt(int64(len(a))),
+					redact.SafeInt(int64(len(b))),
+					err)
 				// Recurse. This is a little odd because the client's batch
 				// state doesn't consist only of this payload, but the inflight
 				// payloads of all ParallelIO workers. Therefore reducing the


### PR DESCRIPTION
Backport 1/1 commits from #169374 on behalf of @aerfrei.

----

Previously we saw spikes in changefeed internal
retries without accompanying error logs. This change adds a log to the missing code path causing internal retries.

This change should make sure we can tell that this error path was the cause for the internal retries.

Epic: none

Release note: None

----

Release justification: Log only change needed for debugging issues in cloud.