### PR TITLE
changefeedccl: add cluster setting for kafka v2 inflight produce requests

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -447,6 +447,20 @@ var KafkaMaxRequestSize = settings.RegisterByteSizeSetting(
 	settings.WithPublic,
 )
 
+// KafkaV2MaxInflightProduceRequestsPerBroker controls the maximum number of
+// concurrent produce requests the kafka v2 sink will issue to a single broker.
+// This corresponds to franz-go's MaxProduceRequestsInflightPerBroker option.
+// The default of 5 matches the Sarama v1 sink. ParallelIO handles ordering
+// independently of franz-go, so values >1 are safe.
+var KafkaV2MaxInflightProduceRequestsPerBroker = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"changefeed.kafka_v2.max_inflight_produce_requests_per_broker",
+	"the maximum number of concurrent produce requests the kafka v2 sink will "+
+		"issue to a single broker",
+	5,
+	settings.PositiveInt,
+)
+
 // PartitionAlgEnabled enables the partition_alg changefeed option.
 // TODO(#126991): delete reference to changefeed.new_kafka_sink_enabled
 // when enabled everywhere.

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -77,10 +77,10 @@ func newKafkaSinkClientV2(
 	baseOpts := []kgo.Opt{
 		// Disable idempotency to maintain parity with the v1 sink and not add surface area for unknowns.
 		kgo.DisableIdempotentWrite(),
-		// Allow up to 5 concurrent produce requests per broker, matching the
-		// Sarama client's default. This is safe because ParallelIO handles
+		// Allow multiple concurrent produce requests per broker (default 5,
+		// matching the Sarama client). This is safe because ParallelIO handles
 		// ordering independently of franz-go.
-		kgo.MaxProduceRequestsInflightPerBroker(5),
+		kgo.MaxProduceRequestsInflightPerBroker(int(changefeedbase.KafkaV2MaxInflightProduceRequestsPerBroker.Get(&settings.SV))),
 
 		kgo.SeedBrokers(bootstrapBrokers...),
 		kgo.WithLogger(kgoLogAdapter{ctx: ctx}),

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -409,6 +409,20 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 	}
 }
 
+func TestKafkaSinkClientV2_MaxInflightProduceRequestsPerBrokerSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	fx := newKafkaSinkV2Fx(t, withRealClient(), withSettings(func(s *cluster.Settings) {
+		changefeedbase.KafkaV2MaxInflightProduceRequestsPerBroker.Override(ctx, &s.SV, 17)
+	}))
+	defer fx.close()
+
+	client := fx.bs.client.(*kafkaSinkClientV2).client.(*kgo.Client)
+	require.Equal(t, 17, client.OptValue("MaxProduceRequestsInflightPerBroker"))
+}
+
 func shallowMerge(a, b map[string]any) map[string]any {
 	res := make(map[string]any, len(a))
 	for k, v := range a {


### PR DESCRIPTION
PR #168405 raised `MaxProduceRequestsInflightPerBroker` from the franz-go default of 1 to 5 to match the Sarama v1 sink, with the value hardcoded. Per [Jeff's post-merge suggestion](https://github.com/cockroachdb/cockroach/pull/168405#issuecomment-4254700808), lift it into a non-public cluster setting, `changefeed.kafka_v2.max_inflight_produce_requests_per_broker`, so support can recommend a tuned value if a deployment turns out to want one — without requiring a binary change.

The default stays at 5; the setting is intentionally non-public.

See also: #168405

Epic: none

Release note: None