### PR TITLE
kvserver/logstore: route raft log clears through a single ClearRange helper

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4018,9 +4018,15 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 					kvserverpb.RangeTombstone{NextReplicaID: math.MaxInt32},
 				))
 				// Ditto for the unreplicated RangeID keys. Note that it is also split
-				// into two range clears, to work around the RaftReplicaID key.
+				// into three range clears, to work around the RaftReplicaID key and
+				// to force all raft log clearing to go through logstore.
 				require.NoError(t, sst.ClearRawRange(
-					keys.RaftHardStateKey(rangeID), sl.RaftReplicaIDKey(), true, false,
+					keys.RaftHardStateKey(rangeID), sl.RaftLogPrefix(), true, false,
+				))
+				require.NoError(t, storage.ClearRangeWithHeuristic(
+					ctx, receivingEng, &sst,
+					sl.RaftLogPrefix(), sl.RaftLogPrefix().PrefixEnd(),
+					kvstorage.ClearRangeThresholdPointKeys(),
 				))
 				require.NoError(t, sl.ClearRaftReplicaID(&sst))
 				require.NoError(t, sst.ClearRawRange(

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -171,19 +171,28 @@ func destroyReplicaImpl(
 		); err != nil {
 			return err
 		}
+		if err := logstore.ClearRange(
+			ctx, rw.Raft.RO, rw.Raft.WO, buf,
+			info.RaftAppliedIndex+1 /* lo */, math.MaxUint64 /* hi */, ClearRangeThresholdPointKeys(),
+			false, /* sizeKnown */
+		); err != nil {
+			return err
+		}
+	} else {
 		if err := storage.ClearRangeWithHeuristic(
 			ctx, rw.Raft.RO, rw.Raft.WO,
-			buf.RaftLogKey(info.RaftAppliedIndex+1), sl.RaftReplicaIDKey(),
+			buf.RangeTombstoneKey().Next(), sl.RaftLogPrefix(),
 			ClearRangeThresholdPointKeys(),
 		); err != nil {
 			return err
 		}
-	} else if err := storage.ClearRangeWithHeuristic(
-		ctx, rw.Raft.RO, rw.Raft.WO,
-		buf.RangeTombstoneKey().Next(), sl.RaftReplicaIDKey(),
-		ClearRangeThresholdPointKeys(),
-	); err != nil {
-		return err
+		if err := logstore.ClearRange(
+			ctx, rw.Raft.RO, rw.Raft.WO, buf,
+			0 /* lo */, math.MaxUint64 /* hi */, ClearRangeThresholdPointKeys(),
+			false, /* sizeKnown */
+		); err != nil {
+			return err
+		}
 	}
 	if err := sl.ClearRaftReplicaID(rw.State.WO); err != nil {
 		return err
@@ -265,10 +274,14 @@ func RewriteRaftState(
 	if err := sl.SetHardState(ctx, raftWO, hs); err != nil {
 		return errors.Wrapf(err, "unable to write HardState")
 	}
-	// Clear the raft log. Note that there are no Pebble range keys in this span.
-	raftLog := sl.RaftLogPrefix() // NB: use only until next StateLoader call
-	if err := raftWO.ClearRawRange(
-		raftLog, raftLog.PrefixEnd(), true /* pointKeys */, false, /* rangeKeys */
+	// Clear the raft log via the logstore. Note that there are no Pebble range
+	// keys in this span. We use the count-based path (sizeKnown=true) with
+	// pointKeyThreshold=1 to force a single range tombstone over the whole log
+	// span, without scanning.
+	if err := logstore.ClearRange(
+		ctx, nil /* reader */, raftWO, sl.RangeIDPrefixBuf,
+		0 /* lo */, math.MaxUint64 /* hi */, 1, /* pointKeyThreshold */
+		true, /* sizeKnown */
 	); err != nil {
 		return errors.Wrapf(err, "unable to clear the raft log")
 	}

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -277,11 +277,10 @@ func (t *WAGTruncator) maybeAdvanceAllowedIndex() {
 func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
 ) error {
-	if err := storage.ClearRangeWithHeuristic(
-		ctx, raft.RO, raft.WO,
-		keys.RaftLogPrefix(rangeID),           /* start */
-		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
-		ClearRangeThresholdPointKeys(),
+	if err := logstore.ClearRange(
+		ctx, raft.RO, raft.WO, keys.MakeRangeIDPrefixBuf(rangeID),
+		0 /* lo */, lastIndex+1 /* hi */, ClearRangeThresholdPointKeys(),
+		false, /* sizeKnown */
 	); err != nil {
 		return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
 	}

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -482,28 +482,14 @@ func Compact(
 	// the new truncation index. This is performed atomically with updating the
 	// RaftTruncatedState so that the state of the log is consistent.
 	prefixBuf := &loader.RangeIDPrefixBuf
-	numTruncatedEntries := next.Index - prev.Index
-	if numTruncatedEntries >= raftLogTruncationClearRangeThreshold {
-		start := prefixBuf.RaftLogKey(prev.Index + 1).Clone()
-		end := prefixBuf.RaftLogKey(next.Index + 1).Clone() // end is exclusive
-		if err := writer.ClearRawRange(start, end, true, false); err != nil {
-			return errors.Wrapf(err,
-				"unable to clear truncated Raft entries for %+v after index %d",
-				next, prev.Index)
-		}
-	} else {
-		// NB: RangeIDPrefixBufs have sufficient capacity (32 bytes) to avoid
-		// allocating when constructing Raft log keys (16 bytes).
-		prefix := prefixBuf.RaftLogPrefix()
-		for idx := prev.Index + 1; idx <= next.Index; idx++ {
-			if err := writer.ClearUnversioned(
-				keys.RaftLogKeyFromPrefix(prefix, idx),
-				storage.ClearOptions{},
-			); err != nil {
-				return errors.Wrapf(err, "unable to clear truncated Raft entries for %+v at index %d",
-					next, idx)
-			}
-		}
+	if err := ClearRange(
+		ctx, nil /* reader */, writer, *prefixBuf,
+		prev.Index+1, next.Index+1, int(raftLogTruncationClearRangeThreshold),
+		true, /* sizeKnown */
+	); err != nil {
+		return errors.Wrapf(err,
+			"unable to clear truncated Raft entries for %+v after index %d",
+			next, prev.Index)
 	}
 
 	key := prefixBuf.RaftTruncatedStateKey()
@@ -517,6 +503,66 @@ func Compact(
 		ctx, writer, key, hlc.Timestamp{}, value, storage.MVCCWriteOptions{},
 	); err != nil {
 		return errors.Wrap(err, "unable to write RaftTruncatedState")
+	}
+	return nil
+}
+
+// ClearRange clears raft log entries in the half-open index range [lo, hi),
+// choosing between per-entry point deletes and a single Pebble range tombstone
+// based on pointKeyThreshold. Returns nil if lo >= hi.
+//
+// If sizeKnown == false: storage.ClearRangeWithHeuristic is used. It scans up
+//
+//	to pointKeyThreshold keys to decide. r must be non-nil. The bounds may
+//	use the sentinels lo == 0 (start at the raft log prefix) and
+//	hi == math.MaxUint64 (clear to the end of the raft log keyspace).
+//
+// If sizeKnown == true: The caller knows exactly how many entries to be
+// truncated. It arithmetically checks whether to use point or range deletions
+// based on pointKeyThreshold instead of iterating the indices.
+func ClearRange(
+	ctx context.Context,
+	r storage.Reader,
+	w storage.Writer,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo, hi kvpb.RaftIndex,
+	pointKeyThreshold int,
+	sizeKnown bool,
+) error {
+	if !sizeKnown && r == nil {
+		return errors.AssertionFailedf("ClearRange: scan mode requires a non-nil reader")
+	}
+	if lo >= hi {
+		return nil
+	}
+	// NB: RangeIDPrefixBuf shares a backing buffer across calls — successive
+	// RaftLogKey/RaftLogPrefix invocations may overwrite earlier results, so
+	// clone start and end.
+	var start, end roachpb.Key
+	if lo == 0 {
+		start = prefixBuf.RaftLogPrefix().Clone()
+	} else {
+		start = prefixBuf.RaftLogKey(lo).Clone()
+	}
+	if hi == math.MaxUint64 {
+		end = prefixBuf.RaftLogPrefix().PrefixEnd()
+	} else {
+		end = prefixBuf.RaftLogKey(hi).Clone()
+	}
+	if !sizeKnown {
+		return storage.ClearRangeWithHeuristic(ctx, r, w, start, end, pointKeyThreshold)
+	}
+	// Count-based path: no scan, decide arithmetically.
+	if hi-lo >= kvpb.RaftIndex(pointKeyThreshold) {
+		return w.ClearRawRange(start, end, true /* pointKeys */, false /* rangeKeys */)
+	}
+	prefix := prefixBuf.RaftLogPrefix()
+	for idx := lo; idx < hi; idx++ {
+		if err := w.ClearUnversioned(
+			keys.RaftLogKeyFromPrefix(prefix, idx), storage.ClearOptions{},
+		); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -8,11 +8,13 @@ package logstore
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -20,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,4 +112,124 @@ func TestRaftStorageWrites(t *testing.T) {
 	output = strings.ReplaceAll(output, "\n\n", "\n")
 	output = strings.ReplaceAll(output, "\n\n", "\n")
 	echotest.Require(t, output, filepath.Join("testdata", t.Name()+".txt"))
+}
+
+// TestClearRange verifies the choice between per-entry point deletes and a
+// single Pebble range tombstone across ClearRange's two modes (sizeKnown vs
+// scan-based).
+func TestClearRange(t *testing.T) {
+	ctx := context.Background()
+	const rangeID = roachpb.RangeID(123)
+	prefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
+
+	// countOps tallies point deletes and range deletes recorded in a Pebble
+	// batch's wire representation.
+	countOps := func(t *testing.T, batchRepr []byte) (points, ranges int) {
+		t.Helper()
+		r, err := storage.NewBatchReader(batchRepr)
+		require.NoError(t, err)
+		for r.Next() {
+			switch r.KeyKind() {
+			case pebble.InternalKeyKindDelete, pebble.InternalKeyKindDeleteSized:
+				points++
+			case pebble.InternalKeyKindRangeDelete:
+				ranges++
+			}
+		}
+		return points, ranges
+	}
+
+	// Populate the following Raft log entries: [5,6,7,8,9].
+	populate := func(t *testing.T, eng storage.Engine) {
+		t.Helper()
+		entries := []raftpb.Entry{
+			{Index: 5, Term: 1}, {Index: 6, Term: 1}, {Index: 7, Term: 1},
+			{Index: 8, Term: 1}, {Index: 9, Term: 1},
+		}
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := logAppend(ctx, prefixBuf.RaftLogPrefix(), b, RaftState{}, entries)
+		require.NoError(t, err)
+		require.NoError(t, b.Commit(true /* sync */))
+	}
+
+	// Returns the raft log indices still present in the engine.
+	remainingIndices := func(t *testing.T, eng storage.Engine) []kvpb.RaftIndex {
+		t.Helper()
+		prefix := prefixBuf.RaftLogPrefix()
+		iter, err := eng.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
+			LowerBound: prefix, UpperBound: prefix.PrefixEnd(),
+		})
+		require.NoError(t, err)
+		defer iter.Close()
+		var indices []kvpb.RaftIndex
+		iter.SeekGE(storage.MakeMVCCMetadataKey(prefix))
+		for {
+			ok, err := iter.Valid()
+			require.NoError(t, err)
+			if !ok {
+				break
+			}
+			key := iter.UnsafeKey().Key
+			idx, err := keys.DecodeRaftLogKeyFromSuffix(key[len(prefix):])
+			require.NoError(t, err)
+			indices = append(indices, idx)
+			iter.Next()
+		}
+		return indices
+	}
+
+	tests := []struct {
+		lo, hi                 kvpb.RaftIndex
+		threshold              int
+		sizeKnown              bool
+		wantPoints, wantRanges int
+		wantIndices            []kvpb.RaftIndex // raft log indices remaining in eng
+	}{
+		{lo: 0, hi: math.MaxUint64, threshold: 1, sizeKnown: false, wantPoints: 0, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 1, sizeKnown: true, wantPoints: 0, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 6, sizeKnown: false, wantPoints: 5, wantRanges: 0},
+		// If sizeKnown=true, the count is calculated by hi-lo.
+		{lo: 0, hi: math.MaxUint64, threshold: 6, sizeKnown: true, wantPoints: 0, wantRanges: 1},
+
+		{lo: 1, hi: 6, threshold: 3, sizeKnown: false, wantPoints: 1, wantRanges: 0, wantIndices: []kvpb.RaftIndex{6, 7, 8, 9}},
+		{lo: 1, hi: 6, threshold: 3, sizeKnown: true, wantPoints: 0, wantRanges: 1, wantIndices: []kvpb.RaftIndex{6, 7, 8, 9}},
+		{lo: 1, hi: 6, threshold: 6, sizeKnown: false, wantPoints: 1, wantRanges: 0, wantIndices: []kvpb.RaftIndex{6, 7, 8, 9}},
+		{lo: 1, hi: 6, threshold: 6, sizeKnown: true, wantPoints: 5, wantRanges: 0, wantIndices: []kvpb.RaftIndex{6, 7, 8, 9}},
+
+		{lo: 1, hi: 11, threshold: 3, sizeKnown: false, wantPoints: 0, wantRanges: 1},
+		{lo: 1, hi: 11, threshold: 3, sizeKnown: true, wantPoints: 0, wantRanges: 1},
+		{lo: 1, hi: 11, threshold: 6, sizeKnown: false, wantPoints: 5, wantRanges: 0},
+		{lo: 1, hi: 11, threshold: 6, sizeKnown: true, wantPoints: 0, wantRanges: 1},
+
+		{lo: 5, hi: 9, threshold: 3, sizeKnown: false, wantPoints: 0, wantRanges: 1, wantIndices: []kvpb.RaftIndex{9}},
+		{lo: 5, hi: 9, threshold: 3, sizeKnown: true, wantPoints: 0, wantRanges: 1, wantIndices: []kvpb.RaftIndex{9}},
+		{lo: 5, hi: 9, threshold: 6, sizeKnown: false, wantPoints: 4, wantRanges: 0, wantIndices: []kvpb.RaftIndex{9}},
+		{lo: 5, hi: 9, threshold: 6, sizeKnown: true, wantPoints: 4, wantRanges: 0, wantIndices: []kvpb.RaftIndex{9}},
+
+		{lo: 5, hi: 5, threshold: 1, sizeKnown: true, wantPoints: 0, wantRanges: 0, wantIndices: []kvpb.RaftIndex{5, 6, 7, 8, 9}},  // no-op
+		{lo: 10, hi: 5, threshold: 1, sizeKnown: true, wantPoints: 0, wantRanges: 0, wantIndices: []kvpb.RaftIndex{5, 6, 7, 8, 9}}, // no-op
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			eng := storage.NewDefaultInMemForTesting()
+			defer eng.Close()
+			populate(t, eng)
+			batch := eng.NewBatch()
+			defer batch.Close()
+			var r storage.Reader
+			if !tc.sizeKnown {
+				r = eng
+			}
+			require.NoError(t, ClearRange(
+				ctx, r, batch, prefixBuf, tc.lo, tc.hi, tc.threshold, tc.sizeKnown,
+			))
+			points, ranges := countOps(t, batch.Repr())
+			require.Equal(t, tc.wantPoints, points)
+			require.Equal(t, tc.wantRanges, ranges)
+			require.NoError(t, batch.Commit(true /* sync */))
+			require.Equal(t, tc.wantIndices, remainingIndices(t, eng), "remaining raft indices")
+		})
+	}
 }


### PR DESCRIPTION
This is a mechanical refactor. All raft log truncations now flow through a single logstore.ClearRange helper. Previously, callers in kvstorage (destroyReplicaImpl, RewriteRaftState, WAGTruncator. clearReplicaRaftLogAndSideloaded) bypassed the logstore package and called storage.ClearRangeWithHeuristic or w.ClearRawRange directly, making it hard to reason about how the log was being touched.

There are three main ways to clear a raft log range, all now expressed via ClearRange:

  1. Blindly delete the whole raft log span using ClearRawRange. Pass sizeKnown=true with pointKeyThreshold=1 to force the range tombstone path without scanning. Used by RewriteRaftState (snapshot application).

  2. Delete a range using ClearRangeWithHeuristic when the entry count is not known. Pass sizeKnown=false and a non-nil reader; the heuristic scans up to pointKeyThreshold keys to choose between point deletes and a single range tombstone. Used by destroyReplicaImpl and WAGTruncator.

  3. When the entry count is known, decide between point and range deletions arithmetically (hi-lo vs threshold) without iterating the log. Pass sizeKnown=true with exact bounds. Used by Compact, which knows the truncation interval up front.

A new TestClearRange exercises all three paths and verifies both the batch ops emitted (point deletes vs range tombstones) and the engine state remaining after each call.


Release note: None