### PR TITLE
logstore: funnel all raft log deletions through logstore package

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3865,7 +3865,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "rebalanceRHSAway", func(t *testing.T, rebalanceRHSAway bool) {
 		// We will be testing the SSTs written on store3's engine.
-		var receivingEng, sendingEng storage.Engine
+		var recvStateEng, recvLogEng, sendStateEng storage.Engine
 		// All of these variables will be populated later, after starting the
 		// cluster.
 		var keyStart, keyA, keyB, keyC, keyD, keyEnd roachpb.Key
@@ -3925,7 +3925,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 			// Construct SSTs for the the first 4 bullets as numbered above, but
 			// only ultimately keep the last one.
-			snapReader := sendingEng.NewSnapshot()
+			snapReader := sendStateEng.NewSnapshot()
 			defer snapReader.Close()
 
 			// Write a Pebble range deletion tombstone to each of the SSTs then
@@ -4018,9 +4018,15 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 					kvserverpb.RangeTombstone{NextReplicaID: math.MaxInt32},
 				))
 				// Ditto for the unreplicated RangeID keys. Note that it is also split
-				// into two range clears, to work around the RaftReplicaID key.
+				// into three range clears, to work around the RaftReplicaID key and
+				// to force all raft log clearing to go through logstore.
 				require.NoError(t, sst.ClearRawRange(
-					keys.RaftHardStateKey(rangeID), sl.RaftReplicaIDKey(), true, false,
+					keys.RaftHardStateKey(rangeID), sl.RaftLogPrefix(), true, false,
+				))
+				require.NoError(t, storage.ClearRangeWithHeuristic(
+					ctx, recvLogEng, &sst,
+					sl.RaftLogPrefix(), sl.RaftLogPrefix().PrefixEnd(),
+					kvstorage.ClearRangeThresholdPointKeys(),
 				))
 				require.NoError(t, sl.ClearRaftReplicaID(&sst))
 				require.NoError(t, sst.ClearRawRange(
@@ -4042,7 +4048,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 				EndKey:   roachpb.RKey(keyEnd),
 			}
 			require.NoError(t, storage.ClearRangeWithHeuristic(
-				ctx, receivingEng, &sst,
+				ctx, recvStateEng, &sst,
 				desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey(),
 				kvstorage.ClearRangeThresholdPointKeys(),
 			))
@@ -4053,7 +4059,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			// byte-by-byte equal.
 			var dumpDir string
 			for i := range sstNamesSubset {
-				actualSST, err := fs.ReadFile(receivingEng.Env(), sstNamesSubset[i])
+				actualSST, err := fs.ReadFile(recvStateEng.Env(), sstNamesSubset[i])
 				require.NoError(t, err)
 				if !bytes.Equal(expectedSSTs[i], actualSST) { // intentionally not printing
 					t.Logf("%d=%s", i, sstNamesSubset[i])
@@ -4094,8 +4100,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			})
 		defer tc.Stopper().Stop(ctx)
 		store1, store3 := tc.GetFirstStoreFromServer(t, 0), tc.GetFirstStoreFromServer(t, 2)
-		sendingEng = store1.StateEngine()
-		receivingEng = store3.StateEngine()
+		sendStateEng = store1.StateEngine()
+		recvStateEng = store3.StateEngine()
+		recvLogEng = store3.LogEngine()
 		distSender := tc.Servers[0].DistSenderI().(kv.Sender)
 
 		// This test works across 5 ranges in total. We start with a scratch

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -161,30 +161,33 @@ func destroyReplicaImpl(
 	//
 	// TODO(pav-kv): make a helper for piece-wise clearing, instead of using a
 	// series of ClearRangeWithHeuristic.
-	if info.Separated {
-		// With separated engines, only clear the unapplied suffix of the raft log.
-		// The applied entries are cleared during WAG garbage collection.
-		if err := storage.ClearRangeWithHeuristic(
-			ctx, rw.Raft.RO, rw.Raft.WO,
-			buf.RangeTombstoneKey().Next(), sl.RaftLogPrefix(),
-			ClearRangeThresholdPointKeys(),
-		); err != nil {
-			return err
-		}
-		if err := storage.ClearRangeWithHeuristic(
-			ctx, rw.Raft.RO, rw.Raft.WO,
-			buf.RaftLogKey(info.RaftAppliedIndex+1), sl.RaftReplicaIDKey(),
-			ClearRangeThresholdPointKeys(),
-		); err != nil {
-			return err
-		}
-	} else if err := storage.ClearRangeWithHeuristic(
+	if err := storage.ClearRangeWithHeuristic(
 		ctx, rw.Raft.RO, rw.Raft.WO,
-		buf.RangeTombstoneKey().Next(), sl.RaftReplicaIDKey(),
+		buf.RangeTombstoneKey().Next(), sl.RaftLogPrefix(),
 		ClearRangeThresholdPointKeys(),
 	); err != nil {
 		return err
 	}
+	clearAfter := kvpb.RaftIndex(0) // index 0 never has an entry
+	if info.Separated {
+		// With separated engines, only clear the unapplied suffix of the raft log.
+		// The applied entries are cleared during WAG garbage collection.
+		clearAfter = info.RaftAppliedIndex
+	}
+	// Note: We could just clear the whole raft log in the
+	// ClearRangeWithHeuristic() above. However, we want to funnel all raft log
+	// deletions through the logstore package to make it easier to reason about
+	// them.
+	// TODO(ibrahim): We could know `hi` if DestroyReplicaInfo passes down the
+	// log's last index.
+	if err := logstore.ClearRange(
+		ctx, rw.Raft.RO, rw.Raft.WO, buf,
+		clearAfter /* lo */, math.MaxUint64 /* hi */, ClearRangeThresholdPointKeys(),
+	); err != nil {
+		return err
+	}
+	// We're technically skipping the keys between the raft log and
+	// RaftReplicaID. This is ok because there are no keys there.
 	if err := sl.ClearRaftReplicaID(rw.State.WO); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -265,10 +265,16 @@ func RewriteRaftState(
 	if err := sl.SetHardState(ctx, raftWO, hs); err != nil {
 		return errors.Wrapf(err, "unable to write HardState")
 	}
-	// Clear the raft log. Note that there are no Pebble range keys in this span.
-	raftLog := sl.RaftLogPrefix() // NB: use only until next StateLoader call
-	if err := raftWO.ClearRawRange(
-		raftLog, raftLog.PrefixEnd(), true /* pointKeys */, false, /* rangeKeys */
+	// Clear the raft log via the logstore. Note that there are no Pebble range
+	// keys in this span. We use ClearRangeSizeKnown with pointKeyThreshold=0 to
+	// force a single range tombstone over the whole log span, without scanning.
+	// TODO(ibrahim): We can actually know the log bounds using truncIndex and lastIndex.
+	// TODO(sep-raft-log): delegate clearing <= AppliedIndex to WAG cleanup when engines
+	// are separated.
+	if err := logstore.ClearRangeSizeKnown(
+		raftWO, sl.RangeIDPrefixBuf,
+		0 /* lo */, math.MaxUint64 /* hi */, 0, /* pointKeyThreshold */
+		false, /* maybeUseSingleDel */
 	); err != nil {
 		return errors.Wrapf(err, "unable to clear the raft log")
 	}

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -271,23 +271,24 @@ func (t *WAGTruncator) maybeAdvanceAllowedIndex() {
 	}
 }
 
-// clearReplicaRaftLogAndSideloaded clears raft log entries at or below the given index for
-// a destroyed or subsumed replica, and it also deletes the sideloaded files associated with the
-// deleted entries.
+// clearReplicaRaftLogAndSideloaded clears raft log entries at or below the
+// given index for a destroyed or subsumed replica, and it also deletes the
+// sideloaded files associated with the deleted entries.
 func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
-	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
+	ctx context.Context, raft Raft, rangeID roachpb.RangeID, hi kvpb.RaftIndex,
 ) error {
-	if logstore.UseRaftLogSingleDelete(t.eng.Separated()) {
-		if err := clearRaftLogWithSingleDelete(
-			ctx, raft.RO, raft.WO, rangeID, lastIndex,
-		); err != nil {
-			return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
-		}
-	} else if err := storage.ClearRangeWithHeuristic(
-		ctx, raft.RO, raft.WO,
-		keys.RaftLogPrefix(rangeID),           /* start */
-		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
-		ClearRangeThresholdPointKeys(),
+	prefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
+	// We want to delete all raft log entries <= hi. Since Raft log
+	// doesn't have holes, we can get the first index, calculate the log size,
+	// and call ClearRangeSizeKnown(). If no entries exist in [RaftLogPrefix, hi]
+	// (e.g., this replica never received entries) this operation is a no-op.
+	// NB: lo == hi if nothing is found.
+	if lo, err := emptyLogPrefix(ctx, raft.RO, prefixBuf, hi); err != nil {
+		return errors.Wrapf(err, "finding first raft log index for r%d", rangeID)
+	} else if err := logstore.ClearRangeSizeKnown(
+		raft.WO, prefixBuf,
+		lo, hi, // if not found, lo == hi which is a no-op
+		ClearRangeThresholdPointKeys(), logstore.UseRaftLogSingleDelete(t.eng.Separated()),
 	); err != nil {
 		return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
 	}
@@ -304,7 +305,7 @@ func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	//  DiskSideloadStorage every time we want to clear some sideloaded files.
 	ss := logstore.NewDiskSideloadStorage(t.st, rangeID, t.eng.StateEngine().GetAuxiliaryDir(),
 		rate.NewLimiter(rate.Inf, math.MaxInt64), t.eng.StateEngine().Env())
-	if err := ss.TruncateTo(ctx, lastIndex); err != nil {
+	if err := ss.TruncateTo(ctx, hi); err != nil {
 		return err
 	}
 	// We must sync the sideloaded storage after truncation to avoid leaking the
@@ -312,39 +313,37 @@ func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	return ss.Sync()
 }
 
-// clearRaftLogWithSingleDelete clears raft log entries using SingleDelete for
-// each point key. Unlike the regular truncation path, this always uses point
-// deletions and never falls back to a range tombstone for simplicity.
-// TODO(ibrahim): Let this function use the same pointDelThreshold heuristic
-// when clearning the raft log.
-func clearRaftLogWithSingleDelete(
-	ctx context.Context,
-	r storage.Reader,
-	w storage.Writer,
-	rangeID roachpb.RangeID,
-	lastIndex kvpb.RaftIndex,
-) error {
-	start := keys.RaftLogPrefix(rangeID)
-	end := keys.RaftLogKey(rangeID, lastIndex+1)
+// emptyLogPrefix returns the index preceding the first existing raft log entry
+// at <= lastIndex. Returns lastIndex if the entire prefix is empty.
+func emptyLogPrefix(
+	ctx context.Context, r storage.Reader, prefixBuf keys.RangeIDPrefixBuf, lastIndex kvpb.RaftIndex,
+) (kvpb.RaftIndex, error) {
+	start := prefixBuf.RaftLogPrefix().Clone()
+	end := prefixBuf.RaftLogKey(lastIndex).Next()
 	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsOnly,
 		LowerBound: start,
 		UpperBound: end,
 	})
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer iter.Close()
-
 	ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: start})
-	for ; ok; ok, err = iter.NextEngineKey() {
-		key, kerr := iter.UnsafeEngineKey()
-		if kerr != nil {
-			return kerr
-		}
-		if err := w.SingleClearEngineKey(key); err != nil {
-			return err
-		}
+	if err != nil || !ok {
+		return lastIndex, err // error or not found
 	}
-	return err
+	key, err := iter.UnsafeEngineKey()
+	if err != nil {
+		return 0, err
+	}
+	firstIndex, err := keys.DecodeRaftLogKeyFromSuffix(key.Key[len(start):])
+	if err != nil {
+		return 0, err
+	}
+	// NB: index 0 must never have an entry.
+	if firstIndex == 0 || firstIndex > lastIndex {
+		return 0, errors.AssertionFailedf("unexpected firstIndex: %d compared to lastIndex: %d", firstIndex, lastIndex)
+	}
+	return firstIndex - 1, nil
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -275,6 +275,44 @@ func TestTruncateAppliedOnly(t *testing.T) {
 	}
 }
 
+// TestEmptyLogPrefix exercises the search for the smallest raft log index
+// in [RaftLogPrefix, hi].
+func TestEmptyLogPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	const rangeID = roachpb.RangeID(1)
+	prefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
+
+	tests := []struct {
+		entries []kvpb.RaftIndex
+		last    kvpb.RaftIndex
+		wantIdx kvpb.RaftIndex
+	}{
+		{entries: nil, last: 100, wantIdx: 100},
+		{entries: []kvpb.RaftIndex{}, last: 0, wantIdx: 0},
+		{entries: []kvpb.RaftIndex{}, last: 100, wantIdx: 100},
+		{entries: []kvpb.RaftIndex{15}, last: 0, wantIdx: 0},
+		{entries: []kvpb.RaftIndex{15}, last: 14, wantIdx: 14},
+		{entries: []kvpb.RaftIndex{15}, last: 15, wantIdx: 14},
+		{entries: []kvpb.RaftIndex{15}, last: 16, wantIdx: 14},
+		{entries: []kvpb.RaftIndex{15, 16}, last: 15, wantIdx: 14},
+		{entries: []kvpb.RaftIndex{15, 16}, last: 100, wantIdx: 14},
+	}
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			e := makeTestEngines()
+			defer e.Close()
+			for _, idx := range tc.entries {
+				e.writeRaftLogEntry(t, rangeID, idx)
+			}
+			idx, err := emptyLogPrefix(ctx, e.LogEngine(), prefixBuf, tc.last)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantIdx, idx)
+		})
+	}
+}
+
 // TestTruncateAndClearRaftState verifies that WAG truncation only clears raft
 // log entries and sideloaded files up to the destroyed/subsumed replica's last
 // index. Entries and files beyond that index may belong to a newer replica and

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -636,6 +636,91 @@ func Compact(
 	return nil
 }
 
