### PR TITLE
sql: lower the priority of AUTO CREATE STATS job to BulkLowPri

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -1146,7 +1146,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) (r
 		}
 
 		return nil
-	}, isql.WithPriority(admissionpb.BulkNormalPri)); err != nil {
+	}, isql.WithPriority(admissionpb.BulkLowPri)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The AUTO CREATE STATS job uses `BulkNormalPri`, but AC doesn't turn on for read-heavy workloads since we don't track disk read B/W. However, we have a new mechanism for throttling disk read B/W for `BulkLowPri` Scans. This change ensures that this job is subject to this throttling.

Epic: CRDB-47073
Release note: None