### PR TITLE
sql/sem/tree: quote INDEX in formatted column-def lists

### DIFF
--- a/pkg/crosscluster/logical/sqlwriter/testdata/ldr_statements
+++ b/pkg/crosscluster/logical/sqlwriter/testdata/ldr_statements
@@ -22,7 +22,7 @@ DELETE FROM [104 AS replication_target] WHERE (((id = $1::INT8) AND (name IS NOT
 
 show-select table=basic_table
 ----
-SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.name, replication_target.value, replication_target.data FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, index) INNER LOOKUP JOIN [104 AS replication_target] ON replication_target.id = key_list.key1
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.name, replication_target.value, replication_target.data FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, "index") INNER LOOKUP JOIN [104 AS replication_target] ON replication_target.id = key_list.key1
 
 exec
 CREATE TYPE status AS ENUM ('pending', 'active', 'completed', 'cancelled');
@@ -56,7 +56,7 @@ DELETE FROM [107 AS replication_target] WHERE (((((id = $1::INT8) AND (title IS 
 
 show-select table=tasks
 ----
-SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.title, replication_target.description, replication_target.status, replication_target.priority, replication_target.created_at FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, index) INNER LOOKUP JOIN [107 AS replication_target] ON replication_target.id = key_list.key1
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.title, replication_target.description, replication_target.status, replication_target.priority, replication_target.created_at FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, "index") INNER LOOKUP JOIN [107 AS replication_target] ON replication_target.id = key_list.key1
 
 # Test a table with a stored and virtual computed column. Note that the
 # computed columns are not included in the INSERT/UPDATE/DELETE statements.
@@ -92,7 +92,7 @@ DELETE FROM [108 AS replication_target] WHERE ((((id = $1::INT8) AND (name IS NO
 # discount_price is included because its part of the primary key.
 show-select table=products
 ----
-SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.name, replication_target.unit_price, replication_target.quantity, replication_target.total_value, replication_target.last_updated FROM ROWS FROM (unnest($1::INT8[], $2::DECIMAL[])) WITH ORDINALITY AS key_list (key1, key2, index) INNER LOOKUP JOIN [108 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.total_value = key_list.key2)
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.name, replication_target.unit_price, replication_target.quantity, replication_target.total_value, replication_target.last_updated FROM ROWS FROM (unnest($1::INT8[], $2::DECIMAL[])) WITH ORDINALITY AS key_list (key1, key2, "index") INNER LOOKUP JOIN [108 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.total_value = key_list.key2)
 
 # Test a table with an expression, inverted index, and partial index. The
 # indexes are not expected to impact the INSERT/UPDATE/DELETE statements.
@@ -141,7 +141,7 @@ DELETE FROM [109 AS replication_target] WHERE ((((((id = $1::INT8) AND (first_na
 
 show-select table=employees
 ----
-SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.first_name, replication_target.last_name, replication_target.email, replication_target.salary, replication_target.department, replication_target.hire_date FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, index) INNER LOOKUP JOIN [109 AS replication_target] ON replication_target.id = key_list.key1
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.first_name, replication_target.last_name, replication_target.email, replication_target.salary, replication_target.department, replication_target.hire_date FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, "index") INNER LOOKUP JOIN [109 AS replication_target] ON replication_target.id = key_list.key1
 
 exec
 ALTER DATABASE defaultdb PRIMARY REGION "us-east1";
@@ -175,7 +175,7 @@ DELETE FROM [112 AS replication_target] WHERE (((((id = $1::UUID) AND (user_id I
 
 show-select table=user_events
 ----
-SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.user_id, replication_target.event_type, replication_target.event_data, replication_target.created_at, replication_target.region FROM ROWS FROM (unnest($1::UUID[], $2::@100111)) WITH ORDINALITY AS key_list (key1, key2, index) INNER LOOKUP JOIN [112 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.region = key_list.key2)
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.user_id, replication_target.event_type, replication_target.event_data, replication_target.created_at, replication_target.region FROM ROWS FROM (unnest($1::UUID[], $2::@100111)) WITH ORDINALITY AS key_list (key1, key2, "index") INNER LOOKUP JOIN [112 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.region = key_list.key2)
 
 # Test table with array primary key - this requires point select due to array-of-arrays limitations
 exec

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -2877,6 +2877,59 @@ SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t (a "Nice Enum 📙", b S
 SELECT * FROM ROWS FROM (json_to_record('_')) AS t (a "Nice Enum 📙", b STRING, c foo) -- literals removed
 SELECT * FROM ROWS FROM (_('')) AS _ (_ _, _ STRING, _ _) -- identifiers removed
 
+# Regression test for #168372: a column name in an AS column-def list must be
+# quoted when it is the unreserved keyword INDEX, because the lexer's INDEX
+# disambiguation heuristic reclassifies a bare INDEX followed by an identifier
+# and '(' (e.g. a parameterized type like VARBIT(61)) into
+# INDEX_BEFORE_NAME_THEN_PAREN, which the 'name' grammar production rejects.
+#
+# The input uses BIT VARYING(61) (a two-word type) so the initial parse
+# succeeds: the lexer only sees INDEX followed by BIT followed by VARYING (not
+# '('). The formatter normalizes the type to VARBIT(61), which would trigger
+# the reclassification on re-parse if INDEX were left bare.
+
+parse
+SELECT * FROM json_to_record('') AS t (index BIT VARYING(61))
+----
+SELECT * FROM ROWS FROM (json_to_record('')) AS t ("index" VARBIT(61)) -- normalized!
+SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t ("index" VARBIT(61)) -- fully parenthesized
+SELECT * FROM ROWS FROM (json_to_record('_')) AS t ("index" VARBIT(61)) -- literals removed
+SELECT * FROM ROWS FROM (_('')) AS _ (_ VARBIT(61)) -- identifiers removed
+
+parse
+SELECT * FROM json_to_record('') AS t (index BIT VARYING(61)[])
+----
+SELECT * FROM ROWS FROM (json_to_record('')) AS t ("index" VARBIT(61)[]) -- normalized!
+SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t ("index" VARBIT(61)[]) -- fully parenthesized
+SELECT * FROM ROWS FROM (json_to_record('_')) AS t ("index" VARBIT(61)[]) -- literals removed
+SELECT * FROM ROWS FROM (_('')) AS _ (_ VARBIT(61)[]) -- identifiers removed
+
+parse
+SELECT * FROM json_to_record('') AS t (a INT, index BIT VARYING(61), b INT)
+----
+SELECT * FROM ROWS FROM (json_to_record('')) AS t (a INT8, "index" VARBIT(61), b INT8) -- normalized!
+SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t (a INT8, "index" VARBIT(61), b INT8) -- fully parenthesized
+SELECT * FROM ROWS FROM (json_to_record('_')) AS t (a INT8, "index" VARBIT(61), b INT8) -- literals removed
+SELECT * FROM ROWS FROM (_('')) AS _ (_ INT8, _ VARBIT(61), _ INT8) -- identifiers removed
+
+# Already-quoted INDEX as a column name continues to round-trip.
+parse
+SELECT * FROM json_to_record('') AS t ("index" BIT VARYING(61))
+----
+SELECT * FROM ROWS FROM (json_to_record('')) AS t ("index" VARBIT(61)) -- normalized!
+SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t ("index" VARBIT(61)) -- fully parenthesized
+SELECT * FROM ROWS FROM (json_to_record('_')) AS t ("index" VARBIT(61)) -- literals removed
+SELECT * FROM ROWS FROM (_('')) AS _ (_ VARBIT(61)) -- identifiers removed
+
+# Reduced reproducer of the original RandomSyntaxSelect failure (#168372).
+parse
+SELECT * FROM [FUNCTION 198]() AS TEMP (INDEX BIT VARYING(61) ARRAY[233])
+----
+SELECT * FROM ROWS FROM ([FUNCTION 198]()) AS temp ("index" VARBIT(61)[]) -- normalized!
+SELECT (*) FROM ROWS FROM (([FUNCTION 198]())) AS temp ("index" VARBIT(61)[]) -- fully parenthesized
+SELECT * FROM ROWS FROM ([FUNCTION 198]()) AS temp ("index" VARBIT(61)[]) -- literals removed
+SELECT * FROM ROWS FROM ([FUNCTION 198]()) AS _ (_ VARBIT(61)[]) -- identifiers removed
+
 parse
 SELECT 123 AS OF FROM t
 ----

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -213,11 +214,25 @@ type ColumnDef struct {
 
 // Format implements the NodeFormatter interface.
 func (c *ColumnDef) Format(ctx *FmtCtx) {
-	ctx.FormatNode(&c.Name)
+	if !ctx.flags.HasFlags(FmtAnonymize) && needsLexerEscapeAsColName(string(c.Name)) {
+		lexbase.EncodeEscapedSQLIdent(&ctx.Buffer, string(c.Name))
+	} else {
+		ctx.FormatNode(&c.Name)
+	}
 	if c.Type != nil {
 		ctx.WriteByte(' ')
 		ctx.FormatTypeReference(c.Type)
 	}
+}
+
+// needsLexerEscapeAsColName returns true when n must be force-quoted to be
+// recognized as a column name by the parser, even though it is not a reserved
+// keyword. This is necessary for identifiers that the lexer reclassifies into
+// a non-name token based on lookahead (e.g. INDEX followed by an identifier
+// and '(' becomes INDEX_BEFORE_NAME_THEN_PAREN). See the INDEX disambiguation
+// comment in pkg/sql/parser/lexer.go for details.
+func needsLexerEscapeAsColName(n string) bool {
+	return n == "index"
 }
 
 // ColumnDefList represents a list of ColumnDefs.


### PR DESCRIPTION
Fix a parse-format-reparse roundtrip bug. The formatter output the unreserved keyword INDEX bare as a column name in record-type aliases (e.g. `AS t (index VARBIT(61))`), which failed to re-parse: the lexer's INDEX disambiguation heuristic reclassifies a bare `INDEX` followed by an identifier and `(` into INDEX_BEFORE_NAME_THEN_PAREN, which the `name` grammar production rejects.

The original failure parsed because the type was written as the two-word form `BIT VARYING(61)` (no `(` after `BIT`, so no reclassification). The formatter normalized the type to `VARBIT(61)`, which then matched the lookahead pattern on re-parse.

Force-quote `index` in ColumnDef.Format so the formatted output round-trips regardless of what type follows.

Fixes: #168372

Release note: None