### PR TITLE
changefeedccl: deflake TestRetryResetOnProgress

### DIFF
--- a/pkg/ccl/changefeedccl/retry_test.go
+++ b/pkg/ccl/changefeedccl/retry_test.go
@@ -19,6 +19,7 @@ import (
 // its initial value.
 func TestRetryResetOnProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer testingUseFastRetry()()
 
 	ctx := context.Background()
 	r := getRetry(ctx, 10*time.Minute, 10*time.Minute)


### PR DESCRIPTION
This test was flaky because if the other tests in the shard took too                                                   
long to run, this test would not have enough time to complete.                                                         
Since the test only verifies that Reset() resets the retry backoff                                                     
and that durations increase with multiple attempts, the actual backoff                                               
values don't matter and we can use the fast retry hook to finish faster. 

Fixes: #169707
Release note: None