### PR TITLE
logical,txnlock: rewrite fkDependsOn

### DIFF
--- a/pkg/crosscluster/logical/txnlock/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnlock/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "column_set.go",
         "doc.go",
+        "foreign_key_ordering.go",
         "lock_synthesis.go",
         "schema.go",
         "sort.go",
@@ -58,6 +59,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/crosscluster/logical/txnlock/foreign_key_ordering.go
+++ b/pkg/crosscluster/logical/txnlock/foreign_key_ordering.go
@@ -1,0 +1,225 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package txnlock
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/errors"
+)
+
+type fkApplyOrder int
+
+const (
+	noApplyOrder fkApplyOrder = iota
+	childFirst
+	parentFirst
+)
+
+// deriveFKApplyOrder takes two rows and a single FK constraint, and determines if the two
+// rows have a dependency ordering.
+//
+// When ordering rows based on FK constraints, we need to avoid a state where we have
+// a FK reference that points to a non-existent value. This can happen in two ways:
+// we haven't yet created the referenced value, or we deleted the referenced value.
+// Consider the following table which maps row operations to the effect it has
+// on the referenced value:
+//
+//	┌──────────────────────┬────────────────────────────────────────┐
+//	│        Row op        │               column Op                │
+//	├──────────────────────┼────────────────────────────────────────┤
+//	│ INSERT               │ create (null → new)                    │
+//	├──────────────────────┼────────────────────────────────────────┤
+//	│ DELETE               │ delete (old → null)                    │
+//	├──────────────────────┼────────────────────────────────────────┤
+//	│ UPDATE, FK unchanged │ none                                   │
+//	├──────────────────────┼────────────────────────────────────────┤
+//	│ UPDATE, FK changed   │ both delete and create (old → new)     │
+//	├──────────────────────┼────────────────────────────────────────┤
+//	│ TOMBSTONE UPDATE     │ none                                   │
+//	└──────────────────────┴────────────────────────────────────────┘
+//
+// We can consider each FK constraint in isolation. For any two rows A and B, all
+// FK constraints must agree with the dependency direction (or lack of) or we will
+// get a cycle conflict.
+//
+// For any given FK constraint, there is a parent and child row. The parent is the
+// row with the column being referenced by the child row's FK. The following table
+// returns for the given parent and child column ops:
+//
+//  1. [parent]: the child may be depedent on the parent row
+//
+//  2. [child]: the parent may be dependent on the child row
+//
+//  3. [n/a]: the rows _must_ have no dependency on each other
+//
+//  4. [either]: either the parent or child may have a dependency on each other
+//
+//     ┌──────────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+//     │  parent \ child  │    none     │   create    │   delete    │    both     │
+//     ├──────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+//     │ none             │     n/a     │     n/a     │     n/a     │     n/a     │
+//     ├──────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+//     │ create           │     n/a     │    parent   │     n/a     │    parent   │
+//     ├──────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+//     │ delete           │     n/a     │     n/a     │    child    │    child    │
+//     ├──────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+//     │ both             │     n/a     │    parent   │    child    │    either   │
+//     └──────────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+//
+// The following case analyses implicitly consider the trivial disjoint
+// case so we will address it once here and handwave/refer back to it later.
+// If the parent/child rows are not touching the same value at any point then
+// it's not possible for there to be a dependency. A FK dependency means that
+// if we must apply the rows in a certain way or we will have a dangling FK
+// reference that points to a non-existent row on the child. However, because
+// the values are disjoint, this is not possible.
+//
+// 1-7 - [none/*], [*/none]: If either parent/child row is none, then we can trivially show
+// there must be no dependency. Consider the parent, none means that the referenced value must
+// exist before and after our row was applied. Likewise, if the child's col op
+// is none it must mean we are pointing to a value that already exists and must continue
+// to exist after the child row. If the parent row created the value, the former would be
+// false, and if the parent row deleted the value, the latter would be false. In other words,
+// if either row is a none col op, then we hit the disjoint case.
+//
+// 8 - [create\create]: If both parent and child are creating a value and the FK's are not disjoint,
+// then it must be that the parent is creating a value that the child is referencing. We need to
+// apply the parent row first in this case.
+//
+// 9 - [create\delete]: Assume the parent and child touch the same referenced FK value. If the parent
+// is creating the value, then it does not exist before we apply this row. However, if the child
+// is deleting the value, then it must be referencing a value that already exists before the delete.
+// i.e. The assumption is impossible and this is always the disjoint case.
+//
+// 10 - [create\both]: Combining the above [create\create] and [create\delete], we can see the
+// delete side is always disjoint and the create side means we need to apply the parent row
+// first if the values aren't disjoint.
+//
+// 11 - [delete\create]:  Assume the parent and child touch the same referenced FK value. If the parent
+// is deleting the value, the child's reference would be dangling after the delete. Therefore this
+// assumption is impossible and it's always the disjoint case.
+//
+// 12 - [delete\delete]: If both parent and child are deleting a value and the FK's are not disjoint,
+// then it must be the parent deleting the value that the child is referencing. We need to
+// delete the child row first in this case.
+//
+// 13 - [delete\both]: Combining the above [delete\create] and [delete\delete], we can see the
+// create side is always disjoint and the delete side means we need to apply the child side
+// first if the values aren't disjoint.
+//
+// 14 - [both\create]: Combining the above [create\create] and [delete\create], we can see the
+// delete side is always disjoint and the create side means we need to apply the parent
+// first if the values aren't disjoint.
+//
+// 15 - [both\delete]: Combining the above [create\delete] and [delete\delete], we can see the
+// create side is always disjoint and the delete side means we need to apply the child
+// first if the values aren't disjoint.
+//
+// 16 - [both\both]: Let the parent rows update on the referenced column be from values (i → j):
+//
+//			a. child (i → j): This case is impossible without deferred constraints as we cannot
+//			apply the child first before j exists and we cannot apply the parent first or child will
+//			have a dangling reference to i.
+//
+//			b. child (i → k): We need to apply the child first to free up the reference to i.
+//
+//			c. child (k → j): We need to apply the parent first so j exists for our child to point at.
+//
+//			d. child (k → l): Disjoint values, no dependency.
+//
+//			e. child (k → i), (j → k): These both always have no dependencies. In order for the child to start
+//	   	referencing a value that the parent deleted, some other row must have inserted the value back or
+//	   	deleted our reference first. In either case, we have a dependency on this other row, not the
+//	   	parent. Similar logic applies for if the child no longer references the value the parent creates:
+//	   	some other row must have deleted the value first or created the child reference first.
+func deriveFKApplyOrder(
+	ctx context.Context,
+	evalCtx *eval.Context,
+	parent, child ldrdecoder.DecodedRow,
+	parentConstraint, childConstraint columnSet,
+) (fkApplyOrder, error) {
+	parentOp, err := parentConstraint.colOp(ctx, evalCtx, parent)
+	if err != nil {
+		return noApplyOrder, err
+	}
+	childOp, err := childConstraint.colOp(ctx, evalCtx, child)
+	if err != nil {
+		return noApplyOrder, err
+	}
+
+	// Cases 1-7:
+	if parentOp == noOp || childOp == noOp {
+		return noApplyOrder, nil
+	}
+
+	// Cases 8-10, 14, 16, all cases can be reduced down to:
+	// Parent first if the columns are not disjoint. We only need to check the new
+	// row value as the parent create will always be null (disjoint) for the prev row.
+	if parentOp == createOp || parentOp == createAndDeleteOp {
+		eq, err := columnSetEqual(
+			ctx, evalCtx, &childConstraint, &parentConstraint, child.Row, parent.Row,
+		)
+		if err != nil {
+			return noApplyOrder, err
+		}
+		if eq {
+			return parentFirst, nil
+		}
+	}
+	// Cases 11-13, 15, 16, all cases can be reduced down to:
+	// Child first if the columns are not disjoint. We only need to check the prev
+	// row value as the parent delete will always be null (disjoint) for the new row.
+	if parentOp == deleteOp || parentOp == createAndDeleteOp {
+		eq, err := columnSetEqual(
+			ctx, evalCtx, &childConstraint, &parentConstraint, child.PrevRow, parent.PrevRow,
+		)
+		if err != nil {
+			return noApplyOrder, err
+		}
+		if eq {
+			return childFirst, nil
+		}
+	}
+	return noApplyOrder, nil
+}
+
+// colOp describes how a row affects a column.
+type colOp int
+
+const (
+	noOp colOp = iota
+	createOp
+	deleteOp
+	createAndDeleteOp
+)
+
+// colOp returns the given colOp for a row.
+func (c *columnSet) colOp(
+	ctx context.Context, evalCtx *eval.Context, row ldrdecoder.DecodedRow,
+) (colOp, error) {
+	switch {
+	case row.IsDeleteRow():
+		return deleteOp, nil
+	case row.IsInsertRow():
+		return createOp, nil
+	case row.IsUpdateRow():
+		eq, err := c.equal(ctx, evalCtx, row.Row, row.PrevRow)
+		if err != nil {
+			return noOp, err
+		}
+		if eq {
+			return noOp, nil
+		}
+		return createAndDeleteOp, nil
+	case row.IsTombstoneUpdate():
+		return noOp, nil
+	default:
+		return noOp, errors.AssertionFailedf("unexpected row type")
+	}
+}

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis.go
@@ -29,8 +29,30 @@ type LockSet struct {
 	SortedRows ldrdecoder.TxnEnvelope
 }
 
