### PR TITLE
roachtest: skip azure for cdc/message-too-large-error

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3429,7 +3429,7 @@ CONFIGURE ZONE USING
 		Leases:           registry.MetamorphicLeases,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          15 * time.Minute,
-		CompatibleClouds: registry.AllExceptIBM,
+		CompatibleClouds: registry.AllClouds.NoIBM().NoAzure(),
 		Run:              runMessageTooLarge,
 	})
 	for _, perTablePTS := range []bool{false} {


### PR DESCRIPTION
This test failed when apt-get install was slow on azure. This is a pattern we saw elsewhere.

This test is not testing any Azure specific behavior and we have general Azure coverage for CDC in the designated roachtest, so we remove it to avoid flakes.

Fixes: #167885

Epic: none

Release note: None