+// ClearRange clears raft log entries in the range (lo, hi]. It calls
+// storage.ClearRangeWithHeuristic() which scans up to pointKeyThreshold keys to
+// choose between point deletes and a single Pebble range tombstone.
+// No-op if lo >= hi. Uses point deletes when number of entries < pointKeyThreshold,
+// or a range deletion otherwise.
+func ClearRange(
+	ctx context.Context,
+	r storage.Reader,
+	w storage.Writer,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo, hi kvpb.RaftIndex,
+	pointKeyThreshold int,
+) error {
+	if lo >= hi {
+		return nil
+	}
+	start, end := raftLogBounds(prefixBuf, lo, hi)
+	return storage.ClearRangeWithHeuristic(ctx, r, w, start, end, pointKeyThreshold)
+}
+
+// ClearRangeSizeKnown clears raft log entries in range (lo, hi] when the caller
+// already knows how many entries the range contains. Uses point deletes
+// when hi-lo < pointKeyThreshold, or a range deletion otherwise.
+// No-op if lo >= hi.
+//
+// If maybeUseSingleDel is true, it uses SingleDelete instead of regular Delete
+// if the size is <= pointKeyThreshold.
+func ClearRangeSizeKnown(
+	w storage.Writer,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo, hi kvpb.RaftIndex,
+	pointKeyThreshold int,
+	maybeUseSingleDel bool,
+) error {
+	if lo >= hi {
+		return nil
+	}
+	if hi-lo >= kvpb.RaftIndex(pointKeyThreshold) {
+		start, end := raftLogBounds(prefixBuf, lo, hi)
+		return w.ClearRawRange(start, end, true /* pointKeys */, false /* rangeKeys */)
+	}
+	raftLogPrefix := prefixBuf.RaftLogPrefix()
+	// NB: each iteration consumes a key before the next call mutates the bytes
+	// after raftLogPrefix.
+	// NB: avoid overflow in the unlikely case hi == MaxUint64.
+	for idx := lo; idx < hi; idx++ {
+		key := keys.RaftLogKeyFromPrefix(raftLogPrefix, idx+1)
+		var err error
+		if maybeUseSingleDel {
+			err = w.SingleClearUnversioned(key)
+		} else {
+			err = w.ClearUnversioned(key, storage.ClearOptions{})
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// raftLogBounds converts (lo, hi] to their roachpb keys. The sentinels lo == 0
+// and hi == math.MaxUint64 expand to raftLogPrefix and raftLogPrefix.PrefixEnd
+// respectively.
+//
+// The returned keys are independent of prefixBuf's underlying buffer:
+// keys.RaftLogKeyFromPrefix returns a slice that aliases the bytes immediately
+// after the raft log prefix, so building two bounds from the same prefix
+// without cloning would have the second call clobber the first.
+func raftLogBounds(
+	prefixBuf keys.RangeIDPrefixBuf, lo, hi kvpb.RaftIndex,
+) (start, end roachpb.Key) {
+	raftLogPrefix := prefixBuf.RaftLogPrefix()
+	if lo == 0 {
+		start = raftLogPrefix.Clone()
+	} else {
+		start = keys.RaftLogKeyFromPrefix(raftLogPrefix, lo+1).Clone()
+	}
+	if hi == math.MaxUint64 {
+		end = raftLogPrefix.PrefixEnd()
+	} else {
+		end = keys.RaftLogKeyFromPrefix(raftLogPrefix, hi+1).Clone()
+	}
+	return start, end
+}
+
 // ComputeSize computes the size (in bytes) of the raft log from the storage
 // engine. This will iterate over the raft log and sideloaded files, so
 // depending on the size of these it can be mildly to extremely expensive and

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -591,37 +591,17 @@ func Compact(
 	// Truncate the Raft log from the entry after the previous truncation index to
 	// the new truncation index. This is performed atomically with updating the
 	// RaftTruncatedState so that the state of the log is consistent.
-	prefixBuf := &loader.RangeIDPrefixBuf
-	numTruncatedEntries := next.Index - prev.Index
-	if numTruncatedEntries >= raftLogTruncationClearRangeThreshold {
-		start := prefixBuf.RaftLogKey(prev.Index + 1).Clone()
-		end := prefixBuf.RaftLogKey(next.Index + 1).Clone() // end is exclusive
-		if err := writer.ClearRawRange(start, end, true, false); err != nil {
-			return errors.Wrapf(err,
-				"unable to clear truncated Raft entries for %+v after index %d",
-				next, prev.Index)
-		}
-	} else {
-		// NB: RangeIDPrefixBufs have sufficient capacity (32 bytes) to avoid
-		// allocating when constructing Raft log keys (16 bytes).
-		useSingleDelete := UseRaftLogSingleDelete(enginesSeparated)
-		prefix := prefixBuf.RaftLogPrefix()
-		for idx := prev.Index + 1; idx <= next.Index; idx++ {
-			key := keys.RaftLogKeyFromPrefix(prefix, idx)
-			var err error
-			if useSingleDelete {
-				err = writer.SingleClearUnversioned(key)
-			} else {
-				err = writer.ClearUnversioned(key, storage.ClearOptions{})
-			}
-			if err != nil {
-				return errors.Wrapf(err, "unable to clear truncated Raft entries for %+v at index %d",
-					next, idx)
-			}
-		}
+	if err := ClearRangeSizeKnown(
+		writer, loader.RangeIDPrefixBuf,
+		prev.Index, next.Index, int(raftLogTruncationClearRangeThreshold),
+		UseRaftLogSingleDelete(enginesSeparated),
+	); err != nil {
+		return errors.Wrapf(err,
+			"unable to clear truncated Raft entries for %+v after index %d",
+			next, prev.Index)
 	}
 
-	key := prefixBuf.RaftTruncatedStateKey()
+	key := loader.RaftTruncatedStateKey()
 	var value roachpb.Value
 	if _, err := next.MarshalToSizedBuffer(value.AllocBytes(next.Size())); err != nil {
 		return err

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -8,11 +8,13 @@ package logstore
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -21,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,4 +127,176 @@ func TestRaftStorageWrites(t *testing.T) {
 		output = strings.ReplaceAll(output, "\n\n", "\n")
 		echotest.Require(t, output, filepath.Join("testdata", t.Name()))
 	})
+}
+
+type clearRangeHelper struct {
+	t         *testing.T
+	rangeID   roachpb.RangeID
+	prefixBuf keys.RangeIDPrefixBuf
+	eng       storage.Engine
+}
+
+func newClearRangeHelper(t *testing.T) *clearRangeHelper {
+	const rangeID = roachpb.RangeID(123)
+	h := &clearRangeHelper{
+		t:         t,
+		rangeID:   rangeID,
+		prefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),
+		eng:       storage.NewDefaultInMemForTesting(),
+	}
+	return h
+}
+
+// close releases the engine.
+func (h *clearRangeHelper) close() {
+	h.eng.Close()
+}
+
+// populate writes the raft log entries [15,16,17,18,19] using logAppend.
+func (h *clearRangeHelper) populate(ctx context.Context, firstIndex uint64, lastIndex uint64) {
+	h.t.Helper()
+	var entries []raftpb.Entry
+	for i := firstIndex; i <= lastIndex; i++ {
+		entries = append(entries, raftpb.Entry{Index: i, Term: 10})
+	}
+	b := h.eng.NewBatch()
+	defer b.Close()
+	_, err := logAppend(
+		ctx, h.prefixBuf.RaftLogPrefix(), b, RaftState{}, entries, false, /* enginesSeparated */
+	)
+	require.NoError(h.t, err)
+	require.NoError(h.t, b.Commit(false /* sync */))
+}
+
+// countBatchOps tallies the deletion ops recorded in a Pebble batch's wire
+// representation, classifying them as point deletes, single deletes, or range
+// deletes.
+func (h *clearRangeHelper) countBatchOps(batchRepr []byte) (points, singleDels, ranges int) {
+	h.t.Helper()
+	r, err := storage.NewBatchReader(batchRepr)
+	require.NoError(h.t, err)
+	for r.Next() {
+		switch r.KeyKind() {
+		case pebble.InternalKeyKindDelete, pebble.InternalKeyKindDeleteSized:
+			points++
+		case pebble.InternalKeyKindSingleDelete:
+			singleDels++
+		case pebble.InternalKeyKindRangeDelete:
+			ranges++
+		}
+	}
+	return points, singleDels, ranges
+}
+
+// raftLogIndices returns the raft log indices present in the engine's raft log.
+func (h *clearRangeHelper) raftLogIndices(ctx context.Context) []kvpb.RaftIndex {
+	h.t.Helper()
+	prefix := h.prefixBuf.RaftLogPrefix()
+	iter, err := h.eng.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
+		LowerBound: prefix, UpperBound: prefix.PrefixEnd(),
+	})
+	require.NoError(h.t, err)
+	defer iter.Close()
+	var indices []kvpb.RaftIndex
+	iter.SeekGE(storage.MakeMVCCMetadataKey(prefix))
+	for {
+		ok, err := iter.Valid()
+		require.NoError(h.t, err)
+		if !ok {
+			break
+		}
+		key := iter.UnsafeKey().Key
+		idx, err := keys.DecodeRaftLogKeyFromSuffix(key[len(prefix):])
+		require.NoError(h.t, err)
+		indices = append(indices, idx)
+		iter.Next()
+	}
+	return indices
+}
+
+// TestClearRange verifies the scan-based heuristic in ClearRange: when the
+// number of raft log keys actually present in (lo, hi] is below the threshold,
+// the function emits per-entry point deletes; otherwise it emits a single
+// Pebble range tombstone.
+// The test populates raft log indices [15,19].
+func TestClearRange(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		lo, hi                 kvpb.RaftIndex
+		threshold              int
+		wantPoints, wantRanges int
+		wantIndices            []kvpb.RaftIndex
+	}{
+		{lo: 0, hi: math.MaxUint64, threshold: 1, wantPoints: 0, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 6, wantPoints: 5, wantRanges: 0},
+		{lo: 10, hi: 15, threshold: 3, wantPoints: 1, wantRanges: 0, wantIndices: []kvpb.RaftIndex{16, 17, 18, 19}},
+		{lo: 10, hi: 15, threshold: 6, wantPoints: 1, wantRanges: 0, wantIndices: []kvpb.RaftIndex{16, 17, 18, 19}},
+		{lo: 10, hi: 19, threshold: 3, wantPoints: 0, wantRanges: 1},
+		{lo: 10, hi: 19, threshold: 6, wantPoints: 5, wantRanges: 0},
+		{lo: 14, hi: 18, threshold: 3, wantPoints: 0, wantRanges: 1, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 14, hi: 18, threshold: 6, wantPoints: 4, wantRanges: 0, wantIndices: []kvpb.RaftIndex{19}},
+		// Empty / inverted ranges are no-ops.
+		{lo: 15, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+		{lo: 100, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+	}
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			h := newClearRangeHelper(t)
+			defer h.close()
+			h.populate(ctx, 15 /* firstIndex */, 19 /* lastIndex */)
+			batch := h.eng.NewBatch()
+			defer batch.Close()
+			require.NoError(t, ClearRange(ctx, h.eng, batch, h.prefixBuf, tc.lo, tc.hi, tc.threshold))
+			points, singles, ranges := h.countBatchOps(batch.Repr())
+			require.Equal(t, tc.wantPoints, points)
+			require.Equal(t, 0, singles) // ClearRange doesn't use SingleDelete.
+			require.Equal(t, tc.wantRanges, ranges)
+			require.NoError(t, batch.Commit(false /* sync */))
+			require.Equal(t, tc.wantIndices, h.raftLogIndices(ctx))
+		})
+	}
+}
+
+// TestClearRangeSizeKnown verifies that it correctly chooses between point
+// deletes, single deletes, and range deletes based on the provided args.
+// The test populates raft log indices [15,19].
+func TestClearRangeSizeKnown(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		lo, hi                              kvpb.RaftIndex
+		threshold                           int
+		maybeUseSingleDel                   bool
+		wantPoints, wantSingles, wantRanges int
+		wantIndices                         []kvpb.RaftIndex
+	}{
+		{lo: 0, hi: math.MaxUint64, threshold: 0, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 10, maybeUseSingleDel: true, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 1, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 1, maybeUseSingleDel: true, wantRanges: 1},
+		{lo: 14, hi: 18, threshold: 3, wantRanges: 1, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 14, hi: 18, threshold: 3, maybeUseSingleDel: true, wantRanges: 1, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 14, hi: 18, threshold: 6, wantPoints: 4, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 14, hi: 18, threshold: 6, maybeUseSingleDel: true, wantSingles: 4, wantIndices: []kvpb.RaftIndex{19}},
+		// Empty / inverted ranges are no-ops.
+		{lo: 15, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+		{lo: 100, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+	}
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			h := newClearRangeHelper(t)
+			defer h.close()
+			h.populate(ctx, 15 /* firstIndex */, 19 /* lastIndex */)
+			batch := h.eng.NewBatch()
+			defer batch.Close()
+			require.NoError(t, ClearRangeSizeKnown(
+				batch, h.prefixBuf, tc.lo, tc.hi, tc.threshold, tc.maybeUseSingleDel,
+			))
+			points, singles, ranges := h.countBatchOps(batch.Repr())
+			require.Equal(t, tc.wantPoints, points)
+			require.Equal(t, tc.wantSingles, singles)
+			require.Equal(t, tc.wantRanges, ranges)
+			require.NoError(t, batch.Commit(false /* sync */))
+			require.Equal(t, tc.wantIndices, h.raftLogIndices(ctx))
+		})
+	}
 }


### PR DESCRIPTION
There are three main ways to clear a raft log range, all now expressed via ClearRange:

1. Delete a range using ClearRangeWithHeuristic when the entry count is not known.

2. When the entry count is known (during log truncations) we do an arithmatic calculation to determine whether we issue point/range deletions.

3. Blindly delete the whole raft log span using ClearRawRange. This is done when applying a raft snapshot.

4) Delete using SingleDeletes regardless of the deletion size if size isn't known (used by the WAG truncator).

This PR introduces three helpers ClearRange(), ClearRangeSizeKnown() to funnel all of these use cases through logstore.

References: https://github.com/cockroachdb/cockroach/issues/8979

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>