### PR TITLE
pgwire: add password policy observability metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1200,6 +1200,17 @@ layers:
       how_to_use: See Description.
       visibility: ESSENTIAL
       owner: cockroachdb/sql-foundations
+    - name: auth.min_password_length
+      exported_name: auth_min_password_length
+      description: The configured minimum password length (server.user_login.min_password_length)
+      y_axis_label: Characters
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: Use this metric to confirm minimum password length policy is enforced. Alert if the value drops below your organization's required minimum to detect configuration drift.
+      visibility: ESSENTIAL
+      owner: cockroachdb/sql-foundations
     - name: auth.password.conn.latency
       exported_name: auth_password_conn_latency
       description: Latency to establish and authenticate a SQL connection using password

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1211,6 +1211,17 @@ layers:
       how_to_use: See Description.
       visibility: ESSENTIAL
       owner: cockroachdb/sql-foundations
+    - name: auth.password_encryption.is_scram
+      exported_name: auth_password_encryption_is_scram
+      description: Whether server.user_login.password_encryption is set to scram-sha-256 (1) or crdb-bcrypt (0)
+      y_axis_label: State
+      type: GAUGE
+      unit: CONST
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: Use this metric to verify that SCRAM-SHA-256 password encryption is enabled across your cluster. A value of 0 indicates crdb-bcrypt is in use and the cluster has not adopted the stronger SCRAM-SHA-256 hashing method.
+      visibility: ESSENTIAL
+      owner: cockroachdb/sql-foundations
     - name: auth.scram.conn.latency
       exported_name: auth_scram_conn_latency
       description: Latency to establish and authenticate a SQL connection using SCRAM

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -76,6 +76,7 @@ owners:
   auth_ldap_conn_latency: cockroachdb/sql-foundations
   auth_ldap_conn_latency_internal: cockroachdb/sql-foundations
   auth_password_conn_latency: cockroachdb/sql-foundations
+  auth_password_encryption_is_scram: cockroachdb/sql-foundations
   auth_scram_conn_latency: cockroachdb/sql-foundations
   backup_last_failed_time_kms_inaccessible: cockroachdb/disaster-recovery
   batch_requests_bytes: cockroachdb/kv

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -75,6 +75,7 @@ owners:
   auth_jwt_conn_latency: cockroachdb/sql-foundations
   auth_ldap_conn_latency: cockroachdb/sql-foundations
   auth_ldap_conn_latency_internal: cockroachdb/sql-foundations
+  auth_min_password_length: cockroachdb/sql-foundations
   auth_password_conn_latency: cockroachdb/sql-foundations
   auth_password_encryption_is_scram: cockroachdb/sql-foundations
   auth_scram_conn_latency: cockroachdb/sql-foundations

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -141,6 +141,8 @@ go_test(
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/col/coldatatestutils",
+        "//pkg/security",
+        "//pkg/security/password",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",

--- a/pkg/sql/pgwire/auth_internal_test.go
+++ b/pkg/sql/pgwire/auth_internal_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -292,9 +295,10 @@ func TestCheckClientUsernameMatchesMapping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mock AuthConn with real metrics
+			st := cluster.MakeTestingClusterSettings()
 			sqlMetrics := sql.MakeMemMetrics("test", metric.TestSampleInterval)
 			mockAC := &mockAuthConn{
-				metrics: newTenantSpecificMetrics(sqlMetrics, metric.TestSampleInterval),
+				metrics: newTenantSpecificMetrics(sqlMetrics, metric.TestSampleInterval, &st.SV),
 			}
 
 			// Create AuthBehaviors with appropriate mapper
@@ -349,8 +353,9 @@ func TestAuthCertSANMetrics(t *testing.T) {
 	require.True(t, b.UsedCertSANAuth())
 
 	// Verify metric counters are properly initialized and incrementable.
+	st := cluster.MakeTestingClusterSettings()
 	sqlMetrics := sql.MakeMemMetrics("test", metric.TestSampleInterval)
-	metrics := newTenantSpecificMetrics(sqlMetrics, metric.TestSampleInterval)
+	metrics := newTenantSpecificMetrics(sqlMetrics, metric.TestSampleInterval, &st.SV)
 	require.NotNil(t, metrics.AuthCertSANConnTotal)
 	require.NotNil(t, metrics.AuthCertSANConnSuccess)
 
@@ -364,4 +369,30 @@ func TestAuthCertSANMetrics(t *testing.T) {
 	metrics.AuthCertSANConnTotal.Inc(1)
 	failures := metrics.AuthCertSANConnTotal.Count() - metrics.AuthCertSANConnSuccess.Count()
 	require.Equal(t, int64(1), failures)
+}
+
+func TestPasswordEncryptionIsSCRAMGauge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeTestingClusterSettings()
+	sqlMetrics := sql.MakeMemMetrics("test", metric.TestSampleInterval)
+	metrics := newTenantSpecificMetrics(
+		sqlMetrics, metric.TestSampleInterval, &st.SV,
+	)
+
+	// Default is scram-sha-256, so gauge should report 1.
+	require.Equal(t, int64(1), metrics.PasswordEncryptionIsSCRAM.Value())
+
+	// Switch to crdb-bcrypt and verify the gauge reflects the change.
+	security.PasswordHashMethod.Override(
+		context.Background(), &st.SV, password.HashBCrypt,
+	)
+	require.Equal(t, int64(0), metrics.PasswordEncryptionIsSCRAM.Value())
+
+	// Switch back to scram-sha-256.
+	security.PasswordHashMethod.Override(
+		context.Background(), &st.SV, password.HashSCRAMSHA256,
+	)
+	require.Equal(t, int64(1), metrics.PasswordEncryptionIsSCRAM.Value())
 }

--- a/pkg/sql/pgwire/auth_internal_test.go
+++ b/pkg/sql/pgwire/auth_internal_test.go
@@ -396,3 +396,29 @@ func TestPasswordEncryptionIsSCRAMGauge(t *testing.T) {
 	)
 	require.Equal(t, int64(1), metrics.PasswordEncryptionIsSCRAM.Value())
 }
