### PR TITLE
release-26.2: mmaprototype: return ok bool from getMeans / computeMeansForStoreSet

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -959,7 +959,12 @@ func (cs *clusterState) computeCandidatesForReplicaTransfer(
 	// these stores before computing the means, we can use it verbatim, otherwise
 	// we will recompute the means again below.
 	cs.scratchDisj[0] = conj
-	means := cs.meansMemo.getMeans(cs.scratchDisj[:1])
+	means, ok := cs.meansMemo.getMeans(cs.scratchDisj[:1])
+	if !ok {
+		// No store satisfies the constraint expression.
+		passObs.replicaShed(ctx, noCandidate)
+		return candidateSet{}, sheddingSLS
+	}
 
 	// Pre-means filtering: copy to scratch, then filter in place.
 	// Filter out stores that have a non-OK replica disposition.
@@ -979,8 +984,16 @@ func (cs *clusterState) computeCandidatesForReplicaTransfer(
 		return candidateSet{}, sheddingSLS
 	} else {
 		// Some stores were filtered; recompute means over filtered set.
-		cs.scratchMeans = computeMeansForStoreSet(
+		// filteredStores is non-empty (checked above).
+		var ok bool
+		cs.scratchMeans, ok = computeMeansForStoreSet(
 			cs, filteredStores, cs.meansMemo.scratchNodes, cs.meansMemo.scratchStores)
+		if !ok {
+			// Unreachable: filteredStores is non-empty (checked above). Gate
+			// the assert so variadic arg boxing doesn't allocate on the
+			// success path.
+			assertTruef(ctx, false, "computeMeansForStoreSet returned !ok for non-empty filteredStores=%v", filteredStores)
+		}
 		effectiveMeans = &cs.scratchMeans
 		ml.logf(ctx, 3,
 			"pre-means filtered %d stores → remaining %v, means: store=%v node=%v",

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1756,7 +1756,12 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 	}
 	localss := cs.stores[msg.StoreID]
 	cs.meansMemo.clear()
-	clusterMeans := cs.meansMemo.getMeans(nil)
+	clusterMeans, ok := cs.meansMemo.getMeans(nil)
+	if !ok {
+		// No stores are known to the allocator yet (e.g. the local store
+		// descriptor has not been gossiped at startup). Nothing to do.
+		return
+	}
 	// Sort by store ID for deterministic log output in tests.
 	storeIDs := make([]roachpb.StoreID, 0, len(cs.stores))
 	for storeID := range cs.stores {
@@ -2655,7 +2660,10 @@ func (cs *clusterState) computeLoadSummary(
 // TODO(wenyihu6): check to make sure obs here is correct
 func (cs *clusterState) loadSummaryForAllStores(ctx context.Context) string {
 	var buf redact.StringBuilder
-	clusterMeans := cs.meansMemo.getMeans(nil)
+	clusterMeans, ok := cs.meansMemo.getMeans(nil)
+	if !ok {
+		return "no stores known to allocator"
+	}
 	buf.Printf("cluster means: (stores-load %v) (stores-capacity %v)\n",
 		clusterMeans.storeLoad.load, clusterMeans.storeLoad.capacity)
 	buf.Printf("(nodes-cpu-load %v) (nodes-cpu-capacity %v)\n",

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -217,7 +217,11 @@ func (re *rebalanceEnv) rebalanceStores(
 	// responsible for equalizing load across two nodes that have 30% and 50%
 	// cpu utilization while the cluster mean is 70% utilization (as an
 	// example).
-	clusterMeans := re.meansMemo.getMeans(nil)
+	clusterMeans, ok := re.meansMemo.getMeans(nil)
+	if !ok {
+		passML.logf(ctx, 2, "no stores known to allocator; skipping rebalancing pass")
+		return nil
+	}
 	var sheddingStores []sheddingStore
 	passML.logf(ctx, 2,
 		"cluster means: (stores-load %s) (stores-capacity %s) (nodes-cpu-load %d) (nodes-cpu-capacity %d)",
@@ -897,7 +901,13 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 
 		// NB: candsPL is not empty - it includes at least the current leaseholder
 		// and one additional candidate.
-		means := computeMeansForStoreSet(re, candsPL, scratchNodes, scratchStores)
+		means, ok := computeMeansForStoreSet(re, candsPL, scratchNodes, scratchStores)
+		if !ok {
+			// Unreachable: candsPL is non-empty. Gate the assert so variadic
+			// arg boxing doesn't allocate on the success path (this site is in
+			// a hot inner loop).
+			assertTruef(ctx, false, "computeMeansForStoreSet returned !ok for non-empty candsPL=%v", candsPL)
+		}
 		sls := re.computeLoadSummary(ctx, store.StoreID, &means.storeLoad, &means.nodeLoad, ml)
 		if sls.dimSummary[CPURate] < overloadSlow {
 			// This store is not cpu overloaded relative to these candidates for

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -327,6 +327,11 @@ func (m meanNodeLoad) SafeFormat(w redact.SafePrinter, _ rune) {
 // storeLoadSummary for some of the stores in this set. This cache is lazily
 // populated and is implicitly invalidated if the loadSeqNum of the
 // storeLoadSummary no longer matches that of storeState.loadSeqNum.
+//
+// An entry with len(stores) == 0 represents a constraint expression that
+// no store satisfies. Such entries are still cached (for O(1) repeat
+// lookups) but meansLoad is left zero; meansMemo.getMeans signals this
+// case to callers via its ok return.
 type meansForStoreSet struct {
 	constraintsDisj
 	meansLoad
@@ -437,16 +442,24 @@ type loadInfoProvider interface {
 	computeLoadSummary(context.Context, roachpb.StoreID, *meanStoreLoad, *meanNodeLoad, mmaLogger) storeLoadSummary
 }
 
-// getMeans returns the means for an expression.
-func (mm *meansMemo) getMeans(expr constraintsDisj) *meansForStoreSet {
-	means, ok := mm.meansMap.get(expr)
-	if ok {
-		return means
+// getMeans returns the means for an expression. Returns ok=false if no
+// stores satisfy the expression (or, for a nil expr, if the allocator knows
+// of no stores at all). When ok is false the returned *meansForStoreSet
+// value is unspecified; callers must not pass it to getStoreLoadSummary or
+// otherwise consume it. Empty results are still inserted into the cache so
+// repeated lookups within an allocator pass remain O(1).
+func (mm *meansMemo) getMeans(expr constraintsDisj) (*meansForStoreSet, bool) {
+	means, hit := mm.meansMap.get(expr)
+	if hit {
+		return means, len(means.stores) > 0
 	}
 	means.constraintsDisj = expr
 	mm.constraintMatcher.constrainStoresForExpr(expr, &means.stores)
-	means.meansLoad = computeMeansForStoreSet(mm.loadInfoProvider, means.stores, mm.scratchNodes, mm.scratchStores)
-	return means
+	if len(means.stores) == 0 {
+		return means, false
+	}
+	means.meansLoad, _ = computeMeansForStoreSet(mm.loadInfoProvider, means.stores, mm.scratchNodes, mm.scratchStores)
+	return means, true
 }
 
 // getStoreLoadSummary returns the load summary for a store in the context of
@@ -471,6 +484,11 @@ func (mm *meansMemo) getStoreLoadSummary(
 // stores may contain duplicate storeIDs, in which case computeMeansForStoreSet
 // should deduplicate processing of the stores. stores should be immutable.
 //
+// If stores is empty, computeMeansForStoreSet returns the zero meansLoad
+// and ok=false. Callers must check ok before consuming the returned means;
+// the zero value would otherwise misclassify stores as overloaded due to
+// zero capacity.
+//
 // TODO: fix callers to exclude stores based on node failure detection, from
 // the mean.
 func computeMeansForStoreSet(
@@ -478,9 +496,9 @@ func computeMeansForStoreSet(
 	stores []roachpb.StoreID,
 	scratchNodes map[roachpb.NodeID]*NodeLoad,
 	scratchStores map[roachpb.StoreID]struct{},
-) (means meansLoad) {
+) (means meansLoad, ok bool) {
 	if len(stores) == 0 {
-		panic(fmt.Sprintf("no stores for meansForStoreSet: %v", stores))
+		return meansLoad{}, false
 	}
 	clear(scratchNodes)
 	clear(scratchStores)
@@ -540,7 +558,7 @@ func computeMeansForStoreSet(
 		float64(means.nodeLoad.loadCPU) / float64(means.nodeLoad.capacityCPU)
 	means.nodeLoad.loadCPU /= LoadValue(n)
 	means.nodeLoad.capacityCPU /= LoadValue(n)
-	return means
+	return means, true
 }
 
 // loadSummary aggregates across all load dimensions for a store, or a node.

--- a/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
@@ -312,7 +312,11 @@ func TestMeansMemo(t *testing.T) {
 					cc := parseConstraints(t, parts)
 					disj = append(disj, interner.internConstraintsConj(cc))
 				}
-				mss = mm.getMeans(disj)
+				var ok bool
+				mss, ok = mm.getMeans(disj)
+				if !ok {
+					return "ok: false (no stores match)\n"
+				}
 				var b strings.Builder
 				fmt.Fprintf(&b, "stores: ")
 				printPostingList(&b, mss.stores)
@@ -358,4 +362,30 @@ func TestMeansMemo(t *testing.T) {
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
 		})
+}
+
+// TestComputeMeansForStoreSetEmpty verifies that computeMeansForStoreSet
+// returns ok=false (rather than panicking) when given no stores. This is the
+// empty-set contract relied on by getMeans and by callers that may receive a
+// constraint conjunction matching no stores.
+func TestComputeMeansForStoreSetEmpty(t *testing.T) {
+	loadProvider := &testLoadInfoProvider{
+		t:      t,
+		sloads: map[roachpb.StoreID]storeLoadAndNodeID{},
+		nloads: map[roachpb.NodeID]*NodeLoad{},
+	}
+	scratchNodes := map[roachpb.NodeID]*NodeLoad{}
+	scratchStores := map[roachpb.StoreID]struct{}{}
+
+	for _, name := range []string{"nil slice", "empty slice"} {
+		t.Run(name, func(t *testing.T) {
+			var stores []roachpb.StoreID
+			if name == "empty slice" {
+				stores = []roachpb.StoreID{}
+			}
+			means, ok := computeMeansForStoreSet(loadProvider, stores, scratchNodes, scratchStores)
+			require.False(t, ok)
+			require.Equal(t, meansLoad{}, means)
+		})
+	}
 }

--- a/pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go
@@ -87,7 +87,15 @@ func (a *allocatorState) BuildMMARebalanceAdvisor(
 	scratchNodes := map[roachpb.NodeID]*NodeLoad{}
 	scratchStores := map[roachpb.StoreID]struct{}{}
 	cands = append(cands, existing)
-	means := computeMeansForStoreSet(a.cs, cands, scratchNodes, scratchStores)
+	means, ok := computeMeansForStoreSet(a.cs, cands, scratchNodes, scratchStores)
+	if !ok {
+		// Unreachable: cands always contains at least `existing`. Assert in
+		// test builds; in production, fall back to a no-op advisor rather than
+		// return a zero-valued means that would misclassify stores. Gating on
+		// !ok avoids variadic arg boxing on the success path.
+		assertTruef(context.Background(), false, "computeMeansForStoreSet returned !ok for non-empty cands=%v", cands)
+		return NoopMMARebalanceAdvisor()
+	}
 	return &MMARebalanceAdvisor{
 		existingStoreID: existing,
 		means:           means,

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/empty_store_set.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/empty_store_set.txt
@@ -1,0 +1,12 @@
+# Regression test for #170171 / #170136: a store-leaseholder message that
+# arrives while the MMA allocator has no stores registered must not panic
+# ("no stores for meansForStoreSet: []").
+#
+# This case is reachable in production at process startup, before any
+# gossip callback has called Allocator.SetStore. With the fix, getMeans
+# returns ok=false and processStoreLeaseholderMsgInternal returns early.
+
+# No set-store: MMA has zero stores registered.
+store-leaseholder-msg
+store-id=1
+----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/means_memo
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/means_memo
@@ -77,3 +77,9 @@ stores: 1, 2, 3
 store-means (load,cap,util): cpu: (43, unknown, 0.00) write-bw: (166, 566, 0.29) bytes: (1800, 4533, 0.40)
    secondary-load: [100 0]
 node-mean cpu (load,cap,util): (225, 750, 0.30)
+
+# Constraint that no store satisfies returns ok=false rather than panicking.
+get-means
++=purple
+----
+ok: false (no stores match)


### PR DESCRIPTION
Backport 1/1 commits from #170196 on behalf of @tbg.

----

## Summary

`computeMeansForStoreSet` panicked with `"no stores for meansForStoreSet: []"`
when called with an empty store slice. The condition is reachable in tests
where the MMA allocator has no stores registered (the `LocalTestCluster`
gossip wiring is incomplete) and is also theoretically reachable in production
via two paths:

1. `mmaStoreRebalancer` ticks before any `SetStore` call has surfaced the
   local store via gossip.
2. A constraint conjunction in `findCandidates` legitimately matches zero
   stores.

Neither case is fatal — both should be a no-op. This change encodes that in
the type system: `getMeans` and `computeMeansForStoreSet` now return an
explicit `ok` bool, and every caller handles `ok=false` as "skip this work":

- `processStoreLeaseholderMsgInternal` returns early.
- `rebalanceStores` logs and returns nil changes.
- `findCandidates` mirrors the existing "no viable candidates" branch.
- `BuildMMARebalanceAdvisor` falls back to `NoopMMARebalanceAdvisor`.
- `loadSummaryForAllStores` prints `"no stores known to allocator"`.

Empty results are still cached so repeat lookups within an allocator pass
remain O(1).

Reproduced pre-fix on run 8 of `--stress --race`; post-fix runs to 41+ with
no panic.

Out of scope (separate follow-ups):

- `mma_store_rebalancer.go` short-circuit when `len(KnownStores()) == 0`.
- `LocalTestCluster.Start` calling `SetStore` (tracked in #169444).

Resolves: #170171
Resolves: #170136
Epic: none

Release note (bug fix): Fixed a panic ("no stores for meansForStoreSet")
in the multi-metric allocator (MMA) store rebalancer that could fire when
the rebalancer's periodic tick raced gossip propagation of store
descriptors during process startup. The rebalancer now skips its work for
that tick and retries on the next interval.

----

Release justification: targeted fix for a panic when multi metric allocator is enabled.