### PR TITLE
sql: wait for hint cache initial scan in TestTrace

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -214,6 +214,15 @@ func TestTrace(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wait for each node's statement_hints rangefeed to complete its initial
+	// scan. Otherwise, the first query on a node will fall through to a DB read
+	// in MaybeGetStatementHints (because hintedHashes is still nil) and pollute
+	// the trace with internal-query spans like colbatchscan / colindexjoin.
+	for i := 0; i < numNodes; i++ {
+		hc := cluster.ApplicationLayer(i).ExecutorConfig().(sql.ExecutorConfig).StatementHintsCache
+		hc.Await(context.Background())
+	}
+
 	for _, test := range testData {
 		optionalSpans := append([]string{}, alwaysOptionalSpans...)
 		// Check if DRPC is enabled. When DRPC is enabled, remote KV requests


### PR DESCRIPTION
TestTrace was flaky because the first query against a given node would race the StatementHintsCache rangefeed's initial scan on that node. While hintedHashes is still nil, MaybeGetStatementHints conservatively falls through to a DB read for the statement_hints table, even when the table is empty. That internal lookup runs with vectorize on (the nodeUserLocalOnly override only forces DistSQL off), so it emits colbatchscan, colindexjoin, flow coordinator, and materializer spans into the user session trace. None of those are listed in alwaysOptionalSpans, so the test fails with "expected span: \"commit sql txn\", got: \"colbatchscan\"" once it walks the alphabetized span list.

Wait for each application layer's StatementHintsCache to complete its initial scan before any sub-test runs. After Await returns, hintedHashes is initialized, so empty-table lookups short-circuit without a DB read and the trace only contains the spans the test expects.

Fixes: #169887
Epic: none

Release note: None