### PR TITLE
sql/pgcatalog: populate custom_plans and generic_plans in pg_prepared_statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -673,3 +673,168 @@ PREPARE p159124 AS SELECT k FROM t159124 WHERE s = current_user()
 
 statement ok
 EXECUTE p159124
+
+# Test that custom_plans and generic_plans columns are populated in
+# pg_prepared_statements.
+subtest pg_prepared_statements_plan_counts
+
+statement ok
+DEALLOCATE ALL
+
+statement ok
+CREATE TABLE t_plan_counts (a INT PRIMARY KEY, b INT, INDEX (b))
+
+statement ok
+INSERT INTO t_plan_counts SELECT i, i FROM generate_series(1, 1000) AS g(i)
+
+# After PREPARE, both counters start at 0.
+statement ok
+PREPARE p_counts(int) AS SELECT * FROM t_plan_counts WHERE b = $1
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+0  0
+
+# force_custom_plan increments custom_plans.
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+statement ok
+EXECUTE p_counts(1)
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+1  0
+
+statement ok
+EXECUTE p_counts(2)
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+2  0
+
+# force_generic_plan increments generic_plans.
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+EXECUTE p_counts(1)
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+2  1
+
+statement ok
+EXECUTE p_counts(2)
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+2  2
+
+# Ideal generic plan (no placeholders) always counts as generic,
+# even with force_custom_plan.
+statement ok
+PREPARE p_ideal AS SELECT 1
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+statement ok
+EXECUTE p_ideal
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_ideal'
+----
+0  1
+
+statement ok
+EXECUTE p_ideal
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_ideal'
+----
+0  2
+
+# Auto mode: first 5 executions use custom plans.
+statement ok
+DEALLOCATE p_counts
+
+statement ok
+PREPARE p_counts(int) AS SELECT * FROM t_plan_counts WHERE b = $1
+
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+EXECUTE p_counts(1)
+
+statement ok
+EXECUTE p_counts(2)
+
+statement ok
+EXECUTE p_counts(3)
+
+statement ok
+EXECUTE p_counts(4)
+
+statement ok
+EXECUTE p_counts(5)
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+5  0
+
+# 6th execution triggers generic plan evaluation.
+statement ok
+EXECUTE p_counts(6)
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+5  1
+
+# DEALLOCATE and re-PREPARE resets counters.
+statement ok
+DEALLOCATE p_counts
+
+statement ok
+PREPARE p_counts(int) AS SELECT * FROM t_plan_counts WHERE b = $1
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'p_counts'
+----
+0  0
+
+statement ok
+DEALLOCATE ALL
+
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+DROP TABLE t_plan_counts
+
+subtest no_memo_reuse
+
+# Create a prepared statement that won't allow memo reuse.
+statement ok
+PREPARE show_tables AS SHOW TABLES
+
+statement ok
+EXECUTE show_tables;
+
+query II
+SELECT custom_plans, generic_plans FROM pg_prepared_statements WHERE name = 'show_tables'
+----
+1  0
+
+statement ok
+DEALLOCATE ALL
+
+subtest end

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3257,8 +3257,8 @@ https://www.postgresql.org/docs/18/view-pg-prepared-statements.html`,
 				paramTypes,
 				resultTypes, // result_types
 				fromSQL,
-				tree.DNull, // custom_plans
-				tree.DNull, // generic_plans
+				tree.NewDInt(tree.DInt(stmt.CustomPlanCount)),  // custom_plans
+				tree.NewDInt(tree.DInt(stmt.GenericPlanCount)), // generic_plans
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -687,6 +687,9 @@ func (opc *optPlanningCtx) reuseMemo(cachedMemo *memo.Memo) (*memo.Memo, error) 
 		// The query could have been already fully optimized in
 		// buildReusableMemo, in which case it is considered a "generic" plan.
 		opc.flags.Set(planFlagGeneric)
+		if prep := opc.p.stmt.Prepared; prep != nil {
+			prep.GenericPlanCount++
+		}
 		return cachedMemo, nil
 	}
 	f := opc.optimizer.Factory()
@@ -707,6 +710,7 @@ func (opc *optPlanningCtx) reuseMemo(cachedMemo *memo.Memo) (*memo.Memo, error) 
 		costWithOptimizationCost := mem.RootExpr().Cost()
 		costWithOptimizationCost.Add(mem.OptimizationCost())
 		prep.Costs.AddCustom(costWithOptimizationCost)
+		prep.CustomPlanCount++
 	}
 	return mem, nil
 }
@@ -1055,6 +1059,11 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		return memo, nil
 	}
 
+	// If this is a prepared statement that was built from scratch
+	// count it as a custom plan execution.
+	if prep := opc.p.stmt.Prepared; prep != nil {
+		prep.CustomPlanCount++
+	}
 	return f.ReleaseMemo(), nil
 }
 

--- a/pkg/sql/prep/statement.go
+++ b/pkg/sql/prep/statement.go
@@ -58,6 +58,14 @@ type Statement struct {
 	// Costs tracks the costs of previously optimized custom and generic plans.
 	Costs planCosts
 
+	// CustomPlanCount tracks the number of times a custom plan was used when
+	// executing this prepared statement.
+	CustomPlanCount int64
+
+	// GenericPlanCount tracks the number of times a generic plan was used when
+	// executing this prepared statement.
+	GenericPlanCount int64
+
 	// refCount keeps track of the number of references to this PreparedStatement.
 	// New references are registered through incRef().
 	// Once refCount hits 0 (through calls to decRef()), the following memAcc is


### PR DESCRIPTION
Previously, the `custom_plans` and `generic_plans` columns in
`pg_prepared_statements` always returned NULL. These columns were added
for PG 18 catalog alignment but left unpopulated.

This commit adds `CustomPlanCount` and `GenericPlanCount` fields to
`prep.Statement` and increments them. The counters are then exposed
in the `pg_prepared_statements` virtual table populate function.

The counting matches PostgreSQL semantics: every EXECUTE increments
exactly one counter regardless of `plan_cache_mode`. Ideal generic
plans (no placeholders) always count as generic.

Resolves: https://github.com/cockroachdb/cockroach/issues/168554
Epic: CRDB-39727

Release note (sql change): The `custom_plans` and `generic_plans`
columns in `pg_prepared_statements` now report the number of times
a custom or generic plan was used for each prepared statement,
matching PostgreSQL behavior.