### PR TITLE
obs/statementstore: cancel in-flight flush on stopper quiesce

### DIFF
--- a/pkg/obs/statementstore/statement_store.go
+++ b/pkg/obs/statementstore/statement_store.go
@@ -235,6 +235,12 @@ func (ss *StatementStore) Start(ctx context.Context, stopper *stop.Stopper) {
 
 	if err := stopper.RunAsyncTask(ctx,
 		"statement-store-writer", func(ctx context.Context) {
+			// Tie ctx to the stopper's quiesce signal so that an in-flight
+			// flush is interrupted at shutdown. Without this, drainAndFlush
+			// can block indefinitely inside the internal executor (e.g. on
+			// RAC2 flow control) and prevent the stopper from quiescing.
+			ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+			defer cancel()
 			ticker := time.NewTicker(flushInterval.Get(&ss.settings.SV))
 			defer ticker.Stop()
 			for {


### PR DESCRIPTION
The statement store's background writer goroutine selects on stopper.ShouldQuiesce(), but that signal can only be observed between flushes. If a flush is in-progress when shutdown begins, drainAndFlush is blocked inside the internal executor (e.g. waiting on RAC2 flow control) and cannot return, so the goroutine never reaches the next select iteration and the stopper cannot quiesce.

This change ties the writer's context to the stopper's quiesce signal via WithCancelOnQuiesce. On shutdown the cancellation propagates through db.Txn into the executor, the in-flight INSERT returns context cancelled, drainAndFlush unwinds, and the goroutine reaches the ShouldQuiesce branch and exits cleanly.

In-flight and pending statement fingerprints are dropped on shutdown, but this was already the case before this change — the pending buffer is in-memory and there is no graceful drain. The only behavior change is that the stopper now quiesces promptly instead of hanging until forced shutdown.

Closes https://github.com/cockroachdb/cockroach/issues/169504
Epic: None
Release note: None