### PR TITLE
optbuilder: support unparenthesized composite-type field access in PL/pgSQL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -438,4 +438,30 @@ DROP TYPE comp_owner;
 REVOKE CREATE ON SCHEMA public FROM comp_owner_user;
 DROP USER comp_owner_user
 
+# Accessing a field of a composite-typed column without parens is rejected by
+# the SQL grammar (the parser interprets `name1.name2` as `relation.column`).
+# Postgres has the same limitation. Verify we emit the helpful HINT pointing
+# at the parenthesized workaround.
+subtest unparenthesized_field_access_hint
+
+statement ok
+CREATE TYPE comp_field AS (x INT, y INT);
+
+statement ok
+CREATE TABLE comp_field_t (v comp_field);
+
+statement ok
+INSERT INTO comp_field_t VALUES (ROW(1, 2));
+
+query I
+SELECT (v).x FROM comp_field_t;
+----
+1
+
+query error pgcode 42P01 pq: no data source matches prefix: v in this context\nHINT: to access a field of a composite-typed column, surround the column name in parentheses: \(colName\)\.fieldName
+SELECT v.x FROM comp_field_t;
+
+statement ok
+DROP TABLE comp_field_t; DROP TYPE comp_field;
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_record
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_record
@@ -448,4 +448,179 @@ SELECT * FROM f113186() AS foo(x INT);
 statement error pgcode 42P13 pq: return type mismatch in function declared to return record
 SELECT * FROM f113186() AS foo(x TIMESTAMP);
 
