### PR TITLE
sql: add always on query-level SQL CPU tracking

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -97,7 +97,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
-        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -7,7 +7,6 @@ package tenantcostclient_test
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,9 +14,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks
-	"github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl/tenantcostclient"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl/tenantcostserver"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
@@ -26,26 +24,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
 )
 
-// TestEstimateQueryRUConsumption is a sanity check for the RU estimates
-// produced for queries that are run by a tenant under EXPLAIN ANALYZE. The RU
-// consumption of a query is not deterministic, since it depends on inexact
-// quantities like the (already estimated) CPU usage. Therefore, the test runs
-// each query multiple times and then checks that the total estimated RU
-// consumption is within reasonable distance from the actual measured RUs for
-// the tenant.
+// TestEstimateQueryRUConsumption verifies that EXPLAIN ANALYZE produces
+// reasonable per-query RU estimates for a tenant. Each query type is checked
+// against an expected value with a tolerance, rather than comparing against
+// measured tenant consumption.
 func TestEstimateQueryRUConsumption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// This test becomes flaky when the machine/cluster is under significant
-	// background load, so we disable running it under stress and/or race.
-	skip.UnderStress(t)
-	skip.UnderRace(t)
-	skip.WithIssue(t, 109179, "this test is flaky due to background activity when run during CI")
+	skip.UnderRace(t, "slow multi-tenant test")
 
 	ctx := context.Background()
 
@@ -54,27 +44,18 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	stats.UseStatisticsOnSystemTables.Override(ctx, &st.SV, false)
 	stats.AutomaticStatisticsOnSystemTables.Override(ctx, &st.SV, false)
 
-	// Lower the target duration for reporting tenant usage so that it can be
-	// measured accurately. Avoid decreasing too far, since doing so can add
-	// measurable overhead.
-	tenantcostclient.TargetPeriodSetting.Override(ctx, &st.SV, time.Millisecond*500)
-
 	params := base.TestServerArgs{
 		Settings:          st,
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	}
 
-	s, mainDB, _ := serverutils.StartServer(t, params)
+	s, _, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
-	sysDB := sqlutils.MakeSQLRunner(mainDB)
 
