### PR TITLE
kvserver: prioritize rangefeed catchup scans by admission priority

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -371,6 +371,7 @@ go_test(
         "replica_raft_test.go",
         "replica_raft_truncation_test.go",
         "replica_raftlog_test.go",
+        "replica_rangefeed_internal_test.go",
         "replica_rangefeed_lag_observer_test.go",
         "replica_rangefeed_test.go",
         "replica_rankings_test.go",

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -35,11 +35,7 @@ type Limiters struct {
 	BulkIOWriteRate                      *rate.Limiter
 	ConcurrentAddSSTableRequests         limit.ConcurrentRequestLimiter
 	ConcurrentAddSSTableAsWritesRequests limit.ConcurrentRequestLimiter
-	// ConcurrentRangefeedIters is a semaphore used to limit the number of
-	// rangefeeds in the "catch-up" state across the store. The "catch-up" state
-	// is a temporary state at the beginning of a rangefeed which is expensive
-	// because it uses an engine iterator.
-	ConcurrentRangefeedIters limit.ConcurrentRequestLimiter
+	ConcurrentRangefeedIters             limit.ConcurrentRequestLimiter
 	// BulkIOReadRate and ConcurrentBulkReadRequests work in concert to
 	// throttle low-priority bulk read operations like TTL (Reverse)Scan and
 	// Export.

--- a/pkg/kv/kvserver/multiqueue/BUILD.bazel
+++ b/pkg/kv/kvserver/multiqueue/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "multiqueue",
-    srcs = ["multi_queue.go"],
+    srcs = [
+        "multi_queue.go",
+        "weighted_multi_queue.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/multiqueue",
     visibility = ["//visibility:public"],
     deps = [
@@ -15,7 +18,10 @@ go_library(
 go_test(
     name = "multiqueue_test",
     size = "small",
-    srcs = ["multi_queue_test.go"],
+    srcs = [
+        "multi_queue_test.go",
+        "weighted_multi_queue_test.go",
+    ],
     embed = [":multiqueue"],
     deps = [
         "//pkg/testutils",

--- a/pkg/kv/kvserver/multiqueue/multi_queue.go
+++ b/pkg/kv/kvserver/multiqueue/multi_queue.go
@@ -13,69 +13,66 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// Task represents a request for a Permit for a piece of work that needs to be
-// done. It is created by a call to MultiQueue.Add. After creation,
-// Task.GetWaitChan is called to get a permit, and after all work related to
-// this task is done, MultiQueue.Release must be called so future tasks can run.
-// Alternatively, if the user decides they no longer want to run their work,
-// MultiQueue.Cancel can be called to release the permit without waiting for the
-// permit.
-type Task struct {
+// Task represents a queued request for a Permit. The caller waits on
+// GetWaitChan, then must Release (or Cancel before dispatch) on the issuing
+// queue. The type parameter P is the permit type issued by that queue
+// (Permit for MultiQueue, WeightedPermit for WeightedMultiQueue) and is
+// generally inferred at the call site.
+type Task[P any] struct {
 	priority  float64
 	queueType int
 	heapIdx   int
-	permitC   chan *Permit
+	permitC   chan *P
 }
 
 // GetWaitChan returns a permit channel which is used to wait for the permit to
 // become available.
-func (t *Task) GetWaitChan() <-chan *Permit {
+func (t *Task[P]) GetWaitChan() <-chan *P {
 	return t.permitC
 }
 
-func (t *Task) String() string {
+func (t *Task[P]) String() string {
 	return redact.Sprintf("{Queue type : %d, Priority :%f}", t.queueType, t.priority).StripMarkers()
 }
 
 // notifyHeap is a standard go heap over tasks.
-type notifyHeap []*Task
+type notifyHeap[P any] []*Task[P]
 
-func (h notifyHeap) Len() int {
+func (h notifyHeap[P]) Len() int {
 	return len(h)
 }
 
-func (h notifyHeap) Less(i, j int) bool {
+func (h notifyHeap[P]) Less(i, j int) bool {
 	return h[j].priority < h[i].priority
 }
 
-func (h notifyHeap) Swap(i, j int) {
+func (h notifyHeap[P]) Swap(i, j int) {
 	h[i], h[j] = h[j], h[i]
 	h[i].heapIdx = i
 	h[j].heapIdx = j
 }
 
-func (h *notifyHeap) Push(x interface{}) {
-	t := x.(*Task)
-	// Set the index to the end, it will be moved later
+func (h *notifyHeap[P]) Push(x any) {
+	t := x.(*Task[P])
+	// Set the index to the end, it will be moved later.
 	t.heapIdx = h.Len()
 	*h = append(*h, t)
 }
 
-func (h *notifyHeap) Pop() interface{} {
+func (h *notifyHeap[P]) Pop() any {
 	old := *h
 	n := len(old)
 	x := old[n-1]
 	old[n-1] = nil
 	*h = old[0 : n-1]
-	// No longer in the heap so clear the index
+	// No longer in the heap so clear the index.
 	x.heapIdx = -1
-
 	return x
 }
 
-// tryRemove attempts to remove the task from this queue by iterating through
-// the queue. Will returns true if the task was successfully removed.
-func (h *notifyHeap) tryRemove(task *Task) bool {
+// tryRemove attempts to remove the task from this queue. Returns true if the
+// task was successfully removed.
+func (h *notifyHeap[P]) tryRemove(task *Task[P]) bool {
 	if task.heapIdx < 0 {
 		return false
 	}
@@ -83,12 +80,28 @@ func (h *notifyHeap) tryRemove(task *Task) bool {
 	return true
 }
 
+// tryDrainPermit handles the Cancel/dispatch race: if the dispatcher already
+// delivered a permit, drain and return it (caller must release). Returns nil
+// if no permit was waiting. Closes the task's channel if a permit was drained.
+func tryDrainPermit[P any](task *Task[P]) *P {
+	select {
+	case p, ok := <-task.permitC:
+		if ok {
+			close(task.permitC)
+			return p
+		}
+	default:
+		// The permit has already been received by the caller, who must release it.
+	}
+	return nil
+}
+
 // MultiQueue is a type that round-robins through a set of typed queues, each
 // independently prioritized. A MultiQueue is constructed with a concurrencySem
 // which is the number of concurrent jobs this queue will allow to run. Tasks
 // are added to the queue using MultiQueue.Add. That will return a channel that
-// should be received from. It will be notified when the waiting job is ready to
-// be run. Once the job is completed, MultiQueue.TaskDone must be called to
+// should be received from. It will be notified when the waiting job is ready
+// to be run. Once the job is completed, MultiQueue.Release must be called to
 // return the Permit to the queue so that the next Task can be started.
 type MultiQueue struct {
 	mu               syncutil.Mutex
@@ -96,7 +109,7 @@ type MultiQueue struct {
 	remainingRuns    int
 	mapping          map[int]int
 	lastQueueIndex   int
-	outstanding      []notifyHeap
+	outstanding      []notifyHeap[Permit]
 }
 
 // NewMultiQueue creates a new queue. The queue is not started, and start needs
@@ -112,7 +125,7 @@ func NewMultiQueue(maxConcurrency int) *MultiQueue {
 	return &queue
 }
 
-// Permit is a token which is returned from a Task.GetWaitChan call.
+// Permit is a token returned from a MultiQueue Task.GetWaitChan call.
 type Permit struct {
 	valid bool
 }
@@ -131,7 +144,7 @@ func (m *MultiQueue) tryRunNextLocked() {
 		// If all queues are empty then return, as there is nothing to run.
 		index := (m.lastQueueIndex + i + 1) % len(m.outstanding)
 		if m.outstanding[index].Len() > 0 {
-			task := heap.Pop(&m.outstanding[index]).(*Task)
+			task := heap.Pop(&m.outstanding[index]).(*Task[Permit])
 			task.permitC <- &Permit{valid: true}
 			m.remainingRuns--
 			m.lastQueueIndex = index
@@ -160,7 +173,9 @@ func (m *MultiQueue) updateConcurrencyLimitLocked(newLimit int) {
 // Add returns a Task that must be closed (calling m.Release(..)) to
 // release the Permit. The number of types is expected to
 // be relatively small and not be changing over time.
-func (m *MultiQueue) Add(queueType int, priority float64, maxQueueLength int64) (*Task, error) {
+func (m *MultiQueue) Add(
+	queueType int, priority float64, maxQueueLength int64,
+) (*Task[Permit], error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -181,9 +196,9 @@ func (m *MultiQueue) Add(queueType int, priority float64, maxQueueLength int64) 
 		// a new queue type.
 		pos = len(m.outstanding)
 		m.mapping[queueType] = pos
-		m.outstanding = append(m.outstanding, notifyHeap{})
+		m.outstanding = append(m.outstanding, notifyHeap[Permit]{})
 	}
-	newTask := Task{
+	newTask := Task[Permit]{
 		priority:  priority,
 		permitC:   make(chan *Permit, 1),
 		heapIdx:   -1,
@@ -197,34 +212,22 @@ func (m *MultiQueue) Add(queueType int, priority float64, maxQueueLength int64) 
 	return &newTask, nil
 }
 
-// Cancel will cancel a Task that may not have started yet. This is useful if it
-// is determined that it is no longer required to run this Task.
-func (m *MultiQueue) Cancel(task *Task) {
+// Cancel will cancel a Task that may not have started yet. This is useful if
+// it is determined that it is no longer required to run this Task.
+func (m *MultiQueue) Cancel(task *Task[Permit]) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	// Find the right queue and try to remove it. Queues monotonically grow, and a
-	// Task will track its position within the queue.
+	// Find the right queue and try to remove it. Queues monotonically grow, and
+	// a Task tracks its position within the queue.
 	queueIdx := m.mapping[task.queueType]
-	ok := m.outstanding[queueIdx].tryRemove(task)
-	// Close the permit channel so that waiters stop blocking.
-	if ok {
+	if m.outstanding[queueIdx].tryRemove(task) {
 		close(task.permitC)
 		return
 	}
-	// If we get here, we are racing with the task being started. The concern is
-	// that the caller may also call MultiQueue.Release since the task was
-	// started. Either we get the permit or the caller, so we guarantee only one
-	// release will be called.
-	select {
-	case p, ok := <-task.permitC:
-		// Only release if the channel is open, and we can get the permit.
-		if ok {
-			close(task.permitC)
-			m.releaseLocked(p)
-		}
-	default:
-		// If we are not able to get the permit, this means the permit has already
-		// been given to the caller, and they must call Release on it.
+	// Race with the dispatcher: drain a delivered permit if one is waiting and
+	// release it on the caller's behalf.
+	if p := tryDrainPermit(task); p != nil {
+		m.releaseLocked(p)
 	}
 }
 

--- a/pkg/kv/kvserver/multiqueue/multi_queue_test.go
+++ b/pkg/kv/kvserver/multiqueue/multi_queue_test.go
@@ -146,7 +146,7 @@ func TestMultiQueueCancelInProgress(t *testing.T) {
 
 	started := 0
 	completed := 0
-	startTask := func(task *Task) (*Permit, bool) {
+	startTask := func(task *Task[Permit]) (*Permit, bool) {
 		select {
 		case permit, ok := <-task.GetWaitChan():
 			if ok {
@@ -161,7 +161,7 @@ func TestMultiQueueCancelInProgress(t *testing.T) {
 		return nil, false
 	}
 
-	completeTask := func(task *Task, permit *Permit) {
+	completeTask := func(task *Task[Permit], permit *Permit) {
 		releaseStarted := make(chan struct{})
 		releaseFinished := make(chan struct{})
 		go func() {
@@ -360,7 +360,7 @@ func TestMultiQueueFull(t *testing.T) {
 }
 
 // verifyOrder makes sure that the chans are called in the specified order.
-func verifyOrder(t *testing.T, queue *MultiQueue, tasks ...*Task) {
+func verifyOrder(t *testing.T, queue *MultiQueue, tasks ...*Task[Permit]) {
 	// each time, verify that the only available channel is the "next" one in order
 	for i, task := range tasks {
 		if task == nil {

--- a/pkg/kv/kvserver/multiqueue/weighted_multi_queue.go
+++ b/pkg/kv/kvserver/multiqueue/weighted_multi_queue.go
@@ -1,0 +1,355 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package multiqueue
+
+import (
+	"container/heap"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+// WeightedPermit is the opaque token returned by WeightedMultiQueue
+// dispatches. Each permit must be passed to exactly one Release call on the
+// issuing queue (or returned via Cancel before the caller receives it).
+type WeightedPermit struct {
+	// typeIndex is the queue's internal index for the issuing type, used by
+	// Release to update per-type accounting without a map lookup.
+	typeIndex int8
+	valid     bool
+}
+
+// WeightedMultiQueue is a fixed-configuration variant of MultiQueue that
+// dispatches across a known set of queue types using a weighted round-robin
+// cycle, with optional per-type concurrency caps. All queue types must be
+// declared at construction; the dispatch cycle is precomputed.
+//
+// Each queue type t is assigned Weight consecutive positions in a cycle of
+// length sum(Weight). The dispatcher walks the cycle from cyclePosition and
+// grants the next free slot to the first eligible type it finds — eligible
+// meaning non-empty and below its MaxActive cap. Empty or capped types yield
+// their slots, so e.g. an empty high-pri queue lets low-pri receive every
+// dispatch (subject to its cap), and a low-pri queue at its cap lets every
+// freed slot go to high-pri. Within a type, tasks are heap-ordered by
+// priority.
+//
+// MaxActive caps and the total concurrency limit may be updated at runtime
+// via UpdateConfig; weights and the set of types are immutable after
+// construction.
+type WeightedMultiQueue struct {
+	// typeIndex maps a user-facing QueueType to its internal index in the
+	// per-type slices below. Immutable after construction.
+	typeIndex map[int]int
+
+	// weights is the per-type dispatch weight, indexed by internal type index.
+	// Immutable after construction.
+	weights []int
+
+	// cycle is the precomputed dispatch order. cycle[k] is the internal type
+	// index whose turn it is at cycle position k. len(cycle) == sum(weights).
+	//
+	// The cycle is built as contiguous per-type blocks (weights [8,1] yield
+	// [H,H,H,H,H,H,H,H,L]).
+	cycle []int
+
+	mu struct {
+		syncutil.Mutex
+
+		concurrencyLimit int
+		remainingRuns    int
+
+		// maxActive caps concurrent permits per type; 0 means uncapped. Indexed
+		// by internal type index. Mutable via UpdateConfig.
+		maxActive []int
+
+		// activeByType counts permits currently held per type.
+		activeByType []int
+
+		// waiters is the per-type heap of queued tasks.
+		waiters []notifyHeap[WeightedPermit]
+
+		cyclePosition int
+	}
+}
+
+// TypeConfig configures one queue type within a WeightedMultiQueue.
+type TypeConfig struct {
+	// QueueType is the user-facing identifier passed to Add/Cancel.
+	QueueType int
+	// Weight is the dispatch weight (must be positive). Higher weights
+	// receive proportionally more dispatches under contention.
+	Weight int
+	// MaxActive caps concurrent permits held by this type; 0 is uncapped.
+	MaxActive int
+}
+
+// NewWeightedMultiQueue constructs a queue with the given total concurrency
+// and per-type configs. Slice order determines cycle order. QueueType
+// identifiers must be unique. Panics if len(types) > math.MaxInt8 (127),
+// since WeightedPermit stores the type index in an int8.
+func NewWeightedMultiQueue(maxConcurrency int, types []TypeConfig) *WeightedMultiQueue {
+	if len(types) == 0 {
+		panic(errors.AssertionFailedf("WeightedMultiQueue requires at least one TypeConfig"))
+	}
+	if len(types) > math.MaxInt8 {
+		panic(errors.AssertionFailedf(
+			"WeightedMultiQueue supports at most %d types, got %d", math.MaxInt8, len(types)))
+	}
+	q := &WeightedMultiQueue{
+		typeIndex: make(map[int]int, len(types)),
+		weights:   make([]int, len(types)),
+	}
+	q.mu.concurrencyLimit = maxConcurrency
+	q.mu.remainingRuns = maxConcurrency
+	q.mu.maxActive = make([]int, len(types))
+	q.mu.activeByType = make([]int, len(types))
+	q.mu.waiters = make([]notifyHeap[WeightedPermit], len(types))
+	totalWeight := 0
+	for i, tc := range types {
+		if tc.Weight <= 0 {
+			panic(errors.AssertionFailedf(
+				"queue type %d weight must be positive, got %d", tc.QueueType, tc.Weight))
+		}
+		if tc.MaxActive < 0 {
+			panic(errors.AssertionFailedf(
+				"queue type %d MaxActive must be non-negative, got %d", tc.QueueType, tc.MaxActive))
+		}
+		if _, dup := q.typeIndex[tc.QueueType]; dup {
+			panic(errors.AssertionFailedf("duplicate queue type %d", tc.QueueType))
+		}
+		q.typeIndex[tc.QueueType] = i
+		q.weights[i] = tc.Weight
+		q.mu.maxActive[i] = tc.MaxActive
+		totalWeight += tc.Weight
+	}
+	q.cycle = make([]int, 0, totalWeight)
+	for i, w := range q.weights {
+		for j := 0; j < w; j++ {
+			q.cycle = append(q.cycle, i)
+		}
+	}
+	return q
+}
+
+// Add submits a task at the given queueType and priority. Returns an error
+// for an unknown queueType, or if the pool is saturated and adding would
+// exceed maxQueueLength (when non-negative). The caller must Release the
+// returned task's permit (or Cancel before dispatch).
+func (q *WeightedMultiQueue) Add(
+	queueType int, priority float64, maxQueueLength int64,
+) (*Task[WeightedPermit], error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	idx, ok := q.typeIndex[queueType]
+	if !ok {
+		return nil, errors.AssertionFailedf("unknown queue type %d", queueType)
+	}
+
+	// Reject before queueing if the pool is saturated and a length cap was
+	// requested. Mirrors MultiQueue.Add.
+	if q.mu.remainingRuns == 0 && maxQueueLength >= 0 {
+		if int64(q.queueLenLocked()) > maxQueueLength {
+			return nil, errors.Newf("queue full: %d queued, max %d",
+				q.queueLenLocked(), maxQueueLength)
+		}
+	}
+
+	task := &Task[WeightedPermit]{
+		priority:  priority,
+		permitC:   make(chan *WeightedPermit, 1),
+		heapIdx:   -1,
+		queueType: queueType,
+	}
+	heap.Push(&q.mu.waiters[idx], task)
+	q.tryRunNextLocked()
+	return task, nil
+}
+
+// Cancel removes a task from its queue. If the dispatcher has already
+// delivered a permit, Cancel races the caller's receive: whichever wins
+// releases the permit. A no-op if the caller has already received it.
+func (q *WeightedMultiQueue) Cancel(task *Task[WeightedPermit]) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	idx, ok := q.typeIndex[task.queueType]
+	if !ok {
+		panic(errors.AssertionFailedf("unknown queue type %d", task.queueType))
+	}
+	// Tasks removed from the heap before dispatch never incremented
+	// activeByType, so only the drain path needs releaseLocked.
+	if q.mu.waiters[idx].tryRemove(task) {
+		close(task.permitC)
+		return
+	}
+	if p := tryDrainPermit(task); p != nil {
+		q.releaseLocked(p)
+	}
+}
+
+// Release returns a permit to the queue. Panics on double release.
+func (q *WeightedMultiQueue) Release(p *WeightedPermit) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.releaseLocked(p)
+}
+
+func (q *WeightedMultiQueue) releaseLocked(p *WeightedPermit) {
+	if !p.valid {
+		panic(errors.AssertionFailedf("double release of permit"))
+	}
+	p.valid = false
+	q.mu.activeByType[p.typeIndex]--
+	// After UpdateConfig lowers concurrencyLimit while permits are held, we
+	// can be over-active (totalActive > concurrencyLimit, remainingRuns = 0).
+	// In that state a release shrinks the over-allocation rather than freeing
+	// a slot; remainingRuns stays at 0 until activity drops below the new
+	// limit. Once we cross back below, normal accounting resumes.
+	if q.totalActiveLocked() < q.mu.concurrencyLimit {
+		q.mu.remainingRuns++
+	}
+	q.tryRunNextLocked()
+}
+
+// totalActiveLocked returns the count of currently-held permits across all
+// types.
+func (q *WeightedMultiQueue) totalActiveLocked() int {
+	sum := 0
+	for _, a := range q.mu.activeByType {
+		sum += a
+	}
+	return sum
+}
+
+// ConfigOption configures a WeightedMultiQueue update applied via
+// UpdateConfig. All options in a single UpdateConfig call take effect under
+// the same lock acquisition, so observers cannot see an interim state.
+type ConfigOption interface {
+	apply(*configOptions)
+}
+
+type configOptions struct {
+	concurrencyLimit *int
+	maxActiveByType  map[int]int
+}
+
+type configOptionFunc func(*configOptions)
+
+func (f configOptionFunc) apply(o *configOptions) { f(o) }
+
+// WithConcurrencyLimit sets the total concurrency cap. Already-active tasks
+// are unaffected; queued tasks may dispatch immediately on a relax.
+func WithConcurrencyLimit(n int) ConfigOption {
+	return configOptionFunc(func(o *configOptions) {
+		o.concurrencyLimit = &n
+	})
+}
+
+// WithTypeMaxActive sets the per-type cap. Pass 0 to remove. Panics on
+// unknown queueType or negative maxActive when applied.
+func WithTypeMaxActive(queueType, maxActive int) ConfigOption {
+	return configOptionFunc(func(o *configOptions) {
+		if o.maxActiveByType == nil {
+			o.maxActiveByType = make(map[int]int)
+		}
+		o.maxActiveByType[queueType] = maxActive
+	})
+}
+
+// UpdateConfig applies one or more configuration changes atomically with
+// respect to dispatch. After the changes are applied it drains any waiters
+// newly made eligible (a raise to concurrency or a per-type cap can wake
+// many waiters at once).
+func (q *WeightedMultiQueue) UpdateConfig(opts ...ConfigOption) {
+	var o configOptions
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if o.concurrencyLimit != nil {
+		diff := *o.concurrencyLimit - q.mu.concurrencyLimit
+		q.mu.remainingRuns = max(q.mu.remainingRuns+diff, 0)
+		q.mu.concurrencyLimit = *o.concurrencyLimit
+	}
+	for queueType, maxActive := range o.maxActiveByType {
+		if maxActive < 0 {
+			panic(errors.AssertionFailedf("maxActive must be non-negative, got %d", maxActive))
+		}
+		idx, ok := q.typeIndex[queueType]
+		if !ok {
+			panic(errors.AssertionFailedf("unknown queue type %d", queueType))
+		}
+		q.mu.maxActive[idx] = maxActive
+	}
+	q.dispatchAllLocked()
+}
+
+// AvailableLen returns the number of tasks that can be added without
+// queueing. 0 if any tasks are queued.
+func (q *WeightedMultiQueue) AvailableLen() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.mu.remainingRuns
+}
+
+// QueueLen returns the length of the queue if one more task were added.
+func (q *WeightedMultiQueue) QueueLen() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queueLenLocked()
+}
+
+func (q *WeightedMultiQueue) queueLenLocked() int {
+	if q.mu.remainingRuns > 0 {
+		return 0
+	}
+	count := 1
+	for _, h := range q.mu.waiters {
+		count += len(h)
+	}
+	return count
+}
+
+// tryRunNextLocked dispatches at most one task, walking the precomputed
+// cycle from cyclePosition for up to one full cycle.
+func (q *WeightedMultiQueue) tryRunNextLocked() {
+	if q.mu.remainingRuns <= 0 {
+		return
+	}
+	n := len(q.cycle)
+	for tries := 0; tries < n; tries++ {
+		pos := (q.mu.cyclePosition + tries) % n
+		idx := q.cycle[pos]
+		if q.mu.waiters[idx].Len() == 0 {
+			continue
+		}
+		if q.mu.maxActive[idx] > 0 && q.mu.activeByType[idx] >= q.mu.maxActive[idx] {
+			continue
+		}
+		task := heap.Pop(&q.mu.waiters[idx]).(*Task[WeightedPermit])
+		q.mu.activeByType[idx]++
+		task.permitC <- &WeightedPermit{valid: true, typeIndex: int8(idx)}
+		q.mu.remainingRuns--
+		q.mu.cyclePosition = (pos + 1) % n
+		return
+	}
+}
+
+// dispatchAllLocked drains as many waiters as the current limits allow.
+// Add and Release dispatch at most one task per call, which is sufficient
+// when capacity grew by one slot. UpdateConfig can grow capacity by many
+// slots at once and must wake every newly-eligible waiter.
+func (q *WeightedMultiQueue) dispatchAllLocked() {
+	for {
+		before := q.mu.remainingRuns
+		q.tryRunNextLocked()
+		if q.mu.remainingRuns == before {
+			return
+		}
+	}
+}

--- a/pkg/kv/kvserver/multiqueue/weighted_multi_queue_test.go
+++ b/pkg/kv/kvserver/multiqueue/weighted_multi_queue_test.go
@@ -1,0 +1,443 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package multiqueue
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// Queue type constants used by the WeightedMultiQueue tests. Their integer
+// values do not affect dispatch order — only the order of TypeConfig entries
+// passed to NewWeightedMultiQueue does.
+const (
+	wHigh    = 100
+	wLow     = 200
+	wBlocker = 300
+)
+
+// verifyWMQOrder asserts that the given queue dispatches tasks in the
+// specified order, releasing each permit before checking for the next.
+func verifyWMQOrder(t *testing.T, queue *WeightedMultiQueue, tasks ...*Task[WeightedPermit]) {
+	t.Helper()
+	for i, task := range tasks {
+		// No later task should be ready yet.
+		for j, t2 := range tasks[i+1:] {
+			select {
+			case <-t2.GetWaitChan():
+				require.Failf(t, "task ready out of order",
+					"iter %d, future task index %d", i, i+1+j)
+			default:
+			}
+		}
+		select {
+		case p := <-task.GetWaitChan():
+			queue.Release(p)
+		default:
+			require.Failf(t, "expected task ready", "iter %d", i)
+		}
+	}
+}
+
+// TestWeightedMultiQueueWeightedRRRatio verifies that with both queue types
+// backlogged, the dispatcher follows the configured weight ratio.
+func TestWeightedMultiQueueWeightedRRRatio(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 8},
+		{QueueType: wLow, Weight: 1},
+		{QueueType: wBlocker, Weight: 1},
+	})
+	// Hold the single concurrency slot so all subsequent Adds queue.
+	blocker, err := queue.Add(wBlocker, 0, -1)
+	require.NoError(t, err)
+
+	const cycles = 3
+	const highPerCycle = 8
+	highTasks := make([]*Task[WeightedPermit], cycles*highPerCycle)
+	for i := range highTasks {
+		// Distinct, descending priorities → heap pops in insertion order.
+		highTasks[i], err = queue.Add(wHigh, float64(len(highTasks)-i), -1)
+		require.NoError(t, err)
+	}
+	lowTasks := make([]*Task[WeightedPermit], cycles)
+	for i := range lowTasks {
+		lowTasks[i], err = queue.Add(wLow, float64(len(lowTasks)-i), -1)
+		require.NoError(t, err)
+	}
+	queue.Release(<-blocker.GetWaitChan())
+
+	// blocker dispatches from cycle position 9 (it's the third declared type
+	// with weight 1, so it owns the last slot of the 10-position cycle).
+	// After dispatching, cyclePosition advances to (9+1) % 10 = 0, so high-pri
+	// (positions 0..7) drains first, then low-pri (position 8), then
+	// blocker's empty slot is skipped, then the cycle wraps. Pattern: 8H, 1L,
+	// 8H, 1L, ...
+	want := make([]*Task[WeightedPermit], 0, len(highTasks)+len(lowTasks))
+	for c := 0; c < cycles; c++ {
+		for j := 0; j < highPerCycle; j++ {
+			want = append(want, highTasks[c*highPerCycle+j])
+		}
+		want = append(want, lowTasks[c])
+	}
+	verifyWMQOrder(t, queue, want...)
+}
+
+// TestWeightedMultiQueueEmptyHighDrainsLow verifies that when the high queue
+// is empty, every dispatch goes to low (subject to its cap, if any).
+func TestWeightedMultiQueueEmptyHighDrainsLow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 8},
+		{QueueType: wLow, Weight: 1},
+		{QueueType: wBlocker, Weight: 1},
+	})
+	blocker, err := queue.Add(wBlocker, 0, -1)
+	require.NoError(t, err)
+
+	l1, _ := queue.Add(wLow, 3, -1)
+	l2, _ := queue.Add(wLow, 2, -1)
+	l3, _ := queue.Add(wLow, 1, -1)
+
+	queue.Release(<-blocker.GetWaitChan())
+	verifyWMQOrder(t, queue, l1, l2, l3)
+}
+
+// TestWeightedMultiQueueLowCapEnforced verifies that the per-type cap on the
+// low-pri queue prevents dispatch beyond the cap, even with free pool slots.
+func TestWeightedMultiQueueLowCapEnforced(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(4, []TypeConfig{
+		{QueueType: wHigh, Weight: 8},
+		{QueueType: wLow, Weight: 1, MaxActive: 2},
+	})
+
+	// Fill the low-pri cap.
+	low1, _ := queue.Add(wLow, 0, -1)
+	low2, _ := queue.Add(wLow, 0, -1)
+	p1 := <-low1.GetWaitChan()
+	p2 := <-low2.GetWaitChan()
+
+	// A third low-pri task must not be dispatched even though there are 2
+	// free pool slots.
+	low3, _ := queue.Add(wLow, 0, -1)
+	select {
+	case <-low3.GetWaitChan():
+		t.Fatal("low3 should not be dispatched while low cap is reached")
+	default:
+	}
+
+	// A high-pri task should receive a permit immediately from the free pool.
+	high1, _ := queue.Add(wHigh, 0, -1)
+	select {
+	case p := <-high1.GetWaitChan():
+		queue.Release(p)
+	default:
+		t.Fatal("high1 should be dispatched immediately")
+	}
+
+	// Releasing one of the low-pri tasks should free up a low-pri slot and
+	// allow low3 to start.
+	queue.Release(p1)
+	select {
+	case p := <-low3.GetWaitChan():
+		queue.Release(p)
+	default:
+		t.Fatal("low3 should be dispatched after a low-pri permit is released")
+	}
+	queue.Release(p2)
+}
+
+// TestWeightedMultiQueueLowCapHighDrainsAll verifies that when low is at cap
+// and high has waiters, freed slots flow to high regardless of cycle position.
+func TestWeightedMultiQueueLowCapHighDrainsAll(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(3, []TypeConfig{
+		{QueueType: wHigh, Weight: 8},
+		{QueueType: wLow, Weight: 1, MaxActive: 1},
+	})
+	// Saturate the low-pri cap.
+	low1, _ := queue.Add(wLow, 0, -1)
+	pLow1 := <-low1.GetWaitChan()
+
+	// Add a backlog of low-pri and high-pri waiters.
+	low2, _ := queue.Add(wLow, 0, -1)
+	low3, _ := queue.Add(wLow, 0, -1)
+	high1, _ := queue.Add(wHigh, 0, -1)
+	high2, _ := queue.Add(wHigh, 0, -1)
+
+	// Free the low-pri slot; high1 dispatches (low at cap → skipped; cycle
+	// favors high anyway).
+	queue.Release(pLow1)
+	pHigh1 := <-high1.GetWaitChan()
+
+	// Free another slot; high2.
+	queue.Release(pHigh1)
+	pHigh2 := <-high2.GetWaitChan()
+
+	// Free another slot; high backlog drained → low2 dispatches.
+	queue.Release(pHigh2)
+	pLow2 := <-low2.GetWaitChan()
+
+	// low3 must wait until pLow2 is released because of the cap.
+	select {
+	case <-low3.GetWaitChan():
+		t.Fatal("low3 should not be dispatched while low cap is reached")
+	default:
+	}
+	queue.Release(pLow2)
+	pLow3 := <-low3.GetWaitChan()
+	queue.Release(pLow3)
+}
+
+// TestWeightedMultiQueueUpdateConfigTypeMaxActive verifies that runtime cap
+// changes take effect immediately for new dispatches, and that relaxing the
+// cap wakes every waiter newly made eligible (not just one).
+func TestWeightedMultiQueueUpdateConfigTypeMaxActive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(4, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+		{QueueType: wLow, Weight: 1, MaxActive: 1},
+	})
+
+	low1, _ := queue.Add(wLow, 0, -1)
+	pLow1 := <-low1.GetWaitChan()
+
+	// low2 and low3 both block on the cap.
+	low2, _ := queue.Add(wLow, 0, -1)
+	low3, _ := queue.Add(wLow, 0, -1)
+	for i, t2 := range []*Task[WeightedPermit]{low2, low3} {
+		select {
+		case <-t2.GetWaitChan():
+			t.Fatalf("low%d should not be dispatched while low cap is reached", i+2)
+		default:
+		}
+	}
+
+	// Relax the cap to 3. Both low2 and low3 should now dispatch without any
+	// release — UpdateConfig must drain all newly-eligible waiters.
+	queue.UpdateConfig(WithTypeMaxActive(wLow, 3))
+	p2 := <-low2.GetWaitChan()
+	p3 := <-low3.GetWaitChan()
+	queue.Release(p2)
+	queue.Release(p3)
+	queue.Release(pLow1)
+}
+
+// TestWeightedMultiQueueUpdateConfigConcurrencyLimit verifies raise (wakes
+// multiple waiters) and lower (already-active unaffected, new dispatches
+// respect the new cap).
+func TestWeightedMultiQueueUpdateConfigConcurrencyLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+	})
+
+	// Saturate the single slot, then queue two waiters.
+	t1, _ := queue.Add(wHigh, 0, -1)
+	p1 := <-t1.GetWaitChan()
+	t2, _ := queue.Add(wHigh, 0, -1)
+	t3, _ := queue.Add(wHigh, 0, -1)
+	for i, task := range []*Task[WeightedPermit]{t2, t3} {
+		select {
+		case <-task.GetWaitChan():
+			t.Fatalf("task t%d should not be dispatched at concurrency=1", i+2)
+		default:
+		}
+	}
+
+	// Raise to 3: both t2 and t3 should wake on the same call.
+	queue.UpdateConfig(WithConcurrencyLimit(3))
+	p2 := <-t2.GetWaitChan()
+	p3 := <-t3.GetWaitChan()
+
+	// Lower back to 1. Already-held permits are not revoked; remainingRuns
+	// goes negative-then-clamped via the diff.
+	queue.UpdateConfig(WithConcurrencyLimit(1))
+
+	// A new task must wait until enough permits release to bring activity
+	// below the new limit.
+	t4, _ := queue.Add(wHigh, 0, -1)
+	select {
+	case <-t4.GetWaitChan():
+		t.Fatal("t4 should not be dispatched while 3 permits are still held under limit=1")
+	default:
+	}
+	queue.Release(p1)
+	queue.Release(p2)
+	select {
+	case <-t4.GetWaitChan():
+		t.Fatal("t4 should not be dispatched until activity drops below the new limit")
+	default:
+	}
+	queue.Release(p3)
+	p4 := <-t4.GetWaitChan()
+	queue.Release(p4)
+}
+
+// TestWeightedMultiQueueDoubleRelease verifies that releasing the same
+// permit twice panics with an assertion-failed error.
+func TestWeightedMultiQueueDoubleRelease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+	})
+	task, _ := queue.Add(wHigh, 0, -1)
+	p := <-task.GetWaitChan()
+	queue.Release(p)
+	require.Panics(t, func() { queue.Release(p) })
+}
+
+// TestWeightedMultiQueueCancelDispatchRace exercises the tryDrainPermit
+// branch in Cancel: the dispatcher delivered a permit before the caller
+// received it, and Cancel arrives in the same window. The drained permit
+// must be returned to the pool so that a queued waiter can dispatch.
+func TestWeightedMultiQueueCancelDispatchRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+	})
+
+	// Hold the only slot.
+	hold, _ := queue.Add(wHigh, 0, -1)
+	pHold := <-hold.GetWaitChan()
+
+	// Queue two waiters. Releasing the held slot will dispatch the first.
+	t1, _ := queue.Add(wHigh, 0, -1)
+	t2, _ := queue.Add(wHigh, 0, -1)
+	queue.Release(pHold)
+
+	// t1's permit is now sitting in the channel. Cancel without receiving:
+	// Cancel must drain the permit and release it so t2 can dispatch.
+	queue.Cancel(t1)
+
+	select {
+	case p := <-t2.GetWaitChan():
+		queue.Release(p)
+	default:
+		t.Fatal("t2 should dispatch after Cancel released t1's drained permit")
+	}
+}
+
+// TestWeightedMultiQueueMaxQueueLength verifies that Add rejects when the
+// pool is saturated and the queue length cap would be exceeded.
+func TestWeightedMultiQueueMaxQueueLength(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+	})
+
+	// Saturate the pool.
+	hold, err := queue.Add(wHigh, 0, -1)
+	require.NoError(t, err)
+	pHold := <-hold.GetWaitChan()
+	defer queue.Release(pHold)
+
+	// First queued task fits under maxQueueLength=1 (queueLenLocked returns
+	// 1 — "if one more is added").
+	_, err = queue.Add(wHigh, 0, 1)
+	require.NoError(t, err)
+
+	// Second queued task pushes queue length to 2, exceeding the cap.
+	_, err = queue.Add(wHigh, 0, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "queue full")
+}
+
+// TestWeightedMultiQueueAvailableLenQueueLen exercises the public
+// AvailableLen and QueueLen accessors across saturation transitions.
+func TestWeightedMultiQueueAvailableLenQueueLen(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(2, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+	})
+
+	require.Equal(t, 2, queue.AvailableLen())
+	require.Equal(t, 0, queue.QueueLen())
+
+	// Take one slot.
+	t1, _ := queue.Add(wHigh, 0, -1)
+	p1 := <-t1.GetWaitChan()
+	require.Equal(t, 1, queue.AvailableLen())
+	require.Equal(t, 0, queue.QueueLen())
+
+	// Take the second slot.
+	t2, _ := queue.Add(wHigh, 0, -1)
+	p2 := <-t2.GetWaitChan()
+	require.Equal(t, 0, queue.AvailableLen())
+	// Pool saturated: QueueLen reports the length if one more were added.
+	require.Equal(t, 1, queue.QueueLen())
+
+	// Queue a waiter; QueueLen now reports current(1) + hypothetical(1) = 2.
+	_, _ = queue.Add(wHigh, 0, -1)
+	require.Equal(t, 2, queue.QueueLen())
+
+	queue.Release(p1)
+	queue.Release(p2)
+}
+
+// TestWeightedMultiQueueUnknownType verifies that Add rejects an unknown
+// queue type rather than panicking or silently misrouting.
+func TestWeightedMultiQueueUnknownType(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	queue := NewWeightedMultiQueue(1, []TypeConfig{
+		{QueueType: wHigh, Weight: 1},
+	})
+	_, err := queue.Add(wLow, 0, -1)
+	require.Error(t, err)
+}
+
+// TestWeightedMultiQueueConstructorValidation verifies that NewWeightedMultiQueue
+// panics on invalid configurations.
+func TestWeightedMultiQueueConstructorValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	require.Panics(t, func() {
+		NewWeightedMultiQueue(1, nil)
+	}, "empty types")
+	require.Panics(t, func() {
+		NewWeightedMultiQueue(1, []TypeConfig{
+			{QueueType: wHigh, Weight: 0},
+		})
+	}, "zero weight")
+	require.Panics(t, func() {
+		NewWeightedMultiQueue(1, []TypeConfig{
+			{QueueType: wHigh, Weight: 1, MaxActive: -1},
+		})
+	}, "negative MaxActive")
+	require.Panics(t, func() {
+		NewWeightedMultiQueue(1, []TypeConfig{
+			{QueueType: wHigh, Weight: 1},
+			{QueueType: wHigh, Weight: 1},
+		})
+	}, "duplicate QueueType")
+}

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/multiqueue"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -216,10 +217,22 @@ var rangeFeedBulkDeliverySize = settings.RegisterIntSetting(
 	int64(metamorphic.ConstantWithTestRange("rangefeed-bulk_delivery", 2<<20, 0, 4<<20)),
 )
 
-// RangeFeed registers a rangefeed over the specified span. It sends updates to
-// the provided stream and returns with a future error when the rangefeed is
-// complete. The surrounding store's ConcurrentRequestLimiter is used to limit
-// the number of rangefeeds using catch-up iterators at the same time.
+// catchupQueueTypeFor maps a rangefeed admission priority to a catchup-scan
+// queue type. Requests at >= admissionpb.NormalPri (e.g. system-table
+// rangefeeds via rangefeed.WithSystemTablePriority) go to catchupQueueHigh;
+// the rest (typically BulkNormalPri) go to catchupQueueLow.
+func catchupQueueTypeFor(priority int32) int {
+	if admissionpb.WorkPriority(priority) >= admissionpb.NormalPri {
+		return catchupQueueHigh
+	}
+	return catchupQueueLow
+}
+
+// RangeFeed registers a rangefeed over the specified span. It sends updates
+// to the stream and returns with a future error when the rangefeed is
+// complete. The surrounding store's catchupScanQueue limits and prioritizes
+// concurrent catch-up scans; the queue type is derived from
+// args.AdmissionHeader.Priority via catchupQueueTypeFor.
 func (r *Replica) RangeFeed(
 	streamCtx context.Context,
 	args *kvpb.RangeFeedRequest,
@@ -275,27 +288,47 @@ func (r *Replica) RangeFeed(
 			perConsumerRelease = perConsumerAlloc.Release
 		}
 
-		alloc, err := r.store.limiters.ConcurrentRangefeedIters.Begin(streamCtx)
-		if err != nil {
-			perConsumerRelease()
-			return nil, err
+		var release func()
+		if catchupScanPrioritizationEnabled.Get(
+			&r.store.ClusterSettings().SV,
+		) {
+			queueType := catchupQueueTypeFor(args.AdmissionHeader.Priority)
+			task, err := r.store.catchupScanQueue.Add(
+				queueType, 0 /* priority */, -1, /* maxQueueLen */
+			)
+			if err != nil {
+				perConsumerRelease()
+				return nil, errors.Wrap(err, "rangefeed catchup scan")
+			}
+			var permit *multiqueue.WeightedPermit
+			select {
+			case permit = <-task.GetWaitChan():
+			case <-streamCtx.Done():
+				r.store.catchupScanQueue.Cancel(task)
+				perConsumerRelease()
+				return nil, streamCtx.Err()
+			}
+			release = func() { r.store.catchupScanQueue.Release(permit) }
+		} else {
+			alloc, err := r.store.limiters.ConcurrentRangefeedIters.Begin(streamCtx)
+			if err != nil {
+				perConsumerRelease()
+				return nil, err
+			}
+			release = alloc.Release
 		}
 
-		// Finish the iterator limit if we exit before the iterator finishes.
-		// The release function will be hooked into the Close method on the
-		// iterator below. The sync.Once prevents any races between exiting early
-		// from this call and finishing the catch-up scan underneath the
-		// rangefeed.Processor. We need to release here in case we fail to
-		// register the processor, or, more perniciously, in the case where the
-		// processor gets registered by shut down before starting the catch-up
-		// scan.
+		// iterSemRelease must be idempotent. The catch-up scan inside
+		// rangefeed.Processor releases when it finishes, but we also need to
+		// release on the early-exit paths below (failed registration, or ctx
+		// cancellation after the processor was registered but before the
+		// scan started). The sync.Once collapses both paths.
 		var iterSemReleaseOnce sync.Once
 		iterSemRelease = func() {
 			iterSemReleaseOnce.Do(func() {
-				alloc.Release()
+				release()
 				perConsumerRelease()
 			})
-
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_rangefeed_internal_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_internal_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatchupQueueTypeFor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name     string
+		priority admissionpb.WorkPriority
+		expected int
+	}{
+		{name: "below normal goes to low", priority: admissionpb.NormalPri - 1, expected: catchupQueueLow},
+		{name: "normal goes to high", priority: admissionpb.NormalPri, expected: catchupQueueHigh},
+		{name: "above normal goes to high", priority: admissionpb.NormalPri + 1, expected: catchupQueueHigh},
+		{name: "bulk goes to low", priority: admissionpb.BulkNormalPri, expected: catchupQueueLow},
+		{name: "user-high goes to high", priority: admissionpb.UserHighPri, expected: catchupQueueHigh},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, catchupQueueTypeFor(int32(tc.priority)))
+		})
+	}
+}
+
+func TestCatchupQueueLowMaxActive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name     string
+		n        int
+		expected int
+	}{
+		{name: "n=1 cap equals total (no headroom possible)", n: 1, expected: 1},
+		{name: "n=2 reserves 1, cap=1", n: 2, expected: 1},
+		{name: "n=3 reserves 1, cap=2", n: 3, expected: 2},
+		{name: "n=4 reserves 1, cap=3", n: 4, expected: 3},
+		{name: "n=8 reserves 2, cap=6", n: 8, expected: 6},
+		{name: "n=16 reserves 4, cap=12", n: 16, expected: 12},
+		{name: "n=100 reserves 25, cap=75", n: 100, expected: 75},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, catchupQueueLowMaxActive(tc.n))
+		})
+	}
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -266,6 +266,30 @@ var ConcurrentRangefeedItersLimit = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
+var catchupScanPrioritizationEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.rangefeed.catchup_scan_prioritization.enabled",
+	"prioritize system-table rangefeed catchup scans over bulk consumers; "+
+		"when false, all catchup scans share a single FIFO semaphore",
+	true,
+)
+
+const (
+	catchupQueueHigh       = 0
+	catchupQueueLow        = 1
+	catchupQueueHighWeight = 8
+	catchupQueueLowWeight  = 1
+)
+
+// catchupQueueLowMaxActive caps concurrently-active low-priority catchup
+// scans, reserving max(1, n/4) of the n total slots as headroom for
+// high-priority requests. At n=1 the cap equals total capacity (no headroom
+// is possible); at small n the integer division means the reservation is
+// rounded down to 1.
+func catchupQueueLowMaxActive(n int) int {
+	return max(1, n-max(1, n/4))
+}
+
 var PerConsumerCatchupLimit = settings.RegisterIntSetting(
 	settings.SystemOnly,
 	"kv.rangefeed.per_consumer_catchup_scan_limit",
@@ -905,20 +929,26 @@ type Store struct {
 	raftLogQueue         *raftLogQueue      // Raft log truncation queue
 	// Carries out truncations proposed by the raft log queue, and "replicated"
 	// via raft, when they are safe. Created in Store.Start.
-	raftTruncator        *raftLogTruncator
-	wagTruncator         *kvstorage.WAGTruncator     // Initialized only on separate engines.
-	raftSnapshotQueue    *raftSnapshotQueue          // Raft repair queue
-	tsMaintenanceQueue   *timeSeriesMaintenanceQueue // Time series maintenance queue
-	scanner              *replicaScanner             // Replica scanner
-	consistencyQueue     *consistencyQueue           // Replica consistency check queue
-	consistencyLimiter   *quotapool.RateLimiter      // Rate limits consistency checks
-	metrics              *StoreMetrics
-	intentResolver       *intentresolver.IntentResolver
-	recoveryMgr          txnrecovery.Manager
-	storeLiveness        storeliveness.Fabric
-	syncWaiters          []*logstore.SyncWaiterLoop
-	raftEntryCache       *raftentry.Cache
-	limiters             batcheval.Limiters
+	raftTruncator      *raftLogTruncator
+	wagTruncator       *kvstorage.WAGTruncator     // Initialized only on separate engines.
+	raftSnapshotQueue  *raftSnapshotQueue          // Raft repair queue
+	tsMaintenanceQueue *timeSeriesMaintenanceQueue // Time series maintenance queue
+	scanner            *replicaScanner             // Replica scanner
+	consistencyQueue   *consistencyQueue           // Replica consistency check queue
+	consistencyLimiter *quotapool.RateLimiter      // Rate limits consistency checks
+	metrics            *StoreMetrics
+	intentResolver     *intentresolver.IntentResolver
+	recoveryMgr        txnrecovery.Manager
+	storeLiveness      storeliveness.Fabric
+	syncWaiters        []*logstore.SyncWaiterLoop
+	raftEntryCache     *raftentry.Cache
+	limiters           batcheval.Limiters
+	// catchupScanQueue limits and prioritizes rangefeed catch-up scans across
+	// the store. Requests are classified by AdmissionHeader.Priority into a
+	// high-pri queue (system-table rangefeeds at >= admissionpb.NormalPri) and
+	// a low-pri queue (BulkNormalPri changefeeds and similar). See the
+	// catchupQueue* constants for the dispatch weights and headroom policy.
+	catchupScanQueue     *multiqueue.WeightedMultiQueue
 	txnWaitMetrics       *txnwait.Metrics
 	raftMetrics          *raft.Metrics
 	sstSnapshotStorage   snaprecv.SSTSnapshotStorage
@@ -1693,13 +1723,28 @@ func NewStore(
 		s.limiters.ConcurrentAddSSTableAsWritesRequests.SetLimit(
 			int(addSSTableAsWritesRequestLimit.Get(&cfg.Settings.SV)))
 	})
-	s.limiters.ConcurrentRangefeedIters = limit.MakeConcurrentRequestLimiter(
-		"rangefeedIterLimiter", int(ConcurrentRangefeedItersLimit.Get(&cfg.Settings.SV)),
-	)
-	ConcurrentRangefeedItersLimit.SetOnChange(&cfg.Settings.SV, func(ctx context.Context) {
-		s.limiters.ConcurrentRangefeedIters.SetLimit(
-			int(ConcurrentRangefeedItersLimit.Get(&cfg.Settings.SV)))
-	})
+	{
+		n := int(ConcurrentRangefeedItersLimit.Get(&cfg.Settings.SV))
+		s.limiters.ConcurrentRangefeedIters = limit.MakeConcurrentRequestLimiter(
+			"rangefeedIterLimiter", n,
+		)
+		s.catchupScanQueue = multiqueue.NewWeightedMultiQueue(n, []multiqueue.TypeConfig{
+			{QueueType: catchupQueueHigh, Weight: catchupQueueHighWeight},
+			{QueueType: catchupQueueLow, Weight: catchupQueueLowWeight,
+				MaxActive: catchupQueueLowMaxActive(n)},
+		})
+		ConcurrentRangefeedItersLimit.SetOnChange(&cfg.Settings.SV, func(ctx context.Context) {
+			n := int(ConcurrentRangefeedItersLimit.Get(&cfg.Settings.SV))
+			s.limiters.ConcurrentRangefeedIters.SetLimit(n)
+			// Apply both updates under a single lock acquisition so that an
+			// interim state can't dispatch a low-pri task that would violate
+			// the new cap.
+			s.catchupScanQueue.UpdateConfig(
+				multiqueue.WithConcurrencyLimit(n),
+				multiqueue.WithTypeMaxActive(catchupQueueLow, catchupQueueLowMaxActive(n)),
+			)
+		})
+	}
 
 	rateLimit := bulkIOReadLimit.Get(&cfg.Settings.SV)
 	s.limiters.BulkIOReadRate.Init(tokenbucket.TokensPerSecond(rateLimit), tokenbucket.Tokens(rateLimit))


### PR DESCRIPTION
Classify catchup scans into high-pri (>= NormalPri) and low-pri
(< NormalPri) queues dispatched via weighted round-robin (8:1).

The 8:1 ratio was arbitrarily choosen.

Since catch-up scans hold their permit for the full scan duration, 
low-pri concurrency is capped to reserve headroom for high-priority
rangefeeds. With n=16, an in-progress bulk changefeed of 100 ranges 
and a fresh system rangefeed sees bulk scans capped at 12 and system 
rangefeed dispatches into reserved slots immediately; under the old FIFO 
semaphore the high priority rangefeed would queue behind the bulk backlog.

The old FIFO semaphore is retained behind a non-public setting (kv.rangefeed.catchup_scan_prioritization.enabled=false).

Release note (general change): rangefeed catch-up scans for system
tables now receive dispatch priority over bulk consumers.

Epic: none