### PR TITLE
release-26.1: oidcccl: increase HTTP client timeout in OIDC authorization tests

### DIFF
--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -42,7 +42,7 @@ go_library(
 
 go_test(
     name = "oidcccl_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "authentication_oidc_test.go",
         "authorization_oidc_test.go",

--- a/pkg/ccl/oidcccl/authorization_oidc_test.go
+++ b/pkg/ccl/oidcccl/authorization_oidc_test.go
@@ -309,6 +309,9 @@ func TestOIDCAuthorization_TokenPaths(t *testing.T) {
 			rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
 			client, err := rpcCtx.GetHTTPClient()
 			require.NoError(t, err)
+			// The default 10s timeout is too short under race detection where OIDC
+			// callback processing can take 20s+.
+			client.Timeout = 45 * time.Second
 			// Prevent automatic redirects so we can capture cookies and headers.
 			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
@@ -377,6 +380,9 @@ func TestOIDCAuthorization_UserinfoPaths(t *testing.T) {
 	rpc := app.NewClientRPCContext(ctx, username.TestUserName())
 	cl, err := rpc.GetHTTPClient()
 	require.NoError(t, err)
+	// The default 10s timeout is too short under race detection where OIDC
+	// callback processing can take 20s+.
+	cl.Timeout = 45 * time.Second
 	cl.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 	// Create an RSA key pair for signing and verifying tokens.
@@ -714,6 +720,9 @@ func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
 	rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
 	client, err := rpcCtx.GetHTTPClient()
 	require.NoError(t, err)
+	// The default 10s timeout is too short under race detection where OIDC
+	// callback processing can take 20s+.
+	client.Timeout = 45 * time.Second
 	// Prevent automatic redirects so we can capture cookies and headers.
 	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 


### PR DESCRIPTION
Backport 1/1 commits from #167376 on behalf of @souravcrl.

/cc @cockroachdb/release

---

The OIDC authorization tests (`TestOIDCAuthorization_TokenPaths`,
`TestOIDCAuthorization_UserinfoPaths`, `TestOIDCAuthorization_RoleGrantAndRevoke`)
were flaking under race detection because the default 10s HTTP client
timeout from `rpcCtx.GetHTTPClient()` is too short for the OIDC callback
processing, which can take 20s+ under race. Increase the timeout to 45s
for all three test functions. Also bump the Bazel test size from `small`
(60s / 180s with race) to `medium` (300s / 900s with race) to accommodate
the longer individual subtest durations.

The original fix in #167376 (role membership cleanup between subtests) is
already present on release-26.1, but the underlying timeout issue persists.

Fixes: #169626

Release note: None

---

Release justification: Fix for flaky test TestOIDCAuthorization_TokenPaths on release-26.1

Epic: none