### PR TITLE
roachtest: validate LDAP auto-provisioning and last login tracking

### DIFF
--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -18,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -192,8 +195,7 @@ func runLDAPConnectionLatencyTest(
 		option.NewStartOpts(option.NoBackupSchedule), settings)
 	require.NoError(t, err)
 
-	// Prepare the user which will later be used for ldap bind.
-	prepareSQLUserForLDAP(ctx, t, c, ldapTestUserName)
+	// Roles are auto-provisioned on first LDAP login.
 
 	nodeArr := make([]int, numNodes)
 	for i := 1; i <= numNodes; i++ {
@@ -222,11 +224,29 @@ func runLDAPConnectionLatencyTest(
 			ldapTestUserName, ldapTestUserPassword)
 	}
 
-	// Create the SQL authenticating URL and test the connection.
+	// Create the SQL authenticating URL and test the connection. This
+	// triggers auto-provisioning of the jdoe role via LDAP.
+	authStart := timeutil.Now()
 	testAuthCmd := fmt.Sprintf(
 		"./cockroach sql --url \"%s\" --certs-dir=certs", urlTemplate("localhost"))
 	err = c.RunE(ctx, option.WithNodes(nodeListOptions), testAuthCmd)
 	require.NoError(t, err)
+
+	// Validate auto-provisioning: the role should have been created with
+	// a PROVISIONSRC option containing the "ldap:" prefix.
+	validateAutoProvisioning(ctx, t, c, ldapTestUserName)
+
+	// Validate estimated_last_login_time propagation: poll until the
+	// column is populated (the lastLoginUpdater batches updates
+	// asynchronously via singleflight).
+	validateLastLoginTime(ctx, t, c, ldapTestUserName, authStart)
+
+	// Grant admin to the auto-provisioned user so the connectionlatency
+	// workload can create its database.
+	adminConn := createPgxConnWithExternalURL(ctx, t, c)
+	defer func() { _ = adminConn.Close(ctx) }()
+	runSQLQueryForConnection(ctx, t, adminConn,
+		fmt.Sprintf("GRANT admin TO %s", ldapTestUserName))
 
 	runWorkload := func(roachNodes, loadNode option.NodeListOption, locality string) {
 		var urlString string
@@ -497,6 +517,12 @@ func setupCRDBForLDAPAuth(ctx context.Context, t test.Test, c cluster.Cluster, h
 		"server.ldap_authentication.domain.custom_ca", fmt.Sprintf("'%s'", trimmed))
 	runSQLQueryForConnection(ctx, t, conn, caCertQuery)
 
+	// Enable LDAP auto-provisioning so that SQL roles are created
+	// automatically on first successful LDAP authentication.
+	provisioningQuery := createClusterSettingQuery(
+		"security.provisioning.ldap.enabled", "true")
+	runSQLQueryForConnection(ctx, t, conn, provisioningQuery)
+
 	// This is required for better debugging in-case of failures in authentication.
 	debuggingQuery := createClusterSettingQuery(
 		"server.auth_log.sql_sessions.enabled", "true")
@@ -518,26 +544,6 @@ func createClusterSettingQuery(key, value string) string {
 	return fmt.Sprintf("SET cluster setting %s=%s", key, value)
 }
 
-// prepareUserForLDAP creates a SQL user and grants admin privilege
-// to the user. The `ldapUserName` must be same as the username
-// on the LDAP server.
-func prepareSQLUserForLDAP(
-	ctx context.Context, t test.Test, c cluster.Cluster, ldapUserName string,
-) {
-	// Connect to the node to create the required SQL users
-	// which will be authenticated using LDAP.
-	conn := createPgxConnWithExternalURL(ctx, t, c)
-
-	runSQLQueryForConnection(ctx, t, conn,
-		fmt.Sprintf("CREATE ROLE %s LOGIN", ldapUserName))
-
-	// connectionlatency workload checks the presence of the database named
-	// `connectionlatency`, if not present it creates it using the logged-in user
-	// Hence for ease of use, giving admin privilege to the user.
-	runSQLQueryForConnection(ctx, t, conn,
-		fmt.Sprintf("GRANT admin to %s", ldapUserName))
-}
-
 // createPgxConnWithExternalURL returns a psql connection
 // using the cluster's external url.
 func createPgxConnWithExternalURL(ctx context.Context, t test.Test, c cluster.Cluster) *pgx.Conn {
@@ -548,4 +554,52 @@ func createPgxConnWithExternalURL(ctx context.Context, t test.Test, c cluster.Cl
 	conn, err := pgx.Connect(ctx, pgURL[0])
 	require.NoError(t, err)
 	return conn
+}
+
+// validateAutoProvisioning checks that the given user was auto-provisioned
+// by LDAP authentication by verifying the PROVISIONSRC role option contains
+// the "ldap:" prefix.
+func validateAutoProvisioning(
+	ctx context.Context, t test.Test, c cluster.Cluster, username string,
+) {
+	conn := createPgxConnWithExternalURL(ctx, t, c)
+	defer func() { _ = conn.Close(ctx) }()
+
+	var provisionSrc *string
+	err := conn.QueryRow(ctx,
+		"SELECT value FROM system.role_options "+
+			"WHERE username = $1 AND option = 'PROVISIONSRC'",
+		username).Scan(&provisionSrc)
+	require.NoError(t, err, "PROVISIONSRC role option not found for user %s", username)
+	require.NotNil(t, provisionSrc)
+	require.Contains(t, *provisionSrc, "ldap:",
+		"expected PROVISIONSRC to have ldap: prefix, got %q", *provisionSrc)
+	t.L().Printf("Auto-provisioning validated for user %s: PROVISIONSRC=%s",
+		username, *provisionSrc)
+}
+
+// validateLastLoginTime polls system.users until estimated_last_login_time is
+// populated for the given user. It measures and logs the propagation time from
+// the authentication instant. The lastLoginUpdater processes updates
+// asynchronously via singleflight, so we poll with a short interval.
+func validateLastLoginTime(
+	ctx context.Context, t test.Test, c cluster.Cluster, username string, authTime time.Time,
+) {
+	conn := createPgxConnWithExternalURL(ctx, t, c)
+	defer func() { _ = conn.Close(ctx) }()
+
+	err := retry.ForDuration(30*time.Second, func() error {
+		var lastLogin *time.Time
+		if err := conn.QueryRow(ctx,
+			"SELECT estimated_last_login_time FROM system.users WHERE username = $1",
+			username).Scan(&lastLogin); err != nil {
+			return err
+		}
+		if lastLogin == nil {
+			return fmt.Errorf("estimated_last_login_time not yet populated for user %s", username)
+		}
+		return nil
+	})
+	require.NoError(t, err,
+		"timed out waiting for estimated_last_login_time for user %s", username)
 }

--- a/pkg/cmd/roachtest/tests/ldap_connection_scale.go
+++ b/pkg/cmd/roachtest/tests/ldap_connection_scale.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -81,17 +82,22 @@ func runLDAPConnectionScaleTest(ctx context.Context, t test.Test, c cluster.Clus
 	userGroupFileContent, userUidList := prepareUserAndGroups()
 	importUserAndGroupsForLDAPScale(ctx, t, c, nodeListOptions, userGroupFileContent)
 
-	// Create the users with login role which will later
-	// used for authentication.
-	prepareSQLUserForLDAPScale(ctx, t, c)
+	// Roles are auto-provisioned on first LDAP login.
 
-	// Setup CRDB specific configs for LDAP authentication.
-	// Update the relevant cluster settings for configuring and debugging.
+	// Setup CRDB specific configs for LDAP authentication including
+	// auto-provisioning enablement.
 	setupCRDBFOrLDAPScale(ctx, t, c, hostName)
 
 	// Test that `ldapScaleUserCount` number of connections
-	// can be created in parallel.
+	// can be created in parallel (roles are auto-provisioned).
+	authStart := timeutil.Now()
 	testParallelConnections(ctx, t, c, userUidList, numNodes)
+
+	// Validate auto-provisioning for a sample of users.
+	validateAutoProvisioningScale(ctx, t, c, userUidList)
+
+	// Validate estimated_last_login_time propagation for a sample user.
+	validateLastLoginTime(ctx, t, c, userUidList[0], authStart)
 }
 
 // prepareUserAndGroups prepares user and group LDIF file content.
@@ -195,20 +201,6 @@ func importUserAndGroupsForLDAPScale(
 	require.NoError(t, err)
 }
 
-// prepareSQLUserForLDAPScale runs a cockroach command to
-// log in to the sql shell using the root user credentials.
-// Then create role with the name in format user<num>
-// using CRDB sql syntax of for loop.
-func prepareSQLUserForLDAPScale(ctx context.Context, t test.Test, c cluster.Cluster) {
-	query := fmt.Sprintf("./cockroach sql --certs-dir=%s "+
-		"--host=localhost:{pgport:1} -e '\\| for ((i=%d;i<=%d;++i)); "+
-		"do echo \"CREATE ROLE user$i LOGIN;\"; done'",
-		install.CockroachNodeCertsDir, 1, ldapScaleUserCount)
-	err := c.RunE(ctx, option.WithNodes(c.Node(1)), query)
-	require.NoError(t, err)
-	t.L().Printf("Created all login roles in crdb.")
-}
-
 // Setup CRDB specific configs for LDAP authentication.
 // Update the relevant cluster settings for configuring and debugging.
 func setupCRDBFOrLDAPScale(ctx context.Context, t test.Test, c cluster.Cluster, hostName string) {
@@ -238,6 +230,12 @@ func setupCRDBFOrLDAPScale(ctx context.Context, t test.Test, c cluster.Cluster, 
 	caCertQuery := createClusterSettingQuery(
 		"server.ldap_authentication.domain.custom_ca", fmt.Sprintf("'%s'", trimmed))
 	runSQLQueryForConnection(ctx, t, conn, caCertQuery)
+
+	// Enable LDAP auto-provisioning so that SQL roles are created
+	// automatically on first successful LDAP authentication.
+	provisioningQuery := createClusterSettingQuery(
+		"security.provisioning.ldap.enabled", "true")
+	runSQLQueryForConnection(ctx, t, conn, provisioningQuery)
 
 	// This is required for better debugging in-case of failures in authentication.
 	debuggingQuery := createClusterSettingQuery(
@@ -342,4 +340,43 @@ func testParallelConnections(
 		}
 	}
 	t.L().Printf("All Connections closed.")
+}
+
+// validateAutoProvisioningScale checks that a sample of auto-provisioned users
+// have the PROVISIONSRC role option with the "ldap:" prefix.
+func validateAutoProvisioningScale(
+	ctx context.Context, t test.Test, c cluster.Cluster, userUidList []string,
+) {
+	conn := createPgxConnWithExternalURL(ctx, t, c)
+	defer func() { _ = conn.Close(ctx) }()
+
+	// Check the first, middle, and last users as a representative sample.
+	sampleIndices := []int{0, len(userUidList) / 2, len(userUidList) - 1}
+	for _, idx := range sampleIndices {
+		username := userUidList[idx]
+		var provisionSrc *string
+		err := conn.QueryRow(ctx,
+			"SELECT value FROM system.role_options "+
+				"WHERE username = $1 AND option = 'PROVISIONSRC'",
+			username).Scan(&provisionSrc)
+		require.NoError(t, err,
+			"PROVISIONSRC role option not found for user %s", username)
+		require.NotNil(t, provisionSrc)
+		require.Contains(t, *provisionSrc, "ldap:",
+			"expected PROVISIONSRC to have ldap: prefix for user %s, got %q",
+			username, *provisionSrc)
+		t.L().Printf("Auto-provisioning validated for user %s: PROVISIONSRC=%s",
+			username, *provisionSrc)
+	}
+
+	// Verify total count of provisioned users matches expected.
+	var count int
+	err := conn.QueryRow(ctx,
+		"SELECT count(*) FROM system.role_options WHERE option = 'PROVISIONSRC' AND value LIKE 'ldap:%'",
+	).Scan(&count)
+	require.NoError(t, err)
+	t.L().Printf("Total auto-provisioned users with PROVISIONSRC: %d (expected %d)",
+		count, ldapScaleUserCount)
+	require.Equal(t, ldapScaleUserCount, count,
+		"expected all %d users to have PROVISIONSRC", ldapScaleUserCount)
 }


### PR DESCRIPTION
## Summary

- Updates `ldap_connection_latency` and `ldap_connection_scale` roachtests to validate LDAP auto-provisioning and `estimated_last_login_time` propagation.
- Removes pre-creation of SQL roles; tests now rely on `security.provisioning.ldap.enabled` to auto-create roles on first LDAP login.
- Adds `validateAutoProvisioning` / `validateAutoProvisioningScale` to verify `PROVISIONSRC` role option with `ldap:` prefix.
- Adds `validateLastLoginTime` to poll `system.users` until `estimated_last_login_time` is populated, logging propagation time.

Informs #150607

Epic: CRDB-52460

Release Note: None