### PR TITLE
admission: make GetCTTWorkQueue mode-aware 

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -607,7 +607,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		storesForRACv2,
 		admissionKnobs,
 	)
-	db.SQLKVResponseAdmissionQ = gcoords.RegularCPU.GetSQLWorkQueue(admission.SQLKVResponseWork)
+	db.SQLKVResponseAdmissionQ = gcoords.RegularCPU.GetSQLResponseWorkQueue(admission.SQLKVResponseWork)
 	db.AdmissionPacerFactory = gcoords.ElasticCPU
 	sqlCPUProvider := admission.NewSQLCPUProvider(
 		&st.SV,
@@ -1257,7 +1257,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			externalStorage:          externalStorage,
 			externalStorageFromURI:   externalStorageFromURI,
 			isMeta1Leaseholder:       node.stores.IsMeta1Leaseholder,
-			sqlSQLResponseAdmissionQ: gcoords.RegularCPU.GetSQLWorkQueue(admission.SQLSQLResponseWork),
+			sqlSQLResponseAdmissionQ: gcoords.RegularCPU.GetSQLResponseWorkQueue(admission.SQLSQLResponseWork),
 			spanConfigKVAccessor:     spanConfig.kvAccessorForTenantRecords,
 			kvStoresIterator:         kvserver.MakeStoresIterator(node.stores),
 			inspectzServer:           inspectzServer,

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -132,58 +132,53 @@ type CPUGrantCoordinators struct {
 }
 
 // GetKVWorkQueue returns a WorkQueue to use for KVWork. If CPU time
-// token AC is enabled (via admission.cpu_time_tokens.mode or the legacy
-// enabled bool), it returns a WorkQueue that implements CPU time token
-// AC. Else it returns a WorkQueue that does slots-based AC.
+// token AC is enabled (via `admission.cpu_time_tokens.mode` or the
+// legacy enabled bool), it returns a CTT-mode WorkQueue. Else it
+// returns a slots-based WorkQueue.
 //
 // In serverless mode, there is one WorkQueue for system tenant work
 // and another for app tenant work. The system tenant WorkQueue is
 // backed by a granter that allows greater resource usage than the app
-// tenant WorkQueue. This is a prioritization scheme. In resource
-// manager mode, only queue[0] will be used (not yet implemented). For
-// details regarding the granters, see cpu_time_token_granter.go.
+// tenant WorkQueue. In resource manager mode, all work flows through
+// `queues[rmQueueTier]`. For details on the granters, see
+// `cpu_time_token_granter.go`.
 func (coord *CPUGrantCoordinators) GetKVWorkQueue(isSystemTenant bool) *WorkQueue {
 	if !cpuTimeTokenACIsEnabled(&coord.st.SV) {
 		return coord.slotsCoord.GetWorkQueue(KVWork)
 	}
 	mode := cpuTimeTokenMode(coord.cpuTimeCoord.filler.activeMode.Load())
-	switch mode {
-	case offMode:
-		// activeMode should never be offMode in normal operation: the
-		// constructor maps off to serverless, and resetInterval never
-		// returns offMode. This case is a defensive fallback.
+	if mode == offMode {
+		// `activeMode` should never be `offMode` in normal operation
+		// (the constructor maps off to serverless and `resetInterval`
+		// never returns offMode). Defensive fallback to slots.
 		return coord.slotsCoord.GetWorkQueue(KVWork)
-	case serverlessMode:
-		if isSystemTenant {
-			return coord.cpuTimeCoord.getWorkQueue(systemTenant)
-		}
-		return coord.cpuTimeCoord.getWorkQueue(appTenant)
-	case resourceManagerMode:
-		// RM mode uses a single WorkQueue for all work.
-		return coord.cpuTimeCoord.getWorkQueue(0)
-	default:
-		panic(fmt.Sprintf("unexpected mode %d", mode))
 	}
+	return coord.cpuTimeCoord.routeCTTByTenant(isSystemTenant, mode)
 }
 
 // GetCTTWorkQueue returns the CPU time token WorkQueue unconditionally,
-// without checking whether CPU time token AC is enabled. The caller is
-// responsible for gating on the setting. This avoids a race in GetKVWorkQueue
-// where the setting can flip between the caller's check and the internal
-// re-check, returning a slot-based queue to a caller that expects a CTT queue.
+// without checking whether CPU time token AC is enabled. Caller must
+// gate on the cluster setting; `activeMode` is read here so a mode flip
+// between the caller's gate and the routing is reflected.
+//
+// Panics if `activeMode == offMode`: the caller's gating contract
+// implies CTT is enabled, so reaching offMode here is a constructor or
+// `resetInterval` invariant violation, not a recoverable race.
 func (coord *CPUGrantCoordinators) GetCTTWorkQueue(isSystemTenant bool) *WorkQueue {
-	if isSystemTenant {
-		return coord.cpuTimeCoord.getWorkQueue(systemTenant)
+	mode := cpuTimeTokenMode(coord.cpuTimeCoord.filler.activeMode.Load())
+	if mode == offMode {
+		panic(errors.AssertionFailedf("GetCTTWorkQueue called with activeMode=offMode"))
 	}
-	return coord.cpuTimeCoord.getWorkQueue(appTenant)
+	return coord.cpuTimeCoord.routeCTTByTenant(isSystemTenant, mode)
 }
 
-// GetSQLWorkQueue returns a WorkQueue for SQLKVResponseWork or
-// SQLSQLResponseWork. If any other queue is requested from this function,
-// it panics.
-func (coord *CPUGrantCoordinators) GetSQLWorkQueue(workKind WorkKind) *WorkQueue {
+// GetSQLResponseWorkQueue returns a slots-based WorkQueue for the
+// response-side SQL admission paths (SQLKVResponseWork, SQLSQLResponseWork).
+// These are distinct from GetCTTWorkQueue, which handles SQL CPU
+// admission via CPU time tokens. Panics if workKind is anything else.
+func (coord *CPUGrantCoordinators) GetSQLResponseWorkQueue(workKind WorkKind) *WorkQueue {
 	if workKind != SQLKVResponseWork && workKind != SQLSQLResponseWork {
-		panic(fmt.Sprintf("workKind %q not supported by GetSQLWorkQueue", workKind))
+		panic(fmt.Sprintf("workKind %q not supported by GetSQLResponseWorkQueue", workKind))
 	}
 	return coord.slotsCoord.queues[workKind].(*WorkQueue)
 }
@@ -322,6 +317,26 @@ func makeCPUTimeTokenGrantCoordinator(
 	}
 
 	return coordinator
+}
+
+// routeCTTByTenant returns the CTT WorkQueue for the given tenant
+// kind under the given mode. Serverless mode splits queues by tenant;
+// RM mode collapses to queues[rmQueueTier]. Caller must have
+// established mode != offMode.
+func (coord *cpuTimeTokenGrantCoordinator) routeCTTByTenant(
+	isSystemTenant bool, mode cpuTimeTokenMode,
+) *WorkQueue {
+	switch mode {
+	case serverlessMode:
+		if isSystemTenant {
+			return coord.getWorkQueue(systemTenant)
+		}
+		return coord.getWorkQueue(appTenant)
+	case resourceManagerMode:
+		return coord.getWorkQueue(rmQueueTier)
+	default:
+		panic(errors.AssertionFailedf("routeCTTByTenant: unexpected mode %d", mode))
+	}
 }
 
 func (coord *cpuTimeTokenGrantCoordinator) getWorkQueue(tier resourceTier) *WorkQueue {

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -145,3 +145,94 @@ func TestCPUTimeTokenACEnableAndDisable(t *testing.T) {
 	require.Equal(t, usesCPUTimeTokens, cpuCoords.GetKVWorkQueue(true /* isSystemTenant */).mode)
 	require.NotEqual(t, cpuCoords.GetKVWorkQueue(false /* isSystemTenant */), cpuCoords.GetKVWorkQueue(true /* isSystemTenant */))
 }
+
+// TestGetCTTWorkQueueRoutesByMode pins the per-mode routing of
+// GetCTTWorkQueue: serverless splits by tenant; RM collapses both
+// tenants to queues[rmQueueTier]; offMode panics (caller must gate).
+// Without these invariants RM mode would silently send work through
+// tenant-keyed queues, defeating the single-queue invariant the
+// granter relies on.
+func TestGetCTTWorkQueueRoutesByMode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var ambientCtx log.AmbientContext
+	settings := cluster.MakeTestingClusterSettings()
+	registry := metric.NewRegistry()
+	var opts Options
+	knobs := &TestingKnobs{DisableCPUTimeTokenFillerGoroutine: true}
+	coords := NewGrantCoordinators(ambientCtx, settings, opts, registry, &noopOnLogEntryAdmitted{}, knobs)
+	defer coords.Close()
+	cpuCoords := coords.RegularCPU
+	setActiveMode := func(mode cpuTimeTokenMode) {
+		cpuCoords.cpuTimeCoord.filler.activeMode.Store(int64(mode))
+	}
+
+	sysQ := cpuCoords.cpuTimeCoord.queues[systemTenant].(*WorkQueue)
+	appQ := cpuCoords.cpuTimeCoord.queues[appTenant].(*WorkQueue)
+	rmQ := cpuCoords.cpuTimeCoord.queues[rmQueueTier].(*WorkQueue)
+
+	for _, tc := range []struct {
+		name             string
+		mode             cpuTimeTokenMode
+		wantSys, wantApp *WorkQueue
+	}{
+		{name: "serverless", mode: serverlessMode, wantSys: sysQ, wantApp: appQ},
+		{name: "resource_manager", mode: resourceManagerMode, wantSys: rmQ, wantApp: rmQ},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setActiveMode(tc.mode)
+			require.Same(t, tc.wantSys, cpuCoords.GetCTTWorkQueue(true /* isSystemTenant */))
+			require.Same(t, tc.wantApp, cpuCoords.GetCTTWorkQueue(false /* isSystemTenant */))
+		})
+	}
+
+	t.Run("off_panics", func(t *testing.T) {
+		setActiveMode(offMode)
+		require.Panics(t, func() {
+			cpuCoords.GetCTTWorkQueue(true /* isSystemTenant */)
+		}, "GetCTTWorkQueue with activeMode=offMode must panic; caller is responsible for gating")
+	})
+
+	// Mode transitions: flipping serverless -> RM -> serverless on the
+	// same coords must reflect on the very next GetCTTWorkQueue call.
+	// Routes the exact bug this fix addresses (stale activeMode).
+	t.Run("transitions", func(t *testing.T) {
+		setActiveMode(serverlessMode)
+		require.Same(t, sysQ, cpuCoords.GetCTTWorkQueue(true /* isSystemTenant */))
+		setActiveMode(resourceManagerMode)
+		require.Same(t, rmQ, cpuCoords.GetCTTWorkQueue(true /* isSystemTenant */))
+		setActiveMode(serverlessMode)
+		require.Same(t, sysQ, cpuCoords.GetCTTWorkQueue(true /* isSystemTenant */))
+	})
+}
+
+// TestGetSQLResponseWorkQueue pins the contract: the function returns
+// a slots-based WorkQueue for SQLKVResponseWork and SQLSQLResponseWork,
+// and panics on any other WorkKind. The panic is the only protection
+// against a caller misusing this for SQL CPU admission (which belongs
+// on GetCTTWorkQueue).
+func TestGetSQLResponseWorkQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var ambientCtx log.AmbientContext
+	settings := cluster.MakeTestingClusterSettings()
+	registry := metric.NewRegistry()
+	var opts Options
+	knobs := &TestingKnobs{DisableCPUTimeTokenFillerGoroutine: true}
+	coords := NewGrantCoordinators(ambientCtx, settings, opts, registry, &noopOnLogEntryAdmitted{}, knobs)
+	defer coords.Close()
+	cpuCoords := coords.RegularCPU
+
+	for _, kind := range []WorkKind{SQLKVResponseWork, SQLSQLResponseWork} {
+		q := cpuCoords.GetSQLResponseWorkQueue(kind)
+		require.NotNil(t, q)
+		require.Equal(t, usesTokens, q.mode,
+			"GetSQLResponseWorkQueue must return a slots/tokens-based queue")
+	}
+
+	require.Panics(t, func() {
+		cpuCoords.GetSQLResponseWorkQueue(KVWork)
+	}, "GetSQLResponseWorkQueue must panic for workKind=KVWork")
+}

--- a/pkg/util/admission/cpu_time_token_granter.go
+++ b/pkg/util/admission/cpu_time_token_granter.go
@@ -48,6 +48,10 @@ const (
 	numResourceTiers
 )
 
+// rmQueueTier is the tier that owns all work in Resource Manager mode.
+// RM collapses tiers into a single queue, so this is an alias of tier 0.
+const rmQueueTier = 0
+
 func (rt resourceTier) String() string {
 	return redact.StringWithoutMarkers(rt)
 }


### PR DESCRIPTION
Previously, `GetCTTWorkQueue` routed by tenant kind regardless of
the active CPU time token AC mode. That was wrong for Resource
Manager mode, because RM funnels all work through
`queues[rmQueueTier]`.

This commit fixes it by reading `activeMode` and dispatching through
a shared `routeCTTByTenant` helper that both `GetCTTWorkQueue` and
`GetKVWorkQueue` use: serverless splits by tenant.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>