### PR TITLE
sql: don't finalize partial-match implicit txn diagnostics

### DIFF
--- a/pkg/sql/txn_instrumentation.go
+++ b/pkg/sql/txn_instrumentation.go
@@ -339,6 +339,17 @@ func (h *txnInstrumentationHelper) Finalize(
 		return
 	}
 	if collector.InProgress() {
+		// An InProgress collector at Finalize time corresponds to an implicit
+		// transaction: there is no terminal statement to drive the state
+		// machine through MaybeContinueDiagnostics. If any expected statement
+		// fingerprints remain uncaptured, the implicit transaction was a
+		// partial match for the request and must not be finalized.
+		if len(collector.stmtsFpsToCapture) > 0 {
+			log.Dev.VInfof(ctx, 2, "txn diag: aborting partial collection for "+
+				"request %d, txn %s, txn fingerprint %s, %d stmt fingerprints not captured",
+				collector.requestId, txnID, txnFpStr, len(collector.stmtsFpsToCapture))
+			return
+		}
 		log.Dev.VInfof(ctx, 2, "txn diag: finalizing collection for "+
 			"request %d, txn %s, txn fingerprint %s",
 			collector.requestId, txnID, txnFpStr)


### PR DESCRIPTION
## Summary

A transaction diagnostics request could be marked completed after an implicit transaction matched only a prefix of the request's expected statement fingerprints, producing an incomplete bundle.

When an explicit transaction partially matches a request, `MaybeContinueDiagnostics` observes the `COMMIT` (or other terminal statement) and resets the collector before `Finalize` runs. An implicit transaction has no terminal statement, so the collector reaches `Finalize` in the `InProgress` state, and `Finalize` unconditionally promotes it to `ReadyToFinalize` and writes the partial bundle.

This change gates the `InProgress` → `ReadyToFinalize` transition on `len(stmtsFpsToCapture) == 0`. When fingerprints remain uncaptured, `Finalize` returns early; the deferred `Reset` moves the request back to the pending pool so a subsequent matching transaction can fulfill it.

The bug was introduced in #154887 ("sql: fix transaction diagnostics for implicit txns"), which also added the `partial_match_transaction` subtest in `TestTxnBundleCollection`. That subtest has been failing on `master` since. The bug is not user-visible on v25.4: there, statements executed in implicit transactions generated different fingerprints from the same statements in explicit transactions, so the partial-match scenario could not occur in practice.

Fixes #169461

Release note: None
