### PR TITLE
sql: fix relocate test flake from mid-rebalance queue disable

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -167,6 +167,58 @@ FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS]`)
 	}
 }
 
+// disableQueuesAndStabilize disables the split, lease, and replicate queues and
+// waits for replica state to stabilize.
+func disableQueuesAndStabilize(
+	t *testing.T,
+	ctx context.Context,
+	testCluster serverutils.TestClusterInterface,
+	db *gosql.DB,
+	expectedNumReplicas int,
+) {
+	// Prevent new splits and lease transfers.
+	testCluster.ToggleSplitQueues(false)
+	testCluster.ToggleLeaseQueues(false)
+
+	// Wait for learner replicas to be promoted. The replicate queue must stay
+	// active throughout because learner promotion requires a Raft snapshot
+	// transfer that cannot complete if the queue is toggled on and off.
+	testutils.SucceedsSoon(t, func() error {
+		var count int
+		if err := db.QueryRowContext(ctx,
+			`SELECT count(*) FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS] WHERE learner_replicas != '{}'`,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count > 0 {
+			return errors.Newf("waiting for %d ranges with LEARNER replicas to clear", count)
+		}
+		return nil
+	})
+
+	// Disable the replicate queue and check that replica counts are correct.
+	// If a rebalance was in progress (add phase done, remove phase pending),
+	// re-enable the queue so it can finish, then retry.
+	testutils.SucceedsSoon(t, func() error {
+		testCluster.ToggleReplicateQueues(false)
+		var count int
+		if err := db.QueryRowContext(ctx,
+			fmt.Sprintf(
+				`SELECT count(*) FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS]
+				 WHERE array_length(replicas, 1) != %d`, expectedNumReplicas),
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count > 0 {
+			testCluster.ToggleReplicateQueues(true)
+			return errors.Newf(
+				"waiting for %d ranges with unexpected replica count to stabilize", count,
+			)
+		}
+		return nil
+	})
+}
+
 // getToReplica determines the "to" node for a relocate command by finding the NodeID
 // in clusterNodeIDs that is not in replicaNodeIDs.
 func getToReplica(clusterNodeIDs []roachpb.NodeID, replicaNodeIDs []roachpb.NodeID) roachpb.NodeID {
@@ -768,21 +820,7 @@ func TestRelocateVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
-					testutils.SucceedsSoon(t, func() error {
-						var count int
-						if err := db.QueryRowContext(ctx,
-							`SELECT count(*) FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS] WHERE learner_replicas != '{}'`,
-						).Scan(&count); err != nil {
-							return err
-						}
-						if count > 0 {
-							return errors.Newf("waiting for %d ranges with LEARNER replicas to clear", count)
-						}
-						return nil
-					})
-					testCluster.ToggleLeaseQueues(false)
-					testCluster.ToggleReplicateQueues(false)
-					testCluster.ToggleSplitQueues(false)
+					disableQueuesAndStabilize(t, ctx, testCluster, db, expectedNumReplicas)
 					tExp.validate(
 						t,
 						func() (_ *gosql.Rows, msg string, _ error) {
@@ -861,21 +899,7 @@ func TestExperimentalRelocateVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
-					testutils.SucceedsSoon(t, func() error {
-						var count int
-						if err := db.QueryRowContext(ctx,
-							`SELECT count(*) FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS] WHERE learner_replicas != '{}'`,
-						).Scan(&count); err != nil {
-							return err
-						}
-						if count > 0 {
-							return errors.Newf("waiting for %d ranges with LEARNER replicas to clear", count)
-						}
-						return nil
-					})
-					testCluster.ToggleLeaseQueues(false)
-					testCluster.ToggleReplicateQueues(false)
-					testCluster.ToggleSplitQueues(false)
+					disableQueuesAndStabilize(t, ctx, testCluster, db, expectedNumReplicas)
 					tExp.validate(
 						t,
 						func() (*gosql.Rows, string, error) {
@@ -967,21 +991,7 @@ func TestRelocateNonVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
-					testutils.SucceedsSoon(t, func() error {
-						var count int
-						if err := db.QueryRowContext(ctx,
-							`SELECT count(*) FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS] WHERE learner_replicas != '{}'`,
-						).Scan(&count); err != nil {
-							return err
-						}
-						if count > 0 {
-							return errors.Newf("waiting for %d ranges with LEARNER replicas to clear", count)
-						}
-						return nil
-					})
-					testCluster.ToggleLeaseQueues(false)
-					testCluster.ToggleReplicateQueues(false)
-					testCluster.ToggleSplitQueues(false)
+					disableQueuesAndStabilize(t, ctx, testCluster, db, expectedNumReplicas)
 					tExp.validate(
 						t,
 						func() (*gosql.Rows, string, error) {
@@ -1054,21 +1064,7 @@ func TestExperimentalRelocateNonVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
-					testutils.SucceedsSoon(t, func() error {
-						var count int
-						if err := db.QueryRowContext(ctx,
-							`SELECT count(*) FROM [SHOW RANGES FROM INDEX t@primary WITH DETAILS] WHERE learner_replicas != '{}'`,
-						).Scan(&count); err != nil {
-							return err
-						}
-						if count > 0 {
-							return errors.Newf("waiting for %d ranges with LEARNER replicas to clear", count)
-						}
-						return nil
-					})
-					testCluster.ToggleLeaseQueues(false)
-					testCluster.ToggleReplicateQueues(false)
-					testCluster.ToggleSplitQueues(false)
+					disableQueuesAndStabilize(t, ctx, testCluster, db, expectedNumReplicas)
 					tExp.validate(
 						t,
 						func() (*gosql.Rows, string, error) {


### PR DESCRIPTION
The relocate tests (TestRelocateVoters, TestRelocateNonVoters, and
their EXPERIMENTAL variants) had a race between WaitForFullReplication
completing and the test disabling background queues. A span config
boundary split could create a new range, and the replicate queue would
start a two-phase rebalance on it (add new replica, then remove old).
If the test disabled queues between these two phases, the range was
left permanently over-replicated, causing getReplicaState to time out
waiting for the expected replica count.

Extract a disableQueuesAndStabilize helper that closes this race:
1. Disable split and lease queues first so no new ranges appear.
2. Disable the replicate queue and verify both learner replicas and
   replica counts look correct. If either check fails, re-enable the
   replicate queue so it can finish in-flight work, then retry.

Fixes: #169391
Epic: none