+# Unparenthesized field access on a composite-typed PL/pgSQL variable.
+# Regression test for #114687.
+subtest unparenthesized_composite_access
+
+statement ok
+CREATE TYPE composite_xy AS (x INT, y INT);
+
+# Composite-typed declared variable.
+statement ok
+CREATE PROCEDURE p_unparen_decl() LANGUAGE plpgsql AS $$
+  DECLARE v composite_xy := ROW(1, 2);
+  BEGIN RAISE NOTICE 'x=% y=%', v.x, v.y; END
+$$;
+
+statement ok
+CALL p_unparen_decl();
+
+# Composite-typed function parameter.
+statement ok
+CREATE FUNCTION f_unparen_param(val composite_xy) RETURNS INT LANGUAGE plpgsql AS $$
+  BEGIN RETURN val.x + val.y; END
+$$;
+
+query I
+SELECT f_unparen_param(ROW(10, 20)::composite_xy);
+----
+30
+
+# Assignment LHS with field indirection plus unparenthesized RHS access.
+statement ok
+CREATE FUNCTION f_unparen_assign(val composite_xy) RETURNS composite_xy LANGUAGE plpgsql AS $$
+  BEGIN
+    val.x := val.x + 100;
+    RETURN val;
+  END
+$$;
+
+query T
+SELECT f_unparen_assign(ROW(1, 2)::composite_xy);
+----
+(101,2)
+
+# Parenthesized form continues to work (regression).
+statement ok
+CREATE FUNCTION f_paren_param(val composite_xy) RETURNS INT LANGUAGE plpgsql AS $$
+  BEGIN RETURN (val).x + (val).y; END
+$$;
+
+query I
+SELECT f_paren_param(ROW(3, 4)::composite_xy);
+----
+7
+
+# Standalone SQL statement (no INTO target) referencing a composite variable's
+# field -- exercises the buildSQLStatement path.
+statement ok
+CREATE TABLE t_unparen_stmt (a INT, b INT);
+
+statement ok
+CREATE PROCEDURE p_unparen_stmt() LANGUAGE plpgsql AS $$
+  DECLARE v composite_xy := ROW(11, 22);
+  BEGIN INSERT INTO t_unparen_stmt VALUES (v.x, v.y); END
+$$;
+
+statement ok
+CALL p_unparen_stmt();
+
+query II
+SELECT a, b FROM t_unparen_stmt;
+----
+11  22
+
+# SELECT ... INTO referencing a composite variable's field.
+statement ok
+CREATE FUNCTION f_unparen_into(val composite_xy) RETURNS INT LANGUAGE plpgsql AS $$
+  DECLARE r INT;
+  BEGIN SELECT val.x + val.y INTO r; RETURN r; END
+$$;
+
+query I
+SELECT f_unparen_into(ROW(7, 8)::composite_xy);
+----
+15
+
+# Bound cursor whose query references a composite variable's field. The bound
+# query is built when OPEN is processed, so this exercises buildSQLStatement
+# via the cursor path.
+statement ok
+CREATE PROCEDURE p_unparen_cursor() LANGUAGE plpgsql AS $$
+  DECLARE
+    v composite_xy := ROW(31, 32);
+    c CURSOR FOR SELECT v.x, v.y;
+    rx INT; ry INT;
+  BEGIN
+    OPEN c;
+    FETCH c INTO rx, ry;
+    CLOSE c;
+    RAISE NOTICE 'cursor x=% y=%', rx, ry;
+  END
+$$;
+
+statement ok
+CALL p_unparen_cursor();
+
+# A non-composite PL/pgSQL variable accessed with .field produces a bare
+# error matching Postgres -- the "surround in parentheses" hint would be
+# misleading because parens won't help when the variable is scalar.
+statement error pgcode 42P01 pq: no data source matches prefix: n in this context$
+CREATE PROCEDURE p_non_composite() LANGUAGE plpgsql AS $$
+  DECLARE n INT := 5;
+  BEGIN RAISE NOTICE '%', n.bogus; END
+$$;
+
+# A composite variable that shadows an in-scope table column produces an
+# ambiguous-reference error, matching Postgres' plpgsql_post_column_ref
+# behavior.
+statement ok
+CREATE TABLE shadow_v (x INT, y INT);
+
+statement ok
+INSERT INTO shadow_v VALUES (10, 20);
+
+statement error pgcode 42702 column reference "shadow_v\.x" is ambiguous\nDETAIL: It could refer to either a PL/pgSQL variable or a table column\.
+CREATE FUNCTION f_ambiguous() RETURNS INT LANGUAGE plpgsql AS $$
+  DECLARE shadow_v composite_xy := ROW(1, 2); r INT;
+  BEGIN SELECT shadow_v.x INTO r FROM shadow_v; RETURN r; END
+$$;
+
+# A PL/pgSQL variable whose name matches an existing table still resolves
+# unambiguously when the SQL statement does not reference that table.
+statement ok
+CREATE FUNCTION f_var_shadow_no_table_ref() RETURNS INT LANGUAGE plpgsql AS $$
+  DECLARE shadow_v composite_xy := ROW(1, 2);
+  BEGIN RETURN shadow_v.x; END
+$$;
+
+query I
+SELECT f_var_shadow_no_table_ref();
+----
+1
+
+# A nested CALL must not inherit the caller's PL/pgSQL variable namespace:
+# the callee's reference to the shadow_v table must resolve to the table
+# even though the caller has a shadow_v variable of its own.
+statement ok
+CREATE PROCEDURE p_uses_shadow_table(bar composite_xy, OUT r INT) LANGUAGE plpgsql AS $$
+  BEGIN SELECT shadow_v.x INTO r FROM shadow_v; END
+$$;
+
+statement ok
+CREATE FUNCTION f_call_shadow_table() RETURNS INT LANGUAGE plpgsql AS $$
+  DECLARE shadow_v composite_xy := ROW(1, 2); r INT;
+  BEGIN CALL p_uses_shadow_table(shadow_v, r); RETURN r; END
+$$;
+
+query I
+SELECT f_call_shadow_table();
+----
+10
+
+statement ok
+DROP FUNCTION f_call_shadow_table;
+DROP PROCEDURE p_uses_shadow_table;
+DROP FUNCTION f_var_shadow_no_table_ref;
+DROP TABLE shadow_v;
+DROP PROCEDURE p_unparen_cursor;
+DROP FUNCTION f_unparen_into;
+DROP PROCEDURE p_unparen_stmt;
+DROP TABLE t_unparen_stmt;
+DROP FUNCTION f_paren_param;
+DROP FUNCTION f_unparen_assign;
+DROP FUNCTION f_unparen_param;
+DROP PROCEDURE p_unparen_decl;
+DROP TYPE composite_xy;
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_unsupported
@@ -52,16 +52,4 @@ BEGIN
 END;
 $$;
 
