### PR TITLE
ui: add V2 SQL Activity pages to DB Console

### DIFF
--- a/pkg/server/dbconsole/sql_activity.go
+++ b/pkg/server/dbconsole/sql_activity.go
@@ -1,0 +1,945 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package dbconsole
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
+
+// Query parameter keys, matching the conventions used in api_v2_constants.go.
+const (
+	sortByKey          = "sortBy"
+	sortOrderKey       = "sortOrder"
+	pageNumKey         = "pageNum"
+	pageSizeKey        = "pageSize"
+	searchKey          = "search"
+	appNameKey         = "appName"
+	databaseKey        = "database"
+	excludeInternalKey = "excludeInternal"
+
+	defaultPageSize = 20
+	defaultPageNum  = 1
+	maxPageSize     = 100
+)
+
+// PaginatedResponse wraps any result set with pagination metadata.
+// The JSON shape matches the PaginatedResponse used by the database
+// metadata endpoints in the server package.
+type PaginatedResponse[T any] struct {
+	Results        T              `json:"results"`
+	PaginationInfo paginationInfo `json:"pagination_info"`
+}
+
+type paginationInfo struct {
+	TotalResults int64 `json:"total_results"`
+	PageSize     int   `json:"page_size"`
+	PageNum      int   `json:"page_num"`
+}
+
+// StatementRow represents a single row of aggregated statement statistics.
+type StatementRow struct {
+	FingerprintID        string  `json:"fingerprint_id"`
+	ExecutionCount       int64   `json:"execution_count"`
+	SvcLatMean           float64 `json:"svc_lat_mean"`
+	SvcLatStdDev         float64 `json:"svc_lat_stddev"`
+	CPUSQLNanosMean      float64 `json:"cpu_sql_nanos_mean"`
+	CPUSQLNanosStdDev    float64 `json:"cpu_sql_nanos_stddev"`
+	ContentionTimeMean   float64 `json:"contention_time_mean"`
+	ContentionTimeStdDev float64 `json:"contention_time_stddev"`
+	KVCPUTimeNanosMean   float64 `json:"kv_cpu_time_nanos_mean"`
+	KVCPUTimeNanosStdDev float64 `json:"kv_cpu_time_nanos_stddev"`
+	AdmWaitTimeMean      float64 `json:"admission_wait_time_mean"`
+	AdmWaitTimeStdDev    float64 `json:"admission_wait_time_stddev"`
+	RowsReadMean         float64 `json:"rows_read_mean"`
+	RowsWrittenMean      float64 `json:"rows_written_mean"`
+	BytesReadMean        float64 `json:"bytes_read_mean"`
+	BytesReadStdDev      float64 `json:"bytes_read_stddev"`
+	MaxRetries           int64   `json:"max_retries"`
+	AppName              string  `json:"app_name"`
+	PctOfTotalRuntime    float64 `json:"pct_of_total_runtime"`
+	Query                string  `json:"query"`
+	QuerySummary         string  `json:"query_summary"`
+	Database             string  `json:"database"`
+}
+
+// TransactionRow represents a single row of aggregated transaction statistics.
+type TransactionRow struct {
+	FingerprintID        string   `json:"fingerprint_id"`
+	ExecutionCount       int64    `json:"execution_count"`
+	SvcLatMean           float64  `json:"svc_lat_mean"`
+	SvcLatStdDev         float64  `json:"svc_lat_stddev"`
+	CPUSQLNanosMean      float64  `json:"cpu_sql_nanos_mean"`
+	CPUSQLNanosStdDev    float64  `json:"cpu_sql_nanos_stddev"`
+	ContentionTimeMean   float64  `json:"contention_time_mean"`
+	ContentionTimeStdDev float64  `json:"contention_time_stddev"`
+	KVCPUTimeNanosMean   float64  `json:"kv_cpu_time_nanos_mean"`
+	KVCPUTimeNanosStdDev float64  `json:"kv_cpu_time_nanos_stddev"`
+	AdmWaitTimeMean      float64  `json:"admission_wait_time_mean"`
+	AdmWaitTimeStdDev    float64  `json:"admission_wait_time_stddev"`
+	RowsReadMean         float64  `json:"rows_read_mean"`
+	RowsWrittenMean      float64  `json:"rows_written_mean"`
+	BytesReadMean        float64  `json:"bytes_read_mean"`
+	BytesReadStdDev      float64  `json:"bytes_read_stddev"`
+	MaxRetries           int64    `json:"max_retries"`
+	CommitLatMean        float64  `json:"commit_lat_mean"`
+	CommitLatStdDev      float64  `json:"commit_lat_stddev"`
+	AppName              string   `json:"app_name"`
+	PctOfTotalRuntime    float64  `json:"pct_of_total_runtime"`
+	QuerySummaries       []string `json:"query_summaries"`
+}
+
+// stmtSortColumns maps API sort column names to SQL expressions for statements.
+var stmtSortColumns = map[string]string{
+	"execution_count":      "cnt",
+	"svc_lat_mean":         "svc_lat_mean",
+	"cpu_sql_nanos_mean":   "cpu_sql_nanos_mean",
+	"contention_time_mean": "contention_time_mean",
+	"kv_cpu_time_mean":     "kv_cpu_time_nanos_mean",
+	"adm_wait_time_mean":   "admission_wait_time_mean",
+	"pct_of_total_runtime": "pct_of_total_runtime",
+	"rows_read_mean":       "rows_read_mean",
+	"rows_written_mean":    "rows_written_mean",
+	"bytes_read_mean":      "bytes_read_mean",
+	"max_retries":          "max_retries",
+}
+
+// txnSortColumns maps API sort column names to SQL expressions for
+// transactions.
+var txnSortColumns = map[string]string{
+	"execution_count":      "cnt",
+	"svc_lat_mean":         "svc_lat_mean",
+	"cpu_sql_nanos_mean":   "cpu_sql_nanos_mean",
+	"contention_time_mean": "contention_time_mean",
+	"kv_cpu_time_mean":     "kv_cpu_time_nanos_mean",
+	"adm_wait_time_mean":   "admission_wait_time_mean",
+	"pct_of_total_runtime": "pct_of_total_runtime",
+	"rows_read_mean":       "rows_read_mean",
+	"rows_written_mean":    "rows_written_mean",
+	"bytes_read_mean":      "bytes_read_mean",
+	"max_retries":          "max_retries",
+	"commit_lat_mean":      "commit_lat_mean",
+}
+
+// validateSortOrderValue validates the sort order value and returns the
+// SQL sort order value and a boolean indicating if the value is valid.
+// If the value is empty, it defaults to "DESC".
+func validateSortOrderValue(sortOrder string) (string, bool) {
+	toUpper := strings.ToUpper(sortOrder)
+	switch toUpper {
+	case "":
+		return "DESC", true
+	case "ASC", "DESC":
+		return toUpper, true
+	default:
+		return "", false
+	}
+}
+
+// defaultTimeRange is the fallback time window used when clients omit the
+// start/end query parameters. Without a bound the queries would do a full
+// table scan of the statistics tables, which under write-heavy workloads
+// causes severe read-write contention and can hang the cluster.
+const defaultTimeRange = 1 * time.Hour
+
+// parseTimeRange extracts start and end timestamps from query params.
+// Both are expected as integer seconds since the Unix epoch. If neither
+// is provided, the range defaults to the last defaultTimeRange.
+func parseTimeRange(r *http.Request) (start, end time.Time, err error) {
+	if s := r.URL.Query().Get("start"); s != "" {
+		sec, parseErr := strconv.ParseInt(s, 10, 64)
+		if parseErr != nil {
+			return time.Time{}, time.Time{},
+				fmt.Errorf("invalid start time: expected seconds since epoch: %w", parseErr)
+		}
+		start = time.Unix(sec, 0).UTC()
+	}
+	if e := r.URL.Query().Get("end"); e != "" {
+		sec, parseErr := strconv.ParseInt(e, 10, 64)
+		if parseErr != nil {
+			return time.Time{}, time.Time{},
+				fmt.Errorf("invalid end time: expected seconds since epoch: %w", parseErr)
+		}
+		end = time.Unix(sec, 0).UTC()
+	}
+	// Default to the last hour when no time range is specified, to avoid
+	// unbounded full-table scans on hot statistics tables.
+	if start.IsZero() && end.IsZero() {
+		end = time.Now().UTC()
+		start = end.Add(-defaultTimeRange)
+	}
+	return start, end, nil
+}
+
+// safeStdDev computes sqrt(sumSq/count - mean^2), returning 0 if the value
+// would be negative (due to floating-point imprecision) or if count is 0.
+func safeStdDev(sumSq, count, mean float64) float64 {
+	if count == 0 {
+		return 0
+	}
+	variance := sumSq/count - mean*mean
+	if variance < 0 {
+		return 0
+	}
+	return math.Sqrt(variance)
+}
+
+// GetStatements returns paginated, sorted, aggregated statement statistics.
+//
+// Query Parameters:
+//   - start: seconds since Unix epoch for the beginning of the time range.
+//   - end: seconds since Unix epoch for the end of the time range.
+//   - pageSize: number of results per page (default 20, max 100).
+//   - pageNum: 1-based page number (default 1).
+//   - sortBy: column to sort by (default "svc_lat_mean").
+//   - sortOrder: "ASC" or "DESC" (default "DESC").
+//   - search: case-insensitive substring match against the statement
+//     fingerprint text.
+//   - appName: exact match on the application name.
+//   - database: exact match on the database name (from system.statements).
+//   - excludeInternal: when "false", include internal app names (default
+//     true, i.e. internal statements are excluded).
+//
+// @Summary Get aggregated statement statistics
+// @Description Returns paginated, sorted statement statistics aggregated by
+// @Description fingerprint and app_name for the given time range.
+// @Tags SQL Activity
+// @Produce json
+// @Param start query int false "Start time (seconds since epoch)"
+// @Param end query int false "End time (seconds since epoch)"
+// @Param pageSize query int false "Page size" default(20)
+// @Param pageNum query int false "Page number" default(1)
+// @Param sortBy query string false "Sort column" default(svc_lat_mean)
+// @Param sortOrder query string false "Sort order" default(DESC)
+// @Param search query string false "Search fingerprint text"
+// @Param appName query string false "Application name filter"
+// @Param database query string false "Database name filter"
+// @Param excludeInternal query string false "Exclude internal app names" default(true)
+// @Success 200 {object} PaginatedResponse[[]StatementRow]
+// @Failure 400 {object} ErrorResponse "Bad request"
+// @Failure 500 {object} ErrorResponse "Internal error"
+// @Security ApiKeyAuth
+// @Router /statements [get]
+func (api *ApiV2DBConsole) GetStatements(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	start, end, err := parseTimeRange(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	queryValues := r.URL.Query()
+	pageNum, err := apiutil.GetIntQueryStringVal(queryValues, pageNumKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", pageNumKey),
+			http.StatusBadRequest)
+		return
+	}
+	pageSize, err := apiutil.GetIntQueryStringVal(queryValues, pageSizeKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", pageSizeKey),
+			http.StatusBadRequest)
+		return
+	}
+
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	if pageNum <= 0 {
+		pageNum = defaultPageNum
+	}
+
+	offset := (pageNum - 1) * pageSize
+
+	sortByQs := queryValues.Get(sortByKey)
+	var sortBy string
+	if col, ok := stmtSortColumns[sortByQs]; ok {
+		sortBy = col
+	} else {
+		sortBy = "svc_lat_mean"
+	}
+
+	var sortOrder string
+	if sortByQs != "" {
+		sortOrder, _ = validateSortOrderValue(queryValues.Get(sortOrderKey))
+	} else {
+		sortOrder = "DESC"
+	}
+
+	search := queryValues.Get(searchKey)
+	appName := queryValues.Get(appNameKey)
+	database := queryValues.Get(databaseKey)
+	excludeInternal := queryValues.Get(excludeInternalKey) != "false"
+
+	// Build the count query. Two copies of queryFilters are needed because
+	// filter methods are stateful (they append to args and advance the
+	// placeholder index).
+	countFilters := newQueryFilters(start, end, search, appName, database, excludeInternal)
+	countTimeWhere := countFilters.timeWhereClause()
+	countAppFilter := countFilters.appNameFilter("ss")
+
+	countInternalFilter := countFilters.internalFilter("ss")
+
+	var countQuery string
+	if countFilters.hasJoinFilter() {
+		// When searching or filtering by database, join system.statements.
+		countSearchFilter := countFilters.searchFilter()
+		countDBFilter := countFilters.databaseFilter()
+		countQuery = fmt.Sprintf(`
+SELECT count(*) FROM (
+  SELECT ss.fingerprint_id
+  FROM system.statement_statistics ss
+  JOIN system.statements q ON q.fingerprint_id = ss.fingerprint_id
+  WHERE %s%s%s%s%s
+  GROUP BY ss.fingerprint_id, ss.app_name
+) sub
+AS OF SYSTEM TIME follower_read_timestamp()`, countTimeWhere, countInternalFilter, countAppFilter, countSearchFilter, countDBFilter)
+	} else {
+		countQuery = fmt.Sprintf(`
+SELECT count(*) FROM (
+  SELECT ss.fingerprint_id
+  FROM system.statement_statistics ss
+  WHERE %s%s%s
+  GROUP BY ss.fingerprint_id, ss.app_name
+) sub
+AS OF SYSTEM TIME follower_read_timestamp()`, countTimeWhere, countInternalFilter, countAppFilter)
+	}
+
+	// Build the data query with its own filter set.
+	dataFilters := newQueryFilters(start, end, search, appName, database, excludeInternal)
+	dataTimeWhere := dataFilters.timeWhereClause()
+	dataInternalFilter := dataFilters.internalFilter("ss")
+	dataAppFilter := dataFilters.appNameFilter("ss")
+	dataSearchFilter := dataFilters.searchFilter()
+	dataDBFilter := dataFilters.databaseFilter()
+
+	// Main data query. All aggregate columns come from the covering index
+	// (stmt_fp_ts_cov_counts) since they are STORED columns in that index,
+	// and the WHERE clause matches the partial index predicate.
+	// The JOIN with system.statements fetches query text and summary without
+	// touching the statistics JSONB column. When a search filter is active
+	// the LEFT JOIN effectively becomes an INNER JOIN via the WHERE clause.
+	dataQuery := fmt.Sprintf(`
+SELECT
+  encode(ss.fingerprint_id, 'hex') AS fingerprint_id,
+  SUM(ss.execution_count)::INT8 AS cnt,
+  SUM(ss.svc_lat_sum) / NULLIF(SUM(ss.execution_count::FLOAT8), 0)
+    AS svc_lat_mean,
+  SUM(ss.cpu_sql_nanos_sum) / NULLIF(SUM(ss.exec_sample_count::FLOAT8), 0)
+    AS cpu_sql_nanos_mean,
+  SUM(ss.contention_time_sum) / NULLIF(SUM(ss.exec_sample_count::FLOAT8), 0)
+    AS contention_time_mean,
+  SUM(ss.kv_cpu_time_nanos_sum) / NULLIF(SUM(ss.execution_count::FLOAT8), 0)
+    AS kv_cpu_time_nanos_mean,
+  SUM(ss.admission_wait_time_sum) / NULLIF(SUM(ss.exec_sample_count::FLOAT8), 0)
+    AS admission_wait_time_mean,
+  SUM(ss.svc_lat_sum_sq) AS svc_lat_sum_sq,
+  SUM(ss.cpu_sql_nanos_sum_sq) AS cpu_sql_nanos_sum_sq,
+  SUM(ss.contention_time_sum_sq) AS contention_time_sum_sq,
+  SUM(ss.kv_cpu_time_nanos_sum_sq) AS kv_cpu_time_nanos_sum_sq,
+  SUM(ss.admission_wait_time_sum_sq) AS admission_wait_time_sum_sq,
+  SUM(ss.execution_count::FLOAT8) AS total_exec_count,
+  SUM(ss.exec_sample_count::FLOAT8) AS total_sample_count,
+  SUM(ss.rows_read_sum) / NULLIF(SUM(ss.execution_count::FLOAT8), 0)
+    AS rows_read_mean,
+  SUM(ss.rows_written_sum) / NULLIF(SUM(ss.execution_count::FLOAT8), 0)
+    AS rows_written_mean,
+  SUM(ss.bytes_read_sum) / NULLIF(SUM(ss.execution_count::FLOAT8), 0)
+    AS bytes_read_mean,
+  SUM(ss.bytes_read_sum_sq) AS bytes_read_sum_sq,
+  MAX(ss.max_retries)::INT8 AS max_retries,
+  ss.app_name,
+  SUM(ss.svc_lat_sum) / NULLIF(SUM(SUM(ss.svc_lat_sum)) OVER (), 0)
+    AS pct_of_total_runtime,
+  COALESCE(q.fingerprint, '') AS query,
+  COALESCE(q.summary, '') AS query_summary,
+  COALESCE(q.db, '') AS database
+FROM system.statement_statistics ss
+LEFT JOIN system.statements q ON q.fingerprint_id = ss.fingerprint_id
+AS OF SYSTEM TIME follower_read_timestamp()
+WHERE %s%s%s%s%s
+GROUP BY ss.fingerprint_id, ss.app_name, q.fingerprint, q.summary, q.db
+ORDER BY %s %s
+LIMIT %d OFFSET %d`,
+		dataTimeWhere, dataInternalFilter, dataAppFilter, dataSearchFilter, dataDBFilter,
+		sortBy, sortOrder,
+		pageSize, offset)
+
+	ie := api.InternalDB.Executor()
+
+	// Execute count query.
+	countRow, err := ie.QueryRowEx(
+		ctx,
+		"dbconsole-stmt-stats-count",
+		nil, /* txn */
+		sessiondata.NodeUserSessionDataOverride,
+		countQuery, countFilters.args...,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+	var totalCount int64
+	if countRow != nil && len(countRow) > 0 {
+		totalCount = int64(tree.MustBeDInt(countRow[0]))
+	}
+
+	// Execute data query.
+	it, err := ie.QueryIteratorEx(
+		ctx,
+		"dbconsole-stmt-stats",
+		nil, /* txn */
+		sessiondata.NodeUserSessionDataOverride,
+		dataQuery, dataFilters.args...,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+	defer func() { _ = it.Close() }()
+
+	statements := make([]StatementRow, 0, pageSize)
+	for {
+		ok, err := it.Next(ctx)
+		if err != nil {
+			srverrors.APIV2InternalError(ctx, err, w)
+			return
+		}
+		if !ok {
+			break
+		}
+		row := it.Cur()
+		// Column indices match the SELECT order above.
+		fpID := string(tree.MustBeDString(row[0]))
+		cnt := int64(tree.MustBeDInt(row[1]))
+		svcLatMean := float64(tree.MustBeDFloat(row[2]))
+		cpuMean := float64(tree.MustBeDFloat(row[3]))
+		contentionMean := float64(tree.MustBeDFloat(row[4]))
+		kvCPUMean := float64(tree.MustBeDFloat(row[5]))
+		admWaitMean := float64(tree.MustBeDFloat(row[6]))
+		svcLatSumSq := float64(tree.MustBeDFloat(row[7]))
+		cpuSumSq := float64(tree.MustBeDFloat(row[8]))
+		contentionSumSq := float64(tree.MustBeDFloat(row[9]))
+		kvCPUSumSq := float64(tree.MustBeDFloat(row[10]))
+		admWaitSumSq := float64(tree.MustBeDFloat(row[11]))
+		totalExecCount := float64(tree.MustBeDFloat(row[12]))
+		totalSampleCount := float64(tree.MustBeDFloat(row[13]))
+		rowsReadMean := float64(tree.MustBeDFloat(row[14]))
+		rowsWrittenMean := float64(tree.MustBeDFloat(row[15]))
+		bytesReadMean := float64(tree.MustBeDFloat(row[16]))
+		bytesReadSumSq := float64(tree.MustBeDFloat(row[17]))
+		maxRetries := int64(tree.MustBeDInt(row[18]))
+		appName := string(tree.MustBeDString(row[19]))
+		pctRuntime := float64(tree.MustBeDFloat(row[20]))
+		query := string(tree.MustBeDString(row[21]))
+		querySummary := string(tree.MustBeDString(row[22]))
+		database := string(tree.MustBeDString(row[23]))
+
+		statements = append(statements, StatementRow{
+			FingerprintID:        fpID,
+			ExecutionCount:       cnt,
+			SvcLatMean:           svcLatMean,
+			SvcLatStdDev:         safeStdDev(svcLatSumSq, totalExecCount, svcLatMean),
+			CPUSQLNanosMean:      cpuMean,
+			CPUSQLNanosStdDev:    safeStdDev(cpuSumSq, totalSampleCount, cpuMean),
+			ContentionTimeMean:   contentionMean,
+			ContentionTimeStdDev: safeStdDev(contentionSumSq, totalSampleCount, contentionMean),
+			KVCPUTimeNanosMean:   kvCPUMean,
+			KVCPUTimeNanosStdDev: safeStdDev(kvCPUSumSq, totalExecCount, kvCPUMean),
+			AdmWaitTimeMean:      admWaitMean,
+			AdmWaitTimeStdDev:    safeStdDev(admWaitSumSq, totalSampleCount, admWaitMean),
+			RowsReadMean:         rowsReadMean,
+			RowsWrittenMean:      rowsWrittenMean,
+			BytesReadMean:        bytesReadMean,
+			BytesReadStdDev:      safeStdDev(bytesReadSumSq, totalExecCount, bytesReadMean),
+			MaxRetries:           maxRetries,
+			AppName:              appName,
+			PctOfTotalRuntime:    pctRuntime,
+			Query:                query,
+			QuerySummary:         querySummary,
+			Database:             database,
+		})
+	}
+
+	resp := PaginatedResponse[[]StatementRow]{
+		Results: statements,
+		PaginationInfo: paginationInfo{
+			TotalResults: totalCount,
+			PageSize:     pageSize,
+			PageNum:      pageNum,
+		},
+	}
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, resp)
+}
+
+// GetTransactions returns paginated, sorted, aggregated transaction statistics.
+//
+// Query Parameters:
+//   - start: seconds since Unix epoch for the beginning of the time range.
+//   - end: seconds since Unix epoch for the end of the time range.
+//   - pageSize: number of results per page (default 20, max 100).
+//   - pageNum: 1-based page number (default 1).
+//   - sortBy: column to sort by (default "svc_lat_mean").
+//   - sortOrder: "ASC" or "DESC" (default "DESC").
+//   - appName: exact match on the application name.
+//   - excludeInternal: when "false", include internal app names (default
+//     true, i.e. internal transactions are excluded).
+//
+// @Summary Get aggregated transaction statistics
+// @Description Returns paginated, sorted transaction statistics aggregated by
+// @Description fingerprint and app_name for the given time range.
+// @Tags SQL Activity
+// @Produce json
+// @Param start query int false "Start time (seconds since epoch)"
+// @Param end query int false "End time (seconds since epoch)"
+// @Param pageSize query int false "Page size" default(20)
+// @Param pageNum query int false "Page number" default(1)
+// @Param sortBy query string false "Sort column" default(svc_lat_mean)
+// @Param sortOrder query string false "Sort order" default(DESC)
+// @Param appName query string false "Application name filter"
+// @Param excludeInternal query string false "Exclude internal app names" default(true)
+// @Success 200 {object} PaginatedResponse[[]TransactionRow]
+// @Failure 400 {object} ErrorResponse "Bad request"
+// @Failure 500 {object} ErrorResponse "Internal error"
+// @Security ApiKeyAuth
+// @Router /transactions [get]
+func (api *ApiV2DBConsole) GetTransactions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	start, end, err := parseTimeRange(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	queryValues := r.URL.Query()
+	pageNum, err := apiutil.GetIntQueryStringVal(queryValues, pageNumKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", pageNumKey),
+			http.StatusBadRequest)
+		return
+	}
+	pageSize, err := apiutil.GetIntQueryStringVal(queryValues, pageSizeKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", pageSizeKey),
+			http.StatusBadRequest)
+		return
+	}
+
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	if pageNum <= 0 {
+		pageNum = defaultPageNum
+	}
+
+	offset := (pageNum - 1) * pageSize
+
+	sortByQs := queryValues.Get(sortByKey)
+	var sortBy string
+	if col, ok := txnSortColumns[sortByQs]; ok {
+		sortBy = col
+	} else {
+		sortBy = "svc_lat_mean"
+	}
+
+	var sortOrder string
+	if sortByQs != "" {
+		sortOrder, _ = validateSortOrderValue(queryValues.Get(sortOrderKey))
+	} else {
+		sortOrder = "DESC"
+	}
+
+	appName := queryValues.Get(appNameKey)
+	excludeInternal := queryValues.Get(excludeInternalKey) != "false"
+
+	countFilters := newQueryFilters(start, end, "", appName, "" /* database */, excludeInternal)
+	whereClause := countFilters.timeWhereClause()
+	countInternalFilter := countFilters.internalFilter("ts")
+	countAppFilter := countFilters.appNameFilter("ts")
+
+	countQuery := fmt.Sprintf(`
+SELECT count(*) FROM (
+  SELECT ts.fingerprint_id
+  FROM system.transaction_statistics ts
+  WHERE %s%s%s
+  GROUP BY ts.fingerprint_id, ts.app_name
+) sub
+AS OF SYSTEM TIME follower_read_timestamp()`, whereClause, countInternalFilter, countAppFilter)
+
+	// Need a separate filter set for the data query since filter methods
+	// are stateful.
+	dataFilters := newQueryFilters(start, end, "", appName, "" /* database */, excludeInternal)
+	dataWhereClause := dataFilters.timeWhereClause()
+	dataInternalFilter := dataFilters.internalFilter("ts")
+	dataAppFilter := dataFilters.appNameFilter("ts")
+
+	dataQuery := fmt.Sprintf(`
+SELECT
+  encode(ts.fingerprint_id, 'hex') AS fingerprint_id,
+  SUM(ts.execution_count)::INT8 AS cnt,
+  SUM(ts.svc_lat_sum) / NULLIF(SUM(ts.execution_count::FLOAT8), 0)
+    AS svc_lat_mean,
+  SUM(ts.cpu_sql_nanos_sum) / NULLIF(SUM(ts.exec_sample_count::FLOAT8), 0)
+    AS cpu_sql_nanos_mean,
+  SUM(ts.contention_time_sum) / NULLIF(SUM(ts.exec_sample_count::FLOAT8), 0)
+    AS contention_time_mean,
+  SUM(ts.kv_cpu_time_nanos_sum) / NULLIF(SUM(ts.execution_count::FLOAT8), 0)
+    AS kv_cpu_time_nanos_mean,
+  SUM(ts.admission_wait_time_sum) / NULLIF(SUM(ts.exec_sample_count::FLOAT8), 0)
+    AS admission_wait_time_mean,
+  SUM(ts.svc_lat_sum_sq) AS svc_lat_sum_sq,
+  SUM(ts.cpu_sql_nanos_sum_sq) AS cpu_sql_nanos_sum_sq,
+  SUM(ts.contention_time_sum_sq) AS contention_time_sum_sq,
+  SUM(ts.kv_cpu_time_nanos_sum_sq) AS kv_cpu_time_nanos_sum_sq,
+  SUM(ts.admission_wait_time_sum_sq) AS admission_wait_time_sum_sq,
+  SUM(ts.execution_count::FLOAT8) AS total_exec_count,
+  SUM(ts.exec_sample_count::FLOAT8) AS total_sample_count,
+  SUM(ts.rows_read_sum) / NULLIF(SUM(ts.execution_count::FLOAT8), 0)
+    AS rows_read_mean,
+  SUM(ts.rows_written_sum) / NULLIF(SUM(ts.execution_count::FLOAT8), 0)
+    AS rows_written_mean,
+  SUM(ts.bytes_read_sum) / NULLIF(SUM(ts.execution_count::FLOAT8), 0)
+    AS bytes_read_mean,
+  SUM(ts.bytes_read_sum_sq) AS bytes_read_sum_sq,
+  MAX(ts.max_retries)::INT8 AS max_retries,
+  SUM(ts.commit_lat_sum) / NULLIF(SUM(ts.execution_count::FLOAT8), 0)
+    AS commit_lat_mean,
+  SUM(ts.commit_lat_sum_sq) AS commit_lat_sum_sq,
+  ts.app_name,
+  SUM(ts.svc_lat_sum) / NULLIF(SUM(SUM(ts.svc_lat_sum)) OVER (), 0)
+    AS pct_of_total_runtime
+FROM system.transaction_statistics ts
+  AS OF SYSTEM TIME follower_read_timestamp()
+WHERE %s%s%s
+GROUP BY ts.fingerprint_id, ts.app_name
+ORDER BY %s %s
+LIMIT %d OFFSET %d`,
+		dataWhereClause, dataInternalFilter, dataAppFilter,
+		sortBy, sortOrder,
+		pageSize, offset)
+
+	ie := api.InternalDB.Executor()
+
+	countRow, err := ie.QueryRowEx(
+		ctx,
+		"dbconsole-txn-stats-count",
+		nil, /* txn */
+		sessiondata.NodeUserSessionDataOverride,
+		countQuery, countFilters.args...,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+	var totalCount int64
+	if countRow != nil && len(countRow) > 0 {
+		totalCount = int64(tree.MustBeDInt(countRow[0]))
+	}
+
+	it, err := ie.QueryIteratorEx(
+		ctx,
+		"dbconsole-txn-stats",
+		nil, /* txn */
+		sessiondata.NodeUserSessionDataOverride,
+		dataQuery, dataFilters.args...,
+	)
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+	defer func() { _ = it.Close() }()
+
+	transactions := make([]TransactionRow, 0, pageSize)
+	for {
+		ok, err := it.Next(ctx)
+		if err != nil {
+			srverrors.APIV2InternalError(ctx, err, w)
+			return
+		}
+		if !ok {
+			break
+		}
+		row := it.Cur()
+		fpID := string(tree.MustBeDString(row[0]))
+		cnt := int64(tree.MustBeDInt(row[1]))
+		svcLatMean := float64(tree.MustBeDFloat(row[2]))
+		cpuMean := float64(tree.MustBeDFloat(row[3]))
+		contentionMean := float64(tree.MustBeDFloat(row[4]))
+		kvCPUMean := float64(tree.MustBeDFloat(row[5]))
+		admWaitMean := float64(tree.MustBeDFloat(row[6]))
+		svcLatSumSq := float64(tree.MustBeDFloat(row[7]))
+		cpuSumSq := float64(tree.MustBeDFloat(row[8]))
+		contentionSumSq := float64(tree.MustBeDFloat(row[9]))
+		kvCPUSumSq := float64(tree.MustBeDFloat(row[10]))
+		admWaitSumSq := float64(tree.MustBeDFloat(row[11]))
+		totalExecCount := float64(tree.MustBeDFloat(row[12]))
+		totalSampleCount := float64(tree.MustBeDFloat(row[13]))
+		rowsReadMean := float64(tree.MustBeDFloat(row[14]))
+		rowsWrittenMean := float64(tree.MustBeDFloat(row[15]))
+		bytesReadMean := float64(tree.MustBeDFloat(row[16]))
+		bytesReadSumSq := float64(tree.MustBeDFloat(row[17]))
+		maxRetries := int64(tree.MustBeDInt(row[18]))
+		commitLatMean := float64(tree.MustBeDFloat(row[19]))
+		commitLatSumSq := float64(tree.MustBeDFloat(row[20]))
+		appName := string(tree.MustBeDString(row[21]))
+		pctRuntime := float64(tree.MustBeDFloat(row[22]))
+
+		transactions = append(transactions, TransactionRow{
+			FingerprintID:        fpID,
+			ExecutionCount:       cnt,
+			SvcLatMean:           svcLatMean,
+			SvcLatStdDev:         safeStdDev(svcLatSumSq, totalExecCount, svcLatMean),
+			CPUSQLNanosMean:      cpuMean,
+			CPUSQLNanosStdDev:    safeStdDev(cpuSumSq, totalSampleCount, cpuMean),
+			ContentionTimeMean:   contentionMean,
+			ContentionTimeStdDev: safeStdDev(contentionSumSq, totalSampleCount, contentionMean),
+			KVCPUTimeNanosMean:   kvCPUMean,
+			KVCPUTimeNanosStdDev: safeStdDev(kvCPUSumSq, totalExecCount, kvCPUMean),
+			AdmWaitTimeMean:      admWaitMean,
+			AdmWaitTimeStdDev:    safeStdDev(admWaitSumSq, totalSampleCount, admWaitMean),
+			RowsReadMean:         rowsReadMean,
+			RowsWrittenMean:      rowsWrittenMean,
+			BytesReadMean:        bytesReadMean,
+			BytesReadStdDev:      safeStdDev(bytesReadSumSq, totalExecCount, bytesReadMean),
+			MaxRetries:           maxRetries,
+			CommitLatMean:        commitLatMean,
+			CommitLatStdDev:      safeStdDev(commitLatSumSq, totalExecCount, commitLatMean),
+			AppName:              appName,
+			PctOfTotalRuntime:    pctRuntime,
+		})
+	}
+
+	// Fetch statement query summaries for each transaction in the page.
+	// This is a separate query to avoid degrading the covering index
+	// performance of the main aggregation (metadata is not in the covering
+	// index). We look up one arbitrary row per transaction fingerprint_id
+	// to get the stmtFingerprintIDs from metadata, unnest them, and join
+	// to system.statements.
+	if len(transactions) > 0 {
+		txnFPIDs := make([]string, len(transactions))
+		txnIndexByFPID := make(map[string][]int, len(transactions))
+		for i, txn := range transactions {
+			txnFPIDs[i] = txn.FingerprintID
+			txnIndexByFPID[txn.FingerprintID] = append(
+				txnIndexByFPID[txn.FingerprintID], i,
+			)
+		}
+
+		// Build a VALUES list of decoded transaction fingerprint IDs for the
+		// batch lookup. Each txnFPID is a hex string from our own query output,
+		// so it is safe to interpolate via decode().
+		var valuesBuilder strings.Builder
+		for i, fpID := range txnFPIDs {
+			if i > 0 {
+				valuesBuilder.WriteString(", ")
+			}
+			fmt.Fprintf(&valuesBuilder, "(decode('%s', 'hex'))", fpID)
+		}
+
+		// For each transaction fingerprint, pick one row to get the metadata
+		// JSONB, unnest stmtFingerprintIDs, and join system.statements to get
+		// the query summaries.
+		var summInternalFilter string
+		if excludeInternal {
+			summInternalFilter = "\n    AND ts.app_name NOT LIKE '$ internal%%'"
+		}
+		summaryQuery := fmt.Sprintf(`
+SELECT
+  encode(sub.txn_fp, 'hex') AS txn_fingerprint_id,
+  array_agg(DISTINCT q.summary) AS query_summaries
+FROM (
+  SELECT
+    ts.fingerprint_id AS txn_fp,
+    jsonb_array_elements_text(ts.metadata->'stmtFingerprintIDs')
+      AS stmt_fp_hex
+  FROM system.transaction_statistics ts
+  AS OF SYSTEM TIME follower_read_timestamp()
+  WHERE ts.fingerprint_id IN (SELECT column1 FROM (VALUES %s) AS v)%s
+  GROUP BY ts.fingerprint_id, ts.metadata->'stmtFingerprintIDs'
+) sub
+JOIN system.statements q
+  ON q.fingerprint_id = decode(sub.stmt_fp_hex, 'hex')
+GROUP BY sub.txn_fp`, valuesBuilder.String(), summInternalFilter)
+
+		summIt, summErr := ie.QueryIteratorEx(
+			ctx,
+			"dbconsole-txn-stmt-summaries",
+			nil, /* txn */
+			sessiondata.NodeUserSessionDataOverride,
+			summaryQuery,
+		)
+		if summErr != nil {
+			srverrors.APIV2InternalError(ctx, summErr, w)
+			return
+		}
+		defer func() { _ = summIt.Close() }()
+
+		for {
+			ok, err := summIt.Next(ctx)
+			if err != nil {
+				srverrors.APIV2InternalError(ctx, err, w)
+				return
+			}
+			if !ok {
+				break
+			}
+			summRow := summIt.Cur()
+			txnFPID := string(tree.MustBeDString(summRow[0]))
+			summariesArr := tree.MustBeDArray(summRow[1])
+			summaries := make([]string, 0, summariesArr.Len())
+			for _, d := range summariesArr.Array {
+				if d != tree.DNull {
+					summaries = append(summaries, string(tree.MustBeDString(d)))
+				}
+			}
+			if indices, ok := txnIndexByFPID[txnFPID]; ok {
+				for _, idx := range indices {
+					transactions[idx].QuerySummaries = summaries
+				}
+			}
+		}
+	}
+
+	resp := PaginatedResponse[[]TransactionRow]{
+		Results: transactions,
+		PaginationInfo: paginationInfo{
+			TotalResults: totalCount,
+			PageSize:     pageSize,
+			PageNum:      pageNum,
+		},
+	}
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, resp)
+}
+
+// queryFilters holds the parameterized filter state for building SQL queries.
+// It tracks placeholder indices so that time range and search filters can
+// share a single args slice.
+type queryFilters struct {
+	conditions      []string
+	args            []interface{}
+	nextArgIdx      int
+	search          string
+	appName         string
+	database        string
+	excludeInternal bool
+}
+
+// newQueryFilters builds filters from the provided time range and optional
+// search, app name, database, and internal-exclusion values.
+func newQueryFilters(
+	start, end time.Time, search, appName, database string, excludeInternal bool,
+) queryFilters {
+	qf := queryFilters{
+		nextArgIdx:      1,
+		search:          search,
+		appName:         appName,
+		database:        database,
+		excludeInternal: excludeInternal,
+	}
+
+	if !start.IsZero() {
+		qf.conditions = append(qf.conditions,
+			fmt.Sprintf("aggregated_ts >= $%d", qf.nextArgIdx))
+		qf.args = append(qf.args, start)
+		qf.nextArgIdx++
+	}
+	if !end.IsZero() {
+		qf.conditions = append(qf.conditions,
+			fmt.Sprintf("aggregated_ts < $%d", qf.nextArgIdx))
+		qf.args = append(qf.args, end)
+		qf.nextArgIdx++
+	}
+
+	return qf
+}
+
+// timeWhereClause returns the time-range portion of a WHERE clause.
+// If no time filters exist it returns "true".
+func (qf *queryFilters) timeWhereClause() string {
+	if len(qf.conditions) == 0 {
+		return "true"
+	}
+	return strings.Join(qf.conditions, " AND ")
+}
+
+// internalFilter returns a SQL fragment that excludes internal app names
+// when excludeInternal is true. The alias is the table alias (e.g. "ss"
+// or "ts"). Returns empty string when internal statements should be
+// included.
+func (qf *queryFilters) internalFilter(alias string) string {
+	if !qf.excludeInternal {
+		return ""
+	}
+	return fmt.Sprintf(" AND %s.app_name NOT LIKE '$ internal%%%%'", alias)
+}
+
+// searchFilter returns a parameterized ILIKE condition for the search term
+// (e.g. "AND q.fingerprint ILIKE $3") and appends the wrapped search value
+// to the args slice. Returns empty string if no search is active.
+func (qf *queryFilters) searchFilter() string {
+	if qf.search == "" {
+		return ""
+	}
+	clause := fmt.Sprintf(" AND q.fingerprint ILIKE $%d", qf.nextArgIdx)
+	qf.args = append(qf.args, fmt.Sprintf("%%%s%%", qf.search))
+	qf.nextArgIdx++
+	return clause
+}
+
+// hasSearch reports whether a search filter is active.
+func (qf *queryFilters) hasSearch() bool {
+	return qf.search != ""
+}
+
+// appNameFilter returns a parameterized equality condition for app_name
+// (e.g. " AND ss.app_name = $3") using the given table alias, and appends
+// the value to the args slice. Returns empty string if no app name filter
+// is active.
+func (qf *queryFilters) appNameFilter(alias string) string {
+	if qf.appName == "" {
+		return ""
+	}
+	clause := fmt.Sprintf(" AND %s.app_name = $%d", alias, qf.nextArgIdx)
+	qf.args = append(qf.args, qf.appName)
+	qf.nextArgIdx++
+	return clause
+}
+
+// databaseFilter returns a parameterized equality condition for the database
+// column on system.statements (e.g. " AND q.db = $4") and appends the value
+// to the args slice. Returns empty string if no database filter is active.
+func (qf *queryFilters) databaseFilter() string {
+	if qf.database == "" {
+		return ""
+	}
+	clause := fmt.Sprintf(" AND q.db = $%d", qf.nextArgIdx)
+	qf.args = append(qf.args, qf.database)
+	qf.nextArgIdx++
+	return clause
+}
+
+// hasJoinFilter reports whether any filter requires a JOIN to
+// system.statements (search or database).
+func (qf *queryFilters) hasJoinFilter() bool {
+	return qf.search != "" || qf.database != ""
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -33,3 +33,4 @@ export * from "./clusterSettingsApi";
 export * from "./dataDistributionApi";
 export * from "./liveWorkloadApi";
 export * from "./sessionsApi";
+export * from "./sqlActivityApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlActivityApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlActivityApi.ts
@@ -1,0 +1,351 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { fetchDataJSON } from "src/api/fetchData";
+
+import { useSwrWithClusterId } from "../util";
+
+import { PaginationRequest, ResultsWithPagination } from "./types";
+
+// ---------------------------------------------------------------------------
+// API paths
+// ---------------------------------------------------------------------------
+const STATEMENTS_API = "api/v2/dbconsole/statements/";
+const TRANSACTIONS_API = "api/v2/dbconsole/transactions/";
+
+// ---------------------------------------------------------------------------
+// Server response types (snake_case, matching Go JSON tags)
+// ---------------------------------------------------------------------------
+type PaginationInfoServer = {
+  total_results: number;
+  page_size: number;
+  page_num: number;
+};
+
+type StatementRowServer = {
+  fingerprint_id: string;
+  execution_count: number;
+  svc_lat_mean: number;
+  svc_lat_stddev: number;
+  cpu_sql_nanos_mean: number;
+  cpu_sql_nanos_stddev: number;
+  contention_time_mean: number;
+  contention_time_stddev: number;
+  kv_cpu_time_nanos_mean: number;
+  kv_cpu_time_nanos_stddev: number;
+  admission_wait_time_mean: number;
+  admission_wait_time_stddev: number;
+  rows_read_mean: number;
+  rows_written_mean: number;
+  bytes_read_mean: number;
+  bytes_read_stddev: number;
+  max_retries: number;
+  app_name: string;
+  pct_of_total_runtime: number;
+  query: string;
+  query_summary: string;
+  database: string;
+};
+
+type TransactionRowServer = {
+  fingerprint_id: string;
+  execution_count: number;
+  svc_lat_mean: number;
+  svc_lat_stddev: number;
+  cpu_sql_nanos_mean: number;
+  cpu_sql_nanos_stddev: number;
+  contention_time_mean: number;
+  contention_time_stddev: number;
+  kv_cpu_time_nanos_mean: number;
+  kv_cpu_time_nanos_stddev: number;
+  admission_wait_time_mean: number;
+  admission_wait_time_stddev: number;
+  rows_read_mean: number;
+  rows_written_mean: number;
+  bytes_read_mean: number;
+  bytes_read_stddev: number;
+  max_retries: number;
+  commit_lat_mean: number;
+  commit_lat_stddev: number;
+  app_name: string;
+  pct_of_total_runtime: number;
+  query_summaries: string[];
+};
+
+type StatementsResponseServer = {
+  results: StatementRowServer[];
+  pagination_info: PaginationInfoServer;
+};
+
+type TransactionsResponseServer = {
+  results: TransactionRowServer[];
+  pagination_info: PaginationInfoServer;
+};
+
+// ---------------------------------------------------------------------------
+// Client types (camelCase)
+// ---------------------------------------------------------------------------
+export type StatementRow = {
+  fingerprintId: string;
+  executionCount: number;
+  svcLatMean: number;
+  svcLatStddev: number;
+  cpuSqlNanosMean: number;
+  cpuSqlNanosStddev: number;
+  contentionTimeMean: number;
+  contentionTimeStddev: number;
+  kvCpuTimeNanosMean: number;
+  kvCpuTimeNanosStddev: number;
+  admissionWaitTimeMean: number;
+  admissionWaitTimeStddev: number;
+  rowsReadMean: number;
+  rowsWrittenMean: number;
+  bytesReadMean: number;
+  bytesReadStddev: number;
+  maxRetries: number;
+  appName: string;
+  pctOfTotalRuntime: number;
+  query: string;
+  querySummary: string;
+  database: string;
+  key: string;
+};
+
+export type TransactionRow = {
+  fingerprintId: string;
+  executionCount: number;
+  svcLatMean: number;
+  svcLatStddev: number;
+  cpuSqlNanosMean: number;
+  cpuSqlNanosStddev: number;
+  contentionTimeMean: number;
+  contentionTimeStddev: number;
+  kvCpuTimeNanosMean: number;
+  kvCpuTimeNanosStddev: number;
+  admissionWaitTimeMean: number;
+  admissionWaitTimeStddev: number;
+  rowsReadMean: number;
+  rowsWrittenMean: number;
+  bytesReadMean: number;
+  bytesReadStddev: number;
+  maxRetries: number;
+  commitLatMean: number;
+  commitLatStddev: number;
+  appName: string;
+  pctOfTotalRuntime: number;
+  querySummaries: string[];
+  key: string;
+};
+
+// ---------------------------------------------------------------------------
+// Sort options (matching Go backend)
+// ---------------------------------------------------------------------------
+export enum StatementSortOptions {
+  EXECUTION_COUNT = "execution_count",
+  SVC_LAT_MEAN = "svc_lat_mean",
+  CPU_SQL_NANOS_MEAN = "cpu_sql_nanos_mean",
+  CONTENTION_TIME_MEAN = "contention_time_mean",
+  KV_CPU_TIME_MEAN = "kv_cpu_time_mean",
+  ADM_WAIT_TIME_MEAN = "adm_wait_time_mean",
+  PCT_OF_TOTAL_RUNTIME = "pct_of_total_runtime",
+  ROWS_READ_MEAN = "rows_read_mean",
+  ROWS_WRITTEN_MEAN = "rows_written_mean",
+  BYTES_READ_MEAN = "bytes_read_mean",
+  MAX_RETRIES = "max_retries",
+}
+
+export enum TransactionSortOptions {
+  EXECUTION_COUNT = "execution_count",
+  SVC_LAT_MEAN = "svc_lat_mean",
+  CPU_SQL_NANOS_MEAN = "cpu_sql_nanos_mean",
+  CONTENTION_TIME_MEAN = "contention_time_mean",
+  KV_CPU_TIME_MEAN = "kv_cpu_time_mean",
+  ADM_WAIT_TIME_MEAN = "adm_wait_time_mean",
+  PCT_OF_TOTAL_RUNTIME = "pct_of_total_runtime",
+  ROWS_READ_MEAN = "rows_read_mean",
+  ROWS_WRITTEN_MEAN = "rows_written_mean",
+  BYTES_READ_MEAN = "bytes_read_mean",
+  MAX_RETRIES = "max_retries",
+  COMMIT_LAT_MEAN = "commit_lat_mean",
+}
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+export type SqlActivityStatementsRequest = {
+  start?: number; // seconds since Unix epoch
+  end?: number; // seconds since Unix epoch
+  pagination: PaginationRequest;
+  sortBy?: string;
+  sortOrder?: string;
+  search?: string;
+  appName?: string;
+  database?: string;
+  excludeInternal?: boolean;
+};
+
+export type TransactionsRequest = {
+  start?: number; // seconds since Unix epoch
+  end?: number; // seconds since Unix epoch
+  pagination: PaginationRequest;
+  sortBy?: string;
+  sortOrder?: string;
+  appName?: string;
+  excludeInternal?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Converters
+// ---------------------------------------------------------------------------
+const convertStatementRow = (s: StatementRowServer): StatementRow => ({
+  fingerprintId: s.fingerprint_id,
+  executionCount: s.execution_count,
+  svcLatMean: s.svc_lat_mean,
+  svcLatStddev: s.svc_lat_stddev,
+  cpuSqlNanosMean: s.cpu_sql_nanos_mean,
+  cpuSqlNanosStddev: s.cpu_sql_nanos_stddev,
+  contentionTimeMean: s.contention_time_mean,
+  contentionTimeStddev: s.contention_time_stddev,
+  kvCpuTimeNanosMean: s.kv_cpu_time_nanos_mean,
+  kvCpuTimeNanosStddev: s.kv_cpu_time_nanos_stddev,
+  admissionWaitTimeMean: s.admission_wait_time_mean,
+  admissionWaitTimeStddev: s.admission_wait_time_stddev,
+  rowsReadMean: s.rows_read_mean,
+  rowsWrittenMean: s.rows_written_mean,
+  bytesReadMean: s.bytes_read_mean,
+  bytesReadStddev: s.bytes_read_stddev,
+  maxRetries: s.max_retries,
+  appName: s.app_name,
+  pctOfTotalRuntime: s.pct_of_total_runtime,
+  query: s.query,
+  querySummary: s.query_summary,
+  database: s.database,
+  key: `${s.fingerprint_id}-${s.app_name}`,
+});
+
+const convertTransactionRow = (t: TransactionRowServer): TransactionRow => ({
+  fingerprintId: t.fingerprint_id,
+  executionCount: t.execution_count,
+  svcLatMean: t.svc_lat_mean,
+  svcLatStddev: t.svc_lat_stddev,
+  cpuSqlNanosMean: t.cpu_sql_nanos_mean,
+  cpuSqlNanosStddev: t.cpu_sql_nanos_stddev,
+  contentionTimeMean: t.contention_time_mean,
+  contentionTimeStddev: t.contention_time_stddev,
+  kvCpuTimeNanosMean: t.kv_cpu_time_nanos_mean,
+  kvCpuTimeNanosStddev: t.kv_cpu_time_nanos_stddev,
+  admissionWaitTimeMean: t.admission_wait_time_mean,
+  admissionWaitTimeStddev: t.admission_wait_time_stddev,
+  rowsReadMean: t.rows_read_mean,
+  rowsWrittenMean: t.rows_written_mean,
+  bytesReadMean: t.bytes_read_mean,
+  bytesReadStddev: t.bytes_read_stddev,
+  maxRetries: t.max_retries,
+  commitLatMean: t.commit_lat_mean,
+  commitLatStddev: t.commit_lat_stddev,
+  appName: t.app_name,
+  pctOfTotalRuntime: t.pct_of_total_runtime,
+  querySummaries: t.query_summaries ?? [],
+  key: `${t.fingerprint_id}-${t.app_name}`,
+});
+
+const convertPagination = (p: PaginationInfoServer) => ({
+  pageNum: p?.page_num ?? 0,
+  pageSize: p?.page_size ?? 0,
+  totalResults: p?.total_results ?? 0,
+});
+
+// ---------------------------------------------------------------------------
+// Fetch functions
+// ---------------------------------------------------------------------------
+const buildURLParams = (
+  req: SqlActivityStatementsRequest | TransactionsRequest,
+): string => {
+  const p = new URLSearchParams();
+  if (req.start) p.append("start", req.start.toString());
+  if (req.end) p.append("end", req.end.toString());
+  if (req.pagination.pageSize)
+    p.append("pageSize", req.pagination.pageSize.toString());
+  if (req.pagination.pageNum)
+    p.append("pageNum", req.pagination.pageNum.toString());
+  if (req.sortBy) p.append("sortBy", req.sortBy);
+  if (req.sortOrder) p.append("sortOrder", req.sortOrder);
+  if ("appName" in req && req.appName) p.append("appName", req.appName);
+  if ("search" in req && req.search) p.append("search", req.search);
+  if ("database" in req && req.database) p.append("database", req.database);
+  if (req.excludeInternal === false) p.append("excludeInternal", "false");
+  return p.toString();
+};
+
+export const getStatements = async (
+  req: SqlActivityStatementsRequest,
+): Promise<ResultsWithPagination<StatementRow[]>> => {
+  const resp = await fetchDataJSON<StatementsResponseServer, null>(
+    STATEMENTS_API + "?" + buildURLParams(req),
+  );
+  return {
+    results: resp.results?.map(convertStatementRow) ?? [],
+    pagination: convertPagination(resp.pagination_info),
+  };
+};
+
+export const getTransactions = async (
+  req: TransactionsRequest,
+): Promise<ResultsWithPagination<TransactionRow[]>> => {
+  const resp = await fetchDataJSON<TransactionsResponseServer, null>(
+    TRANSACTIONS_API + "?" + buildURLParams(req),
+  );
+  return {
+    results: resp.results?.map(convertTransactionRow) ?? [],
+    pagination: convertPagination(resp.pagination_info),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// SWR hooks
+// ---------------------------------------------------------------------------
+const createStatementsKey = (req: SqlActivityStatementsRequest) => ({
+  name: "sqlActivityStatements",
+  start: req.start,
+  end: req.end,
+  sortBy: req.sortBy,
+  sortOrder: req.sortOrder,
+  search: req.search,
+  appName: req.appName,
+  database: req.database,
+  excludeInternal: req.excludeInternal,
+  pageSize: req.pagination.pageSize,
+  pageNum: req.pagination.pageNum,
+});
+
+export const useSqlActivityStatements = (req: SqlActivityStatementsRequest) => {
+  const { data, error, isLoading, mutate } = useSwrWithClusterId(
+    createStatementsKey(req),
+    () => getStatements(req),
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+  return { data, error, isLoading, refresh: mutate };
+};
+
+const createTransactionsKey = (req: TransactionsRequest) => ({
+  name: "sqlActivityTransactions",
+  start: req.start,
+  end: req.end,
+  sortBy: req.sortBy,
+  sortOrder: req.sortOrder,
+  appName: req.appName,
+  excludeInternal: req.excludeInternal,
+  pageSize: req.pagination.pageSize,
+  pageNum: req.pagination.pageNum,
+});
+
+export const useSqlActivityTransactions = (req: TransactionsRequest) => {
+  const { data, error, isLoading, mutate } = useSwrWithClusterId(
+    createTransactionsKey(req),
+    () => getTransactions(req),
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+  return { data, error, isLoading, refresh: mutate };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/pages/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/index.ts
@@ -4,3 +4,4 @@
 // included in the /LICENSE file.
 
 export * from "./databases";
+export * from "./sqlActivity";

--- a/pkg/ui/workspaces/cluster-ui/src/pages/sqlActivity/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/sqlActivity/index.ts
@@ -1,0 +1,7 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+export * from "./statementsPageV2";
+export * from "./transactionsPageV2";

--- a/pkg/ui/workspaces/cluster-ui/src/pages/sqlActivity/statementsPageV2.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/sqlActivity/statementsPageV2.tsx
@@ -1,0 +1,621 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Switch } from "antd";
+import classNames from "classnames/bind";
+import moment from "moment-timezone";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+
+import {
+  StatementRow,
+  StatementSortOptions,
+  SqlActivityStatementsRequest,
+  useSqlActivityStatements,
+} from "src/api/sqlActivityApi";
+import { useResetSQLStats } from "src/api/sqlStatsApi";
+import { barChartFactory } from "src/barCharts/barChartFactory";
+import { Button } from "src/button";
+import { commonStyles } from "src/common";
+import { Tooltip } from "src/components/tooltip";
+import { PageLayout, PageSection } from "src/layouts";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { ResultsPerPageLabel } from "src/pagination";
+import {
+  calculateActiveFilters,
+  defaultFilters,
+  Filter,
+  Filters,
+} from "src/queryFilter";
+import { Search } from "src/search";
+import {
+  SortDirection,
+  Table,
+  TableChangeFn,
+  TableColumnProps,
+} from "src/sharedFromCloud/table";
+import ClearStats from "src/sqlActivity/clearStats";
+import {
+  TimeScale,
+  TimeScaleDropdown,
+  timeScale1hMinOptions,
+  toRoundedDateRange,
+} from "src/timeScaleDropdown";
+import timeScaleStyles from "src/timeScaleDropdown/timeScale.module.scss";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
+import { Bytes, Count, Duration, PercentageCustom } from "src/util";
+
+const timeScaleStylesCx = classNames.bind(timeScaleStyles);
+
+// ---------------------------------------------------------------------------
+// URL parameter helpers
+// ---------------------------------------------------------------------------
+const URL_KEYS = {
+  sortBy: "sortBy",
+  sortOrder: "sortOrder",
+  page: "page",
+  search: "q",
+  app: "app",
+  database: "db",
+  start: "start",
+  end: "end",
+  excludeInternal: "excludeInternal",
+} as const;
+
+interface URLState {
+  sortField: string;
+  sortOrder: "asc" | "desc";
+  page: number;
+  search: string;
+  app: string;
+  database: string;
+  start: number; // seconds since epoch
+  end: number; // seconds since epoch
+  excludeInternal: boolean;
+}
+
+const parseURLState = (searchStr: string): Partial<URLState> => {
+  const p = new URLSearchParams(searchStr);
+  const result: Partial<URLState> = {};
+  if (p.has(URL_KEYS.sortBy)) result.sortField = p.get(URL_KEYS.sortBy);
+  if (p.has(URL_KEYS.sortOrder)) {
+    const v = p.get(URL_KEYS.sortOrder);
+    if (v === "asc" || v === "desc") result.sortOrder = v;
+  }
+  if (p.has(URL_KEYS.page)) {
+    const n = parseInt(p.get(URL_KEYS.page), 10);
+    if (!isNaN(n) && n > 0) result.page = n;
+  }
+  if (p.has(URL_KEYS.search)) result.search = p.get(URL_KEYS.search);
+  if (p.has(URL_KEYS.app)) result.app = p.get(URL_KEYS.app);
+  if (p.has(URL_KEYS.database)) result.database = p.get(URL_KEYS.database);
+  if (p.has(URL_KEYS.start)) {
+    const n = parseInt(p.get(URL_KEYS.start), 10);
+    if (!isNaN(n)) result.start = n;
+  }
+  if (p.has(URL_KEYS.end)) {
+    const n = parseInt(p.get(URL_KEYS.end), 10);
+    if (!isNaN(n)) result.end = n;
+  }
+  if (p.has(URL_KEYS.excludeInternal)) {
+    result.excludeInternal = p.get(URL_KEYS.excludeInternal) !== "false";
+  }
+  return result;
+};
+
+const buildURLParams = (state: URLState): string => {
+  const p = new URLSearchParams();
+  p.set(URL_KEYS.sortBy, state.sortField);
+  p.set(URL_KEYS.sortOrder, state.sortOrder);
+  if (state.page > 1) p.set(URL_KEYS.page, state.page.toString());
+  if (state.search) p.set(URL_KEYS.search, state.search);
+  if (state.app) p.set(URL_KEYS.app, state.app);
+  if (state.database) p.set(URL_KEYS.database, state.database);
+  if (state.start) p.set(URL_KEYS.start, state.start.toString());
+  if (state.end) p.set(URL_KEYS.end, state.end.toString());
+  if (!state.excludeInternal) {
+    p.set(URL_KEYS.excludeInternal, "false");
+  }
+  return p.toString();
+};
+
+// ---------------------------------------------------------------------------
+// Bar chart factories for V2 StatementRow
+// ---------------------------------------------------------------------------
+const svcLatBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "bar-chart__parse", value: d => d.svcLatMean }],
+  v => Duration(v * 1e9),
+  { name: "bar-chart__overall-dev", value: d => d.svcLatStddev },
+);
+
+const cpuBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "cpu", value: d => d.cpuSqlNanosMean }],
+  v => Duration(v),
+  { name: "cpu-dev", value: d => d.cpuSqlNanosStddev },
+);
+
+const contentionBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "contention", value: d => d.contentionTimeMean }],
+  v => Duration(v * 1e9),
+  { name: "contention-dev", value: d => d.contentionTimeStddev },
+);
+
+const kvCpuBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "kv-cpu-time", value: d => d.kvCpuTimeNanosMean }],
+  v => Duration(v),
+  { name: "kv-cpu-time-dev", value: d => d.kvCpuTimeNanosStddev },
+);
+
+const admWaitBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "admission-wait-time", value: d => d.admissionWaitTimeMean }],
+  v => Duration(v),
+  { name: "admission-wait-time-dev", value: d => d.admissionWaitTimeStddev },
+);
+
+const bytesReadBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "bytes-read", value: d => d.bytesReadMean }],
+  Bytes,
+  { name: "bytes-read-dev", value: d => d.bytesReadStddev },
+);
+
+const countBarChart = barChartFactory<StatementRow>(
+  "grey",
+  [{ name: "count-first-try", value: d => d.executionCount }],
+  v => Count(v),
+);
+
+const retryBarChart = barChartFactory<StatementRow>(
+  "red",
+  [{ name: "count-retry", value: d => d.maxRetries }],
+  v => Count(v),
+);
+
+// ---------------------------------------------------------------------------
+// Column definitions
+// ---------------------------------------------------------------------------
+
+const makeColumns = (
+  rows: StatementRow[],
+): (TableColumnProps<StatementRow> & {
+  sortKey?: StatementSortOptions;
+})[] => {
+  const countRenderer = countBarChart(rows);
+  const svcLatRenderer = svcLatBarChart(rows);
+  const cpuRenderer = cpuBarChart(rows);
+  const contentionRenderer = contentionBarChart(rows);
+  const kvCpuRenderer = kvCpuBarChart(rows);
+  const admWaitRenderer = admWaitBarChart(rows);
+  const bytesReadRenderer = bytesReadBarChart(rows);
+  const retryRenderer = retryBarChart(rows);
+
+  return [
+    {
+      title: <Tooltip title="SQL statement fingerprint.">Statement</Tooltip>,
+      width: 400,
+      render: (row: StatementRow) => (
+        <div
+          style={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            maxWidth: 400,
+          }}
+          title={row.query}
+        >
+          {row.querySummary || row.query}
+        </div>
+      ),
+    },
+    {
+      title: (
+        <Tooltip title="Cumulative number of executions of statements with this fingerprint within the specified time interval.">
+          Execution Count
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.EXECUTION_COUNT,
+      sorter: true,
+      align: "right" as const,
+      render: countRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average service latency per execution.">
+          Service Latency
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.SVC_LAT_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: svcLatRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average CPU time spent executing within the SQL layer per execution.">
+          SQL CPU Time
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.CPU_SQL_NANOS_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: cpuRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average time spent waiting for locks and contention per execution.">
+          Contention Time
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.CONTENTION_TIME_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: contentionRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average CPU time spent in the KV layer per execution.">
+          KV CPU Time
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.KV_CPU_TIME_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: kvCpuRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average time spent waiting in admission control per execution.">
+          Admission Wait Time
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.ADM_WAIT_TIME_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: admWaitRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average number of rows read per execution.">
+          Rows Read
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.ROWS_READ_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: (row: StatementRow) => Count(row.rowsReadMean),
+    },
+    {
+      title: (
+        <Tooltip title="Average number of rows written per execution.">
+          Rows Written
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.ROWS_WRITTEN_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: (row: StatementRow) => Count(row.rowsWrittenMean),
+    },
+    {
+      title: (
+        <Tooltip title="Average number of bytes read per execution.">
+          Bytes Read
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.BYTES_READ_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: bytesReadRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Maximum number of retries observed across all executions.">
+          Max Retries
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.MAX_RETRIES,
+      sorter: true,
+      align: "right" as const,
+      render: retryRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Percentage of total cluster service latency used by this statement fingerprint.">
+          % of Runtime
+        </Tooltip>
+      ),
+      sortKey: StatementSortOptions.PCT_OF_TOTAL_RUNTIME,
+      sorter: true,
+      align: "right" as const,
+      render: (row: StatementRow) =>
+        PercentageCustom(row.pctOfTotalRuntime, 1, 2),
+    },
+    {
+      title: "App Name",
+      render: (row: StatementRow) => row.appName || "(unset)",
+    },
+    {
+      title: "Database",
+      render: (row: StatementRow) => row.database || "(unknown)",
+    },
+  ];
+};
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+const defaultTimeScale: TimeScale = {
+  ...timeScale1hMinOptions["Past Hour"],
+  key: "Past Hour",
+  fixedWindowEnd: false,
+};
+
+const PAGE_SIZE = 20;
+
+// ---------------------------------------------------------------------------
+// Helpers to convert TimeScale <-> ISO strings for the API
+// ---------------------------------------------------------------------------
+const timeScaleToDateRange = (
+  ts: TimeScale,
+): { start: number; end: number } => {
+  const [s, e] = toRoundedDateRange(ts);
+  return { start: s.unix(), end: e.unix() };
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export const StatementsPageV2 = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  // Parse initial state from URL.
+  const urlState = useMemo(
+    () => parseURLState(location.search),
+    // Only parse on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // If URL has start/end, build a fixed-window TimeScale from them.
+  const initialTimeScale = useMemo((): TimeScale => {
+    if (urlState.start && urlState.end) {
+      const s = moment.unix(urlState.start).utc();
+      const e = moment.unix(urlState.end).utc();
+      if (s.isValid() && e.isValid()) {
+        return {
+          ...defaultTimeScale,
+          key: "Custom",
+          fixedWindowEnd: e,
+          windowSize: moment.duration(e.diff(s)),
+        };
+      }
+    }
+    return defaultTimeScale;
+  }, [urlState.start, urlState.end]);
+
+  const [timeScale, setTimeScale] = useState<TimeScale>(initialTimeScale);
+  const [page, setPage] = useState(urlState.page ?? 1);
+  const [sortField, setSortField] = useState<string>(
+    urlState.sortField ?? StatementSortOptions.SVC_LAT_MEAN,
+  );
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(
+    urlState.sortOrder ?? "desc",
+  );
+  const [search, setSearch] = useState(urlState.search ?? "");
+  const [filters, setFilters] = useState<Filters>({
+    ...defaultFilters,
+    app: urlState.app ?? "",
+    database: urlState.database ?? "",
+  });
+  const [excludeInternal, setExcludeInternal] = useState(
+    urlState.excludeInternal ?? true,
+  );
+  const [requestTime] = useState(moment.utc());
+
+  const { reset: resetSQLStats } = useResetSQLStats();
+
+  const { start, end } = timeScaleToDateRange(timeScale);
+
+  // Sync state to URL via history.replace.
+  useEffect(() => {
+    const qs = buildURLParams({
+      sortField,
+      sortOrder,
+      page,
+      search,
+      app: filters.app ?? "",
+      database: filters.database ?? "",
+      start,
+      end,
+      excludeInternal,
+    });
+    history.replace({ search: qs });
+  }, [
+    sortField,
+    sortOrder,
+    page,
+    search,
+    filters,
+    start,
+    end,
+    excludeInternal,
+    history,
+  ]);
+
+  const req: SqlActivityStatementsRequest = {
+    start,
+    end,
+    pagination: { pageSize: PAGE_SIZE, pageNum: page },
+    sortBy: sortField,
+    sortOrder,
+    search: search || undefined,
+    appName: filters.app || undefined,
+    database: filters.database || undefined,
+    excludeInternal,
+  };
+
+  const { data, error, isLoading, refresh } = useSqlActivityStatements(req);
+
+  const onApply = useCallback(() => {
+    refresh();
+  }, [refresh]);
+
+  const rows = data?.results ?? [];
+  const totalResults = data?.pagination.totalResults ?? 0;
+
+  const columns = useMemo(() => makeColumns(data?.results), [data?.results]);
+
+  const colsWithSort = useMemo(() => {
+    const sort = { field: sortField, order: sortOrder };
+    return columns.map(col => {
+      const sd: SortDirection = sort.order === "desc" ? "descend" : "ascend";
+      return {
+        ...col,
+        sortOrder: sort.field === col.sortKey && col.sorter ? sd : null,
+      };
+    });
+  }, [columns, sortField, sortOrder]);
+
+  const onTableChange: TableChangeFn<StatementRow> = (pagination, sorter) => {
+    setPage(pagination.current);
+    if (sorter) {
+      const colKey = sorter.columnKey;
+      if (typeof colKey !== "number") return;
+      const col = columns[colKey];
+      if (col.sortKey) {
+        setSortField(col.sortKey);
+        setSortOrder(sorter.order === "descend" ? "desc" : "asc");
+      }
+    }
+  };
+
+  const onSubmitFilters = (f: Filters) => {
+    setFilters(f);
+    setPage(1);
+  };
+
+  const activeFilters = calculateActiveFilters(filters);
+
+  return (
+    <PageLayout>
+      <PageSection>
+        <h3 className={commonStyles("base-heading")}>Statements (V2)</h3>
+        <section
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
+          <PageConfig>
+            <PageConfigItem>
+              <Search
+                placeholder="Search statements"
+                onSubmit={(val: string) => {
+                  setSearch(val);
+                  setPage(1);
+                }}
+                defaultValue={search}
+              />
+            </PageConfigItem>
+            <PageConfigItem>
+              <Filter
+                onSubmitFilters={onSubmitFilters}
+                appNames={[]}
+                dbNames={[]}
+                activeFilters={activeFilters}
+                filters={filters}
+                showDB={true}
+                hideTimeLabel={true}
+              />
+            </PageConfigItem>
+            <PageConfigItem>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  cursor: "pointer",
+                }}
+              >
+                <Switch
+                  checked={!excludeInternal}
+                  onChange={(checked: boolean) => {
+                    setExcludeInternal(!checked);
+                    setPage(1);
+                  }}
+                />
+                Show internal
+              </label>
+            </PageConfigItem>
+          </PageConfig>
+          <PageConfig>
+            <PageConfigItem>
+              <TimeScaleDropdown
+                currentScale={timeScale}
+                setTimeScale={setTimeScale}
+                options={timeScale1hMinOptions}
+              />
+            </PageConfigItem>
+            <PageConfigItem>
+              <Button type="secondary" onClick={onApply}>
+                Apply
+              </Button>
+            </PageConfigItem>
+          </PageConfig>
+        </section>
+        <section>
+          <PageConfig>
+            <PageConfigItem>
+              <p className={timeScaleStylesCx("time-label")}>
+                <TimeScaleLabel
+                  timeScale={timeScale}
+                  requestTime={requestTime}
+                />
+                {", "}
+                <ResultsPerPageLabel
+                  pagination={{
+                    pageSize: PAGE_SIZE,
+                    current: page,
+                    total: totalResults,
+                  }}
+                  pageName="statements"
+                />
+              </p>
+            </PageConfigItem>
+            <PageConfigItem className={`${commonStyles("separator")}`}>
+              <ClearStats
+                resetSQLStats={resetSQLStats}
+                tooltipType="statement"
+              />
+            </PageConfigItem>
+          </PageConfig>
+        </section>
+        <Table
+          loading={isLoading}
+          error={error}
+          columns={colsWithSort}
+          dataSource={rows}
+          dataTest="statements-v2-table"
+          pagination={{
+            size: "small",
+            current: page,
+            pageSize: PAGE_SIZE,
+            showSizeChanger: false,
+            position: ["bottomCenter"],
+            total: totalResults,
+          }}
+          onChange={onTableChange}
+        />
+      </PageSection>
+    </PageLayout>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/pages/sqlActivity/transactionsPageV2.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/sqlActivity/transactionsPageV2.tsx
@@ -1,0 +1,476 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Switch } from "antd";
+import classNames from "classnames/bind";
+import moment from "moment-timezone";
+import React, { useMemo, useState } from "react";
+
+import { useResetSQLStats } from "src/api/sqlStatsApi";
+import {
+  TransactionRow,
+  TransactionSortOptions,
+  TransactionsRequest,
+  useSqlActivityTransactions,
+} from "src/api/sqlActivityApi";
+import { barChartFactory } from "src/barCharts/barChartFactory";
+import { Tooltip } from "src/components/tooltip";
+import { PageLayout, PageSection } from "src/layouts";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { ResultsPerPageLabel } from "src/pagination";
+import {
+  calculateActiveFilters,
+  defaultFilters,
+  Filter,
+  Filters,
+} from "src/queryFilter";
+import ClearStats from "src/sqlActivity/clearStats";
+import { TimeScaleLabel } from "src/timeScaleDropdown/timeScaleLabel";
+import {
+  TimeScale,
+  TimeScaleDropdown,
+  timeScale1hMinOptions,
+  toRoundedDateRange,
+} from "src/timeScaleDropdown";
+import timeScaleStyles from "src/timeScaleDropdown/timeScale.module.scss";
+import { commonStyles } from "src/common";
+import {
+  SortDirection,
+  Table,
+  TableChangeFn,
+  TableColumnProps,
+} from "src/sharedFromCloud/table";
+import { Bytes, Count, Duration, PercentageCustom } from "src/util";
+
+const timeScaleStylesCx = classNames.bind(timeScaleStyles);
+
+// ---------------------------------------------------------------------------
+// Bar chart factories for V2 TransactionRow
+// ---------------------------------------------------------------------------
+const svcLatBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "bar-chart__parse", value: d => d.svcLatMean }],
+  v => Duration(v * 1e9),
+  { name: "bar-chart__overall-dev", value: d => d.svcLatStddev },
+);
+
+const commitLatBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "bar-chart__parse", value: d => d.commitLatMean }],
+  v => Duration(v * 1e9),
+  { name: "bar-chart__overall-dev", value: d => d.commitLatStddev },
+);
+
+const cpuBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "cpu", value: d => d.cpuSqlNanosMean }],
+  v => Duration(v),
+  { name: "cpu-dev", value: d => d.cpuSqlNanosStddev },
+);
+
+const contentionBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "contention", value: d => d.contentionTimeMean }],
+  v => Duration(v * 1e9),
+  { name: "contention-dev", value: d => d.contentionTimeStddev },
+);
+
+const kvCpuBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "kv-cpu-time", value: d => d.kvCpuTimeNanosMean }],
+  v => Duration(v),
+  { name: "kv-cpu-time-dev", value: d => d.kvCpuTimeNanosStddev },
+);
+
+const admWaitBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "admission-wait-time", value: d => d.admissionWaitTimeMean }],
+  v => Duration(v),
+  { name: "admission-wait-time-dev", value: d => d.admissionWaitTimeStddev },
+);
+
+const bytesReadBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "bytes-read", value: d => d.bytesReadMean }],
+  Bytes,
+  { name: "bytes-read-dev", value: d => d.bytesReadStddev },
+);
+
+const countBarChart = barChartFactory<TransactionRow>(
+  "grey",
+  [{ name: "count-first-try", value: d => d.executionCount }],
+  v => Count(v),
+);
+
+const retryBarChart = barChartFactory<TransactionRow>(
+  "red",
+  [{ name: "count-retry", value: d => d.maxRetries }],
+  v => Count(v),
+);
+
+// ---------------------------------------------------------------------------
+// Column definitions
+// ---------------------------------------------------------------------------
+
+const makeColumns = (
+  rows: TransactionRow[],
+): (TableColumnProps<TransactionRow> & {
+  sortKey?: TransactionSortOptions;
+})[] => {
+  const countRenderer = countBarChart(rows);
+  const svcLatRenderer = svcLatBarChart(rows);
+  const commitLatRenderer = commitLatBarChart(rows);
+  const cpuRenderer = cpuBarChart(rows);
+  const contentionRenderer = contentionBarChart(rows);
+  const kvCpuRenderer = kvCpuBarChart(rows);
+  const admWaitRenderer = admWaitBarChart(rows);
+  const bytesReadRenderer = bytesReadBarChart(rows);
+  const retryRenderer = retryBarChart(rows);
+
+  return [
+    {
+      title: (
+        <Tooltip title="Statement fingerprints that make up this transaction.">
+          Transaction
+        </Tooltip>
+      ),
+      width: 400,
+      render: (row: TransactionRow) => {
+        const text =
+          row.querySummaries?.length > 0
+            ? row.querySummaries.join(" ; ")
+            : row.fingerprintId;
+        return (
+          <div
+            style={{
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              maxWidth: 400,
+            }}
+            title={text}
+          >
+            {text}
+          </div>
+        );
+      },
+    },
+    {
+      title: (
+        <Tooltip title="Cumulative number of executions of this transaction fingerprint within the specified time interval.">
+          Execution Count
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.EXECUTION_COUNT,
+      sorter: true,
+      align: "right" as const,
+      render: countRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average service latency per execution.">
+          Service Latency
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.SVC_LAT_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: svcLatRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average commit latency per execution.">
+          Commit Latency
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.COMMIT_LAT_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: commitLatRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average CPU time spent executing within the SQL layer per execution.">
+          SQL CPU Time
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.CPU_SQL_NANOS_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: cpuRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average time spent waiting for locks and contention per execution.">
+          Contention Time
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.CONTENTION_TIME_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: contentionRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average CPU time spent in the KV layer per execution.">
+          KV CPU Time
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.KV_CPU_TIME_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: kvCpuRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average time spent waiting in admission control per execution.">
+          Admission Wait Time
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.ADM_WAIT_TIME_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: admWaitRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Average number of rows read per execution.">
+          Rows Read
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.ROWS_READ_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: (row: TransactionRow) => Count(row.rowsReadMean),
+    },
+    {
+      title: (
+        <Tooltip title="Average number of rows written per execution.">
+          Rows Written
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.ROWS_WRITTEN_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: (row: TransactionRow) => Count(row.rowsWrittenMean),
+    },
+    {
+      title: (
+        <Tooltip title="Average number of bytes read per execution.">
+          Bytes Read
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.BYTES_READ_MEAN,
+      sorter: true,
+      align: "right" as const,
+      render: bytesReadRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Maximum number of retries observed across all executions.">
+          Max Retries
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.MAX_RETRIES,
+      sorter: true,
+      align: "right" as const,
+      render: retryRenderer,
+    },
+    {
+      title: (
+        <Tooltip title="Percentage of total cluster service latency used by this transaction fingerprint.">
+          % of Runtime
+        </Tooltip>
+      ),
+      sortKey: TransactionSortOptions.PCT_OF_TOTAL_RUNTIME,
+      sorter: true,
+      align: "right" as const,
+      render: (row: TransactionRow) =>
+        PercentageCustom(row.pctOfTotalRuntime, 1, 2),
+    },
+    {
+      title: "App Name",
+      render: (row: TransactionRow) => row.appName || "(unset)",
+    },
+  ];
+};
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+const defaultTimeScale: TimeScale = {
+  ...timeScale1hMinOptions["Past Hour"],
+  key: "Past Hour",
+  fixedWindowEnd: false,
+};
+
+const PAGE_SIZE = 20;
+
+const timeScaleToDateRange = (
+  ts: TimeScale,
+): { start: number; end: number } => {
+  const [s, e] = toRoundedDateRange(ts);
+  return { start: s.unix(), end: e.unix() };
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export const TransactionsPageV2 = () => {
+  const [timeScale, setTimeScale] = useState<TimeScale>(defaultTimeScale);
+  const [page, setPage] = useState(1);
+  const [sortField, setSortField] = useState<string>(
+    TransactionSortOptions.SVC_LAT_MEAN,
+  );
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [filters, setFilters] = useState<Filters>(defaultFilters);
+  const [excludeInternal, setExcludeInternal] = useState(true);
+  const [requestTime] = useState(moment.utc());
+
+  const { reset: resetSQLStats } = useResetSQLStats();
+
+  const { start, end } = timeScaleToDateRange(timeScale);
+  const req: TransactionsRequest = {
+    start,
+    end,
+    pagination: { pageSize: PAGE_SIZE, pageNum: page },
+    sortBy: sortField,
+    sortOrder,
+    appName: filters.app || undefined,
+    excludeInternal,
+  };
+
+  const { data, error, isLoading } = useSqlActivityTransactions(req);
+
+  const rows = data?.results ?? [];
+  const totalResults = data?.pagination.totalResults ?? 0;
+
+  const columns = useMemo(() => makeColumns(rows), [rows]);
+
+  const sort = { field: sortField, order: sortOrder };
+  const colsWithSort = useMemo(
+    () =>
+      columns.map(col => {
+        const sd: SortDirection =
+          sort.order === "desc" ? "descend" : "ascend";
+        return {
+          ...col,
+          sortOrder:
+            sort.field === col.sortKey && col.sorter ? sd : null,
+        };
+      }),
+    [sort, columns],
+  );
+
+  const onTableChange: TableChangeFn<TransactionRow> = (
+    pagination,
+    sorter,
+  ) => {
+    setPage(pagination.current);
+    if (sorter) {
+      const colKey = sorter.columnKey;
+      if (typeof colKey !== "number") return;
+      const col = columns[colKey];
+      if (col.sortKey) {
+        setSortField(col.sortKey);
+        setSortOrder(sorter.order === "descend" ? "desc" : "asc");
+      }
+    }
+  };
+
+  const onSubmitFilters = (f: Filters) => {
+    setFilters(f);
+    setPage(1);
+  };
+
+  const activeFilters = calculateActiveFilters(filters);
+
+  return (
+    <PageLayout>
+      <PageSection>
+        <h3 className={commonStyles("base-heading")}>Transactions (V2)</h3>
+        <section style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <PageConfig>
+            <PageConfigItem>
+              <Filter
+                onSubmitFilters={onSubmitFilters}
+                appNames={[]}
+                activeFilters={activeFilters}
+                filters={filters}
+                hideTimeLabel={true}
+              />
+            </PageConfigItem>
+            <PageConfigItem>
+              <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
+                <Switch
+                  checked={!excludeInternal}
+                  onChange={(checked: boolean) => {
+                    setExcludeInternal(!checked);
+                    setPage(1);
+                  }}
+                />
+                Show internal
+              </label>
+            </PageConfigItem>
+          </PageConfig>
+          <PageConfig>
+            <PageConfigItem>
+              <TimeScaleDropdown
+                currentScale={timeScale}
+                setTimeScale={setTimeScale}
+                options={timeScale1hMinOptions}
+              />
+            </PageConfigItem>
+          </PageConfig>
+        </section>
+        <section>
+          <PageConfig>
+            <PageConfigItem>
+              <p className={timeScaleStylesCx("time-label")}>
+                <TimeScaleLabel
+                  timeScale={timeScale}
+                  requestTime={requestTime}
+                />
+                {", "}
+                <ResultsPerPageLabel
+                  pagination={{
+                    pageSize: PAGE_SIZE,
+                    current: page,
+                    total: totalResults,
+                  }}
+                  pageName="transactions"
+                />
+              </p>
+            </PageConfigItem>
+            <PageConfigItem
+              className={`${commonStyles("separator")}`}
+            >
+              <ClearStats
+                resetSQLStats={resetSQLStats}
+                tooltipType="transaction"
+              />
+            </PageConfigItem>
+          </PageConfig>
+        </section>
+        <Table
+          loading={isLoading}
+          error={error}
+          columns={colsWithSort}
+          dataSource={rows}
+          dataTest="transactions-v2-table"
+          pagination={{
+            size: "small",
+            current: page,
+            pageSize: PAGE_SIZE,
+            showSizeChanger: false,
+            position: ["bottomCenter"],
+            total: totalResults,
+          }}
+          onChange={onTableChange}
+        />
+      </PageSection>
+    </PageLayout>
+  );
+};

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -11,6 +11,8 @@ import {
   DatabaseDetailsPageV2,
   TableDetailsPageV2,
   ScheduleDetails,
+  StatementsPageV2,
+  TransactionsPageV2,
 } from "@cockroachlabs/cluster-ui";
 import { ConfigProvider } from "antd";
 import { ConnectedRouter } from "connected-react-router";
@@ -381,6 +383,17 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                             exact
                             path="/debug/hotranges/:node_id"
                             component={HotRanges}
+                          />
+                          {/* SQL Activity V2 (debug pages) */}
+                          <Route
+                            exact
+                            path="/debug/statements"
+                            component={StatementsPageV2}
+                          />
+                          <Route
+                            exact
+                            path="/debug/transactions"
+                            component={TransactionsPageV2}
                           />
                           <Route
                             exact

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -303,6 +303,17 @@ export default function Debug() {
           disabled={disable_kv_level_advanced_debug}
         />
         <StatementDiagnosticsConnected />
+        <PanelTitle>SQL Activity (V2)</PanelTitle>
+        <DebugPanelLink
+          name="Statements (V2)"
+          url="#/debug/statements"
+          note="View statement statistics using the new V2 API with server-side pagination and sorting."
+        />
+        <DebugPanelLink
+          name="Transactions (V2)"
+          url="#/debug/transactions"
+          note="View transaction statistics using the new V2 API with server-side pagination and sorting."
+        />
         <PanelTitle>Configuration</PanelTitle>
         <DebugPanelLink
           name="Cluster Settings"


### PR DESCRIPTION
Add `StatementsPageV2` and `TransactionsPageV2` React components to the DB Console, accessible via the Advanced Debug page under "SQL Activity (V2)". These pages use the new V2 BFF endpoints with server-side pagination and sorting via SWR hooks.

Features:
- SWR-based data fetching with automatic cache key management.
- Server-side pagination and sorting (no client-side aggregation).
- Time scale dropdown with URL state persistence.
- Search, app name, database, and internal statement filters.
- Bar chart visualizations for latency, CPU, contention, and I/O metrics using the existing barChartFactory.
- Transaction page shows constituent statement summaries via the secondary query in the transactions endpoint.

The pages are currently only linked from the debug panel to allow iterative development before replacing the existing SQL Activity pages.

Also includes the regenerated top-level pkg/BUILD.bazel for the new statementstore package.

Epic: none
Release note: None