### PR TITLE
dev: add --coverage flag to dev test

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -35,6 +35,7 @@ const (
 	testArgsFlag     = "test-args"
 	vModuleFlag      = "vmodule"
 	showDiffFlag     = "show-diff"
+	coverageFlag     = "coverage"
 )
 
 // List of bazel integration tests that will fail when running `dev test pkg/...`
@@ -131,6 +132,7 @@ pkg/kv/kvserver:kvserver_test) instead.`,
 	testCmd.Flags().String(testArgsFlag, "", "additional arguments to pass to the go test binary")
 	testCmd.Flags().String(vModuleFlag, "", "comma-separated list of pattern=N settings for file-filtered logging")
 	testCmd.Flags().Bool(showDiffFlag, false, "generate a diff for expectation mismatches when possible")
+	testCmd.Flags().Bool(coverageFlag, false, "run tests with code coverage and produce an lcov report")
 	return testCmd
 }
 
@@ -174,6 +176,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		count        = mustGetFlagInt(cmd, countFlag)
 		vModule      = mustGetFlagString(cmd, vModuleFlag)
 		showDiff     = mustGetFlagBool(cmd, showDiffFlag)
+		coverage     = mustGetFlagBool(cmd, coverageFlag)
 
 		// These are tests that require access to another directory for
 		// --rewrite. These can either be single directories or
@@ -213,6 +216,9 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	if stress && streamOutput {
 		return fmt.Errorf("cannot combine --%s and --%s", stressFlag, streamOutputFlag)
 	}
+	if coverage && stress {
+		return fmt.Errorf("cannot combine --%s and --%s", coverageFlag, stressFlag)
+	}
 
 	if rewrite {
 		ignoreCache = true
@@ -227,7 +233,11 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	var goTags []string
-	args = append(args, "test")
+	if coverage {
+		args = append(args, "coverage")
+	} else {
+		args = append(args, "test")
+	}
 	addCommonBazelArguments(&args)
 	if race {
 		args = append(args, "--config=race", "--test_sharding_strategy=disabled")
@@ -277,6 +287,13 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 
 	args = append(args, testTargets...)
 	args = append(args, "--test_env=GOTRACEBACK=all")
+	if coverage {
+		args = append(args,
+			"--@io_bazel_rules_go//go/config:cover_format=lcov",
+			"--combined_report=lcov",
+			"--instrumentation_filter=//pkg/...",
+		)
+	}
 
 	if rewrite {
 		if stress {
@@ -393,6 +410,18 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 			log.Printf("WARNING: the build succeeded but no tests were found.")
 			err = nil
 		}
+	}
+
+	if coverage && err == nil {
+		outputPath, pathErr := d.getBazelInfo(ctx, "output_path", nil)
+		if pathErr != nil {
+			return pathErr
+		}
+		lcovFile := filepath.Join(outputPath, "_coverage", "_coverage_report.dat")
+		log.Printf("Coverage report: %s", lcovFile)
+		log.Printf("To generate an HTML report, run:")
+		log.Printf("  genhtml --exclude 'external/*' %s -o coverage-html && open coverage-html/index.html", lcovFile)
+		log.Printf("Install genhtml via: brew install lcov")
 	}
 
 	return err

--- a/pkg/cmd/dev/testdata/recorderdriven/test
+++ b/pkg/cmd/dev/testdata/recorderdriven/test
@@ -97,3 +97,9 @@ dev test pkg/spanconfig/spanconfigstore --count 1
 ----
 bazel query 'kind(.*_test, pkg/spanconfig/spanconfigstore:all)'
 bazel test //pkg/spanconfig/spanconfigstore:spanconfigstore_test --test_env=GOTRACEBACK=all --nocache_test_results --test_output errors --build_event_binary_file=/tmp/path
+
+dev test pkg/security --coverage
+----
+bazel query 'kind(.*_test, pkg/security:all)'
+bazel coverage //pkg/security:security_test --test_env=GOTRACEBACK=all --@io_bazel_rules_go//go/config:cover_format=lcov --combined_report=lcov --instrumentation_filter=//pkg/... --test_output errors --build_event_binary_file=/tmp/path
+bazel info output_path --color=no

--- a/pkg/cmd/dev/testdata/recorderdriven/test.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/test.rec
@@ -143,3 +143,14 @@ bazel query 'kind(.*_test, pkg/spanconfig/spanconfigstore:all)'
 
 bazel test //pkg/spanconfig/spanconfigstore:spanconfigstore_test --test_env=GOTRACEBACK=all --nocache_test_results --test_output errors --build_event_binary_file=/tmp/path
 ----
+
+bazel query 'kind(.*_test, pkg/security:all)'
+----
+//pkg/security:security_test
+
+bazel coverage //pkg/security:security_test --test_env=GOTRACEBACK=all --@io_bazel_rules_go//go/config:cover_format=lcov --combined_report=lcov --instrumentation_filter=//pkg/... --test_output errors --build_event_binary_file=/tmp/path
+----
+
+bazel info output_path --color=no
+----
+/private/var/tmp/_bazel/output


### PR DESCRIPTION
`./dev test pkg/foo --coverage` runs `bazel coverage` with lcov output.
After a successful run, prints the path to the lcov report and a
genhtml command to generate an HTML report.

    ./dev test pkg/security --coverage
    # ... bazel coverage runs ...
    # Coverage report: /private/var/tmp/_bazel/output/_coverage/_coverage_report.dat
    # To generate an HTML report, run:
    #   genhtml --exclude 'external/*' <lcov-file> -o coverage-html && open coverage-html/index.html
    # Install genhtml via: brew install lcov

The `--instrumentation_filter` defaults to `//pkg/...` (matching CI)
and can be overridden via `-- --instrumentation_filter=...`.

Epic: none
Release note: None