### PR TITLE
jobs: handle NULL claim_instance_id in JobCoordinatorID

### DIFF
--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -74,6 +74,10 @@ const PauseRequestExplained = "pausing due to error; use RESUME JOB to try to pr
 // knows or finds out it no longer has a job lease.
 var errJobLeaseNotHeld = errors.New("job lease not held")
 
+// errJobNotClaimed is a sentinel error for when a job exists but is not
+// currently claimed by any node (i.e. claim_instance_id is NULL).
+var errJobNotClaimed = errors.New("job not claimed")
+
 // InvalidStateError is the error returned when the desired operation is
 // invalid given the job's current state.
 type InvalidStateError struct {

--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -169,7 +169,13 @@ func JobCoordinatorID(
 		return 0, err
 	}
 	if row == nil {
-		return 0, errors.Errorf("coordinator not found for job %d", jobID)
+		return 0, NewJobNotFoundError(jobID)
+	}
+	if row[0] == tree.DNull {
+		return 0, errors.Mark(
+			errors.Newf("job %d is not currently claimed by any node", jobID),
+			errJobNotClaimed,
+		)
 	}
 	coordinatorID, ok := row[0].(*tree.DInt)
 	if !ok {

--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -239,7 +239,25 @@ func TestReadWriteProfilerExecutionDetails(t *testing.T) {
 	})
 
 	t.Run("execution details for invalid job ID", func(t *testing.T) {
-		runner.ExpectErr(t, `coordinator not found for job -123`, `SELECT crdb_internal.request_job_execution_details(-123)`)
+		runner.ExpectErr(t, `job with ID -123 does not exist`, `SELECT crdb_internal.request_job_execution_details(-123)`)
+	})
+
+	t.Run("execution details for unclaimed job", func(t *testing.T) {
+		defer jobs.TestingRegisterConstructor(jobspb.TypeImport, func(j *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+			return fakeExecResumer{}
+		}, jobs.UsesTenantCostControl)()
+
+		var importJobID int
+		runner.QueryRow(t, `IMPORT INTO t CSV DATA ('nodelocal://1/foo') WITH DETACHED`).Scan(&importJobID)
+		jobutils.WaitForJobToSucceed(t, runner, jobspb.JobID(importJobID))
+
+		// NULL out the claim_instance_id to simulate an unclaimed job.
+		runner.Exec(t, `UPDATE system.jobs SET claim_instance_id = NULL WHERE id = $1`, importJobID)
+
+		runner.ExpectErr(
+			t, `is not currently claimed by any node`,
+			`SELECT crdb_internal.request_job_execution_details($1)`, importJobID,
+		)
 	})
 
 	t.Run("read/write terminal trace", func(t *testing.T) {


### PR DESCRIPTION
`JobCoordinatorID` hit an assertion failure when `claim_instance_id` was
NULL, which happens when a job has completed or was never claimed. Handle
this case by returning a new `JobNotClaimedError` instead.

Fixes: #168746

Fixes: #145909

Release note (bug fix): Fixed an assertion failure in the job profiler
that could occur when requesting execution details for a job that is
not currently running.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>