### PR TITLE
sql: synthesize NOT NULL rows in pg_constraint

### DIFF
--- a/pkg/backup/testdata/backup-restore/file_table_read_write
+++ b/pkg/backup/testdata/backup-restore/file_table_read_write
@@ -38,6 +38,8 @@ WHERE rel.relname='userfiles_$user_upload_payload'
 ORDER BY conname;
 ----
 file_id_fk
+userfiles_$user_upload_payload_byte_offset_not_null
+userfiles_$user_upload_payload_file_id_not_null
 userfiles_$user_upload_payload_pkey
 
 subtest end

--- a/pkg/cli/clisqlexec/run_query_test.go
+++ b/pkg/cli/clisqlexec/run_query_test.go
@@ -215,10 +215,11 @@ ALTER TABLE test_utf.żółw ADD CONSTRAINT żó UNIQUE (value)`)); err != nil {
 	}
 	expected = `
   table_name | constraint_name
--------------+------------------
+-------------+-------------------
   żółw       | żó
+  żółw       | żółw_id_not_null
   żółw       | żółw_pkey
-(2 rows)
+(3 rows)
 `
 	if a, e := b.String(), expected[1:]; a != e {
 		t.Errorf("expected output:\n%s\ngot:\n%s", e, a)

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -251,6 +251,7 @@ func (d *delegator) delegateShowConstraints(n *tree.ShowConstraints) (tree.State
            WHEN 'u' THEN 'UNIQUE'
            WHEN 'c' THEN 'CHECK'
            WHEN 'f' THEN 'FOREIGN KEY'
+           WHEN 'n' THEN 'NOT NULL'
            ELSE c.contype::TEXT
         END AS constraint_type,
         c.condef AS details,

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -6389,7 +6389,10 @@ CREATE TABLE t (
 			{"1", "1"}, {"2", "2"}, {"3", "3"},
 		})
 		sqlDB.CheckQueryResults(t, `SELECT constraint_name, validated from [SHOW CONSTRAINTS FROM t] ORDER BY 1;`, [][]string{
-			{"check_crdb_internal_x_shard_16", "true"}, {"t_pkey", "true"},
+			{"check_crdb_internal_x_shard_16", "true"},
+			{"t_crdb_internal_x_shard_16_not_null", "true"},
+			{"t_pkey", "true"},
+			{"t_rowid_not_null", "true"},
 		})
 	})
 }

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -112,6 +112,7 @@ SHOW CONSTRAINTS FROM t
 table_name  constraint_name  constraint_type  details                              validated
 t           check_a          CHECK            CHECK ((a > 0))                      true
 t           foo              UNIQUE           UNIQUE (b ASC)                       true
+t           t_a_not_null     NOT NULL         NOT NULL                             true
 t           t_f_fkey         FOREIGN KEY      FOREIGN KEY (f) REFERENCES other(b)  true
 t           t_pkey           PRIMARY KEY      PRIMARY KEY (a ASC)                  true
 
@@ -139,10 +140,11 @@ INSERT INTO t (a) VALUES (-3)
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK        CHECK ((a > 0))                      true
-t  foo       UNIQUE       UNIQUE (b ASC)                       true
-t  t_f_fkey  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
-t  t_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)                  true
+t  check_a       CHECK        CHECK ((a > 0))                      true
+t  foo           UNIQUE       UNIQUE (b ASC)                       true
+t  t_a_not_null  NOT NULL     NOT NULL                             true
+t  t_f_fkey      FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
+t  t_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
 statement error duplicate constraint name
 ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
@@ -168,11 +170,12 @@ ALTER TABLE t ADD CHECK (a > 0)
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK        CHECK ((a > 0))                      true
-t  check_a1  CHECK        CHECK ((a > 0))                      true
-t  foo       UNIQUE       UNIQUE (b ASC)                       true
-t  t_f_fkey  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
-t  t_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)                  true
+t  check_a       CHECK        CHECK ((a > 0))                      true
+t  check_a1      CHECK        CHECK ((a > 0))                      true
+t  foo           UNIQUE       UNIQUE (b ASC)                       true
+t  t_a_not_null  NOT NULL     NOT NULL                             true
+t  t_f_fkey      FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
+t  t_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
 statement error constraint "typo" of relation "t" does not exist
 ALTER TABLE t VALIDATE CONSTRAINT typo
@@ -190,11 +193,12 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK        CHECK ((a > 0))                      true
-t  check_a1  CHECK        CHECK ((a > 0))                      true
-t  foo       UNIQUE       UNIQUE (b ASC)                       true
-t  t_f_fkey  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
-t  t_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)                  true
+t  check_a       CHECK        CHECK ((a > 0))                      true
+t  check_a1      CHECK        CHECK ((a > 0))                      true
+t  foo           UNIQUE       UNIQUE (b ASC)                       true
+t  t_a_not_null  NOT NULL     NOT NULL                             true
+t  t_f_fkey      FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
+t  t_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
 statement ok
 ALTER TABLE t DROP CONSTRAINT check_a, DROP CONSTRAINT check_a1
@@ -468,12 +472,14 @@ ALTER TABLE t ADD i INT AS (g - 1) STORED CHECK (i > 0)
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_f   CHECK        CHECK ((f > 1))      true
-t  check_g   CHECK        CHECK ((g > 0))      true
-t  check_h   CHECK        CHECK ((h > 0))      true
-t  check_h1  CHECK        CHECK ((h < 10))     true
-t  t_h_key   UNIQUE       UNIQUE (h ASC)       true
-t  t_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  check_f       CHECK        CHECK ((f > 1))      true
+t  check_g       CHECK        CHECK ((g > 0))      true
+t  check_h       CHECK        CHECK ((h > 0))      true
+t  check_h1      CHECK        CHECK ((h < 10))     true
+t  t_a_not_null  NOT NULL     NOT NULL             true
+t  t_h_key       UNIQUE       UNIQUE (h ASC)       true
+t  t_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_y_not_null  NOT NULL     NOT NULL             true
 
 statement ok
 DROP TABLE t
@@ -506,13 +512,14 @@ ALTER TABLE t ADD COLUMN u INT UNIQUE, ADD COLUMN v INT UNIQUE, ADD CONSTRAINT c
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_c_b  CHECK        CHECK ((c > b))      true
-t  ck         CHECK        CHECK ((a > 0))      true
-t  t_d_key    UNIQUE       UNIQUE (d ASC)       true
-t  t_e_key    UNIQUE       UNIQUE (e ASC)       true
-t  t_pkey     PRIMARY KEY  PRIMARY KEY (a ASC)  true
-t  t_u_key    UNIQUE       UNIQUE (u ASC)       true
-t  t_v_key    UNIQUE       UNIQUE (v ASC)       true
+t  check_c_b     CHECK        CHECK ((c > b))      true
+t  ck            CHECK        CHECK ((a > 0))      true
+t  t_a_not_null  NOT NULL     NOT NULL             true
+t  t_d_key       UNIQUE       UNIQUE (d ASC)       true
+t  t_e_key       UNIQUE       UNIQUE (e ASC)       true
+t  t_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_u_key       UNIQUE       UNIQUE (u ASC)       true
+t  t_v_key       UNIQUE       UNIQUE (v ASC)       true
 
 statement ok
 DROP TABLE t
@@ -1062,10 +1069,12 @@ ALTER TABLE t ALTER COLUMN a SET NOT NULL
 statement error null value in column "a" violates not-null constraint
 INSERT INTO t VALUES (NULL)
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  t_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t  t_a_not_null      NOT NULL     NOT NULL                 true
+t  t_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t  t_rowid_not_null  NOT NULL     NOT NULL                 true
 
 statement ok
 ALTER TABLE t ALTER COLUMN a DROP NOT NULL
@@ -1098,7 +1107,9 @@ SHOW CONSTRAINTS FROM t
 ----
 t  a_auto_not_null   CHECK        CHECK ((a IS NOT NULL))  true
 t  a_auto_not_null1  CHECK        CHECK ((a IS NOT NULL))  true
+t  t_a_not_null      NOT NULL     NOT NULL                 true
 t  t_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t  t_rowid_not_null  NOT NULL     NOT NULL                 true
 
 statement ok
 DROP TABLE t
@@ -1122,9 +1133,10 @@ ALTER TABLE t ADD CHECK (a < 16) NOT VALID
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK        CHECK ((a < 100))           true
-t  check_a1  CHECK        CHECK ((a < 16)) NOT VALID  false
-t  t_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)     true
+t  check_a           CHECK        CHECK ((a < 100))           true
+t  check_a1          CHECK        CHECK ((a < 16)) NOT VALID  false
+t  t_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)     true
+t  t_rowid_not_null  NOT NULL     NOT NULL                    true
 
 query error pq: failed to satisfy CHECK constraint \(a < 16:::INT8\)
 INSERT INTO t VALUES (20)
@@ -1141,9 +1153,10 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a1
 query TTTTB nosort
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK        CHECK ((a < 100))        true
-t  check_a1  CHECK        CHECK ((a < 16))         true
-t  t_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t  check_a           CHECK        CHECK ((a < 100))        true
+t  check_a1          CHECK        CHECK ((a < 16))         true
+t  t_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t  t_rowid_not_null  NOT NULL     NOT NULL                 true
 
 subtest regression_42858
 
@@ -1852,19 +1865,20 @@ ALTER TABLE unique_without_index_partial ADD CONSTRAINT uniq_a_2 UNIQUE WITHOUT 
 query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-table_name            constraint_name             constraint_type  details                                 validated
-unique_without_index  my_partial_unique_f         UNIQUE           UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE           UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_e2                UNIQUE           UNIQUE WITHOUT INDEX (e) NOT VALID      false
-unique_without_index  my_unique_f                 UNIQUE           UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_a_b                  UNIQUE           UNIQUE WITHOUT INDEX (a, b)             true
-unique_without_index  unique_b                    UNIQUE           UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_b_1                  UNIQUE           UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_c                    UNIQUE           UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE           UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE           UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE           UNIQUE (c ASC)                          true
-unique_without_index  unique_without_index_pkey   PRIMARY KEY      PRIMARY KEY (rowid ASC)                 true
+table_name            constraint_name                      constraint_type  details                                 validated
+unique_without_index  my_partial_unique_f                  UNIQUE           UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                          UNIQUE           UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_e2                         UNIQUE           UNIQUE WITHOUT INDEX (e) NOT VALID      false
+unique_without_index  my_unique_f                          UNIQUE           UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_a_b                           UNIQUE           UNIQUE WITHOUT INDEX (a, b)             true
+unique_without_index  unique_b                             UNIQUE           UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_b_1                           UNIQUE           UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_c                             UNIQUE           UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                             UNIQUE           UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                           UNIQUE           UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_c_key           UNIQUE           UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey            PRIMARY KEY      PRIMARY KEY (rowid ASC)                 true
+unique_without_index  unique_without_index_rowid_not_null  NOT NULL         NOT NULL                                true
 
 statement ok
 ALTER TABLE unique_without_index RENAME COLUMN a TO aa
@@ -1881,18 +1895,19 @@ ALTER TABLE unique_without_index RENAME CONSTRAINT unique_b TO unique_b_2
 query TTTTB nosort
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_e2                UNIQUE       UNIQUE WITHOUT INDEX (e) NOT VALID      false
-unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_a_b                  UNIQUE       UNIQUE WITHOUT INDEX (aa, b)            true
-unique_without_index  unique_b_1                  UNIQUE       UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_b_2                  UNIQUE       UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_c_key  UNIQUE       UNIQUE (c ASC)                          true
-unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  my_partial_unique_f                  UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                          UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_e2                         UNIQUE       UNIQUE WITHOUT INDEX (e) NOT VALID      false
+unique_without_index  my_unique_f                          UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_a_b                           UNIQUE       UNIQUE WITHOUT INDEX (aa, b)            true
+unique_without_index  unique_b_1                           UNIQUE       UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_b_2                           UNIQUE       UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_c                             UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                             UNIQUE       UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                           UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_c_key           UNIQUE       UNIQUE (c ASC)                          true
+unique_without_index  unique_without_index_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  unique_without_index_rowid_not_null  NOT NULL     NOT NULL                                true
 
 # Drop an index-backed unique constraint using ALTER TABLE DROP CONSTRAINT.
 skipif config local-legacy-schema-changer local-mixed-25.4 local-mixed-26.1
@@ -1927,15 +1942,16 @@ ALTER TABLE unique_without_index DROP CONSTRAINT my_unique_e2
 query TTTTB nosort
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_a_b                  UNIQUE       UNIQUE WITHOUT INDEX (aa, b)            true
-unique_without_index  unique_b_1                  UNIQUE       UNIQUE WITHOUT INDEX (b)                true
-unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  my_partial_unique_f                  UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                          UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_f                          UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_a_b                           UNIQUE       UNIQUE WITHOUT INDEX (aa, b)            true
+unique_without_index  unique_b_1                           UNIQUE       UNIQUE WITHOUT INDEX (b)                true
+unique_without_index  unique_c                             UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                             UNIQUE       UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                           UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  unique_without_index_rowid_not_null  NOT NULL     NOT NULL                                true
 
 # Dropping a column in a unique constraint drops the constraint.
 statement ok
@@ -1944,21 +1960,23 @@ ALTER TABLE unique_without_index DROP COLUMN b
 query TTTTB nosort
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_d                    UNIQUE       UNIQUE WITHOUT INDEX (d)                true
-unique_without_index  unique_d_e                  UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
-unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  my_partial_unique_f                  UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                          UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_f                          UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_c                             UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_d                             UNIQUE       UNIQUE WITHOUT INDEX (d)                true
+unique_without_index  unique_d_e                           UNIQUE       UNIQUE WITHOUT INDEX (d, e)             true
+unique_without_index  unique_without_index_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  unique_without_index_rowid_not_null  NOT NULL     NOT NULL                                true
 
 query TTTTB nosort
 SHOW CONSTRAINTS FROM uwi_child
 ----
-uwi_child  fk_d_e            FOREIGN KEY  FOREIGN KEY (d, e) REFERENCES unique_without_index(d, e)  true
-uwi_child  fk_e_d            FOREIGN KEY  FOREIGN KEY (e, d) REFERENCES unique_without_index(e, d)  true
-uwi_child  uwi_child_d_fkey  FOREIGN KEY  FOREIGN KEY (d) REFERENCES unique_without_index(d)        true
-uwi_child  uwi_child_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)                                   true
+uwi_child  fk_d_e                    FOREIGN KEY  FOREIGN KEY (d, e) REFERENCES unique_without_index(d, e)  true
+uwi_child  fk_e_d                    FOREIGN KEY  FOREIGN KEY (e, d) REFERENCES unique_without_index(e, d)  true
+uwi_child  uwi_child_d_fkey          FOREIGN KEY  FOREIGN KEY (d) REFERENCES unique_without_index(d)        true
+uwi_child  uwi_child_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)                                   true
+uwi_child  uwi_child_rowid_not_null  NOT NULL     NOT NULL                                                  true
 
 # Attempting to drop a column with a foreign key reference fails.
 statement error pq: "unique_d" is referenced by foreign key from table "uwi_child"
@@ -1971,16 +1989,18 @@ ALTER TABLE unique_without_index DROP COLUMN d CASCADE
 query TTTTB nosort
 SHOW CONSTRAINTS FROM unique_without_index
 ----
-unique_without_index  my_partial_unique_f         UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
-unique_without_index  my_unique_e                 UNIQUE       UNIQUE WITHOUT INDEX (e)                true
-unique_without_index  my_unique_f                 UNIQUE       UNIQUE WITHOUT INDEX (f)                true
-unique_without_index  unique_c                    UNIQUE       UNIQUE WITHOUT INDEX (c)                true
-unique_without_index  unique_without_index_pkey   PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  my_partial_unique_f                  UNIQUE       UNIQUE WITHOUT INDEX (f) WHERE (f > 0)  true
+unique_without_index  my_unique_e                          UNIQUE       UNIQUE WITHOUT INDEX (e)                true
+unique_without_index  my_unique_f                          UNIQUE       UNIQUE WITHOUT INDEX (f)                true
+unique_without_index  unique_c                             UNIQUE       UNIQUE WITHOUT INDEX (c)                true
+unique_without_index  unique_without_index_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)                 true
+unique_without_index  unique_without_index_rowid_not_null  NOT NULL     NOT NULL                                true
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM uwi_child
 ----
-uwi_child  uwi_child_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+uwi_child  uwi_child_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+uwi_child  uwi_child_rowid_not_null  NOT NULL     NOT NULL                 true
 
 # Regression for #54629.
 statement ok
@@ -3428,9 +3448,10 @@ SELECT table_name, constraint_name, constraint_type, validated
 FROM [SHOW CONSTRAINTS FROM t_96115]
 ORDER BY constraint_type;
 ----
-table_name  constraint_name  constraint_type  validated
-t_96115     check_i_j        CHECK            true
-t_96115     t_96115_pkey     PRIMARY KEY      true
+table_name  constraint_name     constraint_type  validated
+t_96115     check_i_j           CHECK            true
+t_96115     t_96115_i_not_null  NOT NULL         true
+t_96115     t_96115_pkey        PRIMARY KEY      true
 
 statement ok
 ALTER TABLE t_96115 DROP CONSTRAINT check_i_j;
@@ -3441,8 +3462,9 @@ SELECT table_name, constraint_name, constraint_type, validated
 FROM [SHOW CONSTRAINTS FROM t_96115]
 ORDER BY constraint_type;
 ----
-table_name  constraint_name  constraint_type  validated
-t_96115     t_96115_pkey     PRIMARY KEY      true
+table_name  constraint_name     constraint_type  validated
+t_96115     t_96115_i_not_null  NOT NULL         true
+t_96115     t_96115_pkey        PRIMARY KEY      true
 
 statement ok
 ALTER TABLE t_96115 ADD CHECK (i > nextval('seq_96115') AND j::typ_96115 = 'a'::typ_96115);
@@ -3453,9 +3475,10 @@ SELECT table_name, constraint_name, constraint_type, validated
 FROM [SHOW CONSTRAINTS FROM t_96115]
 ORDER BY constraint_type;
 ----
-table_name  constraint_name  constraint_type  validated
-t_96115     check_i_j        CHECK            true
-t_96115     t_96115_pkey     PRIMARY KEY      true
+table_name  constraint_name     constraint_type  validated
+t_96115     check_i_j           CHECK            true
+t_96115     t_96115_i_not_null  NOT NULL         true
+t_96115     t_96115_pkey        PRIMARY KEY      true
 
 statement ok
 DROP SEQUENCE seq_96115 CASCADE;
@@ -3466,8 +3489,9 @@ SELECT table_name, constraint_name, constraint_type, validated
 FROM [SHOW CONSTRAINTS FROM t_96115]
 ORDER BY constraint_type;
 ----
-table_name  constraint_name  constraint_type  validated
-t_96115     t_96115_pkey     PRIMARY KEY      true
+table_name  constraint_name     constraint_type  validated
+t_96115     t_96115_i_not_null  NOT NULL         true
+t_96115     t_96115_pkey        PRIMARY KEY      true
 
 statement ok
 CREATE SEQUENCE seq_96115;
@@ -3501,9 +3525,10 @@ SELECT table_name, constraint_name, constraint_type, validated
 FROM [SHOW CONSTRAINTS FROM t_96115]
 ORDER BY constraint_type;
 ----
-table_name  constraint_name  constraint_type  validated
-t_96115     t_96115_pkey     PRIMARY KEY      true
-t_96115     unique_j         UNIQUE           true
+table_name  constraint_name     constraint_type  validated
+t_96115     t_96115_i_not_null  NOT NULL         true
+t_96115     t_96115_pkey        PRIMARY KEY      true
+t_96115     unique_j            UNIQUE           true
 
 statement ok
 ALTER TABLE t_96115 DROP CONSTRAINT unique_j;
@@ -3513,8 +3538,9 @@ SELECT table_name, constraint_name, constraint_type, validated
 FROM [SHOW CONSTRAINTS FROM t_96115]
 ORDER BY constraint_type;
 ----
-table_name  constraint_name  constraint_type  validated
-t_96115     t_96115_pkey     PRIMARY KEY      true
+table_name  constraint_name     constraint_type  validated
+t_96115     t_96115_i_not_null  NOT NULL         true
+t_96115     t_96115_pkey        PRIMARY KEY      true
 
 statement ok
 DROP TABLE t_96115;
@@ -3591,9 +3617,10 @@ DROP INDEX t_97538_2_j_key;
 query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t_97538_1
 ----
-table_name  constraint_name   constraint_type  details                                  validated
-t_97538_1   t_97538_1_i_fkey  FOREIGN KEY      FOREIGN KEY (i) REFERENCES t_97538_2(j)  true
-t_97538_1   t_97538_1_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)                      true
+table_name  constraint_name       constraint_type  details                                  validated
+t_97538_1   t_97538_1_i_fkey      FOREIGN KEY      FOREIGN KEY (i) REFERENCES t_97538_2(j)  true
+t_97538_1   t_97538_1_i_not_null  NOT NULL         NOT NULL                                 true
+t_97538_1   t_97538_1_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)                      true
 
 # Add back the unique index, and drop the unique without index constraint (without CASCADE) this time.
 statement ok
@@ -3607,19 +3634,21 @@ ALTER TABLE t_97538_2 DROP CONSTRAINT unique_j;
 query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t_97538_1
 ----
-table_name  constraint_name   constraint_type  details                                  validated
-t_97538_1   t_97538_1_i_fkey  FOREIGN KEY      FOREIGN KEY (i) REFERENCES t_97538_2(j)  true
-t_97538_1   t_97538_1_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)                      true
+table_name  constraint_name       constraint_type  details                                  validated
+t_97538_1   t_97538_1_i_fkey      FOREIGN KEY      FOREIGN KEY (i) REFERENCES t_97538_2(j)  true
+t_97538_1   t_97538_1_i_not_null  NOT NULL         NOT NULL                                 true
+t_97538_1   t_97538_1_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)                      true
 
 statement ok
 DROP INDEX t_97538_2_j_key CASCADE;
 
 # Now ensure that the FK is dropped as a result of the cascade.
-query TTTTB colnames
+query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t_97538_1
 ----
-table_name  constraint_name  constraint_type  details              validated
-t_97538_1   t_97538_1_pkey   PRIMARY KEY      PRIMARY KEY (i ASC)  true
+table_name  constraint_name       constraint_type  details              validated
+t_97538_1   t_97538_1_i_not_null  NOT NULL         NOT NULL             true
+t_97538_1   t_97538_1_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)  true
 
 # This subtest ensures that dropping a column that is referenced
 # by constraints works properly.
@@ -3828,11 +3857,25 @@ ALTER TABLE t_96729 ADD PRIMARY KEY (i) NOT VALID;
 statement ok
 ALTER TABLE t_96729 ADD PRIMARY KEY (i);
 
-query TTTTB colnames
+skipif config local-legacy-schema-changer
+query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t_96729
 ----
-table_name  constraint_name  constraint_type  details              validated
-t_96729     t_96729_pkey     PRIMARY KEY      PRIMARY KEY (i ASC)  true
+table_name  constraint_name     constraint_type  details              validated
+t_96729     t_96729_i_not_null  NOT NULL         NOT NULL             true
+t_96729     t_96729_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)  true
+
+# Legacy schema changer keeps the old rowid column when ALTER PRIMARY KEY swaps
+# to an explicit PK column, so the synthesized rowid NOT NULL row is still
+# present.
+onlyif config local-legacy-schema-changer
+query TTTTB colnames,nosort
+SHOW CONSTRAINTS FROM t_96729
+----
+table_name  constraint_name         constraint_type  details              validated
+t_96729     t_96729_i_not_null      NOT NULL         NOT NULL             true
+t_96729     t_96729_pkey            PRIMARY KEY      PRIMARY KEY (i ASC)  true
+t_96729     t_96729_rowid_not_null  NOT NULL         NOT NULL             true
 
 # This subtests ensures adding UNIQUE constraint works properly.
 subtest alter_table_add_unique_96728
@@ -3849,9 +3892,10 @@ ALTER TABLE t_96728 ADD UNIQUE (j, k) WHERE (i > 0);
 query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t_96728
 ----
-table_name  constraint_name  constraint_type  details                              validated
-t_96728     t_96728_j_k_key  UNIQUE           UNIQUE (j ASC, k ASC) WHERE (i > 0)  true
-t_96728     t_96728_pkey     PRIMARY KEY      PRIMARY KEY (i ASC)                  true
+table_name  constraint_name     constraint_type  details                              validated
+t_96728     t_96728_i_not_null  NOT NULL         NOT NULL                             true
+t_96728     t_96728_j_k_key     UNIQUE           UNIQUE (j ASC, k ASC) WHERE (i > 0)  true
+t_96728     t_96728_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)                  true
 
 # This subtest tests behavior when there are multiple commands (ADD COLUMN, DROP COLUMN,
 # ALTER PRIMARY KEY, ADD CONSTRAINT) in one ALTER TABLE statement.

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2478,6 +2478,7 @@ CHECK ((c > a))
 CHECK ((c > 0)) NOT VALID
 FOREIGN KEY (a) REFERENCES pg_indexdef_test(a) ON DELETE CASCADE
 FOREIGN KEY (c) REFERENCES pg_indexdef_test(a) NOT VALID
+NOT NULL
 
 # These functions always return NULL since we don't support comments on vtable columns and databases.
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -446,16 +446,18 @@ CREATE TABLE unique_without_index1 (a INT, b INT, CONSTRAINT ab UNIQUE WITHOUT I
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM unique_without_index] ORDER BY constraint_name
 ----
-table_name            constraint_name            constraint_type  details                   validated
-unique_without_index  unique_a                   UNIQUE           UNIQUE WITHOUT INDEX (a)  true
-unique_without_index  unique_without_index_pkey  PRIMARY KEY      PRIMARY KEY (rowid ASC)   true
+table_name            constraint_name                      constraint_type  details                   validated
+unique_without_index  unique_a                             UNIQUE           UNIQUE WITHOUT INDEX (a)  true
+unique_without_index  unique_without_index_pkey            PRIMARY KEY      PRIMARY KEY (rowid ASC)   true
+unique_without_index  unique_without_index_rowid_not_null  NOT NULL         NOT NULL                  true
 
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM unique_without_index1] ORDER BY constraint_name
 ----
-table_name             constraint_name             constraint_type  details                      validated
-unique_without_index1  ab                          UNIQUE           UNIQUE WITHOUT INDEX (a, b)  true
-unique_without_index1  unique_without_index1_pkey  PRIMARY KEY      PRIMARY KEY (rowid ASC)      true
+table_name             constraint_name                       constraint_type  details                      validated
+unique_without_index1  ab                                    UNIQUE           UNIQUE WITHOUT INDEX (a, b)  true
+unique_without_index1  unique_without_index1_pkey            PRIMARY KEY      PRIMARY KEY (rowid ASC)      true
+unique_without_index1  unique_without_index1_rowid_not_null  NOT NULL         NOT NULL                     true
 
 # Unique constraints without an index use the same name generation logic as
 # check constraints. A named constraint following an anonymous constraint

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -2222,6 +2222,7 @@ SELECT details FROM [SHOW CONSTRAINTS FROM t97643];
 ----
 PRIMARY KEY (rowid ASC)
 CHECK ((parse_time('abc'::text) = parse_time('abc'::text)))
+NOT NULL
 
 subtest experimental_strftime_year_padding
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -437,19 +437,21 @@ DROP INDEX t2_96731_idx CASCADE;
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM t1_96731] ORDER BY constraint_name
 ----
-table_name  constraint_name  constraint_type  details                                 validated
-t1_96731    t1_96731_j_fkey  FOREIGN KEY      FOREIGN KEY (j) REFERENCES t2_96731(j)  true
-t1_96731    t1_96731_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)                     true
+table_name  constraint_name      constraint_type  details                                 validated
+t1_96731    t1_96731_i_not_null  NOT NULL         NOT NULL                                true
+t1_96731    t1_96731_j_fkey      FOREIGN KEY      FOREIGN KEY (j) REFERENCES t2_96731(j)  true
+t1_96731    t1_96731_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)                     true
 
 # Drop the last unique index will drop the FK as well this time.
 statement ok
 DROP INDEX t2_96731_idx2 CASCADE;
 
-query TTTTB colnames
+query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t1_96731;
 ----
-table_name  constraint_name  constraint_type  details              validated
-t1_96731    t1_96731_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)  true
+table_name  constraint_name      constraint_type  details              validated
+t1_96731    t1_96731_i_not_null  NOT NULL         NOT NULL             true
+t1_96731    t1_96731_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)  true
 
 # Recreate the unique index and FK constraint.
 statement ok
@@ -472,9 +474,10 @@ DROP INDEX t2_96731_idx CASCADE;
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM t1_96731] ORDER BY constraint_name
 ----
-table_name  constraint_name  constraint_type  details                                 validated
-t1_96731    t1_96731_j_fkey  FOREIGN KEY      FOREIGN KEY (j) REFERENCES t2_96731(j)  true
-t1_96731    t1_96731_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)                     true
+table_name  constraint_name      constraint_type  details                                 validated
+t1_96731    t1_96731_i_not_null  NOT NULL         NOT NULL                                true
+t1_96731    t1_96731_j_fkey      FOREIGN KEY      FOREIGN KEY (j) REFERENCES t2_96731(j)  true
+t1_96731    t1_96731_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)                     true
 
 # Recreate the unique index, drop the unique_without_index constraint,
 # and add another one on different columns.
@@ -491,11 +494,12 @@ ALTER TABLE t2_96731 ADD CONSTRAINT unique_i UNIQUE WITHOUT INDEX (i);
 statement ok
 DROP INDEX t2_96731_idx CASCADE;
 
-query TTTTB colnames
+query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t1_96731;
 ----
-table_name  constraint_name  constraint_type  details              validated
-t1_96731    t1_96731_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)  true
+table_name  constraint_name      constraint_type  details              validated
+t1_96731    t1_96731_i_not_null  NOT NULL         NOT NULL             true
+t1_96731    t1_96731_pkey        PRIMARY KEY      PRIMARY KEY (i ASC)  true
 
 statement ok
 DROP TABLE t1_96731, t2_96731;
@@ -536,6 +540,7 @@ SELECT constraint_name from [SHOW CONSTRAINTS FROM fk_ref_dst];
 fk_ref_dst_pkey
 j_fk
 m_fk
+fk_ref_dst_k_not_null
 
 subtest safe_updates_rejects_drop_index
 

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -1506,7 +1506,8 @@ JOIN pg_catalog.pg_class t ON c.conrelid = t.oid
 WHERE t.relname = 'expr_tab'
 ORDER BY c.conname
 ----
-expr_tab_pkey  PRIMARY KEY (a ASC, (b + 100:::INT8) ASC, lower(c) ASC)
+expr_tab_a_not_null  NOT NULL
+expr_tab_pkey        PRIMARY KEY (a ASC, (b + 100:::INT8) ASC, lower(c) ASC)
 
 # Test with a table where the primary key starts with an expression
 statement ok
@@ -1552,7 +1553,8 @@ JOIN pg_catalog.pg_class t ON c.conrelid = t.oid
 WHERE t.relname = 'expr_tab2'
 ORDER BY c.conname
 ----
-expr_tab2_pkey  PRIMARY KEY ((a + b) ASC, c ASC)
+expr_tab2_c_not_null  NOT NULL
+expr_tab2_pkey        PRIMARY KEY ((a + b) ASC, c ASC)
 
 # Test with multiple expressions in primary key
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -439,8 +439,9 @@ CREATE TABLE "user content".review_stats (
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM "user content".review_stats] ORDER BY constraint_name
 ----
-review_stats  review_stats_pkey  PRIMARY KEY  PRIMARY KEY (id ASC)                                true
-review_stats  reviewfk           FOREIGN KEY  FOREIGN KEY (id) REFERENCES "customer reviews"(id)  true
+review_stats  review_stats_id_not_null  NOT NULL     NOT NULL                                            true
+review_stats  review_stats_pkey         PRIMARY KEY  PRIMARY KEY (id ASC)                                true
+review_stats  reviewfk                  FOREIGN KEY  FOREIGN KEY (id) REFERENCES "customer reviews"(id)  true
 
 statement error pgcode 23503 insert on table "review_stats" violates foreign key constraint "reviewfk"\nDETAIL: Key \(id\)=\(5\) is not present in table "customer reviews"
 INSERT INTO "user content".review_stats (id, upvotes) VALUES (5, 1)
@@ -454,10 +455,11 @@ DELETE FROM "user content"."customer reviews" WHERE id = 2
 statement ok
 ALTER TABLE "user content".review_stats DROP CONSTRAINT reviewfk
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM "user content".review_stats
 ----
-review_stats  review_stats_pkey  PRIMARY KEY  PRIMARY KEY (id ASC)  true
+review_stats  review_stats_id_not_null  NOT NULL     NOT NULL              true
+review_stats  review_stats_pkey         PRIMARY KEY  PRIMARY KEY (id ASC)  true
 
 statement count 2
 DELETE FROM "user content"."customer reviews"
@@ -583,6 +585,7 @@ SELECT * FROM [SHOW CONSTRAINTS FROM delivery] ORDER BY constraint_name
 ----
 delivery  delivery_order_shipment_fkey  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
 delivery  delivery_pkey                 PRIMARY KEY  PRIMARY KEY (rowid ASC)                                          true
+delivery  delivery_rowid_not_null       NOT NULL     NOT NULL                                                         true
 
 statement ok
 UPDATE products SET upc = '885155001450' WHERE sku = '780'
@@ -596,6 +599,7 @@ SELECT * FROM [SHOW CONSTRAINTS FROM delivery] ORDER BY constraint_name
 delivery  delivery_item_fkey            FOREIGN KEY  FOREIGN KEY (item) REFERENCES products(upc)                      true
 delivery  delivery_order_shipment_fkey  FOREIGN KEY  FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment)  true
 delivery  delivery_pkey                 PRIMARY KEY  PRIMARY KEY (rowid ASC)                                          true
+delivery  delivery_rowid_not_null       NOT NULL     NOT NULL                                                         true
 
 statement ok
 ALTER TABLE "user content"."customer reviews"
@@ -748,10 +752,12 @@ ALTER TABLE "user content"."customer reviews" RESET (schema_locked)
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM orders] ORDER BY constraint_name
 ----
-table_name  constraint_name      constraint_type  details                                                                               validated
-orders      orders_pkey          PRIMARY KEY      PRIMARY KEY (id ASC, shipment ASC)                                                    true
-orders      orders_product_fkey  FOREIGN KEY      FOREIGN KEY (product) REFERENCES products(sku) ON DELETE RESTRICT ON UPDATE RESTRICT  true
-orders      valid_customer       FOREIGN KEY      FOREIGN KEY (customer) REFERENCES customers(id)                                       true
+table_name  constraint_name           constraint_type  details                                                                               validated
+orders      orders_id_not_null        NOT NULL         NOT NULL                                                                              true
+orders      orders_pkey               PRIMARY KEY      PRIMARY KEY (id ASC, shipment ASC)                                                    true
+orders      orders_product_fkey       FOREIGN KEY      FOREIGN KEY (product) REFERENCES products(sku) ON DELETE RESTRICT ON UPDATE RESTRICT  true
+orders      orders_shipment_not_null  NOT NULL         NOT NULL                                                                              true
+orders      valid_customer            FOREIGN KEY      FOREIGN KEY (customer) REFERENCES customers(id)                                       true
 
 skipif config local-legacy-schema-changer
 statement error pq: "products_upc_key" is referenced by foreign key from table "delivery"
@@ -1048,10 +1054,13 @@ CREATE TABLE domain_modules (
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM domain_modules] ORDER BY constraint_name
 ----
-domain_modules  domain_modules_domain_id_fk  FOREIGN KEY  FOREIGN KEY (domain_id) REFERENCES domains(id)  true
-domain_modules  domain_modules_module_id_fk  FOREIGN KEY  FOREIGN KEY (module_id) REFERENCES modules(id)  true
-domain_modules  domain_modules_pkey          PRIMARY KEY  PRIMARY KEY (id ASC)                            true
-domain_modules  domain_modules_uq            UNIQUE       UNIQUE (domain_id ASC, module_id ASC)           true
+domain_modules  domain_modules_domain_id_fk        FOREIGN KEY  FOREIGN KEY (domain_id) REFERENCES domains(id)  true
+domain_modules  domain_modules_domain_id_not_null  NOT NULL     NOT NULL                                        true
+domain_modules  domain_modules_id_not_null         NOT NULL     NOT NULL                                        true
+domain_modules  domain_modules_module_id_fk        FOREIGN KEY  FOREIGN KEY (module_id) REFERENCES modules(id)  true
+domain_modules  domain_modules_module_id_not_null  NOT NULL     NOT NULL                                        true
+domain_modules  domain_modules_pkey                PRIMARY KEY  PRIMARY KEY (id ASC)                            true
+domain_modules  domain_modules_uq                  UNIQUE       UNIQUE (domain_id ASC, module_id ASC)           true
 
 statement ok
 INSERT INTO modules VALUES(3)
@@ -3076,8 +3085,9 @@ ALTER TABLE pet ADD CONSTRAINT fk_constraint FOREIGN KEY (id) REFERENCES person 
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM pet] ORDER BY constraint_name
 ----
-pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id) NOT VALID  false
-pet  pet_pkey       PRIMARY KEY  PRIMARY KEY (id ASC)                              true
+pet  fk_constraint    FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id) NOT VALID  false
+pet  pet_id_not_null  NOT NULL     NOT NULL                                          true
+pet  pet_pkey         PRIMARY KEY  PRIMARY KEY (id ASC)                              true
 
 statement error pq: foreign key violation: "pet" row id=0 has no match in "person"
 ALTER TABLE pet VALIDATE CONSTRAINT fk_constraint
@@ -3091,8 +3101,9 @@ ALTER TABLE pet VALIDATE CONSTRAINT fk_constraint
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM pet] ORDER BY constraint_name
 ----
-pet  fk_constraint  FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id)  true
-pet  pet_pkey       PRIMARY KEY  PRIMARY KEY (id ASC)                    true
+pet  fk_constraint    FOREIGN KEY  FOREIGN KEY (id) REFERENCES person(id)  true
+pet  pet_id_not_null  NOT NULL     NOT NULL                                true
+pet  pet_pkey         PRIMARY KEY  PRIMARY KEY (id ASC)                    true
 
 statement ok
 DROP TABLE person, pet

--- a/pkg/sql/logictest/testdata/logic_test/hidden_columns
+++ b/pkg/sql/logictest/testdata/logic_test/hidden_columns
@@ -94,10 +94,11 @@ CREATE TABLE t1(a INT, b INT, c INT NOT VISIBLE , PRIMARY KEY(b));
 CREATE TABLE t2(b INT NOT VISIBLE, c INT, d INT, PRIMARY KEY (d));
 CREATE TABLE t5(b INT NOT VISIBLE, c INT, d INT, PRIMARY KEY (d), FOREIGN KEY(b) REFERENCES t1(b));
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM t2
 ----
-t2  t2_pkey  PRIMARY KEY  PRIMARY KEY (d ASC)  true
+t2  t2_d_not_null  NOT NULL     NOT NULL             true
+t2  t2_pkey        PRIMARY KEY  PRIMARY KEY (d ASC)  true
 
 statement ok
 ALTER TABLE t2 ADD FOREIGN KEY (b) REFERENCES t2
@@ -105,8 +106,9 @@ ALTER TABLE t2 ADD FOREIGN KEY (b) REFERENCES t2
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM t2] ORDER BY constraint_name
 ----
-t2  t2_b_fkey  FOREIGN KEY  FOREIGN KEY (b) REFERENCES t2(d)  true
-t2  t2_pkey    PRIMARY KEY  PRIMARY KEY (d ASC)               true
+t2  t2_b_fkey      FOREIGN KEY  FOREIGN KEY (b) REFERENCES t2(d)  true
+t2  t2_d_not_null  NOT NULL     NOT NULL                          true
+t2  t2_pkey        PRIMARY KEY  PRIMARY KEY (d ASC)               true
 
 # adding a foreign key constraint that references a hidden column
 
@@ -123,13 +125,17 @@ ALTER TABLE t3 ALTER PRIMARY KEY USING COLUMNS(b);
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM t3] ORDER BY constraint_name
 ----
-t3  t3_c_key  UNIQUE       UNIQUE (c ASC)       true
-t3  t3_pkey   PRIMARY KEY  PRIMARY KEY (b ASC)  true
+t3  t3_b_not_null  NOT NULL     NOT NULL             true
+t3  t3_c_key       UNIQUE       UNIQUE (c ASC)       true
+t3  t3_c_not_null  NOT NULL     NOT NULL             true
+t3  t3_pkey        PRIMARY KEY  PRIMARY KEY (b ASC)  true
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM t4
 ----
-t4  t4_pkey  PRIMARY KEY  PRIMARY KEY (d ASC)  true
+t4  t4_d_not_null  NOT NULL     NOT NULL             true
+t4  t4_e_not_null  NOT NULL     NOT NULL             true
+t4  t4_pkey        PRIMARY KEY  PRIMARY KEY (d ASC)  true
 
 statement ok
 ALTER TABLE t4 ALTER PRIMARY KEY USING COLUMNS(e);
@@ -137,5 +143,7 @@ ALTER TABLE t4 ALTER PRIMARY KEY USING COLUMNS(e);
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM t4] ORDER BY constraint_name
 ----
-t4  t4_d_key  UNIQUE       UNIQUE (d ASC)       true
-t4  t4_pkey   PRIMARY KEY  PRIMARY KEY (e ASC)  true
+t4  t4_d_key       UNIQUE       UNIQUE (d ASC)       true
+t4  t4_d_not_null  NOT NULL     NOT NULL             true
+t4  t4_e_not_null  NOT NULL     NOT NULL             true
+t4  t4_pkey        PRIMARY KEY  PRIMARY KEY (e ASC)  true

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -354,10 +354,15 @@ SHOW INDEXES FROM information_schema.tables
 ----
 table_name  index_name  non_unique  seq_in_index  column_name  definition  direction  storing  implicit  visible  visibility
 
-query TTTTB colnames
+query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM information_schema.tables
 ----
-table_name  constraint_name  constraint_type  details  validated
+table_name  constraint_name                     constraint_type  details   validated
+tables      tables_is_insertable_into_not_null  NOT NULL         NOT NULL  true
+tables      tables_table_catalog_not_null       NOT NULL         NOT NULL  true
+tables      tables_table_name_not_null          NOT NULL         NOT NULL  true
+tables      tables_table_schema_not_null        NOT NULL         NOT NULL  true
+tables      tables_table_type_not_null          NOT NULL         NOT NULL  true
 
 query TTTTTB colnames
 SHOW GRANTS ON information_schema.tables

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -364,10 +364,11 @@ CREATE UNIQUE INDEX t11_b_key ON t11 (b) WHERE a > 0
 query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM t11
 ----
-table_name  constraint_name  constraint_type  details                       validated
-t11         t11_a_key        UNIQUE           UNIQUE (a ASC) WHERE (b > 0)  true
-t11         t11_b_key        UNIQUE           UNIQUE (b ASC) WHERE (a > 0)  true
-t11         t11_pkey         PRIMARY KEY      PRIMARY KEY (rowid ASC)       true
+table_name  constraint_name     constraint_type  details                       validated
+t11         t11_a_key           UNIQUE           UNIQUE (a ASC) WHERE (b > 0)  true
+t11         t11_b_key           UNIQUE           UNIQUE (b ASC) WHERE (a > 0)  true
+t11         t11_pkey            PRIMARY KEY      PRIMARY KEY (rowid ASC)       true
+t11         t11_rowid_not_null  NOT NULL         NOT NULL                      true
 
 # Update a non-indexed column referenced by the predicate.
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -363,7 +363,8 @@ table_name  index_name  non_unique  seq_in_index  column_name  definition  direc
 query TTTTB colnames
 SHOW CONSTRAINTS FROM pg_catalog.pg_namespace
 ----
-table_name  constraint_name  constraint_type  details  validated
+table_name    constraint_name                constraint_type  details   validated
+pg_namespace  pg_namespace_nspname_not_null  NOT NULL         NOT NULL  true
 
 query TTTTTB colnames
 SHOW GRANTS ON pg_catalog.pg_namespace
@@ -1738,28 +1739,39 @@ FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-conname        connamespace  contype  condef
-t1_pkey        109           p        PRIMARY_KEY_(p_ASC)
-t1_a_key       109           u        UNIQUE_(a_ASC)
-index_key      109           u        UNIQUE_(b_ASC,_c_ASC)
-primary        109           p        PRIMARY_KEY_(value_ASC)
-primary        109           p        PRIMARY_KEY_(value_ASC)
-t2_pkey        109           p        PRIMARY_KEY_(rowid_ASC)
-fk             109           f        FOREIGN_KEY_(t1_id)_REFERENCES_t1(a)
-t3_pkey        109           p        PRIMARY_KEY_(rowid_ASC)
-check_b        109           c        CHECK_((b_>_11))
-check_c        109           c        CHECK_((c_!=_''::text))
-fk             109           f        FOREIGN_KEY_(a,_b)_REFERENCES_t1(b,_c)
-t4_pkey        109           p        PRIMARY_KEY_(rowid_ASC)
-unique_a       109           u        UNIQUE_WITHOUT_INDEX_(a)
-uwi_b_c        109           u        UNIQUE_WITHOUT_INDEX_(b,_c)
-uwi_b_partial  109           u        UNIQUE_WITHOUT_INDEX_(b)_WHERE_(c_=_'foo'::text)
-t5_pkey        109           p        PRIMARY_KEY_(rowid_ASC)
-fk_b_c         109           f        FOREIGN_KEY_(b,_c)_REFERENCES_t4(b,_c)_MATCH_FULL_ON_UPDATE_RESTRICT
-t5_a_fkey      109           f        FOREIGN_KEY_(a)_REFERENCES_t4(a)_ON_DELETE_CASCADE
-t6_pkey        109           p        PRIMARY_KEY_(rowid_ASC)
-t6_expr_key    109           u        UNIQUE_(lower(c)_ASC)
-mv1_pkey       109           p        PRIMARY_KEY_(rowid_ASC)
+conname                  connamespace  contype  condef
+t1_pkey                  109           p        PRIMARY_KEY_(p_ASC)
+t1_a_key                 109           u        UNIQUE_(a_ASC)
+index_key                109           u        UNIQUE_(b_ASC,_c_ASC)
+t1_p_not_null            109           n        NOT_NULL
+t1_m_not_null            109           n        NOT_NULL
+t1_n_not_null            109           n        NOT_NULL
+primary                  109           p        PRIMARY_KEY_(value_ASC)
+t1_m_seq_value_not_null  109           n        NOT_NULL
+primary                  109           p        PRIMARY_KEY_(value_ASC)
+t1_n_seq_value_not_null  109           n        NOT_NULL
+t2_pkey                  109           p        PRIMARY_KEY_(rowid_ASC)
+fk                       109           f        FOREIGN_KEY_(t1_id)_REFERENCES_t1(a)
+t2_rowid_not_null        109           n        NOT_NULL
+t3_pkey                  109           p        PRIMARY_KEY_(rowid_ASC)
+check_b                  109           c        CHECK_((b_>_11))
+check_c                  109           c        CHECK_((c_!=_''::text))
+fk                       109           f        FOREIGN_KEY_(a,_b)_REFERENCES_t1(b,_c)
+t3_rowid_not_null        109           n        NOT_NULL
+t4_pkey                  109           p        PRIMARY_KEY_(rowid_ASC)
+unique_a                 109           u        UNIQUE_WITHOUT_INDEX_(a)
+uwi_b_c                  109           u        UNIQUE_WITHOUT_INDEX_(b,_c)
+uwi_b_partial            109           u        UNIQUE_WITHOUT_INDEX_(b)_WHERE_(c_=_'foo'::text)
+t4_rowid_not_null        109           n        NOT_NULL
+t5_pkey                  109           p        PRIMARY_KEY_(rowid_ASC)
+fk_b_c                   109           f        FOREIGN_KEY_(b,_c)_REFERENCES_t4(b,_c)_MATCH_FULL_ON_UPDATE_RESTRICT
+t5_a_fkey                109           f        FOREIGN_KEY_(a)_REFERENCES_t4(a)_ON_DELETE_CASCADE
+t5_rowid_not_null        109           n        NOT_NULL
+t6_pkey                  109           p        PRIMARY_KEY_(rowid_ASC)
+t6_expr_key              109           u        UNIQUE_(lower(c)_ASC)
+t6_rowid_not_null        109           n        NOT_NULL
+mv1_pkey                 109           p        PRIMARY_KEY_(rowid_ASC)
+mv1_rowid_not_null       109           n        NOT_NULL
 
 query TTBBBOOOB colnames,rowsort
 SELECT conname, contype, condeferrable, condeferred, convalidated, conrelid, contypid, conindid, conenforced
@@ -1767,34 +1779,45 @@ FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-conname        contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid    conenforced
-t1_pkey        p        false          false        true          110       0         3687884466  true
-t1_a_key       u        false          false        true          110       0         3687884465  true
-index_key      u        false          false        true          110       0         3687884464  true
-primary        p        false          false        true          111       0         2342807459  true
-primary        p        false          false        true          112       0         5181036     true
-t2_pkey        p        false          false        true          113       0         2955071325  true
-fk             f        false          false        true          113       0         3687884465  true
-t3_pkey        p        false          false        true          114       0         2695335054  true
-check_b        c        false          false        true          114       0         0           true
-check_c        c        false          false        true          114       0         0           true
-fk             f        false          false        true          114       0         3687884464  true
-t4_pkey        p        false          false        true          116       0         3214807592  true
-unique_a       u        false          false        true          116       0         0           true
-uwi_b_c        u        false          false        true          116       0         0           true
-uwi_b_partial  u        false          false        true          116       0         0           true
-t5_pkey        p        false          false        true          117       0         1869730585  true
-fk_b_c         f        false          false        true          117       0         0           true
-t5_a_fkey      f        false          false        true          117       0         0           true
-t6_pkey        p        false          false        true          120       0         2129466852  true
-t6_expr_key    u        false          false        true          120       0         2129466848  true
-mv1_pkey       p        false          false        true          121       0         784389845   true
+conname                  contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid    conenforced
+t1_pkey                  p        false          false        true          110       0         3687884466  true
+t1_a_key                 u        false          false        true          110       0         3687884465  true
+index_key                u        false          false        true          110       0         3687884464  true
+t1_p_not_null            n        false          false        true          110       0         0           true
+t1_m_not_null            n        false          false        true          110       0         0           true
+t1_n_not_null            n        false          false        true          110       0         0           true
+primary                  p        false          false        true          111       0         2342807459  true
+t1_m_seq_value_not_null  n        false          false        true          111       0         0           true
+primary                  p        false          false        true          112       0         5181036     true
+t1_n_seq_value_not_null  n        false          false        true          112       0         0           true
+t2_pkey                  p        false          false        true          113       0         2955071325  true
+fk                       f        false          false        true          113       0         3687884465  true
+t2_rowid_not_null        n        false          false        true          113       0         0           true
+t3_pkey                  p        false          false        true          114       0         2695335054  true
+check_b                  c        false          false        true          114       0         0           true
+check_c                  c        false          false        true          114       0         0           true
+fk                       f        false          false        true          114       0         3687884464  true
+t3_rowid_not_null        n        false          false        true          114       0         0           true
+t4_pkey                  p        false          false        true          116       0         3214807592  true
+unique_a                 u        false          false        true          116       0         0           true
+uwi_b_c                  u        false          false        true          116       0         0           true
+uwi_b_partial            u        false          false        true          116       0         0           true
+t4_rowid_not_null        n        false          false        true          116       0         0           true
+t5_pkey                  p        false          false        true          117       0         1869730585  true
+fk_b_c                   f        false          false        true          117       0         0           true
+t5_a_fkey                f        false          false        true          117       0         0           true
+t5_rowid_not_null        n        false          false        true          117       0         0           true
+t6_pkey                  p        false          false        true          120       0         2129466852  true
+t6_expr_key              u        false          false        true          120       0         2129466848  true
+t6_rowid_not_null        n        false          false        true          120       0         0           true
+mv1_pkey                 p        false          false        true          121       0         784389845   true
+mv1_rowid_not_null       n        false          false        true          121       0         0           true
 
 query T
 SELECT conname
 FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
-WHERE n.nspname = 'public' AND contype NOT IN ('c', 'f', 'p', 'u')
+WHERE n.nspname = 'public' AND contype NOT IN ('c', 'f', 'n', 'p', 'u')
 ORDER BY con.oid
 ----
 
@@ -1842,28 +1865,39 @@ FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-conname        conislocal  coninhcount  connoinherit  conkey
-t1_pkey        true        0            true          {1}
-t1_a_key       true        0            true          {2}
-index_key      true        0            true          {3,4}
-primary        true        0            true          {1}
-primary        true        0            true          {1}
-t2_pkey        true        0            true          {2}
-fk             true        0            true          {1}
-t3_pkey        true        0            true          {4}
-check_b        true        0            true          {2}
-check_c        true        0            true          {3}
-fk             true        0            true          {1,2}
-t4_pkey        true        0            true          {4}
-unique_a       true        0            true          NULL
-uwi_b_c        true        0            true          NULL
-uwi_b_partial  true        0            true          NULL
-t5_pkey        true        0            true          {4}
-fk_b_c         true        0            true          {2,3}
-t5_a_fkey      true        0            true          {1}
-t6_pkey        true        0            true          {6}
-t6_expr_key    true        0            true          {7}
-mv1_pkey       true        0            true          {2}
+conname                  conislocal  coninhcount  connoinherit  conkey
+t1_pkey                  true        0            true          {1}
+t1_a_key                 true        0            true          {2}
+index_key                true        0            true          {3,4}
+t1_p_not_null            true        0            false         {1}
+t1_m_not_null            true        0            false         {14}
+t1_n_not_null            true        0            false         {15}
+primary                  true        0            true          {1}
+t1_m_seq_value_not_null  true        0            false         {1}
+primary                  true        0            true          {1}
+t1_n_seq_value_not_null  true        0            false         {1}
+t2_pkey                  true        0            true          {2}
+fk                       true        0            true          {1}
+t2_rowid_not_null        true        0            false         {2}
+t3_pkey                  true        0            true          {4}
+check_b                  true        0            true          {2}
+check_c                  true        0            true          {3}
+fk                       true        0            true          {1,2}
+t3_rowid_not_null        true        0            false         {4}
+t4_pkey                  true        0            true          {4}
+unique_a                 true        0            true          NULL
+uwi_b_c                  true        0            true          NULL
+uwi_b_partial            true        0            true          NULL
+t4_rowid_not_null        true        0            false         {4}
+t5_pkey                  true        0            true          {4}
+fk_b_c                   true        0            true          {2,3}
+t5_a_fkey                true        0            true          {1}
+t5_rowid_not_null        true        0            false         {4}
+t6_pkey                  true        0            true          {6}
+t6_expr_key              true        0            true          {7}
+t6_rowid_not_null        true        0            false         {6}
+mv1_pkey                 true        0            true          {2}
+mv1_rowid_not_null       true        0            false         {2}
 
 query TTTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc, pg_get_constraintdef(con.oid) as condef
@@ -4461,20 +4495,22 @@ CREATE TABLE t(x INT UNIQUE);
 query TTT
 SELECT conname, confupdtype, confdeltype FROM pg_constraint ORDER BY conname
 ----
-t_pkey    NULL  NULL
-t_x_key   NULL  NULL
-u_a_fkey  a     a
-u_b_fkey  a     r
-u_c_fkey  a     n
-u_d_fkey  a     d
-u_e_fkey  a     c
-u_f_fkey  a     a
-u_g_fkey  r     a
-u_h_fkey  n     a
-u_i_fkey  d     a
-u_j_fkey  c     a
-u_k_fkey  n     r
-u_pkey    NULL  NULL
+t_pkey            NULL  NULL
+t_rowid_not_null  NULL  NULL
+t_x_key           NULL  NULL
+u_a_fkey          a     a
+u_b_fkey          a     r
+u_c_fkey          a     n
+u_d_fkey          a     d
+u_e_fkey          a     c
+u_f_fkey          a     a
+u_g_fkey          r     a
+u_h_fkey          n     a
+u_i_fkey          d     a
+u_j_fkey          c     a
+u_k_fkey          n     r
+u_pkey            NULL  NULL
+u_rowid_not_null  NULL  NULL
 
 statement ok
 DROP TABLE u; DROP TABLE t
@@ -4492,11 +4528,13 @@ CREATE TABLE w(
 query TT
 SELECT conname, confmatchtype FROM pg_constraint ORDER BY conname
 ----
-v_pkey      NULL
-v_x_y_key   NULL
-w_a_b_fkey  f
-w_c_d_fkey  s
-w_pkey      NULL
+v_pkey            NULL
+v_rowid_not_null  NULL
+v_x_y_key         NULL
+w_a_b_fkey        f
+w_c_d_fkey        s
+w_pkey            NULL
+w_rowid_not_null  NULL
 
 statement ok
 DROP DATABASE d34862 CASCADE; SET database=test
@@ -4638,10 +4676,11 @@ ON c.conrelid = t.oid
 WHERE t.relname = 'partial_index_table'
 ORDER BY conname
 ----
-conname                     condef
-partial_index_table_a_key   UNIQUE (a ASC) WHERE (a > 0)
-partial_index_table_a_key1  UNIQUE (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
-partial_index_table_pkey    PRIMARY KEY (rowid ASC)
+conname                             condef
+partial_index_table_a_key           UNIQUE (a ASC) WHERE (a > 0)
+partial_index_table_a_key1          UNIQUE (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
+partial_index_table_pkey            PRIMARY KEY (rowid ASC)
+partial_index_table_rowid_not_null  NOT NULL
 
 subtest regression_46799
 statement ok
@@ -6298,5 +6337,62 @@ statement ok
 DROP TABLE pg_attrdef_alter_identity
 
 subtest end
+
+subtest pg_constraint_not_null
+
+# Match PostgreSQL: every NOT NULL column gets a synthetic pg_constraint row of
+# type 'n', regardless of whether the column became non-nullable via an explicit
+# modifier, a primary key, or ALTER TABLE ... SET NOT NULL. The constraint
+# name must follow PG's default ("<table>_<column>_not_null") so pg_dump
+# suppresses the explicit CONSTRAINT clause and emits a bare NOT NULL.
+
+statement ok
+CREATE TABLE notnull_test (
+  id INT PRIMARY KEY,
+  explicit_nn TEXT NOT NULL,
+  nullable TEXT,
+  later_nn TEXT,
+  pk_explicit_nn INT NOT NULL
+);
+ALTER TABLE notnull_test ALTER COLUMN later_nn SET NOT NULL;
+
+query TTT rowsort
+SELECT conname, contype::text, conkey::text
+FROM pg_catalog.pg_constraint
+WHERE conrelid = 'notnull_test'::regclass AND contype = 'n'
+----
+notnull_test_id_not_null              n  {1}
+notnull_test_explicit_nn_not_null     n  {2}
+notnull_test_later_nn_not_null        n  {4}
+notnull_test_pk_explicit_nn_not_null  n  {5}
+
+# The PK column also has its dedicated pg_constraint row of type 'p' — both
+# rows coexist, matching PG.
+query TTT rowsort
+SELECT conname, contype::text, conkey::text
+FROM pg_catalog.pg_constraint
+WHERE conrelid = 'notnull_test'::regclass AND contype IN ('p', 'n') AND conkey = '{1}'
+----
+notnull_test_pkey         p  {1}
+notnull_test_id_not_null  n  {1}
+
+# pg_dump 18 joins on (a.attrelid = co.conrelid AND co.contype = 'n'
+# AND co.conkey = array[a.attnum]). Confirm that join finds exactly the
+# non-nullable columns and nothing else.
+query TT rowsort
+SELECT a.attname, co.conname
+FROM pg_catalog.pg_attribute a
+LEFT JOIN pg_catalog.pg_constraint co
+  ON a.attrelid = co.conrelid AND co.contype = 'n' AND co.conkey = array[a.attnum]
+WHERE a.attrelid = 'notnull_test'::regclass AND a.attnum > 0
+----
+id              notnull_test_id_not_null
+explicit_nn     notnull_test_explicit_nn_not_null
+nullable        NULL
+later_nn        notnull_test_later_nn_not_null
+pk_explicit_nn  notnull_test_pk_explicit_nn_not_null
+
+statement ok
+DROP TABLE notnull_test
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -38,10 +38,11 @@ CREATE TABLE public.t (
 query TT
 SELECT conname, contype FROM pg_catalog.pg_constraint ORDER BY conname
 ----
-cc      c
-cf      f
-cu      u
-t_pkey  p
+cc                c
+cf                f
+cu                u
+t_pkey            p
+t_rowid_not_null  n
 
 subtest rename_works
 
@@ -81,10 +82,11 @@ CREATE TABLE public.t (
 query TT
 SELECT conname, contype FROM pg_catalog.pg_constraint ORDER BY conname
 ----
-cc2     c
-cf2     f
-cu2     u
-t_pkey  p
+cc2               c
+cf2               f
+cu2               u
+t_pkey            p
+t_rowid_not_null  n
 
 
 subtest duplicate_constraints
@@ -148,10 +150,11 @@ CREATE TABLE public.t (
 query TT
 SELECT conname, contype FROM pg_catalog.pg_constraint ORDER BY conname
 ----
-cc4     c
-cf4     f
-cu4     u
-t_pkey  p
+cc4               c
+cf4               f
+cu4               u
+t_pkey            p
+t_rowid_not_null  n
 
 # Allow renames of the implicit primary key.
 statement ok
@@ -160,11 +163,12 @@ CREATE TABLE implicit (a int, b int)
 statement ok
 ALTER TABLE implicit RENAME CONSTRAINT implicit_pkey TO something_else
 
-query TTTTB colnames
+query TTTTB colnames,nosort
 SHOW CONSTRAINTS FROM implicit
 ----
-table_name  constraint_name  constraint_type  details                  validated
-implicit    something_else   PRIMARY KEY      PRIMARY KEY (rowid ASC)  true
+table_name  constraint_name          constraint_type  details                  validated
+implicit    implicit_rowid_not_null  NOT NULL         NOT NULL                 true
+implicit    something_else           PRIMARY KEY      PRIMARY KEY (rowid ASC)  true
 
 statement error duplicate constraint name: \"something_else\"
 ALTER TABLE implicit ADD CONSTRAINT something_else CHECK(b > 0)

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -42,6 +42,7 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM test.child] ORDER BY constraint_name
 ----
+child  child_id_not_null   NOT NULL     NOT NULL                                                 true
 child  child_pkey          PRIMARY KEY  PRIMARY KEY (id ASC)                                     true
 child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id) NOT VALID  false
 
@@ -51,6 +52,7 @@ ALTER TABLE test.child VALIDATE CONSTRAINT fk_child_parent_id
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM test.child] ORDER BY constraint_name
 ----
+child  child_id_not_null   NOT NULL     NOT NULL                                       true
 child  child_pkey          PRIMARY KEY  PRIMARY KEY (id ASC)                           true
 child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  true
 
@@ -84,6 +86,7 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM test.child] ORDER BY constraint_name
 ----
+child  child_id_not_null   NOT NULL     NOT NULL                                       true
 child  child_pkey          PRIMARY KEY  PRIMARY KEY (id ASC)                           true
 child  fk_child_parent_id  FOREIGN KEY  FOREIGN KEY (parent_id) REFERENCES parent(id)  true
 
@@ -926,9 +929,10 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM check_table] ORDER BY constraint_name
 ----
-check_table  c_0               CHECK        CHECK ((c > 0)) NOT VALID  false
-check_table  check_table_pkey  PRIMARY KEY  PRIMARY KEY (k ASC)        true
-check_table  d_0               CHECK        CHECK ((d > 0))            true
+check_table  c_0                     CHECK        CHECK ((c > 0)) NOT VALID  false
+check_table  check_table_k_not_null  NOT NULL     NOT NULL                   true
+check_table  check_table_pkey        PRIMARY KEY  PRIMARY KEY (k ASC)        true
+check_table  d_0                     CHECK        CHECK ((d > 0))            true
 
 statement ok
 BEGIN
@@ -959,9 +963,10 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM check_table] ORDER BY constraint_name
 ----
-check_table  c_0               CHECK        CHECK ((c > 0)) NOT VALID  false
-check_table  check_table_pkey  PRIMARY KEY  PRIMARY KEY (k ASC)        true
-check_table  d_0               CHECK        CHECK ((d > 0))            true
+check_table  c_0                     CHECK        CHECK ((c > 0)) NOT VALID  false
+check_table  check_table_k_not_null  NOT NULL     NOT NULL                   true
+check_table  check_table_pkey        PRIMARY KEY  PRIMARY KEY (k ASC)        true
+check_table  d_0                     CHECK        CHECK ((d > 0))            true
 
 # Adding column e was rolled back
 query TTBTTTB rowsort
@@ -995,10 +1000,11 @@ ALTER TABLE check_table ADD CHECK (a >= 0)
 statement error pgcode XXA00 violates unique constraint "idx"
 COMMIT
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  check_table_pkey  PRIMARY KEY  PRIMARY KEY (k ASC)  true
+check_table  check_table_k_not_null  NOT NULL     NOT NULL             true
+check_table  check_table_pkey        PRIMARY KEY  PRIMARY KEY (k ASC)  true
 
 statement ok
 BEGIN
@@ -1012,10 +1018,11 @@ ALTER TABLE check_table ADD CHECK (a < 0)
 statement error pgcode XXA00 validation of CHECK \"a < 0:::INT8\" failed on row
 COMMIT
 
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  check_table_pkey  PRIMARY KEY  PRIMARY KEY (k ASC)  true
+check_table  check_table_k_not_null  NOT NULL     NOT NULL             true
+check_table  check_table_pkey        PRIMARY KEY  PRIMARY KEY (k ASC)  true
 
 statement ok
 DROP TABLE check_table
@@ -1144,10 +1151,11 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM check_table] ORDER BY constraint_name
 ----
-check_table  check_table_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
-check_table  ck_a              CHECK        CHECK ((a = 0))          true
-check_table  ck_b              CHECK        CHECK ((b > 0))          true
-check_table  ck_c              CHECK        CHECK ((c > b))          true
+check_table  check_table_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+check_table  check_table_rowid_not_null  NOT NULL     NOT NULL                 true
+check_table  ck_a                        CHECK        CHECK ((a = 0))          true
+check_table  ck_b                        CHECK        CHECK ((b > 0))          true
+check_table  ck_c                        CHECK        CHECK ((c > b))          true
 
 # Also test insert/update to ensure constraint was added in a valid state (with correct column IDs, etc.)
 
@@ -1518,8 +1526,9 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM y] ORDER BY constraint_name
 ----
-y  y_b_fkey  FOREIGN KEY  FOREIGN KEY (b) REFERENCES x(b)  true
-y  y_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)              true
+y  y_a_not_null  NOT NULL     NOT NULL                         true
+y  y_b_fkey      FOREIGN KEY  FOREIGN KEY (b) REFERENCES x(b)  true
+y  y_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)              true
 
 # Also test dropping the index on the referenced side
 statement ok
@@ -1541,18 +1550,20 @@ COMMIT
 
 # Verify that table x is in a consistent state (otherwise, SHOW CONSTRAINTS
 # would fail with an error).
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM x
 ----
-x  x_pkey   PRIMARY KEY  PRIMARY KEY (a ASC)  true
+x  x_a_not_null  NOT NULL     NOT NULL             true
+x  x_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)  true
 
 # Verify that table y is in a consistent state (otherwise, SHOW
 # CONSTRAINTS would fail with an error). The foreign constraint here
 # hasn't been rolled back because the index hasn't been rolled back.
-query TTTTB
+query TTTTB nosort
 SHOW CONSTRAINTS FROM y
 ----
-y  y_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)              true
+y  y_a_not_null  NOT NULL     NOT NULL             true
+y  y_pkey        PRIMARY KEY  PRIMARY KEY (a ASC)  true
 
 statement ok
 DROP TABLE x, y
@@ -1864,7 +1875,9 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM t_52501_valid] ORDER BY constraint_name
 ----
-t_52501_valid  t_52501_valid_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t_52501_valid  t_52501_valid_a_not_null      NOT NULL     NOT NULL                 true
+t_52501_valid  t_52501_valid_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+t_52501_valid  t_52501_valid_rowid_not_null  NOT NULL     NOT NULL                 true
 
 query TB
 SELECT column_name, is_nullable FROM [SHOW COLUMNS FROM t_52501_valid] WHERE column_name = 'a'
@@ -1911,8 +1924,9 @@ COMMIT
 query TTTTB
 SELECT * FROM [SHOW CONSTRAINTS FROM child_54265] ORDER BY constraint_name
 ----
-child_54265  child_54265_a_fkey  FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a) NOT VALID  false
-child_54265  child_54265_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)                               true
+child_54265  child_54265_a_fkey          FOREIGN KEY  FOREIGN KEY (a) REFERENCES parent_54265(a) NOT VALID  false
+child_54265  child_54265_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)                               true
+child_54265  child_54265_rowid_not_null  NOT NULL     NOT NULL                                              true
 
 # Test that dropping a unique index used by a foreign key reference causes the
 # foreign key addition to fail.

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -344,11 +344,12 @@ table_name  index_name  non_unique  seq_in_index  column_name  definition  direc
 descriptor  primary     false       1             id           id          ASC        false    false     true     1
 descriptor  primary     false       2             descriptor   descriptor  N/A        true     false     true     1
 
-query TTTTB colnames
+query TTTTB colnames,nosort
 SELECT * FROM [SHOW CONSTRAINT FROM system.descriptor]
 ----
-table_name  constraint_name  constraint_type  details               validated
-descriptor  primary          PRIMARY KEY      PRIMARY KEY (id ASC)  true
+table_name  constraint_name         constraint_type  details               validated
+descriptor  primary                 PRIMARY KEY      PRIMARY KEY (id ASC)  true
+descriptor  descriptor_id_not_null  NOT NULL         NOT NULL              true
 
 query TTBITTTBBBF colnames,rowsort
 SELECT * FROM [SHOW KEYS FROM system.descriptor]

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -104,6 +104,7 @@ SELECT * FROM [SHOW CONSTRAINTS FROM c WITH COMMENT] ORDER BY constraint_name
 ----
 table_name  constraint_name  constraint_type  details               validated  comment
 c           c_bar_key        UNIQUE           UNIQUE (bar ASC)      true       NULL
+c           c_id_not_null    NOT NULL         NOT NULL              true       NULL
 c           c_pkey           PRIMARY KEY      PRIMARY KEY (id ASC)  true       NULL
 c           foo_positive     CHECK            CHECK ((foo > 0))     true       NULL
 
@@ -278,12 +279,13 @@ CREATE TABLE test.dupe_generated (
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM test.dupe_generated] ORDER BY constraint_name
 ----
-table_name      constraint_name      constraint_type  details                  validated
-dupe_generated  check_bar            CHECK            CHECK ((bar > 2))        true
-dupe_generated  check_foo            CHECK            CHECK ((foo > 2))        true
-dupe_generated  check_foo1           CHECK            CHECK ((foo < 10))       true
-dupe_generated  check_foo2           CHECK            CHECK ((foo > 1))        true
-dupe_generated  dupe_generated_pkey  PRIMARY KEY      PRIMARY KEY (rowid ASC)  true
+table_name      constraint_name                constraint_type  details                  validated
+dupe_generated  check_bar                      CHECK            CHECK ((bar > 2))        true
+dupe_generated  check_foo                      CHECK            CHECK ((foo > 2))        true
+dupe_generated  check_foo1                     CHECK            CHECK ((foo < 10))       true
+dupe_generated  check_foo2                     CHECK            CHECK ((foo > 1))        true
+dupe_generated  dupe_generated_pkey            PRIMARY KEY      PRIMARY KEY (rowid ASC)  true
+dupe_generated  dupe_generated_rowid_not_null  NOT NULL         NOT NULL                 true
 
 statement ok
 CREATE TABLE test.named_constraints (
@@ -354,13 +356,15 @@ test.public.named_constraints  CREATE TABLE public.named_constraints (
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM test.named_constraints] ORDER BY constraint_name
 ----
-table_name         constraint_name  constraint_type  details                                    validated
-named_constraints  bar              UNIQUE           UNIQUE (id ASC, name ASC)                  true
-named_constraints  ck1              CHECK            CHECK ((length(nickname) < 10))            true
-named_constraints  ck2              CHECK            CHECK ((length(nickname) < length(name)))  true
-named_constraints  pk               PRIMARY KEY      PRIMARY KEY (id ASC)                       true
-named_constraints  uq               UNIQUE           UNIQUE (email ASC)                         true
-named_constraints  uq2              UNIQUE           UNIQUE (username ASC)                      true
+table_name         constraint_name                  constraint_type  details                                    validated
+named_constraints  bar                              UNIQUE           UNIQUE (id ASC, name ASC)                  true
+named_constraints  ck1                              CHECK            CHECK ((length(nickname) < 10))            true
+named_constraints  ck2                              CHECK            CHECK ((length(nickname) < length(name)))  true
+named_constraints  named_constraints_id_not_null    NOT NULL         NOT NULL                                   true
+named_constraints  named_constraints_name_not_null  NOT NULL         NOT NULL                                   true
+named_constraints  pk                               PRIMARY KEY      PRIMARY KEY (id ASC)                       true
+named_constraints  uq                               UNIQUE           UNIQUE (email ASC)                         true
+named_constraints  uq2                              UNIQUE           UNIQUE (username ASC)                      true
 
 statement error duplicate constraint name: "pk"
 CREATE TABLE test.dupe_named_constraints (

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1397,6 +1397,58 @@ func populateTableConstraints(
 			return err
 		}
 	}
+
+	// Synthesize a NOT NULL constraint row for each non-nullable column.
+	// PostgreSQL exposes one of these for every NOT NULL column (whether it
+	// became non-nullable via an explicit modifier, a primary key, or
+	// ALTER TABLE ... SET NOT NULL); CockroachDB doesn't model NOT NULL as a
+	// separate constraint object, so we materialize the rows on the fly to
+	// match. Naming the synthetic constraint "<table>_<column>_not_null" lines
+	// up with PostgreSQL's default name.
+	for _, col := range table.AccessibleColumns() {
+		if col.IsNullable() {
+			continue
+		}
+		conkey, err := colIDArrayToDatum([]descpb.ColumnID{col.GetID()})
+		if err != nil {
+			return err
+		}
+		conname := fmt.Sprintf("%s_%s_not_null", table.GetName(), col.GetName())
+		if err := addRow(
+			h.NotNullConstraintOid(db.GetID(), sc.GetID(), table.GetID(), col.GetID()), // oid
+			tree.NewDName(conname),      // conname
+			namespaceOid,                // connamespace
+			conTypeNotNull,              // contype
+			tree.DBoolFalse,             // condeferrable
+			tree.DBoolFalse,             // condeferred
+			tree.DBoolTrue,              // convalidated
+			tblOid,                      // conrelid
+			oidZero,                     // contypid
+			oidZero,                     // conindid
+			oidZero,                     // conparentid
+			oidZero,                     // confrelid
+			tree.DNull,                  // confupdtype
+			tree.DNull,                  // confdeltype
+			tree.DNull,                  // confmatchtype
+			tree.DBoolTrue,              // conislocal
+			zeroVal,                     // coninhcount
+			tree.DBoolFalse,             // connoinherit
+			conkey,                      // conkey
+			tree.DNull,                  // confkey
+			tree.DNull,                  // conpfeqop
+			tree.DNull,                  // conppeqop
+			tree.DNull,                  // conffeqop
+			tree.DNull,                  // confdelsetcols
+			tree.DNull,                  // conexclop
+			tree.DNull,                  // conbin
+			tree.DNull,                  // consrc
+			tree.NewDString("NOT NULL"), // condef
+			tree.DBoolTrue,              // conenforced
+			tree.DBoolFalse,             // conperiod
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -6312,6 +6364,7 @@ const (
 	policyTypeTag
 	roleMembershipTypeTag
 	domainConstraintTypeTag
+	notNullConstraintTypeTag
 )
 
 func (h oidHasher) writeTypeTag(tag oidTypeTag) {
@@ -6434,6 +6487,22 @@ func (h oidHasher) DomainConstraintOid(
 	h.writeTypeTag(domainConstraintTypeTag)
 	h.writeUInt32(uint32(typeOid))
 	h.writeUInt32(uint32(constraintID))
+	return h.getOid()
+}
+
+// NotNullConstraintOid returns a stable OID for the synthetic NOT NULL
+// constraint that pg_catalog.pg_constraint exposes for a non-nullable column.
+// CockroachDB does not model NOT NULL as a separate constraint object, so the
+// constraint is materialized on the fly and keyed by the (db, schema, table,
+// column) tuple to keep the OID stable across catalog reads.
+func (h oidHasher) NotNullConstraintOid(
+	dbID descpb.ID, scID descpb.ID, tableID descpb.ID, columnID descpb.ColumnID,
+) *tree.DOid {
+	h.writeTypeTag(notNullConstraintTypeTag)
+	h.writeDB(dbID)
+	h.writeSchema(scID)
+	h.writeTable(tableID)
+	h.writeUInt32(uint32(columnID))
 	return h.getOid()
 }
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -529,7 +529,10 @@ func TestPGPreparedQuery(t *testing.T) {
 		}},
 		{"SHOW CONSTRAINTS FROM system.users", []preparedQueryTest{
 			baseTest.Results("users", "primary", "PRIMARY KEY", "PRIMARY KEY (username ASC)", true).
-				Results("users", "users_user_id_idx", "UNIQUE", "UNIQUE (user_id ASC)", true),
+				Results("users", "users_isRole_not_null", "NOT NULL", "NOT NULL", true).
+				Results("users", "users_user_id_idx", "UNIQUE", "UNIQUE (user_id ASC)", true).
+				Results("users", "users_user_id_not_null", "NOT NULL", "NOT NULL", true).
+				Results("users", "users_username_not_null", "NOT NULL", "NOT NULL", true),
 		}},
 		{"SHOW TIME ZONE", []preparedQueryTest{
 			baseTest.Results("UTC"),

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3989,9 +3989,13 @@ func (og *operationGenerator) randConstraint(
 	if err := og.setSeedInDB(ctx, tx); err != nil {
 		return "", err
 	}
+	// NOT NULL rows in pg_constraint are synthesized from non-nullable column
+	// metadata, so they cannot be dropped via ALTER TABLE ... DROP CONSTRAINT.
+	// Skip them when picking a random constraint for drop.
 	q := fmt.Sprintf(`
   SELECT constraint_name
     FROM [SHOW CONSTRAINTS FROM %s]
