### PR TITLE
opt: add Select / DistinctOn reordering rules

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -378,6 +378,48 @@ SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY 
 ----
 1
 
+#########################
+# DISTINCT with filters #
+#########################
+
+# Filter on a non-grouping column. The filter constrains which row is picked per
+# group, making the result deterministic: only rows with y=2 are available, so
+# groups x=1 and x=2 each produce exactly one output row.
+query II rowsort
+SELECT * FROM (SELECT DISTINCT ON (x) x, y FROM xyz) WHERE y = 2
+----
+1  2
+2  2
+
+# Filter on a grouping column.
+query II
+SELECT * FROM (SELECT DISTINCT ON (x) x, y FROM xyz) WHERE x = 2
+----
+2  2
+
+# Ordered DISTINCT ON: filter must NOT be evaluated before the DISTINCT ON,
+# since the ordering determines which row is picked. Verify the result is
+# correct.
+query II rowsort
+SELECT * FROM (SELECT DISTINCT ON (x) x, y FROM xyz ORDER BY x, y) WHERE y = 1
+----
+1  1
+4  1
+
+# Correlated EXISTS with a filter inside the DISTINCT ON that references a
+# grouping column and an outer column.
+query II rowsort
+SELECT x, y FROM xyz AS o WHERE EXISTS(
+    SELECT 1 FROM (SELECT DISTINCT ON (x) x FROM xyz AS i WHERE i.x > o.y)
+)
+----
+1  1
+1  1
+1  1
+1  2
+2  2
+4  1
+
 # Regression test for #90763. Ensure NULLS LAST works with DISTINCT ON.
 statement ok
 CREATE TABLE author (

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -2009,47 +2009,46 @@ full-join (hash)
  ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  ├── lax-key: (1,6)
  ├── fd: (1)~~>(2), (6)~~>(7), (1,6)~~>(2,7)
+ ├── prune: (2,7)
  ├── reject-nulls: (1,2,6,7)
- ├── select
+ ├── distinct-on
  │    ├── columns: t1.x:1(int) t1.y:2(int!null)
+ │    ├── grouping columns: t1.x:1(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    ├── distinct-on
- │    │    ├── columns: t1.x:1(int) t1.y:2(int)
- │    │    ├── grouping columns: t1.x:1(int)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    ├── prune: (2)
+ │    ├── prune: (2)
+ │    ├── select
+ │    │    ├── columns: t1.x:1(int) t1.y:2(int!null)
+ │    │    ├── prune: (1)
  │    │    ├── scan t1
  │    │    │    ├── columns: t1.x:1(int) t1.y:2(int)
  │    │    │    └── prune: (1,2)
- │    │    └── aggregations
- │    │         └── first-agg [as=t1.y:2, type=int, outer=(2)]
- │    │              └── variable: t1.y:2 [type=int]
- │    └── filters
- │         └── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
- │              ├── variable: t1.y:2 [type=int]
- │              └── null [type=unknown]
- ├── select
+ │    │    └── filters
+ │    │         └── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │    │              ├── variable: t1.y:2 [type=int]
+ │    │              └── null [type=unknown]
+ │    └── aggregations
+ │         └── first-agg [as=t1.y:2, type=int, outer=(2)]
+ │              └── variable: t1.y:2 [type=int]
+ ├── distinct-on
  │    ├── columns: t2.x:6(int) t2.y:7(int!null)
+ │    ├── grouping columns: t2.x:6(int)
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
- │    ├── distinct-on
- │    │    ├── columns: t2.x:6(int) t2.y:7(int)
- │    │    ├── grouping columns: t2.x:6(int)
- │    │    ├── key: (6)
- │    │    ├── fd: (6)-->(7)
- │    │    ├── prune: (7)
+ │    ├── prune: (7)
+ │    ├── select
+ │    │    ├── columns: t2.x:6(int) t2.y:7(int!null)
+ │    │    ├── prune: (6)
  │    │    ├── scan t2
  │    │    │    ├── columns: t2.x:6(int) t2.y:7(int)
  │    │    │    └── prune: (6,7)
- │    │    └── aggregations
- │    │         └── first-agg [as=t2.y:7, type=int, outer=(7)]
- │    │              └── variable: t2.y:7 [type=int]
- │    └── filters
- │         └── is-not [type=bool, outer=(7), constraints=(/7: (/NULL - ]; tight)]
- │              ├── variable: t2.y:7 [type=int]
- │              └── null [type=unknown]
+ │    │    └── filters
+ │    │         └── is-not [type=bool, outer=(7), constraints=(/7: (/NULL - ]; tight)]
+ │    │              ├── variable: t2.y:7 [type=int]
+ │    │              └── null [type=unknown]
+ │    └── aggregations
+ │         └── first-agg [as=t2.y:7, type=int, outer=(7)]
+ │              └── variable: t2.y:7 [type=int]
  └── filters
       └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
            ├── variable: t1.x:1 [type=int]

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -1567,6 +1567,58 @@ func (c *CustomFuncs) MakeAnyNotNullScalarGroupBy(input memo.RelExpr) memo.RelEx
 	)
 }
 
