### PR TITLE
kvstorage: disable WAG retention in BenchmarkWAGTruncation

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -719,6 +719,8 @@ func BenchmarkWAGTruncation(b *testing.B) {
 			b.StopTimer()
 			st := cluster.MakeTestingClusterSettings()
 			wagTruncatorBatchSize.Override(ctx, &st.SV, batchSize)
+			// Disable WAG retention to allow full WAG truncation.
+			wagSuffixRetentionCount.Override(ctx, &st.SV, 0)
 			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
 			engines := MakeEngines(eng)


### PR DESCRIPTION
WAG retention prevents truncating some WAG nodes.
This commit disables it in BenchmarkWAGTruncation.

Fixes: #169639

Release note: None