### PR TITLE
release-26.1: server,ui: persist ?cluster= as tenant cookie for SPA and OIDC routing

### DIFF
--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -121,6 +121,15 @@ func (m mockOidcManager) UserInfo(
 
 var _ IOIDCManager = &mockOidcManager{}
 
+func findCookie(resp *http.Response, name string) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
 func TestOIDCEnabled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -133,8 +142,7 @@ func TestOIDCEnabled(t *testing.T) {
 	usernameUnderTest := "test"
 	basePath := "/some/random/path"
 
-	realNewManager := NewOIDCManager
-	NewOIDCManager = func(ctx context.Context, conf oidcAuthenticationConf, redirectURL string, scopes []string) (IOIDCManager, error) {
+	defer testutils.HookGlobal(&NewOIDCManager, func(ctx context.Context, conf oidcAuthenticationConf, redirectURL string, scopes []string) (IOIDCManager, error) {
 		c := &oauth2.Config{
 			ClientID:     conf.clientID,
 			ClientSecret: conf.clientSecret,
@@ -146,10 +154,7 @@ func TestOIDCEnabled(t *testing.T) {
 			Scopes: scopes,
 		}
 		return &mockOidcManager{oauth2Config: c, claimEmail: fmt.Sprintf("%s@example.com", usernameUnderTest)}, nil
-	}
-	defer func() {
-		NewOIDCManager = realNewManager
-	}()
+	})()
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, fmt.Sprintf(`CREATE USER %s with password 'unused'`, usernameUnderTest))
@@ -185,10 +190,8 @@ func TestOIDCEnabled(t *testing.T) {
 	if resp.StatusCode != 302 {
 		t.Fatalf("expected 302 status code but got: %d", resp.StatusCode)
 	}
-	if resp.Cookies()[0].Name != secretCookieName {
-		t.Fatal("Missing cookie")
-	}
-	cookie := resp.Cookies()[0]
+	cookie := findCookie(resp, secretCookieName)
+	require.NotNil(t, cookie, "Missing oidc_secret cookie")
 
 	authURL, err := url.Parse(resp.Header.Get("Location"))
 	require.NoError(t, err)
@@ -208,7 +211,7 @@ func TestOIDCEnabled(t *testing.T) {
 		t.Fatal("HMAC generated incorrectly.")
 	}
 
-	key, err := base64.URLEncoding.DecodeString(resp.Cookies()[0].Value)
+	key, err := base64.URLEncoding.DecodeString(cookie.Value)
 	require.NoError(t, err)
 	mac := hmac.New(sha256.New, key)
 	mac.Write(state.Token)
@@ -240,15 +243,8 @@ func TestOIDCEnabled(t *testing.T) {
 	if resp.Header.Get("Location") != basePath {
 		t.Fatalf("expected to be redirected to %s", basePath)
 	}
-	foundCookie := false
-	for _, c := range resp.Cookies() {
-		if c.Name == authserver.SessionCookieName {
-			foundCookie = true
-		}
-	}
-	if !foundCookie {
-		t.Fatalf("no session cookie found in callback response")
-	}
+	require.NotNil(t, findCookie(resp, authserver.SessionCookieName),
+		"no session cookie found in callback response")
 }
 
 func TestKeyAndSignedTokenIsValid(t *testing.T) {
@@ -762,8 +758,7 @@ func TestOIDCProvisioning(t *testing.T) {
 	basePath := "/base/path/for/provisioning"
 
 	// Mock the OIDC manager to simulate responses from an Identity Provider.
-	realNewManager := NewOIDCManager
-	NewOIDCManager = func(ctx context.Context, conf oidcAuthenticationConf, redirectURL string, scopes []string) (IOIDCManager, error) {
+	defer testutils.HookGlobal(&NewOIDCManager, func(ctx context.Context, conf oidcAuthenticationConf, redirectURL string, scopes []string) (IOIDCManager, error) {
 		c := &oauth2.Config{
 			ClientID:     conf.clientID,
 			ClientSecret: conf.clientSecret,
@@ -773,12 +768,8 @@ func TestOIDCProvisioning(t *testing.T) {
 			},
 			Scopes: scopes,
 		}
-		// The mockOidcManager will extract `usernameUnderTest` from this email claim.
 		return &mockOidcManager{oauth2Config: c, claimEmail: fmt.Sprintf("%s@example.com", usernameUnderTest)}, nil
-	}
-	defer func() {
-		NewOIDCManager = realNewManager
-	}()
+	})()
 
 	// Configure the necessary OIDC cluster settings for the test.
 	OIDCProviderURL.Override(ctx, &ts.ClusterSettings().SV, "https://provider.example.com")
@@ -815,8 +806,8 @@ func TestOIDCProvisioning(t *testing.T) {
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusFound, resp.StatusCode)
 
-		cookie := resp.Cookies()[0]
-		require.Equal(t, secretCookieName, cookie.Name)
+		cookie := findCookie(resp, secretCookieName)
+		require.NotNil(t, cookie, "expected oidc_secret cookie")
 
 		authURL, err := url.Parse(resp.Header.Get("Location"))
 		require.NoError(t, err)
@@ -863,7 +854,8 @@ func TestOIDCProvisioning(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusFound, resp.StatusCode)
-		cookie := resp.Cookies()[0]
+		cookie := findCookie(resp, secretCookieName)
+		require.NotNil(t, cookie, "expected oidc_secret cookie")
 		authURL, err := url.Parse(resp.Header.Get("Location"))
 		require.NoError(t, err)
 		stateParam := authURL.Query().Get("state")
@@ -906,7 +898,8 @@ func TestOIDCProvisioning(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusFound, resp.StatusCode)
-		cookie := resp.Cookies()[0]
+		cookie := findCookie(resp, secretCookieName)
+		require.NotNil(t, cookie, "expected oidc_secret cookie")
 		authURL, err := url.Parse(resp.Header.Get("Location"))
 		require.NoError(t, err)
 		stateParam := authURL.Query().Get("state")
@@ -948,7 +941,8 @@ func TestOIDCProvisioning(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusFound, resp.StatusCode)
-		cookie := resp.Cookies()[0]
+		cookie := findCookie(resp, secretCookieName)
+		require.NotNil(t, cookie, "expected oidc_secret cookie")
 		authURL, err := url.Parse(resp.Header.Get("Location"))
 		require.NoError(t, err)
 		stateParam := authURL.Query().Get("state")
@@ -994,8 +988,7 @@ func TestOIDCExchangeVerifyFailure(t *testing.T) {
 	basePath := "/some/oidc/path"
 
 	// Intercept NewOIDCManager and return the failing mock.
-	realNewManager := NewOIDCManager
-	NewOIDCManager = func(
+	defer testutils.HookGlobal(&NewOIDCManager, func(
 		ctx context.Context,
 		conf oidcAuthenticationConf,
 		redirectURL string,
@@ -1013,8 +1006,7 @@ func TestOIDCExchangeVerifyFailure(t *testing.T) {
 			claimEmail:           fmt.Sprintf("%s@example.com", usernameUnderTest),
 			forceExchangeFailure: true,
 		}, nil
-	}
-	defer func() { NewOIDCManager = realNewManager }()
+	})()
 
 	// Minimal cluster‑setting wiring to enable OIDC.
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -1041,7 +1033,8 @@ func TestOIDCExchangeVerifyFailure(t *testing.T) {
 	defer loginResp.Body.Close()
 	require.Equal(t, http.StatusFound, loginResp.StatusCode)
 
-	cookie := loginResp.Cookies()[0]
+	cookie := findCookie(loginResp, secretCookieName)
+	require.NotNil(t, cookie, "expected oidc_secret cookie")
 	authURL, err := url.Parse(loginResp.Header.Get("Location"))
 	require.NoError(t, err)
 	stateParam := authURL.Query().Get("state")

--- a/pkg/ccl/oidcccl/authorization_oidc_test.go
+++ b/pkg/ccl/oidcccl/authorization_oidc_test.go
@@ -320,7 +320,15 @@ func TestOIDCAuthorization_TokenPaths(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusFound, resp.StatusCode)
 
-			stateCookie := resp.Cookies()[0]
+			// Find by name; in shared-process multi-tenant mode the tenant cookie precedes oidc_secret.
+			var stateCookie *http.Cookie
+			for _, c := range resp.Cookies() {
+				if c.Name == secretCookieName {
+					stateCookie = c
+					break
+				}
+			}
+			require.NotNil(t, stateCookie, "expected oidc_secret cookie")
 			loc, err := url.Parse(resp.Header.Get("Location"))
 			require.NoError(t, err)
 			state := loc.Query().Get("state")
@@ -552,7 +560,15 @@ func TestOIDCAuthorization_UserinfoPaths(t *testing.T) {
 
 			resp, err := cl.Get(app.AdminURL().WithPath("/oidc/v1/login").String())
 			require.NoError(t, err)
-			cookie := resp.Cookies()[0]
+			// Find by name; in shared-process multi-tenant mode the tenant cookie precedes oidc_secret.
+			var cookie *http.Cookie
+			for _, c := range resp.Cookies() {
+				if c.Name == secretCookieName {
+					cookie = c
+					break
+				}
+			}
+			require.NotNil(t, cookie, "expected oidc_secret cookie")
 			loc, _ := url.Parse(resp.Header.Get("Location"))
 			state := loc.Query().Get("state")
 
@@ -657,7 +673,15 @@ func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusFound, resp.StatusCode)
 
-		stateCookie := resp.Cookies()[0]
+		// Find by name; in shared-process multi-tenant mode the tenant cookie precedes oidc_secret.
+		var stateCookie *http.Cookie
+		for _, c := range resp.Cookies() {
+			if c.Name == secretCookieName {
+				stateCookie = c
+				break
+			}
+		}
+		require.NotNil(t, stateCookie, "expected oidc_secret cookie")
 		loc, err := url.Parse(resp.Header.Get("Location"))
 		require.NoError(t, err)
 		state := loc.Query().Get("state")

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -150,6 +150,16 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 		s.getHTTPHandlerFn()(w, r)
 		return
 	}
+	// Persist the ?cluster= query parameter as the tenant cookie so that
+	// subsequent SPA requests (which use relative URLs without ?cluster=)
+	// and OIDC IdP callbacks (which strip all query parameters) continue
+	// to route to the correct tenant. Only set after getServer confirms
+	// the tenant exists to avoid persisting invalid names.
+	if r.URL.Query().Get(ClusterNameParamInQueryURL) != "" {
+		http.SetCookie(w, authserver.CreateTenantSelectCookie(
+			string(tenantName), !c.disableTLSForHTTP, /* forHTTPSOnly */
+		))
+	}
 	s.getHTTPHandlerFn()(w, r)
 }
 

--- a/pkg/server/server_controller_http_test.go
+++ b/pkg/server/server_controller_http_test.go
@@ -11,11 +11,32 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
+
+func requireCookie(t *testing.T, resp *http.Response, name, expectedValue string) {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			require.Equal(t, expectedValue, c.Value)
+			return
+		}
+	}
+	t.Fatalf("expected cookie %q not found", name)
+}
+
+func requireNoCookie(t *testing.T, resp *http.Response, name string) {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == name && c.Value != "" {
+			t.Fatalf("expected no %q cookie, got value %q", name, c.Value)
+		}
+	}
+}
 
 func TestNoFallbackParam(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -47,5 +68,79 @@ func TestNoFallbackParam(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, resp.StatusCode, http.StatusOK)
+	})
+}
+
+// TestClusterQueryParamSetsTenantCookie verifies that requests with
+// ?cluster=<name> cause the server to set the tenant select cookie in
+// the response. This enables the Single Page App to route subsequent
+// requests (which don't carry ?cluster=) to the same tenant.
+func TestClusterQueryParamSetsTenantCookie(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+	})
+	defer s.Stopper().Stop(ctx)
+
+	_, _, err := s.TenantController().StartSharedProcessTenant(ctx,
+		base.TestSharedProcessTenantArgs{TenantName: "apptenant"},
+	)
+	require.NoError(t, err)
+
+	httpClient, err := s.SystemLayer().GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+	defer httpClient.CloseIdleConnections()
+	// Don't follow redirects so we can inspect response cookies.
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	baseURL := s.SystemLayer().AdminURL().String()
+
+	t.Run("cluster param sets tenant cookie", func(t *testing.T) {
+		resp, err := httpClient.Get(baseURL + "/health?cluster=system")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		requireCookie(t, resp, authserver.TenantSelectCookieName, "system")
+	})
+
+	t.Run("cluster param sets tenant cookie for non-system tenant", func(t *testing.T) {
+		resp, err := httpClient.Get(baseURL + "/health?cluster=apptenant")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		requireCookie(t, resp, authserver.TenantSelectCookieName, "apptenant")
+	})
+
+	t.Run("no cluster param does not set tenant cookie", func(t *testing.T) {
+		resp, err := httpClient.Get(baseURL + "/health")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		requireNoCookie(t, resp, authserver.TenantSelectCookieName)
+	})
+
+	t.Run("cluster param overrides existing tenant cookie", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(
+			ctx, "GET", baseURL+"/health?cluster=system", nil,
+		)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: authserver.TenantSelectCookieName, Value: "other"})
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		requireCookie(t, resp, authserver.TenantSelectCookieName, "system")
+	})
+
+	t.Run("invalid cluster does not set tenant cookie", func(t *testing.T) {
+		resp, err := httpClient.Get(baseURL + "/health?cluster=doesnotexist")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		requireNoCookie(t, resp, authserver.TenantSelectCookieName)
 	})
 }

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
@@ -39,7 +39,11 @@ export default class TenantDropdown extends React.Component<
   onTenantChange(tenant: string) {
     if (tenant !== this.state.currentTenant) {
       setCookie(tenantIDKey, tenant);
-      location.reload();
+      // Update ?cluster= in the URL so the server-side cookie persistence
+      // (which reads ?cluster=) stays in sync with the dropdown selection.
+      const url = new URL(window.location.href);
+      url.searchParams.set("cluster", tenant);
+      window.location.href = url.toString();
     }
   }
 


