### PR TITLE
sql: emit parameter names, modes, and DEFAULTs in pg_get_function_arguments

### DIFF
--- a/pkg/backup/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/backup/testdata/backup-restore/plpgsql_user_defined_functions
@@ -618,8 +618,8 @@ query-sql
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1 public add(int8, int8) admin ALL true
-db1 public add(int8, int8) root ALL true
+db1 public add(x int8, y int8) admin ALL true
+db1 public add(x int8, y int8) root ALL true
 
 exec-sql
 SET ROLE = root
@@ -652,8 +652,8 @@ query-sql cluster=s5
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1 public add(int8, int8) admin ALL true
-db1 public add(int8, int8) root ALL true
+db1 public add(x int8, y int8) admin ALL true
+db1 public add(x int8, y int8) root ALL true
 
 # Backing up and restoring a database with a function resets privileges on
 # functions to the default privileges because we cannot be sure if the same
@@ -694,8 +694,8 @@ query-sql
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1 public add(int8, int8) admin ALL true
-db1 public add(int8, int8) root ALL true
+db1 public add(x int8, y int8) admin ALL true
+db1 public add(x int8, y int8) root ALL true
 
 exec-sql
 SET ROLE = root
@@ -725,6 +725,6 @@ query-sql cluster=s6
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1_new public add(int8, int8) admin ALL true
-db1_new public add(int8, int8) public EXECUTE false
-db1_new public add(int8, int8) root ALL true
+db1_new public add(x int8, y int8) admin ALL true
+db1_new public add(x int8, y int8) public EXECUTE false
+db1_new public add(x int8, y int8) root ALL true

--- a/pkg/backup/testdata/backup-restore/user-defined-functions
+++ b/pkg/backup/testdata/backup-restore/user-defined-functions
@@ -507,8 +507,8 @@ query-sql
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1 public add(int8, int8) admin ALL true
-db1 public add(int8, int8) root ALL true
+db1 public add(x int8, y int8) admin ALL true
+db1 public add(x int8, y int8) root ALL true
 
 exec-sql
 SET ROLE = root
@@ -541,8 +541,8 @@ query-sql cluster=s5
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1 public add(int8, int8) admin ALL true
-db1 public add(int8, int8) root ALL true
+db1 public add(x int8, y int8) admin ALL true
+db1 public add(x int8, y int8) root ALL true
 
 # Backing up and restoring a database with a function resets privileges on
 # functions to the default privileges because we cannot be sure if the same
@@ -583,8 +583,8 @@ query-sql
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1 public add(int8, int8) admin ALL true
-db1 public add(int8, int8) root ALL true
+db1 public add(x int8, y int8) admin ALL true
+db1 public add(x int8, y int8) root ALL true
 
 exec-sql
 SET ROLE = root
@@ -614,6 +614,6 @@ query-sql cluster=s6
 SELECT database_name, schema_name, routine_signature, grantee, privilege_type, is_grantable
 FROM [SHOW GRANTS ON FUNCTION add]
 ----
-db1_new public add(int8, int8) admin ALL true
-db1_new public add(int8, int8) public EXECUTE false
-db1_new public add(int8, int8) root ALL true
+db1_new public add(x int8, y int8) admin ALL true
+db1_new public add(x int8, y int8) public EXECUTE false
+db1_new public add(x int8, y int8) root ALL true

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -2152,7 +2152,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
       AND n.nspname <> 'crdb_internal'
       AND pg_catalog.pg_function_is_visible(p.oid) ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type
-public,myfunc,int8,int8,func
+public,myfunc,int8,val int8,func
 
 cli
 \df abs
@@ -2343,7 +2343,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
       AND n.nspname <> 'crdb_internal'
       AND pg_catalog.pg_function_is_visible(p.oid) ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type
-public,myfunc,int8,int8,func
+public,myfunc,int8,val int8,func
 
 cli
 \dfn+
@@ -2378,7 +2378,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
       AND n.nspname <> 'crdb_internal'
       AND pg_catalog.pg_function_is_visible(p.oid) ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type,Volatility,Owner,Security,Access privileges,Source code,Description
-public,myfunc,int8,int8,func,v,root,invoker,,SELECT val;,NULL
+public,myfunc,int8,val int8,func,v,root,invoker,,SELECT val;,NULL
 
 cli
 \dfwa %tile%

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3051,6 +3051,129 @@ bool
 query error pq: more than one function named 'unnest'
 SELECT pg_get_function_result('unnest'::regproc);
 
