### PR TITLE
ui: upgrade uplot from 1.6.19 to 1.6.31+

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -178,8 +178,8 @@ importers:
         specifier: 2.2.5
         version: 2.2.5(react@16.12.0)
       uplot:
-        specifier: ^1.6.19
-        version: 1.6.19
+        specifier: ^1.6.31
+        version: 1.6.32
     devDependencies:
       '@babel/cli':
         specifier: ^7.8.3
@@ -636,8 +636,8 @@ importers:
         specifier: 2.2.5
         version: 2.2.5(react@16.12.0)
       uplot:
-        specifier: ^1.6.19
-        version: 1.6.19
+        specifier: ^1.6.31
+        version: 1.6.32
       util:
         specifier: ^0.12.5
         version: 0.12.5
@@ -11076,8 +11076,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  uplot@1.6.19:
-    resolution: {integrity: sha512-s5Oab13s8zUzuZ/KiSV0GRhEvuKptAg2831fkt2PFsginIP1NSsiNrcozlc+tTPuUEAt+4rAXqX521I1DrZwEg==}
+  uplot@1.6.32:
+    resolution: {integrity: sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -25996,7 +25996,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uplot@1.6.19: {}
+  uplot@1.6.32: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -74,7 +74,7 @@
     "redux": ">=4.0.5",
     "reselect": "^4.0.0",
     "swr": "2.2.5",
-    "uplot": "^1.6.19"
+    "uplot": "^1.6.31"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
@@ -62,7 +62,7 @@ const generateSeriesLegend = (
     colorBox.style.marginRight = "12px";
 
     const label = document.createElement("span");
-    label.textContent = series.label || "";
+    label.textContent = typeof series.label === "string" ? series.label : "";
 
     const dataValue = uPlot.data[index][idx];
     const value = document.createElement("div");

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -66,7 +66,7 @@
     "redux": "^4.1.0",
     "reselect": "^4.0.0",
     "swr": "2.2.5",
-    "uplot": "^1.6.19",
+    "uplot": "^1.6.31",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -118,10 +118,7 @@ function touPlot(
 }
 
 // TODO (koorosh): the same logic can be achieved with uPlot's series.gaps API starting from 1.6.15 version.
-export function fillGaps(
-  data: uPlot.AlignedData[0],
-  sampleDuration?: Long,
-): uPlot.AlignedData[0] {
+export function fillGaps(data: number[], sampleDuration?: Long): number[] {
   if (data.length === 0 || !sampleDuration) {
     return data;
   }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -149,7 +149,8 @@ function hoverTooltipPlugin(
     tooltip.style.left = tooltipLeftOffset + lft + shiftY + "px";
 
     timeNode.textContent = `Time: ${xFormatter(u.data[0][dataIdx])}`;
-    labelNode.textContent = `${u.series[seriesIdx].label}:`;
+    const seriesLabel = u.series[seriesIdx].label;
+    labelNode.textContent = `${typeof seriesLabel === "string" ? seriesLabel : ""}:`;
     dataNode.textContent = ` ${yFormatter(u.data[seriesIdx][dataIdx])}`;
 
     const stroke = u.series[seriesIdx].stroke;


### PR DESCRIPTION
Upgrade uplot to satisfy the ^1.6.31 range (resolves to 1.6.32),
remediating CVE-2024-21489 (prototype pollution in `uPlot.assign()`
and internal `copy()`). Even though the CVE is not exploitable in
our usage, we're required to remediate.

The new version changes `series.label` from `string` to
`string | HTMLElement`, requiring a type guard in the bar chart
tooltip plugin.

Notable behavioral changes between 1.6.19 and 1.6.32:
- 1.6.24: `series.value`/`series.values` callbacks now receive
  `null` on mouseleave — our code already guards against this.
- 1.6.29: `setSeries` hook fires before `setLegend` (was after).
- 1.6.29: `u.batch()` executes synchronously instead of via microtask.

Full build (including UI bundle) passes.

Fixes: #169438
Epic: none
Release note: None