### PR TITLE
server: add GC pressure detection and sys.gc.cpu.percent metric

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -243,6 +243,29 @@ events.
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
 
+### `g_c_pressure_detected`
+
+An event of type `g_c_pressure_detected` is recorded when the Go garbage collector is consuming
+a high fraction of available CPU capacity, indicating that the heap is
+approaching the GOMEMLIMIT soft memory limit. Sustained GC pressure
+degrades performance and may indicate that the node needs more memory.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `NodeID` | The node ID where the event was originated. | no |
+| `GCCPUFraction` | The GC CPU usage as a fraction of total available CPU capacity (0.0 to 1.0). | no |
+| `GoAllocBytes` | The current Go heap allocation in bytes. | no |
+| `GoLimitBytes` | The configured GOMEMLIMIT soft memory limit in bytes (0 if unset). | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+
 ### `low_disk_space`
 
 An event of type `low_disk_space` is emitted when a store is reaching capacity, as we reach

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -11441,6 +11441,16 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       visibility: SUPPORT
       owner: cockroachdb/obs-prs
+    - name: sys.gc.cpu.percent
+      exported_name: sys_gc_cpu_percent
+      description: Current GC CPU usage as a fraction of total available CPU capacity
+      y_axis_label: CPU Time
+      type: GAUGE
+      unit: PERCENT
+      aggregation: AVG
+      derivative: NONE
+      visibility: SUPPORT
+      owner: cockroachdb/obs-prs
     - name: sys.gc.pause.ns
       exported_name: sys_gc_pause_ns
       description: Total GC pause

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -1252,6 +1252,7 @@ owners:
   sys_gc_assist_enabled: cockroachdb/obs-prs
   sys_gc_assist_ns: cockroachdb/obs-prs
   sys_gc_count: cockroachdb/obs-prs
+  sys_gc_cpu_percent: cockroachdb/obs-prs
   sys_gc_pause_ns: cockroachdb/obs-prs
   sys_gc_pause_percent: cockroachdb/obs-prs
   sys_gc_stop_ns: cockroachdb/obs-prs

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -3018,6 +3018,7 @@ sys_fd_softlimit: sys.fd.softlimit
 sys_gc_assist_enabled: sys.gc.assist.enabled
 sys_gc_assist_ns: sys.gc.assist.ns
 sys_gc_count: sys.gc.count
+sys_gc_cpu_percent: sys.gc.cpu.percent
 sys_gc_pause_ns: sys.gc.pause.ns
 sys_gc_pause_percent: sys.gc.pause.percent
 sys_gc_stop_ns: sys.gc.stop.ns

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -484,6 +484,7 @@ go_test(
         "drain_test.go",
         "drpc_test.go",
         "external_tenant_drpc_test.go",
+        "gc_pressure_test.go",
         "get_local_files_test.go",
         "graphite_test.go",
         "grpc_gateway_test.go",

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/gcassist"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -49,6 +51,62 @@ var gcAssistEnabled = settings.RegisterBoolSetting(
 		"picks up the GODEBUG gcnoassist flag as its default",
 	gcassist.Enabled(), // default reflects GODEBUG=gcnoassist at startup
 )
