### PR TITLE
logical: transactional LDR rejects computed columns in constraints

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -491,7 +491,13 @@ func doLDRPlan(
 				}
 			}
 
-			err := tabledesc.CheckLogicalReplicationCompatibility(&srcExternalCatalog.Tables[i], destTableDesc.TableDesc(), details.SkipSchemaCheck || details.CreateTable, writer == sqlclustersettings.LDRWriterTypeLegacyKV)
+			err := tabledesc.CheckLogicalReplicationCompatibility(
+				&srcExternalCatalog.Tables[i],
+				destTableDesc.TableDesc(),
+				details.SkipSchemaCheck || details.CreateTable,
+				writer == sqlclustersettings.LDRWriterTypeLegacyKV,
+				details.Mode == jobspb.LogicalReplicationDetails_Transactional,
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -3113,6 +3113,7 @@ func TestSchemaValidation(t *testing.T) {
 		name        string
 		sourceSetup []string
 		destSetup   []string
+		mode        string
 		expectedErr string
 	}
 
@@ -3252,6 +3253,62 @@ func TestSchemaValidation(t *testing.T) {
 			},
 			expectedErr: "cannot create logical replication stream: RefCursor is not supported by LDR",
 		},
+		{
+			name: "txn_mode_virtual_computed_in_unique_index",
+			mode: "transactional",
+			destSetup: []string{
+				"ALTER TABLE tab ADD COLUMN virtual_col INT AS (pk + 1) VIRTUAL",
+				"CREATE UNIQUE INDEX virtual_idx ON tab(virtual_col)",
+			},
+			sourceSetup: []string{
+				"ALTER TABLE tab ADD COLUMN virtual_col INT AS (pk + 1) VIRTUAL",
+				"CREATE UNIQUE INDEX virtual_idx ON tab(virtual_col)",
+			},
+			expectedErr: "cannot create logical replication stream: table tab has a computed column virtual_col that is a key of unique index virtual_idx",
+		},
+		{
+			name: "txn_mode_stored_computed_in_unique_index",
+			mode: "transactional",
+			destSetup: []string{
+				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
+				"CREATE UNIQUE INDEX stored_idx ON tab(stored_col)",
+			},
+			sourceSetup: []string{
+				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
+				"CREATE UNIQUE INDEX stored_idx ON tab(stored_col)",
+			},
+			expectedErr: "cannot create logical replication stream: table tab has a computed column stored_col that is a key of unique index stored_idx",
+		},
+		{
+			name: "txn_mode_stored_computed_in_outbound_fk",
+			mode: "transactional",
+			destSetup: []string{
+				"CREATE TABLE parent (id INT PRIMARY KEY)",
+				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
+				"ALTER TABLE tab ADD CONSTRAINT fk_stored FOREIGN KEY (stored_col) REFERENCES parent(id)",
+			},
+			sourceSetup: []string{
+				"CREATE TABLE parent (id INT PRIMARY KEY)",
+				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
+				"ALTER TABLE tab ADD CONSTRAINT fk_stored FOREIGN KEY (stored_col) REFERENCES parent(id)",
+			},
+			expectedErr: "cannot create logical replication stream: table tab has a computed column stored_col that is part of foreign key fk_stored",
+		},
+		{
+			name: "txn_mode_stored_computed_in_inbound_fk",
+			mode: "transactional",
+			destSetup: []string{
+				"DROP TABLE tab",
+				"CREATE TABLE tab (pk INT, stored_col INT AS (pk + 1) STORED, PRIMARY KEY (stored_col), payload STRING)",
+				"CREATE TABLE child (id INT PRIMARY KEY, ref INT REFERENCES tab(stored_col))",
+			},
+			sourceSetup: []string{
+				"DROP TABLE tab",
+				"CREATE TABLE tab (pk INT, stored_col INT AS (pk + 1) STORED, PRIMARY KEY (stored_col), payload STRING)",
+				"CREATE TABLE child (id INT PRIMARY KEY, ref INT REFERENCES tab(stored_col))",
+			},
+			expectedErr: "cannot create logical replication stream: table tab has a computed column stored_col that is referenced by foreign key",
+		},
 	}
 
 	for i, tc := range validationTests {
@@ -3278,10 +3335,14 @@ func TestSchemaValidation(t *testing.T) {
 				dbSource.Exec(t, sql)
 			}
 
+			mode := tc.mode
+			if mode == "" {
+				mode = "validated"
+			}
 			dbDest.ExpectErr(
 				t,
 				tc.expectedErr,
-				"CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH MODE = 'validated'",
+				fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH MODE = '%s'", mode),
 				sourceURL.String(),
 			)
 			replicationtestutils.WaitForAllProducerJobsToFail(t, dbSource)

--- a/pkg/crosscluster/logical/resume_row.go
+++ b/pkg/crosscluster/logical/resume_row.go
@@ -254,7 +254,13 @@ func (p *LogicalReplicationPlanner) planRowReplication(
 				return errors.Wrapf(err, "failed to look up schema descriptor for table %d", pair.DstDescriptorID)
 			}
 
-			if err := tabledesc.CheckLogicalReplicationCompatibility(&srcTableDesc, dstTableDesc.TableDesc(), payload.SkipSchemaCheck || payload.CreateTable, writer == sqlclustersettings.LDRWriterTypeLegacyKV); err != nil {
+			if err := tabledesc.CheckLogicalReplicationCompatibility(
+				&srcTableDesc,
+				dstTableDesc.TableDesc(),
+				payload.SkipSchemaCheck || payload.CreateTable,
+				writer == sqlclustersettings.LDRWriterTypeLegacyKV,
+				false, /* isTxnMode */
+			); err != nil {
 				return err
 			}
 

--- a/pkg/sql/catalog/tabledesc/logical_replication_helpers.go
+++ b/pkg/sql/catalog/tabledesc/logical_replication_helpers.go
@@ -23,7 +23,10 @@ import (
 // descriptor is a valid target for logical replication and is equivalent to the
 // source table.
 func CheckLogicalReplicationCompatibility(
-	src, dst *descpb.TableDescriptor, skipTableEquivalenceCheck bool, requireKvWriterCompatible bool,
+	src, dst *descpb.TableDescriptor,
+	skipTableEquivalenceCheck bool,
+	requireKvWriterCompatible bool,
+	isTxnMode bool,
 ) error {
 	const cannotLDRMsg = "cannot create logical replication stream"
 	if !skipTableEquivalenceCheck {
@@ -39,7 +42,7 @@ func CheckLogicalReplicationCompatibility(
 		return pgerror.Wrapf(err, pgcode.InvalidTableDefinition, cannotLDRMsg)
 	}
 
-	if err := checkExpressionEvaluation(dst, requireKvWriterCompatible); err != nil {
+	if err := checkExpressionEvaluation(dst, requireKvWriterCompatible, isTxnMode); err != nil {
 		return pgerror.Wrapf(err, pgcode.InvalidTableDefinition, cannotLDRMsg)
 	}
 	if err := checkUniqueWithoutIndex(dst); err != nil {
@@ -122,8 +125,13 @@ func checkOutboundReferences(dst *descpb.TableDescriptor) error {
 // columns, even the computed ones, along with a list of columns that we've
 // already determined should be updated.
 //
+// For transactional LDR, we additionally disallow computed columns in
+// secondary unique indexes and foreign key constraints.
+//
 // TODO(msbutler): allow virtual computed columns in pk.
-func checkExpressionEvaluation(dst *descpb.TableDescriptor, requireKVCompatible bool) error {
+func checkExpressionEvaluation(
+	dst *descpb.TableDescriptor, requireKVCompatible bool, isTxnMode bool,
+) error {
 	// Disallow virtual columns if they are a key of an index.
 	// NB: it is impossible for a virtual column to be stored in an index.
 	columns := make([]catalog.Column, len(dst.Columns))
@@ -139,6 +147,12 @@ func checkExpressionEvaluation(dst *descpb.TableDescriptor, requireKVCompatible 
 				"table %s has a virtual computed column %s that appears in the primary key",
 				dst.Name, columns[pkColOrd].GetName(),
 			)
+		}
+	}
+
+	if isTxnMode {
+		if err := checkComputedColumnsInConstraints(dst, columns, colOrd); err != nil {
+			return err
 		}
 	}
 
@@ -158,6 +172,63 @@ func checkExpressionEvaluation(dst *descpb.TableDescriptor, requireKVCompatible 
 						dst.Name, columns[keyColOrd].GetName(), idx.Name,
 					)
 				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkComputedColumnsInConstraints rejects computed columns that are
+// in a unique or a foreign key constraint. Lock derivation hashes column datums
+// from the decoded row, which does not contain computed columns.
+//
+// TODO(#164507): support stored computed columns.
+func checkComputedColumnsInConstraints(
+	dst *descpb.TableDescriptor, columns []catalog.Column, colOrd catalog.TableColMap,
+) error {
+	getComputedCol := func(colID descpb.ColumnID) (catalog.Column, bool) {
+		ord, ok := colOrd.Get(colID)
+		if !ok || !columns[ord].IsComputed() {
+			return nil, false
+		}
+		return columns[ord], true
+	}
+
+	for _, idx := range dst.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		for _, colID := range idx.KeyColumnIDs {
+			if col, ok := getComputedCol(colID); ok {
+				return errors.Newf(
+					"table %s has a computed column %s that is a key of unique index %s",
+					dst.Name, col.GetName(), idx.Name,
+				)
+			}
+		}
+	}
+
+	// CRDB doesn't currently support FKs over virtual computed columns (#59671)
+	// but the check should be harmless in case we add support.
+	for _, fk := range dst.OutboundFKs {
+		for _, colID := range fk.OriginColumnIDs {
+			if col, ok := getComputedCol(colID); ok {
+				return errors.Newf(
+					"table %s has a computed column %s that is part of foreign key %s",
+					dst.Name, col.GetName(), fk.Name,
+				)
+			}
+		}
+	}
+
+	for _, fk := range dst.InboundFKs {
+		for _, colID := range fk.ReferencedColumnIDs {
+			if col, ok := getComputedCol(colID); ok {
+				return errors.Newf(
+					"table %s has a computed column %s that is referenced by foreign key %s",
+					dst.Name, col.GetName(), fk.Name,
+				)
 			}
 		}
 	}


### PR DESCRIPTION
This change rejects any schemas that have either virtual or stored columns in constraints. Support for stored columns is tracked in #164507. Virtual columns would require the lock synthesis to support expression evaluation, which we do not plan to support for now.

Fixes: https://github.com/cockroachdb/cockroach/issues/164506
Release note: none