### PR TITLE
logstore: WIP test-only double raft append assertion

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4018,9 +4018,15 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 					kvserverpb.RangeTombstone{NextReplicaID: math.MaxInt32},
 				))
 				// Ditto for the unreplicated RangeID keys. Note that it is also split
-				// into two range clears, to work around the RaftReplicaID key.
+				// into three range clears, to work around the RaftReplicaID key and
+				// to force all raft log clearing to go through logstore.
 				require.NoError(t, sst.ClearRawRange(
-					keys.RaftHardStateKey(rangeID), sl.RaftReplicaIDKey(), true, false,
+					keys.RaftHardStateKey(rangeID), sl.RaftLogPrefix(), true, false,
+				))
+				require.NoError(t, storage.ClearRangeWithHeuristic(
+					ctx, receivingEng, &sst,
+					sl.RaftLogPrefix(), sl.RaftLogPrefix().PrefixEnd(),
+					kvstorage.ClearRangeThresholdPointKeys(),
 				))
 				require.NoError(t, sl.ClearRaftReplicaID(&sst))
 				require.NoError(t, sst.ClearRawRange(

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -171,19 +171,26 @@ func destroyReplicaImpl(
 		); err != nil {
 			return err
 		}
+		if err := logstore.ClearRange(
+			ctx, rw.Raft.RO, rw.Raft.WO, buf,
+			info.RaftAppliedIndex+1 /* lo */, math.MaxUint64 /* hi */, ClearRangeThresholdPointKeys(),
+		); err != nil {
+			return err
+		}
+	} else {
 		if err := storage.ClearRangeWithHeuristic(
 			ctx, rw.Raft.RO, rw.Raft.WO,
-			buf.RaftLogKey(info.RaftAppliedIndex+1), sl.RaftReplicaIDKey(),
+			buf.RangeTombstoneKey().Next(), sl.RaftLogPrefix(),
 			ClearRangeThresholdPointKeys(),
 		); err != nil {
 			return err
 		}
-	} else if err := storage.ClearRangeWithHeuristic(
-		ctx, rw.Raft.RO, rw.Raft.WO,
-		buf.RangeTombstoneKey().Next(), sl.RaftReplicaIDKey(),
-		ClearRangeThresholdPointKeys(),
-	); err != nil {
-		return err
+		if err := logstore.ClearRange(
+			ctx, rw.Raft.RO, rw.Raft.WO, buf,
+			0 /* lo */, math.MaxUint64 /* hi */, ClearRangeThresholdPointKeys(),
+		); err != nil {
+			return err
+		}
 	}
 	if err := sl.ClearRaftReplicaID(rw.State.WO); err != nil {
 		return err
@@ -265,10 +272,13 @@ func RewriteRaftState(
 	if err := sl.SetHardState(ctx, raftWO, hs); err != nil {
 		return errors.Wrapf(err, "unable to write HardState")
 	}
-	// Clear the raft log. Note that there are no Pebble range keys in this span.
-	raftLog := sl.RaftLogPrefix() // NB: use only until next StateLoader call
-	if err := raftWO.ClearRawRange(
-		raftLog, raftLog.PrefixEnd(), true /* pointKeys */, false, /* rangeKeys */
+	// Clear the raft log via the logstore. Note that there are no Pebble range
+	// keys in this span. We use ClearRangeSizeKnown with pointKeyThreshold=1 to
+	// force a single range tombstone over the whole log span, without scanning.
+	if err := logstore.ClearRangeSizeKnown(
+		raftWO, sl.RangeIDPrefixBuf,
+		0 /* lo */, math.MaxUint64 /* hi */, 1, /* pointKeyThreshold */
+		false, /* maybeUseSingleDel */
 	); err != nil {
 		return errors.Wrapf(err, "unable to clear the raft log")
 	}

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -277,7 +277,13 @@ func (t *WAGTruncator) maybeAdvanceAllowedIndex() {
 func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
 ) error {
-	if err := storage.ClearRangeWithHeuristic(
+	if logstore.UseRaftLogSingleDelete {
+		if err := clearRaftLogWithSingleDelete(
+			ctx, raft.RO, raft.WO, rangeID, lastIndex,
+		); err != nil {
+			return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
+		}
+	} else if err := storage.ClearRangeWithHeuristic(
 		ctx, raft.RO, raft.WO,
 		keys.RaftLogPrefix(rangeID),           /* start */
 		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
@@ -304,4 +310,40 @@ func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	// We must sync the sideloaded storage after truncation to avoid leaking the
 	// files in case of a node crash.
 	return ss.Sync()
+}
+
+// clearRaftLogWithSingleDelete clears raft log entries using SingleDelete for
+// each point key. Unlike the regular truncation path, this always uses point
+// deletions and never falls back to a range tombstone, because range tombstones
+// are incompatible with SingleDelete.
+func clearRaftLogWithSingleDelete(
+	ctx context.Context,
+	r storage.Reader,
+	w storage.Writer,
+	rangeID roachpb.RangeID,
+	lastIndex kvpb.RaftIndex,
+) error {
+	start := keys.RaftLogPrefix(rangeID)
+	end := keys.RaftLogKey(rangeID, lastIndex+1)
+	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsOnly,
+		LowerBound: start,
+		UpperBound: end,
+	})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: start})
+	for ; ok; ok, err = iter.NextEngineKey() {
+		key, kerr := iter.UnsafeEngineKey()
+		if kerr != nil {
+			return kerr
+		}
+		if err := w.SingleClearEngineKey(key); err != nil {
+			return err
+		}
+	}
+	return err
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -277,7 +277,7 @@ func (t *WAGTruncator) maybeAdvanceAllowedIndex() {
 func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
 ) error {
-	if logstore.UseRaftLogSingleDelete {
+	if logstore.UseRaftLogSingleDelete(t.eng.Separated()) {
 		if err := clearRaftLogWithSingleDelete(
 			ctx, raft.RO, raft.WO, rangeID, lastIndex,
 		); err != nil {

--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -277,17 +277,17 @@ func (t *WAGTruncator) maybeAdvanceAllowedIndex() {
 func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	ctx context.Context, raft Raft, rangeID roachpb.RangeID, lastIndex kvpb.RaftIndex,
 ) error {
+	prefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
 	if logstore.UseRaftLogSingleDelete(t.eng.Separated()) {
-		if err := clearRaftLogWithSingleDelete(
-			ctx, raft.RO, raft.WO, rangeID, lastIndex,
+		if err := logstore.ClearRangeWithSingleDeletes(
+			ctx, raft.RO, raft.WO, prefixBuf,
+			0 /* lo */, lastIndex+1, /* hi */
 		); err != nil {
 			return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
 		}
-	} else if err := storage.ClearRangeWithHeuristic(
-		ctx, raft.RO, raft.WO,
-		keys.RaftLogPrefix(rangeID),           /* start */
-		keys.RaftLogKey(rangeID, lastIndex+1), /* end */
-		ClearRangeThresholdPointKeys(),
+	} else if err := logstore.ClearRange(
+		ctx, raft.RO, raft.WO, prefixBuf,
+		0 /* lo */, lastIndex+1 /* hi */, ClearRangeThresholdPointKeys(),
 	); err != nil {
 		return errors.Wrapf(err, "clearing raft log entries for r%d", rangeID)
 	}
@@ -310,40 +310,4 @@ func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	// We must sync the sideloaded storage after truncation to avoid leaking the
 	// files in case of a node crash.
 	return ss.Sync()
-}
-
-// clearRaftLogWithSingleDelete clears raft log entries using SingleDelete for
-// each point key. Unlike the regular truncation path, this always uses point
-// deletions and never falls back to a range tombstone, because range tombstones
-// are incompatible with SingleDelete.
-func clearRaftLogWithSingleDelete(
-	ctx context.Context,
-	r storage.Reader,
-	w storage.Writer,
-	rangeID roachpb.RangeID,
-	lastIndex kvpb.RaftIndex,
-) error {
-	start := keys.RaftLogPrefix(rangeID)
-	end := keys.RaftLogKey(rangeID, lastIndex+1)
-	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsOnly,
-		LowerBound: start,
-		UpperBound: end,
-	})
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-
-	ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: start})
-	for ; ok; ok, err = iter.NextEngineKey() {
-		key, kerr := iter.UnsafeEngineKey()
-		if kerr != nil {
-			return kerr
-		}
-		if err := w.SingleClearEngineKey(key); err != nil {
-			return err
-		}
-	}
-	return err
 }

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -440,6 +440,29 @@ func storeHardState(
 // maintain exclusive access to the raft log for the duration of the method
 // call.
 //
+// assertNoLiveRaftLogEntry returns an assertion error if the raft log key for
+// the given index has a live value in the reader. Used to verify the
+// precondition for MVCCBlindPut, which must land on an empty key for the
+// SingleDelete invariant (exactly one Set per key over its lifetime) to hold.
+// Intended for test-build callers (gated on buildutil.CrdbTestBuild).
+func assertNoLiveRaftLogEntry(
+	ctx context.Context, reader storage.Reader, raftLogPrefix roachpb.Key, index kvpb.RaftIndex,
+) error {
+	key := keys.RaftLogKeyFromPrefix(raftLogPrefix, index)
+	// Raft log entries are inline values (hlc.Timestamp{}). MVCCGet's Value is
+	// absent when the key has no value or the most recent write is a
+	// (Single)Delete tombstone, so a present Value here means a live entry.
+	res, err := storage.MVCCGet(ctx, reader, key, hlc.Timestamp{}, storage.MVCCGetOptions{})
+	if err != nil {
+		return err
+	}
+	if res.Value.IsPresent() {
+		return errors.AssertionFailedf(
+			"raft log entry %d already has a live value before blind put", index)
+	}
+	return nil
+}
+
 // logAppend is intentionally oblivious to the existence of sideloaded
 // proposals. They are managed by the caller, including cleaning up obsolete
 // on-disk payloads in case the log tail is replaced.
@@ -471,14 +494,26 @@ func logAppend(
 	opts := storage.MVCCWriteOptions{Stats: diff, Category: fs.ReplicationReadCategory}
 	for i := range entries {
 		ent := &entries[i]
-		key := keys.RaftLogKeyFromPrefix(raftLogPrefix, kvpb.RaftIndex(ent.Index))
+		index := kvpb.RaftIndex(ent.Index)
+		key := keys.RaftLogKeyFromPrefix(raftLogPrefix, index)
 
 		if err := value.SetProto(ent); err != nil {
 			return RaftState{}, err
 		}
 		value.InitChecksum(key)
 		var err error
-		if kvpb.RaftIndex(ent.Index) > prev.LastIndex {
+		if index > prev.LastIndex {
+			// Test-only: a fresh-index BlindPut must land on an empty key. If
+			// not, a subsequent SingleDelete of this entry would leave a stale
+			// Set behind, breaking the SingleDelete invariant. On the unindexed
+			// raft log batch the read passes through to the engine, which is
+			// what we want — prev.LastIndex reflects the engine's committed
+			// state, so any live value at index > prev.LastIndex is a real bug.
+			if buildutil.CrdbTestBuild {
+				if err := assertNoLiveRaftLogEntry(ctx, rw, raftLogPrefix, index); err != nil {
+					return RaftState{}, err
+				}
+			}
 			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
 		} else if useSingleDelete {
 			// When using SingleDelete for truncation, we must ensure each raft
@@ -493,6 +528,11 @@ func logAppend(
 			if err = rw.SingleClearUnversioned(key); err != nil {
 				return RaftState{}, err
 			}
+			// No post-SingleClear assertion: it would need to read in-batch
+			// state to verify the clear took effect, but the raft log batch is
+			// unindexed and reads pass through to the engine, which still sees
+			// the original Set. An indexed-batch path would also pin an
+			// iterator on the batch and risk leaking on shutdown.
 			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
 		} else {
 			_, err = storage.MVCCPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"math/rand"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,14 +50,46 @@ var DisableSyncRaftLog = settings.RegisterBoolSetting(
 	settings.WithUnsafe,
 )
 
-// UseRaftLogSingleDelete controls whether to use Pebble's SingleDelete
-// instead of Delete when clearing individual raft log entries during
-// truncation and log suffix replacement. SingleDelete is more efficient
-// because it can be compacted away faster, but requires that each key has
-// been Set exactly once since the last delete. This is naturally the case
-// for raft log entries in the common path.
-var UseRaftLogSingleDelete = envutil.EnvOrDefaultBool(
-	"COCKROACH_RAFT_LOG_SINGLE_DELETE", false)
+// raftLogSingleDeleteMode selects how UseRaftLogSingleDelete decides whether to
+// use Pebble's SingleDelete for raft log entries deletions.
+type raftLogSingleDeleteMode int
+
+const (
+	// raftLogSingleDeleteDefault defers the choice to engine separation.
+	raftLogSingleDeleteDefault raftLogSingleDeleteMode = iota
+	// raftLogSingleDeleteEnabled forces SingleDelete on.
+	raftLogSingleDeleteEnabled
+	// raftLogSingleDeleteDisabled forces SingleDelete off.
+	raftLogSingleDeleteDisabled
+)
+
+// raftLogSingleDeleteEnv reflects the COCKROACH_RAFT_LOG_SINGLE_DELETE env var.
+var raftLogSingleDeleteEnv = func() raftLogSingleDeleteMode {
+	switch strings.ToLower(envutil.EnvOrDefaultString(
+		"COCKROACH_RAFT_LOG_SINGLE_DELETE", "default")) {
+	case "true":
+		return raftLogSingleDeleteEnabled
+	case "false":
+		return raftLogSingleDeleteDisabled
+	default:
+		return raftLogSingleDeleteDefault
+	}
+}()
+
+// UseRaftLogSingleDelete reports whether to use Pebble's SingleDelete instead
+// of regular Delete when clearing individual raft log entries deletions.
+// TODO(ibrahim): Remove this function once single deletions are the default for
+// raft log.
+func UseRaftLogSingleDelete(separated bool) bool {
+	switch raftLogSingleDeleteEnv {
+	case raftLogSingleDeleteEnabled:
+		return true
+	case raftLogSingleDeleteDisabled:
+		return false
+	default:
+		return separated
+	}
+}
 
 var enableNonBlockingRaftLogSync = settings.RegisterBoolSetting(
 	settings.SystemOnly,
@@ -136,8 +169,11 @@ type WriteStats struct {
 
 // LogStore is a stub of a separated Raft log storage.
 type LogStore struct {
-	RangeID     roachpb.RangeID
-	Engine      storage.Engine
+	RangeID roachpb.RangeID
+	Engine  storage.Engine
+	// Separated is true iff the raft log engine is separated from the state
+	// machine engine.
+	Separated   bool
 	Sideload    SideloadStorage
 	StateLoader StateLoader // used only for writes under raftMu
 	SyncWaiter  *SyncWaiterLoop
@@ -216,6 +252,7 @@ func (s *LogStore) storeEntriesAndCommitBatch(
 		state.ByteSize += entryStats.SideloadedBytes
 		if state, err = logAppend(
 			ctx, s.StateLoader.RaftLogPrefix(), batch, state, thinEntries,
+			UseRaftLogSingleDelete(s.Separated),
 		); err != nil {
 			const expl = "during append"
 			return RaftState{}, errors.Wrap(err, expl)
@@ -412,6 +449,7 @@ func logAppend(
 	rw storage.ReadWriter,
 	prev RaftState,
 	entries []raftpb.Entry,
+	useSingleDelete bool,
 ) (RaftState, error) {
 	if len(entries) == 0 {
 		return prev, nil
@@ -442,7 +480,7 @@ func logAppend(
 		var err error
 		if kvpb.RaftIndex(ent.Index) > prev.LastIndex {
 			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
-		} else if UseRaftLogSingleDelete {
+		} else if useSingleDelete {
 			// When using SingleDelete for truncation, we must ensure each raft
 			// log key has exactly one Set. Overwriting via MVCCPut would create a
 			// second Set. Instead, cancel the old Set with a SingleDelete, then
@@ -471,7 +509,7 @@ func logAppend(
 			// Note that the caller is in charge of deleting any sideloaded payloads
 			// (which they must only do *after* the batch has committed).
 			key := keys.RaftLogKeyFromPrefix(raftLogPrefix, i)
-			if UseRaftLogSingleDelete {
+			if useSingleDelete {
 				// These tail entries have exactly one Set each — they were
 				// appended once and are now being cut from the log.
 				// TODO(pav-kv): the stats won't account for the removed entries'
@@ -506,6 +544,7 @@ func Compact(
 	next kvserverpb.RaftTruncatedState,
 	loader StateLoader,
 	writer storage.Writer,
+	useSingleDelete bool,
 ) error {
 	if next.Index <= prev.Index {
 		// TODO(pav-kv): return an assertion failure error.
@@ -531,7 +570,7 @@ func Compact(
 		for idx := prev.Index + 1; idx <= next.Index; idx++ {
 			key := keys.RaftLogKeyFromPrefix(prefix, idx)
 			var err error
-			if UseRaftLogSingleDelete {
+			if useSingleDelete {
 				err = writer.SingleClearUnversioned(key)
 			} else {
 				err = writer.ClearUnversioned(key, storage.ClearOptions{})

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -553,36 +553,17 @@ func Compact(
 	// Truncate the Raft log from the entry after the previous truncation index to
 	// the new truncation index. This is performed atomically with updating the
 	// RaftTruncatedState so that the state of the log is consistent.
-	prefixBuf := &loader.RangeIDPrefixBuf
-	numTruncatedEntries := next.Index - prev.Index
-	if numTruncatedEntries >= raftLogTruncationClearRangeThreshold {
-		start := prefixBuf.RaftLogKey(prev.Index + 1).Clone()
-		end := prefixBuf.RaftLogKey(next.Index + 1).Clone() // end is exclusive
-		if err := writer.ClearRawRange(start, end, true, false); err != nil {
-			return errors.Wrapf(err,
-				"unable to clear truncated Raft entries for %+v after index %d",
-				next, prev.Index)
-		}
-	} else {
-		// NB: RangeIDPrefixBufs have sufficient capacity (32 bytes) to avoid
-		// allocating when constructing Raft log keys (16 bytes).
-		prefix := prefixBuf.RaftLogPrefix()
-		for idx := prev.Index + 1; idx <= next.Index; idx++ {
-			key := keys.RaftLogKeyFromPrefix(prefix, idx)
-			var err error
-			if useSingleDelete {
-				err = writer.SingleClearUnversioned(key)
-			} else {
-				err = writer.ClearUnversioned(key, storage.ClearOptions{})
-			}
-			if err != nil {
-				return errors.Wrapf(err, "unable to clear truncated Raft entries for %+v at index %d",
-					next, idx)
-			}
-		}
+	if err := ClearRangeSizeKnown(
+		writer, loader.RangeIDPrefixBuf,
+		prev.Index+1, next.Index+1, int(raftLogTruncationClearRangeThreshold),
+		useSingleDelete,
+	); err != nil {
+		return errors.Wrapf(err,
+			"unable to clear truncated Raft entries for %+v after index %d",
+			next, prev.Index)
 	}
 
-	key := prefixBuf.RaftTruncatedStateKey()
+	key := loader.RangeIDPrefixBuf.RaftTruncatedStateKey()
 	var value roachpb.Value
 	if _, err := next.MarshalToSizedBuffer(value.AllocBytes(next.Size())); err != nil {
 		return err
@@ -593,6 +574,121 @@ func Compact(
 		ctx, writer, key, hlc.Timestamp{}, value, storage.MVCCWriteOptions{},
 	); err != nil {
 		return errors.Wrap(err, "unable to write RaftTruncatedState")
+	}
+	return nil
+}
+
+// raftLogBounds converts a half-open raft log index range [lo, hi) to its
+// engine key span. The sentinels lo == 0 and hi == math.MaxUint64 expand to
+// RaftLogPrefix and RaftLogPrefix.PrefixEnd respectively.
+func raftLogBounds(
+	prefixBuf keys.RangeIDPrefixBuf, lo, hi kvpb.RaftIndex,
+) (start, end roachpb.Key) {
+	if lo == 0 {
+		start = prefixBuf.RaftLogPrefix().Clone()
+	} else {
+		start = prefixBuf.RaftLogKey(lo).Clone()
+	}
+	if hi == math.MaxUint64 {
+		end = prefixBuf.RaftLogPrefix().PrefixEnd()
+	} else {
+		end = prefixBuf.RaftLogKey(hi).Clone()
+	}
+	return start, end
+}
+
+// ClearRange clears raft log entries in the half-open index range [lo, hi)
+// when the entry count is unknown. It scans up to pointKeyThreshold keys via
+// storage.ClearRangeWithHeuristic to choose between per-entry point deletes
+// and a single Pebble range tombstone. Returns nil if lo >= hi.
+func ClearRange(
+	ctx context.Context,
+	r storage.Reader,
+	w storage.Writer,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo, hi kvpb.RaftIndex,
+	pointKeyThreshold int,
+) error {
+	if lo >= hi {
+		return nil
+	}
+	start, end := raftLogBounds(prefixBuf, lo, hi)
+	return storage.ClearRangeWithHeuristic(ctx, r, w, start, end, pointKeyThreshold)
+}
+
+// ClearRangeWithSingleDeletes clears raft log entries in the half-open index
+// range [lo, hi) using SingleDelete for every point key found by scanning the
+// log.
+func ClearRangeWithSingleDeletes(
+	ctx context.Context,
+	r storage.Reader,
+	w storage.Writer,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo, hi kvpb.RaftIndex,
+) error {
+	if lo >= hi {
+		return nil
+	}
+	start, end := raftLogBounds(prefixBuf, lo, hi)
+	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsOnly,
+		LowerBound: start,
+		UpperBound: end,
+	})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: start})
+	for ; ok; ok, err = iter.NextEngineKey() {
+		key, kerr := iter.UnsafeEngineKey()
+		if kerr != nil {
+			return kerr
+		}
+		if err := w.SingleClearEngineKey(key); err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// ClearRangeSizeKnown clears raft log entries in the half-open index range
+// [lo, hi) when the caller already knows how many entries the range contains.
+// The choice between point deletes and a Pebble range tombstone is made
+// arithmetically (hi - lo vs pointKeyThreshold) without scanning. Returns nil
+// if lo >= hi.
+//
+// If maybeUseSingleDel is true, it uses SingleDelete instead of regular Delete
+// if the size is <= pointKeyThreshold.
+func ClearRangeSizeKnown(
+	w storage.Writer,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo, hi kvpb.RaftIndex,
+	pointKeyThreshold int,
+	maybeUseSingleDel bool,
+) error {
+	if lo >= hi {
+		return nil
+	}
+	if hi-lo >= kvpb.RaftIndex(pointKeyThreshold) {
+		start, end := raftLogBounds(prefixBuf, lo, hi)
+		return w.ClearRawRange(start, end, true /* pointKeys */, false /* rangeKeys */)
+	}
+	// NB: RangeIDPrefixBufs have sufficient capacity (32 bytes) to avoid
+	// allocating when constructing Raft log keys (16 bytes).
+	prefix := prefixBuf.RaftLogPrefix()
+	for idx := lo; idx < hi; idx++ {
+		key := keys.RaftLogKeyFromPrefix(prefix, idx)
+		var err error
+		if maybeUseSingleDel {
+			err = w.SingleClearUnversioned(key)
+		} else {
+			err = w.ClearUnversioned(key, storage.ClearOptions{})
+		}
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -49,6 +49,15 @@ var DisableSyncRaftLog = settings.RegisterBoolSetting(
 	settings.WithUnsafe,
 )
 
+// UseRaftLogSingleDelete controls whether to use Pebble's SingleDelete
+// instead of Delete when clearing individual raft log entries during
+// truncation and log suffix replacement. SingleDelete is more efficient
+// because it can be compacted away faster, but requires that each key has
+// been Set exactly once since the last delete. This is naturally the case
+// for raft log entries in the common path.
+var UseRaftLogSingleDelete = envutil.EnvOrDefaultBool(
+	"COCKROACH_RAFT_LOG_SINGLE_DELETE", false)
+
 var enableNonBlockingRaftLogSync = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.raft_log.non_blocking_synchronization.enabled",
@@ -433,6 +442,20 @@ func logAppend(
 		var err error
 		if kvpb.RaftIndex(ent.Index) > prev.LastIndex {
 			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
+		} else if UseRaftLogSingleDelete {
+			// When using SingleDelete for truncation, we must ensure each raft
+			// log key has exactly one Set. Overwriting via MVCCPut would create a
+			// second Set. Instead, cancel the old Set with a SingleDelete, then
+			// write the new entry with a blind put. SingleDelete is safe here
+			// because every prior write followed this same pattern, so each key
+			// has exactly one Set.
+			// TODO(pav-kv): the stats will slightly overcount because BlindPut
+			// adds the full entry size without subtracting the old entry.
+			// Overwrites are rare (leader changes), and ByteSize is approximate.
+			if err = rw.SingleClearUnversioned(key); err != nil {
+				return RaftState{}, err
+			}
+			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
 		} else {
 			_, err = storage.MVCCPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
 		}
@@ -447,10 +470,20 @@ func logAppend(
 		for i := newLastIndex + 1; i <= prev.LastIndex; i++ {
 			// Note that the caller is in charge of deleting any sideloaded payloads
 			// (which they must only do *after* the batch has committed).
-			_, _, err := storage.MVCCDelete(ctx, rw, keys.RaftLogKeyFromPrefix(raftLogPrefix, i),
-				hlc.Timestamp{}, opts)
-			if err != nil {
-				return RaftState{}, err
+			key := keys.RaftLogKeyFromPrefix(raftLogPrefix, i)
+			if UseRaftLogSingleDelete {
+				// These tail entries have exactly one Set each — they were
+				// appended once and are now being cut from the log.
+				// TODO(pav-kv): the stats won't account for the removed entries'
+				// size. This is acceptable because ByteSize is approximate.
+				if err := rw.SingleClearUnversioned(key); err != nil {
+					return RaftState{}, err
+				}
+			} else {
+				if _, _, err := storage.MVCCDelete(ctx, rw, key,
+					hlc.Timestamp{}, opts); err != nil {
+					return RaftState{}, err
+				}
 			}
 		}
 	}
@@ -496,10 +529,14 @@ func Compact(
 		// allocating when constructing Raft log keys (16 bytes).
 		prefix := prefixBuf.RaftLogPrefix()
 		for idx := prev.Index + 1; idx <= next.Index; idx++ {
-			if err := writer.ClearUnversioned(
-				keys.RaftLogKeyFromPrefix(prefix, idx),
-				storage.ClearOptions{},
-			); err != nil {
+			key := keys.RaftLogKeyFromPrefix(prefix, idx)
+			var err error
+			if UseRaftLogSingleDelete {
+				err = writer.SingleClearUnversioned(key)
+			} else {
+				err = writer.ClearUnversioned(key, storage.ClearOptions{})
+			}
+			if err != nil {
 				return errors.Wrapf(err, "unable to clear truncated Raft entries for %+v at index %d",
 					next, idx)
 			}

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -8,11 +8,13 @@ package logstore
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -20,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,4 +112,217 @@ func TestRaftStorageWrites(t *testing.T) {
 	output = strings.ReplaceAll(output, "\n\n", "\n")
 	output = strings.ReplaceAll(output, "\n\n", "\n")
 	echotest.Require(t, output, filepath.Join("testdata", t.Name()+".txt"))
+}
+
+type logstoreTruncHelper struct {
+	t         *testing.T
+	ctx       context.Context
+	rangeID   roachpb.RangeID
+	prefixBuf keys.RangeIDPrefixBuf
+	eng       storage.Engine
+}
+
+func newLogstoreTruncHelper(t *testing.T, ctx context.Context) *logstoreTruncHelper {
+	const rangeID = roachpb.RangeID(123)
+	h := &logstoreTruncHelper{
+		t:         t,
+		ctx:       ctx,
+		rangeID:   rangeID,
+		prefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),
+		eng:       storage.NewDefaultInMemForTesting(),
+	}
+	h.populate()
+	return h
+}
+
+// close releases the engine.
+func (h *logstoreTruncHelper) close() {
+	h.eng.Close()
+}
+
+// populate writes the raft log entries [15,16,17,18,19] using logAppend.
+func (h *logstoreTruncHelper) populate() {
+	h.t.Helper()
+	entries := []raftpb.Entry{
+		{Index: 15, Term: 10}, {Index: 16, Term: 10}, {Index: 17, Term: 10},
+		{Index: 18, Term: 10}, {Index: 19, Term: 10},
+	}
+	b := h.eng.NewBatch()
+	defer b.Close()
+	_, err := logAppend(
+		h.ctx, h.prefixBuf.RaftLogPrefix(), b, RaftState{}, entries, false, /* useSingleDelete */
+	)
+	require.NoError(h.t, err)
+	require.NoError(h.t, b.Commit(true /* sync */))
+}
+
+// countBatchOps tallies the deletion ops recorded in a Pebble batch's wire
+// representation, classifying them as point deletes, single deletes, or range
+// deletes.
+func (h *logstoreTruncHelper) countBatchOps(batchRepr []byte) (points, singleDels, ranges int) {
+	h.t.Helper()
+	r, err := storage.NewBatchReader(batchRepr)
+	require.NoError(h.t, err)
+	for r.Next() {
+		switch r.KeyKind() {
+		case pebble.InternalKeyKindDelete, pebble.InternalKeyKindDeleteSized:
+			points++
+		case pebble.InternalKeyKindSingleDelete:
+			singleDels++
+		case pebble.InternalKeyKindRangeDelete:
+			ranges++
+		}
+	}
+	return points, singleDels, ranges
+}
+
+// raftLogIndices returns the raft log indices present in the engine's raft log
+// span.
+func (h *logstoreTruncHelper) raftLogIndices() []kvpb.RaftIndex {
+	h.t.Helper()
+	prefix := h.prefixBuf.RaftLogPrefix()
+	iter, err := h.eng.NewMVCCIterator(h.ctx, storage.MVCCKeyIterKind, storage.IterOptions{
+		LowerBound: prefix, UpperBound: prefix.PrefixEnd(),
+	})
+	require.NoError(h.t, err)
+	defer iter.Close()
+	var indices []kvpb.RaftIndex
+	iter.SeekGE(storage.MakeMVCCMetadataKey(prefix))
+	for {
+		ok, err := iter.Valid()
+		require.NoError(h.t, err)
+		if !ok {
+			break
+		}
+		key := iter.UnsafeKey().Key
+		idx, err := keys.DecodeRaftLogKeyFromSuffix(key[len(prefix):])
+		require.NoError(h.t, err)
+		indices = append(indices, idx)
+		iter.Next()
+	}
+	return indices
+}
+
+// TestClearRange verifies the scan-based heuristic in ClearRange: when the
+// number of raft log keys actually present in [lo, hi) is below the threshold,
+// the function emits per-entry point deletes; otherwise it emits a single
+// Pebble range tombstone.
+func TestClearRange(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		lo, hi                 kvpb.RaftIndex
+		threshold              int
+		wantPoints, wantRanges int
+		wantIndices            []kvpb.RaftIndex
+	}{
+		{lo: 0, hi: math.MaxUint64, threshold: 1, wantPoints: 0, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 6, wantPoints: 5, wantRanges: 0},
+		{lo: 11, hi: 16, threshold: 3, wantPoints: 1, wantRanges: 0, wantIndices: []kvpb.RaftIndex{16, 17, 18, 19}},
+		{lo: 11, hi: 16, threshold: 6, wantPoints: 1, wantRanges: 0, wantIndices: []kvpb.RaftIndex{16, 17, 18, 19}},
+		{lo: 11, hi: 20, threshold: 3, wantPoints: 0, wantRanges: 1},
+		{lo: 11, hi: 20, threshold: 6, wantPoints: 5, wantRanges: 0},
+		{lo: 15, hi: 19, threshold: 3, wantPoints: 0, wantRanges: 1, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 15, hi: 19, threshold: 6, wantPoints: 4, wantRanges: 0, wantIndices: []kvpb.RaftIndex{19}},
+		// Empty / inverted ranges are no-ops.
+		{lo: 15, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+		{lo: 100, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			h := newLogstoreTruncHelper(t, ctx)
+			defer h.close()
+			batch := h.eng.NewBatch()
+			defer batch.Close()
+			require.NoError(t, ClearRange(ctx, h.eng, batch, h.prefixBuf, tc.lo, tc.hi, tc.threshold))
+			points, singleDels, ranges := h.countBatchOps(batch.Repr())
+			require.Equal(t, tc.wantPoints, points)
+			require.Equal(t, 0, singleDels)
+			require.Equal(t, tc.wantRanges, ranges)
+			require.NoError(t, batch.Commit(true /* sync */))
+			require.Equal(t, tc.wantIndices, h.raftLogIndices())
+		})
+	}
+}
+
+// TestClearRangeSizeKnown verifies that it correctly chooses between point
+// deletes, single deletes, and range deletes based on the provided args.
+func TestClearRangeSizeKnown(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		lo, hi                                 kvpb.RaftIndex
+		threshold                              int
+		maybeUseSingleDel                      bool
+		wantPoints, wantSingleDels, wantRanges int
+		wantIndices                            []kvpb.RaftIndex
+	}{
+		{lo: 0, hi: math.MaxUint64, threshold: 1, wantRanges: 1},
+		{lo: 0, hi: math.MaxUint64, threshold: 1, maybeUseSingleDel: true, wantRanges: 1},
+		{lo: 15, hi: 19, threshold: 3, wantRanges: 1, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 15, hi: 19, threshold: 3, maybeUseSingleDel: true, wantRanges: 1, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 15, hi: 19, threshold: 6, wantPoints: 4, wantIndices: []kvpb.RaftIndex{19}},
+		{lo: 15, hi: 19, threshold: 6, maybeUseSingleDel: true, wantSingleDels: 4, wantIndices: []kvpb.RaftIndex{19}},
+		// Empty / inverted ranges are no-ops.
+		{lo: 15, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+		{lo: 100, hi: 15, threshold: 1, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			h := newLogstoreTruncHelper(t, ctx)
+			defer h.close()
+			batch := h.eng.NewBatch()
+			defer batch.Close()
+			require.NoError(t, ClearRangeSizeKnown(
+				batch, h.prefixBuf, tc.lo, tc.hi, tc.threshold, tc.maybeUseSingleDel,
+			))
+			points, singleDels, ranges := h.countBatchOps(batch.Repr())
+			require.Equal(t, tc.wantPoints, points)
+			require.Equal(t, tc.wantSingleDels, singleDels)
+			require.Equal(t, tc.wantRanges, ranges)
+			require.NoError(t, batch.Commit(true /* sync */))
+			require.Equal(t, tc.wantIndices, h.raftLogIndices())
+		})
+	}
+}
+
+// TestClearRangeWithSingleDeletes verifies that ClearRangeWithSingleDeletes
+// emits one SingleDelete per raft log key actually present in [lo, hi), never
+// a regular Delete and never a range tombstone.
+func TestClearRangeWithSingleDeletes(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		lo, hi         kvpb.RaftIndex
+		wantSingleDels int
+		wantIndices    []kvpb.RaftIndex
+	}{
+		{lo: 0, hi: math.MaxUint64, wantSingleDels: 5},
+		{lo: 11, hi: 16, wantSingleDels: 1, wantIndices: []kvpb.RaftIndex{16, 17, 18, 19}},
+		{lo: 11, hi: 20, wantSingleDels: 5},
+		{lo: 15, hi: 19, wantSingleDels: 4, wantIndices: []kvpb.RaftIndex{19}},
+
+		// Empty / inverted ranges are no-ops.
+		{lo: 15, hi: 15, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+		{lo: 100, hi: 15, wantIndices: []kvpb.RaftIndex{15, 16, 17, 18, 19}},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			h := newLogstoreTruncHelper(t, ctx)
+			defer h.close()
+			batch := h.eng.NewBatch()
+			defer batch.Close()
+			require.NoError(t, ClearRangeWithSingleDeletes(
+				ctx, h.eng, batch, h.prefixBuf, tc.lo, tc.hi,
+			))
+			points, singleDels, ranges := h.countBatchOps(batch.Repr())
+			require.Equal(t, tc.wantSingleDels, singleDels)
+			// ClearRangeWithSingleDeletes() never issues regular point/range deletes.
+			require.Equal(t, 0, points)
+			require.Equal(t, 0, ranges)
+			require.NoError(t, batch.Commit(true /* sync */))
+			require.Equal(t, tc.wantIndices, h.raftLogIndices())
+		})
+	}
 }

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -67,7 +67,7 @@ func TestRaftStorageWrites(t *testing.T) {
 		batch := writeBatch(func(rw storage.ReadWriter) {
 			require.NoError(t, storeHardState(ctx, rw, sl, hs))
 			var err error
-			newState, err = logAppend(ctx, sl.RaftLogPrefix(), rw, state, entries)
+			newState, err = logAppend(ctx, sl.RaftLogPrefix(), rw, state, entries, false /* useSingleDelete */)
 			require.NoError(t, err)
 		})
 		state = newState
@@ -77,7 +77,7 @@ func TestRaftStorageWrites(t *testing.T) {
 	truncate := func(name string, ts kvserverpb.RaftTruncatedState) {
 		t.Helper()
 		batch := writeBatch(func(rw storage.ReadWriter) {
-			require.NoError(t, Compact(ctx, trunc, ts, sl, rw))
+			require.NoError(t, Compact(ctx, trunc, ts, sl, rw, false /* useSingleDelete */))
 		})
 		trunc = ts
 		state.ByteSize = stats()

--- a/pkg/kv/kvserver/logstore/sync_waiter.go
+++ b/pkg/kv/kvserver/logstore/sync_waiter.go
@@ -7,6 +7,7 @@ package logstore
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -42,6 +43,10 @@ type syncWaiterCallback interface {
 type SyncWaiterLoop struct {
 	q       chan syncBatch
 	stopped chan struct{}
+	// inFlightEnqueues counts enqueue calls that have observed w.stopped open
+	// and may still send on w.q. waitLoop's quiesce path waits on this before
+	// draining so that no late send can land on w.q after the drain returns.
+	inFlightEnqueues sync.WaitGroup
 
 	logEveryEnqueueBlocked log.EveryN
 }
@@ -82,8 +87,22 @@ func (w *SyncWaiterLoop) Start(ctx context.Context, stopper *stop.Stopper) {
 
 // waitLoop pulls off the SyncWaiterLoop's queue. For each syncWaiter, it waits
 // for the sync to complete and then calls the associated callback.
+//
+// On stopper quiesce, the loop drains any remaining queued syncWaiters and
+// closes them before returning. The drain is race-free against in-flight
+// enqueue calls: w.stopped is closed first so no new enqueue can begin, then
+// inFlightEnqueues is waited on so any enqueue already past its w.stopped
+// check has a chance to either land its item on w.q or bail out, and only
+// then is w.q drained. The drain skips SyncWait and the callback — raft is
+// also shutting down and has no consumer for the durability notification,
+// and Pebble's own Close path drains in-progress WAL syncs. We still need to
+// call Close so that any resources held by the syncWaiter (e.g. cached
+// pebble iterators on in-flight batches) are released before engine close
+// runs and trips Pebble's leaked-iterator check.
 func (w *SyncWaiterLoop) waitLoop(ctx context.Context, stopper *stop.Stopper) {
-	defer close(w.stopped)
+	var closeOnce sync.Once
+	closeStopped := func() { closeOnce.Do(func() { close(w.stopped) }) }
+	defer closeStopped()
 	for {
 		select {
 		case w := <-w.q:
@@ -93,7 +112,16 @@ func (w *SyncWaiterLoop) waitLoop(ctx context.Context, stopper *stop.Stopper) {
 			w.cb.run()
 			w.wg.Close()
 		case <-stopper.ShouldQuiesce():
-			return
+			closeStopped()
+			w.inFlightEnqueues.Wait()
+			for {
+				select {
+				case w := <-w.q:
+					w.wg.Close()
+				default:
+					return
+				}
+			}
 		}
 	}
 }
@@ -110,6 +138,18 @@ func (w *SyncWaiterLoop) waitLoop(ctx context.Context, stopper *stop.Stopper) {
 // If the SyncWaiterLoop has already been stopped, the callback will never be
 // called.
 func (w *SyncWaiterLoop) enqueue(ctx context.Context, wg syncWaiter, cb syncWaiterCallback) {
+	// Reserve a slot in inFlightEnqueues before checking w.stopped. waitLoop
+	// closes w.stopped and then waits on inFlightEnqueues to drain, so this
+	// ordering ensures: either (a) w.stopped is observed open here and we
+	// proceed to send (waitLoop's Wait will block until we finish), or (b)
+	// w.stopped is observed closed and we bail without touching w.q.
+	w.inFlightEnqueues.Add(1)
+	defer w.inFlightEnqueues.Done()
+	select {
+	case <-w.stopped:
+		return
+	default:
+	}
 	b := syncBatch{wg, cb}
 	select {
 	case w.q <- b:

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -566,6 +567,7 @@ func (t *raftLogTruncator) tryEnactTruncations(
 	if err := handleTruncatedStateBelowRaftPreApply(ctx, truncState,
 		pendingTruncs.mu.truncs[enactIndex].RaftTruncatedState,
 		stateLoader.StateLoader, batch,
+		logstore.UseRaftLogSingleDelete(eng.Separated()),
 	); err != nil {
 		log.KvExec.Errorf(ctx, "while attempting to truncate raft log: %+v", err)
 		pendingTruncs.reset()

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -550,6 +551,7 @@ func (b *replicaAppBatch) stageTruncation(
 	if err := handleTruncatedStateBelowRaftPreApply(
 		ctx, b.truncState, *truncatedState,
 		b.r.raftMu.stateLoader.StateLoader, b.batch.Raft(),
+		logstore.UseRaftLogSingleDelete(b.r.logStorage.ls.Separated),
 	); err != nil {
 		return errors.Wrap(err, "unable to handle truncated state")
 	}

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -235,6 +235,7 @@ func newUninitializedReplicaWithoutRaftGroup(store *Store, id roachpb.FullReplic
 	r.logStorage.ls = &logstore.LogStore{
 		RangeID:     id.RangeID,
 		Engine:      store.LogEngine(),
+		Separated:   store.EnginesSeparated(),
 		Sideload:    sideloaded,
 		StateLoader: r.raftMu.stateLoader.StateLoader,
 		// NOTE: use the same SyncWaiter loop for all raft log writes performed by a

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -3030,8 +3030,9 @@ func handleTruncatedStateBelowRaftPreApply(
 	next kvserverpb.RaftTruncatedState,
 	loader logstore.StateLoader,
 	writer storage.Writer,
+	useSingleDelete bool,
 ) error {
-	return logstore.Compact(ctx, prev, next, loader, writer)
+	return logstore.Compact(ctx, prev, next, loader, writer, useSingleDelete)
 }
 
 // shouldCampaignAfterConfChange returns true if the current replica should

--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -89,6 +89,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 				// Apply truncation.
 				require.NoError(t, handleTruncatedStateBelowRaftPreApply(
 					ctx, currentTruncatedState, suggestedTruncatedState, loader, eng,
+					false, /* useSingleDelete */
 				))
 
 				// Check the truncated state.

--- a/pkg/kv/kvserver/replica_raftlog_test.go
+++ b/pkg/kv/kvserver/replica_raftlog_test.go
@@ -193,7 +193,8 @@ func (rt *replicaLogStorageTest) truncate(
 	rt.raftMu.Lock()
 	defer rt.raftMu.Unlock()
 	require.NoError(rt.t, handleTruncatedStateBelowRaftPreApply(
-		ctx, prev, next, rt.ls.ls.StateLoader, b))
+		ctx, prev, next, rt.ls.ls.StateLoader, b,
+		logstore.UseRaftLogSingleDelete(rt.ls.ls.Separated)))
 	rt.ls.stagePendingTruncationRaftMuLocked(pendingTruncation{
 		RaftTruncatedState: next,
 		expectedFirstIndex: prev.Index + 1,

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -569,6 +569,12 @@ func (s spanSetWriter) ClearEngineKey(key storage.EngineKey, opts storage.ClearO
 	return s.w.ClearEngineKey(key, opts)
 }
 
+func (s spanSetWriter) SingleClearUnversioned(key roachpb.Key) error {
+	// Pass-through, since single clear of unversioned keys is only used for
+	// raft log entries which are unreplicated range-ID local keys.
+	return s.w.SingleClearUnversioned(key)
+}
+
 func (s spanSetWriter) SingleClearEngineKey(key storage.EngineKey) error {
 	// Pass-through, since single clear is only used for the lock table, which
 	// is not in the spans.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -646,6 +646,18 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearUnversioned(key roachpb.Key, opts ClearOptions) error
+	// SingleClearUnversioned removes an unversioned item from the db using a
+	// Pebble SingleDelete. It has the same purpose as ClearUnversioned but uses
+	// SingleDelete which is more efficient when the caller can guarantee that
+	// the key has been Set exactly once since the last SingleDelete/Delete.
+	//
+	// WARNING: using this on a key that has been Set multiple times without an
+	// intervening delete will not fully remove the key — it only cancels the
+	// most recent Set, leaving older Sets visible. See the Pebble SingleDelete
+	// documentation for the full contract.
+	//
+	// It is safe to modify the contents of the arguments after it returns.
+	SingleClearUnversioned(key roachpb.Key) error
 	// ClearEngineKey removes the given point key from the engine. It does not
 	// affect range keys.  Note that clear actually removes entries from the
 	// storage engine. This is a general-purpose and low-level method that should

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -939,6 +939,11 @@ func (rw clearKeyPrintingReadWriter) ClearEngineKey(
 	return rw.ReadWriter.ClearEngineKey(key, opts)
 }
 
+func (rw clearKeyPrintingReadWriter) SingleClearUnversioned(key roachpb.Key) error {
+	rw.buf.Printf("called SingleClearUnversioned(%v)\n", key)
+	return rw.ReadWriter.SingleClearUnversioned(key)
+}
+
 func (rw clearKeyPrintingReadWriter) SingleClearEngineKey(key storage.EngineKey) error {
 	rw.buf.Printf("called SingleClearEngineKey(%v)\n", key)
 	return rw.ReadWriter.SingleClearEngineKey(key)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1751,6 +1751,14 @@ func (p *Pebble) ClearUnversioned(key roachpb.Key, opts ClearOptions) error {
 	return p.clear(MVCCKey{Key: key}, opts)
 }
 
+// SingleClearUnversioned implements the Engine interface.
+func (p *Pebble) SingleClearUnversioned(key roachpb.Key) error {
+	if len(key) == 0 {
+		return emptyKeyError()
+	}
+	return p.db.SingleDelete(EncodeMVCCKey(MVCCKey{Key: key}), pebble.Sync)
+}
+
 // ClearEngineKey implements the Engine interface.
 func (p *Pebble) ClearEngineKey(key EngineKey, opts ClearOptions) error {
 	if len(key.Key) == 0 {
@@ -3042,6 +3050,10 @@ func (p *pebbleReadOnly) ClearMVCC(key MVCCKey, opts ClearOptions) error {
 }
 
 func (p *pebbleReadOnly) ClearUnversioned(key roachpb.Key, opts ClearOptions) error {
+	return errors.AssertionFailedf("not implemented")
+}
+
+func (p *pebbleReadOnly) SingleClearUnversioned(key roachpb.Key) error {
 	return errors.AssertionFailedf("not implemented")
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -129,6 +129,15 @@ func (wb *writeBatch) clear(key MVCCKey, opts ClearOptions) error {
 	return wb.batch.DeleteSized(wb.buf, opts.ValueSize, nil)
 }
 
+// SingleClearUnversioned implements the Writer interface.
+func (wb *writeBatch) SingleClearUnversioned(key roachpb.Key) error {
+	if len(key) == 0 {
+		return emptyKeyError()
+	}
+	wb.buf = EncodeMVCCKeyToBuf(wb.buf[:0], MVCCKey{Key: key})
+	return wb.batch.SingleDelete(wb.buf, nil)
+}
+
 // SingleClearEngineKey implements the Writer interface.
 func (wb *writeBatch) SingleClearEngineKey(key EngineKey) error {
 	if len(key.Key) == 0 {

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -474,6 +474,11 @@ func (fw *SSTWriter) clear(key MVCCKey, opts ClearOptions) error {
 	return fw.fw.Delete(fw.scratch)
 }
 
+// SingleClearUnversioned implements the Writer interface.
+func (fw *SSTWriter) SingleClearUnversioned(key roachpb.Key) error {
+	return errors.AssertionFailedf("not implemented")
+}
+
 // SingleClearEngineKey implements the Writer interface.
 func (fw *SSTWriter) SingleClearEngineKey(key EngineKey) error {
 	return errors.AssertionFailedf("not implemented")


### PR DESCRIPTION
Introduce a SingleClearUnversioned method on the storage Writer interface, and
use it for clearing raft log entries when UseRaftLogSingleDelete is enabled.
This applies to all raft log deletion paths: truncation (Compact), log
overwrites, and tail trimming in logAppend.

In clearRaftLogWithSingleDelete (used by WAGTruncator for destroyed/subsumed
replicas), always use point SingleDeletes instead of counting keys and falling
back to a range tombstone, for simplicity.

Epic: none
Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>