### PR TITLE
backup: keep exclude_data_from_backup intact through DROP TABLE

### DIFF
--- a/pkg/backup/backup_tenant_test.go
+++ b/pkg/backup/backup_tenant_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -17,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/importer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -228,4 +231,147 @@ func TestTenantBackupMultiRegionDatabases(t *testing.T) {
 		tenSQLDB.Exec(t, "DROP DATABASE nonMrDB CASCADE")
 		tenSQLDB.Exec(t, fmt.Sprintf("RESTORE DATABASE nonMrDB FROM LATEST IN '%s'", tenDst))
 	}
+}
+
+// TestBackupTenantDroppedExcludeFromBackupTable pins down a bug where a
+// host-issued tenant backup would fail with BatchTimestampBeforeGCError after
+// a table marked exclude_data_from_backup was dropped while the backup's
+// protected timestamp was held.
+//
+// The bug had two layers, and the test exercises both:
+//
+//  1. The declarative schema changer cleared
+//     descriptor.ExcludeDataFromBackup as part of DROP TABLE (each
+//     TableStorageParam element transitioning PUBLIC -> ABSENT emitted a
+//     ResetTableStorageParam op, which mutated the soon-to-be-deleted
+//     descriptor). This made the spanconfig reconciler regenerate the
+//     span config record without the flag, which made KV stop attaching
+//     DataExcludedFromBackup to the GC error, which made the backup
+//     processor unable to recover.
+//
+//  2. Even with the descriptor field preserved, the GC job was free to
+//     delete the descriptor and zone config while the backup PTS was
+//     still held (because both KVSubscriber and the gcjob's isProtected
+//     filter out backup PTSes that opt into IgnoreIfExcludedFromBackup
+//     for excluded spans). Removing the descriptor took the span config
+//     record with it, breaking the backup the same way as (1).
+//
+// The fix is in two parts: the schema changer no-ops storage-param resets
+// on a descriptor that's already been marked DROP, and the GC job blocks
+// descriptor cleanup until any covering PTS (under a "descriptor cleanup"
+// scope that does not honor IgnoreIfExcludedFromBackup) is released.
+//
+// The test pauses a tenant backup after its PTS is written, drops the
+// excluded table inside the tenant, force-advances MVCC GC past the PTS
+// time, then resumes the backup and requires it to complete.
+func TestBackupTenantDroppedExcludeFromBackupTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// TODO(at): enable once LinkExternalSSTable is permitted for secondary tenants.
+	backuptestutils.DisableFastRestoreForTest(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	hostDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	// Speed up PTS reconciliation and closed timestamps so the host's KV
+	// nodes quickly observe span-config and PTS changes coming from the
+	// tenant. The GC poll interval is system-visible, so set it from the
+	// host as well; the tenant inherits the value.
+	hostDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'`)
+	hostDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+	hostDB.Exec(t, `SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s'`)
+
+	tenantID := roachpb.MustMakeTenantID(10)
+	_, tSQL := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
+		TenantID:     tenantID,
+		TestingKnobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	})
+	defer tSQL.Close()
+	tenantDB := sqlutils.MakeSQLRunner(tSQL)
+
+	// Drop the GC TTL inside the tenant so MVCC GC can quickly catch up
+	// after the table is dropped. Disable range merges so the dropped
+	// table's range stays distinct from the rest of the tenant; otherwise
+	// the post-clear merge would mask the test bug behind the replica's
+	// cached span config no longer reporting ExcludeDataFromBackup.
+	tenantDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 1`)
+	hostDB.Exec(t, `SET CLUSTER SETTING kv.range_merge.queue.enabled = false`)
+
+	// Create an excluded table inside the tenant with some data, plus a
+	// trailing sibling table so the excluded table's range is bounded on
+	// both sides (otherwise r100 would extend to /Tenant/11/Max and its
+	// cached span config would not necessarily report
+	// ExcludeDataFromBackup, masking the bug).
+	tenantDB.Exec(t, `CREATE DATABASE db`)
+	tenantDB.Exec(t, `USE db`)
+	tenantDB.Exec(t, `CREATE TABLE t (k INT PRIMARY KEY, v STRING)`)
+	tenantDB.Exec(t, `ALTER TABLE t SET (exclude_data_from_backup = true)`)
+	tenantDB.Exec(t, `INSERT INTO t SELECT generate_series(1, 100), 'initial'`)
+	tenantDB.Exec(t, `CREATE TABLE bookend (k INT PRIMARY KEY)`)
+
+	// The table needs its own range so the ExcludeDataFromBackup span
+	// config applies and the GC queue treats it independently.
+	waitForTableSplit(t, tSQL, "t", "db")
+	waitForTableSplit(t, tSQL, "bookend", "db")
+
+	// Pause the tenant backup just after its PTS has been written but
+	// before its export flow starts.
+	hostDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.flow'`)
+	const backupURI = "userfile:///exclude-tenant-test"
+	var backupJobID jobspb.JobID
+	hostDB.QueryRow(t,
+		fmt.Sprintf(`BACKUP TENANT 10 INTO '%s' WITH detached`, backupURI),
+	).Scan(&backupJobID)
+	jobutils.WaitForJobToPause(t, hostDB, backupJobID)
+	hostDB.Exec(t, `RESET CLUSTER SETTING jobs.debug.pausepoints`)
+
+	// Wait for the host's span config reconciler to pick up the backup's
+	// PTS record as a system span config. The GC job's descriptor-cleanup
+	// gate reads PTS info from span configs (an async derived view), so
+	// the protection must be visible there before we trigger GC.
+	kvAccessor := tc.Server(0).SpanConfigKVAccessor().(spanconfig.KVAccessor)
+	testutils.SucceedsSoon(t, func() error {
+		configs, err := kvAccessor.GetAllSystemSpanConfigsThatApply(ctx, tenantID)
+		if err != nil {
+			return err
+		}
+		for _, cfg := range configs {
+			for _, pp := range cfg.GCPolicy.ProtectionPolicies {
+				if pp.IgnoreIfExcludedFromBackup {
+					return nil
+				}
+			}
+		}
+		return errors.New("backup PTS not yet reconciled into system span configs")
+	})
+
+	// Drop the table while the backup PTS is held. The tenant can't call
+	// crdb_internal.kv_enqueue_replica itself (host-only), so capture the
+	// range ID from the tenant and drive GC from the host side.
+	var rangeID int
+	tenantDB.QueryRow(t, `SELECT range_id FROM [SHOW RANGES FROM TABLE db.t]`).Scan(&rangeID)
+	tenantDB.Exec(t, `DROP TABLE db.t`)
+
+	// Repeatedly enqueue the range for MVCC GC. Because the span is
+	// excluded, MVCC GC ignores the host's backup PTS and reclaims the
+	// data, advancing the GC threshold past the backup's read timestamp.
+	// This is what causes the resumed backup to hit BatchTimestampBeforeGCError;
+	// the test then verifies that the error carries DataExcludedFromBackup
+	// so the backup processor can swallow it.
+	const enqueueGC = `SELECT crdb_internal.kv_enqueue_replica($1, 'mvccGC', true, true)`
+	deadline := timeutil.Now().Add(10 * time.Second)
+	for timeutil.Now().Before(deadline) {
+		hostDB.Exec(t, enqueueGC, rangeID)
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	hostDB.Exec(t, `RESUME JOB $1`, backupJobID)
+	jobutils.WaitForJobToSucceed(t, hostDB, backupJobID)
 }

