### PR TITLE
sql: remove redundant `ALTER TYPE ... SET SCHEMA` event logging

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -110,9 +110,8 @@ func (n *alterTypeNode) startExec(params runParams) error {
 		})
 		eventLogDone = true
 	case *tree.AlterTypeSetSchema:
-		// TODO(knz): this is missing dedicated logging,
-		// See https://github.com/cockroachdb/cockroach/issues/57741
 		err = params.p.setTypeSchema(params.ctx, n, string(t.Schema))
+		eventLogDone = true // done inside setTypeSchema().
 	case *tree.AlterTypeOwner:
 		owner, err := decodeusername.FromRoleSpec(
 			params.SessionData(), username.PurposeValidation, t.Owner,

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -977,13 +977,14 @@ ALTER TYPE eventlog RENAME TO eventlog_renamed
 query ITT
 SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
- WHERE ("eventType" = 'alter_type' OR "eventType" = 'rename_type') AND info::JSONB->>'TypeName' LIKE '%eventlog%'
+ WHERE "eventType" IN ('alter_type', 'rename_type', 'set_schema')
+   AND (info::JSONB->>'TypeName' LIKE '%eventlog%' OR info::JSONB->>'DescriptorName' LIKE '%eventlog%')
 ORDER BY "timestamp", info
 ----
 1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
 1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "TypeName": "defaultdb.testing.eventlog", "User": "root"}
+1  set_schema   {"DescriptorName": "defaultdb.public.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.testing.eventlog", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "User": "root"}
+1  set_schema   {"DescriptorName": "defaultdb.testing.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.public.eventlog", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "User": "root"}
 1  rename_type  {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -967,13 +967,14 @@ ALTER TYPE eventlog RENAME TO eventlog_renamed
 query ITT
 SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
- WHERE ("eventType" = 'alter_type' OR "eventType" = 'rename_type') AND info::JSONB->>'TypeName' LIKE '%eventlog%'
+ WHERE "eventType" IN ('alter_type', 'rename_type', 'set_schema')
+   AND (info::JSONB->>'TypeName' LIKE '%eventlog%' OR info::JSONB->>'DescriptorName' LIKE '%eventlog%')
 ORDER BY "timestamp", info
 ----
 1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
 1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "TypeName": "defaultdb.testing.eventlog", "User": "root"}
+1  set_schema   {"DescriptorName": "defaultdb.public.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.testing.eventlog", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "User": "root"}
+1  set_schema   {"DescriptorName": "defaultdb.testing.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.public.eventlog", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "User": "root"}
 1  rename_type  {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
 
 statement ok


### PR DESCRIPTION
The schemachanger was logging a general `alter_type` event and a
particular `set_schema` event. This change removes the duplicative
logging.

Part of: #164216
See: #57741
Supports: #168255
Epic: CRDB-31325

Release note: None
