### PR TITLE
crosscluster/physical disallow replication from an offline source

### DIFF
--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -1713,3 +1713,93 @@ func TestAlterExternalConnection(t *testing.T) {
 	srcTime := c.SrcCluster.Server(0).Clock().Now()
 	c.WaitUntilReplicatedTime(srcTime, jobspb.JobID(ingestionJobID))
 }
+
+// TestPCROfflineSource verifies that PCR will not replicate from an
+// offline source tenant. The invariant has two flavors:
+//
+//   - Creation: starting a new replication stream against a source tenant whose
+//     service has not been started must fail. Regression test for #169481.
+//   - Steady state: an existing replication stream whose source tenant
+//     transitions to offline must be torn down. With multiple destinations
+//     replicating from the same source ("hub-and-spoke"), every outbound stream
+//     must be torn down — not just the one that triggered the transition.
+//     Regression test for #169480, where an untouched second spoke would
+//     silently lose data after a failover/failback cycle on the first spoke.
+func TestPCROfflineSource(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// Two single-node servers shared across subtests. Each subtest uses unique
+	// tenant names so it does not interfere with the others.
+	srcServer, srcConn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer srcServer.Stopper().Stop(ctx)
+	destServer, destConn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer destServer.Stopper().Stop(ctx)
+
+	srcSql := sqlutils.MakeSQLRunner(srcConn)
+	destSql := sqlutils.MakeSQLRunner(destConn)
+	srcServerURL := replicationtestutils.GetReplicationURI(t, srcServer, destServer, serverutils.User(username.RootUser))
+
+	replicationtestutils.ConfigureDefaultSettings(t, srcSql)
+	replicationtestutils.ConfigureDefaultSettings(t, destSql)
+
+	// startOnlineSource creates a source tenant on srcServer with its service
+	// running.
+	startOnlineSource := func(t *testing.T, name string) {
+		srcSql.Exec(t, fmt.Sprintf("CREATE VIRTUAL CLUSTER %s", name))
+		srcSql.Exec(t, fmt.Sprintf("ALTER VIRTUAL CLUSTER %s START SERVICE SHARED", name))
+	}
+
+	// startReplication starts replication from a source tenant on srcServer
+	// into a destination tenant on destServer and waits for the destination to
+	// catch up. Returns the consumer ingestion job ID.
+	startReplication := func(t *testing.T, srcName, dstName string) jobspb.JobID {
+		destSql.Exec(t,
+			fmt.Sprintf("CREATE VIRTUAL CLUSTER %s FROM REPLICATION OF %s ON $1", dstName, srcName),
+			srcServerURL.String())
+		_, consumerJobID := replicationtestutils.GetStreamJobIds(t, ctx, destSql, roachpb.TenantName(dstName))
+		var ts string
+		srcSql.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&ts)
+		replicationtestutils.WaitUntilReplicatedTime(t,
+			replicationtestutils.DecimalTimeToHLC(t, ts), destSql, jobspb.JobID(consumerJobID))
+		return jobspb.JobID(consumerJobID)
+	}
+
+	t.Run("create against offline source is rejected", func(t *testing.T) {
+		// Source tenant exists but its service was never started.
+		srcSql.Exec(t, "CREATE VIRTUAL CLUSTER offlinesrc")
+		destSql.ExpectErr(t,
+			`cannot replicate from tenant "offlinesrc".*service mode is none`,
+			"CREATE VIRTUAL CLUSTER offlinedst FROM REPLICATION OF offlinesrc ON $1",
+			srcServerURL.String())
+	})
+
+	t.Run("running stream is torn down when source goes offline", func(t *testing.T) {
+		startOnlineSource(t, "src")
+		consumer := startReplication(t, "src", "dst")
+
+		srcSql.Exec(t, "ALTER VIRTUAL CLUSTER src STOP SERVICE")
+		jobutils.WaitForJobToPause(t, destSql, consumer)
+	})
+
+	t.Run("hub-and-spoke: every spoke is torn down when shared source goes offline", func(t *testing.T) {
+		startOnlineSource(t, "hub")
+		spokeA := startReplication(t, "hub", "spokea")
+		spokeB := startReplication(t, "hub", "spokeb")
+
+		srcSql.Exec(t, "ALTER VIRTUAL CLUSTER hub STOP SERVICE")
+		jobutils.WaitForJobToPause(t, destSql, spokeA)
+		jobutils.WaitForJobToPause(t, destSql, spokeB)
+	})
+}

--- a/pkg/crosscluster/producer/producer_job.go
+++ b/pkg/crosscluster/producer/producer_job.go
@@ -154,6 +154,7 @@ func (p *producerJobResumer) Resume(ctx context.Context, execCtx interface{}) er
 			return ctx.Err()
 		case <-p.timer.Ch():
 			p.timer.Reset(crosscluster.StreamReplicationStreamLivenessTrackFrequency.Get(execCfg.SV()))
