### PR TITLE
timeutil: remove dead Timer.Read field

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -721,7 +721,6 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 
 		select {
 		case <-ca.aggTimer.C:
-			ca.aggTimer.Read = true
 			ca.aggTimer.Reset(tracingAggTimerInterval)
 			return nil, bulkutil.ConstructTracingAggregatorProducerMeta(ca.Ctx(),
 				ca.FlowCtx.NodeID.SQLInstanceID(), ca.FlowCtx.ID, ca.agg)
@@ -1591,7 +1590,6 @@ func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 
 		select {
 		case <-cf.aggTimer.C:
-			cf.aggTimer.Read = true
 			cf.aggTimer.Reset(1 * time.Second)
 			return nil, bulkutil.ConstructTracingAggregatorProducerMeta(cf.Ctx(),
 				cf.FlowCtx.NodeID.SQLInstanceID(), cf.FlowCtx.ID, cf.agg)

--- a/pkg/gossip/util.go
+++ b/pkg/gossip/util.go
@@ -101,11 +101,11 @@ func batchAndConsume(ch <-chan struct{}, batchDuration time.Duration) {
 	var batchTimer timeutil.Timer
 	defer batchTimer.Stop()
 	batchTimer.Reset(batchDuration)
-	for !batchTimer.Read {
+	for {
 		select {
 		case <-ch: // event happened while we are waiting for our batchTimer to end.
 		case <-batchTimer.C:
-			batchTimer.Read = true
+			return
 		}
 	}
 }

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -437,7 +437,6 @@ func (s *Store) maybeThrottleBatch(
 				res.Release()
 				return batchThrottleCallback{}, errors.Wrap(ctx.Err(), "context ended while throttling bulk read request")
 			case <-timer.C:
-				timer.Read = true
 				ok, delay = obtainTokens()
 			}
 		}

--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -228,7 +228,6 @@ func (s *Sampler) run(ctx context.Context) {
 	for {
 		select {
 		case <-timer.C:
-			timer.Read = true
 			timer.Reset(time.Duration(s.interval.Load()))
 			if Enabled.Get(&s.st.SV) {
 				s.takeSample(ctx)

--- a/pkg/util/timeutil/timer.go
+++ b/pkg/util/timeutil/timer.go
@@ -41,8 +41,7 @@ type Timer struct {
 	timer *time.Timer
 	// C is a local "copy" of timer.C that can be used in a select case before
 	// the timer has been initialized (via Reset).
-	C    <-chan time.Time
-	Read bool
+	C <-chan time.Time
 }
 
 // AsTimerI returns the Timer as a TimerI. This is helpful


### PR DESCRIPTION
The `Read` field on `timeutil.Timer` was the manual-drain workaround for pre-Go 1.23 `time.Timer.Reset` semantics. Commit 26310c1d ("timerutil: remove Read field", April 2025) removed the internal logic that consulted the field and the lint pass that enforced its use, but left the public field on the struct itself and a handful of callers still assigning to it. This change finishes that cleanup.

In `gossip.batchAndConsume`, the `Read` field was load-bearing as the loop predicate; that callsite is converted to return on the timer-fire branch.

Epic: none
Release note: None