### PR TITLE
sql/schemachanger: allow ALTER COLUMN TYPE with dependent routines

### DIFF
--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -278,8 +278,9 @@ USE defaultdb;
 			expectedErr: `pq: cannot rename column "b" because function "f" depends on it`,
 		},
 		{
-			stmt:        "ALTER TABLE t ALTER COLUMN b TYPE STRING",
-			expectedErr: `pq: cannot alter type of column "b" because function "f" depends on it`,
+			stmt:           "ALTER TABLE t ALTER COLUMN b TYPE STRING",
+			expectedErr:    `pq: cannot alter type of column "b" because function "f" depends on it`,
+			dscExpectedErr: `pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index`,
 		},
 		{
 			stmt:        "DROP INDEX t@t_idx_b",

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -968,20 +968,784 @@ DROP TABLE t_with_default;
 
 subtest dep_function
 
+# Compatible type change (INT4 → INT8) should succeed with dependent function.
 statement ok
-CREATE TABLE T_FOR_FUNCTION (C1 INT, C2 INT);
+CREATE TABLE t_for_function (c1 INT4, c2 INT4);
 
 statement ok
-CREATE OR REPLACE FUNCTION F1() RETURNS INT AS 'SELECT C2 FROM T_FOR_FUNCTION' LANGUAGE SQL;
-
-statement error pq: cannot alter type of column "c2" because function "f1" depends on it\nHINT: consider dropping "f1" first.
-ALTER TABLE T_FOR_FUNCTION ALTER COLUMN C2 SET DATA TYPE TEXT;
+CREATE OR REPLACE FUNCTION f1() RETURNS INT AS 'SELECT c2 FROM t_for_function' LANGUAGE SQL;
 
 statement ok
-DROP FUNCTION F1;
+ALTER TABLE t_for_function ALTER COLUMN c2 SET DATA TYPE INT8;
+
+# Verify the function still works after the type change.
+statement ok
+INSERT INTO t_for_function VALUES (1, 42);
+
+query I
+SELECT f1();
+----
+42
+
+# Incompatible type change (INT → TEXT) should fail because the function body
+# would become invalid: the return type is INT but the column would be TEXT.
+statement error pq: cannot alter type of column "c2" because function "f1" would become invalid
+ALTER TABLE t_for_function ALTER COLUMN c2 SET DATA TYPE TEXT;
 
 statement ok
-DROP TABLE T_FOR_FUNCTION;
+DROP FUNCTION f1;
+
+statement ok
+DROP TABLE t_for_function;
+
+# Compatible type change (VARCHAR(30) → VARCHAR(60)) with dependent function.
+statement ok
+CREATE TABLE t_for_function_vc (c1 INT, c2 VARCHAR(30));
+
+statement ok
+CREATE FUNCTION f_vc() RETURNS VARCHAR AS 'SELECT c2 FROM t_for_function_vc' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_for_function_vc ALTER COLUMN c2 SET DATA TYPE VARCHAR(60);
+
+statement ok
+INSERT INTO t_for_function_vc VALUES (1, 'hello');
+
+query T
+SELECT f_vc();
+----
+hello
+
+statement ok
+DROP FUNCTION f_vc;
+
+statement ok
+DROP TABLE t_for_function_vc;
+
+# Multiple functions depending on the same column.
+statement ok
+CREATE TABLE t_multi_fn (c1 INT4);
+
+statement ok
+CREATE FUNCTION f_multi_1() RETURNS INT AS 'SELECT c1 FROM t_multi_fn' LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_multi_2() RETURNS INT AS 'SELECT c1 + 1 FROM t_multi_fn' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_multi_fn ALTER COLUMN c1 SET DATA TYPE INT8;
+
+statement ok
+INSERT INTO t_multi_fn VALUES (10);
+
+query I
+SELECT f_multi_1();
+----
+10
+
+query I
+SELECT f_multi_2();
+----
+11
+
+statement ok
+DROP FUNCTION f_multi_1;
+
+statement ok
+DROP FUNCTION f_multi_2;
+
+statement ok
+DROP TABLE t_multi_fn;
+
+# PL/pgSQL function depending on column.
+statement ok
+CREATE TABLE t_plpgsql (c1 INT4);
+
+statement ok
+CREATE FUNCTION f_plpgsql() RETURNS INT AS $$
+  BEGIN
+    RETURN (SELECT c1 FROM t_plpgsql LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+ALTER TABLE t_plpgsql ALTER COLUMN c1 SET DATA TYPE INT8;
+
+statement ok
+INSERT INTO t_plpgsql VALUES (99);
+
+query I
+SELECT f_plpgsql();
+----
+99
+
+statement ok
+DROP FUNCTION f_plpgsql;
+
+statement ok
+DROP TABLE t_plpgsql;
+
+# Stored procedure depending on column.
+statement ok
+CREATE TABLE t_proc (c1 INT4, c2 INT);
+
+statement ok
+CREATE PROCEDURE p1(OUT result INT) AS 'SELECT c1 FROM t_proc LIMIT 1' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_proc ALTER COLUMN c1 SET DATA TYPE INT8;
+
+statement ok
+INSERT INTO t_proc VALUES (55, 1);
+
+query I
+CALL p1(NULL);
+----
+55
+
+statement ok
+DROP PROCEDURE p1;
+
+statement ok
+DROP TABLE t_proc;
+
+# Function depending on a single column of a multi-column table.
+statement ok
+CREATE TABLE t_ref1 (a INT4, b TEXT);
+
+statement ok
+CREATE FUNCTION f_ref() RETURNS INT AS 'SELECT a FROM t_ref1' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_ref1 ALTER COLUMN a SET DATA TYPE INT8;
+
+statement ok
+INSERT INTO t_ref1 VALUES (7, 'test');
+
+query I
+SELECT f_ref();
+----
+7
+
+statement ok
+DROP FUNCTION f_ref;
+
+statement ok
+DROP TABLE t_ref1;
+
+# Function referencing multiple columns where only one is altered.
+statement ok
+CREATE TABLE t_multi_col (a INT4, b INT4);
+
+statement ok
+CREATE FUNCTION f_multi_col() RETURNS INT AS 'SELECT a + b FROM t_multi_col' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_multi_col ALTER COLUMN a SET DATA TYPE INT8;
+
+statement ok
+INSERT INTO t_multi_col VALUES (3, 4);
+
+query I
+SELECT f_multi_col();
+----
+7
+
+statement ok
+DROP FUNCTION f_multi_col;
+
+statement ok
+DROP TABLE t_multi_col;
+
+# Incompatible type change (INT → TEXT) should fail for procedures too, and the
+# error message should say "procedure" not "function".
+statement ok
+CREATE TABLE t_proc_err (c1 INT);
+
+statement ok
+CREATE PROCEDURE p_err(OUT result INT) AS 'SELECT c1 FROM t_proc_err LIMIT 1' LANGUAGE SQL;
+
+statement error pq: cannot alter type of column "c1" because procedure "p_err" would become invalid
+ALTER TABLE t_proc_err ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP PROCEDURE p_err;
+
+statement ok
+DROP TABLE t_proc_err;
+
+# General column conversion (triggered by USING clause) should reject dependent
+# functions because the column is replaced with a new column ID.
+statement ok
+CREATE TABLE t_gen_fn (c1 INT4);
+
+statement ok
+CREATE FUNCTION f_gen() RETURNS INT AS 'SELECT c1 FROM t_gen_fn' LANGUAGE SQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_gen" depends on it
+ALTER TABLE t_gen_fn ALTER COLUMN c1 SET DATA TYPE INT8 USING c1::INT8;
+
+statement ok
+DROP FUNCTION f_gen;
+
+statement ok
+DROP TABLE t_gen_fn;
+
+# General column conversion (USING clause) should reject dependent PL/pgSQL
+# functions too.
+statement ok
+CREATE TABLE t_gen_plpgsql (c1 INT4);
+
+statement ok
+CREATE FUNCTION f_gen_plpgsql() RETURNS INT AS $$
+  BEGIN
+    RETURN (SELECT c1 FROM t_gen_plpgsql LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_gen_plpgsql" depends on it
+ALTER TABLE t_gen_plpgsql ALTER COLUMN c1 SET DATA TYPE INT8 USING c1::INT8;
+
+statement ok
+DROP FUNCTION f_gen_plpgsql;
+
+statement ok
+DROP TABLE t_gen_plpgsql;
+
+# General column conversion (USING clause) should reject dependent procedures.
+statement ok
+CREATE TABLE t_gen_proc (c1 INT4);
+
+statement ok
+CREATE PROCEDURE p_gen(OUT result INT) AS 'SELECT c1 FROM t_gen_proc LIMIT 1' LANGUAGE SQL;
+
+statement error pq: cannot alter type of column "c1" because procedure "p_gen" depends on it
+ALTER TABLE t_gen_proc ALTER COLUMN c1 SET DATA TYPE INT8 USING c1::INT8;
+
+statement ok
+DROP PROCEDURE p_gen;
+
+statement ok
+DROP TABLE t_gen_proc;
+
+subtest dep_function_narrowing
+
+# Narrowing integer types (INT8 → INT4). The function returns INT8, and after
+# narrowing the column to INT4, the function body still type-checks because INT4
+# is implicitly assignable to INT8.
+statement ok
+CREATE TABLE t_narrow_int (c1 INT8);
+
+statement ok
+CREATE FUNCTION f_narrow_int() RETURNS INT8 AS 'SELECT c1 FROM t_narrow_int' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_narrow_int ALTER COLUMN c1 SET DATA TYPE INT4;
+
+statement ok
+INSERT INTO t_narrow_int VALUES (42);
+
+query I
+SELECT f_narrow_int();
+----
+42
+
+statement ok
+DROP FUNCTION f_narrow_int;
+
+statement ok
+DROP TABLE t_narrow_int;
+
+# Narrowing INT8 → INT2 with SQL function.
+statement ok
+CREATE TABLE t_narrow_int2 (c1 INT8);
+
+statement ok
+CREATE FUNCTION f_narrow_int2() RETURNS INT8 AS 'SELECT c1 FROM t_narrow_int2' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_narrow_int2 ALTER COLUMN c1 SET DATA TYPE INT2;
+
+statement ok
+INSERT INTO t_narrow_int2 VALUES (7);
+
+query I
+SELECT f_narrow_int2();
+----
+7
+
+statement ok
+DROP FUNCTION f_narrow_int2;
+
+statement ok
+DROP TABLE t_narrow_int2;
+
+# Narrowing INT8 → INT4 with PL/pgSQL function.
+statement ok
+CREATE TABLE t_narrow_plpgsql (c1 INT8);
+
+statement ok
+CREATE FUNCTION f_narrow_plpgsql() RETURNS INT8 AS $$
+  BEGIN
+    RETURN (SELECT c1 FROM t_narrow_plpgsql LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+ALTER TABLE t_narrow_plpgsql ALTER COLUMN c1 SET DATA TYPE INT4;
+
+statement ok
+INSERT INTO t_narrow_plpgsql VALUES (123);
+
+query I
+SELECT f_narrow_plpgsql();
+----
+123
+
+statement ok
+DROP FUNCTION f_narrow_plpgsql;
+
+statement ok
+DROP TABLE t_narrow_plpgsql;
+
+# Narrowing INT8 → INT4 with SQL stored procedure.
+statement ok
+CREATE TABLE t_narrow_proc (c1 INT8);
+
+statement ok
+CREATE PROCEDURE p_narrow(OUT result INT8) AS 'SELECT c1 FROM t_narrow_proc LIMIT 1' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_narrow_proc ALTER COLUMN c1 SET DATA TYPE INT4;
+
+statement ok
+INSERT INTO t_narrow_proc VALUES (88);
+
+query I
+CALL p_narrow(NULL);
+----
+88
+
+statement ok
+DROP PROCEDURE p_narrow;
+
+statement ok
+DROP TABLE t_narrow_proc;
+
+# Narrowing FLOAT8 → FLOAT4 with SQL function.
+statement ok
+CREATE TABLE t_narrow_float (c1 FLOAT8);
+
+statement ok
+CREATE FUNCTION f_narrow_float() RETURNS FLOAT8 AS 'SELECT c1 FROM t_narrow_float' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_narrow_float ALTER COLUMN c1 SET DATA TYPE FLOAT4;
+
+statement ok
+INSERT INTO t_narrow_float VALUES (3.14);
+
+query R
+SELECT f_narrow_float();
+----
+3.14
+
+statement ok
+DROP FUNCTION f_narrow_float;
+
+statement ok
+DROP TABLE t_narrow_float;
+
+# Narrowing VARCHAR(100) → VARCHAR(50) with SQL function.
+statement ok
+CREATE TABLE t_narrow_vc (c1 VARCHAR(100));
+
+statement ok
+CREATE FUNCTION f_narrow_vc() RETURNS VARCHAR AS 'SELECT c1 FROM t_narrow_vc' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_narrow_vc ALTER COLUMN c1 SET DATA TYPE VARCHAR(50);
+
+statement ok
+INSERT INTO t_narrow_vc VALUES ('hello world');
+
+query T
+SELECT f_narrow_vc();
+----
+hello world
+
+statement ok
+DROP FUNCTION f_narrow_vc;
+
+statement ok
+DROP TABLE t_narrow_vc;
+
+subtest dep_function_incompatible
+
+# Incompatible type change (INT → TEXT) with PL/pgSQL function. PL/pgSQL
+# performs implicit return casts, so the body revalidation passes. However,
+# INT → TEXT is a general conversion that rejects dependent routines.
+statement ok
+CREATE TABLE t_incompat_plpgsql (c1 INT);
+
+statement ok
+CREATE FUNCTION f_incompat_plpgsql() RETURNS INT AS $$
+  BEGIN
+    RETURN (SELECT c1 FROM t_incompat_plpgsql LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_incompat_plpgsql" depends on it
+ALTER TABLE t_incompat_plpgsql ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP FUNCTION f_incompat_plpgsql;
+
+statement ok
+DROP TABLE t_incompat_plpgsql;
+
+# Incompatible type change (INT → TEXT) with PL/pgSQL procedure.
+statement ok
+CREATE TABLE t_incompat_plpgsql_proc (c1 INT);
+
+statement ok
+CREATE PROCEDURE p_incompat_plpgsql(OUT result INT) AS $$
+  BEGIN
+    SELECT c1 INTO result FROM t_incompat_plpgsql_proc LIMIT 1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because procedure "p_incompat_plpgsql" depends on it
+ALTER TABLE t_incompat_plpgsql_proc ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP PROCEDURE p_incompat_plpgsql;
+
+statement ok
+DROP TABLE t_incompat_plpgsql_proc;
+
+# Incompatible type change (INT → BOOL) with SQL function. INT cannot be
+# assignment-cast to BOOL, so the automatic cast check rejects the ALTER before
+# routine revalidation runs.
+statement ok
+CREATE TABLE t_incompat_bool (c1 INT);
+
+statement ok
+CREATE FUNCTION f_incompat_bool() RETURNS INT AS 'SELECT c1 FROM t_incompat_bool' LANGUAGE SQL;
+
+statement error pq: column "c1" cannot be cast automatically to type BOOL
+ALTER TABLE t_incompat_bool ALTER COLUMN c1 SET DATA TYPE BOOL;
+
+statement ok
+DROP FUNCTION f_incompat_bool;
+
+statement ok
+DROP TABLE t_incompat_bool;
+
+subtest dep_function_expression
+
+# Function uses column in arithmetic expression; changing column to TEXT makes
+# the expression invalid.
+statement ok
+CREATE TABLE t_expr_arith (c1 INT);
+
+statement ok
+CREATE FUNCTION f_expr_arith() RETURNS INT AS 'SELECT c1 + 1 FROM t_expr_arith' LANGUAGE SQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_expr_arith" would become invalid
+ALTER TABLE t_expr_arith ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP FUNCTION f_expr_arith;
+
+statement ok
+DROP TABLE t_expr_arith;
+
+# PL/pgSQL function uses column in arithmetic expression; changing column to
+# TEXT makes the expression invalid.
+statement ok
+CREATE TABLE t_expr_arith_plpgsql (c1 INT);
+
+statement ok
+CREATE FUNCTION f_expr_arith_plpgsql() RETURNS INT AS $$
+  BEGIN
+    RETURN (SELECT c1 * 2 FROM t_expr_arith_plpgsql LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_expr_arith_plpgsql" would become invalid
+ALTER TABLE t_expr_arith_plpgsql ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP FUNCTION f_expr_arith_plpgsql;
+
+statement ok
+DROP TABLE t_expr_arith_plpgsql;
+
+subtest dep_function_mixed
+
+# Both a SQL function and a PL/pgSQL function depend on the same column.
+# Widening should succeed for both.
+statement ok
+CREATE TABLE t_mixed (c1 INT4);
+
+statement ok
+CREATE FUNCTION f_mixed_sql() RETURNS INT AS 'SELECT c1 FROM t_mixed' LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_mixed_plpgsql() RETURNS INT AS $$
+  BEGIN
+    RETURN (SELECT c1 FROM t_mixed LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+ALTER TABLE t_mixed ALTER COLUMN c1 SET DATA TYPE INT8;
+
+statement ok
+INSERT INTO t_mixed VALUES (77);
+
+query I
+SELECT f_mixed_sql();
+----
+77
+
+query I
+SELECT f_mixed_plpgsql();
+----
+77
+
+statement ok
+DROP FUNCTION f_mixed_sql;
+
+statement ok
+DROP FUNCTION f_mixed_plpgsql;
+
+statement ok
+DROP TABLE t_mixed;
+
+# Both a SQL function and a PL/pgSQL function depend on the same column.
+# Incompatible change should fail.
+statement ok
+CREATE TABLE t_mixed_err (c1 INT);
+
+statement ok
+CREATE FUNCTION f_mixed_err_sql() RETURNS INT AS 'SELECT c1 FROM t_mixed_err' LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_mixed_err_plpgsql() RETURNS INT AS $$
+  BEGIN
+    RETURN (SELECT c1 FROM t_mixed_err LIMIT 1);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_mixed_err_sql" would become invalid
+ALTER TABLE t_mixed_err ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP FUNCTION f_mixed_err_sql;
+
+statement ok
+DROP FUNCTION f_mixed_err_plpgsql;
+
+statement ok
+DROP TABLE t_mixed_err;
+
+# A SQL function and a SQL stored procedure depend on the same column.
+# Narrowing should succeed for both.
+statement ok
+CREATE TABLE t_mixed_fn_proc (c1 INT8);
+
+statement ok
+CREATE FUNCTION f_mixed_fn() RETURNS INT8 AS 'SELECT c1 FROM t_mixed_fn_proc' LANGUAGE SQL;
+
+statement ok
+CREATE PROCEDURE p_mixed_proc(OUT result INT8) AS 'SELECT c1 FROM t_mixed_fn_proc LIMIT 1' LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_mixed_fn_proc ALTER COLUMN c1 SET DATA TYPE INT4;
+
+statement ok
+INSERT INTO t_mixed_fn_proc VALUES (33);
+
+query I
+SELECT f_mixed_fn();
+----
+33
+
+query I
+CALL p_mixed_proc(NULL);
+----
+33
+
+statement ok
+DROP FUNCTION f_mixed_fn;
+
+statement ok
+DROP PROCEDURE p_mixed_proc;
+
+statement ok
+DROP TABLE t_mixed_fn_proc;
+
+# PL/pgSQL stored procedure with compatible narrowing.
+statement ok
+CREATE TABLE t_proc_plpgsql (c1 INT8);
+
+statement ok
+CREATE PROCEDURE p_plpgsql_narrow(OUT result INT8) AS $$
+  BEGIN
+    SELECT c1 INTO result FROM t_proc_plpgsql LIMIT 1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+ALTER TABLE t_proc_plpgsql ALTER COLUMN c1 SET DATA TYPE INT4;
+
+statement ok
+INSERT INTO t_proc_plpgsql VALUES (44);
+
+query I
+CALL p_plpgsql_narrow(NULL);
+----
+44
+
+statement ok
+DROP PROCEDURE p_plpgsql_narrow;
+
+statement ok
+DROP TABLE t_proc_plpgsql;
+
+# PL/pgSQL stored procedure with incompatible type change. Like PL/pgSQL
+# functions, the body revalidation passes due to implicit casts, but the
+# general conversion rejects dependent routines.
+statement ok
+CREATE TABLE t_proc_plpgsql_err (c1 INT);
+
+statement ok
+CREATE PROCEDURE p_plpgsql_err(OUT result INT) AS $$
+  BEGIN
+    SELECT c1 INTO result FROM t_proc_plpgsql_err LIMIT 1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because procedure "p_plpgsql_err" depends on it
+ALTER TABLE t_proc_plpgsql_err ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+statement ok
+DROP PROCEDURE p_plpgsql_err;
+
+statement ok
+DROP TABLE t_proc_plpgsql_err;
+
+# General conversion (USING clause) should reject dependent PL/pgSQL
+# stored procedures.
+statement ok
+CREATE TABLE t_gen_plpgsql_proc (c1 INT4);
+
+statement ok
+CREATE PROCEDURE p_gen_plpgsql(OUT result INT) AS $$
+  BEGIN
+    SELECT c1 INTO result FROM t_gen_plpgsql_proc LIMIT 1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pq: cannot alter type of column "c1" because procedure "p_gen_plpgsql" depends on it
+ALTER TABLE t_gen_plpgsql_proc ALTER COLUMN c1 SET DATA TYPE INT8 USING c1::INT8;
+
+statement ok
+DROP PROCEDURE p_gen_plpgsql;
+
+statement ok
+DROP TABLE t_gen_plpgsql_proc;
+
+# Mixed compatible/incompatible: one function uses the column in arithmetic
+# (c1 + 1), another just selects it. ALTER to TEXT should fail because the
+# arithmetic function would become invalid.
+statement ok
+CREATE TABLE t_mixed_compat (c1 INT);
+
+statement ok
+CREATE FUNCTION f_mixed_arith() RETURNS INT AS 'SELECT c1 + 1 FROM t_mixed_compat' LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_mixed_select() RETURNS TEXT AS 'SELECT c1 FROM t_mixed_compat' LANGUAGE SQL;
+
+statement error pq: cannot alter type of column "c1" because function "f_mixed_arith" would become invalid
+ALTER TABLE t_mixed_compat ALTER COLUMN c1 SET DATA TYPE TEXT;
+
+# Verify both functions still work after the failed ALTER.
+statement ok
+INSERT INTO t_mixed_compat VALUES (10);
+
+query I
+SELECT f_mixed_arith();
+----
+11
+
+query T
+SELECT f_mixed_select();
+----
+10
+
+statement ok
+DROP FUNCTION f_mixed_arith;
+
+statement ok
+DROP FUNCTION f_mixed_select;
+
+statement ok
+DROP TABLE t_mixed_compat;
+
+subtest dep_function_dml
+
+# Function with INSERT referencing the column type; widen INT4 → INT8.
+statement ok
+CREATE TABLE t_dml (c1 INT4 PRIMARY KEY);
+
+statement ok
+CREATE FUNCTION f_dml_insert() RETURNS VOID AS $$
+  INSERT INTO t_dml(c1) VALUES(42);
+  SELECT NULL;
+$$ LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_dml_update() RETURNS VOID AS $$
+  UPDATE t_dml SET c1 = c1 + 1 WHERE true;
+  SELECT NULL;
+$$ LANGUAGE SQL;
+
+statement ok
+ALTER TABLE t_dml ALTER COLUMN c1 SET DATA TYPE INT8;
+
+# Verify the functions work after the ALTER.
+query T
+SELECT f_dml_insert();
+----
+NULL
+
+query I
+SELECT c1 FROM t_dml;
+----
+42
+
+query T
+SELECT f_dml_update();
+----
+NULL
+
+query I
+SELECT c1 FROM t_dml;
+----
+43
+
+statement ok
+DROP FUNCTION f_dml_update;
+
+statement ok
+DROP FUNCTION f_dml_insert;
+
+statement ok
+DROP TABLE t_dml;
 
 subtest ttl
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -204,7 +204,14 @@ statement ok
 SELECT f_unqualified_twocol()
 
 # Altering a column type is not allowed in postgres or CRDB.
+onlyif config local-legacy-schema-changer
 statement error pgcode 2BP01 pq: cannot alter type of column "b" because function "f_unqualified_twocol" depends on it
+ALTER TABLE t_twocol ALTER b TYPE FLOAT;
+
+# The declarative schema changer revalidates the function body and gives a more
+# specific error explaining why the function would become invalid.
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 pq: cannot alter type of column "b" because function "f_unqualified_twocol" would become invalid
 ALTER TABLE t_twocol ALTER b TYPE FLOAT;
 
 # TODO(#101934): Postgres allows column renaming when only referenced by UDFs.

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1886,6 +1886,28 @@ func (b *builderState) BuildReferenceProvider(stmt tree.Statement) scbuildstmt.R
 	return provider
 }
 
+// BuildReferenceProviderErr implements the scbuildstmt.FunctionHelpers interface.
+func (b *builderState) BuildReferenceProviderErr(
+	stmt tree.Statement,
+) (scbuildstmt.ReferenceProvider, error) {
+	return b.referenceProviderFactory.NewReferenceProvider(b.ctx, stmt)
+}
+
+// MustReadDescriptor implements the scbuildstmt.BuilderState interface.
+func (b *builderState) MustReadDescriptor(id descpb.ID) catalog.Descriptor {
+	return b.readDescriptor(id)
+}
+
+// AddSyntheticDescriptor implements the scbuildstmt.BuilderState interface.
+func (b *builderState) AddSyntheticDescriptor(desc catalog.Descriptor) {
+	b.cr.AddSyntheticDescriptor(b.ctx, desc)
+}
+
+// ResetSyntheticDescriptors implements the scbuildstmt.BuilderState interface.
+func (b *builderState) ResetSyntheticDescriptors() {
+	b.cr.ResetSyntheticDescriptors(b.ctx)
+}
+
 func (b *builderState) BuildUserPrivilegesFromDefaultPrivileges(
 	db *scpb.Database,
 	sc *scpb.Schema,

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -156,6 +156,13 @@ type CatalogReader interface {
 
 	// MustReadDescriptor looks up a descriptor by ID.
 	MustReadDescriptor(ctx context.Context, id descpb.ID) catalog.Descriptor
+
+	// AddSyntheticDescriptor injects a synthetic descriptor that overrides
+	// any real descriptor with the same ID for subsequent reads.
+	AddSyntheticDescriptor(ctx context.Context, desc catalog.Descriptor)
+
+	// ResetSyntheticDescriptors removes all injected synthetic descriptors.
+	ResetSyntheticDescriptors(ctx context.Context)
 }
 
 // TableReader implements functions for inspecting tables during the build phase,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -8,8 +8,11 @@ package scbuildstmt
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -47,6 +50,9 @@ func alterTableAlterColumnType(
 	newColType.TypeT = b.ResolveTypeRef(t.ToType)
 
 	// Check for elements depending on the column we are altering.
+	// Dependent functions are collected rather than rejected; they will be
+	// re-validated against the new column type below.
+	var dependentFunctions []*scpb.FunctionBody
 	walkColumnDependencies(b, col, "alter type of", "column", func(e scpb.Element, op, objType string) {
 		switch e := e.(type) {
 		case *scpb.Column:
@@ -64,8 +70,7 @@ func alterTableAlterColumnType(
 			}
 			panic(sqlerrors.NewDependentBlocksOpError(op, objType, t.Column.String(), "view", nsDep.Name))
 		case *scpb.FunctionBody:
-			fnName := b.QueryByID(e.FunctionID).FilterFunctionName().MustGetOneElement()
-			panic(sqlerrors.NewDependentBlocksOpError(op, objType, t.Column.String(), "function", fnName.Name))
+			dependentFunctions = append(dependentFunctions, e)
 		case *scpb.TriggerDeps:
 			tableElts := b.QueryByID(e.TableID)
 			tableName := tableElts.FilterNamespace().MustGetOneElement()
@@ -104,6 +109,17 @@ func alterTableAlterColumnType(
 	validateAutomaticCastForNewType(b, tbl.TableID, colID, t.Column.String(),
 		oldColType.Type, newColType.Type, t.Using != nil)
 
+	// Re-validate dependent functions against the new column type. This injects
+	// a synthetic table descriptor with the new type and re-runs the optbuilder
+	// on each function body. If any function body fails type-checking, the ALTER
+	// is rejected with a descriptive error.
+	var validatedRoutines []validatedRoutine
+	if len(dependentFunctions) > 0 {
+		validatedRoutines = revalidateDependentRoutines(
+			b, tbl.TableID, colID, newColType.Type, t.Column, dependentFunctions,
+		)
+	}
+
 	kind, err := schemachange.ClassifyConversionFromTree(b, t, oldColType.Type, newColType.Type,
 		newColType.IsVirtual)
 	if err != nil {
@@ -120,6 +136,10 @@ func alterTableAlterColumnType(
 	default:
 		panic(errors.AssertionFailedf("alter type conversion %v not handled", kind))
 	}
+
+	// Update FunctionBody elements for dependent routines whose column
+	// references may have changed due to the type alteration.
+	updateDependentRoutineBodies(b, validatedRoutines)
 }
 
 // ValidateColExprForNewType will ensure that the existing expressions for
@@ -294,7 +314,7 @@ func handleGeneralColumnConversion(
 	// additional validation checks required that are incompatible with this
 	// process.
 	walkColumnDependencies(b, col, "alter type of", "column", func(e scpb.Element, op, objType string) {
-		switch e.(type) {
+		switch e := e.(type) {
 		case *scpb.SequenceOwner:
 			panic(sqlerrors.NewAlterColumnTypeColOwnsSequenceNotSupportedErr())
 		case *scpb.CheckConstraint, *scpb.CheckConstraintUnvalidated,
@@ -303,6 +323,16 @@ func handleGeneralColumnConversion(
 			panic(sqlerrors.NewAlterColumnTypeColWithConstraintNotSupportedErr())
 		case *scpb.SecondaryIndex:
 			panic(sqlerrors.NewAlterColumnTypeColInIndexNotSupportedErr())
+		case *scpb.FunctionBody:
+			fnName := b.QueryByID(e.FunctionID).FilterFunctionName().MustGetOneElement()
+			kind := "function"
+			if fd, ok := b.MustReadDescriptor(e.FunctionID).(catalog.FunctionDescriptor); ok &&
+				fd.IsProcedure() {
+				kind = "procedure"
+			}
+			panic(sqlerrors.NewDependentBlocksOpError(
+				op, objType, t.Column.String(), kind, fnName.Name,
+			))
 		}
 	}, false /* allowPartialIdxPredicateRef */)
 
@@ -593,4 +623,173 @@ func getColumnCommentForColumnReplacement(
 		newColumnComment = protoutil.Clone(oldColumnComment).(*scpb.ColumnComment)
 	}
 	return
+}
+
+// validatedRoutine pairs a dependent FunctionBody element with the
+// ReferenceProvider produced by re-validating the routine body against the
+// modified catalog. The two fields are correlated: refProvider was built from
+// the routine body in routineBody, and will be used to update the tracked
+// dependency references on that element.
+type validatedRoutine struct {
+	routineBody *scpb.FunctionBody
+	refProvider ReferenceProvider
+}
+
+// revalidateDependentRoutines checks that all dependent function bodies remain
+// valid after the column type change. It injects a synthetic table descriptor
+// with the new column type, re-parses each function body into a CREATE ROUTINE
+// AST, and runs BuildReferenceProviderErr (which invokes optbuilder) to
+// type-check the body against the modified catalog. Returns the validated
+// routines with their new reference providers for subsequent element updates.
+func revalidateDependentRoutines(
+	b BuildCtx,
+	tableID catid.DescID,
+	colID catid.ColumnID,
+	newType *types.T,
+	colName tree.Name,
+	dependentFunctions []*scpb.FunctionBody,
+) []validatedRoutine {
+	// Build a synthetic table descriptor with the target column's type changed.
+	desc := b.MustReadDescriptor(tableID)
+	tblDesc, ok := desc.(catalog.TableDescriptor)
+	if !ok {
+		panic(errors.AssertionFailedf(
+			"expected table descriptor for ID %d, got %T", tableID, desc,
+		))
+	}
+	mut := tblDesc.NewBuilder().(tabledesc.TableDescriptorBuilder).
+		BuildExistingMutableTable()
+	found := false
+	for i := range mut.Columns {
+		if mut.Columns[i].ID == colID {
+			mut.Columns[i].Type = newType
+			found = true
+			break
+		}
+	}
+	if !found {
+		panic(errors.AssertionFailedf(
+			"column %d not found in public columns of table %d", colID, tableID,
+		))
+	}
+	b.AddSyntheticDescriptor(mut.ImmutableCopy())
+	// ResetSyntheticDescriptors clears all synthetics, not just the one we added.
+	// This is safe because no other code injects synthetic descriptors during the
+	// build phase.
+	defer b.ResetSyntheticDescriptors()
+
+	// Clear the SemaCtx properties so that the function body type-checking
+	// doesn't inherit ALTER TABLE restrictions (e.g. subquery rejection).
+	semaCtx := b.SemaCtx()
+	defer semaCtx.Properties.Restore(semaCtx.Properties)
+	semaCtx.Properties.Require("", 0)
+
+	validated := make([]validatedRoutine, 0, len(dependentFunctions))
+	for _, fnBody := range dependentFunctions {
+		fnDesc := b.MustReadDescriptor(fnBody.FunctionID)
+		fd, ok := fnDesc.(catalog.FunctionDescriptor)
+		if !ok {
+			panic(errors.AssertionFailedf(
+				"expected function descriptor for ID %d, got %T",
+				fnBody.FunctionID, fnDesc,
+			))
+		}
+
+		createRoutine, err := fd.ToCreateExpr()
+		if err != nil {
+			panic(errors.Wrapf(err, "converting function %d to CREATE expression",
+				fnBody.FunctionID))
+		}
+
+		// ToCreateExpr unconditionally emits volatility, leakproof, and null
+		// input behavior options for all routine types. The optbuilder rejects
+		// these for procedures (they are only valid for functions in CREATE
+		// PROCEDURE syntax). Strip them here to avoid spurious validation
+		// failures.
+		if createRoutine.IsProcedure {
+			filtered := createRoutine.Options[:0]
+			for _, opt := range createRoutine.Options {
+				switch opt.(type) {
+				case tree.RoutineVolatility, tree.RoutineLeakproof,
+					tree.RoutineNullInputBehavior:
+				default:
+					filtered = append(filtered, opt)
+				}
+			}
+			createRoutine.Options = filtered
+		}
+
+		refProvider, err := b.BuildReferenceProviderErr(createRoutine)
+		if err != nil {
+			fnName := b.QueryByID(fnBody.FunctionID).
+				FilterFunctionName().MustGetOneElement()
+			kind := "function"
+			if fd.IsProcedure() {
+				kind = "procedure"
+			}
+			panic(errors.WithDetail(
+				pgerror.Newf(
+					pgcode.DependentObjectsStillExist,
+					"cannot alter type of column %q because %s %q would become invalid",
+					colName, kind, fnName.Name,
+				),
+				err.Error(),
+			))
+		}
+
+		validated = append(validated, validatedRoutine{
+			routineBody: fnBody,
+			refProvider: refProvider,
+		})
+	}
+	return validated
+}
+
+// updateDependentRoutineBodies replaces FunctionBody elements for routines
+// that were re-validated after a column type change. The body text is unchanged
+// since CockroachDB re-parses and re-optimizes routine bodies on each
+// invocation; only the tracked dependency references need updating.
+func updateDependentRoutineBodies(b BuildCtx, validated []validatedRoutine) {
+	for _, vf := range validated {
+		newFnBody := &scpb.FunctionBody{
+			FunctionID: vf.routineBody.FunctionID,
+			Body:       vf.routineBody.Body,
+			Lang:       vf.routineBody.Lang,
+		}
+		if err := vf.refProvider.ForEachTableReference(
+			func(
+				tblID descpb.ID, idxID descpb.IndexID, colIDs descpb.ColumnIDs,
+			) error {
+				newFnBody.UsesTables = append(
+					newFnBody.UsesTables,
+					scpb.FunctionBody_TableReference{
+						TableID:   tblID,
+						ColumnIDs: colIDs,
+						IndexID:   idxID,
+					},
+				)
+				return nil
+			},
+		); err != nil {
+			panic(err)
+		}
+		if err := vf.refProvider.ForEachViewReference(
+			func(viewID descpb.ID, colIDs descpb.ColumnIDs) error {
+				newFnBody.UsesViews = append(
+					newFnBody.UsesViews,
+					scpb.FunctionBody_ViewReference{
+						ViewID:    viewID,
+						ColumnIDs: colIDs,
+					},
+				)
+				return nil
+			},
+		); err != nil {
+			panic(err)
+		}
+		newFnBody.UsesFunctionIDs = vf.refProvider.ReferencedRoutines().Ordered()
+		newFnBody.UsesSequenceIDs = vf.refProvider.ReferencedSequences().Ordered()
+		newFnBody.UsesTypeIDs = vf.refProvider.ReferencedTypes().Ordered()
+		b.Replace(newFnBody)
+	}
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -122,6 +122,16 @@ type BuilderState interface {
 	// the builder knows to avoid loading existing descriptor for decomposition.
 	GenerateUniqueDescID() catid.DescID
 
+	// MustReadDescriptor looks up a descriptor by ID, panicking if not found.
+	MustReadDescriptor(id descpb.ID) catalog.Descriptor
+
+	// AddSyntheticDescriptor injects a synthetic descriptor that overrides
+	// the real descriptor with the same ID for subsequent catalog reads.
+	AddSyntheticDescriptor(desc catalog.Descriptor)
+
+	// ResetSyntheticDescriptors removes all injected synthetic descriptors.
+	ResetSyntheticDescriptors()
+
 	// BuildUserPrivilegesFromDefaultPrivileges generates owner and user
 	// privileges elements from default privileges of the given database
 	// and schemas for the given descriptor and object type.
@@ -363,6 +373,11 @@ type TableHelpers interface {
 
 type FunctionHelpers interface {
 	BuildReferenceProvider(stmt tree.Statement) ReferenceProvider
+
+	// BuildReferenceProviderErr is like BuildReferenceProvider but returns an
+	// error instead of panicking when the statement fails type-checking.
+	BuildReferenceProviderErr(stmt tree.Statement) (ReferenceProvider, error)
+
 	WrapFunctionBody(fnID descpb.ID, bodyStr string, lang catpb.Function_Language,
 		returnType tree.ResolvableTypeReference, provider ReferenceProvider) *scpb.FunctionBody
 	ReplaceSeqTypeNamesInStatements(queryStr string, lang catpb.Function_Language) string

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -305,6 +305,16 @@ func (d *buildDeps) MustReadDescriptor(ctx context.Context, id descpb.ID) catalo
 	return desc
 }
 
+// AddSyntheticDescriptor implements the scbuild.CatalogReader interface.
+func (d *buildDeps) AddSyntheticDescriptor(_ context.Context, desc catalog.Descriptor) {
+	d.descsCollection.AddSyntheticDescriptor(desc)
+}
+
+// ResetSyntheticDescriptors implements the scbuild.CatalogReader interface.
+func (d *buildDeps) ResetSyntheticDescriptors(_ context.Context) {
+	d.descsCollection.ResetSyntheticDescriptors()
+}
+
 // GetAllSchemasInDatabase implements the scbuild.CatalogReader interface.
 func (d *buildDeps) GetAllSchemasInDatabase(
 	ctx context.Context, database catalog.DatabaseDescriptor,

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -653,6 +653,9 @@ func (s *TestState) GetAllSchemasInDatabase(
 
 // MustReadDescriptor implements the scbuild.CatalogReader interface.
 func (s *TestState) MustReadDescriptor(ctx context.Context, id descpb.ID) catalog.Descriptor {
+	if synth, ok := s.syntheticDescs[id]; ok {
+		return synth
+	}
 	desc, err := s.mustReadImmutableDescriptor(id)
 	if err != nil {
 		panic(err)
@@ -664,6 +667,19 @@ func (s *TestState) MustReadDescriptor(ctx context.Context, id descpb.ID) catalo
 		panic(err)
 	}
 	return desc
+}
+
+// AddSyntheticDescriptor implements the scbuild.CatalogReader interface.
+func (s *TestState) AddSyntheticDescriptor(_ context.Context, desc catalog.Descriptor) {
+	if s.syntheticDescs == nil {
+		s.syntheticDescs = make(map[descpb.ID]catalog.Descriptor)
+	}
+	s.syntheticDescs[desc.GetID()] = desc
+}
+
+// ResetSyntheticDescriptors implements the scbuild.CatalogReader interface.
+func (s *TestState) ResetSyntheticDescriptors(_ context.Context) {
+	s.syntheticDescs = nil
 }
 
 // mustReadImmutableDescriptor looks up a descriptor and returns a immutable

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -83,6 +83,8 @@ type TestState struct {
 	catalogChanges     catalogChanges
 	refProviderFactory scbuild.ReferenceProviderFactory
 	clusterSettings    *cluster.Settings
+
+	syntheticDescs map[descpb.ID]catalog.Descriptor
 }
 
 type catalogChanges struct {


### PR DESCRIPTION
Previously, ALTER TABLE ... ALTER COLUMN TYPE unconditionally failed when UDFs or stored procedures referenced the column, even for compatible type changes like INT4→INT8 or VARCHAR(30)→VARCHAR(60). This was a significant limitation for users with many routines who needed to widen column types without downtime.

This change makes the schema changer re-validate dependent routine bodies against the new column type before rejecting the ALTER. A synthetic table descriptor with the new type is injected into the catalog, and each dependent function/procedure body is type-checked via BuildReferenceProvider. If validation passes, the ALTER proceeds and FunctionBody elements are updated with refreshed dependency references. If any routine body would become invalid with the new type, a descriptive error is returned.

Fixes: #160622

Release note (sql change): ALTER TABLE ... ALTER COLUMN TYPE now succeeds when dependent functions or stored procedures reference the column, as long as the type change is compatible with the routine bodies. Previously, any dependent routine would unconditionally block the type change. Incompatible changes still produce a clear error identifying which routine would become invalid.