### PR TITLE
release-26.2: workload/rand: shard test target

### DIFF
--- a/pkg/workload/rand/BUILD.bazel
+++ b/pkg/workload/rand/BUILD.bazel
@@ -29,7 +29,7 @@ go_library(
 
 go_test(
     name = "rand_test",
-    size = "small",
+    size = "large",
     srcs = [
         "diff_test.go",
         "rand_test.go",
@@ -37,6 +37,7 @@ go_test(
     ],
     data = ["//c-deps:libgeos"],
     embed = [":rand"],
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/crosscluster/ldrrandgen",


### PR DESCRIPTION
Backport 1/1 commits from #169449 on behalf of @aerfrei.

----

Previously we saw timeouts of the test TestRandRun. Since these
tests run with a small-size timeout, they were particularly sensitive
to this test's variation in how long it ran, including causing
other tests to time out.

Now, these tests get 4 shards and large size.

Fixes: https://github.com/cockroachdb/cockroach/issues/166863
Fixes: https://github.com/cockroachdb/cockroach/issues/169390
Epic: none

Release note: None

----

Release justification: Test only.