+// CanHoistCorrelatedFiltersAbove returns true if there is at least one
+// correlated filter in the list (i.e. one that references columns outside of
+// inputCols). Columns outside inputCols are assumed to be outer (correlated)
+// references available at any scope level.
+func (c *CustomFuncs) CanHoistCorrelatedFiltersAbove(
+	filters memo.FiltersExpr, inputCols opt.ColSet,
+) bool {
+	for i := range filters {
+		filterCols := filters[i].ScalarProps().OuterCols
+		if !filterCols.SubsetOf(inputCols) {
+			return true
+		}
+	}
+	return false
+}
+
+// AddFirstAggsForHoistedFilters returns the aggregations augmented with
+// FirstAgg columns for any input columns that are referenced by correlated
+// filters but are not already in the DistinctOn's output (outputCols). This
+// makes those columns available above the DistinctOn so that the hoisted
+// filters can reference them. This is valid for an unordered DistinctOn because
+// the choice of row per group is nondeterministic.
+func (c *CustomFuncs) AddFirstAggsForHoistedFilters(
+	aggregations memo.AggregationsExpr, filters memo.FiltersExpr, inputCols, outputCols opt.ColSet,
+) memo.AggregationsExpr {
+	// Collect the set of columns needed by correlated filters that aren't
+	// already in the output.
+	var missing opt.ColSet
+	for i := range filters {
+		filterCols := filters[i].ScalarProps().OuterCols
+		if filterCols.SubsetOf(inputCols) {
+			// Not correlated; will remain inside the DistinctOn.
+			continue
+		}
+		// Add local columns that are missing from the output.
+		missing.UnionWith(filterCols.Intersection(inputCols).Difference(outputCols))
+	}
+	if missing.Empty() {
+		return aggregations
+	}
+	// Add a FirstAgg for each missing column.
+	newAggs := make(memo.AggregationsExpr, len(aggregations), len(aggregations)+missing.Len())
+	copy(newAggs, aggregations)
+	missing.ForEach(func(col opt.ColumnID) {
+		newAggs = append(newAggs, c.f.ConstructAggregationsItem(
+			c.f.ConstructFirstAgg(c.f.ConstructVariable(col)),
+			col,
+		))
+	})
+	return newAggs
+}
+
 // CanHoistUnboundFilterFromExistsSubquery returns true if the
 // HoistUnboundFilterFromExistsSubquery rule is enabled by session-setting.
 func (c *CustomFuncs) CanHoistUnboundFilterFromExistsSubquery() bool {

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -327,6 +327,56 @@
     $private
 )
 
+# HoistSelectAboveUnorderedDistinctOn hoists correlated filter conditions from
+# inside an unordered DistinctOn's input Select to above the DistinctOn. This
+# is the reverse of PushSelectIntoUnorderedDistinctOn and is valid because an
+# unordered DistinctOn can choose any row from each group, so filtering before
+# or after the grouping produces equivalent results.
+#
+# This rule aids decorrelation by moving correlated filters to a position where
+# TryDecorrelateSelect can handle them, avoiding the more expensive
+# TryDecorrelateGroupBy transformation that requires EnsureKey and additional
+# ConstAgg columns.
+#
+# Uncorrelated filters remain inside the DistinctOn for early filtering. If a
+# correlated filter references an input column that is not already in the
+# DistinctOn's output, a FirstAgg aggregation is added for that column so
+# it becomes available above the DistinctOn.
+#
+# Example:
+#   DistinctOn(Select(input, [s = outer.s, i > 0]), aggs, priv)
+#   =>
+#   Select(DistinctOn(Select(input, [i > 0]), aggs', priv), [s = outer.s])
+#   (where aggs' = aggs + FirstAgg(s) if s was not already projected)
+[HoistSelectAboveUnorderedDistinctOn, Normalize]
+(DistinctOn
+    (Select $input:* $filters:*)
+    $aggregations:*
+    $groupingPrivate:* &
+        (IsUnorderedGrouping $groupingPrivate) &
+        (CanHoistCorrelatedFiltersAbove
+            $filters
+            (OutputCols $input)
+        )
+)
+=>
+(Select
+    (DistinctOn
+        (Select
+            $input
+            (ExtractBoundConditions $filters (OutputCols $input))
+        )
+        (AddFirstAggsForHoistedFilters
+            $aggregations
+            $filters
+            (OutputCols $input)
+            (GroupingOutputCols $groupingPrivate $aggregations)
+        )
+        $groupingPrivate
+    )
+    (ExtractUnboundConditions $filters (OutputCols $input))
+)
+
 # TryDecorrelateGroupBy "pushes down" a Join into a GroupBy operator, in an
 # attempt to keep "digging" down to find and eliminate unnecessary correlation.
 # The eventual hope is to trigger the DecorrelateJoin rule to turn a JoinApply

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -316,6 +316,58 @@ $input
     (ExtractUnboundConditions $filters $passthrough)
 )
 