+type TestingKnobs struct {
+	// Testing hook called on every DeriveLocks call.
+	LockValidation func(ctx context.Context, ls *LockSynthesizer, rows []ldrdecoder.DecodedRow, rowLocks [][]Lock) error
+}
+
+// Option configures a LockSynthesizer.
+type Option interface {
+	apply(*LockSynthesizer)
+}
+
+type optionFunc func(*LockSynthesizer)
+
+func (f optionFunc) apply(ls *LockSynthesizer) { f(ls) }
+
+// WithTestingKnobs attaches TestingKnobs to the LockSynthesizer.
+func WithTestingKnobs(knobs TestingKnobs) Option {
+	return optionFunc(func(ls *LockSynthesizer) {
+		ls.knobs = knobs
+	})
+}
+
 type LockSynthesizer struct {
 	tableConstraints map[descpb.ID]*tableConstraints
+	knobs            TestingKnobs
 }
 
 func NewLockSynthesizer(
@@ -39,9 +61,13 @@ func NewLockSynthesizer(
 	lm *lease.Manager,
 	clock *hlc.Clock,
 	tableMappings []ldrdecoder.TableMapping,
+	opts ...Option,
 ) (*LockSynthesizer, error) {
 	ls := &LockSynthesizer{
 		tableConstraints: make(map[descpb.ID]*tableConstraints, len(tableMappings)),
+	}
+	for _, opt := range opts {
+		opt.apply(ls)
 	}
 
 	timestamp := lease.TimestampToReadTimestamp(clock.Now())
@@ -107,6 +133,12 @@ func (ls *LockSynthesizer) DeriveLocks(
 			}
 			lr.rows = append(lr.rows, int32(i))
 			locks[lock.Hash] = lr
+		}
+	}
+
+	if ls.knobs.LockValidation != nil {
+		if err := ls.knobs.LockValidation(ctx, ls, rows, rowLocks); err != nil {
+			return LockSet{}, err
 		}
 	}
 

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
@@ -113,10 +113,10 @@ func requireSortOrder(
 		// Compare PK value (first datum).
 		wantPK := want.Row[0]
 		gotPK := got.Row[0]
-		if want.IsDelete {
+		if want.IsDeleteRow() {
 			wantPK = want.PrevRow[0]
 		}
-		if got.IsDelete {
+		if got.IsDeleteRow() {
 			gotPK = got.PrevRow[0]
 		}
 		require.Equal(t, wantPK, gotPK,
@@ -908,7 +908,7 @@ func TestDeriveLocks(t *testing.T) {
 			// Deleting such a row would appear as though the fk was updated
 			// rather than deleted if we only checked the row values, instead
 			// of the actual decoded row IsDelete. This would cause this test
-			// to errornously detect a cycle.
+			// to erroneously detect a cycle.
 			name: "fk_delete_child_then_parent_pk_fk",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
@@ -1075,6 +1075,29 @@ func TestDeriveLocks(t *testing.T) {
 				readLockCount: 1,
 				order:         []int{1, 0},
 			},
+		},
+		{
+			// Test that tombstone events are properly ordered with their deletes,
+			// and that FK locks are unnecessarily emitted.
+			name: "tombstone_event",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.DeleteEvent(txnTime, fkChildRow(1, 10, 50, 0)),
+				},
+				// PK(id=1) + outbound FK(parent_id=10, read) + outbound FK(parent_ref=50, read).
+				writeLockCount: 1,
+				readLockCount:  2,
+				order:          []int{0},
+			},
+			txn2: txnCase{
+				events: []streampb.StreamEvent_KV{
+					childEB.TombstoneEvent(txnTime, fkChildRow(1, 10, 50, 0)),
+				},
+				// PK only, tombstone events shouldn't emit FK locks.
+				writeLockCount: 1,
+				order:          []int{0},
+			},
+			writeOverlapCount: 1,
 		},
 		{
 			// Updating a parent's non-constraint column and inserting a

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
@@ -21,8 +21,55 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
+
+// assertDependencyGeneratesLock is an expensive test-only invariant
+// check installed via TestingKnobs.LockValidation:
+//
+// If two rows have a lock conflict, they may have a dependency but are
+// not guaranteed to. However, if two rows _don't_ have a lock conflict,
+// they must not have a dependency.
+func assertDependencyGeneratesLock(
+	ctx context.Context, ls *LockSynthesizer, rows []ldrdecoder.DecodedRow, rowLocks [][]Lock,
+) error {
+	// Iterate every pair of rows and see if we generate a dependency.
+	// N.B. we normally only check for dependencies if we had a lock
+	// conflict.
+	for i := range rows {
+		// Find all the locks generated for row_i.
+		iLocks := make(map[LockHash]bool, len(rowLocks[i]))
+		for _, l := range rowLocks[i] {
+			iLocks[l.Hash] = true
+		}
+		for j := range rows {
+			if i == j {
+				continue
+			}
+			dep, err := ls.dependsOn(ctx, rows[i], rows[j])
+			if err != nil {
+				return err
+			}
+			// if row i is dependent on row j, then the two must share at least one
+			// lock hash.
+			if dep {
+				matchingLock := false
+				for _, l := range rowLocks[j] {
+					if iLocks[l.Hash] {
+						matchingLock = true
+						break
+					}
+				}
+				if !matchingLock {
+					return errors.AssertionFailedf(
+						"row %d depends on row %d but we did not generate a lock", i, j)
+				}
+			}
+		}
+	}
+	return nil
+}
 
 // overlappingLocks counts lock hashes shared between two LockSets,
 // separated by whether the overlap involves a write lock (at least one
@@ -349,6 +396,9 @@ func TestDeriveLocks(t *testing.T) {
 			{DestID: compositeFKParentDesc.GetID()},
 			{DestID: compositeChildDesc.GetID()},
 		},
+		WithTestingKnobs(TestingKnobs{
+			LockValidation: assertDependencyGeneratesLock,
+		}),
 	)
 	require.NoError(t, err)
 
@@ -1024,6 +1074,27 @@ func TestDeriveLocks(t *testing.T) {
 				// child: FK(parent_id=5)
 				readLockCount: 1,
 				order:         []int{1, 0},
+			},
+		},
+		{
+			// Updating a parent's non-constraint column and inserting a
+			// child that references the parent's UC in the same txn. The
+			// parent update touches no FK/UC columns, so it emits only a
+			// PK lock and does not conflict with the child's FK read
+			// locks on the unchanged referenced values.
+			name: "fk_update_parent_unreferenced_col_insert_child_same_txn",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					parentEB.UpdateEvent(txnTime,
+						fkParentRow(10, 50, 1),
+						fkParentRow(10, 50, 0)),
+					childEB.InsertEvent(txnTime, fkChildRow(1, 10, 50, 0)),
+				},
+				// parent update: PK only.
+				// child insert: PK + FK(read,parent_id=10) + FK(read,parent_ref=50).
+				writeLockCount: 2,
+				readLockCount:  2,
+				order:          []int{0, 1},
 			},
 		},
 		{

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
@@ -191,6 +191,12 @@ func selfRefRow(id, parentID, data int) tree.Datums {
 	}
 }
 
