### PR TITLE
sql/sqlstats: stop persisting query metadata in drained stmt stats

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -607,9 +607,13 @@ WITH contention_fingerprints AS (
     WHERE blocking_txn_fingerprint_id != '\x0000000000000000'
 ),
 fingerprint_queries AS (
-    -- Only fetch statement data for fingerprints that appear in contention events
-    SELECT DISTINCT fingerprint_id, metadata->>'query' as query
+    -- Only fetch statement data for fingerprints that appear in contention events.
+    -- Source the query text from system.statements; fall back to
+    -- metadata->>'query' for rows that predate the system.statements backfill.
+    SELECT DISTINCT ss.fingerprint_id,
+                    COALESCE(s.fingerprint, ss.metadata->>'query') as query
     FROM system.statement_statistics ss
+    LEFT JOIN system.statements s ON s.fingerprint_id = ss.fingerprint_id
     WHERE EXISTS (
         SELECT 1 FROM contention_fingerprints cf
         WHERE cf.waiting_stmt_fingerprint_id = ss.fingerprint_id

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -1725,7 +1725,9 @@ func TestDrainSqlStats(t *testing.T) {
 	stmts, txns := filterStatementStatsByAppName(resp.Statements, resp.Transactions, appName)
 	require.Len(t, stmts, 1)
 	require.Equal(t, int64(3), stmts[0].Stats.Count)
-	require.Equal(t, "SELECT _", stmts[0].Key.Query)
+	require.Equal(t,
+		appstatspb.ConstructStatementFingerprintID("SELECT _", "defaultdb"),
+		stmts[0].ID)
 	require.Len(t, txns, 1)
 	require.Equal(t, int64(3), txns[0].Stats.Count)
 	require.Len(t, txns[0].StatementFingerprintIDs, 1)
@@ -1773,7 +1775,9 @@ func TestDrainSqlStats_partialOutage(t *testing.T) {
 	stmts, txns := filterStatementStatsByAppName(resp.Statements, resp.Transactions, appName)
 	require.Len(t, stmts, 1)
 	require.Equal(t, int64(2), stmts[0].Stats.Count)
-	require.Equal(t, "SELECT _", stmts[0].Key.Query)
+	require.Equal(t,
+		appstatspb.ConstructStatementFingerprintID("SELECT _", "defaultdb"),
+		stmts[0].ID)
 	require.Len(t, txns, 1)
 	require.Equal(t, int64(2), txns[0].Stats.Count)
 }

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -33,11 +33,16 @@ type DrainSqlStatsRespBuilder struct {
 	txnMap               map[txnDrainKey]*appstatspb.CollectedTransactionStatistics
 }
 
-// stmtDrainKey includes the aggregated timestamp so that stats from different
-// aggregation windows are not merged together during drain.
+// stmtDrainKey identifies a statement statistics row for cross-node
+// dedup/merge during a drain. Stats sharing this key are merged; stats
+// differing in any field are kept separate. The aggregated timestamp
+// keeps different aggregation windows in distinct buckets.
 type stmtDrainKey struct {
-	key          appstatspb.StatementStatisticsKey
-	aggregatedTs time.Time
+	fingerprintID            appstatspb.StmtFingerprintID
+	transactionFingerprintID appstatspb.TransactionFingerprintID
+	app                      string
+	planHash                 uint64
+	aggregatedTs             time.Time
 }
 
 // txnDrainKey includes the aggregated timestamp so that stats from different
@@ -60,7 +65,13 @@ func (b *DrainSqlStatsRespBuilder) AddStmtStats(
 	stmtStats []*appstatspb.CollectedStatementStatistics,
 ) {
 	for _, stmt := range stmtStats {
-		dk := stmtDrainKey{key: stmt.Key, aggregatedTs: stmt.AggregatedTs}
+		dk := stmtDrainKey{
+			fingerprintID:            stmt.ID,
+			transactionFingerprintID: stmt.Key.TransactionFingerprintID,
+			app:                      stmt.Key.App,
+			planHash:                 stmt.Key.PlanHash,
+			aggregatedTs:             stmt.AggregatedTs,
+		}
 		if existingStmt, ok := b.stmtMap[dk]; !ok {
 			b.stmtMap[dk] = stmt
 		} else {

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -251,14 +251,20 @@ message NumericStat {
 }
 
 message StatementStatisticsKey {
-  optional string query = 1 [(gogoproto.nullable) = false];
+  // query, database, and query_summary are deprecated. Consumers should
+  // source these values from system.statements (exposed via the query,
+  // query_summary, and database columns on
+  // crdb_internal.statement_statistics{,_persisted} and
+  // crdb_internal.statement_activity).
+  // TODO(CRDB-62872): remove in 27.1.
+  optional string query = 1 [(gogoproto.nullable) = false, deprecated=true];
   optional string app = 2 [(gogoproto.nullable) = false];
   optional bool distSQL = 3 [(gogoproto.nullable) = false];
   optional bool vec = 7 [(gogoproto.nullable) = false];
   optional bool full_scan = 8 [(gogoproto.nullable) = false];
-  optional string database = 9 [(gogoproto.nullable) = false];
+  optional string database = 9 [(gogoproto.nullable) = false, deprecated=true];
   optional uint64 plan_hash = 10 [(gogoproto.nullable) = false];
-  optional string query_summary = 12 [(gogoproto.nullable) = false];
+  optional string query_summary = 12 [(gogoproto.nullable) = false, deprecated=true];
 
   reserved 4, 5, 6;
   optional uint64 transaction_fingerprint_id = 11

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
@@ -57,6 +58,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -65,10 +65,13 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 	appName := "controller_test"
 	sqlDB.Exec(t, "SET application_name = $1", appName)
 
-	expectedStmtFingerprintToFingerprintID := make(map[string]string)
+	// Map canonical fingerprint text to the expected hex-encoded fingerprint
+	// ID. Persisted rows are identified by fingerprint ID rather than query
+	// text because the query column is populated asynchronously via a JOIN
+	// against system.statements.
+	expectedFingerprintIDs := make(map[string]string)
 	for fingerprint, query := range testCasesForDisk {
-		// We will populate the fingerprint ID later.
-		expectedStmtFingerprintToFingerprintID[fingerprint] = ""
+		expectedFingerprintIDs[fingerprint] = sqlstatstestutil.FingerprintIDHex(fingerprint, "defaultdb")
 		sqlDB.Exec(t, query)
 	}
 
@@ -79,14 +82,14 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider()
 	sqlStats.MaybeFlush(ctx, cluster.ApplicationLayer(0).AppStopper())
 
-	checkInsertedStmtStatsAndUpdateFingerprintIDs(t, appName, observer, expectedStmtFingerprintToFingerprintID)
-	checkInsertedTxnStats(t, appName, observer, expectedStmtFingerprintToFingerprintID)
+	checkInsertedStmtStats(t, appName, observer, expectedFingerprintIDs)
+	checkInsertedTxnStats(t, appName, observer, expectedFingerprintIDs)
 
 	// Run few additional queries, so we would also have some SQL stats in-memory.
 	for fingerprint, query := range testCasesForMem {
 		sqlDB.Exec(t, query)
-		if _, ok := expectedStmtFingerprintToFingerprintID[fingerprint]; !ok {
-			expectedStmtFingerprintToFingerprintID[fingerprint] = ""
+		if _, ok := expectedFingerprintIDs[fingerprint]; !ok {
+			expectedFingerprintIDs[fingerprint] = sqlstatstestutil.FingerprintIDHex(fingerprint, "defaultdb")
 		}
 	}
 	sqlstatstestutil.WaitForStatementEntriesAtLeast(t, observer,
@@ -95,8 +98,8 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 
 	// Sanity check that we still have the same count since we are still within
 	// the same aggregation interval.
-	checkInsertedStmtStatsAndUpdateFingerprintIDs(t, appName, observer, expectedStmtFingerprintToFingerprintID)
-	checkInsertedTxnStats(t, appName, observer, expectedStmtFingerprintToFingerprintID)
+	checkInsertedStmtStats(t, appName, observer, expectedFingerprintIDs)
+	checkInsertedTxnStats(t, appName, observer, expectedFingerprintIDs)
 
 	// Resets cluster wide SQL stats.
 	require.NoError(t, sqlStats.ResetClusterSQLStats(ctx))
@@ -113,29 +116,27 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 	require.Equal(t, 0 /* expected */, count)
 }
 
-func checkInsertedStmtStatsAndUpdateFingerprintIDs(
+func checkInsertedStmtStats(
 	t *testing.T,
 	appName string,
 	observer *sqlutils.SQLRunner,
-	expectedStmtFingerprintToFingerprintID map[string]string,
+	expectedFingerprintIDs map[string]string,
 ) {
 	result := observer.QueryStr(t,
 		`
-SELECT encode(fingerprint_id, 'hex'), metadata ->> 'query'
+SELECT encode(fingerprint_id, 'hex')
 FROM crdb_internal.statement_statistics
 WHERE app_name = $1`, appName)
 
-	for expectedFingerprint := range expectedStmtFingerprintToFingerprintID {
-		var found bool
-		for _, row := range result {
-			if expectedFingerprint == row[1] {
-				found = true
-
-				// Populate fingerprintID.
-				expectedStmtFingerprintToFingerprintID[expectedFingerprint] = row[0]
-			}
-		}
-		require.True(t, found, "expect %s to be found, but it was not", expectedFingerprint)
+	got := make(map[string]struct{}, len(result))
+	for _, row := range result {
+		got[row[0]] = struct{}{}
+	}
+	for canonical, expectedID := range expectedFingerprintIDs {
+		_, found := got[expectedID]
+		require.True(t, found,
+			"expected fingerprint %q (id=%s) to be found, but it was not",
+			canonical, expectedID)
 	}
 }
 

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -1121,6 +1121,12 @@ func (s *stubTime) Now() time.Time {
 	return timeutil.Now()
 }
 
+// fingerprintIDHex returns the hex fingerprint_id for stmtNoConst executed
+// against the default database.
+func fingerprintIDHex(stmtNoConst string) string {
+	return sqlstatstestutil.FingerprintIDHex(stmtNoConst, "defaultdb")
+}
+
 func verifyInsertedFingerprintExecCount(
 	t *testing.T,
 	sqlConn *sqlutils.SQLRunner,
@@ -1137,7 +1143,7 @@ SELECT
 FROM
     system.transaction_statistics T,
     system.statement_statistics S
-WHERE S.metadata ->> 'query' = $1
+WHERE S.fingerprint_id = decode($1, 'hex')
 	  AND T.aggregated_ts = $2
     AND T.node_id = $3
     AND T.app_name = 'flush_unit_test'
@@ -1145,7 +1151,7 @@ WHERE S.metadata ->> 'query' = $1
     AND S.node_id = T.node_id
     AND S.aggregated_ts = T.aggregated_ts
     AND S.app_name = T.app_name
-`, fingerprint, ts, instanceID)
+`, fingerprintIDHex(fingerprint), ts, instanceID)
 
 	require.True(t, row.Next(), "no stats found for fingerprint: %s", fingerprint)
 
@@ -1174,12 +1180,12 @@ SELECT
 FROM
 	system.statement_statistics
 WHERE
-	metadata ->> 'query' = $1 AND
+	fingerprint_id = decode($1, 'hex') AND
   node_id = $2 AND
   app_name = 'flush_unit_test'
 GROUP BY
   (fingerprint_id, node_id)
-`, fingerprint, instanceID)
+`, fingerprintIDHex(fingerprint), instanceID)
 
 	var stmtFingerprintID string
 	var numOfInsertedStmtEntry int64
@@ -1283,9 +1289,9 @@ SELECT
 FROM
 	system.statement_statistics
 WHERE
-	metadata ->> 'query' = $1 AND
+	fingerprint_id = decode($1, 'hex') AND
   app_name = $2
-`, fingerprint, appName)
+`, fingerprintIDHex(fingerprint), appName)
 
 	var gatewayNodeID int64
 	var allNodesIds string

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -29,6 +29,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FingerprintIDHex returns the hex-encoded statement fingerprint ID assigned
+// to a redacted statement (the "stmtNoConstants" form) executed against the
+// given database.
+func FingerprintIDHex(stmtNoConstants string, database string) string {
+	return sqlstatsutil.EncodeStmtFingerprintIDToString(
+		appstatspb.ConstructStatementFingerprintID(stmtNoConstants, database))
+}
+
 // GetRandomizedCollectedStatementStatisticsForTest returns a
 // appstatspb.CollectedStatementStatistics with its fields randomly filled.
 func GetRandomizedCollectedStatementStatisticsForTest(

--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/consistent_flush_timestamp
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/consistent_flush_timestamp
@@ -31,18 +31,20 @@ ORDER BY aggregated_ts
 2021-09-20 14:00:00 +0000 UTC,c5999b4f9e57aca0,["6afa260318561b7f"]
 
 
+# Identify rows by fingerprint_id rather than query text — the query column is
+# sourced from system.statements via a LEFT JOIN populated asynchronously, so
+# newly-persisted rows can briefly see an empty query.
 observe-sql
 SELECT
   aggregated_ts,
-  encode(fingerprint_id, 'hex'),
-  metadata ->> 'query'
+  encode(fingerprint_id, 'hex')
 FROM
   crdb_internal.statement_statistics
 WHERE
   app_name = 'consistent-test'
 ORDER BY aggregated_ts
 ----
-2021-09-20 14:00:00 +0000 UTC,6afa260318561b7f,SELECT _
+2021-09-20 14:00:00 +0000 UTC,6afa260318561b7f
 
 sql-stats-flush
 ----
@@ -50,15 +52,14 @@ sql-stats-flush
 observe-sql
 SELECT
   aggregated_ts,
-  encode(fingerprint_id, 'hex'),
-  metadata ->> 'query'
+  encode(fingerprint_id, 'hex')
 FROM
   crdb_internal.statement_statistics
 WHERE
   app_name = 'consistent-test'
 ORDER BY aggregated_ts
 ----
-2021-09-20 14:00:00 +0000 UTC,6afa260318561b7f,SELECT _
+2021-09-20 14:00:00 +0000 UTC,6afa260318561b7f
 
 observe-sql
 SELECT
@@ -85,16 +86,15 @@ wait-for-stmt-stats app=consistent-test count=1
 observe-sql
 SELECT
   aggregated_ts,
-  encode(fingerprint_id, 'hex'),
-  metadata ->> 'query'
+  encode(fingerprint_id, 'hex')
 FROM
   crdb_internal.statement_statistics
 WHERE
   app_name = 'consistent-test'
 ORDER BY aggregated_ts
 ----
-2021-09-20 14:00:00 +0000 UTC,6afa260318561b7f,SELECT _
-2021-09-20 15:00:00 +0000 UTC,6afa260318561b7f,SELECT _
+2021-09-20 14:00:00 +0000 UTC,6afa260318561b7f
+2021-09-20 15:00:00 +0000 UTC,6afa260318561b7f
 
 observe-sql
 SELECT

--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/stmt_grouping_in_explicit_txn
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/stmt_grouping_in_explicit_txn
@@ -64,7 +64,6 @@ observe-sql
 SELECT
   encode(s.fingerprint_id, 'hex') AS stmtFingerprintID,
   encode(t.fingerprint_id, 'hex') AS txnFingerprintID,
-  s.metadata ->> 'query' AS query,
   (s.statistics -> 'statistics' ->> 'cnt')::INT AS count
 FROM
   crdb_internal.statement_statistics s,
@@ -74,27 +73,25 @@ WHERE
   encode(s.transaction_fingerprint_id, 'hex') = encode(t.fingerprint_id, 'hex') AND
   jsonb_array_length(t.metadata -> 'stmtFingerprintIDs') >= 3
 ORDER BY
-  2, 4
+  2, 3
 ----
-6afa260318561b7f,b1b479ea9b0432fa,SELECT _,2
-a2fb423e64738b46,b1b479ea9b0432fa,SELECT _, _,6
-6afa260318561b7f,d617ebef6c48a954,SELECT _,1
-a2fb423e64738b46,d617ebef6c48a954,SELECT _, _,2
+6afa260318561b7f,b1b479ea9b0432fa,2
+a2fb423e64738b46,b1b479ea9b0432fa,6
+6afa260318561b7f,d617ebef6c48a954,1
+a2fb423e64738b46,d617ebef6c48a954,2
 
-# Ensures that implicit transaction stats are collected separately.
+# Ensures that implicit transaction stats are collected separately. Implicit
+# transactions are identified by excluding the >=3-statement explicit
+# transactions captured above.
 observe-sql
 SELECT
   encode(fingerprint_id, 'hex') AS stmtFingerprintID,
   encode(transaction_fingerprint_id, 'hex') AS txnFingerprintID,
-  metadata ->> 'query',
   (statistics -> 'statistics' ->> 'cnt')::INT
 FROM
   crdb_internal.statement_statistics
 WHERE
   app_name = 'test' AND
-  metadata ->> 'query' IN (
-    'SELECT _', 'SELECT _, _'
-  ) AND
   encode(transaction_fingerprint_id, 'hex') NOT IN (
     SELECT
       encode(fingerprint_id, 'hex')
@@ -106,8 +103,8 @@ WHERE
 ORDER BY
   2
 ----
-a2fb423e64738b46,0d98ff72e2723c99,SELECT _, _,1
-6afa260318561b7f,c5999b4f9e57aca0,SELECT _,2
+a2fb423e64738b46,0d98ff72e2723c99,1
+6afa260318561b7f,c5999b4f9e57aca0,2
 
 
 sql-stats-flush
@@ -139,7 +136,6 @@ observe-sql
 SELECT
   encode(s.fingerprint_id, 'hex') AS stmtFingerprintID,
   encode(t.fingerprint_id, 'hex') AS txnFingerprintID,
-  s.metadata ->> 'query' AS query,
   (s.statistics -> 'statistics' ->> 'cnt')::INT AS count
 FROM
   crdb_internal.statement_statistics s,
@@ -149,27 +145,23 @@ WHERE
   encode(s.transaction_fingerprint_id, 'hex') = encode(t.fingerprint_id, 'hex') AND
   jsonb_array_length(t.metadata -> 'stmtFingerprintIDs') >= 3
 ORDER BY
-  2, 4
+  2, 3
 ----
-6afa260318561b7f,b1b479ea9b0432fa,SELECT _,2
-a2fb423e64738b46,b1b479ea9b0432fa,SELECT _, _,6
-6afa260318561b7f,d617ebef6c48a954,SELECT _,1
-a2fb423e64738b46,d617ebef6c48a954,SELECT _, _,2
+6afa260318561b7f,b1b479ea9b0432fa,2
+a2fb423e64738b46,b1b479ea9b0432fa,6
+6afa260318561b7f,d617ebef6c48a954,1
+a2fb423e64738b46,d617ebef6c48a954,2
 
 # Ensures that implicit transaction stats are collected separately.
 observe-sql
 SELECT
   encode(fingerprint_id, 'hex') AS stmtFingerprintID,
   encode(transaction_fingerprint_id, 'hex') AS txnFingerprintID,
-  metadata ->> 'query',
   (statistics -> 'statistics' ->> 'cnt')::INT
 FROM
   crdb_internal.statement_statistics
 WHERE
   app_name = 'test' AND
-  metadata ->> 'query' IN (
-    'SELECT _', 'SELECT _, _'
-  ) AND
   encode(transaction_fingerprint_id, 'hex') NOT IN (
     SELECT
       encode(fingerprint_id, 'hex')
@@ -182,5 +174,5 @@ ORDER BY
   (statistics -> 'statistics' ->> 'cnt')::INT
 ASC
 ----
-a2fb423e64738b46,0d98ff72e2723c99,SELECT _, _,1
-6afa260318561b7f,c5999b4f9e57aca0,SELECT _,2
+a2fb423e64738b46,0d98ff72e2723c99,1
+6afa260318561b7f,c5999b4f9e57aca0,2

--- a/pkg/sql/sqlstats/sqlstats_test.go
+++ b/pkg/sql/sqlstats/sqlstats_test.go
@@ -14,12 +14,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,15 +136,23 @@ func TestStmtStatsQueryColumns(t *testing.T) {
 	s.SQLServer().(*sql.Server).GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	// Verify statement_statistics_persisted populates query/query_summary/database
-	// via the JOIN with system.statements.
+	// via the JOIN with system.statements. The statementstore writer is
+	// asynchronous, so wait for the row to appear.
 	var pQuery, pQuerySummary, pDatabase string
-	obsDB.QueryRow(t,
-		`SELECT query, query_summary, database
-		 FROM crdb_internal.statement_statistics_persisted
-		 WHERE app_name = $1 AND query LIKE '%SELECT _'`, appName,
-	).Scan(&pQuery, &pQuerySummary, &pDatabase)
+	testutils.SucceedsSoon(t, func() error {
+		row := obsDB.DB.QueryRowContext(ctx,
+			`SELECT query, query_summary, database
+			 FROM crdb_internal.statement_statistics_persisted
+			 WHERE app_name = $1 AND query LIKE '%SELECT _'`, appName)
+		if err := row.Scan(&pQuery, &pQuerySummary, &pDatabase); err != nil {
+			return err
+		}
+		if pQuery == "" {
+			return errors.New("query column not yet populated by statementstore")
+		}
+		return nil
+	})
 
-	require.NotEmpty(t, pQuery, "persisted: query column should be populated")
 	require.Contains(t, pQuery, "SELECT")
 	require.NotEmpty(t, pQuerySummary, "persisted: query_summary column should be populated")
 	require.Equal(t, "testdb", pDatabase, "persisted: database column should match")

--- a/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
@@ -12,6 +12,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
+        "//pkg/obs/statementstore",
         "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -16,6 +16,8 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/obs/statementstore"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
@@ -535,6 +537,17 @@ func (s *Container) DrainStats(
 	var distSQLUsed, vectorized, fullScan bool
 	var querySummary string
 
+	// Once V26_3 is active, query, query summary, and database are sourced
+	// from system.statements; omit them from the persisted metadata JSONB to
+	// avoid duplication. Mixed-version clusters keep populating them so
+	// older binaries reading metadata->>'query' continue to work. If the
+	// statement store is disabled, system.statements will not be populated,
+	// so we must keep writing the fields into the metadata JSONB to avoid
+	// losing the query metadata entirely.
+	omitDeprecatedKeyFields := s.st != nil &&
+		s.st.Version.IsActive(ctx, clusterversion.V26_3) &&
+		statementstore.StatementStoreEnabled.Get(&s.st.SV)
+
 	for key, stmt := range stmts {
 		func() {
 			stmt.mu.Lock()
@@ -546,18 +559,25 @@ func (s *Container) DrainStats(
 			querySummary = stmt.mu.querySummary
 		}()
 
+		stmtKey := appstatspb.StatementStatisticsKey{
+			Query:                    stmt.meta.stmtNoConstants,
+			QuerySummary:             querySummary,
+			DistSQL:                  distSQLUsed,
+			Vec:                      vectorized,
+			FullScan:                 fullScan,
+			App:                      s.appName,
+			Database:                 stmt.meta.database,
+			PlanHash:                 key.planHash,
+			TransactionFingerprintID: key.transactionFingerprintID,
+		}
+		if omitDeprecatedKeyFields {
+			stmtKey.Query = ""
+			stmtKey.QuerySummary = ""
+			stmtKey.Database = ""
+		}
+
 		statementStats = append(statementStats, &appstatspb.CollectedStatementStatistics{
-			Key: appstatspb.StatementStatisticsKey{
-				Query:                    stmt.meta.stmtNoConstants,
-				QuerySummary:             querySummary,
-				DistSQL:                  distSQLUsed,
-				Vec:                      vectorized,
-				FullScan:                 fullScan,
-				App:                      s.appName,
-				Database:                 stmt.meta.database,
-				PlanHash:                 key.planHash,
-				TransactionFingerprintID: key.transactionFingerprintID,
-			},
+			Key:                 stmtKey,
 			ID:                  stmt.ID,
 			Stats:               data,
 			AggregatedTs:        key.aggregatedTs,

--- a/pkg/sql/testdata/sql_activity/sql_activity_update_job
+++ b/pkg/sql/testdata/sql_activity/sql_activity_update_job
@@ -38,11 +38,11 @@ update-app ignore=true
 
 # Check the values got properly added to the system tables.
 run-sql useApp=true
-SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
-system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+SELECT aggregated_ts, encode(fingerprint_id, 'hex'), statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
 ----
-2024-01-01 01:00:00 +0000 UTC,"SELECT _",1
-2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,58d6127c4c85189b,1
+2024-01-01 01:00:00 +0000 UTC,6afa260318561b7f,1
 
 run-sql useApp=true
 SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
@@ -53,11 +53,11 @@ system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, finger
 
 # Check the values got properly added to the top activity tables.
 run-sql useApp=true
-SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
-system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+SELECT aggregated_ts, encode(fingerprint_id, 'hex'), statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
 ----
-2024-01-01 01:00:00 +0000 UTC,"SELECT _",1
-2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,58d6127c4c85189b,1
+2024-01-01 01:00:00 +0000 UTC,6afa260318561b7f,1
 
 run-sql useApp=true
 SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
@@ -110,14 +110,14 @@ update-app ignore=true
 
 # Check the values got properly added to the system tables
 run-sql useApp=true
-SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
-system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+SELECT aggregated_ts, encode(fingerprint_id, 'hex'), statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
 ----
-2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
-2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
-2024-01-01 01:00:00 +0000 UTC,"SET application_name = _",1
-2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
-2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
+2024-01-01 01:00:00 +0000 UTC,58d6127c4c85189b,1
+2024-01-01 01:00:00 +0000 UTC,6afa260318561b7f,3
+2024-01-01 01:00:00 +0000 UTC,a8370357cd0f6f08,1
+2024-01-01 02:00:00 +0000 UTC,6afa260318561b7f,1
+2024-01-01 02:00:00 +0000 UTC,e76e463042ee3d91,1
 
 run-sql useApp=true
 SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
@@ -131,14 +131,14 @@ system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, finger
 
 # Check the values got properly added to the top activity tables
 run-sql useApp=true
-SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
-system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+SELECT aggregated_ts, encode(fingerprint_id, 'hex'), statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
 ----
-2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
-2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
-2024-01-01 01:00:00 +0000 UTC,"SET application_name = _",1
-2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
-2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
+2024-01-01 01:00:00 +0000 UTC,58d6127c4c85189b,1
+2024-01-01 01:00:00 +0000 UTC,6afa260318561b7f,3
+2024-01-01 01:00:00 +0000 UTC,a8370357cd0f6f08,1
+2024-01-01 02:00:00 +0000 UTC,6afa260318561b7f,1
+2024-01-01 02:00:00 +0000 UTC,e76e463042ee3d91,1
 
 run-sql useApp=true
 SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM


### PR DESCRIPTION
## Summary

Stop carrying a redundant copy of statement query text, query summary, and
database in the `system.statement_statistics` metadata JSONB once the cluster
has finalized 26.3. Those fields are now canonically sourced from
`system.statements` (populated by the statementstore writer and exposed via
the `query`, `query_summary`, and `database` columns on the
`crdb_internal.statement_statistics{,_persisted}` and
`crdb_internal.statement_activity` views).

## Commit overview

The first three commits prepare the call sites so the last one can flip the
behavior without losing information on the wire or in `debug zip`:

- `server: read query columns directly in CombinedStatementStats` — switch
  the combined stats reader to source query columns from the views' new
  joined columns.
- `server: key DrainSqlStatsRespBuilder dedup map by stmt fingerprint ID` —
  rekey the cross-node drain dedup map so it doesn't collapse distinct
  fingerprints once `Key.Query`/`Database`/`QuerySummary` are zeroed.
- `appstatspb: deprecate query, database, query_summary on stmt key` —
  mark the proto fields deprecated; kept on the wire one release for
  mixed-version compatibility.
- `sql/sqlstats: stop persisting query metadata in drained stmt stats` —
  zero the three fields in `DrainStats` once `V26_3` is active, and update
  `cockroach debug zip` to source query text via a `LEFT JOIN` to
  `system.statements` (with a `COALESCE` fallback for rows that predate
  the backfill migration).

Resolves: CRDB-62872
Epic: CRDB-62868