### PR TITLE
sql/schemachanger: order CHECK cleanup before column rename on drop

### DIFF
--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/sql/backfill",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/desctestutils",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/rowenc",

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
@@ -858,5 +859,85 @@ func TestAlterTableDMLInjection(t *testing.T) {
 				require.ErrorContains(t, err, expectedErr)
 			}
 		}))
+	}
+}
+
+// TestDropNotNullColumnPlaceholderLeak verifies that DROP COLUMN CASCADE
+// of a column with a dependent CHECK constraint does not surface the
+// column's placeholder name in errors from concurrent INSERTs that trip
+// the CHECK. The leak occurs when the CHECK is still being enforced
+// after ColumnName has transitioned to ABSENT and rewritten the
+// predicate to reference the placeholder name.
+func TestDropNotNullColumnPlaceholderLeak(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var sqlDB *sqlutils.SQLRunner
+	var setupDone atomic.Bool
+	// Replace the column ID with \d+ to match any column.
+	placeholderRe := regexp.MustCompile(
+		strings.Replace(regexp.QuoteMeta(tabledesc.ColumnNamePlaceholder(0)), "0", `\d+`, 1))
+	var leakedErrors, unexpectedErrors []string
+	var insertAttempts int
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
+				BeforeStage: func(p scplan.Plan, stageIdx int) error {
+					if !setupDone.Load() {
+						return nil
+					}
+					if len(p.TargetState.Statements) == 0 ||
+						!strings.Contains(p.TargetState.Statements[0].Statement, "DROP COLUMN") {
+						return nil
+					}
+					// Sequence-backed key avoids PK conflicts across stages.
+					insertAttempts++
+					_, err := sqlDB.DB.ExecContext(ctx,
+						`INSERT INTO t (k) VALUES (nextval('seq'))`)
+					stage := p.Stages[stageIdx]
+					switch {
+					case err == nil:
+					case placeholderRe.MatchString(err.Error()):
+						leakedErrors = append(leakedErrors,
+							fmt.Sprintf("stage=%s:%d err=%v", stage.Phase, stage.Ordinal, err))
+					default:
+						unexpectedErrors = append(unexpectedErrors,
+							fmt.Sprintf("stage=%s:%d err=%v", stage.Phase, stage.Ordinal, err))
+					}
+					// Returning a non-nil error here would be injected into the
+					// schema-change executor and fail the DROP. Record observations
+					// instead and let the DROP run to completion.
+					return nil
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB = sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
+
+	sqlDB.Exec(t, `CREATE SEQUENCE seq`)
+	sqlDB.Exec(t, `CREATE TABLE t (k INT PRIMARY KEY, i INT)`)
+	sqlDB.Exec(t, `INSERT INTO t (k, i) VALUES (-1, 1)`)
+	sqlDB.Exec(t, `ALTER TABLE t ADD CONSTRAINT c CHECK (i IS NOT NULL)`)
+
+	setupDone.Store(true)
+	_, err := sqlDB.DB.ExecContext(ctx, `ALTER TABLE t DROP COLUMN i CASCADE`)
+	require.NoError(t, err)
+
+	// Ensure the hook fires.
+	require.Greater(t, insertAttempts, 0)
+
+	if len(unexpectedErrors) > 0 {
+		t.Logf("note: %d INSERT(s) failed with non-placeholder errors:\n  %s",
+			len(unexpectedErrors), strings.Join(unexpectedErrors, "\n  "))
+	}
+
+	if len(leakedErrors) > 0 {
+		t.Fatalf("placeholder column name leaked into %d error(s):\n  %s",
+			len(leakedErrors), strings.Join(leakedErrors, "\n  "))
 	}
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_constraint.go
@@ -96,20 +96,21 @@ func init() {
 	)
 }
 
-// These rules ensure that a unique without index constraint with a column
-// name in its expression is cleaned up before the column name is dropped.
-// This is needed because unique without index constraints can have predicates
-// that reference columns by name.
+// Constraints whose stored expression text references a column by name
+// must be cleaned up before that column's ColumnName transitions to
+// ABSENT. The rule is scoped to the drop case to avoid a planner cycle
+// with transient variants used during multi-column rename.
 func init() {
-	registerDepRuleForDrop(
-		"unique without index constraint should be cleaned up before column name references",
+	registerDepRule(
+		"constraint with column-name references should be cleaned up before column name",
 		scgraph.Precedence,
 		"constraint", "referenced-column-name",
-		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			fromColumnID := rel.Var("fromColumnID")
 			return rel.Clauses{
 				from.Type(
+					(*scpb.CheckConstraint)(nil),
+					(*scpb.CheckConstraintUnvalidated)(nil),
 					(*scpb.UniqueWithoutIndexConstraint)(nil),
 					(*scpb.UniqueWithoutIndexConstraintUnvalidated)(nil),
 				),
@@ -117,6 +118,7 @@ func init() {
 				to.Type((*scpb.ColumnName)(nil)),
 				to.El.AttrEqVar(screl.ColumnID, fromColumnID),
 				JoinOnDescID(from, to, "table-id"),
+				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),
 			}
 		},
 	)

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3229,6 +3229,21 @@ deprules
     - $dependent-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
+- name: constraint with column-name references should be cleaned up before column name
+  from: constraint-Node
+  kind: Precedence
+  to: referenced-column-name-Node
+  query:
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
+    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
+    - $referenced-column-name[Type] = '*scpb.ColumnName'
+    - $referenced-column-name[ColumnID] = $fromColumnID
+    - joinOnDescID($constraint, $referenced-column-name, $table-id)
+    - toAbsent($constraint-Target, $referenced-column-name-Target)
+    - $constraint-Node[CurrentStatus] = ABSENT
+    - $referenced-column-name-Node[CurrentStatus] = ABSENT
+    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
+    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
 - name: cross-descriptor constraint is absent before referenced descriptor is dropped
   from: cross-desc-constraint-Node
   kind: Precedence
@@ -5567,68 +5582,6 @@ deprules
     - $types-Node[CurrentStatus] = TRANSIENT_DROPPED
     - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
     - joinTargetNode($types, $types-Target, $types-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - toAbsent($constraint-Target, $referenced-column-name-Target)
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - transient($constraint-Target, $referenced-column-name-Target)
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $referenced-column-name-Target[TargetStatus] = ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - $referenced-column-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
 
 deprules
 ----
@@ -8861,6 +8814,21 @@ deprules
     - $dependent-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
+- name: constraint with column-name references should be cleaned up before column name
+  from: constraint-Node
+  kind: Precedence
+  to: referenced-column-name-Node
+  query:
+    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
+    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
+    - $referenced-column-name[Type] = '*scpb.ColumnName'
+    - $referenced-column-name[ColumnID] = $fromColumnID
+    - joinOnDescID($constraint, $referenced-column-name, $table-id)
+    - toAbsent($constraint-Target, $referenced-column-name-Target)
+    - $constraint-Node[CurrentStatus] = ABSENT
+    - $referenced-column-name-Node[CurrentStatus] = ABSENT
+    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
+    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
 - name: cross-descriptor constraint is absent before referenced descriptor is dropped
   from: cross-desc-constraint-Node
   kind: Precedence
@@ -11199,65 +11167,3 @@ deprules
     - $types-Node[CurrentStatus] = TRANSIENT_DROPPED
     - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
     - joinTargetNode($types, $types-Target, $types-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - toAbsent($constraint-Target, $referenced-column-name-Target)
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - transient($constraint-Target, $referenced-column-name-Target)
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - $constraint-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $referenced-column-name-Target[TargetStatus] = ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
-- name: unique without index constraint should be cleaned up before column name references
-  from: constraint-Node
-  kind: Precedence
-  to: referenced-column-name-Node
-  query:
-    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
-    - $constraint[ReferencedColumnIDs] CONTAINS $fromColumnID
-    - $referenced-column-name[Type] = '*scpb.ColumnName'
-    - $referenced-column-name[ColumnID] = $fromColumnID
-    - joinOnDescID($constraint, $referenced-column-name, $table-id)
-    - $constraint-Target[TargetStatus] = ABSENT
-    - $constraint-Node[CurrentStatus] = ABSENT
-    - $referenced-column-name-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $referenced-column-name-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
-    - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -553,6 +553,10 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
 deps
 DROP INDEX idx3 CASCADE
 ----
+- from: [CheckConstraint:{DescID: 105, IndexID: 0, ConstraintID: 3, ReferencedColumnIDs: [5]}, ABSENT]
+  to:   [ColumnName:{DescID: 105, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT]
+  kind: Precedence
+  rule: constraint with column-name references should be cleaned up before column name
 - from: [CheckConstraint:{DescID: 105, IndexID: 0, ConstraintID: 3, ReferencedColumnIDs: [5]}, PUBLIC]
   to:   [CheckConstraint:{DescID: 105, IndexID: 0, ConstraintID: 3, ReferencedColumnIDs: [5]}, VALIDATED]
   kind: PreviousTransactionPrecedence


### PR DESCRIPTION
DROP COLUMN CASCADE could surface a confusing error referencing an internal placeholder column name (crdb_internal_column_<id>_name_placeholder) when a dependent CHECK constraint was still being enforced as the column was being renamed to its placeholder mid-drop. Concurrent INSERTs that omitted the dropping column would trip the CHECK and the error report would expose the placeholder.

This commit reintroduces a dependency ordering for CHECK constraints so that they are cleaned up before the corresponding column name transition takes effect.

Fixes #169116.

Release note (bug fix): Fixed a bug where DROP COLUMN CASCADE could return a confusing error mentioning an internal placeholder column name when concurrent writes raced with the schema change.

Epic: none