### PR TITLE
backup: nil-check planner txn in remap helpers

### DIFF
--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -309,6 +309,9 @@ func remapSchemas(
 ) (bool, error) {
 
 	txn := p.InternalSQLTxn()
+	if txn == nil {
+		return false, errors.AssertionFailedf("remapSchemas: planner has no active transaction")
+	}
 	col := txn.Descriptors()
 	shouldBufferDeprecatedPrivilegeNotice := false
 
@@ -379,6 +382,9 @@ func remapTables(
 ) (bool, error) {
 
 	txn := p.InternalSQLTxn()
+	if txn == nil {
+		return false, errors.AssertionFailedf("remapTables: planner has no active transaction")
+	}
 	col := txn.Descriptors()
 	shouldBufferDeprecatedPrivilegeNotice := false
 
@@ -615,6 +621,9 @@ func remapTypes(
 ) (bool, error) {
 
 	txn := p.InternalSQLTxn()
+	if txn == nil {
+		return false, errors.AssertionFailedf("remapTypes: planner has no active transaction")
+	}
 	col := txn.Descriptors()
 	shouldBufferDeprecatedPrivilegeNotice := false
 
@@ -768,6 +777,9 @@ func remapFunctions(
 	descriptorRewrites jobspb.DescRewriteMap,
 ) error {
 	txn := p.InternalSQLTxn()
+	if txn == nil {
+		return errors.AssertionFailedf("remapFunctions: planner has no active transaction")
+	}
 	col := txn.Descriptors()
 
 	for _, function := range functionsByID {
@@ -1085,6 +1097,9 @@ func allocateDescriptorRewrites(
 	}
 
 	txn := p.InternalSQLTxn()
+	if txn == nil {
+		return nil, 0, errors.AssertionFailedf("allocateDescriptorRewrites: planner has no active transaction")
+	}
 	col := txn.Descriptors()
 	// Check that any DBs being restored do _not_ exist.
 	// Fail fast if the necessary databases don't exist or are otherwise


### PR DESCRIPTION
Guards `p.InternalSQLTxn()` against returning nil before dereferencing `txn.Descriptors()` in five sites in `pkg/backup/restore_planning.go` (`remapSchemas`, `remapTables`, `remapTypes`, `remapFunctions`, `allocateDescriptorRewrites`). The planner method returns nil when `p.txn == nil`, which is what triggered the Sentry-reported nil deref at `restore_planning.go:278`.

Fixes #169502.

Release note: None