+# pg_get_function_arguments / pg_get_function_identity_arguments must include
+# parameter names, modes, and DEFAULT clauses for user-defined routines so the
+# emitted CREATE FUNCTION text is restorable. NULL OIDs return NULL; unknown
+# OIDs likewise return NULL rather than erroring.
+
+query TT
+SELECT pg_get_function_arguments(NULL::oid),
+       pg_get_function_identity_arguments(NULL::oid)
+----
+NULL  NULL
+
+query TT
+SELECT pg_get_function_arguments(0::oid),
+       pg_get_function_identity_arguments(0::oid)
+----
+NULL  NULL
+
+statement ok
+CREATE FUNCTION pgfa_simple(n INT) RETURNS INT LANGUAGE SQL AS 'SELECT n + 1';
+
+statement ok
+CREATE FUNCTION pgfa_anon(INT) RETURNS INT LANGUAGE SQL AS 'SELECT $1 + 1';
+
+statement ok
+CREATE FUNCTION pgfa_default(n INT DEFAULT 5) RETURNS INT LANGUAGE SQL AS 'SELECT n';
+
+statement ok
+CREATE FUNCTION pgfa_two_default(a INT, b INT DEFAULT 10) RETURNS INT LANGUAGE SQL AS 'SELECT a + b';
+
+statement ok
+CREATE FUNCTION pgfa_out(a INT, OUT b INT, OUT c TEXT) LANGUAGE SQL AS $$SELECT 1, 'x'$$;
+
+statement ok
+CREATE FUNCTION pgfa_inout(INOUT a INT) RETURNS INT LANGUAGE SQL AS 'SELECT a';
+
+statement ok
+CREATE PROCEDURE pgfa_psimple(a INT) LANGUAGE SQL AS 'SELECT 1';
+
+statement ok
+CREATE PROCEDURE pgfa_pinout(INOUT a INT) LANGUAGE SQL AS 'SELECT a';
+
+# Cover real-array, same-schema UDT, cross-schema UDT, and array-of-UDT
+# parameter types so the dumped signatures stay restorable.
+statement ok
+CREATE TYPE pgfa_color AS ENUM ('r','g','b');
+
+statement ok
+CREATE SCHEMA pgfa_s;
+
+statement ok
+CREATE TYPE pgfa_s.kind AS ENUM ('x','y');
+
+statement ok
+CREATE FUNCTION pgfa_arr(arrarg INT[]) RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+
+statement ok
+CREATE FUNCTION pgfa_arr_udt(arrarg pgfa_color[]) RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+
+statement ok
+CREATE FUNCTION pgfa_udt(typearg pgfa_color) RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+
+statement ok
+CREATE FUNCTION pgfa_xschema(a pgfa_s.kind) RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+
+query T rowsort
+SELECT proname || ' | ' || pg_get_function_arguments(oid) || ' | ' || pg_get_function_identity_arguments(oid)
+FROM pg_proc WHERE proname LIKE 'pgfa\_%'
+----
+pgfa_anon | int8 | int8
+pgfa_arr | arrarg int8[] | arrarg int8[]
+pgfa_arr_udt | arrarg public.pgfa_color[] | arrarg public.pgfa_color[]
+pgfa_default | n int8 DEFAULT 5 | n int8
+pgfa_inout | INOUT a int8 | INOUT a int8
+pgfa_out | a int8, OUT b int8, OUT c text | a int8, OUT b int8, OUT c text
+pgfa_pinout | INOUT a int8 | INOUT a int8
+pgfa_psimple | IN a int8 | IN a int8
+pgfa_simple | n int8 | n int8
+pgfa_two_default | a int8, b int8 DEFAULT 10 | a int8, b int8
+pgfa_udt | typearg public.pgfa_color | typearg public.pgfa_color
+pgfa_xschema | a pgfa_s.kind | a pgfa_s.kind
+
+statement ok
+DROP FUNCTION pgfa_simple;
+DROP FUNCTION pgfa_anon;
+DROP FUNCTION pgfa_default;
+DROP FUNCTION pgfa_two_default;
+DROP FUNCTION pgfa_out;
+DROP FUNCTION pgfa_inout;
+DROP FUNCTION pgfa_arr;
+DROP FUNCTION pgfa_arr_udt;
+DROP FUNCTION pgfa_udt;
+DROP FUNCTION pgfa_xschema;
+DROP PROCEDURE pgfa_psimple;
+DROP PROCEDURE pgfa_pinout;
+DROP TYPE pgfa_color;
+DROP TYPE pgfa_s.kind;
+DROP SCHEMA pgfa_s;
+
+# Built-in variadic and homogeneous overloads have to fall back to types-only
+# formatting since they do not populate RoutineParams. The prior SQL
+# implementation walked pg_proc.proargtypes regardless of overload kind, so
+# emit the inner type names instead of an empty string here too.
+query T
+SELECT pg_get_function_arguments('concat'::regproc::oid)
+----
+any
+
+query T
+SELECT pg_get_function_arguments(
+  (SELECT oid FROM pg_proc WHERE proname='format' AND pronargs=2))
+----
+text, any
+
+query T
+SELECT pg_get_function_arguments('greatest'::regproc::oid)
+----
+anyelement
+
+query T
+SELECT pg_get_function_arguments('least'::regproc::oid)
+----
+anyelement
+
 query T
 SELECT CASE WHEN true THEN (1, 2) ELSE NULL END
 ----

--- a/pkg/sql/logictest/testdata/logic_test/grant_inherited
+++ b/pkg/sql/logictest/testdata/logic_test/grant_inherited
@@ -30,24 +30,24 @@ GRANT meeter TO granter
 statement ok
 GRANT greeter TO alice WITH ADMIN OPTION
 
-query TTBB colnames,rowsort
-SELECT * FROM "".crdb_internal.kv_inherited_role_members
+query TTBB colnames
+SELECT * FROM [SELECT * FROM "".crdb_internal.kv_inherited_role_members] ORDER BY 1,2,3,4
 ----
 role     inheriting_member  member_is_explicit  member_is_admin
+admin    root               true                true
 granter  alice              true                false
+granter  bob                true                false
+granter  chuck              true                false
+granter  dave               true                false
 greeter  alice              true                true
 meeter   alice              false               false
-granter  bob                true                false
 meeter   bob                false               false
-granter  chuck              true                false
 meeter   chuck              false               false
-granter  dave               true                false
 meeter   dave               false               false
 meeter   granter            true                false
-admin    root               true                true
 
-query TTB colnames,rowsort
-SHOW GRANTS ON ROLE
+query TTB colnames
+SELECT * FROM [SHOW GRANTS ON ROLE] ORDER BY 1,2,3
 ----
 role_name  member   is_admin
 admin      root     true
@@ -61,8 +61,8 @@ meeter     granter  false
 statement ok
 GRANT ALL ON DATABASE defaultdb TO meeter WITH GRANT OPTION
 
-query TTTB colnames,rowsort
-SHOW GRANTS ON DATABASE defaultdb FOR alice
+query TTTB colnames
+SELECT * FROM [SHOW GRANTS ON DATABASE defaultdb FOR alice] ORDER BY 1,2,3,4
 ----
 database_name  grantee  privilege_type  is_grantable
 defaultdb      meeter   ALL             true
@@ -75,8 +75,8 @@ CREATE SCHEMA sc
 statement ok
 GRANT ALL ON SCHEMA sc TO meeter WITH GRANT OPTION
 
-query TTTTB colnames,rowsort
-SHOW GRANTS ON SCHEMA sc FOR alice
+query TTTTB colnames
+SELECT * FROM [SHOW GRANTS ON SCHEMA sc FOR alice] ORDER BY 1,2,3,4,5
 ----
 database_name  schema_name  grantee  privilege_type  is_grantable
 test           sc           meeter   ALL             true
@@ -87,8 +87,8 @@ CREATE SEQUENCE sq
 statement ok
 GRANT ALL ON SEQUENCE sq TO meeter WITH GRANT OPTION
 
-query TTTTTB colnames,rowsort
-SHOW GRANTS ON SEQUENCE sq FOR alice
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON SEQUENCE sq FOR alice] ORDER BY 1,2,3,4,5,6
 ----
 database_name  schema_name  table_name  grantee  privilege_type  is_grantable
 test           public       sq          meeter   ALL             true
@@ -99,8 +99,8 @@ CREATE TABLE tbl (i INT PRIMARY KEY);
 statement ok
 GRANT ALL ON TABLE tbl TO meeter WITH GRANT OPTION
 
-query TTTTTB colnames,rowsort
-SHOW GRANTS ON TABLE tbl FOR alice
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON TABLE tbl FOR alice] ORDER BY 1,2,3,4,5,6
 ----
 database_name  schema_name  table_name  grantee  privilege_type  is_grantable
 test           public       tbl         meeter   ALL             true
