### PR TITLE
kvstorage: add raft log replay for WAG catch-up

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -8,15 +8,19 @@ package kvserver
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/time/rate"
@@ -241,6 +245,9 @@ func (b *appBatch) runPostAddTriggers(
 // WriteBatch and ReplicatedEvalResult are zeroed out, but the applied index
 // still advances. This matches the online path's behavior.
 //
+// TODO(mira): Apply non-trivial side effects such as AddSSTable ingestions
+// (runPostAddTriggers). Currently only the WriteBatch is applied.
+//
 // The caller is responsible for calling addAppliedStateToBatch and committing
 // the batch after applying one or more entries.
 func (b *appBatch) applyEntry(ctx context.Context, cmd *replicatedCmd) error {
@@ -307,4 +314,104 @@ func (b *appBatch) addAppliedStateToBatch(ctx context.Context) error {
 	// lease index along with the MVCC stats, all in one key.
 	b.asAlloc = b.state.ToRangeAppliedState()
 	return b.sl.SetRangeAppliedState(ctx, b.batch.State(), &b.asAlloc)
+}
+
+// replayBatch implements kvstorage.ReplayBatch using appBatch.
+type replayBatch struct {
+	ab appBatch
+	// cmd is reused across ApplyEntry calls. Decode resets all fields before
+	// populating, so no state leaks between entries.
+	cmd replicatedCmd
+}
+
+// AppliedIndex implements kvstorage.ReplayBatch.
+func (rb *replayBatch) AppliedIndex() kvpb.RaftIndex {
+	return rb.ab.state.RaftAppliedIndex
+}
+
+// ApplyEntry implements kvstorage.ReplayBatch.
+func (rb *replayBatch) ApplyEntry(ctx context.Context, ent raftpb.Entry) (bool, error) {
+	if err := rb.cmd.Decode(&ent); err != nil {
+		return false, err
+	}
+	if err := rb.ab.applyEntry(ctx, &rb.cmd); err != nil {
+		return false, err
+	}
+	return rb.cmd.IsTrivial(), nil
+}
+
+// Commit implements kvstorage.ReplayBatch.
+func (rb *replayBatch) Commit(ctx context.Context) error {
+	if err := rb.ab.addAppliedStateToBatch(ctx); err != nil {
+		return err
+	}
+	return rb.ab.batch.Commit(false /* sync */)
+}
+
+// Close implements kvstorage.ReplayBatch.
+func (rb *replayBatch) Close() {
+	rb.ab.batch.Close()
+}
+
+// MakeNewReplayBatchFn returns a NewReplayBatchFn that creates ReplayBatch
+// instances backed by appBatch. Each call loads the range's descriptor via a
+// point read using the provided start key, then loads the full ReplicaState.
+//
+// The state engine (not a snapshot) must be passed so that reads see writes
+// committed by previous replay batches.
+func MakeNewReplayBatchFn(
+	stateEng storage.Engine, bf *kvstorage.BatchFactory,
+) kvstorage.NewReplayBatchFn {
+	return func(
+		ctx context.Context, rangeID roachpb.RangeID, startKey roachpb.RKey,
+	) (kvstorage.ReplayBatch, error) {
+		desc, err := loadRangeDescriptor(ctx, stateEng, rangeID, startKey)
+		if err != nil {
+			return nil, err
+		}
+		// TODO(mira): Consider caching the StateLoader across calls for the
+		// same rangeID to avoid re-constructing key prefixes.
+		sl := kvstorage.MakeStateLoader(rangeID)
+		state, err := sl.Load(ctx, stateEng, &desc)
+		if err != nil {
+			return nil, err
+		}
+		return &replayBatch{
+			ab: appBatch{
+				state:                  state,
+				batch:                  bf.NewBatch(),
+				sl:                     sl,
+				initialForceFlushIndex: state.ForceFlushIndex,
+			},
+		}, nil
+	}
+}
+
+// loadRangeDescriptor loads the descriptor for the given range using a point
+// read at the provided start key. We read at MaxTimestamp because descriptors
+// are versioned MVCC keys. Inconsistent mode reads the latest committed value,
+// skipping any intents. This is safe because descriptor intents from
+// split/merge transactions are always resolved synchronously with the
+// transaction commit, so there is no window in which a committed intent
+// could be missed.
+func loadRangeDescriptor(
+	ctx context.Context, reader kvstorage.StateRO, rangeID roachpb.RangeID, startKey roachpb.RKey,
+) (roachpb.RangeDescriptor, error) {
+	var desc roachpb.RangeDescriptor
+	descKey := keys.RangeDescriptorKey(startKey)
+	ok, err := storage.MVCCGetProto(ctx, reader, descKey,
+		hlc.MaxTimestamp, &desc, storage.MVCCGetOptions{
+			Inconsistent: true, ReadCategory: fs.UnknownReadCategory})
+	if err != nil {
+		return roachpb.RangeDescriptor{}, errors.Wrapf(err, "reading descriptor for r%d", rangeID)
+	}
+	if !ok {
+		return roachpb.RangeDescriptor{}, errors.Errorf(
+			"descriptor not found for r%d at key %s", rangeID, descKey)
+	}
+	if desc.RangeID != rangeID {
+		return roachpb.RangeDescriptor{}, errors.AssertionFailedf(
+			"descriptor at key %s has r%d, expected r%d", descKey, desc.RangeID, rangeID)
+	}
+	return desc, nil
 }

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/kv/kvserver/kvstorage/wag",
         "//pkg/kv/kvserver/kvstorage/wag/wagpb",
         "//pkg/kv/kvserver/logstore",
+        "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/spanset",
         "//pkg/raft/raftpb",

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -100,7 +100,7 @@ func DestroyReplica(
 	info DestroyReplicaInfo,
 	next roachpb.ReplicaID,
 ) error {
-	w.AddEvent(wagpb.MakeAddr(info.FullReplicaID, info.RaftAppliedIndex), wagpb.EventDestroy)
+	w.AddEvent(wagpb.MakeAddr(info.FullReplicaID, info.RaftAppliedIndex), wagpb.EventDestroy, info.Keys.Key)
 	return destroyReplicaImpl(ctx, rw, info, next)
 }
 
@@ -218,7 +218,7 @@ func destroyReplicaImpl(
 func SubsumeReplica(
 	ctx context.Context, rw ReadWriter, w *wag.Writer, info DestroyReplicaInfo,
 ) error {
-	w.AddEvent(wagpb.MakeAddr(info.FullReplicaID, info.RaftAppliedIndex), wagpb.EventSubsume)
+	w.AddEvent(wagpb.MakeAddr(info.FullReplicaID, info.RaftAppliedIndex), wagpb.EventSubsume, info.Keys.Key)
 	info.Keys = roachpb.RSpan{} // forget about the user keys
 	return destroyReplicaImpl(ctx, rw, info, MergedTombstoneReplicaID)
 }

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -140,7 +140,7 @@ func CreateUninitializedReplica(
 	// Before this point, raft and state machine state of this replica are
 	// non-existent. The only RangeID-specific key that can be present is the
 	// RangeTombstone inspected above.
-	w.AddEvent(wagpb.MakeAddr(id, 0), wagpb.EventCreate)
+	w.AddEvent(wagpb.MakeAddr(id, 0), wagpb.EventCreate, nil /* startKey */)
 	if err := sl.SetRaftReplicaID(ctx, stateRW.WO, id.ReplicaID); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica-sep-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica-sep-eng.txt
@@ -27,7 +27,7 @@ Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b75
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 
 Delete (Sized at 33): 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): 
 Delete (Sized at 34): 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/3:12,EventDestroy)
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/3:12,EventDestroy,"a")
 > Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:4 
 > Delete: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 
 > Delete (Sized at 20): 0.000000001,0 /Local/Range"a"/RangeDescriptor (0x016b126100017264736300000000000000000109): 

--- a/pkg/kv/kvserver/kvstorage/testdata/TestSubsumeReplica-sep-eng.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestSubsumeReplica-sep-eng.txt
@@ -27,6 +27,6 @@ Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b75
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 
 Delete (Sized at 33): 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): 
 Delete (Sized at 34): 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/3:12,EventSubsume)
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r123/3:12,EventSubsume,"a")
 > Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:2147483647 
 > Delete: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.go
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.go
@@ -42,5 +42,9 @@ func (e Event) String() string {
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (e Event) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("(%s,%s)", e.Addr, e.Type)
+	if len(e.StartKey) > 0 {
+		w.Printf("(%s,%s,%s)", e.Addr, e.Type, e.StartKey)
+	} else {
+		w.Printf("(%s,%s)", e.Addr, e.Type)
+	}
 }

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -58,6 +58,12 @@ message Event {
   Addr addr = 1 [(gogoproto.nullable) = false];
   // Type identifies the kind of lifecycle event.
   EventType type = 2;
+  // StartKey is the range's start key at the time of the event. It allows
+  // replay to load the range descriptor via a point read rather than scanning
+  // all descriptors. Empty only for EventCreate (uninitialized replicas have
+  // no descriptor yet).
+  bytes start_key = 3 [
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RKey"];
 }
 
 // Addr describes the full address of a WAG event, consisting of RangeID,

--- a/pkg/kv/kvserver/kvstorage/wag/writer.go
+++ b/pkg/kv/kvserver/kvstorage/wag/writer.go
@@ -7,6 +7,7 @@ package wag
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 )
 
