### PR TITLE
release-26.2: sql: step read sequence in execPrepare after savepoint rollback

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -88,6 +88,14 @@ func (ex *connExecutor) execPrepare(
 		statementHintsCache,
 		ex.sessionData().Database,
 	)
+	// Step the read sequence so that any KV reads during Prepare (e.g.
+	// descriptor resolution) use a sequence number past ignored ranges
+	// from a prior savepoint rollback.
+	if _, isOpen := ex.machine.CurState().(stateOpen); isOpen {
+		if err := ex.stepReadSequence(ctx); err != nil {
+			return retErr(err)
+		}
+	}
 	_, err := ex.addPreparedStmt(
 		ctx,
 		parseCmd.Name,

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -435,6 +435,16 @@ func (ex *connExecutor) execBind(
 
 	numQArgs := uint16(len(ps.InferredTypes))
 
+	// Step the read sequence so that any KV reads during Bind (e.g.
+	// ResolveTypeByOID for enum parameters, descriptor staleness checks)
+	// use a sequence number past ignored ranges from a prior savepoint
+	// rollback.
+	if _, isOpen := ex.machine.CurState().(stateOpen); isOpen {
+		if err := ex.stepReadSequence(ctx); err != nil {
+			return retErr(err)
+		}
+	}
+
 	// Decode the arguments, except for internal queries for which we just verify
 	// that the arguments match what's expected.
 	qargs := make(tree.QueryArguments, numQArgs)

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -2618,3 +2618,87 @@ func TestPrepareAfterSavepointRollback(t *testing.T) {
 	_, err = p.Until(false /* keepErrMsg */, until...)
 	require.NoError(t, err)
 }
+
+// TestBindAfterSavepointRollback reproduces the same class of bug as
+// TestPrepareAfterSavepointRollback but through the Bind (pgwire Bind)
+// entry point instead of Parse. It uses an enum-typed parameter to
+// trigger ResolveTypeByOID inside execBind's resolve() closure — the
+// exact code path that runs BEFORE stepReadSequence in the unfixed code.
+//
+// The test disables descriptor leasing so that the enum type resolution
+// falls through to storage, issuing real KV reads through the user's
+// transaction.
+func TestBindAfterSavepointRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Insecure: true,
+	})
+	defer s.Stopper().Stop(ctx)
+	defer lease.TestingDisableTableLeases()()
+
+	p, err := pgtest.NewPGTest(ctx, s.SQLAddr(), username.RootUser)
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	until := pgtest.ParseMessages("ReadyForQuery")
+
+	// Create an enum type and a table that uses it, plus a plain table
+	// for the INSERT inside the savepoint.
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_insert (id INT PRIMARY KEY)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TYPE te AS ENUM ('a', 'b')"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_bind (id INT, val te)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// Parse OUTSIDE the transaction. The autocommit descriptor collection
+	// used during Parse is discarded, so the enum type will not be cached
+	// in the new transaction's collection created at BEGIN.
+	require.NoError(t, p.SendOneLine(`Parse {"Query": "INSERT INTO t_for_bind VALUES ($1, $2)"}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+	_, err = p.Until(false /* keepErrMsg */, pgtest.ParseMessages("ParseComplete\nReadyForQuery")...)
+	require.NoError(t, err)
+
+	// BEGIN → SAVEPOINT → INSERT → ROLLBACK TO SAVEPOINT.
+	require.NoError(t, p.SendOneLine(`Query {"String": "BEGIN"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "INSERT INTO t_for_insert VALUES (1)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "ROLLBACK TO SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// Bind with enum-typed parameters. resolve() calls ResolveTypeByOID
+	// for the enum OID — the enum is not in this txn's descriptor
+	// collection (Parse used a different collection), so it falls through
+	// to storage (leases disabled) and issues a KV read on the user's txn.
+	// Without the fix, readSeq=0 is inside the ignored range [0, 1].
+	require.NoError(t, p.SendOneLine(`Bind {"ParameterFormatCodes": [0, 0], "Parameters": [{"text":"1"}, {"text":"a"}]}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+
+	_, err = p.Until(
+		true, /* keepErrMsg */
+		pgtest.ParseMessages("BindComplete\nReadyForQuery")...)
+	require.NoError(t, err,
+		"Bind after ROLLBACK TO SAVEPOINT hit readSeq-in-ignored-range assertion; see #169720")
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "COMMIT"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+}

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/colfetcher"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
@@ -2540,4 +2541,80 @@ func TestInternalAppNamePrefix(t *testing.T) {
 		finalUserMetrics = sqlServer.Metrics.ExecutedStatementCounters.InsertCount.Count()
 		require.Greater(t, finalUserMetrics, initialUserMetrics)
 	})
+}
+
+// TestPrepareAfterSavepointRollback reproduces #169720: after ROLLBACK TO
+// SAVEPOINT, the transaction's read sequence number can remain in the ignored
+// range because execPrepare (pgwire Parse) does not call Step() to advance it.
+// Any KV read during the Prepare then hits the assertion in
+// checkReadSeqNotIgnoredLocked.
+//
+// The test disables descriptor leasing so that descriptor lookups fall
+// through to storage, issuing real KV reads through the user's transaction.
+// A second table (t_for_parse) is used as the Parse target — it has never
+// been accessed in this transaction, so the descriptor collection has no
+// cached entry and must resolve it from storage.
+func TestPrepareAfterSavepointRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Insecure: true,
+	})
+	defer s.Stopper().Stop(ctx)
+	defer lease.TestingDisableTableLeases()()
+
+	p, err := pgtest.NewPGTest(ctx, s.SQLAddr(), username.RootUser)
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	until := pgtest.ParseMessages("ReadyForQuery")
+
+	// Two tables: t_for_insert is the INSERT target (cached in the txn's
+	// descriptor collection after the INSERT), t_for_parse is the Parse
+	// target (never accessed in this txn, forcing a storage lookup).
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_insert (id INT PRIMARY KEY)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_parse (id INT PRIMARY KEY)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// BEGIN → SAVEPOINT → INSERT → ROLLBACK TO SAVEPOINT.
+	// After the rollback the ignored seqnum range is [0, 1] and readSeq
+	// remains 0 (stepping mode does not auto-advance it).
+	require.NoError(t, p.SendOneLine(`Query {"String": "BEGIN"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "INSERT INTO t_for_insert VALUES (1)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "ROLLBACK TO SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// Parse "SELECT * FROM t_for_parse" — descriptor lookup for t_for_parse
+	// goes to storage (leases disabled, not in collection cache) and issues
+	// a KV read on the user's txn. Without the fix, readSeq=0 is inside the
+	// ignored range [0, 1], triggering the assertion.
+	require.NoError(t, p.SendOneLine(`Parse {"Query": "SELECT * FROM t_for_parse"}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+
+	_, err = p.Until(
+		true, /* keepErrMsg */
+		pgtest.ParseMessages("ParseComplete\nReadyForQuery")...)
+	require.NoError(t, err,
+		"Parse after ROLLBACK TO SAVEPOINT hit readSeq-in-ignored-range assertion; see #169720")
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "COMMIT"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Backport 2/2 commits from #169970 on behalf of @stevendanna.

----

In stepping mode (used by all SQL transactions), the read sequence number is only advanced on explicit Step() calls. After ROLLBACK TO SAVEPOINT, the rolled-back sequence numbers are added to the ignored list, but the read sequence is not advanced past them because stepping mode suppresses automatic advancement.

execStmtInOpenState calls Step() before executing statements, so normal statement execution works correctly. However, execPrepare (pgwire extended protocol Parse) did not call Step(), so any KV reads during Prepare — such as descriptor resolution when table leases are unavailable — would use a read sequence number that falls within the ignored range, tripping the assertion in checkReadSeqNotIgnoredLocked.

Add a stepReadSequence() call in execPrepare when in the open transaction state, matching what execStmtInOpenState already does.

Resolves: #169720
Epic: none

Release note (bug fix): Fixed a bug where using the pgwire extended query protocol to prepare a statement after rolling back to a savepoint could cause an internal error
("read sequence number is ignored after savepoint rollback"). This affected client drivers that use the Parse message (extended protocol) rather than simple query execution.

----

Release justification: