### PR TITLE
admission: add ResourceGroupID type and WorkInfo field

### DIFF
--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -272,6 +272,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"WorkKind":  {},
 						"QueueKind": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb": {
+						"ResourceGroupID": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb": {
 						"TraceID": {},
 						"SpanID":  {},

--- a/pkg/util/admission/admissionpb/admissionpb.go
+++ b/pkg/util/admission/admissionpb/admissionpb.go
@@ -220,6 +220,12 @@ func WorkClassFromStoreWorkType(workType StoreWorkType) WorkClass {
 	return class
 }
 
+// ResourceGroupID identifies a resource group for admission control.
+type ResourceGroupID uint64
+
+// SafeValue implements redact.SafeValue.
+func (ResourceGroupID) SafeValue() {}
+
 // WorkClassFromPri translates a WorkPriority to its given WorkClass.
 func WorkClassFromPri(pri WorkPriority) WorkClass {
 	class := RegularWorkClass

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -171,6 +171,11 @@ type WorkInfo struct {
 	// TenantID is the id of the tenant. For single-tenant clusters, this will
 	// always be the SystemTenantID.
 	TenantID roachpb.TenantID
+	// ResourceGroupID identifies the resource group to which this work
+	// belongs. When the resource manager is enabled, admission decisions
+	// use the resource group rather than the tenant to distribute
+	// capacity. Zero means the resource group is unset.
+	ResourceGroupID admissionpb.ResourceGroupID
 	// Priority is utilized within a tenant.
 	Priority admissionpb.WorkPriority
 	// CreateTime is equivalent to Time.UnixNano() at the creation time of this


### PR DESCRIPTION
Define a typed ResourceGroupID in admissionpb and add it to WorkInfo,
placed alongside TenantID. The field is unused for now; future work
will wire it up so callers can pass a resource group identity through
admission control.

Epic: CRDB-48797

Release note: None