### PR TITLE
release-25.4: cloud/amazon: retry s3 requests on credential-expiry errors

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -623,12 +623,26 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		addLoadOption(config.WithClientLogMode(s.opts.logMode))
 	}
 	addLoadOption(config.WithRetryer(func() aws.Retryer {
-		return retry.NewStandard(func(opts *retry.StandardOptions) {
+		standard := retry.NewStandard(func(opts *retry.StandardOptions) {
 			opts.MaxAttempts = int(maxRetries.Get(&s.settings.SV))
 			if !enableClientRetryTokenBucket.Get(&s.settings.SV) {
 				opts.RateLimiter = ratelimit.None
 			}
 		})
+		// Treat credential-expiry errors as retryable. When the configured
+		// credentials provider issues short-lived tokens, a long-running upload
+		// can race their expiry: a request signed just before the credentials
+		// expire can arrive at S3 just after, surfacing as ExpiredToken /
+		// ExpiredTokenException / RequestExpired and failing the operation. The
+		// v1 SDK swallowed this race by classifying these codes as retryable
+		// (aws-sdk-go aws/request/retryer.go: credsExpiredCodes); aws-sdk-go-v2's
+		// default retryable set dropped them, so what was a transparent retry in
+		// v1 became a hard, user-visible failure in v2. Restore the v1 behavior.
+		// The codes mirror v1's credsExpiredCodes set exactly. The cache itself
+		// notices it is past Expires by the time the retry's backoff completes,
+		// so an explicit Invalidate() is not required to force a fresh retrieve.
+		return retry.AddWithErrorCodes(standard,
+			"ExpiredToken", "ExpiredTokenException", "RequestExpired")
 	}))
 
 	switch s.opts.auth {


### PR DESCRIPTION
Backport 1/1 commits from #169763 on behalf of @dt.

----

When the configured credentials provider issues short-lived tokens, a long-running operation that issues many concurrent multipart `UploadPart` calls can race the credential expiry: a request signed just before the credentials expire can arrive at S3 just after, and S3 returns `ExpiredToken` / `ExpiredTokenException` / `RequestExpired`.

`aws-sdk-go` v1 swallowed this race by classifying these three codes as retryable in its default retryer (see [`credsExpiredCodes`][v1-codes] folded into [`isCodeRetryable`][v1-isretry], plus the matching post-attempt cache invalidation in
[the after-retry handler][v1-handler] which calls `Credentials.Expire()` between attempts). `aws-sdk-go-v2`'s standard retryer ships [`DefaultRetryableErrorCodes`][v2-codes] containing only `RequestTimeout` / `RequestTimeoutException`, so what was a transparent retry in v1 became a hard, user-visible failure when CRDB migrated to v2.

This commit restores the v1 behavior for the s3 client by wrapping the standard retryer with [`retry.AddWithErrorCodes`][v2-add] for the same three codes v1 used. The cache-invalidation half from v1 is not separately needed in practice: by the time the retry's backoff completes, local time has advanced past the cached credentials' \`Expires\`, so [the cache's `IsExpired` check on `Retrieve`][v2-cache] forces a fresh retrieve on the next signing pass on its own.

The `aws_kms.go` retryer has the same gap and could be addressed in a follow-up; this commit keeps the s3 fix isolated for ease of backporting to release branches.

[v1-codes]: https://github.com/aws/aws-sdk-go/blob/v1.40.37/aws/request/retryer.go#L98-L105
[v1-isretry]: https://github.com/aws/aws-sdk-go/blob/v1.40.37/aws/request/retryer.go#L112-L118
[v1-handler]: https://github.com/aws/aws-sdk-go/blob/v1.40.37/aws/corehandlers/handlers.go#L209-L214
[v2-codes]: https://github.com/aws/aws-sdk-go-v2/blob/v1.36.3/aws/retry/standard.go#L51-L65
[v2-add]: https://github.com/aws/aws-sdk-go-v2/blob/v1.36.3/aws/retry/retry.go#L10-L23
[v2-cache]: https://github.com/aws/aws-sdk-go-v2/blob/v1.36.3/aws/credential_cache.go#L98

Release note (bug fix): A long-running BACKUP to s3 using AUTH=implicit no longer fails with an ExpiredToken error when it races the rotation of the underlying short-lived credentials; the s3 client now retries ExpiredToken, ExpiredTokenException, and RequestExpired the same way the legacy aws-sdk-go v1 client did.

----

Release justification: adds a low risk retry which, as retry, can only affect requests that would otherwise have failed making it a strict improvement for cases that would otherwise be a serious issue (inability to backup/maintain DR SLAs)