### PR TITLE
changefeedccl: deflake TestChangefeedSchemaChangeNoBackfill

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2799,6 +2799,7 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `SET CLUSTER SETTING sql.catalog.descriptor_lease_duration = '15s'`)
 
 		_ = maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
 


### PR DESCRIPTION
The test has many subtests, each of which involves a schema change.
Since the default lease duration is 5 minutes, each subtest can take up
to 5 minutes or more to complete due to waiting for the changefeed's
lease to expire before the schema change is applied. This means that the
total duration can sometimes exceed the 15 minute timeout. Lowering the
lease duration will allow the schema change to complete much faster.

Before:
//pkg/ccl/changefeedccl:changefeedccl_test                               PASSED in 1191.1s
  Stats over 1000 runs: max = 1191.1s, min = 6.8s, avg = 34.6s, dev = 78.7s

After:
//pkg/ccl/changefeedccl:changefeedccl_test                               PASSED in 211.9s
  Stats over 1000 runs: max = 211.9s, min = 7.0s, avg = 27.5s, dev = 30.6s

Release note: None
Fixes: #169932