### PR TITLE
sql/importer: cap metamorphic batch sizes in TestImportCSVStmt

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -1917,6 +1917,12 @@ func setupTestImportCSVStmt(
 	skip.UnderShort(t)
 	skip.UnderRace(t, "takes >1min under race")
 
+	// The test isn't validating these batch sizes, but extreme metamorphic
+	// values (e.g. 1) cause the package to time out. Raise them to a floor that
+	// still exercises batching code paths.
+	t.Cleanup(row.TestingSetDatumRowConverterBatchSize(10))
+	t.Cleanup(row.TestingRaiseDefaultKVBatchSize(10))
+
 	const nodes = 3
 
 	numFiles = nodes + 2

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -58,6 +58,21 @@ var defaultKVBatchSize = rowinfra.KeyLimit(metamorphic.ConstantWithTestRange(
 	100,                                 /* max */
 ))
 
+// TestingRaiseDefaultKVBatchSize raises defaultKVBatchSize to minSize if it is
+// currently lower; otherwise it leaves the value untouched. The returned
+// function restores the previous value. This is useful for tests that should
+// not run with extremely small metamorphic batch sizes.
+func TestingRaiseDefaultKVBatchSize(minSize int) func() {
+	if defaultKVBatchSize >= rowinfra.KeyLimit(minSize) {
+		return func() {}
+	}
+	prev := defaultKVBatchSize
+	defaultKVBatchSize = rowinfra.KeyLimit(minSize)
+	return func() {
+		defaultKVBatchSize = prev
+	}
+}
+
 // elasticCPUDurationPerLowPriReadResponse controls how many CPU tokens are allotted
 // each time we seek admission for response handling during internally submitted
 // low priority reads (like row-level TTL selects).


### PR DESCRIPTION
The test has been timing out under metamorphic builds when `kv-batch-size` and `datum-row-converter-batch-size` are randomized to their minimum (1). With 18 subtests sharing one cluster, those values blow through the 15-minute package timeout.

Override both to 10 in the test setup. Adds TestingRaiseDefaultKVBatchSize to pkg/sql/row since `kv-batch-size` had no testing setter; the existing TestingSetDatumRowConverterBatchSize covers the other.

Local timing with both constants forced to 1 vs 10: 74.6s -> 28.2s.

Fixes: #167087
Release note: None