### PR TITLE
release-25.4: server: wait for full replication in TestCheckRestartSafe_Criticality

### DIFF
--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -364,6 +364,7 @@ func TestCheckRestartSafe_Criticality(t *testing.T) {
 
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	defer testCluster.Stopper().Stop(ctx)
+	require.NoError(t, testCluster.WaitForFullReplication())
 
 	ts1 := testCluster.Server(0)
 
@@ -375,7 +376,6 @@ func TestCheckRestartSafe_Criticality(t *testing.T) {
 	require.Greater(t, res.RaftLeadershipOnNodeCount, int32(0))
 	require.Equal(t, int32(1), res.StoreNotDrainingCount)
 
-	require.Equal(t, int32(0), res.UnderreplicatedRangeCount)
 	require.Equal(t, int32(0), res.UnderreplicatedRangeCount)
 
 	err = drain(ctx, ts1, t)


### PR DESCRIPTION
Backport 1/1 commits from #169990 on behalf of @dhartunian.

----

The test asserts zero under-replicated ranges before draining, but
doesn't wait for the cluster to finish initial replication after
startup. Under CI resource pressure (the failing run logged "disk
slowness detected: unable to sync log files within 10s"), ranges may
still be up-replicating when the assertion fires, causing 78
under-replicated ranges where zero were expected.

Add `WaitForFullReplication()` after cluster start, matching the
pattern already used by `TestCheckRestartSafe_RangeStatus` and other
tests in the same file. Also remove a duplicate assertion.

Fixes: #167850
Epic: none
Release note: None

----

Release justification: