### PR TITLE
roachtestutil: surface row iteration error

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -259,6 +259,9 @@ func ClusterVersionFromKV(
 	defer rows.Close()
 
 	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return zero, err
+		}
 		return zero, fmt.Errorf("no version found in system.settings")
 	}
 


### PR DESCRIPTION
Adds a check on row iteration errors.

Fixes: #169310
See: #169924
Epic: none
Release note: None
