### PR TITLE
sql: fix fk_subset_unique SHOW CONSTRAINTS result

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk_subset_unique
+++ b/pkg/sql/logictest/testdata/logic_test/fk_subset_unique
@@ -718,7 +718,8 @@ ALTER TABLE drop_ref_parent DROP COLUMN b CASCADE
 query TTTTB nosort
 SHOW CONSTRAINTS FROM drop_ref_child
 ----
-drop_ref_child  drop_ref_child_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+drop_ref_child  drop_ref_child_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+drop_ref_child  drop_ref_child_rowid_not_null  NOT NULL     NOT NULL                 true
 
 statement ok
 DROP TABLE drop_ref_child, drop_ref_parent
@@ -761,7 +762,8 @@ ALTER TABLE uwi_inbound_parent DROP COLUMN d CASCADE
 query TTTTB nosort
 SHOW CONSTRAINTS FROM uwi_inbound_child
 ----
-uwi_inbound_child  uwi_inbound_child_pkey  PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+uwi_inbound_child  uwi_inbound_child_pkey            PRIMARY KEY  PRIMARY KEY (rowid ASC)  true
+uwi_inbound_child  uwi_inbound_child_rowid_not_null  NOT NULL     NOT NULL                 true
 
 statement ok
 DROP TABLE uwi_inbound_child;


### PR DESCRIPTION
Add missing NOT NULL constraint rows to SHOW CONSTRAINTS expected output, introduced by the NOT NULL synthesis in pg_constraint (d3bcee942cab69a8da69fa2c439328a431412fc3).

Fixes #170064
Fixes #170059
Fixes #170057
Fixes #170061
Fixes #170063
Fixes #170062
Fixes #170058
Fixes #170060
Fixes #170055
Fixes #170056

Release note: None