--- a/pkg/backup/schedule_pts_chaining_test.go
+++ b/pkg/backup/schedule_pts_chaining_test.go
@@ -15,11 +15,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -523,11 +525,24 @@ func TestScheduleChainingWithDatabaseExpansion(t *testing.T) {
 // TestSchedulePTSChainingExcludeFromBackupDrop tests that a scheduled
 // incremental backup with revision_history succeeds when a table with
 // exclude_data_from_backup=true is dropped between full and incremental.
+//
+// This was the regression test for the backup-side fix in #169087, which
+// taught the backup processor to skip ExportRequests for spans whose
+// descriptors were dropped. The test deliberately sets up the bad state
+// (span config record removed because the descriptor was deleted) to
+// exercise that recovery path. Subsequent changes to the GC job
+// (#169148) prevent that bad state from arising naturally because
+// descriptor cleanup now waits for any covering PTS to be released, and
+// the chained schedule PTS would normally block it. The
+// SkipWaitingForPTSRelease knob is used here to bypass that wait so the
+// test can still set up the original scenario.
 func TestSchedulePTSChainingExcludeFromBackupDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	th, cleanup := newTestHelper(t)
+	th, cleanup := newTestHelper(t, func(knobs *base.TestingKnobs) {
+		knobs.GCJob = &sql.GCJobTestingKnobs{SkipWaitingForPTSRelease: true}
+	})
 	defer cleanup()
 
 	th.sqlDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'`)

--- a/pkg/sql/gcjob/BUILD.bazel
+++ b/pkg/sql/gcjob/BUILD.bazel
@@ -59,7 +59,6 @@ go_test(
     embed = [":gcjob"],
     deps = [
         "//pkg/base",
-        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
@@ -70,7 +69,6 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/spanconfig",
-        "//pkg/sql",
         "//pkg/sql/isql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -394,10 +394,10 @@ func (r schemaChangeGCResumer) deleteDataAndWaitForGC(
 	}
 	persistProgress(ctx, &execCfg, r.job, progress, sql.StatusWaitingForMVCCGC)
 	r.job.MarkIdle(true)
-	return waitForGC(ctx, &execCfg, details, progress)
+	return r.waitForGC(ctx, &execCfg, details, progress)
 }
 
-func waitForGC(
+func (r schemaChangeGCResumer) waitForGC(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	details *jobspb.SchemaChangeGCDetails,
@@ -411,7 +411,7 @@ func waitForGC(
 		)
 	case details.Tables != nil:
 		return errors.Wrap(
-			deleteTableDescriptorsAfterGC(ctx, execCfg, details, progress),
+			deleteTableDescriptorsAfterGC(ctx, execCfg, r.job, details, progress),
 			"attempted to delete table data",
 		)
 	default:

--- a/pkg/sql/gcjob/gc_protected_timestamp_test.go
+++ b/pkg/sql/gcjob/gc_protected_timestamp_test.go
@@ -9,16 +9,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,13 +29,6 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
-		},
-	})
-	defer srv.Stopper().Stop(ctx)
-	execCfg := srv.ExecutorConfig().(sql.ExecutorConfig)
 
 	ts := func(nanos int) hlc.Timestamp {
 		return hlc.Timestamp{
@@ -193,7 +182,8 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					kvAccessor := &manualKVAccessor{}
 					tc.setup(t, kvAccessor)
 					isProtected, err := isProtected(
-						ctx, jobspb.InvalidJobID, tc.droppedAtTime, &execCfg, kvAccessor, scratchRange, sc.scope,
+						ctx, jobspb.InvalidJobID, tc.droppedAtTime,
+						keys.SystemSQLCodec, nil /* knobs */, kvAccessor, scratchRange, sc.scope,
 					)
 					require.NoError(t, err)
 					require.Equal(t, sc.expected, isProtected)

--- a/pkg/sql/gcjob/gc_protected_timestamp_test.go
+++ b/pkg/sql/gcjob/gc_protected_timestamp_test.go
@@ -60,10 +60,11 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name                string
-		setup               func(t *testing.T, kvAccessor *manualKVAccessor)
-		droppedAtTime       int64
-		expectedIsProtected bool
+		name                          string
+		setup                         func(t *testing.T, kvAccessor *manualKVAccessor)
+		droppedAtTime                 int64
+		expectedProtectedForDataGC    bool
+		expectedProtectedForDescClean bool
 	}{
 		{
 			name: "span-config-pts-applies",
@@ -72,8 +73,9 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					makeSpanConfig(10, false /* excludeFromBackup */, false /* ignoreIfExcludedFromBackup */),
 				}
 			},
-			droppedAtTime:       13, // The table/index was dropped after the PTS was laid
-			expectedIsProtected: true,
+			droppedAtTime:                 13, // The table/index was dropped after the PTS was laid
+			expectedProtectedForDataGC:    true,
+			expectedProtectedForDescClean: true,
 		},
 		{
 			name: "span-config-pts-exists-but-does-not-apply",
@@ -82,8 +84,9 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					makeSpanConfig(10, false /* excludeFromBackup */, false /* ignoreIfExcludedFromBackup */),
 				}
 			},