+# PushSelectIntoUnorderedDistinctOn pushes Select filters into the input of an
+# unordered DistinctOn. Unlike PushSelectIntoGroupBy, which only pushes filters
+# on grouping or ConstAgg columns, this rule pushes filters that reference any
+# column of the DistinctOn's input — including first-agg columns.
+#
+# This is valid because an unordered DistinctOn can return any row from each
+# group. Filtering before the DistinctOn simply constrains which rows are
+# available to be chosen; groups that are entirely eliminated by the filter
+# produce no output row, which is equivalent to choosing a row and then
+# filtering it away afterward.
+#
+# The rule is restricted to unordered DistinctOn: an ordered DistinctOn must
+# pick a specific row determined by the ordering, so pre-filtering could change
+# which row is selected.
+#
+# Note: Do not add EnsureDistinctOn to the match pattern. Pushing the select
+# filters through the EnsureDistinctOn can prevent it from detecting duplicate
+# rows and therefore change error behavior.
+#
+# Filters referencing outer columns are not pushed; they remain above the
+# DistinctOn.
+[PushSelectIntoUnorderedDistinctOn, Normalize]
+(Select
+    $input:(DistinctOn
+        $groupingInput:*
+        $aggregations:*
+        $groupingPrivate:* &
+            (IsUnorderedGrouping $groupingPrivate)
+    )
+    $filters:[
+        ...
+        $item:* &
+            (IsBoundBy
+                $item
+                $inputCols:(OutputCols $groupingInput)
+            )
+        ...
+    ]
+)
+=>
+(Select
+    (DistinctOn
+        (Select
+            $groupingInput
+            (ExtractBoundConditions $filters $inputCols)
+        )
+        $aggregations
+        $groupingPrivate
+    )
+    (ExtractUnboundConditions $filters $inputCols)
+)
+
 # RemoveNotNullCondition removes a filter with an IS NOT NULL condition
 # when the given column has a NOT NULL constraint.
 [RemoveNotNullCondition, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1946,7 +1946,7 @@ project
       └── 'foo' [as=cst:5]
 
 # Decorrelate DistinctOn.
-norm expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy disable=PushSelectIntoUnorderedDistinctOn
 SELECT *
 FROM a
 WHERE EXISTS
@@ -2733,32 +2733,18 @@ group-by (hash)
  ├── grouping columns: x:1!null
  ├── key: (1)
  ├── fd: (1)-->(2)
- ├── select
+ ├── inner-join (hash)
  │    ├── columns: x:1!null y:2!null i:6!null f:7!null
- │    ├── key: (1,7)
- │    ├── fd: (1)-->(2), (1,7)-->(2,6), (1)==(6), (6)==(1)
- │    ├── distinct-on
- │    │    ├── columns: x:1!null y:2!null i:6 f:7!null
- │    │    ├── grouping columns: x:1!null f:7!null
- │    │    ├── key: (1,7)
- │    │    ├── fd: (1)-->(2), (1,7)-->(2,6)
- │    │    ├── inner-join (cross)
- │    │    │    ├── columns: x:1!null y:2!null i:6 f:7!null
- │    │    │    ├── fd: (1)-->(2)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:1!null y:2
- │    │    │    │    ├── key: (1)
- │    │    │    │    └── fd: (1)-->(2)
- │    │    │    ├── scan a
- │    │    │    │    └── columns: i:6 f:7
- │    │    │    └── filters
- │    │    │         └── y:2 > f:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
- │    │    └── aggregations
- │    │         ├── first-agg [as=i:6, outer=(6)]
- │    │         │    └── i:6
- │    │         └── const-agg [as=y:2, outer=(2)]
- │    │              └── y:2
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (1)-->(2), (1)==(6), (6)==(1)
+ │    ├── scan xy
+ │    │    ├── columns: x:1!null y:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan a
+ │    │    └── columns: i:6 f:7
  │    └── filters
+ │         ├── y:2 > f:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
  │         └── x:1 = i:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── aggregations
       └── const-agg [as=y:2, outer=(2)]
@@ -2951,76 +2937,36 @@ norm expect=TryDecorrelateLimitOne
 SELECT * FROM a WHERE (SELECT x FROM xy WHERE y=i LIMIT 1)=k AND (SELECT u FROM uv WHERE v=i LIMIT 1)=k
 ----
 project
- ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 u:12!null
-      ├── key: (1)
-      ├── fd: (1)-->(2-5), (1)==(12), (12)==(1)
-      ├── distinct-on
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 u:12
-      │    ├── grouping columns: k:1!null
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,12)
-      │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8!null u:12 v:13
-      │    │    ├── key: (1,12)
-      │    │    ├── fd: (1)-->(2-5), (12)-->(13), (1)==(8), (8)==(1)
-      │    │    ├── select
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8!null
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5), (1)==(8), (8)==(1)
-      │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8
-      │    │    │    │    ├── grouping columns: k:1!null
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-5,8)
-      │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
-      │    │    │    │    │    ├── key: (1,8)
-      │    │    │    │    │    ├── fd: (1)-->(2-5), (8)-->(9)
-      │    │    │    │    │    ├── scan a
-      │    │    │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    └── fd: (1)-->(2-5)
-      │    │    │    │    │    ├── scan xy
-      │    │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    │    └── filters
-      │    │    │    │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-agg [as=i:2, outer=(2)]
-      │    │    │    │         │    └── i:2
-      │    │    │    │         ├── const-agg [as=f:3, outer=(3)]
-      │    │    │    │         │    └── f:3
-      │    │    │    │         ├── const-agg [as=s:4, outer=(4)]
-      │    │    │    │         │    └── s:4
-      │    │    │    │         ├── const-agg [as=j:5, outer=(5)]
-      │    │    │    │         │    └── j:5
-      │    │    │    │         └── first-agg [as=x:8, outer=(8)]
-      │    │    │    │              └── x:8
-      │    │    │    └── filters
-      │    │    │         └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-      │    │    ├── scan uv
-      │    │    │    ├── columns: u:12!null v:13
-      │    │    │    ├── key: (12)
-      │    │    │    └── fd: (12)-->(13)
-      │    │    └── filters
-      │    │         └── v:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
-      │    └── aggregations
-      │         ├── const-agg [as=i:2, outer=(2)]
-      │         │    └── i:2
-      │         ├── const-agg [as=f:3, outer=(3)]
-      │         │    └── f:3
-      │         ├── const-agg [as=s:4, outer=(4)]
-      │         │    └── s:4
-      │         ├── const-agg [as=j:5, outer=(5)]
-      │         │    └── j:5
-      │         └── first-agg [as=u:12, outer=(12)]
-      │              └── u:12
+ └── inner-join (hash)
+      ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null y:9!null u:12!null v:13!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      ├── key: (12)
+      ├── fd: (1)-->(2-5), (8)-->(9), (12)-->(13), (2)==(9,13), (9)==(2,13), (13)==(2,9), (1)==(8,12), (8)==(1,12), (12)==(1,8)
+      ├── inner-join (hash)
+      │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null y:9!null
+      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │    ├── key: (8)
+      │    ├── fd: (1)-->(2-5), (8)-->(9), (2)==(9), (9)==(2), (1)==(8), (8)==(1)
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    ├── scan xy
+      │    │    ├── columns: x:8!null y:9
+      │    │    ├── key: (8)
+      │    │    └── fd: (8)-->(9)
+      │    └── filters
+      │         ├── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      │         └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      ├── scan uv
+      │    ├── columns: u:12!null v:13
+      │    ├── key: (12)
+      │    └── fd: (12)-->(13)
       └── filters
