### PR TITLE
admission: unify burst refill path across CTT modes

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -153,20 +153,9 @@ type cpuTimeTokenFiller struct {
 	//  2. refill rates and granter buckets - the delta between old and
 	//     new rates is applied to the granter, so token levels converge
 	//     to the new mode within one interval.
-	//  3. WorkQueue.useResourceGroup - set via configureQueue, which
-	//     switches group ID derivation between TenantID (serverless)
-	//     and Priority (resource manager).
-	//  4. activeMode (this field) - stored last, after refill and queue
-	//     configuration are complete, so that GetKVWorkQueue routes to
-	//     the correct queue only after the queues are ready.
-	//
-	// TODO(wenyihu6): All four steps can be simplified once
-	// serverless mode is mapped to a single WorkQueue with resource
-	// groups. Serverless tenants would just be resource groups with
-	// specific configs (e.g. system tenant = maxCPU group), so the
-	// rmStrategy handles both modes and the strategy swap (step 1),
-	// queue config toggle (step 3), and routing via activeMode
-	// (step 4) all become unnecessary.
+	//  3. activeMode (this field) - stored last, after refill is
+	//     complete, so that GetKVWorkQueue routes to the correct queue
+	//     only after the queues are ready.
 	activeMode atomic.Int64
 }
 
@@ -570,11 +559,9 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 	// real strategy - the constructor defaults offMode to
 	// serverlessMode, and GetKVWorkQueue handles the off case before
 	// reaching activeMode routing.
-	modeChanged := false
 	newMode := cpuTimeTokenACMode.Get(&a.settings.SV)
 	if newMode != offMode && newMode != a.strategy.mode() {
 		a.strategy = a.newStrategy(newMode)
-		modeChanged = true
 	}
 
 	targets := a.strategy.computeTargets(&a.settings.SV)
@@ -619,17 +606,6 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		}
 	}
 
-	// Apply queue configuration after refill is complete, so admission
-	// behavior only changes once tokens are in place. The returned mode
-	// is stored into filler.activeMode by the caller, which is what
-	// GetKVWorkQueue reads to route work. If activeMode were updated
-	// before tokens and queue config, callers could route work into a
-	// CTT queue that has stale token levels or wrong group derivation
-	// (e.g. TenantID instead of Priority), breaking fair-sharing until
-	// the next interval.
-	if modeChanged {
-		a.configureQueue()
-	}
 	return a.strategy.mode()
 }
 
@@ -652,20 +628,6 @@ func (a *cpuTimeTokenAllocator) newStrategy(mode cpuTimeTokenMode) modeStrategy 
 	default:
 		panic(errors.AssertionFailedf("unknown cpuTimeTokenMode: %d", mode))
 	}
-}
-
-// configureQueue applies mode-specific settings to the WorkQueue.
-// Called from the constructor after the initial strategy is installed and from
-// resetInterval on a strategy swap.
-//
-// TODO(wenyihu6): in a follow-on change, this should also trigger an apply of
-// the configHolder snapshot to groupInfo so that derived per-group state
-// (weight, MaxCPU, burstFrac) lands before the cycle's refill runs.
-//
-// TODO(wenyihu6): becomes unnecessary once serverless tenants are
-// modeled as resource groups in a single WorkQueue.
-func (a *cpuTimeTokenAllocator) configureQueue() {
-	a.queues[0].setUseResourceGroup(a.strategy.mode() == resourceManagerMode)
 }
 
 // refillGranter increments per-bucket refill metrics, then delegates
@@ -699,8 +661,6 @@ type workQueueIForAllocator interface {
 	// refillGroupBurstBuckets refills every group's burst bucket,
 	// scaling rate and cap by each group's burstFrac.
 	refillGroupBurstBuckets(rate, cap float64)
-	// setUseResourceGroup toggles RM-style group derivation.
-	setUseResourceGroup(enabled bool)
 }
 
 // cpuTimeModel abstracts cpuTimeLinearModel for testing.

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -293,18 +293,18 @@ type modeStrategy interface {
 	// computeTargets reads mode-specific cluster settings and returns
 	// the target utilizations for model fitting.
 	computeTargets(sv *settings.Values) targetUtilizations
-	// refillBurst refills per-tenant burst buckets. tokens is the
-	// per-tick allocation (from allocateTokens) or per-interval delta
-	// (from resetInterval). refillRates is the current refill rates.
-	refillBurst(tokens tokenCounts, refillRates rates)
+	// groupBurstRates returns per-tier (rate, cap) pairs from which
+	// per-group burst amounts are derived. The allocator iterates
+	// queues and calls refillGroupBurstBuckets with these values.
+	groupBurstRates(allocations tokenCounts, refillRates rates) [numResourceTiers][2]float64
 }
 
 // serverlessStrategy implements modeStrategy for Serverless mode,
 // which uses 2 WorkQueues (systemTenant, appTenant) with per-tier
-// utilization targets. Each tier's burst bucket gets noBurst/4 of
-// that tier's allocation and rate.
+// utilization targets. Each tier's burst bucket gets
+// noBurst * defaultTenantGroupConfig.BurstFrac (0.25) of that tier's
+// allocation and rate.
 type serverlessStrategy struct {
-	queues [numResourceTiers]workQueueIForAllocator
 }
 
 func (s *serverlessStrategy) mode() cpuTimeTokenMode {
@@ -335,23 +335,27 @@ func (s *serverlessStrategy) computeTargets(sv *settings.Values) targetUtilizati
 	return targets
 }
 
