### PR TITLE
sqlstats: dedup txn fingerprints in DrainSqlStatsRespBuilder

### DIFF
--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -28,6 +28,7 @@ import (
 // different aggregation windows are not combined.
 type DrainSqlStatsRespBuilder struct {
 	stmtFingerprintCount map[appstatspb.StmtFingerprintID]struct{}
+	txnFingerprintCount  map[appstatspb.TransactionFingerprintID]struct{}
 	stmtMap              map[stmtDrainKey]*appstatspb.CollectedStatementStatistics
 	txnMap               map[txnDrainKey]*appstatspb.CollectedTransactionStatistics
 }
@@ -49,6 +50,7 @@ type txnDrainKey struct {
 func NewDrainSqlStatsRespBuilder() *DrainSqlStatsRespBuilder {
 	return &DrainSqlStatsRespBuilder{
 		stmtFingerprintCount: make(map[appstatspb.StmtFingerprintID]struct{}),
+		txnFingerprintCount:  make(map[appstatspb.TransactionFingerprintID]struct{}),
 		stmtMap:              make(map[stmtDrainKey]*appstatspb.CollectedStatementStatistics),
 		txnMap:               make(map[txnDrainKey]*appstatspb.CollectedTransactionStatistics),
 	}
@@ -84,11 +86,15 @@ func (b *DrainSqlStatsRespBuilder) AddTxnStats(
 		} else {
 			existingTx.Stats.Add(&txn.Stats)
 		}
+
+		if _, ok := b.txnFingerprintCount[txn.TransactionFingerprintID]; !ok {
+			b.txnFingerprintCount[txn.TransactionFingerprintID] = struct{}{}
+		}
 	}
 }
 
 func (b *DrainSqlStatsRespBuilder) Build() *serverpb.DrainStatsResponse {
-	fingerprintCount := len(b.stmtFingerprintCount) + len(b.txnMap)
+	fingerprintCount := len(b.stmtFingerprintCount) + len(b.txnFingerprintCount)
 	response := &serverpb.DrainStatsResponse{
 		Statements:       make([]*appstatspb.CollectedStatementStatistics, 0, len(b.stmtMap)),
 		Transactions:     make([]*appstatspb.CollectedTransactionStatistics, 0, len(b.txnMap)),


### PR DESCRIPTION
DrainSqlStatsRespBuilder.Build computed FingerprintCount as len(stmtFingerprintCount) + len(txnMap), which was asymmetric: stmtFingerprintCount is keyed by StmtFingerprintID alone, while txnMap is keyed by (TransactionFingerprintID, aggregatedTs). It overcounts when the same transaction fingerprint appears under multiple aggregation windows.

This was introduced by #168518 which switched the drain builder to key txnMap by (fingerprint, aggregatedTs) so stats from different windows are no longer merged. The Build() fingerprint count was not updated to keep dedup by fingerprint ID alone.

Add a parallel txnFingerprintCount map (mirroring
stmtFingerprintCount) and use it in Build(). The per-window entries in txnMap are still preserved separately.

Resolves: #169776
Epic: none
Release note: None