@@ -111,8 +111,8 @@ CREATE TYPE typ AS ENUM ('a', 'b')
 statement ok
 GRANT ALL ON TYPE typ TO meeter WITH GRANT OPTION
 
-query TTTTTB colnames,rowsort
-SHOW GRANTS ON TYPE typ FOR alice
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON TYPE typ FOR alice] ORDER BY 1,2,3,4,5,6
 ----
 database_name  schema_name  type_name  grantee  privilege_type  is_grantable
 test           public       typ        meeter   ALL             true
@@ -130,12 +130,12 @@ $$
 statement ok
 GRANT EXECUTE ON FUNCTION fn TO meeter WITH GRANT OPTION
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON FUNCTION fn FOR alice
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON FUNCTION fn FOR alice] ORDER BY 1,2,3,4,5,6,7
 ----
 database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
-test           public       100111      fn(int8)           meeter   EXECUTE         true
-test           public       100111      fn(int8)           public   EXECUTE         false
+test           public       100111      fn(x int8)         meeter   EXECUTE         true
+test           public       100111      fn(x int8)         public   EXECUTE         false
 
 statement ok
 CREATE EXTERNAL CONNECTION conn AS 'nodelocal://1/foo';
@@ -143,8 +143,8 @@ CREATE EXTERNAL CONNECTION conn AS 'nodelocal://1/foo';
 statement ok
 GRANT ALL ON EXTERNAL CONNECTION conn TO meeter WITH GRANT OPTION
 
-query TTTB colnames,rowsort
-SHOW GRANTS ON EXTERNAL CONNECTION conn FOR alice
+query TTTB colnames
+SELECT * FROM [SHOW GRANTS ON EXTERNAL CONNECTION conn FOR alice] ORDER BY 1,2,3,4
 ----
 connection_name  grantee  privilege_type  is_grantable
 conn             meeter   ALL             true
@@ -152,8 +152,8 @@ conn             meeter   ALL             true
 statement ok
 GRANT SYSTEM ALL TO meeter WITH GRANT OPTION
 
-query TTB colnames,rowsort
-SHOW SYSTEM GRANTS FOR alice
+query TTB colnames
+SELECT * FROM [SHOW SYSTEM GRANTS FOR alice] ORDER BY 1,2,3
 ----
 grantee  privilege_type  is_grantable
 meeter   ALL             true
@@ -179,14 +179,14 @@ GRANT USAGE ON SCHEMA test_schema TO public
 statement ok
 GRANT CREATE ON SCHEMA test_schema TO parent
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS FOR child
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS FOR child] ORDER BY 1,2,3,4,5,6,7
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 test           public       NULL         schema       public   CREATE          false
 test           public       NULL         schema       public   USAGE           false
 test           public       _typ         type         public   USAGE           false
-test           public       fn(int8)     routine      public   EXECUTE         false
+test           public       fn(x int8)   routine      public   EXECUTE         false
 test           public       typ          type         public   USAGE           false
 test           test_schema  NULL         schema       parent   CREATE          false
 test           test_schema  NULL         schema       public   USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2888,21 +2888,21 @@ __OID__  pg_proc  __OID__       __OID__   -1      false     c
 
 ## pg_catalog.pg_proc
 
-query TOTOOTTO colnames,rowsort
+query TOTOOFFO colnames,rowsort
 SELECT proname, pronamespace, nspname, proowner, prolang, procost, prorows, provariadic
 FROM pg_catalog.pg_proc p
 JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 WHERE proname='substring'
 ----
 proname    pronamespace  nspname     proowner    prolang  procost  prorows  provariadic
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
-substring  4294967089    pg_catalog  3233629770  12       NULL     NULL     0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
+substring  4294967089    pg_catalog  3233629770  12       1        0        0
 
 query TTBB colnames,rowsort
 SELECT proname, prokind, prosecdef, proleakproof
@@ -2925,14 +2925,14 @@ FROM pg_catalog.pg_proc
 WHERE proname='substring'
 ----
 proname    proisstrict  proretset  provolatile  proparallel
-substring  true         false      i            NULL
-substring  true         false      i            NULL
-substring  true         false      i            NULL
-substring  true         false      i            NULL
-substring  true         false      i            NULL
-substring  true         false      i            NULL
-substring  true         false      i            NULL
-substring  true         false      i            NULL
+substring  true         false      i            u
+substring  true         false      i            u
+substring  true         false      i            u
+substring  true         false      i            u
+substring  true         false      i            u
+substring  true         false      i            u
+substring  true         false      i            u
+substring  true         false      i            u
 
 # Verify that proretset is true for set-returning functions.
 query OTBT

--- a/pkg/sql/logictest/testdata/logic_test/procedure_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_privileges
@@ -25,33 +25,33 @@ NULL     root     test              public           test_priv_p1_100107  test  
 NULL     root     test              public           test_priv_p2_100108  test             public          test_priv_p2  ALL             YES
 NULL     root     test              test_priv_sc1    test_priv_p3_100109  test             test_priv_sc1   test_priv_p3  ALL             YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee  privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin    ALL             true
-test           public         100107      test_priv_p1()      public   EXECUTE         false
-test           public         100107      test_priv_p1()      root     ALL             true
-test           public         100108      test_priv_p2(int8)  admin    ALL             true
-test           public         100108      test_priv_p2(int8)  public   EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root     ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      admin    ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public   EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root     ALL             true
+database_name  schema_name    routine_id  routine_signature      grantee  privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin    ALL             true
+test           public         100107      test_priv_p1()         public   EXECUTE         false
+test           public         100107      test_priv_p1()         root     ALL             true
+test           public         100108      test_priv_p2(IN int8)  admin    ALL             true
+test           public         100108      test_priv_p2(IN int8)  public   EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root     ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         admin    ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public   EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root     ALL             true
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1(), test_priv_p2(INT), test_priv_p3()
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1(), test_priv_p2(INT), test_priv_p3()] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee  privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin    ALL             true
-test           public         100107      test_priv_p1()      public   EXECUTE         false
-test           public         100107      test_priv_p1()      root     ALL             true
-test           public         100108      test_priv_p2(int8)  admin    ALL             true
-test           public         100108      test_priv_p2(int8)  public   EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root     ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      admin    ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public   EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root     ALL             true
+database_name  schema_name    routine_id  routine_signature      grantee  privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin    ALL             true
+test           public         100107      test_priv_p1()         public   EXECUTE         false
+test           public         100107      test_priv_p1()         root     ALL             true
+test           public         100108      test_priv_p2(IN int8)  admin    ALL             true
+test           public         100108      test_priv_p2(IN int8)  public   EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root     ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         admin    ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public   EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root     ALL             true
 
 statement error pgcode 42883 procedure test_priv_p2\(string\) does not exist
 SHOW GRANTS ON PROCEDURE test_priv_p2(STRING)
