### PR TITLE
release-26.1: server: don't gate failed txn insights on contention resolution

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -406,12 +406,15 @@ func (b *baseStatusServer) localExecutionInsights(
 		insightsCopy := *insight
 		insightsCopy.Statements = make([]*insightspb.Statement, len(insight.Statements))
 		copy(insightsCopy.Statements, insight.Statements)
-		if insight.Transaction != nil && slices.Contains(insight.Transaction.Causes, insightspb.Cause_HighContention) {
-			// Collect high contention insights seperately, they need additional validation / filtering.
-			// If it is valid we will add it to the response later.
+		if insight.Transaction != nil &&
+			slices.Contains(insight.Transaction.Causes, insightspb.Cause_HighContention) &&
+			!slices.Contains(insight.Transaction.Problems, insightspb.Problem_FailedExecution) {
+			// Collect high-contention-only insights separately for
+			// validation against resolved contention events. Insights
+			// that also have FailedExecution are independently valid
+			// and should not be gated on contention resolution.
 			highContentionInsights[insightsCopy.Transaction.ID] = insightsCopy
 		} else {
-			// All other insights are included in the response.
 			response.Insights = append(response.Insights, insightsCopy)
 		}
 	})


### PR DESCRIPTION
Backport 1/1 commits from #169295 on behalf of @dhartunian.

----

When listing execution insights via `crdb_internal.node_txn_execution_insights`,
`localExecutionInsights` defers all insights with `HighContention` as a cause
to contention event validation — the insight is only returned once the blocking
transaction's fingerprint ID has been resolved. This filtering applied
unconditionally, even when the insight was independently valid due to
`FailedExecution`.

A transaction that fails on COMMIT with a 40001 serialization conflict gets
both `FailedExecution` (problem) and `HighContention` (cause). Under race,
contention resolution can be slow enough to exceed the SucceedsSoon timeout
(3m45s), causing the insight to never appear.

The fix adds a `!FailedExecution` guard to the contention validation path so
that failed transaction insights are always returned immediately, regardless
of contention resolution state.

Fixes: #169115
Epic: none
Release note: None

----

Release justification: low-risk change to improve observability; existing tests cover this case