### PR TITLE
kvserver: write EventInit for RHS on split

### DIFF
--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -368,8 +368,9 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 				in := splitPreApplyInput{
 					lhsID:               lhsRangeState.replica.FullReplicaID,
 					raftIndex:           ps.raftIndex,
+					rhsID:               roachpb.FullReplicaID{RangeID: split.RightDesc.RangeID, ReplicaID: rhsReplDesc.ReplicaID},
+					rhsSpan:             split.RightDesc.RSpan(),
 					rhsDestroyed:        rhsDestroyed,
-					rhsDesc:             split.RightDesc,
 					initClosedTimestamp: hlc.Timestamp{WallTime: 100}, // dummy timestamp
 					lhsLastReplicaGC:    hlc.Timestamp{},              // dummy timestamp
 				}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -30,6 +30,11 @@ type splitPreApplyInput struct {
 	lhsID roachpb.FullReplicaID
 	// raftIndex is the raft log index of the split command.
 	raftIndex kvpb.RaftIndex
+	// rhsID identifies the RHS replica from the split trigger. When rhsDestroyed
+	// is true, this ReplicaID is stale (a newer one may exist).
+	rhsID roachpb.FullReplicaID
+	// rhsSpan is the key span of the post-split RHS range.
+	rhsSpan roachpb.RSpan
 	// rhsDestroyed is set to true iff the RHS replica (the one with the
 	// matching ReplicaID from the SplitTrigger used to construct a
 	// splitPreApplyInput) has already been removed from the store.
@@ -40,8 +45,6 @@ type splitPreApplyInput struct {
 	// cleared and any RangeID-local replicated state in the split batch also
 	// needs to be cleared.
 	rhsDestroyed bool
-	// rhsDesc is the descriptor for the post split RHS range.
-	rhsDesc roachpb.RangeDescriptor
 	// initClosedTimestamp is the initial closed timestamp that the RHS replica
 	// inherits from the pre-split range. Set iff rhsDestroyed is false.
 	initClosedTimestamp hlc.Timestamp
@@ -83,6 +86,13 @@ func validateAndPrepareSplit(
 			r.StoreID(), split)
 	}
 
+	res := splitPreApplyInput{
+		lhsID:     roachpb.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID},
+		raftIndex: raftIndex,
+		rhsID:     roachpb.FullReplicaID{RangeID: split.RightDesc.RangeID, ReplicaID: splitRightReplDesc.ReplicaID},
+		rhsSpan:   split.RightDesc.RSpan(),
+	}
+
 	// Try to obtain the RHS replica. In the common case, it exists and its
 	// ReplicaID matches the one in the split trigger. In the less common case,
 	// the ReplicaID has already been removed from this store, and it may have
@@ -108,13 +118,8 @@ func validateAndPrepareSplit(
 				)
 			}
 		}
-
-		return splitPreApplyInput{
-			lhsID:        roachpb.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID},
-			raftIndex:    raftIndex,
-			rhsDestroyed: true,
-			rhsDesc:      split.RightDesc,
-		}, nil
+		res.rhsDestroyed = true
+		return res, nil
 	}
 	// Sanity check the common case -- the RHS replica that exists should match
 	// the ReplicaID in the split trigger. In particular, it shouldn't older than
@@ -138,21 +143,16 @@ func validateAndPrepareSplit(
 		initClosedTS = &hlc.Timestamp{}
 	}
 	initClosedTS.Forward(r.GetCurrentClosedTimestamp(ctx))
+	res.initClosedTimestamp = *initClosedTS
 
 	// Read the LHS last replica GC timestamp, to copy to the RHS.
 	lhsLastReplicaGC, err := r.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		return splitPreApplyInput{}, err
 	}
+	res.lhsLastReplicaGC = lhsLastReplicaGC
 
-	return splitPreApplyInput{
-		lhsID:               roachpb.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID},
-		raftIndex:           raftIndex,
-		rhsDestroyed:        false,
-		rhsDesc:             split.RightDesc,
-		initClosedTimestamp: *initClosedTS,
-		lhsLastReplicaGC:    lhsLastReplicaGC,
-	}, nil
+	return res, nil
 }
 
 // splitPreApply is called when the raft command is applied. Any changes to the