@@ -102,22 +102,22 @@ NULL     test_user  test              public           test_priv_p1_100107  test
 NULL     test_user  test              public           test_priv_p2_100108  test             public          test_priv_p2  EXECUTE         YES
 NULL     test_user  test              test_priv_sc1    test_priv_p3_100109  test             test_priv_sc1   test_priv_p3  EXECUTE         YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee    privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin      ALL             true
-test           public         100107      test_priv_p1()      public     EXECUTE         false
-test           public         100107      test_priv_p1()      root       ALL             true
-test           public         100107      test_priv_p1()      test_user  EXECUTE         true
-test           public         100108      test_priv_p2(int8)  admin      ALL             true
-test           public         100108      test_priv_p2(int8)  public     EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root       ALL             true
-test           public         100108      test_priv_p2(int8)  test_user  EXECUTE         true
-test           test_priv_sc1  100109      test_priv_p3()      admin      ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public     EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root       ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      test_user  EXECUTE         true
+database_name  schema_name    routine_id  routine_signature      grantee    privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin      ALL             true
+test           public         100107      test_priv_p1()         public     EXECUTE         false
+test           public         100107      test_priv_p1()         root       ALL             true
+test           public         100107      test_priv_p1()         test_user  EXECUTE         true
+test           public         100108      test_priv_p2(IN int8)  admin      ALL             true
+test           public         100108      test_priv_p2(IN int8)  public     EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root       ALL             true
+test           public         100108      test_priv_p2(IN int8)  test_user  EXECUTE         true
+test           test_priv_sc1  100109      test_priv_p3()         admin      ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public     EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root       ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         test_user  EXECUTE         true
 
 statement error pgcode 2BP01 pq: cannot drop role/user test_user: grants still exist on.*
 DROP USER test_user;
@@ -139,22 +139,22 @@ NULL     test_user  test              public           test_priv_p1_100107  test
 NULL     test_user  test              public           test_priv_p2_100108  test             public          test_priv_p2  EXECUTE         NO
 NULL     test_user  test              test_priv_sc1    test_priv_p3_100109  test             test_priv_sc1   test_priv_p3  EXECUTE         NO
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee    privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin      ALL             true
-test           public         100107      test_priv_p1()      public     EXECUTE         false
-test           public         100107      test_priv_p1()      root       ALL             true
-test           public         100107      test_priv_p1()      test_user  EXECUTE         false
-test           public         100108      test_priv_p2(int8)  admin      ALL             true
-test           public         100108      test_priv_p2(int8)  public     EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root       ALL             true
-test           public         100108      test_priv_p2(int8)  test_user  EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      admin      ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public     EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root       ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      test_user  EXECUTE         false
+database_name  schema_name    routine_id  routine_signature      grantee    privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin      ALL             true
+test           public         100107      test_priv_p1()         public     EXECUTE         false
+test           public         100107      test_priv_p1()         root       ALL             true
+test           public         100107      test_priv_p1()         test_user  EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  admin      ALL             true
+test           public         100108      test_priv_p2(IN int8)  public     EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root       ALL             true
+test           public         100108      test_priv_p2(IN int8)  test_user  EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         admin      ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public     EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root       ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         test_user  EXECUTE         false
 
 statement ok
 REVOKE EXECUTE ON PROCEDURE test_priv_p1(), test_priv_p2(int), test_priv_sc1.test_priv_p3 FROM test_user;
@@ -167,19 +167,19 @@ ORDER BY grantee, routine_name;
 ----
 grantor  grantee  specific_catalog  specific_schema  specific_name  routine_catalog  routine_schema  routine_name  privilege_type  is_grantable
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee  privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin    ALL             true
-test           public         100107      test_priv_p1()      public   EXECUTE         false
-test           public         100107      test_priv_p1()      root     ALL             true
-test           public         100108      test_priv_p2(int8)  admin    ALL             true
-test           public         100108      test_priv_p2(int8)  public   EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root     ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      admin    ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public   EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root     ALL             true
+database_name  schema_name    routine_id  routine_signature      grantee  privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin    ALL             true
+test           public         100107      test_priv_p1()         public   EXECUTE         false
+test           public         100107      test_priv_p1()         root     ALL             true
+test           public         100108      test_priv_p2(IN int8)  admin    ALL             true
+test           public         100108      test_priv_p2(IN int8)  public   EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root     ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         admin    ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public   EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root     ALL             true
 
 # Granting on functions should have no effect on procedures.
 statement ok
@@ -207,22 +207,22 @@ NULL     test_user  test              public           test_priv_p1_100107  test
 NULL     test_user  test              public           test_priv_p2_100108  test             public          test_priv_p2  EXECUTE         YES
 NULL     test_user  test              test_priv_sc1    test_priv_p3_100109  test             test_priv_sc1   test_priv_p3  EXECUTE         YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee    privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin      ALL             true
-test           public         100107      test_priv_p1()      public     EXECUTE         false
-test           public         100107      test_priv_p1()      root       ALL             true
-test           public         100107      test_priv_p1()      test_user  EXECUTE         true
-test           public         100108      test_priv_p2(int8)  admin      ALL             true
-test           public         100108      test_priv_p2(int8)  public     EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root       ALL             true
-test           public         100108      test_priv_p2(int8)  test_user  EXECUTE         true
-test           test_priv_sc1  100109      test_priv_p3()      admin      ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public     EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root       ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      test_user  EXECUTE         true
+database_name  schema_name    routine_id  routine_signature      grantee    privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin      ALL             true
+test           public         100107      test_priv_p1()         public     EXECUTE         false
+test           public         100107      test_priv_p1()         root       ALL             true
+test           public         100107      test_priv_p1()         test_user  EXECUTE         true
+test           public         100108      test_priv_p2(IN int8)  admin      ALL             true
+test           public         100108      test_priv_p2(IN int8)  public     EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root       ALL             true
+test           public         100108      test_priv_p2(IN int8)  test_user  EXECUTE         true
+test           test_priv_sc1  100109      test_priv_p3()         admin      ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public     EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root       ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         test_user  EXECUTE         true
 
 # Revoking on functions should have no effect on procedures.
 statement ok
