### PR TITLE
roachtest/perturbation: enforce 0.8x throughput floor

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/add_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/add_node.go
@@ -21,7 +21,7 @@ type addNode struct{}
 var _ perturbation = addNode{}
 
 func (a addNode) setup() variations {
-	return setup(a, noImpactThresholds())
+	return setup(a, defaultThresholds())
 }
 
 func (a addNode) setupMetamorphic(rng *rand.Rand) variations {

--- a/pkg/cmd/roachtest/tests/perturbation/backup.go
+++ b/pkg/cmd/roachtest/tests/perturbation/backup.go
@@ -25,7 +25,7 @@ type backup struct{}
 var _ perturbation = backup{}
 
 func (b backup) setup() variations {
-	return setup(b, noImpactThresholds())
+	return setup(b, defaultThresholds())
 }
 
 // TODO(baptist): Add variation for incremental backup.

--- a/pkg/cmd/roachtest/tests/perturbation/decommission.go
+++ b/pkg/cmd/roachtest/tests/perturbation/decommission.go
@@ -28,7 +28,7 @@ var _ perturbation = decommission{}
 
 func (d decommission) setup() variations {
 	d.drain = true
-	return setup(d, noImpactThresholds())
+	return setup(d, defaultThresholds())
 }
 
 func (d decommission) setupMetamorphic(rng *rand.Rand) variations {

--- a/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
@@ -30,7 +30,7 @@ var _ perturbation = elasticWorkload{}
 func (e elasticWorkload) setup() variations {
 	// TODO(#137835): Determine why the impact is so high and reduce this once
 	// it is addressed.
-	return setup(e, noImpactThresholds())
+	return setup(e, defaultThresholds())
 }
 
 func (e elasticWorkload) setupMetamorphic(rng *rand.Rand) variations {

--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -268,6 +268,19 @@ func noImpactThresholds() acceptableImpact {
 	}
 }
 
+// defaultThresholds returns the conservative pass/fail criteria applied to
+// production perturbation tests. Latency gates are disabled (p99 in particular
+// is too noisy with current sample sizes), but a throughput floor is enforced:
+// the test fails if measured throughput drops below 80% of baseline (i.e. the
+// throughput impact ratio exceeds 1.25).
+func defaultThresholds() acceptableImpact {
+	return acceptableImpact{
+		maxP99Impact:        math.Inf(1),
+		maxP50Impact:        math.Inf(1),
+		maxThroughputImpact: 1.25,
+	}
+}
+
 // aggregatedStat holds summary statistics for per-tick metrics over a
 // measurement interval. Used for display/logging and pass/fail validation.
 type aggregatedStat struct {

--- a/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
+++ b/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
@@ -29,7 +29,7 @@ var _ perturbation = backfill{}
 func (b backfill) setup() variations {
 	// TODO(#139262): Track down why this test causes stalls and drop the value
 	// to something more reasonable (like 5) once this is done.
-	v := setup(b, noImpactThresholds())
+	v := setup(b, defaultThresholds())
 	return v
 }
 

--- a/pkg/cmd/roachtest/tests/perturbation/intents.go
+++ b/pkg/cmd/roachtest/tests/perturbation/intents.go
@@ -29,7 +29,7 @@ const batchSize = 100
 
 func (i intents) setup() variations {
 	// Most of the slowdown happens during intent resolution.
-	return setup(i, noImpactThresholds())
+	return setup(i, defaultThresholds())
 }
 
 func (i intents) setupMetamorphic(rng *rand.Rand) variations {

--- a/pkg/cmd/roachtest/tests/perturbation/network_partition.go
+++ b/pkg/cmd/roachtest/tests/perturbation/network_partition.go
@@ -31,7 +31,7 @@ var _ perturbation = partition{}
 
 func (p partition) setup() variations {
 	p.partitionSite = true
-	v := setup(p, noImpactThresholds())
+	v := setup(p, defaultThresholds())
 	v.leaseType = registry.ExpirationLeases
 	// TODO(baptist): Remove this setting once #120073 is fixed.
 	v.clusterSettings["kv.lease.reject_on_leader_unknown.enabled"] = "true"

--- a/pkg/cmd/roachtest/tests/perturbation/restart_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/restart_node.go
@@ -25,7 +25,7 @@ var _ perturbation = restart{}
 
 func (r restart) setup() variations {
 	r.cleanRestart = true
-	v := setup(r, noImpactThresholds())
+	v := setup(r, defaultThresholds())
 
 	// TODO(baptist): Remove this setting once #120073 is fixed.
 	v.clusterSettings["kv.lease.reject_on_leader_unknown.enabled"] = "true"

--- a/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
+++ b/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
@@ -32,7 +32,7 @@ var _ perturbation = &slowDisk{}
 func (s *slowDisk) setup() variations {
 	s.slowLiveness = true
 	s.walFailover = true
-	return setup(s, noImpactThresholds())
+	return setup(s, defaultThresholds())
 }
 
 func (s *slowDisk) setupMetamorphic(rng *rand.Rand) variations {


### PR DESCRIPTION
## Summary

Apply a conservative pass/fail threshold to all production perturbation tests: fail if measured throughput drops below 80% of baseline (i.e. the throughput impact ratio exceeds 1.25). Latency gates remain disabled for now -- p99 in particular is too noisy at current sample sizes; we will revisit once we have more data.

The dev variants (`addDev`) continue to use `noImpactThresholds()` so local development is not gated on perf regressions.

### Why 0.8x?

Survey of recent runs on roachperf (3 active tests with new ratio metrics: backfill, backup, restart) shows `tput_ratio` consistently at the HDR quantization floor (~1.02 across all ops/phases). A 1.25 cutoff (= 0.8x throughput) leaves substantial headroom over observed values while still catching meaningful regressions.

### Why no latency gate?

Observed p99 ratios vary widely by test:
- backfill read/follower-read: 14-17x perturbation phase (normal, not regression)
- backup read: 3-7x
- restart: 0.1-1.7x (with `0.1` likely an artifact of low ops during downtime)

A single global p99 cutoff would either let backfill noise through or fire constantly. Per-test cutoffs need more samples to set responsibly.

Touches #168249.

Epic: none
Release note: None