-			droppedAtTime:       8, // The table/index was dropped before the PTS was laid
-			expectedIsProtected: false,
+			droppedAtTime:                 8, // The table/index was dropped before the PTS was laid
+			expectedProtectedForDataGC:    false,
+			expectedProtectedForDescClean: false,
 		},
 		{
 			name: "system-span-config-pts-applies",
@@ -100,10 +103,17 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					makeSpanConfig(7, false /* excludeFromBackup */, false /* ignoreIfExcludedFromBackup */),
 				}
 			},
-			droppedAtTime:       8,
-			expectedIsProtected: true,
+			droppedAtTime:                 8,
+			expectedProtectedForDataGC:    true,
+			expectedProtectedForDescClean: true,
 		},
 		{
+			// In the data-GC scope, the backup PTS is filtered out (the
+			// existing exclude_data_from_backup contract). In the
+			// descriptor-cleanup scope, the same PTS is honored: tearing
+			// down the descriptor would remove the span config record
+			// carrying ExcludeDataFromBackup, breaking the backup
+			// processor's ability to recover from the resulting GC error.
 			name: "system-span-config-pts-is-active-but-excluded-because-of-backup",
 			setup: func(t *testing.T, kvAccessor *manualKVAccessor) {
 				// PTS records on span configs exist, but they were laid after the drop
@@ -120,8 +130,9 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					makeSpanConfig(7, true /* excludeFromBackup */, true /* ignoreIfExcludedFromBackup */),
 				}
 			},
