### PR TITLE
pkg/cli: map sys_uptime to sys.uptime.count in tsdump datadog upload

### DIFF
--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -78,6 +78,17 @@ var (
 		"COUNTER": datadogV2.METRICINTAKETYPE_COUNT.Ptr(),
 	}
 	prometheusNameReplaceRE = regexp.MustCompile("^[^a-zA-Z_:]|[^a-zA-Z0-9_:]")
+
+	// tsdumpMetricNameOverrides provides name overrides for metrics whose
+	// Datadog name from the auto-generated mapping conflicts with the same
+	// metric emitted through a different ingestion pipeline. For example,
+	// sys.uptime is emitted as a gauge via OTel but as a count via tsdump;
+	// Datadog requires a single type per metric name, so tsdump renames it
+	// to sys.uptime.count.
+	tsdumpMetricNameOverrides = map[string]string{
+		"sys_uptime": "sys.uptime.count",
+	}
+
 	// Skip patterns - metrics that we haven't included for historical reasons
 	skipPatterns = []*regexp.Regexp{
 		regexp.MustCompile(`^auth_`),
@@ -483,7 +494,9 @@ func (d *datadogWriter) dump(kv *roachpb.KeyValue) (*datadogV2.MetricSeries, err
 
 	// Convert metric name to Prometheus format and lookup in metricsNameMap
 	promName := prometheusNameReplaceRE.ReplaceAllString(series.Metric, "_")
-	if datadogName, ok := d.metricsNameMap[promName]; ok {
+	if override, ok := tsdumpMetricNameOverrides[promName]; ok {
+		series.Metric = override
+	} else if datadogName, ok := d.metricsNameMap[promName]; ok {
 		series.Metric = datadogName
 	}
 

--- a/pkg/cli/tsdump_upload_test.go
+++ b/pkg/cli/tsdump_upload_test.go
@@ -1274,6 +1274,27 @@ func TestBuildDashboardLink(t *testing.T) {
 	}
 }
 
+// TestSysUptimeMetricMapping verifies that the sys.uptime metric is mapped
+// to sys.uptime.count in the Datadog upload, so it doesn't conflict with
+// the gauge variant (sys.uptime) emitted via the OTel pipeline.
+func TestSysUptimeMetricMapping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	writer, err := makeDatadogWriter("us5", false, "test-api-key", 100, "", 1, false)
+	require.NoError(t, err)
+
+	timestamp := time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC).UnixNano()
+	kv, err := createMockTimeSeriesKV("cr.node.sys.uptime", "1", timestamp, 12345)
+	require.NoError(t, err)
+
+	series, err := writer.dump(&kv)
+	require.NoError(t, err)
+
+	require.Equal(t, "sys.uptime.count", series.Metric,
+		"sys.uptime should be mapped to sys.uptime.count to avoid type conflict with OTel gauge")
+}
+
 // TestChildMetricDumpParsing tests that child metrics with labels are correctly
 // parsed and converted to Datadog format.
 func TestChildMetricDumpParsing(t *testing.T) {


### PR DESCRIPTION
The sys.uptime metric is emitted with different names and types depending on the ingestion pipeline:

- CRDB -> Datadog agent -> Datadog: emits `sys.uptime.count` as a count.
- Cockroach Cloud CRDB -> OTel -> Datadog: emits `sys.uptime` as a gauge.
- CRDB -> tsdump -> Datadog: emits `sys.uptime` as a count.

Datadog expects a single metric type per metric name. When tsdump uploads `sys.uptime` as a count, it conflicts with the gauge variant from the OTel pipeline, causing inconsistent metric evaluation.

The auto-generated Datadog metric mapping (cockroachdb_datadog_metrics.yaml) maps `sys_uptime` to `sys.uptime`, matching the Datadog integration's own naming. Since that file is generated at build time from the upstream Datadog integration source, the fix cannot go there.

Instead, add a tsdump-specific name override that takes precedence over the generated mapping. This emits the metric as `sys.uptime.count`, giving a clear distinction between the counter and gauge variants. Long term we should standardize the metric type across all CRDB ingestion pipelines.

Epic: None
Release note: None