### PR TITLE
sql/plpgsql: report telemetry for the %TYPE / %ROWTYPE hint

### DIFF
--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -4,12 +4,12 @@ package parser
 import (
   "strings"
 
-  "github.com/cockroachdb/cockroach/pkg/build"
   "github.com/cockroachdb/cockroach/pkg/sql/parser"
   "github.com/cockroachdb/cockroach/pkg/sql/scanner"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
   "github.com/cockroachdb/cockroach/pkg/sql/types"
+  unimp "github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
   "github.com/cockroachdb/errors"
   "github.com/cockroachdb/redact"
 )
@@ -584,13 +584,12 @@ decl_datatype:
     case *tree.CastExpr:
       $$.val = t.Type
     default:
-      err := errors.New("unable to parse type of variable declaration")
       if strings.Contains(sqlStr, "%") {
-        err = errors.WithIssueLink(errors.WithHint(err,
-          "you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.",
-        ), errors.IssueLink{IssueURL: build.MakeIssueURL(114676)})
+        return setErr(plpgsqllex, unimp.NewWithIssue(114676,
+          "%TYPE and %ROWTYPE syntax",
+        ))
       }
-      return setErr(plpgsqllex, err)
+      return setErr(plpgsqllex, errors.New("unable to parse type of variable declaration"))
     }
   }
 ;

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -250,13 +250,12 @@ DECLARE
 BEGIN
 END
 ----
-at or near "rowtype": syntax error: unable to parse type of variable declaration
+at or near "rowtype": syntax error: unimplemented: %TYPE and %ROWTYPE syntax
 DETAIL: source SQL:
 DECLARE
   var1 xy%ROWTYPE;
           ^
-HINT: you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
---
+HINT: You have attempted to use a feature that is not yet implemented.
 See: https://go.crdb.dev/issue-v/114676/
 
 error
@@ -266,14 +265,13 @@ DECLARE
 BEGIN
 END
 ----
-at or near "type": syntax error: unable to parse type of variable declaration
+at or near "type": syntax error: unimplemented: %TYPE and %ROWTYPE syntax
 DETAIL: source SQL:
 DECLARE
   var1 INT;
   var2 var1%TYPE;
             ^
-HINT: you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
---
+HINT: You have attempted to use a feature that is not yet implemented.
 See: https://go.crdb.dev/issue-v/114676/
 
 pretty


### PR DESCRIPTION
The PL/pgSQL parser falls back to a heuristic error when type parsing fails and the type expression contains a `%`; the user is shown a hint suggesting they may have attempted to use `%TYPE` or `%ROWTYPE`. The old code attached an issue link to the error via `errors.WithIssueLink` but did not annotate it with `errors.WithTelemetry`, so this site produced no telemetry signal.

Switch to `unimp.NewWithIssue(114676, ...)`, which both attaches the issue link and registers a telemetry counter, so future unimplemented-feature pulls bucket these errors under `unimplemented.#114676` instead of being invisible.

Informs: #114676
Epic: CRDB-63280

Release note: None