### PR TITLE
release 25.4: kvcoord: disable DRPC for TestMuxRangeFeedDoesNotStallOnError

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -340,6 +340,7 @@ func TestMuxRangeFeedDoesNotStallOnError(t *testing.T) {
 	}
 	const numServers int = 3
 	serverArgs := base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
 		RetryOptions: retry.Options{
 			InitialBackoff: 10 * time.Millisecond,
 			MaxBackoff:     10 * time.Millisecond,


### PR DESCRIPTION
## Summary

- Disables DRPC for `TestMuxRangeFeedDoesNotStallOnError` which hangs when DRPC is randomly enabled via `TestDRPCEnabledRandomly`
- The test uses a gRPC `StreamClientInterceptor` to inject errors, which has no effect under DRPC
- The hang is caused by a known `SoftCancel` asymmetry: client sets `SoftCancel: true`, server uses the default (`false`), causing the server's `manageReader` to block in `streamBuffer.Wait` — the same pattern seen in #158270
- The fix landed on master (DRPC library commit `07114ac` + `DialDRPC` refactor) but has not been backported

Fixes: #169719

Release Notes: None
Epic: None

Release justification: Disable failing test