### PR TITLE
intentresolver: add queue latency and local resolution metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -11974,6 +11974,14 @@ layers:
       aggregation: AVG
       derivative: NONE
       visibility: SUPPORT
+    - name: intentresolver.async.queue.latency
+      exported_name: intentresolver_async_queue_latency
+      description: Time intent resolution requests spend in the async queue before processing begins.
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
     - name: intentresolver.async.throttled
       exported_name: intentresolver_async_throttled
       description: Number of intent resolution attempts not run asynchronously due to throttling
@@ -11993,6 +12001,14 @@ layers:
     - name: intentresolver.intents.failed
       exported_name: intentresolver_intents_failed
       description: Number of intent resolution failures. The unit of measurement is a single intent, so if a batch of intent resolution requests fails, the metric will be incremented for each request in the batch.
+      y_axis_label: Intent Resolutions
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: intentresolver.intents.resolved_locally
+      exported_name: intentresolver_intents_resolved_locally
+      description: Number of intent resolution requests handled inline on the local fast-path, without being enqueued for asynchronous processing.
       y_axis_label: Intent Resolutions
       type: COUNTER
       unit: COUNT

--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/internal/client/requestbatcher",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/kv/kvserver/intentresolver/metrics.go
+++ b/pkg/kv/kvserver/intentresolver/metrics.go
@@ -5,7 +5,10 @@
 
 package intentresolver
 
-import "github.com/cockroachdb/cockroach/pkg/util/metric"
+import (
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
 
 var (
 	// Intent resolver metrics.
@@ -31,6 +34,20 @@ var (
 		Measurement: "Intent Resolutions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaIntentsResolvedLocally = metric.Metadata{
+		Name: "intentresolver.intents.resolved_locally",
+		Help: "Number of intent resolution requests handled inline on the local " +
+			"fast-path, without being enqueued for asynchronous processing.",
+		Measurement: "Intent Resolutions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaAsyncQueueLatency = metric.Metadata{
+		Name: "intentresolver.async.queue.latency",
+		Help: "Time intent resolution requests spend in the async queue before " +
+			"processing begins.",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 )
 
 // Metrics contains the metrics for the IntentResolver.
@@ -42,6 +59,12 @@ type Metrics struct {
 
 	// Counter tracking intent cleanup failures.
 	IntentResolutionFailed *metric.Counter
+
+	// Counter tracking intents resolved on the local fast-path (no async dispatch).
+	IntentsResolvedLocally *metric.Counter
+
+	// Histogram of time spent in the async resolver queue before processing.
+	AsyncQueueLatency metric.IHistogram
 }
 
 // MetricStruct implements the metric.Struct interface.
@@ -52,5 +75,12 @@ func makeMetrics() Metrics {
 		IntentResolverAsyncThrottled: metric.NewCounter(metaIntentResolverAsyncThrottled),
 		FinalizedTxnCleanupFailed:    metric.NewCounter(metaFinalizedTxnCleanupFailed),
 		IntentResolutionFailed:       metric.NewCounter(metaIntentCleanupFailed),
+		IntentsResolvedLocally:       metric.NewCounter(metaIntentsResolvedLocally),
+		AsyncQueueLatency: metric.NewHistogram(metric.HistogramOptions{
+			Mode:         metric.HistogramModePreferHdrLatency,
+			Metadata:     metaAsyncQueueLatency,
+			Duration:     base.DefaultHistogramWindowInterval(),
+			BucketConfig: metric.IOLatencyBuckets,
+		}),
 	}
 }


### PR DESCRIPTION
Adds two new metrics to the intent resolver:

- `intentresolver.intents.resolved_locally`: counter tracking intent
  resolution requests handled inline on the local fast-path, without
  being enqueued for asynchronous processing.
- `intentresolver.async.queue.latency`: histogram tracking the time
  intent resolution requests spend in the async queue before
  processing begins.

The metrics are registered on the package's `Metrics` struct but are
not yet incremented by any code path. This PR is a stub intended to
exercise the new Blathers comment that reports the number of
exported metric lines added by a PR — please do not merge.

Epic: none
Release note: None