### PR TITLE
release-25.4: workload/schemachange: don't predict deps on DROP COLUMN

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -149,69 +149,6 @@ func (og *operationGenerator) tableHasDependencies(
 	return og.scanBool(ctx, tx, q, tableName.Object(), tableName.Schema(), skipSelfRef)
 }
 
-func (og *operationGenerator) columnIsDependedOn(
-	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name, includeFKs bool,
-) (bool, error) {
-	// To see if a column is depended on, the ordinal_position of the column is looked up in
-	// information_schema.columns. Then, this position is used to see if that column has view dependencies
-	// or foreign key dependencies which would be stored in crdb_internal.forward_dependencies and
-	// pg_catalog.pg_constraint respectively.
-	//
-	// crdb_internal.forward_dependencies.dependedonby_details is an array of ordinal positions
-	// stored as a list of numbers in a string, so SQL functions are used to parse these values
-	// into arrays. unnest is used to flatten rows with this column of array type into multiple rows,
-	// so performing unions and joins is easier.
-	//
-	// To check if any foreign key references exist to this table, we use pg_constraint
-	// and check if any columns are dependent. We check both confrelid (table is referenced)
-	// and self-referential foreign keys (where conrelid = confrelid).
-	return og.scanBool(ctx, tx, `SELECT EXISTS(
-		SELECT source.column_id
-			FROM (
-			   SELECT DISTINCT column_id
-			     FROM (
-			           SELECT unnest(
-			                   string_to_array(
-			                    rtrim(
-			                     ltrim(
-			                      fd.dependedonby_details,
-			                      'Columns: ['
-			                     ),
-			                     ']'
-			                    ),
-			                    ' '
-			                   )::INT8[]
-			                  ) AS column_id
-			             FROM crdb_internal.forward_dependencies
-			                   AS fd
-			            WHERE fd.descriptor_id
-			                  = $1::REGCLASS
-                    AND fd.dependedonby_type != 'sequence'
-										AND ($5::BOOL || fd.dependedonby_type != 'fk')
-			          )
-			   UNION  (
-			           SELECT unnest(confkey) AS column_id
-			             FROM pg_catalog.pg_constraint
-			            WHERE confrelid = $1::REGCLASS
-			          )
-			   UNION  (
-			           SELECT unnest(conkey) AS column_id
-			             FROM pg_catalog.pg_constraint
-			            WHERE conrelid = $1::REGCLASS
-			              AND confrelid = $1::REGCLASS
-			          )
-			 ) AS cons
-			 INNER JOIN (
-			   SELECT ordinal_position AS column_id
-			     FROM information_schema.columns
-			    WHERE table_schema = $2
-			      AND table_name = $3
-			      AND column_name = $4
-			  ) AS source ON source.column_id = cons.column_id
-)
-`, tableName.String(), tableName.Schema(), tableName.Object(), columnName, includeFKs)
-}
-
 // colIsRefByComputed determines if a column is referenced by a computed column.
 func (og *operationGenerator) colIsRefByComputed(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name,

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1689,16 +1689,10 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		return nil, err
 	}
 
-	// Check if the table has any policies, triggers, or foreign keys.
-	tableHasPolicies, tableHasTriggers, tableHasFK := false, false, false
+	// Check if the table has any policies.
+	tableHasPolicies := false
 	if tableExists {
 		if tableHasPolicies, err = og.tableHasPolicies(ctx, tx, tableName); err != nil {
-			return nil, err
-		}
-		if tableHasTriggers, err = og.tableHasTriggers(ctx, tx, tableName); err != nil {
-			return nil, err
-		}
-		if tableHasFK, err = og.tableHasFK(ctx, tx, tableName); err != nil {
 			return nil, err
 		}
 	}
@@ -1712,10 +1706,6 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		return nil, err
 	}
 	colIsPrimaryKey, err := og.colIsPrimaryKey(ctx, tx, tableName, columnName)
