### PR TITLE
sql/stats: fix data race on Refresher.settingOverrides map

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -343,6 +343,8 @@ type Refresher struct {
 	// this map.
 	misestimateSpans map[indexInfo]roachpb.Spans
 
+	// settingOverridesMu protects settingOverrides from concurrent access.
+	settingOverridesMu sync.RWMutex
 	// settingOverrides holds any autostats cluster setting overrides for each
 	// table.
 	settingOverrides map[descpb.ID]catpb.AutoStatsSettings
@@ -646,14 +648,18 @@ func (r *Refresher) Start(
 				// always added to or deleted from. We could just copy the entire hash
 				// map here, but maybe it is quicker and causes less memory pressure to
 				// just create a map with entries for the tables we're processing.
-				for tableID := range mutationCounts {
-					if settings, ok := r.settingOverrides[tableID]; ok {
-						if settingOverrides == nil {
-							settingOverrides = make(map[descpb.ID]catpb.AutoStatsSettings)
+				func() {
+					r.settingOverridesMu.RLock()
+					defer r.settingOverridesMu.RUnlock()
+					for tableID := range mutationCounts {
+						if settings, ok := r.settingOverrides[tableID]; ok {
+							if settingOverrides == nil {
+								settingOverrides = make(map[descpb.ID]catpb.AutoStatsSettings)
+							}
+							settingOverrides[tableID] = settings
 						}
-						settingOverrides[tableID] = settings
 					}
-				}
+				}()
 
 				r.startedTasksWG.Add(1)
 				if err := stopper.RunAsyncTask(
@@ -752,11 +758,19 @@ func (r *Refresher) Start(
 				// overrides when none exist (so that we don't have to pass two messages
 				// when nothing is overridden).
 				if mut.removeSettingOverrides {
-					delete(r.settingOverrides, mut.tableID)
+					func() {
+						r.settingOverridesMu.Lock()
+						defer r.settingOverridesMu.Unlock()
+						delete(r.settingOverrides, mut.tableID)
+					}()
 				}
 
 			case clusterSettingOverride := <-r.settings:
-				r.settingOverrides[clusterSettingOverride.tableID] = clusterSettingOverride.settings
+				func() {
+					r.settingOverridesMu.Lock()
+					defer r.settingOverridesMu.Unlock()
+					r.settingOverrides[clusterSettingOverride.tableID] = clusterSettingOverride.settings
+				}()
 
 			case <-r.drainAutoStats:
 				log.Dev.Infof(ctx, "draining auto stats refresher")
@@ -1068,9 +1082,13 @@ func (r *Refresher) EstimateStaleness(
 	}
 
 	var explicitSettings *catpb.AutoStatsSettings
-	if s, ok := r.settingOverrides[tableDesc.GetID()]; ok {
-		explicitSettings = &s
-	}
+	func() {
+		r.settingOverridesMu.RLock()
+		defer r.settingOverridesMu.RUnlock()
+		if s, ok := r.settingOverrides[tableDesc.GetID()]; ok {
+			explicitSettings = &s
+		}
+	}()
 	staleTargetFraction := r.autoStatsFractionStaleRows(explicitSettings)
 
 	avgRefreshTime := avgFullRefreshTime(tableStats)

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -1231,7 +1231,9 @@ func TestEstimateStaleness(t *testing.T) {
 
 	fractionStaleRows := 0.4
 	explicitSettings := catpb.AutoStatsSettings{FractionStaleRows: &fractionStaleRows}
+	refresher.settingOverridesMu.Lock()
 	refresher.settingOverrides[table.GetID()] = explicitSettings
+	refresher.settingOverridesMu.Unlock()
 
 	// With fraction_stale_rows = 0.4 and the latest full stat being 5 hours old
 	// (half of avgRefreshTime of 10 hours), we expect 20% staleness.
@@ -1240,7 +1242,9 @@ func TestEstimateStaleness(t *testing.T) {
 	}
 
 	// Reset fraction_stale_rows to default (0.2)
+	refresher.settingOverridesMu.Lock()
 	delete(refresher.settingOverrides, table.GetID())
+	refresher.settingOverridesMu.Unlock()
 
 	// Delete old stats and create stats with 3-hour intervals, the most recent
 	// being 15 hours old.

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1274,6 +1275,120 @@ func TestEstimateStaleness(t *testing.T) {
 	if err = checkEstimatedStaleness(1.5); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestEstimateStalenessConcurrency verifies that concurrent calls to
+// EstimateStaleness and writes to settingOverrides do not race.
+func TestEstimateStalenessConcurrency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	codec, st := s.Codec(), s.ClusterSettings()
+
+	evalCtx := eval.NewTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	AutomaticStatisticsClusterMode.Override(ctx, &st.SV, false)
+
+	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+	sqlRun.Exec(t,
+		`CREATE DATABASE t;
+		CREATE TABLE t.a (k INT PRIMARY KEY);
+		INSERT INTO t.a VALUES (1);`)
+
+	internalDB := s.InternalDB().(descs.DB)
+	table := desctestutils.TestingGetPublicTableDescriptor(s.DB(), codec, "t", "a")
+	cache := NewTableStatisticsCache(
+		ctx,
+		s.ClusterSettings(),
+		s.InternalDB().(descs.DB),
+		s.AppStopper(),
+		nil, /* parentMon */
+	)
+	require.NoError(t, cache.Start(
+		ctx, codec,
+		s.RangeFeedFactory().(*rangefeed.Factory),
+		s.SystemTableIDResolver().(catalog.SystemTableIDResolver),
+	))
+
+	curTime := timeutil.Now().Round(time.Hour)
+	knobs := &TableStatsTestingKnobs{
+		StubTimeNow: func() time.Time { return curTime },
+	}
+	refresher := MakeRefresher(
+		s.AmbientCtx(), st, internalDB, cache,
+		time.Microsecond /* asOfTime */, knobs, false, /* readOnlyTenant */
+	)
+
+	// Create enough stats history for EstimateStaleness to succeed.
+	err := s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		for i := 0; i < 5; i++ {
+			columnIDs := tree.NewDArray(types.Int)
+			if err := columnIDs.Append(tree.NewDInt(tree.DInt(1))); err != nil {
+				return err
+			}
+			offset := 5 + i*10
+			createdAt, err := tree.MakeDTimestamp(
+				curTime.Add(time.Duration(-offset)*time.Hour), time.Hour,
+			)
+			if err != nil {
+				return err
+			}
+			_, err = internalDB.Executor().Exec(
+				ctx, "insert-statistic", txn,
+				`INSERT INTO system.table_statistics (
+					"tableID", "name", "columnIDs", "createdAt",
+					"rowCount", "distinctCount", "nullCount", "avgSize"
+				) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+				table.GetID(), jobspb.AutoStatsName, columnIDs, createdAt,
+				100000 /* rowCount */, 1 /* distinctCount */, 0 /* nullCount */, 4, /* avgSize */
+			)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Wait for EstimateStaleness to succeed, confirming the cache is populated.
+	testutils.SucceedsSoon(t, func() error {
+		_, err := refresher.EstimateStaleness(ctx, table)
+		return err
+	})
+
+	// Race EstimateStaleness reads against settingOverrides writes.
+	var wg sync.WaitGroup
+	const iters = 1000
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_, _ = refresher.EstimateStaleness(ctx, table)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		fractionStaleRows := 0.5
+		settings := catpb.AutoStatsSettings{FractionStaleRows: &fractionStaleRows}
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				refresher.settingOverridesMu.Lock()
+				refresher.settingOverrides[table.GetID()] = settings
+				refresher.settingOverridesMu.Unlock()
+			} else {
+				refresher.settingOverridesMu.Lock()
+				delete(refresher.settingOverrides, table.GetID())
+				refresher.settingOverridesMu.Unlock()
+			}
+		}
+	}()
+	wg.Wait()
 }
 
 func TestAddMisestimate(t *testing.T) {


### PR DESCRIPTION
### sql/stats: add concurrency test for EstimateStaleness

Add TestEstimateStalenessConcurrency which races EstimateStaleness
reads against settingOverrides map writes. Without the mutex added
in the next commit, this test fails under -race.

Informs: #166642

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

---

### sql/stats: fix data race on Refresher.settingOverrides map

EstimateStaleness reads the settingOverrides map from SQL execution
goroutines without synchronization, while the background Refresher
goroutine concurrently writes and deletes entries. In Go, concurrent
map read+write is a fatal error that crashes the node.

Add a sync.RWMutex to protect all accesses to the settingOverrides
map.

Fixes: #166642

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>