### PR TITLE
sql: respect lock_timeout in blocking advisory lock builtins

### DIFF
--- a/pkg/sql/advisorylock/BUILD.bazel
+++ b/pkg/sql/advisorylock/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "//pkg/roachpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/advisorylock/advisory_lock_test.go
+++ b/pkg/sql/advisorylock/advisory_lock_test.go
@@ -753,3 +753,79 @@ func TestAdvisoryLockSQLCrossIsolationWait(t *testing.T) {
 		})
 	}
 }
+
+// TestAdvisoryLockSQLLockTimeout verifies that the blocking advisory-lock
+// builtins respect the lock_timeout session variable, matching PostgreSQL.
+// It also confirms the non-blocking try_ variant is unaffected by
+// lock_timeout, so the timeout plumbing does not poison the WaitPolicy path.
+func TestAdvisoryLockSQLLockTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(context.Background())
+
+	const key = 940001
+
+	// holder takes the advisory lock and parks until released. waiter then
+	// attempts the same key with a short lock_timeout and must receive the
+	// PG-style "canceling statement due to lock timeout" error. Both conns
+	// must share a database since advisory locks are scoped per-database.
+	holder, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, holder.Close()) }()
+	waiter, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, waiter.Close()) }()
+
+	for _, c := range []*gosql.Conn{holder, waiter} {
+		_, err := c.ExecContext(ctx, `SET database = defaultdb`)
+		require.NoError(t, err)
+	}
+
+	_, err = holder.ExecContext(ctx, `BEGIN`)
+	require.NoError(t, err)
+	defer func() { _, _ = holder.ExecContext(context.Background(), `ROLLBACK`) }()
+	_, err = holder.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, key)
+	require.NoError(t, err)
+
+	// Blocking acquire under lock_timeout: must error promptly. Run the
+	// blocking acquire in a goroutine so we can confirm via cluster_locks
+	// that the waiter actually parked in the lock-table queue before
+	// measuring the wait-phase duration; otherwise dispatch jitter under
+	// stress could mask the timeout path.
+	_, err = waiter.ExecContext(ctx, `SET lock_timeout = '250ms'`)
+	require.NoError(t, err)
+	_, err = waiter.ExecContext(ctx, `BEGIN`)
+	require.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := waiter.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, key)
+		errCh <- err
+	}()
+	waitForAdvisoryLockWaiter(t, ctx, db)
+	start := timeutil.Now()
+	err = <-errCh
+	elapsed := timeutil.Since(start)
+	requirePGCode(t, err, pgcode.LockNotAvailable)
+	// Generous upper bound: the timeout is 250ms, so anything close to the
+	// test deadline (30s) means the timeout did not fire.
+	require.Less(t, elapsed, 10*time.Second,
+		"advisory lock acquire should have timed out near 250ms, got %s", elapsed)
+	_, err = waiter.ExecContext(ctx, `ROLLBACK`)
+	require.NoError(t, err)
+
+	// The non-blocking try_ variant must remain unaffected: it returns false
+	// immediately rather than waiting (or surfacing a timeout error).
+	_, err = waiter.ExecContext(ctx, `BEGIN`)
+	require.NoError(t, err)
+	var got bool
+	err = waiter.QueryRowContext(ctx, `SELECT pg_try_advisory_xact_lock($1)`, key).Scan(&got)
+	require.NoError(t, err)
+	require.False(t, got, "pg_try_advisory_xact_lock should return false while another txn holds the key")
+	_, err = waiter.ExecContext(ctx, `ROLLBACK`)
+	require.NoError(t, err)
+}

--- a/pkg/sql/advisorylock/manager.go
+++ b/pkg/sql/advisorylock/manager.go
@@ -7,6 +7,7 @@ package advisorylock
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -15,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -185,9 +188,17 @@ func (m *Manager) getBaseKey(ctx context.Context, txn *kv.Txn) (roachpb.Key, err
 }
 
 // AcquireInTxn acquires a lock in the given transaction. Transaction
-// locks are automatically released on commit / rollback.
+// locks are automatically released on commit / rollback. If wait is true
+// and lockTimeout is positive, the acquisition will be aborted with a
+// pgcode.LockNotAvailable error after the timeout elapses, matching
+// PostgreSQL's lock_timeout semantics.
 func (m *Manager) AcquireInTxn(
-	ctx context.Context, txn *kv.Txn, key LockKey, mode LockMode, wait bool,
+	ctx context.Context,
+	txn *kv.Txn,
+	key LockKey,
+	mode LockMode,
+	wait bool,
+	lockTimeout time.Duration,
 ) error {
 	// Encode the key into the primary index key for the advisory lock table.
 	baseKey, err := m.getBaseKey(ctx, txn)
@@ -199,9 +210,12 @@ func (m *Manager) AcquireInTxn(
 		return err
 	}
 	b := txn.NewBatch()
-	// If waiting is disabled, we will return an error if the lock is not available.
+	// If waiting is disabled, we will return an error if the lock is not
+	// available. Otherwise, honor the session's lock_timeout if one is set.
 	if !wait {
 		b.Header.WaitPolicy = lock.WaitPolicy_Error
+	} else if lockTimeout > 0 {
+		b.Header.LockTimeout = lockTimeout
 	}
 	// Lock the key in the appropriate mode, we are going to be locking
 	// a non-existing key. Additionally, for simplicity this lock will
@@ -219,20 +233,20 @@ func (m *Manager) AcquireInTxn(
 		LockNonExisting:      true, // Key will not exist.
 		KeyLockingDurability: lock.Replicated,
 	})
