### PR TITLE
inspect: remove complex key configurability

### DIFF
--- a/pkg/cmd/roachtest/tests/inspect_throughput.go
+++ b/pkg/cmd/roachtest/tests/inspect_throughput.go
@@ -461,10 +461,6 @@ func makeInspectMultiRegionThroughputTest(
 				t.Fatal(err)
 			}
 
-			if complexKey {
-				enableComplexKeyUniquenessValidation(t, bulkDB)
-			}
-
 			metricName := "inspect"
 			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
 			reg, perfBuf := initInspectHistograms(
@@ -544,18 +540,6 @@ func disableRowCountValidation(t test.Test, db *gosql.DB) {
 	t.Helper()
 	t.L().Printf("Disabling automatic row count validation")
 	_, err := db.Exec("SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'off'")
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-// enableComplexKeyUniquenessValidation enables validation of complex keys (i.e.
-// the unique column does not immediately follow the region column) during the
-// uniqueness check.
-func enableComplexKeyUniquenessValidation(t test.Test, db *gosql.DB) {
-	t.Helper()
-	t.L().Printf("Enabling complex key uniqueness validation")
-	_, err := db.Exec("SET CLUSTER SETTING sql.inspect.uniqueness_check.complex_keys.enabled = true;")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -210,7 +210,6 @@ var checkSpecFactories = []checkFromIndexFunc{
 			idx.Index,
 			idx.TableDescriptor,
 			execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2),
-			uniquenessCheckComplexKeysEnabled.Get(execCfg.SV()),
 		); err != nil {
 			return nil, "", err
 		} else if reason != "" {
@@ -302,10 +301,7 @@ func isSupportedIndexForIndexConsistencyCheck(
 }
 
 func isSupportedIndexForUniquenessCheck(
-	ctx context.Context,
-	index catalog.Index,
-	table catalog.TableDescriptor,
-	isActiveV26_2, isComplexKeysEnabled bool,
+	ctx context.Context, index catalog.Index, table catalog.TableDescriptor, isActiveV26_2 bool,
 ) (reason string, uniquePos int, err error) {
 	if !isActiveV26_2 {
 		return "uniqueness: check requires v26.2", 0, nil
@@ -330,9 +326,5 @@ func isSupportedIndexForUniquenessCheck(
 		return "uniqueness: check only supported on tables with a single unique column", 0, nil
 	}
 
-	if uniquePositions[0] == 1 || isComplexKeysEnabled {
-		return "", uniquePositions[0], nil
-	} else {
-		return "uniqueness: complex key layout requires the cluster setting to opt in to (expensive) validation", 0, nil
-	}
+	return "", uniquePositions[0], nil
 }

--- a/pkg/sql/inspect/uniqueness_check.go
+++ b/pkg/sql/inspect/uniqueness_check.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -26,13 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-)
-
-var uniquenessCheckComplexKeysEnabled = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"sql.inspect.uniqueness_check.complex_keys.enabled",
-	"if true, the uniqueness check is enabled for INSPECT jobs on indexes where the unique column does not immediately follow the region column",
-	false,
 )
 
 type uniquenessCheck struct {
@@ -422,7 +414,6 @@ func (c *uniquenessCheck) loadCatalogInfo(ctx context.Context) error {
 		index,
 		tableDesc,
 		c.execCfg.Settings.Version.IsActive(ctx, clusterversion.V26_2),
-		true, /* isComplexKeysEnabled */ // The cluster setting gates when the job is specced.
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -813,20 +813,6 @@ statement ok
 INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west1', 'filler1', 300, 'titi');
 INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('us-west4', 'filler1', 300, 'tata');
 
-# Run INSPECT which will not use the uniqueness check because it's a complex key.
-
-statement ok
-INSPECT TABLE uniqueness_check_complex;
-
-skipif config local-mixed-25.4 local-mixed-26.1
-statement error pq: no supported checks for index "uniqueness_check_complex_pkey" on table "uniqueness_check_complex" \(cannot check primary index consistency against itself; uniqueness: complex key layout requires the cluster setting to opt in to \(expensive\) validation\)
-INSPECT TABLE uniqueness_check_complex WITH OPTIONS INDEX (uniqueness_check_complex_pkey);
-
-# Enable and run again to see the unique validations.
-
-statement ok
-SET CLUSTER SETTING sql.inspect.uniqueness_check.complex_keys.enabled = true;
-
 skipif config local-mixed-25.4 local-mixed-26.1
 statement error pq: INSPECT found inconsistencies
 INSPECT TABLE uniqueness_check_complex;

--- a/pkg/sql/logictest/testdata/logic_test/inspect_ccl
+++ b/pkg/sql/logictest/testdata/logic_test/inspect_ccl
@@ -47,9 +47,6 @@ INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('ca
 INSERT INTO uniqueness_check_complex (crdb_region, filler, id, data) VALUES ('ap-southeast-2', 'filler1', 300, 'tata');
 
 statement ok
-SET CLUSTER SETTING sql.inspect.uniqueness_check.complex_keys.enabled = true;
-
-statement ok
 INSPECT TABLE uniqueness_check_complex;
 
 statement ok


### PR DESCRIPTION
Nightly testing has established that the complex key uniqueness check
is cheaper than the simple keys so this defensive configuration is
cleaned up.

See also: #164948

Epic: CRDB-58692

Part of: #154551

Release note: None