-# Add a helpful hint to the error when the user attempts to access an element of
-# a composite-typed variable without parentheses.
-subtest element_access_parens
-
-statement error pgcode 42P01 pq: no data source matches prefix: val in this context\nHINT: to access a field of a composite-typed column or variable, surround the column/variable name in parentheses: \(varName\).fieldName
-CREATE FUNCTION f(val xy) RETURNS xy AS $$
-  BEGIN
-    val.x := val.x + 100;
-    RETURN val;
-  END
-$$ LANGUAGE PLpgSQL;
-
 subtest end

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -53,7 +53,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/security/username",

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2410,14 +2410,16 @@ func (b *plpgsqlBuilder) buildSQLExpr(expr ast.Expr, typ *types.T, s *scope) opt
 	// Save any outer CTEs before building the expression, which may have
 	// subqueries with inner CTEs. Also set the maxParamOrd to the number of
 	// routine parameters.
-	defer func(prevCTEs cteSources, prevCheckMaxParamOrd bool, prevMaxParamOrd int) {
+	defer func(prevCTEs cteSources, prevCheckMaxParamOrd bool, prevMaxParamOrd int, prevHook func(*tree.ColumnItem) (tree.Expr, bool)) {
 		b.ob.ctes = prevCTEs
 		s.checkMaxParamOrd = prevCheckMaxParamOrd
 		s.maxParamOrd = prevMaxParamOrd
-	}(b.ob.ctes, s.checkMaxParamOrd, s.maxParamOrd)
+		s.plpgsqlVarRef = prevHook
+	}(b.ob.ctes, s.checkMaxParamOrd, s.maxParamOrd, s.plpgsqlVarRef)
 	b.ob.ctes = nil
 	s.checkMaxParamOrd = true
 	s.maxParamOrd = len(b.rootBlock().vars)
+	s.plpgsqlVarRef = b.rewriteCompositeFieldAccess
 	expr, _ = tree.WalkExpr(s, expr)
 	typedExpr, err := expr.TypeCheck(b.ob.ctx, b.ob.semaCtx, typ)
 	if err != nil {
@@ -2452,12 +2454,14 @@ func (b *plpgsqlBuilder) buildSQLStatement(stmt tree.Statement, inScope *scope) 
 		return outScope
 	}
 	// Set the maxParamOrd to the number of routine parameters.
-	defer func(prevCheckMaxParamOrd bool, prevMaxParamOrd int) {
+	defer func(prevCheckMaxParamOrd bool, prevMaxParamOrd int, prevHook func(*tree.ColumnItem) (tree.Expr, bool)) {
 		inScope.checkMaxParamOrd = prevCheckMaxParamOrd
 		inScope.maxParamOrd = prevMaxParamOrd
-	}(inScope.checkMaxParamOrd, inScope.maxParamOrd)
+		inScope.plpgsqlVarRef = prevHook
+	}(inScope.checkMaxParamOrd, inScope.maxParamOrd, inScope.plpgsqlVarRef)
 	inScope.checkMaxParamOrd = true
 	inScope.maxParamOrd = len(b.rootBlock().vars)
+	inScope.plpgsqlVarRef = b.rewriteCompositeFieldAccess
 	return b.ob.buildStmtAtRootWithScope(stmt, nil /* desiredTypes */, inScope)
 }
 
@@ -2485,6 +2489,61 @@ func (b *plpgsqlBuilder) coerceType(scalar opt.ScalarExpr, typ *types.T) opt.Sca
 		scalar = b.ob.factory.ConstructCast(scalar, typ)
 	}
 	return scalar
