### PR TITLE
kvserver: support sep engines on failing tests

### DIFF
--- a/pkg/kv/kvserver/client_manual_proposal_test.go
+++ b/pkg/kv/kvserver/client_manual_proposal_test.go
@@ -67,15 +67,19 @@ func TestCreateManyUnappliedProbes(t *testing.T) {
 	//   (./cockroach start-single-node --logtostderr=INFO --insecure | grep -F r10/)
 	//
 	// Then wait and watch the `raft.commandsapplied` metric to see r10 apply the entries.
-	p := filepath.Join(t.TempDir(), "cockroach-data")
+	stateEnginePath := filepath.Join(t.TempDir(), "cockroach-data")
+	// logEnginePath is the on-disk path of the store's log engine. In
+	// single-engine mode it equals stateEnginePath; in separated mode it points
+	// at the log-engine directory.
+	var logEnginePath string
 	const entsPerBatch = 10
 	const batches = 3
 	rangeID := roachpb.RangeID(10) // system.settings
 
-	if _, err := os.Stat(p); err != nil {
+	if _, err := os.Stat(stateEnginePath); err != nil {
 		args := base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{StoreSpecs: []base.StoreSpec{
-				{Path: p},
+				{Path: stateEnginePath},
 			}},
 			ReplicationMode: base.ReplicationManual,
 		}
@@ -89,6 +93,7 @@ ORDER BY
 	range_id ASC
 LIMIT
 	1;`).Scan(&rangeID))
+		logEnginePath = tc.GetFirstStoreFromServer(t, 0).LogEngine().Env().Dir
 		tc.Stopper().Stop(ctx)
 
 		defer func() {
@@ -100,23 +105,31 @@ LIMIT
 			require.NoError(t, tc.ServerConn(0).QueryRow(`SELECT count(1) FROM system.settings`).Err())
 			t.Log("read system.settings")
 		}()
-
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	eng, err := storage.Open(ctx, fs.MustInitPhysicalTestingEnv(p), st)
+	stateEng, err := storage.Open(ctx, fs.MustInitPhysicalTestingEnv(stateEnginePath), st)
 	require.NoError(t, err)
-	defer eng.Close()
+	defer stateEng.Close()
+
+	// If engines are separated, open the logEng. If engines are not separated,
+	// logEng is the same as stateEng.
+	logEng := stateEng
+	if logEnginePath != "" && logEnginePath != stateEnginePath {
+		logEng, err = storage.Open(ctx, fs.MustInitPhysicalTestingEnv(logEnginePath), st)
+		require.NoError(t, err)
+		defer logEng.Close()
+	}
 
 	// Determine LastIndex, LastTerm, and next MaxLeaseIndex by scanning
 	// existing log.
-	it, err := raftlog.NewIterator(ctx, rangeID, eng, raftlog.IterOptions{})
+	it, err := raftlog.NewIterator(ctx, rangeID, logEng, raftlog.IterOptions{})
 	require.NoError(t, err)
 	defer it.Close()
 	rsl := logstore.NewStateLoader(rangeID)
-	ts, err := rsl.LoadRaftTruncatedState(ctx, eng)
+	ts, err := rsl.LoadRaftTruncatedState(ctx, logEng)
 	require.NoError(t, err)
-	lastEntryID, err := rsl.LoadLastEntryID(ctx, eng, ts)
+	lastEntryID, err := rsl.LoadLastEntryID(ctx, logEng, ts)
 	require.NoError(t, err)
 	t.Logf("loaded LastEntryID: %+v", lastEntryID)
 	lastIndex := lastEntryID.Index
@@ -127,7 +140,7 @@ LIMIT
 	var lai kvpb.LeaseAppliedIndex
 	var lastTerm uint64
 	require.NoError(t, raftlog.Visit(
-		ctx, eng, rangeID, lastIndex, math.MaxUint64, func(entry raftpb.Entry) error {
+		ctx, logEng, rangeID, lastIndex, math.MaxUint64, func(entry raftpb.Entry) error {
 			ent, err := raftlog.NewEntry(it.Entry())
 			require.NoError(t, err)
 			if lai < ent.Cmd.MaxLeaseIndex {
@@ -138,12 +151,12 @@ LIMIT
 		}))
 
 	sl := kvstorage.MakeStateLoader(rangeID)
-	lease, err := sl.LoadLease(ctx, eng)
+	lease, err := sl.LoadLease(ctx, stateEng)
 	require.NoError(t, err)
 
 	for batchIdx := 0; batchIdx < batches; batchIdx++ {
 		t.Logf("batch %d", batchIdx+1)
-		b := storage.NewOpLoggerBatch(eng.NewBatch())
+		b := storage.NewOpLoggerBatch(stateEng.NewBatch())
 		defer b.Batch.Close()
 
 		var ents []raftpb.Entry
@@ -218,7 +231,7 @@ LIMIT
 		swl.Start(ctx, stopper)
 		ls := logstore.LogStore{
 			RangeID:     rangeID,
-			Engine:      eng,
+			Engine:      logEng,
 			Sideload:    nil,
 			StateLoader: rsl,
 			SyncWaiter:  swl,

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3898,6 +3898,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "rebalanceRHSAway", func(t *testing.T, rebalanceRHSAway bool) {
 		// We will be testing the SSTs written on store3's engine.
 		var recvStateEng, recvLogEng, sendStateEng storage.Engine
+		var enginesSeparated bool
 		// All of these variables will be populated later, after starting the
 		// cluster.
 		var keyStart, keyA, keyB, keyC, keyD, keyEnd roachpb.Key
@@ -3932,7 +3933,15 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			// NOTE: There are no range-local keys or lock table keys, in [d,
 			// /Max) in the store we're sending a snapshot to, so we aren't
 			// expecting SSTs to clear those keys.
-			require.Len(t, sstNames, 9)
+			//
+			// NB: In separated mode, rewriteRaftState writes go to the log-engine
+			// batch instead of an SST in the scratch, so the count drops by 1
+			// (9 → 8) and the subsumed-replica clear SSTs shift left by one.
+			wantSSTs, clearStart := 9, 6
+			if enginesSeparated {
+				wantSSTs, clearStart = 8, 5
+			}
+			require.Len(t, sstNames, wantSSTs)
 
 			// Only try to predict SSTs for:
 			// - The user keys in the snapshot
@@ -3948,7 +3957,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			// The SST with the user keys in the snapshot.
 			sstNamesSubset = append(sstNamesSubset, sstNames[4])
 			// Remaining ones from the predict list above.
-			sstNamesSubset = append(sstNamesSubset, sstNames[6:]...)
+			sstNamesSubset = append(sstNamesSubset, sstNames[clearStart:]...)
 
 			// Construct the expected SSTs and ensure that they are byte-by-byte
 			// equal. This verification ensures that the SSTs have the same
@@ -4024,10 +4033,13 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			expectedSSTs = expectedSSTs[len(expectedSSTs)-1:]
 
 			// Construct SSTs for the range-id local keys of the subsumed
-			// replicas. with RangeIDs 3 and 4. Note that this also targets the
+			// replicas with RangeIDs 3 and 4. Note that this also targets the
 			// unreplicated rangeID-based keys because we're effectively
 			// replicaGC'ing these replicas (while absorbing their user keys
-			// into the LHS).
+			// into the LHS). In separated mode the raft-engine clears (raft
+			// log, HardState, TruncatedState) go to the log-engine batch
+			// instead; only RaftReplicaID stays in the SST since it lives on
+			// the state engine.
 			for _, k := range []roachpb.Key{keyB, keyC} {
 				rangeID := rangeIds[string(k)]
 				sstFile := &storage.MemObject{}
@@ -4052,20 +4064,24 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 				// Ditto for the unreplicated RangeID keys. Note that it is also split
 				// into three range clears, to work around the RaftReplicaID key and
 				// to force all raft log clearing to go through logstore.
-				require.NoError(t, sst.ClearRawRange(
-					keys.RaftHardStateKey(rangeID), sl.RaftLogPrefix(), true, false,
-				))
-				require.NoError(t, storage.ClearRangeWithHeuristic(
-					ctx, recvLogEng, &sst,
-					sl.RaftLogPrefix(), sl.RaftLogPrefix().PrefixEnd(),
-					kvstorage.ClearRangeThresholdPointKeys(),
-				))
+				if !enginesSeparated {
+					require.NoError(t, sst.ClearRawRange(
+						keys.RaftHardStateKey(rangeID), sl.RaftLogPrefix(), true, false,
+					))
+					require.NoError(t, storage.ClearRangeWithHeuristic(
+						ctx, recvLogEng, &sst,
+						sl.RaftLogPrefix(), sl.RaftLogPrefix().PrefixEnd(),
+						kvstorage.ClearRangeThresholdPointKeys(),
+					))
+				}
 				require.NoError(t, sl.ClearRaftReplicaID(&sst))
-				require.NoError(t, sst.ClearRawRange(
-					sl.RaftTruncatedStateKey(),
-					keys.MakeRangeIDUnreplicatedPrefix(rangeID).PrefixEnd(),
-					true, false,
-				))
+				if !enginesSeparated {
+					require.NoError(t, sst.ClearRawRange(
+						sl.RaftTruncatedStateKey(),
+						keys.MakeRangeIDUnreplicatedPrefix(rangeID).PrefixEnd(),
+						true, false,
+					))
+				}
 
 				require.NoError(t, sst.Finish())
 				expectedSSTs = append(expectedSSTs, sstFile.Data())
@@ -4135,6 +4151,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		sendStateEng = store1.StateEngine()
 		recvStateEng = store3.StateEngine()
 		recvLogEng = store3.LogEngine()
+		store3Engines := store3.Engines()
+		enginesSeparated = store3Engines.Separated()
+
 		distSender := tc.Servers[0].DistSenderI().(kv.Sender)
 
 		// This test works across 5 ranges in total. We start with a scratch
@@ -4232,6 +4251,18 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			tc.RemoveVotersOrFatal(t, keyD, tc.Target(0))
 		}
 
+		// In separated mode, capture the soon-to-be-subsumed replicas' applied
+		// indices on store3 so we can later assert that subsumeReplica's
+		// "clear unapplied raft log suffix" worked.
+		subsumedAppliedIdx := map[roachpb.RangeID]kvpb.RaftIndex{}
+		if enginesSeparated {
+			for _, k := range []roachpb.Key{keyB, keyC} {
+				repl := store3.LookupReplica(roachpb.RKey(k))
+				require.NotNilf(t, repl, "store3 should still hold r%d before traffic restore", rangeIds[string(k)])
+				subsumedAppliedIdx[repl.RangeID] = repl.State(ctx).ReplicaState.RaftAppliedIndex
+			}
+		}
+
 		// Restore Raft traffic to the LHS on store3.
 		log.KvDistribution.Infof(ctx, "restored traffic to store 3")
 		tc.Servers[2].RaftTransport().(*kvserver.RaftTransport).ListenIncomingRaftMessages(store3.Ident.StoreID, &kvtestutils.UnreliableRaftHandler{
@@ -4303,6 +4334,29 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			}
 			return nil
 		})
+
+		// In separated mode, also verify that subsumeReplica cleared the
+		// subsumed replicas' raft state on the log engine. This complements
+		// the per-subsumed-replica byte-by-byte SST check above, which under
+		// separated mode only covers the state-engine portion of the clear.
+		if enginesSeparated {
+			for _, k := range []roachpb.Key{keyB, keyC} {
+				rangeID := rangeIds[string(k)]
+				sl := kvstorage.MakeStateLoader(rangeID)
+				hs, err := sl.LoadHardState(ctx, store3.LogEngine())
+				require.NoError(t, err)
+				require.Equal(t, raftpb.HardState{}, hs)
+				ts, err := sl.LoadRaftTruncatedState(ctx, store3.LogEngine())
+				require.NoError(t, err)
+				require.Equal(t, kvserverpb.RaftTruncatedState{}, ts)
+				// The unapplied-suffix clear leaves no raft log entries with
+				// index > the applied index captured before subsume.
+				appliedIdx := subsumedAppliedIdx[rangeID]
+				lastEntryID, err := sl.LoadLastEntryID(ctx, store3.LogEngine(), kvserverpb.RaftTruncatedState{})
+				require.NoError(t, err)
+				require.Equal(t, lastEntryID.Index, appliedIdx)
+			}
+		}
 	})
 }
 

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -158,8 +158,14 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 
 func getEnginesKeySet(t *testing.T, e kvstorage.Engines) map[string]struct{} {
 	t.Helper()
-	require.False(t, e.Separated(), "not supported in this test")
-	return getEngineKeySet(t, e.Engine())
+	if !e.Separated() {
+		return getEngineKeySet(t, e.Engine())
+	}
+	out := getEngineKeySet(t, e.StateEngine())
+	for k := range getEngineKeySet(t, e.LogEngine()) {
+		out[k] = struct{}{}
+	}
+	return out
 }
 
 func getEngineKeySet(t *testing.T, e storage.Engine) map[string]struct{} {
@@ -221,35 +227,61 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 		adminMergeArgs(lhsDesc.StartKey.AsRawKey()))
 	require.NoError(t, pErr.GoError())
 
-	// Collect all the keys again.
-	postKeys := getEnginesKeySet(t, store.Engines())
+	tombstoneKey := string(keys.RangeTombstoneKey(rhsDesc.RangeID))
+	localRangeKeyPrefix := string(keys.MakeRangeIDPrefix(rhsDesc.RangeID))
 
-	// Compute the new keys.
-	for k := range preKeys {
-		delete(postKeys, k)
+	// leftoverSubsumedKeys recomputes the diff against the pre-split state and
+	// returns the subsumed range's local range-ID keys that were not cleaned
+	// up by now.
+	leftoverSubsumedKeys := func() map[string]struct{} {
+		postKeys := getEnginesKeySet(t, store.Engines())
+		for k := range preKeys {
+			delete(postKeys, k)
+		}
+		delete(postKeys, tombstoneKey) // tombstoneKey is expected to exist
+		for k := range postKeys {
+			if !strings.HasPrefix(k, localRangeKeyPrefix) {
+				delete(postKeys, k)
+			}
+		}
+		return postKeys
 	}
 
-	tombstoneKey := string(keys.RangeTombstoneKey(rhsDesc.RangeID))
+	// The tombstone key must exist on disk after the merge.
+	postKeys := getEnginesKeySet(t, store.Engines())
 	if _, ok := postKeys[tombstoneKey]; !ok {
 		t.Errorf("tombstone key (%s) missing after merge", roachpb.Key(tombstoneKey))
 	}
-	delete(postKeys, tombstoneKey)
 
-	// Keep only the subsumed range's local range-ID keys.
-	localRangeKeyPrefix := string(keys.MakeRangeIDPrefix(rhsDesc.RangeID))
-	for k := range postKeys {
-		if !strings.HasPrefix(k, localRangeKeyPrefix) {
-			delete(postKeys, k)
+	// Under separate engines, SubsumeReplica intentionally leaves the subsumed
+	// range's applied raft log entries on the log engine. They are dropped
+	// asynchronously by the WAG truncator when it's safe to do so.
+	//
+	// In single-engine mode, all raft entries are dropped synchronously.
+	assertNoLeftoverKeys := func() error {
+		leftover := leftoverSubsumedKeys()
+		if len(leftover) == 0 {
+			return nil
 		}
-	}
-
-	if numKeys := len(postKeys); numKeys > 0 {
 		var buf bytes.Buffer
-		fmt.Fprintf(&buf, "%d keys were not cleaned up:\n", numKeys)
-		for k := range postKeys {
+		for k := range leftover {
 			fmt.Fprintf(&buf, "%s (%q)\n", roachpb.Key(k), k)
 		}
-		t.Fatal(buf.String())
+		return errors.Newf("%d keys not yet cleaned up:\n%s", len(leftover), buf.String())
+	}
+	if store.EnginesSeparated() {
+		// Turn off the WAGTruncator retention policy so that the WAG node gets
+		// truncated and the raft log entries <= appliedIndex are dropped.
+		_, err := tc.ServerConn(0).ExecContext(ctx,
+			"SET CLUSTER SETTING kv.wag.retention.nodes = 0")
+		require.NoError(t, err)
+
+		// Flush the state engine so the WAG truncator's DurabilityAdvancedCallback
+		// fires and the truncator wakes up to drop the subsumed range's entries.
+		require.NoError(t, store.StateEngine().Flush())
+		testutils.SucceedsSoon(t, assertNoLeftoverKeys)
+	} else {
+		require.NoError(t, assertNoLeftoverKeys())
 	}
 }
 

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -354,7 +354,9 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// Write some arbitrary data only to store on n2. Inconsistent key "e"!
 	s2 := tc.GetFirstStoreFromServer(t, 1)
-	s2AuxDir := s2.TODOBothEngines().GetAuxiliaryDir()
+	// The death rattle file is written to the log engine's auxiliary dir
+	// (see (*Replica).computeChecksumPostApply in replica_consistency.go).
+	s2LogAuxDir := s2.LogEngine().GetAuxiliaryDir()
 	var val roachpb.Value
 	val.SetInt(42)
 	// Put an inconsistent key "e" to s2, and have s1 and s3 still agree.
@@ -440,7 +442,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// A death rattle should have been written on s2. Note that the VFSes are
 	// zero-indexed whereas store IDs are one-indexed.
-	f, err := stickyVFSRegistry.Get(vfsIDs[1]).Open(base.PreventedStartupFile(s2AuxDir))
+	f, err := stickyVFSRegistry.Get(vfsIDs[1]).Open(base.PreventedStartupFile(s2LogAuxDir))
 	require.NoError(t, err)
 	b, err := io.ReadAll(f)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR makes the kvserver tests ready for separate engines. They were tested based on this PR: https://github.com/cockroachdb/cockroach/compare/master...iskettaneh:cockroach:rse_enable_sep_eng

Fixed tests:
1) TestCheckConsistencyInconsistent
2) TestCreateManyUnappliedProbes
3) TestStoreRangeMergeMetadataCleanup
4) TestStoreRangeMergeRaftSnapshot

References: #170122

Release note: None