### PR TITLE
release-26.1: errorutil: emit telemetry for unimplemented errors

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -135,6 +135,7 @@ go_library(
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/interval",

--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	bulkutil "github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1355,8 +1356,7 @@ func getTenantInfo(
 		}
 	}
 	if len(tenants) > 0 && jobDetails.RevisionHistory {
-		return spans, tenants, errors.UnimplementedError(
-			errors.IssueLink{IssueURL: build.MakeIssueURL(47896)},
+		return spans, tenants, unimplemented.NewWithIssue(47896,
 			"can not backup tenants with revision history",
 		)
 	}

--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -583,9 +584,9 @@ func backupPlanHook(
 		for _, t := range targetDescs {
 			if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
 				if tbl.ExternalRowData().TenantID.IsSet() {
-					return errors.UnimplementedError(errors.IssueLink{}, "backing up from a replication target is not supported")
+					return unimplemented.New("backup.replication_target", "backing up from a replication target is not supported")
 				}
-				return errors.UnimplementedError(errors.IssueLink{}, "backing up from external tables is not supported")
+				return unimplemented.New("backup.external_table", "backing up from external tables is not supported")
 			}
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backupresolver"
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -55,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
@@ -192,8 +192,7 @@ func changefeedPlanHook(
 	}
 	if changefeedStmt.Level != tree.ChangefeedLevelTable {
 		return nil, nil, false,
-			errors.UnimplementedError(
-				errors.IssueLink{IssueURL: build.MakeIssueURL(154053)},
+			unimplemented.NewWithIssue(154053,
 				"database-level changefeed is not implemented yet",
 			)
 	}
@@ -703,9 +702,9 @@ func createChangefeedJobRecord(
 	for _, t := range tableNameToDescriptor {
 		if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
 			if tbl.ExternalRowData().TenantID.IsSet() {
-				return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on a replication target are not supported")
+				return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.replication_target", "changefeeds on a replication target are not supported")
 			}
-			return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on external tables are not supported")
+			return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.external_table", "changefeeds on external tables are not supported")
 		}
 	}
 	// This grabs table descriptors once to get their ids.
@@ -724,9 +723,9 @@ func createChangefeedJobRecord(
 		for _, t := range tableNameToDescriptor {
 			if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
 				if tbl.ExternalRowData().TenantID.IsSet() {
-					return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on a replication target are not supported")
+					return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.replication_target", "changefeeds on a replication target are not supported")
 				}
-				return nil, changefeedbase.Targets{}, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on external tables are not supported")
+				return nil, changefeedbase.Targets{}, unimplemented.New("changefeed.external_table", "changefeeds on external tables are not supported")
 			}
 		}
 

--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -98,6 +98,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -104,7 +105,7 @@ func createLogicalReplicationStreamPlanHook(
 		}
 
 		if stmt.From.Database != "" {
-			return errors.UnimplementedErrorf(errors.IssueLink{}, "logical replication streams on databases are unsupported")
+			return unimplemented.New("logical_replication.database", "logical replication streams on databases are unsupported")
 		}
 		if len(stmt.From.Tables) != len(stmt.Into.Tables) {
 			return pgerror.New(pgcode.InvalidParameterValue, "the same number of source and destination tables must be specified")

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -24,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
-	"github.com/cockroachdb/errors"
 )
 
 type alterFunctionOptionsNode struct {
@@ -221,11 +219,8 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	if len(dependentObjects) > 0 {
 		// TODO(#146475): once functions are rewritten to use ID references, we can
 		// allow renames for views.
-		return errors.UnimplementedErrorf(
-			errors.IssueLink{
-				IssueURL: build.MakeIssueURL(83233),
-				Detail:   "renames are disallowed because references are by name",
-			},
+		return unimplemented.NewWithIssueDetailf(83233,
+			"renames are disallowed because references are by name",
 			"cannot rename function %q because other functions or views ([%v]) still depend on it",
 			fnDesc.Name, strings.Join(dependentObjects, ", "))
 	}
@@ -382,12 +377,9 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 		return err
 	}
 	if len(dependentObjects) > 0 {
-		return errors.UnimplementedErrorf(
-			errors.IssueLink{
-				IssueURL: build.MakeIssueURL(83233),
-				Detail: "set schema is disallowed because there are references from " +
-					"other objects by name",
-			},
+		return unimplemented.NewWithIssueDetailf(83233,
+			"set schema is disallowed because there are references from "+
+				"other objects by name",
 			"cannot set schema for function %q because other functions or views ([%v]) still depend on it",
 			fnDesc.Name, strings.Join(dependentObjects, ", "))
 	}


### PR DESCRIPTION
Backport 1/1 commits from #169595 on behalf of @rafiss.

----

Direct calls to errors.UnimplementedError(f) construct an unimplemented-feature error but skip the telemetry annotation that the local pkg/util/errorutil/unimplemented helpers add via errors.WithTelemetry. As a result, these unimplemented features did not show up in telemetry counts.

Replace the call sites with the unimplemented package equivalents: NewWithIssue / NewWithIssueDetailf when an issue is referenced, and New with a feature key when not. Two call sites are intentionally left alone: pkg/util/log/log_decoder.go already wraps the error in errors.WithTelemetry and cannot import the unimplemented package due to a circular dependency, and pkg/kv/kvserver/kvstorage/wag_replay.go is an internal-only TODO path that is not user-reachable.

Notes on backport conflict resolution:
- `pkg/sql/alter_function.go`: on release-26.1, the `newAlterFunctionDependentObjectsError` helper does not exist. The two raw `errors.UnimplementedErrorf` call sites (rename and set schema) were converted to `unimplemented.NewWithIssueDetailf` directly to preserve the intent of the original change.
- `pkg/sql/importer/{read_import_parquet.go,read_import_parquet_logical.go}`: these files were deleted on release-26.1; the deletions were accepted and the corresponding BUILD.bazel deps (`//pkg/base`, `//pkg/build`) were not added.

Epic: None
Release note: None

----

Release justification: only changes a error messages and fixes missing product telemetry