@@ -167,7 +167,7 @@ func splitPreApply(
 	wagWriter *wag.Writer,
 	in splitPreApplyInput,
 ) {
-	rsl := kvstorage.MakeStateLoader(in.rhsDesc.RangeID)
+	rsl := kvstorage.MakeStateLoader(in.rhsID.RangeID)
 	// After PR #149620, the split trigger batch may only contain replicated state
 	// machine keys, and never contains unreplicated / raft keys. One exception:
 	// there can still be historical split proposals that write the initial
@@ -222,8 +222,11 @@ func splitPreApply(
 	// getOrCreateReplica (called upstream via maybeAcquireSplitMergeLock) and
 	// will always precede this split node in the WAG sequence.
 	wagWriter.AddEvent(wagpb.MakeAddr(in.lhsID, in.raftIndex), wagpb.EventSplit)
-
-	if in.rhsDestroyed {
+	if !in.rhsDestroyed {
+		wagWriter.AddEvent(
+			wagpb.MakeAddr(in.rhsID, kvstorage.RaftInitialLogIndex), wagpb.EventInit,
+		)
+	} else {
 		// The RHS replica has already been removed from the store. To apply the
 		// split, we must clear the user data the RHS would have inherited from the
 		// LHS due to the split. Additionally, we also want to clear any
@@ -239,7 +242,7 @@ func splitPreApply(
 		// keys belong to the *current* ReplicaID in the store, rather than the
 		// ReplicaID in the split trigger (which in this case, is stale).
 		if err := kvstorage.RemoveStaleRHSFromSplit(
-			ctx, kvstorage.WrapState(stateRW), in.rhsDesc.RangeID, in.rhsDesc.RSpan(),
+			ctx, kvstorage.WrapState(stateRW), in.rhsID.RangeID, in.rhsSpan,
 		); err != nil {
 			log.KvExec.Fatalf(ctx, "failed to clear range data for removed rhs: %v", err)
 		}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -4578,8 +4578,9 @@ func TestSplitPreApplyWithSeparatedEngines(t *testing.T) {
 	rhsDesc.AddReplica(1, 1, roachpb.VOTER_FULL)
 
 	in := splitPreApplyInput{
+		rhsID:               roachpb.FullReplicaID{RangeID: rhsDesc.RangeID, ReplicaID: 1},
+		rhsSpan:             rhsDesc.RSpan(),
 		rhsDestroyed:        false,
-		rhsDesc:             rhsDesc,
 		initClosedTimestamp: hlc.Timestamp{WallTime: 100},
 	}
 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/legacy_split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/legacy_split_trigger.txt
@@ -57,7 +57,7 @@ log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit) (r2/1:10,EventInit)
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_pre_apply.txt
@@ -164,7 +164,7 @@ log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/7 (0x01737761676e000000000000000700): (r1/1:13,EventSplit)
+Put: 0,0 /Local/Store/wag/7 (0x01737761676e000000000000000700): (r1/1:13,EventSplit) (r4/1:10,EventInit)
 > Put: 0,0 /Local/Range"c"/QueueLastProcessed/"consistencyChecker" (0x016b12630001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,2 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -54,7 +54,7 @@ log engine:
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): (r1/1:11,EventSplit) (r2/1:10,EventInit)
 > Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0
@@ -107,7 +107,7 @@ log engine:
 Put: 0,0 /Local/RangeID/3/u/RaftHardState (0x01698b757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/3/u/RaftTruncatedState (0x01698b757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r1/1:12,EventSplit)
+Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): (r1/1:12,EventSplit) (r3/1:10,EventInit)
 > Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004,0
@@ -146,7 +146,7 @@ log engine:
 Put: 0,0 /Local/RangeID/4/u/RaftHardState (0x01698c757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/4/u/RaftTruncatedState (0x01698c757266747400): index:10 term:5 
 Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
-Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): (r2/1:11,EventSplit)
+Put: 0,0 /Local/Store/wag/6 (0x01737761676e000000000000000600): (r2/1:11,EventSplit) (r4/1:10,EventInit)
 > Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
 > Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified
 > Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0


### PR DESCRIPTION
Previously, split application only wrote an `EventSplit` WAG event for the LHS. The RHS initialization was implicit. Now, when the RHS is not already destroyed, we also write an `EventInit` event for the RHS at `RaftInitialLogIndex`, in the same WAG node as the LHS EventSplit.

Additionally, replace the `rhsDesc roachpb.RangeDescriptor` field in `splitPreApplyInput` with narrower `rhsID` and `rhsSpan` fields, which are exactly what `splitPreApply` needs.

Epic: none
Release note: None