### PR TITLE
ts: declare expected type of each allowlisted child metric

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -1162,21 +1162,16 @@ func (rr registryRecorder) recordChild(
 	})
 }
 
-// hashSep is the field separator written between hashed components in
-// hashLabels. Hoisted to package scope to avoid per-call allocation on the
-// recording hot path.
-var hashSep = []byte{0}
-
-// hashLabels computes a stable hash of a label set. The zero-byte separators
-// close a collision where adjacent fields could otherwise be reassociated
-// (e.g. {name="ab", value="c"} vs {name="a", value="bc"}).
+// hashLabels computes a stable hash of a label set. The zero-byte separator
+// after each field prevents collisions where boundaries could otherwise shift
+// (e.g. without it, {a="bc"} and {ab="c"} would both hash "abc").
 func hashLabels(labels []*prometheusgo.LabelPair) uint64 {
 	h := fnv.New64a()
 	for _, label := range labels {
 		h.Write([]byte(label.GetName()))
-		h.Write(hashSep)
+		h.Write([]byte{0})
 		h.Write([]byte(label.GetValue()))
-		h.Write(hashSep)
+		h.Write([]byte{0})
 	}
 	return h.Sum64()
 }
@@ -1296,15 +1291,13 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 					if count < 0 {
 						continue // Skip malformed snapshots
 					}
-					value := c.ComputedMetric(snapshot)
-					metricName := baseName + c.Suffix
 					*dest = append(*dest, tspb.TimeSeriesData{
-						Name:   fmt.Sprintf(rr.format, metricName),
+						Name:   fmt.Sprintf(rr.format, baseName+c.Suffix),
 						Source: rr.source,
 						Datapoints: []tspb.TimeSeriesDatapoint{
 							{
 								TimestampNanos: rr.timestampNanos,
-								Value:          value,
+								Value:          c.ComputedMetric(snapshot),
 							},
 						},
 					})

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -1233,15 +1233,19 @@ func getOrComputeMetricName(
 	return metricName + suffix
 }
 
