### PR TITLE
logstore: assert raft log appends doesn't encounter a prev value

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag_truncator.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator.go
@@ -283,7 +283,7 @@ func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	// and call ClearRangeSizeKnown(). If no entries exist in [RaftLogPrefix, hi]
 	// (e.g., this replica never received entries) this operation is a no-op.
 	// NB: lo == hi if nothing is found.
-	if lo, err := emptyLogPrefix(ctx, raft.RO, prefixBuf, hi); err != nil {
+	if lo, err := logstore.EmptyLogRange(ctx, raft.RO, prefixBuf, 0 /*lo */, hi); err != nil {
 		return errors.Wrapf(err, "finding first raft log index for r%d", rangeID)
 	} else if err := logstore.ClearRangeSizeKnown(
 		raft.WO, prefixBuf,
@@ -311,39 +311,4 @@ func (t *WAGTruncator) clearReplicaRaftLogAndSideloaded(
 	// We must sync the sideloaded storage after truncation to avoid leaking the
 	// files in case of a node crash.
 	return ss.Sync()
-}
-
-// emptyLogPrefix returns the index preceding the first existing raft log entry
-// at <= lastIndex. Returns lastIndex if the entire prefix is empty.
-func emptyLogPrefix(
-	ctx context.Context, r storage.Reader, prefixBuf keys.RangeIDPrefixBuf, lastIndex kvpb.RaftIndex,
-) (kvpb.RaftIndex, error) {
-	start := prefixBuf.RaftLogPrefix().Clone()
-	end := prefixBuf.RaftLogKey(lastIndex).Next()
-	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsOnly,
-		LowerBound: start,
-		UpperBound: end,
-	})
-	if err != nil {
-		return 0, err
-	}
-	defer iter.Close()
-	ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: start})
-	if err != nil || !ok {
-		return lastIndex, err // error or not found
-	}
-	key, err := iter.UnsafeEngineKey()
-	if err != nil {
-		return 0, err
-	}
-	firstIndex, err := keys.DecodeRaftLogKeyFromSuffix(key.Key[len(start):])
-	if err != nil {
-		return 0, err
-	}
-	// NB: index 0 must never have an entry.
-	if firstIndex == 0 || firstIndex > lastIndex {
-		return 0, errors.AssertionFailedf("unexpected firstIndex: %d compared to lastIndex: %d", firstIndex, lastIndex)
-	}
-	return firstIndex - 1, nil
 }

--- a/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_truncator_test.go
@@ -275,44 +275,6 @@ func TestTruncateAppliedOnly(t *testing.T) {
 	}
 }
 