-			droppedAtTime:       8,
-			expectedIsProtected: false,
+			droppedAtTime:                 8,
+			expectedProtectedForDataGC:    false,
+			expectedProtectedForDescClean: true,
 		},
 		{
 			name: "system-span-config-pts-is-active-excluded-from-backup-but-not-ignored",
@@ -140,8 +151,9 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					makeSpanConfig(7, true /* excludeFromBackup */, false /* ignoreIfExcludedFromBackup */),
 				}
 			},
-			droppedAtTime:       8,
-			expectedIsProtected: true,
+			droppedAtTime:                 8,
+			expectedProtectedForDataGC:    true,
+			expectedProtectedForDescClean: true,
 		},
 		{
 			name: "pts-records-exist-but-none-apply",
@@ -159,22 +171,34 @@ func TestProtectedTimestampsPreventGC(t *testing.T) {
 					makeSpanConfig(8, false /* excludeFromBackup */, false /* ignoreIfExcludedFromBackup */),
 				}
 			},
-			droppedAtTime:       2,
-			expectedIsProtected: false,
+			droppedAtTime:                 2,
+			expectedProtectedForDataGC:    false,
+			expectedProtectedForDescClean: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			kvAccessor := &manualKVAccessor{}
-			tc.setup(t, kvAccessor)
 			scratchRange := roachpb.Span{
 				Key:    keys.ScratchRangeMin,
 				EndKey: keys.SystemSpanConfigKeyMax,
 			}
