### PR TITLE
schemachanger: use specific events for `ALTER TYPE` operations

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -1569,10 +1569,88 @@ An event of type `alter_table` is recorded when a table is altered.
 
 EventAlterType is recorded when a user-defined type is altered.
 
+Deprecated: Use specific event types instead.
+
 
 | Field | Description | Sensitive |
 |--|--|--|
 | `TypeName` | The name of the affected type. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+
+### `alter_type_add_value`
+
+An event of type `alter_type_add_value` is recorded when a value is added to an enum type.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TypeName` | The name of the affected type. | no |
+| `Value` | The value being added. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+
+### `alter_type_drop_value`
+
+An event of type `alter_type_drop_value` is recorded when a value is dropped from an enum type.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TypeName` | The name of the affected type. | no |
+| `Value` | The value being dropped. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+
+### `alter_type_rename_value`
+
+An event of type `alter_type_rename_value` is recorded when a value in an enum type is renamed.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TypeName` | The name of the affected type. | no |
+| `OldValue` | The old value being renamed. | no |
+| `NewValue` | The new value. | no |
 
 
 #### Common fields

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -93,25 +93,35 @@ func (n *alterTypeNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeAlterCounterWithExtra("type", n.n.Cmd.TelemetryName()))
 
 	typeName := tree.AsStringWithFQNames(n.n.Type, params.p.Ann())
-	eventLogDone := false
-	var err error
 	switch t := n.n.Cmd.(type) {
 	case *tree.AlterTypeAddValue:
-		err = params.p.addEnumValue(params.ctx, n.desc, t, tree.AsStringWithFQNames(n.n, params.p.Ann()))
-	case *tree.AlterTypeRenameValue:
-		err = params.p.renameTypeValue(params.ctx, n, string(t.OldVal), string(t.NewVal))
-	case *tree.AlterTypeRename:
-		if err = params.p.renameType(params.ctx, n, string(t.NewName)); err != nil {
+		if err := params.p.addEnumValue(params.ctx, n.desc, t, tree.AsStringWithFQNames(n.n, params.p.Ann())); err != nil {
 			return err
 		}
-		err = params.p.logEvent(params.ctx, n.desc.ID, &eventpb.RenameType{
+		return params.p.logEvent(params.ctx, n.desc.ID, &eventpb.AlterTypeAddValue{
+			TypeName: typeName,
+			Value:    string(t.NewVal),
+		})
+	case *tree.AlterTypeRenameValue:
+		if err := params.p.renameTypeValue(params.ctx, n, string(t.OldVal), string(t.NewVal)); err != nil {
+			return err
+		}
+		return params.p.logEvent(params.ctx, n.desc.ID, &eventpb.AlterTypeRenameValue{
+			TypeName: typeName,
+			OldValue: string(t.OldVal),
+			NewValue: string(t.NewVal),
+		})
+	case *tree.AlterTypeRename:
+		if err := params.p.renameType(params.ctx, n, string(t.NewName)); err != nil {
+			return err
+		}
+		return params.p.logEvent(params.ctx, n.desc.ID, &eventpb.RenameType{
 			TypeName:    typeName,
 			NewTypeName: string(t.NewName),
 		})
-		eventLogDone = true
 	case *tree.AlterTypeSetSchema:
-		err = params.p.setTypeSchema(params.ctx, n, string(t.Schema))
-		eventLogDone = true // done inside setTypeSchema().
+		// Event logged inside setTypeSchema.
+		return params.p.setTypeSchema(params.ctx, n, string(t.Schema))
 	case *tree.AlterTypeOwner:
 		owner, err := decodeusername.FromRoleSpec(
 			params.SessionData(), username.PurposeValidation, t.Owner,
@@ -119,30 +129,19 @@ func (n *alterTypeNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		if err = params.p.alterTypeOwner(params.ctx, n, owner); err != nil {
-			return err
-		}
-		eventLogDone = true // done inside alterTypeOwner().
+		// Event logged inside alterTypeOwner.
+		return params.p.alterTypeOwner(params.ctx, n, owner)
 	case *tree.AlterTypeDropValue:
-		err = params.p.dropEnumValue(params.ctx, n.desc, t.Val)
-	default:
-		err = errors.AssertionFailedf("unknown alter type cmd %s", t)
-	}
-	if err != nil {
-		return err
-	}
-
-	if !eventLogDone {
-		// Write a log event.
-		if err := params.p.logEvent(params.ctx,
-			n.desc.ID,
-			&eventpb.AlterType{
-				TypeName: typeName,
-			}); err != nil {
+		if err := params.p.dropEnumValue(params.ctx, n.desc, t.Val); err != nil {
 			return err
 		}
+		return params.p.logEvent(params.ctx, n.desc.ID, &eventpb.AlterTypeDropValue{
+			TypeName: typeName,
+			Value:    string(t.Val),
+		})
+	default:
+		return errors.AssertionFailedf("unknown alter type cmd %s", t)
 	}
-	return nil
 }
 
 func findEnumMemberByName(

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -965,6 +965,9 @@ statement ok
 ALTER TYPE eventlog RENAME VALUE 'test' TO 'testing'
 
 statement ok
+ALTER TYPE eventlog DROP VALUE 'testing'
+
+statement ok
 CREATE SCHEMA testing
 
 statement ok
@@ -977,15 +980,16 @@ ALTER TYPE eventlog RENAME TO eventlog_renamed
 query ITT
 SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
- WHERE "eventType" IN ('alter_type', 'rename_type', 'set_schema')
+ WHERE "eventType" IN ('alter_type_add_value', 'alter_type_drop_value', 'alter_type_rename_value', 'rename_type', 'set_schema')
    AND (info::JSONB->>'TypeName' LIKE '%eventlog%' OR info::JSONB->>'DescriptorName' LIKE '%eventlog%')
 ORDER BY "timestamp", info
 ----
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  set_schema   {"DescriptorName": "defaultdb.public.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.testing.eventlog", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "User": "root"}
-1  set_schema   {"DescriptorName": "defaultdb.testing.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.public.eventlog", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "User": "root"}
-1  rename_type  {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type_add_value     {"EventType": "alter_type_add_value", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root", "Value": "test"}
+1  alter_type_rename_value  {"EventType": "alter_type_rename_value", "NewValue": "testing", "OldValue": "test", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type_drop_value    {"EventType": "alter_type_drop_value", "Statement": "ALTER TYPE defaultdb.public.eventlog DROP VALUE 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root", "Value": "testing"}
+1  set_schema               {"DescriptorName": "defaultdb.public.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.testing.eventlog", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "User": "root"}
+1  set_schema               {"DescriptorName": "defaultdb.testing.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.public.eventlog", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "User": "root"}
+1  rename_type              {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
 
 statement ok
 DROP TYPE eventlog_renamed

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -958,6 +958,9 @@ statement ok
 ALTER TYPE eventlog RENAME VALUE 'test' TO 'testing'
 
 statement ok
+ALTER TYPE eventlog DROP VALUE 'testing'
+
+statement ok
 CREATE SCHEMA testing
 
 statement ok
@@ -970,15 +973,16 @@ ALTER TYPE eventlog RENAME TO eventlog_renamed
 query ITT
 SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
- WHERE "eventType" IN ('alter_type', 'rename_type', 'set_schema')
+ WHERE "eventType" IN ('alter_type_add_value', 'alter_type_drop_value', 'alter_type_rename_value', 'rename_type', 'set_schema')
    AND (info::JSONB->>'TypeName' LIKE '%eventlog%' OR info::JSONB->>'DescriptorName' LIKE '%eventlog%')
 ORDER BY "timestamp", info
 ----
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  alter_type   {"EventType": "alter_type", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
-1  set_schema   {"DescriptorName": "defaultdb.public.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.testing.eventlog", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "User": "root"}
-1  set_schema   {"DescriptorName": "defaultdb.testing.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.public.eventlog", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "User": "root"}
-1  rename_type  {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type_add_value     {"EventType": "alter_type_add_value", "Statement": "ALTER TYPE defaultdb.public.eventlog ADD VALUE 'test'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root", "Value": "test"}
+1  alter_type_rename_value  {"EventType": "alter_type_rename_value", "NewValue": "testing", "OldValue": "test", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME VALUE 'test' TO 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
+1  alter_type_drop_value    {"EventType": "alter_type_drop_value", "Statement": "ALTER TYPE defaultdb.public.eventlog DROP VALUE 'testing'", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root", "Value": "testing"}
+1  set_schema               {"DescriptorName": "defaultdb.public.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.testing.eventlog", "Statement": "ALTER TYPE defaultdb.public.eventlog SET SCHEMA testing", "Tag": "ALTER TYPE", "User": "root"}
+1  set_schema               {"DescriptorName": "defaultdb.testing.eventlog", "DescriptorType": "type", "EventType": "set_schema", "NewDescriptorName": "defaultdb.public.eventlog", "Statement": "ALTER TYPE defaultdb.testing.eventlog SET SCHEMA public", "Tag": "ALTER TYPE", "User": "root"}
+1  rename_type              {"EventType": "rename_type", "NewTypeName": "eventlog_renamed", "Statement": "ALTER TYPE defaultdb.public.eventlog RENAME TO eventlog_renamed", "Tag": "ALTER TYPE", "TypeName": "defaultdb.public.eventlog", "User": "root"}
 
 statement ok
 DROP TYPE eventlog_renamed

--- a/pkg/sql/schemachanger/scbuild/event_log.go
+++ b/pkg/sql/schemachanger/scbuild/event_log.go
@@ -566,22 +566,21 @@ func (pb payloadBuilder) build(b buildCtx) logpb.EventPayload {
 			SequenceName: fullyQualifiedName(b, seq),
 		}
 	}
-	if _, _, enumType := scpb.FindEnumType(b.QueryByID(screl.GetDescID(pb.Element()))); enumType != nil {
-		// If the enum type has a payload attached use that instead of ALTER TYPE.
-		if pb.maybePayload != nil {
-			return pb.maybePayload
+	if _, _, e := scpb.FindEnumType(b.QueryByID(screl.GetDescID(pb.Element()))); e != nil {
+		if pb.maybePayload == nil {
+			panic(errors.AssertionFailedf(
+				"missing event payload for ALTER TYPE on enum %s", fullyQualifiedName(b, e),
+			))
 		}
-		return &eventpb.AlterType{
-			TypeName: fullyQualifiedName(b, enumType),
-		}
+		return pb.maybePayload
 	}
-	if _, _, aliasType := scpb.FindAliasType(b.QueryByID(screl.GetDescID(pb.Element()))); aliasType != nil {
-		if pb.maybePayload != nil {
-			return pb.maybePayload
+	if _, _, e := scpb.FindAliasType(b.QueryByID(screl.GetDescID(pb.Element()))); e != nil {
+		if pb.maybePayload == nil {
+			panic(errors.AssertionFailedf(
+				"missing event payload for ALTER TYPE on alias type %s", fullyQualifiedName(b, e),
+			))
 		}
-		return &eventpb.AlterType{
-			TypeName: fullyQualifiedName(b, aliasType),
-		}
+		return pb.maybePayload
 	}
 	return nil
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -208,8 +208,9 @@ func alterTypeAddValue(
 	}
 	b.Add(enumValue)
 
-	b.LogEventForExistingPayload(enumValue, &eventpb.AlterType{
+	b.LogEventForExistingPayload(enumValue, &eventpb.AlterTypeAddValue{
 		TypeName: tn.FQString(),
+		Value:    newVal,
 	})
 }
 
@@ -269,8 +270,10 @@ func alterTypeRenameValue(
 	}
 	b.Add(enumValue)
 
-	b.LogEventForExistingPayload(enumValue, &eventpb.AlterType{
+	b.LogEventForExistingPayload(enumValue, &eventpb.AlterTypeRenameValue{
 		TypeName: tn.FQString(),
+		OldValue: oldVal,
+		NewValue: newVal,
 	})
 }
 
@@ -340,8 +343,9 @@ func alterTypeDropValue(
 			}
 			found = true
 			b.Drop(e)
-			b.LogEventForExistingPayload(e, &eventpb.AlterType{
+			b.LogEventForExistingPayload(e, &eventpb.AlterTypeDropValue{
 				TypeName: tn.FQString(),
+				Value:    dropVal,
 			})
 		},
 	)

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_add_value/alter_type_add_value.side_effects
@@ -13,13 +13,14 @@ begin transaction #1
 checking for feature: ALTER TYPE
 increment telemetry for sql.schema.alter_type.add_value
 increment telemetry for sql.udts.alter_enum
-write *eventpb.AlterType to event log:
+write *eventpb.AlterTypeAddValue to event log:
   sql:
     descriptorId: 104
     statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› ADD VALUE ‹'atlantic'›
     tag: ALTER TYPE
     user: root
   typeName: defaultdb.public.salmon
+  value: atlantic
 ## StatementPhase stage 1 of 1 with 1 MutationType op
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_drop_value/alter_type_drop_value.side_effects
@@ -13,13 +13,14 @@ begin transaction #1
 checking for feature: ALTER TYPE
 increment telemetry for sql.schema.alter_type.drop_value
 increment telemetry for sql.udts.alter_enum
-write *eventpb.AlterType to event log:
+write *eventpb.AlterTypeDropValue to event log:
   sql:
     descriptorId: 104
     statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› DROP VALUE ‹'atlantic'›
     tag: ALTER TYPE
     user: root
   typeName: defaultdb.public.salmon
+  value: atlantic
 ## StatementPhase stage 1 of 1 with 1 MutationType op
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_type_rename_value/alter_type_rename_value.side_effects
@@ -13,7 +13,9 @@ begin transaction #1
 checking for feature: ALTER TYPE
 increment telemetry for sql.schema.alter_type.rename_value
 increment telemetry for sql.udts.alter_enum
-write *eventpb.AlterType to event log:
+write *eventpb.AlterTypeRenameValue to event log:
+  newValue: coho
+  oldValue: atlantic
   sql:
     descriptorId: 104
     statement: ALTER TYPE ‹defaultdb›.‹public›.‹salmon› RENAME VALUE ‹'atlantic'› TO ‹'coho'›

--- a/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
+++ b/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
@@ -49,6 +49,12 @@ export const DROP_VIEW = "drop_view";
 export const CREATE_TYPE = "create_type";
 // Recorded when a type is altered.
 export const ALTER_TYPE = "alter_type";
+// Recorded when a value is added to an enum type.
+export const ALTER_TYPE_ADD_VALUE = "alter_type_add_value";
+// Recorded when a value in an enum type is renamed.
+export const ALTER_TYPE_RENAME_VALUE = "alter_type_rename_value";
+// Recorded when a value is dropped from an enum type.
+export const ALTER_TYPE_DROP_VALUE = "alter_type_drop_value";
 // Recorded when a type's owner is changed.
 export const ALTER_TYPE_OWNER = "alter_type_owner";
 // Recorded when a database's comment is changed.

--- a/pkg/ui/workspaces/db-console/src/util/events.ts
+++ b/pkg/ui/workspaces/db-console/src/util/events.ts
@@ -81,6 +81,12 @@ export function getEventDescription(e: clusterUiApi.EventColumns): string {
       return `Type Created: User ${info.User} created type ${info.TypeName}`;
     case eventTypes.ALTER_TYPE:
       return `Type Altered: User ${info.User} altered type ${info.TypeName}`;
+    case eventTypes.ALTER_TYPE_ADD_VALUE:
+      return `Type Value Added: User ${info.User} added value ${info.Value} to type ${info.TypeName}`;
+    case eventTypes.ALTER_TYPE_RENAME_VALUE:
+      return `Type Value Renamed: User ${info.User} renamed value ${info.OldValue} to ${info.NewValue} on type ${info.TypeName}`;
+    case eventTypes.ALTER_TYPE_DROP_VALUE:
+      return `Type Value Dropped: User ${info.User} dropped value ${info.Value} from type ${info.TypeName}`;
     case eventTypes.ALTER_TYPE_OWNER:
       return `Type Owner Altered: User ${info.User} altered the owner of the type ${info.TypeName} to ${info.Owner}`;
     case eventTypes.DROP_TYPE:
@@ -253,6 +259,8 @@ export interface EventInfo {
   TypeName?: string;
   User: string;
   Value?: string;
+  OldValue?: string;
+  NewValue?: string;
   ViewName?: string;
   // The following are three names for the same key (it was renamed twice).
   // All ar included for backwards compatibility.

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -463,11 +463,45 @@ message DropType {
 }
 
 // EventAlterType is recorded when a user-defined type is altered.
+// 
+// Deprecated: Use specific event types instead.
 message AlterType {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   // The name of the affected type.
   string type_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
+// AlterTypeAddValue is recorded when a value is added to an enum type.
+message AlterTypeAddValue {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The name of the affected type.
+  string type_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The value being added.
+  string value = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
+// AlterTypeRenameValue is recorded when a value in an enum type is renamed.
+message AlterTypeRenameValue {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The name of the affected type.
+  string type_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The old value being renamed.
+  string old_value = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The new value.
+  string new_value = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
+// AlterTypeDropValue is recorded when a value is dropped from an enum type.
+message AlterTypeDropValue {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The name of the affected type.
+  string type_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The value being dropped.
+  string value = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // RenameType is recorded when a user-defined type is renamed.

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -180,6 +180,15 @@ func (m *AlterTable) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_S
 func (m *AlterType) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *AlterTypeAddValue) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *AlterTypeDropValue) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *AlterTypeRenameValue) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *CommentOnColumn) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -820,6 +820,66 @@ func (m *AlterType) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *AlterTypeAddValue) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TypeName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TypeName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TypeName)))
+		b = append(b, '"')
+	}
+
+	if m.Value != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Value\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Value)))
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *AlterTypeDropValue) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TypeName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TypeName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TypeName)))
+		b = append(b, '"')
+	}
+
+	if m.Value != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Value\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Value)))
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
@@ -847,6 +907,46 @@ func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBy
 		b = append(b, redact.StartMarker()...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Owner)))))
 		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *AlterTypeRenameValue) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TypeName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TypeName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TypeName)))
+		b = append(b, '"')
+	}
+
+	if m.OldValue != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"OldValue\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.OldValue)))
+		b = append(b, '"')
+	}
+
+	if m.NewValue != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NewValue\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.NewValue)))
 		b = append(b, '"')
 	}
 


### PR DESCRIPTION
Previously the general `alter_type` event was used for multiple `ALTER
TYPE` operations. This change adopts specific events for subcommands.

Part of: #164216
Informed by: #169780
Epic: CRDB-31325

Release note (sql change): Specific events are used for `ALTER TYPE`
operations instead of the general `alter_type` event.