+
 			progress, err := replicationutils.LoadReplicationProgress(ctx, execCfg.InternalDB, p.job.ID())
 			if knobs := execCfg.StreamingTestingKnobs; knobs != nil && knobs.AfterResumerJobLoad != nil {
 				err = knobs.AfterResumerJobLoad(err)
@@ -189,6 +190,20 @@ func (p *producerJobResumer) Resume(ctx context.Context, execCtx interface{}) er
 				log.VEventf(ctx, 1, "checking if stream replication expiration %s timed out", expiration)
 				if expiration.Before(p.timeSource.Now()) {
 					return errors.Errorf("replication stream %d timed out", p.job.ID())
+				}
+
+				details := p.job.Details().(jobspb.StreamReplicationDetails)
+				if details.TenantID.IsSet() {
+					isLive, err := checkTenantLiveness(ctx, execCfg, details)
+					if err != nil {
+						log.Dev.Errorf(ctx,
+							"replication stream %d failed checking tenant liveness (retrying): %v",
+							p.job.ID(), err)
+						continue
+					}
+					if !isLive {
+						return errors.Newf("source tenant %d is no longer online", details.TenantID)
+					}
 				}
 			default:
 				return errors.New("unrecognized stream ingestion status")
@@ -256,6 +271,60 @@ func (p *producerJobResumer) removeJobFromTenantRecord(
 // CollectProfile implements jobs.Resumer interface
 func (p *producerJobResumer) CollectProfile(_ context.Context, _ interface{}) error {
 	return nil
+}
+
+// checkTenantLiveness validates that the tenant this producer is streaming is currently online.
+//
+// TODO(art):
+//
+// This current approach of checking the liveness within the producer job's poller has some core
+// correctness issues that are non-trivial to address. The crux of the problem is that this approach
+// leaves a window of time where the rangefeeds in the producer's underlying event streams can emit
+// non MVCC-compliant values while the tenant is offline, but before the poller calling this
+// function notices. This leaves open the possibility that a cutover could happen against a resolved
+// timestamp which includes these non-compliant values, putting us in the relm of undefined behavior.
+// In practice, at present, the non-compliant values we would see will be the result of revert
+// range commands driven by cutover events.
+//
+// We additionally considered using an additional rangefeed in EventStream which watches the tenant
+// record span, and tears down the stream when a tenant goes offline. This is essentially just a faster
+// version of the current approach. While it would mitigate the probability that we have issues by
+// making the producer-side reaction happen within a smaller window, it is not fundamentally
+// more correct.
+//
+// For a more robust approach, we considered two options:
+//
+//  1. Make rangefeeds trustworthy.
+//     Currently, rangefeeds are not robust enough in their reporting of non-MVCC compliant values.
+//     While in theory, we could use the knowledge that we have seen non-MVCC compliant values to
+//     avoid cutting over to an invalid checkpoint, the reporting we currently get from rangefeeds
+//     is not robust enough to be viable. Namely, seeing this information requires a happy path
+//     connected rangefeed, and we can potentially lose this knowledge during, for example, a
+//     spurious network blip. We can also lose this knowlege in cases where we need to do a catchup
+//     scan after a non-MVCC compliant value has been emitted.
+//
+//  2. Disallow rangefeeds on offline tenants.
+//     Conceptually this approach is relatively straightforward. We are essentially moving the logic
+//     we have here currently to within rangefeeds, namely to avoid non-MVCC compliance in the first
+//     place. To pull this off we would need an additional mechanism. We considered using leases, or
+//     potentially having a registry of active rangefeeds which can control such feeds during a
+//     tenant transitioning it's liveness.
+func checkTenantLiveness(
+	ctx context.Context, execCfg *sql.ExecutorConfig, details jobspb.StreamReplicationDetails,
+) (bool, error) {
+	var tenantInfo *mtinfopb.TenantInfo
+	err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, t isql.Txn) error {
+		var err error
+		tenantInfo, err = sql.GetTenantRecordByID(ctx, t, details.TenantID, execCfg.Settings)
+		return err
+	})
+	if err != nil {
+		return false, err
+	} else if tenantInfo.ServiceMode == mtinfopb.ServiceModeNone ||
+		tenantInfo.ServiceMode == mtinfopb.ServiceModeStopping {
+		return false, nil
+	}
+	return true, nil
 }
 
 func init() {

--- a/pkg/crosscluster/producer/stream_lifetime.go
+++ b/pkg/crosscluster/producer/stream_lifetime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -82,6 +83,28 @@ func StartReplicationProducerJob(
 
 	if tenantID.IsSystem() && !kvserver.RangefeedEnabled.Get(&evalCtx.Settings.SV) {
 		return streampb.ReplicationProducerSpec{}, errors.Errorf("kv.rangefeed.enabled must be true to start a replication job")
+	}
+
+	// Reject creation of a streaming producer against a source tenant that
+	// isn't online. The post-cutover retention producer (assumeSucceeded=true)
+	// is exempt because it intentionally runs on a tenant that may not yet be
+	// fully serving and exists only to hold a PTS.
+	if !assumeSucceeded && !tenantID.IsSystem() {
+		switch tenantRecord.ServiceMode {
+		case mtinfopb.ServiceModeShared, mtinfopb.ServiceModeExternal:
+		default:
+			return streampb.ReplicationProducerSpec{}, errors.Newf(
+				"cannot replicate from tenant %q (%s): service mode is %s, must be %s or %s",
+				tenantRecord.Name, tenantID, tenantRecord.ServiceMode,
+				mtinfopb.ServiceModeShared, mtinfopb.ServiceModeExternal,
+			)
+		}
+		if tenantRecord.DataState != mtinfopb.DataStateReady {
+			return streampb.ReplicationProducerSpec{}, errors.Newf(
+				"cannot replicate from tenant %q (%s) in data state %s",
+				tenantRecord.Name, tenantID, tenantRecord.DataState,
+			)
+		}
 	}
 
 	var replicationStartTime hlc.Timestamp


### PR DESCRIPTION
This patch adds two checks, one at creation time, and one in the producer job, which disallow replication from an offline source. This fixes a couple of edge case bugs in PCR which occured when replication continued despite the source tenant being offline.

Fixes: #169481
Fixes: #169480

Release note: None