### PR TITLE
npgsql: skip flaky test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -775,6 +775,7 @@ var npgsqlBlocklist = blocklist{
 var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Cancel_async_soft`:                                   "flaky",
 	`Npgsql.Tests.ConnectionTests(Multiplexing).Fail_connect_then_succeed(True)`:                     "flaky",
+	`Npgsql.Tests.CopyTests(Multiplexing).Import_commit_in_middle_of_row`:                            "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Import_numeric`:                                            "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Import_string_array`:                                       "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Prepended_messages`:                                        "flaky",


### PR DESCRIPTION
The non-multiplexing version was already skipped.

Epic: none
Fixes: #169318

Release note: None
