### PR TITLE
sql: prep work for defer optbuild for routine stmts

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3716,7 +3716,6 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 			b.setMutationFlags(s)
 		}
 	}
-
 	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
 	planGen := b.buildRoutinePlanGenerator(
 		udf.Def.Params,
@@ -3728,6 +3727,7 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		false, /* allowOuterWithRefs */
 		nil,   /* wrapRootExpr */
 		0,     /* resultBufferID */
+		nil,   /* bodyBuilder */
 	)
 
 	r := tree.NewTypedRoutineExpr(

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -714,7 +714,8 @@ func (b *Builder) buildExistsSubquery(
 			nil,  /* stmtASTs */
 			true, /* allowOuterWithRefs */
 			wrapRootExpr,
-			0, /* resultBufferID */
+			0,   /* resultBufferID */
+			nil, /* bodyBuilder */
 		)
 		return tree.NewTypedCoalesceExpr(tree.TypedExprs{
 			tree.NewTypedRoutineExpr(
@@ -843,6 +844,7 @@ func (b *Builder) buildSubquery(
 			true, /* allowOuterWithRefs */
 			nil,  /* wrapRootExpr */
 			0,    /* resultBufferID */
+			nil,  /* bodyBuilder */
 		)
 		_, tailCall := b.tailCalls[subquery]
 		return tree.NewTypedRoutineExpr(
@@ -1014,7 +1016,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	// Execution expects there to be more than one body statement if a cursor is
 	// opened or the result of the first statement is directed to a buffer.
 	firstStmtOut := udf.Def.FirstStmtOutput
-	if len(udf.Def.Body) <= 1 &&
+	if udf.Def.Body != nil && len(udf.Def.Body) <= 1 &&
 		(firstStmtOut.CursorDeclaration != nil || firstStmtOut.TargetBufferID != 0) {
 		panic(errors.AssertionFailedf(
 			"expected more than one body statement for a routine that " +
@@ -1039,6 +1041,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		false, /* allowOuterWithRefs */
 		nil,   /* wrapRootExpr */
 		udf.Def.ResultBufferID,
+		nil, /* bodyBuilder */
 	)
 
 	// Enable stepping for volatile functions so that statements within the UDF
@@ -1114,6 +1117,7 @@ func (b *Builder) initRoutineExceptionHandler(
 			false, /* allowOuterWithRefs */
 			nil,   /* wrapRootExpr */
 			0,     /* resultBufferID */
+			nil,   /* bodyBuilder */
 		)
 		// Build a routine with no arguments for the exception handler. The actual
 		// arguments will be supplied when (if) the handler is invoked.
@@ -1165,6 +1169,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 	allowOuterWithRefs bool,
 	wrapRootExpr wrapRootExprFn,
 	resultBufferID memo.RoutineResultBufferID,
+	bodyBuilder memo.RoutineBodyBuilder,
 ) tree.RoutinePlanGenerator {
 	// argOrd returns the ordinal of the argument within the arguments list that
 	// can be substituted for each reference to the given function parameter
@@ -1211,6 +1216,33 @@ func (b *Builder) buildRoutinePlanGenerator(
 		defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
 			log.VEventf(ctx, 1, "%v", caughtErr)
 		})
+
+		// If a BodyBuilder is set, build the routine body now (deferred from
+		// plan time to execution time).
+		if bodyBuilder != nil {
+			if stmts != nil {
+				return errors.AssertionFailedf("routine body already built before BodyBuilder invocation")
+			}
+			var tmpO xform.Optimizer
+			tmpO.Init(ctx, b.evalCtx, b.catalog)
+			builtBody, builtProps, newParams, err := bodyBuilder.Build(
+				ctx, b.semaCtx, b.evalCtx, b.catalog, tmpO.Factory(),
+			)
+			if err != nil {
+				return err
+			}
+			stmts = builtBody
+			stmtProps = builtProps
+			originalMemo = tmpO.Factory().Memo()
+			argOrd = func(col opt.ColumnID) (ord int, ok bool) {
+				for i, param := range newParams {
+					if col == param {
+						return i, true
+					}
+				}
+				return 0, false
+			}
+		}
 
 		dbName := b.evalCtx.SessionData().Database
 		appName := b.evalCtx.SessionData().ApplicationName

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -734,7 +734,8 @@ type UDFDefinition struct {
 	Params opt.ColList
 
 	// Body contains a relational expression for each statement in the function
-	// body. It is unset during construction of a recursive UDF.
+	// body. It is nil during construction of a recursive UDF, and when body
+	// building is deferred to execution time (see BodyBuilder).
 	Body []RelExpr
 
 	// BodyProps contains the physical properties with which each body statement
@@ -777,6 +778,11 @@ type UDFDefinition struct {
 	// results to the same buffer. This is used to implement the PL/pgsql
 	// RETURN NEXT and RETURN QUERY statements.
 	ResultBufferID RoutineResultBufferID
+
+	// BodyBuilder, when non-nil, defers body building to execution time.
+	// When set, Body and BodyProps are nil at plan time; they will be
+	// populated by calling BodyBuilder.Build() at execution time.
+	BodyBuilder RoutineBodyBuilder
 }
 
 // ExceptionBlock contains the information needed to match and handle errors in
@@ -1440,6 +1446,26 @@ type PostQueryBuilder interface {
 		bindingProps *props.Relational,
 		colMap opt.ColMap,
 	) (RelExpr, error)
+}
+
+// RoutineBodyBuilder defers building of SQL routine body statements to
+// execution time. At plan time, the builder captures metadata (parameter
+// types, privilege context, statement tree state). At execution time,
+// Build constructs the body RelExprs in a fresh memo.
+//
+// Like PostQueryBuilder, Build does not mutate captured state; it is
+// safe to call concurrently if the plan is cached and reused.
+//
+// Note: factory is always *norm.Factory; declared as interface{} to
+// avoid circular package dependencies.
+type RoutineBodyBuilder interface {
+	Build(
+		ctx context.Context,
+		semaCtx *tree.SemaContext,
+		evalCtx *eval.Context,
+		catalog cat.Catalog,
+		factory interface{},
+	) (body []RelExpr, bodyProps []*physical.Required, params opt.ColList, err error)
 }
 
 // GroupingOrderType is the grouping column order type for group by and distinct

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1082,30 +1082,40 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 			if len(def.Params) > 0 {
 				f.formatColList(tp, "params:", def.Params, opt.ColSet{} /* notNullCols */)
 			}
-			n := tp.Child("body")
-			for i := range def.Body {
-				stmtNode := n
-				if i == 0 {
-					if def.FirstStmtOutput.CursorDeclaration != nil {
-						// The first statement is opening a cursor.
-						stmtNode = n.Child("open-cursor")
-					} else if def.FirstStmtOutput.TargetBufferID != 0 {
-						// The first statement is writing to a target buffer.
-						stmtNode = n.Child("add-to-srf-result")
+			if def.Body != nil {
+				n := tp.Child("body")
+				for i := range def.Body {
+					stmtNode := n
+					if i == 0 {
+						if def.FirstStmtOutput.CursorDeclaration != nil {
+							// The first statement is opening a cursor.
+							stmtNode = n.Child("open-cursor")
+						} else if def.FirstStmtOutput.TargetBufferID != 0 {
+							// The first statement is writing to a target buffer.
+							stmtNode = n.Child("add-to-srf-result")
+						}
+					}
+					prevTailCalls := f.tailCalls
+
+					// Routine calls in the last body statement may be tail calls if
+					// ResultBufferID is unset. If it is set, the result of the last
+					// body statement is not directly used as the result of the UDF
+					// call, so it cannot contain tail calls.
+					if i == len(def.Body)-1 && def.ResultBufferID == 0 {
+						f.tailCalls = make(map[opt.ScalarExpr]struct{})
+						ExtractTailCalls(def.Body[i], f.tailCalls)
+					}
+					f.formatExpr(def.Body[i], stmtNode)
+					f.tailCalls = prevTailCalls
+				}
+			} else {
+				// Deferred-build routine: body is not yet built. Show ASTs.
+				n := tp.Child("body (deferred)")
+				for i, ast := range def.BodyASTs {
+					if ast != nil {
+						n.Childf("stmt%d: %s", i+1, tree.AsString(ast))
 					}
 				}
-				prevTailCalls := f.tailCalls
-
-				// Routine calls in the last body statement may be tail calls if
-				// ResultBufferID is unset. If it is set, the result of the last body
-				// statement is not directly used as the result of the UDF call, so it
-				// cannot contain tail calls.
-				if i == len(def.Body)-1 && def.ResultBufferID == 0 {
-					f.tailCalls = make(map[opt.ScalarExpr]struct{})
-					ExtractTailCalls(def.Body[i], f.tailCalls)
-				}
-				f.formatExpr(def.Body[i], stmtNode)
-				f.tailCalls = prevTailCalls
 			}
 			delete(f.withinUDFs, def)
 		} else if _, recursive := f.withinUDFs[def]; recursive {

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -379,10 +379,13 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (retErr error) {
 				newDef = &defCopy
 				newRoutineDefs[t.Def] = newDef
 				// Make sure to copy the slice that stores the body statements, rather
-				// than mutating the original.
-				newDef.Body = make([]memo.RelExpr, len(t.Def.Body))
-				for i := range t.Def.Body {
-					newDef.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
+				// than mutating the original. BodyBuilder is immutable and
+				// memo-independent; the struct copy above suffices.
+				if t.Def.Body != nil {
+					newDef.Body = make([]memo.RelExpr, len(t.Def.Body))
+					for i := range t.Def.Body {
+						newDef.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
+					}
 				}
 			}
 			return f.ConstructUDFCall(newArgs, &memo.UDFCallPrivate{Def: newDef})

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -6,24 +6,28 @@
 package optbuilder
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	plpgsql "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
@@ -446,26 +450,18 @@ func (b *Builder) buildRoutine(
 			panic(err)
 		}
 
-		var appendedNullForVoidReturn bool
-		// Add a VALUES (NULL) statement if the return type of the function is
-		// VOID. We cannot simply project NULL from the last statement because
-		// all columns would be pruned and the contents of last statement would
-		// not be executed.
-		// TODO(mgartner): This will add some planning overhead for every
-		// invocation of the function. Is there a more efficient way to do this?
-		if f.ResolvedType().Family() == types.VoidFamily {
-			stmts = append(stmts, statements.Statement[tree.Statement]{
-				AST: &tree.Select{
-					Select: &tree.ValuesClause{
-						Rows: []tree.Exprs{{tree.DNull}},
-					},
-				},
-			})
-			appendedNullForVoidReturn = true
+		// Extract the ASTs for buildSQLRoutineBodyStmts.
+		stmtASTs := make([]tree.Statement, len(stmts))
+		for i := range stmts {
+			stmtASTs[i] = stmts[i].AST
 		}
-		body, bodyProps, bodyTags, bodyASTs = b.buildSQLRoutineBodyStmts(
-			stmts, bodyScope, f, inScope, isSetReturning, oldInsideDataSource, appendedNullForVoidReturn,
+		body, bodyProps, bodyTags = b.buildSQLRoutineBodyStmts(
+			stmtASTs, bodyScope, f.ResolvedType(), f, inScope, isSetReturning,
+			oldInsideDataSource,
 		)
+
+		// Collect the original (pre-VOID-append) ASTs for the UDFDefinition.
+		bodyASTs = stmtASTs
 
 		if b.verboseTracing {
 			bodyStmts = make([]string, len(stmts))
@@ -546,49 +542,91 @@ func (b *Builder) buildRoutine(
 	return routine
 }
 
-// buildSQLRoutineBodyStmts eagerly builds the body statements of a SQL routine
-// into RelExprs. Each statement is built and type-checked against the routine's
-// return type.
+// buildSQLRoutineBodyStmts builds the body statements of a SQL routine into
+// RelExprs. It is used on both the eager path (plan-time) and the deferred path
+// (execution-time), distinguished by funcExpr:
+//
+//   - Eager path (funcExpr != nil): called at plan time from
+//     buildRoutine. The return type may still need finalization (e.g. resolving
+//     AnyTuple for RETURNS RECORD routines), so finalizeRoutineReturnType is
+//     called. funcExpr and inScope are required for this
+//     finalization.
+//
+//   - Deferred path (funcExpr == nil): called at execution time from
+//     sqlRoutineBodyBuilder.Build. The return type (rTyp) was already resolved
+//     and persisted at plan time — AnyTuple and ReturnsRecordType are always
+//     resolved before reaching this path. Only validateReturnType is needed to
+//     confirm that the rebuilt body columns are still compatible.
+//
+// rTyp is the routine's return type on both paths: on the eager path it is
+// funcExpr.ResolvedType(); on the deferred path it is the type captured
+// at plan time. It is always used for the VOID-return check (appending
+// VALUES (NULL)).
 func (b *Builder) buildSQLRoutineBodyStmts(
-	stmts statements.Statements,
+	stmtASTs []tree.Statement,
 	bodyScope *scope,
-	f *tree.FuncExpr,
+	rTyp *types.T,
+	funcExpr *tree.FuncExpr,
 	inScope *scope,
 	isSetReturning bool,
 	insideDataSource bool,
-	appendedNullForVoidReturn bool,
-) (
-	body []memo.RelExpr,
-	bodyProps []*physical.Required,
-	bodyTags []string,
-	bodyASTs []tree.Statement,
-) {
-	body = make([]memo.RelExpr, len(stmts))
-	bodyProps = make([]*physical.Required, len(stmts))
-	bodyTags = make([]string, len(stmts))
-	bodyASTs = make([]tree.Statement, len(stmts))
-	for i := range stmts {
+) (body []memo.RelExpr, bodyProps []*physical.Required, bodyTags []string) {
+	// Add a VALUES (NULL) statement if the return type of the function is
+	// VOID. We cannot simply project NULL from the last statement because
+	// all columns would be pruned and the contents of last statement would
+	// not be executed.
+	// TODO(mgartner): This will add some planning overhead for every
+	// invocation of the function. Is there a more efficient way to do this?
+	var appendedNullForVoidReturn bool
+	if rTyp.Family() == types.VoidFamily {
+		stmtASTs = append(append([]tree.Statement(nil), stmtASTs...), &tree.Select{
+			Select: &tree.ValuesClause{
+				Rows: []tree.Exprs{{tree.DNull}},
+			},
+		})
+		appendedNullForVoidReturn = true
+	}
+
+	body = make([]memo.RelExpr, len(stmtASTs))
+	bodyProps = make([]*physical.Required, len(stmtASTs))
+	bodyTags = make([]string, len(stmtASTs))
+	for i, ast := range stmtASTs {
 		// TODO(michae2): We should be checking the statement hints cache here to
 		// find any external statement hints that could apply to this statement.
-		stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+		stmtScope := b.buildStmtAtRootWithScope(ast, nil /* desiredTypes */, bodyScope)
 
-		// The last statement produces the output of the UDF.
-		if i == len(stmts)-1 {
-			rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, insideDataSource)
+		// The last statement produces the output of the routine.
+		if i == len(stmtASTs)-1 {
+			if funcExpr != nil {
+				// Eager path: finalize the return type. This handles AnyTuple
+				// resolution for RETURNS RECORD routines, column-definition-list
+				// validation for data-source usage, and type annotation on the
+				// FuncExpr. See finalizeRoutineReturnType for details.
+				rTyp = b.finalizeRoutineReturnType(
+					funcExpr, stmtScope, inScope, insideDataSource,
+				)
+			} else {
+				// Deferred path: the return type is already resolved. Just
+				// validate that the rebuilt body columns are compatible.
+				if err := validateReturnType(
+					b.ctx, b.semaCtx, rTyp, stmtScope.cols,
+				); err != nil {
+					panic(err)
+				}
+			}
 			stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, insideDataSource, rTyp)
 		}
 		body[i] = stmtScope.expr
 		bodyProps[i] = stmtScope.makePhysicalProps()
-		bodyASTs[i] = stmts[i].AST
 		// We don't need a statement tag for the artificial appended `SELECT NULL`
 		// statement.
-		if appendedNullForVoidReturn && i == len(stmts)-1 {
+		if appendedNullForVoidReturn && i == len(stmtASTs)-1 {
 			bodyTags[i] = ""
 		} else {
-			bodyTags[i] = stmts[i].AST.StatementTag()
+			bodyTags[i] = ast.StatementTag()
 		}
 	}
-	return body, bodyProps, bodyTags, bodyASTs
+	return body, bodyProps, bodyTags
 }
 
 // finishRoutineReturnStmt manages the output columns for a statement that will
@@ -955,6 +993,87 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 	)
 	outScope.expr = b.factory.ConstructCall(routine, &memo.CallPrivate{})
 	return outScope
+}
+
+// sqlRoutineBodyBuilder implements memo.RoutineBodyBuilder for SQL routines.
+// It captures all metadata needed to build the routine body at execution time
+// instead of plan time.
+type sqlRoutineBodyBuilder struct {
+	stmtASTs         []tree.Statement
+	paramTypes       []*types.T
+	paramNames       []tree.Name
+	rTyp             *types.T
+	isSetReturning   bool
+	insideDataSource bool
+	privilegeUser    string
+	routineType      tree.RoutineType
+	stmtTreeInitFn   func() statementTree
+}
+
+var _ memo.RoutineBodyBuilder = &sqlRoutineBodyBuilder{}
+
+// Build constructs the body RelExprs for a SQL routine in a fresh memo.
+// It is called at execution time, after plan-time metadata has been captured.
+func (rb *sqlRoutineBodyBuilder) Build(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	catalog cat.Catalog,
+	factoryI interface{},
+) (body []memo.RelExpr, bodyProps []*physical.Required, params opt.ColList, retErr error) {
+	// Enact panic handling similar to Builder.Build().
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
+
+	factory := factoryI.(*norm.Factory)
+	b := New(ctx, semaCtx, evalCtx, catalog, factory, nil /* stmt */)
+
+	// Initialize the statement tree from the captured init function.
+	if rb.stmtTreeInitFn != nil {
+		b.stmtTree = rb.stmtTreeInitFn()
+	}
+
+	// Configure the builder for routine body building.
+	b.insideUDF = true
+	b.insideSQLRoutine = true
+	b.trackSchemaDeps = false
+
+	// Builtin routines need access to internal tables.
+	if rb.routineType == tree.BuiltinRoutine {
+		defer b.DisableUnsafeInternalCheck()()
+	}
+
+	// Restore the effective privilege user for SECURITY DEFINER contexts.
+	if rb.privilegeUser != "" {
+		privUser := username.MakeSQLUsernameFromPreNormalizedString(rb.privilegeUser)
+		b.dataSourcePrivilegeUserOverride = privUser
+		b.executePrivilegeUserOverride = privUser
+	}
+
+	// Create body scope with parameter columns.
+	bodyScope := b.allocScope()
+	params = make(opt.ColList, len(rb.paramTypes))
+	for i := range rb.paramTypes {
+		var name tree.Name
+		if i < len(rb.paramNames) {
+			name = rb.paramNames[i]
+		}
+		argColName := funcParamColName(name, i)
+		col := b.synthesizeColumn(
+			bodyScope, argColName, rb.paramTypes[i], nil /* expr */, nil, /* scalar */
+		)
+		col.setParamOrd(i)
+		params[i] = col.id
+	}
+
+	// Build the body statements using the shared helper. Pass
+	// funcExpr=nil to indicate the deferred path (return type is already
+	// resolved).
+	body, bodyProps, _ = b.buildSQLRoutineBodyStmts(
+		rb.stmtASTs, bodyScope, rb.rTyp,
+		nil /* funcExpr */, nil, /* inScope */
+		rb.isSetReturning, rb.insideDataSource,
+	)
+	return body, bodyProps, params, nil
 }
 
 // buildDoBody builds the body of the anonymous routine for a DO statement.

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -463,32 +463,9 @@ func (b *Builder) buildRoutine(
 			})
 			appendedNullForVoidReturn = true
 		}
-		body = make([]memo.RelExpr, len(stmts))
-		bodyProps = make([]*physical.Required, len(stmts))
-		bodyTags = make([]string, len(stmts))
-		bodyASTs = make([]tree.Statement, len(stmts))
-		for i := range stmts {
-			// TODO(michae2): We should be checking the statement hints cache here to
-			// find any external statement hints that could apply to this statement.
-			stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
-
-			// The last statement produces the output of the UDF.
-			if i == len(stmts)-1 {
-				rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
-				stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, oldInsideDataSource, rTyp)
-			}
-			body[i] = stmtScope.expr
-			bodyProps[i] = stmtScope.makePhysicalProps()
-			bodyASTs[i] = stmts[i].AST
-			// We don't need a statement tag for the artificial appended `SELECT NULL`
-			// statement.
-			if appendedNullForVoidReturn && i == len(stmts)-1 {
-				bodyTags[i] = ""
-			} else {
-				bodyTags[i] = stmts[i].AST.StatementTag()
-			}
-
-		}
+		body, bodyProps, bodyTags, bodyASTs = b.buildSQLRoutineBodyStmts(
+			stmts, bodyScope, f, inScope, isSetReturning, oldInsideDataSource, appendedNullForVoidReturn,
+		)
 
 		if b.verboseTracing {
 			bodyStmts = make([]string, len(stmts))
@@ -567,6 +544,51 @@ func (b *Builder) buildRoutine(
 		},
 	)
 	return routine
+}
+
+// buildSQLRoutineBodyStmts eagerly builds the body statements of a SQL routine
+// into RelExprs. Each statement is built and type-checked against the routine's
+// return type.
+func (b *Builder) buildSQLRoutineBodyStmts(
+	stmts statements.Statements,
+	bodyScope *scope,
+	f *tree.FuncExpr,
+	inScope *scope,
+	isSetReturning bool,
+	insideDataSource bool,
+	appendedNullForVoidReturn bool,
+) (
+	body []memo.RelExpr,
+	bodyProps []*physical.Required,
+	bodyTags []string,
+	bodyASTs []tree.Statement,
+) {
+	body = make([]memo.RelExpr, len(stmts))
+	bodyProps = make([]*physical.Required, len(stmts))
+	bodyTags = make([]string, len(stmts))
+	bodyASTs = make([]tree.Statement, len(stmts))
+	for i := range stmts {
+		// TODO(michae2): We should be checking the statement hints cache here to
+		// find any external statement hints that could apply to this statement.
+		stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+
+		// The last statement produces the output of the UDF.
+		if i == len(stmts)-1 {
+			rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, insideDataSource)
+			stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, insideDataSource, rTyp)
+		}
+		body[i] = stmtScope.expr
+		bodyProps[i] = stmtScope.makePhysicalProps()
+		bodyASTs[i] = stmts[i].AST
+		// We don't need a statement tag for the artificial appended `SELECT NULL`
+		// statement.
+		if appendedNullForVoidReturn && i == len(stmts)-1 {
+			bodyTags[i] = ""
+		} else {
+			bodyTags[i] = stmts[i].AST.StatementTag()
+		}
+	}
+	return body, bodyProps, bodyTags, bodyASTs
 }
 
 // finishRoutineReturnStmt manages the output columns for a statement that will

--- a/pkg/sql/opt/optbuilder/statement_tree.go
+++ b/pkg/sql/opt/optbuilder/statement_tree.go
@@ -61,6 +61,17 @@ import (
 // the initialized statement tree. Note that some care must be taken to ensure
 // that the statementTreeNode references remain valid and up-to-date (see the
 // stmts comment below).
+//
+// +--------------------+
+// | Deferred Routines  |
+// +--------------------+
+// Deferred routines are similar to AFTER triggers: their body statements are
+// not built into RelExprs at plan time but deferred to execution time (see
+// RoutineBodyBuilder). Like AFTER triggers, their mutation checks must also
+// be deferred. We use the same mechanism: GetInitFnForDeferredRoutine captures
+// references to the ancestor statementTreeNodes so that the deferred builder
+// can initialize a statement tree that includes all ancestor mutations at
+// build time.
 type statementTree struct {
 	// stmts is a stack of statement nodes, as described in the struct comment.
 	// It is a slice of pointers to ensure that slice appends don't invalidate
@@ -209,11 +220,27 @@ func (st *statementTree) CanMutateTable(
 	return true
 }
 
+// GetInitFnForDeferredRoutine returns a function that can be used to initialize
+// the statement tree for a deferred-build SQL routine. Unlike
+// GetInitFnForPostQuery, this method captures ALL stack levels including the
+// current one, because CTE mutations register at the current level and must be
+// visible to the deferred routine's conflict checks.
+func (st *statementTree) GetInitFnForDeferredRoutine() func() statementTree {
+	return st.getInitFn(st.stmts)
+}
+
 // GetInitFnForPostQuery returns a function that can be used to initialize the
-// statement tree for a post-query that is a child of the current statement.
-// This is necessary because the post-query is not built until after the main
-// statement has finished executing. The returned function may be nil if the
-// statement tree does not need to be initialized for the post-query.
+// statement tree for a post-query of the current statement. This is necessary
+// because the post-query is not built until after the main statement has
+// finished executing. The returned function may be nil if the statement tree
+// does not need to be initialized for the post-query.
+//
+// Unlike GetInitFnForDeferredRoutine, this excludes the current level because
+// post-queries are effectively siblings of the originating statement for
+// conflict-checking purposes — they execute after a sequence point step and
+// don't conflict with the originating statement's mutations. Routine body
+// statements, by contrast, are children that execute within the originating
+// statement and must conflict with its mutations.
 //
 // NOTE: cascades are checked up-front by Builder.checkMultipleMutationsCascade,
 // but the statement tree still must be propagated to them via this function in
@@ -222,26 +249,30 @@ func (st *statementTree) GetInitFnForPostQuery() func() statementTree {
 	if len(st.stmts) <= 1 {
 		return nil
 	}
-	// Save references to the ancestor statementTreeNodes. Modifications to them
-	// after this point should be reflected in the references, ensuring that all
-	// ancestor mutations are visible by the time the post-query plan is built.
-	//
-	// This is necessary because the full set of mutations in the current
-	// statement may not be known at the time the statement tree is saved. For
-	// example, a CTE in which the first branch triggers a post-query, and the
-	// second is a mutation.
-	ancestorStatements := make([]*statementTreeNode, len(st.stmts)-1)
-	copy(ancestorStatements, st.stmts[:len(st.stmts)-1])
+	return st.getInitFn(st.stmts[:len(st.stmts)-1])
+}
+
+// getInitFn returns a function that initializes a new statementTree by
+// flattening the given stack levels into a single ancestor node. The
+// returned function may be nil if levels is empty.
+//
+// References to the statementTreeNodes are captured by pointer, so mutations
+// registered after this call (e.g. by sibling CTEs) are visible when the
+// returned function is invoked.
+//
+// Child mutations are omitted because they can only conflict with ancestor
+// nodes, and those conflicts have already been checked.
+func (st *statementTree) getInitFn(levels []*statementTreeNode) func() statementTree {
+	if len(levels) == 0 {
+		return nil
+	}
+	saved := make([]*statementTreeNode, len(levels))
+	copy(saved, levels)
 	return func() statementTree {
-		// Combine the non-child mutated tables for all ancestor nodes into a single
-		// ancestor node. This provides all the information needed to check for
-		// conflicts in a trigger run as a post-query. We can omit the child
-		// mutation tables because they can only conflict with the ancestor nodes,
-		// and that case has already been checked.
 		var node statementTreeNode
-		for i := range ancestorStatements {
-			node.simpleInsertTables.UnionWith(ancestorStatements[i].simpleInsertTables)
-			node.generalMutationTables.UnionWith(ancestorStatements[i].generalMutationTables)
+		for i := range saved {
+			node.simpleInsertTables.UnionWith(saved[i].simpleInsertTables)
+			node.generalMutationTables.UnionWith(saved[i].generalMutationTables)
 		}
 		return statementTree{stmts: []*statementTreeNode{&node}}
 	}

--- a/pkg/sql/opt/optbuilder/statement_tree_test.go
+++ b/pkg/sql/opt/optbuilder/statement_tree_test.go
@@ -21,6 +21,8 @@ func TestStatementTree(t *testing.T) {
 		post
 		getInit
 		init
+		getInitDeferred
+		initDeferred
 		t1
 		t2
 		fail
@@ -473,7 +475,7 @@ func TestStatementTree(t *testing.T) {
 				pop,
 			},
 		},
-		// 25.
+		// 26.
 		// Original:
 		// Push
 		//     Push
@@ -505,39 +507,13 @@ func TestStatementTree(t *testing.T) {
 				pop,
 			},
 		},
-		// 26.
-		// Original:
-		// Push
-		//     CanMutateTable(t1, default)
-		//     Push
-		//         GetInitFnForPostQuery()
-		//     Pop
-		// Pop
-		//
-		// Post-Query:
-		// initFn()
-		// Push
-		//     CanMutateTable(t1, default) FAIL
-		{
-			cmds: []cmd{
-				push,
-				mut | t1,
-				push,
-				getInit,
-				pop,
-				pop,
-				init,
-				push,
-				mut | t1 | fail,
-			},
-		},
 		// 27.
 		// Original:
 		// Push
+		//     CanMutateTable(t1, default)
 		//     Push
 		//         GetInitFnForPostQuery()
 		//     Pop
-		//     CanMutateTable(t1, default)
 		// Pop
 		//
 		// Post-Query:
@@ -547,10 +523,10 @@ func TestStatementTree(t *testing.T) {
 		{
 			cmds: []cmd{
 				push,
+				mut | t1,
 				push,
 				getInit,
 				pop,
-				mut | t1,
 				pop,
 				init,
 				push,
@@ -558,6 +534,32 @@ func TestStatementTree(t *testing.T) {
 			},
 		},
 		// 28.
+		// Original:
+		// Push
+		//     Push
+		//         GetInitFnForPostQuery()
+		//     Pop
+		//     CanMutateTable(t1, default)
+		// Pop
+		//
+		// Post-Query:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				push,
+				getInit,
+				pop,
+				mut | t1,
+				pop,
+				init,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 29.
 		// Original:
 		// Push
 		//     CanMutateTable(t1, default)
@@ -587,11 +589,308 @@ func TestStatementTree(t *testing.T) {
 				mut | t1 | fail,
 			},
 		},
+		// 30.
+		// Pointer-based capture sees late-arriving mutations.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		//     CanMutateTable(t2, default) <-- added after capture
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t2, default) FAIL <-- visible via pointer
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				mut | t2,
+				pop,
+				initDeferred,
+				push,
+				mut | t2 | fail,
+			},
+		},
+		// 31.
+		// Current-level mutations visible in deferred routine.
+		// e.g. UPDATE t SET x = my_udf() where my_udf body also mutates t.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 32.
+		// Different-table mutations allowed.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t2, default)
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t2,
+				pop,
+			},
+		},
+		// 33.
+		// Nested ancestor mutations visible.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     Push
+		//         GetInitFnForDeferredRoutine()
+		//     Pop
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				push,
+				getInitDeferred,
+				pop,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 34.
+		// Sibling CTE mutations visible via pointer capture.
+		// Original:
+		// Push
+		//     Push
+		//         GetInitFnForDeferredRoutine()
+		//     Pop
+		//     CanMutateTable(t1, default) <-- sibling mutation after capture
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default) FAIL
+		{
+			cmds: []cmd{
+				push,
+				push,
+				getInitDeferred,
+				pop,
+				mut | t1,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | fail,
+			},
+		},
+		// 35.
+		// Child mutations merged via Pop are NOT visible to deferred routine.
+		// The child's mutation is a sibling of the deferred routine (e.g. two
+		// CTEs), so it should not conflict.
+		// e.g. WITH cte1 AS (SELECT my_udf()), cte2 AS (UPDATE t ...) ...
+		// Original:
+		// Push
+		//     GetInitFnForDeferredRoutine()
+		//     Push
+		//         CanMutateTable(t1, default)
+		//     Pop  <-- t1 merges into parent's children*, not simpleInsert/generalMutation
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default)  <-- OK, sibling mutation
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				getInitDeferred,
+				push,
+				mut | t1,
+				pop,
+				pop,
+				initDeferred,
+				push,
+				mut | t1,
+				pop,
+			},
+		},
+		// 36.
+		// simpleInsert+simpleInsert on same table OK.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, simpleInsert)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, simpleInsert)
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				mut | t1 | simple,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | simple,
+				pop,
+			},
+		},
+		// 37.
+		// generalMutation+simpleInsert on same table FAIL.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, simpleInsert) FAIL
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1 | simple | fail,
+			},
+		},
+		// 38.
+		// Empty stack returns nil initFn.
+		//
+		// Deferred Routine:
+		// initFn() == nil => empty statementTree
+		// Push
+		//     CanMutateTable(t1, default)
+		// Pop
+		{
+			cmds: []cmd{
+				getInitDeferred,
+				initDeferred,
+				push,
+				mut | t1,
+				pop,
+			},
+		},
+		// 39.
+		// Sibling body statements within deferred routine don't conflict.
+		// Original:
+		// Push
+		//     CanMutateTable(t1, default)
+		//     GetInitFnForDeferredRoutine()
+		// Pop
+		//
+		// Deferred Routine:
+		// initFn()
+		// Push
+		//     Push
+		//         CanMutateTable(t2, default)
+		//     Pop
+		//     Push
+		//         CanMutateTable(t2, default)
+		//     Pop
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				mut | t1,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				push,
+				mut | t2,
+				pop,
+				push,
+				mut | t2,
+				pop,
+				pop,
+			},
+		},
+		// 40.
+		// Two separate deferred routine invocations mutating the same table.
+		// The deferred routines are siblings, so they should not conflict.
+		// Original:
+		// Push
+		//     GetInitFnForDeferredRoutine()  -- routine 1
+		//     GetInitFnForDeferredRoutine()  -- routine 2
+		// Pop
+		//
+		// Deferred Routine 1:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default)
+		// Pop
+		//
+		// Deferred Routine 2:
+		// initFn()
+		// Push
+		//     CanMutateTable(t1, default)
+		// Pop
+		{
+			cmds: []cmd{
+				push,
+				getInitDeferred,
+				getInitDeferred,
+				pop,
+				initDeferred,
+				push,
+				mut | t1,
+				pop,
+				initDeferred,
+				push,
+				mut | t1,
+				pop,
+			},
+		},
 	}
 
 	for i, tc := range testCases {
 		var mt statementTree
 		var pqTreeFn func() statementTree
+		var deferredTreeFns []func() statementTree
 		for j, c := range tc.cmds {
 			switch {
 			case c&push == push:
@@ -611,6 +910,22 @@ func TestStatementTree(t *testing.T) {
 					mt = statementTree{}
 				} else {
 					mt = pqTreeFn()
+				}
+
+			case c&getInitDeferred == getInitDeferred:
+				deferredTreeFns = append(deferredTreeFns, mt.GetInitFnForDeferredRoutine())
+
+			case c&initDeferred == initDeferred:
+				if len(deferredTreeFns) == 0 {
+					mt = statementTree{}
+				} else {
+					fn := deferredTreeFns[0]
+					deferredTreeFns = deferredTreeFns[1:]
+					if fn == nil {
+						mt = statementTree{}
+					} else {
+						mt = fn()
+					}
 				}
 
 			case c&mut == mut:


### PR DESCRIPTION
This PR is about setting up some preparing work for deferring optbuild for routine body statement. Please see individual commits for details. The main change is the introduction of `sqlRoutineBodyBuilder` and `GetInitFnForDeferredRoutine`, which is inspired by the existing logic for post-queries. 

The actual implementation will be done in #169933.

Informs: https://github.com/cockroachdb/cockroach/issues/167687

Release note: None