### PR TITLE
roachtest: add CPU time token admission control roachtests

### DIFF
--- a/monitoring/grafana-dashboards/by-roachtest/cpu-time-token-admission-control.json
+++ b/monitoring/grafana-dashboards/by-roachtest/cpu-time-token-admission-control.json
@@ -1,0 +1,1537 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "name": "Roachtest annotation",
+        "target": {
+          "refId": "Anno",
+          "tags": [
+            "$test_run_id",
+            "$test_name"
+          ],
+          "type": "tags"
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 2150,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "crdb-console-run-name"
+      ],
+      "targetBlank": false,
+      "title": "Other dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Global",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sys_cpu_combined_percent_normalized{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "admission_cpu_time_tokens_multiplier{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Multiplier (token-to-CPU-time ratio)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_usage_consumed{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_usage_returned{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "net ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Net Token Usage Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Exhausted Duration (fraction of wall-clock time bucket was exhausted)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_exhausted_duration_nanos_system_tenant_can_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) / 1e9",
+          "legendFormat": "system_tenant/can_burst ({{instance}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_exhausted_duration_nanos_system_tenant_no_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) / 1e9",
+          "legendFormat": "system_tenant/no_burst ({{instance}})",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Exhausted Duration - system_tenant",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_exhausted_duration_nanos_app_tenant_can_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) / 1e9",
+          "legendFormat": "app_tenant/can_burst ({{instance}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_exhausted_duration_nanos_app_tenant_no_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) / 1e9",
+          "legendFormat": "app_tenant/no_burst ({{instance}})",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Exhausted Duration - app_tenant",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Refill Rates",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_refill_added_system_tenant_can_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_refill_removed_system_tenant_can_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "net can_burst ({{instance}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_refill_added_system_tenant_no_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_refill_removed_system_tenant_no_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "net no_burst ({{instance}})",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Net Refill Rate - system_tenant",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_refill_added_app_tenant_can_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_refill_removed_app_tenant_can_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "net can_burst ({{instance}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_refill_added_app_tenant_no_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_refill_removed_app_tenant_no_burst{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "net no_burst ({{instance}})",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Net Refill Rate - app_tenant",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Per-Tenant Admission (system_tenant tier)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_per_tenant_admitted_count_system_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval])",
+          "legendFormat": "tenant={{tenant_id}} ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admitted Rate - system_tenant tier",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_per_tenant_wait_time_nanos_system_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval]) / rate(admission_cpu_time_tokens_per_tenant_admitted_count_system_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval])",
+          "legendFormat": "tenant={{tenant_id}} ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mean Wait Time - system_tenant tier",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_per_tenant_tokens_used_system_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_per_tenant_tokens_returned_system_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval])",
+          "legendFormat": "net tenant={{tenant_id}} ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Net Token Flow - system_tenant tier",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Per-Tenant Admission (app_tenant tier)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_per_tenant_admitted_count_app_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval])",
+          "legendFormat": "tenant={{tenant_id}} ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admitted Rate - app_tenant tier",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_per_tenant_wait_time_nanos_app_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval]) / rate(admission_cpu_time_tokens_per_tenant_admitted_count_app_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval])",
+          "legendFormat": "tenant={{tenant_id}} ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mean Wait Time - app_tenant tier",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(admission_cpu_time_tokens_per_tenant_tokens_used_app_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval]) - rate(admission_cpu_time_tokens_per_tenant_tokens_returned_app_tenant{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\",instance=~\"$node\",tenant_id!=\"\"}[$__rate_interval])",
+          "legendFormat": "net tenant={{tenant_id}} ({{instance}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Net Token Flow - app_tenant tier",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "crdb-console-run-name",
+    "admission-control",
+    "cpu-time-tokens"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "v9Zz2K6nz"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "joshimhoff-1777568165",
+          "value": "joshimhoff-1777568165"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(sys_uptime{job=\"cockroachdb\"},test_run_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Test Run ID",
+        "multi": false,
+        "name": "test_run_id",
+        "options": [],
+        "query": {
+          "query": "label_values(sys_uptime{job=\"cockroachdb\"},test_run_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": false,
+          "text": "admission-control-multitenant-isolation-kv-read-noisy-neighbor",
+          "value": "admission-control-multitenant-isolation-kv-read-noisy-neighbor"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(sys_uptime{job=\"cockroachdb\",test_run_id=~\"$test_run_id\"},test_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Test",
+        "multi": false,
+        "name": "test_name",
+        "options": [],
+        "query": {
+          "query": "label_values(sys_uptime{job=\"cockroachdb\",test_run_id=~\"$test_run_id\"},test_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(sys_uptime{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(sys_uptime{job=\"cockroachdb\",test_run_id=~\"$test_run_id\",test_name=~\"$test_name\"},instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CPU Time Token Admission Control",
+  "uid": "cpu-time-tokens",
+  "version": 1,
+  "weekStart": ""
+}

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "admission_control_multi_store_index_backfill.go",
         "admission_control_multi_store_overload.go",
         "admission_control_multitenant_fairness.go",
+        "admission_control_multitenant_isolation.go",
         "admission_control_row_level_ttl.go",
         "admission_control_single_node_index_backfill.go",
         "admission_control_snapshot_overload.go",

--- a/pkg/cmd/roachtest/tests/admission_control.go
+++ b/pkg/cmd/roachtest/tests/admission_control.go
@@ -29,6 +29,7 @@ func registerAdmission(r registry.Registry) {
 	registerElasticControlForRowLevelTTL(r)
 	registerMultiStoreOverload(r)
 	registerMultiTenantFairness(r)
+	registerMultiTenantIsolation(r)
 	registerSnapshotOverload(r)
 	registerSnapshotOverloadIO(r)
 	registerTPCCOverload(r)

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"time"
 
+	rpgrafana "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/grafana"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 )
@@ -82,6 +84,30 @@ func registerMultiTenantFairness(r registry.Registry) {
 			maxOps:      1000,
 			query:       "UPSERT INTO kv(k, v)",
 		},
+		// Concurrency is set much higher than the non-cpu-time-token
+		// variants (3500 vs 250) to push CPU utilization into the range
+		// where admission control actively queues requests. Without
+		// sufficient load, AC never engages and the test wouldn't
+		// exercise fairness under queueing.
+		//
+		// TODO(joshimhoff): Do the non-cpu-time-token variants above
+		// actually saturate the KV node enough to trigger AC queueing?
+		// If not, they may not be testing what they claim. They also
+		// only log results rather than asserting on them, and neither
+		// does this cpu-time-token variant. The isolation tests in
+		// admission_control_multitenant_isolation.go do make hard
+		// assertions.
+		{
+			name:           "read-heavy/even/cpu-time-tokens",
+			concurrency:    func(int) int { return 3500 },
+			blockSize:      5,
+			readPercent:    95,
+			duration:       20 * time.Minute,
+			batch:          100,
+			maxOps:         100_000,
+			query:          "SELECT k, v FROM kv",
+			cpuTimeTokenAC: true,
+		},
 	}
 
 	for _, s := range specs {
@@ -102,20 +128,30 @@ func registerMultiTenantFairness(r registry.Registry) {
 }
 
 type multiTenantFairnessSpec struct {
-	name  string
-	query string // query for which we'll check statistics for
+	name string
 
-	readPercent int           // --read-percent
-	blockSize   int           // --min-block-bytes, --max-block-bytes
-	duration    time.Duration // --duration
-	concurrency func(int) int // --concurrency
-	batch       int           // --batch
-	maxOps      int           // --max-ops
+	readPercent    int           // --read-percent
+	blockSize      int           // --min-block-bytes, --max-block-bytes
+	duration       time.Duration // --duration
+	concurrency    func(int) int // --concurrency
+	batch          int           // --batch
+	maxOps         int           // --max-ops
+	cpuTimeTokenAC bool
+
+	query string // statement fingerprint to filter in statement_statistics
 }
 
 func runMultiTenantFairness(
 	ctx context.Context, t test.Test, c cluster.Cluster, s multiTenantFairnessSpec,
 ) {
+	annotatePhase := func(text string) {
+		if err := c.AddGrafanaAnnotation(
+			ctx, t.L(), rpgrafana.AddAnnotationRequest{Text: text},
+		); err != nil {
+			t.L().Printf("annotation error: %v", err)
+		}
+	}
+
 	crdbNode := c.Node(1)
 	if c.IsLocal() {
 		s.duration = 30 * time.Second
@@ -144,6 +180,9 @@ func runMultiTenantFairness(
 	promCfg.WithNodeExporter(crdbNode.InstallNodes())
 	promCfg.WithCluster(crdbNode.InstallNodes())
 	promCfg.WithGrafanaDashboardJSON(grafana.MultiTenantFairnessGrafanaJSON)
+	if s.cpuTimeTokenAC {
+		logCPUTimeTokenDashboardLink(t, c)
+	}
 
 	systemConn := c.Conn(ctx, t.L(), crdbNode[0])
 	defer systemConn.Close()
@@ -206,7 +245,16 @@ func runMultiTenantFairness(
 		c.Run(ctx, option.WithNodes(node), initKV)
 	}
 
+	if s.cpuTimeTokenAC {
+		if _, err := systemConn.ExecContext(
+			ctx, `SET CLUSTER SETTING admission.cpu_time_tokens.enabled = true`,
+		); err != nil {
+			t.Fatalf("failed to enable cpu time tokens: %v", err)
+		}
+	}
+
 	t.L().Printf("loading per-tenant data (<%s)", 10*time.Minute)
+	annotatePhase("loading data")
 	m1 := c.NewDeprecatedMonitor(ctx, c.All())
 	for name, node := range virtualClusters {
 		pgurl := fmt.Sprintf("{pgurl:%d:%s}", node[0], name)
@@ -246,9 +294,12 @@ func runMultiTenantFairness(
 
 	waitDur := 2 * time.Minute
 	t.L().Printf("loaded data for all tenants, sleeping (<%s)", waitDur)
+	annotatePhase("data loaded")
 	time.Sleep(waitDur)
 
 	t.L().Printf("running virtual cluster workloads (<%s)", s.duration+time.Minute)
+	annotatePhase("running workloads")
+	workloadStart := timeutil.Now()
 	m2 := c.NewDeprecatedMonitor(ctx, crdbNode)
 	var n int
 	for name, node := range virtualClusters {
@@ -268,6 +319,11 @@ func runMultiTenantFairness(
 				Flag("read-percent", s.readPercent).
 				Flag("concurrency", s.concurrency(n)).
 				Arg("%s", pgurl)
+			// With cpu-time-token AC the cluster runs near CPU capacity,
+			// so AC throttling may cause some workload errors.
+			if s.cpuTimeTokenAC {
+				cmd.Option("tolerate-errors")
+			}
 
 			if err := c.RunE(ctx, option.WithNodes(node), cmd.String()); err != nil {
 				return err
@@ -278,6 +334,11 @@ func runMultiTenantFairness(
 		})
 	}
 	m2.Wait()
+	workloadEnd := timeutil.Now()
+
+	if s.cpuTimeTokenAC {
+		verifyCPUUtilization(ctx, c, t, crdbNode, workloadStart, workloadEnd)
+	}
 
 	// Pull workload performance from crdb_internal.statement_statistics. We
 	// could alternatively get these from the workload itself but this was
@@ -340,6 +401,8 @@ func runMultiTenantFairness(
 		// TODO(irfansharif): This is a weak assertion. Variation occurs when
 		// there are workload differences during periods where AC is not
 		// inducing any queuing. Remove?
+		// TODO(josh): Consider making this fail the test for cpu-time-token
+		// variants.
 		t.L().Printf("throughput not within expectations: %f > %f %v", maxThroughputDelta, failThreshold, throughput)
 	}
 
@@ -347,6 +410,8 @@ func runMultiTenantFairness(
 	t.L().Printf("max-latency-delta=%d%% mean-latency-per-tenant=%v\n", int(maxLatencyDelta*100), meanLatencies)
 	if !ok {
 		// TODO(irfansharif): Same as above -- this is a weak assertion.
+		// TODO(josh): Consider only testing latency isolation from
+		// admission_control_multitenant_isolation.go.
 		t.L().Printf("latency not within expectations: %f > %f %v", maxLatencyDelta, failThreshold, meanLatencies)
 	}
 

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
@@ -303,7 +303,7 @@ func runMultiTenantIsolation(
 	t.L().Printf("phase 2: running both tenants (%s)", phase2Duration)
 	annotatePhase("phase 2: both tenants")
 	workloadStart := timeutil.Now()
-	m2 := c.NewDeprecatedMonitor(ctx, kvNode)
+	m2 := c.NewDeprecatedMonitor(ctx, c.All())
 
 	// Quiet tenant workload.
 	m2.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
@@ -446,11 +446,20 @@ func verifyCPUUtilization(
 	}
 }
 
+// dashboardLinkRe extracts the test_run_id from a roachtest cluster name of
+// the form "<test_run_id>-NN-...".
+var dashboardLinkRe = regexp.MustCompile(`^(.+)-\d{2}-`)
+
 // logCPUTimeTokenDashboardLink logs a link to the CPU time token admission
-// control dashboard on the shared Grafana instance.
+// control dashboard on the shared Grafana instance. Best-effort: cluster
+// names that do not match the expected pattern (e.g. local runs where
+// c.Name() is "local") skip the link rather than failing the test.
 func logCPUTimeTokenDashboardLink(t test.Test, c cluster.Cluster) {
-	m := regexp.MustCompile(`^(.+)-\d{2}-`).FindStringSubmatch(c.Name())
-	require.NotNil(t, m, "could not extract test_run_id from cluster name %q", c.Name())
+	m := dashboardLinkRe.FindStringSubmatch(c.Name())
+	if m == nil {
+		t.L().Printf("skipping Grafana dashboard link: cluster name %q does not match expected pattern", c.Name())
+		return
+	}
 	t.L().Printf(
 		"Grafana dashboard: https://grafana.testeng.crdb.io/d/cpu-time-tokens/cpu-time-token-admission-control"+
 			"?orgId=1&var-DS_PROMETHEUS=v9Zz2K6nz&var-test_run_id=%s&var-node=All",

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
@@ -7,6 +7,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"regexp"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -288,21 +290,7 @@ func runMultiTenantIsolation(
 	_, err = quietConn.ExecContext(ctx, "USE "+dbName)
 	require.NoError(t, err)
 
-	var baselineLatency float64
-	if s.kv != nil {
-		err = quietConn.QueryRowContext(ctx, `
-			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
-			FROM crdb_internal.statement_statistics
-			WHERE metadata @> '{"db":"kv"}' AND metadata @> $1`,
-			fmt.Sprintf(`{"querySummary": "%s"}`, s.kv.query),
-		).Scan(&baselineLatency)
-	} else {
-		err = quietConn.QueryRowContext(ctx, `
-			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
-			FROM crdb_internal.statement_statistics
-			WHERE metadata @> '{"db":"tpcc"}'`,
-		).Scan(&baselineLatency)
-	}
+	baselineLatency, err := fetchAvgQuietLatency(ctx, quietConn, s)
 	require.NoError(t, err)
 	t.L().Printf("phase 1 baseline latency: %f", baselineLatency)
 
@@ -377,31 +365,59 @@ func runMultiTenantIsolation(
 	verifyCPUUtilization(ctx, c, t, kvNode, workloadStart, workloadEnd)
 
 	// Collect phase 2 latency from statement statistics.
-	var quietLatency float64
-	if s.kv != nil {
-		err = quietConn.QueryRowContext(ctx, `
-			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
-			FROM crdb_internal.statement_statistics
-			WHERE metadata @> '{"db":"kv"}' AND metadata @> $1`,
-			fmt.Sprintf(`{"querySummary": "%s"}`, s.kv.query),
-		).Scan(&quietLatency)
-	} else {
-		err = quietConn.QueryRowContext(ctx, `
-			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
-			FROM crdb_internal.statement_statistics
-			WHERE metadata @> '{"db":"tpcc"}'`,
-		).Scan(&quietLatency)
-	}
+	quietLatency, err := fetchAvgQuietLatency(ctx, quietConn, s)
 	require.NoError(t, err)
 	quietLatencyDur := time.Duration(quietLatency * float64(time.Second))
 	baselineDur := time.Duration(baselineLatency * float64(time.Second))
 
-	t.L().Printf("phase 2 quiet latency: %s (baseline: %s, ratio: %.2f)",
-		quietLatencyDur, baselineDur, quietLatency/baselineLatency)
+	ratioStr := "n/a"
+	if baselineLatency > 0 {
+		ratioStr = fmt.Sprintf("%.2f", quietLatency/baselineLatency)
+	}
+	t.L().Printf("phase 2 quiet latency: %s (baseline: %s, ratio: %s)",
+		quietLatencyDur, baselineDur, ratioStr)
 
 	if quietLatencyDur > s.quietLatencyMax {
 		t.Fatalf("quiet tenant latency %s exceeds max %s", quietLatencyDur, s.quietLatencyMax)
 	}
+}
+
+// fetchAvgQuietLatency returns the avg run latency (in seconds) recorded for
+// the quiet tenant's workload-fingerprint statements in the current SQL stats
+// window. It returns an error if no matching statements are recorded so the
+// caller fails with a descriptive message rather than the cryptic
+// "converting NULL to float64" Scan error.
+func fetchAvgQuietLatency(
+	ctx context.Context, conn *gosql.DB, s multiTenantIsolationSpec,
+) (float64, error) {
+	var (
+		row    *gosql.Row
+		filter string
+	)
+	if s.kv != nil {
+		filter = fmt.Sprintf(`db=kv, querySummary=%q`, s.kv.query)
+		row = conn.QueryRowContext(ctx, `
+			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
+			FROM crdb_internal.statement_statistics
+			WHERE metadata @> '{"db":"kv"}' AND metadata @> $1`,
+			fmt.Sprintf(`{"querySummary": "%s"}`, s.kv.query),
+		)
+	} else {
+		filter = `db=tpcc`
+		row = conn.QueryRowContext(ctx, `
+			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
+			FROM crdb_internal.statement_statistics
+			WHERE metadata @> '{"db":"tpcc"}'`,
+		)
+	}
+	var avg gosql.NullFloat64
+	if err := row.Scan(&avg); err != nil {
+		return 0, errors.Wrapf(err, "scanning avg quiet latency (%s)", filter)
+	}
+	if !avg.Valid {
+		return 0, errors.Newf("no statement statistics matched filter %s", filter)
+	}
+	return avg.Float64, nil
 }
 
 // verifyCPUUtilization queries the combined CPU utilization metric over the

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
@@ -420,8 +420,16 @@ func fetchAvgQuietLatency(
 	return avg.Float64, nil
 }
 
+// cpuRampUpSamples is the number of leading 1-minute datapoints dropped from
+// the CPU average to exclude workload ramp-up bias. The combined CPU
+// timeseries is sampled at one-minute intervals, so 2 corresponds to ~2
+// minutes of warm-up.
+const cpuRampUpSamples = 2
+
 // verifyCPUUtilization queries the combined CPU utilization metric over the
-// given time window and asserts that the average is between 70% and 90%.
+// given time window and asserts that the average is in the expected band.
+// adminNode must designate a single KV node: the response is summed across
+// sources, so multi-node lists would aggregate per-node fractions.
 func verifyCPUUtilization(
 	ctx context.Context,
 	c cluster.Cluster,
@@ -443,6 +451,11 @@ func verifyCPUUtilization(
 		})
 
 	datapoints := response.Results[0].Datapoints
+	// Drop ramp-up samples so the average reflects steady-state behavior
+	// rather than the cold-start window.
+	if len(datapoints) > cpuRampUpSamples {
+		datapoints = datapoints[cpuRampUpSamples:]
+	}
 	if len(datapoints) == 0 {
 		t.Fatal("not enough CPU utilization datapoints")
 	}
@@ -453,12 +466,20 @@ func verifyCPUUtilization(
 	}
 	avgCPU := sum / float64(len(datapoints))
 
-	t.L().Printf("average CPU utilization: %.2f%%", avgCPU*100)
-	if avgCPU < 0.70 || avgCPU > 0.90 {
-		t.Fatalf(
-			"average CPU utilization %.2f%% not in expected range [70%%, 90%%]",
-			avgCPU*100,
-		)
+	t.L().Printf("average CPU utilization: %.2f%% (%d samples after %d ramp-up)",
+		avgCPU*100, len(datapoints), cpuRampUpSamples)
+
+	// The lower bound guards test validity: if CPU stays below the target
+	// band, the workload isn't actually saturating the cluster and the
+	// isolation/fairness signal isn't being exercised. The upper bound
+	// guards AC behavior: CPU above the band means AC is failing to throttle
+	// to its target utilization (default 0.8). The two failures have
+	// different root causes so they get distinct messages.
+	switch {
+	case avgCPU < 0.70:
+		t.Fatalf("workload did not saturate cluster: average CPU %.2f%% < 70%%", avgCPU*100)
+	case avgCPU > 0.90:
+		t.Fatalf("AC may be under-throttling: average CPU %.2f%% > 90%%", avgCPU*100)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_isolation.go
@@ -1,0 +1,459 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	rpgrafana "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// This test sets up a 3-node cluster -- one KV node (4 vCPUs) and two 32-vCPU
+// machines each running a SQL pod and workload generator co-located, one
+// "quiet" and one "noisy". The SQL/workload nodes are oversized so they aren't
+// the bottleneck -- today CPU time token AC only runs in the KV layer, not the
+// SQL layer. It tests that the quiet tenant's latency is isolated from a noisy
+// neighbor driving heavy load. The test runs both tenants concurrently and
+// asserts the quiet tenant's avg latency stays below a configured ceiling. It
+// also verifies that CPU utilization is in the 70-90% range.
+func registerMultiTenantIsolation(r registry.Registry) {
+	specs := []multiTenantIsolationSpec{
+		// Simplest KV test: the quiet tenant's concurrency is so small it
+		// should always be able to burst (see cpu_time_token_granter.go).
+		//
+		// KV tests focus on reads to ensure CPU is the bottleneck resource,
+		// not LSM or disk.
+		{
+			name:            "kv-tiny/noisy-neighbor",
+			quietLatencyMax: 10 * time.Millisecond,
+			kv: &multiTenantIsolationKVSpec{
+				readPercent:      95,
+				blockSize:        20,
+				batch:            100,
+				maxOps:           100_000,
+				quietConcurrency: 1,
+				noisyConcurrency: 3500,
+				query:            "SELECT k, v FROM kv",
+			},
+		},
+		// Larger quiet workload that can't burst, but is still much smaller
+		// than the noisy tenant so shouldn't be queued excessively.
+		{
+			name:            "kv-read/noisy-neighbor",
+			quietLatencyMax: 150 * time.Millisecond,
+			kv: &multiTenantIsolationKVSpec{
+				readPercent:      95,
+				blockSize:        20,
+				batch:            100,
+				maxOps:           100_000,
+				quietConcurrency: 25,
+				noisyConcurrency: 3500,
+				query:            "SELECT k, v FROM kv",
+			},
+		},
+		// TPCC exercises a more complex workload at the KV level than
+		// simple point reads/writes.
+		{
+			name:            "tpcc/noisy-neighbor",
+			quietLatencyMax: 20 * time.Millisecond,
+			tpcc: &multiTenantIsolationTPCCSpec{
+				quietWarehouses: 1,
+				noisyWarehouses: 200,
+			},
+		},
+	}
+	for _, s := range specs {
+		s := s
+		r.Add(registry.TestSpec{
+			Name: fmt.Sprintf("admission-control/multitenant-isolation/%s", s.name),
+			// Node 1: KV (4 vCPUs), Nodes 2-3: SQL pod + workload generator
+			// (32 vCPUs each, oversized so they aren't the bottleneck -- today
+			// CPU time token AC only runs in the KV layer, not the SQL layer).
+			Cluster: r.MakeClusterSpec(
+				3, spec.CPU(4), spec.VolumeSize(4096), spec.DisableLocalSSD(),
+				spec.WorkloadNodeCount(2), spec.WorkloadNodeCPU(32),
+			),
+			Owner:            registry.OwnerAdmissionControl,
+			Benchmark:        true,
+			CompatibleClouds: registry.CloudsWithServiceRegistration,
+			// TODO(joshimhoff): Consider moving to Weekly once tests are proven stable.
+			Suites:  registry.Suites(registry.Nightly),
+			Timeout: 60 * time.Minute,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runMultiTenantIsolation(ctx, t, c, s)
+			},
+		})
+	}
+}
+
+type multiTenantIsolationSpec struct {
+	name            string
+	kv              *multiTenantIsolationKVSpec
+	tpcc            *multiTenantIsolationTPCCSpec
+	quietLatencyMax time.Duration // max avg latency for quiet tenant during noisy period
+}
+
+type multiTenantIsolationKVSpec struct {
+	readPercent      int    // --read-percent
+	blockSize        int    // --min-block-bytes, --max-block-bytes
+	batch            int    // --batch
+	maxOps           int    // --max-ops
+	quietConcurrency int    // --concurrency for quiet tenant
+	noisyConcurrency int    // --concurrency for noisy tenant
+	query            string // querySummary filter for statement_statistics
+}
+
+type multiTenantIsolationTPCCSpec struct {
+	quietWarehouses int // --warehouses for quiet tenant
+	noisyWarehouses int // --warehouses for noisy tenant
+}
+
+func runMultiTenantIsolation(
+	ctx context.Context, t test.Test, c cluster.Cluster, s multiTenantIsolationSpec,
+) {
+	annotatePhase := func(text string) {
+		if err := c.AddGrafanaAnnotation(
+			ctx, t.L(), rpgrafana.AddAnnotationRequest{Text: text},
+		); err != nil {
+			t.L().Printf("annotation error: %v", err)
+		}
+	}
+
+	logCPUTimeTokenDashboardLink(t, c)
+
+	kvNode := c.Node(1)
+	quietSQLNode := c.Node(2)
+	noisySQLNode := c.Node(3)
+
+	t.L().Printf("starting cockroach")
+	c.Start(ctx, t.L(),
+		option.NewStartOpts(option.NoBackupSchedule),
+		install.MakeClusterSettings(),
+		kvNode,
+	)
+
+	systemConn := c.Conn(ctx, t.L(), kvNode[0])
+	defer systemConn.Close()
+
+	if _, err := systemConn.ExecContext(
+		ctx, `SET CLUSTER SETTING admission.cpu_time_tokens.enabled = true`,
+	); err != nil {
+		t.Fatalf("failed to enable cpu time tokens: %v", err)
+	}
+	if _, err := systemConn.ExecContext(
+		ctx, `SET CLUSTER SETTING server.child_metrics.enabled = true`,
+	); err != nil {
+		t.Fatalf("failed to enable child metrics: %v", err)
+	}
+	// Set effectively unlimited rate limiter so CPU time tokens are the
+	// binding constraint.
+	if _, err := systemConn.ExecContext(
+		ctx, `SET CLUSTER SETTING kv.tenant_rate_limiter.rate_limit = '1000000'`,
+	); err != nil {
+		t.Fatalf("failed to set tenant rate limiter limit: %v", err)
+	}
+
+	// Start virtual clusters.
+	quietName := "app-quiet"
+	noisyName := "app-noisy"
+
+	type vcInfo struct {
+		name       string
+		node       option.NodeListOption
+		warehouses int // TPCC only
+	}
+	var vcs []vcInfo
+	if s.tpcc != nil {
+		vcs = []vcInfo{
+			{quietName, quietSQLNode, s.tpcc.quietWarehouses},
+			{noisyName, noisySQLNode, s.tpcc.noisyWarehouses},
+		}
+	} else {
+		vcs = []vcInfo{
+			{quietName, quietSQLNode, 0},
+			{noisyName, noisySQLNode, 0},
+		}
+	}
+
+	for _, vc := range vcs {
+		c.StartServiceForVirtualCluster(
+			ctx, t.L(),
+			option.StartVirtualClusterOpts(vc.name, vc.node, option.NoBackupSchedule),
+			install.MakeClusterSettings(),
+		)
+		t.L().Printf("virtual cluster %q started on n%d", vc.name, vc.node[0])
+
+		// Set generous resource limits.
+		_, err := systemConn.ExecContext(
+			ctx, fmt.Sprintf(
+				"SELECT crdb_internal.update_tenant_resource_limits('%s', 1000000000, 10000, 1000000)",
+				vc.name,
+			),
+		)
+		require.NoError(t, err)
+	}
+
+	// Initialize workload schema and load data in parallel across tenants.
+	t.L().Printf("initializing and loading data for all tenants")
+	annotatePhase("loading data")
+	m1 := c.NewDeprecatedMonitor(ctx, c.All())
+	for _, vc := range vcs {
+		vc := vc
+		m1.Go(func(ctx context.Context) error {
+			if s.tpcc != nil {
+				initCmd := fmt.Sprintf(
+					"%s workload init tpcc --warehouses=%d {pgurl:%d:%s}",
+					test.DefaultCockroachPath, vc.warehouses, vc.node[0], vc.name,
+				)
+				return c.RunE(ctx, option.WithNodes(vc.node), initCmd)
+			}
+			initCmd := fmt.Sprintf(
+				"%s workload init kv {pgurl:%d:%s}",
+				test.DefaultCockroachPath, vc.node[0], vc.name,
+			)
+			if err := c.RunE(ctx, option.WithNodes(vc.node), initCmd); err != nil {
+				return err
+			}
+			pgurl := fmt.Sprintf("{pgurl:%d:%s}", vc.node[0], vc.name)
+			loadCmd := roachtestutil.NewCommand("%s workload run kv", test.DefaultCockroachPath).
+				Option("secure").
+				Flag("min-block-bytes", s.kv.blockSize).
+				Flag("max-block-bytes", s.kv.blockSize).
+				Flag("batch", s.kv.batch).
+				Flag("max-ops", s.kv.maxOps).
+				Flag("concurrency", 25).
+				Arg("%s", pgurl)
+			return c.RunE(ctx, option.WithNodes(vc.node), loadCmd.String())
+		})
+	}
+	m1.Wait()
+
+	waitDur := 2 * time.Minute
+	t.L().Printf("loaded data, sleeping %s", waitDur)
+	annotatePhase("data loaded")
+	time.Sleep(waitDur)
+
+	// Reset SQL stats on quiet tenant before baseline measurement.
+	quietConn := c.Conn(ctx, t.L(), quietSQLNode[0], option.VirtualClusterName(quietName))
+	defer quietConn.Close()
+	_, err := quietConn.ExecContext(ctx, "SELECT crdb_internal.reset_sql_stats()")
+	require.NoError(t, err)
+
+	// Phase 1: run only the quiet tenant workload to establish a baseline.
+	phase1Duration := 5 * time.Minute
+	t.L().Printf("phase 1: running quiet tenant only (%s)", phase1Duration)
+	annotatePhase("phase 1: quiet tenant only")
+	quietPgurl := fmt.Sprintf("{pgurl:%d:%s}", quietSQLNode[0], quietName)
+	if s.tpcc != nil {
+		quietCmd := roachtestutil.NewCommand("%s workload run tpcc", test.DefaultCockroachPath).
+			Option("secure").
+			Flag("warehouses", s.tpcc.quietWarehouses).
+			Flag("duration", phase1Duration).
+			Arg("%s", quietPgurl)
+		c.Run(ctx, option.WithNodes(quietSQLNode), quietCmd.String())
+	} else {
+		quietCmd := roachtestutil.NewCommand("%s workload run kv", test.DefaultCockroachPath).
+			Option("secure").
+			Flag("write-seq", fmt.Sprintf("R%d", s.kv.maxOps*s.kv.batch)).
+			Flag("min-block-bytes", s.kv.blockSize).
+			Flag("max-block-bytes", s.kv.blockSize).
+			Flag("batch", s.kv.batch).
+			Flag("duration", phase1Duration).
+			Flag("read-percent", s.kv.readPercent).
+			Flag("concurrency", s.kv.quietConcurrency).
+			Arg("%s", quietPgurl)
+		c.Run(ctx, option.WithNodes(quietSQLNode), quietCmd.String())
+	}
+
+	// Collect baseline latency from statement statistics.
+	dbName := "kv"
+	if s.tpcc != nil {
+		dbName = "tpcc"
+	}
+	_, err = quietConn.ExecContext(ctx, "USE "+dbName)
+	require.NoError(t, err)
+
+	var baselineLatency float64
+	if s.kv != nil {
+		err = quietConn.QueryRowContext(ctx, `
+			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
+			FROM crdb_internal.statement_statistics
+			WHERE metadata @> '{"db":"kv"}' AND metadata @> $1`,
+			fmt.Sprintf(`{"querySummary": "%s"}`, s.kv.query),
+		).Scan(&baselineLatency)
+	} else {
+		err = quietConn.QueryRowContext(ctx, `
+			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
+			FROM crdb_internal.statement_statistics
+			WHERE metadata @> '{"db":"tpcc"}'`,
+		).Scan(&baselineLatency)
+	}
+	require.NoError(t, err)
+	t.L().Printf("phase 1 baseline latency: %f", baselineLatency)
+
+	// Reset SQL stats on quiet tenant before phase 2.
+	_, err = quietConn.ExecContext(ctx, "SELECT crdb_internal.reset_sql_stats()")
+	require.NoError(t, err)
+
+	// Phase 2: run both tenants concurrently.
+	phase2Duration := 15 * time.Minute
+	t.L().Printf("phase 2: running both tenants (%s)", phase2Duration)
+	annotatePhase("phase 2: both tenants")
+	workloadStart := timeutil.Now()
+	m2 := c.NewDeprecatedMonitor(ctx, kvNode)
+
+	// Quiet tenant workload.
+	m2.Go(func(ctx context.Context) error {
+		var cmd *roachtestutil.Command
+		if s.tpcc != nil {
+			cmd = roachtestutil.NewCommand("%s workload run tpcc", test.DefaultCockroachPath).
+				Option("secure").
+				Flag("warehouses", s.tpcc.quietWarehouses).
+				Flag("duration", phase2Duration).
+				Arg("%s", quietPgurl)
+		} else {
+			cmd = roachtestutil.NewCommand("%s workload run kv", test.DefaultCockroachPath).
+				Option("secure").
+				Flag("write-seq", fmt.Sprintf("R%d", s.kv.maxOps*s.kv.batch)).
+				Flag("min-block-bytes", s.kv.blockSize).
+				Flag("max-block-bytes", s.kv.blockSize).
+				Flag("batch", s.kv.batch).
+				Flag("duration", phase2Duration).
+				Flag("read-percent", s.kv.readPercent).
+				Flag("concurrency", s.kv.quietConcurrency).
+				Arg("%s", quietPgurl)
+		}
+		return c.RunE(ctx, option.WithNodes(quietSQLNode), cmd.String())
+	})
+
+	// Run noisy tenant workload.
+	noisyPgurl := fmt.Sprintf("{pgurl:%d:%s}", noisySQLNode[0], noisyName)
+	m2.Go(func(ctx context.Context) error {
+		var cmd *roachtestutil.Command
+		if s.tpcc != nil {
+			cmd = roachtestutil.NewCommand("%s workload run tpcc", test.DefaultCockroachPath).
+				Option("secure").
+				Option("tolerate-errors").
+				Flag("warehouses", s.tpcc.noisyWarehouses).
+				Flag("wait", 0).
+				Flag("duration", phase2Duration).
+				Arg("%s", noisyPgurl)
+		} else {
+			cmd = roachtestutil.NewCommand("%s workload run kv", test.DefaultCockroachPath).
+				Option("secure").
+				Option("tolerate-errors").
+				Flag("write-seq", fmt.Sprintf("R%d", s.kv.maxOps*s.kv.batch)).
+				Flag("min-block-bytes", s.kv.blockSize).
+				Flag("max-block-bytes", s.kv.blockSize).
+				Flag("batch", s.kv.batch).
+				Flag("duration", phase2Duration).
+				Flag("read-percent", s.kv.readPercent).
+				Flag("concurrency", s.kv.noisyConcurrency).
+				Arg("%s", noisyPgurl)
+		}
+		return c.RunE(ctx, option.WithNodes(noisySQLNode), cmd.String())
+	})
+
+	m2.Wait()
+	workloadEnd := timeutil.Now()
+	annotatePhase("workload complete")
+
+	// Verify CPU utilization is near the target.
+	verifyCPUUtilization(ctx, c, t, kvNode, workloadStart, workloadEnd)
+
+	// Collect phase 2 latency from statement statistics.
+	var quietLatency float64
+	if s.kv != nil {
+		err = quietConn.QueryRowContext(ctx, `
+			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
+			FROM crdb_internal.statement_statistics
+			WHERE metadata @> '{"db":"kv"}' AND metadata @> $1`,
+			fmt.Sprintf(`{"querySummary": "%s"}`, s.kv.query),
+		).Scan(&quietLatency)
+	} else {
+		err = quietConn.QueryRowContext(ctx, `
+			SELECT avg((statistics -> 'statistics' -> 'runLat' -> 'mean')::FLOAT)
+			FROM crdb_internal.statement_statistics
+			WHERE metadata @> '{"db":"tpcc"}'`,
+		).Scan(&quietLatency)
+	}
+	require.NoError(t, err)
+	quietLatencyDur := time.Duration(quietLatency * float64(time.Second))
+	baselineDur := time.Duration(baselineLatency * float64(time.Second))
+
+	t.L().Printf("phase 2 quiet latency: %s (baseline: %s, ratio: %.2f)",
+		quietLatencyDur, baselineDur, quietLatency/baselineLatency)
+
+	if quietLatencyDur > s.quietLatencyMax {
+		t.Fatalf("quiet tenant latency %s exceeds max %s", quietLatencyDur, s.quietLatencyMax)
+	}
+}
+
+// verifyCPUUtilization queries the combined CPU utilization metric over the
+// given time window and asserts that the average is between 70% and 90%.
+func verifyCPUUtilization(
+	ctx context.Context,
+	c cluster.Cluster,
+	t test.Test,
+	adminNode option.NodeListOption,
+	start, end time.Time,
+) {
+	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, t.L(), adminNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminURL := adminUIAddrs[0]
+	response := mustGetMetrics(
+		ctx, c, t, adminURL, install.SystemInterfaceName, start, end, []tsQuery{
+			{
+				name:      "cr.node.sys.cpu.combined.percent-normalized",
+				queryType: total,
+			},
+		})
+
+	datapoints := response.Results[0].Datapoints
+	if len(datapoints) == 0 {
+		t.Fatal("not enough CPU utilization datapoints")
+	}
+
+	var sum float64
+	for _, dp := range datapoints {
+		sum += dp.Value
+	}
+	avgCPU := sum / float64(len(datapoints))
+
+	t.L().Printf("average CPU utilization: %.2f%%", avgCPU*100)
+	if avgCPU < 0.70 || avgCPU > 0.90 {
+		t.Fatalf(
+			"average CPU utilization %.2f%% not in expected range [70%%, 90%%]",
+			avgCPU*100,
+		)
+	}
+}
+
+// logCPUTimeTokenDashboardLink logs a link to the CPU time token admission
+// control dashboard on the shared Grafana instance.
+func logCPUTimeTokenDashboardLink(t test.Test, c cluster.Cluster) {
+	m := regexp.MustCompile(`^(.+)-\d{2}-`).FindStringSubmatch(c.Name())
+	require.NotNil(t, m, "could not extract test_run_id from cluster name %q", c.Name())
+	t.L().Printf(
+		"Grafana dashboard: https://grafana.testeng.crdb.io/d/cpu-time-tokens/cpu-time-token-admission-control"+
+			"?orgId=1&var-DS_PROMETHEUS=v9Zz2K6nz&var-test_run_id=%s&var-node=All",
+		m[1],
+	)
+}


### PR DESCRIPTION
**roachtest: add CPU time token admission control roachtests**

CPU time token AC runs in the KV layer and is currently used only in
serverless deployments, where SQL and KV run on separate pods. These
tests reflect that topology: SQL pods and workload generators run on
dedicated VMs, separate from the KV node.

Two categories of tests are added:

1. A cpu-time-token variant of the multitenant fairness test
(read-heavy/even) that enables admission.cpu_time_tokens.enabled and
drives high concurrency to push CPU into the 70-90% range where AC
actively queues requests. Fairness metrics are logged but not
asserted on; CPU utilization is a hard assertion.

2. Noisy-neighbor isolation tests (kv-tiny, kv-read, tpcc) that verify
a quiet tenant's average latency stays below a per-test ceiling when a
noisy neighbor is driving heavy load. CPU utilization in the 70-90%
range is also verified as a hard assertion.

Also adds a Grafana dashboard JSON for CPU time token AC metrics,
placed in monitoring/grafana-dashboards/by-roachtest/ for the shared
Grafana instance.

Fixes: https://github.com/cockroachdb/cockroach/issues/154620
Release note: None