### PR TITLE
sql: add type-specific error for dropped descriptors

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -1175,9 +1175,8 @@ type FunctionDescriptor interface {
 func FilterDroppedDescriptor(desc Descriptor) error {
 	if !desc.Dropped() {
 		return nil
-
 	}
-	return NewInactiveDescriptorError(ErrDescriptorDropped)
+	return NewInactiveDescriptorError(NewDescriptorDroppedError(desc))
 }
 
 // FilterOfflineDescriptor returns an error if the descriptor state is OFFLINE.

--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -57,9 +57,29 @@ func (a *addingDescriptorError) Error() string { return a.cause.Error() }
 func (a *addingDescriptorError) Unwrap() error { return a.cause }
 
 // ErrDescriptorDropped is returned when the descriptor is being dropped.
-// TODO (lucy): Make the error message specific to each descriptor type (e.g.,
-// "table is being dropped") and add the pgcodes (UndefinedTable, etc.).
+//
+// Use NewDescriptorDroppedError to create type-specific errors.
 var ErrDescriptorDropped = errors.New("descriptor is being dropped")
+
+// NewDescriptorDroppedError returns a type-specific error indicating that the
+// descriptor is being dropped.
+func NewDescriptorDroppedError(desc Descriptor) error {
+	code := pgcode.Uncategorized
+	switch desc.DescriptorType() {
+	case Table:
+		code = pgcode.UndefinedTable
+	case Database:
+		code = pgcode.UndefinedDatabase
+	case Schema:
+		code = pgcode.UndefinedSchema
+	case Type:
+		code = pgcode.UndefinedObject
+	case Function:
+		code = pgcode.UndefinedFunction
+	}
+	return pgerror.Wrapf(ErrDescriptorDropped, code,
+		"%s %q is being dropped", desc.DescriptorType(), desc.GetName())
+}
 
 func (i *inactiveDescriptorError) Error() string { return i.cause.Error() }
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -688,7 +688,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	// try to acquire at a bogus version to make sure we don't get back a lease we
 	// already had.
 	_, err = t.acquireMinVersion(1, tableDesc.GetID(), tableDesc.GetVersion()+123)
-	if !testutils.IsError(err, "descriptor is being dropped") {
+	if !errors.Is(err, catalog.ErrDescriptorDropped) {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 }
@@ -797,7 +797,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 
 	// Ensure that dropped descriptors cannot be acquired.
 	_, err = acquire(ctx, s, tableDesc.GetID())
-	if !testutils.IsError(err, "descriptor is being dropped") {
+	if !errors.Is(err, catalog.ErrDescriptorDropped) {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 
@@ -819,7 +819,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 
 	// Now we shouldn't be able to acquire any more.
 	_, err = acquire(ctx, s, tableDesc.GetID())
-	if !testutils.IsError(err, "descriptor is being dropped") {
+	if !errors.Is(err, catalog.ErrDescriptorDropped) {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 	// Validate we can read the descriptor before the drop.

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -300,7 +300,7 @@ func (c Catalog) ValidateNamespaceEntry(key catalog.NameKey) error {
 		return catalog.NewReferencedDescriptorNotFoundError("schema", ne.GetID())
 	}
 	if desc.Dropped() {
-		return catalog.ErrDescriptorDropped
+		return catalog.NewDescriptorDroppedError(desc)
 	}
 	if ne.GetParentID() == desc.GetParentID() &&
 		ne.GetParentSchemaID() == desc.GetParentSchemaID() &&

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -55,7 +55,7 @@ public  b  table  root  0  NULL
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a
 
-statement error pq: \[\d+ AS a\]: descriptor is being dropped
+statement error pq: \[\d+ AS a\]: relation "a" is being dropped: descriptor is being dropped
 SELECT * FROM [$t_id AS a]
 
 statement error pgcode 42P01 relation "a" does not exist

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -337,7 +337,7 @@ EXPLAIN (VERBOSE) SELECT 1 FROM [$t_id() as num_ref_alias]
 statement ok
 DROP TABLE num_ref
 
-query error pq: \[\d+\(1\) AS num_ref_alias\]: descriptor is being dropped
+query error pq: \[\d+\(1\) AS num_ref_alias\]: relation "num_ref" is being dropped: descriptor is being dropped
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id(1) AS num_ref_alias]
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The generic dropping descriptor error is clumsy. This change adds
type-specific details so testing code can expect a particularly labeled
error.

Epic: none
Part of: #169638

Release note: None
