### PR TITLE
followerreads: fix TestBoundedStalenessDataDriven lease placement flake

### DIFF
--- a/pkg/kv/followerreads/boundedstaleness_test.go
+++ b/pkg/kv/followerreads/boundedstaleness_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -276,6 +277,9 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 		tc.ToggleLeaseQueues(false)
 		tc.ToggleSplitQueues(false)
 		tc.ToggleReplicateQueues(false)
+		kvserverbase.OverrideLoadBasedRebalancingMode(
+			ctx, &tc.Server(0).SystemLayer().ClusterSettings().SV, kvserverbase.LBRebalancingOff,
+		)
 
 		savedTraceStmt := ""
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/kv/followerreads/testdata/boundedstaleness/single_row
+++ b/pkg/kv/followerreads/testdata/boundedstaleness/single_row
@@ -11,6 +11,12 @@ CREATE TABLE t(pk INT PRIMARY KEY) WITH (schema_locked = false);
 INSERT INTO t VALUES (1);
 ----
 
+# Explicitly place the lease on n1 (node_idx=0). The lease can land on any node
+# after table creation depending on Raft leadership of the parent range.
+exec
+ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM [SHOW RANGES FROM TABLE t];
+----
+
 # The tests assume that the leaseholder is node_idx=0 (n1), assert that here.
 query ignore-events
 SELECT DISTINCT(lease_holder) FROM [SHOW RANGES FROM TABLE t WITH DETAILS];


### PR DESCRIPTION
Previously, TestBoundedStalenessDataDriven assumed that the leaseholder for table t was on node 1 without enforcing it. This started failing frequently after the FTW retirement (#169669).

The root cause is a race during `StartTestCluster`. When a new tenant is created, a range split occurs at the tenant boundaries. The lease queue then processes this new range to consider a lease transfer.

Previously, when FTW was enabled, `shouldTransferLeaseForAccessLocality` would return [shouldNotTransfer](https://github.com/cockroachdb/cockroach/blob/master/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go#L2993) since the range was younger than `MinLeaseTransferStatsDuration`, blocking the lease from being transferred.

With FTW disabled, the function returns `decideWithoutStats` instead, allowing lease count convergence to proceed immediately, which results in the lease being transferred away to the node with the lowest lease count.

This all happens in `StartTestCluster` before the lease queue is disabled.

This fixes the flake by explicitly relocating the lease to n1 after table creation and disabling the store rebalancer to prevent it from moving the lease back.

Resolves: #169200
Epic: none

Release note: None