+           ├── v:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
            └── k:1 = u:12 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
 
 # With nested limited queries.
@@ -3039,70 +2985,36 @@ WHERE
 )=k
 ----
 project
- ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
  ├── key: (1)
  ├── fd: (1)-->(2-5)
- └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8!null
-      ├── key: (1)
-      ├── fd: (1)-->(2-5), (1)==(8), (8)==(1)
-      ├── distinct-on
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8
-      │    ├── grouping columns: k:1!null
+ └── inner-join (hash)
+      ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null y:9!null u:12!null v:13!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      ├── key: (12)
+      ├── fd: (1)-->(2-5), (8)-->(9), (12)-->(13), (2)==(9,13), (9)==(2,13), (13)==(2,9), (1)==(8,12), (8)==(1,12), (12)==(1,8)
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,8)
-      │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9 u:12
-      │    │    ├── key: (1,8)
-      │    │    ├── fd: (1)-->(2-5), (8)-->(9), (8)==(12), (12)==(8)
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-5)
-      │    │    ├── select
-      │    │    │    ├── columns: x:8!null y:9 u:12!null
-      │    │    │    ├── key: (8)
-      │    │    │    ├── fd: (8)-->(9), (8)==(12), (12)==(8)
-      │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: x:8!null y:9 u:12
-      │    │    │    │    ├── grouping columns: x:8!null
-      │    │    │    │    ├── key: (8)
-      │    │    │    │    ├── fd: (8)-->(9,12)
-      │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    ├── columns: x:8!null y:9 u:12 v:13
-      │    │    │    │    │    ├── key: (8,12)
-      │    │    │    │    │    ├── fd: (8)-->(9), (12)-->(13)
-      │    │    │    │    │    ├── scan xy
-      │    │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    │    ├── scan uv
-      │    │    │    │    │    │    ├── columns: u:12!null v:13
-      │    │    │    │    │    │    ├── key: (12)
-      │    │    │    │    │    │    └── fd: (12)-->(13)
-      │    │    │    │    │    └── filters
-      │    │    │    │    │         └── v:13 = y:9 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-agg [as=y:9, outer=(9)]
-      │    │    │    │         │    └── y:9
-      │    │    │    │         └── first-agg [as=u:12, outer=(12)]
-      │    │    │    │              └── u:12
-      │    │    │    └── filters
-      │    │    │         └── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
-      │    │    └── filters
-      │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
-      │    └── aggregations
-      │         ├── const-agg [as=i:2, outer=(2)]
-      │         │    └── i:2
-      │         ├── const-agg [as=f:3, outer=(3)]
-      │         │    └── f:3
-      │         ├── const-agg [as=s:4, outer=(4)]
-      │         │    └── s:4
-      │         ├── const-agg [as=j:5, outer=(5)]
-      │         │    └── j:5
-      │         └── first-agg [as=x:8, outer=(8)]
-      │              └── x:8
+      │    └── fd: (1)-->(2-5)
+      ├── inner-join (hash)
+      │    ├── columns: x:8!null y:9!null u:12!null v:13!null
+      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │    ├── key: (12)
+      │    ├── fd: (8)-->(9), (12)-->(13), (9)==(13), (13)==(9), (8)==(12), (12)==(8)
+      │    ├── scan xy
+      │    │    ├── columns: x:8!null y:9
+      │    │    ├── key: (8)
+      │    │    └── fd: (8)-->(9)
+      │    ├── scan uv
+      │    │    ├── columns: u:12!null v:13
+      │    │    ├── key: (12)
+      │    │    └── fd: (12)-->(13)
+      │    └── filters
+      │         ├── v:13 = y:9 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
+      │         └── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
       └── filters
+           ├── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
            └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # With inner join + ORDER BY.
@@ -4070,44 +3982,38 @@ semi-join (hash)
 norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE (SELECT y FROM xy WHERE y=k LIMIT 1) = i
 ----
-project
+distinct-on
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── grouping columns: k:1!null
  ├── key: (1)
- ├── fd: (1)-->(2-5)
- └── select
-      ├── columns: k:1!null i:2!null f:3 s:4 j:5 y:9!null
-      ├── key: (1)
-      ├── fd: (1)-->(2-5,9), (2)==(9), (9)==(2)
-      ├── distinct-on
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9
-      │    ├── grouping columns: k:1!null
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,9)
-      │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-      │    │    ├── fd: (1)-->(2-5)
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-5)
-      │    │    ├── scan xy
-      │    │    │    └── columns: y:9
-      │    │    └── filters
-      │    │         └── y:9 = k:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
-      │    └── aggregations
-      │         ├── const-agg [as=i:2, outer=(2)]
-      │         │    └── i:2
-      │         ├── const-agg [as=f:3, outer=(3)]
-      │         │    └── f:3
-      │         ├── const-agg [as=s:4, outer=(4)]
-      │         │    └── s:4
-      │         ├── const-agg [as=j:5, outer=(5)]
-      │         │    └── j:5
-      │         └── first-agg [as=y:9, outer=(9)]
-      │              └── y:9
-      └── filters
-           └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ ├── fd: (1)-->(2-5), (1)==(2), (2)==(1)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 y:9!null
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (1)-->(3-5), (1)==(2,9), (2)==(1,9), (9)==(1,2)
+ │    ├── select
+ │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(3-5), (1)==(2), (2)==(1)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2-5)
+ │    │    └── filters
+ │    │         └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+ │    ├── scan xy
+ │    │    └── columns: y:9
+ │    └── filters
+ │         └── k:1 = y:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ └── aggregations
+      ├── const-agg [as=i:2, outer=(2)]
+      │    └── i:2
+      ├── const-agg [as=f:3, outer=(3)]
+      │    └── f:3
+      ├── const-agg [as=s:4, outer=(4)]
+      │    └── s:4
+      └── const-agg [as=j:5, outer=(5)]
+           └── j:5
 
 # Multiple other conjuncts, including uncorrelated subquery (don't hoist).
 norm expect=HoistSelectSubquery disable=InlineConstVar
