### PR TITLE
kvserver: deflake TestFlowControlSendQueueRangeFeed

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -3393,6 +3393,9 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 						return disableWorkQueueGrantingServers[idx].Load()
 					},
 				},
+				KVClient: &kvcoord.ClientTestingKnobs{
+					DontRandomizeLeaseholderOnCtxError: true,
+				},
 			},
 		}
 	}


### PR DESCRIPTION
Every other flow control integration test that blocks admission granting
sets `DontRandomizeLeaseholderOnCtxError`, but this one slipped through
the cracks.

Closes https://github.com/cockroachdb/cockroach/issues/169478

Epic: none
Release note: None