### PR TITLE
sql: allow dropping column referenced in partial index predicate

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -273,7 +273,9 @@ t7  CREATE TABLE public.t7 (
       INDEX t6i3 (b DESC) WHERE b > 8:::INT8
     ) WITH (schema_locked = true);
 
-# Dropping a column referenced in the predicate drops the index.
+# Dropping a column referenced in the predicate drops the index. The
+# declarative schema changer handles this directly; the legacy schema
+# changer still requires explicitly dropping the index first (see #97813).
 
 statement ok
 CREATE TABLE t8 (
@@ -285,8 +287,15 @@ CREATE TABLE t8 (
     FAMILY (a, b, c)
 )
 
-# TODO(mgartner): Lift this restriction. See #96924.
+onlyif config local-legacy-schema-changer
 statement error cannot drop column "c" because it is referenced by partial index "t8_a_idx1"\nHINT: drop the partial index first, then drop the column
+ALTER TABLE t8 DROP COLUMN c
+
+onlyif config local-legacy-schema-changer
+statement ok
+DROP INDEX t8_a_idx1
+
+statement ok
 ALTER TABLE t8 DROP COLUMN c
 
 onlyif config schema-locked-disabled
@@ -296,12 +305,10 @@ SHOW CREATE TABLE t8
 t8  CREATE TABLE public.t8 (
       a INT8 NULL,
       b INT8 NULL,
-      c STRING NULL,
       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
       CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
       INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
-      INDEX t8_a_idx1 (a ASC) WHERE c = 'foo':::STRING,
-      FAMILY fam_0_a_b_c_rowid (a, b, c, rowid)
+      FAMILY fam_0_a_b_c_rowid (a, b, rowid)
     );
 
 skipif config schema-locked-disabled
@@ -311,12 +318,10 @@ SHOW CREATE TABLE t8
 t8  CREATE TABLE public.t8 (
       a INT8 NULL,
       b INT8 NULL,
-      c STRING NULL,
       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
       CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
       INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
-      INDEX t8_a_idx1 (a ASC) WHERE c = 'foo':::STRING,
-      FAMILY fam_0_a_b_c_rowid (a, b, c, rowid)
+      FAMILY fam_0_a_b_c_rowid (a, b, rowid)
     ) WITH (schema_locked = true);
 
 # CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
@@ -2368,24 +2373,34 @@ CREATE TABLE t96924 (
 statement ok
 ALTER TABLE t96924 DROP COLUMN a
 
+# Under the declarative schema changer, dropping a column referenced in a
+# partial index predicate drops the dependent index in the same statement.
+# The legacy schema changer still requires the user to drop the index first.
+
+onlyif config local-legacy-schema-changer
 statement error pq: cannot drop column "b" because it is referenced by partial index "t96924_b_key"\nHINT: drop the partial index first, then drop the column
 ALTER TABLE t96924 DROP COLUMN b
 
+onlyif config local-legacy-schema-changer
 statement ok
 DROP INDEX t96924_b_key CASCADE
 
 statement ok
 ALTER TABLE t96924 DROP COLUMN b
 
+onlyif config local-legacy-schema-changer
 statement error pq: cannot drop column "c" because it is referenced by partial index "t96924_c_key"\nHINT: drop the partial index first, then drop the column
 ALTER TABLE t96924 DROP COLUMN c
 
+onlyif config local-legacy-schema-changer
 statement ok
 DROP INDEX t96924_c_key CASCADE
 
 statement ok
 ALTER TABLE t96924 DROP COLUMN c
 
+# Partial unique-without-index predicates still block the column drop in
+# both schema changers (this restriction will be lifted separately).
 statement error pq: cannot drop column "d" because it is referenced by partial unique constraint "unique_d"\nHINT: drop the unique constraint first, then drop the column
 ALTER TABLE t96924 DROP COLUMN d
 
@@ -2395,9 +2410,11 @@ ALTER TABLE t96924 DROP CONSTRAINT unique_d
 statement ok
 ALTER TABLE t96924 DROP COLUMN d
 
+onlyif config local-legacy-schema-changer
 statement error pq: cannot drop column "e" because it is referenced by partial index "t96924_e_f_idx"\nHINT: drop the partial index first, then drop the column
 ALTER TABLE t96924 DROP COLUMN e
 
+onlyif config local-legacy-schema-changer
 statement ok
 DROP INDEX t96924_e_f_idx CASCADE
 
@@ -2409,19 +2426,22 @@ ALTER TABLE t96924 DROP COLUMN e
 statement ok
 ALTER TABLE t96924 DROP COLUMN f
 
-# Column `h` is used in the predicate of another index that does not key on `h`,
-# we will prevent dropping column `h` as well.
+# Column `h` is referenced only in the predicate of another index that does
+# not key on `h`. The declarative schema changer drops both atomically; the
+# legacy schema changer requires dropping the index first.
+onlyif config local-legacy-schema-changer
 statement error pq: cannot drop column "h" because it is referenced by partial index "t96924_g_idx"\nHINT: drop the partial index first, then drop the column
 ALTER TABLE t96924 DROP COLUMN h
 
+onlyif config local-legacy-schema-changer
 statement ok
 DROP INDEX t96924_g_idx
 
 statement ok
 ALTER TABLE t96924 DROP COLUMN h
 
-# Similarly, column `i` cannot be dropped since it's used in the predicate of
-# of a UWI constraint.
+# Column `i` is used in the predicate of a UWI constraint, which still
+# blocks the drop in both schema changers.
 statement error pq: cannot drop column "i" because it is referenced by partial unique constraint "unique_g"\nHINT: drop the unique constraint first, then drop the column
 ALTER TABLE t96924 DROP COLUMN i
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1544,29 +1544,43 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 
 			expr := mb.parsePartialIndexPredicateExpr(i)
 
+			// Resolve the predicate against putScope and delScope. If the
+			// predicate references a column that is not in the mutation
+			// scope — typically because the column is being dropped together
+			// with this partial index — we cannot evaluate the predicate
+			// for this row. Project constant fallback values instead: PUT
+			// false (we shouldn't insert into a partial index that is being
+			// dropped) and DEL true (we should issue a delete to be safe;
+			// the kv layer will no-op if the entry doesn't exist).
+			putTexpr, delTexpr, ok := mb.resolvePartialIndexPredicate(expr, putScope, delScope)
+			if !ok {
+				if putScope != nil {
+					putTexpr = tree.DBoolFalse
+				}
+				if delScope != nil {
+					delTexpr = tree.DBoolTrue
+				}
+			}
+
 			// Build synthesized PUT columns.
 			if putScope != nil {
-				texpr := putScope.resolveAndRequireType(expr, types.Bool)
-
 				// Use an anonymous name because the column cannot be referenced
 				// in other expressions.
 				colName := scopeColName("").WithMetadataName(fmt.Sprintf("partial_index_put%d", ord+1))
-				scopeCol := projectionScope.addColumn(colName, texpr)
+				scopeCol := projectionScope.addColumn(colName, putTexpr)
 
-				mb.b.buildScalar(texpr, putScope, projectionScope, scopeCol, nil)
+				mb.b.buildScalar(putTexpr, putScope, projectionScope, scopeCol, nil)
 				mb.partialIndexPutColIDs[ord] = scopeCol.id
 			}
 
 			// Build synthesized DEL columns.
 			if delScope != nil {
-				texpr := delScope.resolveAndRequireType(expr, types.Bool)
-
 				// Use an anonymous name because the column cannot be referenced
 				// in other expressions.
 				colName := scopeColName("").WithMetadataName(fmt.Sprintf("partial_index_del%d", ord+1))
-				scopeCol := projectionScope.addColumn(colName, texpr)
+				scopeCol := projectionScope.addColumn(colName, delTexpr)
 
-				mb.b.buildScalar(texpr, delScope, projectionScope, scopeCol, nil)
+				mb.b.buildScalar(delTexpr, delScope, projectionScope, scopeCol, nil)
 				mb.partialIndexDelColIDs[ord] = scopeCol.id
 			}
 
@@ -2070,6 +2084,43 @@ func (mb *mutationBuilder) parseColExpr(
 
 	cache[ord] = expr
 	return expr
+}
+
+// resolvePartialIndexPredicate type-checks the given partial-index predicate
+// expression against putScope and delScope (either may be nil). It returns the
+// resulting typed expressions plus ok=true on success.
+//
+// Resolution can fail with a panic when the predicate references a column that
+// is not visible in the mutation scope — most notably when the column is being
+// dropped together with this partial index, in which case the column is a
+// mutation column and reference attempts produce either an UndefinedColumn
+// error or a "column is being backfilled" InvalidColumnReference error. In
+// either of those cases this function recovers and returns ok=false so the
+// caller can skip the index. Other panic causes are re-raised unchanged.
+func (mb *mutationBuilder) resolvePartialIndexPredicate(
+	expr tree.Expr, putScope, delScope *scope,
+) (putTexpr, delTexpr tree.TypedExpr, ok bool) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		if rErr, isErr := r.(error); isErr {
+			switch pgerror.GetPGCode(rErr) {
+			case pgcode.UndefinedColumn, pgcode.InvalidColumnReference:
+				ok = false
+				return
+			}
+		}
+		panic(r)
+	}()
+	if putScope != nil {
+		putTexpr = putScope.resolveAndRequireType(expr, types.Bool)
+	}
+	if delScope != nil {
+		delTexpr = delScope.resolveAndRequireType(expr, types.Bool)
+	}
+	return putTexpr, delTexpr, true
 }
 
 // parsePartialIndexPredicateExpr parses the partial index predicate for the

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -199,7 +199,13 @@ func (mb *mutationBuilder) inferArbitersFromConflictOrds(
 		// If the index is a pseudo-partial index, it can always be an arbiter.
 		// Furthermore, it is the only arbiter needed because it guarantees
 		// uniqueness of its columns across all rows.
-		pred := h.partialIndexPredicate(idx)
+		pred, ok := h.partialIndexPredicate(idx)
+		if !ok {
+			// The index's predicate is not available (e.g. because the index
+			// is being dropped together with a column referenced in its
+			// predicate); it cannot be used as an arbiter.
+			continue
+		}
 		if pred.IsTrue() {
 			return makeSingleIndexArbiterSet(mb, idx)
 		}
@@ -699,18 +705,29 @@ func (h *arbiterPredicateHelper) tableScope() *scope {
 	return h.tableScopeLazy
 }
 
-// partialIndexPredicate returns the partial index predicate of the given index.
-// Rather than build the predicate scalar expression from the tree.Expr in the
-// catalog, it fetches the predicates from the table metadata. These predicates
-// are populated when the Scan expression is built for the tableScope. This
-// eliminates unnecessarily rebuilding partial index predicate expressions.
-func (h *arbiterPredicateHelper) partialIndexPredicate(idx cat.IndexOrdinal) memo.FiltersExpr {
+// partialIndexPredicate returns the partial index predicate of the given
+// index. Rather than build the predicate scalar expression from the tree.Expr
+// in the catalog, it fetches the predicates from the table metadata. These
+// predicates are populated when the Scan expression is built for the
+// tableScope. This eliminates unnecessarily rebuilding partial index predicate
+// expressions.
+//
+// Returns ok=false when the index has no predicate available in the table
+// metadata, which can happen if the predicate references a column that is not
+// in the table's ordinary scope (e.g. mid-drop). In that case the index cannot
+// be used as an arbiter.
+func (h *arbiterPredicateHelper) partialIndexPredicate(
+	idx cat.IndexOrdinal,
+) (_ memo.FiltersExpr, ok bool) {
 	// Call tableScope to ensure that buildScan has been called to populate
 	// tabMeta with partial index predicates.
 	h.tableScope()
 
-	pred, _ := h.tabMeta.PartialIndexPredicate(idx)
-	return *pred.(*memo.FiltersExpr)
+	pred, ok := h.tabMeta.PartialIndexPredicate(idx)
+	if !ok {
+		return nil, false
+	}
+	return *pred.(*memo.FiltersExpr), true
 }
 
 // partialUniqueConstraintPredicate returns the predicate of the given unique

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -10,8 +10,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -96,13 +99,45 @@ func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta, scan
 		}
 
 		// Build the partial index predicate as a memo.FiltersExpr and add it
-		// to the table metadata.
-		predExpr, err := b.buildPartialIndexPredicate(tabMeta, tableScope, expr, "index predicate")
+		// to the table metadata. If the predicate references a column that is
+		// no longer in the table's ordinary scope (e.g. the column is being
+		// dropped and is in a non-public state), skip the index. Callers of
+		// TableMeta.PartialIndexPredicate handle the resulting absence by
+		// foregoing predicate-based reasoning for that index, which is the
+		// correct fallback for an index in the process of being dropped.
+		predExpr, err := b.tryBuildPartialIndexPredicate(tabMeta, tableScope, expr)
 		if err != nil {
+			if pgerror.GetPGCode(err) == pgcode.UndefinedColumn {
+				log.VEventf(b.ctx, 2,
+					"skipping partial index predicate for index %d on table %d: %v",
+					index.ID(), tabMeta.MetaID, err)
+				continue
+			}
 			panic(err)
 		}
 		tabMeta.AddPartialIndexPredicate(indexOrd, &predExpr)
 	}