-// recordChangefeedChildMetrics iterates through changefeed metrics in the registry and processes child metrics
-// for those that have TsdbRecordLabeled set to true in their metadata.
-// Records up to 1024 child metrics per metric to prevent unbounded memory usage and performance issues.
+// recordChangefeedChildMetrics iterates through changefeed metrics in the
+// registry and processes child metrics for those that have TsdbRecordLabeled
+// set to true in their metadata. Records up to 1024 child metrics per metric
+// to prevent unbounded memory usage and performance issues.
+//
+// A metric whose runtime type does not match its declared class is skipped.
 func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesData) {
 	maxChildMetricsPerMetric := 1024
 
 	labels := rr.registry.GetLabels()
 	rr.registry.Each(func(name string, v interface{}) {
-		if _, allowed := tsutil.AllowedChildMetrics[name]; !allowed {
+		class, allowed := tsutil.LookupChildMetricClass(name)
+		if !allowed {
 			return
 		}
 		// Check if the metric has child collection enabled in its metadata
@@ -1254,8 +1258,14 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 			return // Skip this metric if child collection is not enabled
 		}
 
-		// Handle AggHistogram - use direct child access for per-child snapshots
-		if aggHist, isAggHist := v.(*aggmetric.AggHistogram); isAggHist {
+		switch class {
+		case tsutil.Histogram:
+			aggHist, ok := v.(*aggmetric.AggHistogram)
+			if !ok {
+				// Runtime type doesn't match the declared class; skip rather
+				// than silently emit under the wrong shape.
+				return
+			}
 			var childMetricsCount int
 			aggHist.EachChild(func(labelNames, labelVals []string, child *aggmetric.Histogram) {
 				if childMetricsCount >= maxChildMetricsPerMetric {
@@ -1304,53 +1314,58 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 				}
 				childMetricsCount++
 			})
-			return
-		}
 
-		// Handle Counter and Gauge metrics via Prometheus export
-		prom, ok := v.(metric.PrometheusExportable)
-		if !ok {
-			return
-		}
-		promIter, ok := v.(metric.PrometheusIterable)
-		if !ok {
-			return
-		}
-		m := prom.ToPrometheusMetric()
-		m.Label = append(labels, prom.GetLabels(false /* useStaticLabels */)...)
-
-		var childMetricsCount int
-		processChildMetric := func(childMetric *prometheusgo.Metric) {
-			if childMetricsCount >= maxChildMetricsPerMetric {
+		case tsutil.Counter, tsutil.Gauge:
+			prom, ok := v.(metric.PrometheusExportable)
+			if !ok {
 				return
 			}
-
-			var value float64
-			if childMetric.Gauge != nil {
-				value = *childMetric.Gauge.Value
-			} else if childMetric.Counter != nil {
-				value = *childMetric.Counter.Value
-			} else {
+			promIter, ok := v.(metric.PrometheusIterable)
+			if !ok {
 				return
 			}
-
-			// Check cache for encoded name
+			m := prom.ToPrometheusMetric()
+			m.Label = append(labels, prom.GetLabels(false /* useStaticLabels */)...)
 			promName := prom.GetName(false /* useStaticLabels */)
-			metricName := getOrComputeMetricName(rr.childMetricNameCache, promName, childMetric.Label)
 
-			*dest = append(*dest, tspb.TimeSeriesData{
-				Name:   fmt.Sprintf(rr.format, metricName),
-				Source: rr.source,
-				Datapoints: []tspb.TimeSeriesDatapoint{
-					{
-						TimestampNanos: rr.timestampNanos,
-						Value:          value,
+			var childMetricsCount int
+			promIter.Each(m.Label, func(childMetric *prometheusgo.Metric) {
+				if childMetricsCount >= maxChildMetricsPerMetric {
+					return
+				}
+
+				var value float64
+				switch class {
+				case tsutil.Counter:
+					if childMetric.Counter == nil {
+						return
+					}
+					value = *childMetric.Counter.Value
+				case tsutil.Gauge:
+					if childMetric.Gauge == nil {
+						return
+					}
+					value = *childMetric.Gauge.Value
+				default:
+					return
+				}
+
+				// Check cache for encoded name
+				metricName := getOrComputeMetricName(rr.childMetricNameCache, promName, childMetric.Label)
+
+				*dest = append(*dest, tspb.TimeSeriesData{
+					Name:   fmt.Sprintf(rr.format, metricName),
+					Source: rr.source,
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						{
+							TimestampNanos: rr.timestampNanos,
+							Value:          value,
+						},
 					},
-				},
+				})
+				childMetricsCount++
 			})
-			childMetricsCount++
 		}
-		promIter.Each(m.Label, processChildMetric)
 	})
 }
 

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -1284,7 +1284,7 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 
 		// Test with counter
 		counter := aggmetric.NewCounter(metric.Metadata{
-			Name:     "changefeed.internal_retry_message_count",
+			Name:     "changefeed.error_retries",
 			Category: metric.Metadata_CHANGEFEEDS,
 		}, "type")
 		reg.AddMetric(counter)
@@ -1407,17 +1407,106 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 		require.Equal(t, float64(7), seen[wantErrorRetries])
 		require.Equal(t, float64(99), seen[wantLaggingRanges])
 	})
+
+	// Dispatch is driven by tsutil.LookupChildMetricClass, not by the runtime
+	// Go type. If a metric is allowlisted as one class but registered as another
+	// (e.g., via a future implementation change), it must be skipped.
+	t.Run("runtime type mismatch with declared class is skipped", func(t *testing.T) {
+		// Pre-assert each class so the test fails if the allowlist is reshaped.
+		const (
+			counterName   = "changefeed.error_retries"
+			gaugeName     = "changefeed.lagging_ranges"
+			histogramName = "changefeed.emitted_batch_sizes"
+		)
+		assertClass := func(name string, want tsutil.ChildMetricClass) {
+			t.Helper()
+			got, ok := tsutil.LookupChildMetricClass(name)
+			require.Truef(t, ok, "%q is not allowlisted", name)
+			require.Equalf(t, want, got, "%q is allowlisted as %v, want %v", name, got, want)
+		}
+		assertClass(counterName, tsutil.Counter)
+		assertClass(gaugeName, tsutil.Gauge)
+		assertClass(histogramName, tsutil.Histogram)
+
+		registerCounter := func(reg *metric.Registry, name string) {
+			m := aggmetric.NewCounter(metric.Metadata{
+				Name:     name,
+				Category: metric.Metadata_CHANGEFEEDS,
+			}, "scope")
+			m.AddChild("default").Inc(42)
+			reg.AddMetric(m)
+		}
+		registerGauge := func(reg *metric.Registry, name string) {
+			m := aggmetric.NewGauge(metric.Metadata{
+				Name:     name,
+				Category: metric.Metadata_CHANGEFEEDS,
+			}, "scope")
+			m.AddChild("default").Update(42)
+			reg.AddMetric(m)
+		}
+		registerHistogram := func(reg *metric.Registry, name string) {
+			m := aggmetric.NewHistogram(metric.HistogramOptions{
+				Metadata: metric.Metadata{
+					Name:     name,
+					Category: metric.Metadata_CHANGEFEEDS,
+				},
+				Duration:     10 * time.Second,
+				BucketConfig: metric.IOLatencyBuckets,
+				Mode:         metric.HistogramModePrometheus,
+			}, "scope")
+			m.AddChild("default").RecordValue(42)
+			reg.AddMetric(m)
+		}
+
+		// Cover every mismatch direction in the dispatch matrix.
+		tests := []struct {
+			name       string
+			metricName string
+			register   func(*metric.Registry, string)
+		}{
+			{name: "counter declared, gauge runtime", metricName: counterName, register: registerGauge},
+			{name: "counter declared, histogram runtime", metricName: counterName, register: registerHistogram},
+			{name: "gauge declared, counter runtime", metricName: gaugeName, register: registerCounter},
+			{name: "gauge declared, histogram runtime", metricName: gaugeName, register: registerHistogram},
+			{name: "histogram declared, counter runtime", metricName: histogramName, register: registerCounter},
+			{name: "histogram declared, gauge runtime", metricName: histogramName, register: registerGauge},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				reg := metric.NewRegistry()
+				tc.register(reg, tc.metricName)
+
+				var cache syncutil.Map[uint64, cacheEntry]
+				recorder := registryRecorder{
+					registry:             reg,
+					format:               nodeTimeSeriesPrefix,
+					source:               "test-source",
+					timestampNanos:       manual.Now().UnixNano(),
+					childMetricNameCache: &cache,
+				}
+
+				var dest []tspb.TimeSeriesData
+				recorder.recordChangefeedChildMetrics(&dest)
+
+				require.Empty(t, dest,
+					"metric whose runtime type disagrees with declared class must not be recorded; got %v", dest)
+				cacheEntries := 0
+				cache.Range(func(uint64, *cacheEntry) bool { cacheEntries++; return true })
+				require.Zero(t, cacheEntries,
+					"skipped metrics must not poison the child metric name cache")
+			})
+		}
+	})
 }
 
 func BenchmarkRecordChangefeedChildMetrics(b *testing.B) {
 	manual := timeutil.NewManualTime(timeutil.Unix(0, 100))
 	enableChildCollection := true
 
-	// Get metrics from the allowed list and convert to slice for indexing
-	allowedMetricsList := make([]string, 0, len(tsutil.AllowedChildMetrics))
-	for metricName := range tsutil.AllowedChildMetrics {
-		allowedMetricsList = append(allowedMetricsList, metricName)
-	}
+	// Pick a known gauge-allowlisted metric name so the dispatch consistently
+	// routes through the scalar path under benchmark.
+	const gaugeMetricName = "changefeed.lagging_ranges"
 
 	// Benchmark with varying numbers of child metrics
 	for childCount := 10; childCount <= 1024; childCount *= 10 {
@@ -1427,7 +1516,7 @@ func BenchmarkRecordChangefeedChildMetrics(b *testing.B) {
 			// Create a single gauge with varying numbers of children
 			gauge := aggmetric.NewGauge(
 				metric.Metadata{
-					Name:              allowedMetricsList[0],
+					Name:              gaugeMetricName,
 					TsdbRecordLabeled: &enableChildCollection,
 					Category:          metric.Metadata_CHANGEFEEDS,
 				},

--- a/pkg/ts/tsutil/util.go
+++ b/pkg/ts/tsutil/util.go
@@ -35,14 +35,13 @@ var AllowedChildMetrics = map[string]struct{}{
 
 // IsAllowedChildMetric checks if a metric name matches one of the allowed child metrics.
 func IsAllowedChildMetric(name string) bool {
-	metricName := name
 	for _, prefix := range []string{"cr.node.", "cr.store."} {
-		if strings.HasPrefix(metricName, prefix) {
-			metricName = strings.TrimPrefix(metricName, prefix)
+		if strings.HasPrefix(name, prefix) {
+			name = strings.TrimPrefix(name, prefix)
 			break
 		}
 	}
-	_, ok := AllowedChildMetrics[metricName]
+	_, ok := AllowedChildMetrics[name]
 	return ok
 }
 

--- a/pkg/ts/tsutil/util.go
+++ b/pkg/ts/tsutil/util.go
@@ -14,23 +14,46 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 )
 
-// AllowedChildMetrics is the list of metrics that should have child metrics
-// collected and recorded to TSDB. This is a curated list to prevent unbounded
-// cardinality while still capturing the most important per-changefeed metrics.
-var AllowedChildMetrics = map[string]struct{}{
-	"changefeed.max_behind_nanos":                     {},
-	"changefeed.error_retries":                        {},
-	"changefeed.internal_retry_message_count":         {},
-	"changefeed.stage.downstream_client_send.latency": {},
-	"changefeed.emitted_messages":                     {},
-	"changefeed.sink_backpressure_nanos":              {},
-	"changefeed.backfill_pending_ranges":              {},
-	"changefeed.sink_io_inflight":                     {},
-	"changefeed.lagging_ranges":                       {},
-	"changefeed.aggregator_progress":                  {},
-	"changefeed.checkpoint_progress":                  {},
-	"changefeed.emitted_batch_sizes":                  {},
-	"changefeed.total_ranges":                         {},
+// ChildMetricClass identifies the class an entry in allowedChildMetrics is
+// expected to be.
+type ChildMetricClass int
+
+const (
+	// Counter expects a Prometheus counter at runtime.
+	Counter ChildMetricClass = iota + 1
+	// Gauge expects a Prometheus gauge at runtime.
+	Gauge
+	// Histogram expects an aggmetric.AggHistogram at runtime.
+	Histogram
+)
+
+// allowedChildMetrics is the list of metrics that should have child metrics
+// collected and recorded to TSDB, mapped to the type each metric is expected
+// to be. This is a curated list to prevent unbounded cardinality while still
+// capturing the most important per-changefeed metrics.
+//
+// Use LookupChildMetricClass to read entries.
+var allowedChildMetrics = map[string]ChildMetricClass{
+	"changefeed.aggregator_progress":                  Gauge,
+	"changefeed.backfill_pending_ranges":              Gauge,
+	"changefeed.checkpoint_progress":                  Gauge,
+	"changefeed.emitted_batch_sizes":                  Histogram,
+	"changefeed.emitted_messages":                     Counter,
+	"changefeed.error_retries":                        Counter,
+	"changefeed.internal_retry_message_count":         Gauge,
+	"changefeed.lagging_ranges":                       Gauge,
+	"changefeed.max_behind_nanos":                     Gauge,
+	"changefeed.sink_backpressure_nanos":              Histogram,
+	"changefeed.sink_io_inflight":                     Gauge,
+	"changefeed.stage.downstream_client_send.latency": Histogram,
+	"changefeed.total_ranges":                         Gauge,
+}
+
+// LookupChildMetricClass returns the declared ChildMetricClass for an
+// child metric in allowedChildMetrics if it is present.
+func LookupChildMetricClass(name string) (ChildMetricClass, bool) {
+	class, ok := allowedChildMetrics[name]
+	return class, ok
 }
 
 // IsAllowedChildMetric checks if a metric name matches one of the allowed child metrics.
@@ -41,7 +64,7 @@ func IsAllowedChildMetric(name string) bool {
 			break
 		}
 	}
-	_, ok := AllowedChildMetrics[name]
+	_, ok := allowedChildMetrics[name]
 	return ok
 }
 


### PR DESCRIPTION
Previously, AllowedChildMetrics was a set of metric names with no information about what kind of Prometheus metric each one represents. recordChangefeedChildMetrics decided how to record each entry by attempting type assertions at runtime. This made the TSDB shape of an entry an emergent property of whatever Go type the metric happened to have at registration time -- a future implementation change (e.g. swapping a counter for a histogram, or replacing a gauge with a different aggmetric variant) would silently rewrite what gets written to TSDB.

This change declares the expected kind alongside the name. The recorder now dispatches on the declared class and verifies the runtime type matches before recording; a mismatch skips the metric rather than emitting it under the wrong shape. Split the two recording paths into recordHistogramChildren and recordScalarChildren to keep the dispatch readable.

The map is unexported and accessed via LookupChildMetricClass so the declared kind cannot be bypassed by callers iterating the map directly.

Resolves: #169179
Epic: none
Release note: None

-----

this is stacked behind #169817 