+}
+
+// lookupPLpgSQLVar searches the active block stack for a PL/pgSQL variable
+// with the given name and returns its declared type. The second return value
+// is false if no such variable exists. Unlike resolveVariableForAssign, this
+// does not panic and does not enforce constness.
+func (b *plpgsqlBuilder) lookupPLpgSQLVar(name ast.Variable) (typ *types.T, found bool) {
+	for i := len(b.blocks) - 1; i >= 0; i-- {
+		if t, ok := b.blocks[i].varTypes[name]; ok {
+			return t, true
+		}
+	}
+	return nil, false
+}
+
+// rewriteCompositeFieldAccess implements the scope.plpgsqlVarRef hook. It
+// rewrites a SQL ColumnItem of the form `var.field` into the equivalent
+// parenthesized field-access expression `(var).field` when `var` names a
+// composite-typed PL/pgSQL variable that has a field with the given name.
+// The second return value indicates whether the prefix names any PL/pgSQL
+// variable in scope (composite or not), so that callers can suppress hints
+// that wouldn't apply. This mirrors the plpgsql_post_column_ref hook in
+// postgres' pl_comp.c.
+func (b *plpgsqlBuilder) rewriteCompositeFieldAccess(
+	t *tree.ColumnItem,
+) (rewritten tree.Expr, knownVar bool) {
+	if t.TableName == nil {
+		return nil, false
+	}
+	prefix := t.TableName.Object()
+	if prefix == "" {
+		return nil, false
+	}
+	varTyp, found := b.lookupPLpgSQLVar(ast.Variable(prefix))
+	if !found {
+		return nil, false
+	}
+	if varTyp.Family() != types.TupleFamily {
+		return nil, true
+	}
+	// The field name must match one of the tuple's labels.
+	var matched bool
+	for _, label := range varTyp.TupleLabels() {
+		if label == string(t.ColumnName) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, true
+	}
+	return &tree.ColumnAccessExpr{
+		Expr:    &tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{prefix}},
+		ColName: t.ColumnName,
+	}, true
 }
 
 // resolveVariableForAssign attempts to retrieve the type of the variable with

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -121,6 +120,20 @@ type scope struct {
 	// references to internally-generated parameters such as those for PL/pgSQL
 	// sub-routines.
 	maxParamOrd int
+
+	// plpgsqlVarRef, if non-nil, is invoked by VisitPre to give PL/pgSQL a
+	// chance to rewrite a ColumnItem of the form `var.field` (where `var` is
+	// a composite-typed PL/pgSQL variable) into a parenthesized field-access
+	// expression. This mirrors the post-column-ref hook Postgres installs in
+	// pl_comp.c. It returns:
+	//   - rewritten != nil: the rewritten expression to use in place of the
+	//     ColumnItem.
+	//   - rewritten == nil && knownVar: the prefix names a PL/pgSQL variable
+	//     in scope, but no field-access rewrite applies (e.g. the variable is
+	//     scalar or no field with the given name exists).
+	//   - rewritten == nil && !knownVar: the prefix does not name any
+	//     PL/pgSQL variable in scope.
+	plpgsqlVarRef func(*tree.ColumnItem) (rewritten tree.Expr, knownVar bool)
 }
 
 // exprKind is used to represent the kind of the current expression in the
@@ -215,6 +228,20 @@ func (s *scope) replace() *scope {
 	r := s.builder.allocScope()
 	r.parent = s.parent
 	return r
+}
+
+// findPLpgSQLVarRef walks the parent scope chain and returns the nearest
+// non-nil plpgsqlVarRef hook, or nil if no ancestor has one installed. This
+// mirrors how findFuncArgCol locates checkMaxParamOrd / maxParamOrd by
+// traversing parents, so the hook only has to be set on the scope passed to
+// buildSQLExpr / buildSQLStatement and not propagated through push/replace.
+func (s *scope) findPLpgSQLVarRef() func(*tree.ColumnItem) (tree.Expr, bool) {
+	for ; s != nil; s = s.parent {
+		if s.plpgsqlVarRef != nil {
+			return s.plpgsqlVarRef
+		}
+	}
+	return nil
 }
 
 // appendColumnsFromScope adds newly bound variables to this scope.
