### PR TITLE
CODEOWNERS: add specialized indexing team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,7 +79,7 @@
 /pkg/sql/control_job*        @cockroachdb/sql-queries-prs @cockroachdb/jobs-prs
 /pkg/sql/job_exec_context*   @cockroachdb/sql-queries-prs @cockroachdb/jobs-prs
 /pkg/sql/delegate/*job*.go   @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
-/pkg/sql/vecindex/           @cockroachdb/sql-queries-prs
+/pkg/sql/vecindex/           @cockroachdb/specialized-indexing-prs
 /pkg/sql/partition*.go       @cockroachdb/sql-queries-prs
 /pkg/sql/temporary_schema*   @cockroachdb/sql-queries-prs
 #!/pkg/sql/BUILD.bazel       @cockroachdb/sql-queries-noreview

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -20,6 +20,10 @@ cockroachdb/sql-queries:
   # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
   silence_mentions: true
+cockroachdb/specialized-indexing:
+  aliases:
+    cockroachdb/specialized-indexing-prs: other
+  label: T-specialized-indexing
 cockroachdb/kv:
   aliases:
     cockroachdb/kv-triage: roachtest

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10455,7 +10455,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
-      owner: cockroachdb/sql-queries
+      owner: cockroachdb/specialized-indexing
     - name: sql.vecindex.successful_splits
       exported_name: sql_vecindex_successful_splits
       description: Total number of vector index partitions split without error
@@ -10464,7 +10464,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-      owner: cockroachdb/sql-queries
+      owner: cockroachdb/specialized-indexing
     - name: sqlliveness.is_alive.cache_hits
       exported_name: sqlliveness_is_alive_cache_hits
       description: Number of calls to IsAlive that return from the cache

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -1122,8 +1122,8 @@ owners:
   sql_txns_open: cockroachdb/sql-queries
   sql_update_count: cockroachdb/sql-queries
   sql_update_started_count: cockroachdb/sql-queries
-  sql_vecindex_pending_splits_merges: cockroachdb/sql-queries
-  sql_vecindex_successful_splits: cockroachdb/sql-queries
+  sql_vecindex_pending_splits_merges: cockroachdb/specialized-indexing
+  sql_vecindex_successful_splits: cockroachdb/specialized-indexing
   sqlliveness_is_alive_cache_hits: cockroachdb/server
   sqlliveness_is_alive_cache_misses: cockroachdb/server
   sqlliveness_sessions_deleted: cockroachdb/server


### PR DESCRIPTION
This commit updates the CODEOWNERS and TEAMS.yaml files to point vector indexing issues at the new specialized indexing team.

Epic: None
Release note: None