@@ -253,22 +253,22 @@ NULL     test_user  test              public           test_priv_p1_100107  test
 NULL     test_user  test              public           test_priv_p2_100108  test             public          test_priv_p2  EXECUTE         NO
 NULL     test_user  test              test_priv_sc1    test_priv_p3_100109  test             test_priv_sc1   test_priv_p3  EXECUTE         NO
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee    privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin      ALL             true
-test           public         100107      test_priv_p1()      public     EXECUTE         false
-test           public         100107      test_priv_p1()      root       ALL             true
-test           public         100107      test_priv_p1()      test_user  EXECUTE         false
-test           public         100108      test_priv_p2(int8)  admin      ALL             true
-test           public         100108      test_priv_p2(int8)  public     EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root       ALL             true
-test           public         100108      test_priv_p2(int8)  test_user  EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      admin      ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public     EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root       ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      test_user  EXECUTE         false
+database_name  schema_name    routine_id  routine_signature      grantee    privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin      ALL             true
+test           public         100107      test_priv_p1()         public     EXECUTE         false
+test           public         100107      test_priv_p1()         root       ALL             true
+test           public         100107      test_priv_p1()         test_user  EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  admin      ALL             true
+test           public         100108      test_priv_p2(IN int8)  public     EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root       ALL             true
+test           public         100108      test_priv_p2(IN int8)  test_user  EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         admin      ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public     EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root       ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         test_user  EXECUTE         false
 
 # Revoking on functions should have no effect on procedures.
 statement ok
@@ -296,19 +296,19 @@ ORDER BY grantee, routine_name;
 ----
 grantor  grantee  specific_catalog  specific_schema  specific_name  routine_catalog  routine_schema  routine_name  privilege_type  is_grantable
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee  privilege_type  is_grantable
-test           public         100107      test_priv_p1()      admin    ALL             true
-test           public         100107      test_priv_p1()      public   EXECUTE         false
-test           public         100107      test_priv_p1()      root     ALL             true
-test           public         100108      test_priv_p2(int8)  admin    ALL             true
-test           public         100108      test_priv_p2(int8)  public   EXECUTE         false
-test           public         100108      test_priv_p2(int8)  root     ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      admin    ALL             true
-test           test_priv_sc1  100109      test_priv_p3()      public   EXECUTE         false
-test           test_priv_sc1  100109      test_priv_p3()      root     ALL             true
+database_name  schema_name    routine_id  routine_signature      grantee  privilege_type  is_grantable
+test           public         100107      test_priv_p1()         admin    ALL             true
+test           public         100107      test_priv_p1()         public   EXECUTE         false
+test           public         100107      test_priv_p1()         root     ALL             true
+test           public         100108      test_priv_p2(IN int8)  admin    ALL             true
+test           public         100108      test_priv_p2(IN int8)  public   EXECUTE         false
+test           public         100108      test_priv_p2(IN int8)  root     ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         admin    ALL             true
+test           test_priv_sc1  100109      test_priv_p3()         public   EXECUTE         false
+test           test_priv_sc1  100109      test_priv_p3()         root     ALL             true
 
 # Granting on ROUTINES should affect both functions and procedures.
 statement ok
@@ -366,8 +366,8 @@ NULL     admin    test              public           test_priv_p1_100111  test  
 NULL     public   test              public           test_priv_p1_100111  test             public          test_priv_p1  EXECUTE         NO
 NULL     root     test              public           test_priv_p1_100111  test             public          test_priv_p1  ALL             YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1] ORDER BY 1,2,3,4,5,6,7
 ----
 database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
 test           public       100111      test_priv_p1()     admin    ALL             true
@@ -396,21 +396,21 @@ grantor  grantee    specific_catalog  specific_schema  specific_name        rout
 NULL     test_user  test              public           test_priv_p2_100112  test             public          test_priv_p2  EXECUTE         YES
 NULL     test_user  test              test_priv_sc1    test_priv_p3_100113  test             test_priv_sc1   test_priv_p3  EXECUTE         YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee    privilege_type  is_grantable
-test           public         100111      test_priv_p1()      admin      ALL             true
-test           public         100111      test_priv_p1()      public     EXECUTE         false
-test           public         100111      test_priv_p1()      root       ALL             true
-test           public         100112      test_priv_p2(int8)  admin      ALL             true
-test           public         100112      test_priv_p2(int8)  public     EXECUTE         false
-test           public         100112      test_priv_p2(int8)  root       ALL             true
-test           public         100112      test_priv_p2(int8)  test_user  EXECUTE         true
-test           test_priv_sc1  100113      test_priv_p3()      admin      ALL             true
-test           test_priv_sc1  100113      test_priv_p3()      public     EXECUTE         false
-test           test_priv_sc1  100113      test_priv_p3()      root       ALL             true
-test           test_priv_sc1  100113      test_priv_p3()      test_user  EXECUTE         true
+database_name  schema_name    routine_id  routine_signature      grantee    privilege_type  is_grantable
+test           public         100111      test_priv_p1()         admin      ALL             true
+test           public         100111      test_priv_p1()         public     EXECUTE         false
+test           public         100111      test_priv_p1()         root       ALL             true
+test           public         100112      test_priv_p2(IN int8)  admin      ALL             true
+test           public         100112      test_priv_p2(IN int8)  public     EXECUTE         false
+test           public         100112      test_priv_p2(IN int8)  root       ALL             true
+test           public         100112      test_priv_p2(IN int8)  test_user  EXECUTE         true
+test           test_priv_sc1  100113      test_priv_p3()         admin      ALL             true
+test           test_priv_sc1  100113      test_priv_p3()         public     EXECUTE         false
+test           test_priv_sc1  100113      test_priv_p3()         root       ALL             true
+test           test_priv_sc1  100113      test_priv_p3()         test_user  EXECUTE         true
 
 statement ok
 DROP PROCEDURE test_priv_p2;
@@ -426,8 +426,8 @@ NULL     admin    test              public           test_priv_p1_100111  test  
 NULL     public   test              public           test_priv_p1_100111  test             public          test_priv_p1  EXECUTE         NO
 NULL     root     test              public           test_priv_p1_100111  test             public          test_priv_p1  ALL             YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1] ORDER BY 1,2,3,4,5,6,7
 ----
 database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
 test           public       100111      test_priv_p1()     admin    ALL             true
@@ -457,19 +457,19 @@ NULL     root     test              public           test_priv_p1_100111  test  
 NULL     root     test              public           test_priv_p2_100114  test             public          test_priv_p2  ALL             YES
 NULL     root     test              test_priv_sc1    test_priv_p3_100115  test             test_priv_sc1   test_priv_p3  ALL             YES
 
-query TTTTTTB colnames,rowsort
-SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON PROCEDURE test_priv_p1, test_priv_p2, test_priv_p3] ORDER BY 1,2,3,4,5,6,7
 ----