-	tenantID := serverutils.TestTenantID()
 	tenant1, tenantDB1 := serverutils.StartTenant(t, s, base.TestTenantArgs{
-		TenantID: tenantID,
+		TenantID: serverutils.TestTenantID(),
 		TestingKnobs: base.TestingKnobs{
 			SQLEvalContext: &eval.TestingKnobs{
-				// We disable the randomization of some batch sizes because with
-				// some low values the test takes much longer.
 				ForceProductionValues: true,
 			},
 		},
@@ -83,120 +64,105 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	defer tenantDB1.Close()
 	tdb := sqlutils.MakeSQLRunner(tenantDB1)
 	tdb.Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false")
-	tdb.Exec(t, "CREATE TABLE abcd (a INT, b INT, c INT, d INT, INDEX (a, b, c))")
+	tdb.Exec(t, "CREATE TABLE abcd (a INT, b INT, c INT, d INT, INDEX foo (a, b, c))")
+	tdb.Exec(t, "INSERT INTO abcd (SELECT t%2, t%3, t, -t FROM generate_series(1,20000) g(t))")
+
+	// Scan both indexes to resolve all intents.
+	tdb.Exec(t, "SELECT count(*) FROM abcd@primary")
+	tdb.Exec(t, "SELECT count(*) FROM abcd@foo")
+
+	// Each test case specifies a baseRU covering the deterministic portion
+	// of the RU estimate (KV reads/writes and network egress). The CPU
+	// portion is computed from the observed SQL CPU time using the default
+	// PodCPUSecond cost (333.3333 RU/s). The total expected RU is
+	// baseRU + cpuRU, and the actual estimate must be within 10%.
+	const tolerancePct = 0.1
+	podCPUPerSec := tenantcostmodel.SQLCPUSecondCost.Default()
 
 	type testCase struct {
-		sql   string
-		count int
+		name   string
+		sql    string
+		baseRU float64
 	}
 	testCases := []testCase{
-		{ // Insert statement
-			sql:   "INSERT INTO abcd (SELECT t%2, t%3, t, -t FROM generate_series(1,20000) g(t))",
-			count: 1,
+		{
+			name:   "point query",
+			sql:    "SELECT a FROM abcd WHERE (a, b) = (1, 1)",
+			baseRU: 34.5,
 		},
-		{ // Point query
-			sql:   "SELECT a FROM abcd WHERE (a, b) = (1, 1)",
-			count: 10,
+		{
+			name:   "range query",
+			sql:    "SELECT a FROM abcd WHERE (a, b) = (1, 1) AND c > 0 AND c < 10000",
+			baseRU: 17.3,
 		},
-		{ // Range query
-			sql:   "SELECT a FROM abcd WHERE (a, b) = (1, 1) AND c > 0 AND c < 10000",
-			count: 10,
+		{
+			name:   "aggregate",
+			sql:    "SELECT count(*) FROM abcd",
+			baseRU: 13,
 		},
-		{ // Aggregate
-			sql:   "SELECT count(*) FROM abcd",
-			count: 10,
+		{
+			name:   "distinct",
+			sql:    "SELECT DISTINCT ON (a, b) * FROM abcd",
+			baseRU: 15.2,
 		},
-		{ // Distinct
-			sql:   "SELECT DISTINCT ON (a, b) * FROM abcd",
-			count: 10,
+		{
+			name:   "full table scan",
+			sql:    "SELECT a FROM abcd",
+			baseRU: 208.2,
 		},
-		{ // Full table scan
-			sql:   "SELECT a FROM abcd",
-			count: 10,
+		{
+			name:   "lookup join",
+			sql:    "SELECT a FROM (VALUES (1, 1), (0, 2)) v(x, y) INNER LOOKUP JOIN abcd ON (a, b) = (x, y)",
+			baseRU: 70,
 		},
-		{ // Lookup join
-			sql:   "SELECT a FROM (VALUES (1, 1), (0, 2)) v(x, y) INNER LOOKUP JOIN abcd ON (a, b) = (x, y)",
-			count: 10,
+		{
+			name:   "index join",
+			sql:    "SELECT * FROM abcd WHERE (a, b) = (0, 0)",
+			baseRU: 525.9,
 		},
-		{ // Index join
-			sql:   "SELECT * FROM abcd WHERE (a, b) = (0, 0)",
-			count: 10,
-		},
-		{ // No kv IO, lots of network egress.
-			sql:   "SELECT 'deadbeef' FROM generate_series(1, 50000)",
-			count: 10,
-		},
-		{ // Delete (this also ensures that two runs work with the same dataset)
-			sql:   "DELETE FROM abcd WHERE true",
-			count: 1,
+		{
+			name:   "no kv IO, network egress",
+			sql:    "SELECT 'deadbeef' FROM generate_series(1, 50000)",
+			baseRU: 830.1,
 		},
 	}
 
-	var err error
-	var tenantEstimatedRUs float64
 	for _, tc := range testCases {
-		for i := 0; i < tc.count; i++ {
-			output := tdb.QueryStr(t, "EXPLAIN ANALYZE "+tc.sql)
+		t.Run(tc.name, func(t *testing.T) {
+			output := tdb.QueryStr(t, "EXPLAIN ANALYZE (VERBOSE) "+tc.sql)
 			var estimatedRU float64
+			var cpuTime time.Duration
 			for _, row := range output {
 				if len(row) != 1 {
 					t.Fatalf("expected one column")
 				}
-				val := row[0]
-				if strings.Contains(val, "estimated RUs consumed") {
-					substr := strings.Split(val, " ")
-					require.Equalf(t, 4, len(substr), "expected RU consumption message to have four words")
-					ruCountStr := strings.Replace(strings.TrimSpace(substr[3]), ",", "", -1)
-					estimatedRU, err = strconv.ParseFloat(ruCountStr, 64)
-					require.NoError(t, err, "failed to retrieve estimated RUs")
-					break
+				if estimatedRU == 0 && strings.Contains(row[0], "estimated RUs consumed") {
+					fields := strings.Fields(row[0])
+					ruStr := strings.ReplaceAll(fields[len(fields)-1], ",", "")
+					var err error
+					estimatedRU, err = strconv.ParseFloat(ruStr, 64)
+					require.NoError(t, err, "failed to parse estimated RUs from %q", row[0])
+				}
+				if cpuTime == 0 && strings.Contains(row[0], "sql cpu time") {
+					fields := strings.Fields(row[0])
+					var err error
+					cpuTime, err = time.ParseDuration(fields[len(fields)-1])
+					require.NoError(t, err, "failed to parse sql cpu time from %q", row[0])
 				}
 			}
-			tenantEstimatedRUs += estimatedRU
-		}
-	}
 
-	getTenantRUs := func() float64 {
-		// Sleep to ensure the measured RU consumption gets recorded in the
-		// tenant_usage table.
-		time.Sleep(time.Second)
-		var consumptionBytes []byte
-		var consumption kvpb.TenantConsumption
-		var tenantRUs float64
-		rows := sysDB.Query(t,
-			fmt.Sprintf(
-				"SELECT total_consumption FROM system.tenant_usage WHERE tenant_id = %d AND instance_id = 0",
-				tenantID.ToUint64(),
-			),
-		)
-		for rows.Next() {
-			require.NoError(t, rows.Scan(&consumptionBytes))
-			if len(consumptionBytes) == 0 {
-				continue
-			}
-			require.NoError(t, protoutil.Unmarshal(consumptionBytes, &consumption))
-			tenantRUs += consumption.RU
-		}
-		return tenantRUs
+			// Compute expected RU as base (deterministic) + CPU portion
+			// derived from the observed SQL CPU time.
+			cpuRU := cpuTime.Seconds() * podCPUPerSec
+			expectedRU := tc.baseRU + cpuRU
+			minRU := expectedRU * (1 - tolerancePct)
+			maxRU := expectedRU * (1 + tolerancePct)
+			t.Logf("estimated=%.2f expected=%.2f base=%.2f cpuRU=%.2f cpuTime=%s",
+				estimatedRU, expectedRU, tc.baseRU, cpuRU, cpuTime)
+			require.GreaterOrEqualf(t, estimatedRU, minRU,
+				"estimated RUs (%.2f) below minimum (%.2f)", estimatedRU, minRU)
+			require.LessOrEqualf(t, estimatedRU, maxRU,
+				"estimated RUs (%.2f) above maximum (%.2f)", estimatedRU, maxRU)
+		})
 	}
-	tenantStartRUs := getTenantRUs()
-
-	var tenantMeasuredRUs float64
-	for _, tc := range testCases {
-		for i := 0; i < tc.count; i++ {
-			tdb.QueryStr(t, tc.sql)
-		}
-	}
-
-	// Check the estimated RU aggregate for all the queries against the actual
-	// measured RU consumption for the tenant.
-	tenantMeasuredRUs = getTenantRUs() - tenantStartRUs
-	const deltaFraction = 0.25
-	allowedDelta := tenantMeasuredRUs * deltaFraction
-	require.InDeltaf(t, tenantMeasuredRUs, tenantEstimatedRUs, allowedDelta,
-		"estimated RUs (%.2f) were not within %.2f RUs of the expected value (%.2f)",
-		tenantEstimatedRUs,
-		allowedDelta,
-		tenantMeasuredRUs,
-	)
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -954,12 +954,6 @@ func (c *tenantSideCostController) onExternalIO(
 	return nil
 }
 
-// GetCPUMovingAvg is used to obtain an exponential moving average estimate
-// for the CPU usage in seconds per each second of wall-clock time.
-func (c *tenantSideCostController) GetCPUMovingAvg() float64 {
-	return math.Float64frombits(c.avgSQLCPUPerSec.Load())
-}
-
 // GetRequestUnitModel is part of the multitenant.TenantSideCostController
 // interface.
 func (c *tenantSideCostController) GetRequestUnitModel() *tenantcostmodel.RequestUnitModel {

--- a/pkg/multitenant/cost_controller.go
+++ b/pkg/multitenant/cost_controller.go
@@ -30,10 +30,6 @@ type TenantSideCostController interface {
 		nextLiveInstanceIDFn NextLiveInstanceIDFn,
 	) error
 
-	// GetCPUMovingAvg returns an exponential moving average used for estimating
-	// the CPU usage (in CPU secs) per wall-clock second.
-	GetCPUMovingAvg() float64
-
 	// GetRequestUnitModel returns the request unit cost model that this
 	// TenantSideCostController is using.
 	GetRequestUnitModel() *tenantcostmodel.RequestUnitModel

--- a/pkg/multitenant/multitenantcpu/BUILD.bazel
+++ b/pkg/multitenant/multitenantcpu/BUILD.bazel
@@ -6,9 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/multitenant",
         "//pkg/server/status",
         "//pkg/util/log",
-        "//pkg/util/timeutil",
     ],
 )

--- a/pkg/multitenant/multitenantcpu/cpu_usage.go
+++ b/pkg/multitenant/multitenantcpu/cpu_usage.go
@@ -7,63 +7,10 @@ package multitenantcpu
 
 import (
 	"context"
-	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
-
-// CPUUsageHelper is used to estimate the RUs consumed by a query due to CPU
-// usage. It works by using a moving average for the process CPU usage to
-// project what the usage *would* be if the query hadn't run, then subtracts
-// that from the actual measured CPU usage.
-//
-// TODO(drewk): this isn't accurate when there are many concurrent queries.
-// We should use the grunning library for a more accurate measurement.
-type CPUUsageHelper struct {
-	startCPU        float64
-	avgCPUPerSecond float64
-	startTime       time.Time
-	costController  multitenant.TenantSideCostController
-}
-
-// StartCollection should be called at the beginning of execution for a flow.
-// It is a no-op for non-tenants (e.g. when costController is nil).
-func (h *CPUUsageHelper) StartCollection(
-	ctx context.Context, costController multitenant.TenantSideCostController,
-) {
-	if costController == nil {
-		return
-	}
-	h.costController = costController
-	h.startTime = timeutil.Now()
-	h.startCPU = GetCPUSeconds(ctx)
-	h.avgCPUPerSecond = h.costController.GetCPUMovingAvg()
-}
-
-// EndCollection should be called at the end of execution for a flow in order to
-// get the estimated number of RUs consumed due to CPU usage. It returns zero
-// for non-tenants. It is a no-op if StartCollection was never called.
-func (h *CPUUsageHelper) EndCollection(ctx context.Context) (ruFomCPU float64) {
-	if h.costController == nil || h.costController.GetRequestUnitModel() == nil {
-		return 0
-	}
-	cpuDelta := GetCPUSeconds(ctx) - h.startCPU
-	timeElapsed := timeutil.Since(h.startTime).Seconds()
-	expectedCPUDelta := timeElapsed * h.avgCPUPerSecond
-	cpuUsageSeconds := cpuDelta - expectedCPUDelta
-	if cpuUsageSeconds < 0 {
-		cpuUsageSeconds = 0
-	}
-	if cpuUsageSeconds > timeElapsed {
-		// It's unlikely that any single query will have such high CPU usage, so
-		// bound the estimate above to reduce the possibility of gross error.
-		cpuUsageSeconds = timeElapsed
-	}
-	return float64(h.costController.GetRequestUnitModel().PodCPUCost(cpuUsageSeconds))
-}
 
 // GetCPUSeconds returns the total CPU usage of the current process in seconds.
 // It is used for measuring tenant RU consumption.

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1586,10 +1586,6 @@ func (noopTenantSideCostController) OnExternalIO(
 ) {
 }
 
-func (noopTenantSideCostController) GetCPUMovingAvg() float64 {
-	return 0
-}
-
 func (noopTenantSideCostController) GetRequestUnitModel() *tenantcostmodel.RequestUnitModel {
 	return nil
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -355,7 +355,6 @@ go_library(
         "//pkg/multitenant",
         "//pkg/multitenant/mtinfo",
         "//pkg/multitenant/mtinfopb",
-        "//pkg/multitenant/multitenantcpu",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/obs/ash",

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -131,6 +131,7 @@ func (t *TransactionStatistics) Add(other *TransactionStatistics) {
 	t.BytesRead.Add(other.BytesRead, transactionStatsCount, other.Count)
 	t.RowsWritten.Add(other.RowsWritten, transactionStatsCount, other.Count)
 	t.KVCPUTimeNanos.Add(other.KVCPUTimeNanos, transactionStatsCount, other.Count)
+	t.SQLCPUTimeNanos.Add(other.SQLCPUTimeNanos, transactionStatsCount, other.Count)
 
 	t.ExecStats.Add(other.ExecStats)
 
@@ -187,6 +188,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.RowsRead.Add(other.RowsRead, statementStatsCount, other.Count)
 	s.RowsWritten.Add(other.RowsWritten, statementStatsCount, other.Count)
 	s.KVCPUTimeNanos.Add(other.KVCPUTimeNanos, statementStatsCount, other.Count)
+	s.SQLCPUTimeNanos.Add(other.SQLCPUTimeNanos, statementStatsCount, other.Count)
 	s.Nodes = util.CombineUnique(s.Nodes, other.Nodes)
 	s.KVNodeIDs = util.CombineUnique(s.KVNodeIDs, other.KVNodeIDs)
 	s.Regions = util.CombineUnique(s.Regions, other.Regions)

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -147,6 +147,10 @@ message StatementStatistics {
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 38 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
 
+  // sql_cpu_time_nanos is the SQL-only CPU time in nanoseconds, computed as
+  // total grunning (gateway + remote) minus local KV CPU time.
+  optional NumericStat sql_cpu_time_nanos = 41 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLCPUTimeNanos"];
+
   // canary_stats tracks execution statistics for the subset of executions
   // that used canary (newest) table statistics for planning. This is used
   // to compare performance between canary and stable statistics rollout
@@ -211,6 +215,10 @@ message TransactionStatistics {
   // representative of the "synchronous" portion of work performed by KV
   // (ex/ not replication related work).
   optional NumericStat kv_cpu_time_nanos = 12 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTimeNanos"];
+
+  // sql_cpu_time_nanos is the SQL-only CPU time in nanoseconds, computed as
+  // total grunning (gateway + remote) minus local KV CPU time.
+  optional NumericStat sql_cpu_time_nanos = 13 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLCPUTimeNanos"];
 }
 
 

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -95,10 +95,11 @@ type KVReader interface {
 	// GetConsumedRU returns the number of RUs that were consumed during the
 	// KV reads.
 	GetConsumedRU() uint64
-	// GetKVCPUTime returns the CPU time consumed *on the current goroutine* by
-	// KV requests. It must be safe for concurrent use. It is used to calculate
-	// the SQL CPU time.
-	GetKVCPUTime() time.Duration
+	// GetLocalKVCPUTime returns the CPU time (in nanoseconds) spent on the
+	// calling goroutine during KV operations. It is measured via grunning
+	// deltas around txn.Send() calls. It must be safe for concurrent use.
+	// It is used to calculate the SQL CPU time.
+	GetLocalKVCPUTime() int64
 	// GetKVResponseCPUTime returns the CPU time as reported by KV BatchResponses
 	// processed by the KVReader throughout its lifetime so far.
 	GetKVResponseCPUTime() int64

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -276,22 +276,22 @@ type cFetcher struct {
 	// stableKVs indicates whether the KVs returned by nextKVer are stable (i.e.
 	// are not invalidated) across NextKV() calls.
 	stableKVs bool
-	// bytesRead, kvPairsRead, kvCPUTime, and batchRequestsIssued store the total number of
-	// bytes read, key-values pairs read, CPU time reported by KV BatchResponses, and of
-	// BatchRequests issued, respectively, by this cFetcher throughout its lifetime in
-	// case when the underlying row.KVFetcher has already been closed and nil-ed out.
+	// bytesRead, kvPairsRead, kvCPUTime, localKVCPUTime, and
+	// batchRequestsIssued store the total number of bytes read, key-value
+	// pairs read, CPU time reported by KV BatchResponses, local KV CPU time,
+	// and BatchRequests issued, respectively, by this cFetcher throughout its
+	// lifetime in case when the underlying row.KVFetcher has already been
+	// closed and nil-ed out.
 	//
 	// The fields should not be accessed directly by the users of the cFetcher -
-	// getBytesRead(), getKVPairsRead(), getKVCpuTime(), and getBatchRequestsIssued() should be
-	// used instead.
+	// getBytesRead(), getKVPairsRead(), getKVCPUTime(), getLocalKVCPUTime(),
+	// and getBatchRequestsIssued() should be used instead.
 	bytesRead           int64
 	kvPairsRead         int64
 	kvCPUTime           int64
+	localKVCPUTime      int64
 	batchRequestsIssued int64
-	// cpuStopWatch tracks the CPU time spent by this cFetcher while fulfilling KV
-	// requests *in the current goroutine*.
-	cpuStopWatch *timeutil.CPUStopWatch
-	pacer        *admission.Pacer
+	pacer               *admission.Pacer
 
 	// machine contains fields that get updated during the run of the fetcher.
 	machine struct {
@@ -563,9 +563,6 @@ func (cf *cFetcher) Init(
 	}
 	cf.stableKVs = nextKVer.Init(cf.getFirstKeyOfRow)
 	cf.accountingHelper.Init(allocator, cf.memoryLimit, cf.table.typs, cf.alwaysReallocate)
-	if cf.cFetcherArgs.collectStats {
-		cf.cpuStopWatch = timeutil.NewCPUStopWatch()
-	}
 	if cf.txn != nil {
 		if pri := admissionpb.WorkPriority(cf.txn.AdmissionHeader().Priority); pri <= admissionpb.BulkNormalPri {
 			cf.pacer = cf.txn.DB().AdmissionPacerFactory.NewPacer(
@@ -778,12 +775,10 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			return nil, errors.AssertionFailedf("invalid fetcher state")
 		case stateInitFetch:
 			cf.machine.firstKeyOfRow = nil
-			cf.cpuStopWatch.Start()
 			// Here we ignore partialRow return parameter because it can only be
 			// true when moreKVs is false, in which case we have already
 			// finalized the last row and will emit the batch as is.
 			moreKVs, _, kv, err := cf.nextKVer.NextKV(ctx, cf.mvccDecodeStrategy)
-			cf.cpuStopWatch.Stop()
 			if err != nil {
 				return nil, convertFetchError(&cf.table.spec, err)
 			}
@@ -948,9 +943,7 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			cf.machine.state[0] = stateFetchNextKVWithUnfinishedRow
 
 		case stateFetchNextKVWithUnfinishedRow:
-			cf.cpuStopWatch.Start()
 			moreKVs, partialRow, kv, err := cf.nextKVer.NextKV(ctx, cf.mvccDecodeStrategy)
-			cf.cpuStopWatch.Stop()
 			if err != nil {
 				return nil, convertFetchError(&cf.table.spec, err)
 			}
@@ -1507,6 +1500,15 @@ func (cf *cFetcher) getKVCPUTime() int64 {
 	return cf.kvCPUTime
 }
 
+// getLocalKVCPUTime returns the CPU time spent on the calling goroutine during
+// KV operations, as measured by grunning deltas around txn.Send() calls.
+func (cf *cFetcher) getLocalKVCPUTime() int64 {
+	if cf.fetcher != nil {
+		return cf.fetcher.GetLocalKVCPUTime()
+	}
+	return cf.localKVCPUTime
+}
+
 // getBatchRequestsIssued returns the number of BatchRequests issued by the
 // cFetcher throughout its lifetime so far.
 func (cf *cFetcher) getBatchRequestsIssued() int64 {
@@ -1546,6 +1548,7 @@ func (cf *cFetcher) Close(ctx context.Context) {
 			cf.bytesRead = cf.fetcher.GetBytesRead()
 			cf.kvPairsRead = cf.fetcher.GetKVPairsRead()
 			cf.kvCPUTime = cf.fetcher.GetKVCPUTime()
+			cf.localKVCPUTime = cf.fetcher.GetLocalKVCPUTime()
 			cf.batchRequestsIssued = cf.fetcher.GetBatchRequestsIssued()
 			cf.fetcher.Close(ctx)
 			cf.fetcher = nil

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -7,7 +7,6 @@ package colfetcher
 
 import (
 	"context"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -18,11 +17,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -36,10 +33,6 @@ type ColBatchDirectScan struct {
 	spec        *fetchpb.IndexFetchSpec
 	resultTypes []*types.T
 	hasDatumVec bool
-
-	// cpuStopWatch tracks the CPU time spent by this ColBatchDirectScan while
-	// fulfilling KV requests *in the current goroutine*.
-	cpuStopWatch *timeutil.CPUStopWatch
 
 	deserializer            colexecutils.Deserializer
 	deserializerInitialized bool
@@ -82,9 +75,7 @@ func (s *ColBatchDirectScan) Next() (ret coldata.Batch, metadata *execinfrapb.Pr
 	var res row.KVBatchFetcherResponse
 	var err error
 	for {
-		s.cpuStopWatch.Start()
 		res, err = s.fetcher.NextBatch(s.Ctx)
-		s.cpuStopWatch.Stop()
 		if err != nil {
 			colexecerror.InternalError(convertFetchError(s.spec, err))
 		}
@@ -169,12 +160,9 @@ func (s *ColBatchDirectScan) GetBatchRequestsIssued() int64 {
 // TODO(yuzefovich): check whether GetScanStats and GetConsumedRU should be
 // reimplemented.
 
-// GetKVCPUTime is part of the colexecop.KVReader interface.
-//
-// Note that this KV CPU time, unlike for the ColBatchScan, includes the
-// decoding time done by the cFetcherWrapper.
-func (s *ColBatchDirectScan) GetKVCPUTime() time.Duration {
-	return s.cpuStopWatch.Elapsed()
+// GetLocalKVCPUTime is part of the colexecop.KVReader interface.
+func (s *ColBatchDirectScan) GetLocalKVCPUTime() int64 {
+	return s.fetcher.GetLocalKVCPUTime()
 }
 
 // Release implements the execreleasable.Releasable interface.
@@ -248,10 +236,6 @@ func NewColBatchDirectScan(
 			break
 		}
 	}
-	var cpuStopWatch *timeutil.CPUStopWatch
-	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
-		cpuStopWatch = timeutil.NewCPUStopWatch()
-	}
 	return &ColBatchDirectScan{
 		colBatchScanBase: base,
 		fetcher:          fetcher,
@@ -259,6 +243,5 @@ func NewColBatchDirectScan(
 		spec:             &fetchSpec,
 		resultTypes:      tableArgs.typs,
 		hasDatumVec:      hasDatumVec,
-		cpuStopWatch:     cpuStopWatch,
 	}, tableArgs.typs, nil
 }

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -132,6 +132,7 @@ func (s *ColBatchDirectScan) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.getRowsReadSinceLastMeta()
 	meta.Metrics.KVCPUTime = s.GetKVResponseCPUTime()
+	meta.Metrics.LocalKVCPUTime = s.GetLocalKVCPUTime()
 	meta.Metrics.StageID = s.stageID
 	trailingMeta = append(trailingMeta, *meta)
 	return trailingMeta

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -8,7 +8,6 @@ package colfetcher
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -322,9 +321,11 @@ func (s *ColBatchScan) GetBatchRequestsIssued() int64 {
 	return s.cf.getBatchRequestsIssued()
 }
 
-// GetKVCPUTime is part of the colexecop.KVReader interface.
-func (s *ColBatchScan) GetKVCPUTime() time.Duration {
-	return s.cf.cpuStopWatch.Elapsed()
+// GetLocalKVCPUTime is part of the colexecop.KVReader interface.
+func (s *ColBatchScan) GetLocalKVCPUTime() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cf.getLocalKVCPUTime()
 }
 
 // Release implements the execreleasable.Releasable interface.

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -288,6 +288,7 @@ func (s *ColBatchScan) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.getRowsReadSinceLastMeta()
 	meta.Metrics.KVCPUTime = s.GetKVResponseCPUTime()
+	meta.Metrics.LocalKVCPUTime = s.GetLocalKVCPUTime()
 	meta.Metrics.StageID = s.stageID
 	trailingMeta = append(trailingMeta, *meta)
 	return trailingMeta

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"math"
 	"sort"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -472,9 +471,11 @@ func (s *ColIndexJoin) GetBatchRequestsIssued() int64 {
 	return s.cf.getBatchRequestsIssued()
 }
 
-// GetKVCPUTime is part of the colexecop.KVReader interface.
-func (s *ColIndexJoin) GetKVCPUTime() time.Duration {
-	return s.cf.cpuStopWatch.Elapsed()
+// GetLocalKVCPUTime is part of the colexecop.KVReader interface.
+func (s *ColIndexJoin) GetLocalKVCPUTime() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cf.getLocalKVCPUTime()
 }
 
 // UsedStreamer is part of the colexecop.KVReader interface.

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -427,6 +427,7 @@ func (s *ColIndexJoin) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.GetRowsRead()
 	meta.Metrics.KVCPUTime = s.GetKVResponseCPUTime()
+	meta.Metrics.LocalKVCPUTime = s.GetLocalKVCPUTime()
 	trailingMeta = append(trailingMeta, *meta)
 	if !s.flowCtx.Gateway {
 		if trace := tracing.SpanFromContext(s.Ctx).GetConfiguredRecording(); trace != nil {

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -81,6 +82,11 @@ type Outbox struct {
 	// A copy of Run's caller ctx, with no StreamID tag.
 	// Used to pass a clean context to the input.Next.
 	runnerCtx context.Context
+
+	// cpuStopWatch measures goroutine CPU time for the outbox goroutine.
+	// The zero value is valid; Stop() returns 0 if grunning is not
+	// supported or Start was not called.
+	cpuStopWatch timeutil.CPUStopWatch
 }
 
 // NewOutbox creates a new Outbox.
@@ -209,6 +215,9 @@ func (o *Outbox) Run(
 	flowCtxCancel context.CancelFunc,
 	connectionTimeout time.Duration,
 ) {
+	if o.flowCtx != nil {
+		o.cpuStopWatch.Start()
+	}
 	flowCtx := ctx
 	// Derive a child context so that we can cancel all components rooted in
 	// this outbox.
@@ -422,6 +431,16 @@ func (o *Outbox) sendDrainedMetadata(
 		for _, meta := range o.inputMetaInfo.MetadataSources.DrainMeta() {
 			msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.LocalMetaToRemoteProducerMeta(ctx, meta))
 		}
+	}
+	// Always-on: each outbox emits its goroutine's CPU time via Metrics
+	// metadata. The gateway sums all SQLCPUTime entries and subtracts
+	// total LocalKVCPUTime to derive SQL CPU.
+	if delta := o.cpuStopWatch.Stop(); delta > 0 {
+		sqlCPUMeta := execinfrapb.ProducerMetadata{}
+		sqlCPUMeta.Metrics = execinfrapb.GetMetricsMeta()
+		sqlCPUMeta.Metrics.SQLCPUTime = int64(delta)
+		msg.Data.Metadata = append(msg.Data.Metadata,
+			execinfrapb.LocalMetaToRemoteProducerMeta(ctx, sqlCPUMeta))
 	}
 	if !o.flowCtx.Gateway {
 		if trace := tracing.SpanFromContext(ctx).GetConfiguredRecording(); trace != nil {

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
@@ -590,6 +591,10 @@ func (r *HashRouter) getDrainState() hashRouterDrainState {
 // output calculated by hashing columns. Cancel the given context to terminate
 // early.
 func (r *HashRouter) Run(ctx context.Context) {
+	var cpuStopWatch timeutil.CPUStopWatch
+	if r.flowCtx != nil {
+		cpuStopWatch.Start()
+	}
 	var span *tracing.Span
 	ctx, span = execinfra.ProcessorSpan(ctx, r.flowCtx, "hash router", r.processorID)
 	if span != nil {
@@ -670,6 +675,15 @@ func (r *HashRouter) Run(ctx context.Context) {
 			}
 		}
 		drainedMeta = append(drainedMeta, r.inputMetaInfo.MetadataSources.DrainMeta()...)
+	}
+	// Emit this goroutine's CPU time as metadata. The hash router goroutine
+	// executes upstream operators via Input.Next(), so its CPU includes all
+	// upstream operator work.
+	if delta := cpuStopWatch.Stop(); delta > 0 {
+		grunningMeta := execinfrapb.ProducerMetadata{}
+		grunningMeta.Metrics = execinfrapb.GetMetricsMeta()
+		grunningMeta.Metrics.SQLCPUTime = int64(delta)
+		drainedMeta = append(drainedMeta, grunningMeta)
 	}
 	// Non-blocking send of metadata so that one of the outputs can return it
 	// in DrainMeta.

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -247,7 +247,7 @@ type vectorizedStatsCollectorImpl struct {
 
 // GetStats is part of the colexecop.VectorizedStatsCollector interface.
 func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats {
-	numBatches, numTuples, time, cpuTime, ok := vsc.batchInfoCollector.finishAndGetStats()
+	numBatches, numTuples, wallTime, cpuTime, ok := vsc.batchInfoCollector.finishAndGetStats()
 	if !ok {
 		// The stats collection wasn't successful for some reason, so we will
 		// return an empty object (since nil is not allowed by the contract of
@@ -265,12 +265,6 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 	var s *execinfrapb.ComponentStats
 	if vsc.columnarizer != nil {
 		s = vsc.columnarizer.GetStats()
-
-		// If the columnarizer is wrapping an operator that performs KV operations,
-		// we must subtract the CPU time spent performing KV work on a SQL goroutine
-		// from the measured CPU time. If the wrapped operator does not perform KV
-		// operations, this value will be zero.
-		cpuTime -= s.KV.KVCPUTime.Value()
 	} else {
 		// There was no root columnarizer, so create a new stats object.
 		s = &execinfrapb.ComponentStats{Component: vsc.componentID}
@@ -292,7 +286,7 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 		// themselves). Similarly, for those wrapped processors it is ok to show the
 		// time as "execution time" since "KV time" would only make sense for
 		// tableReaders, and they are less likely to be wrapped than others.
-		s.KV.KVTime.Set(time)
+		s.KV.KVTime.Set(wallTime)
 		s.KV.BytesRead.Set(uint64(vsc.kvReader.GetBytesRead()))
 		s.KV.KVPairsRead.Set(uint64(vsc.kvReader.GetKVPairsRead()))
 		s.KV.TuplesRead.Set(uint64(vsc.kvReader.GetRowsRead()))
@@ -307,9 +301,9 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 
 		// In order to account for SQL CPU time, we have to subtract the CPU time
 		// spent while serving KV requests on a SQL goroutine.
-		cpuTime -= vsc.kvReader.GetKVCPUTime()
+		cpuTime -= time.Duration(vsc.kvReader.GetLocalKVCPUTime())
 	} else {
-		s.Exec.ExecTime.Set(time)
+		s.Exec.ExecTime.Set(wallTime)
 	}
 	if cpuTime > 0 && grunning.Supported {
 		// Note that in rare cases, the measured CPU time can be less than zero

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -496,7 +496,6 @@ func (s *vectorizedFlowCreator) makeGetStatsFnForOutbox(
 				FlowStats: execinfrapb.FlowStats{
 					MaxMemUsage:  optional.MakeUint(uint64(flowCtx.Mon.MaximumBytes())),
 					MaxDiskUsage: optional.MakeUint(uint64(flowCtx.DiskMonitor.MaximumBytes())),
-					ConsumedRU:   optional.MakeUint(uint64(flowCtx.TenantCPUMonitor.EndCollection(ctx))),
 				},
 			})
 		}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1834,6 +1834,7 @@ type connExecutor struct {
 		// statements in this txn so far.
 		rowsWritten    int64
 		kvCPUTimeNanos time.Duration
+		sqlCPUTime     time.Duration
 
 		// rowsWrittenLogged and rowsReadLogged indicates whether we have
 		// already logged an event about reaching written/read rows setting,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
-	"github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu"
 	"github.com/cockroachdb/cockroach/pkg/obs/statementstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -1890,10 +1889,6 @@ type connExecutor struct {
 	// statsCollector is used to collect statistics about SQL statements and
 	// transactions.
 	statsCollector *sslocal.StatsCollector
-
-	// cpuStatsCollector is used to estimate RU consumption due to CPU usage for
-	// tenants.
-	cpuStatsCollector multitenantcpu.CPUUsageHelper
 
 	// applicationName is the same as sessionData.ApplicationName. It's copied
 	// here as an atomic so that it can be read concurrently by serialize().

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3222,6 +3222,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			stats.sqlCPUTime = 0
 		}
 	}
+	ex.extraTxnState.sqlCPUTime += stats.sqlCPUTime
 
 	if ppInfo := getPausablePortalInfo(planner); ppInfo != nil && !ppInfo.dispatchToExecutionEngine.cleanup.isComplete {
 		// We need to ensure that we're using the planner bound to the first-time
@@ -4517,6 +4518,7 @@ func (ex *connExecutor) onTxnRestart(ctx context.Context) {
 		ex.extraTxnState.bytesRead = 0
 		ex.extraTxnState.rowsWritten = 0
 		ex.extraTxnState.kvCPUTimeNanos = 0
+		ex.extraTxnState.sqlCPUTime = 0
 
 		if ex.server.cfg.TestingKnobs.BeforeRestart != nil {
 			ex.server.cfg.TestingKnobs.BeforeRestart(ctx, ex.state.mu.autoRetryReason)
@@ -4550,6 +4552,7 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.extraTxnState.idleLatency = 0
 	ex.extraTxnState.rowsRead = 0
 	ex.extraTxnState.kvCPUTimeNanos = 0
+	ex.extraTxnState.sqlCPUTime = 0
 	ex.extraTxnState.bytesRead = 0
 	ex.extraTxnState.rowsWritten = 0
 	ex.extraTxnState.rowsWrittenLogged = false
@@ -4663,6 +4666,7 @@ func (ex *connExecutor) recordTransactionFinish(
 		RowsWritten:             ex.extraTxnState.rowsWritten,
 		BytesRead:               ex.extraTxnState.bytesRead,
 		KVCPUTimeNanos:          ex.extraTxnState.kvCPUTimeNanos,
+		SQLCPUTimeNanos:         ex.extraTxnState.sqlCPUTime,
 		Priority:                ex.state.mu.priority,
 		// TODO(107318): add isolation level
 		// TODO(107318): add qos

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2976,6 +2976,10 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// https://github.com/cockroachdb/cockroach/issues/99410
 	ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.PlannerStartLogicalPlan, crtime.NowMono())
 
+	// Start measuring goroutine CPU time for SQL CPU measurement.
+	var cpuStopWatch timeutil.CPUStopWatch
+	cpuStopWatch.Start()
+
 	if execinfra.IncludeRUEstimateInExplainAnalyze.Get(ex.server.cfg.SV()) {
 		if server := ex.server.cfg.DistSQLSrv; server != nil {
 			// Begin measuring CPU usage for tenants. This is a no-op for non-tenants.
@@ -3215,6 +3219,18 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	ex.extraTxnState.rowsWritten += stats.rowsWritten
 	ex.extraTxnState.kvCPUTimeNanos += stats.kvCPUTimeNanos
 
+	// Compute corrected SQL CPU time: add gateway grunning to the
+	// accumulated remote grunning, then subtract local KV CPU time
+	// (which overlaps with grunning).
+	gatewayGrunning := cpuStopWatch.Stop()
+	if gatewayGrunning > 0 {
+		stats.sqlCPUTime += gatewayGrunning
+		stats.sqlCPUTime -= stats.localKVCPUTime
+		if stats.sqlCPUTime < 0 {
+			stats.sqlCPUTime = 0
+		}
+	}
+
 	if ppInfo := getPausablePortalInfo(planner); ppInfo != nil && !ppInfo.dispatchToExecutionEngine.cleanup.isComplete {
 		// We need to ensure that we're using the planner bound to the first-time
 		// execution of a portal.
@@ -3285,6 +3301,12 @@ func populateQueryLevelStats(
 		}
 		log.Dev.VInfof(ctx, 1, msg, ih.fingerprint, err)
 	} else {
+		// Use the always-on SQL CPU measurement if it exceeds the trace-derived
+		// value. This ensures always-on accuracy even when tracing provides a
+		// partial picture.
+		if topLevelStats.sqlCPUTime > ih.queryLevelStatsWithErr.Stats.SQLCPUTime {
+			ih.queryLevelStatsWithErr.Stats.SQLCPUTime = topLevelStats.sqlCPUTime
+		}
 		// If this query is being run by a tenant, record the RUs consumed by CPU
 		// usage and network egress to the client.
 		if execinfra.IncludeRUEstimateInExplainAnalyze.Get(cfg.SV()) && cfg.DistSQLSrv != nil {
@@ -3618,8 +3640,14 @@ type topLevelQueryStats struct {
 	// kvCPUTimeNanos is the CPU time consumed by KV operations during query execution.
 	kvCPUTimeNanos time.Duration
 	// localKVCPUTime is the goroutine CPU time spent in KV calls on the local
-	// node, as measured by the grunning library.
+	// node, as measured by the grunning library. It is subtracted from the
+	// grunning measurement to compute the SQL-only CPU time.
 	localKVCPUTime time.Duration
+	// sqlCPUTime accumulates uncorrected grunning time from remote flows
+	// (via Metrics.SQLCPUTime metadata). After the statement completes, the
+	// gateway grunning is added and localKVCPUTime is subtracted to
+	// produce the corrected SQL CPU time.
+	sqlCPUTime time.Duration
 	// NB: when adding another field here, consider whether
 	// forwardInnerQueryStats method needs an adjustment.
 }
@@ -3634,6 +3662,7 @@ func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
 	s.clientTime += other.clientTime
 	s.kvCPUTimeNanos += other.kvCPUTimeNanos
 	s.localKVCPUTime += other.localKVCPUTime
+	s.sqlCPUTime += other.sqlCPUTime
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3617,6 +3617,9 @@ type topLevelQueryStats struct {
 	clientTime time.Duration
 	// kvCPUTimeNanos is the CPU time consumed by KV operations during query execution.
 	kvCPUTimeNanos time.Duration
+	// localKVCPUTime is the goroutine CPU time spent in KV calls on the local
+	// node, as measured by the grunning library.
+	localKVCPUTime time.Duration
 	// NB: when adding another field here, consider whether
 	// forwardInnerQueryStats method needs an adjustment.
 }
@@ -3630,6 +3633,7 @@ func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
 	s.networkEgressEstimate += other.networkEgressEstimate
 	s.clientTime += other.clientTime
 	s.kvCPUTimeNanos += other.kvCPUTimeNanos
+	s.localKVCPUTime += other.localKVCPUTime
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
-	"github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
 	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -2980,13 +2979,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	var cpuStopWatch timeutil.CPUStopWatch
 	cpuStopWatch.Start()
 
-	if execinfra.IncludeRUEstimateInExplainAnalyze.Get(ex.server.cfg.SV()) {
-		if server := ex.server.cfg.DistSQLSrv; server != nil {
-			// Begin measuring CPU usage for tenants. This is a no-op for non-tenants.
-			ex.cpuStatsCollector.StartCollection(ctx, server.TenantCostController)
-		}
-	}
-
 	// If we've been tasked with backfilling a schema change operation at a
 	// particular system time, it's important that we do planning for the
 	// operation at the timestamp that we're expecting to perform the backfill at,
@@ -3238,7 +3230,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		// Note that here we append the cleanup function without a defer since
 		// there is no more code relevant to pausable portals model below.
 		ppInfo.dispatchToExecutionEngine.cleanup.appendFunc(func(ctx context.Context) {
-			populateQueryLevelStats(ctx, &curPlanner, ex.server.cfg, ppInfo.dispatchToExecutionEngine.queryStats, &ex.cpuStatsCollector)
+			populateQueryLevelStats(ctx, &curPlanner, ex.server.cfg, ppInfo.dispatchToExecutionEngine.queryStats)
 			ppInfo.dispatchToExecutionEngine.stmtFingerprintID = ex.recordStatementSummary(
 				ctx, &curPlanner, int(ex.state.mu.autoRetryCounter), planner.autoRetryStmtCounter,
 				ppInfo.dispatchToExecutionEngine.rowsAffected, ppInfo.curRes.ErrAllowReleased(),
@@ -3246,7 +3238,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			)
 		})
 	} else {
-		populateQueryLevelStats(ctx, planner, ex.server.cfg, &stats, &ex.cpuStatsCollector)
+		populateQueryLevelStats(ctx, planner, ex.server.cfg, &stats)
 		ex.recordStatementSummary(
 			ctx, planner, int(ex.state.mu.autoRetryCounter), planner.autoRetryStmtCounter,
 			res.RowsAffected(), res.Err(), stats,
@@ -3270,11 +3262,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 //   - queryLevelStatsWithErr contains query-level execution statistics are
 //     collected using the statement's trace and the plan's flow metadata.
 func populateQueryLevelStats(
-	ctx context.Context,
-	p *planner,
-	cfg *ExecutorConfig,
-	topLevelStats *topLevelQueryStats,
-	cpuStats *multitenantcpu.CPUUsageHelper,
+	ctx context.Context, p *planner, cfg *ExecutorConfig, topLevelStats *topLevelQueryStats,
 ) {
 	ih := &p.instrumentation
 	ih.topLevelStats = *topLevelStats
@@ -3314,7 +3302,11 @@ func populateQueryLevelStats(
 				if costCfg := costController.GetRequestUnitModel(); costCfg != nil {
 					networkEgressRUEstimate := costCfg.PGWireEgressCost(topLevelStats.networkEgressEstimate)
 					ih.queryLevelStatsWithErr.Stats.RUEstimate += float64(networkEgressRUEstimate)
-					ih.queryLevelStatsWithErr.Stats.RUEstimate += cpuStats.EndCollection(ctx)
+					// Use the always-on SQL CPU measurement (gateway +
+					// remote, corrected for local KV) for the CPU portion
+					// of the RU estimate.
+					ih.queryLevelStatsWithErr.Stats.RUEstimate += float64(
+						costCfg.PodCPUCost(topLevelStats.sqlCPUTime.Seconds()))
 				}
 			}
 		}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -268,6 +268,10 @@ func (d *deleteNode) kvCPUTime() int64 {
 	return d.run.td.kvCPUTime
 }
 
+func (d *deleteNode) localKVCPUTime() int64 {
+	return d.run.td.localKVCPUTime
+}
+
 func (d *deleteNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -17,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -54,6 +56,13 @@ type deleteRangeNode struct {
 	// kvCPUTimeAccum tracks the cumulative CPU time (in nanoseconds) that KV
 	// reported in BatchResponse headers during the execution of this delete range.
 	kvCPUTimeAccum int64
+
+	// localKVCPUTimeAccum tracks the cumulative goroutine CPU time (in
+	// nanoseconds) spent in KV calls during delete range execution, as measured
+	// by the grunning library.
+	localKVCPUTimeAccum int64
+	// cpuStopWatch measures grunning time around KV calls.
+	cpuStopWatch timeutil.CPUStopWatch
 }
 
 var _ planNode = &deleteRangeNode{}
@@ -81,6 +90,10 @@ func (d *deleteRangeNode) returnsRowsAffected() bool {
 
 func (d *deleteRangeNode) kvCPUTime() int64 {
 	return d.kvCPUTimeAccum
+}
+
+func (d *deleteRangeNode) localKVCPUTime() int64 {
+	return d.localKVCPUTimeAccum
 }
 
 // startExec implements the planNode interface.
@@ -126,7 +139,12 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 			b.Header.DeadlockTimeout = params.SessionData().DeadlockTimeout
 			d.deleteSpans(params, b, spans)
 			log.VEventf(ctx, 2, "fast delete: processing %d spans", len(spans))
-			if err := params.p.txn.Run(ctx, b); err != nil {
+			d.cpuStopWatch.Start()
+			runErr := params.p.txn.Run(ctx, b)
+			if delta := d.cpuStopWatch.Stop(); delta > 0 {
+				atomic.AddInt64(&d.localKVCPUTimeAccum, int64(delta))
+			}
+			if runErr != nil {
 				return row.ConvertBatchError(ctx, d.desc, b, false /* alwaysConvertCondFailed */)
 			}
 
@@ -149,7 +167,12 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		b.Header.DeadlockTimeout = params.SessionData().DeadlockTimeout
 		d.deleteSpans(params, b, spans)
 		log.VEventf(ctx, 2, "fast delete: processing %d spans and committing", len(spans))
-		if err := params.p.txn.CommitInBatch(ctx, b); err != nil {
+		d.cpuStopWatch.Start()
+		commitErr := params.p.txn.CommitInBatch(ctx, b)
+		if delta := d.cpuStopWatch.Stop(); delta > 0 {
+			atomic.AddInt64(&d.localKVCPUTimeAccum, int64(delta))
+		}
+		if commitErr != nil {
 			return row.ConvertBatchError(ctx, d.desc, b, false /* alwaysConvertCondFailed */)
 		}
 

--- a/pkg/sql/delete_swap.go
+++ b/pkg/sql/delete_swap.go
@@ -147,6 +147,10 @@ func (d *deleteSwapNode) kvCPUTime() int64 {
 	return d.run.td.kvCPUTime
 }
 
+func (d *deleteSwapNode) localKVCPUTime() int64 {
+	return d.run.td.localKVCPUTime
+}
+
 func (d *deleteSwapNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1643,6 +1643,7 @@ func forwardInnerQueryStats(f metadataForwarder, stats topLevelQueryStats) {
 	meta.Metrics.IndexRowsWritten = stats.indexRowsWritten
 	meta.Metrics.IndexBytesWritten = stats.indexBytesWritten
 	meta.Metrics.KVCPUTime = int64(stats.kvCPUTimeNanos)
+	meta.Metrics.LocalKVCPUTime = int64(stats.localKVCPUTime)
 	// stats.networkEgressEstimate and stats.clientTime are ignored since they
 	// only matter at the "true" top-level query (and actually should be zero
 	// here anyway).
@@ -1701,6 +1702,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 		r.stats.indexRowsWritten += meta.Metrics.IndexRowsWritten
 		r.stats.indexBytesWritten += meta.Metrics.IndexBytesWritten
 		r.stats.kvCPUTimeNanos += time.Duration(meta.Metrics.KVCPUTime)
+		r.stats.localKVCPUTime += time.Duration(meta.Metrics.LocalKVCPUTime)
 
 		if sm, ok := r.scanStageEstimateMap[meta.Metrics.StageID]; ok {
 			sm.rowsRead += uint64(meta.Metrics.RowsRead)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1644,6 +1644,10 @@ func forwardInnerQueryStats(f metadataForwarder, stats topLevelQueryStats) {
 	meta.Metrics.IndexBytesWritten = stats.indexBytesWritten
 	meta.Metrics.KVCPUTime = int64(stats.kvCPUTimeNanos)
 	meta.Metrics.LocalKVCPUTime = int64(stats.localKVCPUTime)
+	// Do not forward sqlCPUTime: the outer query's gateway grunning
+	// already includes the inner query's CPU (same goroutine), so
+	// forwarding it would double-count.
+	//
 	// stats.networkEgressEstimate and stats.clientTime are ignored since they
 	// only matter at the "true" top-level query (and actually should be zero
 	// here anyway).
@@ -1703,6 +1707,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 		r.stats.indexBytesWritten += meta.Metrics.IndexBytesWritten
 		r.stats.kvCPUTimeNanos += time.Duration(meta.Metrics.KVCPUTime)
 		r.stats.localKVCPUTime += time.Duration(meta.Metrics.LocalKVCPUTime)
+		r.stats.sqlCPUTime += time.Duration(meta.Metrics.SQLCPUTime)
 
 		if sm, ok := r.scanStageEstimateMap[meta.Metrics.StageID]; ok {
 			sm.rowsRead += uint64(meta.Metrics.RowsRead)
@@ -2998,7 +3003,21 @@ func (dsp *DistSQLPlanner) planAndRunChecksInParallel(
 			},
 			func(ctx context.Context) {
 				defer wg.Done()
+				// Measure this worker goroutine's CPU time. It is not
+				// captured by the main cpuStopWatch in
+				// dispatchToExecutionEngine since it runs on a separate
+				// goroutine. We add raw grunning here; the top-level
+				// correction in dispatchToExecutionEngine will subtract
+				// localKVCPUTime (which is propagated via
+				// addTopLevelQueryStats).
+				var cpuStopWatch timeutil.CPUStopWatch
+				cpuStopWatch.Start()
 				runCheck(ctx, checkPlanIdx, parallelCheckWorkerGoroutine)
+				if workerGrunning := cpuStopWatch.Stop(); workerGrunning > 0 {
+					mu.Lock()
+					recv.stats.sqlCPUTime += workerGrunning
+					mu.Unlock()
+				}
 			}); err != nil {
 			// The server is quiescing, so we just make sure to wait for all
 			// already started checks to complete after canceling them.

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/multitenant",
-        "//pkg/multitenant/multitenantcpu",
         "//pkg/obs/ash",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -87,11 +86,6 @@ type FlowCtx struct {
 	// DiskMonitor is this flow's disk monitor. All disk usage for this flow must
 	// be registered through this monitor.
 	DiskMonitor *mon.BytesMonitor
-
-	// TenantCPUMonitor is used to estimate a query's CPU usage for tenants
-	// running EXPLAIN ANALYZE. Currently, it is only used by remote flows.
-	// The gateway flow is handled by the connExecutor.
-	TenantCPUMonitor multitenantcpu.CPUUsageHelper
 }
 
 // NewEvalCtx returns a modifiable copy of the FlowCtx's eval.Context.

--- a/pkg/sql/execinfrapb/component_stats.go
+++ b/pkg/sql/execinfrapb/component_stats.go
@@ -391,10 +391,6 @@ func (s *ComponentStats) Union(other *ComponentStats) *ComponentStats {
 	if !result.FlowStats.MaxDiskUsage.HasValue() {
 		result.FlowStats.MaxDiskUsage = other.FlowStats.MaxDiskUsage
 	}
-	if !result.FlowStats.ConsumedRU.HasValue() {
-		result.FlowStats.ConsumedRU = other.FlowStats.ConsumedRU
-	}
-
 	return &result
 }
 

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -213,8 +213,5 @@ message OutputStats {
 message FlowStats {
   optional util.optional.Uint max_mem_usage = 1 [(gogoproto.nullable) = false];
   optional util.optional.Uint max_disk_usage = 2 [(gogoproto.nullable) = false];
-  // Amount of RUs consumed due to CPU usage while executing the flow. Currently
-  // only used for remote flows.
-  optional util.optional.Uint consumed_ru = 3 [(gogoproto.nullable) = false,
-    (gogoproto.customname) = "ConsumedRU"];
+  reserved 3;
 }

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -160,14 +160,9 @@ message KVStats {
   optional util.optional.Uint range_key_contained_points = 19 [(gogoproto.nullable) = false];
   optional util.optional.Uint range_key_skipped_points = 20 [(gogoproto.nullable) = false];
 
-  // Cumulated CPU time spent fulfilling KV requests on a SQL goroutine. This
-  // would not include CPU time spent on a remote node, but would include time
-  // spent on a Scan's goroutine. This is only used to calculate SQL CPU time
-  // for processors in the row-engine that perform KV requests.
-  // TODO(drewk): measure wall-clock KV time directly as well, and display it
-  // alongside total execution time for operators that perform KV work.
-  optional util.optional.Duration kv_cpu_time = 11 [(gogoproto.nullable) = false,
-    (gogoproto.customname) = "KVCPUTime"];
+  // Field 11 was KVCPUTime, removed in favor of grunning-based measurement
+  // at the KV send layer.
+  reserved 11;
 
   optional util.optional.Uint num_gets = 21 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_scans = 22 [(gogoproto.nullable) = false];

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -338,7 +338,11 @@ message RemoteProducerMetadata {
     // used at the gateway to compute SQL CPU time by subtracting it from the
     // total goroutine CPU time.
     optional int64 local_kv_cpu_time = 8 [(gogoproto.nullable) = false, (gogoproto.customname) = "LocalKVCPUTime"];
-    // NEXT ID: 9
+    // SQLCPUTime carries goroutine CPU time (in nanoseconds) for this flow.
+    // Remote flows send their accumulated grunning time here; the gateway
+    // subtracts total LocalKVCPUTime to derive SQL-only CPU.
+    optional int64 sql_cpu_time = 9 [(gogoproto.nullable) = false, (gogoproto.customname) = "SQLCPUTime"];
+    // NEXT ID: 10
   }
   oneof value {
     RangeInfos range_info = 1;

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -333,7 +333,12 @@ message RemoteProducerMetadata {
     // representative of the "synchronous" portion of work performed by KV.
     // See the CPUTime field in the kvpb.BatchResponse_Header.
     optional int64 kv_cpu_time = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTime"];
-    // NEXT ID: 8
+    // LocalKVCPUTime is the goroutine CPU time (in nanoseconds) spent in KV
+    // calls on the local node, as measured by the grunning library. This is
+    // used at the gateway to compute SQL CPU time by subtracting it from the
+    // total goroutine CPU time.
+    optional int64 local_kv_cpu_time = 8 [(gogoproto.nullable) = false, (gogoproto.customname) = "LocalKVCPUTime"];
+    // NEXT ID: 9
   }
   oneof value {
     RangeInfos range_info = 1;

--- a/pkg/sql/execstats/traceanalyzer.go
+++ b/pkg/sql/execstats/traceanalyzer.go
@@ -324,9 +324,6 @@ func (a *TraceAnalyzer) ProcessStats() {
 					a.queryLevelStats.MaxDiskUsage = diskUsage
 				}
 			}
-			if v.FlowStats.ConsumedRU.HasValue() {
-				s.RUEstimate += float64(v.FlowStats.ConsumedRU.Value())
-			}
 		}
 	}
 }

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -213,7 +213,7 @@ func (ex *connExecutor) recordStatementSummary(
 			).
 			PlanGist(planner.instrumentation.planGist.String(), planner.instrumentation.planGist.Hash()).
 			LatencyRecorder(ex.statsCollector).
-			QueryLevelStats(stats.bytesRead, stats.rowsRead, stats.rowsWritten, stats.kvCPUTimeNanos.Nanoseconds()).
+			QueryLevelStats(stats.bytesRead, stats.rowsRead, stats.rowsWritten, stats.kvCPUTimeNanos.Nanoseconds(), stats.sqlCPUTime.Nanoseconds()).
 			ExecStats(queryLevelStats).
 			// TODO(mgartner): Use a slice of struct{uint64, uint64} instead of
 			// converting to strings.

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/util/cancelchecker",
         "//pkg/util/ctxlog",
         "//pkg/util/growstack",
+        "//pkg/util/grunning",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxlog"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -515,7 +516,13 @@ func (f *FlowBase) StartInternal(
 				gh := cpuHandle.RegisterGoroutine()
 				defer gh.Close(ctx)
 			}
-			processors[i].Run(ctx, outputs[i])
+			output := outputs[i]
+			if grunning.Supported {
+				w := &grunningMetaOutput{RowReceiver: outputs[i]}
+				w.cpuStopWatch.Start()
+				output = w
+			}
+			processors[i].Run(ctx, output)
 			f.waitGroup.Done()
 		}(i)
 	}
@@ -801,4 +808,24 @@ func MakeCPUHandle(
 		return ctx, nil, nil, err
 	}
 	return newCtx, cpuHandle, gh, err
+}
+
+// grunningMetaOutput wraps a RowReceiver to inject a SQLCPUTime metadata entry
+// just before ProducerDone closes the channel. This captures the processor
+// goroutine's CPU time via grunning, measured from the start time recorded when
+// the wrapper was created (on the processor goroutine).
+type grunningMetaOutput struct {
+	execinfra.RowReceiver
+	cpuStopWatch timeutil.CPUStopWatch
+}
+
+// ProducerDone implements the execinfra.RowReceiver interface.
+func (g *grunningMetaOutput) ProducerDone() {
+	if delta := g.cpuStopWatch.Stop(); delta > 0 {
+		meta := execinfrapb.GetProducerMeta()
+		meta.Metrics = execinfrapb.GetMetricsMeta()
+		meta.Metrics.SQLCPUTime = int64(delta)
+		g.RowReceiver.Push(nil, meta)
+	}
+	g.RowReceiver.ProducerDone()
 }

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -493,13 +493,6 @@ func (f *FlowBase) StartInternal(
 
 	f.setStatus(flowRunning)
 
-	if execinfra.IncludeRUEstimateInExplainAnalyze.Get(&f.Cfg.Settings.SV) &&
-		!f.Gateway && f.CollectStats {
-		// Remote flows begin collecting CPU usage here, and finish when the last
-		// outbox finishes. Gateway flows are handled by the connExecutor.
-		f.FlowCtx.TenantCPUMonitor.StartCollection(ctx, f.Cfg.TenantCostController)
-	}
-
 	if log.V(1) {
 		log.Dev.Infof(ctx, "registered flow %s", f.ID.Short())
 	}

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -336,7 +336,6 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 					if !m.isGatewayNode && m.numOutboxes != nil && atomic.AddInt32(m.numOutboxes, -1) == 0 {
 						m.flowStats.FlowStats.MaxMemUsage.Set(uint64(m.flowCtx.Mon.MaximumBytes()))
 						m.flowStats.FlowStats.MaxDiskUsage.Set(uint64(m.flowCtx.DiskMonitor.MaximumBytes()))
-						m.flowStats.FlowStats.ConsumedRU.Set(uint64(m.flowCtx.TenantCPUMonitor.EndCollection(ctx)))
 					}
 					span.RecordStructured(&m.streamStats)
 					span.RecordStructured(&m.flowStats)

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -89,6 +89,11 @@ type Outbox struct {
 
 	// isGatewayNode specifies whether this outbox is running on the gateway node.
 	isGatewayNode bool
+
+	// cpuStopWatch measures goroutine CPU time for the outbox goroutine.
+	// The zero value is valid; Stop() returns 0 if grunning is not
+	// supported or Start was not called.
+	cpuStopWatch timeutil.CPUStopWatch
 }
 
 var _ execinfra.RowReceiver = &Outbox{}
@@ -309,6 +314,20 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 		case msg, ok := <-m.RowChannel.C:
 			if !ok {
 				// No more data.
+
+				// Always-on: each outbox emits its goroutine's CPU
+				// time via Metrics metadata. The gateway sums all
+				// SQLCPUTime entries and subtracts total
+				// LocalKVCPUTime to derive SQL CPU.
+				if delta := m.cpuStopWatch.Stop(); delta > 0 {
+					meta := &execinfrapb.ProducerMetadata{}
+					meta.Metrics = execinfrapb.GetMetricsMeta()
+					meta.Metrics.SQLCPUTime = int64(delta)
+					if err := m.AddRow(ctx, nil, meta); err != nil {
+						return err
+					}
+				}
+
 				if m.statsCollectionEnabled {
 					err := m.flush(ctx)
 					if err != nil {
@@ -435,6 +454,7 @@ func (m *Outbox) Start(ctx context.Context, wg *sync.WaitGroup, flowCtxCancel co
 			gh := cpuHandle.RegisterGoroutine()
 			defer gh.Close(ctx)
 		}
+		m.cpuStopWatch.Start()
 		growstack.Grow()
 		defer wg.Done()
 		m.setErr(m.mainLoop(ctx, wg))

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -394,3 +394,7 @@ func (n *insertNode) returnsRowsAffected() bool {
 func (n *insertNode) kvCPUTime() int64 {
 	return n.run.ti.kvCPUTime
 }
+
+func (n *insertNode) localKVCPUTime() int64 {
+	return n.run.ti.localKVCPUTime
+}

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -87,6 +89,14 @@ type insertFastPathRun struct {
 	// in BatchResponse headers for FK and uniqueness check batches. The KVCPUTime
 	// performed by the INSERT is tracked by the table inserter (insertRun.ti.kvCPUTime).
 	kvCPUTime int64
+
+	// localKVCPUTime tracks the cumulative goroutine CPU time (in nanoseconds)
+	// spent in FK and uniqueness check KV calls, as measured by the grunning
+	// library. The local KV CPU time for the INSERT itself is tracked by the
+	// table inserter (insertRun.ti.localKVCPUTime).
+	localKVCPUTime int64
+	// cpuStopWatch measures grunning time around FK/uniqueness check KV calls.
+	cpuStopWatch timeutil.CPUStopWatch
 }
 
 // insertFastPathFKUniqSpanInfo records information about each Request in the
@@ -314,7 +324,11 @@ func (n *insertFastPathNode) runUniqChecks(params runParams) error {
 	// Run the uniqueness checks batch.
 	ba := n.run.uniqBatch.ShallowCopy()
 	log.VEventf(params.ctx, 2, "uniqueness check: sending a batch with %d requests", len(ba.Requests))
+	n.run.cpuStopWatch.Start()
 	br, err := params.p.txn.Send(params.ctx, ba)
+	if delta := n.run.cpuStopWatch.Stop(); delta > 0 {
+		atomic.AddInt64(&n.run.localKVCPUTime, int64(delta))
+	}
 	if err != nil {
 		return err.GoError()
 	}
@@ -347,7 +361,11 @@ func (n *insertFastPathNode) runFKChecks(params runParams) error {
 	// Run the FK checks batch.
 	ba := n.run.fkBatch.ShallowCopy()
 	log.VEventf(params.ctx, 2, "fk check: sending a batch with %d requests", len(ba.Requests))
+	n.run.cpuStopWatch.Start()
 	br, err := params.p.txn.Send(params.ctx, ba)
+	if delta := n.run.cpuStopWatch.Stop(); delta > 0 {
+		atomic.AddInt64(&n.run.localKVCPUTime, int64(delta))
+	}
 	if err != nil {
 		return err.GoError()
 	}
@@ -389,7 +407,11 @@ func (n *insertFastPathNode) runFKUniqChecks(params runParams) error {
 	ba.Header.LockTimeout = n.run.fkBatch.Header.LockTimeout
 	ba.Header.DeadlockTimeout = n.run.fkBatch.Header.DeadlockTimeout
 	log.VEventf(params.ctx, 2, "fk / uniqueness check: sending a batch with %d requests", len(ba.Requests))
+	n.run.cpuStopWatch.Start()
 	br, err := params.p.txn.Send(params.ctx, ba)
+	if delta := n.run.cpuStopWatch.Stop(); delta > 0 {
+		atomic.AddInt64(&n.run.localKVCPUTime, int64(delta))
+	}
 	if err != nil {
 		return err.GoError()
 	}
@@ -581,6 +603,10 @@ func (n *insertFastPathNode) returnsRowsAffected() bool {
 
 func (n *insertFastPathNode) kvCPUTime() int64 {
 	return n.run.ti.kvCPUTime + n.run.kvCPUTime
+}
+
+func (n *insertFastPathNode) localKVCPUTime() int64 {
+	return n.run.ti.localKVCPUTime + n.run.localKVCPUTime
 }
 
 // See planner.autoCommit.

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -934,12 +934,7 @@ func (ih *instrumentationHelper) emitExplainAnalyzePlanToOutputBuilder(
 		if grunning.Supported {
 			ob.AddKVCPUTime(ih.topLevelStats.kvCPUTimeNanos)
 		}
-		if !ih.containsMutation && ih.vectorized && grunning.Supported {
-			// Currently we cannot separate SQL CPU time from local KV CPU time for
-			// mutations, since they do not collect statistics. Additionally, CPU time
-			// is only collected for vectorized plans since it is gathered by the
-			// vectorizedStatsCollector operator.
-			// TODO(drewk): lift these restrictions.
+		if grunning.Supported {
 			ob.AddSQLCPUTime(queryStats.SQLCPUTime)
 		}
 		if ih.isTenant && ih.vectorized {
@@ -1130,8 +1125,6 @@ func (m execNodeTraceMetadata) annotateExplain(
 		}
 	}
 
-	noMutations := !p.curPlan.flags.IsSet(planFlagContainsMutation)
-
 	var walk func(n *explain.Node)
 	walk = func(n *explain.Node) {
 		wrapped := n.WrappedNode()
@@ -1189,18 +1182,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 					nodeStats.ExecTime.MaybeAdd(stats.Exec.ExecTime)
 					nodeStats.MaxAllocatedMem.MaybeAdd(stats.Exec.MaxAllocatedMem)
 					nodeStats.MaxAllocatedDisk.MaybeAdd(stats.Exec.MaxAllocatedDisk)
-					if noMutations && !makeDeterministic {
-						// Currently we cannot separate SQL CPU time from local
-						// KV CPU time for mutations, since they do not collect
-						// statistics. Additionally, some platforms do not
-						// support usage of the grunning library, so we can't
-						// show this field when a deterministic output is
-						// required.
-						// TODO(drewk): once the grunning library is fully
-						// supported we can unconditionally display the CPU time
-						// here and in output.go and component_stats.go.
-						nodeStats.SQLCPUTime.MaybeAdd(stats.Exec.CPUTime)
-					}
+					nodeStats.SQLCPUTime.MaybeAdd(stats.Exec.CPUTime)
 					nodeStats.UsedFollowerRead = nodeStats.UsedFollowerRead || stats.KV.UsedFollowerRead
 				}
 			}

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -199,9 +199,9 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 		}
 	}
 
-	// Mutation queries shouldn't output CPU time.
-	runQuery("CREATE TABLE t (x INT PRIMARY KEY, y INT);", true /* hideCPU */)
-	runQuery("INSERT INTO t (SELECT t, t%127 FROM generate_series(1, 10000) g(t));", true /* hideCPU */)
+	// Mutation queries should also output CPU time with always-on measurement.
+	runQuery("CREATE TABLE t (x INT PRIMARY KEY, y INT);", false /* hideCPU */)
+	runQuery("INSERT INTO t (SELECT t, t%127 FROM generate_series(1, 10000) g(t));", false /* hideCPU */)
 
 	// Split the table across the nodes in order to make the following test cases
 	// more interesting.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -169,6 +169,11 @@ type mutationPlanNode interface {
 	// in BatchResponse headers during the execution of this mutation. It should
 	// only be called once Next returns false.
 	kvCPUTime() int64
+
+	// localKVCPUTime returns the cumulative goroutine CPU time (in nanoseconds)
+	// spent in KV calls during the execution of this mutation, as measured by
+	// the grunning library. It should only be called once Next returns false.
+	localKVCPUTime() int64
 }
 
 // planNodeReadingOwnWrites can be implemented by planNodes which do

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -269,6 +269,7 @@ func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetad
 		metrics.IndexRowsWritten = m.indexRowsWritten()
 		metrics.IndexBytesWritten = m.indexBytesWritten()
 		metrics.KVCPUTime = m.kvCPUTime()
+		metrics.LocalKVCPUTime = m.localKVCPUTime()
 		meta = append(meta, execinfrapb.ProducerMetadata{Metrics: metrics})
 	}
 	// Note that we could be wrapping multiple planNodes at once, so we have to

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -418,7 +418,7 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 				statsBuilder.StatementError(err)
 				return err
 			}
-			statsBuilder.QueryLevelStats(queryStats.bytesRead, queryStats.rowsRead, queryStats.rowsWritten, queryStats.kvCPUTimeNanos.Nanoseconds())
+			statsBuilder.QueryLevelStats(queryStats.bytesRead, queryStats.rowsRead, queryStats.rowsWritten, queryStats.kvCPUTimeNanos.Nanoseconds(), queryStats.sqlCPUTime.Nanoseconds())
 			forwardInnerQueryStats(g.p.routineMetadataForwarder, queryStats)
 			if openCursor {
 				return cursorHelper.createCursor(g.p)

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -108,6 +108,7 @@ go_test(
         "external_row_data_test.go",
         "fetcher_mvcc_test.go",
         "fetcher_test.go",
+        "kv_batch_fetcher_test.go",
         "main_test.go",
     ],
     embed = [":row"],

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -154,6 +154,12 @@ type KVBatchFetcher interface {
 	// use and is able to handle a case of uninitialized fetcher.
 	GetKVCPUTime() int64
 
+	// GetLocalKVCPUTime returns the CPU time spent on the calling goroutine
+	// during KV operations (the "local fast path" portion). It is measured via
+	// grunning deltas around txn.Send() calls. It is safe for concurrent use
+	// and is able to handle a case of uninitialized fetcher.
+	GetLocalKVCPUTime() int64
+
 	// Close releases the resources of this KVBatchFetcher. Must be called once
 	// the fetcher is no longer in use. Note that observability-related methods
 	// can still be safely called after Close.
@@ -508,6 +514,7 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 		var kvPairsRead int64
 		var batchRequestsIssued int64
 		var kvCPUTime int64
+		var localKVCPUTime int64
 		fetcherArgs := newTxnKVFetcherArgs{
 			reverse:                    args.Reverse,
 			lockStrength:               args.LockStrength,
@@ -521,10 +528,14 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 			kvPairsRead:                &kvPairsRead,
 			batchRequestsIssued:        &batchRequestsIssued,
 			kvCPUTime:                  &kvCPUTime,
+			localKVCPUTime:             &localKVCPUTime,
 			workloadID:                 args.WorkloadID,
 		}
 		if args.Txn != nil {
-			fetcherArgs.sendFn = makeSendFunc(args.Txn, args.Spec.External, &batchRequestsIssued, &kvCPUTime)
+			fetcherArgs.sendFn = makeSendFunc(
+				args.Txn, args.Spec.External,
+				&batchRequestsIssued, &kvCPUTime, &localKVCPUTime,
+			)
 			fetcherArgs.admission.requestHeader = args.Txn.AdmissionHeader()
 			fetcherArgs.admission.responseQ = args.Txn.DB().SQLKVResponseAdmissionQ
 			fetcherArgs.admission.pacerFactory = args.Txn.DB().AdmissionPacerFactory
@@ -551,7 +562,10 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 func (rf *Fetcher) SetTxn(txn *kv.Txn) error {
 	var batchRequestsIssued int64
 	var kvCPUTime int64
-	sendFn := makeSendFunc(txn, rf.args.Spec.External, &batchRequestsIssued, &kvCPUTime)
+	var localKVCPUTime int64
+	sendFn := makeSendFunc(
+		txn, rf.args.Spec.External, &batchRequestsIssued, &kvCPUTime, &localKVCPUTime,
+	)
 	return rf.setTxnAndSendFn(txn, sendFn)
 }
 
@@ -1426,6 +1440,15 @@ func (rf *Fetcher) GetKVCPUTime() int64 {
 		return 0
 	}
 	return rf.kvFetcher.GetKVCPUTime()
+}
+
+// GetLocalKVCPUTime returns the CPU time spent on the calling goroutine during
+// KV operations.
+func (rf *Fetcher) GetLocalKVCPUTime() int64 {
+	if rf == nil || rf.kvFetcher == nil {
+		return 0
+	}
+	return rf.kvFetcher.GetLocalKVCPUTime()
 }
 
 // GetBatchRequestsIssued returns total number of BatchRequests issued by the

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -740,4 +740,6 @@ func TestFetcherUninitialized(t *testing.T) {
 	// before the fetcher was fully initialized.
 	var fetcher Fetcher
 	assert.Zero(t, fetcher.GetBytesRead())
+	assert.Zero(t, fetcher.GetKVCPUTime())
+	assert.Zero(t, fetcher.GetLocalKVCPUTime())
 }

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -280,16 +281,24 @@ func makeSendFunc(
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
 	batchRequestsIssued *int64,
 	kvCPUTime *int64,
+	localKVCPUTime *int64,
 ) sendFunc {
 	if ext != nil {
-		return makeExternalSpanSendFunc(ext, txn.DB(), batchRequestsIssued, kvCPUTime)
+		return makeExternalSpanSendFunc(
+			ext, txn.DB(), batchRequestsIssued, kvCPUTime, localKVCPUTime,
+		)
 	}
+	var w timeutil.CPUStopWatch
 	return func(
 		ctx context.Context,
 		ba *kvpb.BatchRequest,
 	) (*kvpb.BatchResponse, error) {
 		log.VEventf(ctx, 2, "kv fetcher: sending a batch with %d requests", len(ba.Requests))
+		w.Start()
 		res, err := txn.Send(ctx, ba)
+		if delta := w.Stop(); delta > 0 && localKVCPUTime != nil {
+			atomic.AddInt64(localKVCPUTime, int64(delta))
+		}
 		if err != nil {
 			return nil, err.GoError()
 		}
@@ -309,8 +318,11 @@ func makeExternalSpanSendFunc(
 	db *kv.DB,
 	batchRequestsIssued *int64,
 	kvCPUTime *int64,
+	localKVCPUTime *int64,
 ) sendFunc {
 	return func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+		var w timeutil.CPUStopWatch
+
 		for _, req := range ba.Requests {
 			// We only allow external row data for a few known types of request.
 			switch r := req.GetInner().(type) {
@@ -337,10 +349,14 @@ func makeExternalSpanSendFunc(
 				if err := txn.SetFixedTimestamp(ctx, ext.AsOf); err != nil {
 					return err
 				}
-				var err *kvpb.Error
-				res, err = txn.Send(ctx, ba)
-				if err != nil {
-					return err.GoError()
+				var pErr *kvpb.Error
+				w.Start()
+				res, pErr = txn.Send(ctx, ba)
+				if delta := w.Stop(); delta > 0 && localKVCPUTime != nil {
+					atomic.AddInt64(localKVCPUTime, int64(delta))
+				}
+				if pErr != nil {
+					return pErr.GoError()
 				}
 				return nil
 			})
@@ -372,6 +388,7 @@ type newTxnKVFetcherArgs struct {
 	kvPairsRead                *int64
 	batchRequestsIssued        *int64
 	kvCPUTime                  *int64
+	localKVCPUTime             *int64
 	rawMVCCValues              bool
 	workloadID                 uint64
 	workloadType               workloadid.WorkloadType
@@ -414,7 +431,9 @@ func newTxnKVFetcherInternal(args newTxnKVFetcherArgs) *txnKVFetcher {
 		args.admission.pacerFactory,
 		args.admission.settingsValues,
 	)
-	f.kvBatchMetrics.init(args.kvPairsRead, args.batchRequestsIssued, args.kvCPUTime)
+	f.kvBatchMetrics.init(
+		args.kvPairsRead, args.batchRequestsIssued, args.kvCPUTime, args.localKVCPUTime,
+	)
 	return f
 }
 
@@ -1100,13 +1119,15 @@ type kvBatchMetrics struct {
 		kvPairsRead         *int64
 		batchRequestsIssued *int64
 		kvCPUTime           *int64
+		localKVCPUTime      *int64
 	}
 }
 
-func (h *kvBatchMetrics) init(kvPairsRead, batchRequestsIssued, kvCPUTime *int64) {
+func (h *kvBatchMetrics) init(kvPairsRead, batchRequestsIssued, kvCPUTime, localKVCPUTime *int64) {
 	h.atomics.kvPairsRead = kvPairsRead
 	h.atomics.batchRequestsIssued = batchRequestsIssued
 	h.atomics.kvCPUTime = kvCPUTime
+	h.atomics.localKVCPUTime = localKVCPUTime
 }
 
 // Record records metrics for the given batch response. It should be called
@@ -1156,4 +1177,12 @@ func (h *kvBatchMetrics) GetKVCPUTime() int64 {
 		return 0
 	}
 	return atomic.LoadInt64(h.atomics.kvCPUTime)
+}
+
+// GetLocalKVCPUTime implements the KVBatchFetcher interface.
+func (h *kvBatchMetrics) GetLocalKVCPUTime() int64 {
+	if h == nil || h.atomics.localKVCPUTime == nil {
+		return 0
+	}
+	return atomic.LoadInt64(h.atomics.localKVCPUTime)
 }

--- a/pkg/sql/row/kv_batch_fetcher_test.go
+++ b/pkg/sql/row/kv_batch_fetcher_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package row
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKVBatchMetricsCPUTime verifies the guard branches and accumulation
+// behavior of GetKVCPUTime and GetLocalKVCPUTime on kvBatchMetrics.
+func TestKVBatchMetricsCPUTime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("accumulation", func(t *testing.T) {
+		var kvPairsRead, batchRequestsIssued, kvCPUTime, localKVCPUTime int64
+		var m kvBatchMetrics
+		m.init(&kvPairsRead, &batchRequestsIssued, &kvCPUTime, &localKVCPUTime)
+
+		atomic.StoreInt64(&kvCPUTime, 100)
+		atomic.StoreInt64(&localKVCPUTime, 42)
+		require.Equal(t, int64(100), m.GetKVCPUTime())
+		require.Equal(t, int64(42), m.GetLocalKVCPUTime())
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		var kvPairsRead, batchRequestsIssued int64
+		var m kvBatchMetrics
+		m.init(
+			&kvPairsRead, &batchRequestsIssued,
+			nil /* kvCPUTime */, nil, /* localKVCPUTime */
+		)
+
+		require.Equal(t, int64(0), m.GetKVCPUTime())
+		require.Equal(t, int64(0), m.GetLocalKVCPUTime())
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var m *kvBatchMetrics
+		require.Equal(t, int64(0), m.GetKVCPUTime())
+		require.Equal(t, int64(0), m.GetLocalKVCPUTime())
+	})
+}

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -61,6 +61,7 @@ func newTxnKVStreamer(
 	kvPairsRead *int64,
 	batchRequestsIssued *int64,
 	kvCPUTime *int64,
+	localKVCPUTime *int64,
 	rawMVCCValues bool,
 	reverse bool,
 ) KVBatchFetcher {
@@ -72,7 +73,7 @@ func newTxnKVStreamer(
 		acc:            acc,
 		rawMVCCValues:  rawMVCCValues,
 	}
-	f.kvBatchMetrics.init(kvPairsRead, batchRequestsIssued, kvCPUTime)
+	f.kvBatchMetrics.init(kvPairsRead, batchRequestsIssued, kvCPUTime, localKVCPUTime)
 	return f
 }
 

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -7,6 +7,7 @@ package row
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // KVFetcher wraps KVBatchFetcher, providing a NextKV interface that returns the
@@ -69,12 +71,16 @@ func newTxnKVFetcher(
 		batchRequestsIssued int64
 		kvPairsRead         int64
 		kvCPUTime           int64
+		localKVCPUTime      int64
 	})
 	var sendFn sendFunc
 	if bsHeader == nil {
-		sendFn = makeSendFunc(txn, ext, &alloc.batchRequestsIssued, &alloc.kvCPUTime)
+		sendFn = makeSendFunc(
+			txn, ext, &alloc.batchRequestsIssued, &alloc.kvCPUTime, &alloc.localKVCPUTime,
+		)
 	} else {
 		negotiated := false
+		var w timeutil.CPUStopWatch
 		sendFn = func(ctx context.Context, ba *kvpb.BatchRequest) (br *kvpb.BatchResponse, _ error) {
 			if ext != nil {
 				return nil, unimplemented.New(
@@ -88,12 +94,16 @@ func newTxnKVFetcher(
 			// Only use NegotiateAndSend if we have not yet negotiated a timestamp.
 			// If we have, fallback to Send which will already have the timestamp
 			// fixed.
+			w.Start()
 			if !negotiated {
 				ba.BoundedStaleness = bsHeader
 				br, pErr = txn.NegotiateAndSend(ctx, ba)
 				negotiated = true
 			} else {
 				br, pErr = txn.Send(ctx, ba)
+			}
+			if delta := w.Stop(); delta > 0 {
+				atomic.AddInt64(&alloc.localKVCPUTime, int64(delta))
 			}
 			if pErr != nil {
 				return nil, pErr.GoError()
@@ -120,6 +130,7 @@ func newTxnKVFetcher(
 		kvPairsRead:                &alloc.kvPairsRead,
 		batchRequestsIssued:        &alloc.batchRequestsIssued,
 		kvCPUTime:                  &alloc.kvCPUTime,
+		localKVCPUTime:             &alloc.localKVCPUTime,
 		workloadID:                 workloadID,
 		workloadType:               workloadType,
 	}
@@ -223,7 +234,7 @@ func NewStreamingKVFetcher(
 	var kvPairsRead int64
 	var batchRequestsIssued int64
 	var kvCPUTime int64
-	sendFn := makeSendFunc(txn, ext, &batchRequestsIssued, &kvCPUTime)
+	sendFn := makeSendFunc(txn, ext, &batchRequestsIssued, &kvCPUTime, nil /* localKVCPUTime */)
 	streamer := kvstreamer.NewStreamer(
 		distSender,
 		metrics,
@@ -258,7 +269,9 @@ func NewStreamingKVFetcher(
 	)
 	return newKVFetcher(newTxnKVStreamer(
 		streamer, lockStrength, lockDurability, kvFetcherMemAcc,
-		&kvPairsRead, &batchRequestsIssued, &kvCPUTime, rawMVCCValues, reverse,
+		&kvPairsRead, &batchRequestsIssued, &kvCPUTime,
+		nil, /* localKVCPUTime */
+		rawMVCCValues, reverse,
 	))
 }
 
@@ -443,6 +456,11 @@ func (f *KVProvider) GetBatchRequestsIssued() int64 {
 
 // GetKVCPUTime implements the KVBatchFetcher interface.
 func (f *KVProvider) GetKVCPUTime() int64 {
+	return 0
+}
+
+// GetLocalKVCPUTime implements the KVBatchFetcher interface.
+func (f *KVProvider) GetLocalKVCPUTime() int64 {
 	return 0
 }
 

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -801,7 +801,6 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 			LockWaitTime:        optional.MakeTimeValue(ij.contentionEventsListener.GetLockWaitTime()),
 			LatchWaitTime:       optional.MakeTimeValue(ij.contentionEventsListener.GetLatchWaitTime()),
 			BatchRequestsIssued: optional.MakeUint(uint64(ij.fetcher.GetBatchRequestsIssued())),
-			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 		},
 		Exec: execinfrapb.ExecStats{
 			MaxAllocatedMem:  optional.MakeUint(uint64(ij.MemMonitor.MaximumBytes() + ij.unlimitedMemMonitor.MaximumBytes())),
@@ -822,6 +821,7 @@ func (ij *invertedJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = ij.fetcher.GetBytesRead()
 	meta.Metrics.RowsRead = ij.rowsRead
 	meta.Metrics.KVCPUTime = ij.fetcher.GetKVCPUTime()
+	meta.Metrics.LocalKVCPUTime = ij.fetcher.GetLocalKVCPUTime()
 	if tfs := execinfra.GetLeafTxnFinalState(ij.Ctx(), ij.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1321,7 +1321,6 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			LockWaitTime:        optional.MakeTimeValue(jr.contentionEventsListener.GetLockWaitTime()),
 			LatchWaitTime:       optional.MakeTimeValue(jr.contentionEventsListener.GetLatchWaitTime()),
 			BatchRequestsIssued: optional.MakeUint(uint64(jr.fetcher.GetBatchRequestsIssued())),
-			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 			UsedStreamer:        jr.usesStreamer,
 		},
 		Output: jr.OutputHelper.Stats(),

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1353,6 +1353,7 @@ func (jr *joinReader) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.RowsRead = jr.rowsRead
 	meta.Metrics.BytesRead = jr.fetcher.GetBytesRead()
 	meta.Metrics.KVCPUTime = jr.fetcher.GetKVCPUTime()
+	meta.Metrics.LocalKVCPUTime = jr.fetcher.GetLocalKVCPUTime()
 	if tfs := execinfra.GetLeafTxnFinalState(jr.Ctx(), jr.txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -43,6 +43,7 @@ type rowFetcher interface {
 
 	Reset()
 	GetKVCPUTime() int64
+	GetLocalKVCPUTime() int64
 	GetBytesRead() int64
 	GetKVPairsRead() int64
 	GetBatchRequestsIssued() int64

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -76,7 +76,6 @@ type rowFetcherStatCollector struct {
 	// stats contains the collected stats.
 	stats              execinfrapb.InputStats
 	startScanStallTime time.Duration
-	cpuStopWatch       *timeutil.CPUStopWatch
 }
 
 var _ rowFetcher = &rowFetcherStatCollector{}
@@ -85,7 +84,6 @@ var _ rowFetcher = &rowFetcherStatCollector{}
 func newRowFetcherStatCollector(f *row.Fetcher) *rowFetcherStatCollector {
 	res := &rowFetcherStatCollector{Fetcher: f}
 	res.stats.NumTuples.Set(0)
-	res.cpuStopWatch = timeutil.NewCPUStopWatch()
 	return res
 }
 
@@ -98,10 +96,8 @@ func (c *rowFetcherStatCollector) StartScan(
 	limitHint rowinfra.RowLimit,
 ) error {
 	start := timeutil.Now()
-	c.cpuStopWatch.Start()
 	err := c.Fetcher.StartScan(ctx, spans, spanIDs, batchBytesLimit, limitHint)
 	c.startScanStallTime += timeutil.Since(start)
-	c.cpuStopWatch.Stop()
 	return err
 }
 
@@ -117,25 +113,21 @@ func (c *rowFetcherStatCollector) StartInconsistentScan(
 	qualityOfService sessiondatapb.QoSLevel,
 ) error {
 	start := timeutil.Now()
-	c.cpuStopWatch.Start()
 	err := c.Fetcher.StartInconsistentScan(
 		ctx, db, initialTimestamp, maxTimestampAge, spans, batchBytesLimit, limitHint, qualityOfService,
 	)
 	c.startScanStallTime += timeutil.Since(start)
-	c.cpuStopWatch.Stop()
 	return err
 }
 
 // NextRow is part of the rowFetcher interface.
 func (c *rowFetcherStatCollector) NextRow(ctx context.Context) (rowenc.EncDatumRow, int, error) {
 	start := timeutil.Now()
-	c.cpuStopWatch.Start()
 	row, spanID, err := c.Fetcher.NextRow(ctx)
 	if row != nil {
 		c.stats.NumTuples.Add(1)
 	}
 	c.stats.WaitTime.Add(timeutil.Since(start))
-	c.cpuStopWatch.Stop()
 	return row, spanID, err
 }
 
@@ -144,13 +136,11 @@ func (c *rowFetcherStatCollector) NextRowInto(
 	ctx context.Context, destination rowenc.EncDatumRow, colIdxMap catalog.TableColMap,
 ) (ok bool, err error) {
 	start := timeutil.Now()
-	c.cpuStopWatch.Start()
 	ok, err = c.Fetcher.NextRowInto(ctx, destination, colIdxMap)
 	if ok {
 		c.stats.NumTuples.Add(1)
 	}
 	c.stats.WaitTime.Add(timeutil.Since(start))
-	c.cpuStopWatch.Stop()
 	return ok, err
 }
 
@@ -165,20 +155,15 @@ func getInputStats(input execinfra.RowSource) (execinfrapb.InputStats, bool) {
 	return isc.stats, true
 }
 
-type rowFetcherStats struct {
-	execinfrapb.InputStats
-	kvCPUTime time.Duration
-}
-
 // getFetcherInputStats is a utility function to check whether the given input
 // is collecting row fetcher stats, returning true and the stats if so. If
 // false is returned, the input is not collecting row fetcher stats.
-func getFetcherInputStats(f rowFetcher) (rowFetcherStats, bool) {
+func getFetcherInputStats(f rowFetcher) (execinfrapb.InputStats, bool) {
 	rfsc, ok := f.(*rowFetcherStatCollector)
 	if !ok {
-		return rowFetcherStats{}, false
+		return execinfrapb.InputStats{}, false
 	}
 	// Add row fetcher start scan stall time to Next() stall time.
 	rfsc.stats.WaitTime.Add(rfsc.startScanStallTime)
-	return rowFetcherStats{InputStats: rfsc.stats, kvCPUTime: rfsc.cpuStopWatch.Elapsed()}, true
+	return rfsc.stats, true
 }

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -320,7 +320,6 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			LockWaitTime:        optional.MakeTimeValue(tr.contentionEventsListener.GetLockWaitTime()),
 			LatchWaitTime:       optional.MakeTimeValue(tr.contentionEventsListener.GetLatchWaitTime()),
 			BatchRequestsIssued: optional.MakeUint(uint64(tr.fetcher.GetBatchRequestsIssued())),
-			KVCPUTime:           optional.MakeTimeValue(is.kvCPUTime),
 		},
 		Output: tr.OutputHelper.Stats(),
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -349,6 +349,7 @@ func (tr *tableReader) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = tr.fetcher.GetBytesRead()
 	meta.Metrics.KVCPUTime = tr.fetcher.GetKVCPUTime()
 	meta.Metrics.RowsRead = tr.rowsRead
+	meta.Metrics.LocalKVCPUTime = tr.fetcher.GetLocalKVCPUTime()
 	meta.Metrics.StageID = tr.stageID
 	return append(trailingMeta, *meta)
 }

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -7,7 +7,6 @@ package rowexec
 
 import (
 	"context"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -194,7 +193,6 @@ func (v *vectorSearchProcessor) execStatsForTrace() *execinfrapb.ComponentStats 
 			BytesRead:           optional.MakeUint(uint64(kvStats.KVBytesRead)),
 			KVPairsRead:         optional.MakeUint(uint64(kvStats.KVPairsRead)),
 			KVTime:              optional.MakeTimeValue(kvStats.KVTime),
-			KVCPUTime:           optional.MakeTimeValue(time.Duration(kvStats.KVCPUTime)),
 			ContentionTime:      optional.MakeTimeValue(v.contentionEventsListener.GetContentionTime()),
 			LockWaitTime:        optional.MakeTimeValue(v.contentionEventsListener.GetLockWaitTime()),
 			LatchWaitTime:       optional.MakeTimeValue(v.contentionEventsListener.GetLatchWaitTime()),
@@ -476,7 +474,6 @@ func (v *vectorMutationSearchProcessor) execStatsForTrace() *execinfrapb.Compone
 			BytesRead:           optional.MakeUint(uint64(kvStats.KVBytesRead)),
 			KVPairsRead:         optional.MakeUint(uint64(kvStats.KVPairsRead)),
 			KVTime:              optional.MakeTimeValue(kvStats.KVTime),
-			KVCPUTime:           optional.MakeTimeValue(time.Duration(kvStats.KVCPUTime)),
 			ContentionTime:      optional.MakeTimeValue(v.contentionEventsListener.GetContentionTime()),
 			LockWaitTime:        optional.MakeTimeValue(v.contentionEventsListener.GetLockWaitTime()),
 			LatchWaitTime:       optional.MakeTimeValue(v.contentionEventsListener.GetLatchWaitTime()),

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -215,6 +215,7 @@ func (v *vectorSearchProcessor) generateMeta() []execinfrapb.ProducerMetadata {
 
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.KVCPUTime = kvStats.KVCPUTime
+	meta.Metrics.LocalKVCPUTime = kvStats.LocalKVCPUTime
 	meta.Metrics.BytesRead = kvStats.KVBytesRead
 
 	// Currently, vector search is not distributed, but when distribution
@@ -494,6 +495,7 @@ func (v *vectorMutationSearchProcessor) generateMeta() []execinfrapb.ProducerMet
 
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.KVCPUTime = kvStats.KVCPUTime
+	meta.Metrics.LocalKVCPUTime = kvStats.LocalKVCPUTime
 	meta.Metrics.BytesRead = kvStats.KVBytesRead
 
 	// Currently, vector mutation search is not distributed, but when

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -868,7 +868,6 @@ func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 		}
 		kvStats.TuplesRead.MaybeAdd(fis.NumTuples)
 		kvStats.KVTime.MaybeAdd(fis.WaitTime)
-		kvStats.KVCPUTime.MaybeAdd(optional.MakeTimeValue(fis.kvCPUTime))
 	}
 	ret := &execinfrapb.ComponentStats{
 		KV:     kvStats,
@@ -918,6 +917,14 @@ func (z *zigzagJoiner) getBatchRequestsIssued() int64 {
 	return batchRequestsIssued
 }
 
+func (z *zigzagJoiner) getLocalKVCPUTime() int64 {
+	var localKVCPUTime int64
+	for i := range z.infos {
+		localKVCPUTime += z.infos[i].fetcher.GetLocalKVCPUTime()
+	}
+	return localKVCPUTime
+}
+
 func (z *zigzagJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
 	meta := &trailingMeta[0]
@@ -925,6 +932,7 @@ func (z *zigzagJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = z.getBytesRead()
 	meta.Metrics.RowsRead = z.getRowsRead()
 	meta.Metrics.KVCPUTime = z.getKVCPUTime()
+	meta.Metrics.LocalKVCPUTime = z.getLocalKVCPUTime()
 	if tfs := execinfra.GetLeafTxnFinalState(z.Ctx(), z.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -925,6 +925,14 @@ func (z *zigzagJoiner) getLocalKVCPUTime() int64 {
 	return localKVCPUTime
 }
 
+func (z *zigzagJoiner) getLocalKVCPUTime() int64 {
+	var localKVCPUTime int64
+	for i := range z.infos {
+		localKVCPUTime += z.infos[i].fetcher.GetLocalKVCPUTime()
+	}
+	return localKVCPUTime
+}
+
 func (z *zigzagJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
 	meta := &trailingMeta[0]

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -100,6 +100,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "mean": {{.Float}},
            "sqDiff": {{.Float}}
          },
+         "sqlCPUTimeNanos": {
+           "mean": {{.Float}},
+           "sqDiff": {{.Float}}
+         },
          "nodes": [{{joinInts .IntArray}}],
          "kvNodeIds": [{{joinInt32s .Int32Array}}],
          "regions": [{{joinStrings .StringArray}}],
@@ -576,6 +580,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
       "sqDiff": {{.Float}}
     },
     "kvCPUTimeNanos": {
+      "mean": {{.Float}},
+      "sqDiff": {{.Float}}
+    },
+    "sqlCPUTimeNanos": {
       "mean": {{.Float}},
       "sqDiff": {{.Float}}
     }

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -304,6 +304,7 @@ func (t *innerTxnStats) jsonFields() jsonFields {
 		{"rowsRead", (*numericStats)(&t.RowsRead)},
 		{"rowsWritten", (*numericStats)(&t.RowsWritten)},
 		{"kvCPUTimeNanos", (*numericStats)(&t.KVCPUTimeNanos)},
+		{"sqlCPUTimeNanos", (*numericStats)(&t.SQLCPUTimeNanos)},
 	}
 }
 
@@ -334,6 +335,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"rowsRead", (*numericStats)(&s.RowsRead)},
 		{"rowsWritten", (*numericStats)(&s.RowsWritten)},
 		{"kvCPUTimeNanos", (*numericStats)(&s.KVCPUTimeNanos)},
+		{"sqlCPUTimeNanos", (*numericStats)(&s.SQLCPUTimeNanos)},
 		{"nodes", (*int64Array)(&s.Nodes)},
 		{"kvNodeIds", (*int32Array)(&s.KVNodeIDs)},
 		{"regions", (*stringArray)(&s.Regions)},

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -118,6 +118,7 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 	stats.mu.data.RowsRead.Record(stats.mu.data.Count, float64(value.RowsRead))
 	stats.mu.data.RowsWritten.Record(stats.mu.data.Count, float64(value.RowsWritten))
 	stats.mu.data.KVCPUTimeNanos.Record(stats.mu.data.Count, float64(value.KVCPUTimeNanos))
+	stats.mu.data.SQLCPUTimeNanos.Record(stats.mu.data.Count, float64(value.SQLCPUTimeNanos))
 	stats.mu.data.LastExecTimestamp = s.getTimeNow()
 	stats.mu.data.Nodes = util.CombineUnique(stats.mu.data.Nodes, value.Nodes)
 	stats.mu.data.KVNodeIDs = util.CombineUnique(stats.mu.data.KVNodeIDs, value.KVNodeIDs)
@@ -259,6 +260,7 @@ func (s *Container) RecordTransaction(ctx context.Context, value *sqlstats.Recor
 	stats.mu.data.RowsWritten.Record(stats.mu.data.Count, float64(value.RowsWritten))
 	stats.mu.data.BytesRead.Record(stats.mu.data.Count, float64(value.BytesRead))
 	stats.mu.data.KVCPUTimeNanos.Record(stats.mu.data.Count, float64(value.KVCPUTimeNanos.Nanoseconds()))
+	stats.mu.data.SQLCPUTimeNanos.Record(stats.mu.data.Count, float64(value.SQLCPUTimeNanos.Nanoseconds()))
 
 	if value.CollectedExecStats {
 		stats.mu.data.ExecStats.Count++

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -88,6 +88,7 @@ type RecordedStmtStats struct {
 	RowsRead                 int64
 	RowsWritten              int64
 	KVCPUTimeNanos           int64
+	SQLCPUTimeNanos          int64
 	Nodes                    []int64
 	KVNodeIDs                []int32
 	StatementType            tree.StatementType
@@ -176,6 +177,7 @@ type RecordedTxnStats struct {
 	RowsWritten             int64
 	BytesRead               int64
 	KVCPUTimeNanos          time.Duration
+	SQLCPUTimeNanos         time.Duration
 	Priority                roachpb.UserPriority
 	TxnErr                  error
 	Application             string
@@ -291,7 +293,7 @@ func (b *RecordedStatementStatsBuilder) LatencyRecorder(
 }
 
 func (b *RecordedStatementStatsBuilder) QueryLevelStats(
-	bytesRead int64, rowsRead int64, rowsWritten int64, kvCPUTime int64,
+	bytesRead int64, rowsRead int64, rowsWritten int64, kvCPUTime int64, sqlCPUTime int64,
 ) *RecordedStatementStatsBuilder {
 	if b == nil {
 		return b
@@ -300,6 +302,7 @@ func (b *RecordedStatementStatsBuilder) QueryLevelStats(
 	b.stmtStats.RowsRead = rowsRead
 	b.stmtStats.RowsWritten = rowsWritten
 	b.stmtStats.KVCPUTimeNanos = kvCPUTime
+	b.stmtStats.SQLCPUTimeNanos = sqlCPUTime
 	return b
 }
 

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -7,6 +7,7 @@ package sql
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -76,6 +78,12 @@ type tableWriterBase struct {
 	// kvCPUTime tracks the cumulative CPU time (in nanoseconds) that KV
 	// reported in BatchResponse headers during the execution of this table writer.
 	kvCPUTime int64
+	// localKVCPUTime tracks the cumulative goroutine CPU time (in nanoseconds)
+	// spent in KV calls during the execution of this table writer, as measured
+	// by the grunning library.
+	localKVCPUTime int64
+	// cpuStopWatch is used to measure grunning time around KV calls.
+	cpuStopWatch timeutil.CPUStopWatch
 	// rowsWrittenLimit if positive indicates that
 	// `transaction_rows_written_err` is enabled. The limit will be checked in
 	// finalize() before deciding whether it is safe to auto commit (if auto
@@ -153,7 +161,12 @@ func (tb *tableWriterBase) setRowsWrittenLimit(sd *sessiondata.SessionData) {
 // tableWriters.
 func (tb *tableWriterBase) flushAndStartNewBatch(ctx context.Context) error {
 	log.VEventf(ctx, 2, "writing batch with %d requests", len(tb.b.Requests()))
-	if err := tb.txn.Run(ctx, tb.b); err != nil {
+	tb.cpuStopWatch.Start()
+	err := tb.txn.Run(ctx, tb.b)
+	if delta := tb.cpuStopWatch.Stop(); delta > 0 {
+		atomic.AddInt64(&tb.localKVCPUTime, int64(delta))
+	}
+	if err != nil {
 		return row.ConvertBatchError(ctx, tb.desc, tb.b, false /* alwaysConvertCondFailed */)
 	}
 	if err := tb.tryDoResponseAdmission(ctx); err != nil {
@@ -194,10 +207,18 @@ func (tb *tableWriterBase) finalize(ctx context.Context) (err error) {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
+		tb.cpuStopWatch.Start()
 		err = tb.txn.CommitInBatch(ctx, tb.b)
+		if delta := tb.cpuStopWatch.Stop(); delta > 0 {
+			atomic.AddInt64(&tb.localKVCPUTime, int64(delta))
+		}
 	} else {
 		log.VEventf(ctx, 2, "writing batch with %d requests", len(tb.b.Requests()))
+		tb.cpuStopWatch.Start()
 		err = tb.txn.Run(ctx, tb.b)
+		if delta := tb.cpuStopWatch.Stop(); delta > 0 {
+			atomic.AddInt64(&tb.localKVCPUTime, int64(delta))
+		}
 	}
 	if err != nil {
 		return row.ConvertBatchError(ctx, tb.desc, tb.b, false /* alwaysConvertCondFailed */)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -315,6 +315,10 @@ func (u *updateNode) kvCPUTime() int64 {
 	return u.run.tu.kvCPUTime
 }
 
+func (u *updateNode) localKVCPUTime() int64 {
+	return u.run.tu.localKVCPUTime
+}
+
 func (u *updateNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/update_swap.go
+++ b/pkg/sql/update_swap.go
@@ -146,6 +146,10 @@ func (u *updateSwapNode) kvCPUTime() int64 {
 	return u.run.tu.kvCPUTime
 }
 
+func (u *updateSwapNode) localKVCPUTime() int64 {
+	return u.run.tu.localKVCPUTime
+}
+
 func (u *updateSwapNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -237,6 +237,10 @@ func (n *upsertNode) kvCPUTime() int64 {
 	return n.run.tw.kvCPUTime
 }
 
+func (n *upsertNode) localKVCPUTime() int64 {
+	return n.run.tw.localKVCPUTime
+}
+
 func (n *upsertNode) enableAutoCommit() {
 	n.run.tw.enableAutoCommit()
 }

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -49,6 +49,10 @@ type KVStats struct {
 	// KVCPUTime is the CPU time reported by KV, in nanoseconds. This uses
 	// int64 (not time.Duration) to match the BatchResponse.CPUTime field.
 	KVCPUTime int64
+	// LocalKVCPUTime is the goroutine CPU time (in nanoseconds) spent in KV
+	// calls, measured via grunning around txn.Run calls. This captures the
+	// local CPU overhead of KV operations on the calling goroutine.
+	LocalKVCPUTime int64
 }
 
 // Txn provides a context to make transactional changes to a vector index.
@@ -72,6 +76,9 @@ type Txn struct {
 
 	// kvStats accumulates KV statistics during batch execution.
 	kvStats KVStats
+
+	// cpuStopWatch measures goroutine CPU time around KV calls via grunning.
+	cpuStopWatch timeutil.CPUStopWatch
 
 	// collectKVStats indicates whether KV statistics should be collected.
 	collectKVStats bool
@@ -613,6 +620,7 @@ func (tx *Txn) getFullVectorsFromPK(
 		tx.kvStats.KVBytesRead += fetcher.GetBytesRead()
 		tx.kvStats.KVPairsRead += fetcher.GetKVPairsRead()
 		tx.kvStats.KVCPUTime += fetcher.GetKVCPUTime()
+		tx.kvStats.LocalKVCPUTime += fetcher.GetLocalKVCPUTime()
 	}
 
 	return err
@@ -722,7 +730,12 @@ func (tx *Txn) runAndRecordStats(ctx context.Context, b *kv.Batch) error {
 	}
 
 	start := timeutil.Now()
-	if err := tx.kv.Run(ctx, b); err != nil {
+	tx.cpuStopWatch.Start()
+	err := tx.kv.Run(ctx, b)
+	if delta := tx.cpuStopWatch.Stop(); delta > 0 {
+		tx.kvStats.LocalKVCPUTime += int64(delta)
+	}
+	if err != nil {
 		return err
 	}
 

--- a/pkg/util/timeutil/BUILD.bazel
+++ b/pkg/util/timeutil/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     name = "timeutil_test",
     size = "medium",
     srcs = [
+        "cpustopwatch_test.go",
         "main_test.go",
         "manual_time_test.go",
         "now_test.go",
@@ -48,6 +49,7 @@ go_test(
     ],
     embed = [":timeutil"],
     deps = [
+        "//pkg/util/grunning",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/util/timeutil/cpustopwatch.go
+++ b/pkg/util/timeutil/cpustopwatch.go
@@ -9,93 +9,31 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-// CPUStopWatch is a wrapper around cpuStopWatch that is safe to use
-// concurrently. If CPUStopWatch is nil, all operations are no-ops and no
-// locks are acquired.
+// CPUStopWatch measures CPU time on the current goroutine between Start and
+// Stop calls. It is designed to be held as a value, not a pointer. The zero
+// value is valid (Stop returns 0). All methods check grunning.Supported
+// internally, so the caller need not guard.
 type CPUStopWatch struct {
-	mu struct {
-		syncutil.Mutex
-		cpuStopWatch cpuStopWatch
-	}
+	start time.Duration
 }
 
-// NewCPUStopWatch returns a new CPUStopWatch if the grunning library is
-// supported. Otherwise, it returns nil.
-func NewCPUStopWatch() *CPUStopWatch {
-	if grunning.Supported {
-		return &CPUStopWatch{}
-	}
-	return nil
-}
-
-// Start starts the CPU stop watch if it hasn't already been started.
+// Start begins a CPU measurement interval. No-op if grunning is not supported
+// on this platform.
 func (w *CPUStopWatch) Start() {
-	if w == nil {
-		return
+	if grunning.Supported {
+		w.start = grunning.Time()
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.mu.cpuStopWatch.start()
 }
 
-// Stop stops the CPU stop watch if it hasn't already been stopped and
-// accumulates the CPU time that has been spent since it was started. If the
-// CPU stop watch has already been stopped, it is a noop.
-func (w *CPUStopWatch) Stop() {
-	if w == nil {
-		return
-	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.mu.cpuStopWatch.stop()
-}
-
-// Elapsed returns the total CPU time measured by the stop watch so far.
-func (w *CPUStopWatch) Elapsed() time.Duration {
-	if w == nil {
+// Stop ends the current measurement interval and returns the elapsed CPU time.
+// Returns 0 if grunning is not supported or Start was not called.
+func (w *CPUStopWatch) Stop() time.Duration {
+	if !grunning.Supported || w.start == 0 {
 		return 0
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.mu.cpuStopWatch.elapsed()
-}
-
-// cpuStopWatch is a utility stop watch for measuring CPU time spent by a
-// component. It can be safely started and stopped multiple times, but is
-// not safe to use concurrently. If cpuStopWatch is nil, all operations are
-// no-ops.
-//
-// Note that the grunning library uses a non-monotonic clock, so the measured
-// duration between clock start and stop can come out as negative. This can lead
-// to discrepancies in the measured CPU time - for example, a child stopwatch
-// that is started and stopped while a parent stopwatch is running can rarely
-// measure a larger CPU time duration than the parent. Users must be prepared to
-// handle this case.
-type cpuStopWatch struct {
-	startCPU time.Duration
-	totalCPU time.Duration
-}
-
-func (w *cpuStopWatch) start() {
-	if w == nil {
-		return
-	}
-	w.startCPU = grunning.Time()
-}
-
-func (w *cpuStopWatch) stop() {
-	if w == nil {
-		return
-	}
-	w.totalCPU += grunning.Elapsed(w.startCPU, grunning.Time())
-}
-
-func (w *cpuStopWatch) elapsed() time.Duration {
-	if w == nil {
-		return 0
-	}
-	return w.totalCPU
+	elapsed := grunning.Elapsed(w.start, grunning.Time())
+	w.start = 0
+	return elapsed
 }

--- a/pkg/util/timeutil/cpustopwatch_test.go
+++ b/pkg/util/timeutil/cpustopwatch_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package timeutil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCPUStopWatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("stop without start", func(t *testing.T) {
+		// Stop without Start should return 0.
+		var w timeutil.CPUStopWatch
+		require.Zero(t, w.Stop())
+	})
+
+	if !grunning.Supported {
+		t.Skip("grunning not supported on this platform")
+	}
+
+	// burnCPU does enough work to register a nonzero grunning delta on most
+	// platforms.
+	burnCPU := func() {
+		sum := 0
+		for i := range 100000 {
+			sum += i
+		}
+		_ = sum
+	}
+
+	t.Run("single cycle", func(t *testing.T) {
+		var w timeutil.CPUStopWatch
+		w.Start()
+		burnCPU()
+		delta := w.Stop()
+		require.Greater(t, delta, time.Duration(0))
+	})
+
+	t.Run("multiple cycles", func(t *testing.T) {
+		// Sum deltas across multiple Start/Stop cycles.
+		var w timeutil.CPUStopWatch
+		var total time.Duration
+		for range 3 {
+			w.Start()
+			burnCPU()
+			total += w.Stop()
+		}
+		require.Greater(t, total, time.Duration(0),
+			"expected nonzero accumulated CPU after three cycles")
+	})
+
+	t.Run("idempotent stop", func(t *testing.T) {
+		// Second Stop should return 0.
+		var w timeutil.CPUStopWatch
+		w.Start()
+		burnCPU()
+		first := w.Stop()
+		require.Greater(t, first, time.Duration(0))
+
+		second := w.Stop()
+		require.Zero(t, second, "second Stop should return 0")
+	})
+
+	t.Run("restart after stop", func(t *testing.T) {
+		// A new Start/Stop cycle after a previous one should produce a
+		// nonzero value.
+		var w timeutil.CPUStopWatch
+		w.Start()
+		burnCPU()
+		_ = w.Stop()
+
+		w.Start()
+		burnCPU()
+		delta := w.Stop()
+		require.Greater(t, delta, time.Duration(0),
+			"restart should produce nonzero delta")
+	})
+}

--- a/pkg/util/timeutil/stopwatch.go
+++ b/pkg/util/timeutil/stopwatch.go
@@ -8,7 +8,6 @@ package timeutil
 import (
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/crlib/crtime"
 )
@@ -29,9 +28,12 @@ type StopWatch struct {
 		// timeSource is the source of time used by the stop watch. It is always
 		// crtime.NowMono except for tests.
 		timeSource func() crtime.Mono
-		// cpuStopWatch is used to track CPU usage. It may be nil, in which case any
-		// operations on it are no-ops.
-		cpuStopWatch *cpuStopWatch
+		// cpuStopWatch tracks goroutine CPU time when trackCPU is true.
+		cpuStopWatch CPUStopWatch
+		// cpuElapsed is the accumulated CPU time across all Start/Stop cycles.
+		cpuElapsed time.Duration
+		// trackCPU is true if this StopWatch was created with NewStopWatchWithCPU.
+		trackCPU bool
 	}
 }
 
@@ -44,9 +46,7 @@ func NewStopWatch() *StopWatch {
 // addition to wall-clock time.
 func NewStopWatchWithCPU() *StopWatch {
 	w := NewStopWatch()
-	if grunning.Supported {
-		w.mu.cpuStopWatch = &cpuStopWatch{}
-	}
+	w.mu.trackCPU = true
 	return w
 }
 
@@ -69,7 +69,9 @@ func (w *StopWatch) Start() {
 	if !w.mu.started {
 		w.mu.started = true
 		w.mu.startedAt = w.mu.timeSource()
-		w.mu.cpuStopWatch.start()
+		if w.mu.trackCPU {
+			w.mu.cpuStopWatch.Start()
+		}
 	}
 }
 
@@ -84,7 +86,9 @@ func (w *StopWatch) Stop() {
 		// We don't use w.mu.startedAt.Elapsed() here so that testing time sources
 		// work correctly.
 		w.mu.elapsed += w.mu.timeSource().Sub(w.mu.startedAt)
-		w.mu.cpuStopWatch.stop()
+		if w.mu.trackCPU {
+			w.mu.cpuElapsed += w.mu.cpuStopWatch.Stop()
+		}
 	}
 }
 
@@ -96,12 +100,12 @@ func (w *StopWatch) Elapsed() time.Duration {
 }
 
 // ElapsedCPU returns the total CPU time measured by the stop watch so far. It
-// returns zero if cpuStopWatch is nil (which is the case if NewStopWatchWithCPU
-// was not called or the platform does not support grunning).
+// returns zero if the StopWatch was not created with NewStopWatchWithCPU or
+// the platform does not support grunning.
 func (w *StopWatch) ElapsedCPU() time.Duration {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.mu.cpuStopWatch.elapsed()
+	return w.mu.cpuElapsed
 }
 
 // CurrentElapsed returns the duration the stopwatch has been started and a bool


### PR DESCRIPTION
#### sql: add grunning-based local KV CPU tracking to fetcher infrastructure

Redesign CPUStopWatch as a stack-allocated value type where Start()
records the grunning timestamp and Stop() returns the elapsed CPU
duration. Callers atomically accumulate the delta themselves. All
methods check grunning.Supported internally, so callers need not guard.

Use the new CPUStopWatch to move KV CPU measurement from the caller
side (wrapping each NextKV call) down into the KV send layer (wrapping
txn.Send calls). This captures the local goroutine CPU overhead of KV
operations more accurately.

Key changes:
- Simplify CPUStopWatch from a heap-allocated, mutex-protected type to
  a stack-friendly value type. The old private cpuStopWatch (used by
  StopWatch) is moved to stopwatch.go.
- Add `localKVCPUTime *int64` plumbing through KVBatchFetcher, KVFetcher,
  and Fetcher, with atomic accumulation in the send closures.
- The streaming KV fetcher passes nil since it dispatches KV requests on
  async goroutines where per-goroutine grunning is not meaningful.
- Remove the old per-operator CPUStopWatch that wrapped NextKV calls and
  reserve the old KVCPUTime field in ComponentStats.
- Add LocalKVCPUTime to the Metrics proto for metadata-based propagation.

Informs #168272
Release note: None

#### sql: propagate local KV CPU from mutation and vecindex operators

Add CPUStopWatch instrumentation to mutation operators (INSERT, UPDATE,
DELETE, UPSERT and their variants) and vecindex store transactions.

For mutations going through tableWriterBase, the CPUStopWatch wraps
Run() and CommitInBatch() calls. For deleteRangeNode and
insertFastPathNode, which have their own KV send paths, the
CPUStopWatch is embedded directly. For vecindex, the CPUStopWatch
wraps kv.Run() calls in runAndRecordStats().

All mutation nodes expose localKVCPUTime() via the mutationPlanNode
interface, which feeds into the metadata propagation chain.

Informs #168272
Release note: None

#### sql: propagate LocalKVCPUTime from all KV operators for query-level CPU

Add a LocalKVCPUTime field to the Metrics proto message to carry the
grunning-based local KV CPU time from operators to the gateway. Report
this metric from all KV-reading operators: ColBatchScan,
ColBatchDirectScan, ColIndexJoin, tableReader, joinReader,
invertedJoiner, zigzagJoiner, and wrapped mutationPlanNodes.

Accumulate LocalKVCPUTime in topLevelQueryStats via the DistSQLReceiver
pushMeta path, and forward it through forwardInnerQueryStats for
cascades and triggers.

Informs #168272
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### sql: add always-on per-query SQL CPU measurement

Introduce unconditional grunning-based CPU capture on both gateway and
remote flows, and aggregate the measurements at the gateway to produce
per-query SQL CPU time.

On the gateway, goroutine CPU time is sampled at statement start and
again at completion. Remote flows capture grunning at flow start and
emit the delta as Metrics.SQLCPUTime trailing metadata when the last
outbox finishes. The gateway aggregates these into sqlCPUTimeNanos
after subtracting local KV CPU time (which overlaps with grunning).

Key changes:
- Gateway captures grunning.Time() at statement start unconditionally
  (gated on grunning.Supported, not IncludeRUEstimateInExplainAnalyze).
- Remote flows capture grunning.Time() at flow start unconditionally.
- Both row-engine and vectorized outboxes emit per-flow grunning via
  Metrics.SQLCPUTime when the last outbox on a remote node finishes.
- Vectorized outbox flow-level stats (MaxMemUsage, MaxDiskUsage,
  ConsumedRU) are moved from getStats to sendDrainedMetadata for
  symmetry with the row-engine outbox.
- EXPLAIN ANALYZE unconditionally displays SQL CPU time, removing the
  previous vectorized-only and non-mutation restrictions.

The CPUUsageHelper (process-wide CPU estimator) remains alive and
continues to handle RU estimation for EXPLAIN ANALYZE; it will be
replaced in a subsequent commit.

Fixes #168272
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### sql: replace CPUUsageHelper with always-on SQL CPU for RU estimation

Now that per-query SQL CPU time is always available via grunning-based
measurement, remove the old process-wide CPU estimator (CPUUsageHelper)
and use the per-query measurement for RU estimation in EXPLAIN ANALYZE.


Key changes:
- Delete CPUUsageHelper type from multitenantcpu package.
- Remove cpuStatsCollector from connExecutor and TenantCPUMonitor from
  FlowCtx.
- Remove TenantCPUMonitor.StartCollection from remote flow startup.
- Remove ConsumedRU emission from both row-engine and vectorized
  outboxes (no longer needed since RU is computed at the gateway from
  per-query SQL CPU).
- Remove FlowStats.ConsumedRU accumulation in trace analyzer.
- Switch RU estimation in populateQueryLevelStats from
  cpuStats.EndCollection to costCfg.PodCPUCost(sqlCPUTimeNanos).
- Rewrite TestEstimateQueryRUConsumption to validate per-query RU
  estimates against expected values with tolerance.

Informs #168272
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

#### sql: record SQL CPU time in statement and transaction statistics

Wire the always-on sqlCPUTimeNanos measurement into the statement and
transaction stats recording pipeline.

- Add sql_cpu_time_nanos field to StatementStatistics and
  TransactionStatistics protos.
- Accumulate per-statement SQL CPU time at the transaction level.
- Record in RecordStatement and RecordTransaction.
- Add JSON serialization support.

Informs #168272
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>