+
+func TestMinPasswordLengthGauge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeTestingClusterSettings()
+	sqlMetrics := sql.MakeMemMetrics("test", metric.TestSampleInterval)
+	metrics := newTenantSpecificMetrics(
+		sqlMetrics, metric.TestSampleInterval, &st.SV,
+	)
+
+	// Default min password length is 1.
+	require.Equal(t, int64(1), metrics.MinPasswordLength.Value())
+
+	// Increase to 12 and verify the gauge reflects the change.
+	security.MinPasswordLength.Override(
+		context.Background(), &st.SV, 12,
+	)
+	require.Equal(t, int64(12), metrics.MinPasswordLength.Value())
+
+	// Set back to 1.
+	security.MinPasswordLength.Override(
+		context.Background(), &st.SV, 1,
+	)
+	require.Equal(t, int64(1), metrics.MinPasswordLength.Value())
+}

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -687,8 +687,8 @@ func client(ctx context.Context, serverAddr net.Addr, wg *sync.WaitGroup) error 
 
 func newTestServer() *Server {
 	sqlMetrics := sql.MakeMemMetrics("test" /* endpoint */, time.Second /* histogramWindow */)
-	metrics := newTenantSpecificMetrics(sqlMetrics /* sqlMemMetrics */, metric.TestSampleInterval)
 	st := cluster.MakeTestingClusterSettings()
+	metrics := newTenantSpecificMetrics(sqlMetrics /* sqlMemMetrics */, metric.TestSampleInterval, &st.SV)
 	s := &Server{
 		tenantMetrics: metrics,
 		destinationMetrics: destinationAggMetrics{

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -293,6 +293,19 @@ var (
 			"indicates crdb-bcrypt is in use and the cluster has not " +
 			"adopted the stronger SCRAM-SHA-256 hashing method.",
 	}
+	MetaMinPasswordLength = metric.Metadata{
+		Name: "auth.min_password_length",
+		Help: "The configured minimum password length " +
+			"(server.user_login.min_password_length)",
+		Measurement: "Characters",
+		Unit:        metric.Unit_COUNT,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_SQL,
+		HowToUse: "Use this metric to confirm minimum password length " +
+			"policy is enforced. Alert if the value drops below your " +
+			"organization's required minimum to detect configuration " +
+			"drift.",
+	}
 )
 
 const (
@@ -456,6 +469,7 @@ type tenantSpecificMetrics struct {
 	AuthCertSANConnTotal        *metric.Counter
 	AuthCertSANConnSuccess      *metric.Counter
 	PasswordEncryptionIsSCRAM   *metric.FunctionalGauge
+	MinPasswordLength           *metric.FunctionalGauge
 }
 
 func newTenantSpecificMetrics(
@@ -500,6 +514,10 @@ func newTenantSpecificMetrics(
 					return 1
 				}
 				return 0
+			}),
+		MinPasswordLength: metric.NewFunctionalGauge(
+			MetaMinPasswordLength, func() int64 {
+				return security.MinPasswordLength.Get(sv)
 			}),
 	}
 }

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/password"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -279,6 +280,19 @@ var (
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This metric tracks successful authentications when SAN-based certificate validation is enabled. Use this to monitor adoption and success rate of SAN authentication. Failure rate = auth.cert.san.conn.total - auth.cert.san.conn.success.",
 	}