-	if err != nil {
-		return nil, err
-	}
-	columnIsDependedOn, err := og.columnIsDependedOn(ctx, tx, tableName, columnName, false /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}
@@ -1737,7 +1727,6 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		{code: pgcode.ObjectNotInPrerequisiteState, condition: columnIsInAddingOrDroppingIndex},
 		{code: pgcode.UndefinedColumn, condition: !columnExists},
 		{code: pgcode.InvalidColumnReference, condition: colIsPrimaryKey || colIsRefByComputed},
-		{code: pgcode.DependentObjectsStillExist, condition: columnIsDependedOn},
 		{code: pgcode.FeatureNotSupported, condition: hasAlterPKSchemaChange && !og.useDeclarativeSchemaChanger},
 	})
 	stmt.potentialExecErrors.addAll(codesWithConditions{
@@ -1750,36 +1739,12 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		// It is possible that we cannot drop column because
 		// it is referenced in a policy expression.
 		{code: pgcode.InvalidTableDefinition, condition: tableHasPolicies},
-		// It is possible that we cannot drop column because
-		// it is depended on by a trigger or foreign key.
-		{code: pgcode.DependentObjectsStillExist, condition: tableHasTriggers || tableHasFK},
+		// Predicting DependentObjectsStillExist precisely has been a source of
+		// flakes, so permit it as a valid outcome instead.
+		{code: pgcode.DependentObjectsStillExist, condition: true},
 	})
 	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, tableName.String(), columnName.String())
 	return stmt, nil
-}
-
-// tableHasTriggers checks if a table has any triggers defined
-func (og *operationGenerator) tableHasTriggers(
-	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
-) (bool, error) {
-	// Query to check if a table has any triggers
-	query := `
-	SELECT EXISTS (
-		SELECT 1
-		FROM information_schema.triggers
-		WHERE event_object_schema = $1
-		AND event_object_table = $2
-		LIMIT 1
-	)
-	`
-
-	var hasTriggers bool
-	err := tx.QueryRow(ctx, query, tableName.Schema(), tableName.Object()).Scan(&hasTriggers)
-	if err != nil {
-		return false, err
-	}
-
-	return hasTriggers, nil
 }
 
 // tableHasPolicies checks if a table has any row-level security policies defined
@@ -1806,19 +1771,6 @@ func (og *operationGenerator) tableHasPolicies(
 	}
 
 	return hasPolicies, nil
-}
-
-// tableHasFK checks if a table participates in any foreign key constraints.
-func (og *operationGenerator) tableHasFK(
-	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
-) (bool, error) {
-	return og.scanBool(ctx, tx, `
-SELECT EXISTS (
-	SELECT 1
-	  FROM pg_constraint
-	 WHERE contype = 'f'
-	   AND (conrelid = $1::REGCLASS OR confrelid = $1::REGCLASS)
-)`, tableName.String())
 }
 
 func (og *operationGenerator) dropColumnDefault(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
@@ -2677,11 +2629,6 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 		return nil, err
 	}
 
-	columnHasDependencies, err := og.columnIsDependedOn(ctx, tx, tableName, columnForTypeChange.name, true /* includeFKs */)
-	if err != nil {
-		return nil, err
-	}
-
 	colIsRefByComputed, err := og.colIsRefByComputed(ctx, tx, tableName, columnForTypeChange.name)
 	if err != nil {
 		return nil, err
@@ -2723,7 +2670,7 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 
 	stmt.potentialExecErrors.addAll(codesWithConditions{
 		{code: pgcode.UndefinedObject, condition: newType == nil},
-		{code: pgcode.DependentObjectsStillExist, condition: columnHasDependencies || colIsRefByComputed || hasOngoingAlterPKSchemaChange},
+		{code: pgcode.DependentObjectsStillExist, condition: colIsRefByComputed || hasOngoingAlterPKSchemaChange},
 	})
 
 	stmt.sql = fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s SET DATA TYPE %s`,


### PR DESCRIPTION
Backport 1/1 commits from #169328.

/cc @cockroachdb/release

---

The schemachange workload tried to predict precisely when DROP COLUMN would fail with DependentObjectsStillExist. Keeping that prediction in sync with the schema changer has been a steady source of flakes.

Move the error to potentialExecErrors so it is permitted but not required, and delete the dependency-detection helpers that fed the old prediction.

Resolves #168658

Release note: None
Epic: none

Release justification: test only fix
