### PR TITLE
roachprod/aws: randomize default AZ selection within us-east-2

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -11,6 +11,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"regexp"
@@ -564,6 +565,13 @@ var DefaultConfig = func() (cfg *awsConfig) {
 // https://github.com/cockroachdb/cockroach/issues/105968.
 var defaultZones = []string{
 	"us-east-2a",
+	"us-east-2b",
+	"us-east-2c",
+}
+
+// defaultGeoExtraZones are the additional zones used for geo-distributed
+// clusters, appended to a randomly selected zone from defaultZones.
+var defaultGeoExtraZones = []string{
 	"us-west-2b",
 	"eu-west-2b",
 }
@@ -875,10 +883,11 @@ func (p *Provider) Create(
 }
 
 func DefaultZones(geoDistributed bool) []string {
+	zone := defaultZones[rand.Intn(len(defaultZones))]
 	if geoDistributed {
-		return defaultZones
+		return append([]string{zone}, defaultGeoExtraZones...)
 	}
-	return []string{defaultZones[0]}
+	return []string{zone}
 }
 
 // createInstances creates EC2 instances in parallel with rate limiting.


### PR DESCRIPTION
Previously, non-geo-distributed clusters always used us-east-2a, concentrating all cluster creation requests in a single AZ and causing frequent InsufficientInstanceCapacity errors (~96/day).

Randomize the AZ selection across us-east-2a/b/c (mirroring GCE's existing rand.Shuffle pattern) to spread load. Each cluster still places all nodes in the same AZ.

For geo-distributed clusters, one random us-east-2 AZ is used alongside the existing us-west-2b and eu-west-2b.

Epic: none
Release note: None