### PR TITLE
sql: use single-node cluster in TestTelemetryLoggingDataDriven

### DIFF
--- a/pkg/sql/telemetry_datadriven_test.go
+++ b/pkg/sql/telemetry_datadriven_test.go
@@ -101,7 +101,12 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 			getTimeNow:       st.TimeNow,
 			getTracingStatus: sts.TracingStatus,
 		}
-		tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		// NB: use a single-node cluster so that the leaseholder for any
+		// user table is always the gateway. With multiple nodes, the
+		// leaseholder can land on a non-gateway node and the physical
+		// planner will distribute the flow, making the Distribution field
+		// in telemetry log events nondeterministic. See #169735.
+		tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					SQLExecutor: &ExecutorTestingKnobs{


### PR DESCRIPTION
The test previously started a 3-node cluster but only ever used the gateway (node 0). The expected output in the data files hard-codes "Distribution": "local" for every sampled_query event. With multiple nodes, the leaseholder for the user table created by each subtest (e.g. CREATE TABLE t()) can land on a non-gateway node. When that happens, the physical planner places the table reader on the leaseholder, the resulting flow has more than one participant, and the Distribution field is reported as "full" instead of "local", causing the test to fail.

Drop to a single-node cluster so the leaseholder is always the gateway. The test exercises no multi-node behavior, so this is a no-op for coverage and slightly faster to set up.

Fixes: #169735

Release note: None