### PR TITLE
revlog: follow-up testing

### DIFF
--- a/docs/RFCS/20260420_continuous_backup.md
+++ b/docs/RFCS/20260420_continuous_backup.md
@@ -380,7 +380,7 @@ job's progress payload:
   written by producers no longer on the new plan.
 
 Closed ticks need nothing in the checkpoint — their markers are
-already durable on S3 and discoverable via the LIST walk.
+already durable on S3.
 
 **On resume:**
 
@@ -401,11 +401,15 @@ already durable on S3 and discoverable via the LIST walk.
 
 Events flushed between the persisted frontier and the crash get
 re-derived from the resumed rangefeed; the new files have new
-random names and are recorded fresh. The narrow race where the
-coordinator wrote a close marker but died before persisting
-that fact is handled by the resume-time LIST walk — markers
-that already exist on S3 win, and the coordinator skips
-re-opening those ticks.
+random names and are recorded fresh. If the coordinator wrote a
+close marker but died before persisting that fact, the tick is
+re-closed on resume with the re-derived data — the overwritten
+manifest is correct because the catch-up scan re-delivers every
+event past the persisted frontier. The pre-crash data files for
+the tick become orphaned on storage, but orphaned files are an
+inevitable consequence of any write-then-record design and are
+harmless (readers only consult files listed in the manifest).
+No resume-time LIST walk is needed.
 
 ##### Job creation
 

--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -216,6 +216,7 @@ go_test(
         "restore_test.go",
         "revision_reader_test.go",
         "revlog_job_test.go",
+        "revlog_marker_test.go",
         "schedule_exec_test.go",
         "schedule_pts_chaining_test.go",
         "show_test.go",

--- a/pkg/backup/revlog_marker_test.go
+++ b/pkg/backup/revlog_marker_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatJobMarkerName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	name := formatJobMarkerName(now, jobspb.JobID(42))
+	require.Contains(t, name, "_42.pb")
+	require.True(t, len(name) > 23, "name should be at least 19 digit nanos + _ + id + .pb")
+
+	// Verify lex ordering: earlier time < later time.
+	earlier := formatJobMarkerName(now.Add(-time.Hour), jobspb.JobID(100))
+	later := formatJobMarkerName(now.Add(time.Hour), jobspb.JobID(1))
+	require.Less(t, earlier, later,
+		"earlier timestamps should sort before later ones")
+}
+
+func TestParseJobMarkerJobID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name       string
+		input      string
+		expectedID jobspb.JobID
+		expectedOK bool
+	}{
+		{
+			name:       "valid marker",
+			input:      "0000001715342400000000000_42.pb",
+			expectedID: 42,
+			expectedOK: true,
+		},
+		{
+			name:       "no underscore",
+			input:      "nounderscorehere.pb",
+			expectedID: 0,
+			expectedOK: false,
+		},
+		{
+			name:       "trailing underscore",
+			input:      "123_.pb",
+			expectedID: 0,
+			expectedOK: false,
+		},
+		{
+			name:       "non-numeric job ID",
+			input:      "123_abc.pb",
+			expectedID: 0,
+			expectedOK: false,
+		},
+		{
+			name:       "empty string",
+			input:      "",
+			expectedID: 0,
+			expectedOK: false,
+		},
+		{
+			name:       "no .pb suffix",
+			input:      "123_42",
+			expectedID: 42,
+			expectedOK: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := parseJobMarkerJobID(tc.input)
+			require.Equal(t, tc.expectedOK, ok)
+			if ok {
+				require.Equal(t, tc.expectedID, id)
+			}
+		})
+	}
+}
+
+func TestFormatParseJobMarkerRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	ids := []jobspb.JobID{1, 42, 1000, jobspb.JobID(1<<31 - 1)}
+
+	for _, id := range ids {
+		name := formatJobMarkerName(now, id)
+		parsedID, ok := parseJobMarkerJobID(name)
+		require.True(t, ok, "should parse marker name %q", name)
+		require.Equal(t, id, parsedID, "round-trip for jobID %d", id)
+	}
+}

--- a/pkg/revlog/BUILD.bazel
+++ b/pkg/revlog/BUILD.bazel
@@ -34,9 +34,13 @@ go_test(
     name = "revlog_test",
     srcs = [
         "coverage_test.go",
+        "encoding_test.go",
         "framing_test.go",
+        "haslog_test.go",
+        "paths_test.go",
         "revlog_test.go",
         "schema_test.go",
+        "tick_writer_test.go",
     ],
     embed = [":revlog"],
     deps = [

--- a/pkg/revlog/encoding_test.go
+++ b/pkg/revlog/encoding_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlog
+
+import (
+	"bytes"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecodeKeyRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tests := []struct {
+		name string
+		key  roachpb.Key
+		ts   hlc.Timestamp
+	}{
+		{name: "empty key, zero ts", key: roachpb.Key{}, ts: hlc.Timestamp{}},
+		{name: "single byte", key: roachpb.Key{0x42}, ts: hlc.Timestamp{WallTime: 1}},
+		{name: "key with sentinel byte", key: roachpb.Key{0x00, 0xff, 0x00}, ts: hlc.Timestamp{WallTime: 100, Logical: 1}},
+		{name: "multi-byte key", key: roachpb.Key("hello/world"), ts: hlc.Timestamp{WallTime: 1714646400000000000, Logical: 5}},
+		{name: "large walltime", key: roachpb.Key("k"), ts: hlc.Timestamp{WallTime: math.MaxInt64}},
+		{name: "large logical", key: roachpb.Key("k"), ts: hlc.Timestamp{WallTime: 1, Logical: math.MaxInt32}},
+		{name: "max both", key: roachpb.Key("k"), ts: hlc.Timestamp{WallTime: math.MaxInt64, Logical: math.MaxInt32}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := EncodeKey(tc.key, tc.ts)
+			gotKey, gotTS, err := DecodeKey(enc)
+			require.NoError(t, err)
+			require.Equal(t, tc.key, gotKey)
+			require.Equal(t, tc.ts, gotTS)
+		})
+	}
+}
+
+func TestEncodeKeyPrefixIsStrictPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	keys := []roachpb.Key{
+		{},
+		roachpb.Key("a"),
+		roachpb.Key("hello"),
+		{0x00, 0xff},
+	}
+	timestamps := []hlc.Timestamp{
+		{},
+		{WallTime: 1},
+		{WallTime: 1, Logical: 1},
+		{WallTime: math.MaxInt64, Logical: math.MaxInt32},
+	}
+	for _, k := range keys {
+		prefix := EncodeKeyPrefix(k)
+		for _, ts := range timestamps {
+			full := EncodeKey(k, ts)
+			require.True(t, bytes.HasPrefix(full, prefix),
+				"EncodeKey(%q, %s) should have EncodeKeyPrefix(%q) as a prefix",
+				k, ts, k)
+			require.Greater(t, len(full), len(prefix),
+				"full encoding should be strictly longer than prefix")
+		}
+	}
+}
+
+func TestEncodeKeySortOrder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type kts struct {
+		key roachpb.Key
+		ts  hlc.Timestamp
+	}
+	// Pairs in expected ascending order: user_key asc, then ts asc.
+	ordered := []kts{
+		{roachpb.Key("a"), hlc.Timestamp{WallTime: 1}},
+		{roachpb.Key("a"), hlc.Timestamp{WallTime: 2}},
+		{roachpb.Key("a"), hlc.Timestamp{WallTime: 2, Logical: 1}},
+		{roachpb.Key("b"), hlc.Timestamp{WallTime: 1}},
+		{roachpb.Key("b"), hlc.Timestamp{WallTime: 1, Logical: 5}},
+		{roachpb.Key("c"), hlc.Timestamp{WallTime: 0}},
+	}
+	encoded := make([][]byte, len(ordered))
+	for i, o := range ordered {
+		encoded[i] = EncodeKey(o.key, o.ts)
+	}
+	for i := 1; i < len(encoded); i++ {
+		require.Negative(t, bytes.Compare(encoded[i-1], encoded[i]),
+			"expected encoded[%d] < encoded[%d] for (%s,%s) < (%s,%s)",
+			i-1, i, ordered[i-1].key, ordered[i-1].ts, ordered[i].key, ordered[i].ts)
+	}
+}
+
+func TestDecodeKeyErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tests := []struct {
+		name    string
+		input   []byte
+		wantErr string
+	}{
+		{name: "empty", input: []byte{}, wantErr: "decoding revlog key user_key"},
+		{name: "truncated", input: []byte{0x12, 0x01}, wantErr: "decoding revlog key"},
+		{name: "trailing bytes", input: append(EncodeKey(roachpb.Key("k"), hlc.Timestamp{WallTime: 1}), 0xff), wantErr: "trailing bytes"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := DecodeKey(tc.input)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestEncodeKeySortOrderShuffled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type kts struct {
+		key roachpb.Key
+		ts  hlc.Timestamp
+	}
+	pairs := []kts{
+		{roachpb.Key("z"), hlc.Timestamp{WallTime: 100}},
+		{roachpb.Key("a"), hlc.Timestamp{WallTime: 1}},
+		{roachpb.Key("m"), hlc.Timestamp{WallTime: 50}},
+		{roachpb.Key("a"), hlc.Timestamp{WallTime: 2}},
+		{roachpb.Key("m"), hlc.Timestamp{WallTime: 10}},
+	}
+	encoded := make([][]byte, len(pairs))
+	for i, p := range pairs {
+		encoded[i] = EncodeKey(p.key, p.ts)
+	}
+	slices.SortFunc(encoded, bytes.Compare)
+
+	// After sorting encoded forms, decoding should yield
+	// (user_key asc, walltime asc) order.
+	var prev kts
+	for i, enc := range encoded {
+		k, ts, err := DecodeKey(enc)
+		require.NoError(t, err)
+		if i > 0 {
+			keyCompare := bytes.Compare(prev.key, k)
+			if keyCompare == 0 {
+				require.True(t, prev.ts.Less(ts),
+					"same key %q: expected ts %s < %s", k, prev.ts, ts)
+			} else {
+				require.Negative(t, keyCompare,
+					"expected key %q < %q", prev.key, k)
+			}
+		}
+		prev = kts{k, ts}
+	}
+}

--- a/pkg/revlog/haslog_test.go
+++ b/pkg/revlog/haslog_test.go
@@ -17,35 +17,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHasLogEmpty(t *testing.T) {
+func TestHasLog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
 	es := newTestStorage(t)
 	defer es.Close()
 
-	has, err := revlog.HasLog(ctx, es)
-	require.NoError(t, err)
-	require.False(t, has, "empty storage should not have a log")
-}
+	t.Run("empty", func(t *testing.T) {
+		has, err := revlog.HasLog(ctx, es)
+		require.NoError(t, err)
+		require.False(t, has, "empty storage should not have a log")
+	})
 
-func TestHasLogWithTick(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
+	t.Run("with-tick", func(t *testing.T) {
+		te := hlc.Timestamp{
+			WallTime: time.Date(2026, 5, 10, 12, 0, 10, 0, time.UTC).UnixNano(),
+		}
+		manifest := revlogpb.Manifest{
+			TickStart: hlc.Timestamp{WallTime: te.WallTime - 10*int64(time.Second)},
+			TickEnd:   te,
+		}
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, manifest))
 
-	es := newTestStorage(t)
-	defer es.Close()
-
-	te := hlc.Timestamp{
-		WallTime: time.Date(2026, 5, 10, 12, 0, 10, 0, time.UTC).UnixNano(),
-	}
-	manifest := revlogpb.Manifest{
-		TickStart: hlc.Timestamp{WallTime: te.WallTime - 10*int64(time.Second)},
-		TickEnd:   te,
-	}
-	require.NoError(t, revlog.WriteTickManifest(ctx, es, manifest))
-
-	has, err := revlog.HasLog(ctx, es)
-	require.NoError(t, err)
-	require.True(t, has, "storage with a tick should have a log")
+		has, err := revlog.HasLog(ctx, es)
+		require.NoError(t, err)
+		require.True(t, has, "storage with a tick should have a log")
+	})
 }

--- a/pkg/revlog/haslog_test.go
+++ b/pkg/revlog/haslog_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlog_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/revlog"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasLogEmpty(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+
+	has, err := revlog.HasLog(ctx, es)
+	require.NoError(t, err)
+	require.False(t, has, "empty storage should not have a log")
+}
+
+func TestHasLogWithTick(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+
+	te := hlc.Timestamp{
+		WallTime: time.Date(2026, 5, 10, 12, 0, 10, 0, time.UTC).UnixNano(),
+	}
+	manifest := revlogpb.Manifest{
+		TickStart: hlc.Timestamp{WallTime: te.WallTime - 10*int64(time.Second)},
+		TickEnd:   te,
+	}
+	require.NoError(t, revlog.WriteTickManifest(ctx, es, manifest))
+
+	has, err := revlog.HasLog(ctx, es)
+	require.NoError(t, err)
+	require.True(t, has, "storage with a tick should have a log")
+}

--- a/pkg/revlog/paths.go
+++ b/pkg/revlog/paths.go
@@ -101,12 +101,19 @@ func FormatHLCName(ts hlc.Timestamp) string {
 
 // ParseHLCName is the inverse of FormatHLCName.
 func ParseHLCName(s string) (hlc.Timestamp, error) {
-	var wall int64
-	var logical int32
-	if _, err := fmt.Sscanf(s, "%019d_%010d", &wall, &logical); err != nil {
-		return hlc.Timestamp{}, errors.Wrapf(err, "parsing HLC name %q", s)
+	// Fixed-width: 19 digits + "_" + 10 digits = 30 characters.
+	if len(s) != 30 || s[19] != '_' {
+		return hlc.Timestamp{}, errors.Newf("parsing HLC name %q: expected 30-char fixed-width format", s)
 	}
-	return hlc.Timestamp{WallTime: wall, Logical: logical}, nil
+	wall, err := strconv.ParseInt(s[:19], 10, 64)
+	if err != nil {
+		return hlc.Timestamp{}, errors.Wrapf(err, "parsing HLC name %q wall component", s)
+	}
+	logical, err := strconv.ParseInt(s[20:], 10, 32)
+	if err != nil {
+		return hlc.Timestamp{}, errors.Wrapf(err, "parsing HLC name %q logical component", s)
+	}
+	return hlc.Timestamp{WallTime: wall, Logical: int32(logical)}, nil
 }
 
 // CoveragePath is the path of one coverage epoch's object.

--- a/pkg/revlog/paths_test.go
+++ b/pkg/revlog/paths_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlog
+
+import (
+	"math"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatParseTickEndRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tests := []struct {
+		name string
+		time time.Time
+	}{
+		{name: "normal", time: time.Date(2026, 4, 20, 15, 30, 10, 0, time.UTC)},
+		{name: "midnight", time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "year boundary", time: time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)},
+		{name: "leap day", time: time.Date(2028, 2, 29, 12, 0, 0, 0, time.UTC)},
+		{name: "end of day", time: time.Date(2026, 6, 15, 23, 59, 50, 0, time.UTC)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := hlc.Timestamp{WallTime: tc.time.UnixNano()}
+			formatted := FormatTickEnd(ts)
+			parsed, err := ParseTickEnd(formatted)
+			require.NoError(t, err)
+			require.Equal(t, ts, parsed)
+		})
+	}
+}
+
+func TestFormatParseHLCNameRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tests := []struct {
+		name string
+		ts   hlc.Timestamp
+	}{
+		{name: "zero", ts: hlc.Timestamp{}},
+		{name: "normal", ts: hlc.Timestamp{WallTime: 1714646400000000000, Logical: 5}},
+		{name: "max wall", ts: hlc.Timestamp{WallTime: math.MaxInt64}},
+		{name: "max logical", ts: hlc.Timestamp{Logical: math.MaxInt32}},
+		{name: "max both", ts: hlc.Timestamp{WallTime: math.MaxInt64, Logical: math.MaxInt32}},
+		{name: "logical only", ts: hlc.Timestamp{Logical: 42}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := FormatHLCName(tc.ts)
+			parsed, err := ParseHLCName(formatted)
+			require.NoError(t, err)
+			require.Equal(t, tc.ts, parsed)
+		})
+	}
+}
+
+func TestFormatHLCNameLexSort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	timestamps := []hlc.Timestamp{
+		{WallTime: 0, Logical: 0},
+		{WallTime: 0, Logical: 1},
+		{WallTime: 1, Logical: 0},
+		{WallTime: 100, Logical: 0},
+		{WallTime: 100, Logical: 5},
+		{WallTime: 1714646400000000000, Logical: 0},
+		{WallTime: math.MaxInt64, Logical: 0},
+		{WallTime: math.MaxInt64, Logical: math.MaxInt32},
+	}
+	formatted := make([]string, len(timestamps))
+	for i, ts := range timestamps {
+		formatted[i] = FormatHLCName(ts)
+	}
+	// Verify the formatted strings are already sorted.
+	require.True(t, slices.IsSorted(formatted),
+		"formatted HLC names should be in ascending lex order: %v", formatted)
+
+	// Shuffle and re-sort to double-check.
+	shuffled := slices.Clone(formatted)
+	shuffled[0], shuffled[len(shuffled)-1] = shuffled[len(shuffled)-1], shuffled[0]
+	slices.Sort(shuffled)
+	require.Equal(t, formatted, shuffled)
+}
+
+func TestPathConstruction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	te := hlc.Timestamp{
+		WallTime: time.Date(2026, 4, 20, 15, 30, 10, 0, time.UTC).UnixNano(),
+	}
+	require.Equal(t, "log/resolved/2026-04-20/15-30.10.pb", MarkerPath(te))
+	require.Equal(t, "log/data/2026-04-20/15-30.10/", DataDirPath(te))
+	require.Equal(t, "log/data/2026-04-20/15-30.10/42.sst", DataFilePath(te, 42))
+
+	hlcTs := hlc.Timestamp{WallTime: 1000000000, Logical: 7}
+	require.Equal(t, "log/coverage/0000000001000000000_0000000007", CoveragePath(hlcTs))
+	require.Equal(t, "log/schema/descs/0000000001000000000_0000000007/99.pb", SchemaDescPath(hlcTs, 99))
+	require.Equal(t, "log/schema/descs/0000000001000000000_0000000007/", SchemaDescDirPath(hlcTs))
+}
+
+func TestParseTickEndInvalid(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	for _, input := range []string{
+		"",
+		"not-a-date",
+		"2026-04-20",
+		"15-30.10",
+		"2026/04/20/15-30.10",
+	} {
+		_, err := ParseTickEnd(input)
+		require.Errorf(t, err, "input: %q", input)
+	}
+}
+
+func TestParseHLCNameInvalid(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	for _, input := range []string{
+		"",
+		"not-an-hlc",
+		"123_456",
+		"0000000000000000001",
+		"abc_0000000001",
+	} {
+		_, err := ParseHLCName(input)
+		require.Errorf(t, err, "input: %q", input)
+	}
+}

--- a/pkg/revlog/restorerevlog/BUILD.bazel
+++ b/pkg/revlog/restorerevlog/BUILD.bazel
@@ -48,9 +48,13 @@ go_library(
 
 go_test(
     name = "restorerevlog_test",
-    srcs = ["restore_test.go"],
+    srcs = [
+        "restore_test.go",
+        "validate_resolve_test.go",
+    ],
     embed = [":restorerevlog"],
     deps = [
+        "//pkg/backup/backupinfo",
         "//pkg/cloud",
         "//pkg/cloud/cloudpb",
         "//pkg/cloud/nodelocal",
@@ -58,6 +62,8 @@ go_test(
         "//pkg/revlog/revlogpb",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/execinfrapb",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/revlog/restorerevlog/validate_resolve_test.go
+++ b/pkg/revlog/restorerevlog/validate_resolve_test.go
@@ -1,0 +1,389 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package restorerevlog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backupinfo"
+	"github.com/cockroachdb/cockroach/pkg/revlog"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateResolved(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("no ticks at all", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		err := ValidateResolved(ctx, es,
+			testTickEnd(0),  // backupEndTime
+			testTickEnd(30), // revlogTimestamp (AOST)
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no resolved ticks")
+	})
+
+	t.Run("ticks do not reach AOST", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(0), TickEnd: testTickEnd(10),
+		}))
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(10), TickEnd: testTickEnd(20),
+		}))
+
+		err := ValidateResolved(ctx, es,
+			testTickEnd(0),  // backupEndTime
+			testTickEnd(30), // AOST past last tick
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "has not resolved")
+	})
+
+	t.Run("ticks reach AOST exactly", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(0), TickEnd: testTickEnd(10),
+		}))
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(10), TickEnd: testTickEnd(20),
+		}))
+
+		err := ValidateResolved(ctx, es,
+			testTickEnd(0),  // backupEndTime
+			testTickEnd(20), // AOST = last tick end
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("ticks past AOST", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(0), TickEnd: testTickEnd(10),
+		}))
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(10), TickEnd: testTickEnd(20),
+		}))
+
+		err := ValidateResolved(ctx, es,
+			testTickEnd(0),  // backupEndTime
+			testTickEnd(15), // AOST between ticks
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("single tick covers AOST", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		require.NoError(t, revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: testTickEnd(0), TickEnd: testTickEnd(10),
+		}))
+
+		err := ValidateResolved(ctx, es,
+			testTickEnd(0), // backupEndTime
+			testTickEnd(5), // AOST within single tick
+		)
+		require.NoError(t, err)
+	})
+}
+
+// makeDesc constructs a catalog.Descriptor from a table proto,
+// using the same path ApplyDescriptorChanges uses internally.
+func makeDesc(id descpb.ID, name string) catalog.Descriptor {
+	return backupinfo.NewDescriptorForManifest(
+		&descpb.Descriptor{
+			Union: &descpb.Descriptor_Table{
+				Table: &descpb.TableDescriptor{ID: id, Name: name},
+			},
+		},
+	)
+}
+
+func makeDescProto(id descpb.ID, name string) *descpb.Descriptor {
+	return &descpb.Descriptor{
+		Union: &descpb.Descriptor_Table{
+			Table: &descpb.TableDescriptor{ID: id, Name: name},
+		},
+	}
+}
+
+func makeDroppedDescProto(id descpb.ID, name string) *descpb.Descriptor {
+	return &descpb.Descriptor{
+		Union: &descpb.Descriptor_Table{
+			Table: &descpb.TableDescriptor{
+				ID: id, Name: name,
+				State: descpb.DescriptorState_DROP,
+			},
+		},
+	}
+}
+
+func TestApplyDescriptorChanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	backupEnd := hlc.Timestamp{WallTime: 100 * int64(time.Second)}
+	revlogTS := hlc.Timestamp{WallTime: 200 * int64(time.Second)}
+
+	t.Run("no schema changes", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		backupDescs := []catalog.Descriptor{makeDesc(1, "t1")}
+		result, newIDs, err := ApplyDescriptorChanges(
+			ctx, es, backupDescs, backupEnd, revlogTS,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Empty(t, newIDs)
+	})
+
+	t.Run("new table added", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		backupDescs := []catalog.Descriptor{makeDesc(1, "t1")}
+
+		changeTS := hlc.Timestamp{WallTime: 150 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, changeTS, 2, makeDescProto(2, "t2"),
+		))
+
+		result, newIDs, err := ApplyDescriptorChanges(
+			ctx, es, backupDescs, backupEnd, revlogTS,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		require.Contains(t, newIDs, descpb.ID(2))
+	})
+
+	t.Run("tombstone removes descriptor", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		backupDescs := []catalog.Descriptor{
+			makeDesc(1, "t1"), makeDesc(2, "t2"),
+		}
+
+		changeTS := hlc.Timestamp{WallTime: 150 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, changeTS, 2, nil, /* tombstone */
+		))
+
+		result, newIDs, err := ApplyDescriptorChanges(
+			ctx, es, backupDescs, backupEnd, revlogTS,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, descpb.ID(1), result[0].GetID())
+		require.Empty(t, newIDs)
+	})
+
+	t.Run("DROP state filters table", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		backupDescs := []catalog.Descriptor{
+			makeDesc(1, "t1"), makeDesc(2, "t2"),
+		}
+
+		changeTS := hlc.Timestamp{WallTime: 150 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, changeTS, 2, makeDroppedDescProto(2, "t2"),
+		))
+
+		result, _, err := ApplyDescriptorChanges(
+			ctx, es, backupDescs, backupEnd, revlogTS,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, descpb.ID(1), result[0].GetID())
+	})
+
+	t.Run("multiple changes keeps latest", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		backupDescs := []catalog.Descriptor{makeDesc(1, "t1")}
+
+		change1 := hlc.Timestamp{WallTime: 120 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, change1, 1, makeDescProto(1, "t1_renamed"),
+		))
+		change2 := hlc.Timestamp{WallTime: 180 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, change2, 1, makeDescProto(1, "t1_final"),
+		))
+
+		result, _, err := ApplyDescriptorChanges(
+			ctx, es, backupDescs, backupEnd, revlogTS,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, "t1_final", result[0].GetName())
+	})
+
+	t.Run("changes outside window ignored", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		backupDescs := []catalog.Descriptor{makeDesc(1, "t1")}
+
+		beforeBackup := hlc.Timestamp{WallTime: 50 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, beforeBackup, 1, makeDescProto(1, "too_early"),
+		))
+		afterRevlog := hlc.Timestamp{WallTime: 300 * int64(time.Second)}
+		require.NoError(t, revlog.WriteSchemaDesc(
+			ctx, es, afterRevlog, 1, makeDescProto(1, "too_late"),
+		))
+
+		result, _, err := ApplyDescriptorChanges(
+			ctx, es, backupDescs, backupEnd, revlogTS,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, "t1", result[0].GetName())
+	})
+}
+
+func TestMergeTickEventsEdgeCases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("single event", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		m := writeTestTick(t, ctx, es, testTickEnd(10), 1, []revlog.Event{
+			testEvent("only", 500, 0, "val"),
+		})
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks: []revlogpb.Manifest{m},
+		})
+		require.Len(t, merged, 1)
+		require.Equal(t, "only", string(merged[0].Key.Key))
+	})
+
+	t.Run("all events filtered by AOST", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		m := writeTestTick(t, ctx, es, testTickEnd(10), 1, []revlog.Event{
+			testEvent("a", 1000, 0, "v1"),
+			testEvent("b", 2000, 0, "v2"),
+		})
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks:            []revlogpb.Manifest{m},
+			RestoreTimestamp: hlc.Timestamp{WallTime: 500},
+		})
+		require.Empty(t, merged)
+	})
+
+	t.Run("same key same ts across ticks deduplicates", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		m1 := writeTestTick(t, ctx, es, testTickEnd(10), 1, []revlog.Event{
+			testEvent("a", 1000, 0, "v1"),
+		})
+		m2 := writeTestTick(t, ctx, es, testTickEnd(20), 2, []revlog.Event{
+			testEvent("a", 1000, 0, "v1"),
+		})
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks: []revlogpb.Manifest{m1, m2},
+		})
+		require.Len(t, merged, 1)
+	})
+
+	t.Run("many ticks merged correctly", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		var manifests []revlogpb.Manifest
+		for i := 0; i < 10; i++ {
+			m := writeTestTick(t, ctx, es, testTickEnd(10*(i+1)), int64(i+1), []revlog.Event{
+				testEvent("k", int64(i*100+50), 0, "v"),
+			})
+			manifests = append(manifests, m)
+		}
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks: manifests,
+		})
+		require.Len(t, merged, 1)
+		require.Equal(t, int64(950), merged[0].Key.Timestamp.WallTime)
+	})
+
+	t.Run("logical timestamp distinguishes revisions", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		m := writeTestTick(t, ctx, es, testTickEnd(10), 1, []revlog.Event{
+			testEvent("k", 1000, 0, "v0"),
+			testEvent("k", 1000, 1, "v1"),
+			testEvent("k", 1000, 2, "v2"),
+		})
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks: []revlogpb.Manifest{m},
+		})
+		require.Len(t, merged, 1)
+		require.Equal(t, int32(2), merged[0].Key.Timestamp.Logical)
+		require.Equal(t, []byte("v2"), merged[0].Value)
+	})
+
+	t.Run("AOST with logical timestamp", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		m := writeTestTick(t, ctx, es, testTickEnd(10), 1, []revlog.Event{
+			testEvent("k", 1000, 0, "v0"),
+			testEvent("k", 1000, 1, "v1"),
+			testEvent("k", 1000, 2, "v2"),
+		})
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks:            []revlogpb.Manifest{m},
+			RestoreTimestamp: hlc.Timestamp{WallTime: 1000, Logical: 1},
+		})
+		require.Len(t, merged, 1)
+		require.Equal(t, int32(1), merged[0].Key.Timestamp.Logical)
+		require.Equal(t, []byte("v1"), merged[0].Value)
+	})
+
+	t.Run("tombstone overwrites prior value", func(t *testing.T) {
+		es := newTestStorage(t)
+		defer es.Close()
+
+		m1 := writeTestTick(t, ctx, es, testTickEnd(10), 1, []revlog.Event{
+			testEvent("k", 1000, 0, "alive"),
+		})
+		m2 := writeTestTick(t, ctx, es, testTickEnd(20), 2, []revlog.Event{
+			testEvent("k", 2000, 0, ""),
+		})
+		merged := collectMergedEntries(t, ctx, es, execinfrapb.RevlogLocalMergeSpec{
+			Ticks: []revlogpb.Manifest{m1, m2},
+		})
+		require.Len(t, merged, 1)
+		require.Empty(t, merged[0].Value)
+	})
+}