@@ -46,11 +47,17 @@ func (w *Writer) Empty() bool {
 // AddEvent stages a lifecycle event. Each event identifies a replica and the
 // type of lifecycle transition (create, split, destroy, etc.). A given RangeID
 // must appear at most once across all events in a Writer.
-func (w *Writer) AddEvent(addr wagpb.Addr, eventType wagpb.EventType) {
+//
+// The startKey is the range's start key, used during replay to load the range
+// descriptor via a point read. It may be nil for EventCreate (uninitialized
+// replicas have no descriptor yet).
+func (w *Writer) AddEvent(addr wagpb.Addr, eventType wagpb.EventType, startKey roachpb.RKey) {
 	if w.disabled() {
 		return
 	}
-	w.events = append(w.events, wagpb.Event{Addr: addr, Type: eventType})
+	w.events = append(w.events, wagpb.Event{
+		Addr: addr, Type: eventType, StartKey: startKey,
+	})
 }
 
 // Flush writes the staged WAG node to the raft engine. The node's

--- a/pkg/kv/kvserver/kvstorage/wag_replay.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
 )
@@ -82,6 +83,28 @@ type raftCatchUpTarget struct {
 	replicaID roachpb.ReplicaID
 	index     kvpb.RaftIndex
 }
+
+// ReplayBatch applies raft entries to the state machine via an internal storage
+// batch. The implementation is responsible for decoding entries and staging
+// their writes. The caller must call Close when done, whether or not Commit
+// was called.
+type ReplayBatch interface {
+	// ApplyEntry applies a single raft entry. Returns whether the entry had
+	// only trivial side effects (no lease change, GC threshold bump, etc.).
+	ApplyEntry(context.Context, raftpb.Entry) (trivial bool, _ error)
+	// AppliedIndex returns the raft applied index after the last ApplyEntry,
+	// or the initial applied index if no entries have been applied yet.
+	AppliedIndex() kvpb.RaftIndex
+	// Commit writes the applied state and commits the batch.
+	Commit(context.Context) error
+	// Close releases batch resources. Safe to call after Commit.
+	Close()
+}
+
+// NewReplayBatchFn creates a fresh ReplayBatch for a range by loading the
+// current ReplicaState from the engine. The startKey is used to locate the
+// range descriptor via a point read.
+type NewReplayBatchFn func(ctx context.Context, rangeID roachpb.RangeID, startKey roachpb.RKey) (ReplayBatch, error)
 
 func assert(cond bool, msg string, e wagpb.Event, s persistedRangeState) {
 	if !cond {

--- a/pkg/kv/kvserver/kvstorage/wag_replay.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay.go
@@ -12,8 +12,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -76,12 +78,13 @@ func loadPersistedRangeState(
 	}, nil
 }
 
-// raftCatchUpTarget identifies a range/replica that must be caught up to a
-// specific raft index via raft log replay before a WAG node can be applied.
+// raftCatchUpTarget identifies a range that must be caught up to a specific
+// raft index via raft log replay before a WAG node can be applied. The start
+// key is used to load the range descriptor via a point read.
 type raftCatchUpTarget struct {
-	rangeID   roachpb.RangeID
-	replicaID roachpb.ReplicaID
-	index     kvpb.RaftIndex
+	rangeID  roachpb.RangeID
+	startKey roachpb.RKey
+	index    kvpb.RaftIndex
 }
 
 // ReplayBatch applies raft entries to the state machine via an internal storage
@@ -235,9 +238,9 @@ func wagNodeCatchUps(node wagpb.Node) iter.Seq[raftCatchUpTarget] {
 	return func(yield func(raftCatchUpTarget) bool) {
 		for _, e := range node.Events {
 			if catchUp := raftCatchUp(e); catchUp > 0 && !yield(raftCatchUpTarget{
-				rangeID:   e.Addr.RangeID,
-				replicaID: e.Addr.ReplicaID,
-				index:     catchUp,
+				rangeID:  e.Addr.RangeID,
+				startKey: e.StartKey,
+				index:    catchUp,
 			}) {
 				return
 			}
@@ -247,8 +250,14 @@ func wagNodeCatchUps(node wagpb.Node) iter.Seq[raftCatchUpTarget] {
 
 // ReplayWAG iterates over the WAG in the log engine and applies any unapplied
 // nodes to the state machine. It is called during store startup, before the
-// store goes online.
-func ReplayWAG(ctx context.Context, raftRO RaftRO, stateRW StateRW) error {
+// store goes online. For each unapplied node, it first replays raft log entries
+// to catch up the affected ranges, then applies the node's mutation.
+//
+// The newBatch callback creates ReplayBatch instances that apply raft entries
+// to the state machine. It is the only injection point from kvserver.
+func ReplayWAG(
+	ctx context.Context, raftRO RaftRO, stateRW StateRW, newBatch NewReplayBatchFn,
+) error {
 	var it wag.Iterator
 	for wagIdx, node := range it.Iter(ctx, raftRO) {
 		if apply, err := canApplyWAGNode(ctx, node, stateRW); err != nil {
@@ -256,17 +265,86 @@ func ReplayWAG(ctx context.Context, raftRO RaftRO, stateRW StateRW) error {
 		} else if !apply {
 			continue
 		}
-		// TODO(mira): For each target in wagNodeCatchUps(node), replay raft log
-		// entries for the target range/replica up to the target index before
-		// applying the WAG node. The current raft log replay in
-		// handleRaftReadyRaftMuLocked needs to be factored out and invoked here.
-		// The catch-up code should assert that the target index is >= the
-		// replica's current applied index.
+		for target := range wagNodeCatchUps(node) {
+			if err := replayRaftLog(ctx, raftRO, target, newBatch); err != nil {
+				return errors.Wrapf(err, "WAG node %d: catch-up r%d", wagIdx, target.rangeID)
+			}
+		}
 		if err := applyMutation(ctx, stateRW, node.Mutation); err != nil {
 			return errors.Wrapf(err, "WAG node %d", wagIdx)
 		}
 	}
 	return it.Error()
+}
+
+// replayRaftLog replays raft log entries for a range from its current applied
+// index up to the target index. It creates a ReplayBatch, iterates entries via
+// raftlog.Visit, and applies each one. Non-trivial entries (lease changes, GC
+// threshold bumps, etc.) trigger a batch flush and state reload so that
+// subsequent entries are checked against up-to-date state.
+func replayRaftLog(
+	ctx context.Context, raftRO RaftRO, target raftCatchUpTarget, newBatch NewReplayBatchFn,
+) error {
+	for {
+		done, err := replayRaftLogBatch(ctx, raftRO, target, newBatch)
+		if err != nil {
+			return errors.Wrapf(err, "replaying raft log for r%d", target.rangeID)
+		}
+		if done {
+			return nil
+		}
+	}
+}
+
+// replayRaftLogBatch creates a ReplayBatch and applies entries from the
+// current applied index up to the target. It returns done=true when all
+// entries have been applied, or done=false if a non-trivial entry was
+// encountered and the caller should invoke this function again so that a
+// fresh batch is created with reloaded state.
+func replayRaftLogBatch(
+	ctx context.Context, raftRO RaftRO, target raftCatchUpTarget, newBatch NewReplayBatchFn,
+) (done bool, _ error) {
+	rb, err := newBatch(ctx, target.rangeID, target.startKey)
+	if err != nil {
+		return false, err
+	}
+	defer rb.Close()
+
+	lo, hi := rb.AppliedIndex(), target.index
+	if lo > hi {
+		return false, errors.AssertionFailedf(
+			"target index %d is behind applied index %d for r%d",
+			hi, lo, target.rangeID)
+	}
+	if lo == hi {
+		return true, nil
+	}
+
+	// TODO(mira): Add a max batch size policy to bound memory usage. Large
+	// ranges with many entries could produce an oversized batch here.
+	var needsReload bool
+	// NB: Visit uses [start, end) semantics.
+	err = raftlog.Visit(ctx, raftRO, target.rangeID, lo+1, hi+1, func(ent raftpb.Entry) error {
+		trivial, err := rb.ApplyEntry(ctx, ent)
+		if err != nil {
+			return err
+		}
+		if !trivial {
+			// Non-trivial entries may change state (lease, GC threshold)
+			// that affects accept/reject decisions for subsequent entries.
+			// Stop iteration so the caller can flush and reload.
+			needsReload = true
+			return iterutil.StopIteration()
+		}
+		return nil
+	})
+	if err = iterutil.Map(err); err != nil {
+		return false, err
+	}
+	if err := rb.Commit(ctx); err != nil {
+		return false, err
+	}
+	return !needsReload, nil
 }
 
 // applyMutation applies a WAG node's mutation to the state machine. It handles

--- a/pkg/kv/kvserver/kvstorage/wag_replay_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay_test.go
@@ -10,12 +10,15 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -148,6 +151,23 @@ func TestCanApply(t *testing.T) {
 	}
 }
 
+// writeRaftLogEntries writes empty raft log entries for the given range and
+// index range [lo, hi] to the log engine so that raftlog.Visit can iterate
+// over them during catch-up replay.
+func writeRaftLogEntries(
+	t *testing.T, logEng storage.Engine, rangeID roachpb.RangeID, lo, hi kvpb.RaftIndex,
+) {
+	t.Helper()
+	ctx := context.Background()
+	for idx := lo; idx <= hi; idx++ {
+		ent := raftpb.Entry{Index: uint64(idx), Term: 1}
+		key := keys.RaftLogKey(rangeID, idx)
+		require.NoError(t, storage.MVCCPutProto(
+			ctx, logEng, key, hlc.Timestamp{}, &ent, storage.MVCCWriteOptions{},
+		))
+	}
+}
+
 // writePersistedRangeState writes the replay-relevant state for a range to the
 // state machine.
 func writePersistedRangeState(
@@ -187,7 +207,7 @@ func TestCanApplyWAGNode(t *testing.T) {
 				{Addr: wagpb.Addr{RangeID: 1, ReplicaID: 3, Index: 51}, Type: wagpb.EventApply},
 			}},
 			shouldApply: true,
-			expCatchUps: []raftCatchUpTarget{{rangeID: 1, replicaID: 3, index: 51}},
+			expCatchUps: []raftCatchUpTarget{{rangeID: 1, index: 51}},
 		}, {
 			name: "single event, already applied",
 			states: map[roachpb.RangeID]persistedRangeState{
@@ -211,7 +231,7 @@ func TestCanApplyWAGNode(t *testing.T) {
 				{Addr: wagpb.Addr{RangeID: 2, ReplicaID: 1, Index: 10}, Type: wagpb.EventInit},
 			}},
 			shouldApply: true,
-			expCatchUps: []raftCatchUpTarget{{rangeID: 1, replicaID: 3, index: 99}},
+			expCatchUps: []raftCatchUpTarget{{rangeID: 1, index: 99}},
 		}, {
 			name: "multi-event split, already applied",
 			states: map[roachpb.RangeID]persistedRangeState{
@@ -260,6 +280,41 @@ func TestCanApplyWAGNode(t *testing.T) {
 	}
 }
 
+// simpleReplayBatch is a test-only ReplayBatch that advances the applied index
+// for each entry without decoding. It persists the updated applied state on
+// Commit.
+type simpleReplayBatch struct {
+	sl       StateLoader
+	stateEng storage.Engine
+	as       *kvserverpb.RangeAppliedState
+}
+
+func (b *simpleReplayBatch) AppliedIndex() kvpb.RaftIndex {
+	return b.as.RaftAppliedIndex
+}
+
+func (b *simpleReplayBatch) ApplyEntry(_ context.Context, ent raftpb.Entry) (bool, error) {
+	b.as.RaftAppliedIndex = kvpb.RaftIndex(ent.Index)
+	return true, nil
+}
+
+func (b *simpleReplayBatch) Commit(ctx context.Context) error {
+	return b.sl.SetRangeAppliedState(ctx, b.stateEng, b.as)
+}
+
+func (b *simpleReplayBatch) Close() {}
+
+func simpleNewBatch(stateEng storage.Engine) NewReplayBatchFn {
+	return func(ctx context.Context, rangeID roachpb.RangeID, _ roachpb.RKey) (ReplayBatch, error) {
+		sl := MakeStateLoader(rangeID)
+		as, err := sl.LoadRangeAppliedState(ctx, stateEng)
+		if err != nil {
+			return nil, err
+		}
+		return &simpleReplayBatch{sl: sl, stateEng: stateEng, as: as}, nil
+	}
+}
+
 // TestReplayWAG is a basic end-to-end test for WAG replay, verifying that applied
 // nodes are skipped and unapplied nodes have their mutations applied to the
 // state machine.
@@ -270,10 +325,10 @@ func TestReplayWAG(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	// getKey reads a single unversioned key from the given engine.
-	getKey := func(t *testing.T, eng storage.Engine, key string) []byte {
+	// getKey reads a single unversioned key from the given reader.
+	getKey := func(t *testing.T, r storage.Reader, key string) []byte {
 		t.Helper()
-		kvs, err := storage.Scan(ctx, eng, roachpb.Key(key), roachpb.Key(key).Next(), 1)
+		kvs, err := storage.Scan(ctx, r, roachpb.Key(key), roachpb.Key(key).Next(), 1)
 		require.NoError(t, err)
 		if len(kvs) == 0 {
 			return nil
@@ -300,8 +355,14 @@ func TestReplayWAG(t *testing.T) {
 			storage.NewDefaultInMemForTesting(), storage.NewDefaultInMemForTesting(),
 		)
 		defer eng.Close()
+		raftRO := RaftRO(eng.LogEngine())
+		stateRW := StateRW(eng.StateEngine())
 
-		require.NoError(t, ReplayWAG(ctx, RaftRO(eng.LogEngine()), StateRW(eng.StateEngine())))
+		noReplay := func(context.Context, roachpb.RangeID, roachpb.RKey) (ReplayBatch, error) {
+			t.Fatal("unexpected newBatch call")
+			return nil, nil
+		}
+		require.NoError(t, ReplayWAG(ctx, raftRO, stateRW, noReplay))
 	})
 
 	t.Run("unapplied nodes are applied", func(t *testing.T) {
@@ -311,31 +372,28 @@ func TestReplayWAG(t *testing.T) {
 		defer eng.Close()
 		var seq wag.Seq
 		bf := MakeBatchFactory(&eng, &seq)
+		raftRO := RaftRO(eng.LogEngine())
+		stateRW := StateRW(eng.StateEngine())
 
-		// Establish the replica in the state engine as initialized. In practice,
-		// EventCreate and EventInit would have done this; here we pre-write the
-		// mark and applied index so that EventApply nodes target an initialized
-		// replica.
-		writePersistedRangeState(t, StateRW(eng.StateEngine()), 1, persistedRangeState{
-			mark: replicaMark(1, 0), appliedIndex: 9,
+		// Establish the replica in the state engine as initialized at index 10.
+		writePersistedRangeState(t, stateRW, 1, persistedRangeState{
+			mark: replicaMark(1, 0), appliedIndex: 10,
 		})
+		// Write raft log entries covering the full catch-up range.
+		writeRaftLogEntries(t, eng.LogEngine(), 1, 11, 25)
 
-		writeWAGNode(t, &bf, wagpb.Addr{RangeID: 1, ReplicaID: 1, Index: 10}, wagpb.EventApply, "key1", "val1")
-		writeWAGNode(t, &bf, wagpb.Addr{RangeID: 1, ReplicaID: 1, Index: 11}, wagpb.EventApply, "key2", "val2")
+		// WAG node at index 15: catch-up replays entries 11-15.
+		writeWAGNode(t, &bf, wagpb.Addr{RangeID: 1, ReplicaID: 1, Index: 15}, wagpb.EventApply, "key1", "val1")
 
-		require.NoError(t, ReplayWAG(ctx, RaftRO(eng.LogEngine()), StateRW(eng.StateEngine())))
-		require.Equal(t, []byte("val1"), getKey(t, eng.StateEngine(), "key1"))
-		require.Equal(t, []byte("val2"), getKey(t, eng.StateEngine(), "key2"))
+		require.NoError(t, ReplayWAG(ctx, raftRO, stateRW, simpleNewBatch(eng.StateEngine())))
+		require.Equal(t, []byte("val1"), getKey(t, stateRW, "key1"))
 
-		// Write two more nodes, then replay again. The first two nodes should
-		// be skipped and only the new ones applied.
-		writeWAGNode(t, &bf, wagpb.Addr{RangeID: 1, ReplicaID: 1, Index: 12}, wagpb.EventApply, "key3", "val3")
-		writeWAGNode(t, &bf, wagpb.Addr{RangeID: 1, ReplicaID: 1, Index: 13}, wagpb.EventApply, "key4", "val4")
+		// Second WAG node at index 25: catch-up replays entries 16-25.
+		// The first node should be skipped on this replay.
+		writeWAGNode(t, &bf, wagpb.Addr{RangeID: 1, ReplicaID: 1, Index: 25}, wagpb.EventApply, "key2", "val2")
 
-		require.NoError(t, ReplayWAG(ctx, RaftRO(eng.LogEngine()), StateRW(eng.StateEngine())))
-		require.Equal(t, []byte("val1"), getKey(t, eng.StateEngine(), "key1"))
-		require.Equal(t, []byte("val2"), getKey(t, eng.StateEngine(), "key2"))
-		require.Equal(t, []byte("val3"), getKey(t, eng.StateEngine(), "key3"))
-		require.Equal(t, []byte("val4"), getKey(t, eng.StateEngine(), "key4"))
+		require.NoError(t, ReplayWAG(ctx, raftRO, stateRW, simpleNewBatch(eng.StateEngine())))
+		require.Equal(t, []byte("val1"), getKey(t, stateRW, "key1"))
+		require.Equal(t, []byte("val2"), getKey(t, stateRW, "key2"))
 	})
 }

--- a/pkg/kv/kvserver/kvstorage/wag_replay_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay_test.go
@@ -290,7 +290,7 @@ func TestReplayWAG(t *testing.T) {
 		t.Helper()
 		b := bf.NewWriteBatch()
 		defer b.Close()
-		b.WagWriter().AddEvent(addr, typ)
+		b.WagWriter().AddEvent(addr, typ, nil /* startKey */)
 		require.NoError(t, b.State().PutUnversioned(roachpb.Key(key), []byte(val)))
 		require.NoError(t, b.Commit(false /* sync */))
 	}

--- a/pkg/kv/kvserver/raftlog/command.go
+++ b/pkg/kv/kvserver/raftlog/command.go
@@ -38,12 +38,14 @@ var _ apply.Command = (*ReplicatedCmd)(nil)
 var _ apply.CheckedCommand = (*ReplicatedCmd)(nil)
 var _ apply.AppliedCommand = (*ReplicatedCmd)(nil)
 
-// Decode populates the receiver from the provided entry.
+// Decode populates the receiver from the provided entry. Safe to call on a
+// previously populated cmd — the old Entry is released and all fields are
+// reset before decoding.
 func (c *ReplicatedCmd) Decode(e *raftpb.Entry) error {
 	if c.Entry != nil {
 		c.Entry.Release()
-		c.Entry = nil
 	}
+	*c = ReplicatedCmd{}
 
 	var err error
 	c.Entry, err = NewEntry(*e)

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -367,6 +367,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 
 		if err := mergePreApply(ctx, b.ReadWriter(), b.batch.WagWriter(), mergePreApplyInput{
 			lhsID:          b.r.ID(),
+			lhsStartKey:    b.state.Desc.StartKey,
 			raftIndex:      cmd.Index(),
 			rhsDestroyInfo: rhsRepl.destroyInfoRaftMuLocked(),
 		}); err != nil {

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -367,6 +367,7 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 
 				in := splitPreApplyInput{
 					lhsID:               lhsRangeState.replica.FullReplicaID,
+					lhsStartKey:         split.LeftDesc.StartKey,
 					raftIndex:           ps.raftIndex,
 					rhsID:               roachpb.FullReplicaID{RangeID: split.RightDesc.RangeID, ReplicaID: rhsReplDesc.ReplicaID},
 					rhsSpan:             split.RightDesc.RSpan(),
@@ -470,8 +471,9 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 						State: kvstorage.WrapState(b.State()),
 						Raft:  kvstorage.Raft{RO: tc.eng.LogEngine(), WO: b.Raft()},
 					}, b.WagWriter(), mergePreApplyInput{
-						lhsID:     lhsRS.replica.FullReplicaID,
-						raftIndex: pm.raftIndex,
+						lhsID:       lhsRS.replica.FullReplicaID,
+						lhsStartKey: merge.LeftDesc.StartKey,
+						raftIndex:   pm.raftIndex,
 						rhsDestroyInfo: kvstorage.DestroyReplicaInfo{
 							FullReplicaID: rhsRS.replica.FullReplicaID,
 							// TODO(pav-kv): support the applied index properly.

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -25,6 +25,8 @@ import (
 type mergePreApplyInput struct {
 	// lhsID identifies the LHS replica applying the merge.
 	lhsID roachpb.FullReplicaID
+	// lhsStartKey is the LHS range's start key, recorded in the WAG event.
+	lhsStartKey roachpb.RKey
 	// raftIndex is the raft log index of the merge command.
 	raftIndex kvpb.RaftIndex
 	// rhsDestroyInfo describes the RHS replica being subsumed.
@@ -42,7 +44,7 @@ func mergePreApply(
 		return err
 	}
 	// Stage a WAG EventMerge for the LHS.
-	wagWriter.AddEvent(wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventMerge)
+	wagWriter.AddEvent(wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventMerge, in.lhsStartKey)
 	return nil
 }
 

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -28,6 +28,8 @@ import (
 type splitPreApplyInput struct {
 	// lhsID identifies the LHS replica applying the split.
 	lhsID roachpb.FullReplicaID
+	// lhsStartKey is the LHS range's start key, recorded in the WAG event.
+	lhsStartKey roachpb.RKey
 	// raftIndex is the raft log index of the split command.
 	raftIndex kvpb.RaftIndex
 	// rhsID identifies the RHS replica from the split trigger. When rhsDestroyed
@@ -87,10 +89,11 @@ func validateAndPrepareSplit(
 	}
 
 	res := splitPreApplyInput{
-		lhsID:     roachpb.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID},
-		raftIndex: raftIndex,
-		rhsID:     roachpb.FullReplicaID{RangeID: split.RightDesc.RangeID, ReplicaID: splitRightReplDesc.ReplicaID},
-		rhsSpan:   split.RightDesc.RSpan(),
+		lhsID:       roachpb.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID},
+		lhsStartKey: split.LeftDesc.StartKey,
+		raftIndex:   raftIndex,
+		rhsID:       roachpb.FullReplicaID{RangeID: split.RightDesc.RangeID, ReplicaID: splitRightReplDesc.ReplicaID},
+		rhsSpan:     split.RightDesc.RSpan(),
 	}
 
 	// Try to obtain the RHS replica. In the common case, it exists and its
@@ -221,10 +224,10 @@ func splitPreApply(
 	// CreateUninitializedReplica WAG node here. That node is written by
 	// getOrCreateReplica (called upstream via maybeAcquireSplitMergeLock) and
 	// will always precede this split node in the WAG sequence.
-	wagWriter.AddEvent(wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventSplit)
+	wagWriter.AddEvent(wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventSplit, in.lhsStartKey)
 	if !in.rhsDestroyed {
 		wagWriter.AddEvent(
-			wagpb.MakeAddr(in.rhsID, kvstorage.RaftInitialLogIndex), wagpb.EventInit,
+			wagpb.MakeAddr(in.rhsID, kvstorage.RaftInitialLogIndex), wagpb.EventInit, in.rhsSpan.Key,
 		)
 	} else {
 		// The RHS replica has already been removed from the store. To apply the

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -133,8 +133,9 @@ func syncAppliedState(r *Replica) error {
 	}
 	if err := wag.Write(b, s.wagSeq.Next(), wagpb.Node{
 		Events: []wagpb.Event{{
-			Addr: wagpb.MakeAddr(r.ID(), r.shMu.state.RaftAppliedIndex),
-			Type: wagpb.EventApply,
+			Addr:     wagpb.MakeAddr(r.ID(), r.shMu.state.RaftAppliedIndex),
+			Type:     wagpb.EventApply,
+			StartKey: r.shMu.state.Desc.StartKey,
 		}},
 	}); err != nil {
 		return errors.Wrapf(err, "writing WAG node")

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/destroy_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/destroy_replica.txt
@@ -23,7 +23,7 @@ state engine:
 log engine:
 Delete (Sized at 38): 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): 
 Delete (Sized at 32): 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): 
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:10,EventDestroy)
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r1/1:10,EventDestroy,"a")
 > Delete (Sized at 28): 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 
 > Delete (Sized at 43): 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): 
 > Delete (Sized at 34): 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): 
@@ -80,7 +80,7 @@ Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:11 (0x01698a757266
 Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:12 (0x01698a757266746c000000000000000c00): 
 Delete (Sized at 42): 0,0 /Local/RangeID/2/u/RaftLog/logIndex:13 (0x01698a757266746c000000000000000d00): 
 Delete (Sized at 32): 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): 
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r2/1:10,EventDestroy)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r2/1:10,EventDestroy,"c")
 > Delete (Sized at 28): 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 
 > Delete (Sized at 43): 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): 
 > Delete (Sized at 34): 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/legacy_split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/legacy_split_trigger.txt
@@ -57,7 +57,7 @@ log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit) (r2/1:10,EventInit)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit,"a") (r2/1:10,EventInit,"m")
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/merge.txt
@@ -68,7 +68,7 @@ state engine:
 log engine:
 Delete (Sized at 38): 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): 
 Delete (Sized at 32): 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): 
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:10,EventSubsume) (r1/1:11,EventMerge)
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): (r2/1:10,EventSubsume,"m") (r1/1:11,EventMerge,"a")
 > Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): key:"m" timestamp:<wall_time:10 > priority:100 
 > Put: 0,0 /Local/RangeID/1/r/AbortSpan/"00000000-0000-0000-0000-000000000002" (0x016989726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff02000100): key:"m" timestamp:<wall_time:10 > priority:100 
 > Delete (Sized at 71): 0,0 /Local/RangeID/2/r/AbortSpan/"00000000-0000-0000-0000-000000000001" (0x01698a726162632d1200ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff01000100): 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
@@ -62,7 +62,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r1/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): (r1/1:11,EventSplit,"a")
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0
@@ -117,7 +117,7 @@ apply-split range-id=1
 state engine:
 (matches WAG node)
 log engine:
-Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): (r1/1:12,EventSplit)
+Put: 0,0 /Local/Store/wag/5 (0x01737761676e000000000000000500): (r1/1:12,EventSplit,"a")
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,1 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004,0
@@ -164,7 +164,7 @@ log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/7 (0x01737761676e000000000000000700): (r1/1:13,EventSplit) (r4/1:10,EventInit)
+Put: 0,0 /Local/Store/wag/7 (0x01737761676e000000000000000700): (r1/1:13,EventSplit,"a") (r4/1:10,EventInit,"c")
 > Put: 0,0 /Local/Range"c"/QueueLastProcessed/"consistencyChecker" (0x016b12630001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,2 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -54,7 +54,7 @@ log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit) (r2/1:10,EventInit)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit,"a") (r2/1:10,EventInit,"m")
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0
@@ -107,7 +107,7 @@ log engine:
 Put: 0,0 /Local/RangeID/3/u/RaftHardState (0x01698b757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/3/u/RaftTruncatedState (0x01698b757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r1/1:12,EventSplit) (r3/1:10,EventInit)
+Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r1/1:12,EventSplit,"a") (r3/1:10,EventInit,"f")
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004,0
@@ -146,7 +146,7 @@ log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): (r2/1:11,EventSplit) (r4/1:10,EventInit)
+Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): (r2/1:11,EventSplit,"m") (r4/1:10,EventInit,"v")
 > Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0


