### PR TITLE
release-25.4: roachtest: fix db-console/mixed-version-endpoints flake

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -287,6 +287,23 @@ func initializeSchemaAndIDs(
 	}
 	defer conn.Close()
 
+	// Check if TPCC is already initialized. In mixed-version testing this
+	// function is called many times across upgrade steps. We only run
+	// `workload init` once to avoid both key-collision errors (without --drop)
+	// and races with background schema operations (with --drop).
+	var exists bool
+	err = conn.QueryRowContext(ctx,
+		"SELECT count(*) > 0 FROM system.namespace WHERE name='warehouse'").Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		initTpcc := fmt.Sprintf("%s workload init tpcc {pgurl:1}", binaryPath)
+		c.Run(ctx, option.WithNodes([]int{1}), initTpcc)
+	} else {
+		l.Printf("TPCC already initialized, skipping workload init")
+	}
+
 	err = conn.QueryRowContext(ctx, "select id, \"parentID\" from system.namespace where name='warehouse'").Scan(&tableID, &databaseID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #166591.

/cc @cockroachdb/release

---

`initializeSchemaAndIDs` is called many times during mixed-version testing due to the randomized test plan. Each call re-ran `workload init tpcc`, causing flakes:
With `--drop`: DROP races with background schema ops from a prior invocation
Without `--drop`: AddSSTable key collisions with older binary versions

Fix: check if TPCC is already initialized via `system.namespace` and skip init on subsequent calls.

Fixes: #169621

Release note: None

Release justification: test only fix
