### PR TITLE
roachtest/operations: use scheduled backups in backup-restore operation

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//pkg/testutils/fingerprintutils",
         "//pkg/util/hlc",
         "//pkg/util/randutil",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/bank",

--- a/pkg/cmd/roachtest/operations/backup_restore.go
+++ b/pkg/cmd/roachtest/operations/backup_restore.go
@@ -7,6 +7,7 @@ package operations
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"reflect"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/fingerprintutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -41,6 +43,120 @@ func (cl *backupRestoreCleanup) Cleanup(
 	if err != nil {
 		o.Fatal(err)
 	}
+}
+
+// createBackupChain creates a backup schedule for the given database, waits for
+// a full backup to complete, then triggers and waits for 24 incremental
+// backups. It returns the HLC timestamp of the latest backup layer (for
+// fingerprint validation).
+func createBackupChain(
+	ctx context.Context, o operation.Operation, conn *gosql.DB, dbName string, bucket string,
+) hlc.Timestamp {
+	scheduleName := fmt.Sprintf("backup-restore-op-%d", timeutil.Now().UnixNano())
+	o.Status(fmt.Sprintf("creating backup schedule %s for db %s", scheduleName, dbName))
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf(
+		`CREATE SCHEDULE IF NOT EXISTS '%s'
+		FOR BACKUP DATABASE %s INTO '%s'
+		WITH revision_history
+		RECURRING '@daily'
+		FULL BACKUP '@weekly'
+		WITH SCHEDULE OPTIONS first_run = 'now'`,
+		scheduleName, dbName, bucket))
+	if err != nil {
+		o.Fatal(err)
+	}
+	defer rows.Close()
+	// The first row is always the incremental schedule and the second is the
+	// full schedule. CREATE SCHEDULE returns columns: schedule_id, label,
+	// status, first_run, schedule, backup_stmt.
+	var incScheduleID, fullScheduleID int64
+	var discard interface{}
+	if !rows.Next() {
+		o.Fatalf("expected incremental schedule row from CREATE SCHEDULE")
+	}
+	if err := rows.Scan(&incScheduleID, &discard, &discard, &discard, &discard, &discard); err != nil {
+		o.Fatal(err)
+	}
+	if !rows.Next() {
+		o.Fatalf("expected full schedule row from CREATE SCHEDULE")
+	}
+	if err := rows.Scan(&fullScheduleID, &discard, &discard, &discard, &discard, &discard); err != nil {
+		o.Fatal(err)
+	}
+
+	// Dropping the full schedule also drops the dependent incremental schedule.
+	defer func() {
+		o.Status("dropping backup schedule")
+		_, _ = conn.ExecContext(ctx, fmt.Sprintf("DROP SCHEDULE %d", fullScheduleID))
+	}()
+
+	retryOpts := retry.Options{
+		InitialBackoff: 2 * time.Second,
+		MaxBackoff:     10 * time.Second,
+		MaxRetries:     30,
+	}
+
+	// Wait for the full backup job to appear.
+	o.Status(fmt.Sprintf("waiting for full backup job (schedule %d)", fullScheduleID))
+	var fullJobID catpb.JobID
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		err = conn.QueryRowContext(ctx,
+			"SELECT id FROM system.jobs WHERE created_by_id = $1", fullScheduleID,
+		).Scan(&fullJobID)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		o.Fatalf("full backup job not found for schedule %d: %v", fullScheduleID, err)
+	}
+
+	// Wait for the full backup to succeed.
+	o.Status(fmt.Sprintf("waiting for full backup job %d to complete", fullJobID))
+	if err := tests.WaitForSucceeded(ctx, conn, fullJobID, 8760*time.Hour /* 1 year - operation specs define their own timeouts */); err != nil {
+		o.Fatal(err)
+	}
+
+	// Run 24 incremental backups via the schedule.
+	for i := range 24 {
+		o.Status(fmt.Sprintf("triggering incremental backup %d of 24", i+1))
+		ts := timeutil.Now()
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"ALTER BACKUP SCHEDULE %d EXECUTE IMMEDIATELY", fullScheduleID))
+		if err != nil {
+			o.Fatal(err)
+		}
+
+		// Wait for the incremental backup job to appear.
+		var incJobID catpb.JobID
+		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+			err = conn.QueryRowContext(ctx,
+				"SELECT id FROM system.jobs WHERE created_by_id = $1 AND created > $2",
+				incScheduleID, ts,
+			).Scan(&incJobID)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			o.Fatalf("incremental backup job not found for schedule %d: %v", incScheduleID, err)
+		}
+
+		o.Status(fmt.Sprintf("waiting for incremental backup job %d to complete", incJobID))
+		if err := tests.WaitForSucceeded(ctx, conn, incJobID, 8760*time.Hour /* 1 year - operation specs define their own timeouts */); err != nil {
+			o.Fatal(err)
+		}
+	}
+
+	// Get the end time of the latest backup for fingerprint validation.
+	var backupEndTime time.Time
+	err = conn.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT max(end_time) FROM [SHOW BACKUP FROM LATEST IN '%s']", bucket,
+	)).Scan(&backupEndTime)
+	if err != nil {
+		o.Fatal(err)
+	}
+	return hlc.Timestamp{WallTime: backupEndTime.UnixNano()}
 }
 
 func runBackupRestore(
@@ -80,7 +196,6 @@ outer:
 		return nil
 	}
 
