### PR TITLE
roachtest: widen disk-bandwidth-limiter lower-bound threshold

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -184,10 +184,9 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 					panic("unreachable")
 				}
 
-				// Allow a 30% upper bound room for error.
+				// Allow a 30% room for error.
 				const bandwidthUpperThreshold = bandwidthLimitMbs * maxUtilFraction * 1.30
-				// Allow a 20% lower bound room for error.
-				const bandwidthLowerThreshold = bandwidthLimitMbs * maxUtilFraction * 0.8
+				const bandwidthLowerThreshold = bandwidthLimitMbs * maxUtilFraction * 0.7
 				// Mean over 30*10 = 300s = 5m
 				const sampleCountForBW = 30
 				const collectionIntervalSeconds = 10.0


### PR DESCRIPTION
The lower-bound threshold for mean total bandwidth was too tight at 20%
(51.2 MiB/s), causing flaky failures across multiple platforms (GCE
amd64, GCE ARM64, IBM s390x) when bandwidth dipped marginally below the
threshold. Widen the margin from 20% to 30% (44.8 MiB/s), matching the
upper-bound margin. The limiter is working correctly in all observed
failures; the test was just too sensitive to normal I/O variability.

Fixes: #169721
Epic: none
Release note: None