@@ -4190,74 +4096,68 @@ norm expect=HoistSelectSubquery
 SELECT * FROM a
 WHERE (SELECT count(*) FROM xy WHERE y=k) > 0 AND (SELECT y FROM xy WHERE y=k LIMIT 1) = i
 ----
-project
+distinct-on
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── grouping columns: k:1!null
  ├── key: (1)
- ├── fd: (1)-->(2-5)
- └── select
-      ├── columns: k:1!null i:2!null f:3 s:4 j:5 y:14!null
-      ├── key: (1)
-      ├── fd: (1)-->(2-5,14), (2)==(14), (14)==(2)
-      ├── distinct-on
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:14
-      │    ├── grouping columns: k:1!null
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,14)
-      │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:12!null y:14
-      │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-      │    │    ├── fd: (1)-->(2-5,12)
-      │    │    ├── select
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:12!null
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5,12)
-      │    │    │    ├── group-by (hash)
-      │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:12!null
-      │    │    │    │    ├── grouping columns: k:1!null
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-5,12)
-      │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9
-      │    │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-      │    │    │    │    │    ├── fd: (1)-->(2-5)
-      │    │    │    │    │    ├── scan a
-      │    │    │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    └── fd: (1)-->(2-5)
-      │    │    │    │    │    ├── scan xy
-      │    │    │    │    │    │    └── columns: y:9
-      │    │    │    │    │    └── filters
-      │    │    │    │    │         └── y:9 = k:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── count [as=count_rows:12, outer=(9)]
-      │    │    │    │         │    └── y:9
-      │    │    │    │         ├── const-agg [as=i:2, outer=(2)]
-      │    │    │    │         │    └── i:2
-      │    │    │    │         ├── const-agg [as=f:3, outer=(3)]
-      │    │    │    │         │    └── f:3
-      │    │    │    │         ├── const-agg [as=s:4, outer=(4)]
-      │    │    │    │         │    └── s:4
-      │    │    │    │         └── const-agg [as=j:5, outer=(5)]
-      │    │    │    │              └── j:5
-      │    │    │    └── filters
-      │    │    │         └── count_rows:12 > 0 [outer=(12), constraints=(/12: [/1 - ]; tight)]
-      │    │    ├── scan xy
-      │    │    │    └── columns: y:14
-      │    │    └── filters
-      │    │         └── y:14 = k:1 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
-      │    └── aggregations
-      │         ├── const-agg [as=i:2, outer=(2)]
-      │         │    └── i:2
-      │         ├── const-agg [as=f:3, outer=(3)]
-      │         │    └── f:3
-      │         ├── const-agg [as=s:4, outer=(4)]
-      │         │    └── s:4
-      │         ├── const-agg [as=j:5, outer=(5)]
-      │         │    └── j:5
-      │         └── first-agg [as=y:14, outer=(14)]
-      │              └── y:14
-      └── filters
-           └── i:2 = y:14 [outer=(2,14), constraints=(/2: (/NULL - ]; /14: (/NULL - ]), fd=(2)==(14), (14)==(2)]
+ ├── fd: (1)-->(2-5), (1)==(2), (2)==(1)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 count_rows:12!null y:14!null
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (1)-->(3-5,12), (1)==(2,14), (2)==(1,14), (14)==(1,2)
+ │    ├── select
+ │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 count_rows:12!null
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5,12), (1)==(2), (2)==(1)
+ │    │    ├── group-by (hash)
+ │    │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 count_rows:12!null
+ │    │    │    ├── grouping columns: k:1!null
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2-5,12), (1)==(2), (2)==(1)
+ │    │    │    ├── left-join (hash)
+ │    │    │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 y:9
+ │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ │    │    │    │    ├── fd: (1)-->(3-5), (1)==(2), (2)==(1)
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: (1)-->(3-5), (1)==(2), (2)==(1)
+ │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    └── columns: y:9
+ │    │    │    │    └── filters
+ │    │    │    │         └── y:9 = k:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │    │    └── aggregations
+ │    │    │         ├── count [as=count_rows:12, outer=(9)]
+ │    │    │         │    └── y:9
+ │    │    │         ├── const-agg [as=i:2, outer=(2)]
+ │    │    │         │    └── i:2
+ │    │    │         ├── const-agg [as=f:3, outer=(3)]
+ │    │    │         │    └── f:3
+ │    │    │         ├── const-agg [as=s:4, outer=(4)]
+ │    │    │         │    └── s:4
+ │    │    │         └── const-agg [as=j:5, outer=(5)]
+ │    │    │              └── j:5
+ │    │    └── filters
+ │    │         └── count_rows:12 > 0 [outer=(12), constraints=(/12: [/1 - ]; tight)]
+ │    ├── scan xy
+ │    │    └── columns: y:14
+ │    └── filters
+ │         └── k:1 = y:14 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
+ └── aggregations
+      ├── const-agg [as=i:2, outer=(2)]
+      │    └── i:2
+      ├── const-agg [as=f:3, outer=(3)]
+      │    └── f:3
+      ├── const-agg [as=s:4, outer=(4)]
+      │    └── s:4
+      └── const-agg [as=j:5, outer=(5)]
+           └── j:5
 
 # Subquery nested below interesting scalar operators like cast, function, tuple,
 # or, etc).

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1641,6 +1641,261 @@ project
            └── u:5 IS DISTINCT FROM i:10 [outer=(5,10)]
 
 # --------------------------------------------------
