### PR TITLE
roachtest: unskip cdc/initial-scan-only/parquet/metamorphic

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2632,7 +2632,6 @@ CONFIGURE ZONE USING
 	})
 	r.Add(registry.TestSpec{
 		Name:             "cdc/initial-scan-only/parquet/metamorphic",
-		Skip:             "#119295",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),


### PR DESCRIPTION
This test was previously skipped due to authentication issues
with GCE. This was incidentally fixed by https://github.com/cockroachdb/cockroach/pull/140369 so we can
unskip the test and get back test coverage.

Fixes: https://github.com/cockroachdb/cockroach/issues/119295

Epic: [CRDB-8035](https://cockroachlabs.atlassian.net/browse/CRDB-8035)

Release note: None