+// pkFKRow builds datums for schemas (id INT PRIMARY KEY) and
+// (id INT PRIMARY KEY REFERENCES pk_fk_parent(id)).
+func pkFKRow(id int) tree.Datums {
+	return tree.Datums{tree.NewDInt(tree.DInt(id))}
+}
+
 // compositeFKParentRow builds datums for schema
 // (a INT, b INT, c INT, d INT, val INT, PRIMARY KEY (a, b), UNIQUE (c, d)).
 func compositeFKParentRow(a, b, c, d, val int) tree.Datums {
@@ -249,6 +255,11 @@ func TestDeriveLocks(t *testing.T) {
 			parent_id INT REFERENCES fk_self_ref(id),
 			data INT
 		)`)
+	runner.Exec(t, `CREATE TABLE pk_fk_parent (id INT PRIMARY KEY)`)
+	runner.Exec(t, `
+		CREATE TABLE pk_fk_child (
+			id INT PRIMARY KEY REFERENCES pk_fk_parent(id)
+		)`)
 	runner.Exec(t, `
 		CREATE TABLE composite_fk_parent (
 			a INT, b INT, c INT, d INT, val INT,
@@ -279,6 +290,12 @@ func TestDeriveLocks(t *testing.T) {
 	selfRefDesc := cdctest.GetHydratedTableDescriptor(
 		t, s.ExecutorConfig(), "fk_self_ref",
 	)
+	pkFKParentDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "pk_fk_parent",
+	)
+	pkFKChildDesc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), "pk_fk_child",
+	)
 	compositeFKParentDesc := cdctest.GetHydratedTableDescriptor(
 		t, s.ExecutorConfig(), "composite_fk_parent",
 	)
