### PR TITLE
release-25.4: sqlstats: guard against div by zero in NumericStat handling

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -122,15 +122,20 @@ func (t *TransactionStatistics) Add(other *TransactionStatistics) {
 	if other.MaxRetries > t.MaxRetries {
 		t.MaxRetries = other.MaxRetries
 	}
-
-	t.IdleLat.Add(other.IdleLat, t.Count, other.Count)
-	t.CommitLat.Add(other.CommitLat, t.Count, other.Count)
-	t.RetryLat.Add(other.RetryLat, t.Count, other.Count)
-	t.ServiceLat.Add(other.ServiceLat, t.Count, other.Count)
-	t.NumRows.Add(other.NumRows, t.Count, other.Count)
-	t.RowsRead.Add(other.RowsRead, t.Count, other.Count)
-	t.BytesRead.Add(other.BytesRead, t.Count, other.Count)
-	t.RowsWritten.Add(other.RowsWritten, t.Count, other.Count)
+	transactionStatsCount := t.Count
+	if transactionStatsCount == 0 && other.Count == 0 {
+		// If both are zero, artificially set the receiver's count to one to avoid
+		// division by zero in Add.
+		transactionStatsCount = 1
+	}
+	t.IdleLat.Add(other.IdleLat, transactionStatsCount, other.Count)
+	t.CommitLat.Add(other.CommitLat, transactionStatsCount, other.Count)
+	t.RetryLat.Add(other.RetryLat, transactionStatsCount, other.Count)
+	t.ServiceLat.Add(other.ServiceLat, transactionStatsCount, other.Count)
+	t.NumRows.Add(other.NumRows, transactionStatsCount, other.Count)
+	t.RowsRead.Add(other.RowsRead, transactionStatsCount, other.Count)
+	t.BytesRead.Add(other.BytesRead, transactionStatsCount, other.Count)
+	t.RowsWritten.Add(other.RowsWritten, transactionStatsCount, other.Count)
 
 	t.ExecStats.Add(other.ExecStats)
 
@@ -170,17 +175,23 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	if other.MaxRetries > s.MaxRetries {
 		s.MaxRetries = other.MaxRetries
 	}
+	statementStatsCount := s.Count
+	if statementStatsCount == 0 && other.Count == 0 {
+		// If both are zero, artificially set the receiver's count to one to avoid
+		// division by zero in Add.
+		statementStatsCount = 1
+	}
 	s.SQLType = other.SQLType
-	s.NumRows.Add(other.NumRows, s.Count, other.Count)
-	s.IdleLat.Add(other.IdleLat, s.Count, other.Count)
-	s.ParseLat.Add(other.ParseLat, s.Count, other.Count)
-	s.PlanLat.Add(other.PlanLat, s.Count, other.Count)
-	s.RunLat.Add(other.RunLat, s.Count, other.Count)
-	s.ServiceLat.Add(other.ServiceLat, s.Count, other.Count)
-	s.OverheadLat.Add(other.OverheadLat, s.Count, other.Count)
-	s.BytesRead.Add(other.BytesRead, s.Count, other.Count)
-	s.RowsRead.Add(other.RowsRead, s.Count, other.Count)
-	s.RowsWritten.Add(other.RowsWritten, s.Count, other.Count)
+	s.NumRows.Add(other.NumRows, statementStatsCount, other.Count)
+	s.IdleLat.Add(other.IdleLat, statementStatsCount, other.Count)
+	s.ParseLat.Add(other.ParseLat, statementStatsCount, other.Count)
+	s.PlanLat.Add(other.PlanLat, statementStatsCount, other.Count)
+	s.RunLat.Add(other.RunLat, statementStatsCount, other.Count)
+	s.ServiceLat.Add(other.ServiceLat, statementStatsCount, other.Count)
+	s.OverheadLat.Add(other.OverheadLat, statementStatsCount, other.Count)
+	s.BytesRead.Add(other.BytesRead, statementStatsCount, other.Count)
+	s.RowsRead.Add(other.RowsRead, statementStatsCount, other.Count)
+	s.RowsWritten.Add(other.RowsWritten, statementStatsCount, other.Count)
 	s.Nodes = util.CombineUnique(s.Nodes, other.Nodes)
 	s.KVNodeIDs = util.CombineUnique(s.KVNodeIDs, other.KVNodeIDs)
 	s.Regions = util.CombineUnique(s.Regions, other.Regions)


### PR DESCRIPTION
Backport 1/1 commits from #161406.

/cc @cockroachdb/release

---
The existing implementation does not handle cases where count is 0 well. It can lead to strange behaviours where the NumericStat turns into NaN or infinity. This change adds logical fallbacks to when both counts are 0, such that NaN or infinity would not appear.

This was caught in deadlock=true tests where the NaN was stored as the app stats.

fixes: #169408
Release Note: None

Release justification: low-risk bug fix, add a defensive guard