### PR TITLE
server,ui: surface query metadata as top-level fields on StatementDetailsResponse

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4744,6 +4744,9 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 | statement_statistics_per_plan_hash | [StatementDetailsResponse.CollectedStatementGroupedByPlanHash](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.server.serverpb.StatementDetailsResponse.CollectedStatementGroupedByPlanHash) | repeated | statement_statistics_per_plan_hash returns the same statement from above, but with its statistics separated by the plan hash. | [reserved](#support-status) |
 | internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
 | statement_statistics_per_aggregated_ts_and_plan_hash | [StatementDetailsResponse.StatementPlanDistribution](#cockroach.server.serverpb.StatementDetailsResponse-cockroach.server.serverpb.StatementDetailsResponse.StatementPlanDistribution) | repeated | statement_statistics_per_aggregated_ts_and_plan_hash returns execution counts grouped by both aggregated timestamp and plan hash for visualizing plan distribution over time. | [reserved](#support-status) |
+| query | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  | query is the statement fingerprint text. | [reserved](#support-status) |
+| query_summary | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  | query_summary is the abbreviated query. | [reserved](#support-status) |
+| database | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  | database is the database the statement was issued against. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1945,6 +1945,12 @@ message StatementDetailsResponse {
   // statement_statistics_per_aggregated_ts_and_plan_hash returns execution counts grouped by both
   // aggregated timestamp and plan hash for visualizing plan distribution over time.
   repeated StatementPlanDistribution statement_statistics_per_aggregated_ts_and_plan_hash = 5 [(gogoproto.nullable) = false];
+  // query is the statement fingerprint text.
+  string query = 6;
+  // query_summary is the abbreviated query.
+  string query_summary = 7;
+  // database is the database the statement was issued against.
+  string database = 8;
 }
 
 message StatementDiagnosticsReport {

--- a/pkg/server/statement_details.go
+++ b/pkg/server/statement_details.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
@@ -66,6 +67,11 @@ type statementDetailsRespBuilder struct {
 	qargs                       []interface{}
 	limit                       int64
 	activityHasData             bool
+	// useNewColumns selects query, query_summary, and database from the
+	// dedicated view columns instead of leaving them blank. Gated on
+	// V26_3, when system.statements is guaranteed to be populated for
+	// new fingerprints.
+	useNewColumns bool
 }
 
 func getStatementDetails(
@@ -100,6 +106,7 @@ func getStatementDetails(
 	// This expression is used to merge the metadata column from statement
 	// activity table.
 	mergeAggStmtMetadataColExpr := mergeAggStmtMetadataColumnLatest
+	useNewColumns := settings.Version.IsActive(ctx, clusterversion.V26_3)
 
 	rb := statementDetailsRespBuilder{
 		ie:                          ie,
@@ -108,9 +115,10 @@ func getStatementDetails(
 		qargs:                       args,
 		limit:                       limit,
 		activityHasData:             activityHasData,
+		useNewColumns:               useNewColumns,
 	}
 
-	statementTotal, err := rb.getTotalStatementDetails(ctx)
+	statementTotal, query, querySummary, database, err := rb.getTotalStatementDetails(ctx)
 	if err != nil {
 		return nil, srverrors.ServerError(ctx, err)
 	}
@@ -160,6 +168,9 @@ func getStatementDetails(
 		StatementStatisticsPerPlanHash:                statementStatisticsPerPlanHash,
 		StatementStatisticsPerAggregatedTsAndPlanHash: statementStatisticsPerAggregatedTsAndPlanHash,
 		InternalAppNamePrefix:                         catconstants.InternalAppNamePrefix,
+		Query:                                         query,
+		QuerySummary:                                  querySummary,
+		Database:                                      database,
 	}
 
 	return response, nil
@@ -230,21 +241,48 @@ func getStatementDetailsQueryClausesAndArgs(
 	return whereClause, args, nil
 }
 
-// getTotalStatementDetails return all the statistics for the selected statement combined.
+// queryMetadataSelectClause returns the SQL fragment for projecting query,
+// query_summary, and database from a statement statistics view. It returns an
+// empty string when the new columns must not be selected (mixed-version
+// clusters where the columns may be missing on remote nodes).
+func queryMetadataSelectClause(useNewColumns bool) string {
+	if !useNewColumns {
+		return ""
+	}
+	return `,
+       max(query)         AS query,
+       max(query_summary) AS query_summary,
+       max(database)      AS database`
+}
+
+// getTotalStatementDetails return all the statistics for the selected
+// statement combined, plus the query/query_summary/database values when the
+// caller has opted into reading them from the dedicated view columns.
 func (rb *statementDetailsRespBuilder) getTotalStatementDetails(
 	ctx context.Context,
-) (serverpb.StatementDetailsResponse_CollectedStatementSummary, error) {
-	const expectedNumDatums = 4
-	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
-	const queryFormat = `
+) (
+	summary serverpb.StatementDetailsResponse_CollectedStatementSummary,
+	query string,
+	querySummary string,
+	database string,
+	_ error,
+) {
+	baseExpectedNumDatums := 4
+	extraColumns := queryMetadataSelectClause(rb.useNewColumns)
+	expectedNumDatums := baseExpectedNumDatums
+	if rb.useNewColumns {
+		expectedNumDatums += 3
+	}
+
+	queryFormat := fmt.Sprintf(`
 SELECT merge_stats_metadata(metadata)    AS metadata,
        array_agg(app_name)               AS app_names,
        merge_statement_stats(statistics) AS statistics,
-       encode(fingerprint_id, 'hex')     AS fingerprint_id
-FROM %s %s
+       encode(fingerprint_id, 'hex')     AS fingerprint_id%s
+FROM %%s %%s
 GROUP BY
     fingerprint_id
-LIMIT 1`
+LIMIT 1`, extraColumns)
 
 	var row tree.Datums
 	var err error
@@ -255,13 +293,13 @@ LIMIT 1`
 SELECT %s                                  AS metadata,
        array_agg(app_name)                 AS app_names,
        merge_statement_stats(statistics)   AS statistics,
-       encode(fingerprint_id, 'hex')       AS fingerprint_id
+       encode(fingerprint_id, 'hex')       AS fingerprint_id%s
 FROM crdb_internal.statement_activity %s
 GROUP BY
     fingerprint_id
-LIMIT 1`, rb.mergeAggStmtMetadataColExpr, rb.whereClause), rb.qargs...)
+LIMIT 1`, rb.mergeAggStmtMetadataColExpr, extraColumns, rb.whereClause), rb.qargs...)
 		if err != nil {
-			return statement, srverrors.ServerError(ctx, err)
+			return summary, "", "", "", srverrors.ServerError(ctx, err)
 		}
 	}
 	// If there are no results from the activity table, retrieve the data from the persisted table.
@@ -273,28 +311,28 @@ LIMIT 1`, rb.mergeAggStmtMetadataColExpr, rb.whereClause), rb.qargs...)
 				CrdbInternalStmtStatsPersisted,
 				rb.whereClause), rb.qargs...)
 		if err != nil {
-			return statement, srverrors.ServerError(ctx, err)
+			return summary, "", "", "", srverrors.ServerError(ctx, err)
 		}
 	}
 
-	// If there are no results from the persisted table, retrieve the data from the combined view
-	// with data in-memory.
+	// If there are no results from the persisted table, retrieve the data from
+	// the combined view with data in-memory.
 	if row.Len() == 0 {
 		row, err = rb.ie.QueryRowEx(ctx, "combined-stmts-details-total-with-memory", nil,
 			sessiondata.NodeUserSessionDataOverride,
 			fmt.Sprintf(queryFormat, CrdbInternalStmtStatsCombined, rb.whereClause), rb.qargs...)
 		if err != nil {
-			return statement, srverrors.ServerError(ctx, err)
+			return summary, "", "", "", srverrors.ServerError(ctx, err)
 		}
 	}
 
 	// If there are no results in-memory, return empty statement object.
 	if row.Len() == 0 {
-		return statement, nil
+		return summary, "", "", "", nil
 	}
 	if row.Len() != expectedNumDatums {
-		return statement, srverrors.ServerError(ctx, errors.Newf(
-			"expected %d columns on getTotalStatementDetails, received %d", expectedNumDatums))
+		return summary, "", "", "", srverrors.ServerError(ctx, errors.Newf(
+			"expected %d columns on getTotalStatementDetails, received %d", expectedNumDatums, row.Len()))
 	}
 
 	var statistics appstatspb.CollectedStatementStatistics
@@ -302,7 +340,7 @@ LIMIT 1`, rb.mergeAggStmtMetadataColExpr, rb.whereClause), rb.qargs...)
 	metadataJSON := tree.MustBeDJSON(row[0]).JSON
 
 	if err = sqlstatsutil.DecodeAggregatedMetadataJSON(metadataJSON, &aggregatedMetadata); err != nil {
-		return statement, srverrors.ServerError(ctx, err)
+		return summary, "", "", "", srverrors.ServerError(ctx, err)
 	}
 
 	apps := tree.MustBeDArray(row[1])
@@ -314,18 +352,24 @@ LIMIT 1`, rb.mergeAggStmtMetadataColExpr, rb.whereClause), rb.qargs...)
 
 	statsJSON := tree.MustBeDJSON(row[2]).JSON
 	if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &statistics.Stats); err != nil {
-		return statement, srverrors.ServerError(ctx, err)
+		return summary, "", "", "", srverrors.ServerError(ctx, err)
 	}
 
 	aggregatedMetadata.FormattedQuery = aggregatedMetadata.Query
 	aggregatedMetadata.FingerprintID = string(tree.MustBeDString(row[3]))
 