### PR DESCRIPTION
  **kvserver: add StartKey to WAG events**

  Add a StartKey field to wagpb.Event and populate it at all WAG event
  creation sites. This records the range's start key at the time of the
  event, allowing replay to load descriptors via O(1) point reads instead
  of scanning all descriptors on disk.

---

  **kvserver,kvstorage: add ReplayBatch interface and implementation**

  Introduce a ReplayBatch interface in kvstorage that abstracts per-entry
  raft log application. The interface has four methods: ApplyEntry (apply
  one raft entry and report triviality), AppliedIndex, Commit (persist
  applied state), and Close. The caller must always call Close when done.

  kvserver provides a thin ReplayBatch implementation wrapping appBatch
  (MakeNewReplayBatchFn). It loads the range descriptor via a point read
  using the start key from the WAG event, so that CheckForcedErr can
  validate lease requests.

---

  **kvstorage: add raft log replay to ReplayWAG**

  Wire the ReplayBatch interface into ReplayWAG. For each unapplied WAG
  node, replayRaftLog catches up the affected ranges by iterating raft log
  entries via raftlog.Visit and applying each through a ReplayBatch.

  Non-trivial entries (lease changes, GC threshold bumps) trigger a batch
  flush and state reload: replayRaftLogBatch applies entries until it
  encounters one, then returns done=false so the outer loop in
  replayRaftLog creates a fresh batch with up-to-date state.

  Informs: #75729
  Release note: None