### PR TITLE
schemachanger: error on resolution of the built-in types

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -202,6 +202,7 @@ func TestExplainGist(t *testing.T) {
 					"expected equivalence dependants to be its closure",                  // #119045
 					"argument expression has type RECORD, need type USER DEFINED RECORD", // #139910
 					"invalid datum type given: RECORD, expected RECORD",                  // #140773
+					"is a built-in type", // #164215
 				} {
 					if strings.Contains(err.Error(), knownErr) {
 						// Don't fail the test on a set of known errors.

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -559,3 +559,17 @@ RESUME JOB (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'ALTER 
 
 statement ok
 RESUME JOB (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'DROP SCHEMA%' AND status='paused' FETCH FIRST 1 ROWS ONLY);
+
+# Regression test for #64398: Test both schemachangers error on the built-in rather than the bad schema.
+subtest regression_64398
+
+statement error pgcode 42809 type "geometry" is a built-in type
+DROP TYPE noexist.geometry
+
+statement error pgcode 42809 type "geometry" is a built-in type
+DROP TYPE noexist.public.geometry
+
+statement ok
+DROP TYPE IF EXISTS noexist.geometry
+
+subtest end

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -125,6 +125,9 @@ func (sr *schemaResolver) LookupObject(
 	if flags.DesiredObjectKind == tree.TypeObject && scName == catconstants.PublicSchemaName {
 		if alias, ok := types.PublicSchemaAliases[obName]; ok {
 			if flags.RequireMutable {
+				if !flags.Required {
+					return false, catalog.ResolvedObjectPrefix{}, nil, nil
+				}
 				return true, catalog.ResolvedObjectPrefix{}, nil, pgerror.Newf(pgcode.WrongObjectType, "type %q is a built-in type", obName)
 			}
 

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1215,6 +1215,12 @@ func (b *builderState) ResolveUserDefinedTypeType(
 		if p.IsExistenceOptional {
 			return nil
 		}
+		// Check if the name refers to a built-in type that couldn't be resolved
+		// because the qualifying schema/database doesn't exist (see #64663).
+		if _, ok := types.PublicSchemaAliases[name.Object()]; ok {
+			panic(pgerror.Newf(pgcode.WrongObjectType,
+				"type %q is a built-in type", name.Object()))
+		}
 		panic(sqlerrors.NewUndefinedTypeError(name))
 	}
 	switch typ.GetKind() {


### PR DESCRIPTION
The legacy schemachanger errors when a built-in
type is treated as a UDT; this change implements
that behavior in the declarative schemachanger.
The existing testing didn't cover a regression in
the DCS so a new test that runs the DDL on both
schemachangers is added.

Part of: #164215
Supports: #166593
Epic: CRDB-31325

Release note: None