-	err = txn.Run(ctx, b)
-	// Detect if the lock is not available if we are not waiting for it.
-	if err != nil {
-		if !wait && isWaitPolicyLockConflict(err) {
-			return LockIsNotAvailableErr
-		}
-		return errors.Wrap(err, "failed to acquire advisory lock in transaction")
+	runErr := txn.Run(ctx, b)
+	if runErr == nil && len(b.Results) > 0 {
+		runErr = b.Results[0].Err
 	}
-	if len(b.Results) > 0 && b.Results[0].Err != nil {
-		resErr := b.Results[0].Err
-		if !wait && isWaitPolicyLockConflict(resErr) {
+	// Detect if the lock is not available if we are not waiting for it,
+	// or if the acquisition exceeded the session's lock_timeout.
+	if runErr != nil {
+		if !wait && isWaitPolicyLockConflict(runErr) {
 			return LockIsNotAvailableErr
 		}
-		return errors.Wrap(resErr, "failed to acquire advisory lock in transaction")
+		if isLockTimeoutConflict(runErr) {
+			return newLockTimeoutErr()
+		}
+		return errors.Wrap(runErr, "failed to acquire advisory lock in transaction")
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -248,6 +262,24 @@ func isWaitPolicyLockConflict(err error) bool {
 		return false
 	}
 	return wi.Reason == kvpb.WriteIntentError_REASON_WAIT_POLICY
+}
+
+// isLockTimeoutConflict checks if the error is a lock conflict error that
+// was surfaced because the request's LockTimeout elapsed before the lock
+// could be acquired.
+func isLockTimeoutConflict(err error) bool {
+	var wi *kvpb.WriteIntentError
+	if !errors.As(err, &wi) {
+		return false
+	}
+	return wi.Reason == kvpb.WriteIntentError_REASON_LOCK_TIMEOUT
+}
+
+// newLockTimeoutErr returns the user-facing error surfaced when an advisory
+// lock acquisition exceeds the session's lock_timeout. The wording and
+// SQLSTATE match PostgreSQL.
+func newLockTimeoutErr() error {
+	return pgerror.New(pgcode.LockNotAvailable, "canceling statement due to lock timeout")
 }
 
 // HeldLockInfo represents information about a held advisory lock.

--- a/pkg/sql/logictest/testdata/logic_test/advisory_lock
+++ b/pkg/sql/logictest/testdata/logic_test/advisory_lock
@@ -1016,6 +1016,74 @@ true
 statement ok
 ROLLBACK
 
+subtest pg_advisory_xact_lock_respects_lock_timeout
+
+# Blocking advisory-lock acquires must honor the session's lock_timeout, the
+# same way row-level locks do. The non-blocking try_ variants are unaffected
+# (they short-circuit via WaitPolicy_Error before any waiting).
+
+# Advisory locks are scoped per-database, so both sessions must use the same
+# database for the contention to be observable. The lock_namespace subtest
+# above leaves the two connections pointed at different databases.
+user root
+
+statement ok
+USE defaultdb
+
+statement ok
+BEGIN
+
+statement ok
+SELECT pg_advisory_xact_lock(7777777)
+
+user testuser
+
+statement ok
+USE defaultdb
+
+statement ok
+SET lock_timeout = '50ms'
+
+statement ok
+BEGIN
+
+statement error pgcode 55P03 canceling statement due to lock timeout
+SELECT pg_advisory_xact_lock(7777777)
+
+statement ok
+ROLLBACK
+
+# Shared waiter on an exclusive holder also times out.
+statement ok
+BEGIN
+
+statement error pgcode 55P03 canceling statement due to lock timeout
+SELECT pg_advisory_xact_lock_shared(7777777)
+
+statement ok
+ROLLBACK
+
+# try_ variants return false rather than waiting: lock_timeout must not affect
+# them.
+statement ok
+BEGIN
+
+query B
+SELECT pg_try_advisory_xact_lock(7777777)
+----
+false
+
+statement ok
+COMMIT
+
+statement ok
+RESET lock_timeout
+
+user root
+
+statement ok
+COMMIT
+
 subtest end
 
 subtest advisory_savepoint_release

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -1352,7 +1352,11 @@ func (p *planner) advisoryXactLockImpl(
 		mode = advisorylock.LockModeShare
 	}
 	lockKey := mk(db.GetID())
-	err = mgr.AcquireInTxn(ctx, p.txn, lockKey, mode, wait /* wait */)
+	// When wait is true, honor the session's lock_timeout (if set). The non-
+	// waiting (try_*) variants ignore lockTimeout entirely on the KV side
+	// because WaitPolicy_Error short-circuits before any waiting happens.
+	lockTimeout := p.SessionData().LockTimeout
+	err = mgr.AcquireInTxn(ctx, p.txn, lockKey, mode, wait /* wait */, lockTimeout /* lockTimeout */)
 	if err != nil {
 		if !wait && errors.Is(err, advisorylock.LockIsNotAvailableErr) {
 			return false, nil


### PR DESCRIPTION
The blocking advisory-lock builtins (`pg_advisory_lock`, `pg_advisory_xact_lock`, and their `_shared` variants) ignored the session's `lock_timeout` and hung indefinitely under contention. PostgreSQL aborts the acquire after the configured timeout.

This change makes the blocking advisory-lock acquires honor `lock_timeout`, surfacing the standard `55P03` "canceling statement due to lock timeout" error when the timeout fires. The non-blocking `try_*` variants keep their existing behavior.

Fixes #170014

Epic: CRDB-49583