### PR TITLE
release-26.1: kvclient/rangefeed: deflake TestRangeFeedStartTimeExclusive

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1320,7 +1320,7 @@ func TestRangeFeedStartTimeExclusive(t *testing.T) {
 			v, err := row.Value.GetInt()
 			require.NoError(t, err)
 			require.EqualValues(t, 3, v)
-		case <-time.After(3 * time.Second):
+		case <-time.After(testutils.SucceedsSoonDuration()):
 			t.Fatal("timed out waiting for event")
 		}
 	})


### PR DESCRIPTION
Backport 1/1 commits from #170088 on behalf of @tbg.

----

The test waited at most 3s for the first event before failing. Under
load this proved insufficient. Use testutils.SucceedsSoonDuration() for
the timeout instead, which scales appropriately under race/deadlock.

Resolves: #170076
Epic: none

Release note: None

----

Release justification: Test-only deflake (zero-risk test fix).