@@ -292,6 +309,8 @@ func TestDeriveLocks(t *testing.T) {
 	parentEB := ldrdecoder.NewTestEventBuilder(t, parentDesc.TableDesc())
 	childEB := ldrdecoder.NewTestEventBuilder(t, childDesc.TableDesc())
 	selfRefEB := ldrdecoder.NewTestEventBuilder(t, selfRefDesc.TableDesc())
+	pkFKParentEB := ldrdecoder.NewTestEventBuilder(t, pkFKParentDesc.TableDesc())
+	pkFKChildEB := ldrdecoder.NewTestEventBuilder(t, pkFKChildDesc.TableDesc())
 	compositeFKParentEB := ldrdecoder.NewTestEventBuilder(t, compositeFKParentDesc.TableDesc())
 	compositeChildEB := ldrdecoder.NewTestEventBuilder(t, compositeChildDesc.TableDesc())
 	txnTime := s.Clock().Now()
@@ -305,6 +324,8 @@ func TestDeriveLocks(t *testing.T) {
 			{SourceDescriptor: parentDesc, DestID: parentDesc.GetID()},
 			{SourceDescriptor: childDesc, DestID: childDesc.GetID()},
 			{SourceDescriptor: selfRefDesc, DestID: selfRefDesc.GetID()},
+			{SourceDescriptor: pkFKParentDesc, DestID: pkFKParentDesc.GetID()},
+			{SourceDescriptor: pkFKChildDesc, DestID: pkFKChildDesc.GetID()},
 			{SourceDescriptor: compositeFKParentDesc, DestID: compositeFKParentDesc.GetID()},
 			{SourceDescriptor: compositeChildDesc, DestID: compositeChildDesc.GetID()},
 		},
@@ -323,6 +344,8 @@ func TestDeriveLocks(t *testing.T) {
 			{DestID: parentDesc.GetID()},
 			{DestID: childDesc.GetID()},
 			{DestID: selfRefDesc.GetID()},
+			{DestID: pkFKParentDesc.GetID()},
+			{DestID: pkFKChildDesc.GetID()},
 			{DestID: compositeFKParentDesc.GetID()},
 			{DestID: compositeChildDesc.GetID()},
 		},
@@ -821,6 +844,28 @@ func TestDeriveLocks(t *testing.T) {
 				},
 				writeLockCount: 5,
 				readLockCount:  0,
+				order:          []int{1, 0},
+			},
+		},
+		{
+			// Deleting a child and its parent where the child's FK column is
+			// also its primary key.
+			//
+			// This test is a regression test for the following behavior:
+			//	1. We always emit the PK for a deleted row.
+			//	2. It's possible for a FK (but not a UC) to decode as
+			//	   the same exact value as its own PK.
+			// Deleting such a row would appear as though the fk was updated
+			// rather than deleted if we only checked the row values, instead
+			// of the actual decoded row IsDelete. This would cause this test
+			// to errornously detect a cycle.
+			name: "fk_delete_child_then_parent_pk_fk",
+			txn1: txnCase{
+				events: []streampb.StreamEvent_KV{
+					pkFKParentEB.DeleteEvent(txnTime, pkFKRow(1)),
+					pkFKChildEB.DeleteEvent(txnTime, pkFKRow(1)),
+				},
+				writeLockCount: 3,
 				order:          []int{1, 0},
 			},
 		},