-// TestEmptyLogPrefix exercises the search for the smallest raft log index
-// in [RaftLogPrefix, hi].
-func TestEmptyLogPrefix(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-	const rangeID = roachpb.RangeID(1)
-	prefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
-
-	tests := []struct {
-		entries []kvpb.RaftIndex
-		last    kvpb.RaftIndex
-		wantIdx kvpb.RaftIndex
-	}{
-		{entries: nil, last: 100, wantIdx: 100},
-		{entries: []kvpb.RaftIndex{}, last: 0, wantIdx: 0},
-		{entries: []kvpb.RaftIndex{}, last: 100, wantIdx: 100},
-		{entries: []kvpb.RaftIndex{15}, last: 0, wantIdx: 0},
-		{entries: []kvpb.RaftIndex{15}, last: 14, wantIdx: 14},
-		{entries: []kvpb.RaftIndex{15}, last: 15, wantIdx: 14},
-		{entries: []kvpb.RaftIndex{15}, last: 16, wantIdx: 14},
-		{entries: []kvpb.RaftIndex{15, 16}, last: 15, wantIdx: 14},
-		{entries: []kvpb.RaftIndex{15, 16}, last: 100, wantIdx: 14},
-	}
-	for _, tc := range tests {
-		t.Run("", func(t *testing.T) {
-			e := makeTestEngines()
-			defer e.Close()
-			for _, idx := range tc.entries {
-				e.writeRaftLogEntry(t, rangeID, idx)
-			}
-			idx, err := emptyLogPrefix(ctx, e.LogEngine(), prefixBuf, tc.last)
-			require.NoError(t, err)
-			require.Equal(t, tc.wantIdx, idx)
-		})
-	}
-}
-
 // TestTruncateAndClearRaftState verifies that WAG truncation only clears raft
 // log entries and sideloaded files up to the destroyed/subsumed replica's last
 // index. Entries and files beyond that index may belong to a newer replica and

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -487,6 +488,21 @@ func logAppend(
 	newLast := kvpb.RaftIndex(entries[len(entries)-1].Index)
 	useSingleDelete := UseRaftLogSingleDelete(enginesSeparated)
 	overlapping := newFirst <= prev.LastIndex
+
+	if util.RaceEnabled {
+		// In race builds, assert that there are no unexpected pre-existing
+		// raft log entries. This is important as we use single-delete for
+		// log truncation, and it relies on not having multiple PUTs for
+		// one key not interleaved by deletes.
+		r := eng.NewReader(storage.StandardDurability)
+		defer r.Close()
+		if hi, err := EmptyLogRange(ctx, r, prefixBuf, prev.LastIndex /* lo */, math.MaxUint64 /* hi */); err != nil {
+			return RaftState{}, err
+		} else if uint64(hi) != math.MaxUint64 {
+			return RaftState{}, errors.AssertionFailedf("unexpected raft log entry at index: %d when appending", hi+1)
+		}
+	}
+
 	// In the common case, the new entries don't overlap the existing log and are
 	// appended to its end. If there is an overlap, the [newFirst, prev.LastIndex]
 	// span is overwritten by the [newFirst, newLast] suffix.
@@ -685,6 +701,48 @@ func raftLogBounds(
 		end = keys.RaftLogKeyFromPrefix(raftLogPrefix, hi+1).Clone()
 	}
 	return start, end
+}
+
+// EmptyLogRange returns the index preceding the first existing raft log entry
+// between (lo, hi]. Returns hi if the entire span is empty.
+func EmptyLogRange(
+	ctx context.Context,
+	r storage.Reader,
+	prefixBuf keys.RangeIDPrefixBuf,
+	lo kvpb.RaftIndex,
+	hi kvpb.RaftIndex,
+) (kvpb.RaftIndex, error) {
+	if lo >= hi {
+		return hi, nil // no-op
+	}
+	pref := prefixBuf.RaftLogPrefix()
+	end := keys.RaftLogKeyFromPrefix(pref, hi).Next().Clone()
+	start := keys.RaftLogKeyFromPrefix(pref, lo).Next()
+	iter, err := r.NewEngineIterator(ctx, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsOnly,
+		LowerBound: start,
+		UpperBound: end,
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+	ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: start})
+	if err != nil || !ok {
+		return hi, err // error or not found
+	}
+	key, err := iter.UnsafeEngineKey()
+	if err != nil {
+		return 0, err
+	}
+	firstIndex, err := keys.DecodeRaftLogKeyFromSuffix(key.Key[len(pref):])
+	if err != nil {
+		return 0, err
+	}
+	if firstIndex <= lo || firstIndex > hi {
+		return 0, errors.AssertionFailedf("firstIndex %d not in (%d,%d]", firstIndex, lo, hi)
+	}
+	return firstIndex - 1, nil
 }
 
 // ComputeSize computes the size (in bytes) of the raft log from the storage

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -306,3 +306,43 @@ func TestClearRangeSizeKnown(t *testing.T) {
 		})
 	}
 }
+
+// TestEmptyLogRange exercises the search for the smallest raft log index
+// in (lo, hi].
+func TestEmptyLogRange(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		first, last kvpb.RaftIndex // pre-populated raft entry bounds (inclusive)
+		lo, hi      kvpb.RaftIndex // EmptyLogRange args
+		wantIdx     kvpb.RaftIndex
+	}{
+		{wantIdx: 0},
+		{lo: 100, wantIdx: 0},
+		{hi: 100, wantIdx: 100},
+		{first: 15, last: 15, wantIdx: 0},
+		{first: 15, last: 15, hi: 14, wantIdx: 14},
+		{first: 15, last: 15, lo: 10, hi: 14, wantIdx: 14},
+		{first: 15, last: 15, lo: 100, hi: 14, wantIdx: 14}, // lo >= hi is a no-op
+		{first: 15, last: 15, hi: 15, wantIdx: 14},
+		{first: 15, last: 15, lo: 14, hi: 15, wantIdx: 14},
+		{first: 15, last: 15, lo: 15, hi: 15, wantIdx: 15}, // lo >= hi is a no-op
+		{first: 15, last: 15, hi: 16, wantIdx: 14},
+		{first: 15, last: 15, lo: 14, hi: 16, wantIdx: 14},
+		{first: 15, last: 16, hi: 15, wantIdx: 14},
+		{first: 15, last: 16, lo: 14, hi: 15, wantIdx: 14},
+		{first: 15, last: 16, hi: 100, wantIdx: 14},
+		{first: 15, last: 16, lo: 14, hi: 100, wantIdx: 14},
+	}
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			h := newClearRangeHelper(t)
+			defer h.close()
+			if tc.first > 0 {
+				h.populate(ctx, uint64(tc.first), uint64(tc.last))
+			}
+			idx, err := EmptyLogRange(ctx, h.eng, h.prefixBuf, tc.lo, tc.hi)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantIdx, idx)
+		})
+	}
+}


### PR DESCRIPTION
When appending raft log entries that we know aren't overwriting previous values, assert that there are no previous entries > last known raft entry

References: https://github.com/cockroachdb/cockroach/issues/8979

Release note: None