+# HoistSelectAboveUnorderedDistinctOn
+# --------------------------------------------------
+
+# Hoist a correlated filter on a first-agg column above the unordered DistinctOn.
+norm expect=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a WHERE EXISTS(
+    SELECT * FROM (SELECT DISTINCT ON (i) i, s FROM a AS inner_a WHERE inner_a.s = a.s)
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.i:9 inner_a.s:11
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(11)
+ │    ├── scan a [as=inner_a]
+ │    │    └── columns: inner_a.i:9 inner_a.s:11
+ │    └── aggregations
+ │         └── first-agg [as=inner_a.s:11, outer=(11)]
+ │              └── inner_a.s:11
+ └── filters
+      └── inner_a.s:11 = a.s:4 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+
+# Hoist a correlated filter on a grouping column.
+norm expect=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a WHERE EXISTS(
+    SELECT * FROM (SELECT DISTINCT ON (i) i, s FROM a AS inner_a WHERE inner_a.i = a.i)
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.i:9
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── key: (9)
+ │    └── scan a [as=inner_a]
+ │         └── columns: inner_a.i:9
+ └── filters
+      └── inner_a.i:9 = a.i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+
+# Mixed correlated and uncorrelated filters: correlated filter is hoisted,
+# uncorrelated filter stays inside the DistinctOn.
+norm expect=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a WHERE EXISTS(
+    SELECT * FROM (
+        SELECT DISTINCT ON (i) i, s FROM a AS inner_a WHERE inner_a.s = a.s AND inner_a.f > 0
+    )
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.i:9 inner_a.s:11
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(11)
+ │    ├── select
+ │    │    ├── columns: inner_a.i:9 inner_a.f:10!null inner_a.s:11
+ │    │    ├── scan a [as=inner_a]
+ │    │    │    └── columns: inner_a.i:9 inner_a.f:10 inner_a.s:11
+ │    │    └── filters
+ │    │         └── inner_a.f:10 > 0.0 [outer=(10), constraints=(/10: [/5e-324 - ]; tight)]
+ │    └── aggregations
+ │         └── first-agg [as=inner_a.s:11, outer=(11)]
+ │              └── inner_a.s:11
+ └── filters
+      └── inner_a.s:11 = a.s:4 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+
+# Hoist a correlated filter using a lateral join. A FirstAgg is added for f,
+# which is referenced by the correlated filter but not projected by the
+# DistinctOn.
+norm expect=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a
+INNER JOIN LATERAL (SELECT DISTINCT ON (i) i FROM a AS inner_a WHERE inner_a.f = a.f)
+ON true
+----
+project
+ ├── columns: k:1!null i:2 f:3!null s:4 j:5 i:9
+ ├── key: (1,9)
+ ├── fd: (1)-->(2-5), (9)-->(3)
+ └── inner-join (hash)
+      ├── columns: a.k:1!null a.i:2 a.f:3!null a.s:4 a.j:5 inner_a.i:9 inner_a.f:10!null
+      ├── key: (1,9)
+      ├── fd: (1)-->(2-5), (9)-->(10), (3)==(10), (10)==(3)
+      ├── scan a
+      │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-5)
+      ├── distinct-on
+      │    ├── columns: inner_a.i:9 inner_a.f:10
+      │    ├── grouping columns: inner_a.i:9
+      │    ├── key: (9)
+      │    ├── fd: (9)-->(10)
+      │    ├── scan a [as=inner_a]
+      │    │    └── columns: inner_a.i:9 inner_a.f:10
+      │    └── aggregations
+      │         └── first-agg [as=inner_a.f:10, outer=(10)]
+      │              └── inner_a.f:10
+      └── filters
+           └── inner_a.f:10 = a.f:3 [outer=(3,10), constraints=(/3: (/NULL - ]; /10: (/NULL - ]), fd=(3)==(10), (10)==(3)]
+
+# Fire when the correlated filter references an input column not in the
+# DistinctOn output. A FirstAgg is added for the missing column (k).
+norm expect=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a WHERE EXISTS(
+    SELECT * FROM (SELECT DISTINCT ON (i) i FROM a AS inner_a WHERE inner_a.k = a.k)
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.k:8!null inner_a.i:9
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(9), (9)-->(8)
+ │    ├── scan a [as=inner_a]
+ │    │    ├── columns: inner_a.k:8!null inner_a.i:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── aggregations
+ │         └── first-agg [as=inner_a.k:8, outer=(8)]
+ │              └── inner_a.k:8
+ └── filters
+      └── inner_a.k:8 = a.k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Fire when multiple correlated filters reference columns not in the DistinctOn
+# output. FirstAgg columns are added for each missing column (k and f).
+norm expect=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a WHERE EXISTS(
+    SELECT * FROM (
+        SELECT DISTINCT ON (i) i FROM a AS inner_a
+        WHERE inner_a.k = a.k AND inner_a.f = a.f
+    )
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.k:8!null inner_a.i:9 inner_a.f:10
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(9,10), (9)-->(8,10)
+ │    ├── scan a [as=inner_a]
+ │    │    ├── columns: inner_a.k:8!null inner_a.i:9 inner_a.f:10
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9,10)
+ │    └── aggregations
+ │         ├── first-agg [as=inner_a.k:8, outer=(8)]
+ │         │    └── inner_a.k:8
+ │         └── first-agg [as=inner_a.f:10, outer=(10)]
+ │              └── inner_a.f:10
+ └── filters
+      ├── inner_a.k:8 = a.k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      └── inner_a.f:10 = a.f:3 [outer=(3,10), constraints=(/3: (/NULL - ]; /10: (/NULL - ]), fd=(3)==(10), (10)==(3)]
+
+# Do *not* fire when the DistinctOn's Select has only uncorrelated filters.
+# The correlated filter (inner_a.i = a.i) is above the DistinctOn, not inside
+# its Select, so there is nothing to hoist.
+norm expect-not=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a
+INNER JOIN LATERAL (
+    SELECT DISTINCT ON (i) i, s FROM a AS inner_a WHERE inner_a.f > 0
+) AS d ON d.i = a.i
+----
+inner-join (hash)
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5 i:9!null s:11
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5), (9)-->(11), (2)==(9), (9)==(2)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.i:9 inner_a.s:11
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(11)
+ │    ├── select
+ │    │    ├── columns: inner_a.i:9 inner_a.f:10!null inner_a.s:11
+ │    │    ├── scan a [as=inner_a]
+ │    │    │    └── columns: inner_a.i:9 inner_a.f:10 inner_a.s:11
+ │    │    └── filters
+ │    │         └── inner_a.f:10 > 0.0 [outer=(10), constraints=(/10: [/5e-324 - ]; tight)]
+ │    └── aggregations
+ │         └── first-agg [as=inner_a.s:11, outer=(11)]
+ │              └── inner_a.s:11
+ └── filters
+      └── inner_a.i:9 = a.i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+
+# Do *not* fire when the DistinctOn has an ordering (ordered DistinctOn).
+norm expect-not=HoistSelectAboveUnorderedDistinctOn
+SELECT * FROM a WHERE EXISTS(
+    SELECT * FROM (
+        SELECT DISTINCT ON (i) i, s FROM a AS inner_a ORDER BY i, s
+    ) AS d WHERE d.s = a.s
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: inner_a.i:9 inner_a.s:11
+ │    ├── grouping columns: inner_a.i:9
+ │    ├── internal-ordering: +11 opt(9)
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(11)
+ │    ├── sort
+ │    │    ├── columns: inner_a.i:9 inner_a.s:11
+ │    │    ├── ordering: +11 opt(9) [actual: +11]
+ │    │    └── scan a [as=inner_a]
+ │    │         └── columns: inner_a.i:9 inner_a.s:11
+ │    └── aggregations
+ │         └── first-agg [as=inner_a.s:11, outer=(11)]
+ │              └── inner_a.s:11
+ └── filters
+      └── inner_a.s:11 = a.s:4 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+
+# --------------------------------------------------
 # TryDecorrelateGroupBy
 # --------------------------------------------------
 norm expect=TryDecorrelateGroupBy
@@ -1946,7 +2201,7 @@ project
       └── 'foo' [as=cst:5]
 
 # Decorrelate DistinctOn.
-norm expect=TryDecorrelateGroupBy disable=PushSelectIntoUnorderedDistinctOn
+norm expect=TryDecorrelateGroupBy disable=(PushSelectIntoUnorderedDistinctOn,HoistSelectAboveUnorderedDistinctOn)
 SELECT *
 FROM a
 WHERE EXISTS
@@ -2720,7 +2975,7 @@ group-by (hash)
            └── y:2
 
 # Right input of SemiJoin is DistinctOn.
-norm expect=TryDecorrelateSemiJoin
+norm expect=TryDecorrelateSemiJoin disable=HoistSelectAboveUnorderedDistinctOn
 SELECT *
 FROM xy
 WHERE EXISTS

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1453,6 +1453,170 @@ select
       └── count_rows:8 = 0 [outer=(8), constraints=(/8: [/0 - /0]; tight), fd=()-->(8)]
 
 # --------------------------------------------------
+# PushSelectIntoUnorderedDistinctOn
+# --------------------------------------------------
+
+# Push down filter on a non-grouping column (first-agg column) into an
+# unordered DistinctOn. This is valid because an unordered DistinctOn can
+# choose any row from a group, so filtering first is correct.
+norm expect=PushSelectIntoUnorderedDistinctOn
+SELECT * FROM (SELECT DISTINCT ON (i) i, s FROM a) WHERE s='foo'
+----
+distinct-on
+ ├── columns: i:2 s:4!null
+ ├── grouping columns: i:2
+ ├── key: (2)
+ ├── fd: ()-->(4)
+ ├── select
+ │    ├── columns: i:2 s:4!null
+ │    ├── fd: ()-->(4)
+ │    ├── scan a
+ │    │    └── columns: i:2 s:4
+ │    └── filters
+ │         └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ └── aggregations
+      └── first-agg [as=s:4, outer=(4)]
+           └── s:4
+
+# Push down filter on a non-grouping column with multiple aggregated columns.
+norm expect=PushSelectIntoUnorderedDistinctOn
+SELECT * FROM (SELECT DISTINCT ON (i) i, s, f FROM a) WHERE s='foo'
+----
+distinct-on
+ ├── columns: i:2 s:4!null f:3
+ ├── grouping columns: i:2
+ ├── key: (2)
+ ├── fd: ()-->(4), (2)-->(3,4)
+ ├── select
+ │    ├── columns: i:2 f:3 s:4!null
+ │    ├── fd: ()-->(4)
+ │    ├── scan a
+ │    │    └── columns: i:2 f:3 s:4
+ │    └── filters
+ │         └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ └── aggregations
+      ├── first-agg [as=s:4, outer=(4)]
+      │    └── s:4
+      └── first-agg [as=f:3, outer=(3)]
+           └── f:3
+
+# Push down multiple filters that all reference grouping input columns.
+norm expect=PushSelectIntoUnorderedDistinctOn
+SELECT * FROM (SELECT DISTINCT ON (i) i, s, f FROM a) WHERE s='foo' AND f > 1.0
+----
+distinct-on
+ ├── columns: i:2 s:4!null f:3!null
+ ├── grouping columns: i:2
+ ├── key: (2)
+ ├── fd: ()-->(4), (2)-->(3,4)
+ ├── select
+ │    ├── columns: i:2 f:3!null s:4!null
+ │    ├── fd: ()-->(4)
+ │    ├── scan a
+ │    │    └── columns: i:2 f:3 s:4
+ │    └── filters
+ │         ├── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ │         └── f:3 > 1.0 [outer=(3), constraints=(/3: [/1.0000000000000002 - ]; tight)]
+ └── aggregations
+      ├── first-agg [as=s:4, outer=(4)]
+      │    └── s:4
+      └── first-agg [as=f:3, outer=(3)]
+           └── f:3
+
+# Do *not* push down into an ordered DistinctOn when the filter references a
+# non-grouping, non-const-agg column. An ordered DistinctOn must pick a specific
+# row (determined by the ordering), so filtering before could change the result.
+norm expect-not=PushSelectIntoUnorderedDistinctOn
+SELECT * FROM (SELECT DISTINCT ON (i) i, s FROM a ORDER BY i, s) WHERE s='foo'
+----
+select
+ ├── columns: i:2 s:4!null
+ ├── key: (2)
+ ├── fd: ()-->(4)
+ ├── distinct-on
+ │    ├── columns: i:2 s:4
+ │    ├── grouping columns: i:2
+ │    ├── internal-ordering: +4 opt(2)
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(4)
+ │    ├── sort
+ │    │    ├── columns: i:2 s:4
+ │    │    ├── ordering: +4 opt(2) [actual: +4]
+ │    │    └── scan a
+ │    │         └── columns: i:2 s:4
+ │    └── aggregations
+ │         └── first-agg [as=s:4, outer=(4)]
+ │              └── s:4
+ └── filters
+      └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# Push down filter that references a column from a join input under unordered
+# DistinctOn.
+norm expect=PushSelectIntoUnorderedDistinctOn
+SELECT * FROM (SELECT DISTINCT ON (i) i, x FROM a JOIN xy ON k=x) WHERE x > 5
+----
+distinct-on
+ ├── columns: i:2 x:8!null
+ ├── grouping columns: i:2
+ ├── key: (8)
+ ├── fd: (8)-->(2), (2)-->(8)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2 x:8!null
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (8)
+ │    ├── fd: (1)-->(2), (1)==(8), (8)==(1)
+ │    ├── select
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── k:1 > 5 [outer=(1), constraints=(/1: [/6 - ]; tight)]
+ │    ├── select
+ │    │    ├── columns: x:8!null
+ │    │    ├── key: (8)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:8!null
+ │    │    │    └── key: (8)
+ │    │    └── filters
+ │    │         └── x:8 > 5 [outer=(8), constraints=(/8: [/6 - ]; tight)]
+ │    └── filters
+ │         └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ └── aggregations
+      └── first-agg [as=x:8, outer=(8)]
+           └── x:8
+
+# Do *not* push down a filter that references outer columns.
+norm expect-not=PushSelectIntoUnorderedDistinctOn
+SELECT * FROM a AS outer_a WHERE EXISTS(
+  SELECT * FROM (SELECT DISTINCT ON (i) i, s FROM a) AS inner_a WHERE inner_a.s = outer_a.s
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a [as=outer_a]
+ │    ├── columns: outer_a.k:1!null outer_a.i:2 outer_a.f:3 outer_a.s:4 outer_a.j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── distinct-on
+ │    ├── columns: a.i:9 a.s:11
+ │    ├── grouping columns: a.i:9
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(11)
+ │    ├── scan a
+ │    │    └── columns: a.i:9 a.s:11
+ │    └── aggregations
+ │         └── first-agg [as=a.s:11, outer=(11)]
+ │              └── a.s:11
+ └── filters
+      └── a.s:11 = outer_a.s:4 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+
+# --------------------------------------------------
 # RemoveNotNullCondition
 # --------------------------------------------------
 exec-ddl


### PR DESCRIPTION
#### opt: push Select into unordered DistinctOn

Add the PushSelectIntoUnorderedDistinctOn normalization rule, which pushes
Select filters into the input of an unordered DistinctOn. Unlike
PushSelectIntoGroupBy (which only pushes filters referencing grouping or
ConstAgg columns), this rule pushes filters that reference any column of
the DistinctOn's input, including first-agg columns.

This is valid because an unordered DistinctOn can return any row from each
group. Filtering before the DistinctOn constrains which rows are available
to be chosen, but since the choice is arbitrary, the result is equivalent
to choosing a row and filtering it afterward. The rule does not apply to
ordered DistinctOn, where the ordering determines which row is selected.

Informs #157840

Release note: None

#### opt: add decorrelation rule for Select under DistinctOn

Add the HoistSelectAboveUnorderedDistinctOn rule, which hoists correlated
filters from inside an unordered DistinctOn's input Select to above the
DistinctOn. This is the reverse of PushSelectIntoUnorderedDistinctOn and
is valid for the same reason: an unordered DistinctOn can choose any row
from each group, so filtering before or after produces equivalent results.

This aids decorrelation by moving correlated filters to a position where
TryDecorrelateSelect can handle them, avoiding the more expensive
TryDecorrelateGroupBy path that requires EnsureKey and additional ConstAgg
columns. Uncorrelated filters remain inside the DistinctOn for early
filtering.

The rule adds a CanHoistCorrelatedFiltersAbove helper that ensures every
correlated filter's local columns are present in the DistinctOn's output,
so the hoisted filter can reference them.

Informs #157840

Release note: None

#### opt: add logic tests for Select/DistinctOn filter rules

Add end-to-end logic tests covering PushSelectIntoUnorderedDistinctOn and
HoistSelectAboveUnorderedDistinctOn. The existing norm tests verify plan
shapes; these tests verify that the optimized plans produce correct results.

Release note: None
Epic: none

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>