### PR TITLE
release-26.2: backup: disable dRPC for additional flaky backup tests

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2322,7 +2322,12 @@ func TestBackupRestoreUserDefinedTypes(t *testing.T) {
 	// ts4: no farewell type exists
 	// ts5: farewell type exists as (third)
 	t.Run("revision-history", func(t *testing.T) {
-		_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
+		// Note (kev-cao): DRPC is currently flaky on this test, disabling while it
+		// is investigated.
+		_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode,
+			0, InitManualReplication, base.TestClusterArgs{
+				ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
+			})
 		defer cleanupFn()
 
 		var ts1, ts2, ts3, ts4, ts5 string

--- a/pkg/backup/datadriven_test.go
+++ b/pkg/backup/datadriven_test.go
@@ -160,6 +160,9 @@ type clusterCfg struct {
 func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 	params := base.TestClusterArgs{}
 	params.ServerArgs.ExternalIODirConfig = cfg.ioConf
+	// Note (kev-cao): DRPC is currently flaky on this test, disabling while it
+	// is investigated.
+	params.ServerArgs.DefaultDRPCOption = base.TestDRPCDisabled
 
 	params.ServerArgs.DefaultTestTenant = cfg.defaultTestTenant
 	var transactionRetryFilter func(roachpb.Transaction) bool

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -44,9 +44,14 @@ func TestShowBackup(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 11
-	tc, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	// Note (kev-cao): DRPC is currently flaky on this test, disabling while it
+	// is investigated.
+	args := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
+	}
+	tc, sqlDB, tempDir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, args)
 	kvDB := tc.Server(0).ApplicationLayer().DB()
-	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
+	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, args)
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 	sqlDB.ExecMultiple(t, strings.Split(`


### PR DESCRIPTION
Backport 1/1 commits from #169570.

/cc @cockroachdb/release

---

Disable metamorphic dRPC enabling for TestShowBackup,
TestBackupRestoreUserDefinedTypes, and all datadriven backup tests.
These tests are flaky with dRPC enabled due to context cancellation
errors. This follows the same pattern as #169501.

See https://cockroachlabs.slack.com/archives/C07T05244KZ/p1776711935608509

Informs: #168934

Informs: #168822

Informs: #168579

Release note: None

---

Release justification: Test-only change