### PR TITLE
sql/parser: default GENERATED ALWAYS AS to VIRTUAL when keyword omitted

### DIFF
--- a/docs/generated/sql/bnf/col_qualification.bnf
+++ b/docs/generated/sql/bnf/col_qualification.bnf
@@ -9,8 +9,7 @@ col_qualification ::=
 	| 'CONSTRAINT' constraint_name 'DEFAULT' b_expr
 	| 'CONSTRAINT' constraint_name 'ON' 'UPDATE' b_expr
 	| 'CONSTRAINT' constraint_name 'REFERENCES' table_name opt_name_parens key_match reference_actions
-	| 'CONSTRAINT' constraint_name generated_as '(' a_expr ')' 'STORED'
-	| 'CONSTRAINT' constraint_name generated_as '(' a_expr ')' 'VIRTUAL'
+	| 'CONSTRAINT' constraint_name generated_as '(' a_expr ')' opt_virtual_or_stored
 	| 'CONSTRAINT' constraint_name 'GENERATED_ALWAYS' 'ALWAYS' 'AS' 'IDENTITY' '(' opt_sequence_option_list ')'
 	| 'CONSTRAINT' constraint_name 'GENERATED_BY_DEFAULT' 'BY' 'DEFAULT' 'AS' 'IDENTITY' '(' opt_sequence_option_list ')'
 	| 'CONSTRAINT' constraint_name 'GENERATED_ALWAYS' 'ALWAYS' 'AS' 'IDENTITY'
@@ -25,8 +24,7 @@ col_qualification ::=
 	| 'DEFAULT' b_expr
 	| 'ON' 'UPDATE' b_expr
 	| 'REFERENCES' table_name opt_name_parens key_match reference_actions
-	| generated_as '(' a_expr ')' 'STORED'
-	| generated_as '(' a_expr ')' 'VIRTUAL'
+	| generated_as '(' a_expr ')' opt_virtual_or_stored
 	| 'GENERATED_ALWAYS' 'ALWAYS' 'AS' 'IDENTITY' '(' opt_sequence_option_list ')'
 	| 'GENERATED_BY_DEFAULT' 'BY' 'DEFAULT' 'AS' 'IDENTITY' '(' opt_sequence_option_list ')'
 	| 'GENERATED_ALWAYS' 'ALWAYS' 'AS' 'IDENTITY'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -5342,8 +5342,7 @@ col_qualification_elem ::=
 	| 'DEFAULT' b_expr
 	| 'ON' 'UPDATE' b_expr
 	| 'REFERENCES' table_name opt_name_parens key_match reference_actions
-	| generated_as '(' a_expr ')' 'STORED'
-	| generated_as '(' a_expr ')' 'VIRTUAL'
+	| generated_as '(' a_expr ')' opt_virtual_or_stored
 	| generated_always_as 'IDENTITY' '(' opt_sequence_option_list ')'
 	| generated_by_default_as 'IDENTITY' '(' opt_sequence_option_list ')'
 	| generated_always_as 'IDENTITY'
@@ -5370,3 +5369,8 @@ opt_name_parens ::=
 generated_as ::=
 	'AS'
 	| generated_always_as
+
+opt_virtual_or_stored ::=
+	'STORED'
+	| 'VIRTUAL'
+	| 

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -344,15 +344,19 @@ DROP TABLE x
 # statement ok
 # DROP TABLE x
 
-statement error use AS \( <expr> \) STORED or AS \( <expr> \) VIRTUAL
+statement error use AS \( <expr> \), AS \( <expr> \) STORED, or AS \( <expr> \) VIRTUAL
 CREATE TABLE y (
   a INT AS 3 STORED
 )
 
-statement error use AS \( <expr> \) STORED or AS \( <expr> \) VIRTUAL
+# Without STORED or VIRTUAL, the column defaults to VIRTUAL (matches PostgreSQL).
+statement ok
 CREATE TABLE y (
   a INT AS (3)
 )
+
+statement ok
+DROP TABLE y
 
 statement ok
 CREATE TABLE tmp (x INT)

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1679,3 +1679,60 @@ statement error division by zero
 UPDATE t_divzero_virtual SET c = 0 WHERE a = 1
 
 subtest end
