### PR TITLE
errorutil: emit telemetry for unimplemented errors

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -142,6 +142,7 @@ go_library(
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/interval",

--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	bulkutil "github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1485,8 +1486,7 @@ func getTenantInfo(
 		}
 	}
 	if len(tenants) > 0 && jobDetails.RevisionHistory {
-		return spans, tenants, errors.UnimplementedError(
-			errors.IssueLink{IssueURL: build.MakeIssueURL(47896)},
+		return spans, tenants, unimplemented.NewWithIssue(47896,
 			"can not backup tenants with revision history",
 		)
 	}

--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -564,9 +565,9 @@ func backupPlanHook(
 		for _, t := range targetDescs {
 			if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
 				if tbl.ExternalRowData().TenantID.IsSet() {
-					return errors.UnimplementedError(errors.IssueLink{}, "backing up from a replication target is not supported")
+					return unimplemented.New("backup.replication_target", "backing up from a replication target is not supported")
 				}
-				return errors.UnimplementedError(errors.IssueLink{}, "backing up from external tables is not supported")
+				return unimplemented.New("backup.external_table", "backing up from external tables is not supported")
 			}
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backupresolver"
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -58,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -194,8 +194,7 @@ func changefeedPlanHook(
 	}
 	if changefeedStmt.Level != tree.ChangefeedLevelTable {
 		return nil, nil, false,
-			errors.UnimplementedError(
-				errors.IssueLink{IssueURL: build.MakeIssueURL(154053)},
+			unimplemented.NewWithIssue(154053,
 				"database-level changefeed is not implemented yet",
 			)
 	}
@@ -705,9 +704,9 @@ func createChangefeedJobRecord(
 	for _, t := range tableNameToDescriptor {
 		if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
 			if tbl.ExternalRowData().TenantID.IsSet() {
-				return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on a replication target are not supported")
+				return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.replication_target", "changefeeds on a replication target are not supported")
 			}
-			return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on external tables are not supported")
+			return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.external_table", "changefeeds on external tables are not supported")
 		}
 	}
 	// This grabs table descriptors once to get their ids.
@@ -726,9 +725,9 @@ func createChangefeedJobRecord(
 		for _, t := range tableNameToDescriptor {
 			if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
 				if tbl.ExternalRowData().TenantID.IsSet() {
-					return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on a replication target are not supported")
+					return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.replication_target", "changefeeds on a replication target are not supported")
 				}
-				return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on external tables are not supported")
+				return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.external_table", "changefeeds on external tables are not supported")
 			}
 		}
 

--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -97,6 +97,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -95,7 +96,7 @@ func createLogicalReplicationStreamPlanHook(
 		defer span.Finish()
 
 		if stmt.From.Database != "" {
-			return errors.UnimplementedErrorf(errors.IssueLink{}, "logical replication streams on databases are unsupported")
+			return unimplemented.New("logical_replication.database", "logical replication streams on databases are unsupported")
 		}
 		if len(stmt.From.Tables) != len(stmt.Into.Tables) {
 			return pgerror.New(pgcode.InvalidParameterValue, "the same number of source and destination tables must be specified")

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -8,7 +8,6 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -531,11 +530,7 @@ func newAlterFunctionDependentObjectsError(
 	operation, detail string, fnDesc *funcdesc.Mutable, dependentObjects []redact.RedactableString,
 ) error {
 	joined := redact.Join(", ", dependentObjects)
-	err := errors.UnimplementedErrorf(
-		errors.IssueLink{
-			IssueURL: build.MakeIssueURL(83233),
-			Detail:   detail,
-		},
+	err := unimplemented.NewWithIssueDetailf(83233, detail,
 		"cannot %s function %q because other objects ([%s]) still depend on it",
 		operation, fnDesc.Name, joined.StripMarkers())
 	return errors.WithSafeDetails(err, "dependents: %s", joined)

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/build",
         "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/col/coldata",

--- a/pkg/sql/importer/read_import_parquet.go
+++ b/pkg/sql/importer/read_import_parquet.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/apache/arrow/go/v11/parquet/file"
 	"github.com/apache/arrow/go/v11/parquet/schema"
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -21,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -628,11 +628,9 @@ func determineColumnsToRead(
 			maxDefLevel := parquetCol.MaxDefinitionLevel()
 			if maxDefLevel > 1 {
 				return nil,
-					errors.UnimplementedErrorf(
-						errors.IssueLink{
-							IssueURL: build.MakeIssueURL(162543),
-							Detail:   "support parquet nested types for import",
-						}, "column %q has nested or repeated structure (definition level %d); "+
+					unimplemented.NewWithIssueDetailf(162543,
+						"support parquet nested types for import",
+						"column %q has nested or repeated structure (definition level %d); "+
 							"only simple required and optional columns are supported",
 						parquetColName, maxDefLevel)
 

--- a/pkg/sql/importer/read_import_parquet_logical.go
+++ b/pkg/sql/importer/read_import_parquet_logical.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -200,11 +201,11 @@ func validateWithLogicalType(
 
 		// Check for unsupported LogicalTypes that require nested column handling
 		if _, ok := logicalType.(schema.ListLogicalType); ok {
-			return errors.UnimplementedErrorf(errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/162543"},
+			return unimplemented.NewWithIssuef(162543,
 				"ListLogicalType not supported (requires nested column chunk handling)")
 		}
 		if _, ok := logicalType.(schema.MapLogicalType); ok {
-			return errors.UnimplementedErrorf(errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/162543"},
+			return unimplemented.NewWithIssuef(162543,
 				"MapLogicalType not supported (requires nested column chunk handling)")
 		}
 		if _, ok := logicalType.(schema.BSONLogicalType); ok {


### PR DESCRIPTION
Direct calls to errors.UnimplementedError(f) construct an unimplemented-feature error but skip the telemetry annotation that the local pkg/util/errorutil/unimplemented helpers add via errors.WithTelemetry. As a result, these unimplemented features did not show up in telemetry counts.

Replace the call sites with the unimplemented package equivalents: NewWithIssue / NewWithIssueDetailf when an issue is referenced, and New with a feature key when not. Two call sites are intentionally left alone: pkg/util/log/log_decoder.go already wraps the error in errors.WithTelemetry and cannot import the unimplemented package due to a circular dependency, and pkg/kv/kvserver/kvstorage/wag_replay.go is an internal-only TODO path that is not user-reachable.

Epic: None
Release note: None