### PR TITLE
roachtest: exclude FIPS from cgroup-limiting index-backfill variants

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -78,22 +78,28 @@ func versionedSnapshotPrefix(t test.Test) string {
 }
 
 func registerIndexBackfill(r registry.Registry) {
-	clusterSpec := r.MakeClusterSpec(
-		10, /* nodeCount */
-		spec.CPU(8),
-		spec.WorkloadNode(),
-		// The use of snapshots requires workload nodes to also have an attached disk.
-		// See: https://github.com/cockroachdb/cockroach/issues/156760
-		spec.WorkloadRequiresDisk(),
-		spec.WorkloadNodeCPU(8),
-		spec.VolumeSize(500),
-		spec.VolumeType("pd-ssd"),
-		spec.GCEMachineType("n2-standard-8"),
-		spec.GCEZones("us-east1-b"),
-		spec.ReuseNone(),
-	)
-
 	for _, v := range indexBackfillVariants {
+		clusterOpts := []spec.Option{
+			spec.CPU(8),
+			spec.WorkloadNode(),
+			// The use of snapshots requires workload nodes to also have an attached disk.
+			// See: https://github.com/cockroachdb/cockroach/issues/156760
+			spec.WorkloadRequiresDisk(),
+			spec.WorkloadNodeCPU(8),
+			spec.VolumeSize(500),
+			spec.VolumeType("pd-ssd"),
+			spec.GCEMachineType("n2-standard-8"),
+			spec.GCEZones("us-east1-b"),
+			spec.ReuseNone(),
+		}
+		if v.withCgroupLimiting {
+			// The cgroup disk staller relies on `lsblk -o NAME,MAJ:MIN,MOUNTPOINTS`,
+			// which requires util-linux >= 2.37 (Ubuntu 22.04+). FIPS images run
+			// Ubuntu 20.04, so exclude FIPS for cgroup-limiting variants. See #169098.
+			clusterOpts = append(clusterOpts, spec.Arch(spec.AllExceptFIPS))
+		}
+		clusterSpec := r.MakeClusterSpec(10 /* nodeCount */, clusterOpts...)
+
 		r.Add(registry.TestSpec{
 			Name:             "admission-control/index-backfill" + v.nameSuffix,
 			Timeout:          12 * time.Hour,


### PR DESCRIPTION
The `admission-control/index-backfill/provisioned-bandwidth=true` and
`/provisioned-bandwidth=false` variants use the cgroup disk staller,
which calls `lsblk -o NAME,MAJ:MIN,MOUNTPOINTS`. The `MOUNTPOINTS`
column requires util-linux >= 2.37 (Ubuntu 22.04+), but FIPS images
ship Ubuntu 20.04 with util-linux 2.34, causing the test to fail
with `unexpected output from lsblk`.

The companion fix in #153964 applied `spec.Arch(spec.AllExceptFIPS)`
to other cgroup-using tests but missed this one. Apply it here, scoped
to the two cgroup-using variants so that the `/no-disk-limit` variant
continues to run on FIPS.

Resolves: #169098
Epic: none

Release note: None