### PR TITLE
release-25.4: roachtest: use title override for schema change workload failures

### DIFF
--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -37,7 +37,9 @@ var (
 cockroachdb/test-eng:
  label: T-testeng
 cockroachdb/dev-inf:
- label: T-dev-inf`
+ label: T-dev-inf
+cockroachdb/sql-foundations:
+ label: T-sql-foundations`
 
 	validTeamsFn   = func() (team.Map, error) { return loadYamlTeams(teamsYaml) }
 	invalidTeamsFn = func() (team.Map, error) { return loadYamlTeams("invalid yaml") }
@@ -215,6 +217,11 @@ func TestCreatePostRequest(t *testing.T) {
 							refError = liveMigrationError("my_VM")
 						case "error-with-owner-sql-foundations":
 							refError = registry.ErrorWithOwner(registry.OwnerSQLFoundations, refError)
+						case "error-with-owner-sql-foundations-title-override":
+							refError = registry.ErrorWithOwner(
+								registry.OwnerSQLFoundations, refError,
+								registry.WithTitleOverride("schema_change_workload_failure"),
+							)
 						case "error-with-owner-test-eng":
 							refError = registry.ErrorWithOwner(registry.OwnerTestEng, refError)
 						case "require-no-error-failed":

--- a/pkg/cmd/roachtest/testdata/github/schema_change_workload_failure
+++ b/pkg/cmd/roachtest/testdata/github/schema_change_workload_failure
@@ -1,0 +1,61 @@
+# Test that schema change workload failures use a title override to
+# separate them from other test failures in GitHub issue deduplication.
+
+add-failure name=(oops) type=(error-with-owner-sql-foundations-title-override)
+----
+ok
+
+post
+----
+----
+roachtest.schema_change_workload_failure [failed]() on test_branch @ [test_SHA]():
+
+
+```
+test github_test failed: oops [owner=sql-foundations]
+```
+
+Parameters:
+ - <code>arch=amd64</code>
+ - <code>cloud=gce</code>
+ - <code>coverageBuild=false</code>
+ - <code>cpu=4</code>
+ - <code>diskCount=0</code>
+ - <code>encrypted=false</code>
+ - <code>fs=ext4</code>
+ - <code>localSSD=true</code>
+ - <code>runtimeAssertionsBuild=false</code>
+<details><summary>Help</summary>
+<p>
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+
+_Logs were not uploaded to Datadog_</p>
+</details>
+/cc @cockroachdb/sql-foundations
+<sub>
+
+[This test on roachdash](https://roachdash.crdb.dev/?filter=status:open%20t:.*schema_change_workload_failure.*&sort=title+created&display=lastcommented+project) | [Improve this report!](https://github.com/cockroachdb/cockroach/tree/master/pkg/cmd/bazci/githubpost/issues)
+
+</sub>
+
+------
+Labels:
+- <code>O-roachtest</code>
+- <code>C-test-failure</code>
+- <code>release-blocker</code>
+- <code>T-sql-foundations</code>
+Rendered:
+https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.schema_change_workload_failure+%5Bfailed%5D%28%29+on+test_branch+%40+%5Btest_SHA%5D%28%29%3A%0A%0A%0A%60%60%60%0Atest+github_test+failed%3A+oops+%5Bowner%3Dsql-foundations%5D%0A%60%60%60%0A%0AParameters%3A%0A+-+%3Ccode%3Earch%3Damd64%3C%2Fcode%3E%0A+-+%3Ccode%3Ecloud%3Dgce%3C%2Fcode%3E%0A+-+%3Ccode%3EcoverageBuild%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Ecpu%3D4%3C%2Fcode%3E%0A+-+%3Ccode%3EdiskCount%3D0%3C%2Fcode%3E%0A+-+%3Ccode%3Eencrypted%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Efs%3Dext4%3C%2Fcode%3E%0A+-+%3Ccode%3ElocalSSD%3Dtrue%3C%2Fcode%3E%0A+-+%3Ccode%3EruntimeAssertionsBuild%3Dfalse%3C%2Fcode%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A%0ASee%3A+%5Broachtest+README%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fblob%2Fmaster%2Fpkg%2Fcmd%2Froachtest%2FREADME.md%29%0A%0A%0A%0ASee%3A+%5BHow+To+Investigate+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FSSSBr8c7%29%0A%0A%0A%0ASee%3A+%5BGrafana%5D%28https%3A%2F%2Fgo.crdb.dev%2Froachtest-grafana%2F%2Fgithub-test%2F1689957243000%2F1689957853000%29%0A%0A%0A_Logs+were+not+uploaded+to+Datadog_%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fsql-foundations%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2Aschema_change_workload_failure.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Fbazci%2Fgithubpost%2Fissues%29%0A%0A%3C%2Fsub%3E%0A%0A------%0ALabels%3A%0A-+%3Ccode%3EO-roachtest%3C%2Fcode%3E%0A-+%3Ccode%3EC-test-failure%3C%2Fcode%3E%0A-+%3Ccode%3Erelease-blocker%3C%2Fcode%3E%0A-+%3Ccode%3ET-sql-foundations%3C%2Fcode%3E%0A&template=none&title=roachtest%3A+schema_change_workload_failure+failed
+----
+----

--- a/pkg/cmd/roachtest/testdata/github/schema_change_workload_failure
+++ b/pkg/cmd/roachtest/testdata/github/schema_change_workload_failure
@@ -20,11 +20,11 @@ Parameters:
  - <code>cloud=gce</code>
  - <code>coverageBuild=false</code>
  - <code>cpu=4</code>
- - <code>diskCount=0</code>
  - <code>encrypted=false</code>
  - <code>fs=ext4</code>
  - <code>localSSD=true</code>
  - <code>runtimeAssertionsBuild=false</code>
+ - <code>ssd=0</code>
 <details><summary>Help</summary>
 <p>
 
@@ -39,8 +39,7 @@ See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/S
 
 See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
 
-
-_Logs were not uploaded to Datadog_</p>
+</p>
 </details>
 /cc @cockroachdb/sql-foundations
 <sub>
@@ -56,6 +55,6 @@ Labels:
 - <code>release-blocker</code>
 - <code>T-sql-foundations</code>
 Rendered:
-https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.schema_change_workload_failure+%5Bfailed%5D%28%29+on+test_branch+%40+%5Btest_SHA%5D%28%29%3A%0A%0A%0A%60%60%60%0Atest+github_test+failed%3A+oops+%5Bowner%3Dsql-foundations%5D%0A%60%60%60%0A%0AParameters%3A%0A+-+%3Ccode%3Earch%3Damd64%3C%2Fcode%3E%0A+-+%3Ccode%3Ecloud%3Dgce%3C%2Fcode%3E%0A+-+%3Ccode%3EcoverageBuild%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Ecpu%3D4%3C%2Fcode%3E%0A+-+%3Ccode%3EdiskCount%3D0%3C%2Fcode%3E%0A+-+%3Ccode%3Eencrypted%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Efs%3Dext4%3C%2Fcode%3E%0A+-+%3Ccode%3ElocalSSD%3Dtrue%3C%2Fcode%3E%0A+-+%3Ccode%3EruntimeAssertionsBuild%3Dfalse%3C%2Fcode%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A%0ASee%3A+%5Broachtest+README%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fblob%2Fmaster%2Fpkg%2Fcmd%2Froachtest%2FREADME.md%29%0A%0A%0A%0ASee%3A+%5BHow+To+Investigate+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FSSSBr8c7%29%0A%0A%0A%0ASee%3A+%5BGrafana%5D%28https%3A%2F%2Fgo.crdb.dev%2Froachtest-grafana%2F%2Fgithub-test%2F1689957243000%2F1689957853000%29%0A%0A%0A_Logs+were+not+uploaded+to+Datadog_%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fsql-foundations%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2Aschema_change_workload_failure.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Fbazci%2Fgithubpost%2Fissues%29%0A%0A%3C%2Fsub%3E%0A%0A------%0ALabels%3A%0A-+%3Ccode%3EO-roachtest%3C%2Fcode%3E%0A-+%3Ccode%3EC-test-failure%3C%2Fcode%3E%0A-+%3Ccode%3Erelease-blocker%3C%2Fcode%3E%0A-+%3Ccode%3ET-sql-foundations%3C%2Fcode%3E%0A&template=none&title=roachtest%3A+schema_change_workload_failure+failed
+https://github.com/cockroachdb/cockroach/issues/new?body=roachtest.schema_change_workload_failure+%5Bfailed%5D%28%29+on+test_branch+%40+%5Btest_SHA%5D%28%29%3A%0A%0A%0A%60%60%60%0Atest+github_test+failed%3A+oops+%5Bowner%3Dsql-foundations%5D%0A%60%60%60%0A%0AParameters%3A%0A+-+%3Ccode%3Earch%3Damd64%3C%2Fcode%3E%0A+-+%3Ccode%3Ecloud%3Dgce%3C%2Fcode%3E%0A+-+%3Ccode%3EcoverageBuild%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Ecpu%3D4%3C%2Fcode%3E%0A+-+%3Ccode%3Eencrypted%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Efs%3Dext4%3C%2Fcode%3E%0A+-+%3Ccode%3ElocalSSD%3Dtrue%3C%2Fcode%3E%0A+-+%3Ccode%3EruntimeAssertionsBuild%3Dfalse%3C%2Fcode%3E%0A+-+%3Ccode%3Essd%3D0%3C%2Fcode%3E%0A%3Cdetails%3E%3Csummary%3EHelp%3C%2Fsummary%3E%0A%3Cp%3E%0A%0A%0ASee%3A+%5Broachtest+README%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Fblob%2Fmaster%2Fpkg%2Fcmd%2Froachtest%2FREADME.md%29%0A%0A%0A%0ASee%3A+%5BHow+To+Investigate+%5C%28internal%5C%29%5D%28https%3A%2F%2Fcockroachlabs.atlassian.net%2Fl%2Fc%2FSSSBr8c7%29%0A%0A%0A%0ASee%3A+%5BGrafana%5D%28https%3A%2F%2Fgo.crdb.dev%2Froachtest-grafana%2F%2Fgithub-test%2F1689957243000%2F1689957853000%29%0A%0A%3C%2Fp%3E%0A%3C%2Fdetails%3E%0A%2Fcc+%40cockroachdb%2Fsql-foundations%0A%3Csub%3E%0A%0A%5BThis+test+on+roachdash%5D%28https%3A%2F%2Froachdash.crdb.dev%2F%3Ffilter%3Dstatus%3Aopen%2520t%3A.%2Aschema_change_workload_failure.%2A%26sort%3Dtitle%2Bcreated%26display%3Dlastcommented%2Bproject%29+%7C+%5BImprove+this+report%21%5D%28https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fcockroach%2Ftree%2Fmaster%2Fpkg%2Fcmd%2Fbazci%2Fgithubpost%2Fissues%29%0A%0A%3C%2Fsub%3E%0A%0A------%0ALabels%3A%0A-+%3Ccode%3EO-roachtest%3C%2Fcode%3E%0A-+%3Ccode%3EC-test-failure%3C%2Fcode%3E%0A-+%3Ccode%3Erelease-blocker%3C%2Fcode%3E%0A-+%3Ccode%3ET-sql-foundations%3C%2Fcode%3E%0A&template=none&title=roachtest%3A+schema_change_workload_failure+failed
 ----
 ----

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -52,7 +52,11 @@ func handleSchemaChangeWorkloadError(ctx context.Context, err error) error {
 			return err
 		}
 		// Context was not cancelled - genuine workload failure.
-		return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "schema change workload failed"))
+		return registry.ErrorWithOwner(
+			registry.OwnerSQLFoundations,
+			errors.Wrapf(err, "schema change workload failed"),
+			registry.WithTitleOverride("schema_change_workload_failure"),
+		)
 	}
 	return err
 }


### PR DESCRIPTION
Backport 1/1 commits from #169578 on behalf of @msbutler.

----

Schema change workload failures in DR roachtests (backup-restore,
c2c) are rerouted to sql-foundations via ErrorWithOwner. However,
since issue deduplication is title-based, a subsequent non-schema-change
failure would match the existing sql-foundations issue instead of
creating a new one for disaster-recovery.

Add a TitleOverride so schema change workload failures get a distinct
issue title ("schema_change_workload_failure"), preventing dedup
collisions with real DR test failures.

Epic: none
Release note: None

----

Release justification: test only change