### PR TITLE
release-26.2: server: deflake TestStatusAPIContentionEvents contention event check

### DIFF
--- a/pkg/server/application_api/contention_test.go
+++ b/pkg/server/application_api/contention_test.go
@@ -106,28 +106,26 @@ SET TRACING=off;
 	sqlstatstestutil.WaitForTransactionEntriesAtLeast(t, obsConn, 1,
 		sqlstatstestutil.TransactionFilter{App: "contentionTest"})
 
-	var resp serverpb.ListContentionEventsResponse
-	require.NoError(t,
-		srvtestutils.GetStatusJSONProtoWithAdminOption(
+	testutils.SucceedsSoon(t, func() error {
+		var resp serverpb.ListContentionEventsResponse
+		if err := srvtestutils.GetStatusJSONProtoWithAdminOption(
 			s2,
 			"contention_events",
 			&resp,
-			true /* isAdmin */),
-	)
-
-	require.GreaterOrEqualf(t, len(resp.Events.IndexContentionEvents), 1,
-		"expecting at least 1 contention event, but found none")
-
-	found := false
-	for _, event := range resp.Events.IndexContentionEvents {
-		if event.TableID == descpb.ID(testTableID) && event.IndexID == descpb.IndexID(1) {
-			found = true
-			break
+			true, /* isAdmin */
+		); err != nil {
+			return err
 		}
-	}
-
-	require.True(t, found,
-		"expect to find contention event for table %d, but found %+v", testTableID, resp)
+		for _, event := range resp.Events.IndexContentionEvents {
+			if event.TableID == descpb.ID(testTableID) && event.IndexID == descpb.IndexID(1) {
+				return nil
+			}
+		}
+		return errors.Newf(
+			"contention event for table %d not found in response: %+v",
+			testTableID, resp,
+		)
+	})
 
 	server1Conn.CheckQueryResultsRetry(t, `
   SELECT count(*)


### PR DESCRIPTION
Backport 1/1 commits from #169156 on behalf of @dhartunian.

----

The test queried the contention events HTTP endpoint once and
immediately asserted the test table's event was present. But
contention events are collected asynchronously — the existing
`WaitForTransactionEntriesAtLeast` call only waits for transaction
stats (a different subsystem), so the contention event may not
have been ingested yet. Under race builds or slow CI, this
manifests as finding system table contention but not the test
table's contention.

Wrap the contention event HTTP query and table-ID check in
`testutils.SucceedsSoon`, matching the retry pattern already used
for statement and transaction stats later in the same test.

Fixes: #169050
Epic: none

Release note: None

----

Release justification: test-only change