+
+subtest implicit_virtual
+
+# Without STORED or VIRTUAL, a generated column defaults to VIRTUAL,
+# matching PostgreSQL.
+statement ok
+CREATE TABLE implicit_virtual_generated (
+  a INT PRIMARY KEY,
+  b INT GENERATED ALWAYS AS (a + 1)
+) WITH (schema_locked = true)
+
+statement error cannot write directly to computed column
+INSERT INTO implicit_virtual_generated (a, b) VALUES (1, 5)
+
+statement ok
+INSERT INTO implicit_virtual_generated (a) VALUES (1), (2)
+
+query II
+SELECT a, b FROM implicit_virtual_generated ORDER BY a
+----
+1  2
+2  3
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE implicit_virtual_generated]
+----
+CREATE TABLE public.implicit_virtual_generated (
+  a INT8 NOT NULL,
+  b INT8 NULL AS (a + 1:::INT8) VIRTUAL,
+  CONSTRAINT implicit_virtual_generated_pkey PRIMARY KEY (a ASC)
+) WITH (schema_locked = true);
+
+# The CRDB-shorthand form (no GENERATED ALWAYS) also defaults to VIRTUAL.
+statement ok
+CREATE TABLE implicit_virtual_shorthand (
+  a INT PRIMARY KEY,
+  b INT AS (a * 2)
+) WITH (schema_locked = true)
+
+statement ok
+INSERT INTO implicit_virtual_shorthand (a) VALUES (5)
+
+query II
+SELECT a, b FROM implicit_virtual_shorthand
+----
+5  10
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE implicit_virtual_shorthand]
+----
+CREATE TABLE public.implicit_virtual_shorthand (
+  a INT8 NOT NULL,
+  b INT8 NULL AS (a * 2:::INT8) VIRTUAL,
+  CONSTRAINT implicit_virtual_shorthand_pkey PRIMARY KEY (a ASC)
+) WITH (schema_locked = true);
+
+subtest end

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1670,7 +1670,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %type <tree.Expr> overlay_placing
 %type <*tree.TenantSpec> virtual_cluster_spec virtual_cluster_spec_opt_all
 
-%type <bool> opt_unique opt_concurrently opt_cluster opt_without_index
+%type <bool> opt_unique opt_concurrently opt_cluster opt_without_index opt_virtual_or_stored
 
 %type <*tree.Limit> limit_clause offset_clause opt_limit_clause
 %type <tree.Expr> select_fetch_first_value
@@ -12010,17 +12010,13 @@ col_qualification_elem:
       Match: $4.compositeKeyMatchMethod(),
     }
   }
-| generated_as '(' a_expr ')' STORED
+| generated_as '(' a_expr ')' opt_virtual_or_stored
   {
-    $$.val = &tree.ColumnComputedDef{Expr: $3.expr(), Virtual: false}
-  }
-| generated_as '(' a_expr ')' VIRTUAL
-  {
-    $$.val = &tree.ColumnComputedDef{Expr: $3.expr(), Virtual: true}
+    $$.val = &tree.ColumnComputedDef{Expr: $3.expr(), Virtual: $5.bool()}
   }
 | generated_as error
   {
-    sqllex.Error("use AS ( <expr> ) STORED or AS ( <expr> ) VIRTUAL")
+    sqllex.Error("use AS ( <expr> ), AS ( <expr> ) STORED, or AS ( <expr> ) VIRTUAL")
     return 1
   }
 | generated_always_as IDENTITY '(' opt_sequence_option_list ')'
@@ -12053,6 +12049,23 @@ opt_without_index:
 | /* EMPTY */
   {
     $$.val = false
+  }
+
+// opt_virtual_or_stored optionally specifies whether a generated column is
+// VIRTUAL or STORED. When neither keyword is given, the column is VIRTUAL,
+// matching PostgreSQL.
+opt_virtual_or_stored:
+  STORED
+  {
+    $$.val = false
+  }
+| VIRTUAL
+  {
+    $$.val = true
+  }
+| /* EMPTY */
+  {
+    $$.val = true
   }
 
 generated_as:

