### PR TITLE
kvserver,localtestcluster: initialize AllocatorSync in tests

### DIFF
--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/mmaintegration"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -59,11 +60,23 @@ func newMMAStoreRebalancer(
 	// Initialize disk utilization thresholds from cluster settings.
 	opts := allocatorimpl.MakeDiskCapacityOptions(&st.SV)
 	mma.SetDiskUtilThresholds(opts.RebalanceToThreshold, opts.ShedAndBlockAllThreshold)
+	as := s.cfg.AllocatorSync
+	if as == nil {
+		// Production code (server.go) is expected to populate AllocatorSync on
+		// the StoreConfig. A handful of test entry points (TestStoreConfig and
+		// the assorted store_rebalancer_test setups) populate StorePool but not
+		// AllocatorSync; fall back to constructing one here so those tests don't
+		// trip a nil-receiver panic from the background rebalancer goroutine.
+		if !buildutil.CrdbTestBuild {
+			panic(errors.AssertionFailedf("AllocatorSync must be set on StoreConfig outside of test builds"))
+		}
+		as = mmaintegration.NewAllocatorSync(s.cfg.StorePool, mma, st, nil /* knobs */)
+	}
 	return &mmaStoreRebalancer{
 		store:              (*mmaStore)(s),
 		mma:                mma,
 		st:                 st,
-		as:                 s.cfg.AllocatorSync,
+		as:                 as,
 		processTimeoutFunc: makeRateLimitedTimeoutFunc(rebalanceSnapshotRate),
 	}
 }

--- a/pkg/testutils/localtestcluster/BUILD.bazel
+++ b/pkg/testutils/localtestcluster/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/load",
+        "//pkg/kv/kvserver/mmaintegration",
         "//pkg/kv/kvserver/storeliveness",
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer",
         "//pkg/roachpb",

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/mmaintegration"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -249,6 +250,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	)
 	cfg.MMAllocator = mmaprototype.NewAllocatorState(timeutil.DefaultTimeSource{},
 		rand.New(rand.NewSource(timeutil.Now().UnixNano())))
+	cfg.AllocatorSync = mmaintegration.NewAllocatorSync(
+		cfg.StorePool, cfg.MMAllocator, cfg.Settings, nil /* knobs */)
 
 	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, ltc.Clock)
 	cfg.ClosedTimestampReceiver = sidetransport.NewReceiver(nc, ltc.stopper, ltc.Stores, nil /* testingKnobs */)


### PR DESCRIPTION
Fixes #170039.

### Problem

`StoreConfig.AllocatorSync` is consulted by the background `mmaStoreRebalancer` goroutine that `Store.Start` launches. Production code (`server.go`) constructs an `AllocatorSync` next to the `MMAllocator` and stores both on the `StoreConfig`. `LocalTestCluster.Start` and `TestStoreConfig`, however, only ever populated `MMAllocator`, leaving `AllocatorSync` nil.

This was latent until the default load-based rebalancing mode flipped to `auto` (which resolves to an MMA mode on v26.3+ clusters). With MMA enabled by default, the rebalancer's first periodic tick now fires `m.as.GetMMAStoreStatuses()` on a nil receiver and crashes the test binary with a SIGSEGV. The race-mode flake of `TestTxnDBReadSkewAnomaly` (#170039) is one symptom; any test exercising `Store.Start` via `LocalTestCluster` or a hand-built `TestStoreConfig` is exposed.

### Fix

The first commit is the targeted fix: `LocalTestCluster.Start` now constructs an `AllocatorSync` alongside the existing `MMAllocator`, mirroring `server.go`. The second commit adds a defensive lazy fallback inside `newMMAStoreRebalancer` (gated on `buildutil.CrdbTestBuild`) so that other tests building a `StoreConfig` by hand via `TestStoreConfig` don't trip the same nil-receiver crash. Production builds still assert that `AllocatorSync` was supplied.

Epic: none

Release note: None