### PR TITLE
sql,cli: implement pg_get_function_sqlbody and use it in \df+

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3753,6 +3753,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_result"></a><code>pg_get_function_result(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the types of the result of the specified function.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_function_sqlbody"></a><code>pg_get_function_sqlbody(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the SQL-standard body of the specified function, or NULL if the function was not defined with the SQL-standard inline body syntax.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_functiondef"></a><code>pg_get_functiondef(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>For user-defined functions, returns the definition of the specified function. For builtin functions, returns the name of the function.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_indexdef"></a><code>pg_get_indexdef(index_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Gets the CREATE INDEX command for index</p>

--- a/pkg/cli/clisqlshell/describe.go
+++ b/pkg/cli/clisqlshell/describe.go
@@ -278,14 +278,11 @@ func describeFunctions(
 		// TODO(sql-sessions): Column "Language" omitted.
 		// (pg_language is not supported)
 		//
-		// TODO(sql-sessions): pg_get_function_sqlbody is not called here
-		// because it is not supported.
-		//
 		// TODO(sql-sessions): The "Description" column is currently
 		// ineffective for UDFs because of
 		// https://github.com/cockroachdb/cockroach/issues/44135
 		buf.WriteString(`,
-       p.prosrc AS "Source code",
+       COALESCE(p.prosrc, pg_catalog.pg_get_function_sqlbody(p.oid)) AS "Source code",
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"`)
 	}
 	buf.WriteString(`

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -2200,7 +2200,7 @@ List of functions:
         pg_catalog.pg_get_userbyid(p.proowner) AS "Owner",
         CASE WHEN p.prosecdef THEN 'definer' ELSE 'invoker' END AS "Security",
        COALESCE(pg_catalog.array_to_string(p.proacl, e'\n'), '') AS "Access privileges",
-       p.prosrc AS "Source code",
+       COALESCE(p.prosrc, pg_catalog.pg_get_function_sqlbody(p.oid)) AS "Source code",
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
@@ -2256,7 +2256,7 @@ List of functions:
         pg_catalog.pg_get_userbyid(p.proowner) AS "Owner",
         CASE WHEN p.prosecdef THEN 'definer' ELSE 'invoker' END AS "Security",
        COALESCE(pg_catalog.array_to_string(p.proacl, e'\n'), '') AS "Access privileges",
-       p.prosrc AS "Source code",
+       COALESCE(p.prosrc, pg_catalog.pg_get_function_sqlbody(p.oid)) AS "Source code",
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
@@ -2311,7 +2311,7 @@ List of functions:
         pg_catalog.pg_get_userbyid(p.proowner) AS "Owner",
         CASE WHEN p.prosecdef THEN 'definer' ELSE 'invoker' END AS "Security",
        COALESCE(pg_catalog.array_to_string(p.proacl, e'\n'), '') AS "Access privileges",
-       p.prosrc AS "Source code",
+       COALESCE(p.prosrc, pg_catalog.pg_get_function_sqlbody(p.oid)) AS "Source code",
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
@@ -2368,7 +2368,7 @@ List of functions:
         pg_catalog.pg_get_userbyid(p.proowner) AS "Owner",
         CASE WHEN p.prosecdef THEN 'definer' ELSE 'invoker' END AS "Security",
        COALESCE(pg_catalog.array_to_string(p.proacl, e'\n'), '') AS "Access privileges",
-       p.prosrc AS "Source code",
+       COALESCE(p.prosrc, pg_catalog.pg_get_function_sqlbody(p.oid)) AS "Source code",
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace

--- a/pkg/sql/logictest/testdata/logic_test/udf_options
+++ b/pkg/sql/logictest/testdata/logic_test/udf_options
@@ -94,6 +94,30 @@ SELECT pg_get_functiondef('soundex'::regproc::oid)
 ----
 soundex
 
+# pg_get_function_sqlbody returns the deparsed body only for functions defined
+# with the SQL-standard inline body syntax (RETURN expr or BEGIN ATOMIC ... END).
+# CockroachDB does not support that syntax (#85144), so prosqlbody is always
+# NULL today, matching Postgres' behavior for AS $$...$$ functions.
+query T
+SELECT pg_get_function_sqlbody('get_l'::regproc::oid)
+----
+NULL
+
+query T
+SELECT pg_get_function_sqlbody(NULL)
+----
+NULL
+
+query T
+SELECT pg_get_function_sqlbody(123456)
+----
+NULL
+
+query T
+SELECT pg_get_function_sqlbody('soundex'::regproc::oid)
+----
+NULL
+
 # Only the volatile functions should see the changes made by the UPDATE in the
 # CTE.
 query IIIIIIII colnames,rowsort

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2949,6 +2949,7 @@ var builtinOidsArray = []string{
 	2994: `st_3dlongestline(geometry_a: geometry, geometry_b: geometry) -> geometry`,
 	2995: `st_3dshortestline(geometry_a: geometry, geometry_b: geometry) -> geometry`,
 	2996: `st_3dperimeter(geometry: geometry) -> float`,
+	2997: `pg_get_function_sqlbody(func_oid: oid) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -909,6 +909,30 @@ FROM defaults_parsed
 		},
 	),
 
+	// pg_get_function_sqlbody returns the deparsed SQL body of a function defined
+	// with the SQL-standard inline body syntax (RETURN expr or BEGIN ATOMIC ...
+	// END), and NULL otherwise. CockroachDB does not yet support that syntax (see
+	// issue #85144), so pg_proc.prosqlbody is always NULL today and this builtin
+	// returns NULL for every input. It exists for compatibility with tools that
+	// probe pg_catalog (e.g. psql's \df+).
+	// https://www.postgresql.org/docs/14/functions-info.html
+	"pg_get_function_sqlbody": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Body: `SELECT prosqlbody
+             FROM pg_catalog.pg_proc
+             WHERE oid=$1
+             LIMIT 1`,
+			Info: "Returns the SQL-standard body of the specified function, or NULL " +
+				"if the function was not defined with the SQL-standard inline body syntax.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
+			Language:          tree.RoutineLangSQL,
+		},
+	),
+
 	// pg_get_indexdef functions like SHOW CREATE INDEX would if we supported that
 	// statement.
 	"pg_get_indexdef": makeBuiltin(


### PR DESCRIPTION
Add the `pg_get_function_sqlbody(oid) -> text` builtin, which Postgres 14+ uses to return the deparsed body of functions defined with the SQL-standard inline syntax (`RETURN expr` or `BEGIN ATOMIC ... END`).

CockroachDB does not yet support that syntax (#85144), so pg_proc.prosqlbody is always NULL and the builtin returns NULL for every input today. Implementing it nonetheless matches PostgreSQL's behavior for legacy `AS $$...$$` functions and unblocks tools that probe pg_catalog.

Epic: CRDB-62553

Release note (sql change): Added the pg_get_function_sqlbody builtin function for compatibility with PostgreSQL 14+. The function returns NULL for all functions today, matching PostgreSQL's behavior for functions defined with the `AS $$...$$` syntax.