### PR TITLE
server: read query columns directly in CombinedStatementStats

### DIFF
--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/crosscluster",
         "//pkg/jobs",

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
@@ -1548,6 +1550,126 @@ func TestCombinedStatementUsesCorrectSourceTable(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+// TestCombinedStatementStatsQueryVersionGating exercises the V26_3 version gate
+// in getQuery / getActivityQuery. Both query variants must execute against the
+// statement_statistics_persisted and statement_activity views during a rolling
+// upgrade. The test runs a CombinedStatementStats RPC against a test server
+// pinned at each side of the gate, with one request shaped to read from the
+// persisted view and one shaped to read from the activity view — covering all
+// four (version × source view) combinations.
+func TestCombinedStatementStatsQueryVersionGating(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// We only care that the queries run; they don't need stress coverage.
+	skip.UnderDuress(t)
+
+	ctx := context.Background()
+
+	// V26_2 is the latest version that still pre-dates the V26_3 gate while
+	// having every system table the views depend on (notably system.statements,
+	// added in V26_2_AddSystemStatementsTable).
+	versions := []struct {
+		name    string
+		version roachpb.Version
+	}{
+		{"pre_v26_3", clusterversion.V26_2.Version()},
+		{"v26_3", clusterversion.V26_3.Version()},
+	}
+
+	mockTs := timeutil.Unix(1696906800, 0)
+
+	for _, v := range versions {
+		t.Run(v.name, func(t *testing.T) {
+			// Use MinSupported as the binary's min so that ClusterVersionOverride
+			// can pin the cluster below Latest. MakeTestingClusterSettings sets
+			// MinSupported to Latest, which would reject a pre-V26_3 override.
+			st := cluster.MakeTestingClusterSettingsWithVersions(
+				clusterversion.Latest.Version(),
+				clusterversion.MinSupported.Version(),
+				false, /* initializeVersion */
+			)
+			statsKnobs := sqlstats.CreateTestingKnobs()
+			statsKnobs.StubTimeNow = func() time.Time { return mockTs }
+			statsKnobs.SynchronousSQLStats = true
+			// Disable flushing so the only rows in the persisted/activity
+			// tables are the ones we insert below.
+			persistedsqlstats.SQLStatsFlushEnabled.Override(ctx, &st.SV, false)
+
+			ts := serverutils.StartServerOnly(t, base.TestServerArgs{
+				Settings: st,
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						ClusterVersionOverride:         v.version,
+						DisableAutomaticVersionUpgrade: make(chan struct{}),
+					},
+					SQLStatsKnobs: statsKnobs,
+				},
+			})
+			defer ts.Stopper().Stop(ctx)
+
+			srv := ts.ApplicationLayer()
+			conn := sqlutils.MakeSQLRunner(srv.SQLConn(t))
+			conn.Exec(t, "SET CLUSTER SETTING sql.stats.activity.flush.enabled = 'f'")
+			conn.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+
+			// Insert a matching row into the persisted and activity tables (and
+			// their txn counterparts) so each RPC code path returns data and
+			// the SQL is fully evaluated rather than short-circuited on empty
+			// input.
+			ie := srv.InternalExecutor().(*sql.InternalExecutor)
+			stmt := sqlstatstestutil.GetRandomizedCollectedStatementStatisticsForTest(t)
+			stmt.ID = 1
+			stmt.AggregatedTs = mockTs
+			stmt.Key.TransactionFingerprintID = 1
+			require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemStmtStats(
+				ctx, ie, []appstatspb.CollectedStatementStatistics{stmt}, 1 /* nodeID */))
+			require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemStmtActivity(
+				ctx, ie, &stmt, nil /* aggInterval */))
+
+			txn := sqlstatstestutil.GetRandomizedCollectedTransactionStatisticsForTest(t)
+			txn.StatementFingerprintIDs = []appstatspb.StmtFingerprintID{1}
+			txn.TransactionFingerprintID = 1
+			txn.AggregatedTs = mockTs
+			require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemTxnStats(
+				ctx, ie, []appstatspb.CollectedTransactionStatistics{txn}, 1 /* nodeID */))
+			require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemTxnActivity(
+				ctx, ie, &txn, nil /* aggInterval */))
+
+			client := srv.GetStatusClient(t)
+
+			// Without a Start time, the activity-table check in
+			// activityTablesHaveFullData short-circuits to false and the RPC
+			// reads from statement_statistics_persisted via getQuery.
+			t.Run("persisted", func(t *testing.T) {
+				resp, err := client.CombinedStatementStats(ctx,
+					&serverpb.CombinedStatementsStatsRequest{
+						Limit:     100,
+						FetchMode: createStmtFetchMode(serverpb.StatsSortOptions_SERVICE_LAT),
+					})
+				require.NoError(t, err)
+				require.Equal(t, server.CrdbInternalStmtStatsPersisted, resp.StmtsSourceTable)
+				require.NotZero(t, len(resp.Statements))
+			})
+
+			// With a Start time at the activity row's aggregated_ts, the
+			// activity table is selected and the RPC reads from
+			// statement_activity via getActivityQuery.
+			t.Run("activity", func(t *testing.T) {
+				resp, err := client.CombinedStatementStats(ctx,
+					&serverpb.CombinedStatementsStatsRequest{
+						Start:     mockTs.Unix(),
+						Limit:     100,
+						FetchMode: createStmtFetchMode(serverpb.StatsSortOptions_SERVICE_LAT),
+					})
+				require.NoError(t, err)
+				require.Equal(t, server.CrdbInternalStmtStatsCached, resp.StmtsSourceTable)
+				require.NotZero(t, len(resp.Statements))
+			})
 		})
 	}
 }

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
@@ -657,52 +658,6 @@ func (r *statementStatsRunner) collectCombinedStatements(
 ) ([]serverpb.StatementsResponse_CollectedStatementStatistics, error) {
 	aostClause := r.testingKnobs.GetAOSTClause()
 	const expectedNumDatums = 9
-	const queryFormat = `
-SELECT 
-    fingerprint_id,
-    app_name,
-    aggregated_ts,
-    COALESCE(CAST(metadata -> 'distSQLCount' AS INT), 0)  AS distSQLCount,
-    COALESCE(CAST(metadata -> 'fullScanCount' AS INT), 0) AS fullScanCount,
-    metadata ->> 'query'                                  AS query,
-    metadata ->> 'querySummary'                           AS querySummary,
-    (SELECT string_agg(elem::text, ',') 
-    FROM json_array_elements_text(metadata->'db') AS elem) AS databases,
-    statistics
-FROM (SELECT fingerprint_id,
-             app_name,
-             max(aggregated_ts)                           AS aggregated_ts,
-             merge_stats_metadata(metadata)               AS metadata,
-             merge_statement_stats(statistics)            AS statistics
-      FROM %s %s
-      GROUP BY
-          fingerprint_id,
-          app_name) %s
-%s`
-	metadataAggFn := mergeAggStmtMetadataColumnLatest
-	activityQuery := strings.Join([]string{`
-SELECT 
-    fingerprint_id,
-    app_name,
-    aggregated_ts,
-    COALESCE(CAST(metadata -> 'distSQLCount' AS INT), 0)  AS distSQLCount,
-    COALESCE(CAST(metadata -> 'fullScanCount' AS INT), 0) AS fullScanCount,
-    metadata ->> 'query'                                  AS query,
-    metadata ->> 'querySummary'                           AS querySummary,
-    (SELECT string_agg(elem::text, ',') 
-    FROM json_array_elements_text(metadata->'db') AS elem) AS databases,
-    statistics
-FROM (SELECT fingerprint_id,
-             app_name,
-             max(aggregated_ts)                                     AS aggregated_ts,
-             `, metadataAggFn, ` AS metadata,
-             merge_statement_stats(statistics)                      AS statistics
-      FROM %s %s
-      GROUP BY
-          fingerprint_id,
-          app_name) %s
-%s`}, "")
-
 	var it isql.Rows
 	var err error
 	defer func() {
@@ -715,7 +670,7 @@ FROM (SELECT fingerprint_id,
 			ctx,
 			r.ie,
 			// The statement activity table has aggregated metadata.
-			activityQuery,
+			getQuery(ctx, settings, mergeAggStmtMetadataColumnLatest),
 			CrdbInternalStmtStatsCached,
 			"activity-by-interval",
 			whereClause,
@@ -726,7 +681,7 @@ FROM (SELECT fingerprint_id,
 		it, err = getIterator(
 			ctx,
 			r.ie,
-			queryFormat,
+			getQuery(ctx, settings, mergeStatsMetadataColumn),
 			r.stmtSourceTable,
 			"by-interval",
 			whereClause,
@@ -765,7 +720,7 @@ FROM (SELECT fingerprint_id,
 		fullScanCount := int64(*row[4].(*tree.DInt))
 		query := string(tree.MustBeDString(row[5]))
 		querySummary := string(tree.MustBeDString(row[6]))
-		databases := string(tree.MustBeDString(row[7]))
+		database := string(tree.MustBeDString(row[7]))
 
 		metadata := appstatspb.CollectedStatementStatistics{
 			Key: appstatspb.StatementStatisticsKey{
@@ -774,7 +729,7 @@ FROM (SELECT fingerprint_id,
 				FullScan:     fullScanCount > 0,
 				Query:        query,
 				QuerySummary: querySummary,
-				Database:     databases,
+				Database:     database,
 			},
 		}
 
@@ -802,6 +757,60 @@ FROM (SELECT fingerprint_id,
 	}
 
 	return statements, nil
+}
+
+func getQuery(ctx context.Context, settings *cluster.Settings, mergeMetadataFn string) string {
+	if settings.Version.IsActive(ctx, clusterversion.V26_3) {
+		return `
+SELECT 
+    fingerprint_id,
+    app_name,
+    aggregated_ts,
+    COALESCE(CAST(metadata -> 'distSQLCount' AS INT), 0)  AS distSQLCount,
+    COALESCE(CAST(metadata -> 'fullScanCount' AS INT), 0) AS fullScanCount,
+    query,
+    querySummary,
+    database,
+    statistics
+FROM (SELECT fingerprint_id,
+             app_name,
+             query,
+             query_summary                                AS querySummary,
+             database                                     AS database,
+             max(aggregated_ts)                           AS aggregated_ts,
+             ` + mergeMetadataFn + `                      AS metadata,
+             merge_statement_stats(statistics)            AS statistics
+      FROM %s %s
+      GROUP BY
+          fingerprint_id,
+          app_name,
+          query,
+          query_summary,
+          database) %s
+%s`
+	}
+
+	return `
+SELECT 
+    fingerprint_id,
+    app_name,
+    aggregated_ts,
+    COALESCE(CAST(metadata -> 'distSQLCount' AS INT), 0)  AS distSQLCount,
+    COALESCE(CAST(metadata -> 'fullScanCount' AS INT), 0) AS fullScanCount,
+    metadata ->> 'query'                                  AS query,
+    metadata ->> 'querySummary'                           AS querySummary,
+    metadata -> 'db' ->> 0                                AS database,
+    statistics
+FROM (SELECT fingerprint_id,
+             app_name,
+             max(aggregated_ts)                           AS aggregated_ts,
+             ` + mergeMetadataFn + `                      AS metadata,
+             merge_statement_stats(statistics)            AS statistics
+      FROM %s %s
+      GROUP BY
+          fingerprint_id,
+          app_name) %s
+%s`
 }
 
 func getIterator(

--- a/pkg/server/statement_details.go
+++ b/pkg/server/statement_details.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	mergeAggStmtMetadataColumnLatest = "merge_aggregated_stmt_metadata(metadata)"
-	mergeAggStmtMetadata_V23_2       = "crdb_internal.merge_aggregated_stmt_metadata(array_agg(metadata))"
+	mergeStatsMetadataColumn         = "merge_stats_metadata(metadata)"
 )
 
 func (s *statusServer) StatementDetails(


### PR DESCRIPTION
The crdb_internal statement statistics views now expose query, query_summary, and database as top-level columns sourced from system.statements. Read these directly in CombinedStatementStats instead of decoding them out of the metadata JSONB on every row.

The new query is gated on V26_3 so that during a rolling upgrade we fall back to the metadata-based query against nodes whose views don't yet project these columns.

Add TestCombinedStatementStatsQueryVersionGating to exercise both query shapes against statement_statistics_persisted and statement_activity.

Resolves: CRDB-62873
Epic: CRDB-62868
Release note: None