### PR TITLE
release-26.1: roachtest: guarantee 3 retries for transient GCE disk creation errors

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
@@ -104,14 +104,27 @@ func copySnapshotDataToNode(
 	// Create a temporary disk from the snapshot. Retry transient GCE API
 	// errors (e.g. HTTP 502) which can occur when many nodes create disks
 	// in parallel against the same zone.
+	//
+	// We use a count-based retry (rather than a duration-based one) because a
+	// single `gcloud compute disks create` invocation can itself take several
+	// minutes to fail with a transient error; a short duration-based budget
+	// would be exhausted on the first attempt before any retry occurs (see
+	// #170038). Retries are bounded only by the test's context, not by an
+	// extra timeout layered on top.
 	l.Printf("n%d: creating temp disk %s from snapshot in zone %s",
 		nodeID, tempDiskName, zone)
 	createDiskCmd := fmt.Sprintf(
 		`gcloud compute disks create %s --source-snapshot=%s --zone=%s --type=pd-ssd --quiet`,
 		tempDiskName, snap.ID, zone,
 	)
+	const createDiskAttempts = 3
+	createDiskBackoff := retry.Options{
+		InitialBackoff: 30 * time.Second,
+		MaxBackoff:     30 * time.Second,
+		Multiplier:     1,
+	}
 	var createDiskErr error
-	if err := retry.ForDuration(2*time.Minute, func() error {
+	if err := retry.WithMaxAttempts(ctx, createDiskBackoff, createDiskAttempts, func() error {
 		result, err := c.RunWithDetailsSingleNode(
 			ctx, l, option.WithNodes(node), createDiskCmd,
 		)
@@ -126,8 +139,9 @@ func copySnapshotDataToNode(
 		createDiskErr = err
 		return nil
 	}); err != nil {
-		// Transient errors exhausted the retry duration.
-		return fmt.Errorf("n%d: failed to create disk from snapshot: %w", nodeID, err)
+		// Transient errors exhausted the retry attempts.
+		return fmt.Errorf("n%d: failed to create disk from snapshot after %d attempts: %w",
+			nodeID, createDiskAttempts, err)
 	}
 	if createDiskErr != nil {
 		return fmt.Errorf("n%d: failed to create disk from snapshot: %w", nodeID, createDiskErr)


### PR DESCRIPTION
Backport 1/1 commits from #170087 on behalf of @tbg.

----

The previous retry loop in `copySnapshotDataToNode` used
`retry.ForDuration(2*time.Minute, ...)`, which checks its deadline at the
top of the loop. A single `gcloud compute disks create` invocation can
itself take several minutes to fail with a transient HTTP 502 error, in
which case the deadline has already elapsed by the time the retry loop
wakes up and no retry is attempted. As a result, a single unlucky GCE 502
fails the test even though the call site was supposed to tolerate them.

Switch to `retry.WithMaxAttempts` so we get a guaranteed three attempts
(with 30s flat backoff between attempts) regardless of how long each
individual `gcloud` call takes. The retry is bounded only by the test
context, not by an extra timeout layered on top.

Resolves #170038
Epic: none

Release note: None

----

Release justification: