### PR TITLE
release-26.2: sql/stats: nil-check cache in TableStatisticsCache.Stop

### DIFF
--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -336,9 +336,16 @@ func (sc *TableStatisticsCache) Clear() {
 func (sc *TableStatisticsCache) Stop() {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	// Clear the cache first so that OnEvictedEntry calls shrinkEntryLocked
-	// for each entry, properly releasing the bytes tracked by the account.
-	sc.mu.cache.Clear()
+	// The stopper closer that calls Stop is registered in
+	// NewTableStatisticsCache *before* sc.mu.cache is initialised. If the
+	// stopper begins draining closers during cache construction (rare, but
+	// observed in TestServerController on shared-process tenants), Stop can
+	// fire on a partially-initialised cache. Guard against that here.
+	if sc.mu.cache != nil {
+		// Clear the cache first so that OnEvictedEntry calls shrinkEntryLocked
+		// for each entry, properly releasing the bytes tracked by the account.
+		sc.mu.cache.Clear()
+	}
 	sc.mu.acc.Clear(context.Background())
 	if sc.mon != nil {
 		sc.mon.Stop(context.Background())


### PR DESCRIPTION
Backport 1/1 commits from #169624.

/cc @cockroachdb/release

---

Fixes #169306

The closer registered in `NewTableStatisticsCache` calls `tableStatsCache.Stop`. The closer is registered *before* `sc.mu.cache` is initialised on line 310. If the parent stopper begins draining closers during cache construction (rare, but observed in `TestServerController` on shared-process tenants), `Stop` fires on a partially-initialised cache and `sc.mu.cache.Clear()` nil-derefs. Guard the `Clear` call with a nil check; `acc.Clear` and `mon.Stop` are already either no-ops or guarded.

Release note: None

---

Release justification: Fixes node panic issue.