### PR TITLE
kvserver: make appBatch self-contained for standalone log application

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -284,6 +284,7 @@ go_test(
     srcs = [
         "addressing_test.go",
         "allocator_impl_test.go",
+        "app_batch_test.go",
         "batch_spanset_test.go",
         "below_raft_protos_test.go",
         "client_atomic_membership_change_test.go",

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -73,15 +73,23 @@ func (s *appBatchStats) merge(ss appBatchStats) {
 // [^1]: https://github.com/cockroachdb/cockroach/issues/75729
 type appBatch struct {
 	appBatchStats
+	// state is the batch's view of the replica's state. It is copied from
+	// under Replica.mu when the batch is initialized and is updated in
+	// stageTrivialReplicatedEvalResult.
+	//
+	// This is a shallow copy so any mutations inside of pointer fields need
+	// to copy-on-write. The exception to this is `state.Stats`, for which
+	// backing memory has already been provided and which may thus be
+	// modified directly.
+	state kvserverpb.ReplicaState
 	// TODO(tbg): this will absorb the following fields from replicaAppBatch:
 	//
 	// - batch
-	// - state
 	// - changeRemovesReplica
 }
 
 func (b *appBatch) assertAndCheckCommand(
-	ctx context.Context, cmd *raftlog.ReplicatedCmd, state *kvserverpb.ReplicaState, isLocal bool,
+	ctx context.Context, cmd *raftlog.ReplicatedCmd, isLocal bool,
 ) (kvserverbase.ForcedErrResult, error) {
 	if log.V(4) {
 		log.KvExec.Infof(ctx, "processing command %x: raftIndex=%d maxLeaseIndex=%d closedts=%s",
@@ -91,7 +99,7 @@ func (b *appBatch) assertAndCheckCommand(
 	if cmd.Index() == 0 {
 		return kvserverbase.ForcedErrResult{}, errors.AssertionFailedf("processRaftCommand requires a non-zero index")
 	}
-	if idx, applied := cmd.Index(), state.RaftAppliedIndex; idx != applied+1 {
+	if idx, applied := cmd.Index(), b.state.RaftAppliedIndex; idx != applied+1 {
 		// If we have an out-of-order index, there's corruption. No sense in
 		// trying to update anything or running the command. Simply return.
 		return kvserverbase.ForcedErrResult{}, errors.AssertionFailedf("applied index jumped from %d to %d", applied, idx)
@@ -101,7 +109,7 @@ func (b *appBatch) assertAndCheckCommand(
 	// well. This just needs a bit more untangling as they reference *Replica, but
 	// for no super-convincing reason.
 
-	return kvserverbase.CheckForcedErr(ctx, cmd.ID, &cmd.Cmd, isLocal, state), nil
+	return kvserverbase.CheckForcedErr(ctx, cmd.ID, &cmd.Cmd, isLocal, &b.state), nil
 }
 
 func (b *appBatch) toCheckedCmd(

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -97,9 +97,6 @@ type appBatch struct {
 	initialForceFlushIndex roachpb.ForceFlushIndex
 	// asAlloc is reused by addAppliedStateToBatch to avoid heap allocations.
 	asAlloc kvserverpb.RangeAppliedState
-	// TODO(tbg): this will absorb the following fields from replicaAppBatch:
-	//
-	// - changeRemovesReplica
 }
 
 func (b *appBatch) assertAndCheckCommand(
@@ -232,6 +229,30 @@ func (b *appBatch) runPostAddTriggers(
 		}
 	}
 
+	return nil
+}
+
+// applyEntry validates and applies a single decoded raft entry to the state
+// machine using the standalone application pipeline. The online path
+// (replicaAppBatch.Stage) calls the same underlying methods with replica-only
+// steps interleaved.
+//
+// Commands that fail CheckForcedErr are applied as empty no-ops: their
+// WriteBatch and ReplicatedEvalResult are zeroed out, but the applied index
+// still advances. This matches the online path's behavior.
+//
+// The caller is responsible for calling addAppliedStateToBatch and committing
+// the batch after applying one or more entries.
+func (b *appBatch) applyEntry(ctx context.Context, cmd *replicatedCmd) error {
+	fr, err := b.assertAndCheckCommand(ctx, &cmd.ReplicatedCmd, false /* isLocal */)
+	if err != nil {
+		return err
+	}
+	b.toCheckedCmd(ctx, &cmd.ReplicatedCmd, fr)
+	if err := b.addWriteBatch(ctx, cmd); err != nil {
+		return err
+	}
+	b.stageTrivialResult(&cmd.ReplicatedCmd, fr)
 	return nil
 }
 

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -87,6 +87,16 @@ type appBatch struct {
 	// batch accumulates writes implied by the raft entries in this batch, across
 	// both the state and raft engines. It is engine separation aware.
 	batch kvstorage.Batch[storage.Batch]
+	// sl is a cached StateLoader for the range, initialized from
+	// raftMu.stateLoader. This avoids re-constructing key prefixes on every
+	// addAppliedStateToBatch call. Safe because the entire appBatch lifecycle
+	// runs under raftMu.
+	sl kvstorage.StateLoader
+	// initialForceFlushIndex records the ForceFlushIndex at the start of the
+	// batch, used by addAppliedStateToBatch to detect whether it changed.
+	initialForceFlushIndex roachpb.ForceFlushIndex
+	// asAlloc is reused by addAppliedStateToBatch to avoid heap allocations.
+	asAlloc kvserverpb.RangeAppliedState
 	// TODO(tbg): this will absorb the following fields from replicaAppBatch:
 	//
 	// - changeRemovesReplica
@@ -254,4 +264,26 @@ func (b *appBatch) stageTrivialResult(cmd *raftlog.ReplicatedCmd, fr kvserverbas
 		// final value being written.
 		b.state.ForceFlushIndex = roachpb.ForceFlushIndex{Index: cmd.Entry.Index}
 	}
+}
+
+// addAppliedStateToBatch writes the applied state to the batch. This records
+// the highest raft and lease index that have been applied, along with the MVCC
+// stats. If the ForceFlushIndex changed during this batch, it is written to
+// its own key first.
+func (b *appBatch) addAppliedStateToBatch(ctx context.Context) error {
+	// Write the ForceFlushIndex if it was staged during this batch. This index
+	// is stored in a separate RangeForceFlushKey but follows the same
+	// deferred-write pattern as RangeAppliedState.
+	if b.state.ForceFlushIndex != b.initialForceFlushIndex {
+		// NB: this branch goes first, so that MVCC stats are accurate below.
+		if err := b.sl.SetForceFlushIndex(
+			ctx, b.batch.State(), b.state.Stats, &b.state.ForceFlushIndex,
+		); err != nil {
+			return err
+		}
+	}
+	// Set the range applied state, which includes the last applied raft and
+	// lease index along with the MVCC stats, all in one key.
+	b.asAlloc = b.state.ToRangeAppliedState()
+	return b.sl.SetRangeAppliedState(ctx, b.batch.State(), &b.asAlloc)
 }

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -83,9 +84,11 @@ type appBatch struct {
 	// backing memory has already been provided and which may thus be
 	// modified directly.
 	state kvserverpb.ReplicaState
+	// batch accumulates writes implied by the raft entries in this batch, across
+	// both the state and raft engines. It is engine separation aware.
+	batch kvstorage.Batch[storage.Batch]
 	// TODO(tbg): this will absorb the following fields from replicaAppBatch:
 	//
-	// - batch
 	// - changeRemovesReplica
 }
 
@@ -139,9 +142,7 @@ func (b *appBatch) runPreAddTriggers(ctx context.Context, cmd *raftlog.Replicate
 }
 
 // addWriteBatch adds the command's writes to the batch.
-func (b *appBatch) addWriteBatch(
-	ctx context.Context, batch storage.Batch, cmd *replicatedCmd,
-) error {
+func (b *appBatch) addWriteBatch(ctx context.Context, cmd *replicatedCmd) error {
 	wb := cmd.Cmd.WriteBatch
 	if wb == nil {
 		return nil
@@ -151,7 +152,7 @@ func (b *appBatch) addWriteBatch(
 	} else {
 		b.numMutations += mutations
 	}
-	if err := batch.ApplyBatchRepr(wb.Data, false); err != nil {
+	if err := b.batch.State().ApplyBatchRepr(wb.Data, false); err != nil {
 		return errors.Wrapf(err, "unable to apply WriteBatch")
 	}
 	return nil

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -221,4 +222,35 @@ func (b *appBatch) runPostAddTriggers(
 	}
 
 	return nil
+}
+
+// stageTrivialResult updates the applied state in b.state to reflect a
+// successfully checked command. This covers the "trivial" fields that are
+// updated for every command: applied index/term, lease applied index, closed
+// timestamp, and MVCC stats.
+func (b *appBatch) stageTrivialResult(cmd *raftlog.ReplicatedCmd, fr kvserverbase.ForcedErrResult) {
+	b.state.RaftAppliedIndex = cmd.Index()
+	b.state.RaftAppliedIndexTerm = kvpb.RaftTerm(cmd.Term)
+	// NB: since the command is "trivial" we know the LeaseIndex field is set to
+	// something meaningful if it's nonzero (e.g. cmd is not a lease request).
+	// For a rejected command, LeaseIndex was zeroed out earlier.
+	if leaseAppliedIndex := fr.LeaseIndex; leaseAppliedIndex != 0 {
+		b.state.LeaseAppliedIndex = leaseAppliedIndex
+	}
+	if cts := cmd.Cmd.ClosedTimestamp; cts != nil && !cts.IsEmpty() {
+		b.state.RaftClosedTimestamp = *cts
+	}
+	// Special-cased MVCC stats handling to exploit commutativity of stats
+	// delta upgrades. Thanks to commutativity, the spanlatch manager does
+	// not have to serialize on the stats key.
+	res := cmd.ReplicatedResult()
+	b.state.Stats.Add(res.Delta.ToStats())
+	if res.DoTimelyApplicationToAllReplicas {
+		// Update the pending ForceFlushIndex of this batch. Writing is deferred
+		// to addAppliedStateToBatch, following the same pattern as AppliedState
+		// fields (RaftAppliedIndex, LeaseAppliedIndex). This allows multiple
+		// commands in the same batch to update ForceFlushIndex, with only the
+		// final value being written.
+		b.state.ForceFlushIndex = roachpb.ForceFlushIndex{Index: cmd.Entry.Index}
+	}
 }

--- a/pkg/kv/kvserver/app_batch_test.go
+++ b/pkg/kv/kvserver/app_batch_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestEntry creates a raftpb.Entry with an encoded RaftCommand for testing.
+func makeTestEntry(
+	t *testing.T, index kvpb.RaftIndex, term kvpb.RaftTerm, cmd kvserverpb.RaftCommand,
+) raftpb.Entry {
+	t.Helper()
+	cmdID := kvserverbase.CmdIDKey(fmt.Sprintf("%08d", index))
+	data, err := raftlog.EncodeCommand(
+		context.Background(), &cmd, cmdID, raftlog.EncodeOptions{},
+	)
+	require.NoError(t, err)
+	return raftpb.Entry{
+		Index: uint64(index),
+		Term:  uint64(term),
+		Type:  raftpb.EntryNormal,
+		Data:  data,
+	}
+}
+
+// makeWriteBatch creates a WriteBatch containing a single unversioned
+// key-value pair.
+func makeWriteBatch(t *testing.T, eng storage.Engine, key, val string) *kvserverpb.WriteBatch {
+	t.Helper()
+	b := eng.NewWriteBatch()
+	defer b.Close()
+	require.NoError(t, b.PutUnversioned(roachpb.Key(key), []byte(val)))
+	return &kvserverpb.WriteBatch{Data: b.Repr()}
+}
+
+// TestAppBatchApplyEntry demonstrates the intended usage of appBatch for
+// standalone log application: create an appBatch with a pebble batch, apply
+// multiple entries, write the applied state, and commit atomically.
+func TestAppBatchApplyEntry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	eng := kvstorage.MakeSeparatedEnginesForTesting(
+		storage.NewDefaultInMemForTesting(), storage.NewDefaultInMemForTesting(),
+	)
+	defer eng.Close()
+	var seq wag.Seq
+	bf := kvstorage.MakeBatchFactory(&eng, &seq)
+
+	lease := roachpb.Lease{Sequence: 1}
+	ms := enginepb.MVCCStats{}
+	rangeID := roachpb.RangeID(1)
+
+	stateEng := eng.StateEngine()
+	ent1 := makeTestEntry(t, 11, 1, kvserverpb.RaftCommand{
+		ProposerLeaseSequence: lease.Sequence,
+		MaxLeaseIndex:         11,
+		WriteBatch:            makeWriteBatch(t, stateEng, "key1", "val1"),
+	})
+	ent2 := makeTestEntry(t, 12, 1, kvserverpb.RaftCommand{
+		ProposerLeaseSequence: lease.Sequence,
+		MaxLeaseIndex:         12,
+		WriteBatch:            makeWriteBatch(t, stateEng, "key2", "val2"),
+	})
+
+	// Create an appBatch with a pebble batch and initial state.
+	ab := appBatch{
+		state: kvserverpb.ReplicaState{
+			RaftAppliedIndex: 10,
+			Lease:            &lease,
+			GCThreshold:      &hlc.Timestamp{},
+			Desc:             &roachpb.RangeDescriptor{RangeID: rangeID},
+			Stats:            &ms,
+		},
+		batch: bf.NewBatch(),
+		sl:    kvstorage.MakeStateLoader(rangeID),
+	}
+	defer ab.batch.Close()
+
+	// Apply multiple entries into the same batch.
+	var cmd replicatedCmd
+	require.NoError(t, cmd.Decode(&ent1))
+	require.NoError(t, ab.applyEntry(ctx, &cmd))
+	require.NoError(t, cmd.Decode(&ent2))
+	require.NoError(t, ab.applyEntry(ctx, &cmd))
+
+	// Write the applied state and commit atomically.
+	require.NoError(t, ab.addAppliedStateToBatch(ctx))
+	require.NoError(t, ab.batch.Commit(false /* sync */))
+
+	// Verify in-memory state was updated.
+	require.Equal(t, kvpb.RaftIndex(12), ab.state.RaftAppliedIndex)
+	require.Equal(t, kvpb.LeaseAppliedIndex(12), ab.state.LeaseAppliedIndex)
+
+	// Verify both write batches were applied to the state engine.
+	for _, kv := range []struct{ k, v string }{{"key1", "val1"}, {"key2", "val2"}} {
+		kvs, err := storage.Scan(
+			ctx, stateEng, roachpb.Key(kv.k), roachpb.Key(kv.k).Next(), 1,
+		)
+		require.NoError(t, err)
+		require.Len(t, kvs, 1)
+		require.Equal(t, []byte(kv.v), kvs[0].Value)
+	}
+}

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -38,7 +38,7 @@ import (
 // to the current view of ReplicaState and staged in the batch. The batch is
 // committed to the state machine's storage engine atomically.
 type replicaAppBatch struct {
-	ab appBatch
+	appBatch
 
 	r          *Replica
 	applyStats *applyCommittedEntriesStats
@@ -131,7 +131,7 @@ func (b *replicaAppBatch) Stage(
 
 	// Run any triggers that should occur before the batch is applied
 	// and before the write batch is staged in the batch.
-	if err := b.ab.runPreAddTriggers(ctx, &cmd.ReplicatedCmd); err != nil {
+	if err := b.runPreAddTriggers(ctx, &cmd.ReplicatedCmd); err != nil {
 		return nil, err
 	}
 
@@ -144,7 +144,7 @@ func (b *replicaAppBatch) Stage(
 	}
 
 	// Stage the command's write batch in the application batch.
-	if err := b.ab.addWriteBatch(ctx, b.batch.State(), cmd); err != nil {
+	if err := b.addWriteBatch(ctx, b.batch.State(), cmd); err != nil {
 		return nil, err
 	}
 
@@ -152,7 +152,7 @@ func (b *replicaAppBatch) Stage(
 	// after the (current) write batch is staged in the batch. Note that additional
 	// calls to `Stage` (for subsequent log entries) may occur before the batch
 	// will be committed, but all of these commands will be `IsTrivial()`.
-	if err := b.ab.runPostAddTriggers(ctx, &cmd.ReplicatedCmd, postAddEnv{
+	if err := b.runPostAddTriggers(ctx, &cmd.ReplicatedCmd, postAddEnv{
 		st:          b.r.store.cfg.Settings,
 		eng:         b.r.store.StateEngine(),
 		sideloaded:  b.r.logStorage.ls.Sideload,
@@ -172,11 +172,11 @@ func (b *replicaAppBatch) Stage(
 	if err := b.stageTrivialReplicatedEvalResult(ctx, cmd); err != nil {
 		return nil, err
 	}
-	b.ab.numEntriesProcessed++
+	b.numEntriesProcessed++
 	size := len(cmd.Data)
-	b.ab.numEntriesProcessedBytes += int64(size)
+	b.numEntriesProcessedBytes += int64(size)
 	if size == 0 {
-		b.ab.numEmptyEntries++
+		b.numEmptyEntries++
 	}
 
 	// The command was checked by shouldApplyCommand, so it can be returned
@@ -270,7 +270,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	if !cmd.IsLocal() {
 		writeBytes, ingestedBytes := cmd.getStoreWriteByteSizes()
 		if writeBytes > 0 || ingestedBytes > 0 {
-			b.ab.numWriteAndIngestedBytes += writeBytes + ingestedBytes
+			b.numWriteAndIngestedBytes += writeBytes + ingestedBytes
 		}
 		// TODO(irfansharif): This code block can be removed once below-raft
 		// admission control is the only form of IO admission control. It pre-dates
@@ -631,7 +631,7 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 // application.
 func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	if log.V(4) {
-		log.KvExec.Infof(ctx, "flushing batch %v of %d entries", b.state, b.ab.numEntriesProcessed)
+		log.KvExec.Infof(ctx, "flushing batch %v of %d entries", b.state, b.numEntriesProcessed)
 	}
 
 	// Add the replica applied state key to the write batch if this change
@@ -725,7 +725,7 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	r.store.metrics.addMVCCStats(ctx, r.tenantMetricsRef, deltaStats)
 
 	// Record the number of keys written to the replica.
-	b.r.loadStats.RecordWriteKeys(float64(b.ab.numMutations))
+	b.r.loadStats.RecordWriteKeys(float64(b.numMutations))
 
 	now := crtime.NowMono()
 	if needsSplitBySize && r.splitQueueThrottle.ShouldProcess(now) {
@@ -771,15 +771,15 @@ func (b *replicaAppBatch) addAppliedStateToBatch(ctx context.Context) error {
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
-	b.applyStats.appBatchStats.merge(b.ab.appBatchStats)
+	b.applyStats.appBatchStats.merge(b.appBatchStats)
 	b.applyStats.numBatchesProcessed++
 	b.applyStats.followerStoreWriteBytes.Merge(b.followerStoreWriteBytes)
-	b.r.recordRequestWriteBytes(b.ab.numWriteAndIngestedBytes)
+	b.r.recordRequestWriteBytes(b.numWriteAndIngestedBytes)
 
-	if n := b.ab.numAddSST; n > 0 {
+	if n := b.numAddSST; n > 0 {
 		b.r.store.metrics.AddSSTableApplications.Inc(int64(n))
 	}
-	if n := b.ab.numAddSSTCopies; n > 0 {
+	if n := b.numAddSSTCopies; n > 0 {
 		b.r.store.metrics.AddSSTableApplicationCopies.Inc(int64(n))
 	}
 
@@ -936,7 +936,7 @@ func (b *replicaAppBatch) assertNoCmdClosedTimestampRegression(
 				"Closed timestamp was set by req: %s under lease: %s; applied at LAI: %d. Batch idx: %d.\n"+
 				"Raft log tail:\n%s",
 			cmd.ID, cmd.Term, cmd.Index(), existingClosed, newClosed, b.state.Lease, req, cmd.LeaseIndex,
-			prevReq, b.closedTimestampSetter.lease, b.closedTimestampSetter.leaseIdx, b.ab.numEntriesProcessed,
+			prevReq, b.closedTimestampSetter.lease, b.closedTimestampSetter.leaseIdx, b.numEntriesProcessed,
 			logTail)
 		logcrash.ReportOrPanic(ctx, &b.r.ClusterSettings().SV, "%v", err)
 	}

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -62,9 +62,6 @@ type replicaAppBatch struct {
 
 	start                   time.Time // time at NewBatch()
 	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
-
-	// Reused by addAppliedStateToBatch to avoid heap allocations.
-	asAlloc kvserverpb.RangeAppliedState
 }
 
 // Stage implements the apply.Batch interface. The method handles the first
@@ -712,26 +709,6 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// addAppliedStateToBatch adds the applied state to the application batch's
-// Pebble batch. This records the highest raft and lease index that have been
-// applied as of this batch. It also records the Range's MVCC stats.
-func (b *replicaAppBatch) addAppliedStateToBatch(ctx context.Context) error {
-	// Write the ForceFlushIndex if it was staged during this batch. This index is
-	// stored in a separate RangeForceFlushKey but follows the same deferred-write
-	// pattern as RangeAppliedState.
-	if b.state.ForceFlushIndex != b.r.shMu.state.ForceFlushIndex {
-		// NB: this branch goes first, so that MVCC stats are accurate below.
-		if err := b.r.raftMu.stateLoader.SetForceFlushIndex(
-			ctx, b.batch.State(), b.state.Stats, &b.state.ForceFlushIndex); err != nil {
-			return err
-		}
-	}
-	// Set the range applied state, which includes the last applied raft and lease
-	// index along with the MVCC stats, all in one key.
-	b.asAlloc = b.state.ToRangeAppliedState()
-	return b.r.raftMu.stateLoader.SetRangeAppliedState(ctx, b.batch.State(), &b.asAlloc)
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -46,15 +46,6 @@ type replicaAppBatch struct {
 	// batch accumulates writes implied by the raft entries in this batch, across
 	// both the state and raft engines. It is engine separation aware.
 	batch kvstorage.Batch[storage.Batch]
-	// state is this batch's view of the replica's state. It is copied from
-	// under the Replica.mu when the batch is initialized and is updated in
-	// stageTrivialReplicatedEvalResult.
-	//
-	// This is a shallow copy so any mutations inside of pointer fields need
-	// to copy-on-write. The exception to this is `state.Stats`, for which
-	// backing memory has already been provided and which may thus be
-	// modified directly.
-	state kvserverpb.ReplicaState
 	// truncState is this batch's view of the raft log truncation state. It is
 	// copied from under the Replica.mu when the batch is initialized, and remains
 	// constant since raftMu is being held throughout the lifetime of this batch.
@@ -108,9 +99,7 @@ func (b *replicaAppBatch) Stage(
 
 	// We'll follow the steps outlined in appBatch's comment here, and will call
 	// into appBatch at appropriate times.
-	var ab appBatch
-
-	fr, err := ab.assertAndCheckCommand(ctx, &cmd.ReplicatedCmd, &b.state, cmd.IsLocal())
+	fr, err := b.assertAndCheckCommand(ctx, &cmd.ReplicatedCmd, cmd.IsLocal())
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +111,7 @@ func (b *replicaAppBatch) Stage(
 
 	// Now update cmd. We'll either put the lease index in it or zero out
 	// the cmd in case there's a forced error.
-	ab.toCheckedCmd(ctx, &cmd.ReplicatedCmd, fr)
+	b.toCheckedCmd(ctx, &cmd.ReplicatedCmd, fr)
 
 	// TODO(tbg): these assertions should be pushed into
 	// (*appBatch).assertAndCheckCommand.

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -580,36 +580,14 @@ func (b *replicaAppBatch) stageTruncation(
 func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	ctx context.Context, cmd *replicatedCmd,
 ) error {
-	b.state.RaftAppliedIndex = cmd.Index()
-	b.state.RaftAppliedIndexTerm = kvpb.RaftTerm(cmd.Term)
+	// Apply the durable state updates shared with standalone log application.
+	b.stageTrivialResult(&cmd.ReplicatedCmd, cmd.ForcedErrResult)
 
-	// NB: since the command is "trivial" we know the LeaseSequence field is set to
-	// something meaningful if it's nonzero (e.g. cmd is not a lease request). For
-	// a rejected command, cmd.LeaseSequence was zeroed out earlier.
-	if leaseAppliedIndex := cmd.LeaseIndex; leaseAppliedIndex != 0 {
-		b.state.LeaseAppliedIndex = leaseAppliedIndex
-	}
+	// Replica-only: record closed timestamp setter info for diagnostics.
 	if cts := cmd.Cmd.ClosedTimestamp; cts != nil && !cts.IsEmpty() {
-		b.state.RaftClosedTimestamp = *cts
 		b.closedTimestampSetter.record(cmd, b.state.Lease)
 	}
 
-	res := cmd.ReplicatedResult()
-
-	// Special-cased MVCC stats handling to exploit commutativity of stats delta
-	// upgrades. Thanks to commutativity, the spanlatch manager does not have to
-	// serialize on the stats key.
-	deltaStats := res.Delta.ToStats()
-	b.state.Stats.Add(deltaStats)
-
-	if res.DoTimelyApplicationToAllReplicas {
-		// Update the pending ForceFlushIndex of this batch. Writing is deferred to
-		// addAppliedStateToBatch, following the same pattern as AppliedState
-		// fields (RaftAppliedIndex, LeaseAppliedIndex). This allows multiple
-		// commands in the same batch to update ForceFlushIndex, with only the final
-		// value being written.
-		b.state.ForceFlushIndex = roachpb.ForceFlushIndex{Index: cmd.Entry.Index}
-	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -43,9 +43,6 @@ type replicaAppBatch struct {
 	r          *Replica
 	applyStats *applyCommittedEntriesStats
 
-	// batch accumulates writes implied by the raft entries in this batch, across
-	// both the state and raft engines. It is engine separation aware.
-	batch kvstorage.Batch[storage.Batch]
 	// truncState is this batch's view of the raft log truncation state. It is
 	// copied from under the Replica.mu when the batch is initialized, and remains
 	// constant since raftMu is being held throughout the lifetime of this batch.
@@ -133,7 +130,7 @@ func (b *replicaAppBatch) Stage(
 	}
 
 	// Stage the command's write batch in the application batch.
-	if err := b.addWriteBatch(ctx, b.batch.State(), cmd); err != nil {
+	if err := b.addWriteBatch(ctx, cmd); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -150,9 +150,11 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	// it is more efficient. If there are exceptions, sparingly use NewReader or
 	// NewBatch (if it needs to read its own writes, which is unlikely).
 	b.batch = r.store.batchFactory.NewBatch()
+	b.sl = r.raftMu.stateLoader
 
 	r.mu.RLock()
 	b.state = r.shMu.state
+	b.initialForceFlushIndex = r.shMu.state.ForceFlushIndex
 	b.truncState = r.asLogStorage().shMu.trunc
 	b.state.Stats = &sm.stats
 	*b.state.Stats = *r.shMu.state.Stats


### PR DESCRIPTION
Move `appBatch` one step closer to standalone Raft log entry application. Embed it in `replicaAppBatch` and move the fields and methods it needs (`state`, `batch`, `stageTrivialResult`, `addAppliedStateToBatch`) down from `replicaAppBatch`. The online path is unchanged -- `replicaAppBatch` accesses the same methods via embedding, interleaving replica-only steps. The new `applyEntry` function sets up the usage of the offline path (i.e. WAG Raft log replay).

This is a pure refactor plus the addition of the currently-unused method `applyEntry`.

Informs: #75729
Release note: None