### PR TITLE
roachtest: smarter cluster creation retries

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -981,6 +981,150 @@ func createFlagsOverride(opts *vm.CreateOpts) {
 	}
 }
 
+// createRetryPlanner owns safe mutations between roachprod create attempts.
+// The outer create loop still retries all create failures; this planner only
+// adds targeted attempt changes when a structured error makes that safe. Today
+// it handles zonal capacity errors by changing create zones. Future policies
+// can add other mutations here, such as falling back from spot to on-demand.
+type createRetryPlanner struct {
+	clusterSpec spec.ClusterSpec
+	params      spec.RoachprodClusterConfig
+	arch        vm.CPUArch
+
+	// explicitZones records whether zones were set by roachtest config or the
+	// test spec. These zones take precedence over provider defaults and provider
+	// capacity error suggestions.
+	explicitZones bool
+	// retryCandidates is the provider's default non-geo zone pool. It is used as
+	// a fallback after zonal capacity failures when no untried provider-suggested
+	// zone is available.
+	retryCandidates []string
+	// attemptedZones tracks zones selected for a create attempt or reported as
+	// failed by the provider. It prevents retrying a zone just because a provider
+	// hint or fallback list points back to it.
+	attemptedZones map[string]struct{}
+	// nextAttemptZones is a one-shot zone override selected after a capacity
+	// failure for the next create attempt.
+	nextAttemptZones []string
+}
+
+func newCreateRetryPlanner(
+	clusterSpec spec.ClusterSpec, params spec.RoachprodClusterConfig, arch vm.CPUArch,
+) *createRetryPlanner {
+	explicitZones := clusterSpec.UsesExplicitZones(params)
+	var retryCandidates []string
+	if !clusterSpec.Geo && !explicitZones {
+		retryCandidates = spec.DefaultRetryZoneCandidates(params.Cloud, arch)
+	}
+	return &createRetryPlanner{
+		clusterSpec:     clusterSpec,
+		params:          params,
+		arch:            arch,
+		explicitZones:   explicitZones,
+		retryCandidates: retryCandidates,
+		attemptedZones:  make(map[string]struct{}),
+	}
+}
+
+// zonesForAttempt returns the zones for the next roachprod create attempt. It
+// consumes a pending retry override when one exists, otherwise it falls back to
+// the test's ordinary roachprod create zones.
+func (p *createRetryPlanner) zonesForAttempt() []string {
+	var zones []string
+	if len(p.nextAttemptZones) > 0 {
+		zones = append([]string(nil), p.nextAttemptZones...)
+		p.nextAttemptZones = nil
+	} else {
+		zones = p.clusterSpec.RoachprodCreateZones(p.params, p.arch)
+	}
+	for _, zone := range zones {
+		if zone != "" {
+			p.attemptedZones[zone] = struct{}{}
+		}
+	}
+	return zones
+}
+
+// recordFailure is called after a roachprod create attempt fails and decides
+// whether the next attempt should change any create inputs. It leaves the
+// ordinary retry loop behavior unchanged for failures it does not recognize or
+// cannot safely plan around. For the current zone retry policy, explicit
+// test/config zones and geo-distributed clusters are left alone because
+// changing their zones would override user intent or require more
+// topology-aware retry planning.
+func (p *createRetryPlanner) recordFailure(err error, l *logger.Logger) {
+	var capacityErr *vm.CreateCapacityError
+	if !errors.As(err, &capacityErr) {
+		return
+	}
+	if capacityErr.Provider != "" && capacityErr.Provider != p.params.Cloud.String() {
+		return
+	}
+	if capacityErr.CapacityClass != vm.CreateCapacityClassZone {
+		return
+	}
+	if p.explicitZones {
+		l.Printf("provider reported capacity error, but zones are explicit; keeping requested zones")
+		return
+	}
+	if p.clusterSpec.Geo {
+		l.Printf("provider reported capacity error, but geo-distributed zone retry overrides are not supported")
+		return
+	}
+
+	retryZones, source := p.selectNextZones(capacityErr)
+	if len(retryZones) == 0 {
+		return
+	}
+	p.nextAttemptZones = retryZones
+	machineType := ""
+	if capacityErr.MachineType != "" {
+		machineType = fmt.Sprintf(" for machine type %s", capacityErr.MachineType)
+	}
+	failedZones := strings.Join(capacityErr.FailedZones, ",")
+	if failedZones == "" {
+		failedZones = "unknown"
+	}
+	l.Printf("provider reported capacity error%s in zone(s) [%s]; retrying next cluster creation in zone(s) [%s] from %s",
+		machineType,
+		failedZones,
+		strings.Join(retryZones, ","),
+		source,
+	)
+}
+
+// selectNextZones chooses the zone override for the next create attempt after a
+// zonal capacity failure. Provider-suggested zones are preferred when they have
+// not already been tried; otherwise it falls back to the first untried default
+// retry candidate. The second return value describes the source of the selected
+// zones for logging.
+func (p *createRetryPlanner) selectNextZones(
+	capacityErr *vm.CreateCapacityError,
+) ([]string, string) {
+	for _, zone := range capacityErr.FailedZones {
+		if zone != "" {
+			p.attemptedZones[zone] = struct{}{}
+		}
+	}
+	for _, zone := range capacityErr.SuggestedZones {
+		if zone == "" {
+			continue
+		}
+		if _, ok := p.attemptedZones[zone]; ok {
+			continue
+		}
+		return []string{zone}, "provider hint"
+	}
+
+	for _, zone := range p.retryCandidates {
+		if _, ok := p.attemptedZones[zone]; ok {
+			continue
+		}
+		return []string{zone}, "untried default zones"
+	}
+	return nil, ""
+}
+
 // clusterMock creates a cluster to be used for (self) testing.
 func (f *clusterFactory) clusterMock(cfg clusterConfig) *roachprodCluster {
 	return &roachprodCluster{
@@ -1075,6 +1219,7 @@ func (f *clusterFactory) newRoachprodCluster(
 		// name. To keep things simple, disable retries in that case.
 		maxAttempts = 1
 	}
+	retryPlanner := newCreateRetryPlanner(cfg.spec, params, selectedArch)
 	// loop assumes maxAttempts is atleast (1).
 	for i := 1; ; i++ {
 		// NB: this intentionally avoids re-using the name across iterations in
@@ -1083,9 +1228,13 @@ func (f *clusterFactory) newRoachprodCluster(
 		// https://github.com/cockroachdb/cockroach/issues/67906#issuecomment-887477675
 		genName := f.genName(cfg)
 
-		// Set the zones used for the cluster. We call this in the loop as the default GCE zone
-		// is randomized to avoid zone exhaustion errors.
-		providerOpts, workloadProviderOpts = cfg.spec.SetRoachprodOptsZones(providerOpts, workloadProviderOpts, params, string(selectedArch))
+		// Set the zones used for this cluster create attempt. The planner keeps
+		// normal default-zone selection and capacity-error retry overrides in one
+		// place.
+		createZones := retryPlanner.zonesForAttempt()
+		providerOpts, workloadProviderOpts = cfg.spec.SetRoachprodOptsZones(
+			providerOpts, workloadProviderOpts, params.Cloud, createZones,
+		)
 		if clusterCloud != spec.Local {
 			providerOptsContainer.SetProviderOpts(clusterCloud.String(), providerOpts)
 			workloadProviderOptsContainer.SetProviderOpts(clusterCloud.String(), workloadProviderOpts)
@@ -1149,6 +1298,9 @@ func (f *clusterFactory) newRoachprodCluster(
 		}
 
 		clusterL.PrintfCtx(ctx, "cluster creation failed, cleaning up in case it was partially created: %s", err)
+		if i < maxAttempts {
+			retryPlanner.recordFailure(err, clusterL)
+		}
 		c.Destroy(ctx, closeLogger, clusterL)
 		if i >= maxAttempts {
 			return nil, nil, err

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -848,69 +848,110 @@ func (s *ClusterSpec) isLocalSSDAvailable(
 	return nil
 }
 
-// SetRoachprodOptsZones updates the providerOpts with the VM zones as specified in the params/spec.
-// We separate this logic from RoachprodOpts as we may need to call this multiple times in order to
-// randomize the default GCE zone.
-func (s *ClusterSpec) SetRoachprodOptsZones(
-	providerOpts, workloadProviderOpts vm.ProviderOpts, params RoachprodClusterConfig, arch string,
-) (vm.ProviderOpts, vm.ProviderOpts) {
-	zonesStr := params.Defaults.Zones
+// RoachprodCreateZones returns the zones to use for a roachprod create attempt.
+func (s *ClusterSpec) RoachprodCreateZones(
+	params RoachprodClusterConfig, arch vm.CPUArch,
+) []string {
 	cloud := params.Cloud
-	switch cloud {
-	case AWS:
-		if s.AWS.Zones != "" {
-			zonesStr = s.AWS.Zones
-		}
-	case GCE:
-		if s.GCE.Zones != "" {
-			zonesStr = s.GCE.Zones
-		}
-	case Azure:
-		if s.Azure.Zones != "" {
-			zonesStr = s.Azure.Zones
-		}
-	case IBM:
-		if s.IBM.Zones != "" {
-			zonesStr = s.IBM.Zones
-		}
-	}
 	var zones []string
-	if zonesStr != "" {
+	if zonesStr, _ := s.roachprodOptsZonesString(params); zonesStr != "" {
 		zones = strings.Split(zonesStr, ",")
-		if !s.Geo {
-			zones = zones[:1]
-		}
 	}
+	if !s.Geo && len(zones) > 1 {
+		zones = zones[:1]
+	}
+	if len(zones) == 0 {
+		zones = DefaultZones(cloud, arch, s.Geo)
+	}
+	return append([]string(nil), zones...)
+}
 
+// SetRoachprodOptsZones updates providerOpts with the zones for a roachprod
+// create attempt.
+func (s *ClusterSpec) SetRoachprodOptsZones(
+	providerOpts, workloadProviderOpts vm.ProviderOpts, cloud Cloud, zones []string,
+) (vm.ProviderOpts, vm.ProviderOpts) {
 	switch cloud {
 	case AWS:
-		if len(zones) == 0 {
-			zones = aws.DefaultZones(s.Geo)
-		}
 		providerOpts.(*aws.ProviderOpts).CreateZones = zones
 		workloadProviderOpts.(*aws.ProviderOpts).CreateZones = zones
 	case GCE:
-		// We randomize the list of default zones for GCE for quota reasons, so decide the zone
-		// early to ensure that the workload node and CRDB cluster have the same default zone.
-		if len(zones) == 0 {
-			zones = gce.DefaultZones(arch, s.Geo)
-		}
 		providerOpts.(*gce.ProviderOpts).Zones = zones
 		workloadProviderOpts.(*gce.ProviderOpts).Zones = zones
 	case Azure:
-		if len(zones) == 0 {
-			zones = azure.DefaultZones(s.Geo)
-		}
 		providerOpts.(*azure.ProviderOpts).Zones = zones
 		workloadProviderOpts.(*azure.ProviderOpts).Zones = zones
 	case IBM:
-		if len(zones) == 0 {
-			zones = ibm.DefaultZones(s.Geo)
-		}
 		providerOpts.(*ibm.ProviderOpts).CreateZones = zones
 		workloadProviderOpts.(*ibm.ProviderOpts).CreateZones = zones
 	}
 	return providerOpts, workloadProviderOpts
+}
+
+// DefaultZones returns the package-level roachprod default zones for the cloud.
+func DefaultZones(cloud Cloud, arch vm.CPUArch, geoDistributed bool) []string {
+	switch cloud {
+	case AWS:
+		return aws.DefaultZones(geoDistributed)
+	case GCE:
+		return gce.DefaultZones(string(arch), geoDistributed)
+	case Azure:
+		return azure.DefaultZones(geoDistributed)
+	case IBM:
+		return ibm.DefaultZones(geoDistributed)
+	default:
+		return nil
+	}
+}
+
+// DefaultRetryZoneCandidates returns the provider's default non-geo zone pool.
+// Roachtest uses this to choose a different zone after provider capacity
+// failures.
+func DefaultRetryZoneCandidates(cloud Cloud, arch vm.CPUArch) []string {
+	switch cloud {
+	case AWS:
+		return aws.DefaultRetryZoneCandidates()
+	case GCE:
+		return gce.DefaultRetryZoneCandidates(string(arch))
+	case Azure:
+		return azure.DefaultRetryZoneCandidates()
+	default:
+		return nil
+	}
+}
+
+func (s *ClusterSpec) roachprodOptsZonesString(params RoachprodClusterConfig) (string, bool) {
+	zonesStr := params.Defaults.Zones
+	explicit := zonesStr != ""
+	switch params.Cloud {
+	case AWS:
+		if s.AWS.Zones != "" {
+			zonesStr = s.AWS.Zones
+			explicit = true
+		}
+	case GCE:
+		if s.GCE.Zones != "" {
+			zonesStr = s.GCE.Zones
+			explicit = true
+		}
+	case Azure:
+		if s.Azure.Zones != "" {
+			zonesStr = s.Azure.Zones
+			explicit = true
+		}
+	case IBM:
+		if s.IBM.Zones != "" {
+			zonesStr = s.IBM.Zones
+			explicit = true
+		}
+	}
+	return zonesStr, explicit
+}
+
+// UsesExplicitZones returns true when the cluster has user-specified zones.
+func (s *ClusterSpec) UsesExplicitZones(params RoachprodClusterConfig) bool {
+	_, explicit := s.roachprodOptsZonesString(params)
+	return explicit
 }
 
 // Expiration is the lifetime of the cluster. It may be destroyed after

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -731,6 +731,142 @@ func TestGCESameDefaultZone(t *testing.T) {
 	}
 }
 
+func TestNewClusterRetriesProviderSuggestedZone(t *testing.T) {
+	const suggestedZone = "us-central1-f"
+	createCalls := runGCECreateRetryTest(t, func(createCalls int, opts ...*cloud.ClusterCreateOpts) error {
+		require.Equal(t, len(opts), 2)
+		crdbZones := opts[0].ProviderOptsContainer[gce.ProviderName].(*gce.ProviderOpts).Zones
+		workloadZones := opts[1].ProviderOptsContainer[gce.ProviderName].(*gce.ProviderOpts).Zones
+		require.Equal(t, crdbZones, workloadZones)
+		require.NotEmpty(t, crdbZones)
+
+		if createCalls == 1 {
+			return &vm.CreateCapacityError{
+				CapacityClass:  vm.CreateCapacityClassZone,
+				Provider:       gce.ProviderName,
+				MachineType:    "t2a-standard-8",
+				FailedZones:    crdbZones,
+				SuggestedZones: []string{suggestedZone},
+				Cause:          errors.New("capacity unavailable"),
+			}
+		}
+
+		require.Equal(t, []string{suggestedZone}, crdbZones)
+		return &roachprod.ClusterAlreadyExistsError{}
+	})
+
+	require.Equal(t, 2, createCalls)
+}
+
+func TestNewClusterRetriesDifferentDefaultZoneAfterCapacityError(t *testing.T) {
+	var firstAttemptZones []string
+	createCalls := runGCECreateRetryTest(t, func(createCalls int, opts ...*cloud.ClusterCreateOpts) error {
+		require.Equal(t, len(opts), 2)
+		crdbZones := opts[0].ProviderOptsContainer[gce.ProviderName].(*gce.ProviderOpts).Zones
+		workloadZones := opts[1].ProviderOptsContainer[gce.ProviderName].(*gce.ProviderOpts).Zones
+		require.Equal(t, crdbZones, workloadZones)
+		require.Len(t, crdbZones, 1)
+
+		if createCalls == 1 {
+			firstAttemptZones = append([]string(nil), crdbZones...)
+			return &vm.CreateCapacityError{
+				CapacityClass: vm.CreateCapacityClassZone,
+				Provider:      gce.ProviderName,
+				MachineType:   "n2-standard-8",
+				FailedZones:   crdbZones,
+				Cause:         errors.New("capacity unavailable"),
+			}
+		}
+
+		require.NotEqual(t, firstAttemptZones, crdbZones)
+		return &roachprod.ClusterAlreadyExistsError{}
+	})
+
+	require.Equal(t, 2, createCalls)
+}
+
+func runGCECreateRetryTest(
+	t *testing.T, createMock func(createCalls int, opts ...*cloud.ClusterCreateOpts) error,
+) int {
+	t.Helper()
+	factory := &clusterFactory{sem: make(chan struct{}, 1), r: newClusterRegistry()}
+	cfg := clusterConfig{spec: spec.MakeClusterSpec(2, spec.WorkloadNode())}
+	prevCloud, prevZones, prevClusterWipe := roachtestflags.Cloud, roachtestflags.Zones, roachtestflags.ClusterWipe
+	roachtestflags.Cloud, roachtestflags.Zones, roachtestflags.ClusterWipe = spec.GCE, "", false
+	t.Cleanup(func() {
+		roachtestflags.Cloud, roachtestflags.Zones = prevCloud, prevZones
+		roachtestflags.ClusterWipe, create = prevClusterWipe, roachprod.Create
+	})
+
+	var createCalls int
+	create = func(ctx context.Context, l *logger.Logger, username string, opts ...*cloud.ClusterCreateOpts) error {
+		createCalls++
+		return createMock(createCalls, opts...)
+	}
+	_, _, err := factory.newCluster(context.Background(), cfg, func(string) {})
+	require.Error(t, err)
+	return createCalls
+}
+
+func TestCreateRetryPlannerFallsBackToUntriedDefaultZone(t *testing.T) {
+	planner := &createRetryPlanner{
+		retryCandidates: []string{"us-east1-b", "us-east1-c", "us-east1-d"},
+		attemptedZones:  map[string]struct{}{"us-east1-b": {}},
+	}
+
+	zones, source := planner.selectNextZones(&vm.CreateCapacityError{
+		FailedZones: []string{"us-east1-b"},
+	})
+	require.Equal(t, []string{"us-east1-c"}, zones)
+	require.Equal(t, "untried default zones", source)
+}
+
+func TestCreateRetryPlannerIgnoresFailedSuggestedZone(t *testing.T) {
+	planner := &createRetryPlanner{
+		retryCandidates: []string{"us-east1-b", "us-east1-c", "us-east1-d"},
+		attemptedZones:  make(map[string]struct{}),
+	}
+
+	zones, source := planner.selectNextZones(&vm.CreateCapacityError{
+		FailedZones:    []string{"us-east1-b"},
+		SuggestedZones: []string{"us-east1-b"},
+	})
+	require.Equal(t, []string{"us-east1-c"}, zones)
+	require.Equal(t, "untried default zones", source)
+}
+
+func TestCreateRetryPlannerRecordFailureSkipsOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		planner createRetryPlanner
+	}{
+		{
+			name:    "explicit zones",
+			planner: createRetryPlanner{explicitZones: true},
+		},
+		{
+			name:    "geo-distributed",
+			planner: createRetryPlanner{clusterSpec: spec.ClusterSpec{Geo: true}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := nilLogger()
+			defer l.Close()
+			planner := tc.planner
+			planner.attemptedZones = make(map[string]struct{})
+			planner.retryCandidates = []string{"us-east1-b", "us-east1-c"}
+
+			planner.recordFailure(&vm.CreateCapacityError{
+				CapacityClass: vm.CreateCapacityClassZone,
+				FailedZones:   []string{"us-east1-b"},
+			}, l)
+
+			require.Empty(t, planner.nextAttemptZones)
+			require.Empty(t, planner.attemptedZones)
+		})
+	}
+}
+
 func TestTransientErrorFallback(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()

--- a/pkg/roachprod/vm/BUILD.bazel
+++ b/pkg/roachprod/vm/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "vm",
     srcs = [
+        "create_capacity_error.go",
         "dns.go",
         "startup.go",
         "startup_args_overrides.go",

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "aws",
     srcs = [
         "aws.go",
+        "capacity_error.go",
         "config.go",
         "keys.go",
         "provider_options.go",
@@ -59,6 +60,7 @@ go_test(
         "//pkg/roachprod/vm",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -883,11 +883,19 @@ func (p *Provider) Create(
 }
 
 func DefaultZones(geoDistributed bool) []string {
-	zone := defaultZones[rand.Intn(len(defaultZones))]
+	zones := DefaultRetryZoneCandidates()
+	zone := zones[rand.Intn(len(zones))]
 	if geoDistributed {
 		return append([]string{zone}, defaultGeoExtraZones...)
 	}
 	return []string{zone}
+}
+
+// DefaultRetryZoneCandidates returns the default non-geo AWS zone pool.
+// DefaultZones chooses from this pool for ordinary creates, and roachtest uses
+// it to choose a different zone after provider capacity failures.
+func DefaultRetryZoneCandidates() []string {
+	return append([]string(nil), defaultZones...)
 }
 
 // createInstances creates EC2 instances in parallel with rate limiting.
@@ -2227,13 +2235,13 @@ func (p *Provider) runInstance(
 
 	if providerOpts.UseSpot {
 		//todo(babusrithar): Add fallback to on-demand instances if spot instances are not available.
-		return runSpotInstance(l, p, args, az.Region.Name, providerOpts)
+		return runSpotInstance(l, p, args, az.Name, az.Region.Name, cfg.machineType, providerOpts)
 	}
 
 	runInstancesOutput := RunInstancesOutput{}
 	err = p.runJSONCommand(l, args, &runInstancesOutput)
 	if err != nil {
-		return nil, err
+		return nil, annotateAWSCapacityError(err, az.Name, cfg.machineType)
 	}
 
 	if len(runInstancesOutput.Instances) == 0 {
@@ -2259,7 +2267,13 @@ func isArmMachineType(machineType string) bool {
 // It returns an error if the spot request is not fulfilled within 2 minutes.
 // It uses describe-spot-instance-requests command to get the status of the spot request.
 func runSpotInstance(
-	l *logger.Logger, p *Provider, args []string, regionName string, providerOpts *ProviderOpts,
+	l *logger.Logger,
+	p *Provider,
+	args []string,
+	zoneName string,
+	regionName string,
+	machineType string,
+	providerOpts *ProviderOpts,
 ) (*vm.VM, error) {
 	waitForSpotDuration := 2 * time.Minute
 
@@ -2270,7 +2284,7 @@ func runSpotInstance(
 	runInstancesOutput := RunInstancesOutput{}
 	err := p.runJSONCommand(l, spotArgs, &runInstancesOutput)
 	if err != nil {
-		return nil, err
+		return nil, annotateAWSCapacityError(err, zoneName, machineType)
 	}
 	// If the spot request is accepted, the run-instances command will return an instance-id.
 	if len(runInstancesOutput.Instances) == 0 {
@@ -2293,7 +2307,9 @@ func runSpotInstance(
 		if err != nil {
 			return nil, err
 		}
-		spotRequestFulfilled, err := processSpotInstanceRequestStatus(l, describeSpotInstanceRequestsOutput, spotInstanceRequestId, instanceId)
+		spotRequestFulfilled, err := processSpotInstanceRequestStatus(
+			l, describeSpotInstanceRequestsOutput, spotInstanceRequestId, instanceId, zoneName, machineType,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -2308,7 +2324,9 @@ func runSpotInstance(
 			if err != nil {
 				return nil, err
 			}
-			return nil, errors.New("waitForSpotDuration over")
+			return nil, newAWSSpotCapacityTimeoutError(
+				zoneName, machineType, spotInstanceRequestId, waitForSpotDuration,
+			)
 		}
 		l.Printf("Sleeping for 10 seconds before checking the status of the spot instance request again")
 		time.Sleep(10 * time.Second)
@@ -2355,15 +2373,24 @@ func processSpotInstanceRequestStatus(
 	describeSpotInstanceRequestsOutput DescribeSpotInstanceRequestsOutput,
 	spotInstanceRequestId string,
 	instanceId string,
+	zoneName string,
+	machineType string,
 ) (fullFilled bool, err error) {
 	if len(describeSpotInstanceRequestsOutput.SpotInstanceRequests) == 0 {
 		return false, errors.Errorf("No Spot Instance Request found for instance-id: %s", instanceId)
 	}
 	requestState := describeSpotInstanceRequestsOutput.SpotInstanceRequests[0].State
 	requestStatusCode := describeSpotInstanceRequestsOutput.SpotInstanceRequests[0].Status.Code
+	requestStatusMessage := describeSpotInstanceRequestsOutput.SpotInstanceRequests[0].Status.Message
 	if requestState == "closed" || requestState == "cancelled" || requestState == "failed" {
-		return false, errors.Errorf("Spot request %s for instance %s not active with state: %s",
-			spotInstanceRequestId, instanceId, requestState)
+		if err := newAWSSpotTerminalCapacityError(
+			zoneName, machineType, spotInstanceRequestId, instanceId,
+			requestState, requestStatusCode, requestStatusMessage,
+		); err != nil {
+			return false, err
+		}
+		return false, errors.Errorf("Spot request %s for instance %s not active with state: %s and status: %s",
+			spotInstanceRequestId, instanceId, requestState, requestStatusCode)
 	}
 	if requestStatusCode == "fulfilled" {
 		l.Printf("Spot request %s for instance %s fulfilled.", spotInstanceRequestId, instanceId)

--- a/pkg/roachprod/vm/aws/capacity_error.go
+++ b/pkg/roachprod/vm/aws/capacity_error.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package aws
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/errors"
+)
+
+var (
+	awsZoneTokenRE    = regexp.MustCompile(`\b[a-z]{2}-[a-z]+-\d[a-z]\b`)
+	awsInstanceTypeRE = regexp.MustCompile(`\b[a-z][0-9][a-z0-9]*\.[a-z0-9]+(?:\.[a-z0-9]+)?\b`)
+)
+
+func maybeAWSCapacityError(cause error, details string) error {
+	if cause == nil {
+		return nil
+	}
+	var capacityErr *vm.CreateCapacityError
+	if errors.As(cause, &capacityErr) {
+		return cause
+	}
+	if !isAWSCapacityError(details) {
+		return cause
+	}
+	failedZones := awsZonesInRequestedAvailabilityZone(details)
+	return newAWSCapacityError(cause, firstAWSInstanceType(details), failedZones, awsSuggestedZones(details, failedZones))
+}
+
+func annotateAWSCapacityError(err error, zone string, machineType string) error {
+	var capacityErr *vm.CreateCapacityError
+	if !errors.As(err, &capacityErr) {
+		return err
+	}
+	if capacityErr.MachineType == "" {
+		capacityErr.MachineType = machineType
+	}
+	if zone != "" && len(capacityErr.FailedZones) == 0 {
+		capacityErr.FailedZones = []string{zone}
+	}
+	return err
+}
+
+func newAWSSpotCapacityTimeoutError(
+	zone string, machineType string, spotRequestID string, timeout time.Duration,
+) error {
+	msg := "spot instance request was not fulfilled"
+	if spotRequestID != "" {
+		msg = "spot instance request " + spotRequestID + " was not fulfilled"
+	}
+	return newAWSCapacityError(errors.Newf("%s within %s", msg, timeout), machineType, zoneSlice(zone), nil)
+}
+
+func newAWSSpotTerminalCapacityError(
+	zone string,
+	machineType string,
+	spotRequestID string,
+	instanceID string,
+	state string,
+	statusCode string,
+	statusMessage string,
+) error {
+	if !isAWSSpotCapacityStatus(statusCode, statusMessage) {
+		return nil
+	}
+	msg := "spot instance request"
+	if spotRequestID != "" {
+		msg += " " + spotRequestID
+	}
+	if instanceID != "" {
+		msg += " for instance " + instanceID
+	}
+	msg += " is not active"
+	if state != "" {
+		msg += " with state " + state
+	}
+	if statusCode != "" {
+		msg += " and status " + statusCode
+	}
+	if statusMessage != "" {
+		msg += ": " + statusMessage
+	}
+	return newAWSCapacityError(errors.Newf("%s", msg), machineType, zoneSlice(zone), nil)
+}
+
+func newAWSCapacityError(
+	cause error, machineType string, failedZones []string, suggestedZones []string,
+) *vm.CreateCapacityError {
+	return &vm.CreateCapacityError{
+		CapacityClass:  vm.CreateCapacityClassZone,
+		Provider:       ProviderName,
+		MachineType:    machineType,
+		FailedZones:    failedZones,
+		SuggestedZones: suggestedZones,
+		Cause:          cause,
+	}
+}
+
+func isAWSSpotCapacityStatus(statusCode string, _ string) bool {
+	// Spot capacity status codes are documented by Amazon EC2.
+	// See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-request-status.html#spot-instance-request-status-codes
+	code := strings.ToLower(statusCode)
+	return code == "capacity-not-available" || code == "instance-terminated-no-capacity"
+}
+
+func isAWSCapacityError(details string) bool {
+	// RunInstances capacity failures are documented by Amazon EC2.
+	// See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/troubleshooting-launch.html#troubleshooting-launch-capacity
+	return strings.Contains(details, "InsufficientInstanceCapacity")
+}
+
+func firstAWSInstanceType(details string) string {
+	return awsInstanceTypeRE.FindString(details)
+}
+
+func zoneSlice(zone string) []string {
+	if zone == "" {
+		return nil
+	}
+	return []string{zone}
+}
+
+func awsZonesInRequestedAvailabilityZone(details string) []string {
+	lower := strings.ToLower(details)
+	idx := strings.Index(lower, "availability zone")
+	if idx == -1 {
+		return nil
+	}
+	next := details[idx:]
+	if period := strings.Index(next, "."); period != -1 {
+		next = next[:period]
+	}
+	return uniqueAWSZones(awsZoneTokenRE.FindAllString(next, -1))
+}
+
+func awsSuggestedZones(details string, failedZones []string) []string {
+	failed := make(map[string]struct{}, len(failedZones))
+	for _, zone := range failedZones {
+		failed[zone] = struct{}{}
+	}
+	return uniqueAWSZonesExcluding(awsZoneTokenRE.FindAllString(details, -1), failed)
+}
+
+func uniqueAWSZones(zones []string) []string {
+	return uniqueAWSZonesExcluding(zones, nil)
+}
+
+func uniqueAWSZonesExcluding(zones []string, exclude map[string]struct{}) []string {
+	if len(zones) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(zones))
+	unique := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		if _, ok := exclude[zone]; ok {
+			continue
+		}
+		if _, ok := seen[zone]; ok {
+			continue
+		}
+		seen[zone] = struct{}{}
+		unique = append(unique, zone)
+	}
+	return unique
+}

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -213,8 +213,9 @@ func (p *Provider) runCommandWithContext(
 		if exitErr := (*exec.ExitError)(nil); errors.As(err, &exitErr) {
 			l.Printf("%s", exitErr)
 		}
-		return nil, errors.Wrapf(err, "failed to run: aws %s: stderr: %v",
+		err = errors.Wrapf(err, "failed to run: aws %s: stderr: %v",
 			strings.Join(args, " "), stderrBuf.String())
+		return nil, maybeAWSCapacityError(err, stderrBuf.String())
 	}
 	return output, nil
 }

--- a/pkg/roachprod/vm/aws/support_test.go
+++ b/pkg/roachprod/vm/aws/support_test.go
@@ -6,11 +6,14 @@
 package aws
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,6 +24,87 @@ func TestWriteStartupScriptTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	echotest.Require(t, string(data), datapathutils.TestDataPath(t, "startup_script"))
+}
+
+func TestMaybeAWSCapacityError(t *testing.T) {
+	const stderr = `An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation: We currently do not have sufficient c6i.2xlarge capacity in the Availability Zone you requested (us-east-2a). Try us-east-2b or us-east-2c.`
+
+	err := maybeAWSCapacityError(errors.New("run-instances failed"), stderr)
+	capacityErr := requireCreateCapacityError(t, err)
+	require.Equal(t, vm.CreateCapacityClassZone, capacityErr.CapacityClass)
+	require.Equal(t, ProviderName, capacityErr.Provider)
+	require.Equal(t, "c6i.2xlarge", capacityErr.MachineType)
+	require.Equal(t, []string{"us-east-2a"}, capacityErr.FailedZones)
+	require.Equal(t, []string{"us-east-2b", "us-east-2c"}, capacityErr.SuggestedZones)
+}
+
+func TestMaybeAWSCapacityErrorIgnoresCapacityWordsWithoutCode(t *testing.T) {
+	cause := errors.New("run-instances failed")
+	require.Equal(t, cause, maybeAWSCapacityError(cause, "insufficient capacity in availability zone"))
+}
+
+func TestAnnotateAWSCapacityErrorAddsMetadata(t *testing.T) {
+	err := maybeAWSCapacityError(errors.New("run-instances failed"), "InsufficientInstanceCapacity")
+	err = annotateAWSCapacityError(err, "us-east-2a", "c6i.2xlarge")
+
+	capacityErr := requireCreateCapacityError(t, err)
+	require.Equal(t, "c6i.2xlarge", capacityErr.MachineType)
+	require.Equal(t, []string{"us-east-2a"}, capacityErr.FailedZones)
+}
+
+func TestNewAWSSpotTerminalCapacityErrorIgnoresNonCapacityStatusWithCapacityMessage(t *testing.T) {
+	err := newAWSSpotTerminalCapacityError(
+		"us-east-2a",
+		"c6i.2xlarge",
+		"sir-123",
+		"i-123",
+		"failed",
+		"bad-parameters",
+		"Launch specification is invalid; capacity cannot be checked.",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestProcessSpotInstanceRequestStatusTerminalState(t *testing.T) {
+	for _, tc := range []struct {
+		code, message string
+		capacity      bool
+	}{
+		{"capacity-not-available", "There is no Spot capacity available.", true},
+		{"bad-parameters", "Launch specification is invalid.", false},
+	} {
+		fulfilled, err := processSpotInstanceRequestStatus(
+			nil, spotInstanceRequestsOutputForTest("failed", tc.code, tc.message),
+			"sir-123", "i-123", "us-east-2a", "c6i.2xlarge",
+		)
+
+		require.False(t, fulfilled)
+		var capacityErr *vm.CreateCapacityError
+		require.Equal(t, tc.capacity, errors.As(err, &capacityErr))
+		if tc.capacity {
+			require.Equal(t, "c6i.2xlarge", capacityErr.MachineType)
+			require.Equal(t, []string{"us-east-2a"}, capacityErr.FailedZones)
+		}
+	}
+}
+
+func requireCreateCapacityError(t *testing.T, err error) *vm.CreateCapacityError {
+	t.Helper()
+	var capacityErr *vm.CreateCapacityError
+	require.True(t, errors.As(err, &capacityErr))
+	return capacityErr
+}
+
+func spotInstanceRequestsOutputForTest(
+	state string, statusCode string, statusMessage string,
+) DescribeSpotInstanceRequestsOutput {
+	var describeOutput DescribeSpotInstanceRequestsOutput
+	_ = json.Unmarshal([]byte(fmt.Sprintf(
+		`{"SpotInstanceRequests":[{"SpotInstanceRequestId":"sir-123","InstanceId":"i-123","State":%q,"Status":{"Code":%q,"Message":%q}}]}`,
+		state, statusCode, statusMessage,
+	)), &describeOutput)
+	return describeOutput
 }
 
 // TestIOPSCalculation tests that IOPS are calculated correctly for io1/io2 volumes,

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "auth.go",
         "azure.go",
+        "capacity_error.go",
         "doc.go",
         "flags.go",
         "ids.go",

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -472,9 +472,16 @@ func parseZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]Zone, error) 
 
 func DefaultZones(geoDistributed bool) []string {
 	if geoDistributed {
-		return defaultZones
+		return append([]string(nil), defaultZones...)
 	}
 	return []string{defaultZones[0]}
+}
+
+// DefaultRetryZoneCandidates returns the default non-geo Azure zone pool.
+// DefaultZones chooses from this pool for ordinary creates, and roachtest uses
+// it to choose a different zone after provider capacity failures.
+func DefaultRetryZoneCandidates() []string {
+	return append([]string(nil), defaultZones...)
 }
 
 // Create implements vm.Provider.
@@ -1189,13 +1196,17 @@ func (p *Provider) createVM(
 
 	future, err := client.CreateOrUpdate(ctx, *group.Name, name, machine)
 	if err != nil {
-		return
+		return compute.VirtualMachine{}, maybeAzureCapacityError(err, zone, providerOpts.MachineType)
 	}
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return
+		return compute.VirtualMachine{}, maybeAzureCapacityError(err, zone, providerOpts.MachineType)
 	}
 
-	return future.Result(client)
+	machine, err = future.Result(client)
+	if err != nil {
+		return compute.VirtualMachine{}, maybeAzureCapacityError(err, zone, providerOpts.MachineType)
+	}
+	return machine, nil
 }
 
 // createNIC creates a network adapter that is bound to the given public IP address.
@@ -1806,14 +1817,14 @@ func (p *Provider) createUltraDisk(
 			},
 		})
 	if err != nil {
-		return compute.Disk{}, err
+		return compute.Disk{}, maybeAzureCapacityError(err, zone, providerOpts.MachineType)
 	}
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return compute.Disk{}, err
+		return compute.Disk{}, maybeAzureCapacityError(err, zone, providerOpts.MachineType)
 	}
 	disk, err := future.Result(client)
 	if err != nil {
-		return compute.Disk{}, err
+		return compute.Disk{}, maybeAzureCapacityError(err, zone, providerOpts.MachineType)
 	}
 	l.Printf("created ultra-disk: %s\n", *disk.Name)
 	return disk, err

--- a/pkg/roachprod/vm/azure/capacity_error.go
+++ b/pkg/roachprod/vm/azure/capacity_error.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package azure
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/errors"
+)
+
+var azureCapacityErrorCodes = []string{
+	"AllocationFailed",
+	"OverconstrainedAllocationRequest",
+	"OverconstrainedZonalAllocationRequest",
+	"SkuNotAvailable",
+	"ZonalAllocationFailed",
+}
+
+func maybeAzureCapacityError(cause error, zone Zone, machineType string) error {
+	if cause == nil {
+		return nil
+	}
+	var capacityErr *vm.CreateCapacityError
+	if errors.As(cause, &capacityErr) {
+		return cause
+	}
+	if !isAzureCapacityError(cause.Error()) {
+		return cause
+	}
+	return &vm.CreateCapacityError{
+		CapacityClass: vm.CreateCapacityClassZone,
+		Provider:      ProviderName,
+		MachineType:   machineType,
+		FailedZones:   []string{zone.String()},
+		Cause:         cause,
+	}
+}
+
+func isAzureCapacityError(details string) bool {
+	for _, code := range azureCapacityErrorCodes {
+		if strings.Contains(details, code) {
+			return true
+		}
+	}
+
+	lower := strings.ToLower(details)
+	if strings.Contains(lower, "currently not available") &&
+		(strings.Contains(lower, "vm size") || strings.Contains(lower, "sku")) {
+		return true
+	}
+	return strings.Contains(lower, "capacity") &&
+		(strings.Contains(lower, "allocation") || strings.Contains(lower, "zone") ||
+			strings.Contains(lower, "vm size") || strings.Contains(lower, "sku"))
+}

--- a/pkg/roachprod/vm/create_capacity_error.go
+++ b/pkg/roachprod/vm/create_capacity_error.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vm
+
+import "fmt"
+
+// CreateCapacityClass identifies the create input dimension constrained by
+// provider capacity.
+type CreateCapacityClass string
+
+const (
+	// CreateCapacityClassZone indicates that the provider could not satisfy the
+	// request in one or more zones.
+	CreateCapacityClassZone CreateCapacityClass = "zone"
+)
+
+// CreateCapacityError is returned by VM providers when cluster creation fails
+// due to provider capacity in one or more zones. Providers may include
+// SuggestedZones when the cloud provider reports zones that can satisfy the
+// request.
+type CreateCapacityError struct {
+	CapacityClass  CreateCapacityClass
+	Provider       string
+	MachineType    string
+	FailedZones    []string
+	SuggestedZones []string
+	Cause          error
+}
+
+func (e *CreateCapacityError) Error() string {
+	msg := fmt.Sprintf("%s create failed due to capacity", e.Provider)
+	if e.MachineType != "" {
+		msg += fmt.Sprintf(" for machine type %s", e.MachineType)
+	}
+	if len(e.FailedZones) > 0 {
+		msg += fmt.Sprintf(" in zone(s) %v", e.FailedZones)
+	}
+	if len(e.SuggestedZones) > 0 {
+		msg += fmt.Sprintf("; suggested zone(s): %v", e.SuggestedZones)
+	}
+	if e.Cause != nil {
+		msg += fmt.Sprintf(": %v", e.Cause)
+	}
+	return msg
+}
+
+// Unwrap returns the original provider error.
+func (e *CreateCapacityError) Unwrap() error {
+	return e.Cause
+}

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "gce",
     srcs = [
+        "capacity_error.go",
         "create_sdk.go",
         "dns.go",
         "dns_sdk.go",

--- a/pkg/roachprod/vm/gce/capacity_error.go
+++ b/pkg/roachprod/vm/gce/capacity_error.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package gce
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/errors"
+)
+
+var (
+	gceZoneTokenRE          = regexp.MustCompile(`\b[a-z]+(?:-[a-z0-9]+)+-[a-z]\b`)
+	gceMetadataZoneRE       = regexp.MustCompile(`(?m)^\s*zone:\s*([a-z]+(?:-[a-z0-9]+)+-[a-z])\s*$`)
+	gceMetadataZonesAvailRE = regexp.MustCompile(`(?m)^\s*zonesAvailable:\s*(.+?)\s*$`)
+	gceMetadataVMTypeRE     = regexp.MustCompile(`(?m)^\s*vmType:\s*([^\s]+)\s*$`)
+	gceResourcePathZoneRE   = regexp.MustCompile(`/zones/([a-z]+(?:-[a-z0-9]+)+-[a-z])\b`)
+)
+
+func maybeGCECapacityError(cause error, details []byte) error {
+	if cause == nil {
+		return nil
+	}
+	var capacityErr *vm.CreateCapacityError
+	if errors.As(cause, &capacityErr) {
+		return cause
+	}
+	capacityErr = parseGCECapacityError(string(details))
+	if capacityErr == nil {
+		return cause
+	}
+	capacityErr.Cause = cause
+	return capacityErr
+}
+
+func annotateGCECapacityError(err error, zone string) error {
+	var capacityErr *vm.CreateCapacityError
+	if !errors.As(err, &capacityErr) {
+		return err
+	}
+	if zone != "" && len(capacityErr.FailedZones) == 0 {
+		capacityErr.FailedZones = []string{zone}
+	}
+	return err
+}
+
+func parseGCECapacityError(details string) *vm.CreateCapacityError {
+	// GCE formats these capacity failures as resource availability errors.
+	// See: https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-resource-availability
+	if !(strings.Contains(details, "ZONE_RESOURCE_POOL_EXHAUSTED") ||
+		strings.Contains(details, "resource_availability") ||
+		strings.Contains(details, "does not have enough resources available")) {
+		return nil
+	}
+
+	capacityErr := &vm.CreateCapacityError{
+		CapacityClass: vm.CreateCapacityClassZone,
+		Provider:      ProviderName,
+	}
+	if match := gceMetadataVMTypeRE.FindStringSubmatch(details); len(match) == 2 {
+		capacityErr.MachineType = strings.TrimSpace(match[1])
+	}
+	if match := gceMetadataZoneRE.FindStringSubmatch(details); len(match) == 2 {
+		capacityErr.FailedZones = append(capacityErr.FailedZones, match[1])
+	} else if match := gceResourcePathZoneRE.FindStringSubmatch(details); len(match) == 2 {
+		capacityErr.FailedZones = append(capacityErr.FailedZones, match[1])
+	}
+	if match := gceMetadataZonesAvailRE.FindStringSubmatch(details); len(match) == 2 {
+		capacityErr.SuggestedZones = uniqueZones(gceZoneTokenRE.FindAllString(match[1], -1))
+	}
+
+	capacityErr.FailedZones = uniqueZones(capacityErr.FailedZones)
+	return capacityErr
+}
+
+func uniqueZones(zones []string) []string {
+	if len(zones) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(zones))
+	unique := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		zone = strings.TrimSpace(zone)
+		if zone == "" {
+			continue
+		}
+		if _, ok := seen[zone]; ok {
+			continue
+		}
+		seen[zone] = struct{}{}
+		unique = append(unique, zone)
+	}
+	return unique
+}

--- a/pkg/roachprod/vm/gce/create_sdk.go
+++ b/pkg/roachprod/vm/gce/create_sdk.go
@@ -224,6 +224,7 @@ func (p *Provider) bulkInsertInstances(
 	// Execute the BulkInsert request (async operation).
 	op, err := client.BulkInsert(ctx, req)
 	if err != nil {
+		err = maybeGCECapacityError(err, []byte(err.Error()))
 		return errors.Wrapf(err, "BulkInsert request failed for zone %s", zone)
 	}
 
@@ -233,6 +234,7 @@ func (p *Provider) bulkInsertInstances(
 		return op.Wait(ctx)
 	}()
 	if err != nil {
+		err = maybeGCECapacityError(err, []byte(err.Error()))
 		return errors.Wrapf(err, "BulkInsert operation failed for zone %s", zone)
 	}
 	l.Printf("BulkInsert: successfully created %d instances in zone %s", len(hostNames), zone)

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -241,8 +241,9 @@ func runJSONCommand(args []string, parsed interface{}) error {
 		// TODO(peter,ajwerner): Remove this hack once gcloud behaves when adding
 		// new zones.
 		if matched, _ := regexp.Match(`.*Unknown zone`, stderr); !matched {
-			return errors.Wrapf(err, "failed to run: gcloud %s\nstdout: %s\nstderr: %s\n",
+			err = errors.Wrapf(err, "failed to run: gcloud %s\nstdout: %s\nstderr: %s\n",
 				strings.Join(args, " "), bytes.TrimSpace(rawJSON), bytes.TrimSpace(stderr))
+			return maybeGCECapacityError(err, stderr)
 		}
 	}
 
@@ -1175,11 +1176,7 @@ type ProjectsVal struct {
 // TODO(manojpillai): use same defaults for ARM64, given c4a wide availability.
 // But review roachtest impact before changing.
 func DefaultZones(arch string, geoDistributed bool) []string {
-	zones := []string{"us-east1-b", "us-east1-c", "us-east1-d"}
-	if vm.ParseArch(arch) == vm.ArchARM64 {
-		// T2A instances are only available in us-central1 in NA.
-		zones = []string{"us-central1-a", "us-central1-b", "us-central1-f"}
-	}
+	zones := DefaultRetryZoneCandidates(arch)
 	rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
 
 	if geoDistributed {
@@ -1197,6 +1194,18 @@ func DefaultZones(arch string, geoDistributed bool) []string {
 	}
 
 	return []string{zones[0]}
+}
+
+// DefaultRetryZoneCandidates returns the default non-geo GCE zone pool.
+// DefaultZones chooses from this pool for ordinary creates, and roachtest uses
+// it to choose a different zone after provider capacity failures.
+func DefaultRetryZoneCandidates(arch string) []string {
+	zones := []string{"us-east1-b", "us-east1-c", "us-east1-d"}
+	if vm.ParseArch(arch) == vm.ArchARM64 {
+		// T2A instances are only available in us-central1 in NA.
+		zones = []string{"us-central1-a", "us-central1-b", "us-central1-f"}
+	}
+	return zones
 }
 
 // Set is part of the pflag.Value interface.
@@ -1883,6 +1892,7 @@ func waitForGroupStability(l *logger.Logger, project, groupName string, zones []
 			cmd := exec.Command("gcloud", groupStableArgs...)
 			output, err := cmd.CombinedOutput()
 			if err != nil {
+				err = annotateGCECapacityError(maybeGCECapacityError(err, output), zone)
 				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", groupStableArgs, output)
 			}
 			return nil
@@ -2001,6 +2011,7 @@ func (p *Provider) Create(
 					cmd := exec.Command("gcloud", argsWithHost...)
 					output, err := cmd.CombinedOutput()
 					if err != nil {
+						err = maybeGCECapacityError(err, output)
 						return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", argsWithHost, output)
 					}
 					return nil
@@ -2201,6 +2212,7 @@ func (p *Provider) Grow(
 				cmd := exec.Command("gcloud", argsWithName...)
 				output, err := cmd.CombinedOutput()
 				if err != nil {
+					err = maybeGCECapacityError(err, output)
 					return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", argsWithName, output)
 				}
 				return nil

--- a/pkg/roachprod/vm/gce/gcloud_test.go
+++ b/pkg/roachprod/vm/gce/gcloud_test.go
@@ -65,6 +65,47 @@ func TestAllowedLocalSSDCount(t *testing.T) {
 	}
 }
 
+func TestParseGCECapacityError(t *testing.T) {
+	const details = `ERROR: (gcloud.compute.instances.create) Could not fetch resource:
+---
+code: ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS
+errorDetails:
+- localizedMessage:
+    locale: en-US
+    message: A t2a-standard-8 VM instance is currently unavailable in the us-central1-a
+      zone. Consider trying your request in the us-central1-f zone(s), which currently
+      has capacity to accommodate your request.
+- errorInfo:
+    domain: compute.googleapis.com
+    metadatas:
+      vmType: t2a-standard-8
+      zone: us-central1-a
+      zonesAvailable: us-central1-f
+    reason: resource_availability
+message: The zone 'projects/cockroach-ephemeral/zones/us-central1-a' does not have
+  enough resources available to fulfill the request.`
+
+	capacityErr := parseGCECapacityError(details)
+	assert.NotNil(t, capacityErr)
+	assert.Equal(t, vm.CreateCapacityClassZone, capacityErr.CapacityClass)
+	assert.Equal(t, ProviderName, capacityErr.Provider)
+	assert.Equal(t, "t2a-standard-8", capacityErr.MachineType)
+	assert.Equal(t, []string{"us-central1-a"}, capacityErr.FailedZones)
+	assert.Equal(t, []string{"us-central1-f"}, capacityErr.SuggestedZones)
+}
+
+func TestAnnotateGCECapacityErrorAddsZone(t *testing.T) {
+	const details = `ERROR: (gcloud.compute.instance-groups.managed.wait-until) The zone does not have enough resources available to fulfill the request.`
+
+	err := maybeGCECapacityError(errors.New("wait-until failed"), []byte(details))
+	err = annotateGCECapacityError(err, "us-central1-a")
+
+	var capacityErr *vm.CreateCapacityError
+	assert.True(t, errors.As(err, &capacityErr))
+	assert.Equal(t, vm.CreateCapacityClassZone, capacityErr.CapacityClass)
+	assert.Equal(t, []string{"us-central1-a"}, capacityErr.FailedZones)
+}
+
 func Test_buildFilterPreemptionCliArgs(t *testing.T) {
 	type args struct {
 		vms         vm.List

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -127,10 +127,6 @@ func (p *Provider) IsCentralizedProvider() bool {
 	return false
 }
 
-func (p *Provider) DefaultZones(_ string, _ bool) []string {
-	return []string{}
-}
-
 func (p *Provider) ConfigureProviderFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
 }
 


### PR DESCRIPTION
Previously, roachtest retried failed roachprod cluster creation up to 3 times, but they could randomly land back in the same unavailable zone.

That made capacity recovery depend on chance, even when the cloud provider error explicitly named other zones with available capacity.

This change has two parts:
1. Roachprod now classifies zonal capacity failures as `vm.CreateCapacityError`.
    The structured error carries the provider, machine type, failed zone, suggested zones when available, and a capacity class that lets callers distinguish zonal capacity failures from other (yet unimplemented) retry policies.

2. Roachtest now uses a `createRetryPlanner` during cluster creation.
    The planner keeps the existing retry loop, but when it sees a zonal capacity error it steers the next create attempt into a provider-suggested or otherwise untried zone. It preserves the existing guard rails for explicit zones and geo-distributed cluster specs.

In nightlies smoke tests, this recovered 26 cluster creates that otherwise failed on capacity errors: 23 on GCE and 3 on AWS.

Epic: none
Release note: None