### PR TITLE
sql: deflake TestTelemetryLoggingDataDriven with single-node cluster

### DIFF
--- a/pkg/sql/telemetry_datadriven_test.go
+++ b/pkg/sql/telemetry_datadriven_test.go
@@ -101,7 +101,7 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 			getTimeNow:       st.TimeNow,
 			getTracingStatus: sts.TracingStatus,
 		}
-		tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					SQLExecutor: &ExecutorTestingKnobs{


### PR DESCRIPTION
## Summary

`TestTelemetryLoggingDataDriven` is flaking on master because its 3-node test cluster makes the `Distribution` field in telemetry output non-deterministic for queries against an empty table.

Since [2013fc4382](https://github.com/cockroachdb/cockroach/commit/2013fc4382) (`sql: unify "distribution" in EXPLAIN and EXPLAIN ANALYZE`), `savePlanInfo` (`pkg/sql/plan.go`) reports the *actual* physical plan distribution rather than the optimizer's recommendation: `"full"` requires both `planFlagFullyDistributed` and `planFlagDistributedExecution`, where the latter is set in `distsql_running.go:987` only when `len(flows) > 1`.

For `SELECT * FROM t LIMIT N` against a freshly-created empty `t` with no statistics:
- The optimizer always recommends `FullyDistributedPlan` (no stats → high estimated cardinality → "worth distributing").
- The DistSQL planner ships the scan to whichever node holds the lease for `t`'s range.
- `maybeMoveSingleFlowToGateway` bails out when `rowCount <= 0` (empty table has no stats), so the plan stays distributed.
- If the lease lands on the **gateway**: `len(flows) == 1` → telemetry reports `"local"`.
- If the lease lands on a **remote node**: 2 flows (remote scan + gateway result-noop) → telemetry reports `"full"`.

The testdata files in `pkg/sql/testdata/telemetry_logging/` were rewritten to expect `"local"` shortly after that commit, which only holds when the lease happens to land on the gateway — non-deterministic in a 3-node cluster.

None of the four testdata files exercise multi-node behavior. The 3-node setup was incidental when the test was created in [4e2b7f412e](https://github.com/cockroachdb/cockroach/commit/4e2b7f412e).

## Verification

Without the fix: 5/5 fresh runs fail on darwin/arm64 with the diff shown in #169840.
With the fix: `--count=10` passes (`max=6.2s, min=4.6s, avg=5.6s`).

Resolves: #169840
Epic: none

Release note: None