+}
+
+// tryBuildPartialIndexPredicate is a recover-wrapping shim around
+// buildPartialIndexPredicate. buildPartialIndexPredicate may panic during name
+// resolution (resolveAndRequireType panics if a referenced column is missing
+// from the scope, e.g. the column is mid-drop). This helper converts an
+// UndefinedColumn panic into a returned error so the caller can decide
+// whether to skip the index. Other panic causes are re-raised.
+func (b *Builder) tryBuildPartialIndexPredicate(
+	tabMeta *opt.TableMeta, tableScope *scope, expr tree.Expr,
+) (predExpr memo.FiltersExpr, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if rErr, ok := r.(error); ok && pgerror.GetPGCode(rErr) == pgcode.UndefinedColumn {
+				err = rErr
+				return
+			}
+			panic(r)
+		}
+	}()
+	return b.buildPartialIndexPredicate(tabMeta, tableScope, expr, "index predicate")
 }
 
 // buildPartialIndexPredicate builds a memo.FiltersExpr from the given

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -482,19 +482,22 @@ func (tm *TableMeta) AddPartialIndexPredicate(ord cat.IndexOrdinal, pred ScalarE
 }
 
 // PartialIndexPredicate returns the given index's predicate scalar expression,
-// if the index is a partial index. Returns ok=false if the index is not a
-// partial index. Panics if the index is a partial index according to the
-// catalog, but a predicate scalar expression does not exist in the table
-// metadata.
+// if the index is a partial index and a predicate is available in the table
+// metadata. Returns ok=false in two cases:
+//
+//  1. The index is not a partial index.
+//  2. The index is a partial index according to the catalog, but its
+//     predicate could not be added to the table metadata. This happens when
+//     the predicate references a column that is not in the table's ordinary
+//     scope at build time (e.g. the column is mid-drop and is in WRITE_ONLY
+//     or DELETE_ONLY). Callers must treat this case the same as case (1):
+//     skip the index for any predicate-based reasoning.
 func (tm *TableMeta) PartialIndexPredicate(ord cat.IndexOrdinal) (pred ScalarExpr, ok bool) {
 	if _, isPartialIndex := tm.Table.Index(ord).Predicate(); !isPartialIndex {
 		return nil, false
 	}
 	pred, ok = tm.partialIndexPredicates[ord]
-	if !ok {
-		panic(errors.AssertionFailedf("partial index predicate does not exist in table metadata"))
-	}
-	return pred, true
+	return pred, ok
 }
 
 // PartialIndexPredicatesUnsafe returns the partialIndexPredicates map.

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -543,7 +543,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 				"CREATE INDEX idx ON tbl (val) WHERE i > 1",
 			},
 			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
