### PR TITLE
kvcoord: fix TestProxyTracing flake by forcing lease queue on all stores

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4398,8 +4398,10 @@ func TestProxyTracing(t *testing.T) {
 
 		checkLeaseCount := func(node, expectedLeaseCount int) error {
 			if count := leaseCount(node); count != expectedLeaseCount {
-				require.NoError(t, tc.GetFirstStoreFromServer(t, 0).
-					ForceLeaseQueueProcess())
+				for i := 0; i < tc.NumServers(); i++ {
+					require.NoError(t, tc.GetFirstStoreFromServer(t, i).
+						ForceLeaseQueueProcess())
+				}
 				return errors.Errorf("expected %d leases on node %d, found %d",
 					expectedLeaseCount, node, count)
 			}


### PR DESCRIPTION
Previously, `checkLeaseCount` only forced the lease queue on store 0
(n1). This worked most of the time because n1 typically held all the
table range leases when the SucceedsSoon loop started. But if n1's lease
queue raced ahead of the SPLIT AT and transferred the lease to n2 before
the splits executed, n2 would process the splits and the new ranges
would inherit their lease on n2. At that point, forcing n1's lease queue
had no effect on those ranges, and n2's natural lease queue processing
could be too slow to transfer them to n3 within the 45s timeout.

Now, the lease queue is forced on all stores so that regardless of where
split-created ranges inherited their lease, the queue will actively
satisfy the lease preferences.

Fixes: #169841

Release note: None
Epic: none