### PR TITLE
cloud/amazon: pre-refresh AWS credentials to avoid in-flight expiry

### DIFF
--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -188,6 +188,10 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 			return nil, errors.New(
 				"implicit credentials disallowed for s3 due to --external-io-disable-implicit-credentials flag")
 		}
+		// Tune the cache that LoadDefaultConfig will wrap around whichever
+		// refreshable provider the default chain selects; see credsCacheOptions
+		// for the rationale.
+		addLoadOption(config.WithCredentialsCacheOptions(credsCacheOptions))
 	default:
 		return nil, errors.Errorf("unsupported value %s for %s", kmsURIParams.auth, cloud.AuthParam)
 	}
@@ -209,7 +213,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 				}
 			})
 			intermediateCreds := stscreds.NewAssumeRoleProvider(client, delegateProvider.roleARN, withExternalID(delegateProvider.externalID))
-			cfg.Credentials = aws.NewCredentialsCache(intermediateCreds)
+			cfg.Credentials = aws.NewCredentialsCache(intermediateCreds, credsCacheOptions)
 		}
 
 		client := sts.NewFromConfig(cfg, func(options *sts.Options) {
@@ -218,7 +222,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 			}
 		})
 		creds := stscreds.NewAssumeRoleProvider(client, kmsURIParams.roleProvider.roleARN, withExternalID(kmsURIParams.roleProvider.externalID))
-		cfg.Credentials = aws.NewCredentialsCache(creds)
+		cfg.Credentials = aws.NewCredentialsCache(creds, credsCacheOptions)
 	}
 
 	reuse := reuseKMSSession.Get(&env.ClusterSettings().SV)

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -177,6 +177,28 @@ var enableClientRetryTokenBucket = settings.RegisterBoolSetting(
 	"enable the client side retry token bucket in the AWS S3 client",
 	false)
 
+// credsCacheOptions configures any aws.CredentialsCache that this package
+// wraps around a refreshable credentials provider (the implicit-auth path's
+// default-chain providers, AssumeRole providers, etc.).
+//
+// aws-sdk-go-v2 defaults CredentialsCacheOptions.ExpiryWindow to zero, which
+// means the cache only refreshes credentials after they have already expired.
+// On long-running operations like a cluster-wide BACKUP, a request can be
+// signed in the last few hundred ms before expiry and arrive at the AWS
+// service already-expired, surfacing as ExpiredToken / ExpiredTokenException
+// and failing the operation. The SDK's docstring on ExpiryWindow describes
+// exactly this race.
+//
+// 30s is comfortably more than the in-flight time of any single signed
+// request, which is what bounds the race; the jitter randomizes the
+// refresh point within the window so a fleet of nodes does not stampede
+// STS on the same instant. Refresh frequency is set by the credentials'
+// own lifetime, not by the window size.
+func credsCacheOptions(o *aws.CredentialsCacheOptions) {
+	o.ExpiryWindow = 30 * time.Second
+	o.ExpiryWindowJitterFrac = 0.5
+}
+
 // roleProvider contains fields about the role that needs to be assumed
 // in order to access the external storage.
 type roleProvider struct {
@@ -639,6 +661,10 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		addLoadOption(config.WithCredentialsProvider(
 			aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(s.opts.accessKey, s.opts.secret, s.opts.tempToken))))
 	case cloud.AuthParamImplicit:
+		// Tune the cache that LoadDefaultConfig will wrap around whichever
+		// refreshable provider the default chain selects; see credsCacheOptions
+		// for the rationale.
+		addLoadOption(config.WithCredentialsCacheOptions(credsCacheOptions))
 	}
 
 	cfg, err := config.LoadDefaultConfig(ctx, loadOptions...)
@@ -668,7 +694,7 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 				}
 			})
 			intermediateCreds := stscreds.NewAssumeRoleProvider(client, delegateProvider.roleARN, withExternalID(delegateProvider.externalID))
-			cfg.Credentials = aws.NewCredentialsCache(intermediateCreds)
+			cfg.Credentials = aws.NewCredentialsCache(intermediateCreds, credsCacheOptions)
 		}
 
 		client := sts.NewFromConfig(cfg, func(options *sts.Options) {
@@ -681,7 +707,7 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		// NOTE: It's critical to wrap all credentials in a CredentialCache to
 		// prevent DDoS'ing STS API endpoints:
 		// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws#CredentialsCache
-		cfg.Credentials = aws.NewCredentialsCache(creds)
+		cfg.Credentials = aws.NewCredentialsCache(creds, credsCacheOptions)
 	}
 
 	region := s.opts.region


### PR DESCRIPTION
`aws-sdk-go-v2` wraps refreshable credential providers in an [`aws.CredentialsCache`][cache], but defaults
[`CredentialsCacheOptions.ExpiryWindow`][window] to zero. The cache therefore only refreshes credentials *after* they have already expired by the local clock. On long-running operations that issue many concurrent signed requests (e.g. a cluster-wide BACKUP doing many concurrent multipart `UploadPart` calls against S3), a request can be signed in the last few hundred ms before expiry and arrive at the AWS service already-expired, surfacing as `ExpiredToken` / `ExpiredTokenException` and failing the operation. This race only matters when the configured credentials provider issues short-lived tokens (so each refresh is a fresh chance to lose the race), which is common for `AUTH=implicit` deployments backed by chain-of-trust providers.

The SDK's own [docstring on `ExpiryWindow`][window] identifies this race as exactly the case the field exists to prevent ("This is beneficial so race conditions with expiring credentials do not cause request to fail unexpectedly due to ExpiredTokenException exceptions").

This commit introduces a `credsCacheOptions` helper that sets a 30-second `ExpiryWindow` with 50% jitter and applies it everywhere the package wraps a refreshable provider:

  - The implicit-auth path in `s3_storage.go` and `aws_kms.go`, by passing [`config.WithCredentialsCacheOptions`][with-opts] so `LoadDefaultConfig`'s eventual cache wrap picks it up.
  - The `AssumeRole` providers (intermediate and final) in both files, where the cache is constructed explicitly via [`aws.NewCredentialsCache`][newcache].

The static-credentials branches are intentionally left alone: a static provider has no underlying refresh, so an `ExpiryWindow` does nothing useful there.

30s is comfortably more than the in-flight time of any single signed request (which is what bounds the race), and the window size does not affect refresh frequency: each set of credentials is still refreshed once per its own lifetime, just 15-30s sooner. The jitter spreads that refresh point across the fleet so multiple nodes do not stampede STS on the same instant.

[cache]: https://github.com/aws/aws-sdk-go-v2/blob/v1.36.3/aws/credential_cache.go#L43
[window]: https://github.com/aws/aws-sdk-go-v2/blob/v1.36.3/aws/credential_cache.go#L13-L26
[with-opts]: https://github.com/aws/aws-sdk-go-v2/blob/config/v1.29.9/config/load_options.go#L591-L601
[newcache]: https://github.com/aws/aws-sdk-go-v2/blob/v1.36.3/aws/credential_cache.go#L74-L96

Release note (bug fix): The AWS S3 and KMS clients now refresh short-lived credentials a few seconds before they expire, rather than only after expiry. This avoids ExpiredToken errors that could occasionally fail long-running BACKUP, RESTORE, or other operations when running with AUTH=implicit against credentials providers that issue short-lived tokens.