### PR TITLE
sql: fix SET NOT NULL in same txn as CREATE TABLE

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2735,16 +2735,20 @@ func runSchemaChangesInTxn(
 	for _, c := range constraintAdditionMutations {
 		if ck := c.AsCheck(); ck != nil {
 			if ck.IsNotNullColumnConstraint() {
-				// Remove the  check constraint we added.
+				// The synthetic IS NOT NULL check was added earlier to drive
+				// backfill validation. Validation succeeded, so flip the
+				// column descriptor's Nullable bit and drop the synthetic
+				// check rather than persisting it on the table.
+				colID := ck.GetReferencedColumnID(0)
+				col := catalog.FindColumnByID(tableDesc, colID)
+				col.ColumnDesc().Nullable = false
 				for i := range tableDesc.Checks {
 					if tableDesc.Checks[i].ConstraintID == ck.GetConstraintID() {
 						tableDesc.Checks = append(tableDesc.Checks[:i], tableDesc.Checks[i+1:]...)
+						break
 					}
-					colID := ck.GetReferencedColumnID(0)
-					col := catalog.FindColumnByID(tableDesc, colID)
-					col.ColumnDesc().Nullable = false
-					continue
 				}
+				continue
 			}
 			tableDesc.Checks = append(tableDesc.Checks, ck.CheckDesc())
 		} else if fk := c.AsForeignKey(); fk != nil {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -5332,7 +5332,7 @@ subtest validate_not_null_during_sc
 statement ok
 SET create_table_with_schema_locked=false
 
-statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(n IS NOT NULL\)
+statement error pgcode 23502 null value in column "n" violates not-null constraint
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SET LOCAL autocommit_before_ddl = false;
 create table t1_135692(n int);

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1859,11 +1859,17 @@ ALTER TABLE t_52501_valid ALTER COLUMN a SET NOT NULL
 statement ok
 COMMIT
 
+# The column should end up NOT NULL with no residual synthetic check
+# constraint. Regression test for #166612.
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM t_52501_valid] ORDER BY constraint_name
 ----
-t_52501_valid  a_auto_not_null     CHECK        CHECK ((a IS NOT NULL))  true
 t_52501_valid  t_52501_valid_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+
+query TB
+SELECT column_name, is_nullable FROM [SHOW COLUMNS FROM t_52501_valid] WHERE column_name = 'a'
+----
+a  false
 
 statement ok
 DROP TABLE t_52501_valid


### PR DESCRIPTION
When ALTER TABLE ... ALTER COLUMN ... SET NOT NULL ran in the same explicit transaction as CREATE TABLE, the column was left nullable and the synthetic IS NOT NULL check constraint that backfill validation added (named ${col}_auto_not_null) was persisted on the table.

The bug was in runSchemaChangesInTxn's constraint-finalization phase. When the synthetic NOT NULL check completed validation, the code that flipped the column descriptor's Nullable flag lived inside an inner search loop over tableDesc.Checks. For a freshly created table that loop body never executed, so Nullable was never updated. The trailing continue statement also targeted that inner loop rather than the outer one, so control fell through to the unconditional Checks = append(...) that re-added the synthetic check we had just removed.

Restructure the NOT NULL branch to set Nullable = false unconditionally, break out of the search loop after the splice, and continue the outer loop so the synthetic check is not re-appended.

No release note since this only affects the legacy schema changer.

Resolves: #166612
Epic: none

Release note: None