-	o.Status(fmt.Sprintf("backing db %s (full)", dbName))
 	var scheme string
 	switch c.Cloud() {
 	case spec.AWS:
@@ -92,37 +207,15 @@ outer:
 	default:
 		scheme = ""
 	}
-	bucket := fmt.Sprintf("%s://%s/operation-backup-restore/%d/?AUTH=implicit", scheme, testutils.BackupTestingBucket(), timeutil.Now().UnixNano())
+	bucket := fmt.Sprintf("%s://%s/operation-backup-restore/%d/?AUTH=implicit",
+		scheme, testutils.BackupTestingBucket(), timeutil.Now().UnixNano())
 
-	backupTS := hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
-
-	if !online {
-		_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s' WITH revision_history", dbName, bucket, backupTS.AsOfSystemTime()))
-		if err != nil {
-			o.Fatal(err)
-		}
-		for i := range 24 {
-			o.Status(fmt.Sprintf("backing up db %s (incremental layer %d)", dbName, i))
-			// Update backupTS to match the latest layer.
-			backupTS = hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
-			_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO LATEST IN '%s' AS OF SYSTEM TIME '%s' WITH revision_history", dbName, bucket, backupTS.AsOfSystemTime()))
-			if err != nil {
-				o.Fatal(err)
-			}
-		}
-	} else {
-		// Revision history doesn't work with online restore.
-		_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS.AsOfSystemTime()))
-		if err != nil {
-			o.Fatal(err)
-		}
-	}
-
-	restoreDBName := fmt.Sprintf("backup_restore_op_%d", rng.Int63())
+	backupTS := createBackupChain(ctx, o, conn, dbName, bucket)
 
 	// Assign cleanup handler early, before RESTORE creates the database.
 	// The cleanup uses DROP DATABASE IF EXISTS, so it's safe even if the
 	// RESTORE fails and the database was never created.
+	restoreDBName := fmt.Sprintf("backup_restore_op_%d", rng.Int63())
 	cleanup = &backupRestoreCleanup{db: restoreDBName}
 
 	onlineStr := "online"
@@ -134,7 +227,9 @@ outer:
 	startTime := timeutil.Now()
 	if !online {
 		o.Status("beginning offline restore")
-		_, err = conn.ExecContext(ctx, fmt.Sprintf("RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s')", dbName, bucket, restoreDBName))
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s')",
+			dbName, bucket, restoreDBName))
 		if err != nil {
 			o.Fatal(err)
 		}
@@ -151,7 +246,9 @@ outer:
 		resCh := make(chan scanResult, 1)
 		go func() {
 			var r scanResult
-			row := conn.QueryRowContext(ctx, fmt.Sprintf("RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s', EXPERIMENTAL DEFERRED COPY)", dbName, bucket, restoreDBName))
+			row := conn.QueryRowContext(ctx, fmt.Sprintf(
+				"RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s', EXPERIMENTAL DEFERRED COPY)",
+				dbName, bucket, restoreDBName))
 			r.err = row.Scan(&r.id, &r.tables, &r.approxRows, &r.approxBytes, &r.downloadJobId)
 			resCh <- r
 		}()
@@ -172,7 +269,7 @@ outer:
 		_, _, _, _ = id, tables, approxRows, approxBytes
 
 		if scanErr == nil {
-			err = tests.WaitForSucceeded(ctx, conn, downloadJobId, 8760*time.Hour /* 1 year - test specs define their own timeouts */)
+			err = tests.WaitForSucceeded(ctx, conn, downloadJobId, 8760*time.Hour /* 1 year - operation specs define their own timeouts */)
 			if err != nil {
 				o.Fatal(err)
 			}


### PR DESCRIPTION
Previously, the backup-restore DRT operation used ad-hoc `BACKUP`
statements which don't lay down a protected timestamp between
incremental backups, leaving the backup chain vulnerable to GC.

This commit switches to using `CREATE SCHEDULE ... FOR BACKUP` with
`EXECUTE IMMEDIATELY` to trigger each incremental. This ensures proper
PTS chaining across the backup chain. The backup logic is extracted into
a `createBackupChain` helper that creates the schedule, runs a full
backup + 24 incrementals, and cleans up the schedule via defer.

Since online restore now supports revision history, the backup path no
longer needs to branch on the `online` parameter.

Fixes: #166549

Release note: None

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>