-database_name  schema_name    routine_id  routine_signature   grantee  privilege_type  is_grantable
-test           public         100111      test_priv_p1()      admin    ALL             true
-test           public         100111      test_priv_p1()      public   EXECUTE         false
-test           public         100111      test_priv_p1()      root     ALL             true
-test           public         100114      test_priv_p2(int8)  admin    ALL             true
-test           public         100114      test_priv_p2(int8)  public   EXECUTE         false
-test           public         100114      test_priv_p2(int8)  root     ALL             true
-test           test_priv_sc1  100115      test_priv_p3()      admin    ALL             true
-test           test_priv_sc1  100115      test_priv_p3()      public   EXECUTE         false
-test           test_priv_sc1  100115      test_priv_p3()      root     ALL             true
+database_name  schema_name    routine_id  routine_signature      grantee  privilege_type  is_grantable
+test           public         100111      test_priv_p1()         admin    ALL             true
+test           public         100111      test_priv_p1()         public   EXECUTE         false
+test           public         100111      test_priv_p1()         root     ALL             true
+test           public         100114      test_priv_p2(IN int8)  admin    ALL             true
+test           public         100114      test_priv_p2(IN int8)  public   EXECUTE         false
+test           public         100114      test_priv_p2(IN int8)  root     ALL             true
+test           test_priv_sc1  100115      test_priv_p3()         admin    ALL             true
+test           test_priv_sc1  100115      test_priv_p3()         public   EXECUTE         false
+test           test_priv_sc1  100115      test_priv_p3()         root     ALL             true
 
 # Make sure has_function_privilege works.
 query B
@@ -574,15 +574,15 @@ SELECT * FROM [
   SHOW GRANTS ON PROCEDURE p_test_show_grants(INT), p_test_show_grants(INT, string, OID)
 ] ORDER BY routine_signature, grantee
 ----
-database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100117      p_test_show_grants(int8)             admin               ALL             true
-test           sc_test_show_grants  100117      p_test_show_grants(int8)             public              EXECUTE         false
-test           sc_test_show_grants  100117      p_test_show_grants(int8)             root                ALL             true
-test           sc_test_show_grants  100117      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  admin               ALL             true
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  root                ALL             true
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+database_name  schema_name          routine_id  routine_signature                             grantee             privilege_type  is_grantable
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)                   admin               ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)                   public              EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)                   root                ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)                   u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  admin               ALL             true
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  public              EXECUTE         false
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  root                ALL             true
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  u_test_show_grants  EXECUTE         false
 
 statement error pgcode 42883 pq: procedure p_test_show_grants\(string\) does not exist
 SHOW GRANTS ON PROCEDURE p_test_show_grants(string);
@@ -590,20 +590,20 @@ SHOW GRANTS ON PROCEDURE p_test_show_grants(string);
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS ON PROCEDURE p_test_show_grants(INT)] ORDER BY grantee
 ----
-database_name  schema_name          routine_id  routine_signature         grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100117      p_test_show_grants(int8)  admin               ALL             true
-test           sc_test_show_grants  100117      p_test_show_grants(int8)  public              EXECUTE         false
-test           sc_test_show_grants  100117      p_test_show_grants(int8)  root                ALL             true
-test           sc_test_show_grants  100117      p_test_show_grants(int8)  u_test_show_grants  EXECUTE         false
+database_name  schema_name          routine_id  routine_signature            grantee             privilege_type  is_grantable
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)  admin               ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)  public              EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)  root                ALL             true
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS ON PROCEDURE p_test_show_grants(INT, string, OID)] ORDER BY routine_signature, grantee
 ----
-database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  admin               ALL             true
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  root                ALL             true
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+database_name  schema_name          routine_id  routine_signature                             grantee             privilege_type  is_grantable
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  admin               ALL             true
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  public              EXECUTE         false
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  root                ALL             true
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  u_test_show_grants  EXECUTE         false
 
 # TODO(mgartner): Fix the error message to mention "procedure" or "routine"
 # instead of "function".
@@ -615,26 +615,26 @@ SELECT * FROM [
   SHOW GRANTS ON PROCEDURE p_test_show_grants(INT), p_test_show_grants(INT, string, OID) FOR u_test_show_grants
 ] ORDER BY routine_id
 ----
-database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100117      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100117      p_test_show_grants(int8)             public              EXECUTE         false
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
-test           sc_test_show_grants  100118      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+database_name  schema_name          routine_id  routine_signature                             grantee             privilege_type  is_grantable
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)                   u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(IN int8)                   public              EXECUTE         false
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  public              EXECUTE         false
+test           sc_test_show_grants  100118      p_test_show_grants(IN int8, IN text, IN oid)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS FOR u_test_show_grants] ORDER BY object_name
 ----
-database_name  schema_name          object_name                          object_type  grantee             privilege_type  is_grantable
-test           public               NULL                                 schema       public              CREATE          false
-test           public               NULL                                 schema       public              USAGE           false
-test           sc_test_show_grants  p_test_show_grants(int8)             routine      public              EXECUTE         false
-test           sc_test_show_grants  p_test_show_grants(int8)             routine      u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  p_test_show_grants(int8, text, oid)  routine      u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  p_test_show_grants(int8, text, oid)  routine      public              EXECUTE         false
-test           sc_test_show_grants  test_priv_f()                        routine      public              EXECUTE         false
-test           public               test_priv_p1()                       routine      public              EXECUTE         false
-test           public               test_priv_p2(int8)                   routine      public              EXECUTE         false
-test           test_priv_sc1        test_priv_p3()                       routine      public              EXECUTE         false
+database_name  schema_name          object_name                                   object_type  grantee             privilege_type  is_grantable
+test           public               NULL                                          schema       public              CREATE          false
+test           public               NULL                                          schema       public              USAGE           false
+test           sc_test_show_grants  p_test_show_grants(IN int8)                   routine      public              EXECUTE         false
+test           sc_test_show_grants  p_test_show_grants(IN int8)                   routine      u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  p_test_show_grants(IN int8, IN text, IN oid)  routine      u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  p_test_show_grants(IN int8, IN text, IN oid)  routine      public              EXECUTE         false
+test           sc_test_show_grants  test_priv_f()                                 routine      public              EXECUTE         false
+test           public               test_priv_p1()                                routine      public              EXECUTE         false
+test           public               test_priv_p2(IN int8)                         routine      public              EXECUTE         false
+test           test_priv_sc1        test_priv_p3()                                routine      public              EXECUTE         false
 
 statement ok
 SET search_path = public;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3423,17 +3423,17 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 			nspOid,                                   // pronamespace
 			nodeOID,                                  // proowner
 			languageInternalOid,                      // prolang
-			tree.DNull,                               // procost
-			tree.DNull,                               // prorows
+			tree.NewDFloat(1),                        // procost
+			defaultProrows(isRetSet),                 // prorows
 			variadicType,                             // provariadic
