### PR TITLE
import: start retry clock on error

### DIFF
--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -920,7 +920,8 @@ func ingestWithRetry(
 	var res kvpb.BulkOpSummary
 	var err error
 	// State to decide when to exit the retry loop.
-	lastProgressChange, lastProgress := timeutil.Now(), getFractionCompleted(job)
+	var lastProgressChange time.Time
+	lastProgress := getFractionCompleted(job)
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		for {
 			res, err = distImport(
@@ -977,7 +978,10 @@ func ingestWithRetry(
 		}
 
 		maxRetryDuration := retryDuration.Get(&execCtx.ExecCfg().Settings.SV)
-		if timeutil.Since(lastProgressChange) > maxRetryDuration {
+		if lastProgressChange.IsZero() {
+			lastProgressChange = timeutil.Now()
+			log.Dev.Warningf(ctx, "encountered retryable error, starting retry duration timer: %+v", err)
+		} else if timeutil.Since(lastProgressChange) > maxRetryDuration {
 			log.Dev.Warningf(ctx, "encountered retryable error but exceeded retry duration, stopping: %+v", err)
 			break
 		} else {


### PR DESCRIPTION
The import job retry was failing when retries began after a late error.
This change adjusts the retry clock to start with the first encountered
error rather than treating it as a `WithTimeout` with a retry loop.

Epic: none
Fixes: #169687

Release note: None