-func (s *serverlessStrategy) refillBurst(tokens tokenCounts, refillRates rates) {
-	for tier := range s.queues {
-		toAdd := tokens[tier][noBurst] / 4
-		burstCapacity := refillRates[tier][noBurst] / 4
-		s.queues[tier].refillBurstBuckets(toAdd, burstCapacity)
+func (s *serverlessStrategy) groupBurstRates(
+	allocations tokenCounts, refillRates rates,
+) [numResourceTiers][2]float64 {
+	var out [numResourceTiers][2]float64
+	for tier := range out {
+		out[tier] = [2]float64{
+			float64(allocations[tier][noBurst]),
+			float64(refillRates[tier][noBurst]),
+		}
 	}
+	return out
 }
 
 // rmStrategy implements modeStrategy for Resource Manager mode, which uses a
 // single WorkQueue with N resource groups and a single utilization target.
 type rmStrategy struct {
-	queue workQueueIForAllocator
 	// canBurstTarget is the canBurst utilization target (e.g. 0.80 when
 	// KVCPUTimeUtilTarget=0.75 + KVCPUTimeUtilBurstDelta=0.05). Set by
-	// computeTargets each interval; used by refillBurst to recover the 100% CPU
-	// rate by dividing the cycle's canBurst allocation by canBurstTarget and
-	// forwards to WorkQueue.refillRMGroupBurstBuckets.
+	// computeTargets each interval; used by groupBurstRates to recover the
+	// 100% CPU rate by dividing the cycle's canBurst allocation by
+	// canBurstTarget.
 	canBurstTarget float64
 }
 
@@ -383,21 +387,28 @@ func (s *rmStrategy) computeTargets(sv *settings.Values) targetUtilizations {
 	return targets
 }
 
-func (s *rmStrategy) refillBurst(tokens tokenCounts, refillRates rates) {
+func (s *rmStrategy) groupBurstRates(
+	allocations tokenCounts, refillRates rates,
+) [numResourceTiers][2]float64 {
+	var out [numResourceTiers][2]float64
 	// Cold-start guard: skip if computeTargets has not run yet (canBurstTarget
 	// is the zero value). Setting validators rule out negative values, so
 	// == 0 catches the only reachable bad state.
 	if s.canBurstTarget == 0 {
-		return
+		return out
 	}
 	// Recover the 100% CPU rate by dividing out canBurstTarget; valid
 	// because cpuTimeTokenLinearModel is linear in target.
 	//
 	// TODO(wenyihu6): instead of computing by division, plumb rate100 from the
 	// model so this division (and canBurstTarget storage) can go away.
-	rate100 := float64(tokens[0][canBurst]) / s.canBurstTarget
+	rate100 := float64(allocations[0][canBurst]) / s.canBurstTarget
 	cap100 := float64(refillRates[0][canBurst]) / s.canBurstTarget
-	s.queue.refillRMGroupBurstBuckets(rate100, cap100)
+	// Mirror to both tiers. RM mode only routes KV work to tier-0,
+	// but tier-1 must stay in sync (see computeTargets).
+	out[0] = [2]float64{rate100, cap100}
+	out[1] = [2]float64{rate100, cap100}
+	return out
 }
 
 // rates stores a token count per second, for example, the refill
@@ -537,15 +548,17 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	refillGranter(a.granter, a.metrics, allocations,
 		bucketCapacities, bucketMinimums, false /* updateMetrics */)
 
-	// Refill per-group burst buckets in the WorkQueues. The burst bucket
-	// refill rate and capacity should be 1/4th of the noBurst refill rate
-	// and capacity (for the corresponding resource tier). If a group's
-	// bucket is mostly full, we allow it to get priority in the queue (see
-	// cpu_time_token_burst.go for more). With cluster settings at their
-	// default values, this implies that an application tenant can burst,
-	// if they are using roughly less than 20% of the CPU on a CRDB node
-	// (0.8 * 0.25 = 0.2).
-	a.strategy.refillBurst(allocations, a.refillRates)
+	// Refill per-group burst buckets in the WorkQueues. Each group's burst
+	// bucket is scaled by its burstFrac (defaultTenantGroupConfig.BurstFrac
+	// = 0.25 for serverless tenants). If a group's bucket is mostly full,
+	// we allow it to get priority in the queue (see cpu_time_token_burst.go
+	// for more). With cluster settings at their default values, this implies
+	// that an application tenant can burst if they are using roughly less
+	// than 20% of the CPU on a CRDB node (0.8 * 0.25 = 0.2).
+	burstRates := a.strategy.groupBurstRates(allocations, a.refillRates)
+	for tier, q := range a.queues {
+		q.refillGroupBurstBuckets(burstRates[tier][0], burstRates[tier][1])
+	}
 }
 
 // resetInterval recomputes refill rates and applies the delta to the
@@ -594,7 +607,10 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		bucketCapacities, bucketMinimums, true /* updateMetrics */)
 	a.refillRates = newRefillRates
 	// Apply the delta to the per-group burst buckets also.
-	a.strategy.refillBurst(deltaRefillRates, a.refillRates)
+	burstRates := a.strategy.groupBurstRates(deltaRefillRates, a.refillRates)
+	for tier, q := range a.queues {
+		q.refillGroupBurstBuckets(burstRates[tier][0], burstRates[tier][1])
+	}
 
 	// Reset allocated.
 	for wc := range a.allocated {
@@ -630,9 +646,9 @@ func (a *cpuTimeTokenAllocator) newStrategy(mode cpuTimeTokenMode) modeStrategy 
 	case offMode:
 		panic(errors.AssertionFailedf("offMode is not a valid strategy; callers must guard against it"))
 	case serverlessMode:
-		return &serverlessStrategy{queues: a.queues}
+		return &serverlessStrategy{}
 	case resourceManagerMode:
-		return &rmStrategy{queue: a.queues[0]}
+		return &rmStrategy{}
 	default:
 		panic(errors.AssertionFailedf("unknown cpuTimeTokenMode: %d", mode))
 	}
@@ -679,26 +695,10 @@ func refillGranter(
 
 // workQueueIForAllocator abstracts the WorkQueue methods called from
 // the allocator/strategy layer, to enable unit testing.
-//
-// TODO(wenyihu6): the two refill methods exist because the modes have
-// different per-tick semantics (serverless: uniform per-tenant +
-// burstBucketCapacity update; RM: per-group scaled, no capacity
-// update). Folding them into a single method would force WorkQueue to
-// dispatch internally on q.mu.useResourceGroup, which can race with the
-// strategy during a mode swap. Two methods keep the dispatch on the
-// strategy side, where the active mode is the source of truth.
-// Stop-gap; should go away when we unify serverless and RM.
 type workQueueIForAllocator interface {
-	refillBurstBuckets(toAdd int64, capacity int64)
-	// refillRMGroupBurstBuckets is the future per-group RM-mode refill
-	// entry point: the implementation will refill every configured RM
-	// group's burst bucket under q.mu, using per-group burstFracs scaled
-	// against rate100/cap100. rate100 may be negative when resetInterval
-	// forwards a delta and refill rates have decreased since the previous
-	// interval; cap100 is the current rate and should be non-negative.
-	// Currently a no-op stub on WorkQueue; safe because RM mode is off
-	// by default.
-	refillRMGroupBurstBuckets(rate100, cap100 float64)
+	// refillGroupBurstBuckets refills every group's burst bucket,
+	// scaling rate and cap by each group's burstFrac.
+	refillGroupBurstBuckets(rate, cap float64)
 	// setUseResourceGroup toggles RM-style group derivation.
 	setUseResourceGroup(enabled bool)
 }

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -97,9 +97,8 @@ type testModel struct {
 }
 
 type testBurstManager struct {
-	tokens           int64
-	burstFrac        float64
-	useResourceGroup bool
+	tokens    int64
+	burstFrac float64
 }
 
 func (m *testBurstManager) refillGroupBurstBuckets(rate, cap float64) {
@@ -112,10 +111,6 @@ func (m *testBurstManager) refillGroupBurstBuckets(rate, cap float64) {
 	if m.tokens < -capacity/4 {
 		m.tokens = -capacity / 4
 	}
-}
-
-func (m *testBurstManager) setUseResourceGroup(enabled bool) {
-	m.useResourceGroup = enabled
 }
 
 func (m *testModel) init() {}
@@ -606,33 +601,6 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 	ctx := context.Background()
 	mode := allocator.resetInterval(ctx)
 	require.Equal(t, serverlessMode, mode)
-}
-
-// TestConfigureQueue verifies that configureQueue calls
-// setUseResourceGroup with the correct value based on the
-// current strategy's mode.
-func TestConfigureQueue(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	mgr := &testBurstManager{}
-	queues := [numResourceTiers]workQueueIForAllocator{
-		testTier0: mgr,
-		testTier1: &testBurstManager{},
-	}
-	allocator := cpuTimeTokenAllocator{
-		queues:   queues,
-		strategy: &serverlessStrategy{},
-	}
-
-	// Serverless mode -> useResourceGroup=false.
-	allocator.configureQueue()
-	require.False(t, mgr.useResourceGroup)
-
-	// RM mode -> useResourceGroup=true.
-	allocator.strategy = &rmStrategy{}
-	allocator.configureQueue()
-	require.True(t, mgr.useResourceGroup)
 }
 
 // TestRMStrategyComputeTargets verifies that computeTargets reads the

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -98,15 +98,13 @@ type testModel struct {
 
 type testBurstManager struct {
 	tokens           int64
+	burstFrac        float64
 	useResourceGroup bool
-	// rmCalls counts calls to refillRMGroupBurstBuckets; rmRate100 and
-	// rmCap100 record the args from the most recent call.
-	rmCalls   int
-	rmRate100 float64
-	rmCap100  float64
 }
 
-func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
+func (m *testBurstManager) refillGroupBurstBuckets(rate, cap float64) {
+	toAdd := int64(rate * m.burstFrac)
+	capacity := int64(cap * m.burstFrac)
 	m.tokens += toAdd
 	if m.tokens > capacity {
 		m.tokens = capacity
@@ -114,12 +112,6 @@ func (m *testBurstManager) refillBurstBuckets(toAdd int64, capacity int64) {
 	if m.tokens < -capacity/4 {
 		m.tokens = -capacity / 4
 	}
-}
-
-func (m *testBurstManager) refillRMGroupBurstBuckets(rate100, cap100 float64) {
-	m.rmCalls++
-	m.rmRate100 = rate100
-	m.rmCap100 = cap100
 }
 
 func (m *testBurstManager) setUseResourceGroup(enabled bool) {
@@ -188,8 +180,8 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 	model.rates[testTier1][canBurst] = 3000
 	model.rates[testTier1][noBurst] = 2000
 	burstMgrs := [numResourceTiers]*testBurstManager{
-		testTier0: {},
-		testTier1: {},
+		testTier0: {burstFrac: defaultTenantGroupConfig.BurstFrac},
+		testTier1: {burstFrac: defaultTenantGroupConfig.BurstFrac},
 	}
 	queues := [numResourceTiers]workQueueIForAllocator{
 		testTier0: burstMgrs[testTier0],
@@ -201,7 +193,7 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 		model:    model,
 		metrics:  metrics,
 		queues:   queues,
-		strategy: &serverlessStrategy{queues: queues},
+		strategy: &serverlessStrategy{},
 	}
 	printBurstMgrs = func() string {
 		var b strings.Builder
@@ -531,43 +523,34 @@ func TestServerlessStrategyComputeTargets(t *testing.T) {
 	require.Equal(t, 0.75, targets[systemTenant][canBurst])
 }
 
-// TestServerlessStrategyRefillBurst verifies that refillBurst
-// distributes noBurst/4 of each tier's tokens and capacity to the
-// per-group burst buckets. The canBurst token counts should be
-// ignored since burst bucket refill is derived solely from the
-// noBurst allocation.
-func TestServerlessStrategyRefillBurst(t *testing.T) {
+// TestServerlessStrategyGroupBurstRates verifies that groupBurstRates
+// returns the noBurst token and rate values for each tier, from which
+// per-group burst amounts are derived (scaled by burstFrac in the
+// WorkQueue). The canBurst token counts should be ignored since burst
+// bucket refill is derived solely from the noBurst allocation.
+func TestServerlessStrategyGroupBurstRates(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	burstMgrs := [numResourceTiers]*testBurstManager{
-		testTier0: {},
-		testTier1: {},
-	}
-	queues := [numResourceTiers]workQueueIForAllocator{
-		testTier0: burstMgrs[testTier0],
-		testTier1: burstMgrs[testTier1],
-	}
-	s := &serverlessStrategy{queues: queues}
+	s := &serverlessStrategy{}
 
-	// Set up token counts and refill rates. refillBurst should pass
-	// tokens[tier][noBurst]/4 as toAdd and refillRates[tier][noBurst]/4
-	// as capacity to each tier's burst manager.
 	var tokens tokenCounts
 	tokens[testTier0][noBurst] = 400
-	tokens[testTier0][canBurst] = 500 // ignored by refillBurst
+	tokens[testTier0][canBurst] = 500 // ignored
 	tokens[testTier1][noBurst] = 200
-	tokens[testTier1][canBurst] = 300 // ignored by refillBurst
+	tokens[testTier1][canBurst] = 300 // ignored
 
 	var refillRates rates
 	refillRates[testTier0][noBurst] = 4000
 	refillRates[testTier1][noBurst] = 2000
 
-	s.refillBurst(tokens, refillRates)
+	out := s.groupBurstRates(tokens, refillRates)
 
-	// Each tier gets noBurst/4 tokens, capped at noBurst/4 capacity.
-	require.Equal(t, int64(100), burstMgrs[testTier0].tokens) // 400/4
-	require.Equal(t, int64(50), burstMgrs[testTier1].tokens)  // 200/4
+	// rate = noBurst tokens, cap = noBurst refill rate.
+	require.Equal(t, float64(400), out[testTier0][0])
+	require.Equal(t, float64(4000), out[testTier0][1])
+	require.Equal(t, float64(200), out[testTier1][0])
+	require.Equal(t, float64(2000), out[testTier1][1])
 }
 
 // TestNewStrategy verifies that newStrategy returns the correct
@@ -577,11 +560,7 @@ func TestNewStrategy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	queues := [numResourceTiers]workQueueIForAllocator{
-		testTier0: &testBurstManager{},
-		testTier1: &testBurstManager{},
-	}
-	allocator := cpuTimeTokenAllocator{queues: queues}
+	allocator := cpuTimeTokenAllocator{}
 
 	s := allocator.newStrategy(serverlessMode)
 	require.Equal(t, serverlessMode, s.mode())
@@ -621,7 +600,7 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 		model:    &testModel{buf: &strings.Builder{}, rates: rates{}},
 		metrics:  metrics,
 		queues:   queues,
-		strategy: &serverlessStrategy{queues: queues},
+		strategy: &serverlessStrategy{},
 	}
 
 	ctx := context.Background()
@@ -643,7 +622,7 @@ func TestConfigureQueue(t *testing.T) {
 	}
 	allocator := cpuTimeTokenAllocator{
 		queues:   queues,
-		strategy: &serverlessStrategy{queues: queues},
+		strategy: &serverlessStrategy{},
 	}
 
 	// Serverless mode -> useResourceGroup=false.
@@ -651,7 +630,7 @@ func TestConfigureQueue(t *testing.T) {
 	require.False(t, mgr.useResourceGroup)
 
 	// RM mode -> useResourceGroup=true.
-	allocator.strategy = &rmStrategy{queue: mgr}
+	allocator.strategy = &rmStrategy{}
 	allocator.configureQueue()
 	require.True(t, mgr.useResourceGroup)
 }
@@ -679,20 +658,19 @@ func TestRMStrategyComputeTargets(t *testing.T) {
 	require.Equal(t, 1.0, s.canBurstTarget)
 }
 
-// TestRMStrategyRefillBurst verifies the cold-start guard, the
-// rate100/cap100 recovery from canBurstTarget, and that only the
-// strategy's bound queue receives the call.
-func TestRMStrategyRefillBurst(t *testing.T) {
+// TestRMStrategyGroupBurstRates verifies the cold-start guard, the
+// rate100/cap100 recovery from canBurstTarget, and that both tiers
+// receive mirrored values.
+func TestRMStrategyGroupBurstRates(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	mgr := &testBurstManager{}
-	other := &testBurstManager{}
-	s := &rmStrategy{queue: mgr}
+	s := &rmStrategy{}
 
-	// Cold-start guard: canBurstTarget=0 -> no call.
-	s.refillBurst(tokenCounts{}, rates{})
-	require.Zero(t, mgr.rmCalls)
+	// Cold-start guard: canBurstTarget=0 -> zeros.
+	out := s.groupBurstRates(tokenCounts{}, rates{})
+	require.Equal(t, [2]float64{0, 0}, out[0])
+	require.Equal(t, [2]float64{0, 0}, out[1])
 
 	// canBurstTarget=1.0 recovers tokens/rates as-is.
 	s.canBurstTarget = 1.0
@@ -700,17 +678,15 @@ func TestRMStrategyRefillBurst(t *testing.T) {
 	tokens[0][canBurst] = 1000
 	var rr rates
 	rr[0][canBurst] = 4000
-	s.refillBurst(tokens, rr)
-	require.Equal(t, 1, mgr.rmCalls)
-	require.Equal(t, 1000.0, mgr.rmRate100)
-	require.Equal(t, 4000.0, mgr.rmCap100)
+	out = s.groupBurstRates(tokens, rr)
+	require.Equal(t, [2]float64{1000, 4000}, out[0])
+	require.Equal(t, [2]float64{1000, 4000}, out[1])
 
 	// canBurstTarget=0.5 doubles both.
 	s.canBurstTarget = 0.5
-	s.refillBurst(tokens, rr)
-	require.Equal(t, 2, mgr.rmCalls)
-	require.Equal(t, 2000.0, mgr.rmRate100)
-	require.Equal(t, 8000.0, mgr.rmCap100)
+	out = s.groupBurstRates(tokens, rr)
+	require.Equal(t, [2]float64{2000, 8000}, out[0])
+	require.Equal(t, [2]float64{2000, 8000}, out[1])
 
 	// Delta path: tokens (rate100) may be negative when refill rates
 	// decrease between intervals. cap100 stays non-negative because
@@ -718,11 +694,7 @@ func TestRMStrategyRefillBurst(t *testing.T) {
 	tokens[0][canBurst] = -500
 	rr[0][canBurst] = 4000
 	s.canBurstTarget = 1.0
-	s.refillBurst(tokens, rr)
-	require.Equal(t, 3, mgr.rmCalls)
-	require.Equal(t, -500.0, mgr.rmRate100)
-	require.Equal(t, 4000.0, mgr.rmCap100)
-
-	// Only the bound queue receives the call.
-	require.Zero(t, other.rmCalls)
+	out = s.groupBurstRates(tokens, rr)
+	require.Equal(t, [2]float64{-500, 4000}, out[0])
+	require.Equal(t, [2]float64{-500, 4000}, out[1])
 }

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -191,8 +191,8 @@ func (coord *CPUGrantCoordinators) GetSQLWorkQueue(workKind WorkKind) *WorkQueue
 // SetResourceGroupConfig installs a new per-resource-group config (weight +
 // maxCPU) into the holder, then signals the RM-mode WorkQueue to refresh its
 // cached per-group state. When RM mode is off, the second step is a no-op:
-// the change stays staged in the holder and is applied automatically when
-// the queue next enters RM mode via setUseResourceGroup(true).
+// the change stays staged in the holder and is applied when the mode
+// setting changes to resourceManagerMode.
 func (coord *CPUGrantCoordinators) SetResourceGroupConfig(config ResourceGroupConfigSet) {
 	coord.cpuTimeCoord.configHolder.Set(config)
 	q, ok := coord.cpuTimeCoord.queues[rmQueueTier].(*WorkQueue)
@@ -297,12 +297,6 @@ func makeCPUTimeTokenGrantCoordinator(
 		allocator.queues[tier] = requesters[tier].(*WorkQueue)
 	}
 	allocator.strategy = allocator.newStrategy(initialMode)
-	// Sync the queue's useResourceGroup with the initial strategy.
-	// Without this, a node that starts in resourceManagerMode would never
-	// have configureQueue called: resetInterval only invokes it on a
-	// strategy swap (modeChanged), and the first resetInterval sees
-	// newMode == a.strategy.mode() so modeChanged is false.
-	allocator.configureQueue()
 
 	coordinator := &cpuTimeTokenGrantCoordinator{
 		filler:       filler,

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -173,15 +173,17 @@ func TestSetResourceGroupConfigViaCoord(t *testing.T) {
 
 	// Public API call. This is the only thing under test.
 	cpuCoords.SetResourceGroupConfig(ResourceGroupConfigSet{
-		rgGroupKey(highResourceGroupID): {Weight: 70, MaxCPU: true},
-		rgGroupKey(lowResourceGroupID):  {Weight: 30, MaxCPU: false},
+		rgGroupKey(highResourceGroupID): {Weight: 70, BurstFrac: 0.7, MaxCPU: true},
+		rgGroupKey(lowResourceGroupID):  {Weight: 30, BurstFrac: 0.3, MaxCPU: false},
 	})
 
 	// Holder reflects the new config.
 	snap := cpuCoords.cpuTimeCoord.configHolder.Snapshot()
 	require.Equal(t, uint32(70), snap[rgGroupKey(highResourceGroupID)].Weight)
+	require.Equal(t, float64(0.7), snap[rgGroupKey(highResourceGroupID)].BurstFrac)
 	require.True(t, snap[rgGroupKey(highResourceGroupID)].MaxCPU)
 	require.Equal(t, uint32(30), snap[rgGroupKey(lowResourceGroupID)].Weight)
+	require.Equal(t, float64(0.3), snap[rgGroupKey(lowResourceGroupID)].BurstFrac)
 	require.False(t, snap[rgGroupKey(lowResourceGroupID)].MaxCPU)
 
 	// RM-mode WorkQueue's cached per-group state reflects the new
@@ -189,9 +191,11 @@ func TestSetResourceGroupConfigViaCoord(t *testing.T) {
 	high := getGroupLocked(rmQueue, rgGroupKey(highResourceGroupID))
 	require.NotNil(t, high, "rg high container should be pre-created by apply")
 	require.Equal(t, uint32(70), high.weight)
+	require.Equal(t, float64(0.7), high.burstFrac)
 	require.True(t, high.cpuTimeBurstBucket.maxCPU)
 	low := getGroupLocked(rmQueue, rgGroupKey(lowResourceGroupID))
 	require.NotNil(t, low, "rg low container should be pre-created by apply")
 	require.Equal(t, uint32(30), low.weight)
+	require.Equal(t, float64(0.3), low.burstFrac)
 	require.False(t, low.cpuTimeBurstBucket.maxCPU)
 }

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -169,7 +169,8 @@ func TestSetResourceGroupConfigViaCoord(t *testing.T) {
 	// Force RM mode so the apply path runs synchronously when refresh
 	// is invoked. Without this, refresh is a no-op and the test would
 	// only assert the holder write.
-	rmQueue.setUseResourceGroup(true)
+	ctx := context.Background()
+	cpuTimeTokenACMode.Override(ctx, &settings.SV, resourceManagerMode)
 
 	// Public API call. This is the only thing under test.
 	cpuCoords.SetResourceGroupConfig(ResourceGroupConfigSet{

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -17,15 +17,18 @@ import (
 // work in Resource Manager mode. Callers must pre-normalize the values; the
 // holder stores them as-is.
 type ResourceGroupConfig struct {
-	// Weight is the group's percentage share of node CPU, in [0, 100]. Used
-	// directly as the heap weight and as the burst-bucket refill share
-	// (Weight/100). Callers should set weights that sum to 100 across the
-	// configured set; the holder does not enforce this.
+	// Weight is the group's share used for fair-share ordering in the heap.
+	// Groups with higher weight get proportionally more CPU time before
+	// yielding to others. Must be > 0.
 	Weight uint32
+	// BurstFrac is the fraction of the 100%-CPU rate allocated to this
+	// group's per-group burst bucket. For example, 0.2 means the group's
+	// burst bucket refills at 20% of the full CPU rate.
+	BurstFrac float64
 	// MaxCPU=true forces canBurst regardless of bucket utilization. The bucket
-	// is still refilled at Weight/100; MaxCPU only exempts the group from the
-	// bucket-fullness gate. Within the same canBurst qualification, groups
-	// remain ordered by used/weight.
+	// is still refilled at BurstFrac of the 100%-CPU rate; MaxCPU only exempts
+	// the group from the bucket-fullness gate. Within the same canBurst
+	// qualification, groups remain ordered by used/weight.
 	MaxCPU bool
 }
 
@@ -45,7 +48,8 @@ func (s ResourceGroupConfigSet) SafeFormat(w redact.SafePrinter, _ rune) {
 	sort.Slice(keys, func(i, j int) bool { return keys[i].id < keys[j].id })
 	for _, k := range keys {
 		cfg := s[k]
-		w.Printf("%s weight=%d maxCPU=%t\n", k, cfg.Weight, cfg.MaxCPU)
+		w.Printf("%s weight=%d burstFrac=%.2f maxCPU=%t\n",
+			k, cfg.Weight, cfg.BurstFrac, cfg.MaxCPU)
 	}
 }
 
@@ -83,8 +87,8 @@ func (s ResourceGroupConfigSet) GetOrDefault(k groupKey) ResourceGroupConfig {
 //
 // TODO(wenyihu6): revisit weights once we have signal from real workloads.
 var defaultRMResourceGroupConfig = ResourceGroupConfigSet{
-	rgGroupKey(highResourceGroupID): {Weight: 80, MaxCPU: true},
-	rgGroupKey(lowResourceGroupID):  {Weight: 20, MaxCPU: false},
+	rgGroupKey(highResourceGroupID): {Weight: 80, BurstFrac: 0.8, MaxCPU: true},
+	rgGroupKey(lowResourceGroupID):  {Weight: 20, BurstFrac: 0.2, MaxCPU: false},
 }
 
 // defaultRGGroupConfig is the safety fallback returned by GetOrDefault for
@@ -97,12 +101,14 @@ var defaultRMResourceGroupConfig = ResourceGroupConfigSet{
 //
 // TODO(wenyihu6): once SQL DDL (CREATE/ALTER RESOURCE GROUP) is wired
 // through, decide whether unknown rgKind IDs should be a hard error.
-var defaultRGGroupConfig = ResourceGroupConfig{Weight: 20, MaxCPU: false}
+var defaultRGGroupConfig = ResourceGroupConfig{Weight: 20, BurstFrac: 0.2, MaxCPU: false}
 
 // defaultTenantGroupConfig is the fallback for tenantKind keys: every tenant
 // gets defaultGroupWeight, since per-tenant weights are no longer
 // configurable. MaxCPU=false because tenants don't carry burst flags.
-var defaultTenantGroupConfig = ResourceGroupConfig{Weight: defaultGroupWeight, MaxCPU: false}
+var defaultTenantGroupConfig = ResourceGroupConfig{
+	Weight: defaultGroupWeight, BurstFrac: 0.25, MaxCPU: false,
+}
 
 // ResourceGroupConfigHolder owns the source-of-truth config set for RM mode.
 // It is pure storage behind an RWMutex; reads (every Admit) vastly outnumber

--- a/pkg/util/admission/resource_group_config_holder_test.go
+++ b/pkg/util/admission/resource_group_config_holder_test.go
@@ -32,6 +32,17 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 		require.Equal(t, defaultTenantGroupConfig,
 			h.Snapshot().GetOrDefault(tenantGroupKey(9999)))
 	})
+
+	t.Run("default_configs_have_burst_frac", func(t *testing.T) {
+		h := newResourceGroupConfigHolder()
+		snap := h.Snapshot()
+		highCfg := snap.GetOrDefault(rgGroupKey(highResourceGroupID))
+		require.Equal(t, float64(0.8), highCfg.BurstFrac)
+		lowCfg := snap.GetOrDefault(rgGroupKey(lowResourceGroupID))
+		require.Equal(t, float64(0.2), lowCfg.BurstFrac)
+		tenantCfg := snap.GetOrDefault(tenantGroupKey(9999))
+		require.Equal(t, float64(0.25), tenantCfg.BurstFrac)
+	})
 }
 
 // TestResourceGroupConfigHolderSet covers Set's wholesale-replace and

--- a/pkg/util/admission/sql_cpu_handle.go
+++ b/pkg/util/admission/sql_cpu_handle.go
@@ -156,11 +156,11 @@ type SQLCPUHandle struct {
 		// reservationSourceGroup is the groupKey of the container the
 		// most recent successful Admit credited. Close uses it to
 		// return the drained reservation to the same container,
-		// without re-deriving from the WorkQueue's current
-		// useResourceGroup state — which may have flipped between
-		// Admit and Close. In RM mode the container is rg-keyed; the
-		// prior tenantGroupKey-based lookup missed and silently leaked
-		// the drained reservation.
+		// without re-deriving from the WorkQueue's current mode
+		// — which may have flipped between Admit and Close. In RM
+		// mode the container is rg-keyed; the prior
+		// tenantGroupKey-based lookup missed and silently leaked the
+		// drained reservation.
 		//
 		// Invariant: at any moment, every token in reservation came
 		// from the most recent successful Admit. Each Admit only fires

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -30,7 +30,7 @@ func TestSQLCPUHandleFastAndSlowPath(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, tg, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -94,7 +94,7 @@ func TestSQLCPUHandleCloseReturnsTokens(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+			q, tg, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 			defer cleanup()
 
 			provider := &sqlCPUProviderImpl{}
@@ -132,7 +132,7 @@ func TestSQLCPUHandleNoWaitBypassAdmission(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, tg, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	// Make tryGet return false — a blocking Admit would hang, but
@@ -183,7 +183,7 @@ func TestSQLCPUHandleConcurrentFastPath(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, tg, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -232,7 +232,7 @@ func TestSQLCPUHandleConcurrentSlowPath(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -267,7 +267,7 @@ func TestSQLCPUHandleConcurrentCloseAndAdmit(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -329,7 +329,7 @@ func TestSQLCPUHandleConcurrentCASAndSwap(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	for iter := 0; iter < 100; iter++ {
@@ -397,7 +397,7 @@ func TestSQLCPUHandleAdmitVsCloseTokenConservation(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -448,7 +448,7 @@ func TestSQLCPUHandleContextCancellation(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -493,7 +493,7 @@ func TestSQLCPUHandleCloseDoesNotBlockOnAdmitTurn(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -540,7 +540,7 @@ func TestSQLCPUHandleSecondDeductionAfterTurn(t *testing.T) {
 
 	ctx := context.Background()
 	tenantID := roachpb.MustMakeTenantID(1)
-	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, tg, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	provider := &sqlCPUProviderImpl{}
@@ -612,11 +612,11 @@ func TestSetResourceGroupConfigRGOnly(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	// Create a tenant-keyed container with id=1.
-	q.setUseResourceGroup(false)
+	cpuTimeTokenACMode.Override(ctx, &st.SV, serverlessMode)
 	tenantHandle := newSQLCPUAdmissionHandle(
 		WorkInfo{
 			TenantID: roachpb.MustMakeTenantID(1),
@@ -625,7 +625,7 @@ func TestSetResourceGroupConfigRGOnly(t *testing.T) {
 	require.NoError(t, tenantHandle.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
 
 	// Create an rg-keyed container with id=1 (highResourceGroupID).
-	q.setUseResourceGroup(true)
+	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
 	rgHandle := newSQLCPUAdmissionHandle(
 		WorkInfo{
 			TenantID: roachpb.MustMakeTenantID(99),
@@ -695,17 +695,17 @@ func requireGroupUsed(t *testing.T, q *WorkQueue, key groupKey) uint64 {
 // the original (Admit-time) container. The reservationSourceGroup
 // field captures the key at Admit time precisely so this scenario
 // stays correct: re-deriving from the WorkQueue's current
-// useResourceGroup would route to a freshly-created container that
+// cpuTimeTokenACMode would route to a freshly-created container that
 // never received the tokens.
 func TestSQLCPUHandleCloseAfterModeFlip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, tg, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 	// Start in serverless mode: Admit creates a tenant-keyed container.
-	q.setUseResourceGroup(false)
+	cpuTimeTokenACMode.Override(ctx, &st.SV, serverlessMode)
 
 	h := admitOnce(t, ctx, q, 7, admissionpb.NormalPri)
 	tenantKey := tenantGroupKey(7)
@@ -715,10 +715,12 @@ func TestSQLCPUHandleCloseAfterModeFlip(t *testing.T) {
 	// Flip mode mid-handle. A subsequent Admit on this WorkQueue would
 	// route to rgGroupKey(highResourceGroupID), but Close should still
 	// target the tenant-keyed container that holds the prior tokens.
-	// Note: setUseResourceGroup(true) pre-creates the rg-keyed
-	// containers via applyConfigLocked, so the rg container exists
-	// before Close runs.
-	q.setUseResourceGroup(true)
+	// Pre-create the rg-keyed containers via applyConfigLocked so the
+	// rg container exists before Close runs.
+	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
+	q.mu.Lock()
+	q.applyConfigLocked(q.configHolder.Snapshot())
+	q.mu.Unlock()
 	rgUsedBefore := requireGroupUsed(t, q, rgGroupKey(highResourceGroupID))
 
 	_ = tg.buf.stringAndReset()

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -327,19 +327,6 @@ type WorkQueue struct {
 		// Periodically GC'd by gcGroupsResetUsedAndUpdateEstimators.
 		groups map[groupKey]*groupInfo
 
-		// useResourceGroup, when true, derives the resource group ID from
-		// WorkInfo.Priority instead of WorkInfo.TenantID. Used in Resource
-		// Manager mode to split work into foreground (priority >= NormalPri)
-		// and background (priority < NormalPri) groups.
-		//
-		// This is a bool rather than a live read of the cluster setting so
-		// that mode transitions can update this and all components have a
-		// consistent view.
-		//
-		// TODO(wenyihu): support mode transitions and consider
-		// replacing this with an enum for serverless vs RM mode.
-		useResourceGroup bool
-
 		// The highest epoch that is closed.
 		closedEpochThreshold int64
 		// Following values are copied from the cluster settings.
@@ -353,16 +340,8 @@ type WorkQueue struct {
 		// applyConfigLocked pre-create. Both fields take this value, so
 		// new groups start full and can burst immediately.
 		//
-		// Serverless mode: refreshed every 1ms by refillBurstBuckets to
-		// match the uniform per-tenant capacity.
-		//
-		// RM mode: left at zero. RM capacities scale by per-group weight,
-		// so no queue-wide value is correct. Seeding with the unscaled
-		// 100% value would briefly grant unearned burst budget to
-		// non-MAX_CPU groups; seeding with zero only throttles a brand-
-		// new group for at most one refill tick (1ms), which is the safer
-		// failure mode. refillRMGroupBurstBuckets installs the correct
-		// per-group capacity on the next tick.
+		// Refreshed every 1ms by refillGroupBurstBuckets to
+		// int64(cap * defaultTenantGroupConfig.BurstFrac).
 		burstBucketCapacity int64
 		// overrideAllToBypassAdmission, when true, causes all work to bypass
 		// admission control. Used by CPU time token AC.
@@ -370,9 +349,8 @@ type WorkQueue struct {
 	}
 
 	// configHolder owns the per-resource-group config for RM mode. Always
-	// non-nil; non-CTT WorkQueues hold their own holder but never read it
-	// because useResourceGroup stays false. See
-	// resource_group_config_holder.go for the type's lifecycle contract.
+	// non-nil. See resource_group_config_holder.go for the type's
+	// lifecycle contract.
 	//
 	// Lock ordering: q.mu is acquired first, holder.mu second. Never the
 	// reverse. All current readers (Snapshot) are called from sites that
@@ -732,9 +710,8 @@ type AdmitResponse struct {
 	requestedCount int64
 }
 
-// Resource group IDs used in Resource Manager mode when
-// useResourceGroup is true. Work is split into two groups based on
-// WorkInfo.Priority.
+// Resource group IDs used in Resource Manager mode. Work is split into
+// two groups based on WorkInfo.Priority.
 const (
 	// highResourceGroupID is used for work with priority >= NormalPri.
 	highResourceGroupID uint64 = 1
@@ -752,30 +729,15 @@ func priorityToResourceGroupKey(pri admissionpb.WorkPriority) groupKey {
 	return rgGroupKey(lowResourceGroupID)
 }
 
-// setUseResourceGroup enables or disables priority-based resource
-// group derivation. When enabled, the resource group ID is derived
-// from WorkInfo.Priority instead of WorkInfo.TenantID.
-//
-// When enabled is true, the current holder snapshot is also applied
-// to q.mu.groups via applyConfigLocked.
-func (q *WorkQueue) setUseResourceGroup(enabled bool) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.mu.useResourceGroup = enabled
-	if enabled {
-		q.applyConfigLocked(q.configHolder.Snapshot())
-	}
-}
-
 // groupKeyForWorkLocked returns the composite groupKey for the given
-// WorkInfo. In RM mode (useResourceGroup), the key is derived from
-// WorkInfo.Priority with kind=rgKind; otherwise it is the TenantID
-// with kind=tenantKind.
+// WorkInfo. In RM mode (cpuTimeTokenACMode == resourceManagerMode), the
+// key is derived from WorkInfo.Priority with kind=rgKind; otherwise it
+// is the TenantID with kind=tenantKind.
 //
 // REQUIRES: q.mu is held.
 func (q *WorkQueue) groupKeyForWorkLocked(info WorkInfo) groupKey {
 	q.mu.AssertHeld()
-	if q.mu.useResourceGroup {
+	if cpuTimeTokenACMode.Get(&q.settings.SV) == resourceManagerMode {
 		return priorityToResourceGroupKey(info.Priority)
 	}
 	return tenantGroupKey(info.TenantID.ToUint64())
@@ -946,8 +908,8 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 					)
 				}
 				// Replicated work is a Serverless-mode-only path
-				// (StoreWorkQueue runs in usesTokens mode and never sets
-				// useResourceGroup), so gKey is always tenant-keyed.
+				// (StoreWorkQueue runs in usesTokens mode), so gKey is
+				// always tenant-keyed.
 				q.onAdmittedReplicatedWork.admittedReplicatedWork(
 					roachpb.MustMakeTenantID(gKey.id),
 					info.Priority,
@@ -1576,12 +1538,11 @@ func (q *WorkQueue) SetOverrideAllToBypassAdmission(override bool) {
 // refreshResourceGroupConfig pushes the current holder snapshot onto
 // q.mu.groups via applyConfigLocked. Call this after configHolder.Set
 // to make a config change visible to in-flight admits. No-op when the
-// queue is not in RM mode; setUseResourceGroup(true) replays the
-// holder snapshot on the next mode entry.
+// queue is not in RM mode.
 func (q *WorkQueue) refreshResourceGroupConfig() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.mu.useResourceGroup {
+	if cpuTimeTokenACMode.Get(&q.settings.SV) == resourceManagerMode {
 		q.applyConfigLocked(q.configHolder.Snapshot())
 	}
 }
@@ -1594,15 +1555,15 @@ func (q *WorkQueue) refreshResourceGroupConfig() {
 // Entries absent from the snapshot are left in q.mu.groups and drain
 // via the GC path.
 //
-// q.mu must be held. Callers: setUseResourceGroup at RM-mode entry,
-// and refreshResourceGroupConfig on a config change.
+// q.mu must be held. Caller: refreshResourceGroupConfig on a config
+// change.
 //
 // New-vs-existing asymmetry: a freshly pre-created groupInfo seeds
 // cpuTimeTokenEstimator and cpuTimeBurstBucket.capacity from package
 // state (defaultCPUTimeTokenEstimator, q.mu.burstBucketCapacity)
 // rather than the snapshot, so the estimator seed and bucket
 // capacity stick at their first-creation values. The bucket capacity
-// catches up on the next refillRMGroupBurstBuckets tick (within 1ms);
+// catches up on the next refillGroupBurstBuckets tick (within 1ms);
 // a Set that changes MaxCPU lands instantly while the implied bucket
 // capacity trails briefly.
 func (q *WorkQueue) applyConfigLocked(config ResourceGroupConfigSet) {
@@ -1787,9 +1748,8 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 }
 
 // groupInfo is the per-group information in the groupHeap. In Serverless mode,
-// the resource group ID is the tenant ID. In RM mode with useResourceGroup,
-// the resource group ID is derived from the work's priority (see
-// priorityToResourceGroupKey).
+// the resource group ID is the tenant ID. In RM mode, the resource group ID is
+// derived from the work's priority (see priorityToResourceGroupKey).
 type groupInfo struct {
 	// groupKey is the composite (id, kind) under which this groupInfo
 	// is stored in WorkQueue.mu.groups.

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -841,10 +841,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// dedicated to that group yet. When we create the groupInfo struct
 		// here, we also create the estimator. We init the estimator using a
 		// global estimator that sees workload across all groups.
-		weights, maxCPU := q.getGroupWeightLocked(gKey)
-		group = newGroupInfo(gKey, weights,
-			q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
-			maxCPU, q.perGroupAggMetrics)
+		weight, burstFrac, maxCPU := q.getGroupConfigLocked(gKey)
+		group = newGroupInfo(gKey, weight, burstFrac,
+			q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(),
+			q.mu.burstBucketCapacity, maxCPU, q.perGroupAggMetrics)
 		q.mu.groups[gKey] = group
 	}
 	// If mode == usesCPUTimeTokens, WorkQueue does CPU time token estimation.
@@ -988,10 +988,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 		// groupInfo struct is declared.
 		group, ok = q.mu.groups[gKey]
 		if !ok {
-			weights, maxCPU := q.getGroupWeightLocked(gKey)
-			group = newGroupInfo(gKey, weights,
-				q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(), q.mu.burstBucketCapacity,
-				maxCPU, q.perGroupAggMetrics)
+			weight, burstFrac, maxCPU := q.getGroupConfigLocked(gKey)
+			group = newGroupInfo(gKey, weight, burstFrac,
+				q.mode, q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(),
+				q.mu.burstBucketCapacity, maxCPU, q.perGroupAggMetrics)
 			q.mu.groups[gKey] = group
 		}
 		q.adjustGroupUsedLocked(group, -info.RequestedCount)
@@ -1466,7 +1466,7 @@ func (q *WorkQueue) refillBurstBucketForGroup(gKey groupKey, toAdd int64, capaci
 // refillRMGroupBurstBuckets refills every rgKind group's burst bucket
 // in a single q.mu critical section. rate100 and cap100 are the 100%
 // CPU per-tick refill rate and bucket capacity; per-group amounts are
-// scaled by group.weight/100. Called by rmStrategy.refillBurst on every
+// scaled by group.burstFrac. Called by rmStrategy.refillBurst on every
 // tick.
 //
 // Iterating q.mu.groups directly (rather than snapshotting the holder)
@@ -1483,9 +1483,8 @@ func (q *WorkQueue) refillRMGroupBurstBuckets(rate100, cap100 float64) {
 		if k.kind != rgKind {
 			continue
 		}
-		burstFrac := float64(group.weight) / 100.0
-		toAdd := int64(rate100 * burstFrac)
-		capacity := int64(cap100 * burstFrac)
+		toAdd := int64(rate100 * group.burstFrac)
+		capacity := int64(cap100 * group.burstFrac)
 		q.refillBurstBucketLocked(group, toAdd, capacity)
 	}
 }
@@ -1577,12 +1576,14 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 // share equal weight.
 const defaultGroupWeight = 1
 
-// getGroupWeightLocked returns the heap weight and maxCPU flag for gKey from
-// the configHolder, which falls back to a kind-appropriate default for
+// getGroupConfigLocked returns the config for gKey from the
+// configHolder, which falls back to a kind-appropriate default for
 // unconfigured keys. q.mu must be held.
-func (q *WorkQueue) getGroupWeightLocked(gKey groupKey) (weight uint32, maxCPU bool) {
+func (q *WorkQueue) getGroupConfigLocked(
+	gKey groupKey,
+) (weight uint32, burstFrac float64, maxCPU bool) {
 	cfg := q.configHolder.Snapshot().GetOrDefault(gKey)
-	return cfg.Weight, cfg.MaxCPU
+	return cfg.Weight, cfg.BurstFrac, cfg.MaxCPU
 }
 
 // SetOverrideAllToBypassAdmission sets whether all work should bypass
@@ -1629,7 +1630,7 @@ func (q *WorkQueue) applyConfigLocked(config ResourceGroupConfigSet) {
 	for k, d := range config {
 		group, ok := q.mu.groups[k]
 		if !ok {
-			group = newGroupInfo(k, d.Weight, q.mode,
+			group = newGroupInfo(k, d.Weight, d.BurstFrac, q.mode,
 				q.mu.defaultCPUTimeTokenEstimator.estimateTokensToBeUsed(),
 				q.mu.burstBucketCapacity, d.MaxCPU, q.perGroupAggMetrics)
 			q.mu.groups[k] = group
@@ -1645,6 +1646,7 @@ func (q *WorkQueue) applyConfigLocked(config ResourceGroupConfigSet) {
 			group.weight = d.Weight
 			needsHeapFix = true
 		}
+		group.burstFrac = d.BurstFrac
 		if group.cpuTimeBurstBucket.maxCPU != d.MaxCPU {
 			prevQual := group.cpuTimeBurstBucket.burstQualification()
 			group.cpuTimeBurstBucket.maxCPU = d.MaxCPU
@@ -1816,6 +1818,10 @@ type groupInfo struct {
 	// The weight assigned to the resource group. Must be > 0. For
 	// resource groups, this is WEIGHT_CPU.
 	weight uint32
+	// burstFrac is the fraction of the 100%-CPU rate allocated to this
+	// group's per-group burst bucket. Sourced from
+	// ResourceGroupConfig.BurstFrac at group creation or config update.
+	burstFrac float64
 	// used is computed over an interval and periodically reset. Ordering
 	// between groups, for fair sharing, utilizes this value.
 	//
@@ -1901,6 +1907,7 @@ var groupInfoPool = sync.Pool{
 func newGroupInfo(
 	gKey groupKey,
 	weight uint32,
+	burstFrac float64,
 	mode workQueueMode,
 	cpuTimeTokenEstimate int64,
 	burstBucketCapacity int64,
@@ -1911,6 +1918,7 @@ func newGroupInfo(
 	*ti = groupInfo{
 		groupKey:              gKey,
 		weight:                weight,
+		burstFrac:             burstFrac,
 		waitingWorkHeap:       ti.waitingWorkHeap,
 		openEpochsHeap:        ti.openEpochsHeap,
 		priorityStates:        makePriorityStates(ti.priorityStates.ps),

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1427,28 +1427,33 @@ func (q *WorkQueue) AdmittedSQLWorkDone(gKey groupKey, remaining int64) {
 	}
 }
 
-// refillBurstBuckets adds tokens to all group burst buckets and updates
-// their capacity. This is called by serverlessStrategy.refillBurst
-// periodically (every 1ms). toAdd and capacity are passed uniformly to
-// all tenants with no per-tenant scaling.
+// refillGroupBurstBuckets refills every group's burst bucket in a
+// single q.mu critical section. rate and cap are the unscaled (100%
+// CPU) per-tick refill rate and bucket capacity; per-group amounts are
+// scaled by group.burstFrac.
 //
-// If a group's burst qualification changes as a result of the refill,
-// the group's position in the groupHeap is updated to maintain correct
-// priority ordering.
-func (q *WorkQueue) refillBurstBuckets(toAdd int64, capacity int64) {
+// burstBucketCapacity is set to int64(cap * defaultTenantGroupConfig.BurstFrac)
+// so that lazily created tenant groups start with the correct capacity.
+//
+// Holding q.mu once (instead of acquiring per group) costs one lock
+// acquire instead of N+1 and makes the refill atomic across groups: no
+// observer can see a partial-refill state.
+func (q *WorkQueue) refillGroupBurstBuckets(rate, cap float64) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	q.mu.burstBucketCapacity = capacity
+	q.mu.burstBucketCapacity = int64(cap * defaultTenantGroupConfig.BurstFrac)
 	for _, group := range q.mu.groups {
+		toAdd := int64(rate * group.burstFrac)
+		capacity := int64(cap * group.burstFrac)
 		q.refillBurstBucketLocked(group, toAdd, capacity)
 	}
 }
 
 // refillBurstBucketForGroup refills a single rgKind group's burst
 // bucket. Test-only: production refills go through
-// refillRMGroupBurstBuckets, which iterates all rgKind groups under one
-// q.mu critical section. This entry point exists for datadriven tests
-// that need to drive one group's bucket to a specific (toAdd, capacity)
+// refillGroupBurstBuckets, which iterates all groups under one q.mu
+// critical section. This entry point exists for datadriven tests that
+// need to drive one group's bucket to a specific (toAdd, capacity)
 // without running the full filler.
 //
 // If the refill flips the group's burst qualification, its groupHeap
@@ -1461,32 +1466,6 @@ func (q *WorkQueue) refillBurstBucketForGroup(gKey groupKey, toAdd int64, capaci
 		return
 	}
 	q.refillBurstBucketLocked(group, toAdd, capacity)
-}
-
-// refillRMGroupBurstBuckets refills every rgKind group's burst bucket
-// in a single q.mu critical section. rate100 and cap100 are the 100%
-// CPU per-tick refill rate and bucket capacity; per-group amounts are
-// scaled by group.burstFrac. Called by rmStrategy.refillBurst on every
-// tick.
-//
-// Iterating q.mu.groups directly (rather than snapshotting the holder)
-// avoids a per-tick allocation. The kind filter skips any tenantKind
-// orphans left over from a prior serverless mode.
-//
-// Holding q.mu once (instead of acquiring per group) costs one lock
-// acquire instead of N+1 and makes the refill atomic across groups: no
-// observer can see a partial-refill state.
-func (q *WorkQueue) refillRMGroupBurstBuckets(rate100, cap100 float64) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	for k, group := range q.mu.groups {
-		if k.kind != rgKind {
-			continue
-		}
-		toAdd := int64(rate100 * group.burstFrac)
-		capacity := int64(cap100 * group.burstFrac)
-		q.refillBurstBucketLocked(group, toAdd, capacity)
-	}
 }
 
 // refillBurstBucketLocked refills a group's burst bucket and fixes its

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -558,10 +558,8 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				d.ScanArgs(t, "v", &v)
 				// Mutate the holder's current config in place: take the
 				// snapshot (seed + prior Sets), flip the requested
-				// group, write back. Force an apply at the end because
-				// the datadriven tests run with useResourceGroup=false
-				// (tenant-keyed groups) but still expect maxCPU flips to
-				// land on existing groups.
+				// group, write back. Force an apply so maxCPU flips
+				// land on existing groups immediately.
 				cfg := q.configHolder.Snapshot()
 				k := rgGroupKey(uint64(group))
 				cur := cfg[k]
@@ -579,7 +577,14 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 			case "set-priority-based-groups":
 				var v bool
 				d.ScanArgs(t, "v", &v)
-				q.setUseResourceGroup(v)
+				if v {
+					cpuTimeTokenACMode.Override(context.Background(), &st.SV, resourceManagerMode)
+					q.mu.Lock()
+					q.applyConfigLocked(q.configHolder.Snapshot())
+					q.mu.Unlock()
+				} else {
+					cpuTimeTokenACMode.Override(context.Background(), &st.SV, serverlessMode)
+				}
 				return ""
 
 			case "refill-burst-bucket-for-group":
@@ -757,12 +762,14 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 // makeCPUTimeTokenWorkQueue creates a WorkQueue in CTT mode for testing. The
 // returned testGranter has tryGet returning true by default (all Admit calls
 // succeed immediately).
-func makeCPUTimeTokenWorkQueue(t *testing.T) (q *WorkQueue, tg *testGranter, cleanup func()) {
+func makeCPUTimeTokenWorkQueue(
+	t *testing.T,
+) (q *WorkQueue, tg *testGranter, st *cluster.Settings, cleanup func()) {
 	var buf builderWithMu
 	tg = &testGranter{buf: &buf}
 	tg.mu.returnValueFromTryGet = true
 
-	st := cluster.MakeTestingClusterSettings()
+	st = cluster.MakeTestingClusterSettings()
 	metrics := makeWorkQueueMetrics("", metric.NewRegistry())
 
 	initialTime := timeutil.FromUnixMicros(
@@ -784,7 +791,7 @@ func makeCPUTimeTokenWorkQueue(t *testing.T) (q *WorkQueue, tg *testGranter, cle
 	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 		KVWork, tg, st, metrics, opts).(*WorkQueue)
 	tg.r = q
-	return q, tg, q.close
+	return q, tg, st, q.close
 }
 
 // TestSQLCPUAdmission verifies the SQL CPU admission integration with the CTT
@@ -799,7 +806,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 	tenantID := roachpb.MustMakeTenantID(1)
 
 	t.Run("explicit-requested-count-skips-estimator", func(t *testing.T) {
-		q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+		q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 		defer cleanup()
 
 		// Train the estimator so it returns something other than 1ns.
@@ -840,7 +847,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 	})
 
 	t.Run("report-cpu-updates-counters", func(t *testing.T) {
-		q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+		q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 		defer cleanup()
 
 		provider := &sqlCPUProviderImpl{}
@@ -872,7 +879,7 @@ func TestSQLCPUAdmission(t *testing.T) {
 	})
 
 	t.Run("context-canceled-propagates-error", func(t *testing.T) {
-		q, tg, cleanup := makeCPUTimeTokenWorkQueue(t)
+		q, tg, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 		defer cleanup()
 
 		// Make tryGet return false so Admit blocks and observes the
@@ -1290,19 +1297,18 @@ func withGroupLocked(q *WorkQueue, fn func()) {
 	fn()
 }
 
-// TestSetUseResourceGroupAppliesHolderSnapshot verifies that the
-// false->true mode flip materializes the holder's snapshot into
+// TestApplyConfigLockedMaterializesGroups verifies that
+// applyConfigLocked materializes the holder's snapshot into
 // q.mu.groups: the seeded high/low rg containers must exist on the
-// queue immediately after the flip, with the configured
-// weight/maxCPU. Without this, lazy-create would still reach the
-// right state on first admit, but operators-facing observers
-// (metrics, debug print) would not see the groups until traffic
-// arrives.
-func TestSetUseResourceGroupAppliesHolderSnapshot(t *testing.T) {
+// queue immediately after, with the configured weight/maxCPU. Without
+// this, lazy-create would still reach the right state on first admit,
+// but operator-facing observers (metrics, debug print) would not see
+// the groups until traffic arrives.
+func TestApplyConfigLockedMaterializesGroups(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	// Custom config replaces the default seed.
@@ -1315,16 +1321,19 @@ func TestSetUseResourceGroupAppliesHolderSnapshot(t *testing.T) {
 	require.Nil(t, getGroupLocked(q, rgGroupKey(highResourceGroupID)))
 	require.Nil(t, getGroupLocked(q, rgGroupKey(lowResourceGroupID)))
 
-	q.setUseResourceGroup(true)
+	// Switch to RM mode and apply the config.
+	ctx := context.Background()
+	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
+	q.refreshResourceGroupConfig()
 
 	// Post-condition: both rg containers pre-created with the
 	// configured weight/maxCPU.
 	high := getGroupLocked(q, rgGroupKey(highResourceGroupID))
-	require.NotNil(t, high, "high rg container should be pre-created on mode flip")
+	require.NotNil(t, high, "high rg container should be pre-created by apply")
 	require.Equal(t, uint32(60), high.weight)
 	require.True(t, high.cpuTimeBurstBucket.maxCPU)
 	low := getGroupLocked(q, rgGroupKey(lowResourceGroupID))
-	require.NotNil(t, low, "low rg container should be pre-created on mode flip")
+	require.NotNil(t, low, "low rg container should be pre-created by apply")
 	require.Equal(t, uint32(40), low.weight)
 	require.False(t, low.cpuTimeBurstBucket.maxCPU)
 }
@@ -1338,7 +1347,7 @@ func TestRefreshResourceGroupConfigInServerlessIsNoOp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 	// Stay in serverless mode (default).
 
@@ -1367,14 +1376,16 @@ func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	q, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	q, _, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
 	q.configHolder.Set(ResourceGroupConfigSet{
 		rgGroupKey(highResourceGroupID): {Weight: 70, MaxCPU: true},
 		rgGroupKey(lowResourceGroupID):  {Weight: 30, MaxCPU: false},
 	})
-	q.setUseResourceGroup(true)
+	ctx := context.Background()
+	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
+	q.refreshResourceGroupConfig()
 
 	// Sanity: the high rg container exists with the configured state.
 	high := getGroupLocked(q, rgGroupKey(highResourceGroupID))

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -535,7 +535,16 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				var toAdd, capacity int64
 				d.ScanArgs(t, "to-add", &toAdd)
 				d.ScanArgs(t, "capacity", &capacity)
-				q.refillBurstBuckets(toAdd, capacity)
+				// Test helper: apply uniform (toAdd, capacity) to every
+				// group, bypassing burstFrac scaling. This keeps testdata
+				// files unchanged. Production code uses
+				// refillGroupBurstBuckets which scales per group.
+				q.mu.Lock()
+				q.mu.burstBucketCapacity = capacity
+				for _, group := range q.mu.groups {
+					q.refillBurstBucketLocked(group, toAdd, capacity)
+				}
+				q.mu.Unlock()
 				return ""
 
 			case "gc-groups-and-reset-used":


### PR DESCRIPTION
This is the first in a series of PRs to consolidate the CPU time token
admission control system from two WorkQueues (one per resource tier) to a
single queue. This PR is mostly mechanical — no values change, no test
expectations change.

The key insight: the existing serverless burst refill (`noBurst / 4`) is
equivalent to `noBurst * BurstFrac` with `BurstFrac = 0.25`. By making
BurstFrac an explicit field on `ResourceGroupConfig`, both serverless and
RM modes can use a single `refillGroupBurstBuckets(rate, cap)` method on
WorkQueue. The two modes differ only in which rate they pass to
`groupBurstRates`:
- Serverless: `noBurst` (per tier)
- RM: `rate100` (recovered from `canBurst / canBurstTarget`)

The final commit replaces the `useResourceGroup` bool (toggled by the
filler goroutine on mode changes) with a direct read of the mode cluster
setting. A new group created under a different mode is no different from
encountering any group for the first time.

Epic: none