### PR TITLE
release-26.1: ui/cluster-ui: add optional headers to jobs/databases pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "26.1.1",
+  "version": "26.1.2",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
@@ -52,6 +52,9 @@ export interface JobsPageStateProps {
   type: number;
   jobsResponse: RequestState<JobsResponse>;
   columns: string[];
+  // When true, suppresses the page header for use inside a parent layout
+  // that already provides its own heading (e.g. the console nav shell).
+  isEmbedded?: boolean;
 }
 
 export interface JobsPageDispatchProps {
@@ -83,6 +86,10 @@ const reqFromProps = (
 };
 
 export class JobsPage extends React.Component<JobsPageProps, PageState> {
+  static defaultProps: Partial<JobsPageProps> = {
+    isEmbedded: false,
+  };
+
   refreshDataInterval: NodeJS.Timeout;
 
   constructor(props: JobsPageProps) {
@@ -290,7 +297,9 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
     return (
       <div>
         <Helmet title="Jobs" />
-        <h3 className={commonStyles("base-heading")}>Jobs</h3>
+        {!this.props.isEmbedded && (
+          <h3 className={commonStyles("base-heading")}>Jobs</h3>
+        )}
         <div>
           <PageConfig>
             <PageConfigItem>

--- a/pkg/ui/workspaces/cluster-ui/src/pages/databases/databasesPageRoot.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/databases/databasesPageRoot.module.scss
@@ -1,0 +1,8 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+.content-section {
+  margin-top: 10px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/pages/databases/databasesPageRoot.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/databases/databasesPageRoot.tsx
@@ -4,6 +4,7 @@
 // included in the /LICENSE file.
 
 import { Row } from "antd";
+import classnames from "classnames/bind";
 import React, { useContext, useMemo } from "react";
 import { Redirect } from "react-router";
 import { Link } from "react-router-dom";
@@ -42,8 +43,11 @@ import {
   TableMetadataJobControl,
 } from "./components";
 import { DatabaseColName } from "./constants";
+import styles from "./databasesPageRoot.module.scss";
 import { DatabaseRow } from "./databaseTypes";
 import { rawDatabaseMetadataToDatabaseRows } from "./utils";
+
+const cx = classnames.bind(styles);
 
 const AUTO_STATS_ENABLED_CS = "sql.stats.automatic_collection.enabled";
 
@@ -142,7 +146,14 @@ const createDatabaseMetadataRequestFromParams = (
   };
 };
 
-export const DatabasesPageV2 = () => {
+export interface DatabasesPageV2Props {
+  // When true, suppresses the page header for use inside a parent layout
+  // that already provides its own heading (e.g. the console nav shell).
+  isEmbedded?: boolean;
+}
+
+export const DatabasesPageV2 = (props: DatabasesPageV2Props) => {
+  const { isEmbedded = false } = props;
   const clusterDetails = useContext(ClusterDetailsContext);
   const isTenant = clusterDetails.isTenant;
   const isCloud = useContext(CockroachCloudContext);
@@ -223,18 +234,7 @@ export const DatabasesPageV2 = () => {
 
   return (
     <PageLayout>
-      <PageHeader
-        title="Databases"
-        actions={
-          !settingsLoading && (
-            <BooleanSetting
-              text={"Auto stats collection"}
-              enabled={settingValues[AUTO_STATS_ENABLED_CS]?.value === "true"}
-              tooltipText={AUTO_STATS_COLLECTION_HELP}
-            />
-          )
-        }
-      />
+      {!isEmbedded && <PageHeader title="Databases" />}
       <PageConfig>
         <PageConfigItem>
           <Search placeholder="Search databases" onSubmit={setSearch} />
@@ -249,8 +249,17 @@ export const DatabasesPageV2 = () => {
             )}
           </PageConfigItem>
         )}
+        {!settingsLoading && (
+          <PageConfigItem>
+            <BooleanSetting
+              text={"Auto stats collection"}
+              enabled={settingValues[AUTO_STATS_ENABLED_CS]?.value === "true"}
+              tooltipText={AUTO_STATS_COLLECTION_HELP}
+            />
+          </PageConfigItem>
+        )}
       </PageConfig>
-      <PageSection>
+      <PageSection className={cx("content-section")}>
         <Row align={"middle"} justify={"space-between"}>
           <PageCount
             page={params.pagination.page}


### PR DESCRIPTION
Informs: CNSL-2186

Backport 1/1 commits from #169819.

/cc @cockroachdb/release

---

Make the page header optional via a `showHeader` prop on both `JobsPage` and `DatabasesPageV2`, allowing parent components to suppress the heading when embedding these pages in other layouts.

Move the "Auto stats collection" toggle from the `PageHeader` actions slot into the `PageConfig` filter bar on the databases page so it sits alongside other page-level controls.

A local stylesheet (`databasesPageRoot.module.scss`) is introduced to add `margin-top: 10px` on the content section below `PageConfig`. This compensates for the shared `PageConfig` container's `margin-bottom: -10px` (a sticky-header spacing trick) without modifying the shared stylesheet that affects 16+ pages.

Release justification: Add optional header support for embedded pages