### PR TITLE
sql: fix nil pointer panic in `QueryIteratorEx`

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -912,9 +912,17 @@ func (ie *InternalExecutor) QueryIteratorEx(
 	stmt string,
 	qargs ...interface{},
 ) (isql.Rows, error) {
-	return ie.execInternal(
+	r, err := ie.execInternal(
 		ctx, opName, newSyncIEResultChannel(), defaultIEExecutionMode, txn, session, ieStmt{stmt: stmt}, qargs...,
 	)
+	// Avoid returning a typed nil *rowsIterator wrapped in a non-nil
+	// isql.Rows interface. Callers check "if it != nil" before calling
+	// methods, but a non-nil interface holding a nil pointer passes that
+	// check and panics on method dispatch (e.g. Close, HasResults).
+	if r == nil {
+		return nil, err
+	}
+	return r, err
 }
 
 // applyInternalExecutorSessionExceptions overrides values from


### PR DESCRIPTION
Previously, `QueryIteratorEx` could return a typed nil `*rowsIterator` wrapped in a non-nil `isql.Rows` interface. Callers (e.g. closeIterator in statement_details.go) guard against nil iterators with "if it != nil", but a non-nil interface holding a nil concrete pointer passes that check. Calling methods like Close() or HasResults() on such a value panics with a nil pointer dereference.

Fixes #169860

Release note (bug fix): Fixed a rare nil pointer panic in the internal SQL executor.