### PR TITLE
obs/ash: attribute explicit txn commit work to txn fingerprint

### DIFF
--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -540,7 +540,7 @@ func encodeWorkloadID(id uint64, typ workloadid.WorkloadType) string {
 		return strconv.FormatUint(id, 10)
 	case workloadid.WorkloadTypeSystem:
 		return workloadid.WorkloadID(id).Name()
-	default: // WorkloadTypeUnknown + WorkloadTypeStatement
+	default: // WorkloadTypeUnknown, WorkloadTypeStatement, WorkloadTypeCommit
 		return encodeStmtFingerprintIDToString(id)
 	}
 }

--- a/pkg/obs/ash/sampler_test.go
+++ b/pkg/obs/ash/sampler_test.go
@@ -189,6 +189,12 @@ func TestEncodeWorkloadID(t *testing.T) {
 			expected: "UNKNOWN",
 		},
 		{
+			name:     "commit uses hex",
+			id:       42,
+			typ:      workloadid.WorkloadTypeCommit,
+			expected: encodeStmtFingerprintIDToString(42),
+		},
+		{
 			name:     "zero ID with unknown type",
 			id:       0,
 			typ:      workloadid.WorkloadTypeUnknown,

--- a/pkg/obs/workloadid/workloadid.go
+++ b/pkg/obs/workloadid/workloadid.go
@@ -143,6 +143,9 @@ const (
 	// WorkloadTypeSystem identifies a system task, encoded using
 	// WorkloadID.Name() by the sampler.
 	WorkloadTypeSystem
+	// WorkloadTypeCommit identifies a transaction fingerprint ID for
+	// commit work, hex-encoded by the sampler.
+	WorkloadTypeCommit
 )
 
 // ToUint32 converts a WorkloadType to uint32 for use in protobuf
@@ -160,6 +163,8 @@ func (t WorkloadType) String() string {
 		return "JOB"
 	case WorkloadTypeSystem:
 		return "SYSTEM"
+	case WorkloadTypeCommit:
+		return "COMMIT"
 	default:
 		return "UNKNOWN"
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2650,6 +2650,17 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retEr
 		return err
 	}
 
+	// For explicit transactions, attribute the commit's deferred KV work
+	// to the transaction fingerprint, otherwise it will be attributed to
+	// the last statement's fingerprint which is misleading.
+	if !ex.implicitTxn() {
+		txnFingerprintID := ex.extraTxnState.transactionStatementsHash.Sum()
+		appNameID := ash.GetOrStoreAppNameID(ex.sessionData().ApplicationName)
+		ex.state.mu.txn.SetWorkloadInfo(
+			txnFingerprintID, appNameID, workloadid.WorkloadTypeCommit,
+		)
+	}
+
 	if err := ex.state.mu.txn.Commit(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
For explicit transactions, the commit's deferred KV work was
previously attributed to the last statement's fingerprint in
ASH samples. This changes the workload info on the KV Txn right
before Commit to carry the transaction fingerprint ID with a new
WorkloadTypeCommit type, so that commit work is correctly
attributed to the transaction as a whole. Implicit transactions
are left unchanged since they already have a meaningful
single-statement fingerprint.

Fixes: https://github.com/cockroachdb/cockroach/issues/165864

Release note (ops change): A new COMMIT workload type is introduced
in ASH. It attributes commit-deferred work for an explicit transaction
with the transaction fingerprint as the workload_id.