### PR TITLE
release-25.3: backupsink: drop pretty.Formatter log that crashes on Azure errors

### DIFF
--- a/pkg/backup/backupsink/BUILD.bazel
+++ b/pkg/backup/backupsink/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/util/unique",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//types",
-        "@com_github_kr_pretty//:pretty",
     ],
 )
 

--- a/pkg/backup/backupsink/file_sst_sink.go
+++ b/pkg/backup/backupsink/file_sst_sink.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/kr/pretty"
 )
 
 var (
@@ -280,7 +279,6 @@ func (s *FileSSTSink) Flush(ctx context.Context) error {
 		return err
 	}
 	if err := s.out.Close(); err != nil {
-		log.Warningf(ctx, "failed to close write in FileSSTSink: % #v", pretty.Formatter(err))
 		return errors.Wrap(err, "writing SST")
 	}
 	wroteSize := s.sst.Meta.Size


### PR DESCRIPTION
Fixes #169668 on release-25.3.

When closing the underlying writer in `FileSSTSink.Flush` failed, we logged the error via `pretty.Formatter`, whose reflection walk dereferences unexported fields. With Azure SDK errors that embed `*http.Response` and internal buffers released by the SDK, this can dereference freed memory and SIGSEGV. The error is already wrapped and returned to the caller, so the warning was redundant.

This is the minimal change: drop the warning line (and the now-unused `kr/pretty` import). master and release-25.4 are not affected — #153056 / d52eb81d730 incidentally removed this block while restructuring SST writer lifetime, so there is no upstream commit to backport; this is a direct fix on the release branch.

Epic: none