### PR DESCRIPTION
Backport 1/1 commits from #168951.

/cc @cockroachdb/release

---

Previously, the ?cluster= query parameter only routed the initial page request to the correct tenant. The SPA's subsequent API calls (like fetch("uiconfig")) used relative URLs without ?cluster= and fell back to the default tenant. This caused the login page to show the wrong tenant's configuration — notably missing the OIDC button when OIDC was only enabled on a non-default tenant.

This also broke the OIDC login flow for non-default tenants: the IdP callback to /oidc/v1/callback carried no tenant routing signal since IdP redirects strip query parameters and headers. Without a tenant cookie, the callback routed to the default tenant where HMAC state validation failed.

Fix: httpMux now persists ?cluster= as the tenant select cookie after confirming the tenant exists via getServer(). The cookie survives the IdP redirect, fixing both the uiconfig routing and OIDC callback routing. The tenant dropdown is updated to sync ?cluster= in the URL when switching tenants to prevent stale URL params from overriding the cookie.

The existing TestOIDCEnabled is updated to find the oidc_secret cookie by name rather than assuming cookie index, since the tenant cookie may now precede it in the response.

Doc: https://docs.google.com/document/d/18iisJDa8_zp4tFvVO8qnFaTFrHhFRFOkSDmq6-6OF7k

Fixes: #166296
Epic: CRDB-54682

Release note (bug fix): Fixed a bug where the DB Console login page did not show the OIDC login button when navigating with ?cluster=<tenant> to a tenant with OIDC enabled. OIDC login on non-default virtual clusters now works correctly.

Release justification: OIDC login fails on non-default virtual clusters because the IdP callback loses tenant routing after redirect. Customer-impacting. Fix is confined to HTTP mux cookie persistence and test updates