@@ -1064,20 +1091,53 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 				}()
 			}
 			if sqlerrors.IsUndefinedRelationError(resolveErr) && t.TableName.Object() != "" {
-				// Attempt to resolve as columnname.fieldname in order to provide a more
-				// helpful error message.
-				_, sourceResolveErr := colinfo.ResolveColumnItem(
-					s.builder.ctx, s, &tree.ColumnItem{ColumnName: tree.Name(t.TableName.Object())},
-				)
-				if sourceResolveErr == nil {
-					panic(errors.WithIssueLink(errors.WithHint(resolveErr,
-						"to access a field of a composite-typed column or variable, "+
-							"surround the column/variable name in parentheses: (varName).fieldName"),
-						errors.IssueLink{IssueURL: build.MakeIssueURL(114687)},
-					))
+				// If we are inside a PL/pgSQL routine and the prefix names a
+				// composite-typed PL/pgSQL variable, rewrite `var.field` into
+				// the equivalent parenthesized field access `(var).field`.
+				// Postgres does this via a post-column-ref parser hook in
+				// pl_comp.c; we reproduce the behavior here.
+				var plpgsqlKnownVar bool
+				if hook := s.findPLpgSQLVarRef(); hook != nil {
+					rewritten, knownVar := hook(t)
+					if rewritten != nil {
+						return true, rewritten
+					}
+					plpgsqlKnownVar = knownVar
+				}
+				// If the prefix already names a PL/pgSQL variable in scope, the
+				// "surround in parentheses" hint would be misleading: parens
+				// won't help when the variable is scalar or lacks the named
+				// field. Postgres also emits no hint in this case. Fall through
+				// to the bare error below.
+				if !plpgsqlKnownVar {
+					// Attempt to resolve as columnname.fieldname in order to provide a more
+					// helpful error message.
+					_, sourceResolveErr := colinfo.ResolveColumnItem(
+						s.builder.ctx, s, &tree.ColumnItem{ColumnName: tree.Name(t.TableName.Object())},
+					)
+					if sourceResolveErr == nil {
+						panic(errors.WithHint(resolveErr,
+							"to access a field of a composite-typed column, "+
+								"surround the column name in parentheses: (colName).fieldName"))
+					}
 				}
 			}
 			panic(resolveErr)
+		}
+		// Check for an ambiguous reference: SQL name resolution succeeded,
+		// but a same-named composite PL/pgSQL variable in scope would also
+		// resolve. Postgres raises ERRCODE_AMBIGUOUS_COLUMN here (see
+		// plpgsql_post_column_ref in pl_comp.c).
+		if t.TableName != nil && t.TableName.Object() != "" {
+			if hook := s.findPLpgSQLVarRef(); hook != nil {
+				if rewritten, _ := hook(t); rewritten != nil {
+					panic(errors.WithDetail(
+						pgerror.Newf(pgcode.AmbiguousColumn,
+							"column reference %q is ambiguous", tree.AsStringWithFlags(t, tree.FmtSimple)),
+						"It could refer to either a PL/pgSQL variable or a table column.",
+					))
+				}
+			}
 		}
 		return false, colI.(*scopeColumn)
 


### PR DESCRIPTION
In PL/pgSQL, accessing a field of a composite-typed variable previously required surrounding the variable name in parentheses, e.g. `(v).x` instead of `v.x`. The unparenthesized form returned an `UndefinedRelationError` because SQL's `name1.name2` syntax is parsed as `relation.column`, never as `column.field`.

Postgres works around this in PL/pgSQL by installing parser hooks that resolve a `ColumnRef` against the PL/pgSQL variable namespace when SQL resolution fails or finds an ambiguous match. This commit reproduces the post-column-ref behavior at the optbuilder layer:

  - `scope` gains a `plpgsqlVarRef` hook field that the PL/pgSQL builder installs while building SQL expressions and statements.
  - When `scope.VisitPre` encounters a `ColumnItem` whose qualified SQL resolution fails, the hook is consulted; if the prefix names a composite-typed PL/pgSQL variable with a matching field label, the node is rewritten to a `ColumnAccessExpr` over the variable (the equivalent of `(v).x`) and the visitor re-resolves it normally.
  - When SQL resolution succeeds and the hook also matches, an `AmbiguousColumn` error is raised, matching Postgres' behavior when a PL/pgSQL variable shadows a real column in scope.
  - When the hook reports that the prefix names a PL/pgSQL variable but no rewrite applies (scalar variable, or composite without the given field), the visitor suppresses the existing "surround in parentheses" hint, since parens would not help in those cases. Postgres similarly emits no hint there.

The "surround in parentheses" hint continues to fire for the original case it was added for: a composite-typed column accessed without parens outside of PL/pgSQL. That case is a fundamental SQL grammar limitation shared with Postgres and is not changed here.

Resolves: #114687
Epic: CRDB-49018

Release note (sql change): PL/pgSQL routines can now access fields of composite-typed variables without surrounding the variable name in parentheses (for example `v.x` in addition to the previously required `(v).x`), matching PostgreSQL behavior. When a PL/pgSQL variable shadows a column with the same name in a SQL statement inside the routine, the reference is now rejected as ambiguous instead of being silently resolved.