### PR TITLE
cluster metrics: add UpdateStartTime for Stopwatch metrics

### DIFF
--- a/pkg/obs/clustermetrics/cmmetrics/metric.go
+++ b/pkg/obs/clustermetrics/cmmetrics/metric.go
@@ -240,6 +240,16 @@ func (s *WriteStopwatch) SetStartTime() {
 	s.dirty.Store(true)
 }
 
+// UpdateStartTime records the provided timestampNanos as the start time and
+// marks dirty. If the stopwatch has been deleted, the call is a no-op.
+func (s *WriteStopwatch) UpdateStartTime(timestampNanos int64) {
+	if s.deleted.Load() {
+		return
+	}
+	s.Gauge.Update(timestampNanos)
+	s.dirty.Store(true)
+}
+
 // Value returns the stored unix timestamp (nanoseconds), or 0 if not started.
 func (s *WriteStopwatch) Value() int64 {
 	return s.Gauge.Value()

--- a/pkg/obs/clustermetrics/cmmetrics/vector.go
+++ b/pkg/obs/clustermetrics/cmmetrics/vector.go
@@ -222,6 +222,12 @@ func (v *WriteStopwatchVec) SetStartTime(labels map[string]string) {
 	v.GaugeVec.Update(labels, v.timeSource.Now().UnixNano())
 }
 
+// UpdateStartTime records the provided timestampNanos as the start time
+// for the given label set.
+func (v *WriteStopwatchVec) UpdateStartTime(labels map[string]string, timestampNanos int64) {
+	v.GaugeVec.Update(labels, timestampNanos)
+}
+
 // Each calls f for every child stopwatch.
 func (v *WriteStopwatchVec) Each(f func(WritableMetric)) {
 	v.GaugeVec.EachChild(func(s *metric.VecChildSnapshot) {

--- a/pkg/obs/clustermetrics/cmwriter/writer_test.go
+++ b/pkg/obs/clustermetrics/cmwriter/writer_test.go
@@ -258,6 +258,14 @@ func TestWriter_Flush(t *testing.T) {
 				require.NotZero(t, stored.StoredValue, "stopwatch should store a nonzero unix timestamp")
 			},
 		}, {
+			name: "stopwatch UpdateStartTime stores provided timestamp",
+			setup: func(env *testEnv) {
+				sw := cmmetrics.NewWriteStopwatch(metric.Metadata{Name: "sw"}, timeutil.DefaultTimeSource{})
+				env.writer.AddMetric(sw)
+				sw.UpdateStartTime(1700000000000000000)
+			},
+			wantStored: map[string]int64{"sw": 1700000000000000000},
+		}, {
 			name: "stopwatch not started is not stored",
 			setup: func(env *testEnv) {
 				sw := cmmetrics.NewWriteStopwatch(metric.Metadata{Name: "sw"}, timeutil.DefaultTimeSource{})
@@ -575,6 +583,26 @@ func TestWriter_VecMetrics(t *testing.T) {
 		stored, ok = env.store.getByLabels("sv", map[string]string{"job": "restore"})
 		require.True(t, ok, "expected labeled stopwatch to be stored")
 		require.NotZero(t, stored.StoredValue, "stopwatch should store a nonzero unix timestamp")
+	})
+
+	t.Run("stopwatch vec UpdateStartTime stores provided timestamp per child", func(t *testing.T) {
+		env := newTestEnv()
+		sv := cmmetrics.NewWriteStopwatchVec(metric.Metadata{Name: "sv"}, timeutil.DefaultTimeSource{}, "job")
+		env.writer.AddMetric(sv)
+
+		const backupNanos int64 = 1700000000000000000
+		const restoreNanos int64 = 1800000000000000000
+		sv.UpdateStartTime(map[string]string{"job": "backup"}, backupNanos)
+		sv.UpdateStartTime(map[string]string{"job": "restore"}, restoreNanos)
+		env.writer.Flush(env.ctx)
+
+		stored, ok := env.store.getByLabels("sv", map[string]string{"job": "backup"})
+		require.True(t, ok, "expected labeled stopwatch to be stored")
+		require.Equal(t, backupNanos, stored.StoredValue)
+
+		stored, ok = env.store.getByLabels("sv", map[string]string{"job": "restore"})
+		require.True(t, ok, "expected labeled stopwatch to be stored")
+		require.Equal(t, restoreNanos, stored.StoredValue)
 	})
 
 	t.Run("stopwatch vec with no children is not flushed", func(t *testing.T) {


### PR DESCRIPTION
Sometimes an explicit time needs to be set instead of time.Now(). For
this, the UpdateStartTime method should be used instead of SetStartTime.

Epic: None
Release note: None