### PR TITLE
sql/stats: add per-table sql_stats_forecasts_min_goodness_of_fit stor…

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1217,6 +1217,8 @@ GO_TARGETS = [
     "//pkg/cmd/github-pull-request-make:github-pull-request-make_test",
     "//pkg/cmd/gossipsim:gossipsim",
     "//pkg/cmd/gossipsim:gossipsim_lib",
+    "//pkg/cmd/importrepl:importrepl",
+    "//pkg/cmd/importrepl:importrepl_lib",
     "//pkg/cmd/kv/datadoggen:datadoggen",
     "//pkg/cmd/kv/datadoggen:datadoggen_lib",
     "//pkg/cmd/kv/datadoggen:datadoggen_test",

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -281,6 +281,10 @@ const (
 	// storing advisory lock state.
 	V26_3_AddAdvisoryLocksTable
 
+	// V26_3_ForecastMinGoodnessOfFitTableSetting adds the per-table
+	// sql_stats_forecasts_min_goodness_of_fit storage parameter.
+	V26_3_ForecastMinGoodnessOfFitTableSetting
+
 	// *************************************************
 	// Step (1) Add new versions above this comment.
 	// Do not add new versions to a patch release.
@@ -367,6 +371,8 @@ var versionTable = [numKeys]roachpb.Version{
 	V26_3_StmtDiagnosticsMaxLatency: {Major: 26, Minor: 2, Internal: 4},
 
 	V26_3_AddAdvisoryLocksTable: {Major: 26, Minor: 2, Internal: 6},
+
+	V26_3_ForecastMinGoodnessOfFitTableSetting: {Major: 26, Minor: 2, Internal: 8},
 	// *************************************************
 	// Step (2): Add new versions above this comment.
 	// *************************************************

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1414,7 +1414,14 @@ message TableDescriptor {
   // before new statistics are fully deployed to all queries throughout the
   // cluster.
   optional int64 stats_canary_window = 71 [(gogoproto.nullable) = false, (gogoproto.casttype)="time.Duration"];
-  // Next ID: 73
+
+  // ForecastStatsMinGoodnessOfFit is the minimum R² (goodness of fit)
+  // measurement that all predictive models in a forecast must have for the
+  // forecast to be used for this table. When set, it overrides the cluster
+  // setting sql.stats.forecasts.min_goodness_of_fit.
+  optional double forecast_stats_min_goodness_of_fit = 73
+    [(gogoproto.nullable) = true, (gogoproto.customname) = "ForecastStatsMinGoodnessOfFit"];
+  // Next ID: 74
 }
 
 // ExternalRowData indicates that the row data for this object is stored outside

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -852,6 +852,11 @@ type TableDescriptor interface {
 	// enabled or disabled for this table. If ok is true, then the enabled value
 	// is valid, otherwise this has not been set at the table level.
 	ForecastStatsEnabled() (enabled bool, ok bool)
+	// ForecastStatsMinGoodnessOfFit indicates the minimum R² (goodness of fit)
+	// for statistics forecasting on this table. If ok is true, then the
+	// minGoodnessOfFit value is valid, otherwise this has not been set at the
+	// table level.
+	ForecastStatsMinGoodnessOfFit() (minGoodnessOfFit float64, ok bool)
 	// HistogramSamplesCount indicates the number of rows to sample when building
 	// a histogram for this table. If ok is true, then the histogramSamplesCount
 	// value is valid, otherwise this has not been set at the table level.

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2663,6 +2663,9 @@ func (desc *wrapper) GetStorageParams(spaceBetweenEqual bool) ([]string, error) 
 	if enabled, ok := desc.ForecastStatsEnabled(); ok {
 		appendStorageParam(`sql_stats_forecasts_enabled`, strconv.FormatBool(enabled))
 	}
+	if minGOF, ok := desc.ForecastStatsMinGoodnessOfFit(); ok {
+		appendStorageParam(`sql_stats_forecasts_min_goodness_of_fit`, fmt.Sprintf("%g", minGOF))
+	}
 	if count, ok := desc.HistogramSamplesCount(); ok {
 		appendStorageParam(`sql_stats_histogram_samples_count`, fmt.Sprintf("%d", count))
 	}
@@ -2783,6 +2786,14 @@ func (desc *wrapper) ForecastStatsEnabled() (enabled bool, ok bool) {
 		return false, false
 	}
 	return *desc.ForecastStats, true
+}
+
+// ForecastStatsMinGoodnessOfFit implements the TableDescriptor interface.
+func (desc *wrapper) ForecastStatsMinGoodnessOfFit() (minGoodnessOfFit float64, ok bool) {
+	if desc.TableDescriptor.ForecastStatsMinGoodnessOfFit == nil {
+		return 0, false
+	}
+	return *desc.TableDescriptor.ForecastStatsMinGoodnessOfFit, true
 }
 
 // HistogramSamplesCount implements the TableDescriptor interface.

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -130,6 +130,7 @@ var validationMap = []struct {
 			"DeclarativeSchemaChangerState": {status: iSolemnlySwearThisFieldIsValidated},
 			"AutoStatsSettings":             {status: iSolemnlySwearThisFieldIsValidated},
 			"ForecastStats":                 {status: thisFieldReferencesNoObjects},
+			"ForecastStatsMinGoodnessOfFit": {status: thisFieldReferencesNoObjects},
 			"ImportStartWallTime":           {status: thisFieldReferencesNoObjects},
 			"HistogramBuckets":              {status: thisFieldReferencesNoObjects},
 			"HistogramSamples":              {status: thisFieldReferencesNoObjects},

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3102,6 +3102,69 @@ statement error parameter "sql_stats_forecasts_enabled" requires a Boolean value
 ALTER TABLE t5 SET (sql_stats_forecasts_enabled = 'invalid')
 
 # -----------------------------------------------------------------------------
+# sql_stats_forecasts_min_goodness_of_fit - float storage parameter for forecast threshold
+# -----------------------------------------------------------------------------
+
+statement ok
+ALTER TABLE t5 SET (sql_stats_forecasts_min_goodness_of_fit = 0.80)
+
+query T
+SELECT
+    crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
+                              d.descriptor, false)->'table'->>'forecastStatsMinGoodnessOfFit'
+FROM
+    system.namespace AS ns
+    INNER JOIN system.descriptor AS d ON d.id = ns.id
+WHERE
+    ns.name = 't5'
+----
+0.8
+
+# Boundary values should succeed.
+statement ok
+ALTER TABLE t5 SET (sql_stats_forecasts_min_goodness_of_fit = 0)
+
+statement ok
+ALTER TABLE t5 SET (sql_stats_forecasts_min_goodness_of_fit = 1)
+
+statement ok
+ALTER TABLE t5 RESET (sql_stats_forecasts_min_goodness_of_fit)
+
+query T
+SELECT
+    crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
+                              d.descriptor, false)->'table'->'forecastStatsMinGoodnessOfFit'
+FROM
+    system.namespace AS ns
+    INNER JOIN system.descriptor AS d ON d.id = ns.id
+WHERE
+    ns.name = 't5'
+----
+NULL
+
+statement error value -0.1 out of range for sql_stats_forecasts_min_goodness_of_fit: must be between 0 and 1
+ALTER TABLE t5 SET (sql_stats_forecasts_min_goodness_of_fit = -0.1)
+
+statement error value 1.5 out of range for sql_stats_forecasts_min_goodness_of_fit: must be between 0 and 1
+ALTER TABLE t5 SET (sql_stats_forecasts_min_goodness_of_fit = 1.5)
+
+# Verify SHOW CREATE TABLE includes the parameter.
+statement ok
+ALTER TABLE t5 SET (sql_stats_forecasts_min_goodness_of_fit = 0.85)
+
+query TT
+SHOW CREATE TABLE t5
+----
+t5  CREATE TABLE public.t5 (
+      a INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t5_pkey PRIMARY KEY (rowid ASC)
+    ) WITH (sql_stats_automatic_collection_min_stale_rows = 1234, sql_stats_automatic_collection_fraction_stale_rows = 0.15, sql_stats_forecasts_min_goodness_of_fit = 0.85, schema_locked = true);
+
+statement ok
+ALTER TABLE t5 RESET (sql_stats_forecasts_min_goodness_of_fit)
+
+# -----------------------------------------------------------------------------
 # sql_stats_automatic_partial_collection_min_stale_rows - integer storage parameter
 # -----------------------------------------------------------------------------
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -2474,5 +2474,95 @@ RESET CLUSTER SETTING sql.stats.forecasts.max_decrease
 statement ok
 RESET CLUSTER SETTING sql.stats.forecasts.min_goodness_of_fit
 
+# Verify the per-table sql_stats_forecasts_min_goodness_of_fit storage
+# parameter overrides the cluster setting. Use the same irregular data as above
+# (300, 220, 30) which doesn't produce a forecast at the default threshold
+# (0.95) but does at a lower threshold (0.9).
+
+statement ok
+CREATE TABLE gof_override (v INT)
+
+statement ok
+ALTER TABLE gof_override INJECT STATISTICS '[
+      {
+          "avg_size": 1,
+          "columns": [
+              "v"
+          ],
+          "created_at": "2023-04-18 00:00:00",
+          "distinct_count": 1,
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 300,
+          "row_count": 300
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "v"
+          ],
+          "created_at": "2023-04-19 00:00:00",
+          "distinct_count": 1,
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 220,
+          "row_count": 220
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "v"
+          ],
+          "created_at": "2023-04-20 00:00:00",
+          "distinct_count": 1,
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 30,
+          "row_count": 30
+      }
+]'
+
+# With the default cluster setting (0.95), no forecast is produced.
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE gof_override WITH FORECAST]
+ORDER BY created
+----
+__auto__  {v}  2023-04-18 00:00:00 +0000 UTC  300  1  300  1
+__auto__  {v}  2023-04-19 00:00:00 +0000 UTC  220  1  220  1
+__auto__  {v}  2023-04-20 00:00:00 +0000 UTC  30   1  30   1
+
+# Lower the threshold on just this table to 0.9.
+statement ok
+ALTER TABLE gof_override SET (sql_stats_forecasts_min_goodness_of_fit = 0.9)
+
+# Now a forecast is produced for this table.
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE gof_override WITH FORECAST]
+ORDER BY created
+----
+__auto__      {v}  2023-04-18 00:00:00 +0000 UTC  300  1  300  1
+__auto__      {v}  2023-04-19 00:00:00 +0000 UTC  220  1  220  1
+__auto__      {v}  2023-04-20 00:00:00 +0000 UTC  30   1  30   1
+__forecast__  {v}  2023-04-21 00:00:00 +0000 UTC  10   1  10   0
+
+# Reset the per-table override.
+statement ok
+ALTER TABLE gof_override RESET (sql_stats_forecasts_min_goodness_of_fit)
+
+# With the override removed, no forecast again.
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE gof_override WITH FORECAST]
+ORDER BY created
+----
+__auto__  {v}  2023-04-18 00:00:00 +0000 UTC  300  1  300  1
+__auto__  {v}  2023-04-19 00:00:00 +0000 UTC  220  1  220  1
+__auto__  {v}  2023-04-20 00:00:00 +0000 UTC  30   1  30   1
+
 statement ok
 SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -182,7 +182,8 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 				}
 
 				if withForecast {
-					forecasts := stats.ForecastTableStatistics(ctx, p.ExtendedEvalContext().Settings, statsList)
+					minGOF := stats.ForecastMinGoodnessOfFit(desc, p.ExtendedEvalContext().Settings)
+					forecasts := stats.ForecastTableStatistics(ctx, p.ExtendedEvalContext().Settings, statsList, minGOF)
 					forecastRows := make([]tree.Datums, 0, len(forecasts))
 					// Iterate in reverse order to match the ORDER BY "columnIDs".
 					for i := len(forecasts) - 1; i >= 0; i-- {

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -1050,7 +1050,7 @@ func (r *Refresher) EstimateStaleness(
 	// NB: we pass nil boolean as 'forecast' argument in order to not invalidate
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
-	tableStats, _, _, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, _, _, err := r.cache.getTableStatsFromCache(ctx, tableDesc.GetID(), forecast, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		return 0, err
 	}
@@ -1160,7 +1160,7 @@ func (r *Refresher) mustDoFullRefresh(
 	// the stats cache entry since we don't care whether there is a forecast or
 	// not in the stats.
 	var forecast *bool
-	tableStats, _, _, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	tableStats, _, _, err := r.cache.getTableStatsFromCache(ctx, tableID, forecast, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		return false, 0, err
 	}

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -262,7 +262,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, _, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+			tableStats, _, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 			if err != nil {
 				return err
 			}
@@ -270,7 +270,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, _, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+					stats, _, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 					if err != nil {
 						return err
 					}
@@ -557,7 +557,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, _, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+			tableStats, _, _, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 			if err != nil {
 				return err
 			}
@@ -565,7 +565,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, _, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+					stats, _, _, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -97,7 +97,7 @@ var maxDecrease = settings.RegisterFloatSetting(
 // ForecastTableStatistics is deterministic: given the same observations it will
 // return the same forecasts.
 func ForecastTableStatistics(
-	ctx context.Context, st *cluster.Settings, observed []*TableStatistic,
+	ctx context.Context, st *cluster.Settings, observed []*TableStatistic, minRequiredFit float64,
 ) []*TableStatistic {
 	// Group observed statistics by column set, skipping over partial statistics
 	// and statistics with inverted histograms.
@@ -141,7 +141,7 @@ func ForecastTableStatistics(
 		at := latest.Add(avgRefresh)
 
 		forecast, err := forecastColumnStatistics(
-			ctx, st, observedByCols[colKey], at, minGoodnessOfFit.Get(&st.SV),
+			ctx, st, observedByCols[colKey], at, minRequiredFit,
 		)
 		if err != nil {
 			log.VEventf(

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -130,6 +130,10 @@ type cacheEntry struct {
 	// forecast is true if stats could contain forecasts.
 	forecast bool
 
+	// minGoodnessOfFit is the minimum R² threshold used when generating
+	// forecasts for this cache entry.
+	minGoodnessOfFit float64
+
 	// userDefinedTypes holds the hydrated user-defined types used in
 	// histograms. A change to one of these types requires evicting the cacheEntry
 	// so that we can re-hydrate them.
@@ -459,7 +463,8 @@ func (sc *TableStatisticsCache) GetFreshTableStats(
 		return nil, nil
 	}
 	forecast := forecastAllowed(table, sc.settings)
-	stats, _, _, err = sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	minGOF := ForecastMinGoodnessOfFit(table, sc.settings)
+	stats, _, _, err = sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, minGOF, table.UserDefinedTypeColumns(), typeResolver, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	return stats, err
 }
 
@@ -490,7 +495,8 @@ func (sc *TableStatisticsCache) GetTableStatsMaybeStable(
 		return nil, false, hlc.Timestamp{}, nil
 	}
 	forecast := forecastAllowed(table, sc.settings)
-	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, table.UserDefinedTypeColumns(), typeResolver, stable, canaryWindowSize, statsAsOf)
+	minGOF := ForecastMinGoodnessOfFit(table, sc.settings)
+	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast, minGOF, table.UserDefinedTypeColumns(), typeResolver, stable, canaryWindowSize, statsAsOf)
 }
 
 // GetTableStatsProtosFromDB looks up statistics for the requested table in
@@ -595,6 +601,18 @@ func forecastAllowed(table catalog.TableDescriptor, clusterSettings *cluster.Set
 	return UseStatisticsForecasts.Get(&clusterSettings.SV)
 }
 
+// ForecastMinGoodnessOfFit returns the resolved minimum goodness-of-fit
+// threshold for the given table, falling back to the cluster setting if the
+// table does not have an override.
+func ForecastMinGoodnessOfFit(
+	table catalog.TableDescriptor, clusterSettings *cluster.Settings,
+) float64 {
+	if minGOF, ok := table.ForecastStatsMinGoodnessOfFit(); ok {
+		return minGOF
+	}
+	return minGoodnessOfFit.Get(&clusterSettings.SV)
+}
+
 // getTableStatsFromCache is like GetFreshTableStats but assumes that the table ID
 // is safe to fetch statistics for: non-system, non-virtual, non-view, etc.
 //
@@ -607,6 +625,7 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 	ctx context.Context,
 	tableID descpb.ID,
 	forecast *bool,
+	minGoodnessOfFit float64,
 	udtCols []catalog.Column,
 	typeResolver *descs.DistSQLTypeResolver,
 	stable bool,
@@ -619,7 +638,7 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 	asOfTs := statsAsOf.OrNow()
 
 	if found, e := sc.lookupStatsLocked(ctx, tableID, false /* stealthy */); found {
-		if e.isStale(forecast, udtCols) {
+		if e.isStale(forecast, minGoodnessOfFit, udtCols) {
 			// Evict the cache entry and build it again.
 			sc.mu.cache.Del(tableID)
 		} else {
@@ -640,13 +659,19 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 		}
 	}
 
-	return sc.addCacheEntryLocked(ctx, tableID, forecast != nil && *forecast, typeResolver, stable, canaryWindowSize, asOfTs)
+	return sc.addCacheEntryLocked(ctx, tableID, forecast != nil && *forecast, minGoodnessOfFit, typeResolver, stable, canaryWindowSize, asOfTs)
 }
 
 // isStale checks whether we need to evict and re-load the cache entry.
-func (e *cacheEntry) isStale(forecast *bool, udtCols []catalog.Column) bool {
+func (e *cacheEntry) isStale(
+	forecast *bool, minGoodnessOfFit float64, udtCols []catalog.Column,
+) bool {
 	// Check whether forecast settings have changed.
 	if forecast != nil && e.forecast != *forecast {
+		return true
+	}
+	// Check whether the min goodness-of-fit threshold has changed.
+	if e.minGoodnessOfFit != minGoodnessOfFit {
 		return true
 	}
 	// Check whether user-defined types have changed (this is similar to
@@ -785,6 +810,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 	ctx context.Context,
 	tableID descpb.ID,
 	forecast bool,
+	minGoodnessOfFit float64,
 	typeResolver *descs.DistSQLTypeResolver,
 	stable bool,
 	canaryWindowSize time.Duration,
@@ -813,6 +839,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 			ctx,
 			tableID,
 			forecast,
+			minGoodnessOfFit,
 			sc.settings,
 			typeResolver,
 		)
@@ -821,7 +848,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 
 	e.mustWait = false
 	e.latestFullStatsTimestamp, e.latestStableFullStatsTimestamp = latestFullStatsTimestamp, latestStableStatsTimestamp
-	e.forecast, e.userDefinedTypes, e.stats, e.stableStats, e.err = forecast, udts, stats, stableStats, err
+	e.forecast, e.minGoodnessOfFit, e.userDefinedTypes, e.stats, e.stableStats, e.err = forecast, minGoodnessOfFit, udts, stats, stableStats, err
 
 	// Wake up any other callers that are waiting on these stats.
 	e.waitCond.Broadcast()
@@ -886,6 +913,7 @@ func (sc *TableStatisticsCache) refreshCacheEntry(
 	e.refreshing = true
 
 	forecast := e.forecast
+	minGOF := e.minGoodnessOfFit
 	var stats []*TableStatistic
 	var stableStats []*TableStatistic
 	var latestStatsTimestamp hlc.Timestamp
@@ -904,6 +932,7 @@ func (sc *TableStatisticsCache) refreshCacheEntry(
 				ctx,
 				tableID,
 				forecast,
+				minGOF,
 				sc.settings,
 				nil, /* typeResolver */
 			)
@@ -1383,6 +1412,7 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 	ctx context.Context,
 	tableID descpb.ID,
 	forecast bool,
+	minGoodnessOfFit float64,
 	st *cluster.Settings,
 	typeResolver *descs.DistSQLTypeResolver,
 ) (
@@ -1475,10 +1505,10 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 	stableStatsList = append(mergedStable, stableStatsList...)
 
 	if forecast {
-		forecasts := ForecastTableStatistics(ctx, sc.settings, statsList)
+		forecasts := ForecastTableStatistics(ctx, sc.settings, statsList, minGoodnessOfFit)
 		statsList = append(statsList, forecasts...)
 
-		forecastsStable := ForecastTableStatistics(ctx, sc.settings, stableStatsList)
+		forecastsStable := ForecastTableStatistics(ctx, sc.settings, stableStatsList, minGoodnessOfFit)
 		stableStatsList = append(stableStatsList, forecastsStable...)
 		// Some forecasts could have a CreatedAt time before or after some collected
 		// stats, so make sure the list is sorted in descending CreatedAt order.

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -119,7 +119,7 @@ func checkStatsForTable(
 
 	// Perform the lookup and refresh, and confirm the
 	// returned stats match the expected values.
-	statsList, _, _, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+	statsList, _, _, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 	if err != nil {
 		t.Fatalf("error retrieving stats: %s", err)
 	}
@@ -803,7 +803,7 @@ func TestCacheWait(t *testing.T) {
 		for n := 0; n < 10; n++ {
 			wg.Add(1)
 			go func() {
-				stats, _, _, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
+				stats, _, _, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, 0 /* minGoodnessOfFit */, nil /* udtCols */, nil /* typeResolver */, false /* stable */, 0 /* canaryWindowSize */, hlc.Timestamp{} /* statsAsOf */)
 				if err != nil {
 					t.Error(err)
 				} else if !checkStats(stats, expectedStats[id]) {
@@ -1348,7 +1348,7 @@ func runStatsCacheDataDriven(
 		}
 
 		tbl := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
-		stats, stableStats, _, _, _, err := sc.getTableStatsFromDB(ctx, tbl.GetID(), forecast, s.ClusterSettings(), nil)
+		stats, stableStats, _, _, _, err := sc.getTableStatsFromDB(ctx, tbl.GetID(), forecast, minGoodnessOfFit.Get(&s.ClusterSettings().SV), s.ClusterSettings(), nil)
 		if err != nil {
 			return fmt.Sprintf("error: %v", err)
 		}

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -650,6 +650,35 @@ var tableParams = map[string]tableParam{
 		onSet:   autoStatsFractionStaleRowsSetFunc,
 		onReset: autoStatsTableSettingResetFunc,
 	},
+	`sql_stats_forecasts_min_goodness_of_fit`: {
+		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
+			if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V26_3_ForecastMinGoodnessOfFitTableSetting) {
+				return "", pgerror.Newf(pgcode.FeatureNotSupported,
+					"%s cannot be used until the cluster upgrade to v26.3 is finalized", key)
+			}
+			floatVal, err := floatFromDatum(ctx, evalCtx, key, datum)
+			if err != nil {
+				return "", err
+			}
+			if floatVal < 0 || floatVal > 1 {
+				return "", pgerror.Newf(pgcode.InvalidParameterValue,
+					"value %g out of range for %s: must be between 0 and 1", floatVal, key)
+			}
+			return fmt.Sprintf("%g", floatVal), nil
+		},
+		onSet: func(ctx context.Context, po *Setter, key string, value string) error {
+			floatVal, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return err
+			}
+			po.TableDesc.TableDescriptor.ForecastStatsMinGoodnessOfFit = &floatVal
+			return nil
+		},
+		onReset: func(_ context.Context, po *Setter, key string, value string) error {
+			po.TableDesc.TableDescriptor.ForecastStatsMinGoodnessOfFit = nil
+			return nil
+		},
+	},
 	`sql_stats_forecasts_enabled`: {
 		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
 			enabled, err := boolFromDatum(ctx, evalCtx, key, datum)


### PR DESCRIPTION
…age parameter

The cluster setting sql.stats.forecasts.min_goodness_of_fit controls the minimum R² (goodness of fit) threshold for statistics forecasts, but it applies cluster-wide. For tables with irregular growth patterns (e.g. very large tables with 26B+ rows), the default threshold (0.95) can be too strict, causing useful forecasts to be rejected.

This change adds a per-table storage parameter
`sql_stats_forecasts_min_goodness_of_fit` that overrides the cluster setting for individual tables:

    ALTER TABLE t SET (sql_stats_forecasts_min_goodness_of_fit = 0.80)

The implementation follows the pattern of the existing `forecast_stats` (ForecastStatsEnabled) table-level override:
- A nullable double field on TableDescriptor (proto field 73)
- A cluster version gate (V26_3_ForecastMinGoodnessOfFitTableSetting)
- The resolved value is threaded through the stats cache alongside the existing `forecast bool`, and passed as a parameter to ForecastTableStatistics instead of reading the cluster setting inside that function.

Release note (sql change): Added per-table storage parameter `sql_stats_forecasts_min_goodness_of_fit` to override the cluster setting `sql.stats.forecasts.min_goodness_of_fit` on individual tables. This allows tuning the forecast goodness-of-fit threshold per table via `ALTER TABLE t SET (sql_stats_forecasts_min_goodness_of_fit = 0.80)`.