--- a/pkg/crosscluster/logical/txnlock/schema.go
+++ b/pkg/crosscluster/logical/txnlock/schema.go
@@ -308,38 +308,56 @@ func (t *tableConstraints) DependsOn(
 func (t *tableConstraints) fkDependsOn(
 	ctx context.Context, otherTC *tableConstraints, a, b ldrdecoder.DecodedRow,
 ) (bool, error) {
-	// a is the child, b is the parent. a depends on b if b is inserting a
-	// parent value that a's new row needs to reference.
-	for _, outbound := range t.OutboundForeignKeyConstraints {
-		inbound, ok := otherTC.InboundForeignKeyConstraints[outbound.mixin]
+	// Check if row a is dependent on row b based on parent and child dependencies.
+	// Note that row a can have both child and parent dependencies on row b, i.e.
+	// we break the check into two parts.
+
+	// Check if a and b have any fk dependencies where a is the child
+	// table and b is the parent table.
+	parent, child := b, a
+	for _, parentConstraint := range otherTC.InboundForeignKeyConstraints {
+		childConstraint, ok := t.OutboundForeignKeyConstraints[parentConstraint.mixin]
 		if !ok {
 			continue
 		}
-		eq, err := columnSetEqual(ctx, t.evalCtx, &outbound, &inbound, a.Row, b.Row)
+		applyOrder, err := deriveFKApplyOrder(ctx, t.evalCtx, parent, child, parentConstraint, childConstraint)
 		if err != nil {
 			return false, err
 		}
-		if eq {
+		switch applyOrder {
+		case noApplyOrder:
+		case parentFirst:
+			// parent (row b) first means that a is dependent on b.
 			return true, nil
+		case childFirst:
+			// child (row a) first means that b is dependent on a, but we don't
+			// return early here because we want to detect cycles. To show a cycle,
+			// we need to prove that (a → b) and (b → a). We will (or already did)
+			// call `fkDependsOn(b, a)` which will check for (b → a), so we only
+			// need to worry about (a → b), i.e. if we return false early here
+			// we might end up proving (b → a) twice and miss the cycle.
 		}
 	}
 
-	// a is the parent, b is the child. a depends on b if b is removing a
-	// child reference that currently prevents a's parent row from being
-	// deleted.
-	for _, inbound := range t.InboundForeignKeyConstraints {
-		outbound, ok := otherTC.OutboundForeignKeyConstraints[inbound.mixin]
+	// Check if a and b have any fk dependencies where a is the parent
+	// table and b is the child table.
+	parent, child = a, b
+	for _, parentConstraint := range t.InboundForeignKeyConstraints {
+		childConstraint, ok := otherTC.OutboundForeignKeyConstraints[parentConstraint.mixin]
 		if !ok {
 			continue
 		}
-		eq, err := columnSetEqual(ctx, t.evalCtx, &inbound, &outbound, a.PrevRow, b.PrevRow)
+		applyOrder, err := deriveFKApplyOrder(ctx, t.evalCtx, parent, child, parentConstraint, childConstraint)
 		if err != nil {
 			return false, err
 		}
-		if eq {
+		switch applyOrder {
+		case noApplyOrder:
+		case parentFirst:
+			// Don't return to detect cycles, same logic as above.
+		case childFirst:
 			return true, nil
 		}
 	}
-
 	return false, nil
 }


### PR DESCRIPTION
This PR adds two regression tests that identify bugs in FK lock synthesis:

1. https://github.com/cockroachdb/cockroach/commit/d50ddaaa6b775ffcfe02137a4c9c072e1925f17a
2. https://github.com/cockroachdb/cockroach/commit/ce2c033a87f1894efddc7bb87d706ccd396f7651

The previous implementation had a few latent bugs that were difficult to reason about. This change rewrites the implementation to instead iterate over all possible combinations of parent/child column operations. This fixes the two bug identified above  and allows the correctness of the function to be easier to glean.

Fixes: https://github.com/cockroachdb/cockroach/issues/169778
Release note: none