### PR TITLE
ts: minor cleanups in child-metric recording

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -1162,21 +1162,16 @@ func (rr registryRecorder) recordChild(
 	})
 }
 
-// hashSep is the field separator written between hashed components in
-// hashLabels. Hoisted to package scope to avoid per-call allocation on the
-// recording hot path.
-var hashSep = []byte{0}
-
-// hashLabels computes a stable hash of a label set. The zero-byte separators
-// close a collision where adjacent fields could otherwise be reassociated
-// (e.g. {name="ab", value="c"} vs {name="a", value="bc"}).
+// hashLabels computes a stable hash of a label set. The zero-byte separator
+// after each field prevents collisions where boundaries could otherwise shift
+// (e.g. without it, {a="bc"} and {ab="c"} would both hash "abc").
 func hashLabels(labels []*prometheusgo.LabelPair) uint64 {
 	h := fnv.New64a()
 	for _, label := range labels {
 		h.Write([]byte(label.GetName()))
-		h.Write(hashSep)
+		h.Write([]byte{0})
 		h.Write([]byte(label.GetValue()))
-		h.Write(hashSep)
+		h.Write([]byte{0})
 	}
 	return h.Sum64()
 }
@@ -1296,15 +1291,13 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 					if count < 0 {
 						continue // Skip malformed snapshots
 					}
-					value := c.ComputedMetric(snapshot)
-					metricName := baseName + c.Suffix
 					*dest = append(*dest, tspb.TimeSeriesData{
-						Name:   fmt.Sprintf(rr.format, metricName),
+						Name:   fmt.Sprintf(rr.format, baseName+c.Suffix),
 						Source: rr.source,
 						Datapoints: []tspb.TimeSeriesDatapoint{
 							{
 								TimestampNanos: rr.timestampNanos,
-								Value:          value,
+								Value:          c.ComputedMetric(snapshot),
 							},
 						},
 					})

--- a/pkg/ts/tsutil/util.go
+++ b/pkg/ts/tsutil/util.go
@@ -35,14 +35,13 @@ var AllowedChildMetrics = map[string]struct{}{
 
 // IsAllowedChildMetric checks if a metric name matches one of the allowed child metrics.
 func IsAllowedChildMetric(name string) bool {
-	metricName := name
 	for _, prefix := range []string{"cr.node.", "cr.store."} {
-		if strings.HasPrefix(metricName, prefix) {
-			metricName = strings.TrimPrefix(metricName, prefix)
+		if strings.HasPrefix(name, prefix) {
+			name = strings.TrimPrefix(name, prefix)
 			break
 		}
 	}
-	_, ok := AllowedChildMetrics[metricName]
+	_, ok := AllowedChildMetrics[name]
 	return ok
 }
 


### PR DESCRIPTION
Four unrelated cleanups:
- Update the incorrect example in the godoc comment for HashLabels
- Drop the hashSep package-level variable in hashLabels and use a []byte{0} literal directly. The compiler does not allocate for that literal, so the hoist was unnecessary.
- Inline single-use value and metricName temporaries in the histogram emit path; they were computed only to be plugged into the next struct literal.
- Remove the metricName := name shadow in IsAllowedChildMetric. The function parameter is already a local string and can be reassigned in place.

No behavior change.

Epic: none
Release note: None