-			skipIssue:    97813,
 		},
 		{
 			desc:         "create expression index",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -89,7 +89,7 @@ func alterTableAlterColumnType(
 		case *scpb.PolicyUsingExpr, *scpb.PolicyWithCheckExpr:
 			panic(sqlerrors.NewAlterDependsOnPolicyExprError(op, objType, t.Column.String()))
 		}
-	}, false /* allowPartialIdxPredicateRef */)
+	}, disallowAllPredicateRefs)
 
 	var err error
 	newColType.Type, err = schemachange.ValidateAlterColumnTypeChecks(
@@ -304,7 +304,7 @@ func handleGeneralColumnConversion(
 		case *scpb.SecondaryIndex:
 			panic(sqlerrors.NewAlterColumnTypeColInIndexNotSupportedErr())
 		}
-	}, false /* allowPartialIdxPredicateRef */)
+	}, disallowAllPredicateRefs)
 
 	// This code path should never be reached for virtual columns, as their values
 	// are always computed dynamically on access and are never stored on disk.
@@ -479,7 +479,7 @@ func maybeWriteNoticeForFKColTypeMismatch(b BuildCtx, col *scpb.Column, colType 
 		case *scpb.ForeignKeyConstraintUnvalidated:
 			writeNoticeHelper(e.ColumnIDs, e.ReferencedColumnIDs, e.ReferencedTableID)
 		}
