### PR TITLE
oidcauth: increase HTTP client timeout in TestOIDCAuthorization_UserinfoPaths

### DIFF
--- a/pkg/security/oidcauth/BUILD.bazel
+++ b/pkg/security/oidcauth/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
 
 go_test(
     name = "oidcauth_test",
+    size = "medium",
     srcs = [
         "authentication_oidc_test.go",
         "authorization_oidc_test.go",

--- a/pkg/security/oidcauth/authorization_oidc_test.go
+++ b/pkg/security/oidcauth/authorization_oidc_test.go
@@ -309,6 +309,9 @@ func TestOIDCAuthorization_TokenPaths(t *testing.T) {
 			rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
 			client, err := rpcCtx.GetHTTPClient()
 			require.NoError(t, err)
+			// The default 10s timeout is too short under race detection where OIDC
+			// callback processing can take 20s+.
+			client.Timeout = 45 * time.Second
 			// Prevent automatic redirects so we can capture cookies and headers.
 			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
@@ -385,6 +388,9 @@ func TestOIDCAuthorization_UserinfoPaths(t *testing.T) {
 	rpc := app.NewClientRPCContext(ctx, username.TestUserName())
 	cl, err := rpc.GetHTTPClient()
 	require.NoError(t, err)
+	// The default 10s timeout is too short under race detection where OIDC
+	// callback processing can take 20s+.
+	cl.Timeout = 45 * time.Second
 	cl.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 	// Create an RSA key pair for signing and verifying tokens.
@@ -738,6 +744,9 @@ func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
 	rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
 	client, err := rpcCtx.GetHTTPClient()
 	require.NoError(t, err)
+	// The default 10s timeout is too short under race detection where OIDC
+	// callback processing can take 20s+.
+	client.Timeout = 45 * time.Second
 	// Prevent automatic redirects so we can capture cookies and headers.
 	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 


### PR DESCRIPTION
The `TestOIDCAuthorization_UserinfoPaths` test was flaking under race
detection because the default 10s HTTP client timeout from
`rpcCtx.GetHTTPClient()` is too short for the OIDC callback processing,
which can take 20s+ under race. Increase the timeout to 45s.

The same fix is also applied to `TestOIDCAuthorization_TokenPaths` and
`TestOIDCAuthorization_RoleGrantAndRevoke` preemptively since they use
the same HTTP client setup.

Fixes: #169627

Release note: None

Epic: none