### PR TITLE
sql/idxrecommendations: stub clock in TestIndexRecommendationsStats

### DIFF
--- a/pkg/sql/idxrecommendations/BUILD.bazel
+++ b/pkg/sql/idxrecommendations/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/idxrecommendations/idx_recommendations_test.go
+++ b/pkg/sql/idxrecommendations/idx_recommendations_test.go
@@ -8,15 +8,18 @@ package idxrecommendations_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxrecommendations"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +28,20 @@ func TestIndexRecommendationsStats(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	testServer, sqlConn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+
+	// Pin all executions to a single SQL stats aggregation window. Without
+	// this, a test run that crosses an hour boundary produces duplicate
+	// (fingerprint, aggregatedTs) entries, which both inflates the count
+	// asserted by WaitForStatementEntriesEqual and makes the index
+	// recommendation visible in only one of the two buckets that QueryRow
+	// then reads non-deterministically.
+	stubTime := timeutil.Now().Truncate(time.Hour)
+	sqlStatsKnobs := sqlstats.CreateTestingKnobs()
+	sqlStatsKnobs.StubTimeNow = func() time.Time { return stubTime }
+
+	testServer, sqlConn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{SQLStatsKnobs: sqlStatsKnobs},
+	})
 	defer testServer.Stopper().Stop(ctx)
 
 	testConn := sqlutils.MakeSQLRunner(sqlConn)


### PR DESCRIPTION
The test runs ~4 minutes and queries `crdb_internal.cluster_statement_statistics`
to assert that exactly one row exists per fingerprint. Since
c09d6297b4a ("sql/sqlstats: partition in-memory stats by aggregation
window") added `aggregatedTs` to the in-memory `stmtKey`, a test run that
crosses an hour boundary produces two rows for the same fingerprint —
one per aggregation window. This broke the count assertion in
`WaitForStatementEntriesEqual` and would also have made the subsequent
`QueryRow` read of `index_recommendations` non-deterministic, since the
recommendation is only attached to the bucket containing the execution
that crossed the per-fingerprint cache trigger.

Pin `SQLStatsKnobs.StubTimeNow` to a fixed instant so every execution
lands in the same aggregation window. This is the same approach used
by `TestSqlActivityUpdateJob` and several tests in
`pkg/server/application_api/sql_stats_test.go`. It eliminates the time
dimension from the test entirely — unlike raising
`sql.stats.aggregation.interval` to its 24h maximum, it does not depend
on test runtime or wall-clock start time.

Resolves: #170092
Resolves: #169861
Epic: none

Release note: None