+
+var gcPressureWarningThreshold = settings.RegisterFloatSetting(
+	settings.SystemVisible,
+	"server.gc_pressure.warning_threshold",
+	"gc cpu fraction (0.0-1.0) above which a warning event is emitted "+
+		"after sustained samples; set to 0 to disable GC pressure warnings",
+	0.25,
+	settings.FloatInRange(0, 1),
+)
+
+const (
+	// gcPressureSustainedSamples is the number of consecutive
+	// above-threshold samples required before warning. This filters
+	// out transient GC spikes (e.g. during bulk ingestion).
+	gcPressureSustainedSamples = 3
+	// gcPressureCooldown is the minimum time between consecutive
+	// GC pressure warnings to avoid log noise during prolonged pressure.
+	gcPressureCooldown = 5 * time.Minute
+)
+
+// gcPressureChecker detects sustained GC pressure by monitoring
+// the GC CPU ratio. When the ratio exceeds the configured threshold
+// for gcPressureSustainedSamples consecutive samples, a warning is
+// emitted. A cooldown prevents excessive warnings.
+type gcPressureChecker struct {
+	consecutiveAbove int
+	lastWarning      time.Time
+}
+
+// check reports whether a GC pressure warning should be emitted.
+// It returns true when gcCPURatio has been at or above threshold
+// for gcPressureSustainedSamples consecutive calls and the cooldown
+// has elapsed since the last warning.
+func (c *gcPressureChecker) check(gcCPURatio, threshold float64, now time.Time) bool {
+	if gcCPURatio >= threshold {
+		c.consecutiveAbove++
+	} else {
+		c.consecutiveAbove = 0
+		return false
+	}
+
+	if c.consecutiveAbove < gcPressureSustainedSamples {
+		return false
+	}
+	if !c.lastWarning.IsZero() &&
+		now.Sub(c.lastWarning) < gcPressureCooldown {
+		return false
+	}
+	c.lastWarning = now
+	// Reset so the checker must re-observe gcPressureSustainedSamples
+	// new above-threshold samples before firing again. Combined with the
+	// cooldown, the effective minimum re-fire interval is
+	// gcPressureCooldown + gcPressureSustainedSamples*sampleInterval.
+	c.consecutiveAbove = 0
+	return true
+}
 
 type sampleEnvironmentCfg struct {
 	st                    *cluster.Settings
@@ -172,6 +230,8 @@ func startSampleEnvironment(
 			defer timer.Stop()
 			timer.Reset(cfg.minSampleInterval)
 
+			var gcChecker gcPressureChecker
+
 			for {
 				select {
 				case <-cfg.stopper.ShouldQuiesce():
@@ -181,6 +241,35 @@ func startSampleEnvironment(
 
 					cgoStats := status.GetCGoMemStats(ctx)
 					cfg.runtime.SampleEnvironment(ctx, cgoStats)
+
+					threshold :=
+						gcPressureWarningThreshold.Get(&cfg.st.SV)
+					if threshold > 0 {
+						gcCPU := cfg.runtime.GcCPUPercent.Value()
+						if gcChecker.check(gcCPU, threshold, timeutil.Now()) {
+							goAlloc := uint64(cfg.runtime.GoAllocBytes.Value())
+							goLimit := uint64(cfg.runtime.GoLimitBytes.Value())
+							ev := &eventpb.GCPressureDetected{
+								NodeID:        int32(srvCfg.IDContainer.Get()),
+								GCCPUFraction: gcCPU,
+								GoAllocBytes:  goAlloc,
+								GoLimitBytes:  goLimit,
+							}
+							ev.CommonDetails().Timestamp =
+								timeutil.Now().UnixNano()
+							log.StructuredEvent(
+								ctx, severity.WARNING, ev,
+							)
+							log.Ops.Warningf(ctx,
+								"GC pressure detected: GC using %.1f%% "+
+									"of available CPU "+
+									"(heap: %d MiB, limit: %d MiB)",
+								gcCPU*100,
+								goAlloc/(1024*1024),
+								goLimit/(1024*1024),
+							)
+						}
+					}
 
 					// Maybe purge jemalloc dirty pages.
 					if overhead, period := jemallocPurgeOverhead.Get(&cfg.st.SV), jemallocPurgePeriod.Get(&cfg.st.SV); overhead > 0 && period > 0 {

--- a/pkg/server/gc_pressure_test.go
+++ b/pkg/server/gc_pressure_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPressureChecker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const threshold = 0.25
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tick := 10 * time.Second
+
+	t.Run("no trigger below threshold", func(t *testing.T) {
+		var c gcPressureChecker
+		now := baseTime
+		for i := 0; i < 10; i++ {
+			now = now.Add(tick)
+			require.False(t, c.check(0.10, threshold, now))
+		}
+	})
+
+	t.Run("no trigger on single sample above threshold", func(t *testing.T) {
+		var c gcPressureChecker
+		require.False(t, c.check(0.30, threshold, baseTime))
+	})
+
+	t.Run("trigger after sustained samples above threshold", func(t *testing.T) {
+		var c gcPressureChecker
+		require.False(t, c.check(0.30, threshold, baseTime))
+		require.False(t, c.check(0.40, threshold, baseTime.Add(tick)))
+		require.True(t, c.check(0.50, threshold, baseTime.Add(2*tick)))
+	})
+
+	t.Run("trigger at exact threshold boundary", func(t *testing.T) {
+		var c gcPressureChecker
+		require.False(t, c.check(threshold, threshold, baseTime))
+		require.False(t, c.check(threshold, threshold, baseTime.Add(tick)))
+		require.True(t, c.check(threshold, threshold, baseTime.Add(2*tick)))
+	})
+
+	t.Run("reset when sample drops below threshold", func(t *testing.T) {
+		var c gcPressureChecker
+		require.False(t, c.check(0.30, threshold, baseTime))
+		require.False(t, c.check(0.40, threshold, baseTime.Add(tick)))
+		require.False(t, c.check(0.10, threshold, baseTime.Add(2*tick)))
+		require.False(t, c.check(0.30, threshold, baseTime.Add(3*tick)))
+		require.False(t, c.check(0.40, threshold, baseTime.Add(4*tick)))
+		require.True(t, c.check(0.50, threshold, baseTime.Add(5*tick)))
+	})
+
+	t.Run("cooldown prevents rapid warnings", func(t *testing.T) {
+		var c gcPressureChecker
+		c.check(0.30, threshold, baseTime)
+		c.check(0.40, threshold, baseTime.Add(tick))
+		require.True(t, c.check(0.50, threshold, baseTime.Add(2*tick)))
+
+		afterTrigger := baseTime.Add(3 * tick)
+		c.check(0.30, threshold, afterTrigger)
+		c.check(0.40, threshold, afterTrigger.Add(tick))
+		require.False(t, c.check(0.50, threshold, afterTrigger.Add(2*tick)))
+	})
+
+	t.Run("cooldown boundary still blocks", func(t *testing.T) {
+		var c gcPressureChecker
+		c.check(0.30, threshold, baseTime)
+		c.check(0.40, threshold, baseTime.Add(tick))
+		require.True(t, c.check(0.50, threshold, baseTime.Add(2*tick)))
+
+		atCooldownEdge := baseTime.Add(gcPressureCooldown - time.Nanosecond)
+		c.check(0.30, threshold, atCooldownEdge)
+		c.check(0.40, threshold, atCooldownEdge.Add(tick))
+		require.False(t, c.check(0.50, threshold, atCooldownEdge.Add(2*tick)))
+	})
+
+	t.Run("warning after cooldown expires", func(t *testing.T) {
+		var c gcPressureChecker
+		c.check(0.30, threshold, baseTime)
+		c.check(0.40, threshold, baseTime.Add(tick))
+		require.True(t, c.check(0.50, threshold, baseTime.Add(2*tick)))
+
+		pastCooldown := baseTime.Add(2*tick + gcPressureCooldown + time.Second)
+		c.check(0.30, threshold, pastCooldown)
+		c.check(0.40, threshold, pastCooldown.Add(tick))
+		require.True(t, c.check(0.50, threshold, pastCooldown.Add(2*tick)))
+	})
+
+	t.Run("threshold zero always triggers if called", func(t *testing.T) {
+		// The call site guards with threshold > 0, but verify the
+		// checker's behavior: any non-negative ratio >= 0 counts.
+		var c gcPressureChecker
+		require.False(t, c.check(0.0, 0.0, baseTime))
+		require.False(t, c.check(0.0, 0.0, baseTime.Add(tick)))
+		require.True(t, c.check(0.0, 0.0, baseTime.Add(2*tick)))
+	})
+}

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -181,6 +181,13 @@ var (
 		Measurement: "CPU Time",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaGCCPUPercent = metric.Metadata{
+		Name:        "sys.gc.cpu.percent",
+		Help:        "Current GC CPU usage as a fraction of total available CPU capacity",
+		Measurement: "CPU Time",
+		Unit:        metric.Unit_PERCENT,
+		Visibility:  metric.Metadata_SUPPORT,
+	}
 	metaNonGCPauseNS = metric.Metadata{
 		Name:        "sys.go.pause.other.ns",
 		Help:        "Estimated non-GC-related total pause time",
@@ -816,6 +823,7 @@ type RuntimeStatSampler struct {
 		cgoCall     int64
 		gcCount     int64
 		gcPauseTime uint64
+		gcTotalCPU  float64
 		disk        DiskStats
 		net         netCounters
 		runnableSum float64
@@ -855,6 +863,7 @@ type RuntimeStatSampler struct {
 	GcAssistNS               *metric.Counter
 	GcAssistEnabled          *metric.Gauge
 	GcTotalNS                *metric.Counter
+	GcCPUPercent             *metric.GaugeFloat64
 	// CPU stats for the CRDB process usage.
 	CPUUserNS              *metric.Counter
 	CPUUserPercent         *metric.GaugeFloat64
@@ -964,6 +973,7 @@ func NewRuntimeStatSampler(ctx context.Context, clock hlc.WallClock) *RuntimeSta
 		GcAssistNS:               metric.NewCounter(metaGCAssistNS),
 		GcAssistEnabled:          metric.NewGauge(metaGCAssistEnabled),
 		GcTotalNS:                metric.NewCounter(metaGCTotalNS),
+		GcCPUPercent:             metric.NewGaugeFloat64(metaGCCPUPercent),
 		NonGcPauseNS:             metric.NewGauge(metaNonGCPauseNS),
 		NonGcStopNS:              metric.NewGauge(metaNonGCStopNS),
 
@@ -1193,6 +1203,14 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	if dur > 0 {
 		gcPauseRatio = float64(gcPauseTotalNs-rsr.last.gcPauseTime) / dur
 	}
+	gcTotalCPUSeconds := rsr.goRuntimeSampler.float64(runtimeMetricGCTotal)
+	var gcCPURatio float64
+	if rsr.last.now != 0 && dur > 0 && cpuCapacity > 0 {
+		// TODO: initalize right after `dur` and use with other metrics too
+		perNs := 1.0 / dur
+		deltaGCNs := max(gcTotalCPUSeconds-rsr.last.gcTotalCPU, 0) * 1e9
+		gcCPURatio = min(deltaGCNs*perNs/cpuCapacity, 1.0)
+	}
 	runnableSum := goschedstats.CumulativeNormalizedRunnableGoroutines()
 	gcAssistSeconds := rsr.goRuntimeSampler.float64(runtimeMetricGCAssist)
 	gcAssistNS := int64(gcAssistSeconds * 1e9)
@@ -1212,6 +1230,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	rsr.last.hostSoftIrqtime = hostSoftIrqtime
 	rsr.last.hostNiceTime = hostNiceTime
 	rsr.last.gcPauseTime = gcPauseTotalNs
+	rsr.last.gcTotalCPU = gcTotalCPUSeconds
 	rsr.last.runnableSum = runnableSum
 
 	// Log summary of statistics to console.
@@ -1283,7 +1302,8 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	} else {
 		rsr.GcAssistEnabled.Update(0)
 	}
-	rsr.GcTotalNS.Update(int64(rsr.goRuntimeSampler.float64(runtimeMetricGCTotal) * 1e9))
+	rsr.GcTotalNS.Update(int64(gcTotalCPUSeconds * 1e9))
+	rsr.GcCPUPercent.Update(gcCPURatio)
 	rsr.NonGcPauseNS.Update(nonGcPauseTotalNs)
 	rsr.NonGcStopNS.Update(nonGcStopTotalNs)
 

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -350,6 +350,30 @@ func TestSampleEnvironment(t *testing.T) {
 	require.GreaterOrEqual(t, s.HostCPUCombinedPercentNorm.Value(), s.CPUCombinedPercentNorm.Value())
 }
 
+func TestGCCPURatio(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDuress(t)
+
+	ctx := context.Background()
+	clock := hlc.NewClockForTesting(nil)
+	s := NewRuntimeStatSampler(ctx, clock.WallClock())
+
+	cgoStats := GetCGoMemStats(ctx)
+
+	// First sample establishes baseline; ratio should be zero.
+	s.SampleEnvironment(ctx, cgoStats)
+	require.Equal(t, float64(0), s.GcCPUPercent.Value())
+
+	// Force GC work between samples so the ratio is measurably non-zero.
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	s.SampleEnvironment(ctx, cgoStats)
+
+	gcCPUPercent := s.GcCPUPercent.Value()
+	require.Greater(t, gcCPUPercent, float64(0))
+	require.LessOrEqual(t, gcCPUPercent, float64(1.0))
+}
+
 func TestNetworkStatsLinux(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/util/log/eventpb/cluster_events.proto
+++ b/pkg/util/log/eventpb/cluster_events.proto
@@ -150,6 +150,26 @@ message LowDiskSpace {
   uint64 total_bytes = 6 [(gogoproto.jsontag) = ",omitempty"];
 }
 
+// GCPressureDetected is recorded when the Go garbage collector is consuming
+// a high fraction of available CPU capacity, indicating that the heap is
+// approaching the GOMEMLIMIT soft memory limit. Sustained GC pressure
+// degrades performance and may indicate that the node needs more memory.
+message GCPressureDetected {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The node ID where the event was originated.
+  int32 node_id = 2 [(gogoproto.customname) = "NodeID", (gogoproto.jsontag) = ",omitempty"];
+
+  // The GC CPU usage as a fraction of total available CPU capacity (0.0 to 1.0).
+  double gc_cpu_fraction = 3 [(gogoproto.customname) = "GCCPUFraction", (gogoproto.jsontag) = ",includeempty"];
+
+  // The current Go heap allocation in bytes.
+  uint64 go_alloc_bytes = 4 [(gogoproto.jsontag) = ",includeempty"];
+
+  // The configured GOMEMLIMIT soft memory limit in bytes (0 if unset).
+  uint64 go_limit_bytes = 5 [(gogoproto.jsontag) = ",includeempty"];
+}
+
 // CertsReload is recorded when the TLS certificates are
 // reloaded/rotated from disk.
 message CertsReload {

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -32,6 +32,9 @@ func (m *DiskSlownessCleared) LoggingChannel() logpb.Channel { return logpb.Chan
 func (m *DiskSlownessDetected) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *GCPressureDetected) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *LowDiskSpace) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3542,6 +3542,44 @@ func (m *ForceDeleteTableDataEntry) AppendJSONFields(printComma bool, b redact.R
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *GCPressureDetected) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if m.NodeID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NodeID\":"...)
+		b = strconv.AppendInt(b, int64(m.NodeID), 10)
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"GCCPUFraction\":"...)
+	b = strconv.AppendFloat(b, float64(m.GCCPUFraction), 'f', -1, 64)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"GoAllocBytes\":"...)
+	b = strconv.AppendUint(b, uint64(m.GoAllocBytes), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"GoLimitBytes\":"...)
+	b = strconv.AppendUint(b, uint64(m.GoLimitBytes), 10)
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *GrantRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)


### PR DESCRIPTION
Add monitoring for sustained Go GC CPU pressure. When the GC consumes more than a configurable fraction of available CPU (default 25%) for 3 consecutive samples, a structured GCPressureDetected event is emitted on the OPS channel along with a human-readable warning.

This helps operators detect when a node's heap is approaching GOMEMLIMIT, which silently degrades query latency before any OOM occurs. Previously there was no alerting surface for this condition.

The new sys.gc.cpu.percent metric exposes the per-sample GC CPU ratio (0-1) for dashboards and alerting rules. A cluster setting server.gc_pressure.warning_threshold controls the threshold (0 disables).

Epic: None
Fixes: #161520
Release note: None