### PR TITLE
importer: fix out-of-bounds panic in Parquet IMPORT with column subsets

### DIFF
--- a/pkg/sql/importer/read_import_parquet.go
+++ b/pkg/sql/importer/read_import_parquet.go
@@ -645,10 +645,10 @@ func determineColumnsToRead(
 // parquetRowConsumer implements importRowConsumer for Parquet files.
 type parquetRowConsumer struct {
 	importCtx      *parallelImportContext
-	fieldNameToIdx map[string]int                 // Maps Parquet column name -> table column index
+	fieldNameToIdx map[string]int                 // Maps Parquet column name -> full-table visible column index
 	columnMetadata map[int]*parquetColumnMetadata // Maps column index -> metadata (for conversion)
 	reader         *file.Reader                   // Parquet file reader (for accessing schema)
-	colMapping     []int                          // Precomputed mapping: parquet col idx -> table col idx (-1 if not mapped)
+	colMapping     []int                          // Precomputed mapping: parquet col idx -> target col idx (-1 if not mapped)
 }
 
 // newParquetRowConsumer creates a consumer that converts Parquet rows to datums.
@@ -659,27 +659,42 @@ func newParquetRowConsumer(
 	strict bool,
 ) (*parquetRowConsumer, error) {
 
-	// Validate schema and build column mapping
+	// Validate schema and build column mapping.
 	fieldNameToIdx, err := producer.validateAndBuildColumnMapping(importCtx)
 	if err != nil {
 		return nil, err
 	}
 
+	// fieldNameToIdx maps column names to full-table visibleCols indices, which
+	// is what type validation needs. DatumRowConverter, however, sizes Datums
+	// and VisibleColTypes to len(targetCols) when an explicit column list is
+	// given, so colMapping must store target-column indices (positions in
+	// targetCols) to avoid out-of-bounds access when a non-last column is
+	// excluded. When no explicit list is given (or in test mode without a
+	// tableDesc), target-idx and full-table-idx coincide and fieldNameToIdx is
+	// already what we want.
+	nameToTargetIdx := fieldNameToIdx
+	if importCtx.tableDesc != nil && len(importCtx.targetCols) > 0 {
+		nameToTargetIdx = make(map[string]int, len(importCtx.targetCols))
+		for targetIdx, colName := range importCtx.targetCols {
+			nameToTargetIdx[strings.ToLower(string(colName))] = targetIdx
+		}
+	}
+
 	// Precompute column mapping to avoid hash lookups in the hot path (FillDatums).
-	// For each Parquet column index, store the corresponding table column index (-1 if not mapped).
+	// For each Parquet column index, store the corresponding target column index (-1 if not mapped).
 	numCols := producer.reader.MetaData().Schema.NumColumns()
 	colMapping := make([]int, numCols)
 	for parquetColIdx := 0; parquetColIdx < numCols; parquetColIdx++ {
-		col := producer.reader.MetaData().Schema.Column(parquetColIdx)
-		parquetColName := col.Name()
-		if tableColIdx, found := fieldNameToIdx[strings.ToLower(parquetColName)]; found {
-			colMapping[parquetColIdx] = tableColIdx
-		} else {
-			colMapping[parquetColIdx] = -1
-			if strict {
-				return nil, errors.Newf(
-					"column %q in Parquet file is not in the target table", parquetColName)
-			}
+		parquetColName := producer.reader.MetaData().Schema.Column(parquetColIdx).Name()
+		if targetIdx, found := nameToTargetIdx[strings.ToLower(parquetColName)]; found {
+			colMapping[parquetColIdx] = targetIdx
+			continue
+		}
+		colMapping[parquetColIdx] = -1
+		if strict {
+			return nil, errors.Newf(
+				"column %q in Parquet file is not in the target table", parquetColName)
 		}
 	}
 
@@ -705,36 +720,33 @@ func (c *parquetRowConsumer) FillDatums(
 
 	rowIdx := view.rowIndex
 
-	// For each column in the Parquet file, find the corresponding table column
+	// For each column in the Parquet file, find the corresponding target column.
 	for parquetColIdx := 0; parquetColIdx < view.numColumns; parquetColIdx++ {
-		// Skip columns we didn't read
+		// Skip columns we didn't read.
 		batch := view.batches[parquetColIdx]
 		if batch == nil {
 			continue
 		}
 
-		// Use precomputed mapping to find table column index (O(1) array access)
-		tableColIdx := c.colMapping[parquetColIdx]
-		if tableColIdx < 0 {
-			// Column not mapped to the target table; skip it.
-			// In strict mode, newParquetRowConsumer would have
-			// already rejected unmapped columns.
+		// Use precomputed mapping to find target column index (O(1) array access).
+		targetColIdx := c.colMapping[parquetColIdx]
+		if targetColIdx < 0 {
+			// Column not in the target column set; skip it.
 			continue
 		}
 
-		// Extract value from batch
+		// Extract value from batch.
 		value, isNull, err := batch.GetValueAt(int(rowIdx))
 		if err != nil {
 			return newImportRowError(err, fmt.Sprintf("row %d", rowNum), rowNum)
 		}
 
-		// Convert to datum
+		// Convert to datum.
 		var datum tree.Datum
 		if isNull {
 			datum = tree.DNull
 		} else {
-			// Convert Parquet value to datum using unified LogicalType conversion
-			targetType := conv.VisibleColTypes[tableColIdx]
+			targetType := conv.VisibleColTypes[targetColIdx]
 			metadata := c.columnMetadata[parquetColIdx]
 			datum, err = convertWithLogicalType(value, targetType, metadata)
 			if err != nil {
@@ -742,8 +754,7 @@ func (c *parquetRowConsumer) FillDatums(
 			}
 		}
 
-		// Set datum in converter
-		conv.Datums[tableColIdx] = datum
+		conv.Datums[targetColIdx] = datum
 	}
 
 	// Set any nil datums to DNull (for columns not in Parquet file)

--- a/pkg/sql/importer/read_import_parquet_test.go
+++ b/pkg/sql/importer/read_import_parquet_test.go
@@ -7,9 +7,11 @@ package importer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow/go/v11/arrow"
@@ -20,9 +22,12 @@ import (
 	"github.com/apache/arrow/go/v11/parquet/file"
 	"github.com/apache/arrow/go/v11/parquet/pqarrow"
 	"github.com/apache/arrow/go/v11/parquet/schema"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -721,13 +726,210 @@ func TestParquetColumnOrderMapping(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, consumer)
 
-	// Verify the mapping is correct:
-	// - "score" should map to visibleCols[3] (index 3 in table schema)
-	// - "name" should map to visibleCols[1] (index 1 in table schema)
-	// - "id" should map to visibleCols[0] (index 0 in table schema)
+	// Verify fieldNameToIdx maps to full-table visibleCols indices.
 	require.Equal(t, 3, consumer.fieldNameToIdx["score"], "score should map to visibleCols index 3")
 	require.Equal(t, 1, consumer.fieldNameToIdx["name"], "name should map to visibleCols index 1")
 	require.Equal(t, 0, consumer.fieldNameToIdx["id"], "id should map to visibleCols index 0")
+
+	// Verify colMapping uses target-column indices (position in targetCols),
+	// not full-table indices. Target order is [score, name, id].
+	require.Equal(t, 0, consumer.colMapping[0], "parquet col 0 (score) -> target index 0")
+	require.Equal(t, 1, consumer.colMapping[1], "parquet col 1 (name) -> target index 1")
+	require.Equal(t, 2, consumer.colMapping[2], "parquet col 2 (id) -> target index 2")
+}
+
+// TestParquetSubsetColumnMapping is a regression test for #169899. When IMPORT
+// INTO excludes columns, colMapping must use target-column indices (position in
+// the targetCols list) rather than full-table visibleCols indices. Using
+// full-table indices caused an out-of-bounds panic in FillDatums because
+// DatumRowConverter.Datums is sized to len(targetCols).
+func TestParquetSubsetColumnMapping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Table schema shared by all sub-tests: [name, id, age, score]. The
+	// primary key is id (not the first column), so test cases can exclude
+	// parquet col 0 (name) while still satisfying IMPORT INTO's requirement
+	// that targetCols include the primary key.
+	tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+		Name: "test_table",
+		Columns: []descpb.ColumnDescriptor{
+			{Name: "name", ID: 2, Type: types.String, Nullable: true},
+			{Name: "id", ID: 1, Type: types.Int, Nullable: true},
+			{Name: "age", ID: 3, Type: types.Int, Nullable: true},
+			{Name: "score", ID: 4, Type: types.Float, Nullable: true},
+		},
+		NextColumnID: 5,
+		Families: []descpb.ColumnFamilyDescriptor{{
+			Name:        "primary",
+			ColumnNames: []string{"name", "id", "age", "score"},
+			ColumnIDs:   []descpb.ColumnID{2, 1, 3, 4},
+		}},
+		PrimaryIndex: descpb.IndexDescriptor{
+			Name:                "primary",
+			ID:                  1,
+			Unique:              true,
+			KeyColumnNames:      []string{"id"},
+			KeyColumnIDs:        []descpb.ColumnID{1},
+			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+		},
+	}).BuildImmutableTable()
+
+	// makeParquetFile writes a single row [name="Alice", id=1, age=30,
+	// score=95.5] using the supplied column names (cases). Type order is
+	// fixed: string, int32, int32, float64.
+	makeParquetFile := func(t *testing.T, colNames [4]string) *fileReader {
+		t.Helper()
+		pqSchema := arrow.NewSchema(
+			[]arrow.Field{
+				{Name: colNames[0], Type: arrow.BinaryTypes.String, Nullable: true},
+				{Name: colNames[1], Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+				{Name: colNames[2], Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+				{Name: colNames[3], Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+			},
+			nil,
+		)
+
+		var buf bytes.Buffer
+		writer, err := pqarrow.NewFileWriter(
+			pqSchema, &buf,
+			parquet.NewWriterProperties(
+				parquet.WithCompression(compress.Codecs.Uncompressed)),
+			pqarrow.DefaultWriterProps(),
+		)
+		require.NoError(t, err)
+
+		rb := array.NewRecordBuilder(memory.DefaultAllocator, pqSchema)
+		rb.Field(0).(*array.StringBuilder).Append("Alice")
+		rb.Field(1).(*array.Int32Builder).Append(1)
+		rb.Field(2).(*array.Int32Builder).Append(30)
+		rb.Field(3).(*array.Float64Builder).Append(95.5)
+		record := rb.NewRecord()
+		defer record.Release()
+
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		return &fileReader{
+			Reader:   reader,
+			ReaderAt: reader,
+			Seeker:   reader,
+			total:    int64(buf.Len()),
+		}
+	}
+
+	lowerCaseNames := [4]string{"name", "id", "age", "score"}
+
+	// Sample row written by makeParquetFile; expected datums below pick out
+	// the targeted subset (lookup is case-insensitive).
+	allDatums := map[string]tree.Datum{
+		"id":    tree.NewDInt(1),
+		"name":  tree.NewDString("Alice"),
+		"age":   tree.NewDInt(30),
+		"score": tree.NewDFloat(95.5),
+	}
+
+	testCases := []struct {
+		name string
+		// parquetColNames overrides the parquet schema column names; defaults
+		// to lowerCaseNames when zero-valued.
+		parquetColNames [4]string
+		targetCols      tree.NameList
+		// Expected colMapping: parquet col index -> target col index (-1 = skipped).
+		wantColMapping []int
+	}{
+		{
+			// Excludes parquet col 0 (name, a non-PK column).
+			name:           "first column excluded",
+			targetCols:     tree.NameList{"id", "age", "score"},
+			wantColMapping: []int{-1, 0, 1, 2},
+		},
+		{
+			// Excluding a non-last column is the original panic from #169899.
+			name:           "middle column excluded",
+			targetCols:     tree.NameList{"name", "id", "score"},
+			wantColMapping: []int{0, 1, -1, 2},
+		},
+		{
+			name:           "last column excluded",
+			targetCols:     tree.NameList{"name", "id", "age"},
+			wantColMapping: []int{0, 1, 2, -1},
+		},
+		{
+			name:           "multiple columns excluded",
+			targetCols:     tree.NameList{"id", "score"},
+			wantColMapping: []int{-1, 0, -1, 1},
+		},
+		{
+			// Parquet matching is case-insensitive; mixed-case parquet column
+			// names must still resolve to the lowercase target columns.
+			name:            "mixed case parquet columns",
+			parquetColNames: [4]string{"Name", "ID", "Age", "Score"},
+			targetCols:      tree.NameList{"id", "age", "score"},
+			wantColMapping:  []int{-1, 0, 1, 2},
+		},
+	}
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
+	defer row.TestingSetDatumRowConverterBatchSize(2)()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			importCtx := &parallelImportContext{
+				targetCols: tc.targetCols,
+				tableDesc:  tableDesc,
+			}
+
+			colNames := tc.parquetColNames
+			if colNames == [4]string{} {
+				colNames = lowerCaseNames
+			}
+			fr := makeParquetFile(t, colNames)
+			producer, err := newParquetRowProducer(fr, importCtx)
+			require.NoError(t, err)
+
+			consumer, err := newParquetRowConsumer(
+				importCtx, producer, &importFileContext{}, false)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantColMapping, consumer.colMapping)
+
+			// Verify all mapped indices are within the target column bounds.
+			// This is the invariant FillDatums relies on: conv.Datums and
+			// conv.VisibleColTypes are sized to len(targetCols).
+			for _, idx := range consumer.colMapping {
+				if idx >= 0 {
+					require.Less(t, idx, len(tc.targetCols),
+						"colMapping index must be < len(targetCols)")
+				}
+			}
+
+			// Drive FillDatums end-to-end. This is the call site that
+			// originally panicked with an out-of-bounds index when a non-last
+			// column was excluded (#169899).
+			conv, err := row.NewDatumRowConverter(
+				ctx, &semaCtx, tableDesc, tc.targetCols, evalCtx.Copy(),
+				nil /* kvCh */, nil /* seqChunkProvider */, nil /* metrics */, nil, /* db */
+			)
+			require.NoError(t, err)
+
+			require.True(t, producer.Scan(), "expected at least one row")
+			rowData, err := producer.Row()
+			require.NoError(t, err)
+			require.NoError(t, consumer.FillDatums(ctx, rowData, 1, conv))
+
+			require.Len(t, conv.Datums, len(tc.targetCols))
+			for i, colName := range tc.targetCols {
+				want := allDatums[strings.ToLower(string(colName))]
+				require.Equalf(t, want, conv.Datums[i],
+					"datum at target index %d (column %q)", i, colName)
+			}
+		})
+	}
 }
 
 // TestParquetCaseConflictingColumns tests that we reject tables with columns


### PR DESCRIPTION
When IMPORT INTO excluded a non-last column from the column list, FillDatums used full-table column indices to access DatumRowConverter.Datums and VisibleColTypes, which are sized to the target column subset. This caused an index-out-of-bounds panic that crashed the coordinator node and cascaded across the cluster as the job relocated.

The fix translates full-table indices to target-column indices when building the colMapping array in newParquetRowConsumer. The existing fieldNameToIdx mapping (used for type validation against the full table schema) is unchanged.

Resolves: #169899
Epic: none

Release note (bug fix): Fixed a bug where IMPORT INTO from Parquet files would crash a node when the column list excluded a non-last table column. The crash cascaded to other nodes as the job coordinator relocated, causing full cluster unavailability.