-	}, false /* allowPartialIdxPredicateRef */)
+	}, disallowAllPredicateRefs)
 }
 
 func getComputeExpressionForBackfill(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -1376,7 +1376,7 @@ func checkIfColumnCanBeDropped(b BuildCtx, columnToDrop *scpb.Column) bool {
 				canBeDropped = false
 			}
 		}
-	}, false /* allowPartialIdxPredicateRef */)
+	}, disallowAllPredicateRefs)
 	return canBeDropped
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -309,7 +309,7 @@ func dropColumn(
 		default:
 			b.Drop(e)
 		}
-	}, false /* allowPartialIdxPredicateRef */)
+	}, disallowUWIPredicateRefs)
 	// TODO(ajwerner): Track the undropped backrefs to populate a detail
 	// message like postgres does. For example:
 	//  SET serial_normalization = sql_sequence;
@@ -333,13 +333,35 @@ func dropColumn(
 	assertAllColumnElementsAreDropped(colElts)
 }
 
+// predicateRefPolicy controls how walkColumnDependencies handles columns
+// that are referenced in a partial-index predicate or partial
+// unique-without-index predicate.
+type predicateRefPolicy int
+
+const (
+	// disallowAllPredicateRefs panics if the column is referenced in either
+	// a partial-index predicate or a partial UWI predicate. Used by code
+	// paths (ALTER PRIMARY KEY, ALTER COLUMN TYPE) where the dependency
+	// rules don't yet sequence the partial-index drop safely.
+	disallowAllPredicateRefs predicateRefPolicy = iota
+	// disallowUWIPredicateRefs panics only for partial UWI references.
+	// Partial-index references are allowed because the declarative schema
+	// changer's dep rule sequences the partial index into DELETE_ONLY
+	// before the column reaches WRITE_ONLY, allowing the index entries to
+	// be removed via blind DELs without evaluating the predicate.
+	disallowUWIPredicateRefs
+	// allowAllPredicateRefs skips the check entirely. Used by ALTER
+	// COLUMN ... RENAME, which doesn't change column existence.
+	allowAllPredicateRefs
+)
+
 func walkColumnDependencies(
 	b BuildCtx,
 	col *scpb.Column,
 	op string,
 	objType string,
 	fn func(e scpb.Element, op string, objType string),
-	allowPartialIdxPredicateRef bool,
+	predicateRefs predicateRefPolicy,
 ) {
 	var sequenceDeps catalog.DescriptorIDSet
 	var indexDeps catid.IndexSet
@@ -347,11 +369,13 @@ func walkColumnDependencies(
 	var constraintDeps catid.ConstraintSet
 	tblElts := b.QueryByID(col.TableID).Filter(orFilter(publicTargetFilter, transientTargetFilter))
 
-	// Panic if `col` is referenced in a predicate of an index or
-	// unique without index constraint.
-	// TODO (xiang): Remove this restriction when #97813 is fixed.
-	if !allowPartialIdxPredicateRef {
+	switch predicateRefs {
+	case disallowAllPredicateRefs:
 		panicIfColReferencedInPredicate(b, col, tblElts, op, objType)
+	case disallowUWIPredicateRefs:
+		panicIfColReferencedInUWIPredicate(b, col, tblElts, op, objType)
+	case allowAllPredicateRefs:
+		// No-op.
 	}
 
 	tblElts.
@@ -517,6 +541,47 @@ func panicIfColReferencedInPredicate(
 		indexNameElem := mustRetrieveIndexNameElem(b, col.TableID, violatingIndex)
 		panic(sqlerrors.ColumnReferencedByPartialIndex(op, objType, colNameElem.Name, indexNameElem.Name))
 	}
+	if violatingUWI != 0 {
+		colNameElem := mustRetrieveColumnNameElem(b, col.TableID, col.ColumnID)
+		uwiNameElem := mustRetrieveConstraintWithoutIndexNameElem(b, col.TableID, violatingUWI)
+		panic(sqlerrors.ColumnReferencedByPartialUniqueWithoutIndexConstraint(
+			op, objType, colNameElem.Name, uwiNameElem.Name))
+	}
+}
+
+// panicIfColReferencedInUWIPredicate disallows dropping a column that is
+// referenced in the predicate of a partial unique-without-index constraint.
+// Unlike partial indexes, UWI predicate evaluation during the column-drop
+// transition is not yet sequenced safely by the declarative schema changer's
+// dependency rules.
+func panicIfColReferencedInUWIPredicate(
+	b BuildCtx, col *scpb.Column, tblElts ElementResultSet, op, objType string,
+) {
+	contains := func(container []catid.ColumnID, target catid.ColumnID) bool {
+		for _, elem := range container {
+			if elem == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	var violatingUWI catid.ConstraintID
+	tblElts.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
+		if violatingUWI != 0 {
+			return
+		}
+		switch elt := e.(type) {
+		case *scpb.UniqueWithoutIndexConstraint:
+			if elt.Predicate != nil && contains(elt.Predicate.ReferencedColumnIDs, col.ColumnID) {
+				violatingUWI = elt.ConstraintID
+			}
+		case *scpb.UniqueWithoutIndexConstraintUnvalidated:
+			if elt.Predicate != nil && contains(elt.Predicate.ReferencedColumnIDs, col.ColumnID) {
+				violatingUWI = elt.ConstraintID
+			}
+		}
+	})
 	if violatingUWI != 0 {
 		colNameElem := mustRetrieveColumnNameElem(b, col.TableID, col.ColumnID)
 		uwiNameElem := mustRetrieveConstraintWithoutIndexNameElem(b, col.TableID, violatingUWI)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_column.go
@@ -95,7 +95,7 @@ func renameColumnChecks(b BuildCtx, col *scpb.Column, oldName, newName tree.Name
 				tree.ErrString(&oldName), fnName.Name),
 			)
 		}
-	}, true /* allowPartialIdxPredicateRef */)
+	}, allowAllPredicateRefs)
 
 	if col.IsInaccessible {
 		panic(pgerror.Newf(


### PR DESCRIPTION
Lifts the temporary safeguard introduced in #97372 that forbids
`ALTER TABLE ... DROP COLUMN` when the column is referenced in a
partial index predicate, in the declarative schema changer path. The
legacy schema changer keeps the restriction. Partial UNIQUE WITHOUT
INDEX predicates also remain blocked in both paths and will be
addressed separately.

The change is split into two commits, reviewable independently:

1. **`schemachanger:`** removes the `panicIfColReferencedInPredicate`
   check on the drop-column path. The existing dep rule
   `secondary index partial no longer public before referenced column`
   already orders the partial index into `DELETE_ONLY` before the
   referenced column reaches `WRITE_ONLY`, so kv-layer writes are safe
   (delete-only secondary indexes issue blind DELs without consulting
   the predicate). The `walkColumnDependencies` toggle changes from a
   bool to a `predicateRefPolicy` enum so each caller (drop-column,
   alter-primary-key, alter-column-type, rename-column) can pick the
   policy that matches its actual constraints. Only the drop-column
   path opts into the lifted restriction.

2. **`opt:`** addresses a latent issue exposed by the first commit.
   With the column in `WRITE_ONLY` and the partial index in
   `DELETE_ONLY`, `addPartialIndexPredicatesForTable` panics
   resolving the predicate against the public-only column scope —
   breaking any concurrent SELECT against the table, not just queries
   that would have used the partial index. The mutation builder's
   PUT/DEL synthesis hits a parallel "column is being backfilled"
   panic. The commit makes `TableMeta.PartialIndexPredicate` return
   `(nil, false)` instead of panicking when an index is partial in
   the catalog but missing from metadata, recovers from
   `UndefinedColumn` / `InvalidColumnReference` panics in the two
   resolution sites, and projects constant `PUT=false` / `DEL=true`
   fallbacks in the mutation builder. All existing callers of
   `PartialIndexPredicate` were audited and already handle
   `ok=false`; one (`mutation_builder_arbiter.partialIndexPredicate`)
   was discarding the flag and is fixed defensively.

The DML-injection test case "drop column with partial index" (which
was skipped under #97813) is re-enabled and passing.

> [!NOTE]
> Marked **draft** while the optbuilder approach gets a sanity-check
> — see https://github.com/cockroachdb/cockroach/issues/97813#issuecomment-4426913777.
> The recover-and-fall-back pattern works but weakens an invariant
> the optimizer otherwise maintains, and there may be a cleaner
> shape (e.g. catalog-layer hiding of partial indexes with
> unresolvable predicates, or schema-changer-side clearing of the
> predicate string at \`DELETE_ONLY\`) worth exploring before this
> merges.

Resolves: #97813
Epic: none

Release note (sql change): ALTER TABLE ... DROP COLUMN no longer
rejects columns referenced in a partial index predicate. The
dependent partial index is dropped automatically as part of the same
statement. The previous behavior — requiring the user to drop the
index first — is still in effect when the legacy schema changer is
in use, and when the column is referenced in a partial UNIQUE WITHOUT
INDEX predicate.