-	statement = serverpb.StatementDetailsResponse_CollectedStatementSummary{
+	if rb.useNewColumns {
+		query = string(tree.MustBeDStringOrDNull(row[4]))
+		querySummary = string(tree.MustBeDStringOrDNull(row[5]))
+		database = string(tree.MustBeDStringOrDNull(row[6]))
+	}
+
+	summary = serverpb.StatementDetailsResponse_CollectedStatementSummary{
 		Metadata: aggregatedMetadata,
 		Stats:    statistics.Stats,
 	}
 
-	return statement, nil
+	return summary, query, querySummary, database, nil
 }
 
 // getStatementDetailsPerAggregatedTs returns the list of statements

--- a/pkg/server/statement_details_test.go
+++ b/pkg/server/statement_details_test.go
@@ -75,6 +75,10 @@ func TestStatementDetails(t *testing.T) {
 	require.NotEmpty(t, resp.Statement.Metadata.FingerprintID)
 	require.Greater(t, resp.Statement.Stats.Count, int64(0))
 
+	require.Equal(t, testQuery, resp.Query)
+	require.NotEmpty(t, resp.QuerySummary)
+	require.Equal(t, "testdb", resp.Database)
+
 	require.NotEmpty(t, resp.StatementStatisticsPerAggregatedTs,
 		"should have statistics grouped by aggregated timestamp")
 	for _, stat := range resp.StatementStatisticsPerAggregatedTs {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -44,12 +44,16 @@ interface PlanDetailsProps {
   plans: PlanHashStats[];
   statementFingerprintID: string;
   hasAdminRole: boolean;
+  database: string;
+  query: string;
 }
 
 export function PlanDetails({
   plans,
   statementFingerprintID,
   hasAdminRole,
+  database,
+  query,
 }: PlanDetailsProps): React.ReactElement {
   const [plan, setPlan] = useState<PlanHashStats | null>(null);
   const [plansSortSetting, setPlansSortSetting] = useState<SortSetting>({
@@ -76,6 +80,8 @@ export function PlanDetails({
         sortSetting={insightsSortSetting}
         onChangeSortSetting={setInsightsSortSetting}
         hasAdminRole={hasAdminRole}
+        database={database}
+        query={query}
       />
     );
   } else {
@@ -86,6 +92,7 @@ export function PlanDetails({
           handleDetails={handleDetails}
           sortSetting={plansSortSetting}
           onChangeSortSetting={setPlansSortSetting}
+          database={database}
         />
       </div>
     );
@@ -97,6 +104,7 @@ interface PlanTableProps {
   handleDetails: (plan: PlanHashStats) => void;
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
+  database: string;
 }
 
 function PlanTable({
@@ -104,8 +112,9 @@ function PlanTable({
   handleDetails,
   sortSetting,
   onChangeSortSetting,
+  database,
 }: PlanTableProps): React.ReactElement {
-  const columns = makeExplainPlanColumns(handleDetails);
+  const columns = makeExplainPlanColumns(handleDetails, database);
   return (
     <PlansSortedTable
       columns={columns}
@@ -124,6 +133,8 @@ interface ExplainPlanProps {
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
   hasAdminRole: boolean;
+  database: string;
+  query: string;
 }
 
 function ExplainPlan({
@@ -133,6 +144,8 @@ function ExplainPlan({
   sortSetting,
   onChangeSortSetting,
   hasAdminRole,
+  database,
+  query,
 }: ExplainPlanProps): React.ReactElement {
   const explainPlan =
     `Plan Gist: ${plan.stats.plan_gists[0]} \n\n` +
@@ -213,10 +226,7 @@ function ExplainPlan({
             />
             <SummaryCardItem
               label="Used Indexes"
-              value={formatIndexes(
-                plan.stats.indexes,
-                plan.metadata.databases[0],
-              )}
+              value={formatIndexes(plan.stats.indexes, database)}
             />
           </SummaryCard>
         </Col>
@@ -224,8 +234,8 @@ function ExplainPlan({
       {hasInsights && (
         <Insights
           idxRecommendations={plan.stats.index_recommendations}
-          database={plan.metadata.databases[0]}
-          query={plan.metadata.query}
+          database={database}
+          query={query}
           statementFingerprintID={statementFingerprintID}
           sortSetting={sortSetting}
           onChangeSortSetting={onChangeSortSetting}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -298,6 +298,7 @@ export function formatIndexes(indexes: string[], database: string): ReactNode {
 
 export function makeExplainPlanColumns(
   handleDetails: (plan: PlanHashStats) => void,
+  database: string,
 ): ColumnDescriptor<PlanHashStats>[] {
   const duration = (v: number) => Duration(v * 1e9);
   const count = (v: number) => v.toFixed(1);
@@ -319,7 +320,7 @@ export function makeExplainPlanColumns(
       name: "indexes",
       title: planDetailsTableTitles.indexes(),
       cell: (item: PlanHashStats) =>
-        formatIndexes(item.stats.indexes, item.metadata.databases[0]),
+        formatIndexes(item.stats.indexes, database),
       sort: (item: PlanHashStats) => item.stats.indexes?.join(""),
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/queryMetadata.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/queryMetadata.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { StatementDetailsResponse } from "../api";
+
+// resolveQuery returns the statement fingerprint text, preferring the
+// top-level Query field on the response and falling back to the deprecated
+// metadata.formatted_query / metadata.query fields for older servers.
+export const resolveQuery = (
+  details: StatementDetailsResponse | undefined,
+): string =>
+  details?.query ||
+  details?.statement?.metadata?.formatted_query ||
+  details?.statement?.metadata?.query ||
+  "";
+
+// resolveQuerySummary returns the abbreviated statement, preferring the
+// top-level QuerySummary field with a fallback to metadata.query_summary.
+export const resolveQuerySummary = (
+  details: StatementDetailsResponse | undefined,
+): string =>
+  details?.query_summary || details?.statement?.metadata?.query_summary || "";
+
+// resolveDatabase returns the database name, preferring the top-level
+// Database field with a fallback to metadata.databases[0].
+export const resolveDatabase = (
+  details: StatementDetailsResponse | undefined,
+): string =>
+  details?.database || details?.statement?.metadata?.databases?.[0] || "";

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -63,6 +63,9 @@ const statementDetailsNoData: StatementDetailsResponse = {
     aggregation_interval: {},
   },
   internal_app_name_prefix: "$ internal",
+  query: "",
+  query_summary: "",
+  database: "",
   statement_statistics_per_aggregated_ts: [],
   statement_statistics_per_plan_hash: [],
   statement_statistics_per_aggregated_ts_and_plan_hash: [],
@@ -816,6 +819,9 @@ const statementDetailsData: StatementDetailsResponse = {
     },
   ],
   internal_app_name_prefix: "$ internal",
+  query: "SELECT * FROM crdb_internal.node_build_info",
+  query_summary: "SELECT * FROM crdb_internal.node_build_info",
+  database: "defaultdb",
   statement_statistics_per_aggregated_ts_and_plan_hash: [],
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -88,6 +88,7 @@ import { Timestamp } from "../timestamp";
 import { filterByTimeScale } from "./diagnostics/diagnosticsUtils";
 import { DiagnosticsView } from "./diagnostics/diagnosticsView";
 import { PlanDetails } from "./planDetails";
+import { resolveDatabase, resolveQuery } from "./queryMetadata";
 import styles from "./statementDetails.module.scss";
 import {
   generateContentionTimeseries,
@@ -254,11 +255,9 @@ export function StatementDetails(
   };
 
   const [currentTab, setCurrentTab] = useState<string>(getInitialTab);
-  const [query, setQuery] = useState<string>(
-    statementDetails?.statement?.metadata?.query,
-  );
+  const [query, setQuery] = useState<string>(resolveQuery(statementDetails));
   const [formattedQuery, setFormattedQuery] = useState<string>(
-    statementDetails?.statement?.metadata?.formatted_query,
+    resolveQuery(statementDetails),
   );
 
   const prevStatementFingerprintIDRef = useRef<string>(statementFingerprintID);
@@ -304,12 +303,9 @@ export function StatementDetails(
 
   // Update query state when statementDetails changes
   useEffect(() => {
-    const newQuery =
-      statementDetails?.statement?.metadata?.query || query || null;
-    const newFormattedQuery =
-      statementDetails?.statement?.metadata?.formatted_query ||
-      formattedQuery ||
-      null;
+    const resolved = resolveQuery(statementDetails);
+    const newQuery = resolved || query || null;
+    const newFormattedQuery = resolved || formattedQuery || null;
     if (newQuery !== query || newFormattedQuery !== formattedQuery) {
       setQuery(newQuery);
       setFormattedQuery(newFormattedQuery);
@@ -418,12 +414,12 @@ export function StatementDetails(
     const { stats } = statementDetails.statement;
     const {
       app_names: appNames,
-      databases,
       fingerprint_id: fingerprintId,
       full_scan_count: fullScanCount,
       vec_count: vecCount,
       total_count: totalCount,
     } = statementDetails.statement.metadata;
+    const databaseName = resolveDatabase(statementDetails);
     const statementStatisticsPerAggregatedTs =
       statementDetails.statement_statistics_per_aggregated_ts;
 
@@ -454,8 +450,8 @@ export function StatementDetails(
     );
     const noSamples = statementSampled ? "" : " (no samples)";
 
-    const db = databases ? (
-      <Text>{databases}</Text>
+    const db = databaseName ? (
+      <Text>{databaseName}</Text>
     ) : (
       <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>
     );
@@ -800,8 +796,9 @@ export function StatementDetails(
       statementDetails.statement_statistics_per_plan_hash;
     const statementStatisticsPerAggregatedTsAndPlanHash =
       statementDetails.statement_statistics_per_aggregated_ts_and_plan_hash;
-    const formattedQueryValue =
-      statementDetails.statement.metadata.formatted_query;
+    const formattedQueryValue = resolveQuery(statementDetails);
+    const databaseName = resolveDatabase(statementDetails);
+    const queryValue = resolveQuery(statementDetails);
 
     // Generate plan distribution data for the chart
     const { data: planDistData, planGists } =
@@ -918,6 +915,8 @@ export function StatementDetails(
             statementFingerprintID={statementFingerprintID}
             plans={statementStatisticsPerPlanHash}
             hasAdminRole={hasAdminRole}
+            database={databaseName}
+            query={queryValue}
           />
         </section>
       </>
@@ -931,10 +930,7 @@ export function StatementDetails(
       return renderNoDataTabContent();
     }
 
-    const fingerprint =
-      statementDetails?.statement?.metadata?.query.length === 0
-        ? formattedQuery
-        : statementDetails?.statement?.metadata?.query;
+    const fingerprint = resolveQuery(statementDetails) || formattedQuery;
     return (
       <DiagnosticsView
         activateDiagnosticsRef={activateDiagnosticsRef}


### PR DESCRIPTION
## Summary

Surface `query`, `query_summary`, and `database` as new top-level fields on
`StatementDetailsResponse`, sourced from the dedicated columns on
`crdb_internal.statement_activity` / `_statistics_persisted` /
`_statistics` (which themselves coalesce from `system.statements`). The
DB Console statement details page reads from the new fields and falls
back to the existing `AggregatedStatementMetadata.query` /
`.databases` for compatibility with older servers.

This unblocks the next phase of stmt-stats work that stops persisting
query/database/query_summary inside the `metadata` JSONB column.

## Approach

- **Proto** adds three top-level string fields to `StatementDetailsResponse`.
- **Server** (`statement_details.go`) projects `max(query)`, `max(query_summary)`, `max(database)` from the source view in `getTotalStatementDetails` and threads them onto the response. Gated on `clusterversion.V26_3` so mixed-version clusters that may route the IE query to a node missing the columns don't break.
- **UI**: three small resolver helpers (`resolveQuery`, `resolveQuerySummary`, `resolveDatabase`) in `pkg/ui/workspaces/cluster-ui/src/statementDetails/queryMetadata.ts` prefer the new fields and fall back to the deprecated `metadata.*` reads. `statementDetails.tsx`, `planDetails.tsx`, and `plansTable.tsx` switch to the resolvers; `database` (invariant per fingerprint) is threaded down as a prop instead of being read per plan.

## Commit structure

Five commits, each independently reviewable: proto fields, server wiring (with test), UI resolvers, UI consumer updates, fixture updates.

Epic: none

Release note: None