--- a/pkg/revlog/revlogjob/BUILD.bazel
+++ b/pkg/revlog/revlogjob/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
     srcs = [
         "builtins_test.go",
         "checkpoint_internal_test.go",
+        "coalesce_checkpoint_test.go",
         "desc_frontier_gating_test.go",
         "descfeed_internal_test.go",
         "descfeed_loop_test.go",
@@ -84,9 +85,12 @@ go_test(
         "main_test.go",
         "metasink_test.go",
         "persister_test.go",
+        "producer_internal_test.go",
         "progress_persist_test.go",
         "pts_test.go",
         "resume_internal_test.go",
+        "termination_test.go",
+        "tick_manager_test.go",
     ],
     embed = [":revlogjob"],
     deps = [
@@ -114,6 +118,7 @@ go_test(
         "//pkg/sql/isql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/util/hlc",
         "//pkg/util/ioctx",

--- a/pkg/revlog/revlogjob/coalesce_checkpoint_test.go
+++ b/pkg/revlog/revlogjob/coalesce_checkpoint_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlogjob_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/revlog"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogjob"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoalesceOnlyTickSurvivesCheckpointAndResume exercises the
+// scenario where a producer forwards small events as coalesces
+// (not as files), the tick can't close yet (another span is
+// lagging), a checkpoint fires, and then a crash occurs.
+//
+// The danger: Checkpoint skips ticks with len(files)==0, so the
+// coalesce entries are not persisted. But the checkpoint DOES
+// persist the advanced frontier for the producer's span. On
+// resume, the rangefeed re-subscribes at the advanced frontier
+// and won't re-deliver the coalesced events. The tick closes
+// without spanA's contributions — permanent data loss.
+//
+// This test verifies the correct behavior: after crash+resume,
+// the tick should close with ALL events, including those that
+// were only in coalesce entries at checkpoint time.
+func TestCoalesceOnlyTickSurvivesCheckpointAndResume(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 0,
+		"Checkpoint omits coalesce-only ticks; "+
+			"frontier advances past events that exist only in inlineEntries")
+
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+
+	// --- First incarnation ---
+	// Two producers on disjoint spans. Both use coalesce path.
+	mgr1, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{spanA, spanB}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr1.DisableDescFrontier()
+
+	prodA, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanA}, ts(100), testTickWidth, ids, mgr1,
+		revlogjob.ResumeState{}, 1<<20, /* forwardThreshold = 1MB */
+	)
+	require.NoError(t, err)
+
+	// Producer A sends events for tick (100, 110] and advances
+	// its frontier past 110. These events take the coalesce path
+	// (small enough to forward).
+	prodA.OnValue(ctx, roachpb.Key("c"), ts(105), []byte("vA1"), nil)
+	prodA.OnValue(ctx, roachpb.Key("d"), ts(106), []byte("vA2"), nil)
+	require.NoError(t, prodA.OnCheckpoint(ctx, spanA, ts(112)))
+
+	// Producer B is lagging — hasn't advanced past startHLC.
+	// This means tick 110 can't close yet (aggregate frontier =
+	// min(112, 100) = 100 < 110).
+
+	// Verify tick is NOT closed.
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Empty(t, ticks, "tick should not close while spanB lags")
+
+	// Checkpoint. This persists frontier={spanA:112, spanB:100}
+	// and should persist the coalesce entries for tick 110.
+	p := &memPersister{}
+	require.NoError(t, mgr1.Checkpoint(ctx, p))
+	loaded, found, err := p.Load(ctx)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// --- Simulate crash + resume ---
+	mgr2, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{spanA, spanB}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr2.DisableDescFrontier()
+	require.NoError(t, mgr2.Rehydrate(loaded))
+
+	// Producer A resumes at frontier=112. It will NOT re-deliver
+	// events with ts in (100, 110].
+	resumeA := mgr2.ResumeForPartition([]roachpb.Span{spanA})
+
+	// Producer B resumes at frontier=100. It will deliver its
+	// events normally.
+	resumeB := mgr2.ResumeForPartition([]roachpb.Span{spanB})
+
+	prodA2, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanA}, ts(100), testTickWidth, ids, mgr2,
+		resumeA, 1<<20,
+	)
+	require.NoError(t, err)
+	prodB2, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanB}, ts(100), testTickWidth, ids, mgr2,
+		resumeB, 1<<20,
+	)
+	require.NoError(t, err)
+
+	// Producer A has nothing new for tick 110 (frontier already
+	// past it). Just advance it further.
+	require.NoError(t, prodA2.OnCheckpoint(ctx, spanA, ts(115)))
+
+	// Producer B catches up and advances past tick 110.
+	prodB2.OnValue(ctx, roachpb.Key("n"), ts(107), []byte("vB"), nil)
+	require.NoError(t, prodB2.OnCheckpoint(ctx, spanB, ts(115)))
+
+	// Now tick 110 should close. It MUST include:
+	// - "c" and "d" from producer A's pre-crash coalesces
+	// - "n" from producer B's post-resume contribution
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+
+	events := readBackEvents(t, ctx, es, ticks[0])
+	require.Len(t, events, 3,
+		"tick must contain events from both producers, "+
+			"including pre-crash coalesces from producer A")
+	require.Equal(t, "c", string(events[0].Key))
+	require.Equal(t, "d", string(events[1].Key))
+	require.Equal(t, "n", string(events[2].Key))
+}

