### PR TITLE
opt: set function name as data source for SRF columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_srf
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_srf
@@ -38,7 +38,7 @@ SELECT * FROM f();
 3
 
 query II nosort
-SELECT * FROM f(), f();
+SELECT * FROM f() AS foo, f() AS bar;
 ----
 1  1
 1  2

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -117,14 +117,19 @@ SELECT * FROM generate_series('2017-11-11 00:00:00'::TIMESTAMP, '2017-11-11 03:0
 ----
 generate_series
 
-query II colnames,rowsort
+# Duplicate SRF names in FROM without aliases now correctly errors,
+# matching Postgres behavior (#150532).
+query error pgcode 42712 source name "generate_series" specified more than once
 SELECT * FROM generate_series(1, 2), generate_series(1, 2)
+
+query II colnames,rowsort
+SELECT * FROM generate_series(1, 2) AS a, generate_series(1, 2) AS b
 ----
-generate_series  generate_series
-1                1
-1                2
-2                1
-2                2
+a  b
+1  1
+1  2
+2  1
+2  2
 
 query I colnames,nosort
 SELECT * FROM generate_series(3, 1, -1)
@@ -1467,3 +1472,110 @@ query T
 SELECT unnest('{}', '{}', '{3}'::int[]);
 ----
 (,,3)
+
+subtest srf_qualified_column_refs
+
+# Regression tests for #150532. SRF columns should be referenceable using the
+# function name as a data source qualifier, matching Postgres behavior.
+
+# Single-column SRF.
+query I
+SELECT generate_series.generate_series FROM generate_series(1, 3) ORDER BY 1
+----
+1
+2
+3
+
+# Multi-column SRF: qualified column reference.
+query T
+SELECT pg_get_keywords.word FROM pg_get_keywords() WHERE pg_get_keywords.word = 'select'
+----
+select
+
+# Multi-column SRF: qualified star.
+query TTT
+SELECT pg_get_keywords.* FROM pg_get_keywords() WHERE pg_get_keywords.word = 'select'
+----
+select  R  reserved
+
+# Schema-qualified invocation: the data source is the unqualified function name.
+query I
+SELECT generate_series.generate_series FROM pg_catalog.generate_series(1, 3) ORDER BY 1
+----
+1
+2
+3
+
+# Non-pg_catalog builtin: def.Name includes schema, but data source is
+# the unqualified function name only.
+query TI
+SELECT _pg_expandarray.x, _pg_expandarray.n
+FROM information_schema._pg_expandarray(ARRAY['a','b']) ORDER BY 2
+----
+a  1
+b  2
+
+# Different SRFs in FROM referenced by function name.
+query IT
+SELECT generate_series.generate_series, unnest.unnest
+FROM generate_series(1, 2), unnest(ARRAY['a', 'b']) ORDER BY 1, 2
+----
+1  a
+1  b
+2  a
+2  b
+
+# Single-column SRF with AS alias: alias overrides function name for both
+# column and table name.
+query I colnames
+SELECT gs FROM generate_series(1, 2) AS gs ORDER BY 1
+----
+gs
+1
+2
+
+# ROWS FROM with qualified reference using the function name.
+query I
+SELECT generate_series.generate_series FROM ROWS FROM(generate_series(1, 2)) ORDER BY 1
+----
+1
+2
+
+# Correlated SRF with qualified reference.
+statement ok
+CREATE TABLE jt_test (id INT PRIMARY KEY, j JSONB)
+
+statement ok
+INSERT INTO jt_test VALUES (1, '{"a": "x", "b": "y"}')
+
+query ITT rowsort
+SELECT jt_test.id, jsonb_each_text.key, jsonb_each_text.value
+FROM jt_test, jsonb_each_text(jt_test.j)
+----
+1  a  x
+1  b  y
+
+statement ok
+DROP TABLE jt_test
+
+# Table and SRF with the same name: the join succeeds but qualified
+# references are ambiguous. Aliasing the table resolves the ambiguity.
+statement ok
+CREATE TABLE unnest (x INT PRIMARY KEY);
+INSERT INTO unnest VALUES (1), (2)
+
+query error pgcode 42P09 ambiguous source name
+SELECT unnest.x FROM unnest, unnest(ARRAY[10])
+
+query II rowsort
+SELECT u.x, unnest.unnest FROM unnest AS u, unnest(ARRAY[10, 20])
+----
+1  10
+1  20
+2  10
+2  20
+
+statement ok
+DROP TABLE unnest
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_rewrite
@@ -200,7 +200,7 @@ $$ LANGUAGE SQL
 query T
 SELECT get_body_str('p_rewrite');
 ----
-"SELECT public.nested_func();\nSELECT nested_func FROM ROWS FROM (public.nested_func());"
+"SELECT public.nested_func();\nSELECT nested_func.nested_func FROM ROWS FROM (public.nested_func());"
 
 subtest end
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -12,8 +12,13 @@ distribution: local
 │
 └── • emptyrow
 
-query T
+# Duplicate SRF names in FROM without aliases now correctly errors,
+# matching Postgres behavior (#150532).
+query error pgcode 42712 source name "generate_series" specified more than once
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
+
+query T
+EXPLAIN SELECT * FROM generate_series(1, 2) AS a, generate_series(1, 2) AS b
 ----
 distribution: local
 ·

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -595,12 +595,6 @@ func (s *scope) removeHiddenCols() {
 	s.cols = s.cols[:n]
 }
 
-// isAnonymousTable returns true if the table name of the first column
-// in this scope is empty.
-func (s *scope) isAnonymousTable() bool {
-	return len(s.cols) > 0 && s.cols[0].table.ObjectName == ""
-}
-
 // setTableAlias qualifies the names of all columns in this scope with the
 // given alias name, as if they were part of a table with that name. If the
 // alias is the empty string, then setTableAlias removes any existing column

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -428,13 +428,12 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 	if as.Alias != "" {
 		colAlias := as.Cols
 
-		// Special case for Postgres compatibility: if a data source does not
-		// currently have a name, and it is a set-generating function or a scalar
-		// function with just one column, and the AS clause doesn't specify column
-		// names, then use the specified table name both as the column name and
-		// table name.
+		// Special case for Postgres compatibility: if a set-generating function
+		// or a scalar function has just one column, and the AS clause doesn't
+		// specify column names, then use the specified table name both as the
+		// column name and table name.
 		noColNameSpecified := len(colAlias) == 0
-		if scope.isAnonymousTable() && noColNameSpecified && scope.singleSRFColumn {
+		if noColNameSpecified && scope.singleSRFColumn {
 			colAlias = tree.ColumnDefList{tree.ColumnDef{Name: as.Alias}}
 		}
 

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -7,6 +7,7 @@ package optbuilder
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -148,6 +149,25 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 		} else {
 			scalar = b.buildScalar(texpr, inScope, outScope, outCol, nil)
 		}
+
+		// For Postgres compatibility, set the data source name of SRF columns
+		// to the unqualified function name. This allows column references to
+		// be qualified with the function name, e.g. jsonb_each_text.key.
+		if def != nil {
+			// def.Name is unqualified for pg_catalog builtins and UDFs, but
+			// includes the schema for non-pg_catalog builtins (e.g.
+			// "information_schema._pg_expandarray"). Strip the prefix to get
+			// the unqualified function name.
+			funcNameStr := def.Name
+			if idx := strings.LastIndex(funcNameStr, "."); idx >= 0 {
+				funcNameStr = funcNameStr[idx+1:]
+			}
+			funcName := tree.Name(funcNameStr)
+			for j := startCols; j < len(outScope.cols); j++ {
+				outScope.cols[j].table = tree.MakeUnqualifiedTableName(funcName)
+			}
+		}
+
 		numExpectedOutputCols := len(outScope.cols) - startCols
 		cols := make(opt.ColList, 0, numExpectedOutputCols)
 		for j := startCols; j < len(outScope.cols); j++ {

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -12,11 +12,18 @@ project-set
  └── zip
       └── generate_series(1, 3)
 
+# Duplicate SRF names in FROM without aliases now correctly errors,
+# matching Postgres behavior (#150532).
 build
 SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
+error (42712): source name "generate_series" specified more than once (missing AS clause)
+
+build
+SELECT * FROM generate_series(1, 2) AS a, generate_series(1, 2) AS b
+----
 inner-join-apply
- ├── columns: generate_series:1 generate_series:2
+ ├── columns: a:1 b:2
  ├── project-set
  │    ├── columns: generate_series:1
  │    ├── values
@@ -1179,3 +1186,217 @@ project-set
  │    └── ()
  └── zip
       └── unnest(ARRAY[(),(),()])
+
+# Regression test for #150532. Columns produced by set-returning functions
+# should have data source names matching the function name, like Postgres.
+
+# Single-column SRF: qualified reference using the function name.
+build
+SELECT generate_series.generate_series FROM generate_series(1, 3)
+----
+project-set
+ ├── columns: generate_series:1
+ ├── values
+ │    └── ()
+ └── zip
+      └── generate_series(1, 3)
+
+# Multi-column SRF: qualified reference using the function name.
+build
+SELECT pg_get_keywords.word FROM pg_get_keywords() LIMIT 1
+----
+limit
+ ├── columns: word:1
+ ├── project
+ │    ├── columns: word:1
+ │    ├── limit hint: 1.00
+ │    └── project-set
+ │         ├── columns: word:1 catcode:2 catdesc:3
+ │         ├── limit hint: 1.00
+ │         ├── values
+ │         │    ├── limit hint: 1.00
+ │         │    └── ()
+ │         └── zip
+ │              └── pg_get_keywords()
+ └── 1
+
+# Multi-column SRF with star: qualified star using the function name.
+build
+SELECT pg_get_keywords.* FROM pg_get_keywords() LIMIT 1
+----
+limit
+ ├── columns: word:1 catcode:2 catdesc:3
+ ├── project-set
+ │    ├── columns: word:1 catcode:2 catdesc:3
+ │    ├── limit hint: 1.00
+ │    ├── values
+ │    │    ├── limit hint: 1.00
+ │    │    └── ()
+ │    └── zip
+ │         └── pg_get_keywords()
+ └── 1
+
+# Schema-qualified invocation: the data source is the unqualified function name.
+build
+SELECT generate_series.generate_series FROM pg_catalog.generate_series(1, 3)
+----
+project-set
+ ├── columns: generate_series:1
+ ├── values
+ │    └── ()
+ └── zip
+      └── generate_series(1, 3)
+
+# Same for a function whose def.Name is schema-qualified (non-pg_catalog builtin).
+build
+SELECT _pg_expandarray.x FROM information_schema._pg_expandarray(ARRAY['a','b'])
+----
+project
+ ├── columns: x:1
+ └── project-set
+      ├── columns: x:1 n:2
+      ├── values
+      │    └── ()
+      └── zip
+           └── information_schema._pg_expandarray(ARRAY['a','b'])
+
+# Explicit alias overrides function name as the data source.
+build
+SELECT t.word FROM pg_get_keywords() AS t LIMIT 1
+----
+limit
+ ├── columns: word:1
+ ├── project
+ │    ├── columns: word:1
+ │    ├── limit hint: 1.00
+ │    └── project-set
+ │         ├── columns: word:1 catcode:2 catdesc:3
+ │         ├── limit hint: 1.00
+ │         ├── values
+ │         │    ├── limit hint: 1.00
+ │         │    └── ()
+ │         └── zip
+ │              └── pg_get_keywords()
+ └── 1
+
+# Duplicate function names without aliases should error, matching Postgres.
+build
+SELECT * FROM unnest(ARRAY[1]), unnest(ARRAY[2])
+----
+error (42712): source name "unnest" specified more than once (missing AS clause)
+
+# Different SRFs in FROM can be referenced by their function names.
+build
+SELECT generate_series.generate_series, unnest.unnest
+FROM generate_series(1, 2), unnest(ARRAY[10, 20])
+----
+inner-join-apply
+ ├── columns: generate_series:1 unnest:2
+ ├── project-set
+ │    ├── columns: generate_series:1
+ │    ├── values
+ │    │    └── ()
+ │    └── zip
+ │         └── generate_series(1, 2)
+ ├── project-set
+ │    ├── columns: unnest:2
+ │    ├── values
+ │    │    └── ()
+ │    └── zip
+ │         └── unnest(ARRAY[10,20])
+ └── filters (true)
+
+# Single-column SRF with AS alias: alias overrides function name for both
+# column and table name.
+build
+SELECT gs FROM generate_series(1, 3) AS gs ORDER BY 1
+----
+sort
+ ├── columns: gs:1
+ ├── ordering: +1
+ └── project-set
+      ├── columns: generate_series:1
+      ├── values
+      │    └── ()
+      └── zip
+           └── generate_series(1, 3)
+
+# ROWS FROM with qualified reference using the function name.
+build
+SELECT generate_series.generate_series FROM ROWS FROM(generate_series(1, 2))
+----
+project-set
+ ├── columns: generate_series:1
+ ├── values
+ │    └── ()
+ └── zip
+      └── generate_series(1, 2)
+
+# Table and SRF with the same name don't conflict in the join (the table's
+# columns carry schema qualification), but qualified references are ambiguous.
+exec-ddl
+CREATE TABLE unnest (x INT)
+----
+
+build
+SELECT unnest.x, unnest.unnest FROM unnest, unnest(ARRAY[1])
+----
+error (42P09): ambiguous source name: "unnest"
+
+# Aliasing the table resolves the ambiguity.
+build
+SELECT u.x, unnest.unnest FROM unnest AS u, unnest(ARRAY[1])
+----
+project
+ ├── columns: x:1 unnest:5
+ └── inner-join-apply
+      ├── columns: x:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4 unnest:5
+      ├── scan unnest [as=u]
+      │    └── columns: x:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── project-set
+      │    ├── columns: unnest:5
+      │    ├── values
+      │    │    └── ()
+      │    └── zip
+      │         └── unnest(ARRAY[1])
+      └── filters (true)
+
+exec-ddl
+DROP TABLE unnest
+----
+
+# Subquery referencing SRF columns by function name.
+exec-ddl
+CREATE TABLE jt (j JSONB)
+----
+
+build
+SELECT (SELECT jt.j) FROM jt, jsonb_each_text(jt.j) WHERE jsonb_each_text.key = 'foo'
+----
+project
+ ├── columns: j:8
+ ├── select
+ │    ├── columns: jt.j:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4 key:5!null value:6
+ │    ├── inner-join-apply
+ │    │    ├── columns: jt.j:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4 key:5 value:6
+ │    │    ├── scan jt
+ │    │    │    └── columns: jt.j:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    │    ├── project-set
+ │    │    │    ├── columns: key:5 value:6
+ │    │    │    ├── values
+ │    │    │    │    └── ()
+ │    │    │    └── zip
+ │    │    │         └── jsonb_each_text(jt.j:1)
+ │    │    └── filters (true)
+ │    └── filters
+ │         └── key:5 = 'foo'
+ └── projections
+      └── subquery [as=j:8]
+           └── max1-row
+                ├── columns: j:7
+                └── project
+                     ├── columns: j:7
+                     ├── values
+                     │    └── ()
+                     └── projections
+                          └── jt.j:1 [as=j:7]


### PR DESCRIPTION
Set the unqualified function name as the data source name on columns produced by set-returning functions in FROM clauses. This matches Postgres behavior, where SRF columns can be qualified with the function name (e.g. `jsonb_each_text.key`).

As a consequence, duplicate SRF names in FROM without aliases now correctly error with "source name specified more than once", also matching Postgres.

Fixes: #150532

Release note (bug fix): Columns produced by set-returning functions in FROM clauses can now be referenced using the function name as a qualifier (e.g. `SELECT jsonb_each_text.key FROM jsonb_each_text(j)`), matching PostgreSQL behavior.