+   WHERE constraint_type <> 'NOT NULL'
 ORDER BY random()
    LIMIT 1;
 `, tableName)


### PR DESCRIPTION
PostgreSQL stores a row in pg_constraint with contype='n' for every non-nullable column, regardless of whether the column became NOT NULL via an explicit modifier, a primary key, or ALTER TABLE ... SET NOT NULL.

Tools such as pg_dump rely on the pg_constraint table to show these contstraints in order to do introspection correctly.

Synthesize a contype='n' row inside populateTableConstraints for every non-nullable accessible column on a table descriptor. Match PostgreSQL behavior, which means:

- Show the default constraint name "<table>_<column>_not_null".
- Emit a NOT NULL row for PK columns too, alongside the existing PK constraint row.

Iterate AccessibleColumns() to align with how pg_attribute is built, keeping the synthesized conkey aligned with the attnums pg_dump's join expects. A new notNullConstraintTypeTag keeps the synthetic OIDs disjoint from CHECK / PK / FK / UNIQUE / domain OIDs.

Resolves: #169937
Epic: CRDB-39727

Release note (sql change): pg_catalog.pg_constraint now exposes NOT NULL constraints as named entries (contype='n', conkey=array of the column's attnum, conname like "<table>_<column>_not_null"), matching PostgreSQL's behavior for non-nullable columns.