### PR TITLE
importer: add Parquet LIST column reader

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "read_import_mysqlout.go",
         "read_import_parquet.go",
         "read_import_parquet_batch.go",
+        "read_import_parquet_list.go",
         "read_import_parquet_logical.go",
         "read_import_parquet_types.go",
         "read_import_pgcopy.go",
@@ -31,6 +32,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/build",
         "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/col/coldata",
@@ -151,6 +153,7 @@ go_test(
         "read_import_base_test.go",
         "read_import_parquet_batch_test.go",
         "read_import_parquet_legacy_test.go",
+        "read_import_parquet_list_test.go",
         "read_import_parquet_logical_test.go",
         "read_import_parquet_test.go",
         "testutils_test.go",

--- a/pkg/sql/importer/read_import_parquet_batch.go
+++ b/pkg/sql/importer/read_import_parquet_batch.go
@@ -28,6 +28,10 @@ type parquetCopyValueFunc func(rowIdx int, valIdx int)
 // Values are stored in type-specific slices (e.g., boolValues, int32Values) based
 // on the column's physical type. The isNull array tracks which rows are NULL.
 //
+// For LIST columns, the batch stores pre-assembled per-row element slices in
+// listRowValues instead of using the typed value slices. Each entry is a []any
+// of raw element values for that row, or nil for a null list.
+//
 // Design: We use separate slices for each type rather than []interface{} to:
 // 1. Avoid heap allocations from boxing primitive values
 // 2. Enable better cache locality during batch processing
@@ -57,6 +61,11 @@ type parquetColumnBatch struct {
 
 	// Null tracking - one entry per row
 	isNull []bool // [rowIdx] -> is this row null?
+
+	// LIST column fields. When isList is true, the typed value slices above
+	// are unused. Instead, per-row arrays are stored in listRowValues.
+	isList        bool
+	listRowValues [][]any // [rowIdx] -> element values (nil = null list, empty = empty list)
 }
 
 // parquetBatchBuffers holds reusable buffers for reading Parquet values.
@@ -236,7 +245,9 @@ func (b *parquetColumnBatch) Read() error {
 
 // GetValueAt extracts the raw Parquet value at the given row index.
 // Returns (value, isNull, error).
-// The value is returned as an interface{} but is typed according to the physical type.
+//
+// For flat columns, the value is typed according to the physical type (int32,
+// string, etc.). For LIST columns, the value is a []any of raw element values.
 func (b *parquetColumnBatch) GetValueAt(rowIdx int) (any, bool, error) {
 	if rowIdx < 0 || rowIdx >= int(b.rowCount) {
 		return nil, false, errors.Newf("row index %d out of bounds [0, %d)", rowIdx, b.rowCount)
@@ -244,6 +255,10 @@ func (b *parquetColumnBatch) GetValueAt(rowIdx int) (any, bool, error) {
 
 	if b.isNull[rowIdx] {
 		return nil, true, nil
+	}
+
+	if b.isList {
+		return b.listRowValues[rowIdx], false, nil
 	}
 
 	switch b.physicalType {

--- a/pkg/sql/importer/read_import_parquet_list.go
+++ b/pkg/sql/importer/read_import_parquet_list.go
@@ -1,0 +1,516 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package importer
+
+import (
+	"github.com/apache/arrow/go/v11/parquet"
+	"github.com/apache/arrow/go/v11/parquet/file"
+	"github.com/apache/arrow/go/v11/parquet/schema"
+	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/errors"
+)
+
+// parquetListLevelInfo describes one LIST nesting level's definition and
+// repetition level thresholds. For a nested LIST(LIST(INT32)) structure,
+// there are two levels: level 0 (outer list) and level 1 (inner list).
+type parquetListLevelInfo struct {
+	// repLevel is the repetition level that indicates a new element starts at
+	// this nesting depth. For the outermost list this is 1 (since rep=0 means
+	// a new top-level row), for the next inner list it is 2, etc.
+	repLevel int16
+
+	// nullListDefLevel: at or below this definition level, the list at this
+	// nesting depth is null. Set to -1 if the list is required (cannot be null).
+	nullListDefLevel int16
+
+	// emptyListDefLevel: exactly this definition level means the list at this
+	// nesting depth is present but empty (no elements).
+	emptyListDefLevel int16
+}
+
+// parquetListColumnInfo holds schema metadata for a LIST column (single-level
+// or nested). Populated once during file open and reused across all batches.
+//
+// A single-level Parquet LIST uses 3-level encoding:
+//
+//	optional group <columnName> (LIST) {
+//	  repeated group list {
+//	    optional/required <type> element;
+//	  }
+//	}
+//
+// A nested LIST(LIST(T)) adds another pair of (group, repeated group) levels.
+// The library flattens these to a single leaf column. Definition and repetition
+// levels encode null-list, empty-list, null-element, and present-element states
+// at each nesting depth.
+type parquetListColumnInfo struct {
+	// columnName is the top-level group node name (the user-visible column name,
+	// e.g. "tags"), as opposed to the leaf name ("element").
+	columnName string
+
+	// Element's physical type and logical/converted type for value conversion.
+	// These describe the leaf (innermost) primitive type.
+	elementPhysicalType  parquet.Type
+	elementLogicalType   schema.LogicalType
+	elementConvertedType schema.ConvertedType
+
+	// nestingDepth is the number of LIST levels.
+	// 1 for LIST(INT), 2 for LIST(LIST(INT)), etc.
+	nestingDepth int
+
+	// levels describes each nesting level from outermost (index 0) to innermost.
+	// Length equals nestingDepth.
+	levels []parquetListLevelInfo
+
+	// Leaf-level thresholds (apply to the innermost list's elements).
+	maxDefLevel            int16 // Maximum definition level for the leaf column.
+	presentElementDefLevel int16 // Exactly this: leaf element value is present.
+
+	// Whether leaf elements within the innermost list can be NULL.
+	elementIsOptional bool
+}
+
+// detectListColumn checks whether the leaf column at colIdx is part of a
+// Parquet LIST encoding and returns the parsed metadata if so. Returns nil
+// if the column is a flat (non-repeated) column.
+func detectListColumn(parquetSchema *schema.Schema, colIdx int) (*parquetListColumnInfo, error) {
+	col := parquetSchema.Column(colIdx)
+
+	// Only columns with repetition levels > 0 can be LIST columns.
+	if col.MaxRepetitionLevel() == 0 {
+		return nil, nil
+	}
+
+	leafNode := col.SchemaNode()
+	parent := leafNode.Parent()
+	if parent == nil {
+		return nil, nil
+	}
+	grandparent := parent.Parent()
+	if grandparent == nil {
+		return nil, nil
+	}
+
+	// Check that the parent is a repeated group (the "list" group).
+	if parent.RepetitionType() != parquet.Repetitions.Repeated {
+		return nil, errors.UnimplementedErrorf(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(162543),
+				Detail: "support parquet nested types for import"},
+			"column %q has nested structure but parent is not a repeated group",
+			col.Name())
+	}
+
+	// Check that the grandparent has LIST logical type or LIST converted type.
+	// Also detect MAP columns so we can return a specific error message.
+	lt := grandparent.LogicalType()
+
+	isListGroup := false
+	if lt != nil {
+		_, isListGroup = lt.(schema.ListLogicalType)
+	}
+	if !isListGroup {
+		isListGroup = grandparent.ConvertedType() == schema.ConvertedTypes.List
+	}
+	if !isListGroup {
+		isMapGroup := false
+		if lt != nil {
+			_, isMapGroup = lt.(schema.MapLogicalType)
+		}
+		if !isMapGroup {
+			ct := grandparent.ConvertedType()
+			isMapGroup = ct == schema.ConvertedTypes.Map || ct == schema.ConvertedTypes.MapKeyValue
+		}
+		if isMapGroup {
+			return nil, errors.UnimplementedErrorf(
+				errors.IssueLink{IssueURL: build.MakeIssueURL(162543),
+					Detail: "support parquet nested types for import"},
+				"column %q is a MAP type, which is not supported for import",
+				grandparent.Name())
+		}
+		return nil, errors.UnimplementedErrorf(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(162543),
+				Detail: "support parquet nested types for import"},
+			"column %q has repeated parent but grandparent is not a LIST group",
+			col.Name())
+	}
+
+	// Reject deeper nesting: the grandparent must be a direct child of the
+	// schema root. If it has more ancestors, this is a nested LIST or a LIST
+	// inside a STRUCT, which we don't support.
+	if ggp := grandparent.Parent(); ggp != nil && ggp.Parent() != nil {
+		return nil, errors.UnimplementedErrorf(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(162543),
+				Detail: "support parquet nested types for import"},
+			"column %q is a nested LIST (LIST of LIST or LIST inside STRUCT), which is not supported",
+			grandparent.Name())
+	}
+
+	// Reject non-primitive leaves (the leaf must be a primitive node, not a group).
+	if leafNode.Type() != schema.Primitive {
+		return nil, errors.UnimplementedErrorf(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(162543),
+				Detail: "support parquet nested types for import"},
+			"column %q is a LIST of a non-primitive type, which is not supported",
+			grandparent.Name())
+	}
+
+	// Validate the repeated group has exactly one child (the element).
+	parentGroup, ok := parent.(*schema.GroupNode)
+	if !ok || parentGroup.NumFields() != 1 {
+		return nil, errors.UnimplementedErrorf(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(162543),
+				Detail: "support parquet nested types for import"},
+			"column %q has LIST structure with unexpected number of children in repeated group",
+			grandparent.Name())
+	}
+
+	// Build the list info with def level thresholds.
+	//
+	// For optional list + optional element (the common case):
+	//   grandparent (optional) -> adds 1 to defLevel => defLevel 0 = null list
+	//   parent (repeated)      -> adds 1 to defLevel => defLevel 1 = empty list
+	//   leaf (optional)        -> adds 1 to defLevel => defLevel 2 = null element, 3 = present
+	//
+	// For optional list + required element:
+	//   grandparent (optional) -> adds 1 => defLevel 0 = null list
+	//   parent (repeated)      -> adds 1 => defLevel 1 = empty list
+	//   leaf (required)        -> no add  => defLevel 2 = present element
+	//
+	// For required list + optional element:
+	//   grandparent (required) -> no add  => (list cannot be null)
+	//   parent (repeated)      -> adds 1 => defLevel 0 = empty list
+	//   leaf (optional)        -> adds 1 => defLevel 1 = null element, 2 = present
+	elementIsOptional := leafNode.RepetitionType() == parquet.Repetitions.Optional
+
+	var nullListDefLevel int16
+	var emptyListDefLevel int16
+	if grandparent.RepetitionType() == parquet.Repetitions.Optional {
+		// Optional list: defLevel 0 = null list, defLevel 1 = empty list.
+		nullListDefLevel = 0
+		emptyListDefLevel = 1
+	} else {
+		// Required list: cannot be null. Empty list at defLevel 0.
+		nullListDefLevel = -1 // sentinel: list can never be null
+		emptyListDefLevel = 0
+	}
+
+	return &parquetListColumnInfo{
+		columnName:           grandparent.Name(),
+		elementPhysicalType:  col.PhysicalType(),
+		elementLogicalType:   deriveLogicalType(col),
+		elementConvertedType: col.ConvertedType(),
+		nestingDepth:         1,
+		levels: []parquetListLevelInfo{
+			{
+				repLevel:          1,
+				nullListDefLevel:  nullListDefLevel,
+				emptyListDefLevel: emptyListDefLevel,
+			},
+		},
+		maxDefLevel:            col.MaxDefinitionLevel(),
+		presentElementDefLevel: col.MaxDefinitionLevel(),
+		elementIsOptional:      elementIsOptional,
+	}, nil
+}
+
+// parquetListOverflowEntry holds one fully-assembled row that was read from
+// a previous chunk but belongs to a later batch.
+type parquetListOverflowEntry struct {
+	values []any // element values (nil = null list, empty = empty list)
+	isNull bool
+}
+
+// parquetListColumnReader wraps a Parquet column chunk reader for LIST columns
+// and persists overflow state across ReadBatch calls. Unlike flat columns
+// (where ReadBatch reads exactly N rows), LIST columns require reading level
+// entries in fixed-size chunks. When a chunk straddles a batch boundary, the
+// over-read rows are buffered here and drained on the next ReadBatch call.
+//
+// Created once per row group in advanceToNextRowGroup for each LIST column.
+type parquetListColumnReader struct {
+	// Schema metadata (immutable after construction).
+	listInfo               *parquetListColumnInfo
+	level                  parquetListLevelInfo
+	presentElementDefLevel int16
+	elementIsOptional      bool
+
+	// Typed I/O closures (set up once in the constructor based on
+	// the element's physical type).
+	readChunk    func() (int64, int, error)
+	extractValue func(valIdx int) any
+
+	// Level buffers (allocated once, reused across ReadBatch calls).
+	defBuf []int16
+	repBuf []int16
+
+	// Overflow state: fully-assembled rows from a previous chunk that
+	// belong to a later batch. Drained first at the start of each
+	// ReadBatch call.
+	overflow []parquetListOverflowEntry
+
+	// Partial row state: when a chunk boundary falls in the middle of a
+	// row's elements, the in-progress row is stashed here and resumed
+	// when the next chunk is read.
+	partialRow    []any
+	partialIsNull bool
+	hasPartialRow bool
+}
+
+// listColumnChunkSize is the number of level entries read per ReadBatch chunk.
+const listColumnChunkSize = 1024
+
+// newParquetListColumnReader creates a stateful reader for a LIST column.
+// The reader persists overflow state between ReadBatch calls so that no
+// level entries are lost when a chunk straddles a batch boundary.
+func newParquetListColumnReader(
+	colReader file.ColumnChunkReader, listInfo *parquetListColumnInfo,
+) (*parquetListColumnReader, error) {
+	if listInfo.nestingDepth != 1 {
+		return nil, errors.AssertionFailedf(
+			"parquetListColumnReader only supports nestingDepth 1, got %d",
+			listInfo.nestingDepth)
+	}
+
+	r := &parquetListColumnReader{
+		listInfo:               listInfo,
+		level:                  listInfo.levels[0],
+		presentElementDefLevel: listInfo.presentElementDefLevel,
+		elementIsOptional:      listInfo.elementIsOptional,
+		defBuf:                 make([]int16, listColumnChunkSize),
+		repBuf:                 make([]int16, listColumnChunkSize),
+	}
+
+	switch listInfo.elementPhysicalType {
+	case parquet.Types.Boolean:
+		valBuf := make([]bool, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.BooleanColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any { return valBuf[valIdx] }
+
+	case parquet.Types.Int32:
+		valBuf := make([]int32, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.Int32ColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any { return valBuf[valIdx] }
+
+	case parquet.Types.Int64:
+		valBuf := make([]int64, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.Int64ColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any { return valBuf[valIdx] }
+
+	case parquet.Types.Int96:
+		valBuf := make([]parquet.Int96, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.Int96ColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any { return valBuf[valIdx] }
+
+	case parquet.Types.Float:
+		valBuf := make([]float32, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.Float32ColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any { return valBuf[valIdx] }
+
+	case parquet.Types.Double:
+		valBuf := make([]float64, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.Float64ColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any { return valBuf[valIdx] }
+
+	case parquet.Types.ByteArray:
+		valBuf := make([]parquet.ByteArray, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.ByteArrayColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any {
+			// Copy bytes since the buffer will be reused.
+			copied := make([]byte, len(valBuf[valIdx]))
+			copy(copied, valBuf[valIdx])
+			return copied
+		}
+
+	case parquet.Types.FixedLenByteArray:
+		valBuf := make([]parquet.FixedLenByteArray, listColumnChunkSize)
+		r.readChunk = func() (int64, int, error) {
+			return colReader.(*file.FixedLenByteArrayColumnChunkReader).ReadBatch(
+				listColumnChunkSize, valBuf, r.defBuf, r.repBuf)
+		}
+		r.extractValue = func(valIdx int) any {
+			copied := make([]byte, len(valBuf[valIdx]))
+			copy(copied, valBuf[valIdx])
+			return parquet.FixedLenByteArray(copied)
+		}
+
+	default:
+		return nil, errors.Newf(
+			"unsupported Parquet physical type for LIST element: %s",
+			listInfo.elementPhysicalType.String())
+	}
+
+	return r, nil
+}
+
+// ReadBatch reads exactly rowsToRead rows from the LIST column and returns
+// a parquetColumnBatch. It first drains any overflow rows saved from a
+// previous call, then reads new chunks as needed. When a chunk contains
+// entries beyond the batch boundary, all entries are processed and excess
+// rows are saved as overflow for the next call.
+func (r *parquetListColumnReader) ReadBatch(rowsToRead int64) (*parquetColumnBatch, error) {
+	batch := &parquetColumnBatch{
+		physicalType:  r.listInfo.elementPhysicalType,
+		rowCount:      rowsToRead,
+		maxDefLevel:   r.listInfo.maxDefLevel,
+		isList:        true,
+		isNull:        make([]bool, rowsToRead),
+		listRowValues: make([][]any, rowsToRead),
+	}
+
+	rowsFilled := int64(0)
+
+	// Phase 1: Drain overflow rows from a previous ReadBatch call.
+	drained := 0
+	for drained < len(r.overflow) && rowsFilled < rowsToRead {
+		entry := r.overflow[drained]
+		batch.listRowValues[rowsFilled] = entry.values
+		batch.isNull[rowsFilled] = entry.isNull
+		drained++
+		rowsFilled++
+	}
+	r.overflow = r.overflow[drained:]
+	if len(r.overflow) == 0 {
+		// Allow GC of the old backing array once fully drained.
+		r.overflow = nil
+	}
+	if rowsFilled >= rowsToRead {
+		return batch, nil
+	}
+
+	// Phase 2: Resume partial row state from a previous chunk.
+	currentElements := r.partialRow
+	currentIsNull := r.partialIsNull
+	inRow := r.hasPartialRow
+	r.partialRow = nil
+	r.partialIsNull = false
+	r.hasPartialRow = false
+
+	// addRow places a completed row into the batch or overflow.
+	addRow := func(elements []any, isNull bool) {
+		if rowsFilled < rowsToRead {
+			batch.listRowValues[rowsFilled] = elements
+			batch.isNull[rowsFilled] = isNull
+			rowsFilled++
+		} else {
+			r.overflow = append(r.overflow, parquetListOverflowEntry{
+				values: elements,
+				isNull: isNull,
+			})
+		}
+	}
+
+	// Phase 3: Read chunks until we have enough rows. Process ALL entries
+	// in each chunk to avoid losing data from the forward-only reader.
+	for rowsFilled < rowsToRead {
+		total, valuesRead, err := r.readChunk()
+		if err != nil {
+			return nil, errors.Wrap(err, "reading LIST column batch")
+		}
+		if total == 0 {
+			if inRow {
+				addRow(currentElements, currentIsNull)
+				inRow = false
+			}
+			break
+		}
+
+		valIdx := 0
+		for i := int64(0); i < total; i++ {
+			if r.repBuf[i] == 0 {
+				// New row boundary. Finalize the previous row if any.
+				if inRow {
+					addRow(currentElements, currentIsNull)
+				}
+				inRow = true
+				currentElements = nil
+				currentIsNull = false
+
+				if r.defBuf[i] <= r.level.nullListDefLevel {
+					// Null list.
+					currentIsNull = true
+				} else if r.defBuf[i] == r.level.emptyListDefLevel {
+					// Empty list (present but no elements).
+					currentElements = []any{}
+				} else if r.defBuf[i] == r.presentElementDefLevel {
+					// Non-empty list, first element is present.
+					currentElements = []any{r.extractValue(valIdx)}
+					valIdx++
+				} else if r.elementIsOptional {
+					// Non-empty list, first element is null.
+					currentElements = []any{nil}
+				} else {
+					return nil, errors.AssertionFailedf(
+						"unexpected definition level %d for required-element LIST column %q at rep=0",
+						r.defBuf[i], r.listInfo.columnName)
+				}
+			} else {
+				// Continuation of current list (repLevel > 0).
+				if r.defBuf[i] == r.presentElementDefLevel {
+					currentElements = append(currentElements, r.extractValue(valIdx))
+					valIdx++
+				} else if r.elementIsOptional {
+					currentElements = append(currentElements, nil)
+				} else {
+					return nil, errors.AssertionFailedf(
+						"unexpected definition level %d for required-element LIST column %q at rep>0",
+						r.defBuf[i], r.listInfo.columnName)
+				}
+			}
+		}
+
+		if valIdx != valuesRead {
+			return nil, errors.AssertionFailedf(
+				"value index mismatch in LIST column %q: tracked %d, library reported %d",
+				r.listInfo.columnName, valIdx, valuesRead)
+		}
+
+		// If the column is exhausted (returned fewer entries than requested),
+		// the in-progress row is the final row and must be finalized now.
+		if total < listColumnChunkSize && inRow {
+			addRow(currentElements, currentIsNull)
+			inRow = false
+		}
+	}
+
+	// Phase 4: Save in-progress row as partial state for the next call.
+	// This happens when a chunk boundary falls mid-row, or when we've
+	// filled the batch but the current row hasn't been finalized yet
+	// (we haven't seen the next rep=0 entry).
+	if inRow {
+		r.partialRow = currentElements
+		r.partialIsNull = currentIsNull
+		r.hasPartialRow = true
+	}
+
+	if rowsFilled < rowsToRead {
+		return nil, errors.Newf(
+			"expected %d rows from LIST column %q, but only %d were available",
+			rowsToRead, r.listInfo.columnName, rowsFilled)
+	}
+
+	return batch, nil
+}

--- a/pkg/sql/importer/read_import_parquet_list_test.go
+++ b/pkg/sql/importer/read_import_parquet_list_test.go
@@ -1,0 +1,1364 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package importer
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v11/arrow"
+	"github.com/apache/arrow/go/v11/arrow/array"
+	"github.com/apache/arrow/go/v11/arrow/memory"
+	"github.com/apache/arrow/go/v11/parquet"
+	"github.com/apache/arrow/go/v11/parquet/compress"
+	"github.com/apache/arrow/go/v11/parquet/file"
+	"github.com/apache/arrow/go/v11/parquet/pqarrow"
+	"github.com/apache/arrow/go/v11/parquet/schema"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParquetListColumnReader tests the parquetListColumnReader which reads
+// Parquet LIST columns using definition/repetition levels.
+// It creates Parquet files with LIST<type> columns using Arrow's ListBuilder,
+// then reads them through parquetListColumnReader and verifies per-row
+// element arrays are correctly reconstructed from flat definition/repetition levels.
+func TestParquetListColumnReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pool := memory.NewGoAllocator()
+
+	// Helper to create a Parquet file from an Arrow schema and record, then
+	// read column 0 as a LIST batch.
+	readListBatch := func(
+		t *testing.T,
+		arrowSchema *arrow.Schema,
+		record arrow.Record,
+		numRows int64,
+	) *parquetColumnBatch {
+		t.Helper()
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		// Detect the LIST column.
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo, "column 0 should be detected as LIST")
+
+		// Read the LIST batch using the stateful reader.
+		rowGroup := parquetReader.RowGroup(0)
+		colReader, err := rowGroup.Column(0)
+		require.NoError(t, err)
+
+		listReader, err := newParquetListColumnReader(colReader, listInfo)
+		require.NoError(t, err)
+		batch, err := listReader.ReadBatch(numRows)
+		require.NoError(t, err)
+		require.True(t, batch.isList)
+		require.Equal(t, numRows, batch.rowCount)
+		return batch
+	}
+
+	// ListStates covers all list states in a single record: multi-element,
+	// null list, empty list, single element, and null elements within a list.
+	t.Run("ListStates", func(t *testing.T) {
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "col", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int64Builder)
+
+		// Row 0: [10, 20, 30]
+		lb.Append(true)
+		vb.Append(10)
+		vb.Append(20)
+		vb.Append(30)
+
+		// Row 1: null list
+		lb.AppendNull()
+
+		// Row 2: [] (empty list)
+		lb.Append(true)
+
+		// Row 3: [42]
+		lb.Append(true)
+		vb.Append(42)
+
+		// Row 4: [1, null, 3] (null elements within list)
+		lb.Append(true)
+		vb.Append(1)
+		vb.AppendNull()
+		vb.Append(3)
+
+		// Row 5: [null] (single null element)
+		lb.Append(true)
+		vb.AppendNull()
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		batch := readListBatch(t, arrowSchema, record, 6)
+
+		// Row 0: [10, 20, 30]
+		val, isNull, err := batch.GetValueAt(0)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements := val.([]any)
+		require.Len(t, elements, 3)
+		require.Equal(t, int64(10), elements[0])
+		require.Equal(t, int64(20), elements[1])
+		require.Equal(t, int64(30), elements[2])
+
+		// Row 1: null list
+		_, isNull, err = batch.GetValueAt(1)
+		require.NoError(t, err)
+		require.True(t, isNull)
+
+		// Row 2: empty list
+		val, isNull, err = batch.GetValueAt(2)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 0)
+
+		// Row 3: [42]
+		val, isNull, err = batch.GetValueAt(3)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 1)
+		require.Equal(t, int64(42), elements[0])
+
+		// Row 4: [1, null, 3]
+		val, isNull, err = batch.GetValueAt(4)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 3)
+		require.Equal(t, int64(1), elements[0])
+		require.Nil(t, elements[1])
+		require.Equal(t, int64(3), elements[2])
+
+		// Row 5: [null]
+		val, isNull, err = batch.GetValueAt(5)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 1)
+		require.Nil(t, elements[0])
+	})
+
+	// PhysicalTypes verifies that each supported Parquet physical type
+	// round-trips correctly through the LIST column reader.
+	t.Run("PhysicalTypes", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			arrowType    arrow.DataType
+			appendValues func(lb *array.ListBuilder)
+			expected     []any
+		}{
+			{
+				name:      "Bool",
+				arrowType: arrow.FixedWidthTypes.Boolean,
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.BooleanBuilder)
+					lb.Append(true)
+					vb.Append(true)
+					vb.Append(false)
+					vb.Append(true)
+				},
+				expected: []any{true, false, true},
+			},
+			{
+				name:      "Int32",
+				arrowType: arrow.PrimitiveTypes.Int32,
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.Int32Builder)
+					lb.Append(true)
+					vb.Append(10)
+					vb.Append(20)
+				},
+				expected: []any{int32(10), int32(20)},
+			},
+			{
+				name:      "Int64",
+				arrowType: arrow.PrimitiveTypes.Int64,
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.Int64Builder)
+					lb.Append(true)
+					vb.Append(100)
+					vb.Append(200)
+				},
+				expected: []any{int64(100), int64(200)},
+			},
+			{
+				name:      "Float32",
+				arrowType: arrow.PrimitiveTypes.Float32,
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.Float32Builder)
+					lb.Append(true)
+					vb.Append(1.5)
+					vb.Append(2.5)
+				},
+				expected: []any{float32(1.5), float32(2.5)},
+			},
+			{
+				name:      "Float64",
+				arrowType: arrow.PrimitiveTypes.Float64,
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.Float64Builder)
+					lb.Append(true)
+					vb.Append(1.5)
+					vb.Append(2.5)
+				},
+				expected: []any{float64(1.5), float64(2.5)},
+			},
+			{
+				name:      "String",
+				arrowType: arrow.BinaryTypes.String,
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.StringBuilder)
+					lb.Append(true)
+					vb.Append("hello")
+					vb.Append("world")
+				},
+				expected: []any{[]byte("hello"), []byte("world")},
+			},
+			{
+				name:      "FixedLenByteArray",
+				arrowType: &arrow.FixedSizeBinaryType{ByteWidth: 4},
+				appendValues: func(lb *array.ListBuilder) {
+					vb := lb.ValueBuilder().(*array.FixedSizeBinaryBuilder)
+					lb.Append(true)
+					vb.Append([]byte{1, 2, 3, 4})
+					vb.Append([]byte{5, 6, 7, 8})
+				},
+				expected: []any{
+					parquet.FixedLenByteArray([]byte{1, 2, 3, 4}),
+					parquet.FixedLenByteArray([]byte{5, 6, 7, 8}),
+				},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				arrowSchema := arrow.NewSchema([]arrow.Field{
+					{Name: "col", Type: arrow.ListOf(tc.arrowType), Nullable: true},
+				}, nil)
+				builder := array.NewRecordBuilder(pool, arrowSchema)
+				defer builder.Release()
+
+				lb := builder.Field(0).(*array.ListBuilder)
+				tc.appendValues(lb)
+
+				record := builder.NewRecord()
+				defer record.Release()
+
+				batch := readListBatch(t, arrowSchema, record, 1)
+
+				val, isNull, err := batch.GetValueAt(0)
+				require.NoError(t, err)
+				require.False(t, isNull)
+				elements := val.([]any)
+				require.Len(t, elements, len(tc.expected))
+				for i, exp := range tc.expected {
+					require.Equal(t, exp, elements[i], "element %d", i)
+				}
+			})
+		}
+	})
+
+	// Int96 requires raw Parquet writing since Arrow doesn't produce Int96
+	// LIST columns natively.
+	t.Run("PhysicalTypes/Int96", func(t *testing.T) {
+		fieldID := int32(-1)
+		leaf, err := schema.NewPrimitiveNode(
+			"element", parquet.Repetitions.Optional,
+			parquet.Types.Int96, -1, fieldID)
+		require.NoError(t, err)
+
+		repeatedGroup, err := schema.NewGroupNode(
+			"list", parquet.Repetitions.Repeated,
+			[]schema.Node{leaf}, fieldID)
+		require.NoError(t, err)
+
+		listGroup, err := schema.NewGroupNodeLogical(
+			"col", parquet.Repetitions.Optional,
+			[]schema.Node{repeatedGroup},
+			schema.ListLogicalType{}, fieldID)
+		require.NoError(t, err)
+
+		root, err := schema.NewGroupNode(
+			"schema", parquet.Repetitions.Required,
+			[]schema.Node{listGroup}, fieldID)
+		require.NoError(t, err)
+
+		buf := new(bytes.Buffer)
+		writer := file.NewParquetWriter(buf, root)
+		rgWriter := writer.AppendRowGroup()
+		colWriter, err := rgWriter.NextColumn()
+		require.NoError(t, err)
+
+		int96Writer := colWriter.(*file.Int96ColumnChunkWriter)
+		val1 := parquet.Int96{1, 2, 3}
+		val2 := parquet.Int96{4, 5, 6}
+		_, err = int96Writer.WriteBatch(
+			[]parquet.Int96{val1, val2},
+			[]int16{3, 3}, // both elements present
+			[]int16{0, 1}, // rep=0: new row, rep=1: continuation
+		)
+		require.NoError(t, err)
+		require.NoError(t, rgWriter.Close())
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo)
+		require.Equal(t, parquet.Types.Int96, listInfo.elementPhysicalType)
+
+		rowGroup := parquetReader.RowGroup(0)
+		colReader, err := rowGroup.Column(0)
+		require.NoError(t, err)
+
+		listReader, err := newParquetListColumnReader(colReader, listInfo)
+		require.NoError(t, err)
+		batch, err := listReader.ReadBatch(1)
+		require.NoError(t, err)
+
+		val, isNull, err := batch.GetValueAt(0)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements := val.([]any)
+		require.Len(t, elements, 2)
+		require.Equal(t, val1, elements[0])
+		require.Equal(t, val2, elements[1])
+	})
+
+	// ManyRowsAcrossChunks exercises multi-chunk reading for different physical
+	// types. 500 rows * 3 elements = 1500 level entries, which exceeds the
+	// internal chunk size of 1024. ByteArray and FixedLenByteArray are
+	// particularly interesting because they copy buffer contents to avoid
+	// reuse corruption.
+	t.Run("ManyRowsAcrossChunks", func(t *testing.T) {
+		t.Run("Int32", func(t *testing.T) {
+			arrowSchema := arrow.NewSchema([]arrow.Field{
+				{Name: "nums", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+			}, nil)
+			builder := array.NewRecordBuilder(pool, arrowSchema)
+			defer builder.Release()
+
+			lb := builder.Field(0).(*array.ListBuilder)
+			vb := lb.ValueBuilder().(*array.Int32Builder)
+
+			numRows := int64(500)
+			for i := int64(0); i < numRows; i++ {
+				lb.Append(true)
+				vb.Append(int32(i * 10))
+				vb.Append(int32(i*10 + 1))
+				vb.Append(int32(i*10 + 2))
+			}
+
+			record := builder.NewRecord()
+			defer record.Release()
+
+			batch := readListBatch(t, arrowSchema, record, numRows)
+
+			for i := int64(0); i < numRows; i++ {
+				val, isNull, err := batch.GetValueAt(int(i))
+				require.NoError(t, err)
+				require.False(t, isNull, "row %d should not be null", i)
+				elements := val.([]any)
+				require.Len(t, elements, 3, "row %d", i)
+				require.Equal(t, int32(i*10), elements[0], "row %d elem 0", i)
+				require.Equal(t, int32(i*10+1), elements[1], "row %d elem 1", i)
+				require.Equal(t, int32(i*10+2), elements[2], "row %d elem 2", i)
+			}
+		})
+
+		t.Run("ByteArray", func(t *testing.T) {
+			arrowSchema := arrow.NewSchema([]arrow.Field{
+				{Name: "strs", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+			}, nil)
+			builder := array.NewRecordBuilder(pool, arrowSchema)
+			defer builder.Release()
+
+			lb := builder.Field(0).(*array.ListBuilder)
+			vb := lb.ValueBuilder().(*array.StringBuilder)
+
+			numRows := int64(500)
+			for i := int64(0); i < numRows; i++ {
+				lb.Append(true)
+				vb.Append(fmt.Sprintf("a_%d", i*10))
+				vb.Append(fmt.Sprintf("b_%d", i*10+1))
+				vb.Append(fmt.Sprintf("c_%d", i*10+2))
+			}
+
+			record := builder.NewRecord()
+			defer record.Release()
+
+			batch := readListBatch(t, arrowSchema, record, numRows)
+
+			for i := int64(0); i < numRows; i++ {
+				val, isNull, err := batch.GetValueAt(int(i))
+				require.NoError(t, err)
+				require.False(t, isNull, "row %d should not be null", i)
+				elements := val.([]any)
+				require.Len(t, elements, 3, "row %d", i)
+				require.Equal(t, []byte(fmt.Sprintf("a_%d", i*10)), elements[0], "row %d elem 0", i)
+				require.Equal(t, []byte(fmt.Sprintf("b_%d", i*10+1)), elements[1], "row %d elem 1", i)
+				require.Equal(t, []byte(fmt.Sprintf("c_%d", i*10+2)), elements[2], "row %d elem 2", i)
+			}
+		})
+
+		t.Run("FixedLenByteArray", func(t *testing.T) {
+			arrowSchema := arrow.NewSchema([]arrow.Field{
+				{Name: "fixed", Type: arrow.ListOf(&arrow.FixedSizeBinaryType{ByteWidth: 4}), Nullable: true},
+			}, nil)
+			builder := array.NewRecordBuilder(pool, arrowSchema)
+			defer builder.Release()
+
+			lb := builder.Field(0).(*array.ListBuilder)
+			vb := lb.ValueBuilder().(*array.FixedSizeBinaryBuilder)
+
+			numRows := int64(500)
+			for i := int64(0); i < numRows; i++ {
+				lb.Append(true)
+				for j := 0; j < 3; j++ {
+					v := int32(i*10 + int64(j))
+					vb.Append([]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+				}
+			}
+
+			record := builder.NewRecord()
+			defer record.Release()
+
+			batch := readListBatch(t, arrowSchema, record, numRows)
+
+			for i := int64(0); i < numRows; i++ {
+				val, isNull, err := batch.GetValueAt(int(i))
+				require.NoError(t, err)
+				require.False(t, isNull, "row %d should not be null", i)
+				elements := val.([]any)
+				require.Len(t, elements, 3, "row %d", i)
+				for j := 0; j < 3; j++ {
+					v := int32(i*10 + int64(j))
+					expected := parquet.FixedLenByteArray([]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+					require.Equal(t, expected, elements[j], "row %d elem %d", i, j)
+				}
+			}
+		})
+	})
+
+	// Verifies that the final row is finalized when the total number of level
+	// entries is an exact multiple of listColumnChunkSize (1024).
+	t.Run("ExactChunkSizeMultiple", func(t *testing.T) {
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "nums", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, schema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		// 1024 rows with 1 element each = exactly 1024 level entries.
+		numRows := int64(listColumnChunkSize)
+		for i := int64(0); i < numRows; i++ {
+			lb.Append(true)
+			vb.Append(int32(i))
+		}
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		batch := readListBatch(t, schema, record, numRows)
+
+		for i := int64(0); i < numRows; i++ {
+			val, isNull, err := batch.GetValueAt(int(i))
+			require.NoError(t, err)
+			require.False(t, isNull, "row %d should not be null", i)
+			elements := val.([]any)
+			require.Len(t, elements, 1, "row %d", i)
+			require.Equal(t, int32(i), elements[0], "row %d", i)
+		}
+	})
+
+	t.Run("PartialRowAcrossChunkBoundary", func(t *testing.T) {
+		// A single row with more elements than listColumnChunkSize (1024)
+		// forces the row to be split across multiple internal read chunks.
+		// The reader must buffer the partial row and reassemble it correctly.
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "big_list", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, schema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		numElements := 2*listColumnChunkSize + 100
+		lb.Append(true)
+		for i := range numElements {
+			vb.Append(int32(i))
+		}
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		batch := readListBatch(t, schema, record, 1)
+
+		val, isNull, err := batch.GetValueAt(0)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements := val.([]any)
+		require.Len(t, elements, numElements)
+		for i := range numElements {
+			require.Equal(t, int32(i), elements[i], "element %d", i)
+		}
+	})
+
+	t.Run("OverflowAcrossMultipleBatches", func(t *testing.T) {
+		// Tests that overflow state is correctly preserved across multiple
+		// ReadBatch calls on the same reader. 500 rows read in batches of
+		// 100 exercises the overflow drain path 4 times.
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "vals", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, schema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		numRows := int64(500)
+		for i := int64(0); i < numRows; i++ {
+			lb.Append(true)
+			vb.Append(int32(i * 10))
+			vb.Append(int32(i*10 + 1))
+			vb.Append(int32(i*10 + 2))
+		}
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			schema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo)
+
+		rowGroup := parquetReader.RowGroup(0)
+		colReader, err := rowGroup.Column(0)
+		require.NoError(t, err)
+
+		listReader, err := newParquetListColumnReader(colReader, listInfo)
+		require.NoError(t, err)
+
+		// Read in 5 batches of 100 rows each.
+		batchSize := int64(100)
+		for batchIdx := int64(0); batchIdx < 5; batchIdx++ {
+			batch, err := listReader.ReadBatch(batchSize)
+			require.NoError(t, err, "batch %d", batchIdx)
+			require.Equal(t, batchSize, batch.rowCount, "batch %d", batchIdx)
+
+			for rowInBatch := int64(0); rowInBatch < batchSize; rowInBatch++ {
+				globalRow := batchIdx*batchSize + rowInBatch
+				val, isNull, err := batch.GetValueAt(int(rowInBatch))
+				require.NoError(t, err, "row %d", globalRow)
+				require.False(t, isNull, "row %d should not be null", globalRow)
+				elements := val.([]any)
+				require.Len(t, elements, 3, "row %d", globalRow)
+				require.Equal(t, int32(globalRow*10), elements[0], "row %d elem 0", globalRow)
+				require.Equal(t, int32(globalRow*10+1), elements[1], "row %d elem 1", globalRow)
+				require.Equal(t, int32(globalRow*10+2), elements[2], "row %d elem 2", globalRow)
+			}
+		}
+	})
+
+	t.Run("RequiredListOptionalElement", func(t *testing.T) {
+		// A required (non-nullable) list with optional elements. The list
+		// itself cannot be null, but elements within it can be.
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "ids", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: false},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		// Row 0: [10, 20]
+		lb.Append(true)
+		vb.Append(10)
+		vb.Append(20)
+
+		// Row 1: [] (empty list, valid for required list)
+		lb.Append(true)
+
+		// Row 2: [null, 30]
+		lb.Append(true)
+		vb.AppendNull()
+		vb.Append(30)
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		batch := readListBatch(t, arrowSchema, record, 3)
+
+		// Row 0: [10, 20]
+		val, isNull, err := batch.GetValueAt(0)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements := val.([]any)
+		require.Len(t, elements, 2)
+		require.Equal(t, int32(10), elements[0])
+		require.Equal(t, int32(20), elements[1])
+
+		// Row 1: empty list
+		val, isNull, err = batch.GetValueAt(1)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 0)
+
+		// Row 2: [null, 30]
+		val, isNull, err = batch.GetValueAt(2)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 2)
+		require.Nil(t, elements[0])
+		require.Equal(t, int32(30), elements[1])
+	})
+
+	t.Run("RequiredListRequiredElement", func(t *testing.T) {
+		// A required list with required (non-nullable) elements.
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "ids", Type: arrow.ListOfNonNullable(arrow.PrimitiveTypes.Int32), Nullable: false},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		// Row 0: [1, 2, 3]
+		lb.Append(true)
+		vb.Append(1)
+		vb.Append(2)
+		vb.Append(3)
+
+		// Row 1: []
+		lb.Append(true)
+
+		// Row 2: [42]
+		lb.Append(true)
+		vb.Append(42)
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		batch := readListBatch(t, arrowSchema, record, 3)
+
+		// Row 0: [1, 2, 3]
+		val, isNull, err := batch.GetValueAt(0)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements := val.([]any)
+		require.Len(t, elements, 3)
+		require.Equal(t, int32(1), elements[0])
+		require.Equal(t, int32(2), elements[1])
+		require.Equal(t, int32(3), elements[2])
+
+		// Row 1: empty list
+		val, isNull, err = batch.GetValueAt(1)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 0)
+
+		// Row 2: [42]
+		val, isNull, err = batch.GetValueAt(2)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements = val.([]any)
+		require.Len(t, elements, 1)
+		require.Equal(t, int32(42), elements[0])
+	})
+
+	t.Run("MultiRowGroup", func(t *testing.T) {
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "vals", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+
+		// Write 3 row groups with 4 rows each (12 rows total).
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+
+		rowsPerGroup := 4
+		numGroups := 3
+		for g := range numGroups {
+			recBuilder := array.NewRecordBuilder(pool, arrowSchema)
+			lb := recBuilder.Field(0).(*array.ListBuilder)
+			vb := lb.ValueBuilder().(*array.Int32Builder)
+			for r := range rowsPerGroup {
+				globalRow := g*rowsPerGroup + r
+				lb.Append(true)
+				vb.Append(int32(globalRow * 100))
+				vb.Append(int32(globalRow*100 + 1))
+			}
+			rec := recBuilder.NewRecord()
+			require.NoError(t, writer.Write(rec))
+			rec.Release()
+			recBuilder.Release()
+		}
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+		require.Equal(t, numGroups, parquetReader.NumRowGroups())
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo)
+
+		for g := range numGroups {
+			rowGroup := parquetReader.RowGroup(g)
+			colReader, err := rowGroup.Column(0)
+			require.NoError(t, err)
+
+			listReader, err := newParquetListColumnReader(colReader, listInfo)
+			require.NoError(t, err)
+			batch, err := listReader.ReadBatch(int64(rowsPerGroup))
+			require.NoError(t, err)
+
+			for r := range rowsPerGroup {
+				globalRow := g*rowsPerGroup + r
+				val, isNull, err := batch.GetValueAt(r)
+				require.NoError(t, err, "row group %d row %d", g, r)
+				require.False(t, isNull, "row group %d row %d", g, r)
+				elements := val.([]any)
+				require.Len(t, elements, 2, "row group %d row %d", g, r)
+				require.Equal(t, int32(globalRow*100), elements[0],
+					"row group %d row %d elem 0", g, r)
+				require.Equal(t, int32(globalRow*100+1), elements[1],
+					"row group %d row %d elem 1", g, r)
+			}
+		}
+	})
+
+	t.Run("LargeRowAcrossRowGroups", func(t *testing.T) {
+		// Three row groups: the first and last have small rows, the middle
+		// has a single row with 2500 elements. This tests that a row whose
+		// element count far exceeds the row group's row budget stays intact
+		// in its own row group and reads back correctly alongside normal rows.
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "vals", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+
+		// Row group 0: 3 small rows with 2 elements each.
+		b0 := array.NewRecordBuilder(pool, arrowSchema)
+		lb0 := b0.Field(0).(*array.ListBuilder)
+		vb0 := lb0.ValueBuilder().(*array.Int32Builder)
+		for r := range 3 {
+			lb0.Append(true)
+			vb0.Append(int32(r * 10))
+			vb0.Append(int32(r*10 + 1))
+		}
+		rec0 := b0.NewRecord()
+		require.NoError(t, writer.Write(rec0))
+		rec0.Release()
+		b0.Release()
+
+		// Row group 1: 1 large row with 2500 elements.
+		b1 := array.NewRecordBuilder(pool, arrowSchema)
+		lb1 := b1.Field(0).(*array.ListBuilder)
+		vb1 := lb1.ValueBuilder().(*array.Int32Builder)
+		numElements := 2500
+		lb1.Append(true)
+		for i := range numElements {
+			vb1.Append(int32(i))
+		}
+		rec1 := b1.NewRecord()
+		require.NoError(t, writer.Write(rec1))
+		rec1.Release()
+		b1.Release()
+
+		// Row group 2: 2 small rows.
+		b2 := array.NewRecordBuilder(pool, arrowSchema)
+		lb2 := b2.Field(0).(*array.ListBuilder)
+		vb2 := lb2.ValueBuilder().(*array.Int32Builder)
+		for r := range 2 {
+			lb2.Append(true)
+			vb2.Append(int32((r + 100) * 10))
+		}
+		rec2 := b2.NewRecord()
+		require.NoError(t, writer.Write(rec2))
+		rec2.Release()
+		b2.Release()
+
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+		require.Equal(t, 3, parquetReader.NumRowGroups())
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo)
+
+		// Read row group 0: 3 small rows.
+		rg0 := parquetReader.RowGroup(0)
+		col0, err := rg0.Column(0)
+		require.NoError(t, err)
+		lr0, err := newParquetListColumnReader(col0, listInfo)
+		require.NoError(t, err)
+		batch0, err := lr0.ReadBatch(3)
+		require.NoError(t, err)
+		for r := range 3 {
+			val, isNull, err := batch0.GetValueAt(r)
+			require.NoError(t, err)
+			require.False(t, isNull, "rg0 row %d", r)
+			elements := val.([]any)
+			require.Len(t, elements, 2, "rg0 row %d", r)
+			require.Equal(t, int32(r*10), elements[0], "rg0 row %d", r)
+			require.Equal(t, int32(r*10+1), elements[1], "rg0 row %d", r)
+		}
+
+		// Read row group 1: 1 large row with 2500 elements.
+		rg1 := parquetReader.RowGroup(1)
+		col1, err := rg1.Column(0)
+		require.NoError(t, err)
+		lr1, err := newParquetListColumnReader(col1, listInfo)
+		require.NoError(t, err)
+		batch1, err := lr1.ReadBatch(1)
+		require.NoError(t, err)
+		val, isNull, err := batch1.GetValueAt(0)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		elements := val.([]any)
+		require.Len(t, elements, numElements)
+		for i := range numElements {
+			require.Equal(t, int32(i), elements[i], "large row elem %d", i)
+		}
+
+		// Read row group 2: 2 small rows.
+		rg2 := parquetReader.RowGroup(2)
+		col2, err := rg2.Column(0)
+		require.NoError(t, err)
+		lr2, err := newParquetListColumnReader(col2, listInfo)
+		require.NoError(t, err)
+		batch2, err := lr2.ReadBatch(2)
+		require.NoError(t, err)
+		for r := range 2 {
+			val, isNull, err := batch2.GetValueAt(r)
+			require.NoError(t, err)
+			require.False(t, isNull, "rg2 row %d", r)
+			elements := val.([]any)
+			require.Len(t, elements, 1, "rg2 row %d", r)
+			require.Equal(t, int32((r+100)*10), elements[0], "rg2 row %d", r)
+		}
+	})
+
+	t.Run("SmallBatchMidRowResume", func(t *testing.T) {
+		// 6 rows with ~300 elements each (1800 total level entries).
+		// ReadBatch(2) three times exercises the partial-row save/resume path:
+		// chunk size is 1024, so a chunk boundary falls mid-row, and the
+		// next ReadBatch call must resume the partial row correctly.
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "big", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		totalRows := 6
+		elementsPerRow := 300
+		for r := range totalRows {
+			lb.Append(true)
+			for e := range elementsPerRow {
+				vb.Append(int32(r*1000 + e))
+			}
+		}
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo)
+
+		rowGroup := parquetReader.RowGroup(0)
+		colReader, err := rowGroup.Column(0)
+		require.NoError(t, err)
+
+		listReader, err := newParquetListColumnReader(colReader, listInfo)
+		require.NoError(t, err)
+
+		batchSize := int64(2)
+		for batchIdx := range 3 {
+			batch, err := listReader.ReadBatch(batchSize)
+			require.NoError(t, err, "batch %d", batchIdx)
+			require.Equal(t, batchSize, batch.rowCount, "batch %d", batchIdx)
+
+			for rowInBatch := range int(batchSize) {
+				globalRow := batchIdx*int(batchSize) + rowInBatch
+				val, isNull, err := batch.GetValueAt(rowInBatch)
+				require.NoError(t, err, "row %d", globalRow)
+				require.False(t, isNull, "row %d should not be null", globalRow)
+				elements := val.([]any)
+				require.Len(t, elements, elementsPerRow, "row %d", globalRow)
+				for e := range elementsPerRow {
+					require.Equal(t, int32(globalRow*1000+e), elements[e],
+						"row %d elem %d", globalRow, e)
+				}
+			}
+		}
+	})
+
+	t.Run("ReadBatchExceedsAvailableRows", func(t *testing.T) {
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "vals", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+
+		for r := range 3 {
+			lb.Append(true)
+			vb.Append(int32(r))
+		}
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+
+		rowGroup := parquetReader.RowGroup(0)
+		colReader, err := rowGroup.Column(0)
+		require.NoError(t, err)
+
+		listReader, err := newParquetListColumnReader(colReader, listInfo)
+		require.NoError(t, err)
+
+		_, err = listReader.ReadBatch(5)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "expected 5 rows")
+		require.ErrorContains(t, err, "only 3 were available")
+	})
+}
+
+// makeListSchema builds a standard 3-level Parquet LIST schema:
+//
+//	root (required) -> listGroup (listRep, LIST) -> repeated group -> leaf (elemRep, elemType)
+//
+// Returns the schema ready for detectListColumn.
+func makeListSchema(
+	t *testing.T,
+	columnName string,
+	listRep parquet.Repetition,
+	elemRep parquet.Repetition,
+	elemType parquet.Type,
+) *schema.Schema {
+	t.Helper()
+	fieldID := int32(-1)
+
+	leaf, err := schema.NewPrimitiveNode("element", elemRep, elemType, -1, fieldID)
+	require.NoError(t, err)
+
+	repeatedGroup, err := schema.NewGroupNode(
+		"list", parquet.Repetitions.Repeated, []schema.Node{leaf}, fieldID)
+	require.NoError(t, err)
+
+	listGroup, err := schema.NewGroupNodeLogical(
+		columnName, listRep, []schema.Node{repeatedGroup},
+		schema.ListLogicalType{}, fieldID)
+	require.NoError(t, err)
+
+	root, err := schema.NewGroupNode(
+		"schema", parquet.Repetitions.Required, []schema.Node{listGroup}, fieldID)
+	require.NoError(t, err)
+
+	return schema.NewSchema(root)
+}
+
+// TestDetectListColumn tests the detectListColumn function with manually
+// constructed Parquet schemas, covering both valid LIST schemas and
+// unsupported/invalid structures that should return errors.
+func TestDetectListColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	fieldID := int32(-1)
+
+	// ValidSchemas covers all combinations of optional/required list and element.
+	t.Run("ValidSchemas", func(t *testing.T) {
+		tests := []struct {
+			name                  string
+			listRep               parquet.Repetition
+			elemRep               parquet.Repetition
+			elemType              parquet.Type
+			expectedElemOptional  bool
+			expectedNullDefLevel  int16
+			expectedEmptyDefLevel int16
+		}{
+			{
+				name:                  "OptionalListOptionalElement",
+				listRep:               parquet.Repetitions.Optional,
+				elemRep:               parquet.Repetitions.Optional,
+				elemType:              parquet.Types.Int32,
+				expectedElemOptional:  true,
+				expectedNullDefLevel:  0,
+				expectedEmptyDefLevel: 1,
+			},
+			{
+				name:                  "OptionalListRequiredElement",
+				listRep:               parquet.Repetitions.Optional,
+				elemRep:               parquet.Repetitions.Required,
+				elemType:              parquet.Types.Int64,
+				expectedElemOptional:  false,
+				expectedNullDefLevel:  0,
+				expectedEmptyDefLevel: 1,
+			},
+			{
+				name:                  "RequiredListOptionalElement",
+				listRep:               parquet.Repetitions.Required,
+				elemRep:               parquet.Repetitions.Optional,
+				elemType:              parquet.Types.Int64,
+				expectedElemOptional:  true,
+				expectedNullDefLevel:  -1,
+				expectedEmptyDefLevel: 0,
+			},
+			{
+				name:                  "RequiredListRequiredElement",
+				listRep:               parquet.Repetitions.Required,
+				elemRep:               parquet.Repetitions.Required,
+				elemType:              parquet.Types.Int32,
+				expectedElemOptional:  false,
+				expectedNullDefLevel:  -1,
+				expectedEmptyDefLevel: 0,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				pqSchema := makeListSchema(t, "col", tc.listRep, tc.elemRep, tc.elemType)
+				info, err := detectListColumn(pqSchema, 0)
+				require.NoError(t, err)
+				require.NotNil(t, info)
+
+				require.Equal(t, "col", info.columnName)
+				require.Equal(t, tc.elemType, info.elementPhysicalType)
+				require.Equal(t, 1, info.nestingDepth)
+				require.Equal(t, tc.expectedElemOptional, info.elementIsOptional)
+				require.Len(t, info.levels, 1)
+				require.Equal(t, tc.expectedNullDefLevel, info.levels[0].nullListDefLevel)
+				require.Equal(t, tc.expectedEmptyDefLevel, info.levels[0].emptyListDefLevel)
+			})
+		}
+	})
+
+	t.Run("FlatColumn", func(t *testing.T) {
+		// A flat column (no repetition) should return nil, nil.
+		leaf, err := schema.NewPrimitiveNode(
+			"flat_col", parquet.Repetitions.Optional,
+			parquet.Types.Int32, -1, fieldID)
+		require.NoError(t, err)
+
+		root, err := schema.NewGroupNode(
+			"schema", parquet.Repetitions.Required,
+			[]schema.Node{leaf}, fieldID)
+		require.NoError(t, err)
+
+		pqSchema := schema.NewSchema(root)
+		info, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.Nil(t, info, "flat column should not be detected as LIST")
+	})
+
+	t.Run("NestedListRejected", func(t *testing.T) {
+		// LIST(LIST(INT32)): should be rejected as unsupported.
+		innerLeaf, err := schema.NewPrimitiveNode(
+			"element", parquet.Repetitions.Optional,
+			parquet.Types.Int32, -1, fieldID)
+		require.NoError(t, err)
+
+		innerRepeated, err := schema.NewGroupNode(
+			"list", parquet.Repetitions.Repeated,
+			[]schema.Node{innerLeaf}, fieldID)
+		require.NoError(t, err)
+
+		innerList, err := schema.NewGroupNodeLogical(
+			"element", parquet.Repetitions.Optional,
+			[]schema.Node{innerRepeated},
+			schema.ListLogicalType{}, fieldID)
+		require.NoError(t, err)
+
+		outerRepeated, err := schema.NewGroupNode(
+			"list", parquet.Repetitions.Repeated,
+			[]schema.Node{innerList}, fieldID)
+		require.NoError(t, err)
+
+		outerList, err := schema.NewGroupNodeLogical(
+			"nested", parquet.Repetitions.Optional,
+			[]schema.Node{outerRepeated},
+			schema.ListLogicalType{}, fieldID)
+		require.NoError(t, err)
+
+		root, err := schema.NewGroupNode(
+			"schema", parquet.Repetitions.Required,
+			[]schema.Node{outerList}, fieldID)
+		require.NoError(t, err)
+
+		pqSchema := schema.NewSchema(root)
+		_, err = detectListColumn(pqSchema, 0)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "nested LIST")
+	})
+
+	t.Run("RepeatedParentNotListGroup", func(t *testing.T) {
+		// A repeated group whose parent does not have LIST annotation.
+		leaf, err := schema.NewPrimitiveNode(
+			"element", parquet.Repetitions.Optional,
+			parquet.Types.Int32, -1, fieldID)
+		require.NoError(t, err)
+
+		repeatedGroup, err := schema.NewGroupNode(
+			"list", parquet.Repetitions.Repeated,
+			[]schema.Node{leaf}, fieldID)
+		require.NoError(t, err)
+
+		nonListGroup, err := schema.NewGroupNode(
+			"not_a_list", parquet.Repetitions.Optional,
+			[]schema.Node{repeatedGroup}, fieldID)
+		require.NoError(t, err)
+
+		root, err := schema.NewGroupNode(
+			"schema", parquet.Repetitions.Required,
+			[]schema.Node{nonListGroup}, fieldID)
+		require.NoError(t, err)
+
+		pqSchema := schema.NewSchema(root)
+		_, err = detectListColumn(pqSchema, 0)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "grandparent is not a LIST group")
+	})
+
+	t.Run("ConvertedTypeListDetected", func(t *testing.T) {
+		// LIST columns annotated with ConvertedType (legacy) should be detected.
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "tags", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+		}, nil)
+		pool := memory.NewGoAllocator()
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		vb := lb.ValueBuilder().(*array.Int32Builder)
+		lb.Append(true)
+		vb.Append(1)
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		info, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		require.Equal(t, "tags", info.columnName)
+	})
+
+	t.Run("MapColumnRejected", func(t *testing.T) {
+		// MAP columns have a similar repeated-group structure to LIST but
+		// with MAP logical type. detectListColumn should reject them with
+		// a MAP-specific error rather than a generic one.
+
+		makeMapSchema := func(
+			t *testing.T, useLogicalType bool,
+		) *schema.Schema {
+			t.Helper()
+			keyNode, err := schema.NewPrimitiveNode(
+				"key", parquet.Repetitions.Required,
+				parquet.Types.ByteArray, -1, fieldID)
+			require.NoError(t, err)
+
+			valueNode, err := schema.NewPrimitiveNode(
+				"value", parquet.Repetitions.Optional,
+				parquet.Types.Int32, -1, fieldID)
+			require.NoError(t, err)
+
+			keyValueGroup, err := schema.NewGroupNode(
+				"key_value", parquet.Repetitions.Repeated,
+				[]schema.Node{keyNode, valueNode}, fieldID)
+			require.NoError(t, err)
+
+			var mapGroup *schema.GroupNode
+			if useLogicalType {
+				mapGroup, err = schema.NewGroupNodeLogical(
+					"my_map", parquet.Repetitions.Optional,
+					[]schema.Node{keyValueGroup},
+					schema.MapLogicalType{}, fieldID)
+			} else {
+				mapGroup, err = schema.NewGroupNodeConverted(
+					"my_map", parquet.Repetitions.Optional,
+					[]schema.Node{keyValueGroup},
+					schema.ConvertedTypes.MapKeyValue, fieldID)
+			}
+			require.NoError(t, err)
+
+			root, err := schema.NewGroupNode(
+				"schema", parquet.Repetitions.Required,
+				[]schema.Node{mapGroup}, fieldID)
+			require.NoError(t, err)
+			return schema.NewSchema(root)
+		}
+
+		t.Run("LogicalType", func(t *testing.T) {
+			pqSchema := makeMapSchema(t, true /* useLogicalType */)
+			for _, colIdx := range []int{0, 1} {
+				_, err := detectListColumn(pqSchema, colIdx)
+				require.Errorf(t, err, "column %d should error", colIdx)
+				require.ErrorContainsf(t, err, "MAP", "column %d should mention MAP", colIdx)
+			}
+		})
+
+		t.Run("ConvertedType", func(t *testing.T) {
+			pqSchema := makeMapSchema(t, false /* useLogicalType */)
+			for _, colIdx := range []int{0, 1} {
+				_, err := detectListColumn(pqSchema, colIdx)
+				require.Errorf(t, err, "column %d should error", colIdx)
+				require.ErrorContainsf(t, err, "MAP", "column %d should mention MAP", colIdx)
+			}
+		})
+	})
+}


### PR DESCRIPTION
Introduce parquetListColumnReader, a stateful reader that reconstructs per-row element arrays from Parquet LIST columns using definition and repetition levels.

The reader processes level entries in fixed 1024-entry chunks from the forward-only column chunk reader. When a chunk straddles a batch boundary, excess rows are buffered as overflow and drained on the next ReadBatch call. Partial rows split across chunk boundaries are also preserved and resumed.

Key components:
- detectListColumn() validates the standard 3-level LIST encoding and populates per-level def/rep thresholds
- parquetListColumnReader persists overflow and partial row state across ReadBatch calls within a row group

The data structures support arbitrary nesting depth in the future if needed: parquetListColumnInfo uses a levels[] array with nestingDepth tracking the number of LIST levels. Currently nestingDepth is always 1.

Part of: #162543

Release note: None