### PR TITLE
sql/sqlstats: stub time in TestExplicitTxnFingerprintAccounting

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -444,6 +444,11 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		Settings: st,
 	})
 
+	// Stub the time so all events fall in the same aggregation window.
+	// Without this, a test run that crosses an aggregation boundary
+	// produces duplicate (fingerprint, aggregatedTs) keys and inflates
+	// the fingerprint count. See #169386.
+	stubNow := time.Date(2026, 3, 15, 10, 30, 45, 0, time.UTC)
 	sqlStats := sslocal.NewSQLStats(
 		st,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
@@ -453,7 +458,9 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		nil, /* discardedStatsCount */
 		monitor,
 		nil, /* reportingSink */
-		nil, /* knobs */
+		&sqlstats.TestingKnobs{
+			StubTimeNow: func() time.Time { return stubNow },
+		},
 	)
 
 	ingester := sslocal.NewSQLStatsIngester(


### PR DESCRIPTION
## Summary

`TestExplicitTxnFingerprintAccounting` records fingerprints through an asynchronous ingester and asserts the cumulative count after each batch. After #168518 added `aggregatedTs` to the in-memory stat keys, a run whose execution crossed an hour-aligned aggregation boundary would re-key the same fingerprints under the new window and inflate the count, causing flakes.

This change pins time via the `StubTimeNow` testing knob so every event lands in the same aggregation window. This matches the pattern already used by `TestObserveTransactionStampsAggregationTimestamp` in the same file.

Fixes #169386.

Epic: none
Release note: None