--- a/pkg/revlog/revlogjob/producer_internal_test.go
+++ b/pkg/revlog/revlogjob/producer_internal_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlogjob
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTickEndFor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const tickWidth = 10 * time.Second
+	tests := []struct {
+		name     string
+		ts       hlc.Timestamp
+		expected hlc.Timestamp
+	}{
+		{
+			name:     "exactly on boundary",
+			ts:       hlc.Timestamp{WallTime: 100 * int64(time.Second)},
+			expected: hlc.Timestamp{WallTime: 100 * int64(time.Second)},
+		},
+		{
+			name:     "on boundary with logical",
+			ts:       hlc.Timestamp{WallTime: 100 * int64(time.Second), Logical: 1},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "just after boundary",
+			ts:       hlc.Timestamp{WallTime: 100*int64(time.Second) + 1},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "just before boundary",
+			ts:       hlc.Timestamp{WallTime: 110*int64(time.Second) - 1},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "mid tick",
+			ts:       hlc.Timestamp{WallTime: 105 * int64(time.Second)},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "zero timestamp",
+			ts:       hlc.Timestamp{},
+			expected: hlc.Timestamp{},
+		},
+		{
+			name:     "one nanosecond",
+			ts:       hlc.Timestamp{WallTime: 1},
+			expected: hlc.Timestamp{WallTime: 10 * int64(time.Second)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tickEndFor(tc.ts, tickWidth)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestNextTickEndAfter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const tickWidth = 10 * time.Second
+	tests := []struct {
+		name     string
+		prev     hlc.Timestamp
+		expected hlc.Timestamp
+	}{
+		{
+			name:     "on boundary",
+			prev:     hlc.Timestamp{WallTime: 100 * int64(time.Second)},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "on boundary with logical",
+			prev:     hlc.Timestamp{WallTime: 100 * int64(time.Second), Logical: 5},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "mid tick",
+			prev:     hlc.Timestamp{WallTime: 105 * int64(time.Second)},
+			expected: hlc.Timestamp{WallTime: 110 * int64(time.Second)},
+		},
+		{
+			name:     "zero",
+			prev:     hlc.Timestamp{},
+			expected: hlc.Timestamp{WallTime: 10 * int64(time.Second)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextTickEndAfter(tc.prev, tickWidth)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestNewProducerValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("empty spans", func(t *testing.T) {
+		_, err := NewProducer(nil, nil, hlc.Timestamp{}, time.Second, nil, nil,
+			ResumeState{}, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one span")
+	})
+
+	t.Run("zero tick width", func(t *testing.T) {
+		_, err := NewProducer(nil, testSpans(), hlc.Timestamp{}, 0, nil, nil,
+			ResumeState{}, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tickWidth must be positive")
+	})
+
+	t.Run("nil sink", func(t *testing.T) {
+		_, err := NewProducer(nil, testSpans(), hlc.Timestamp{}, time.Second,
+			&testFileIDs{}, nil, ResumeState{}, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "sink must be non-nil")
+	})
+
+	t.Run("negative forward threshold", func(t *testing.T) {
+		_, err := NewProducer(nil, testSpans(), hlc.Timestamp{}, time.Second,
+			&testFileIDs{}, &noopSink{}, ResumeState{}, -1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forwardThreshold must be non-negative")
+	})
+}
+
+// helpers for internal tests
+
+type testFileIDs struct{ n int64 }
+
+func (t *testFileIDs) Next() int64 { t.n++; return t.n }
+
+type noopSink struct{}
+
+func (noopSink) Flush(context.Context, *revlogpb.Flush) error { return nil }
+
+func testSpans() []roachpb.Span {
+	return []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}}
+}

--- a/pkg/revlog/revlogjob/settings.go
+++ b/pkg/revlog/revlogjob/settings.go
@@ -22,5 +22,9 @@ var ProducerForwardThreshold = settings.RegisterByteSizeSetting(
 	"per-tick buffer size at or below which a revlog producer "+
 		"forwards events to the coordinator for inline coalescing "+
 		"instead of PUTing them as a standalone data file (0 disables)",
-	1<<20, // 1 MiB
+	// TODO(dt): re-enable once the coordinator flushes coalesced
+	// entries to a durable file before advancing its frontier for
+	// the associated checkpoints. Without that, a crash can lose
+	// coalesced events whose frontier was already persisted.
+	0, // disabled; see TODO above
 )

--- a/pkg/revlog/revlogjob/termination_test.go
+++ b/pkg/revlog/revlogjob/termination_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlogjob_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/revlog"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogjob"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScopeTerminationFlushesPartialTick verifies that when the
+// revlog scope dissolves (all watched descriptors dropped), events
+// buffered in the still-open partial tick are flushed and their
+// manifest is written before the job exits.
+//
+// Without this, a RESTORE to an AOST in the final partial-tick
+// window would see "table existed, no data" — the schema deltas
+// record the table's existence but the revlog has no events for
+// that window.
+//
+// See the TODO in descfeed.go processBatch: the fix is to wait
+// for manager.LastClosed() > resolvedTS before returning
+// ErrScopeTerminated.
+func TestScopeTerminationFlushesPartialTick(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 0, "scope termination does not yet flush the partial tick")
+
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+
+	// Start at ts(100). Tick width = 10s, so tick boundaries are
+	// at 110, 120, etc.
+	startHLC := ts(100)
+	mgr, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, startHLC, testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr.DisableDescFrontier()
+
+	prod, err := revlogjob.NewProducer(
+		es, []roachpb.Span{allSpan}, startHLC, testTickWidth, ids, mgr,
+		revlogjob.ResumeState{}, 0,
+	)
+	require.NoError(t, err)
+
+	// Close one full tick so we have a baseline.
+	prod.OnValue(ctx, roachpb.Key("a"), ts(105), []byte("v1"), nil)
+	require.NoError(t, prod.OnCheckpoint(ctx, allSpan, ts(111)))
+
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1, "first full tick should be closed")
+
+	// Now buffer events in the NEXT tick (110, 120] but don't
+	// advance the frontier past 120 — simulating a scope
+	// termination at ts(115) before the tick closes.
+	prod.OnValue(ctx, roachpb.Key("b"), ts(113), []byte("v2"), nil)
+	prod.OnValue(ctx, roachpb.Key("c"), ts(114), []byte("v3"), nil)
+
+	// Advance frontier to the termination point but NOT past the
+	// tick boundary.
+	require.NoError(t, prod.OnCheckpoint(ctx, allSpan, ts(115)))
+
+	// At this point, scope termination would fire. The events for
+	// keys "b" and "c" are buffered but the tick (110, 120] is
+	// still open. The correct behavior is that the partial tick
+	// is flushed with TickEnd adjusted to the termination point,
+	// or the frontier is forced past the tick boundary so the
+	// close loop fires.
+	//
+	// For now, verify the events ARE in a closed tick — this is
+	// the behavior we want. When the TODO in descfeed.go is
+	// implemented, this test should pass.
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(109), hlc.MaxTimestamp) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1, "partial tick should be closed on termination")
+
+	events := readBackEvents(t, ctx, es, ticks[0])
+	require.Len(t, events, 2, "partial tick should contain the buffered events")
+	require.Equal(t, "b", string(events[0].Key))
+	require.Equal(t, "c", string(events[1].Key))
+}

--- a/pkg/revlog/revlogjob/tick_manager_test.go
+++ b/pkg/revlog/revlogjob/tick_manager_test.go
@@ -1,0 +1,393 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlogjob_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/revlog"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogjob"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// spanA and spanB are two disjoint spans used to simulate
+// multi-producer setups where each producer covers a subset.
+var (
+	spanA = roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")}
+	spanB = roachpb.Span{Key: roachpb.Key("m"), EndKey: roachpb.Key("z")}
+)
+
+// TestTickManagerMultiProducerFlush verifies that two producers
+// covering disjoint spans can both contribute files and checkpoints
+// to the same tick, and the tick only closes once both spans'
+// frontiers cross the boundary.
+func TestTickManagerMultiProducerFlush(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+	mgr, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{spanA, spanB}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr.DisableDescFrontier()
+
+	// Producer A writes a file and advances spanA past tick boundary.
+	prodA, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanA}, ts(100), testTickWidth, ids, mgr,
+		revlogjob.ResumeState{}, 0,
+	)
+	require.NoError(t, err)
+	prodA.OnValue(ctx, roachpb.Key("c"), ts(105), []byte("vA"), nil)
+	require.NoError(t, prodA.OnCheckpoint(ctx, spanA, ts(111)))
+
+	// Tick should NOT be closed yet — spanB is still at startHLC.
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Empty(t, ticks, "tick should not close until both spans advance")
+
+	// Producer B writes a file and advances spanB past tick boundary.
+	prodB, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanB}, ts(100), testTickWidth, ids, mgr,
+		revlogjob.ResumeState{}, 0,
+	)
+	require.NoError(t, err)
+	prodB.OnValue(ctx, roachpb.Key("n"), ts(107), []byte("vB"), nil)
+	require.NoError(t, prodB.OnCheckpoint(ctx, spanB, ts(111)))
+
+	// Now tick should be closed — both spans past ts(110).
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+	require.Equal(t, ts(110), ticks[0].EndTime)
+	require.Len(t, ticks[0].Manifest.Files, 2,
+		"tick should have files from both producers")
+}
+
+// TestTickManagerCoalesceMergeFromMultipleProducers verifies that
+// coalesce contributions from two producers for the same tick are
+// merged and appear in the tick's manifest (either as InlineTail
+// or as a promoted file).
+func TestTickManagerCoalesceMergeFromMultipleProducers(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+	mgr, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{spanA, spanB}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr.DisableDescFrontier()
+
+	// Both producers use the coalesce path (forwardThreshold = 1MB).
+	prodA, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanA}, ts(100), testTickWidth, ids, mgr,
+		revlogjob.ResumeState{}, 1<<20,
+	)
+	require.NoError(t, err)
+	prodB, err := revlogjob.NewProducer(
+		es, []roachpb.Span{spanB}, ts(100), testTickWidth, ids, mgr,
+		revlogjob.ResumeState{}, 1<<20,
+	)
+	require.NoError(t, err)
+
+	prodA.OnValue(ctx, roachpb.Key("c"), ts(105), []byte("vA"), nil)
+	prodA.OnValue(ctx, roachpb.Key("d"), ts(106), []byte("vA2"), nil)
+	require.NoError(t, prodA.OnCheckpoint(ctx, spanA, ts(111)))
+
+	prodB.OnValue(ctx, roachpb.Key("n"), ts(107), []byte("vB"), nil)
+	require.NoError(t, prodB.OnCheckpoint(ctx, spanB, ts(111)))
+
+	// Both producers contributed coalesces; tick should be closed
+	// with the merged entries appearing inline.
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+	require.Empty(t, ticks[0].Manifest.Files,
+		"small coalesces should be inlined, not written as files")
+	require.Len(t, ticks[0].Manifest.InlineTail, 3,
+		"merged inline tail should have all 3 events")
+
+	// Verify events are readable and in key order.
+	events := readBackEvents(t, ctx, es, ticks[0])
+	require.Len(t, events, 3)
+	require.Equal(t, "c", string(events[0].Key))
+	require.Equal(t, "d", string(events[1].Key))
+	require.Equal(t, "n", string(events[2].Key))
+}
+
+// TestTickManagerRehydrateAndResume verifies that the TickManager
+// can be rehydrated from a persisted State and that subsequent
+// flushes continue from where the prior incarnation left off.
+func TestTickManagerRehydrateAndResume(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+
+	// First incarnation: write one tick, leave another open.
+	mgr1, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr1.DisableDescFrontier()
+
+	prod1, err := revlogjob.NewProducer(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids, mgr1,
+		revlogjob.ResumeState{}, 0,
+	)
+	require.NoError(t, err)
+	prod1.OnValue(ctx, roachpb.Key("a"), ts(105), []byte("v1"), nil)
+	prod1.OnValue(ctx, roachpb.Key("b"), ts(115), []byte("v2"), nil)
+	require.NoError(t, prod1.OnCheckpoint(ctx, allSpan, ts(115)))
+
+	// ts(110) tick should be closed; ts(120) tick has "b" buffered
+	// but not closed. Verify first tick closed.
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+	require.Equal(t, ts(110), ticks[0].EndTime)
+
+	// Simulate checkpoint: snapshot the manager's state.
+	resumeState := mgr1.ResumeForPartition([]roachpb.Span{allSpan})
+
+	// Second incarnation: rehydrate and continue.
+	mgr2, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr2.DisableDescFrontier()
+
+	// Rehydrate from the persisted state.
+	state := revlogjob.State{
+		HighWater: ts(110),
+	}
+	require.NoError(t, mgr2.Rehydrate(state))
+
+	// New producer starts with resume state — its flushorder
+	// should continue past any prior files.
+	prod2, err := revlogjob.NewProducer(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids, mgr2,
+		resumeState, 0,
+	)
+	require.NoError(t, err)
+	prod2.OnValue(ctx, roachpb.Key("c"), ts(118), []byte("v3"), nil)
+	require.NoError(t, prod2.OnCheckpoint(ctx, allSpan, ts(121)))
+
+	// Now ts(120) tick should close (from the new producer).
+	// Query from ts(119) to avoid seeing the already-closed ts(110).
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(119), ts(130)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+	require.Equal(t, ts(120), ticks[0].EndTime)
+	require.Equal(t, ts(110), ticks[0].Manifest.TickStart)
+}
+
+// TestTickManagerDescFrontierGatesClose verifies that the close
+// loop respects both the data frontier AND the descriptor frontier.
+func TestTickManagerDescFrontierGatesClose(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+	mgr, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	// Don't disable desc frontier — we want to test gating.
+
+	prod, err := revlogjob.NewProducer(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids, mgr,
+		revlogjob.ResumeState{}, 0,
+	)
+	require.NoError(t, err)
+
+	// Data frontier advances past ts(110), but desc frontier is
+	// still at startHLC = ts(100).
+	prod.OnValue(ctx, roachpb.Key("a"), ts(105), []byte("v"), nil)
+	require.NoError(t, prod.OnCheckpoint(ctx, allSpan, ts(115)))
+
+	// Tick should NOT close — desc frontier blocks it.
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Empty(t, ticks, "desc frontier should gate tick close")
+
+	// Advance desc frontier past the tick boundary.
+	require.NoError(t, mgr.ForwardDescFrontier(ctx, ts(115)))
+
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+	require.Equal(t, ts(110), ticks[0].EndTime)
+}
+
+// TestTickManagerFrontierAdvanceHook verifies that the
+// afterFrontierAdvance callback fires when the aggregate frontier
+// moves forward and does NOT fire on duplicate checkpoints.
+func TestTickManagerFrontierAdvanceHook(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+	mgr, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr.DisableDescFrontier()
+
+	var advances []hlc.Timestamp
+	mgr.SetAfterFrontierAdvance(func(_ context.Context, frontier hlc.Timestamp) {
+		advances = append(advances, frontier)
+	})
+
+	// First flush — frontier moves from ts(100) to ts(105).
+	require.NoError(t, mgr.Flush(ctx, &revlogpb.Flush{
+		Checkpoints: checkpoints(allSpan, ts(105)),
+	}))
+	require.Len(t, advances, 1)
+	require.Equal(t, ts(105), advances[0])
+
+	// Same checkpoint again — no forward movement, no hook fire.
+	require.NoError(t, mgr.Flush(ctx, &revlogpb.Flush{
+		Checkpoints: checkpoints(allSpan, ts(105)),
+	}))
+	require.Len(t, advances, 1, "hook should not fire on no-op forward")
+
+	// Frontier advances again.
+	require.NoError(t, mgr.Flush(ctx, &revlogpb.Flush{
+		Checkpoints: checkpoints(allSpan, ts(108)),
+	}))
+	require.Len(t, advances, 2)
+	require.Equal(t, ts(108), advances[1])
+}
+
+// TestTickManagerAddSpansAt verifies that dynamically adding spans
+// to the frontier causes the close loop to wait for those spans.
+func TestTickManagerAddSpansAt(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+	mgr, err := revlogjob.NewTickManager(
+		es, []roachpb.Span{spanA}, ts(100), testTickWidth, ids,
+	)
+	require.NoError(t, err)
+	mgr.DisableDescFrontier()
+
+	// Advance spanA past tick boundary.
+	require.NoError(t, mgr.Flush(ctx, &revlogpb.Flush{
+		Checkpoints: checkpoints(spanA, ts(115)),
+	}))
+
+	// Tick ts(110) should be closed since spanA is the only span.
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts(99), ts(120)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+
+	// Add spanB at ts(100) (simulating span widening).
+	require.NoError(t, mgr.AddSpansAt([]roachpb.Span{spanB}, ts(100)))
+
+	// Now flush spanA further — ts(120) tick should NOT close
+	// because spanB is still at ts(100).
+	require.NoError(t, mgr.Flush(ctx, &revlogpb.Flush{
+		Checkpoints: checkpoints(spanA, ts(125)),
+	}))
+
+	// Query from ts(119) to only see ticks past what was already closed.
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(119), ts(130)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Empty(t, ticks, "new span should gate tick close")
+
+	// Advance spanB past tick boundary.
+	require.NoError(t, mgr.Flush(ctx, &revlogpb.Flush{
+		Checkpoints: checkpoints(spanB, ts(125)),
+	}))
+
+	ticks = nil
+	for tk, tickErr := range lr.Ticks(ctx, ts(119), ts(130)) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.NotEmpty(t, ticks, "tick should close after new span advances")
+}
+
+// TestTickManagerNewTickManagerValidation checks constructor
+// validation.
+func TestTickManagerNewTickManagerValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	es := newTestStorage(t)
+	defer es.Close()
+	ids := &seqFileIDs{}
+
+	_, err := revlogjob.NewTickManager(es, nil, ts(100), testTickWidth, ids)
+	require.Error(t, err, "empty spans should fail")
+
+	_, err = revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, ts(100), 0, ids,
+	)
+	require.Error(t, err, "zero tickWidth should fail")
+
+	_, err = revlogjob.NewTickManager(
+		es, []roachpb.Span{allSpan}, ts(100), testTickWidth, nil,
+	)
+	require.Error(t, err, "nil fileIDs should fail")
+}
+
+// checkpoints is a helper to build a checkpoint slice for Flush.
+func checkpoints(sp roachpb.Span, resolved hlc.Timestamp) []kvpb.RangeFeedCheckpoint {
+	return []kvpb.RangeFeedCheckpoint{{Span: sp, ResolvedTS: resolved}}
+}

