### PR TITLE
*: update ctx based on RowSource.StartInternal in some processors

### DIFF
--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -84,7 +84,7 @@ func newCompactBackupsProcessor(
 func (p *compactBackupsProcessor) Start(ctx context.Context) {
 	ctx = logtags.AddTag(ctx, "job", p.spec.JobID)
 
-	p.StartInternal(ctx, compactBackupsProcessorName)
+	ctx = p.StartInternal(ctx, compactBackupsProcessorName)
 	ctx, cancel := context.WithCancel(ctx)
 	p.cancelAndWaitForWorker = func() {
 		cancel()

--- a/pkg/crosscluster/logical/txnmode/ldr_applier_processor.go
+++ b/pkg/crosscluster/logical/txnmode/ldr_applier_processor.go
@@ -71,7 +71,7 @@ type ldrApplierProcessor struct {
 
 // Start implements execinfra.RowSource.
 func (p *ldrApplierProcessor) Start(ctx context.Context) {
-	p.StartInternal(ctx, "ldrApplier")
+	ctx = p.StartInternal(ctx, "ldrApplier")
 	p.input.Start(ctx)
 
 	if err := p.setup(ctx); err != nil {

--- a/pkg/crosscluster/logical/txnmode/ldr_coordinator_processor.go
+++ b/pkg/crosscluster/logical/txnmode/ldr_coordinator_processor.go
@@ -98,7 +98,7 @@ type ldrCoordinatorProcessor struct {
 //
 //	feed.Subscribe -> runDecode -> runScheduleAndRoute -> Next()
 func (p *ldrCoordinatorProcessor) Start(ctx context.Context) {
-	p.StartInternal(ctx, "ldrCoordinator")
+	ctx = p.StartInternal(ctx, "ldrCoordinator")
 
 	if err := p.setup(ctx); err != nil {
 		p.MoveToDraining(err)

--- a/pkg/crosscluster/logical/txnmode/ldr_dep_resolver_processor.go
+++ b/pkg/crosscluster/logical/txnmode/ldr_dep_resolver_processor.go
@@ -47,7 +47,7 @@ type ldrDepResolverProcessor struct {
 
 // Start implements execinfra.RowSource.
 func (p *ldrDepResolverProcessor) Start(ctx context.Context) {
-	p.StartInternal(ctx, "ldrDepResolver")
+	ctx = p.StartInternal(ctx, "ldrDepResolver")
 	p.input.Start(ctx)
 
 	p.tracker = txnapply.NewTrackerServer()

--- a/pkg/jobs/ingeststopped/ingesting_check_processor.go
+++ b/pkg/jobs/ingeststopped/ingesting_check_processor.go
@@ -36,7 +36,7 @@ func newIngestStoppedProcessor(
 
 // Start is part of the RowSource interface.
 func (p *proc) Start(ctx context.Context) {
-	p.StartInternal(ctx, "ingeststopped.proc")
+	_ = p.StartInternal(ctx, "ingeststopped.proc")
 	if p.FlowCtx.Cfg.JobRegistry.IsIngesting(p.spec.JobID) {
 		p.MoveToDraining(errors.Errorf("jobs is still ingesting on node %d", p.FlowCtx.NodeID.SQLInstanceID()))
 	} else {

--- a/pkg/sql/bulkmerge/merge_coordinator.go
+++ b/pkg/sql/bulkmerge/merge_coordinator.go
@@ -201,7 +201,7 @@ func (m *mergeCoordinator) handleRow(row rowenc.EncDatumRow) error {
 
 // Start implements execinfra.RowSource.
 func (m *mergeCoordinator) Start(ctx context.Context) {
-	m.StartInternal(ctx, "mergeCoordinator")
+	ctx = m.StartInternal(ctx, "mergeCoordinator")
 	m.input.Start(ctx)
 	m.publishInitialTasks()
 }

--- a/pkg/sql/bulkmerge/merge_loopback.go
+++ b/pkg/sql/bulkmerge/merge_loopback.go
@@ -86,7 +86,7 @@ func (m *mergeLoopback) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadat
 
 // Start implements execinfra.RowSource.
 func (m *mergeLoopback) Start(ctx context.Context) {
-	m.StartInternal(ctx, "mergeLoopback")
+	_ = m.StartInternal(ctx, "mergeLoopback")
 	var ok bool
 	m.loopback, ok = loopback.get(m.FlowCtx)
 	if !ok {

--- a/pkg/sql/cloud_check_processor.go
+++ b/pkg/sql/cloud_check_processor.go
@@ -213,7 +213,7 @@ func getCloudCheckConcurrency(params CloudCheckParams) int {
 
 // Start is part of the RowSource interface.
 func (p *proc) Start(ctx context.Context) {
-	p.StartInternal(ctx, "cloudcheck.proc")
+	_ = p.StartInternal(ctx, "cloudcheck.proc")
 
 	concurrency := getCloudCheckConcurrency(p.spec.Params)
 	p.results = make(chan result, concurrency)

--- a/pkg/sql/rowexec/values.go
+++ b/pkg/sql/rowexec/values.go
@@ -68,7 +68,7 @@ func newValuesProcessor(
 
 // Start is part of the RowSource interface.
 func (v *valuesProcessor) Start(ctx context.Context) {
-	v.StartInternal(ctx, valuesProcName)
+	_ = v.StartInternal(ctx, valuesProcName)
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -111,7 +111,7 @@ func newVectorSearchProcessor(
 
 // Start is part of the RowSource interface.
 func (v *vectorSearchProcessor) Start(ctx context.Context) {
-	v.StartInternal(
+	_ = v.StartInternal(
 		ctx, "vector search", &v.contentionEventsListener,
 		&v.scanStatsListener, &v.tenantConsumptionListener,
 	)


### PR DESCRIPTION
This allows us to put all the work of the main processor goroutine under the processor's tracing span.

Epic: None
Release note: None