-			isProtected, err := isProtected(
-				ctx, jobspb.InvalidJobID, tc.droppedAtTime, &execCfg, kvAccessor, scratchRange,
-			)
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedIsProtected, isProtected)
+			for _, sc := range []struct {
+				name     string
+				scope    protectionScope
+				expected bool
+			}{
+				{name: "data-GC", scope: protectionScopeForDataGC, expected: tc.expectedProtectedForDataGC},
+				{name: "descriptor-cleanup", scope: protectionScopeForDescriptorCleanup, expected: tc.expectedProtectedForDescClean},
+			} {
+				t.Run(sc.name, func(t *testing.T) {
+					kvAccessor := &manualKVAccessor{}
+					tc.setup(t, kvAccessor)
+					isProtected, err := isProtected(
+						ctx, jobspb.InvalidJobID, tc.droppedAtTime, &execCfg, kvAccessor, scratchRange, sc.scope,
+					)
+					require.NoError(t, err)
+					require.Equal(t, sc.expected, isProtected)
+				})
+			}
 		})
 	}
 }

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -175,6 +175,7 @@ func updateTableStatus(
 			execCfg,
 			execCfg.SpanConfigKVAccessor,
 			sp,
+			protectionScopeForDataGC,
 		)
 		if err != nil {
 			log.Dev.Errorf(ctx, "error checking protection status %v", err)
@@ -241,6 +242,7 @@ func updateIndexesStatus(
 			execCfg,
 			execCfg.SpanConfigKVAccessor,
 			sp,
+			protectionScopeForDataGC,
 		)
 		if err != nil {
 			log.Dev.Errorf(ctx, "error checking protection status %v", err)
@@ -290,8 +292,34 @@ func getTableTTL(defTTL int32, zoneCfg *zonepb.ZoneConfig) int32 {
 	return ttlSeconds
 }
 
+// protectionScope describes which protected timestamp records the caller wants
+// considered when asking whether a span is "protected".
+type protectionScope int
+
+const (
+	// protectionScopeForDataGC mirrors the policy enforced by the KV
+	// subscriber: protected timestamps written by backups are ignored on
+	// spans that are excluded from backup, since the whole point of
+	// exclude_data_from_backup is to let MVCC GC reclaim the data despite
+	// any backup-issued PTS. Use this when deciding whether to advance MVCC
+	// GC over the data.
+	protectionScopeForDataGC protectionScope = iota
+
+	// protectionScopeForDescriptorCleanup considers every protected
+	// timestamp record covering the span, including backup-issued PTSes
+	// with IgnoreIfExcludedFromBackup set. Tearing down the descriptor
+	// (and therefore the span config record carrying ExcludeDataFromBackup)
+	// destroys the very signal that lets the data-GC path ignore the
+	// backup PTS, so we must keep the descriptor around until the PTS is
+	// released.
+	protectionScopeForDescriptorCleanup
+)
+
 // isProtected returns true if the supplied span is considered protected, and
 // thus exempt from GC-ing, given the wall time at which it was dropped.
+//
+// The scope argument determines whether backup PTSes that opt into
+// IgnoreIfExcludedFromBackup are honored; see protectionScope for details.
 //
 // This function is intended for table/index spans -- for spans that cover a
 // secondary tenant's keyspace, checkout `isTenantProtected` instead.
@@ -302,6 +330,7 @@ func isProtected(
 	execCfg *sql.ExecutorConfig,
 	kvAccessor spanconfig.KVAccessor,
 	sp roachpb.Span,
+	scope protectionScope,
 ) (bool, error) {
 	// Wrap this in a closure so we can pass the protection status to the testing
 	// knob.
@@ -328,10 +357,11 @@ func isProtected(
 		collectProtectedTimestamps := func(configs ...roachpb.SpanConfig) {
 			for _, config := range configs {
 				for _, protectionPolicy := range config.GCPolicy.ProtectionPolicies {
-					// We don't consider protected timestamps written by backups if the span
-					// is indicated as "excluded from backup". Checkout the field
-					// descriptions for more details about this coupling.
-					if config.ExcludeDataFromBackup && protectionPolicy.IgnoreIfExcludedFromBackup {
+					// In the data-GC scope, drop protected timestamps written by
+					// backups when the span is excluded from backup. See
+					// protectionScope for the rationale.
+					if scope == protectionScopeForDataGC &&
+						config.ExcludeDataFromBackup && protectionPolicy.IgnoreIfExcludedFromBackup {
 						continue
 					}
 					protectedTimestamps = append(protectedTimestamps, protectionPolicy.ProtectedTimestamp)

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -172,7 +172,8 @@ func updateTableStatus(
 			ctx,
 			jobID,
 			tableDropTimes[t.ID],
-			execCfg,
+			execCfg.Codec,
+			execCfg.GCJobTestingKnobs,
 			execCfg.SpanConfigKVAccessor,
 			sp,
 			protectionScopeForDataGC,
@@ -239,7 +240,8 @@ func updateIndexesStatus(
 			ctx,
 			jobID,
 			indexDropTimes[idxProgress.IndexID],
-			execCfg,
+			execCfg.Codec,
+			execCfg.GCJobTestingKnobs,
 			execCfg.SpanConfigKVAccessor,
 			sp,
 			protectionScopeForDataGC,
@@ -327,7 +329,8 @@ func isProtected(
 	ctx context.Context,
 	jobID jobspb.JobID,
 	droppedAtTime int64,
-	execCfg *sql.ExecutorConfig,
+	codec keys.SQLCodec,
+	knobs *sql.GCJobTestingKnobs,
 	kvAccessor spanconfig.KVAccessor,
 	sp roachpb.Span,
 	scope protectionScope,
@@ -342,7 +345,7 @@ func isProtected(
 			return false, err
 		}
 
-		_, tenID, err := keys.DecodeTenantPrefix(execCfg.Codec.TenantPrefix())
+		_, tenID, err := keys.DecodeTenantPrefix(codec.TenantPrefix())
 		if err != nil {
 			return false, err
 		}
@@ -385,8 +388,10 @@ func isProtected(
 		return false, err
 	}
 
-	if fn := execCfg.GCJobTestingKnobs.RunAfterIsProtectedCheck; fn != nil {
-		fn(jobID, isProtected)
+	if knobs != nil {
+		if fn := knobs.RunAfterIsProtectedCheck; fn != nil {
+			fn(jobID, isProtected)
+		}
 	}
 
 	return isProtected, nil

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -272,9 +273,15 @@ func deleteAllSpanData(
 func deleteTableDescriptorsAfterGC(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
+	job *jobs.Job,
 	details *jobspb.SchemaChangeGCDetails,
 	progress *jobspb.SchemaChangeGCProgress,
 ) error {
+	tableDropTimes := make(map[descpb.ID]int64, len(details.Tables))
+	for _, t := range details.Tables {
+		tableDropTimes[t.ID] = t.DropTime
+	}
+
 	checkImmediatelyOnWait := false
 	for _, droppedTable := range progress.Tables {
 		if droppedTable.Status == jobspb.SchemaChangeGCProgress_CLEARED {
@@ -304,7 +311,11 @@ func deleteTableDescriptorsAfterGC(
 			continue
 		}
 
-		// First, delete all the table data.
+		// First, wait until the data range becomes empty: the GC job laid
+		// down MVCC range tombstones in deleteData, and KV will eventually
+		// compact them away. Removing the descriptor and zone config before
+		// this is observable is what would let span configuration disappear
+		// out from under in-flight readers.
 		if err := waitForEmptyPrefix(
 			ctx, execCfg.DB, &execCfg.Settings.SV,
 			execCfg.GCJobTestingKnobs.SkipWaitingForMVCCGC,
@@ -316,6 +327,25 @@ func deleteTableDescriptorsAfterGC(
 		// Assume that once one of our tables have completed GC, the next table may
 		// also have completed GC.
 		checkImmediatelyOnWait = true
+
+		// Now wait for any protected timestamp record covering the span to
+		// be released. The descriptor (and the span config record derived
+		// from it) carries the ExcludeDataFromBackup flag that the backup
+		// processor relies on when handling BatchTimestampBeforeGCError;
+		// cleaning either up while a PTS is still held would silently
+		// remove that signal. See protectionScope for the broader story.
+		if err := waitForNoProtectionsBeforeDropTime(
+			ctx, execCfg, job.ID(),
+			table.GetID(), tableDropTimes[table.GetID()],
+			table.TableSpan(execCfg.Codec),
+			func() {
+				persistProgress(ctx, execCfg, job, progress,
+					sql.StatusWaitingForProtectedTimestamp)
+			},
+		); err != nil {
+			return errors.Wrapf(err, "waiting for PTS release on table %d", table.GetID())
+		}
+
 		delta, err := spanconfig.Delta(ctx, execCfg.SpanConfigSplitter, table, nil /* uncommitted */)
 		if err != nil {
 			return err
@@ -351,4 +381,62 @@ func deleteTableDescriptorsAfterGC(
 		}
 	}
 	return nil
+}
+
+// waitForNoProtectionsBeforeDropTime polls until no protected timestamp record
+// covers the span at a wall time earlier than droppedAtTime. Backup-issued PTS
+// records that opt into IgnoreIfExcludedFromBackup are honored here even on
+// excluded spans; see protectionScope for the rationale.
+//
+// onWait is invoked exactly once, just before we begin polling, so callers can
+// surface a meaningful job status. Returns immediately if SkipWaitingForPTSRelease
+// is set.
+func waitForNoProtectionsBeforeDropTime(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	jobID jobspb.JobID,
+	descID descpb.ID,
+	droppedAtTime int64,
+	sp roachpb.Span,
+	onWait func(),
+) error {
+	if execCfg.GCJobTestingKnobs.SkipWaitingForPTSRelease {
+		return nil
+	}
+	check := func() (bool, error) {
+		isProtected, err := isProtected(
+			ctx, jobID, droppedAtTime, execCfg, execCfg.SpanConfigKVAccessor, sp,
+			protectionScopeForDescriptorCleanup,
+		)
+		if err != nil {
+			return false, err
+		}
+		if fn := execCfg.GCJobTestingKnobs.RunAfterPTSReleaseCheck; fn != nil {
+			fn(jobID, descID, isProtected)
+		}
+		return !isProtected, nil
+	}
+	if released, err := check(); err != nil || released {
+		return err
+	}
+	if onWait != nil {
+		onWait()
+	}
+	var timer timeutil.Timer
+	defer timer.Stop()
+	for {
+		timer.Reset(EmptySpanPollInterval.Get(&execCfg.Settings.SV))
+		select {
+		case <-timer.C:
+			released, err := check()
+			if err != nil {
+				return err
+			}
+			if released {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -405,8 +405,8 @@ func waitForNoProtectionsBeforeDropTime(
 	}
 	check := func() (bool, error) {
 		isProtected, err := isProtected(
-			ctx, jobID, droppedAtTime, execCfg, execCfg.SpanConfigKVAccessor, sp,
-			protectionScopeForDescriptorCleanup,
+			ctx, jobID, droppedAtTime, execCfg.Codec, execCfg.GCJobTestingKnobs,
+			execCfg.SpanConfigKVAccessor, sp, protectionScopeForDescriptorCleanup,
 		)
 		if err != nil {
 			return false, err

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -108,6 +108,13 @@ const (
 	// StatusWaitingForMVCCGC is used for the GC job when it has cleared
 	// the data but is waiting for MVCC GC to remove the data.
 	StatusWaitingForMVCCGC jobs.StatusMessage = "waiting for MVCC GC"
+	// StatusWaitingForProtectedTimestamp is used for the GC job when it has
+	// observed an empty span but is holding off on deleting the table
+	// descriptor and zone config because a protected timestamp record still
+	// covers the span. Tearing down the descriptor would remove the span
+	// config record carrying ExcludeDataFromBackup, breaking the backup
+	// processor's ability to recover from BatchTimestampBeforeGCError.
+	StatusWaitingForProtectedTimestamp jobs.StatusMessage = "waiting for protected timestamp release"
 	// StatusDeletingData is used for the GC job when it is about
 	// to clear the data.
 	StatusDeletingData jobs.StatusMessage = "deleting data"
@@ -3005,12 +3012,21 @@ type GCJobTestingKnobs struct {
 	// protected timestamp status of a table or an index. The protection status is
 	// passed in along with the jobID.
 	RunAfterIsProtectedCheck func(jobID jobspb.JobID, isProtected bool)
+	// RunAfterPTSReleaseCheck is called after each poll of the
+	// protected-timestamp wait that gates descriptor cleanup. It receives
+	// the descriptor ID being inspected and whether the span is still
+	// protected.
+	RunAfterPTSReleaseCheck func(jobID jobspb.JobID, descID descpb.ID, isProtected bool)
 
 	// Notifier is used to optionally inject a new gcjobnotifier.Notifier.
 	Notifier *gcjobnotifier.Notifier
 
 	// If true, the GC job will not wait for MVCC GC.
 	SkipWaitingForMVCCGC bool
+	// If true, the GC job will not wait for protected timestamp records to
+	// be released before deleting a dropped table's descriptor and zone
+	// config.
+	SkipWaitingForPTSRelease bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/schemachanger/scexec/scmutationexec/table.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/table.go
@@ -64,6 +64,28 @@ func (i *immediateVisitor) ResetTableStorageParam(
 	if err != nil {
 		return err
 	}
+	// When DROP TABLE cascades, every TableStorageParam element transitions
+	// PUBLIC -> ABSENT alongside the parent Table. There is no value in
+	// scrubbing the soon-to-be-deleted descriptor's storage-param fields,
+	// and doing so is actively harmful for some params: clearing
+	// ExcludeDataFromBackup, for example, removes the only signal that
+	// lets the spanconfig reconciler keep the ExcludeDataFromBackup flag
+	// on the span config record, which is what the backup processor reads
+	// (via DataExcludedFromBackup on BatchTimestampBeforeGCError) to
+	// recover from a GC error during the post-drop window.
+	//
+	// This early-return is safe under the existing dep rule "descriptor
+	// dropped before dependent element removal" (see
+	// scplan/internal/rules/current/dep_drop_object.go), which lists
+	// TableStorageParam as a simple dependent and orders its
+	// PUBLIC -> ABSENT transition after the parent Table reaches DROPPED
+	// (i.e. after MarkDescriptorAsDropped has set State=DROP). So when
+	// this visitor runs from a DROP TABLE plan, tbl.Dropped() is
+	// guaranteed to be true; from an ALTER TABLE RESET (param) plan it is
+	// false and the reset proceeds normally.
+	if tbl.Dropped() {
+		return nil
+	}
 	setter := tablestorageparam.NewSetter(tbl, false /* isNewObject */)
 	return setter.ResetToZeroValue(ctx, op.Param.Name)
 }


### PR DESCRIPTION
Fixes #169148.

When a table marked \`exclude_data_from_backup=true\` is dropped while a
backup holds a protected timestamp over its span, the resumed (or
incremental) backup fails with \`BatchTimestampBeforeGCError\` and no
\`DataExcludedFromBackup\` flag, so the backup processor cannot recover.
The bug has two independent layers; both are fixed here.

1. **Schema-changer side.** The declarative schema changer cleared
   \`descriptor.ExcludeDataFromBackup\` as part of DROP TABLE (each
   \`TableStorageParam\` element transitioning PUBLIC → ABSENT emits
   \`ResetTableStorageParam\`, which mutates the soon-to-be-deleted
   descriptor). The spanconfig reconciler then regenerated the span
   config record without the flag, and KV stopped attaching
   \`DataExcludedFromBackup\` to the GC error. This was a regression
   introduced in v26.1 by the migration of storage params to the
   declarative model.

2. **GC-job side.** Even with the descriptor field preserved, the GC
   job freely deleted the descriptor and zone config while a backup
   PTS was still held — both \`KVSubscriber\` and the gcjob's
   \`isProtected\` filter out backup PTSes that opt into
   \`IgnoreIfExcludedFromBackup\` for excluded spans. Removing the
   descriptor took the span config record with it, breaking the same
   recovery path.

The first commit handles (1) by no-oping \`ResetTableStorageParam\`
when the descriptor is already in DROP state. The second commit
factors \`isProtected\` to take a scope parameter (data-GC vs
descriptor-cleanup) so we can express "honor every PTS here, even the
backup-issued ones." The third commit wires the new scope into a wait
in \`deleteTableDescriptorsAfterGC\` and adds a tenant-backup
regression test that exercises both fixes end-to-end.

Epic: none