--- a/pkg/revlog/tick_writer_test.go
+++ b/pkg/revlog/tick_writer_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package revlog_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/revlog"
+	"github.com/cockroachdb/cockroach/pkg/revlog/revlogpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteTickManifestValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+
+	te := hlc.Timestamp{
+		WallTime: time.Date(2026, 5, 10, 12, 0, 10, 0, time.UTC).UnixNano(),
+	}
+	ts := hlc.Timestamp{WallTime: te.WallTime - 10*int64(time.Second)}
+
+	t.Run("empty TickEnd", func(t *testing.T) {
+		err := revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: ts,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TickEnd must be set")
+	})
+
+	t.Run("empty TickStart", func(t *testing.T) {
+		err := revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickEnd: te,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TickStart must be set")
+	})
+
+	t.Run("TickStart == TickEnd", func(t *testing.T) {
+		err := revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: te,
+			TickEnd:   te,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TickStart")
+	})
+
+	t.Run("TickStart > TickEnd", func(t *testing.T) {
+		err := revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: te,
+			TickEnd:   ts,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TickStart")
+	})
+
+	t.Run("valid manifest succeeds", func(t *testing.T) {
+		err := revlog.WriteTickManifest(ctx, es, revlogpb.Manifest{
+			TickStart: ts,
+			TickEnd:   te,
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestTickWriterRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	es := newTestStorage(t)
+	defer es.Close()
+
+	te := hlc.Timestamp{
+		WallTime: time.Date(2026, 5, 10, 12, 0, 10, 0, time.UTC).UnixNano(),
+	}
+	ts := hlc.Timestamp{WallTime: te.WallTime - 10*int64(time.Second)}
+
+	tw, err := revlog.NewTickWriter(ctx, es, te, 1, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, tw.Add(
+		roachpb.Key("key1"),
+		hlc.Timestamp{WallTime: te.WallTime - 5*int64(time.Second)},
+		[]byte("val1"), nil,
+	))
+	require.NoError(t, tw.Add(
+		roachpb.Key("key2"),
+		hlc.Timestamp{WallTime: te.WallTime - 3*int64(time.Second)},
+		[]byte("val2"), []byte("prev2"),
+	))
+
+	f, stats, err := tw.Close()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), f.FileID)
+	require.Equal(t, int32(0), f.FlushOrder)
+	require.Equal(t, int64(2), stats.KeyCount)
+	require.Greater(t, stats.LogicalBytes, int64(0))
+	require.Greater(t, stats.SstBytes, int64(0))
+
+	// Write manifest and read back.
+	manifest := revlogpb.Manifest{
+		TickStart: ts,
+		TickEnd:   te,
+		Files:     []revlogpb.File{f},
+		Stats:     stats,
+	}
+	require.NoError(t, revlog.WriteTickManifest(ctx, es, manifest))
+
+	lr := revlog.NewLogReader(es)
+	var ticks []revlog.Tick
+	for tk, tickErr := range lr.Ticks(ctx, ts, te) {
+		require.NoError(t, tickErr)
+		ticks = append(ticks, tk)
+	}
+	require.Len(t, ticks, 1)
+
+	var events []revlog.Event
+	for ev, evErr := range lr.GetTickReader(ctx, ticks[0], nil).Events(ctx) {
+		require.NoError(t, evErr)
+		events = append(events, ev)
+	}
+	require.Len(t, events, 2)
+	require.Equal(t, roachpb.Key("key1"), events[0].Key)
+	require.Equal(t, roachpb.Key("key2"), events[1].Key)
+}


### PR DESCRIPTION
Some unit test and testcluster coverage on this prototype to ensure it doesn't rot too much while it waits to be productionized at some later date (or deleted outright if we decide not to keep it).

Claude spotted a few correctness gaps while it was adding tests so it also disabled the small-tick coalescing while it was here with a TODO capturing the issue for later.