-			tree.DNull,                               // prosupport
+			regprocZero,                              // prosupport
 			kind,                                     // prokind
 			tree.DBoolFalse,                          // prosecdef
 			tree.MakeDBool(tree.DBool(proleakproof)), // proleakproof
 			tree.MakeDBool(tree.DBool(proisstrict)),  // proisstrict
 			tree.MakeDBool(tree.DBool(isRetSet)),     // proretset
 			tree.NewDString(provolatile),             // provolatile
-			tree.DNull,                               // proparallel
+			proParallelUnsafe,                        // proparallel
 			tree.NewDInt(tree.DInt(builtin.Types.Length())), // pronargs
 			tree.NewDInt(tree.DInt(0)),                      // pronargdefaults
 			retType,                                         // prorettype
@@ -3461,7 +3461,28 @@ var (
 	proArgModeOut      = tree.NewDString("o")
 	proArgModeInOut    = tree.NewDString("b")
 	proArgModeVariadic = tree.NewDString("v")
+
+	// proParallelUnsafe is the value of pg_proc.proparallel for functions whose
+	// parallel-safety is unknown or not modeled. CockroachDB does not track
+	// PostgreSQL-style parallel safety on routines, so every function reports
+	// "unsafe", which is the most conservative choice.
+	proParallelUnsafe = tree.NewDString("u")
+
+	// regprocZero is the regproc-typed equivalent of OID 0. It renders as "-",
+	// the conventional placeholder for "no function" in pg_proc columns like
+	// prosupport.
+	regprocZero = tree.NewDOidWithType(0, types.RegProc)
 )
+
+// defaultProrows returns the value pg_proc.prorows uses when CockroachDB has no
+// estimate of its own. It mirrors the PostgreSQL defaults: 1000 for set-returning
+// routines, 0 otherwise.
+func defaultProrows(isRetSet bool) tree.Datum {
+	if isRetSet {
+		return tree.NewDFloat(1000)
+	}
+	return tree.NewDFloat(0)
+}
 
 func addPgProcUDFRow(
 	h oidHasher,
@@ -3563,18 +3584,18 @@ func addPgProcUDFRow(
 		tree.NewDName(fnDesc.GetName()),                 // proname
 		schemaOid(scDesc.GetID()),                       // pronamespace
 		h.UserOid(fnDesc.GetPrivileges().Owner()),       // proowner
-		lang,            // prolang
-		tree.DNull,      // procost
-		tree.DNull,      // prorows
+		lang,                // prolang
+		tree.NewDFloat(100), // procost
+		defaultProrows(fnDesc.GetReturnType().ReturnSet), // prorows
 		oidZero,         // provariadic // TODO(88947): this might need an adjustment.
-		tree.DNull,      // prosupport
+		regprocZero,     // prosupport
 		kind,            // prokind
 		tree.DBoolFalse, // prosecdef
 		tree.MakeDBool(tree.DBool(fnDesc.GetLeakProof())),                                    // proleakproof
 		tree.MakeDBool(fnDesc.GetNullInputBehavior() != catpb.Function_CALLED_ON_NULL_INPUT), // proisstrict
 		tree.MakeDBool(tree.DBool(fnDesc.GetReturnType().ReturnSet)),                         // proretset
 		tree.NewDString(funcVolatility(fnDesc.GetVolatility())),                              // provolatile
-		tree.DNull,                                      // proparallel
+		proParallelUnsafe,                               // proparallel
 		tree.NewDInt(tree.DInt(nArgs)),                  // pronargs
 		tree.NewDInt(tree.DInt(nArgDefaults)),           // pronargdefaults
 		tree.NewDOid(fnDesc.GetReturnType().Type.Oid()), // prorettype

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -637,18 +637,155 @@ func makeToRegOverload(typ *types.T, helpText string) builtinDefinition {
 	)
 }
 
-// Format the array {type,othertype} as type, othertype.
-// If there are no args, output the empty string.
-const getFunctionArgStringQuery = `
-SELECT COALESCE(
-    (SELECT trim('{}' FROM replace(
-        (
-            SELECT array_agg(unnested::REGTYPE::TEXT)
-            FROM unnest(proargtypes) AS unnested
-        )::TEXT, ',', ', '))
-    ), '')
-FROM pg_catalog.pg_proc WHERE oid=$1 GROUP BY oid, proargtypes LIMIT 1
-`
+// formatFunctionArguments returns the comma-separated CREATE FUNCTION argument
+// list for the given OID, matching PostgreSQL's pg_get_function_arguments and
+// pg_get_function_identity_arguments. When printDefaults is false, DEFAULT
+// clauses are omitted (the identity-arguments form). The returned datum is
+// tree.DNull for OIDs that do not resolve to a function — pg_dump and other
+// catalog readers expect NULL rather than an error in that case.
+func formatFunctionArguments(
+	ctx context.Context, evalCtx *eval.Context, funcOID oid.Oid, printDefaults bool,
+) (tree.Datum, error) {
+	_, overload, err := evalCtx.Planner.ResolveFunctionByOID(ctx, funcOID)
+	if err != nil {
+		if errors.Is(err, tree.ErrRoutineUndefined) {
+			return tree.DNull, nil
+		}
+		return nil, err
+	}
+
+	// Built-in overloads do not populate RoutineParams; their parameters live
+	// on overload.Types. Built-ins also have no parameter names, modes, or
+	// DEFAULTs to render, so fall back to a types-only formatting helper.
+	if len(overload.RoutineParams) == 0 {
+		return formatBuiltinArguments(overload), nil
+	}
+
+	isProcedure := overload.Type == tree.ProcedureRoutine
+	var sb strings.Builder
+	for i := range overload.RoutineParams {
+		p := &overload.RoutineParams[i]
+		// TODO(#88947): when CRDB models RETURNS TABLE columns separately from
+		// regular OUT params, skip them here so they aren't emitted in the
+		// arguments list.
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		// Mode prefix. Procedures show every mode (including IN) so that the
+		// dumped signature is unambiguous when used with DROP/ALTER PROCEDURE.
+		// Functions hide the implicit IN mode and only emit the non-IN ones.
+		switch p.Class {
+		case tree.RoutineParamDefault, tree.RoutineParamIn:
+			if isProcedure {
+				sb.WriteString("IN ")
+			}
+		case tree.RoutineParamOut:
+			sb.WriteString("OUT ")
+		case tree.RoutineParamInOut:
+			sb.WriteString("INOUT ")
+		case tree.RoutineParamVariadic:
+			sb.WriteString("VARIADIC ")
+		}
+		if p.Name != "" {
+			sb.WriteString(p.Name.String())
+			sb.WriteString(" ")
+		}
+		sb.WriteString(typeReferencePGName(p.Type))
+		if printDefaults && p.IsInParam() && p.DefaultVal != nil {
+			// DefaultExpr is stored on the descriptor via tree.Serialize, which
+			// adds type-disambiguation annotations like 5:::INT8 as syntactic
+			// AnnotateTypeExpr nodes. Those nodes survive re-parsing and are
+			// not controlled by format flags, so strip them by walking the
+			// expression tree before formatting.
+			sb.WriteString(" DEFAULT ")
+			stripped, _ := tree.WalkExpr(stripTypeAnnotations{}, p.DefaultVal)
+			sb.WriteString(tree.AsString(stripped))
+		}
+	}
+	return tree.NewDString(sb.String()), nil
+}
+
+// formatBuiltinArguments returns the comma-separated input-argument types of
+// a built-in overload. It handles each TypeList kind that built-ins use:
+// fixed-arity (ParamTypes), variadic (VariadicType, e.g. concat, format), and
+// homogeneous (HomogeneousType, e.g. greatest, least).
+func formatBuiltinArguments(overload *tree.Overload) tree.Datum {
+	var sb strings.Builder
+	switch t := overload.Types.(type) {
+	case tree.ParamTypes:
+		for i := range t {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(t[i].Typ.PGName())
+		}
+	case tree.VariadicType:
+		for i, ft := range t.FixedTypes {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(ft.PGName())
+		}
+		if len(t.FixedTypes) > 0 {
+			sb.WriteString(", ")
+		}
+		// Built-ins do not populate pg_proc.proargmodes, so the rendered
+		// signature does not include the VARIADIC keyword either — keeping the
+		// argument list consistent with the proargtypes-only metadata that
+		// callers see for built-ins.
+		sb.WriteString(t.VarType.PGName())
+	case tree.HomogeneousType:
+		sb.WriteString(types.AnyElement.PGName())
+	}
+	return tree.NewDString(sb.String())
+}
+
+// typeReferencePGName renders a parameter type using PostgreSQL-compatible
+// names (e.g. "bytea" instead of "BYTES", "int8" instead of "INT8" — CRDB and
+// PG happen to share most non-string OIDs). User-defined types are
+// schema-qualified, and real arrays render as `<elem>[]` rather than the
+// pg_type internal name `_<elem>` so the output is parseable as a CREATE
+// FUNCTION argument list. For unresolved or OID-based references we fall back
+// to the standard SQLString form.
+func typeReferencePGName(ref tree.ResolvableTypeReference) string {
+	t, ok := ref.(*types.T)
+	if !ok {
+		return ref.SQLString()
+	}
+	// UDTs (enums, composites, domains) need schema qualification so the
+	// dumped signature resolves when restored under a different search_path.
+	// SQLString uses FQName(explicitCatalog=false), matching PG's
+	// format_type_be_qualified output.
+	if t.UserDefined() {
+		return t.SQLString()
+	}
+	// Real arrays render as `<elem>[]`. anyarray, int2vector, and oidvector
+	// have distinct OIDs that PG also exposes by name (not as arrays of
+	// something), so leave those alone.
+	if t.Family() == types.ArrayFamily {
+		switch t.Oid() {
+		case oid.T_anyarray, oid.T_int2vector, oid.T_oidvector:
+			return t.PGName()
+		}
+		return typeReferencePGName(t.ArrayContents()) + "[]"
+	}
+	return t.PGName()
+}
+
+// stripTypeAnnotations is a tree.Visitor that unwraps *tree.AnnotateTypeExpr
+// nodes, replacing each with its inner expression. It is used to drop the
+// CRDB-specific 5:::INT8 disambiguation suffixes from default-value text so
+// the rendered DEFAULT clause is plain SQL.
+type stripTypeAnnotations struct{}
+
+func (stripTypeAnnotations) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
+	if a, ok := expr.(*tree.AnnotateTypeExpr); ok {
+		return true, a.Expr
+	}
+	return true, expr
+}
+
+func (stripTypeAnnotations) VisitPost(expr tree.Expr) tree.Expr { return expr }
 
 var pgBuiltins = map[string]builtinDefinition{
 	// See https://www.postgresql.org/docs/9.6/static/functions-info.html.
@@ -811,12 +948,17 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Body:       getFunctionArgStringQuery,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
+				o := tree.MustBeDOid(args[0])
+				return formatFunctionArguments(ctx, evalCtx, o.Oid, true /* printDefaults */)
+			},
 			Info: "Returns the argument list (with defaults) necessary to identify a function, " +
 				"in the form it would need to appear in within CREATE FUNCTION.",
 			Volatility:        volatility.Stable,
 			CalledOnNullInput: true,
