### PR TITLE
roachtest/operations: fix disk stall recovery and cloud filtering

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -265,7 +265,7 @@ Example:
 					return err
 				}
 			}
-			ops := r.FilteredOperations(registry.MergeRegEx(args), skipRegex)
+			ops := r.FilteredOperations(registry.MergeRegEx(args), skipRegex, roachtestflags.Cloud)
 			for _, op := range ops {
 				fmt.Printf("%s\n", op.Name)
 			}
@@ -514,7 +514,7 @@ func opsToRun(r testRegistryImpl, filter string, skip string) ([]registry.Operat
 			return nil, err
 		}
 	}
-	filteredOps := r.FilteredOperations(regex, skipRegex)
+	filteredOps := r.FilteredOperations(regex, skipRegex, roachtestflags.Cloud)
 	if len(filteredOps) == 0 {
 		return nil, errors.New("no matching operations to run")
 	}

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -192,8 +192,9 @@ func (r testRegistryImpl) AllOperations() []registry.OperationSpec {
 
 // FilteredOperations returns operations filtered by the given regex.
 // If skipRegex is non-nil, operations matching it are excluded.
+// If cloud is set, operations incompatible with that cloud are excluded.
 func (r testRegistryImpl) FilteredOperations(
-	regex *regexp.Regexp, skipRegex *regexp.Regexp,
+	regex *regexp.Regexp, skipRegex *regexp.Regexp, cloud spec.Cloud,
 ) []registry.OperationSpec {
 	var filteredOps []registry.OperationSpec
 	for _, opSpec := range r.AllOperations() {
@@ -201,6 +202,9 @@ func (r testRegistryImpl) FilteredOperations(
 			continue
 		}
 		if skipRegex != nil && skipRegex.MatchString(opSpec.Name) {
+			continue
+		}
+		if cloud.IsSet() && !opSpec.CompatibleClouds.Contains(cloud) {
 			continue
 		}
 		filteredOps = append(filteredOps, opSpec)

--- a/pkg/roachprod/failureinjection/failures/disk_stall.go
+++ b/pkg/roachprod/failureinjection/failures/disk_stall.go
@@ -279,17 +279,7 @@ func (s *CGroupDiskStaller) Recover(ctx context.Context, l *logger.Logger, args 
 		return err
 	}
 
-	// If we are restarting nodes, then we assume the failure above is because
-	// the disk stall was injected too long, and it was an expected death. Restart
-	// any dead nodes.
-	return forEachNode(diskStallArgs.Nodes, func(n install.Nodes) error {
-		err = s.Run(ctx, l, n, "cat", cockroachIOController)
-		if err != nil && diskStallArgs.RestartNodes {
-			l.Printf("failed to log cgroup bandwidth limits, assuming n%d exited and restarting: %v", n, err)
-			return s.StartNodes(ctx, l, n)
-		}
-		return nil
-	})
+	return s.restartCrashedNodes(ctx, l, diskStallArgs.Nodes)
 }
 
 func (s *CGroupDiskStaller) WaitForFailureToPropagate(
@@ -578,15 +568,7 @@ func (s *DmsetupDiskStaller) Recover(
 	}
 
 	if diskStallArgs.RestartNodes {
-		// If the disk stall was injected for long enough that the cockroach process
-		// detected it and shut down the node, then restart it.
-		return forEachNode(nodes, func(n install.Nodes) error {
-			if err := s.PingNode(ctx, l, n); err != nil {
-				l.Printf("failed to connect to n%d, assuming node exited and restarting: %v", n, err)
-				return s.StartNodes(ctx, l, n)
-			}
-			return nil
-		})
+		return s.restartCrashedNodes(ctx, l, nodes)
 	}
 
 	return nil

--- a/pkg/roachprod/failureinjection/failures/failure.go
+++ b/pkg/roachprod/failureinjection/failures/failure.go
@@ -317,6 +317,27 @@ func (f *GenericFailure) StartNodes(
 	return f.Run(ctx, l, nodes, "./cockroach.sh")
 }
 
+// restartCrashedNodes pings each node and restarts any that are unreachable.
+// It uses systemctl stop to clear systemd's "active" state before restarting,
+// since the PID-based kill in Stop() is a no-op when the process has already
+// crashed.
+func (f *GenericFailure) restartCrashedNodes(
+	ctx context.Context, l *logger.Logger, nodes install.Nodes,
+) error {
+	label := install.VirtualClusterLabel(install.SystemInterfaceName, 0)
+	return forEachNode(nodes, func(n install.Nodes) error {
+		if err := f.PingNode(ctx, l, n); err != nil {
+			l.Printf("failed to connect to n%d, assuming node exited and restarting: %v", n, err)
+			stopCmd := fmt.Sprintf("sudo systemctl stop %s 2>/dev/null || true", label)
+			if err := f.Run(ctx, l, n, stopCmd); err != nil {
+				l.Printf("warning: failed to stop service on n%d: %v", n[0], err)
+			}
+			return f.StartNodes(ctx, l, n)
+		}
+		return nil
+	})
+}
+
 // forEachNode is a helper function that calls fn for each node in nodes.
 func forEachNode(nodes install.Nodes, fn func(install.Nodes) error) error {
 	// TODO (darryl): Consider parallelizing this, for now all usages


### PR DESCRIPTION
Previously, disk stall operations (both cgroup and dmsetup) failed during cleanup on DRT clusters because:

1. The operation runner did not enforce CompatibleClouds, allowing GCE-only operations (like disk-stall/dmsetup) to run on AWS.

2. After recovering from a disk stall, the Recover methods tried to restart crashed nodes via start.sh, which refused with "service already active" because systemd still considered the service active even though the cockroach process had crashed. The PID-based kill in Stop() was ineffective since there was no live process to kill.

This commit:
- Adds cloud filtering to FilteredOperations so operations are only selected when compatible with the target cloud.
- Fixes the disk stall Recover path to use systemctl stop to clear systemd state before restarting crashed nodes.
- Extracts the shared ping-stop-restart pattern into a restartCrashedNodes helper on GenericFailure.

Epic: none
Release note: None