### PR TITLE
restore: bulk generate IDs when allocating rewrites

### DIFF
--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -63,6 +63,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -991,16 +992,17 @@ func allocateIDs(
 
 	// First, assign new IDs to objects.
 	// Do this in order to maintain sorting of keys on disk.
-	for _, oldID := range oldIDs {
+	idsToRewrite := util.Filter(oldIDs, func(id descpb.ID) bool {
+		return !descriptorRewrites[id].ToExisting
+	})
+	newID, err := p.ExecCfg().DescIDGenerator.IncrementDescID(ctx, int64(len(idsToRewrite)))
+	if err != nil {
+		return err
+	}
+	for _, oldID := range idsToRewrite {
 		rewrite := descriptorRewrites[oldID]
-		if rewrite.ToExisting {
-			continue
-		}
-		newID, err := p.ExecCfg().DescIDGenerator.GenerateUniqueDescID(ctx)
-		if err != nil {
-			return err
-		}
 		rewrite.ID = newID
+		newID++
 	}
 
 	// Second, iterate through all rewrite objects and update parent IDs

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -487,7 +487,7 @@ type DescIDGenerator interface {
 
 	// IncrementDescID increments the descriptor ID counter by at least inc.
 	// It returns the first ID in the incremented range:
-	// <val> .. <val> + inc  are all available to the caller.
+	// [<val>, <val> + inc) are all available to the caller.
 	IncrementDescID(ctx context.Context, inc int64) (catid.DescID, error)
 }
 


### PR DESCRIPTION
Previously, restore would use `GenerateUniqueDescID` when allocating new IDs for descriptor rewrites. This would perform a KV roundtrip per descriptor ID increment, causing restore planning to hang on clusters with large amounts of descriptors. This commit teaches restore to instead use `IncrementDescID`, which allocates multiple IDs in one roundtrip.

Epic: None

Release note: None