### PR TITLE
ci: fix broken CI for UI only changes

### DIFF
--- a/build/github/affected-targets.sh
+++ b/build/github/affected-targets.sh
@@ -78,10 +78,11 @@ if [ -z "$CANDIDATES" ]; then
 fi
 
 # Let Bazel resolve which candidates are real source file targets, find the
-# build rules that own them, then find all go_test targets that transitively
-# depend on those rules. Exclude integration-tagged tests, which require
-# bespoke setup (e.g. lint_test needs GO_SDK) and have their own CI jobs.
-QUERY="kind('go_test', rdeps(//pkg/..., same_pkg_direct_rdeps(set(${CANDIDATES})))) except attr('tags', 'integration', //pkg/...)"
+# build rules that own them, then find all go_test and jest_test targets that
+# transitively depend on those rules. Exclude integration-tagged tests, which
+# require bespoke setup (e.g. lint_test needs GO_SDK) and have their own CI
+# jobs.
+QUERY="kind('(go|jest)_test', rdeps(//pkg/..., same_pkg_direct_rdeps(set(${CANDIDATES})))) except attr('tags', 'integration', //pkg/...)"
 
 # Temporarily disable errexit so we can inspect the query exit code.
 set +e


### PR DESCRIPTION
For ui only changes (either db console or cluster ui changes), affected-targest.sh returns no affectedd tests, resulting in unit-tests.sh to short circuit and exit without running any bazel tests.

This updates the bazel query to check for `go_test` and `jest_test` to ensure that ui only changes trigger CI and get tested accordingly.

Epic: None
Release note: None