### PR TITLE
admission: introduce ConfigSnapshot, delete modeStrategy, rework groupKey

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -255,10 +255,11 @@ type cpuTimeTokenAllocator struct {
 	// queues holds references to WorkQueues for each resource tier. Used to
 	// refill per-group burst buckets that determine queue priority ordering.
 	// See cpu_time_token_burst.go for more.
-	queues   [numResourceTiers]workQueueIForAllocator
-	settings *cluster.Settings
-	model    cpuTimeModel
-	metrics  *cpuTimeTokenMetrics
+	queues       [numResourceTiers]workQueueIForAllocator
+	settings     *cluster.Settings
+	configHolder *ResourceGroupConfigHolder
+	model        cpuTimeModel
+	metrics      *cpuTimeTokenMetrics
 	// strategy is only accessed by the filler goroutine (via
 	// allocateTokens and resetInterval), so no synchronization is
 	// needed. Contrast with filler.activeMode, which is atomic because
@@ -276,16 +277,27 @@ type cpuTimeTokenAllocator struct {
 
 // modeStrategy encapsulates the mode-specific behavior of the
 // cpuTimeTokenAllocator. serverlessStrategy implements it for
-// Serverless mode; rmStrategy will be added for resource manager mode.
+// Serverless mode; rmStrategy implements it for resource manager mode.
 type modeStrategy interface {
 	mode() cpuTimeTokenMode
-	// computeTargets reads mode-specific cluster settings and returns
-	// the target utilizations for model fitting.
-	computeTargets(sv *settings.Values) targetUtilizations
 	// groupBurstRates returns per-tier (rate, cap) pairs from which
 	// per-group burst amounts are derived. The allocator iterates
 	// queues and calls refillGroupBurstBuckets with these values.
 	groupBurstRates(allocations tokenCounts, refillRates rates) [numResourceTiers][2]float64
+}
+
+// computeTargets derives target utilizations from a ConfigSnapshot.
+// The snapshot provides per-tier non-burstable and burstable ceilings
+// via MaxNonBurstableFraction and MaxFraction.
+func computeTargets(snap ConfigSnapshot) targetUtilizations {
+	var targets targetUtilizations
+	nonBurst := snap.MaxNonBurstableFraction()
+	burst := snap.MaxFraction()
+	for tier := range targets {
+		targets[tier][noBurst] = nonBurst[tier]
+		targets[tier][canBurst] = burst[tier]
+	}
+	return targets
 }
 
 // serverlessStrategy implements modeStrategy for Serverless mode,
@@ -298,30 +310,6 @@ type serverlessStrategy struct {
 
 func (s *serverlessStrategy) mode() cpuTimeTokenMode {
 	return serverlessMode
-}
-
-func (s *serverlessStrategy) computeTargets(sv *settings.Values) targetUtilizations {
-	if numResourceTiers != 2 || numBurstQualifications != 2 {
-		panic(errors.AssertionFailedf(
-			"computeTargets requires numResourceTiers=2 and "+
-				"numBurstQualifications=2 but got %d, %d",
-			numResourceTiers, numBurstQualifications))
-	}
-	// Compute target utilizations from cluster settings. The noBurst targets are
-	// configurable by cluster settings. A canBurst target adds a delta to the
-	// corresponding noBurst target, and the delta is also configurable by a
-	// cluster setting. The code here is not general with respect to
-	// numResourceTiers & numBurstQualifications. This isn't necessary for the
-	// Serverless use case on which we will first introduce CPU time token AC.
-	burstDelta := KVCPUTimeUtilBurstDelta.Get(sv)
-	var targets targetUtilizations
-	appTarget := KVCPUTimeAppUtilGoal.Get(sv)
-	targets[appTenant][noBurst] = appTarget
-	targets[appTenant][canBurst] = appTarget + burstDelta
-	systemTarget := KVCPUTimeSystemUtilGoal.Get(sv)
-	targets[systemTenant][noBurst] = systemTarget
-	targets[systemTenant][canBurst] = systemTarget + burstDelta
-	return targets
 }
 
 func (s *serverlessStrategy) groupBurstRates(
@@ -352,28 +340,6 @@ var _ modeStrategy = &rmStrategy{}
 
 func (s *rmStrategy) mode() cpuTimeTokenMode {
 	return resourceManagerMode
-}
-
-func (s *rmStrategy) computeTargets(sv *settings.Values) targetUtilizations {
-	if numResourceTiers != 2 {
-		panic(errors.AssertionFailedf(
-			"rmStrategy.computeTargets requires numResourceTiers=2 but got %d",
-			numResourceTiers))
-	}
-	var targets targetUtilizations
-	noBurstTarget := KVCPUTimeUtilTarget.Get(sv)
-	burstDelta := KVCPUTimeUtilBurstDelta.Get(sv)
-	targets[0][noBurst] = noBurstTarget
-	targets[0][canBurst] = noBurstTarget + burstDelta
-	s.canBurstTarget = targets[0][canBurst]
-	// Mirror tier-0 to tier-1. RM mode does not route KV admission work to
-	// tier-1; SQL CPU work still uses tier-1 via GetCTTWorkQueue, and the
-	// granter deducts every consumed token from both tiers' buckets (see
-	// tookWithoutPermissionLocked). Equal refill rates keep tier-1 in sync
-	// with tier-0 and preserve the granter's invariant that the lower-ordinal
-	// tier holds >= tokens than the higher. Read more in cpuTimeTokenGranter.
-	targets[1] = targets[0]
-	return targets
 }
 
 func (s *rmStrategy) groupBurstRates(
@@ -564,7 +530,8 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		a.strategy = a.newStrategy(newMode)
 	}
 
-	targets := a.strategy.computeTargets(&a.settings.SV)
+	snap := a.configHolder.Snapshot()
+	targets := computeTargets(snap)
 	newRefillRates := a.model.fit(ctx, targets)
 
 	// deltaRefillRates is the difference in tokens to add per interval (1s)

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -464,25 +464,22 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 }
 
 // resetInterval recomputes refill rates and applies the delta to the
-// granter and burst buckets. If the mode cluster setting has changed,
-// lastMode is updated before computing targets.
+// granter and burst buckets. The snapshot's Mode is folded into
+// lastMode so the filler's activeMode tracks the same value the
+// targets were derived under. offMode is skipped: it is not a real
+// mode for routing purposes — the constructor defaults offMode to
+// serverlessMode, and GetKVWorkQueue handles the off case before
+// reaching activeMode routing.
 func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenMode {
-	// lastMode is only accessed by the filler goroutine, so we can
-	// update it immediately. offMode is skipped because it is not a
-	// real mode - the constructor defaults offMode to serverlessMode,
-	// and GetKVWorkQueue handles the off case before reaching
-	// activeMode routing.
-	newMode := cpuTimeTokenACMode.Get(&a.settings.SV)
-	if newMode != offMode && newMode != a.lastMode {
-		a.lastMode = newMode
-	}
-
 	// Refresh the cached snapshot for this interval. Everything that
 	// runs until the next resetInterval — model.fit, the refillRates
 	// it produces, and the per-tick groupBurstRates calls in
 	// allocateTokens — reads from this snap so the interval is
 	// coherent with one view of the holder.
 	a.snap = a.configHolder.Snapshot()
+	if a.snap.Mode != offMode {
+		a.lastMode = a.snap.Mode
+	}
 	targets := computeTargets(a.snap)
 	newRefillRates := a.model.fit(ctx, targets)
 

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -262,6 +262,11 @@ type cpuTimeTokenAllocator struct {
 	// refillRates stores the number of CPU time tokens to add to each bucket
 	// per interval (1s).
 	refillRates rates
+	// snap is the ConfigSnapshot captured at the most recent
+	// resetInterval. Every operation in the interval reads from this
+	// snap rather than re-querying the holder, so per-tick work stays
+	// coherent with the configuration that produced refillRates.
+	snap ConfigSnapshot
 	// allocated stores the number of tokens added to each bucket in the current
 	// cpuTimeTokenAllocator. No mutex, since only a single goroutine will call
 	// the allocator.
@@ -288,12 +293,14 @@ func computeTargets(snap ConfigSnapshot) targetUtilizations {
 //
 // The 100%-CPU rate is recovered by dividing the canBurst allocation
 // (or refill rate) by canBurstTarget, which is valid because
-// cpuTimeTokenLinearModel is linear in target.
+// cpuTimeTokenLinearModel is linear in target. snap must be the same
+// snapshot used to compute allocations/refillRates this tick;
+// otherwise the recovered rate100 can drift if cluster settings
+// change between calls.
 func (a *cpuTimeTokenAllocator) groupBurstRates(
-	allocations tokenCounts, refillRates rates,
+	snap ConfigSnapshot, allocations tokenCounts, refillRates rates,
 ) [numResourceTiers][2]float64 {
 	var out [numResourceTiers][2]float64
-	snap := a.configHolder.Snapshot()
 	canBurstTarget := snap.MaxFraction()[0]
 	if canBurstTarget == 0 {
 		return out
@@ -450,7 +457,7 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	// for more). With defaultTenantGroupConfig.BurstFrac = 0.20, an
 	// application tenant can burst if it is using roughly less than 20%
 	// of the CPU on a CRDB node.
-	burstRates := a.groupBurstRates(allocations, a.refillRates)
+	burstRates := a.groupBurstRates(a.snap, allocations, a.refillRates)
 	for tier, q := range a.queues {
 		q.refillGroupBurstBuckets(burstRates[tier][0], burstRates[tier][1])
 	}
@@ -470,8 +477,13 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		a.lastMode = newMode
 	}
 
-	snap := a.configHolder.Snapshot()
-	targets := computeTargets(snap)
+	// Refresh the cached snapshot for this interval. Everything that
+	// runs until the next resetInterval — model.fit, the refillRates
+	// it produces, and the per-tick groupBurstRates calls in
+	// allocateTokens — reads from this snap so the interval is
+	// coherent with one view of the holder.
+	a.snap = a.configHolder.Snapshot()
+	targets := computeTargets(a.snap)
 	newRefillRates := a.model.fit(ctx, targets)
 
 	// deltaRefillRates is the difference in tokens to add per interval (1s)
@@ -501,7 +513,7 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		bucketCapacities, bucketMinimums, true /* updateMetrics */)
 	a.refillRates = newRefillRates
 	// Apply the delta to the per-group burst buckets also.
-	burstRates := a.groupBurstRates(deltaRefillRates, a.refillRates)
+	burstRates := a.groupBurstRates(a.snap, deltaRefillRates, a.refillRates)
 	for tier, q := range a.queues {
 		q.refillGroupBurstBuckets(burstRates[tier][0], burstRates[tier][1])
 	}

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -145,17 +145,7 @@ type cpuTimeTokenFiller struct {
 	// resetInterval. Written by the filler goroutine, read by
 	// GetKVWorkQueue via cpuTimeTokenGrantCoordinator.
 	//
-	// On a mode transition, resetInterval coordinates several state
-	// changes so they take effect together at the interval boundary:
-	//  1. strategy (cpuTimeTokenAllocator.strategy) - swapped to the new
-	//     modeStrategy, which controls target computation and burst
-	//     bucket refill routing.
-	//  2. refill rates and granter buckets - the delta between old and
-	//     new rates is applied to the granter, so token levels converge
-	//     to the new mode within one interval.
-	//  3. activeMode (this field) - stored last, after refill is
-	//     complete, so that GetKVWorkQueue routes to the correct queue
-	//     only after the queues are ready.
+	// TODO(ssd): Will be removed in a future commit. See lastMode.
 	activeMode atomic.Int64
 }
 
@@ -247,9 +237,6 @@ var _ cpuTimeTokenAllocatorI = &cpuTimeTokenAllocator{}
 // responsibility of cpuTimeTokenAllocator is to gradually allocate tokens
 // every interval, while respecting the bucket capacities. The computation
 // of the rate of tokens to add every interval is left to cpuTimeModel.
-//
-// Mode-specific behavior (target computation and burst bucket refill)
-// is delegated to a modeStrategy, which is swapped on mode transitions.
 type cpuTimeTokenAllocator struct {
 	granter *cpuTimeTokenGranter
 	// queues holds references to WorkQueues for each resource tier. Used to
@@ -260,11 +247,17 @@ type cpuTimeTokenAllocator struct {
 	configHolder *ResourceGroupConfigHolder
 	model        cpuTimeModel
 	metrics      *cpuTimeTokenMetrics
-	// strategy is only accessed by the filler goroutine (via
-	// allocateTokens and resetInterval), so no synchronization is
-	// needed. Contrast with filler.activeMode, which is atomic because
-	// GetKVWorkQueue reads it from arbitrary goroutines.
-	strategy modeStrategy
+	// lastMode tracks the most recent non-off mode so that
+	// resetInterval can detect mode transitions. Only accessed by the
+	// filler goroutine (via allocateTokens and resetInterval), so no
+	// synchronization is needed. Contrast with filler.activeMode,
+	// which is atomic because GetKVWorkQueue reads it from arbitrary
+	// goroutines.
+	//
+	// TODO(ssd): Will be removed in a future commit. GetKVWorkQueue
+	// and groupKeyForWorkLocked can read the mode setting directly;
+	// activeMode and lastMode are unnecessary indirection.
+	lastMode cpuTimeTokenMode
 
 	// refillRates stores the number of CPU time tokens to add to each bucket
 	// per interval (1s).
@@ -273,17 +266,6 @@ type cpuTimeTokenAllocator struct {
 	// cpuTimeTokenAllocator. No mutex, since only a single goroutine will call
 	// the allocator.
 	allocated tokenCounts
-}
-
-// modeStrategy encapsulates the mode-specific behavior of the
-// cpuTimeTokenAllocator. serverlessStrategy implements it for
-// Serverless mode; rmStrategy implements it for resource manager mode.
-type modeStrategy interface {
-	mode() cpuTimeTokenMode
-	// groupBurstRates returns per-tier (rate, cap) pairs from which
-	// per-group burst amounts are derived. The allocator iterates
-	// queues and calls refillGroupBurstBuckets with these values.
-	groupBurstRates(allocations tokenCounts, refillRates rates) [numResourceTiers][2]float64
 }
 
 // computeTargets derives target utilizations from a ConfigSnapshot.
@@ -300,69 +282,27 @@ func computeTargets(snap ConfigSnapshot) targetUtilizations {
 	return targets
 }
 
-// serverlessStrategy implements modeStrategy for Serverless mode,
-// which uses 2 WorkQueues (systemTenant, appTenant) with per-tier
-// utilization targets. Each tier's burst bucket gets
-// noBurst * defaultTenantGroupConfig.BurstFrac (0.25) of that tier's
-// allocation and rate.
-type serverlessStrategy struct {
-}
-
-func (s *serverlessStrategy) mode() cpuTimeTokenMode {
-	return serverlessMode
-}
-
-func (s *serverlessStrategy) groupBurstRates(
+// groupBurstRates returns per-tier (rate, cap) pairs from which
+// per-group burst amounts are derived. The allocator iterates queues
+// and calls refillGroupBurstBuckets with these values.
+//
+// The 100%-CPU rate is recovered by dividing the canBurst allocation
+// (or refill rate) by canBurstTarget, which is valid because
+// cpuTimeTokenLinearModel is linear in target.
+func (a *cpuTimeTokenAllocator) groupBurstRates(
 	allocations tokenCounts, refillRates rates,
 ) [numResourceTiers][2]float64 {
 	var out [numResourceTiers][2]float64
-	for tier := range out {
-		out[tier] = [2]float64{
-			float64(allocations[tier][noBurst]),
-			float64(refillRates[tier][noBurst]),
-		}
-	}
-	return out
-}
-
-// rmStrategy implements modeStrategy for Resource Manager mode, which uses a
-// single WorkQueue with N resource groups and a single utilization target.
-type rmStrategy struct {
-	// canBurstTarget is the canBurst utilization target (e.g. 0.80 when
-	// KVCPUTimeUtilTarget=0.75 + KVCPUTimeUtilBurstDelta=0.05). Set by
-	// computeTargets each interval; used by groupBurstRates to recover the
-	// 100% CPU rate by dividing the cycle's canBurst allocation by
-	// canBurstTarget.
-	canBurstTarget float64
-}
-
-var _ modeStrategy = &rmStrategy{}
-
-func (s *rmStrategy) mode() cpuTimeTokenMode {
-	return resourceManagerMode
-}
-
-func (s *rmStrategy) groupBurstRates(
-	allocations tokenCounts, refillRates rates,
-) [numResourceTiers][2]float64 {
-	var out [numResourceTiers][2]float64
-	// Cold-start guard: skip if computeTargets has not run yet (canBurstTarget
-	// is the zero value). Setting validators rule out negative values, so
-	// == 0 catches the only reachable bad state.
-	if s.canBurstTarget == 0 {
+	snap := a.configHolder.Snapshot()
+	canBurstTarget := snap.MaxFraction()[0]
+	if canBurstTarget == 0 {
 		return out
 	}
-	// Recover the 100% CPU rate by dividing out canBurstTarget; valid
-	// because cpuTimeTokenLinearModel is linear in target.
-	//
-	// TODO(wenyihu6): instead of computing by division, plumb rate100 from the
-	// model so this division (and canBurstTarget storage) can go away.
-	rate100 := float64(allocations[0][canBurst]) / s.canBurstTarget
-	cap100 := float64(refillRates[0][canBurst]) / s.canBurstTarget
-	// Mirror to both tiers. RM mode only routes KV work to tier-0,
-	// but tier-1 must stay in sync (see computeTargets).
-	out[0] = [2]float64{rate100, cap100}
-	out[1] = [2]float64{rate100, cap100}
+	rate100 := float64(allocations[0][canBurst]) / canBurstTarget
+	cap100 := float64(refillRates[0][canBurst]) / canBurstTarget
+	for tier := range out {
+		out[tier] = [2]float64{rate100, cap100}
+	}
 	return out
 }
 
@@ -503,14 +443,14 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 	refillGranter(a.granter, a.metrics, allocations,
 		bucketCapacities, bucketMinimums, false /* updateMetrics */)
 
-	// Refill per-group burst buckets in the WorkQueues. Each group's burst
-	// bucket is scaled by its burstFrac (defaultTenantGroupConfig.BurstFrac
-	// = 0.25 for serverless tenants). If a group's bucket is mostly full,
-	// we allow it to get priority in the queue (see cpu_time_token_burst.go
-	// for more). With cluster settings at their default values, this implies
-	// that an application tenant can burst if they are using roughly less
-	// than 20% of the CPU on a CRDB node (0.8 * 0.25 = 0.2).
-	burstRates := a.strategy.groupBurstRates(allocations, a.refillRates)
+	// Refill per-group burst buckets in the WorkQueues. groupBurstRates
+	// returns the 100%-CPU rate; refillGroupBurstBuckets scales it by
+	// each group's burstFrac. If a group's bucket is mostly full, we
+	// allow it to get priority in the queue (see cpu_time_token_burst.go
+	// for more). With defaultTenantGroupConfig.BurstFrac = 0.20, an
+	// application tenant can burst if it is using roughly less than 20%
+	// of the CPU on a CRDB node.
+	burstRates := a.groupBurstRates(allocations, a.refillRates)
 	for tier, q := range a.queues {
 		q.refillGroupBurstBuckets(burstRates[tier][0], burstRates[tier][1])
 	}
@@ -518,16 +458,16 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 
 // resetInterval recomputes refill rates and applies the delta to the
 // granter and burst buckets. If the mode cluster setting has changed,
-// the strategy is swapped before computing targets.
+// lastMode is updated before computing targets.
 func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenMode {
-	// a.strategy is only accessed by the filler goroutine, so we can
+	// lastMode is only accessed by the filler goroutine, so we can
 	// update it immediately. offMode is skipped because it is not a
-	// real strategy - the constructor defaults offMode to
-	// serverlessMode, and GetKVWorkQueue handles the off case before
-	// reaching activeMode routing.
+	// real mode - the constructor defaults offMode to serverlessMode,
+	// and GetKVWorkQueue handles the off case before reaching
+	// activeMode routing.
 	newMode := cpuTimeTokenACMode.Get(&a.settings.SV)
-	if newMode != offMode && newMode != a.strategy.mode() {
-		a.strategy = a.newStrategy(newMode)
+	if newMode != offMode && newMode != a.lastMode {
+		a.lastMode = newMode
 	}
 
 	snap := a.configHolder.Snapshot()
@@ -561,7 +501,7 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		bucketCapacities, bucketMinimums, true /* updateMetrics */)
 	a.refillRates = newRefillRates
 	// Apply the delta to the per-group burst buckets also.
-	burstRates := a.strategy.groupBurstRates(deltaRefillRates, a.refillRates)
+	burstRates := a.groupBurstRates(deltaRefillRates, a.refillRates)
 	for tier, q := range a.queues {
 		q.refillGroupBurstBuckets(burstRates[tier][0], burstRates[tier][1])
 	}
@@ -573,28 +513,7 @@ func (a *cpuTimeTokenAllocator) resetInterval(ctx context.Context) cpuTimeTokenM
 		}
 	}
 
-	return a.strategy.mode()
-}
-
-// newStrategy constructs the modeStrategy for the given mode. offMode is not a
-// valid argument - callers must guard against it (resetInterval skips the swap,
-// the constructor maps off to serverless). Queue side effects are not applied
-// here; resetInterval applies them after the refill is complete.
-//
-// No bucket reset is needed on a mode switch. The granter's tier-1 buckets stay
-// alive across transitions, and resetInterval's delta mechanism converges all
-// bucket counts to the new mode's rates within one interval (1s).
-func (a *cpuTimeTokenAllocator) newStrategy(mode cpuTimeTokenMode) modeStrategy {
-	switch mode {
-	case offMode:
-		panic(errors.AssertionFailedf("offMode is not a valid strategy; callers must guard against it"))
-	case serverlessMode:
-		return &serverlessStrategy{}
-	case resourceManagerMode:
-		return &rmStrategy{}
-	default:
-		panic(errors.AssertionFailedf("unknown cpuTimeTokenMode: %d", mode))
-	}
+	return a.lastMode
 }
 
 // refillGranter increments per-bucket refill metrics, then delegates

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -517,7 +517,8 @@ func TestComputeTargets(t *testing.T) {
 }
 
 // TestResetIntervalReturnsMode verifies that resetInterval returns
-// the current lastMode and skips mode update when the cluster
+// the current lastMode, picking up the mode setting on every tick
+// and pinning lastMode at the previous non-off value when the
 // setting is offMode.
 func TestResetIntervalReturnsMode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -530,8 +531,6 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 		testTier0: burstMgrs[testTier0],
 		testTier1: burstMgrs[testTier1],
 	}
-	// Use default settings where cpuTimeTokenACMode is offMode.
-	// resetInterval should not attempt to update lastMode.
 	st := cluster.MakeClusterSettings()
 	require.Equal(t, offMode, cpuTimeTokenACMode.Get(&st.SV))
 	allocator := cpuTimeTokenAllocator{
@@ -545,8 +544,22 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	mode := allocator.resetInterval(ctx)
-	require.Equal(t, serverlessMode, mode)
+
+	// Setting is offMode at construction; resetInterval keeps lastMode
+	// at its prior value (serverless from the constructor).
+	require.Equal(t, serverlessMode, allocator.resetInterval(ctx))
+
+	// Flip to resourceManagerMode; lastMode follows.
+	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
+	require.Equal(t, resourceManagerMode, allocator.resetInterval(ctx))
+
+	// Flip back to serverlessMode; lastMode follows again.
+	cpuTimeTokenACMode.Override(ctx, &st.SV, serverlessMode)
+	require.Equal(t, serverlessMode, allocator.resetInterval(ctx))
+
+	// Flip to offMode; lastMode pins at the previous serverless value.
+	cpuTimeTokenACMode.Override(ctx, &st.SV, offMode)
+	require.Equal(t, serverlessMode, allocator.resetInterval(ctx))
 }
 
 // TestGroupBurstRates verifies the allocator's groupBurstRates method,

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -575,7 +575,7 @@ func TestGroupBurstRates(t *testing.T) {
 	tokens[0][canBurst] = 1000
 	var rr rates
 	rr[0][canBurst] = 4000
-	out := allocator.groupBurstRates(tokens, rr)
+	out := allocator.groupBurstRates(allocator.configHolder.Snapshot(), tokens, rr)
 	require.Equal(t, [2]float64{1000, 4000}, out[0])
 	require.Equal(t, [2]float64{1000, 4000}, out[1])
 
@@ -583,7 +583,7 @@ func TestGroupBurstRates(t *testing.T) {
 	KVCPUTimeAppUtilGoal.Override(ctx, &st.SV, 0.5)
 	KVCPUTimeSystemUtilGoal.Override(ctx, &st.SV, 0.5)
 	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.01)
-	out = allocator.groupBurstRates(tokens, rr)
+	out = allocator.groupBurstRates(allocator.configHolder.Snapshot(), tokens, rr)
 	require.InDelta(t, 1000.0/0.51, out[0][0], 0.01)
 	require.InDelta(t, 4000.0/0.51, out[0][1], 0.01)
 	require.Equal(t, out[0], out[1])
@@ -595,7 +595,7 @@ func TestGroupBurstRates(t *testing.T) {
 	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.5)
 	tokens[0][canBurst] = -500
 	rr[0][canBurst] = 4000
-	out = allocator.groupBurstRates(tokens, rr)
+	out = allocator.groupBurstRates(allocator.configHolder.Snapshot(), tokens, rr)
 	require.Equal(t, [2]float64{-500, 4000}, out[0])
 	require.Equal(t, [2]float64{-500, 4000}, out[1])
 }

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -182,13 +182,15 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 		testTier0: burstMgrs[testTier0],
 		testTier1: burstMgrs[testTier1],
 	}
+	st := cluster.MakeClusterSettings()
 	allocator := cpuTimeTokenAllocator{
-		granter:  granter,
-		settings: cluster.MakeClusterSettings(),
-		model:    model,
-		metrics:  metrics,
-		queues:   queues,
-		strategy: &serverlessStrategy{},
+		granter:      granter,
+		settings:     st,
+		configHolder: newResourceGroupConfigHolder(&st.SV),
+		model:        model,
+		metrics:      metrics,
+		queues:       queues,
+		strategy:     &serverlessStrategy{},
 	}
 	printBurstMgrs = func() string {
 		var b strings.Builder
@@ -493,29 +495,25 @@ func (p *testCPUMetricsProvider) append(dur time.Duration, count int) {
 	}
 }
 
-// TestServerlessStrategyComputeTargets verifies that computeTargets
-// reads the per-tier cluster settings (app and system utilization
-// goals) and adds the burst delta setting to each to produce the
-// canBurst targets.
-func TestServerlessStrategyComputeTargets(t *testing.T) {
+// TestComputeTargets verifies that computeTargets derives per-tier
+// target utilizations from a ConfigSnapshot.
+func TestComputeTargets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	st := cluster.MakeClusterSettings()
-	ctx := context.Background()
-	KVCPUTimeAppUtilGoal.Override(ctx, &st.SV, 0.75)
-	KVCPUTimeSystemUtilGoal.Override(ctx, &st.SV, 0.5)
-	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.25)
+	snap := ConfigSnapshot{
+		AppNoBurstFrac:    0.75,
+		SystemNoBurstFrac: 0.90,
+		BurstDelta:        0.25,
+	}
+	targets := computeTargets(snap)
 
-	s := &serverlessStrategy{}
-	targets := s.computeTargets(&st.SV)
-
-	// noBurst targets come directly from the cluster settings.
-	require.Equal(t, 0.75, targets[appTenant][noBurst])
-	require.Equal(t, 0.5, targets[systemTenant][noBurst])
-	// canBurst targets are noBurst + burstDelta.
-	require.Equal(t, 1.0, targets[appTenant][canBurst])
-	require.Equal(t, 0.75, targets[systemTenant][canBurst])
+	// Tier 0 (system) uses SystemNoBurstFrac.
+	require.Equal(t, 0.90, targets[0][noBurst])
+	require.Equal(t, 1.15, targets[0][canBurst])
+	// Tier 1 (app) uses AppNoBurstFrac.
+	require.Equal(t, 0.75, targets[1][noBurst])
+	require.Equal(t, 1.0, targets[1][canBurst])
 }
 
 // TestServerlessStrategyGroupBurstRates verifies that groupBurstRates
@@ -590,40 +588,18 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 	st := cluster.MakeClusterSettings()
 	require.Equal(t, offMode, cpuTimeTokenACMode.Get(&st.SV))
 	allocator := cpuTimeTokenAllocator{
-		granter:  granter,
-		settings: st,
-		model:    &testModel{buf: &strings.Builder{}, rates: rates{}},
-		metrics:  metrics,
-		queues:   queues,
-		strategy: &serverlessStrategy{},
+		granter:      granter,
+		settings:     st,
+		configHolder: newResourceGroupConfigHolder(&st.SV),
+		model:        &testModel{buf: &strings.Builder{}, rates: rates{}},
+		metrics:      metrics,
+		queues:       queues,
+		strategy:     &serverlessStrategy{},
 	}
 
 	ctx := context.Background()
 	mode := allocator.resetInterval(ctx)
 	require.Equal(t, serverlessMode, mode)
-}
-
-// TestRMStrategyComputeTargets verifies that computeTargets reads the
-// RM cluster settings, populates tier-0, mirrors to tier-1, and caches
-// canBurstTarget for refillBurst.
-func TestRMStrategyComputeTargets(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	st := cluster.MakeClusterSettings()
-	ctx := context.Background()
-	KVCPUTimeUtilTarget.Override(ctx, &st.SV, 0.75)
-	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.25)
-
-	s := &rmStrategy{}
-	targets := s.computeTargets(&st.SV)
-
-	require.Equal(t, 0.75, targets[0][noBurst])
-	require.Equal(t, 1.0, targets[0][canBurst])
-	// Tier-1 mirrors tier-0.
-	require.Equal(t, targets[0], targets[1])
-	// canBurstTarget is cached for refillBurst's rate100 recovery.
-	require.Equal(t, 1.0, s.canBurstTarget)
 }
 
 // TestRMStrategyGroupBurstRates verifies the cold-start guard, the

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -190,7 +190,7 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 		model:        model,
 		metrics:      metrics,
 		queues:       queues,
-		strategy:     &serverlessStrategy{},
+		lastMode:     serverlessMode,
 	}
 	printBurstMgrs = func() string {
 		var b strings.Builder
@@ -516,62 +516,9 @@ func TestComputeTargets(t *testing.T) {
 	require.Equal(t, 1.0, targets[1][canBurst])
 }
 
-// TestServerlessStrategyGroupBurstRates verifies that groupBurstRates
-// returns the noBurst token and rate values for each tier, from which
-// per-group burst amounts are derived (scaled by burstFrac in the
-// WorkQueue). The canBurst token counts should be ignored since burst
-// bucket refill is derived solely from the noBurst allocation.
-func TestServerlessStrategyGroupBurstRates(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	s := &serverlessStrategy{}
-
-	var tokens tokenCounts
-	tokens[testTier0][noBurst] = 400
-	tokens[testTier0][canBurst] = 500 // ignored
-	tokens[testTier1][noBurst] = 200
-	tokens[testTier1][canBurst] = 300 // ignored
-
-	var refillRates rates
-	refillRates[testTier0][noBurst] = 4000
-	refillRates[testTier1][noBurst] = 2000
-
-	out := s.groupBurstRates(tokens, refillRates)
-
-	// rate = noBurst tokens, cap = noBurst refill rate.
-	require.Equal(t, float64(400), out[testTier0][0])
-	require.Equal(t, float64(4000), out[testTier0][1])
-	require.Equal(t, float64(200), out[testTier1][0])
-	require.Equal(t, float64(2000), out[testTier1][1])
-}
-
-// TestNewStrategy verifies that newStrategy returns the correct
-// strategy for serverlessMode and resourceManagerMode and panics
-// for offMode (not a real strategy) and unknown modes.
-func TestNewStrategy(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	allocator := cpuTimeTokenAllocator{}
-
-	s := allocator.newStrategy(serverlessMode)
-	require.Equal(t, serverlessMode, s.mode())
-
-	rm := allocator.newStrategy(resourceManagerMode)
-	require.Equal(t, resourceManagerMode, rm.mode())
-
-	require.Panics(t, func() {
-		allocator.newStrategy(offMode)
-	})
-	require.Panics(t, func() {
-		allocator.newStrategy(cpuTimeTokenMode(99))
-	})
-}
-
 // TestResetIntervalReturnsMode verifies that resetInterval returns
-// the current strategy's mode and skips strategy swap when the
-// cluster setting is offMode.
+// the current lastMode and skips mode update when the cluster
+// setting is offMode.
 func TestResetIntervalReturnsMode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -584,7 +531,7 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 		testTier1: burstMgrs[testTier1],
 	}
 	// Use default settings where cpuTimeTokenACMode is offMode.
-	// resetInterval should not attempt to swap strategy.
+	// resetInterval should not attempt to update lastMode.
 	st := cluster.MakeClusterSettings()
 	require.Equal(t, offMode, cpuTimeTokenACMode.Get(&st.SV))
 	allocator := cpuTimeTokenAllocator{
@@ -594,7 +541,7 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 		model:        &testModel{buf: &strings.Builder{}, rates: rates{}},
 		metrics:      metrics,
 		queues:       queues,
-		strategy:     &serverlessStrategy{},
+		lastMode:     serverlessMode,
 	}
 
 	ctx := context.Background()
@@ -602,43 +549,53 @@ func TestResetIntervalReturnsMode(t *testing.T) {
 	require.Equal(t, serverlessMode, mode)
 }
 
-// TestRMStrategyGroupBurstRates verifies the cold-start guard, the
-// rate100/cap100 recovery from canBurstTarget, and that both tiers
-// receive mirrored values.
-func TestRMStrategyGroupBurstRates(t *testing.T) {
+// TestGroupBurstRates verifies the allocator's groupBurstRates method,
+// which recovers the 100%-CPU rate from the canBurst allocation
+// divided by canBurstTarget (read from the snapshot).
+func TestGroupBurstRates(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s := &rmStrategy{}
+	st := cluster.MakeClusterSettings()
+	ctx := context.Background()
+	allocator := cpuTimeTokenAllocator{
+		configHolder: newResourceGroupConfigHolder(&st.SV),
+	}
 
-	// Cold-start guard: canBurstTarget=0 -> zeros.
-	out := s.groupBurstRates(tokenCounts{}, rates{})
-	require.Equal(t, [2]float64{0, 0}, out[0])
-	require.Equal(t, [2]float64{0, 0}, out[1])
+	// groupBurstRates reads MaxFraction()[0] (system tier), so the
+	// system util goal is what drives canBurstTarget. Override both
+	// per-tier settings to the same value so the test isn't sensitive
+	// to which tier the formula reads.
 
 	// canBurstTarget=1.0 recovers tokens/rates as-is.
-	s.canBurstTarget = 1.0
+	KVCPUTimeAppUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeSystemUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.5)
 	var tokens tokenCounts
 	tokens[0][canBurst] = 1000
 	var rr rates
 	rr[0][canBurst] = 4000
-	out = s.groupBurstRates(tokens, rr)
+	out := allocator.groupBurstRates(tokens, rr)
 	require.Equal(t, [2]float64{1000, 4000}, out[0])
 	require.Equal(t, [2]float64{1000, 4000}, out[1])
 
-	// canBurstTarget=0.5 doubles both.
-	s.canBurstTarget = 0.5
-	out = s.groupBurstRates(tokens, rr)
-	require.Equal(t, [2]float64{2000, 8000}, out[0])
-	require.Equal(t, [2]float64{2000, 8000}, out[1])
+	// canBurstTarget=0.51 scales both by 1/0.51.
+	KVCPUTimeAppUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeSystemUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.01)
+	out = allocator.groupBurstRates(tokens, rr)
+	require.InDelta(t, 1000.0/0.51, out[0][0], 0.01)
+	require.InDelta(t, 4000.0/0.51, out[0][1], 0.01)
+	require.Equal(t, out[0], out[1])
 
 	// Delta path: tokens (rate100) may be negative when refill rates
-	// decrease between intervals. cap100 stays non-negative because
-	// refillRates is the current rate, which is bounded >= 0 by the model.
+	// decrease between intervals.
+	KVCPUTimeAppUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeSystemUtilGoal.Override(ctx, &st.SV, 0.5)
+	KVCPUTimeUtilBurstDelta.Override(ctx, &st.SV, 0.5)
 	tokens[0][canBurst] = -500
 	rr[0][canBurst] = 4000
-	s.canBurstTarget = 1.0
-	out = s.groupBurstRates(tokens, rr)
+	out = allocator.groupBurstRates(tokens, rr)
 	require.Equal(t, [2]float64{-500, 4000}, out[0])
 	require.Equal(t, [2]float64{-500, 4000}, out[1])
 }

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -258,10 +258,12 @@ func makeCPUTimeTokenGrantCoordinator(
 		timeSource: timeSource,
 		closeCh:    make(chan struct{}),
 	}
+	configHolder := newResourceGroupConfigHolder(&settings.SV)
 	allocator := &cpuTimeTokenAllocator{
-		granter:  granter,
-		settings: settings,
-		metrics:  metrics,
+		granter:      granter,
+		settings:     settings,
+		configHolder: configHolder,
+		metrics:      metrics,
 	}
 	model := &cpuTimeTokenLinearModel{
 		granter:            granter,
@@ -274,11 +276,11 @@ func makeCPUTimeTokenGrantCoordinator(
 
 	var requesters [numResourceTiers]requester
 	wqMetrics := makeWorkQueueMetrics("cpu", registry)
-	// One holder shared across both per-tier WorkQueues. RM mode only
-	// uses tier 0; tier 1 sees every Set (the holder is shared) but
-	// never applies, since SetResourceGroupConfig forwards refresh
-	// signals only to tier 0 (rmQueueTier) below.
-	configHolder := newResourceGroupConfigHolder()
+	// The holder is shared across the allocator and both per-tier
+	// WorkQueues. RM mode only uses tier 0; tier 1 sees every Set
+	// (the holder is shared) but never applies, since
+	// SetResourceGroupConfig forwards refresh signals only to tier 0
+	// (rmQueueTier) below.
 	for tier := resourceTier(0); tier < numResourceTiers; tier++ {
 		opts := makeWorkQueueOptions(KVWork)
 		opts.mode = usesCPUTimeTokens

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -298,7 +298,7 @@ func makeCPUTimeTokenGrantCoordinator(
 		// returns a *WorkQueue.
 		allocator.queues[tier] = requesters[tier].(*WorkQueue)
 	}
-	allocator.strategy = allocator.newStrategy(initialMode)
+	allocator.lastMode = initialMode
 
 	coordinator := &cpuTimeTokenGrantCoordinator{
 		filler:       filler,

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -172,31 +172,32 @@ func TestSetResourceGroupConfigViaCoord(t *testing.T) {
 	ctx := context.Background()
 	cpuTimeTokenACMode.Override(ctx, &settings.SV, resourceManagerMode)
 
-	// Public API call. This is the only thing under test.
+	// Public API call with user-defined keys. Built-in keys (high/low)
+	// cannot be overwritten, so we test with non-builtin IDs.
 	cpuCoords.SetResourceGroupConfig(ResourceGroupConfigSet{
-		rgGroupKey(highResourceGroupID): {Weight: 70, BurstFrac: 0.7, MaxCPU: true},
-		rgGroupKey(lowResourceGroupID):  {Weight: 30, BurstFrac: 0.3, MaxCPU: false},
+		rgGroupKey(42): {Weight: 70, BurstFrac: 0.7, MaxCPU: true},
+		rgGroupKey(43): {Weight: 30, BurstFrac: 0.3, MaxCPU: false},
 	})
 
 	// Holder reflects the new config.
 	groups := cpuCoords.cpuTimeCoord.configHolder.Snapshot().Groups
-	require.Equal(t, uint32(70), groups[rgGroupKey(highResourceGroupID)].Weight)
-	require.Equal(t, float64(0.7), groups[rgGroupKey(highResourceGroupID)].BurstFrac)
-	require.True(t, groups[rgGroupKey(highResourceGroupID)].MaxCPU)
-	require.Equal(t, uint32(30), groups[rgGroupKey(lowResourceGroupID)].Weight)
-	require.Equal(t, float64(0.3), groups[rgGroupKey(lowResourceGroupID)].BurstFrac)
-	require.False(t, groups[rgGroupKey(lowResourceGroupID)].MaxCPU)
+	require.Equal(t, uint32(70), groups[rgGroupKey(42)].Weight)
+	require.Equal(t, float64(0.7), groups[rgGroupKey(42)].BurstFrac)
+	require.True(t, groups[rgGroupKey(42)].MaxCPU)
+	require.Equal(t, uint32(30), groups[rgGroupKey(43)].Weight)
+	require.Equal(t, float64(0.3), groups[rgGroupKey(43)].BurstFrac)
+	require.False(t, groups[rgGroupKey(43)].MaxCPU)
 
 	// RM-mode WorkQueue's cached per-group state reflects the new
 	// config (refresh propagated through to applyConfigLocked).
-	high := getGroupLocked(rmQueue, rgGroupKey(highResourceGroupID))
-	require.NotNil(t, high, "rg high container should be pre-created by apply")
-	require.Equal(t, uint32(70), high.weight)
-	require.Equal(t, float64(0.7), high.burstFrac)
-	require.True(t, high.cpuTimeBurstBucket.maxCPU)
-	low := getGroupLocked(rmQueue, rgGroupKey(lowResourceGroupID))
-	require.NotNil(t, low, "rg low container should be pre-created by apply")
-	require.Equal(t, uint32(30), low.weight)
-	require.Equal(t, float64(0.3), low.burstFrac)
-	require.False(t, low.cpuTimeBurstBucket.maxCPU)
+	rg42 := getGroupLocked(rmQueue, rgGroupKey(42))
+	require.NotNil(t, rg42, "rg 42 container should be pre-created by apply")
+	require.Equal(t, uint32(70), rg42.weight)
+	require.Equal(t, float64(0.7), rg42.burstFrac)
+	require.True(t, rg42.cpuTimeBurstBucket.maxCPU)
+	rg43 := getGroupLocked(rmQueue, rgGroupKey(43))
+	require.NotNil(t, rg43, "rg 43 container should be pre-created by apply")
+	require.Equal(t, uint32(30), rg43.weight)
+	require.Equal(t, float64(0.3), rg43.burstFrac)
+	require.False(t, rg43.cpuTimeBurstBucket.maxCPU)
 }

--- a/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator_test.go
@@ -179,13 +179,13 @@ func TestSetResourceGroupConfigViaCoord(t *testing.T) {
 	})
 
 	// Holder reflects the new config.
-	snap := cpuCoords.cpuTimeCoord.configHolder.Snapshot()
-	require.Equal(t, uint32(70), snap[rgGroupKey(highResourceGroupID)].Weight)
-	require.Equal(t, float64(0.7), snap[rgGroupKey(highResourceGroupID)].BurstFrac)
-	require.True(t, snap[rgGroupKey(highResourceGroupID)].MaxCPU)
-	require.Equal(t, uint32(30), snap[rgGroupKey(lowResourceGroupID)].Weight)
-	require.Equal(t, float64(0.3), snap[rgGroupKey(lowResourceGroupID)].BurstFrac)
-	require.False(t, snap[rgGroupKey(lowResourceGroupID)].MaxCPU)
+	groups := cpuCoords.cpuTimeCoord.configHolder.Snapshot().Groups
+	require.Equal(t, uint32(70), groups[rgGroupKey(highResourceGroupID)].Weight)
+	require.Equal(t, float64(0.7), groups[rgGroupKey(highResourceGroupID)].BurstFrac)
+	require.True(t, groups[rgGroupKey(highResourceGroupID)].MaxCPU)
+	require.Equal(t, uint32(30), groups[rgGroupKey(lowResourceGroupID)].Weight)
+	require.Equal(t, float64(0.3), groups[rgGroupKey(lowResourceGroupID)].BurstFrac)
+	require.False(t, groups[rgGroupKey(lowResourceGroupID)].MaxCPU)
 
 	// RM-mode WorkQueue's cached per-group state reflects the new
 	// config (refresh propagated through to applyConfigLocked).

--- a/pkg/util/admission/cpu_time_token_granter.go
+++ b/pkg/util/admission/cpu_time_token_granter.go
@@ -134,7 +134,7 @@ func (cg *cpuTimeTokenChildGranter) continueGrantChain(grantChainID grantChainID
 // Resource Manager mode, tier-1 mirrors tier-0's refill rates and receives
 // the same token deductions, but no work is routed to it, so its admission
 // checks are no-ops. This avoids special-casing the refill and deduction
-// loops. See rmStrategy.computeTargets for details.
+// loops. See computeTargets for details.
 //
 // For more, see the initial design sketch:
 // https://docs.google.com/document/d/1-Kr2gRFTk0QV8kBs7AXRXUwFpK2ZxR1cqIwWCuOx22Q/edit?tab=t.0

--- a/pkg/util/admission/group_key.go
+++ b/pkg/util/admission/group_key.go
@@ -11,66 +11,23 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// groupKind distinguishes the semantic origin of a groupInfo's
-// container in q.mu.groups. The same numeric ID can represent
-// either a tenant (in serverless mode) or a resource group (in RM
-// mode), and tenant IDs and RM resource group IDs are drawn from
-// the same uint64 space (e.g., system tenant ID = 1 collides with
-// highResourceGroupID = 1). Pairing the ID with a kind in the map
-// key prevents these two semantic meanings from ever sharing a
-// container.
-//
-// The zero value is intentionally invalid so that an unset groupKey
-// is detectably so (rather than silently identifying as "tenant 0"
-// the way iota-from-0 would).
-type groupKind uint8
-
-const (
-	// invalidKind is the zero value sentinel; a groupKey with this
-	// kind has not been initialized via tenantGroupKey/rgGroupKey.
-	invalidKind groupKind = iota
-	// tenantKind identifies a container created for a tenant ID
-	// (serverless mode routing via TenantID).
-	tenantKind
-	// rgKind identifies a container created for a resource group
-	// ID (RM mode routing via priorityToResourceGroupKey).
-	rgKind
-)
-
-// String implements fmt.Stringer.
-func (k groupKind) String() string {
-	switch k {
-	case tenantKind:
-		return "tenant"
-	case rgKind:
-		return "rg"
-	case invalidKind:
-		return "invalid"
-	default:
-		return "groupKind(" + strconv.FormatUint(uint64(k), 10) + ")"
-	}
-}
-
-// groupKey is the composite map key for q.mu.groups. It pairs the
-// uint64 group ID with its semantic kind so that, e.g., tenant 1
-// and rg 1 occupy distinct map entries.
+// groupKey is the composite map key for q.mu.groups. It identifies a
+// group by (tenantID, groupID). For tenant groups (serverless mode),
+// tenantID is set and groupID is 0. For resource groups (RM mode),
+// groupID is set and tenantID is 0. Future user-defined groups may
+// have both non-zero. The string representation is "tNgN", e.g.
+// "t1g0" for the system tenant, "t0g1" for the high-priority RM
+// group.
 type groupKey struct {
-	id   uint64
-	kind groupKind
+	tenantID uint64
+	groupID  uint64
 }
 
 // SafeFormat implements redact.SafeFormatter. Formats as e.g.
-// "t1" / "rg2"; useful in SafeFormat output so callers don't have
-// to switch on kind themselves.
+// "t1g0" (tenant 1, no resource group) or "t0g1" (no tenant,
+// resource group 1).
 func (k groupKey) SafeFormat(s redact.SafePrinter, _ rune) {
-	switch k.kind {
-	case tenantKind:
-		s.Printf("t%d", k.id)
-	case rgKind:
-		s.Printf("rg%d", k.id)
-	default:
-		s.Printf("invalid(%d)", k.id)
-	}
+	s.Printf("t%dg%d", k.tenantID, k.groupID)
 }
 
 // String implements fmt.Stringer via SafeFormat.
@@ -80,10 +37,22 @@ func (k groupKey) String() string {
 
 // tenantGroupKey returns the groupKey for a tenant container.
 func tenantGroupKey(id uint64) groupKey {
-	return groupKey{id: id, kind: tenantKind}
+	return groupKey{tenantID: id}
 }
 
 // rgGroupKey returns the groupKey for a resource group container.
 func rgGroupKey(id uint64) groupKey {
-	return groupKey{id: id, kind: rgKind}
+	return groupKey{groupID: id}
+}
+
+// metricLabels returns the (kind, id) label pair for per-group
+// metrics, preserving the existing metric label scheme.
+//
+// TODO(ssd): We will fix up metrics for the unification in a
+// future commit.
+func (k groupKey) metricLabels() (kindStr, idStr string) {
+	if k.groupID == 0 {
+		return "tenant", strconv.FormatUint(k.tenantID, 10)
+	}
+	return "rg", strconv.FormatUint(k.groupID, 10)
 }

--- a/pkg/util/admission/group_key.go
+++ b/pkg/util/admission/group_key.go
@@ -45,6 +45,16 @@ func rgGroupKey(id uint64) groupKey {
 	return groupKey{groupID: id}
 }
 
+// isBuiltin reports whether k names a built-in group (one always
+// installed in ResourceGroupConfigHolder via builtinGroupConfigs).
+// Callers use this to give built-ins lifecycle treatment that
+// caller-managed keys do not get — e.g. exemption from idle-group
+// GC.
+func (k groupKey) isBuiltin() bool {
+	_, ok := builtinGroupConfigs[k]
+	return ok
+}
+
 // metricLabels returns the (kind, id) label pair for per-group
 // metrics, preserving the existing metric label scheme.
 //

--- a/pkg/util/admission/group_key.go
+++ b/pkg/util/admission/group_key.go
@@ -6,6 +6,7 @@
 package admission
 
 import (
+	"cmp"
 	"strconv"
 
 	"github.com/cockroachdb/redact"
@@ -33,6 +34,15 @@ func (k groupKey) SafeFormat(s redact.SafePrinter, _ rune) {
 // String implements fmt.Stringer via SafeFormat.
 func (k groupKey) String() string {
 	return redact.StringWithoutMarkers(k)
+}
+
+// compare orders groupKeys by tenantID, then groupID. Use as a
+// slices.SortFunc comparator via the method expression
+// `groupKey.compare`.
+func (k groupKey) compare(other groupKey) int {
+	return cmp.Or(
+		cmp.Compare(k.tenantID, other.tenantID),
+		cmp.Compare(k.groupID, other.groupID))
 }
 
 // tenantGroupKey returns the groupKey for a tenant container.

--- a/pkg/util/admission/replicated_write_admission_test.go
+++ b/pkg/util/admission/replicated_write_admission_test.go
@@ -298,22 +298,22 @@ func printWorkQueue(q *WorkQueue) string {
 	defer q.mu.Unlock()
 	buf.WriteString(fmt.Sprintf("len(group-heap)=%d", len(q.mu.groupHeap)))
 	if len(q.mu.groupHeap) > 0 {
-		buf.WriteString(fmt.Sprintf(" top-group=t%d", q.mu.groupHeap[0].groupKey.id))
+		buf.WriteString(fmt.Sprintf(" top-group=%s", q.mu.groupHeap[0].groupKey))
 	}
 	var keys []groupKey
 	for k := range q.mu.groups {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].kind != keys[j].kind {
-			return keys[i].kind < keys[j].kind
+		if keys[i].tenantID != keys[j].tenantID {
+			return keys[i].tenantID < keys[j].tenantID
 		}
-		return keys[i].id < keys[j].id
+		return keys[i].groupID < keys[j].groupID
 	})
 	for _, k := range keys {
 		group := q.mu.groups[k]
-		buf.WriteString(fmt.Sprintf("\n group=t%d weight=%d fifo-threshold=%s used=%s",
-			group.groupKey.id,
+		buf.WriteString(fmt.Sprintf("\n group=%s weight=%d fifo-threshold=%s used=%s",
+			group.groupKey,
 			group.weight,
 			admissionpb.WorkPriority(group.fifoPriorityThreshold),
 			printTrimmedBytes(int64(group.used)),

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -7,7 +7,7 @@ package admission
 
 import (
 	"math"
-	"sort"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -48,12 +48,7 @@ func (s ResourceGroupConfigSet) SafeFormat(w redact.SafePrinter, _ rune) {
 	for k := range s {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].tenantID != keys[j].tenantID {
-			return keys[i].tenantID < keys[j].tenantID
-		}
-		return keys[i].groupID < keys[j].groupID
-	})
+	slices.SortFunc(keys, groupKey.compare)
 	for _, k := range keys {
 		cfg := s[k]
 		w.Printf("%s weight=%d burstFrac=%.2f maxCPU=%t\n",

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -127,10 +127,15 @@ var builtinGroupConfigs = ResourceGroupConfigSet{
 
 // ConfigSnapshot is the immutable snapshot returned by
 // ResourceGroupConfigHolder.Snapshot. It bundles the per-group config
-// set with the utilization targets derived from cluster settings.
+// set with the utilization targets derived from cluster settings, plus
+// the cpuTimeTokenACMode value those targets were derived under.
 type ConfigSnapshot struct {
 	// Groups is the per-group config set (built-ins + caller-provided).
 	Groups ResourceGroupConfigSet
+	// Mode is the cpuTimeTokenACMode value read alongside the
+	// utilization targets. Carried so consumers that need both stay
+	// coherent without a second setting read.
+	Mode cpuTimeTokenMode
 	// AppNoBurstFrac is the non-burstable CPU utilization target for
 	// the app tenant tier (e.g. 0.8 for 80% of CPU capacity).
 	AppNoBurstFrac float64
@@ -224,6 +229,7 @@ func (h *ResourceGroupConfigHolder) Snapshot() ConfigSnapshot {
 	if h.sv == nil {
 		return ConfigSnapshot{
 			Groups:            groups,
+			Mode:              serverlessMode,
 			AppNoBurstFrac:    0.8,
 			SystemNoBurstFrac: 0.95,
 			BurstDelta:        0.05,
@@ -231,12 +237,12 @@ func (h *ResourceGroupConfigHolder) Snapshot() ConfigSnapshot {
 	}
 	snap := ConfigSnapshot{
 		Groups:     groups,
+		Mode:       cpuTimeTokenACMode.Get(h.sv),
 		BurstDelta: KVCPUTimeUtilBurstDelta.Get(h.sv),
 	}
 	// TODO(ssd): The mode switch will be removed when settings are
 	// consolidated into a single target_util setting.
-	mode := cpuTimeTokenACMode.Get(h.sv)
-	switch mode {
+	switch snap.Mode {
 	case resourceManagerMode:
 		target := KVCPUTimeUtilTarget.Get(h.sv)
 		snap.AppNoBurstFrac = target

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -84,20 +84,11 @@ func (s ResourceGroupConfigSet) GetOrDefault(k groupKey) ResourceGroupConfig {
 	}
 }
 
-// defaultRMResourceGroupConfig seeds the holder until an explicit Set
-// replaces it. The two ids match priorityToResourceGroupKey (high/low).
-//
-// TODO(wenyihu6): revisit weights once we have signal from real workloads.
-var defaultRMResourceGroupConfig = ResourceGroupConfigSet{
-	rgGroupKey(highResourceGroupID): {Weight: 80, BurstFrac: 0.8, MaxCPU: true},
-	rgGroupKey(lowResourceGroupID):  {Weight: 20, BurstFrac: 0.2, MaxCPU: false},
-}
-
 // defaultRGGroupConfig is the safety fallback returned by GetOrDefault for
 // rgKind keys not in the installed configuration. In steady state this is
-// unreachable: the seed (defaultRMResourceGroupConfig) covers high/low. It
-// exists to keep Admit's lazy-create path total — if a caller installs a
-// config that omits a known rg ID, Admit gets a usable weight rather than a
+// unreachable: the built-in configs cover high/low. It exists to keep
+// Admit's lazy-create path total — if a caller installs a config that
+// omits a known rg ID, Admit gets a usable weight rather than a
 // zero-weight group. Weight=20 mirrors the low default; MaxCPU=false keeps
 // an unconfigured group from bypassing the burst-fullness gate.
 //
@@ -124,7 +115,9 @@ var systemTenantGroupConfig = ResourceGroupConfig{
 // holder. Set seeds from this list first; callers cannot overwrite
 // built-in keys.
 var builtinGroupConfigs = ResourceGroupConfigSet{
-	tenantGroupKey(1): systemTenantGroupConfig,
+	tenantGroupKey(1):               systemTenantGroupConfig,
+	rgGroupKey(highResourceGroupID): {Weight: 80, BurstFrac: 0.8, MaxCPU: true},
+	rgGroupKey(lowResourceGroupID):  {Weight: 20, BurstFrac: 0.2, MaxCPU: false},
 }
 
 // ConfigSnapshot is the immutable snapshot returned by
@@ -183,13 +176,12 @@ type ResourceGroupConfigHolder struct {
 }
 
 // newResourceGroupConfigHolder constructs a holder seeded with
-// defaultRMResourceGroupConfig, so a fresh Snapshot returns the high/low
-// hardcoded groups that WorkQueue applies on first RM-mode activation.
-// sv provides access to cluster settings for utilization targets; nil
-// is accepted for test paths (defaults are used).
+// builtinGroupConfigs. sv provides access to cluster settings for
+// utilization targets; nil is accepted for test paths (defaults are
+// used).
 func newResourceGroupConfigHolder(sv *settings.Values) *ResourceGroupConfigHolder {
 	h := &ResourceGroupConfigHolder{sv: sv}
-	h.Set(defaultRMResourceGroupConfig)
+	h.Set(nil)
 	return h
 }
 

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -176,7 +176,7 @@ func (s ConfigSnapshot) MaxFraction() [numResourceTiers]float64 {
 // writes (config changes only).
 type ResourceGroupConfigHolder struct {
 	// sv provides access to cluster settings for the snapshot's
-	// utilization targets. Nil in test paths.
+	// mode and utilization targets. Required.
 	sv *settings.Values
 
 	mu struct {
@@ -186,10 +186,12 @@ type ResourceGroupConfigHolder struct {
 }
 
 // newResourceGroupConfigHolder constructs a holder seeded with
-// builtinGroupConfigs. sv provides access to cluster settings for
-// utilization targets; nil is accepted for test paths (defaults are
-// used).
+// builtinGroupConfigs. sv must be non-nil; the holder reads cluster
+// settings on every Snapshot.
 func newResourceGroupConfigHolder(sv *settings.Values) *ResourceGroupConfigHolder {
+	if sv == nil {
+		panic(errors.AssertionFailedf("newResourceGroupConfigHolder: sv must be non-nil"))
+	}
 	h := &ResourceGroupConfigHolder{sv: sv}
 	h.Set(nil)
 	return h
@@ -226,15 +228,6 @@ func (h *ResourceGroupConfigHolder) Snapshot() ConfigSnapshot {
 	h.mu.RLock()
 	groups := h.mu.config
 	h.mu.RUnlock()
-	if h.sv == nil {
-		return ConfigSnapshot{
-			Groups:            groups,
-			Mode:              serverlessMode,
-			AppNoBurstFrac:    0.8,
-			SystemNoBurstFrac: 0.95,
-			BurstDelta:        0.05,
-		}
-	}
 	snap := ConfigSnapshot{
 		Groups:     groups,
 		Mode:       cpuTimeTokenACMode.Get(h.sv),

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -109,7 +109,7 @@ var defaultRGGroupConfig = ResourceGroupConfig{Weight: 20, BurstFrac: 0.2, MaxCP
 // gets defaultGroupWeight, since per-tenant weights are no longer
 // configurable. MaxCPU=false because tenants don't carry burst flags.
 var defaultTenantGroupConfig = ResourceGroupConfig{
-	Weight: defaultGroupWeight, BurstFrac: 0.25, MaxCPU: false,
+	Weight: defaultGroupWeight, BurstFrac: 0.20, MaxCPU: false,
 }
 
 // systemTenantGroupConfig is the built-in config for the system tenant

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -6,6 +6,7 @@
 package admission
 
 import (
+	"math"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -110,6 +111,21 @@ var defaultTenantGroupConfig = ResourceGroupConfig{
 	Weight: defaultGroupWeight, BurstFrac: 0.25, MaxCPU: false,
 }
 
+// systemTenantGroupConfig is the built-in config for the system tenant
+// (ID 1). It has maximum weight to ensure system work is never starved,
+// BurstFrac=1.0 so the full burst budget is available, and MaxCPU=true
+// to bypass the burst-fullness gate.
+var systemTenantGroupConfig = ResourceGroupConfig{
+	Weight: math.MaxUint32, BurstFrac: 1.0, MaxCPU: true,
+}
+
+// builtinGroupConfigs are configs that are always present in the
+// holder. Set seeds from this list first; callers cannot overwrite
+// built-in keys.
+var builtinGroupConfigs = ResourceGroupConfigSet{
+	tenantGroupKey(1): systemTenantGroupConfig,
+}
+
 // ResourceGroupConfigHolder owns the source-of-truth config set for RM mode.
 // It is pure storage behind an RWMutex; reads (every Admit) vastly outnumber
 // writes (config changes only).
@@ -130,12 +146,20 @@ func newResourceGroupConfigHolder() *ResourceGroupConfigHolder {
 }
 
 // Set replaces the stored config wholesale. Keys absent from config are
-// dropped.
+// dropped. Built-in configs (builtinGroupConfigs) are always present;
+// callers cannot overwrite them.
 //
 // NB: caller may mutate config after Set returns; the input is copied.
 func (h *ResourceGroupConfigHolder) Set(config ResourceGroupConfigSet) {
-	cp := make(ResourceGroupConfigSet, len(config))
+	cp := make(ResourceGroupConfigSet, len(builtinGroupConfigs)+len(config))
+	for k, v := range builtinGroupConfigs {
+		cp[k] = v
+	}
 	for k, v := range config {
+		if _, ok := builtinGroupConfigs[k]; ok {
+			panic(errors.AssertionFailedf(
+				"ResourceGroupConfigHolder.Set: key %s is a built-in and cannot be overwritten", k))
+		}
 		cp[k] = v
 	}
 	h.mu.Lock()

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -126,10 +127,55 @@ var builtinGroupConfigs = ResourceGroupConfigSet{
 	tenantGroupKey(1): systemTenantGroupConfig,
 }
 
+// ConfigSnapshot is the immutable snapshot returned by
+// ResourceGroupConfigHolder.Snapshot. It bundles the per-group config
+// set with the utilization targets derived from cluster settings.
+type ConfigSnapshot struct {
+	// Groups is the per-group config set (built-ins + caller-provided).
+	Groups ResourceGroupConfigSet
+	// AppNoBurstFrac is the non-burstable CPU utilization target for
+	// the app tenant tier (e.g. 0.8 for 80% of CPU capacity).
+	AppNoBurstFrac float64
+	// SystemNoBurstFrac is the non-burstable CPU utilization target
+	// for the system tenant tier.
+	//
+	// TODO(ssd): SystemNoBurstFrac will be removed when settings are
+	// consolidated; both tiers will use AppNoBurstFrac.
+	SystemNoBurstFrac float64
+	// BurstDelta is the delta added to the non-burstable fraction to
+	// produce the burstable utilization ceiling.
+	BurstDelta float64
+}
+
+// MaxNonBurstableFraction returns the non-burstable CPU utilization
+// target per tier.
+//
+// TODO(ssd): Returns per-tier values for now; will collapse to a
+// scalar when tiers are removed.
+func (s ConfigSnapshot) MaxNonBurstableFraction() [numResourceTiers]float64 {
+	return [numResourceTiers]float64{s.SystemNoBurstFrac, s.AppNoBurstFrac}
+}
+
+// MaxFraction returns the burstable CPU utilization ceiling
+// (noBurstFrac + BurstDelta) per tier.
+//
+// TODO(ssd): Returns per-tier values for now; will collapse to a
+// scalar when tiers are removed.
+func (s ConfigSnapshot) MaxFraction() [numResourceTiers]float64 {
+	return [numResourceTiers]float64{
+		s.SystemNoBurstFrac + s.BurstDelta,
+		s.AppNoBurstFrac + s.BurstDelta,
+	}
+}
+
 // ResourceGroupConfigHolder owns the source-of-truth config set for RM mode.
 // It is pure storage behind an RWMutex; reads (every Admit) vastly outnumber
 // writes (config changes only).
 type ResourceGroupConfigHolder struct {
+	// sv provides access to cluster settings for the snapshot's
+	// utilization targets. Nil in test paths.
+	sv *settings.Values
+
 	mu struct {
 		syncutil.RWMutex
 		config ResourceGroupConfigSet
@@ -139,8 +185,10 @@ type ResourceGroupConfigHolder struct {
 // newResourceGroupConfigHolder constructs a holder seeded with
 // defaultRMResourceGroupConfig, so a fresh Snapshot returns the high/low
 // hardcoded groups that WorkQueue applies on first RM-mode activation.
-func newResourceGroupConfigHolder() *ResourceGroupConfigHolder {
-	h := &ResourceGroupConfigHolder{}
+// sv provides access to cluster settings for utilization targets; nil
+// is accepted for test paths (defaults are used).
+func newResourceGroupConfigHolder(sv *settings.Values) *ResourceGroupConfigHolder {
+	h := &ResourceGroupConfigHolder{sv: sv}
 	h.Set(defaultRMResourceGroupConfig)
 	return h
 }
@@ -167,11 +215,40 @@ func (h *ResourceGroupConfigHolder) Set(config ResourceGroupConfigSet) {
 	h.mu.config = cp
 }
 
-// Snapshot returns the installed config map directly (no copy). The map is
-// immutable post-install: a subsequent Set installs a fresh map rather than
-// mutating in place, so prior snapshots remain stable.
-func (h *ResourceGroupConfigHolder) Snapshot() ResourceGroupConfigSet {
+// Snapshot returns the installed config bundled with utilization
+// targets from cluster settings. The Groups map is returned directly
+// (no copy); it is immutable post-install because Set installs a
+// fresh map rather than mutating in place, so prior snapshots remain
+// stable.
+func (h *ResourceGroupConfigHolder) Snapshot() ConfigSnapshot {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return h.mu.config
+	groups := h.mu.config
+	h.mu.RUnlock()
+	if h.sv == nil {
+		return ConfigSnapshot{
+			Groups:            groups,
+			AppNoBurstFrac:    0.8,
+			SystemNoBurstFrac: 0.95,
+			BurstDelta:        0.05,
+		}
+	}
+	snap := ConfigSnapshot{
+		Groups:     groups,
+		BurstDelta: KVCPUTimeUtilBurstDelta.Get(h.sv),
+	}
+	// TODO(ssd): The mode switch will be removed when settings are
+	// consolidated into a single target_util setting.
+	mode := cpuTimeTokenACMode.Get(h.sv)
+	switch mode {
+	case resourceManagerMode:
+		target := KVCPUTimeUtilTarget.Get(h.sv)
+		snap.AppNoBurstFrac = target
+		snap.SystemNoBurstFrac = target
+	default:
+		// offMode and serverlessMode both use the per-tier settings.
+		// The old constructor mapped offMode → serverlessMode.
+		snap.AppNoBurstFrac = KVCPUTimeAppUtilGoal.Get(h.sv)
+		snap.SystemNoBurstFrac = KVCPUTimeSystemUtilGoal.Get(h.sv)
+	}
+	return snap
 }

--- a/pkg/util/admission/resource_group_config_holder.go
+++ b/pkg/util/admission/resource_group_config_holder.go
@@ -38,16 +38,22 @@ type ResourceGroupConfig struct {
 // Once installed in the holder, callers must treat the map as read-only.
 type ResourceGroupConfigSet map[groupKey]ResourceGroupConfig
 
-// SafeFormat renders one entry per line, sorted by id, e.g.:
+// SafeFormat renders one entry per line, sorted by tenantID then
+// groupID, e.g.:
 //
-//	rg1 weight=80 maxCPU=true
-//	rg2 weight=20 maxCPU=false
+//	t0g1 weight=80 burstFrac=0.80 maxCPU=true
+//	t0g2 weight=20 burstFrac=0.20 maxCPU=false
 func (s ResourceGroupConfigSet) SafeFormat(w redact.SafePrinter, _ rune) {
 	keys := make([]groupKey, 0, len(s))
 	for k := range s {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i].id < keys[j].id })
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].tenantID != keys[j].tenantID {
+			return keys[i].tenantID < keys[j].tenantID
+		}
+		return keys[i].groupID < keys[j].groupID
+	})
 	for _, k := range keys {
 		cfg := s[k]
 		w.Printf("%s weight=%d burstFrac=%.2f maxCPU=%t\n",
@@ -60,45 +66,44 @@ func (s ResourceGroupConfigSet) String() string {
 	return redact.StringWithoutMarkers(s)
 }
 
-// GetOrDefault returns the config for k if installed, otherwise the
-// kind-appropriate fallback (rgKind: defaultRGGroupConfig; tenantKind:
-// defaultTenantGroupConfig). Used by WorkQueue's lazy group creation: an
-// Admit for a key without a corresponding groupInfo consults the set to
-// populate weight and maxCPU on the new groupInfo (burstFrac is computed
-// inline as Weight/100).
+// GetOrDefault returns the config for k if installed, otherwise a
+// fallback: resource groups (tenantID==0) get defaultRGGroupConfig;
+// tenant groups (groupID==0) get defaultTenantGroupConfig. Used by
+// WorkQueue's lazy group creation: an Admit for a key without a
+// corresponding groupInfo consults the set to populate weight and
+// maxCPU on the new groupInfo.
 //
-// TODO(wenyihu6): collapse to a single per-kind-agnostic fallback once we can
-// align the rg and tenant defaults. The kind switch here is a transitional
-// shape; ideally GetOrDefault returns one default that works for any key.
+// TODO(wenyihu6): collapse to a single fallback once we can align the
+// rg and tenant defaults.
 func (s ResourceGroupConfigSet) GetOrDefault(k groupKey) ResourceGroupConfig {
 	if cfg, ok := s[k]; ok {
 		return cfg
 	}
-	switch k.kind {
-	case rgKind:
-		return defaultRGGroupConfig
-	case tenantKind:
+	if k.groupID == 0 {
+		// Tenant group (tenantID is set, groupID is zero).
 		return defaultTenantGroupConfig
-	default:
-		panic(errors.AssertionFailedf("ResourceGroupConfigSet.GetOrDefault: invalid kind %s", k.kind))
 	}
+	// Resource group (groupID is set).
+	return defaultRGGroupConfig
 }
 
-// defaultRGGroupConfig is the safety fallback returned by GetOrDefault for
-// rgKind keys not in the installed configuration. In steady state this is
-// unreachable: the built-in configs cover high/low. It exists to keep
-// Admit's lazy-create path total — if a caller installs a config that
-// omits a known rg ID, Admit gets a usable weight rather than a
-// zero-weight group. Weight=20 mirrors the low default; MaxCPU=false keeps
-// an unconfigured group from bypassing the burst-fullness gate.
+// defaultRGGroupConfig is the safety fallback returned by GetOrDefault
+// for resource group keys (groupID != 0) not in the installed
+// configuration. In steady state this is unreachable: the built-in
+// configs cover high/low. It exists to keep Admit's lazy-create path
+// total — if a caller installs a config that omits a known group ID,
+// Admit gets a usable weight rather than a zero-weight group.
+// Weight=20 mirrors the low default; MaxCPU=false keeps an
+// unconfigured group from bypassing the burst-fullness gate.
 //
 // TODO(wenyihu6): once SQL DDL (CREATE/ALTER RESOURCE GROUP) is wired
-// through, decide whether unknown rgKind IDs should be a hard error.
+// through, decide whether unknown group IDs should be a hard error.
 var defaultRGGroupConfig = ResourceGroupConfig{Weight: 20, BurstFrac: 0.2, MaxCPU: false}
 
-// defaultTenantGroupConfig is the fallback for tenantKind keys: every tenant
-// gets defaultGroupWeight, since per-tenant weights are no longer
-// configurable. MaxCPU=false because tenants don't carry burst flags.
+// defaultTenantGroupConfig is the fallback for tenant group keys
+// (groupID == 0): every tenant gets defaultGroupWeight, since
+// per-tenant weights are no longer configurable. MaxCPU=false because
+// tenants don't carry burst flags.
 var defaultTenantGroupConfig = ResourceGroupConfig{
 	Weight: defaultGroupWeight, BurstFrac: 0.20, MaxCPU: false,
 }

--- a/pkg/util/admission/resource_group_config_holder_test.go
+++ b/pkg/util/admission/resource_group_config_holder_test.go
@@ -52,7 +52,7 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 		lowCfg := snap.Groups.GetOrDefault(rgGroupKey(lowResourceGroupID))
 		require.Equal(t, float64(0.2), lowCfg.BurstFrac)
 		tenantCfg := snap.Groups.GetOrDefault(tenantGroupKey(9999))
-		require.Equal(t, float64(0.25), tenantCfg.BurstFrac)
+		require.Equal(t, float64(0.20), tenantCfg.BurstFrac)
 	})
 }
 

--- a/pkg/util/admission/resource_group_config_holder_test.go
+++ b/pkg/util/admission/resource_group_config_holder_test.go
@@ -20,16 +20,15 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 	t.Run("constructor_seed", func(t *testing.T) {
 		h := newResourceGroupConfigHolder(nil)
 		snap := h.Snapshot()
-		// Built-in system tenant config is always present.
+		// All built-in configs are present.
 		require.Equal(t, systemTenantGroupConfig, snap.Groups[tenantGroupKey(1)])
-		// RM defaults are also present (from the seed).
 		require.Equal(t,
-			defaultRMResourceGroupConfig[rgGroupKey(highResourceGroupID)],
+			builtinGroupConfigs[rgGroupKey(highResourceGroupID)],
 			snap.Groups[rgGroupKey(highResourceGroupID)])
 		require.Equal(t,
-			defaultRMResourceGroupConfig[rgGroupKey(lowResourceGroupID)],
+			builtinGroupConfigs[rgGroupKey(lowResourceGroupID)],
 			snap.Groups[rgGroupKey(lowResourceGroupID)])
-		require.Len(t, snap.Groups, 3) // 1 builtin + 2 RM defaults
+		require.Len(t, snap.Groups, 3) // 3 built-ins
 	})
 
 	t.Run("get_or_default_unknown_rg", func(t *testing.T) {
@@ -59,18 +58,18 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 // TestResourceGroupConfigHolderSet covers Set's wholesale-replace and
 // input-aliasing contracts.
 func TestResourceGroupConfigHolderSet(t *testing.T) {
-	t.Run("replaces_wholesale_dropping_seed", func(t *testing.T) {
+	t.Run("replaces_wholesale", func(t *testing.T) {
 		h := newResourceGroupConfigHolder(nil)
 		h.Set(ResourceGroupConfigSet{
 			rgGroupKey(42): {Weight: 100, MaxCPU: false},
 		})
 		groups := h.Snapshot().Groups
-		// Set is wholesale: the RM seed (high/low) must be gone, the
-		// freshly-Set key must be present, and built-ins stay.
+		// Set is wholesale: the freshly-Set key is present alongside
+		// the built-ins (system tenant + high/low RM groups).
 		require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: false},
 			groups[rgGroupKey(42)])
 		require.Equal(t, systemTenantGroupConfig, groups[tenantGroupKey(1)])
-		require.Len(t, groups, 2) // 1 builtin + 1 caller key
+		require.Len(t, groups, 4) // 3 built-ins + 1 caller key
 	})
 
 	t.Run("input_aliasing_safe", func(t *testing.T) {
@@ -87,7 +86,7 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 		groups := h.Snapshot().Groups
 		require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: false},
 			groups[rgGroupKey(7)])
-		require.Len(t, groups, 2) // 1 builtin + 1 caller key
+		require.Len(t, groups, 4) // 3 built-ins + 1 caller key
 
 		// And the holder's internal map is not aliased to the input.
 		// Same-package access lets us check the underlying pointer.
@@ -103,11 +102,11 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 func TestResourceGroupConfigHolderGet(t *testing.T) {
 	h := newResourceGroupConfigHolder(nil)
 	h.Set(ResourceGroupConfigSet{
-		rgGroupKey(highResourceGroupID): {Weight: 75, MaxCPU: true},
+		rgGroupKey(42): {Weight: 75, MaxCPU: true},
 	})
 	require.Equal(t,
 		ResourceGroupConfig{Weight: 75, MaxCPU: true},
-		h.Snapshot().Groups.GetOrDefault(rgGroupKey(highResourceGroupID)))
+		h.Snapshot().Groups.GetOrDefault(rgGroupKey(42)))
 }
 
 // TestResourceGroupConfigHolderSnapshot verifies Snapshot's contract:
@@ -132,9 +131,9 @@ func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
 	h.Set(ResourceGroupConfigSet{
 		rgGroupKey(42): {Weight: 100, MaxCPU: true},
 	})
-	// snap1 must still have the RM defaults + builtins.
+	// snap1 must still have the built-in configs.
 	require.Equal(t,
-		defaultRMResourceGroupConfig[rgGroupKey(highResourceGroupID)],
+		builtinGroupConfigs[rgGroupKey(highResourceGroupID)],
 		snap1.Groups[rgGroupKey(highResourceGroupID)],
 		"prior snapshot must be unaffected by a subsequent Set")
 	// New snapshot has builtins + the freshly-set key.
@@ -142,7 +141,7 @@ func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
 	require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: true},
 		snap2.Groups[rgGroupKey(42)])
 	require.Equal(t, systemTenantGroupConfig, snap2.Groups[tenantGroupKey(1)])
-	require.Len(t, snap2.Groups, 2)
+	require.Len(t, snap2.Groups, 4) // 3 built-ins + 1 caller key
 }
 
 // TestSystemTenantGroupConfig verifies the field values of the built-in
@@ -165,14 +164,16 @@ func TestBuiltinGroupConfigInSnapshot(t *testing.T) {
 }
 
 // TestSetPanicsOnBuiltinOverwrite verifies that Set panics if the
-// caller tries to overwrite a built-in key.
+// caller tries to overwrite any built-in key.
 func TestSetPanicsOnBuiltinOverwrite(t *testing.T) {
 	h := newResourceGroupConfigHolder(nil)
-	require.Panics(t, func() {
-		h.Set(ResourceGroupConfigSet{
-			tenantGroupKey(1): {Weight: 1, BurstFrac: 0.5, MaxCPU: false},
+	for k := range builtinGroupConfigs {
+		require.Panics(t, func() {
+			h.Set(ResourceGroupConfigSet{
+				k: {Weight: 1, BurstFrac: 0.5, MaxCPU: false},
+			})
 		})
-	})
+	}
 }
 
 // TestConfigSnapshotDefaults verifies the default utilization targets

--- a/pkg/util/admission/resource_group_config_holder_test.go
+++ b/pkg/util/admission/resource_group_config_holder_test.go
@@ -18,40 +18,40 @@ import (
 // adjacent TestResourceGroupConfigHolder* functions.
 func TestResourceGroupConfigHolder(t *testing.T) {
 	t.Run("constructor_seed", func(t *testing.T) {
-		h := newResourceGroupConfigHolder()
+		h := newResourceGroupConfigHolder(nil)
 		snap := h.Snapshot()
 		// Built-in system tenant config is always present.
-		require.Equal(t, systemTenantGroupConfig, snap[tenantGroupKey(1)])
+		require.Equal(t, systemTenantGroupConfig, snap.Groups[tenantGroupKey(1)])
 		// RM defaults are also present (from the seed).
 		require.Equal(t,
 			defaultRMResourceGroupConfig[rgGroupKey(highResourceGroupID)],
-			snap[rgGroupKey(highResourceGroupID)])
+			snap.Groups[rgGroupKey(highResourceGroupID)])
 		require.Equal(t,
 			defaultRMResourceGroupConfig[rgGroupKey(lowResourceGroupID)],
-			snap[rgGroupKey(lowResourceGroupID)])
-		require.Len(t, snap, 3) // 1 builtin + 2 RM defaults
+			snap.Groups[rgGroupKey(lowResourceGroupID)])
+		require.Len(t, snap.Groups, 3) // 1 builtin + 2 RM defaults
 	})
 
 	t.Run("get_or_default_unknown_rg", func(t *testing.T) {
-		h := newResourceGroupConfigHolder()
+		h := newResourceGroupConfigHolder(nil)
 		require.Equal(t, defaultRGGroupConfig,
-			h.Snapshot().GetOrDefault(rgGroupKey(9999)))
+			h.Snapshot().Groups.GetOrDefault(rgGroupKey(9999)))
 	})
 
 	t.Run("get_or_default_unknown_tenant", func(t *testing.T) {
-		h := newResourceGroupConfigHolder()
+		h := newResourceGroupConfigHolder(nil)
 		require.Equal(t, defaultTenantGroupConfig,
-			h.Snapshot().GetOrDefault(tenantGroupKey(9999)))
+			h.Snapshot().Groups.GetOrDefault(tenantGroupKey(9999)))
 	})
 
 	t.Run("default_configs_have_burst_frac", func(t *testing.T) {
-		h := newResourceGroupConfigHolder()
+		h := newResourceGroupConfigHolder(nil)
 		snap := h.Snapshot()
-		highCfg := snap.GetOrDefault(rgGroupKey(highResourceGroupID))
+		highCfg := snap.Groups.GetOrDefault(rgGroupKey(highResourceGroupID))
 		require.Equal(t, float64(0.8), highCfg.BurstFrac)
-		lowCfg := snap.GetOrDefault(rgGroupKey(lowResourceGroupID))
+		lowCfg := snap.Groups.GetOrDefault(rgGroupKey(lowResourceGroupID))
 		require.Equal(t, float64(0.2), lowCfg.BurstFrac)
-		tenantCfg := snap.GetOrDefault(tenantGroupKey(9999))
+		tenantCfg := snap.Groups.GetOrDefault(tenantGroupKey(9999))
 		require.Equal(t, float64(0.25), tenantCfg.BurstFrac)
 	})
 }
@@ -60,21 +60,21 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 // input-aliasing contracts.
 func TestResourceGroupConfigHolderSet(t *testing.T) {
 	t.Run("replaces_wholesale_dropping_seed", func(t *testing.T) {
-		h := newResourceGroupConfigHolder()
+		h := newResourceGroupConfigHolder(nil)
 		h.Set(ResourceGroupConfigSet{
 			rgGroupKey(42): {Weight: 100, MaxCPU: false},
 		})
-		snap := h.Snapshot()
+		groups := h.Snapshot().Groups
 		// Set is wholesale: the RM seed (high/low) must be gone, the
 		// freshly-Set key must be present, and built-ins stay.
 		require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: false},
-			snap[rgGroupKey(42)])
-		require.Equal(t, systemTenantGroupConfig, snap[tenantGroupKey(1)])
-		require.Len(t, snap, 2) // 1 builtin + 1 caller key
+			groups[rgGroupKey(42)])
+		require.Equal(t, systemTenantGroupConfig, groups[tenantGroupKey(1)])
+		require.Len(t, groups, 2) // 1 builtin + 1 caller key
 	})
 
 	t.Run("input_aliasing_safe", func(t *testing.T) {
-		h := newResourceGroupConfigHolder()
+		h := newResourceGroupConfigHolder(nil)
 		input := ResourceGroupConfigSet{
 			rgGroupKey(7): {Weight: 100, MaxCPU: false},
 		}
@@ -84,10 +84,10 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 		input[rgGroupKey(7)] = ResourceGroupConfig{Weight: 1, MaxCPU: true}
 		input[rgGroupKey(8)] = ResourceGroupConfig{Weight: 1, MaxCPU: false}
 
-		snap := h.Snapshot()
+		groups := h.Snapshot().Groups
 		require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: false},
-			snap[rgGroupKey(7)])
-		require.Len(t, snap, 2) // 1 builtin + 1 caller key
+			groups[rgGroupKey(7)])
+		require.Len(t, groups, 2) // 1 builtin + 1 caller key
 
 		// And the holder's internal map is not aliased to the input.
 		// Same-package access lets us check the underlying pointer.
@@ -101,21 +101,21 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 
 // TestResourceGroupConfigHolderGet covers GetOrDefault for a configured key.
 func TestResourceGroupConfigHolderGet(t *testing.T) {
-	h := newResourceGroupConfigHolder()
+	h := newResourceGroupConfigHolder(nil)
 	h.Set(ResourceGroupConfigSet{
 		rgGroupKey(highResourceGroupID): {Weight: 75, MaxCPU: true},
 	})
 	require.Equal(t,
 		ResourceGroupConfig{Weight: 75, MaxCPU: true},
-		h.Snapshot().GetOrDefault(rgGroupKey(highResourceGroupID)))
+		h.Snapshot().Groups.GetOrDefault(rgGroupKey(highResourceGroupID)))
 }
 
 // TestResourceGroupConfigHolderSnapshot verifies Snapshot's contract:
-// the returned map is the holder's installed map (no defensive copy),
+// the Groups map is the holder's installed map (no defensive copy),
 // and a subsequent Set installs a fresh map without mutating the
 // previously-returned snapshot.
 func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
-	h := newResourceGroupConfigHolder()
+	h := newResourceGroupConfigHolder(nil)
 	snap1 := h.Snapshot()
 
 	// Snapshot aliases the internal map (no copy on read). This is
@@ -123,7 +123,7 @@ func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
 	h.mu.RLock()
 	internalPtr := reflect.ValueOf(h.mu.config).Pointer()
 	h.mu.RUnlock()
-	require.Equal(t, internalPtr, reflect.ValueOf(snap1).Pointer(),
+	require.Equal(t, internalPtr, reflect.ValueOf(snap1.Groups).Pointer(),
 		"Snapshot should return the installed map directly")
 
 	// A subsequent Set installs a brand-new map. snap1 must remain
@@ -135,14 +135,14 @@ func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
 	// snap1 must still have the RM defaults + builtins.
 	require.Equal(t,
 		defaultRMResourceGroupConfig[rgGroupKey(highResourceGroupID)],
-		snap1[rgGroupKey(highResourceGroupID)],
+		snap1.Groups[rgGroupKey(highResourceGroupID)],
 		"prior snapshot must be unaffected by a subsequent Set")
 	// New snapshot has builtins + the freshly-set key.
 	snap2 := h.Snapshot()
 	require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: true},
-		snap2[rgGroupKey(42)])
-	require.Equal(t, systemTenantGroupConfig, snap2[tenantGroupKey(1)])
-	require.Len(t, snap2, 2)
+		snap2.Groups[rgGroupKey(42)])
+	require.Equal(t, systemTenantGroupConfig, snap2.Groups[tenantGroupKey(1)])
+	require.Len(t, snap2.Groups, 2)
 }
 
 // TestSystemTenantGroupConfig verifies the field values of the built-in
@@ -157,9 +157,9 @@ func TestSystemTenantGroupConfig(t *testing.T) {
 // config appears in the holder's snapshot immediately after
 // construction, without any explicit Set call beyond the seed.
 func TestBuiltinGroupConfigInSnapshot(t *testing.T) {
-	h := newResourceGroupConfigHolder()
-	snap := h.Snapshot()
-	cfg, ok := snap[tenantGroupKey(1)]
+	h := newResourceGroupConfigHolder(nil)
+	groups := h.Snapshot().Groups
+	cfg, ok := groups[tenantGroupKey(1)]
 	require.True(t, ok, "system tenant (ID 1) must be present in snapshot")
 	require.Equal(t, systemTenantGroupConfig, cfg)
 }
@@ -167,10 +167,44 @@ func TestBuiltinGroupConfigInSnapshot(t *testing.T) {
 // TestSetPanicsOnBuiltinOverwrite verifies that Set panics if the
 // caller tries to overwrite a built-in key.
 func TestSetPanicsOnBuiltinOverwrite(t *testing.T) {
-	h := newResourceGroupConfigHolder()
+	h := newResourceGroupConfigHolder(nil)
 	require.Panics(t, func() {
 		h.Set(ResourceGroupConfigSet{
 			tenantGroupKey(1): {Weight: 1, BurstFrac: 0.5, MaxCPU: false},
 		})
 	})
+}
+
+// TestConfigSnapshotDefaults verifies the default utilization targets
+// returned when the holder is constructed with a nil settings.Values.
+func TestConfigSnapshotDefaults(t *testing.T) {
+	h := newResourceGroupConfigHolder(nil)
+	snap := h.Snapshot()
+	require.Equal(t, 0.8, snap.AppNoBurstFrac)
+	require.Equal(t, 0.95, snap.SystemNoBurstFrac)
+	require.Equal(t, 0.05, snap.BurstDelta)
+}
+
+// TestConfigSnapshotMaxNonBurstableFraction verifies
+// MaxNonBurstableFraction returns per-tier non-burstable targets.
+func TestConfigSnapshotMaxNonBurstableFraction(t *testing.T) {
+	snap := ConfigSnapshot{
+		AppNoBurstFrac:    0.75,
+		SystemNoBurstFrac: 0.90,
+		BurstDelta:        0.10,
+	}
+	expected := [numResourceTiers]float64{0.90, 0.75}
+	require.Equal(t, expected, snap.MaxNonBurstableFraction())
+}
+
+// TestConfigSnapshotMaxFraction verifies MaxFraction returns per-tier
+// burstable targets (noBurstFrac + BurstDelta).
+func TestConfigSnapshotMaxFraction(t *testing.T) {
+	snap := ConfigSnapshot{
+		AppNoBurstFrac:    0.75,
+		SystemNoBurstFrac: 0.90,
+		BurstDelta:        0.10,
+	}
+	expected := [numResourceTiers]float64{1.0, 0.85}
+	require.Equal(t, expected, snap.MaxFraction())
 }

--- a/pkg/util/admission/resource_group_config_holder_test.go
+++ b/pkg/util/admission/resource_group_config_holder_test.go
@@ -10,15 +10,24 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/stretchr/testify/require"
 )
+
+// testHolder constructs a holder backed by a fresh test cluster
+// settings.Values. The holder requires non-nil settings for the
+// snapshot's mode and utilization-target reads.
+func testHolder() *ResourceGroupConfigHolder {
+	st := cluster.MakeTestingClusterSettings()
+	return newResourceGroupConfigHolder(&st.SV)
+}
 
 // TestResourceGroupConfigHolder covers the constructor seed and the
 // unknown-key fallback. The behavioral cases for Set and Snapshot live in
 // adjacent TestResourceGroupConfigHolder* functions.
 func TestResourceGroupConfigHolder(t *testing.T) {
 	t.Run("constructor_seed", func(t *testing.T) {
-		h := newResourceGroupConfigHolder(nil)
+		h := testHolder()
 		snap := h.Snapshot()
 		// All built-in configs are present.
 		require.Equal(t, systemTenantGroupConfig, snap.Groups[tenantGroupKey(1)])
@@ -32,19 +41,19 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 	})
 
 	t.Run("get_or_default_unknown_rg", func(t *testing.T) {
-		h := newResourceGroupConfigHolder(nil)
+		h := testHolder()
 		require.Equal(t, defaultRGGroupConfig,
 			h.Snapshot().Groups.GetOrDefault(rgGroupKey(9999)))
 	})
 
 	t.Run("get_or_default_unknown_tenant", func(t *testing.T) {
-		h := newResourceGroupConfigHolder(nil)
+		h := testHolder()
 		require.Equal(t, defaultTenantGroupConfig,
 			h.Snapshot().Groups.GetOrDefault(tenantGroupKey(9999)))
 	})
 
 	t.Run("default_configs_have_burst_frac", func(t *testing.T) {
-		h := newResourceGroupConfigHolder(nil)
+		h := testHolder()
 		snap := h.Snapshot()
 		highCfg := snap.Groups.GetOrDefault(rgGroupKey(highResourceGroupID))
 		require.Equal(t, float64(0.8), highCfg.BurstFrac)
@@ -59,7 +68,7 @@ func TestResourceGroupConfigHolder(t *testing.T) {
 // input-aliasing contracts.
 func TestResourceGroupConfigHolderSet(t *testing.T) {
 	t.Run("replaces_wholesale", func(t *testing.T) {
-		h := newResourceGroupConfigHolder(nil)
+		h := testHolder()
 		h.Set(ResourceGroupConfigSet{
 			rgGroupKey(42): {Weight: 100, MaxCPU: false},
 		})
@@ -73,7 +82,7 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 	})
 
 	t.Run("input_aliasing_safe", func(t *testing.T) {
-		h := newResourceGroupConfigHolder(nil)
+		h := testHolder()
 		input := ResourceGroupConfigSet{
 			rgGroupKey(7): {Weight: 100, MaxCPU: false},
 		}
@@ -100,7 +109,7 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 
 // TestResourceGroupConfigHolderGet covers GetOrDefault for a configured key.
 func TestResourceGroupConfigHolderGet(t *testing.T) {
-	h := newResourceGroupConfigHolder(nil)
+	h := testHolder()
 	h.Set(ResourceGroupConfigSet{
 		rgGroupKey(42): {Weight: 75, MaxCPU: true},
 	})
@@ -114,7 +123,7 @@ func TestResourceGroupConfigHolderGet(t *testing.T) {
 // and a subsequent Set installs a fresh map without mutating the
 // previously-returned snapshot.
 func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
-	h := newResourceGroupConfigHolder(nil)
+	h := testHolder()
 	snap1 := h.Snapshot()
 
 	// Snapshot aliases the internal map (no copy on read). This is
@@ -156,7 +165,7 @@ func TestSystemTenantGroupConfig(t *testing.T) {
 // config appears in the holder's snapshot immediately after
 // construction, without any explicit Set call beyond the seed.
 func TestBuiltinGroupConfigInSnapshot(t *testing.T) {
-	h := newResourceGroupConfigHolder(nil)
+	h := testHolder()
 	groups := h.Snapshot().Groups
 	cfg, ok := groups[tenantGroupKey(1)]
 	require.True(t, ok, "system tenant (ID 1) must be present in snapshot")
@@ -166,7 +175,7 @@ func TestBuiltinGroupConfigInSnapshot(t *testing.T) {
 // TestSetPanicsOnBuiltinOverwrite verifies that Set panics if the
 // caller tries to overwrite any built-in key.
 func TestSetPanicsOnBuiltinOverwrite(t *testing.T) {
-	h := newResourceGroupConfigHolder(nil)
+	h := testHolder()
 	for k := range builtinGroupConfigs {
 		require.Panics(t, func() {
 			h.Set(ResourceGroupConfigSet{
@@ -177,9 +186,10 @@ func TestSetPanicsOnBuiltinOverwrite(t *testing.T) {
 }
 
 // TestConfigSnapshotDefaults verifies the default utilization targets
-// returned when the holder is constructed with a nil settings.Values.
+// surfaced through Snapshot when the underlying cluster settings are
+// at their registered defaults.
 func TestConfigSnapshotDefaults(t *testing.T) {
-	h := newResourceGroupConfigHolder(nil)
+	h := testHolder()
 	snap := h.Snapshot()
 	require.Equal(t, 0.8, snap.AppNoBurstFrac)
 	require.Equal(t, 0.95, snap.SystemNoBurstFrac)

--- a/pkg/util/admission/resource_group_config_holder_test.go
+++ b/pkg/util/admission/resource_group_config_holder_test.go
@@ -6,6 +6,7 @@
 package admission
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -18,7 +19,17 @@ import (
 func TestResourceGroupConfigHolder(t *testing.T) {
 	t.Run("constructor_seed", func(t *testing.T) {
 		h := newResourceGroupConfigHolder()
-		require.Equal(t, defaultRMResourceGroupConfig, h.Snapshot())
+		snap := h.Snapshot()
+		// Built-in system tenant config is always present.
+		require.Equal(t, systemTenantGroupConfig, snap[tenantGroupKey(1)])
+		// RM defaults are also present (from the seed).
+		require.Equal(t,
+			defaultRMResourceGroupConfig[rgGroupKey(highResourceGroupID)],
+			snap[rgGroupKey(highResourceGroupID)])
+		require.Equal(t,
+			defaultRMResourceGroupConfig[rgGroupKey(lowResourceGroupID)],
+			snap[rgGroupKey(lowResourceGroupID)])
+		require.Len(t, snap, 3) // 1 builtin + 2 RM defaults
 	})
 
 	t.Run("get_or_default_unknown_rg", func(t *testing.T) {
@@ -53,11 +64,13 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 		h.Set(ResourceGroupConfigSet{
 			rgGroupKey(42): {Weight: 100, MaxCPU: false},
 		})
-		// Set is wholesale: the seed (high/low) must be gone, and only the
-		// freshly-Set key must remain.
-		require.Equal(t, ResourceGroupConfigSet{
-			rgGroupKey(42): {Weight: 100, MaxCPU: false},
-		}, h.Snapshot())
+		snap := h.Snapshot()
+		// Set is wholesale: the RM seed (high/low) must be gone, the
+		// freshly-Set key must be present, and built-ins stay.
+		require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: false},
+			snap[rgGroupKey(42)])
+		require.Equal(t, systemTenantGroupConfig, snap[tenantGroupKey(1)])
+		require.Len(t, snap, 2) // 1 builtin + 1 caller key
 	})
 
 	t.Run("input_aliasing_safe", func(t *testing.T) {
@@ -71,9 +84,10 @@ func TestResourceGroupConfigHolderSet(t *testing.T) {
 		input[rgGroupKey(7)] = ResourceGroupConfig{Weight: 1, MaxCPU: true}
 		input[rgGroupKey(8)] = ResourceGroupConfig{Weight: 1, MaxCPU: false}
 
-		require.Equal(t, ResourceGroupConfigSet{
-			rgGroupKey(7): {Weight: 100, MaxCPU: false},
-		}, h.Snapshot())
+		snap := h.Snapshot()
+		require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: false},
+			snap[rgGroupKey(7)])
+		require.Len(t, snap, 2) // 1 builtin + 1 caller key
 
 		// And the holder's internal map is not aliased to the input.
 		// Same-package access lets us check the underlying pointer.
@@ -118,9 +132,45 @@ func TestResourceGroupConfigHolderSnapshot(t *testing.T) {
 	h.Set(ResourceGroupConfigSet{
 		rgGroupKey(42): {Weight: 100, MaxCPU: true},
 	})
-	require.Equal(t, defaultRMResourceGroupConfig, snap1,
+	// snap1 must still have the RM defaults + builtins.
+	require.Equal(t,
+		defaultRMResourceGroupConfig[rgGroupKey(highResourceGroupID)],
+		snap1[rgGroupKey(highResourceGroupID)],
 		"prior snapshot must be unaffected by a subsequent Set")
-	require.Equal(t, ResourceGroupConfigSet{
-		rgGroupKey(42): {Weight: 100, MaxCPU: true},
-	}, h.Snapshot())
+	// New snapshot has builtins + the freshly-set key.
+	snap2 := h.Snapshot()
+	require.Equal(t, ResourceGroupConfig{Weight: 100, MaxCPU: true},
+		snap2[rgGroupKey(42)])
+	require.Equal(t, systemTenantGroupConfig, snap2[tenantGroupKey(1)])
+	require.Len(t, snap2, 2)
+}
+
+// TestSystemTenantGroupConfig verifies the field values of the built-in
+// system tenant config.
+func TestSystemTenantGroupConfig(t *testing.T) {
+	require.Equal(t, uint32(math.MaxUint32), systemTenantGroupConfig.Weight)
+	require.Equal(t, 1.0, systemTenantGroupConfig.BurstFrac)
+	require.True(t, systemTenantGroupConfig.MaxCPU)
+}
+
+// TestBuiltinGroupConfigInSnapshot verifies that the system tenant
+// config appears in the holder's snapshot immediately after
+// construction, without any explicit Set call beyond the seed.
+func TestBuiltinGroupConfigInSnapshot(t *testing.T) {
+	h := newResourceGroupConfigHolder()
+	snap := h.Snapshot()
+	cfg, ok := snap[tenantGroupKey(1)]
+	require.True(t, ok, "system tenant (ID 1) must be present in snapshot")
+	require.Equal(t, systemTenantGroupConfig, cfg)
+}
+
+// TestSetPanicsOnBuiltinOverwrite verifies that Set panics if the
+// caller tries to overwrite a built-in key.
+func TestSetPanicsOnBuiltinOverwrite(t *testing.T) {
+	h := newResourceGroupConfigHolder()
+	require.Panics(t, func() {
+		h.Set(ResourceGroupConfigSet{
+			tenantGroupKey(1): {Weight: 1, BurstFrac: 0.5, MaxCPU: false},
+		})
+	})
 }

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -602,11 +602,13 @@ func TestSQLCPUHandleSecondDeductionAfterTurn(t *testing.T) {
 }
 
 // TestSetResourceGroupConfigRGOnly verifies that SetResourceGroupConfig
-// inputs only affect rg-keyed containers. A numerically equal
-// tenant-keyed container must not inherit the maxCPU flag — that's the
-// cross-namespace collision the kind discriminator in q.mu.groups is
-// meant to prevent. applyConfigLocked enforces this by always keying
-// its writes via rgGroupKey.
+// inputs affect rg-keyed containers and that the kind discriminator in
+// q.mu.groups prevents a rg-keyed maxCPU flip from leaking to a
+// numerically equal tenant-keyed container.
+//
+// We use tenant 5 (not 1) because tenantGroupKey(1) is a built-in
+// config with maxCPU=true (systemTenantGroupConfig), which would
+// confound the cross-namespace isolation check.
 func TestSetResourceGroupConfigRGOnly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -615,40 +617,32 @@ func TestSetResourceGroupConfigRGOnly(t *testing.T) {
 	q, _, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
-	// Create a tenant-keyed container with id=1.
+	// Create a tenant-keyed container with id=5 (no built-in config).
 	cpuTimeTokenACMode.Override(ctx, &st.SV, serverlessMode)
 	tenantHandle := newSQLCPUAdmissionHandle(
 		WorkInfo{
-			TenantID: roachpb.MustMakeTenantID(1),
+			TenantID: roachpb.MustMakeTenantID(5),
 			Priority: admissionpb.NormalPri,
 		}, true, &sqlCPUProviderImpl{}, q)
 	require.NoError(t, tenantHandle.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
 
-	// Create an rg-keyed container with id=1 (highResourceGroupID).
+	// Create an rg-keyed container with id=5.
 	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
-	rgHandle := newSQLCPUAdmissionHandle(
-		WorkInfo{
-			TenantID: roachpb.MustMakeTenantID(99),
-			Priority: admissionpb.NormalPri,
-		}, true, &sqlCPUProviderImpl{}, q)
-	require.NoError(t, rgHandle.reportAndAcquireConsumedCPU(ctx, 1*time.Millisecond, false))
+	// Install a config that seeds rgGroupKey(5).
+	q.configHolder.Set(ResourceGroupConfigSet{
+		rgGroupKey(5): {Weight: 1, MaxCPU: true},
+	})
+	q.refreshResourceGroupConfig()
 
 	// Both containers should now coexist with the same numeric ID.
 	q.mu.Lock()
-	tenantContainer, tenantOK := q.mu.groups[tenantGroupKey(1)]
-	rgContainer, rgOK := q.mu.groups[rgGroupKey(1)]
+	tenantContainer, tenantOK := q.mu.groups[tenantGroupKey(5)]
+	rgContainer, rgOK := q.mu.groups[rgGroupKey(5)]
 	q.mu.Unlock()
-	require.True(t, tenantOK, "tenant 1 container should exist")
-	require.True(t, rgOK, "rg 1 container should exist")
+	require.True(t, tenantOK, "tenant 5 container should exist")
+	require.True(t, rgOK, "rg 5 container should exist")
 	require.NotSame(t, tenantContainer, rgContainer,
-		"tenant 1 and rg 1 must be distinct *groupInfo entries")
-
-	// Set maxCPU on group 1 via the holder + apply path. It should
-	// affect the rg container only.
-	q.configHolder.Set(ResourceGroupConfigSet{
-		rgGroupKey(1): {Weight: 1, MaxCPU: true},
-	})
-	q.refreshResourceGroupConfig()
+		"tenant 5 and rg 5 must be distinct *groupInfo entries")
 
 	q.mu.Lock()
 	tenantMaxCPU := tenantContainer.cpuTimeBurstBucket.maxCPU
@@ -662,7 +656,6 @@ func TestSetResourceGroupConfigRGOnly(t *testing.T) {
 		"rg container should pick up the maxCPU flag")
 
 	tenantHandle.Close()
-	rgHandle.Close()
 }
 
 // admitOnce drives a single slow-path Admit on a new SQLCPUHandle

--- a/pkg/util/admission/sql_cpu_handle_test.go
+++ b/pkg/util/admission/sql_cpu_handle_test.go
@@ -712,7 +712,7 @@ func TestSQLCPUHandleCloseAfterModeFlip(t *testing.T) {
 	// rg container exists before Close runs.
 	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
 	q.mu.Lock()
-	q.applyConfigLocked(q.configHolder.Snapshot())
+	q.applyConfigLocked(q.configHolder.Snapshot().Groups)
 	q.mu.Unlock()
 	rgUsedBefore := requireGroupUsed(t, q, rgGroupKey(highResourceGroupID))
 

--- a/pkg/util/admission/testdata/cpu_time_token_allocator
+++ b/pkg/util/admission/testdata/cpu_time_token_allocator
@@ -22,7 +22,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 # set-tokens v=0 simulates tokens being taken due to admitted work.
 set-tokens v=0
@@ -61,7 +61,7 @@ tier0  1000      800
 tier1  600       400
 burstM
 tier0  200
-tier1  100
+tier1  200
 
 allocate remaining=4
 ----
@@ -70,7 +70,7 @@ tier0  2000      1600
 tier1  1200      800
 burstM
 tier0  400
-tier1  200
+tier1  400
 
 allocate remaining=3
 ----
@@ -79,7 +79,7 @@ tier0  3000      2400
 tier1  1800      1200
 burstM
 tier0  600
-tier1  300
+tier1  600
 
 allocate remaining=2
 ----
@@ -88,7 +88,7 @@ tier0  4000      3200
 tier1  2400      1600
 burstM
 tier0  800
-tier1  400
+tier1  800
 
 allocate remaining=1
 ----
@@ -97,7 +97,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 resetInterval
 ----
@@ -112,7 +112,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 # resetInterval has been called, so a new interval has started.
 # So in theory more tokens can be added. But in this case the
@@ -126,7 +126,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 set-tokens v=0
 ----
@@ -163,7 +163,7 @@ tier0  4000      3200
 tier1  2400      1600
 burstM
 tier0  800
-tier1  400
+tier1  800
 
 resetInterval
 ----
@@ -178,7 +178,7 @@ tier0  4000      3200
 tier1  2400      1600
 burstM
 tier0  800
-tier1  400
+tier1  800
 
 set-tokens v=0
 ----
@@ -199,7 +199,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 resetInterval
 ----
@@ -214,7 +214,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 set-tokens v=0
 ----
@@ -234,7 +234,7 @@ tier0  2500      2000
 tier1  1500      1000
 burstM
 tier0  500
-tier1  250
+tier1  500
 
 allocate remaining=1
 ----
@@ -243,7 +243,7 @@ tier0  5000      4000
 tier1  3000      2000
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 # These final cases test how cpuTimeTokenAllocator handles changes to
 # refillRates. See the comment above deltaRefillRates for a full explanation
@@ -264,7 +264,7 @@ tier0  5001      4001
 tier1  3001      2001
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 set-tokens v=0
 ----
@@ -284,7 +284,7 @@ tier0  5001      4001
 tier1  3001      2001
 burstM
 tier0  1000
-tier1  500
+tier1  1000
 
 # Another test of a change to refillRates. If we decrease refillRates by two
 # (on all buckets), we expect two tokens to be removed from all buckets, as
@@ -302,7 +302,7 @@ tier0  4999      3999
 tier1  2999      1999
 burstM
 tier0  999
-tier1  499
+tier1  999
 
 set-tokens v=0
 ----
@@ -322,7 +322,7 @@ tier0  4999      3999
 tier1  2999      1999
 burstM
 tier0  999
-tier1  499
+tier1  999
 
 set-tokens v=0
 ----
@@ -395,8 +395,8 @@ cpuTTG can_burst no_burst
 tier0  0         -1000
 tier1  -2000     -3000
 burstM
-tier0  -249
-tier1  -124
+tier0  -294
+tier1  -294
 
 # Test resetInterval path. Drive buckets deeply negative again. resetInterval
 # has delta=0 (rates unchanged), but the floor still clamps.
@@ -421,5 +421,5 @@ cpuTTG can_burst no_burst
 tier0  0         -1000
 tier1  -2000     -3000
 burstM
-tier0  -249
-tier1  -124
+tier0  -294
+tier1  -294

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/base
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/base
@@ -23,9 +23,9 @@ id 2: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 3, w: 1, fifo: -128
- group-id: 54 used: 8, w: 1, fifo: -128
-burst-buckets: t53=fullness=0.0% tokens=-3 capacity=0 qual=no_burst t54=fullness=0.0% tokens=-8 capacity=0 qual=no_burst
+ group-id: t53g0 used: 3, w: 1, fifo: -128
+ group-id: t54g0 used: 8, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=0.0% tokens=-3 capacity=0 qual=no_burst t54g0=fullness=0.0% tokens=-8 capacity=0 qual=no_burst
 
 # requested-count at admit time was 3. cpu-time below is 1. This
 # simulates a situation where at admit time, the predicted CPU usage
@@ -43,9 +43,9 @@ returnGrant 2
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
- group-id: 54 used: 8, w: 1, fifo: -128
-burst-buckets: t53=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t54=fullness=0.0% tokens=-8 capacity=0 qual=no_burst
+ group-id: t53g0 used: 1, w: 1, fifo: -128
+ group-id: t54g0 used: 8, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t54g0=fullness=0.0% tokens=-8 capacity=0 qual=no_burst
 
 # In this case, measured CPU usage was more than predicted CPU usage.
 # So, we should take additional tokens from the granter this time.
@@ -57,9 +57,9 @@ tookWithoutPermission 7
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
- group-id: 54 used: 15, w: 1, fifo: -128
-burst-buckets: t53=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t54=fullness=0.0% tokens=-15 capacity=0 qual=no_burst
+ group-id: t53g0 used: 1, w: 1, fifo: -128
+ group-id: t54g0 used: 15, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t54g0=fullness=0.0% tokens=-15 capacity=0 qual=no_burst
 
 ###
 # This test is of the integration of burstQualification with the tenant
@@ -97,9 +97,9 @@ id 1000: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
- group-id: 54 used: 101, w: 1, fifo: -128
-burst-buckets: t53=fullness=99.0% tokens=99 capacity=100 qual=can_burst t54=fullness=-1.0% tokens=-1 capacity=100 qual=no_burst
+ group-id: t53g0 used: 1, w: 1, fifo: -128
+ group-id: t54g0 used: 101, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=99.0% tokens=99 capacity=100 qual=can_burst t54g0=fullness=-1.0% tokens=-1 capacity=100 qual=no_burst
 
 set-try-get-return-value v=false
 ----
@@ -202,9 +202,9 @@ refill-burst-buckets to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 1, w: 4294967295, fifo: -128
- group-id: 2 used: 1, w: 1, fifo: -128
-burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t1g0 used: 1, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 1, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 # Since both burst buckets are full, both tenants can burst.
 admit id=3 tenant=1 requested-count=1
@@ -215,9 +215,9 @@ id 3: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 2, w: 4294967295, fifo: -128
- group-id: 2 used: 1, w: 1, fifo: -128
-burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t1g0 used: 2, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 1, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=4 tenant=2 requested-count=1
 ----
@@ -227,9 +227,9 @@ id 4: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 2, w: 4294967295, fifo: -128
- group-id: 2 used: 2, w: 1, fifo: -128
-burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+ group-id: t1g0 used: 2, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 2, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # Bucket started at 100 tokens. First call to Admit removed 1 token.
 # This call to Admit removes 7 tokens. 100-1-7 = 92 tokens in bucket.
@@ -242,9 +242,9 @@ id 5: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 9, w: 4294967295, fifo: -128
- group-id: 2 used: 2, w: 1, fifo: -128
-burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 maxCPU=true qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+ group-id: t1g0 used: 9, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 2, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=92.0% tokens=92 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # Bucket started at 100 tokens. First call to Admit removed 1 token.
 # This call to Admit removes 10 tokens. 100-1-10 = 89 tokens in bucket.
@@ -258,9 +258,9 @@ id 6: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 9, w: 4294967295, fifo: -128
- group-id: 2 used: 12, w: 1, fifo: -128
-burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 maxCPU=true qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
+ group-id: t1g0 used: 9, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 12, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=92.0% tokens=92 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=89.0% tokens=89 capacity=100 qual=no_burst
 
 # 100-1-7-1 = 91 tokens in the bucket. So tenant 1 can burst still.
 admit id=7 tenant=1 requested-count=1
@@ -271,9 +271,9 @@ id 7: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 10, w: 4294967295, fifo: -128
- group-id: 2 used: 12, w: 1, fifo: -128
-burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
+ group-id: t1g0 used: 10, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 12, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=89.0% tokens=89 capacity=100 qual=no_burst
 
 # 100-1-10-1 = 88. Tenant 2 cannot burst this time.
 admit id=8 tenant=2 requested-count=1
@@ -284,9 +284,9 @@ id 8: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 10, w: 4294967295, fifo: -128
- group-id: 2 used: 13, w: 1, fifo: -128
-burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
+ group-id: t1g0 used: 10, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 13, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 # 100-1-7-1-1 = 90. So this call to Admit, tenant 1 can burst, but
 # the next call, tenant 1 cannot burst.
@@ -298,9 +298,9 @@ id 9: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 11, w: 4294967295, fifo: -128
- group-id: 2 used: 13, w: 1, fifo: -128
-burst-buckets: t1=fullness=90.0% tokens=90 capacity=100 maxCPU=true qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
+ group-id: t1g0 used: 11, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 13, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=90.0% tokens=90 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 admit id=10 tenant=1 requested-count=1
 ----
@@ -310,9 +310,9 @@ id 10: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 12, w: 4294967295, fifo: -128
- group-id: 2 used: 13, w: 1, fifo: -128
-burst-buckets: t1=fullness=89.0% tokens=89 capacity=100 maxCPU=true qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
+ group-id: t1g0 used: 12, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 13, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=89.0% tokens=89 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 # Fill to full again. Both tenants thus can burst.
 refill-burst-buckets to-add=100 capacity=100
@@ -345,9 +345,9 @@ refill-burst-buckets to-add=10 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000013, w: 4294967295, fifo: -128
- group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t1g0 used: 100000013, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 14, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 refill-burst-buckets to-add=116 capacity=100
 ----
@@ -355,9 +355,9 @@ refill-burst-buckets to-add=116 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000013, w: 4294967295, fifo: -128
- group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t1g0 used: 100000013, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 14, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=14 tenant=1 requested-count=1
 ----
@@ -392,9 +392,9 @@ id 16: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 101000015, w: 4294967295, fifo: -128
- group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=-999900.0% tokens=-999900 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t1g0 used: 101000015, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 14, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=-999900.0% tokens=-999900 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 work-done id=16 cpu-time=1
 ----
@@ -403,9 +403,9 @@ returnGrant 999999
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000016, w: 4294967295, fifo: -128
- group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t1g0 used: 100000016, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 14, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=17 tenant=1 requested-count=10
 ----
@@ -425,9 +425,9 @@ refill-burst-buckets to-add=20 capacity=20
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000027, w: 4294967295, fifo: -128
- group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=100.0% tokens=20 capacity=20 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=20 capacity=20 qual=can_burst
+ group-id: t1g0 used: 100000027, w: 4294967295, fifo: -128
+ group-id: t2g0 used: 14, w: 1, fifo: -128
+burst-buckets: t1g0=fullness=100.0% tokens=20 capacity=20 maxCPU=true qual=can_burst t2g0=fullness=100.0% tokens=20 capacity=20 qual=can_burst
 
 admit id=19 tenant=1 requested-count=2
 ----
@@ -473,8 +473,8 @@ refill-burst-buckets to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
-burst-buckets: t53=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+ group-id: t53g0 used: 1, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 admit id=2 tenant=53 requested-count=5
 ----
@@ -484,8 +484,8 @@ id 2: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 6, w: 1, fifo: -128
-burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=can_burst
+ group-id: t53g0 used: 6, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=94.0% tokens=94 capacity=100 qual=can_burst
 
 set-try-get-return-value v=false
 ----
@@ -496,9 +496,9 @@ tryGet: input can_burst, returning false
 
 print
 ----
-closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 53 used: 6, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=can_burst
+closed epoch: 0 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 6, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: t53g0=fullness=94.0% tokens=94 capacity=100 qual=can_burst
 
 granted chain-id=1
 ----
@@ -509,8 +509,8 @@ granted: returned 1
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 7, w: 1, fifo: -128
-burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=can_burst
+ group-id: t53g0 used: 7, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=93.0% tokens=93 capacity=100 qual=can_burst
 
 work-done id=1 cpu-time=2
 ----
@@ -519,8 +519,8 @@ tookWithoutPermission 1
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 8, w: 1, fifo: -128
-burst-buckets: t53=fullness=92.0% tokens=92 capacity=100 qual=can_burst
+ group-id: t53g0 used: 8, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=92.0% tokens=92 capacity=100 qual=can_burst
 
 work-done id=2 cpu-time=3
 ----
@@ -529,8 +529,8 @@ returnGrant 2
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 6, w: 1, fifo: -128
-burst-buckets: t53=fullness=94.0% tokens=94 capacity=100 qual=can_burst
+ group-id: t53g0 used: 6, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=94.0% tokens=94 capacity=100 qual=can_burst
 
 admit id=4 tenant=53 requested-count=1 bypass
 ----
@@ -540,8 +540,8 @@ id 4: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 7, w: 1, fifo: -128
-burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=can_burst
+ group-id: t53g0 used: 7, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=93.0% tokens=93 capacity=100 qual=can_burst
 
 set-try-get-return-value v=false
 ----
@@ -557,8 +557,8 @@ id 5: admit failed
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 7, w: 1, fifo: -128
-burst-buckets: t53=fullness=93.0% tokens=93 capacity=100 qual=can_burst
+ group-id: t53g0 used: 7, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=93.0% tokens=93 capacity=100 qual=can_burst
 
 # Check the transition to no burst.
 set-try-get-return-value v=true
@@ -577,5 +577,5 @@ id 7: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 13, w: 1, fifo: -128
-burst-buckets: t53=fullness=87.0% tokens=87 capacity=100 qual=no_burst
+ group-id: t53g0 used: 13, w: 1, fifo: -128
+burst-buckets: t53g0=fullness=87.0% tokens=87 capacity=100 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/base
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/base
@@ -179,7 +179,7 @@ set-try-get-return-value v=true
 # state for long.
 admit id=1 tenant=1 requested-count=1
 ----
-tryGet: input no_burst, returning true
+tryGet: input can_burst, returning true
 id 1: admit succeeded
 
 # Fill tenant 1's burst bucket to the top with 100 tokens.
@@ -202,9 +202,9 @@ refill-burst-buckets to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 1 used: 1, w: 4294967295, fifo: -128
  group-id: 2 used: 1, w: 1, fifo: -128
-burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 # Since both burst buckets are full, both tenants can burst.
 admit id=3 tenant=1 requested-count=1
@@ -215,9 +215,9 @@ id 3: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 2, w: 1, fifo: -128
+ group-id: 1 used: 2, w: 4294967295, fifo: -128
  group-id: 2 used: 1, w: 1, fifo: -128
-burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=4 tenant=2 requested-count=1
 ----
@@ -227,9 +227,9 @@ id 4: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 2, w: 1, fifo: -128
+ group-id: 1 used: 2, w: 4294967295, fifo: -128
  group-id: 2 used: 2, w: 1, fifo: -128
-burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # Bucket started at 100 tokens. First call to Admit removed 1 token.
 # This call to Admit removes 7 tokens. 100-1-7 = 92 tokens in bucket.
@@ -242,9 +242,9 @@ id 5: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 9, w: 1, fifo: -128
+ group-id: 1 used: 9, w: 4294967295, fifo: -128
  group-id: 2 used: 2, w: 1, fifo: -128
-burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 maxCPU=true qual=can_burst t2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # Bucket started at 100 tokens. First call to Admit removed 1 token.
 # This call to Admit removes 10 tokens. 100-1-10 = 89 tokens in bucket.
@@ -258,9 +258,9 @@ id 6: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 9, w: 1, fifo: -128
+ group-id: 1 used: 9, w: 4294967295, fifo: -128
  group-id: 2 used: 12, w: 1, fifo: -128
-burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=92.0% tokens=92 capacity=100 maxCPU=true qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
 
 # 100-1-7-1 = 91 tokens in the bucket. So tenant 1 can burst still.
 admit id=7 tenant=1 requested-count=1
@@ -271,9 +271,9 @@ id 7: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 1 used: 10, w: 4294967295, fifo: -128
  group-id: 2 used: 12, w: 1, fifo: -128
-burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2=fullness=89.0% tokens=89 capacity=100 qual=no_burst
 
 # 100-1-10-1 = 88. Tenant 2 cannot burst this time.
 admit id=8 tenant=2 requested-count=1
@@ -284,9 +284,9 @@ id 8: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 1 used: 10, w: 4294967295, fifo: -128
  group-id: 2 used: 13, w: 1, fifo: -128
-burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 # 100-1-7-1-1 = 90. So this call to Admit, tenant 1 can burst, but
 # the next call, tenant 1 cannot burst.
@@ -298,21 +298,21 @@ id 9: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 11, w: 1, fifo: -128
+ group-id: 1 used: 11, w: 4294967295, fifo: -128
  group-id: 2 used: 13, w: 1, fifo: -128
-burst-buckets: t1=fullness=90.0% tokens=90 capacity=100 qual=no_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=90.0% tokens=90 capacity=100 maxCPU=true qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 admit id=10 tenant=1 requested-count=1
 ----
-tryGet: input no_burst, returning true
+tryGet: input can_burst, returning true
 id 10: admit succeeded
 
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 12, w: 1, fifo: -128
+ group-id: 1 used: 12, w: 4294967295, fifo: -128
  group-id: 2 used: 13, w: 1, fifo: -128
-burst-buckets: t1=fullness=89.0% tokens=89 capacity=100 qual=no_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=89.0% tokens=89 capacity=100 maxCPU=true qual=can_burst t2=fullness=88.0% tokens=88 capacity=100 qual=no_burst
 
 # Fill to full again. Both tenants thus can burst.
 refill-burst-buckets to-add=100 capacity=100
@@ -345,9 +345,9 @@ refill-burst-buckets to-add=10 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000013, w: 1, fifo: -128
+ group-id: 1 used: 100000013, w: 4294967295, fifo: -128
  group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=-25.0% tokens=-25 capacity=100 qual=no_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 refill-burst-buckets to-add=116 capacity=100
 ----
@@ -355,9 +355,9 @@ refill-burst-buckets to-add=116 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000013, w: 1, fifo: -128
+ group-id: 1 used: 100000013, w: 4294967295, fifo: -128
  group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=91.0% tokens=91 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=14 tenant=1 requested-count=1
 ----
@@ -368,7 +368,7 @@ id 14: admit succeeded
 # Admit, it is below 90% full. No burst.
 admit id=15 tenant=1 requested-count=1
 ----
-tryGet: input no_burst, returning true
+tryGet: input can_burst, returning true
 id 15: admit succeeded
 
 # In production, requestedCount is a prediction of the CPU time
@@ -392,9 +392,9 @@ id 16: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 101000015, w: 1, fifo: -128
+ group-id: 1 used: 101000015, w: 4294967295, fifo: -128
  group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=-999900.0% tokens=-999900 capacity=100 qual=no_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=-999900.0% tokens=-999900 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 work-done id=16 cpu-time=1
 ----
@@ -403,9 +403,9 @@ returnGrant 999999
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000016, w: 1, fifo: -128
+ group-id: 1 used: 100000016, w: 4294967295, fifo: -128
  group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
 
 admit id=17 tenant=1 requested-count=10
 ----
@@ -414,7 +414,7 @@ id 17: admit succeeded
 
 admit id=18 tenant=1 requested-count=1
 ----
-tryGet: input no_burst, returning true
+tryGet: input can_burst, returning true
 id 18: admit succeeded
 
 # Test a bucket capacity change. On first call to Admit, bucket is
@@ -425,9 +425,9 @@ refill-burst-buckets to-add=20 capacity=20
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100000027, w: 1, fifo: -128
+ group-id: 1 used: 100000027, w: 4294967295, fifo: -128
  group-id: 2 used: 14, w: 1, fifo: -128
-burst-buckets: t1=fullness=100.0% tokens=20 capacity=20 qual=can_burst t2=fullness=100.0% tokens=20 capacity=20 qual=can_burst
+burst-buckets: t1=fullness=100.0% tokens=20 capacity=20 maxCPU=true qual=can_burst t2=fullness=100.0% tokens=20 capacity=20 qual=can_burst
 
 admit id=19 tenant=1 requested-count=2
 ----
@@ -436,7 +436,7 @@ id 19: admit succeeded
 
 admit id=20 tenant=1 requested-count=1
 ----
-tryGet: input no_burst, returning true
+tryGet: input can_burst, returning true
 id 20: admit succeeded
 
 ###

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
@@ -125,4 +125,5 @@ print
 closed epoch: 0 groupHeap len: 0
  group-id: t0g1 used: 100001, w: 80, fifo: -128
  group-id: t0g2 used: 1, w: 20, fifo: -128
-burst-buckets: t0g1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=48.0% tokens=48 capacity=100 qual=no_burst
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=48.0% tokens=48 capacity=100 qual=no_burst t1g0=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
@@ -46,10 +46,10 @@ set-max-cpu-groups group=1 v=true
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-1 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=0.0% tokens=-1 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 # Refill 25 tokens with capacity=100. Both buckets: -1+25=24 tokens,
 # 24% full. rg 1 (maxCPU=true) is can_burst despite being well below
@@ -60,10 +60,10 @@ refill-burst-buckets to-add=25 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=25.0% tokens=25 capacity=100 maxCPU=true qual=can_burst rg1=fullness=24.0% tokens=24 capacity=100 maxCPU=true qual=can_burst rg2=fullness=24.0% tokens=24 capacity=100 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=24.0% tokens=24 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=24.0% tokens=24 capacity=100 qual=no_burst t1g0=fullness=25.0% tokens=25 capacity=100 maxCPU=true qual=can_burst
 
 # Queue work for both groups. rg 1's work should be granted first
 # since it has can_burst via maxCPU, even though both have identical
@@ -123,6 +123,6 @@ refill-burst-buckets to-add=25 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 100001, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst rg2=fullness=48.0% tokens=48 capacity=100 qual=no_burst
+ group-id: t0g1 used: 100001, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+burst-buckets: t0g1=fullness=-25.0% tokens=-25 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=48.0% tokens=48 capacity=100 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/max_cpu
@@ -46,9 +46,10 @@ set-max-cpu-groups group=1 v=true
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=0.0% tokens=-1 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-1 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
 # Refill 25 tokens with capacity=100. Both buckets: -1+25=24 tokens,
 # 24% full. rg 1 (maxCPU=true) is can_burst despite being well below
@@ -59,9 +60,10 @@ refill-burst-buckets to-add=25 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=24.0% tokens=24 capacity=100 maxCPU=true qual=can_burst rg2=fullness=24.0% tokens=24 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=25.0% tokens=25 capacity=100 maxCPU=true qual=can_burst rg1=fullness=24.0% tokens=24 capacity=100 maxCPU=true qual=can_burst rg2=fullness=24.0% tokens=24 capacity=100 qual=no_burst
 
 # Queue work for both groups. rg 1's work should be granted first
 # since it has can_burst via maxCPU, even though both have identical

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
@@ -37,9 +37,10 @@ id 2: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 2, w: 80, fifo: -128
  group-id: 2 used: 0, w: 20, fifo: -128
-burst-buckets: rg1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=0 capacity=0 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=0 capacity=0 qual=no_burst
 
 # Admit low-priority work (priority=-30, BulkNormalPri). Should route
 # to group 2 regardless of tenant ID.
@@ -57,9 +58,10 @@ id 4: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 2, w: 80, fifo: -128
  group-id: 2 used: 2, w: 20, fifo: -128
-burst-buckets: rg1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
 
 ###
 # Verify AdmittedWorkDone uses the correct group. Complete work from
@@ -79,9 +81,10 @@ tookWithoutPermission 199
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 101, w: 80, fifo: -128
  group-id: 2 used: 201, w: 20, fifo: -128
-burst-buckets: rg1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
 
 ###
 # Verify burst qualification works correctly with priority-based groups.
@@ -111,9 +114,10 @@ admit id=6 tenant=10 priority=-30 requested-count=1
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 1
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 101, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  group-id: 2 used: 201, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: rg1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
 
 gc-groups-and-reset-used
 ----

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
@@ -157,5 +157,6 @@ print
 closed epoch: 0 groupHeap len: 0
  group-id: t0g1 used: 1, w: 80, fifo: -128
  group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
  group-id: t50g0 used: 1, w: 1, fifo: -128
-burst-buckets: t0g1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst t50g0=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t0g1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst t50g0=fullness=0.0% tokens=-1 capacity=0 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/priority_based_groups
@@ -37,10 +37,10 @@ id 2: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 2, w: 80, fifo: -128
- group-id: 2 used: 0, w: 20, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=0 capacity=0 qual=no_burst
+ group-id: t0g1 used: 2, w: 80, fifo: -128
+ group-id: t0g2 used: 0, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=0 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 # Admit low-priority work (priority=-30, BulkNormalPri). Should route
 # to group 2 regardless of tenant ID.
@@ -58,10 +58,10 @@ id 4: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 2, w: 80, fifo: -128
- group-id: 2 used: 2, w: 20, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst
+ group-id: t0g1 used: 2, w: 80, fifo: -128
+ group-id: t0g2 used: 2, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=0.0% tokens=-2 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-2 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 ###
 # Verify AdmittedWorkDone uses the correct group. Complete work from
@@ -81,10 +81,10 @@ tookWithoutPermission 199
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 101, w: 80, fifo: -128
- group-id: 2 used: 201, w: 20, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
+ group-id: t0g1 used: 101, w: 80, fifo: -128
+ group-id: t0g2 used: 201, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 ###
 # Verify burst qualification works correctly with priority-based groups.
@@ -113,11 +113,11 @@ admit id=6 tenant=10 priority=-30 requested-count=1
 # spurious tryGet output that contaminates the granted output.
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 1
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 101, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- group-id: 2 used: 201, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst
+closed epoch: 0 groupHeap len: 2 top group: t0g1
+ group-id: t0g1 used: 101, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: t0g2 used: 201, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=0.0% tokens=-101 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-201 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 gc-groups-and-reset-used
 ----
@@ -155,7 +155,7 @@ id 7: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 50 used: 1, w: 1, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t50=fullness=0.0% tokens=-1 capacity=0 qual=no_burst rg1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t50g0 used: 1, w: 1, fifo: -128
+burst-buckets: t0g1=fullness=0.0% tokens=-102 capacity=0 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-202 capacity=0 qual=no_burst t50g0=fullness=0.0% tokens=-1 capacity=0 qual=no_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
@@ -41,10 +41,10 @@ refill-burst-bucket-for-group group=1 to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 # Refill rg 2 with a smaller amount. rg 2 should reach 49%
 # (no_burst).
@@ -54,10 +54,10 @@ refill-burst-bucket-for-group group=2 to-add=50 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 ###
 # Verify that refill-burst-bucket-for-group correctly updates the
@@ -90,10 +90,10 @@ refill-burst-bucket-for-group group=2 to-add=50 capacity=100
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 1
- group-id: 1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- group-id: 2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+closed epoch: 0 groupHeap len: 2 top group: t0g1
+ group-id: t0g1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: t0g2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
+burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
 
 # rg 2 should be granted first (it was already at top of heap when
 # rg 1 was no_burst; now both can_burst, ordering by used/weight is
@@ -120,6 +120,6 @@ refill-burst-bucket-for-group group=999 to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=98.0% tokens=98 capacity=100 maxCPU=true qual=can_burst rg2=fullness=98.0% tokens=98 capacity=100 qual=can_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+burst-buckets: t0g1=fullness=98.0% tokens=98 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=98.0% tokens=98 capacity=100 qual=can_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
@@ -41,9 +41,10 @@ refill-burst-bucket-for-group group=1 to-add=100 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=0.0% tokens=-1 capacity=0 qual=no_burst
 
 # Refill rg 2 with a smaller amount. rg 2 should reach 49%
 # (no_burst).
@@ -53,9 +54,10 @@ refill-burst-bucket-for-group group=2 to-add=50 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
 
 ###
 # Verify that refill-burst-bucket-for-group correctly updates the

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/refill_per_group
@@ -93,7 +93,8 @@ print
 closed epoch: 0 groupHeap len: 2 top group: t0g1
  group-id: t0g1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  group-id: t0g2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=99.0% tokens=99 capacity=100 qual=can_burst
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=99.0% tokens=99 capacity=100 qual=can_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst
 
 # rg 2 should be granted first (it was already at top of heap when
 # rg 1 was no_burst; now both can_burst, ordering by used/weight is
@@ -122,4 +123,5 @@ print
 closed epoch: 0 groupHeap len: 0
  group-id: t0g1 used: 1, w: 80, fifo: -128
  group-id: t0g2 used: 1, w: 20, fifo: -128
-burst-buckets: t0g1=fullness=98.0% tokens=98 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=98.0% tokens=98 capacity=100 qual=can_burst
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=98.0% tokens=98 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=98.0% tokens=98 capacity=100 qual=can_burst t1g0=fullness=0.0% tokens=0 capacity=0 maxCPU=true qual=can_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
@@ -40,9 +40,10 @@ refill-burst-buckets to-add=51 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
 
 # Set rg 1 to maxCPU=true via SetMaxCPUGroups. rg 1 should now be
 # can_burst despite being at only 50% fullness.
@@ -52,9 +53,10 @@ set-max-cpu-groups group=1 v=true
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
 
 # Queue work for both groups.
 set-try-get-return-value v=false
@@ -98,9 +100,10 @@ set-max-cpu-groups group=1 v=false
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: rg1=fullness=49.0% tokens=49 capacity=100 qual=no_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst rg1=fullness=49.0% tokens=49 capacity=100 qual=no_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
 
 # Both groups are now no_burst. New work should report no_burst.
 admit id=5 tenant=10 priority=0 requested-count=1
@@ -136,9 +139,10 @@ set-max-cpu-groups group=1 v=true
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 1
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  group-id: 2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: rg1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst rg1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
 
 # rg 1 (can_burst via maxCPU) should be granted before rg 2.
 granted chain-id=1
@@ -189,6 +193,7 @@ id 8: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 1 used: 1, w: 80, fifo: -128
  group-id: 2 used: 0, w: 20, fifo: -128
-burst-buckets: rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=100.0% tokens=100 capacity=100 qual=can_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
@@ -103,7 +103,7 @@ closed epoch: 0 groupHeap len: 0
  group-id: t0g1 used: 1, w: 80, fifo: -128
  group-id: t0g2 used: 1, w: 20, fifo: -128
  group-id: t1g0 used: 0, w: 4294967295, fifo: -128
-burst-buckets: t0g1=fullness=49.0% tokens=49 capacity=100 qual=no_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst
+burst-buckets: t0g1=fullness=49.0% tokens=49 capacity=100 qual=no_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst
 
 # Both groups are now no_burst. New work should report no_burst.
 admit id=5 tenant=10 priority=0 requested-count=1
@@ -142,7 +142,7 @@ closed epoch: 0 groupHeap len: 2 top group: t0g1
  group-id: t0g1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  group-id: t0g2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
  group-id: t1g0 used: 0, w: 4294967295, fifo: -128
-burst-buckets: t0g1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst
+burst-buckets: t0g1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst
 
 # rg 1 (can_burst via maxCPU) should be granted before rg 2.
 granted chain-id=1
@@ -165,13 +165,12 @@ set-max-cpu-groups group=1 v=false
 ----
 
 ###
-# Set maxCPU on a group that doesn't exist yet. The flag should be
-# picked up when the group is first created via Admit. We exercise
-# this by GC'ing rg 1 (used=0, no waiting work) and then setting
-# maxCPU on rg 1 before re-admitting.
+# Run gc-groups-and-reset-used twice to drive groups to used=0
+# without dropping anything observable here: rg 1 / rg 2 / system
+# tenant are built-ins and exempt from GC. Then re-set maxCPU on rg
+# 1 so the next admit hits can_burst.
 ###
 
-# Drain rg 1's used count so it can be GC'd.
 gc-groups-and-reset-used
 ----
 
@@ -181,6 +180,10 @@ gc-groups-and-reset-used
 print
 ----
 closed epoch: 0 groupHeap len: 0
+ group-id: t0g1 used: 0, w: 80, fifo: -128
+ group-id: t0g2 used: 0, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=47.0% tokens=47 capacity=100 qual=no_burst t0g2=fullness=48.0% tokens=48 capacity=100 qual=no_burst t1g0=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst
 
 set-max-cpu-groups group=1 v=true
 ----
@@ -196,4 +199,4 @@ closed epoch: 0 groupHeap len: 0
  group-id: t0g1 used: 1, w: 80, fifo: -128
  group-id: t0g2 used: 0, w: 20, fifo: -128
  group-id: t1g0 used: 0, w: 4294967295, fifo: -128
-burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=100.0% tokens=100 capacity=100 qual=can_burst t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst
+burst-buckets: t0g1=fullness=46.0% tokens=46 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=48.0% tokens=48 capacity=100 qual=no_burst t1g0=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst

--- a/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
+++ b/pkg/util/admission/testdata/cpu_time_token_work_queue/set_max_cpu_groups
@@ -40,10 +40,10 @@ refill-burst-buckets to-add=51 capacity=100
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=50.0% tokens=50 capacity=100 qual=no_burst t1g0=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst
 
 # Set rg 1 to maxCPU=true via SetMaxCPUGroups. rg 1 should now be
 # can_burst despite being at only 50% fullness.
@@ -53,10 +53,10 @@ set-max-cpu-groups group=1 v=true
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst rg1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst rg2=fullness=50.0% tokens=50 capacity=100 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=50.0% tokens=50 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=50.0% tokens=50 capacity=100 qual=no_burst t1g0=fullness=51.0% tokens=51 capacity=100 maxCPU=true qual=can_burst
 
 # Queue work for both groups.
 set-try-get-return-value v=false
@@ -100,10 +100,10 @@ set-max-cpu-groups group=1 v=false
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 1, w: 20, fifo: -128
-burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst rg1=fullness=49.0% tokens=49 capacity=100 qual=no_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 1, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=49.0% tokens=49 capacity=100 qual=no_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst
 
 # Both groups are now no_burst. New work should report no_burst.
 admit id=5 tenant=10 priority=0 requested-count=1
@@ -138,11 +138,11 @@ set-max-cpu-groups group=1 v=true
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 1
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
- group-id: 2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
-burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst rg1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst rg2=fullness=49.0% tokens=49 capacity=100 qual=no_burst
+closed epoch: 0 groupHeap len: 2 top group: t0g1
+ group-id: t0g1 used: 0, w: 80, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: t0g2 used: 0, w: 20, fifo: -128 waiting work heap: [0: pri: bulk-normal-pri, ct: 1, epoch: 0, qt: 100]
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=48.0% tokens=48 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=49.0% tokens=49 capacity=100 qual=no_burst t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst
 
 # rg 1 (can_burst via maxCPU) should be granted before rg 2.
 granted chain-id=1
@@ -193,7 +193,7 @@ id 8: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 1 used: 1, w: 80, fifo: -128
- group-id: 2 used: 0, w: 20, fifo: -128
-burst-buckets: t1=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst rg1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst rg2=fullness=100.0% tokens=100 capacity=100 qual=can_burst
+ group-id: t0g1 used: 1, w: 80, fifo: -128
+ group-id: t0g2 used: 0, w: 20, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+burst-buckets: t0g1=fullness=99.0% tokens=99 capacity=100 maxCPU=true qual=can_burst t0g2=fullness=100.0% tokens=100 capacity=100 qual=can_burst t1g0=fullness=100.0% tokens=100 capacity=100 maxCPU=true qual=can_burst

--- a/pkg/util/admission/testdata/elastic_cpu_work_queue
+++ b/pkg/util/admission/testdata/elastic_cpu_work_queue
@@ -63,7 +63,7 @@ handle:      50ms
 admitted-work-done running=10ms allotted=50ms
 ----
 granter:    return-grant=40ms
-work-queue: adjust-group-used: group=t1 additional-used=-40ms
+work-queue: adjust-group-used: group=t1g0 additional-used=-40ms
 metrics:    acquired=50ms returned=40ms max-available=8s
 
 # Repeat the same but this time simulate what happens if we've taken less than
@@ -83,7 +83,7 @@ handle:      50ms
 admitted-work-done running=70ms allotted=50ms
 ----
 granter:    took-without-permission=20ms
-work-queue: adjust-group-used: group=t1 additional-used=20ms
+work-queue: adjust-group-used: group=t1g0 additional-used=20ms
 metrics:    acquired=70ms returned=0s max-available=8s
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/class_segmentation
+++ b/pkg/util/admission/testdata/replicated_write_admission/class_segmentation
@@ -23,11 +23,11 @@ admit tenant=t1 pri=high-pri create-time=2us size=1B range=r1 log-position=4/21
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=high-pri create-time=2µs size=1B range=r1 log-position=4/21]
-[elastic work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[elastic work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=low-pri create-time=1µs size=1B range=r1 log-position=4/20]
 
 # Produce 1B worth of regular tokens and verify that it only admits work
@@ -45,9 +45,9 @@ print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
 [regular work queue]: len(group-heap)=0
- group=t1 weight=1 fifo-threshold=low-pri used=1B
-[elastic work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=1B
+[elastic work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=low-pri create-time=1µs size=1B range=r1 log-position=4/20]
 
 # Do the same for elastic tokens.

--- a/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_different_range
+++ b/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_different_range
@@ -23,8 +23,8 @@ admit tenant=t1 pri=normal-pri create-time=1us size=1B range=r2 log-position=4/2
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1µs size=1B range=r2 log-position=4/21]
   [1: pri=normal-pri create-time=5µs size=1B range=r1 log-position=4/20]
 [elastic work queue]: len(group-heap)=0
@@ -45,8 +45,8 @@ admitted [tenant=t1 pri=normal-pri create-time=1µs size=1B range=r2 log-positio
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=5µs size=1B range=r1 log-position=4/20]
 [elastic work queue]: len(group-heap)=0
 

--- a/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_same_range
+++ b/pkg/util/admission/testdata/replicated_write_admission/high_create_time_low_position_same_range
@@ -22,8 +22,8 @@ admit tenant=t1 pri=normal-pri create-time=1us size=1B range=r1 log-position=4/2
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=5µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=5.001µs size=1B range=r1 log-position=4/21]
 [elastic work queue]: len(group-heap)=0
@@ -44,8 +44,8 @@ admitted [tenant=t1 pri=normal-pri create-time=5µs size=1B range=r1 log-positio
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=5.001µs size=1B range=r1 log-position=4/21]
 [elastic work queue]: len(group-heap)=0
 

--- a/pkg/util/admission/testdata/replicated_write_admission/high_pri_low_position
+++ b/pkg/util/admission/testdata/replicated_write_admission/high_pri_low_position
@@ -21,8 +21,8 @@ admit tenant=t1 pri=high-pri create-time=1.002us size=1B range=r1 log-position=4
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=high-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
   [1: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
 [elastic work queue]: len(group-heap)=0
@@ -43,8 +43,8 @@ admitted [tenant=t1 pri=high-pri create-time=1.002µs size=1B range=r1 log-posit
 print
 ----
 physical-stats: work-count=2 written-bytes=2B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
 [elastic work queue]: len(group-heap)=0
 

--- a/pkg/util/admission/testdata/replicated_write_admission/overview
+++ b/pkg/util/admission/testdata/replicated_write_admission/overview
@@ -17,8 +17,8 @@ admit tenant=t1 pri=normal-pri create-time=1.001us size=1B range=r1 log-position
 print
 ----
 physical-stats: work-count=1 written-bytes=1B ingested-bytes=0B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
 [elastic work queue]: len(group-heap)=0
 
@@ -31,8 +31,8 @@ admit tenant=t1 pri=normal-pri create-time=1.002us size=1B range=r1 log-position
 print
 ----
 physical-stats: work-count=2 written-bytes=1B ingested-bytes=1B
-[regular work queue]: len(group-heap)=1 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=1 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21 ingested ]
 [elastic work queue]: len(group-heap)=0
@@ -64,7 +64,7 @@ print
 ----
 physical-stats: work-count=2 written-bytes=1B ingested-bytes=1B
 [regular work queue]: len(group-heap)=0
- group=t1 weight=1 fifo-threshold=low-pri used=2B
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=2B
 [elastic work queue]: len(group-heap)=0
 
 # vim:ft=sh

--- a/pkg/util/admission/testdata/replicated_write_admission/tenant_fairness
+++ b/pkg/util/admission/testdata/replicated_write_admission/tenant_fairness
@@ -25,11 +25,11 @@ admit tenant=t2 pri=normal-pri create-time=1.002us size=1B range=r2 log-position
 print
 ----
 physical-stats: work-count=4 written-bytes=4B ingested-bytes=0B
-[regular work queue]: len(group-heap)=2 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=0B
+[regular work queue]: len(group-heap)=2 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 log-position=4/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
- group=t2 weight=1 fifo-threshold=low-pri used=0B
+ group=t2g0 weight=1 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r2 log-position=5/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r2 log-position=5/21]
 [elastic work queue]: len(group-heap)=0
@@ -59,10 +59,10 @@ granter adjust-tokens=+0B
 print
 ----
 physical-stats: work-count=4 written-bytes=4B ingested-bytes=0B
-[regular work queue]: len(group-heap)=2 top-group=t1
- group=t1 weight=1 fifo-threshold=low-pri used=1B
+[regular work queue]: len(group-heap)=2 top-group=t1g0
+ group=t1g0 weight=4294967295 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.002µs size=1B range=r1 log-position=4/21]
- group=t2 weight=1 fifo-threshold=low-pri used=1B
+ group=t2g0 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.002µs size=1B range=r2 log-position=5/21]
 [elastic work queue]: len(group-heap)=0
 

--- a/pkg/util/admission/testdata/store_work_queue
+++ b/pkg/util/admission/testdata/store_work_queue
@@ -23,7 +23,7 @@ storeWriteDone regular: originalTokens 1, doneBytes(write 0,ingested 0) returnin
 set-store-request-estimates write-tokens=100
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: t53g0 used: 1, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
@@ -41,8 +41,8 @@ id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeTokens:100 w
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 101, w: 1, fifo: -128
- group-id: 55 used: 100, w: 1, fifo: -128
+ group-id: t53g0 used: 101, w: 1, fifo: -128
+ group-id: t55g0 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
@@ -60,10 +60,10 @@ storeWriteDone regular: originalTokens 100, doneBytes(write 0,ingested 0) return
 
 print
 ----
-regular workqueue: closed epoch: 0 groupHeap len: 1 top group: 57
- group-id: 53 used: 101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 0]
+regular workqueue: closed epoch: 0 groupHeap len: 1 top group: t57g0
+ group-id: t53g0 used: 101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 0]
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
@@ -77,9 +77,9 @@ granted regular: returned 100
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 100, w: 1, fifo: -128
+ group-id: t53g0 used: 101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
@@ -91,9 +91,9 @@ storeWriteDone regular: originalTokens 100, doneBytes(write 0,ingested 1000000) 
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:100}
@@ -101,9 +101,9 @@ estimates:{writeTokens:100}
 set-store-request-estimates write-tokens=10000
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:10000}
@@ -115,9 +115,9 @@ storeWriteDone regular: originalTokens 100, doneBytes(write 2000,ingested 1000) 
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:0 writeBypassedAccountedBytes:0 ingestedBypassedAccountedBytes:0}}
 estimates:{writeTokens:10000}
@@ -129,9 +129,9 @@ storeWriteDone regular: originalTokens 0, doneBytes(write 1000,ingested 1000000)
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:0 ApproxIngestedIntoL0Bytes:0 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:0} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
@@ -139,9 +139,9 @@ estimates:{writeTokens:10000}
 stats-to-ignore ingested-bytes=12000 ingested-into-L0-bytes=9000 write-bytes=1500
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
@@ -166,11 +166,11 @@ granted elastic: returned 10000
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 10000, w: 1, fifo: -128
+ group-id: t53g0 used: 10000, w: 1, fifo: -128
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -185,12 +185,12 @@ id 6: admit succeeded with handle {tenantID:{InternalValue:54} writeTokens:10000
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 10000, w: 1, fifo: -128
- group-id: 54 used: 10000, w: 1, fifo: -128
+ group-id: t53g0 used: 10000, w: 1, fifo: -128
+ group-id: t54g0 used: 10000, w: 1, fifo: -128
 stats:{workCount:14 writeAccountedBytes:3000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:1500} aboveRaftStats:{workCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -201,12 +201,12 @@ storeWriteDone elastic: originalTokens 10000, doneBytes(write 1000,ingested 0) r
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 10200, w: 1, fifo: -128
- group-id: 54 used: 10000, w: 1, fifo: -128
+ group-id: t53g0 used: 10200, w: 1, fifo: -128
+ group-id: t54g0 used: 10000, w: 1, fifo: -128
 stats:{workCount:15 writeAccountedBytes:4000 ingestedAccountedBytes:2001000 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:1500} aboveRaftStats:{workCount:5 writeAccountedBytes:3000 ingestedAccountedBytes:1001000} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}
 
@@ -217,11 +217,11 @@ storeWriteDone elastic: originalTokens 10000, doneBytes(write 0,ingested 500) re
 print
 ----
 regular workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 50101, w: 1, fifo: -128
- group-id: 55 used: 600, w: 1, fifo: -128
- group-id: 57 used: 2100, w: 1, fifo: -128
+ group-id: t53g0 used: 50101, w: 1, fifo: -128
+ group-id: t55g0 used: 600, w: 1, fifo: -128
+ group-id: t57g0 used: 2100, w: 1, fifo: -128
 elastic workqueue: closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 10200, w: 1, fifo: -128
- group-id: 54 used: 10500, w: 1, fifo: -128
+ group-id: t53g0 used: 10200, w: 1, fifo: -128
+ group-id: t54g0 used: 10500, w: 1, fifo: -128
 stats:{workCount:16 writeAccountedBytes:4000 ingestedAccountedBytes:2001500 statsToIgnore:{ingestStats:{Bytes:12000 ApproxIngestedIntoL0Bytes:9000 MemtableOverlappingFiles:0 LevelBytes:[0 0 0 0 0 0 0] LevelFiles:[0 0 0 0 0 0 0]} writeBytes:1500} aboveRaftStats:{workCount:6 writeAccountedBytes:3000 ingestedAccountedBytes:1001500} aux:{bypassedCount:10 writeBypassedAccountedBytes:1000 ingestedBypassedAccountedBytes:1000000}}
 estimates:{writeTokens:10000}

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -12,7 +12,7 @@ id 1: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: t53g0 used: 1, w: 1, fifo: -128
 
 # tryGet will return false, so work will queue up.
 set-try-get-return-value v=false
@@ -24,8 +24,8 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
 
 admit id=3 tenant=53 priority=0 create-time-millis=2 bypass=false
 ----
@@ -34,8 +34,8 @@ admit id=3 tenant=53 priority=0 create-time-millis=2 bypass=false
 # in the heap because of a smaller create-time-millis.
 print
 ----
-closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
 
 # Request from tenant 71.
 admit id=4 tenant=71 priority=-128 create-time-millis=4 bypass=false
@@ -49,9 +49,9 @@ admit id=5 tenant=71 priority=0 create-time-millis=5 bypass=false
 # Tenant 71 is the top of the heap since has not used any cpu time.
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 71
- group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- group-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100] [1: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t71g0
+ group-id: t53g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: t71g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100] [1: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -63,9 +63,9 @@ granted: returned 1
 # favor of tenant 71.
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t53g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # Cancel a request from tenant 53.
 cancel-work id=3
@@ -74,9 +74,9 @@ id 3: admit failed
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t53g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # The work admitted for tenant 53 is done and consumed no cpu-time
 work-done id=1 cpu-time=0
@@ -86,9 +86,9 @@ returnGrant 1
 # Tenant 53 has used no cpu, so it becomes the top of the heap.
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # Requests from a system and application tenant bypass admission control,
 # but are reflected in the WorkQueue state.
@@ -104,10 +104,10 @@ id 9: admit succeeded
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 1, w: 4294967295, fifo: -128
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- group-id: 71 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t1g0 used: 1, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: t71g0 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # The bypass work is done and consumed 10 and 0 cpu nanos respectively.
 work-done id=6 cpu-time=10
@@ -120,10 +120,10 @@ returnGrant 1
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 10, w: 4294967295, fifo: -128
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t1g0 used: 10, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # Another request from tenant 53, which is behind the existing request in the heap.
 admit id=7 tenant=53 priority=0 create-time-millis=5 bypass=false
@@ -131,10 +131,10 @@ admit id=7 tenant=53 priority=0 create-time-millis=5 bypass=false
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 10, w: 4294967295, fifo: -128
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t1g0 used: 10, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=7
 ----
@@ -146,10 +146,10 @@ granted: returned 1
 # favor of tenant 53.
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 10, w: 4294967295, fifo: -128
- group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t53g0
+ group-id: t1g0 used: 10, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 # The work admitted for tenant 53 is done and has consumed 20 cpu nanos, so
 # tenant 71 moves to the top of the heap.
@@ -159,17 +159,17 @@ returnGrant 1
 
 print
 ----
-closed epoch: 0 groupHeap len: 2 top group: 71
- group-id: 1 used: 10, w: 4294967295, fifo: -128
- group-id: 53 used: 20, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t71g0
+ group-id: t1g0 used: 10, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 20, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 gc-groups-and-reset-used
 ----
-closed epoch: 0 groupHeap len: 2 top group: 71
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- group-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
+closed epoch: 0 groupHeap len: 2 top group: t71g0
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: t71g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=9
 ----
@@ -180,10 +180,10 @@ granted: returned 1
 # Tenant 71 has used 1 cpu nano.
 print
 ----
-closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- group-id: 71 used: 1, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 1 top group: t53g0
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: t71g0 used: 1, w: 1, fifo: -128
 
 # Try to return more cpu than used, to check that there is no overflow.
 work-done id=4 cpu-time=-5
@@ -192,10 +192,10 @@ returnGrant 1
 
 print
 ----
-closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
- group-id: 71 used: 0, w: 1, fifo: -128
+closed epoch: 0 groupHeap len: 1 top group: t53g0
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
+ group-id: t71g0 used: 0, w: 1, fifo: -128
 
 granted chain-id=10
 ----
@@ -207,9 +207,9 @@ granted: returned 1
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 53 used: 1, w: 1, fifo: -128
- group-id: 71 used: 0, w: 1, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 1, w: 1, fifo: -128
+ group-id: t71g0 used: 0, w: 1, fifo: -128
 
 # Granted returns false.
 granted chain-id=10
@@ -219,9 +219,9 @@ granted: returned 0
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 4294967295, fifo: -128
- group-id: 53 used: 1, w: 1, fifo: -128
- group-id: 71 used: 0, w: 1, fifo: -128
+ group-id: t1g0 used: 0, w: 4294967295, fifo: -128
+ group-id: t53g0 used: 1, w: 1, fifo: -128
+ group-id: t71g0 used: 0, w: 1, fifo: -128
 
 init
 ----
@@ -236,13 +236,13 @@ tryGet: returning false
 # Make the request wait long enough that we switch to LIFO.
 advance-time millis=205
 ----
-closed epoch: 2 groupHeap len: 1 top group: 53
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 2 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 print
 ----
-closed epoch: 2 groupHeap len: 1 top group: 53
- group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
+closed epoch: 2 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -253,13 +253,13 @@ granted: returned 1
 print
 ----
 closed epoch: 2 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: -128
+ group-id: t53g0 used: 1, w: 1, fifo: -128
 
 # Switch to LIFO since request waited for 205ms.
 advance-time millis=100
 ----
 closed epoch: 3 groupHeap len: 0
- group-id: 53 used: 1, w: 1, fifo: 1
+ group-id: t53g0 used: 1, w: 1, fifo: 1
 
 admit id=2 tenant=53 priority=0 create-time-millis=50 bypass=false
 ----
@@ -274,8 +274,8 @@ admit id=4 tenant=53 priority=0 create-time-millis=400 bypass=false
 # Two requests are in closed epochs and one is in open epoch.
 print
 ----
-closed epoch: 3 groupHeap len: 1 top group: 53
- group-id: 53 used: 1, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 399, epoch: 3, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 50, epoch: 0, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 1, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 399, epoch: 3, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 50, epoch: 0, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
 
 # Latest request in closed epoch is granted.
 granted chain-id=6
@@ -294,8 +294,8 @@ granted: returned 1
 # Only request is in open epoch.
 print
 ----
-closed epoch: 3 groupHeap len: 1 top group: 53
- group-id: 53 used: 3, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 3, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405]
 
 # Add request to closed epoch.
 admit id=5 tenant=53 priority=0 create-time-millis=300 bypass=false
@@ -309,8 +309,8 @@ admit id=6 tenant=53 priority=0 create-time-millis=500 bypass=false
 # Open epochs heap is ordered in rough FIFO.
 print
 ----
-closed epoch: 3 groupHeap len: 1 top group: 53
- group-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # Add high priority request in open epoch 5.
 admit id=7 tenant=53 priority=127 create-time-millis=550 bypass=false
@@ -320,14 +320,14 @@ admit id=7 tenant=53 priority=127 create-time-millis=550 bypass=false
 # threshold, and so is still using FIFO ordering.
 print
 ----
-closed epoch: 3 groupHeap len: 1 top group: 53
- group-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # Make the request wait for 60ms so we don't switch back to fifo.
 advance-time millis=60
 ----
-closed epoch: 3 groupHeap len: 1 top group: 53
- group-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: high-pri, ct: 550, epoch: 5, qt: 405] [1: pri: normal-pri, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=8
 ----
@@ -347,14 +347,14 @@ admit id=8 tenant=53 priority=0 create-time-millis=350 bypass=false
 
 print
 ----
-closed epoch: 3 groupHeap len: 1 top group: 53
- group-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 3 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405] [1: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # One request moved from open to closed epoch heap.
 advance-time millis=40
 ----
-closed epoch: 4 groupHeap len: 1 top group: 53
- group-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 4 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 400, epoch: 4, qt: 405, lifo-ordering] [1: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=10
 ----
@@ -364,8 +364,8 @@ granted: returned 1
 
 print
 ----
-closed epoch: 4 groupHeap len: 1 top group: 53
- group-id: 53 used: 6, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 4 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 6, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=11
 ----
@@ -375,8 +375,8 @@ granted: returned 1
 
 print
 ----
-closed epoch: 4 groupHeap len: 1 top group: 53
- group-id: 53 used: 7, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
+closed epoch: 4 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 7, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 500, epoch: 5, qt: 405]
 
 # Can dequeue from the open epochs heap if nothing else is remaining.
 granted chain-id=12
@@ -388,7 +388,7 @@ granted: returned 1
 print
 ----
 closed epoch: 4 groupHeap len: 0
- group-id: 53 used: 8, w: 1, fifo: 1
+ group-id: t53g0 used: 8, w: 1, fifo: 1
 
 # Add a request for an already closed epoch.
 admit id=9 tenant=53 priority=0 create-time-millis=380 bypass=false
@@ -397,14 +397,14 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 4 groupHeap len: 1 top group: 53
- group-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 4 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This time advance means the previous request will see significant queueing.
 advance-time millis=100
 ----
-closed epoch: 5 groupHeap len: 1 top group: 53
- group-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 5 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This request in an already closed epoch gets ahead because of higher
 # create-time-millis.
@@ -413,8 +413,8 @@ admit id=10 tenant=53 priority=0 create-time-millis=390 bypass=false
 
 print
 ----
-closed epoch: 5 groupHeap len: 1 top group: 53
- group-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 390, epoch: 3, qt: 605, lifo-ordering] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 5 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 390, epoch: 3, qt: 605, lifo-ordering] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 granted chain-id=12
 ----
@@ -424,14 +424,14 @@ granted: returned 1
 
 print
 ----
-closed epoch: 5 groupHeap len: 1 top group: 53
- group-id: 53 used: 9, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 5 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 9, w: 1, fifo: 1 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This advance will switch all priorities back to FIFO.
 advance-time millis=100
 ----
-closed epoch: 6 groupHeap len: 1 top group: 53
- group-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+closed epoch: 6 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 admit id=11 tenant=53 priority=0 create-time-millis=610 bypass=false
 ----
@@ -444,8 +444,8 @@ admit id=12 tenant=53 priority=-128 create-time-millis=615 bypass=false
 # has the highest create time.
 print
 ----
-closed epoch: 6 groupHeap len: 1 top group: 53
- group-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 610, epoch: 6, qt: 705] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [2: pri: low-pri, ct: 615, epoch: 6, qt: 705]
+closed epoch: 6 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 610, epoch: 6, qt: 705] [1: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [2: pri: low-pri, ct: 615, epoch: 6, qt: 705]
 
 granted chain-id=13
 ----
@@ -457,8 +457,8 @@ granted: returned 1
 # is preferred.
 print
 ----
-closed epoch: 6 groupHeap len: 1 top group: 53
- group-id: 53 used: 10, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [1: pri: low-pri, ct: 615, epoch: 6, qt: 705]
+closed epoch: 6 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 10, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 380, epoch: 3, qt: 505, lifo-ordering] [1: pri: low-pri, ct: 615, epoch: 6, qt: 705]
 
 granted chain-id=14
 ----
@@ -477,7 +477,7 @@ granted: returned 1
 advance-time millis=100
 ----
 closed epoch: 7 groupHeap len: 0
- group-id: 53 used: 12, w: 1, fifo: 1
+ group-id: t53g0 used: 12, w: 1, fifo: 1
 
 # Add a request whose epoch is not closed.
 admit id=13 tenant=53 priority=0 create-time-millis=810 bypass=false
@@ -486,8 +486,8 @@ tryGet: returning false
 
 print
 ----
-closed epoch: 7 groupHeap len: 1 top group: 53
- group-id: 53 used: 12, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 810, epoch: 8, qt: 805]
+closed epoch: 7 groupHeap len: 1 top group: t53g0
+ group-id: t53g0 used: 12, w: 1, fifo: 1 open epochs heap: [0: pri: normal-pri, ct: 810, epoch: 8, qt: 805]
 
 # Cancel that request.
 cancel-work id=13
@@ -497,20 +497,20 @@ id 13: admit failed
 print
 ----
 closed epoch: 7 groupHeap len: 0
- group-id: 53 used: 12, w: 1, fifo: 1
+ group-id: t53g0 used: 12, w: 1, fifo: 1
 
 # Closed epoch advances. The FIFO threshold is not changed since the only
 # request was canceled.
 advance-time millis=100
 ----
 closed epoch: 8 groupHeap len: 0
- group-id: 53 used: 12, w: 1, fifo: 1
+ group-id: t53g0 used: 12, w: 1, fifo: 1
 
 # Closed epoch advances. All priorities are now subject to FIFO.
 advance-time millis=100
 ----
 closed epoch: 9 groupHeap len: 0
- group-id: 53 used: 12, w: 1, fifo: -128
+ group-id: t53g0 used: 12, w: 1, fifo: -128
 
 # If all work should bypass AC, it is admitted without checking
 # resource availability in the granter. That is, we should see

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -105,7 +105,7 @@ id 9: admit succeeded
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 1, w: 1, fifo: -128
+ group-id: 1 used: 1, w: 4294967295, fifo: -128
  group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
  group-id: 71 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -121,7 +121,7 @@ returnGrant 1
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 1 used: 10, w: 4294967295, fifo: -128
  group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
  group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -132,7 +132,7 @@ admit id=7 tenant=53 priority=0 create-time-millis=5 bypass=false
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 1 used: 10, w: 4294967295, fifo: -128
  group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
  group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -147,7 +147,7 @@ granted: returned 1
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 53
- group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 1 used: 10, w: 4294967295, fifo: -128
  group-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
  group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -160,14 +160,14 @@ returnGrant 1
 print
 ----
 closed epoch: 0 groupHeap len: 2 top group: 71
- group-id: 1 used: 10, w: 1, fifo: -128
+ group-id: 1 used: 10, w: 4294967295, fifo: -128
  group-id: 53 used: 20, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
  group-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
 gc-groups-and-reset-used
 ----
 closed epoch: 0 groupHeap len: 2 top group: 71
- group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
  group-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -181,7 +181,7 @@ granted: returned 1
 print
 ----
 closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
  group-id: 71 used: 1, w: 1, fifo: -128
 
@@ -193,7 +193,7 @@ returnGrant 1
 print
 ----
 closed epoch: 0 groupHeap len: 1 top group: 53
- group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 5, epoch: 0, qt: 100]
  group-id: 71 used: 0, w: 1, fifo: -128
 
@@ -207,7 +207,7 @@ granted: returned 1
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 53 used: 1, w: 1, fifo: -128
  group-id: 71 used: 0, w: 1, fifo: -128
 
@@ -219,7 +219,7 @@ granted: returned 0
 print
 ----
 closed epoch: 0 groupHeap len: 0
- group-id: 1 used: 0, w: 1, fifo: -128
+ group-id: 1 used: 0, w: 4294967295, fifo: -128
  group-id: 53 used: 1, w: 1, fifo: -128
  group-id: 71 used: 0, w: 1, fifo: -128
 

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -474,7 +474,7 @@ func initWorkQueue(
 	q.stopCh = stopCh
 	q.configHolder = opts.configHolder
 	if q.configHolder == nil {
-		q.configHolder = newResourceGroupConfigHolder(nil)
+		q.configHolder = newResourceGroupConfigHolder(&settings.SV)
 	}
 	q.perGroupAggMetrics = opts.perGroupAggMetrics
 	q.timeSource = timeSource

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -321,9 +320,8 @@ type WorkQueue struct {
 		// used/weight.
 		groupHeap groupHeap
 		// All groups, including those without waiting work. Keyed by
-		// composite groupKey (id + kind) so the same uint64 ID
-		// representing different semantic kinds (e.g., system tenant
-		// 1 vs rg 1) does not collide on a single container.
+		// groupKey (tenantID, groupID) so that, e.g., system tenant
+		// (t1g0) and rg 1 (t0g1) occupy distinct containers.
 		// Periodically GC'd by gcGroupsResetUsedAndUpdateEstimators.
 		groups map[groupKey]*groupInfo
 
@@ -666,8 +664,8 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 			// group. However, currently we share metrics across WorkQueues --
 			// specifically all the store WorkQueues share the same metric. We
 			// should eliminate that sharing and make those per store metrics.
-			log.Dev.Infof(q.ambientCtx, "%s: FIFO threshold for group %d %s %d",
-				q.workKind, group.groupKey.id, logVerb, group.fifoPriorityThreshold)
+			log.Dev.Infof(q.ambientCtx, "%s: FIFO threshold for group %s %s %d",
+				q.workKind, group.groupKey, logVerb, group.fifoPriorityThreshold)
 		}
 		// Note that we are ignoring the new priority threshold and only
 		// dequeueing the ones that are in the closed epoch. It is possible to
@@ -692,15 +690,11 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 type AdmitResponse struct {
 	// If true, admission control is enabled.
 	Enabled bool
-	// groupKey identifies the groupInfo entry in q.mu.groups under which this
-	// work was admitted. Used by AdmittedWorkDone to look up the correct
-	// groupInfo entry. The underlying ID represents a tenant in Serverless mode
-	// and a resource group in Resource Manager mode; the kind discriminator
-	// distinguishes the two namespaces (system tenant 1 vs. rg 1). Captured at
-	// Admit time so AdmittedWorkDone resolves the same entry even if the queue's
-	// mode (and therefore groupKeyForWorkLocked's output) flipped between the two
-	// calls. AdmittedWorkDone must tolerate lookup misses: the entry may have
-	// been GC'd after a mode switch left it idle.
+	// groupKey identifies the groupInfo entry in q.mu.groups under which
+	// this work was admitted. Captured at Admit time so AdmittedWorkDone
+	// resolves the same entry even if the queue's mode flipped between
+	// the two calls. AdmittedWorkDone must tolerate lookup misses: the
+	// entry may have been GC'd after a mode switch left it idle.
 	groupKey groupKey
 	// requestedCount is the number of slots or tokens taken at Admit time.
 	// It is useful to return, so that in AdmittedWorkDone, we can adjust
@@ -729,10 +723,9 @@ func priorityToResourceGroupKey(pri admissionpb.WorkPriority) groupKey {
 	return rgGroupKey(lowResourceGroupID)
 }
 
-// groupKeyForWorkLocked returns the composite groupKey for the given
-// WorkInfo. In RM mode (cpuTimeTokenACMode == resourceManagerMode), the
-// key is derived from WorkInfo.Priority with kind=rgKind; otherwise it
-// is the TenantID with kind=tenantKind.
+// groupKeyForWorkLocked returns the groupKey for the given WorkInfo.
+// In RM mode the key is derived from WorkInfo.Priority (groupID only);
+// otherwise it is from TenantID (tenantID only).
 //
 // REQUIRES: q.mu is held.
 func (q *WorkQueue) groupKeyForWorkLocked(info WorkInfo) groupKey {
@@ -900,8 +893,8 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 				// fast path, or swapping this entry from the top-most one in
 				// the waiting heap (and fixing the heap).
 				if log.V(1) {
-					log.Dev.Infof(ctx, "fast-path: admitting t%d pri=%s r%s log-position=%s ingested=%t",
-						gKey.id, info.Priority,
+					log.Dev.Infof(ctx, "fast-path: admitting %s pri=%s r%s log-position=%s ingested=%t",
+						gKey, info.Priority,
 						info.ReplicatedWorkInfo.RangeID,
 						info.ReplicatedWorkInfo.LogPosition.String(),
 						info.ReplicatedWorkInfo.Ingested,
@@ -911,7 +904,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 				// (StoreWorkQueue runs in usesTokens mode), so gKey is
 				// always tenant-keyed.
 				q.onAdmittedReplicatedWork.admittedReplicatedWork(
-					roachpb.MustMakeTenantID(gKey.id),
+					roachpb.MustMakeTenantID(gKey.tenantID),
 					info.Priority,
 					info.ReplicatedWorkInfo,
 					info.RequestedCount,
@@ -1005,8 +998,8 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 			queueLen := group.waitingWorkHeap.Len()
 			q.mu.Unlock()
 
-			log.Dev.Infof(ctx, "async-path: len(waiting-work)=%d: enqueued t%d pri=%s r%s log-position=%s ingested=%t",
-				queueLen, gKey.id, info.Priority,
+			log.Dev.Infof(ctx, "async-path: len(waiting-work)=%d: enqueued %s pri=%s r%s log-position=%s ingested=%t",
+				queueLen, gKey, info.Priority,
 				info.ReplicatedWorkInfo.RangeID,
 				info.ReplicatedWorkInfo.LogPosition,
 				info.ReplicatedWorkInfo.Ingested,
@@ -1269,8 +1262,8 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 			queueLen := group.waitingWorkHeap.Len()
 			q.mu.Unlock()
 
-			log.Dev.Infof(q.ambientCtx, "async-path: len(waiting-work)=%d dequeued t%d pri=%s r%s log-position=%s ingested=%t",
-				queueLen, gKey.id, item.priority,
+			log.Dev.Infof(q.ambientCtx, "async-path: len(waiting-work)=%d dequeued %s pri=%s r%s log-position=%s ingested=%t",
+				queueLen, gKey, item.priority,
 				item.replicated.RangeID,
 				item.replicated.LogPosition,
 				item.replicated.Ingested,
@@ -1280,7 +1273,7 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 		// Replicated work is a Serverless-mode-only path; same caveat
 		// as the fast-path admit site above.
 		q.onAdmittedReplicatedWork.admittedReplicatedWork(
-			roachpb.MustMakeTenantID(gKey.id),
+			roachpb.MustMakeTenantID(gKey.tenantID),
 			item.priority,
 			item.replicated,
 			item.requestedCount,
@@ -1411,7 +1404,7 @@ func (q *WorkQueue) refillGroupBurstBuckets(rate, cap float64) {
 	}
 }
 
-// refillBurstBucketForGroup refills a single rgKind group's burst
+// refillBurstBucketForGroup refills a single resource group's burst
 // bucket. Test-only: production refills go through
 // refillGroupBurstBuckets, which iterates all groups under one q.mu
 // critical section. This entry point exists for datadriven tests that
@@ -1453,21 +1446,21 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 	s.Printf("closed epoch: %d ", q.mu.closedEpochThreshold)
 	s.Printf("groupHeap len: %d", len(q.mu.groupHeap))
 	if len(q.mu.groupHeap) > 0 {
-		s.Printf(" top group: %d", q.mu.groupHeap[0].groupKey.id)
+		s.Printf(" top group: %s", q.mu.groupHeap[0].groupKey)
 	}
 	var keys []groupKey
 	for k := range q.mu.groups {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].kind != keys[j].kind {
-			return keys[i].kind < keys[j].kind
+		if keys[i].tenantID != keys[j].tenantID {
+			return keys[i].tenantID < keys[j].tenantID
 		}
-		return keys[i].id < keys[j].id
+		return keys[i].groupID < keys[j].groupID
 	})
 	for _, k := range keys {
 		group := q.mu.groups[k]
-		s.Printf("\n group-id: %d used: %d, w: %d, fifo: %d", group.groupKey.id, group.used,
+		s.Printf("\n group-id: %s used: %d, w: %d, fifo: %d", group.groupKey, group.used,
 			group.weight, group.fifoPriorityThreshold)
 		if len(group.waitingWorkHeap) > 0 {
 			// Sort items within waitingWorkHeap
@@ -1518,8 +1511,8 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 const defaultGroupWeight = 1
 
 // getGroupConfigLocked returns the config for gKey from the
-// configHolder, which falls back to a kind-appropriate default for
-// unconfigured keys. q.mu must be held.
+// configHolder, which falls back to a default for unconfigured keys.
+// q.mu must be held.
 func (q *WorkQueue) getGroupConfigLocked(
 	gKey groupKey,
 ) (weight uint32, burstFrac float64, maxCPU bool) {
@@ -1550,7 +1543,7 @@ func (q *WorkQueue) refreshResourceGroupConfig() {
 // applyConfigLocked upserts each entry in the holder snapshot into
 // q.mu.groups: existing groups have their weight and maxCPU updated
 // (with a heap fix if either changes the heap order), and missing
-// rgKind groups are pre-created so the very first Admit for the ID
+// resource groups are pre-created so the very first Admit for the ID
 // hits the fast path with the configured values already in place.
 // Entries absent from the snapshot are left in q.mu.groups and drain
 // via the GC path.
@@ -1748,10 +1741,10 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 }
 
 // groupInfo is the per-group information in the groupHeap. In Serverless mode,
-// the resource group ID is the tenant ID. In RM mode, the resource group ID is
-// derived from the work's priority (see priorityToResourceGroupKey).
+// the group is keyed by tenant ID. In RM mode, the group is keyed by resource
+// group ID derived from the work's priority (see priorityToResourceGroupKey).
 type groupInfo struct {
-	// groupKey is the composite (id, kind) under which this groupInfo
+	// groupKey is the (tenantID, groupID) under which this groupInfo
 	// is stored in WorkQueue.mu.groups.
 	groupKey groupKey
 	// The weight assigned to the resource group. Must be > 0. For
@@ -1874,8 +1867,7 @@ func newGroupInfo(
 	if aggMetrics != nil {
 		// AddChild takes the label values in the same order as
 		// aggmetric.MakeBuilder declared them: ("kind", "tenant_id").
-		kindStr := gKey.kind.String()
-		idStr := strconv.FormatUint(gKey.id, 10)
+		kindStr, idStr := gKey.metricLabels()
 		ti.perGroupMetrics.admittedCount = aggMetrics.admittedCount.AddChild(kindStr, idStr)
 		ti.perGroupMetrics.waitTimeNanos = aggMetrics.waitTimeNanos.AddChild(kindStr, idStr)
 		ti.perGroupMetrics.tokensUsed = aggMetrics.tokensUsed.AddChild(kindStr, idStr)
@@ -1949,7 +1941,11 @@ func (th *groupHeap) Less(i, j int) bool {
 	// burstQualification method, so we must call it here.
 	if (*th)[i].used*uint64((*th)[j].weight) == (*th)[j].used*uint64((*th)[i].weight) {
 		if (*th)[i].weight == (*th)[j].weight {
-			return (*th)[i].groupKey.id < (*th)[j].groupKey.id
+			ki, kj := (*th)[i].groupKey, (*th)[j].groupKey
+			if ki.tenantID != kj.tenantID {
+				return ki.tenantID < kj.tenantID
+			}
+			return ki.groupID < kj.groupID
 		}
 		return (*th)[i].weight > (*th)[j].weight
 	}

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1458,12 +1458,7 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, _ rune) {
 	for k := range q.mu.groups {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].tenantID != keys[j].tenantID {
-			return keys[i].tenantID < keys[j].tenantID
-		}
-		return keys[i].groupID < keys[j].groupID
-	})
+	slices.SortFunc(keys, groupKey.compare)
 	for _, k := range keys {
 		group := q.mu.groups[k]
 		s.Printf("\n group-id: %s used: %d, w: %d, fifo: %d", group.groupKey, group.used,

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -476,7 +476,7 @@ func initWorkQueue(
 	q.stopCh = stopCh
 	q.configHolder = opts.configHolder
 	if q.configHolder == nil {
-		q.configHolder = newResourceGroupConfigHolder()
+		q.configHolder = newResourceGroupConfigHolder(nil)
 	}
 	q.perGroupAggMetrics = opts.perGroupAggMetrics
 	q.timeSource = timeSource
@@ -1523,7 +1523,7 @@ const defaultGroupWeight = 1
 func (q *WorkQueue) getGroupConfigLocked(
 	gKey groupKey,
 ) (weight uint32, burstFrac float64, maxCPU bool) {
-	cfg := q.configHolder.Snapshot().GetOrDefault(gKey)
+	cfg := q.configHolder.Snapshot().Groups.GetOrDefault(gKey)
 	return cfg.Weight, cfg.BurstFrac, cfg.MaxCPU
 }
 
@@ -1543,7 +1543,7 @@ func (q *WorkQueue) refreshResourceGroupConfig() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if cpuTimeTokenACMode.Get(&q.settings.SV) == resourceManagerMode {
-		q.applyConfigLocked(q.configHolder.Snapshot())
+		q.applyConfigLocked(q.configHolder.Snapshot().Groups)
 	}
 }
 

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1297,7 +1297,13 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 //     intervals that are sized at the frequency with which this
 //     function is called (as of 1/9/26, every 1s).
 //  2. It GCs groupInfo entries, if a group has seen no workload over
-//     the interval.
+//     the interval. Built-in groups (builtinGroupConfigs) are exempt:
+//     they are always installed in the holder, so dropping and
+//     recreating them each interval is wasted churn through
+//     groupInfoPool. The cost is that built-ins not routed to in the
+//     current mode (e.g. the system tenant key in RM mode) keep
+//     publishing per-group metric series with values that stay at
+//     zero.
 //  3. It updates CPU time token estimators. The estimators are only used
 //     if mode == usesCPUTimeTokens.
 func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
@@ -1308,15 +1314,15 @@ func (q *WorkQueue) gcGroupsResetUsedAndUpdateEstimators() {
 	// longer than desired. We could break this iteration into smaller parts if
 	// needed.
 	for gKey, info := range q.mu.groups {
-		if info.used == 0 && !isInGroupHeap(info) {
+		if !gKey.isBuiltin() && info.used == 0 && !isInGroupHeap(info) {
 			delete(q.mu.groups, gKey)
 			releaseGroupInfo(info)
-		} else {
-			info.cpuTimeTokenEstimator.update()
-			info.used = 0
-			// All the heap members will reset used=0, so no need to change heap
-			// ordering.
+			continue
 		}
+		info.cpuTimeTokenEstimator.update()
+		info.used = 0
+		// All the heap members will reset used=0, so no need to change heap
+		// ordering.
 	}
 }
 

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -423,7 +423,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 					tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
 					tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
 				}
-				opts.configHolder = newResourceGroupConfigHolder(nil)
+				opts.configHolder = newResourceGroupConfigHolder(&st.SV)
 				q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 					workKind, tg, st, metrics, opts).(*WorkQueue)
 				q.knobs.DisableCPUTimeTokenEstimation = true
@@ -793,7 +793,7 @@ func makeCPUTimeTokenWorkQueue(
 	opts.timeSource = timeutil.NewManualTime(initialTime)
 	opts.disableEpochClosingGoroutine = true
 	opts.disableGCGroupsAndResetUsed = true
-	opts.configHolder = newResourceGroupConfigHolder(nil)
+	opts.configHolder = newResourceGroupConfigHolder(&st.SV)
 
 	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 		KVWork, tg, st, metrics, opts).(*WorkQueue)

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -556,19 +556,24 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				var v bool
 				d.ScanArgs(t, "group", &group)
 				d.ScanArgs(t, "v", &v)
-				// Mutate the holder's current config in place: take the
-				// snapshot (seed + prior Sets), flip the requested
-				// group, write back. Force an apply so maxCPU flips
-				// land on existing groups immediately.
-				cfg := q.configHolder.Snapshot()
+				// Read the snapshot, copy non-builtin keys into a fresh
+				// map, flip the requested group, and Set. Built-in keys
+				// are omitted because Set re-seeds them automatically.
+				snap := q.configHolder.Snapshot()
+				fresh := make(ResourceGroupConfigSet, len(snap))
+				for gk, gc := range snap {
+					if _, builtin := builtinGroupConfigs[gk]; !builtin {
+						fresh[gk] = gc
+					}
+				}
 				k := rgGroupKey(uint64(group))
-				cur := cfg[k]
+				cur := fresh[k]
 				cur.MaxCPU = v
 				if cur.Weight == 0 {
 					cur.Weight = 1
 				}
-				cfg[k] = cur
-				q.configHolder.Set(cfg)
+				fresh[k] = cur
+				q.configHolder.Set(fresh)
 				q.mu.Lock()
 				q.applyConfigLocked(q.configHolder.Snapshot())
 				q.mu.Unlock()

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -1305,7 +1305,7 @@ func withGroupLocked(q *WorkQueue, fn func()) {
 
 // TestApplyConfigLockedMaterializesGroups verifies that
 // applyConfigLocked materializes the holder's snapshot into
-// q.mu.groups: the seeded high/low rg containers must exist on the
+// q.mu.groups: the built-in high/low rg containers must exist on the
 // queue immediately after, with the configured weight/maxCPU. Without
 // this, lazy-create would still reach the right state on first admit,
 // but operator-facing observers (metrics, debug print) would not see
@@ -1317,12 +1317,6 @@ func TestApplyConfigLockedMaterializesGroups(t *testing.T) {
 	q, _, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
-	// Custom config replaces the default seed.
-	q.configHolder.Set(ResourceGroupConfigSet{
-		rgGroupKey(highResourceGroupID): {Weight: 60, MaxCPU: true},
-		rgGroupKey(lowResourceGroupID):  {Weight: 40, MaxCPU: false},
-	})
-
 	// Pre-condition: no rg containers exist yet (we're in serverless mode).
 	require.Nil(t, getGroupLocked(q, rgGroupKey(highResourceGroupID)))
 	require.Nil(t, getGroupLocked(q, rgGroupKey(lowResourceGroupID)))
@@ -1332,15 +1326,15 @@ func TestApplyConfigLockedMaterializesGroups(t *testing.T) {
 	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
 	q.refreshResourceGroupConfig()
 
-	// Post-condition: both rg containers pre-created with the
-	// configured weight/maxCPU.
+	// Post-condition: both built-in rg containers pre-created with
+	// their configured weight/maxCPU.
 	high := getGroupLocked(q, rgGroupKey(highResourceGroupID))
 	require.NotNil(t, high, "high rg container should be pre-created by apply")
-	require.Equal(t, uint32(60), high.weight)
+	require.Equal(t, uint32(80), high.weight)
 	require.True(t, high.cpuTimeBurstBucket.maxCPU)
 	low := getGroupLocked(q, rgGroupKey(lowResourceGroupID))
 	require.NotNil(t, low, "low rg container should be pre-created by apply")
-	require.Equal(t, uint32(40), low.weight)
+	require.Equal(t, uint32(20), low.weight)
 	require.False(t, low.cpuTimeBurstBucket.maxCPU)
 }
 
@@ -1358,16 +1352,16 @@ func TestRefreshResourceGroupConfigInServerlessIsNoOp(t *testing.T) {
 	// Stay in serverless mode (default).
 
 	q.configHolder.Set(ResourceGroupConfigSet{
-		rgGroupKey(highResourceGroupID): {Weight: 60, MaxCPU: true},
+		rgGroupKey(42): {Weight: 60, MaxCPU: true},
 	})
 	q.refreshResourceGroupConfig()
 
 	// rg containers must NOT have been pre-created.
-	require.Nil(t, getGroupLocked(q, rgGroupKey(highResourceGroupID)),
+	require.Nil(t, getGroupLocked(q, rgGroupKey(42)),
 		"refresh in serverless mode must not pre-create rg containers")
 
 	// But the holder DID record the change (it's caller-side state).
-	cfg := q.configHolder.Snapshot().Groups.GetOrDefault(rgGroupKey(highResourceGroupID))
+	cfg := q.configHolder.Snapshot().Groups.GetOrDefault(rgGroupKey(42))
 	require.Equal(t, uint32(60), cfg.Weight)
 	require.True(t, cfg.MaxCPU)
 }
@@ -1385,18 +1379,14 @@ func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
 	q, _, st, cleanup := makeCPUTimeTokenWorkQueue(t)
 	defer cleanup()
 
-	q.configHolder.Set(ResourceGroupConfigSet{
-		rgGroupKey(highResourceGroupID): {Weight: 70, MaxCPU: true},
-		rgGroupKey(lowResourceGroupID):  {Weight: 30, MaxCPU: false},
-	})
 	ctx := context.Background()
 	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
 	q.refreshResourceGroupConfig()
 
-	// Sanity: the high rg container exists with the configured state.
+	// Sanity: the high rg container exists with the built-in config.
 	high := getGroupLocked(q, rgGroupKey(highResourceGroupID))
 	require.NotNil(t, high)
-	require.Equal(t, uint32(70), high.weight)
+	require.Equal(t, uint32(80), high.weight)
 	require.True(t, high.cpuTimeBurstBucket.maxCPU)
 	// Force GC eligibility: drive used to 0.
 	withGroupLocked(q, func() { high.used = 0 })
@@ -1414,7 +1404,7 @@ func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
 
 	high2 := getGroupLocked(q, rgGroupKey(highResourceGroupID))
 	require.NotNil(t, high2, "next admit should recreate the GC'd group")
-	require.Equal(t, uint32(70), high2.weight,
+	require.Equal(t, uint32(80), high2.weight,
 		"recreated group should pick up configured weight, not default")
 	require.True(t, high2.cpuTimeBurstBucket.maxCPU,
 		"recreated group should pick up configured maxCPU, not default")

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -423,7 +423,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 					tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
 					tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
 				}
-				opts.configHolder = newResourceGroupConfigHolder()
+				opts.configHolder = newResourceGroupConfigHolder(nil)
 				q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 					workKind, tg, st, metrics, opts).(*WorkQueue)
 				q.knobs.DisableCPUTimeTokenEstimation = true
@@ -559,9 +559,9 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				// Read the snapshot, copy non-builtin keys into a fresh
 				// map, flip the requested group, and Set. Built-in keys
 				// are omitted because Set re-seeds them automatically.
-				snap := q.configHolder.Snapshot()
-				fresh := make(ResourceGroupConfigSet, len(snap))
-				for gk, gc := range snap {
+				groups := q.configHolder.Snapshot().Groups
+				fresh := make(ResourceGroupConfigSet, len(groups))
+				for gk, gc := range groups {
 					if _, builtin := builtinGroupConfigs[gk]; !builtin {
 						fresh[gk] = gc
 					}
@@ -575,7 +575,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				fresh[k] = cur
 				q.configHolder.Set(fresh)
 				q.mu.Lock()
-				q.applyConfigLocked(q.configHolder.Snapshot())
+				q.applyConfigLocked(q.configHolder.Snapshot().Groups)
 				q.mu.Unlock()
 				return ""
 
@@ -585,7 +585,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				if v {
 					cpuTimeTokenACMode.Override(context.Background(), &st.SV, resourceManagerMode)
 					q.mu.Lock()
-					q.applyConfigLocked(q.configHolder.Snapshot())
+					q.applyConfigLocked(q.configHolder.Snapshot().Groups)
 					q.mu.Unlock()
 				} else {
 					cpuTimeTokenACMode.Override(context.Background(), &st.SV, serverlessMode)
@@ -791,7 +791,7 @@ func makeCPUTimeTokenWorkQueue(
 	opts.timeSource = timeutil.NewManualTime(initialTime)
 	opts.disableEpochClosingGoroutine = true
 	opts.disableGCGroupsAndResetUsed = true
-	opts.configHolder = newResourceGroupConfigHolder()
+	opts.configHolder = newResourceGroupConfigHolder(nil)
 
 	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 		KVWork, tg, st, metrics, opts).(*WorkQueue)
@@ -1366,7 +1366,7 @@ func TestRefreshResourceGroupConfigInServerlessIsNoOp(t *testing.T) {
 		"refresh in serverless mode must not pre-create rg containers")
 
 	// But the holder DID record the change (it's caller-side state).
-	cfg := q.configHolder.Snapshot().GetOrDefault(rgGroupKey(highResourceGroupID))
+	cfg := q.configHolder.Snapshot().Groups.GetOrDefault(rgGroupKey(highResourceGroupID))
 	require.Equal(t, uint32(60), cfg.Weight)
 	require.True(t, cfg.MaxCPU)
 }

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -556,15 +556,14 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 				var v bool
 				d.ScanArgs(t, "group", &group)
 				d.ScanArgs(t, "v", &v)
-				// Read the snapshot, copy non-builtin keys into a fresh
-				// map, flip the requested group, and Set. Built-in keys
-				// are omitted because Set re-seeds them automatically.
+				// Copy the entire config (including builtins), flip
+				// the requested group, and install directly. We bypass
+				// Set's builtin protection because the test needs to
+				// toggle maxCPU on built-in RM groups.
 				groups := q.configHolder.Snapshot().Groups
 				fresh := make(ResourceGroupConfigSet, len(groups))
 				for gk, gc := range groups {
-					if _, builtin := builtinGroupConfigs[gk]; !builtin {
-						fresh[gk] = gc
-					}
+					fresh[gk] = gc
 				}
 				k := rgGroupKey(uint64(group))
 				cur := fresh[k]
@@ -573,7 +572,9 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 					cur.Weight = 1
 				}
 				fresh[k] = cur
-				q.configHolder.Set(fresh)
+				q.configHolder.mu.Lock()
+				q.configHolder.mu.config = fresh
+				q.configHolder.mu.Unlock()
 				q.mu.Lock()
 				q.applyConfigLocked(q.configHolder.Snapshot().Groups)
 				q.mu.Unlock()

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -665,9 +665,10 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 
 	// At init time, the estimators haven't seen any requests yet. They are
 	// hard-coded to return a single nanosecond token as an estimate in this
-	// case.
+	// case. Use a non-built-in tenant ID so the per-tenant estimator is
+	// eligible for GC at the bottom of the test.
 	info1 := WorkInfo{
-		TenantID: roachpb.MustMakeTenantID(1),
+		TenantID: roachpb.MustMakeTenantID(4),
 	}
 	resp1, err := q.Admit(ctx, info1)
 	require.NoError(t, err)
@@ -1366,13 +1367,11 @@ func TestRefreshResourceGroupConfigInServerlessIsNoOp(t *testing.T) {
 	require.True(t, cfg.MaxCPU)
 }
 
-// TestGCThenLazyRecreateRecoversFromHolder verifies the design's
-// safety claim: after GC removes an idle configured group, the next
-// admit recreates it via the holder with the correct weight/maxCPU.
-// Without this property, GC could silently downgrade a configured
-// group's effective weight to defaultGroupConfig values until the
-// next refresh.
-func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
+// TestGCExemptsBuiltins verifies that gcGroupsResetUsedAndUpdateEstimators
+// keeps built-in groups installed even when they have no recent
+// activity. Built-ins are always present in ResourceGroupConfigHolder,
+// so dropping and recreating them per interval would be wasted churn.
+func TestGCExemptsBuiltins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -1383,29 +1382,65 @@ func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
 	cpuTimeTokenACMode.Override(ctx, &st.SV, resourceManagerMode)
 	q.refreshResourceGroupConfig()
 
-	// Sanity: the high rg container exists with the built-in config.
 	high := getGroupLocked(q, rgGroupKey(highResourceGroupID))
 	require.NotNil(t, high)
-	require.Equal(t, uint32(80), high.weight)
-	require.True(t, high.cpuTimeBurstBucket.maxCPU)
-	// Force GC eligibility: drive used to 0.
+	require.True(t, rgGroupKey(highResourceGroupID).isBuiltin())
 	withGroupLocked(q, func() { high.used = 0 })
 	q.gcGroupsResetUsedAndUpdateEstimators()
 
-	require.Nil(t, getGroupLocked(q, rgGroupKey(highResourceGroupID)),
-		"idle configured group should be GC'd")
+	require.NotNil(t, getGroupLocked(q, rgGroupKey(highResourceGroupID)),
+		"built-in group must survive GC")
+}
 
-	// Next admit recreates the container via the holder.
+// TestGCThenLazyRecreateRecoversFromHolder verifies the design's
+// safety claim: after GC removes an idle configured group, the next
+// admit recreates it via the holder with the correct weight/maxCPU.
+// Without this property, GC could silently downgrade a configured
+// group's effective weight to defaultGroupConfig values until the
+// next refresh. Uses a non-built-in tenant key so the GC step is
+// actually exercised (built-ins are exempt; see TestGCExemptsBuiltins).
+func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	q, _, _, cleanup := makeCPUTimeTokenWorkQueue(t)
+	defer cleanup()
+
+	const tenantID = 42
+	key := tenantGroupKey(tenantID)
+	require.False(t, key.isBuiltin())
+	q.configHolder.Set(ResourceGroupConfigSet{
+		key: {Weight: 99, BurstFrac: 0.5, MaxCPU: true},
+	})
+
+	// Lazy-create via Admit so the queue's groupInfo picks up the
+	// holder config.
 	_, err := q.Admit(context.Background(), WorkInfo{
-		TenantID: roachpb.MustMakeTenantID(1),
+		TenantID: roachpb.MustMakeTenantID(tenantID),
 		Priority: admissionpb.NormalPri,
 	})
 	require.NoError(t, err)
+	g := getGroupLocked(q, key)
+	require.NotNil(t, g)
+	require.Equal(t, uint32(99), g.weight)
+	require.True(t, g.cpuTimeBurstBucket.maxCPU)
 
-	high2 := getGroupLocked(q, rgGroupKey(highResourceGroupID))
-	require.NotNil(t, high2, "next admit should recreate the GC'd group")
-	require.Equal(t, uint32(80), high2.weight,
+	// Force GC eligibility: drive used to 0.
+	withGroupLocked(q, func() { g.used = 0 })
+	q.gcGroupsResetUsedAndUpdateEstimators()
+	require.Nil(t, getGroupLocked(q, key),
+		"idle non-built-in group should be GC'd")
+
+	// Next admit recreates the container via the holder.
+	_, err = q.Admit(context.Background(), WorkInfo{
+		TenantID: roachpb.MustMakeTenantID(tenantID),
+		Priority: admissionpb.NormalPri,
+	})
+	require.NoError(t, err)
+	g2 := getGroupLocked(q, key)
+	require.NotNil(t, g2, "next admit should recreate the GC'd group")
+	require.Equal(t, uint32(99), g2.weight,
 		"recreated group should pick up configured weight, not default")
-	require.True(t, high2.cpuTimeBurstBucket.maxCPU,
+	require.True(t, g2.cpuTimeBurstBucket.maxCPU,
 		"recreated group should pick up configured maxCPU, not default")
 }


### PR DESCRIPTION
Continues the single-queue rework from #170187. This PR restructures the
CPU time token allocator's configuration and strategy layers.

The early commits introduce `systemTenantGroupConfig` (Weight=MaxUint32,
BurstFrac=1.0, MaxCPU=true) and move the priority-based RM groups into
a `builtinGroupConfigs` set that `Set` seeds automatically, panicking if
callers try to overwrite a built-in key.

`ResourceGroupConfigHolder.Snapshot()` now returns a `ConfigSnapshot`
bundling group configs with utilization targets read from cluster
settings. `computeTargets` becomes a free function over the snapshot,
and `groupBurstRates` moves to the allocator — both are now
mode-independent. This deletes the `modeStrategy` interface,
`serverlessStrategy`, and `rmStrategy` entirely; the mode is a stored
enum that only controls group-key derivation.

The final commits rework `groupKey` from `{id, kind}` to `{tenantID,
groupID}`, printing as `tNgN` (e.g. `t1g0` for system tenant, `t0g1`
for the high-priority RM group). Per-group metric labels are preserved
via a `metricLabels()` shim.

Epic: none