-			Language:          tree.RoutineLangSQL,
 		},
 	),
 
@@ -900,12 +1042,17 @@ FROM defaults_parsed
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Body:       getFunctionArgStringQuery,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
+				o := tree.MustBeDOid(args[0])
+				return formatFunctionArguments(ctx, evalCtx, o.Oid, false /* printDefaults */)
+			},
 			Info: "Returns the argument list (without defaults) necessary to identify a function, " +
 				"in the form it would need to appear in within ALTER FUNCTION, for instance.",
 			Volatility:        volatility.Stable,
 			CalledOnNullInput: true,
-			Language:          tree.RoutineLangSQL,
 		},
 	),
 


### PR DESCRIPTION

pg_get_function_arguments and pg_get_function_identity_arguments were
backed by a single SQL body that emitted only the input argument types
from pg_proc.proargtypes, dropping parameter names, modes, and DEFAULT
clauses. As a result, pg_dump produced unrestorable CREATE FUNCTION
text — for example, a UDF declared as add_one(n INT) was dumped as
`CREATE FUNCTION add_one(int8) ... AS 'SELECT n + 1'`, and the body's
reference to `n` failed to resolve on restore.

Replace both builtins with a Go implementation modeled on PostgreSQL's
print_function_arguments. It walks Overload.RoutineParams and, for each
parameter, emits `[mode ]?[name ]?type[ DEFAULT expr]?`. Functions hide
the implicit IN mode while procedures show every mode (so the dumped
signature is unambiguous against DROP/ALTER PROCEDURE). DEFAULT
expressions are stored on the descriptor with type-disambiguation
annotations like 5:::INT8 (real AnnotateTypeExpr nodes that survive
re-parsing); a small visitor strips them before formatting so the
rendered DEFAULT clause is plain SQL.

Built-in overloads, which do not populate RoutineParams, fall back to
types-only formatting so existing callers see the same output they did
before.

Resolves: #169919
Epic: CRDB-62553

Release note (bug fix): pg_get_function_arguments and
pg_get_function_identity_arguments now include parameter names, modes
(OUT/INOUT/VARIADIC), and DEFAULT clauses for user-defined routines,
matching PostgreSQL. Previously they returned only the comma-separated
input argument types.
