### PR TITLE
changefeedccl: log g.Wait error in alter changefeed backfill test

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -2235,7 +2235,7 @@ WITH resolved = '1s', no_initial_scan, min_checkpoint_frequency='1ns'`,
 		})
 		defer func() {
 			closeFeed(t, testFeed)
-			_ = g.Wait()
+			t.Logf("g.Wait error: %v", g.Wait())
 		}()
 
 		// Ensure initial backfill completes


### PR DESCRIPTION
Surface the consumer goroutine's exit error rather than discarding it, to diagnose flakes where seenBarKeys is empty even though highwater advanced.

Epic: none
Release note: None