### PR TITLE
release-26.1: roachtest: use current binary for workload init in mixed-version db-console test

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -121,7 +121,11 @@ func runDBConsoleMixedVersion(ctx context.Context, t test.Test, c cluster.Cluste
 	mvt.InMixedVersion(
 		"test db console endpoints", func(ctx context.Context, l *logger.Logger, rng *rand.Rand,
 			h *mixedversion.Helper) error {
-			if err := initializeSchemaAndIDs(ctx, c, l, h.VersionedCockroachPath(t)); err != nil {
+			// Use the current binary for workload init rather than the
+			// versioned binary. Older binaries can't handle result column
+			// changes (e.g., the inspect_job_id column added to IMPORT
+			// results) when running against a newer cluster.
+			if err := initializeSchemaAndIDs(ctx, c, l, test.DefaultCockroachPath); err != nil {
 				t.Fatal(err)
 			}
 			return testEndpoints(ctx, c, l, getEndpoints(t), true)


### PR DESCRIPTION
Backport 1/1 commits from #169288 on behalf of @dhartunian.

----

The `db-console/mixed-version-endpoints` roachtest has been failing
nightly despite the prior fix in #166591/#168707. The previous fix
addressed a TPCC init race with `--drop`, but a separate failure mode
remained: **cross-version incompatibility in IMPORT result columns**.

When the mixed-version test uses an older cockroach binary (e.g.,
v25.4.8 or v26.1.3) to run `workload init tpcc` against a v26.2
cluster, the older binary fails scanning the `inspect_job_id` column
that was added to IMPORT results in v26.2:

```
Error: importing fixture: importing table warehouse: sql: Scan error
on column index 6, name "inspect_job_id": converting NULL to int64
is unsupported
```

The fix switches from `h.VersionedCockroachPath(t)` (the old binary) to
`test.DefaultCockroachPath` (the current binary, always available on all
nodes) for the workload init call. Workload init is schema-creation work
that does not need to match the cluster's running version.

Confirmed via TeamCity artifact analysis of builds
[21329268](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyAwsBazel/21329268)
and [21327720](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyAwsBazel/21327720).

Fixes: #168448
Epic: none
Release note: None

----

Release justification: test-only change