### PR TITLE
build/roachtest: cache builds to speed up roachtest

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -324,3 +324,17 @@ function check_gcs_path_exists() {
   gsutil ls "$path" &>/dev/null
   return
 }
+
+# Activate GCS service account credentials from GOOGLE_EPHEMERAL_CREDENTIALS.
+# Idempotent — safe to call multiple times.
+function gcs_setup_credentials() {
+  if [[ "${GOOGLE_EPHEMERAL_CREDENTIALS:-}" != "" ]]; then
+    echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
+    gcloud auth activate-service-account --key-file=creds.json
+    export ROACHPROD_USER=teamcity
+    export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/creds.json"
+  else
+    echo 'warning: GOOGLE_EPHEMERAL_CREDENTIALS not set' >&2
+    echo "Assuming that you've run \`gcloud auth login\` from inside the builder." >&2
+  fi
+}

--- a/build/teamcity/cockroach/nightlies/roachtest_compile.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Docker launcher for the standalone roachtest compile-and-cache step.
+# Analogous to roachtest_nightly_gce.sh but only compiles — no test execution.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER -e GOOGLE_EPHEMERAL_CREDENTIALS -e TC_BUILD_BRANCH" \
+  run_bazel build/teamcity/cockroach/nightlies/roachtest_compile_and_cache.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_and_cache.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_and_cache.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Standalone entry point for compiling all roachtest artifacts and populating
+# the GCS build cache. Intended to run as its own TeamCity build so that
+# downstream cloud-specific roachtest jobs (GCE, AWS, Azure) can skip
+# compilation by downloading cached artifacts for the same SHA.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+set -a
+source "$dir/teamcity-support.sh"
+set +a
+
+export ROACHTEST_BUILD_CACHE=true
+
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh amd64 arm64 amd64-fips

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 
 source $root/build/teamcity/util/roachtest_arch_util.sh
 
+if [[ "${ROACHTEST_BUILD_CACHE:-}" == "true" ]]; then
+  gcs_setup_credentials
+fi
+
 if [ "$#" -eq 0 ]; then
   echo "Builds all bits needed for roachtests and stages them in bin/ and lib/."
   echo ""

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -116,6 +116,54 @@ esac
 
 echo "Building $os/$arch/$component..."
 
+# Skip everything if all artifacts already exist locally. Host-arch components
+# (roachtest, roachprod, libgeos) are requested by every roachtest_compile_bits.sh
+# invocation; without this check, the second invocation would download from the
+# cache the file the first invocation just built and uploaded.
+all_local=true
+for artifact in "${artifacts[@]}"; do
+  dst=${artifact#*:}
+  if [[ ! -e "$dst" ]]; then
+    all_local=false
+    break
+  fi
+done
+if $all_local; then
+  echo "All artifacts for $os/$arch/$component already exist locally; skipping."
+  exit 0
+fi
+
+cache_bucket="cockroach-nightly"
+cache_sha="${BUILD_VCS_NUMBER:-$(git rev-parse HEAD)}"
+
+# Try to download cached artifacts from GCS before building.
+if [[ "${ROACHTEST_BUILD_CACHE:-}" == "true" ]]; then
+  cache_base="gs://$cache_bucket/build-cache/$cache_sha/$os/$arch"
+  all_cached=true
+  for artifact in "${artifacts[@]}"; do
+    dst=${artifact#*:}
+    if ! gsutil -q cp "$cache_base/$(basename "$dst")" "$dst" 2>/dev/null; then
+      all_cached=false
+      break
+    fi
+  done
+  if $all_cached; then
+    # gsutil cp does not preserve the executable bit; restore it. The +x on
+    # libgeos*.so is harmless.
+    for artifact in "${artifacts[@]}"; do
+      dst=${artifact#*:}
+      chmod a+wx "$dst"
+    done
+    echo "Cache hit for $os/$arch/$component (SHA $cache_sha)."
+    exit 0
+  fi
+  # Clean up any partially downloaded artifacts.
+  for artifact in "${artifacts[@]}"; do
+    dst=${artifact#*:}
+    rm -f "$dst"
+  done
+fi
+
 bazel build --config $config -c opt "${bazel_args[@]}"
 BAZEL_BIN=$(bazel info bazel-bin --config $config -c opt)
 for artifact in "${artifacts[@]}"; do
@@ -125,3 +173,12 @@ for artifact in "${artifacts[@]}"; do
   # Make files writable to simplify cleanup and copying (e.g., scp retry).
   chmod a+w "$dst"
 done
+
+# Upload built artifacts to the cache.
+if [[ "${ROACHTEST_BUILD_CACHE:-}" == "true" ]]; then
+  cache_base="gs://$cache_bucket/build-cache/$cache_sha/$os/$arch"
+  for artifact in "${artifacts[@]}"; do
+    dst=${artifact#*:}
+    gsutil -q cp "$dst" "$cache_base/$(basename "$dst")" 2>/dev/null || true
+  done
+fi

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -21,6 +21,7 @@ fi
 
 arm_probability="${ARM_PROBABILITY:-0.5}"
 fips_probability="${FIPS_PROBABILITY:-0.02}"
+export ROACHTEST_BUILD_CACHE=true
 
 arch=amd64
 if [[ ${CLOUD} == "ibm" ]]; then

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -7,17 +7,7 @@
 
 # Set up Google credentials. Note that we need this for all clouds since we upload
 # perf artifacts to Google Storage at the end.
-if [[ "$GOOGLE_EPHEMERAL_CREDENTIALS" ]]; then
-  echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
-  gcloud auth activate-service-account --key-file=creds.json
-  export ROACHPROD_USER=teamcity
-
-  # Set GOOGLE_APPLICATION_CREDENTIALS so that gcp go libraries can find it.
-  export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/creds.json"
-else
-  echo 'warning: GOOGLE_EPHEMERAL_CREDENTIALS not set' >&2
-  echo "Assuming that you've run \`gcloud auth login\` from inside the builder." >&2
-fi
+gcs_setup_credentials
 
 # defines get_host_arch
 source  $root/build/teamcity/util/roachtest_arch_util.sh


### PR DESCRIPTION
Previously, both `cockroach` and `roachtest` binaries were cached in a GCS bucket at the end of the build on a release branch. While this allowed for reproduction of failures, it wasn't improving nightlies build time.

To address this, this patch changes two things:
1. introduction of an independent `roachtest_compile.sh` script that compiles and caches all components (binaries and libraries) to GCS
2. cache hit checks in `roachtest_compile_component.sh` to check if the component already exists in cache

The general idea is to change the dependencies of the roachtest nightly TeamCity builds so that `roachtest_compile.sh` is first called once per branch before each cloud provider's roachtest is triggered. This will cut down the compile time of each roachtest by an hour or so.

The change also becomes available for adhoc TeamCity smoke tests when multiple runs are triggered without the commit SHA being changed (e.g. short test then longer test or rerun because of build parameters mistakes).

Epic: none
Release note: None