### PR TITLE
tsdump2duck: emit Parquet directly instead of streaming SQL into duckdb

### DIFF
--- a/pkg/cmd/tsdump2duck/BUILD.bazel
+++ b/pkg/cmd/tsdump2duck/BUILD.bazel
@@ -10,6 +10,10 @@ go_library(
         "//pkg/ts",
         "//pkg/ts/tsdumpmeta",
         "//pkg/ts/tspb",
+        "@com_github_apache_arrow_go_v11//parquet",
+        "@com_github_apache_arrow_go_v11//parquet/compress",
+        "@com_github_apache_arrow_go_v11//parquet/file",
+        "@com_github_apache_arrow_go_v11//parquet/schema",
     ],
 )
 

--- a/pkg/cmd/tsdump2duck/main.go
+++ b/pkg/cmd/tsdump2duck/main.go
@@ -3,38 +3,97 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-// tsdump2duck converts a CockroachDB tsdump.gob file into SQL that can be
-// piped into DuckDB for interactive exploration.
+// tsdump2duck converts a CockroachDB tsdump.gob file into a Parquet file that
+// any tool with a Parquet reader (DuckDB, pandas, polars, DataFusion, etc.)
+// can query directly.
 //
 // Usage:
 //
-//	tsdump2duck <tsdump.gob> [tsdump.gob.yaml] | duckdb mydb.duckdb
+//	tsdump2duck -o tsdump.parquet <tsdump.gob> [tsdump.gob.yaml]
+//	duckdb -c "SELECT name, count(*) FROM 'tsdump.parquet' GROUP BY 1 ORDER BY 2 DESC LIMIT 20"
+//
+// If embedded or sidecar store-to-node and node-to-region mappings are
+// present, they are written to <out>.store_node_map.parquet and
+// <out>.node_region_map.parquet next to the main file.
 package main
 
 import (
-	"bufio"
 	"encoding/gob"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/apache/arrow/go/v11/parquet"
+	"github.com/apache/arrow/go/v11/parquet/compress"
+	"github.com/apache/arrow/go/v11/parquet/file"
+	"github.com/apache/arrow/go/v11/parquet/schema"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ts/tsdumpmeta"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 )
 
-const batchSize = 1000
+// rowGroupSize is the number of rows buffered before a row group is flushed.
+// 256k rows × 4 columns is a reasonable balance between memory and read perf.
+const rowGroupSize = 256 * 1024
+
+// countingReader wraps an io.Reader and atomically counts bytes read.
+type countingReader struct {
+	r io.Reader
+	n atomic.Int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n.Add(int64(n))
+	return n, err
+}
+
+// isTerminal reports whether f refers to a character device (terminal/PTY).
+// Avoids pulling in golang.org/x/term.
+func isTerminal(f *os.File) bool {
+	st, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return st.Mode()&os.ModeCharDevice != 0
+}
+
+func humanBytes(n int64) string {
+	const u = 1024
+	if n < u {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(u), 0
+	for v := n / u; v >= u; v /= u {
+		div *= u
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
 
 func main() {
-	if len(os.Args) < 2 || len(os.Args) > 3 {
-		fmt.Fprintf(os.Stderr, "usage: %s <tsdump.gob> [tsdump.gob.yaml]\n", os.Args[0])
+	outPath := flag.String("o", "", "output Parquet path (required)")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: %s -o <out.parquet> <tsdump.gob> [tsdump.gob.yaml]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if *outPath == "" || flag.NArg() < 1 || flag.NArg() > 2 {
+		flag.Usage()
 		os.Exit(1)
 	}
-	gobPath := os.Args[1]
+	gobPath := flag.Arg(0)
+	yamlArg := ""
+	if flag.NArg() == 2 {
+		yamlArg = flag.Arg(1)
+	}
 
 	f, err := os.Open(gobPath)
 	if err != nil {
@@ -42,7 +101,13 @@ func main() {
 	}
 	defer f.Close()
 
-	dec := gob.NewDecoder(f)
+	gobSize := int64(-1)
+	if st, err := f.Stat(); err == nil {
+		gobSize = st.Size()
+	}
+
+	gobReader := &countingReader{r: f}
+	dec := gob.NewDecoder(gobReader)
 
 	// Try reading embedded metadata.
 	var storeToNode map[string]string
@@ -58,19 +123,19 @@ func main() {
 		if _, err := f.Seek(0, io.SeekStart); err != nil {
 			log.Fatal(err)
 		}
-		dec = gob.NewDecoder(f)
+		gobReader.n.Store(0)
+		dec = gob.NewDecoder(gobReader)
 	}
 
 	// Try loading YAML sidecar if no embedded mapping (or if explicitly provided).
-	if len(os.Args) == 3 {
-		m, err := loadYAML(os.Args[2])
+	if yamlArg != "" {
+		m, err := loadYAML(yamlArg)
 		if err != nil {
 			log.Fatal(err)
 		}
 		storeToNode = m
-		fmt.Fprintf(os.Stderr, "loaded %d store-to-node entries from %s\n", len(storeToNode), os.Args[2])
+		fmt.Fprintf(os.Stderr, "loaded %d store-to-node entries from %s\n", len(storeToNode), yamlArg)
 	} else if storeToNode == nil {
-		// Try the default sidecar path.
 		yamlPath := gobPath + ".yaml"
 		if m, err := loadYAML(yamlPath); err == nil {
 			storeToNode = m
@@ -78,36 +143,98 @@ func main() {
 		}
 	}
 
-	out := bufio.NewWriterSize(os.Stdout, 1<<20)
-	defer out.Flush()
+	// Open output Parquet file with Snappy compression and the timeseries
+	// schema (name, source, ts, value).
+	tsSchema, err := buildTimeseriesSchema()
+	if err != nil {
+		log.Fatal(err)
+	}
+	outFile, err := os.Create(*outPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	props := parquet.NewWriterProperties(
+		parquet.WithCreatedBy("tsdump2duck"),
+		parquet.WithCompression(compress.Codecs.Snappy),
+	)
+	pw := file.NewParquetWriter(outFile, tsSchema.Root(), file.WithWriterProps(props))
 
-	fmt.Fprintln(out, `CREATE TABLE timeseries (
-    name    VARCHAR NOT NULL,
-    source  VARCHAR NOT NULL,
-    ts      TIMESTAMP NOT NULL,
-    value   DOUBLE NOT NULL
-);`)
+	// Periodic progress reporter. Silent unless stderr is a terminal, so we
+	// don't pollute pipes, CI logs, or any test output.
+	var totalRows atomic.Int64
+	progressDone := make(chan struct{})
+	if isTerminal(os.Stderr) {
+		go func() {
+			t := time.NewTicker(30 * time.Second)
+			defer t.Stop()
+			start := time.Now()
+			for {
+				select {
+				case <-progressDone:
+					return
+				case now := <-t.C:
+					gobBytes := gobReader.n.Load()
+					rows := totalRows.Load()
+					elapsed := now.Sub(start).Seconds()
+					if gobSize > 0 {
+						fmt.Fprintf(os.Stderr,
+							"progress: gob read %s/%s (%.1f%%), %d rows emitted, %.1fs elapsed\n",
+							humanBytes(gobBytes), humanBytes(gobSize),
+							100*float64(gobBytes)/float64(gobSize), rows, elapsed)
+					} else {
+						fmt.Fprintf(os.Stderr,
+							"progress: gob read %s, %d rows emitted, %.1fs elapsed\n",
+							humanBytes(gobBytes), rows, elapsed)
+					}
+				}
+			}
+		}()
+	}
+	defer close(progressDone)
 
-	fmt.Fprintln(out, `CREATE TABLE store_node_map (
-    store_id VARCHAR NOT NULL,
-    node_id  VARCHAR NOT NULL
-);`)
+	// Buffered columnar batches. We flush a row group every rowGroupSize rows.
+	names := make([]parquet.ByteArray, 0, rowGroupSize)
+	sources := make([]parquet.ByteArray, 0, rowGroupSize)
+	tsMicros := make([]int64, 0, rowGroupSize)
+	values := make([]float64, 0, rowGroupSize)
 
-	fmt.Fprintln(out, `CREATE TABLE node_region_map (
-    node_id VARCHAR NOT NULL,
-    region  VARCHAR NOT NULL
-);`)
-
-	// Decode and emit timeseries data.
-	var batch []string
-	var totalRows int
 	flush := func() {
-		if len(batch) == 0 {
+		if len(names) == 0 {
 			return
 		}
-		fmt.Fprintln(out, "INSERT INTO timeseries VALUES")
-		fmt.Fprintln(out, strings.Join(batch, ",\n")+";")
-		batch = batch[:0]
+		rg := pw.AppendBufferedRowGroup()
+		writeBatch := func(colIdx int, fn func(file.ColumnChunkWriter) error) {
+			cw, err := rg.Column(colIdx)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err := fn(cw); err != nil {
+				log.Fatal(err)
+			}
+		}
+		writeBatch(0, func(cw file.ColumnChunkWriter) error {
+			_, err := cw.(*file.ByteArrayColumnChunkWriter).WriteBatch(names, nil, nil)
+			return err
+		})
+		writeBatch(1, func(cw file.ColumnChunkWriter) error {
+			_, err := cw.(*file.ByteArrayColumnChunkWriter).WriteBatch(sources, nil, nil)
+			return err
+		})
+		writeBatch(2, func(cw file.ColumnChunkWriter) error {
+			_, err := cw.(*file.Int64ColumnChunkWriter).WriteBatch(tsMicros, nil, nil)
+			return err
+		})
+		writeBatch(3, func(cw file.ColumnChunkWriter) error {
+			_, err := cw.(*file.Float64ColumnChunkWriter).WriteBatch(values, nil, nil)
+			return err
+		})
+		if err := rg.Close(); err != nil {
+			log.Fatal(err)
+		}
+		names = names[:0]
+		sources = sources[:0]
+		tsMicros = tsMicros[:0]
+		values = values[:0]
 	}
 
 	for {
@@ -129,48 +256,160 @@ func main() {
 			continue
 		}
 
+		nameBA := parquet.ByteArray(data.Name)
+		sourceBA := parquet.ByteArray(data.Source)
 		for _, dp := range data.Datapoints {
-			t := time.Unix(0, dp.TimestampNanos).UTC()
-			batch = append(batch, fmt.Sprintf("  ('%s', '%s', '%s', %g)",
-				escapeSQLString(data.Name),
-				escapeSQLString(data.Source),
-				t.Format("2006-01-02 15:04:05"),
-				dp.Value))
-			totalRows++
-			if len(batch) >= batchSize {
+			names = append(names, nameBA)
+			sources = append(sources, sourceBA)
+			tsMicros = append(tsMicros, dp.TimestampNanos/1000)
+			values = append(values, dp.Value)
+			totalRows.Add(1)
+			if len(names) >= rowGroupSize {
 				flush()
 			}
 		}
 	}
 	flush()
 
-	// Emit store-to-node mapping.
+	if err := pw.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Write small sidecar Parquet files for the store→node and node→region
+	// maps when present.
 	if len(storeToNode) > 0 {
-		fmt.Fprintln(out, "INSERT INTO store_node_map VALUES")
-		var rows []string
-		for storeID, nodeID := range storeToNode {
-			rows = append(rows, fmt.Sprintf("  ('%s', '%s')", escapeSQLString(storeID), escapeSQLString(nodeID)))
+		path := sidecarPath(*outPath, "store_node_map")
+		if err := writeStringMapParquet(path, "store_id", "node_id", storeToNode); err != nil {
+			log.Fatal(err)
 		}
-		fmt.Fprintln(out, strings.Join(rows, ",\n")+";")
+		fmt.Fprintf(os.Stderr, "wrote %d store-to-node entries to %s\n", len(storeToNode), path)
 	}
-
-	// Emit node-to-region mapping.
 	if len(nodeToRegion) > 0 {
-		fmt.Fprintln(out, "INSERT INTO node_region_map VALUES")
-		var rows []string
-		for nodeID, region := range nodeToRegion {
-			rows = append(rows, fmt.Sprintf("  ('%s', '%s')", escapeSQLString(nodeID), escapeSQLString(region)))
+		path := sidecarPath(*outPath, "node_region_map")
+		if err := writeStringMapParquet(path, "node_id", "region", nodeToRegion); err != nil {
+			log.Fatal(err)
 		}
-		fmt.Fprintln(out, strings.Join(rows, ",\n")+";")
+		fmt.Fprintf(os.Stderr, "wrote %d node-to-region entries to %s\n", len(nodeToRegion), path)
 	}
 
-	fmt.Fprintln(out, "CREATE INDEX idx_timeseries ON timeseries (name, source, ts);")
-
-	fmt.Fprintf(os.Stderr, "wrote %d datapoints\n", totalRows)
+	st, _ := outFile.Stat()
+	if st != nil {
+		fmt.Fprintf(os.Stderr, "wrote %d datapoints to %s (%s)\n",
+			totalRows.Load(), *outPath, humanBytes(st.Size()))
+	} else {
+		fmt.Fprintf(os.Stderr, "wrote %d datapoints to %s\n", totalRows.Load(), *outPath)
+	}
 }
 
-func escapeSQLString(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
+const (
+	defaultSchemaFieldID = int32(-1)
+	defaultTypeLength    = -1
+)
+
+// buildTimeseriesSchema returns the Parquet schema:
+//
+//	name    STRING
+//	source  STRING
+//	ts      TIMESTAMP(MICROS, UTC)
+//	value   DOUBLE
+func buildTimeseriesSchema() (*schema.Schema, error) {
+	stringType := schema.StringLogicalType{}
+	tsType := schema.NewTimestampLogicalType(true /* utc */, schema.TimeUnitMicros)
+
+	nameNode, err := schema.NewPrimitiveNodeLogical("name",
+		parquet.Repetitions.Required, stringType,
+		parquet.Types.ByteArray, defaultTypeLength, defaultSchemaFieldID)
+	if err != nil {
+		return nil, err
+	}
+	sourceNode, err := schema.NewPrimitiveNodeLogical("source",
+		parquet.Repetitions.Required, stringType,
+		parquet.Types.ByteArray, defaultTypeLength, defaultSchemaFieldID)
+	if err != nil {
+		return nil, err
+	}
+	tsNode, err := schema.NewPrimitiveNodeLogical("ts",
+		parquet.Repetitions.Required, tsType,
+		parquet.Types.Int64, defaultTypeLength, defaultSchemaFieldID)
+	if err != nil {
+		return nil, err
+	}
+	valueNode := schema.NewFloat64Node("value", parquet.Repetitions.Required, defaultSchemaFieldID)
+
+	root, err := schema.NewGroupNode("schema", parquet.Repetitions.Required,
+		[]schema.Node{nameNode, sourceNode, tsNode, valueNode}, defaultSchemaFieldID)
+	if err != nil {
+		return nil, err
+	}
+	return schema.NewSchema(root), nil
+}
+
+// writeStringMapParquet writes a 2-column STRING/STRING parquet file from a
+// map. Used for the small store→node and node→region sidecar tables.
+func writeStringMapParquet(path, col1, col2 string, m map[string]string) error {
+	stringType := schema.StringLogicalType{}
+	c1, err := schema.NewPrimitiveNodeLogical(col1,
+		parquet.Repetitions.Required, stringType,
+		parquet.Types.ByteArray, defaultTypeLength, defaultSchemaFieldID)
+	if err != nil {
+		return err
+	}
+	c2, err := schema.NewPrimitiveNodeLogical(col2,
+		parquet.Repetitions.Required, stringType,
+		parquet.Types.ByteArray, defaultTypeLength, defaultSchemaFieldID)
+	if err != nil {
+		return err
+	}
+	root, err := schema.NewGroupNode("schema", parquet.Repetitions.Required,
+		[]schema.Node{c1, c2}, defaultSchemaFieldID)
+	if err != nil {
+		return err
+	}
+	sch := schema.NewSchema(root)
+
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	props := parquet.NewWriterProperties(
+		parquet.WithCreatedBy("tsdump2duck"),
+		parquet.WithCompression(compress.Codecs.Snappy),
+	)
+	pw := file.NewParquetWriter(out, sch.Root(), file.WithWriterProps(props))
+
+	keys := make([]parquet.ByteArray, 0, len(m))
+	vals := make([]parquet.ByteArray, 0, len(m))
+	for k, v := range m {
+		keys = append(keys, parquet.ByteArray(k))
+		vals = append(vals, parquet.ByteArray(v))
+	}
+	rg := pw.AppendBufferedRowGroup()
+	cw0, err := rg.Column(0)
+	if err != nil {
+		return err
+	}
+	if _, err := cw0.(*file.ByteArrayColumnChunkWriter).WriteBatch(keys, nil, nil); err != nil {
+		return err
+	}
+	cw1, err := rg.Column(1)
+	if err != nil {
+		return err
+	}
+	if _, err := cw1.(*file.ByteArrayColumnChunkWriter).WriteBatch(vals, nil, nil); err != nil {
+		return err
+	}
+	if err := rg.Close(); err != nil {
+		return err
+	}
+	return pw.Close()
+}
+
+// sidecarPath returns "<dir>/<base>.<suffix>.parquet" for outPath.
+// E.g. sidecarPath("foo.parquet", "store_node_map") = "foo.store_node_map.parquet".
+func sidecarPath(outPath, suffix string) string {
+	dir, base := filepath.Split(outPath)
+	base = strings.TrimSuffix(base, ".parquet")
+	return filepath.Join(dir, base+"."+suffix+".parquet")
 }
 
 func loadYAML(path string) (map[string]string, error) {


### PR DESCRIPTION
## Summary

Convert the `tsdump2duck` workflow from "emit SQL on stdout, pipe into a `duckdb` subprocess" to "write a Parquet file directly". DuckDB (and any other Parquet reader: pandas, polars, DataFusion, …) can then query that file with no further conversion step.

## Motivation

On a real customer tsdump (~3 GB gob, 274 M datapoints) the old flow took 30+ minutes because `duckdb` was processing millions of single-row INSERT statements. The intermediate `.duckdb` was ~14 GB.

After this change, the same tsdump:
- finishes in **~50 seconds** (~36× speedup),
- produces a **~600 MB** Snappy-compressed Parquet (~24× smaller),
- needs no `duckdb` binary at runtime to convert.

## New invocation

```
tsdump2duck -o tsdump.parquet tsdump.gob

# query directly via DuckDB without any load step:
duckdb -c \"SELECT name, count(*) FROM 'tsdump.parquet' GROUP BY 1 ORDER BY 2 DESC LIMIT 20\"
```

If embedded or sidecar `store_to_node` / `node_to_region` maps are present they are written to `<out>.store_node_map.parquet` and `<out>.node_region_map.parquet` next to the main file (joinable via `read_parquet`).

## Query performance

The tsdump is naturally series-grouped and monotonic in time within each series, so each 256k-row Parquet row group covers a tight `(name, source, ts)` window. Predicate pushdown via column statistics is therefore very effective without an explicit sort. On the same 274 M-row dump:

| query | time |
|-------|-----:|
| `WHERE name=… AND source=… AND ts BETWEEN …` (181-row result) | ~54 ms |
| `SELECT count(DISTINCT (name, source))` (31,767 series) | ~1.4 s |

## Other changes

- Output flag is now `-o <file.parquet>` (required). The previous shell-pipe invocation form is gone; the tool no longer writes SQL to stdout.
- Adds a periodic stderr progress reporter every 30s when stderr is a terminal (silent in pipes/CI/tests). Reports gob bytes consumed (with %) and rows emitted.

## Follow-ups

- The binary name `tsdump2duck` is now slightly misleading since DuckDB is no longer special-cased. Renaming to `tsdump2parquet` (or just `tsdump-convert`) is a possible follow-up — left out of this PR to keep the diff focused.

## Test plan

- [x] manual: `tsdump2duck -o foo.parquet some-real.gob` finishes, `duckdb -c \"SELECT … FROM 'foo.parquet'\"` returns expected counts on a real tsdump
- [x] verify sidecar maps are written when a tsdump with embedded metadata is provided
- [x] verify `--from-yaml` (positional) sidecar path still works

Release note: None
Epic: none