--- a/pkg/sql/parser/testdata/alter_table
+++ b/pkg/sql/parser/testdata/alter_table
@@ -1257,7 +1257,7 @@ ALTER TABLE a ADD COLUMN b INT GENERATED ALWAYS AS (1 + 1) STORED GENERATED ALWA
 error
 ALTER TABLE a ADD COLUMN b INT GENERATED ALWAYS AS (1+1) IDENTITY
 ----
-at or near "identity": syntax error: use AS ( <expr> ) STORED or AS ( <expr> ) VIRTUAL
+at or near "identity": syntax error
 DETAIL: source SQL:
 ALTER TABLE a ADD COLUMN b INT GENERATED ALWAYS AS (1+1) IDENTITY
                                                          ^

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -1721,6 +1721,23 @@ CREATE TABLE a (b INT8 AS (((a) + (b))) VIRTUAL) -- fully parenthesized
 CREATE TABLE a (b INT8 AS (a + b) VIRTUAL) -- literals removed
 CREATE TABLE _ (_ INT8 AS (_ + _) VIRTUAL) -- identifiers removed
 
+# Without STORED or VIRTUAL the column defaults to VIRTUAL, matching PostgreSQL.
+parse
+CREATE TABLE a (b INT8 GENERATED ALWAYS AS (a + b))
+----
+CREATE TABLE a (b INT8 AS (a + b) VIRTUAL) -- normalized!
+CREATE TABLE a (b INT8 AS (((a) + (b))) VIRTUAL) -- fully parenthesized
+CREATE TABLE a (b INT8 AS (a + b) VIRTUAL) -- literals removed
+CREATE TABLE _ (_ INT8 AS (_ + _) VIRTUAL) -- identifiers removed
+
+parse
+CREATE TABLE a (b INT8 AS (a + b))
+----
+CREATE TABLE a (b INT8 AS (a + b) VIRTUAL) -- normalized!
+CREATE TABLE a (b INT8 AS (((a) + (b))) VIRTUAL) -- fully parenthesized
+CREATE TABLE a (b INT8 AS (a + b) VIRTUAL) -- literals removed
+CREATE TABLE _ (_ INT8 AS (_ + _) VIRTUAL) -- identifiers removed
+
 parse
 CREATE TABLE view (view INT8)
 ----
@@ -2444,12 +2461,13 @@ CREATE TABLE generated_error (
   b INT GENERATED ALWAYS AS (a + 10) IDENTITY
 )
 ----
-at or near "identity": syntax error: use AS ( <expr> ) STORED or AS ( <expr> ) VIRTUAL
+at or near "identity": syntax error
 DETAIL: source SQL:
 CREATE TABLE generated_error (
   a INT,
   b INT GENERATED ALWAYS AS (a + 10) IDENTITY
                                      ^
+HINT: try \h CREATE TABLE
 
 error
 CREATE TABLE generated_error (


### PR DESCRIPTION
Previously CockroachDB required GENERATED ALWAYS AS (expr) (and the shorthand AS (expr)) to be followed explicitly by either STORED or VIRTUAL; omitting the keyword produced a parse error. PostgreSQL recently added virtual generated columns (commit 83ea6c54025) and made VIRTUAL the default when neither keyword is specified, so that GENERATED ALWAYS AS (expr) without a trailing keyword is accepted and yields a virtual column.

This commit matches that behavior. The grammar gains an opt_virtual_or_stored helper non-terminal whose empty alternative returns Virtual=true, mirroring PostgreSQL's opt_virtual_or_stored. The three column-constraint productions for STORED, VIRTUAL, and the previous error fallback collapse into a single production using the new helper. The parse error message is updated to reflect that the trailing keyword is now optional. All existing CRDB syntax keeps working - this is a strict superset.

Epic: CRDB-62553

Release note (sql change): GENERATED ALWAYS AS (expr) and AS (expr) column definitions no longer require a trailing STORED or VIRTUAL keyword. When neither is specified the column is VIRTUAL, matching PostgreSQL.