### PR TITLE
sql: disable VC injection in TestTemporaryObjectCleaner

### DIFF
--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -155,6 +155,17 @@ func TestTemporaryObjectCleaner(t *testing.T) {
 				UseDatabase: "defaultdb",
 				Knobs:       knobs,
 				Settings:    settings,
+				// With an auto-injected virtual cluster, both the system tenant
+				// and the application layer run a TemporaryObjectCleaner per
+				// pod. They share the TempObjectsCleanupCh testing knob, and
+				// the application-layer cleaners run concurrently with no
+				// coordination — exposing a race where a cleaner with a stale
+				// SQL instance reader cache deletes the still-active session's
+				// temp schema. See #169912 for the underlying production race;
+				// disable VC injection here so this test exercises only the
+				// meta1-leaseholder-gated system tenant path it was written
+				// for.
+				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(169912),
 			},
 		},
 	)


### PR DESCRIPTION
The test wires a shared cleanup channel through the `TempObjectsCleanupCh`
testing knob and sends one trigger per node per cycle, expecting one
completion per node. With an auto-injected virtual cluster, both the
system tenant and the application layer run a `TemporaryObjectCleaner`
per pod and they share the same testing knobs — 6 cleaners listen on
a channel that only delivers 3 triggers per cycle. Worse, the
application-layer cleaners run with no coordination (only the system
tenant is gated on the meta1 leaseholder), and concurrent
application-layer cleaners can race on `ListSessions` when a pod's
SQL instance reader cache is briefly stale, deleting the still-active
session's temp schema.

The race in the application-layer cleanup path is the real bug
exposed by this test; it's tracked separately in #169912 (production
fix work). The test itself was written for the system-tenant
single-cleaner-per-cycle path, so disable VC injection here and let
\#169912 drive the production fix.

Fixes #169663.

Epic: none

Release note: None