+	MetaPasswordEncryptionIsSCRAM = metric.Metadata{
+		Name: "auth.password_encryption.is_scram",
+		Help: "Whether server.user_login.password_encryption is set " +
+			"to scram-sha-256 (1) or crdb-bcrypt (0)",
+		Measurement: "State",
+		Unit:        metric.Unit_CONST,
+		Visibility:  metric.Metadata_ESSENTIAL,
+		Category:    metric.Metadata_SQL,
+		HowToUse: "Use this metric to verify that SCRAM-SHA-256 password " +
+			"encryption is enabled across your cluster. A value of 0 " +
+			"indicates crdb-bcrypt is in use and the cluster has not " +
+			"adopted the stronger SCRAM-SHA-256 hashing method.",
+	}
 )
 
 const (
@@ -441,10 +455,11 @@ type tenantSpecificMetrics struct {
 	AuthLDAPConnLatencyInternal metric.IHistogram
 	AuthCertSANConnTotal        *metric.Counter
 	AuthCertSANConnSuccess      *metric.Counter
+	PasswordEncryptionIsSCRAM   *metric.FunctionalGauge
 }
 
 func newTenantSpecificMetrics(
-	sqlMemMetrics sql.MemoryMetrics, histogramWindow time.Duration,
+	sqlMemMetrics sql.MemoryMetrics, histogramWindow time.Duration, sv *settings.Values,
 ) *tenantSpecificMetrics {
 	return &tenantSpecificMetrics{
 		Conns:               metric.NewGauge(MetaConns),
@@ -479,6 +494,13 @@ func newTenantSpecificMetrics(
 			getHistogramOptionsForIOLatency(AuthLDAPConnLatencyInternal, histogramWindow)),
 		AuthCertSANConnTotal:   metric.NewCounter(AuthCertSANConnTotal),
 		AuthCertSANConnSuccess: metric.NewCounter(AuthCertSANConnSuccess),
+		PasswordEncryptionIsSCRAM: metric.NewFunctionalGauge(
+			MetaPasswordEncryptionIsSCRAM, func() int64 {
+				if security.GetConfiguredPasswordHashMethod(sv) == password.HashSCRAMSHA256 {
+					return 1
+				}
+				return 0
+			}),
 	}
 }
 
@@ -511,7 +533,7 @@ func MakeServer(
 		cfg:        cfg,
 		execCfg:    executorConfig,
 
-		tenantMetrics: newTenantSpecificMetrics(sqlMemMetrics, histogramWindow),
+		tenantMetrics: newTenantSpecificMetrics(sqlMemMetrics, histogramWindow, &st.SV),
 		destinationMetrics: destinationAggMetrics{
 			BytesInCount:  aggmetric.NewCounter(MetaBytesIn, "remote"),
 			BytesOutCount: aggmetric.NewCounter(MetaBytesOut, "remote"),


### PR DESCRIPTION
## Summary

- Adds two new functional gauges for password policy observability:
  - `auth.password_encryption.is_scram` — reports whether `server.user_login.password_encryption` is set to `scram-sha-256` (1) or `crdb-bcrypt` (0)
  - `auth.min_password_length` — reports the current value of `server.user_login.min_password_length`
- These gauges read their respective cluster settings on each metric scrape, providing real-time visibility into password policy configuration without instrumenting auth callsites.
- Enables compliance alerting: operators can alert if SCRAM is disabled or if minimum password length drops below organizational requirements.
- Includes unit tests that verify both gauges track cluster setting changes dynamically.

Release note (security change): Two new metrics are added for password
policy observability. `auth.password_encryption.is_scram` reports whether
password encryption is configured to use SCRAM-SHA-256 (1) or crdb-bcrypt
(0), enabling operators to verify password hashing policy across the
cluster. `auth.min_password_length` reports the configured minimum
password length, enabling alerts when the value drops below organizational
security requirements.

Informs: #167911
Epic: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)