### PR TITLE
workload/schemachanger: expect competing drop error in DDL

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -263,7 +263,7 @@ func TestExplainGist(t *testing.T) {
 				// We might be still in the process of cancelling the previous DROP
 				// operation or hit the statement timeout - ignore this particular
 				// error.
-				if !testutils.IsError(err, "descriptor is being dropped") &&
+				if !testutils.IsError(err, "is being dropped") &&
 					!sqltestutils.IsClientSideQueryCanceledErr(err) {
 					t.Fatal(err)
 				}

--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -77,8 +77,8 @@ func NewDescriptorDroppedError(desc Descriptor) error {
 	case Function:
 		code = pgcode.UndefinedFunction
 	}
-	return pgerror.Wrapf(ErrDescriptorDropped, code,
-		"%s %q is being dropped", desc.DescriptorType(), desc.GetName())
+	err := pgerror.Newf(code, "%s %q is being dropped", desc.DescriptorType(), desc.GetName())
+	return errors.Mark(err, ErrDescriptorDropped)
 }
 
 func (i *inactiveDescriptorError) Error() string { return i.cause.Error() }

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -55,7 +55,7 @@ public  b  table  root  0  NULL
 statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a
 
-statement error pq: \[\d+ AS a\]: relation "a" is being dropped: descriptor is being dropped
+statement error pq: \[\d+ AS a\]: relation "a" is being dropped
 SELECT * FROM [$t_id AS a]
 
 statement error pgcode 42P01 relation "a" does not exist

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -337,7 +337,7 @@ EXPLAIN (VERBOSE) SELECT 1 FROM [$t_id() as num_ref_alias]
 statement ok
 DROP TABLE num_ref
 
-query error pq: \[\d+\(1\) AS num_ref_alias\]: relation "num_ref" is being dropped: descriptor is being dropped
+query error pq: \[\d+\(1\) AS num_ref_alias\]: relation "num_ref" is being dropped
 EXPLAIN (VERBOSE) SELECT * FROM [$t_id(1) AS num_ref_alias]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -883,7 +883,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		// Start schema change that eventually runs a partial backfill.
 		if _, err := sqlDB.Exec(
 			"CREATE UNIQUE INDEX bar ON t.test (v)",
-		); err != nil && !testutils.IsError(err, "descriptor is being dropped") {
+		); err != nil && !testutils.IsError(err, "is being dropped") {
 			t.Error(err)
 		}
 		wg.Done()

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -220,6 +220,15 @@ func (og *operationGenerator) randOp(
 			return nil, errors.Wrapf(err, "failed generating operation: %s", op)
 		}
 
+		// Any DDL on a descriptor can race with a concurrent DROP.
+		//
+		// The operation generator checks existence before generating a
+		// statement but that concurrent DROP could cause a serialization
+		// conflict that surfaces as UndefinedTable at commit.
+		if stmt.queryType == OpStmtDDL {
+			og.potentialCommitErrors.add(pgcode.UndefinedTable)
+		}
+
 		// Screen for schema change after write in the same transaction.
 		og.stmtsInTxt = append(og.stmtsInTxt, stmt)
 		// Add candidateExpectedCommitErrors to expectedCommitErrors
@@ -943,11 +952,6 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	// travel query.
 	stmt.potentialExecErrors.add(pgcode.ForeignKeyViolation)
 	og.potentialCommitErrors.add(pgcode.ForeignKeyViolation)
-
-	// It's possible for the table to be dropped concurrently, while we are running
-	// validation. In which case a potential commit error is an undefined table
-	// error.
-	og.potentialCommitErrors.add(pgcode.UndefinedTable)
 
 	// If the child column has an ON UPDATE expression (e.g., crdb_internal_expiration
 	// on TTL tables), specifying an ON UPDATE action on the foreign key constraint


### PR DESCRIPTION
The generic error wasn't expected by the roachtest. The stacked change
introduced type-specific errors and this change updates the roachtest
to expect the drop error on DDLs.

Epic: none
Fixes: #169638

Release note: None
