### PR TITLE
vecbench: add pgvector support, CSV export, and follower reads

### DIFF
--- a/pkg/cmd/vecbench/BUILD.bazel
+++ b/pkg/cmd/vecbench/BUILD.bazel
@@ -4,9 +4,11 @@ go_library(
     name = "vecbench_lib",
     srcs = [
         "chart_printer.go",
+        "csv_writer.go",
         "main.go",
         "mem_provider.go",
         "percentile_estimator.go",
+        "sql_dialect.go",
         "sql_provider.go",
         "vector_provider.go",
     ],

--- a/pkg/cmd/vecbench/csv_writer.go
+++ b/pkg/cmd/vecbench/csv_writer.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"encoding/csv"
+	"os"
+
+	"github.com/cockroachdb/errors"
+)
+
+// appendCSVRow appends a row to a CSV file, writing the header first if the
+// file does not yet exist.
+func appendCSVRow(filename string, header []string, row []string) error {
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return errors.Wrap(err, "opening CSV file")
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return errors.Wrap(err, "stat CSV file")
+	}
+
+	w := csv.NewWriter(f)
+
+	if info.Size() == 0 {
+		if err := w.Write(header); err != nil {
+			return errors.Wrap(err, "writing CSV header")
+		}
+	}
+
+	if err := w.Write(row); err != nil {
+		return errors.Wrap(err, "writing CSV row")
+	}
+
+	w.Flush()
+	return errors.Wrap(w.Error(), "flushing CSV writer")
+}

--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -81,6 +81,12 @@ var flagDBConnStr = flag.String("db", "postgresql://root@localhost:26257",
 	"Database connection string (when not using --memstore)")
 var flagCreateIndexAfterImport = flag.Bool("index-after", false,
 	"Create vector index after data import instead of during table creation (SQL provider only)")
+var flagPgvector = flag.Bool("pgvector", false,
+	"Target PostgreSQL with pgvector extension instead of CockroachDB")
+var flagExportCSV = flag.Bool("export-csv", false,
+	"Export results to results_search.csv and results_build.csv")
+var flagFollowerRead = flag.Bool("follower-read", false,
+	"Use follower reads (AS OF SYSTEM TIME follower_read_timestamp()) for search queries (CockroachDB only)")
 
 // vecbench benchmarks vector index in-memory build and search performance on a
 // variety of datasets. Datasets are downloaded from the
@@ -294,11 +300,39 @@ func (vb *vectorBench) SearchIndex() {
 		p95Latency := latencyEstimator.Estimate(0.95) * 1000
 		p99Latency := latencyEstimator.Estimate(0.99) * 1000
 
+		recall := sumRecall / float64(count) * 100
+		avgLeaf := sumLeafVectors / float64(count)
+		avgAll := sumVectors / float64(count)
+		avgFull := sumFullVectors / float64(count)
+		avgPartitions := sumPartitions / float64(count)
+
 		fmt.Printf("%d\t%0.2f%%\t%0.0f\t%0.0f\t%0.2f\t%0.2f\t%0.2f\t%0.2f\t%0.2f\t%0.2f\n",
-			beamSize, sumRecall/float64(count)*100,
-			sumLeafVectors/float64(count), sumVectors/float64(count),
-			sumFullVectors/float64(count), sumPartitions/float64(count),
+			beamSize, recall, avgLeaf, avgAll, avgFull, avgPartitions,
 			qps, p50Latency, p95Latency, p99Latency)
+
+		if *flagExportCSV {
+			header := []string{
+				"dataset", "backend", "beam", "recall_pct",
+				"leaf_vectors", "all_vectors", "full_vectors", "partitions",
+				"qps", "p50_ms", "p95_ms", "p99_ms",
+			}
+			row := []string{
+				vb.datasetName, backendName(),
+				fmt.Sprintf("%d", beamSize),
+				fmt.Sprintf("%.2f", recall),
+				fmt.Sprintf("%.0f", avgLeaf),
+				fmt.Sprintf("%.0f", avgAll),
+				fmt.Sprintf("%.2f", avgFull),
+				fmt.Sprintf("%.2f", avgPartitions),
+				fmt.Sprintf("%.2f", qps),
+				fmt.Sprintf("%.2f", p50Latency),
+				fmt.Sprintf("%.2f", p95Latency),
+				fmt.Sprintf("%.2f", p99Latency),
+			}
+			if err := appendCSVRow("results_search.csv", header, row); err != nil {
+				fmt.Printf(Red+"Error writing search CSV: %v\n"+Reset, err)
+			}
+		}
 	}
 
 	fmt.Println()
@@ -501,6 +535,10 @@ func (vb *vectorBench) BuildIndex() {
 				progress, err := vb.provider.CheckIndexCreationStatus(vb.ctx)
 				if err != nil {
 					fmt.Printf(Red+"Error checking index status: %v\n"+Reset, err)
+				} else if progress < 0 {
+					// Progress tracking not available (e.g. pgvector).
+					fmt.Printf(ClearLine+White+"\rCreating index... %v"+Reset,
+						timeutil.Since(startIndexTime).Truncate(time.Second))
 				} else {
 					fmt.Printf(ClearLine+White+"\rIndex creation progress: %.1f%% in %v"+Reset,
 						progress*100, timeutil.Since(startIndexTime).Truncate(time.Second))
@@ -510,7 +548,23 @@ func (vb *vectorBench) BuildIndex() {
 	indexCreated:
 	}
 
-	fmt.Printf(White+"\nBuilt index in %v\n"+Reset, roundDuration(startAt.Elapsed()))
+	buildDuration := startAt.Elapsed()
+	fmt.Printf(White+"\nBuilt index in %v\n"+Reset, roundDuration(buildDuration))
+
+	if *flagExportCSV {
+		header := []string{
+			"dataset", "backend", "total_vectors", "dims", "duration_sec",
+		}
+		row := []string{
+			vb.datasetName, backendName(),
+			fmt.Sprintf("%d", vb.data.TrainCount),
+			fmt.Sprintf("%d", vb.data.Dims),
+			fmt.Sprintf("%.2f", buildDuration.Seconds()),
+		}
+		if err := appendCSVRow("results_build.csv", header, row); err != nil {
+			fmt.Printf(Red+"Error writing build CSV: %v\n"+Reset, err)
+		}
+	}
 
 	// Ensure that index is persisted so it can be reused.
 	if err = vb.provider.Save(vb.ctx); err != nil {
@@ -552,6 +606,15 @@ func newVectorProvider(
 	if *flagCreateIndexAfterImport && *flagMemStore {
 		return nil, errors.New("--create-index-after-import flag cannot be used with --memstore")
 	}
+	if *flagPgvector && *flagMemStore {
+		return nil, errors.New("--pgvector and --memstore cannot be used together")
+	}
+	if *flagFollowerRead && *flagMemStore {
+		return nil, errors.New("--follower-read cannot be used with --memstore")
+	}
+	if *flagFollowerRead && *flagPgvector {
+		return nil, errors.New("--follower-read cannot be used with --pgvector")
+	}
 
 	options := cspann.IndexOptions{
 		MinPartitionSize:      minPartitionSize,
@@ -566,7 +629,7 @@ func newVectorProvider(
 	}
 
 	// Use SQL-based provider with connection string from flags.
-	provider, err := NewSQLProvider(context.Background(), datasetName, dims, distanceMetric, options)
+	provider, err := NewSQLProvider(context.Background(), datasetName, dims, distanceMetric, options, *flagFollowerRead)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating SQL provider")
 	}
@@ -576,4 +639,19 @@ func newVectorProvider(
 
 func roundDuration(duration time.Duration) time.Duration {
 	return duration.Truncate(time.Millisecond)
+}
+
+// backendName returns a short identifier for the active backend, used in CSV
+// output to distinguish runs.
+func backendName() string {
+	if *flagMemStore {
+		return "memstore"
+	}
+	if *flagPgvector {
+		return "pgvector"
+	}
+	if *flagFollowerRead {
+		return "crdb-follower"
+	}
+	return "crdb"
 }

--- a/pkg/cmd/vecbench/sql_dialect.go
+++ b/pkg/cmd/vecbench/sql_dialect.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// sqlDialect encapsulates database-specific behavior so that SQLProvider can
+// work with different SQL backends (CockroachDB, PostgreSQL+pgvector, etc.)
+// without conditional branching. Adding a new database backend requires only
+// implementing this interface.
+type sqlDialect interface {
+	// setup runs one-time database initialization such as enabling extensions
+	// or cluster settings.
+	setup(ctx context.Context, pool *pgxpool.Pool) error
+
+	// createIndexQuery returns the SQL statement to create a vector index.
+	createIndexQuery(
+		indexName, tableName string, distMetric vecpb.DistanceMetric,
+	) string
+
+	// checkIndexCreationStatus returns the progress (0.0–1.0) of an
+	// asynchronous index creation job. Returns -1 if the database does not
+	// support progress tracking (e.g. synchronous index creation).
+	checkIndexCreationStatus(ctx context.Context, pool *pgxpool.Pool) (float64, error)
+
+	// formatVectorParam converts a vector into the query parameter format
+	// expected by the database driver.
+	formatVectorParam(vec vector.T) any
+
+	// setSearchEffort configures the per-session search effort on the given
+	// connection.
+	setSearchEffort(ctx context.Context, conn *pgxpool.Conn, beamSize int) error
+
+	// additionalMetrics returns database-specific metrics beyond the common
+	// ones tracked by SQLProvider (e.g. retry count).
+	additionalMetrics() ([]IndexMetric, error)
+}
+
+// crdbDialect implements sqlDialect for CockroachDB.
+type crdbDialect struct{}
+
+func (d *crdbDialect) setup(ctx context.Context, pool *pgxpool.Pool) error {
+	_, err := pool.Exec(ctx, "SET CLUSTER SETTING feature.vector_index.enabled = true")
+	return errors.Wrap(err, "enabling vector indexes")
+}
+
+func (d *crdbDialect) createIndexQuery(
+	indexName, tableName string, distMetric vecpb.DistanceMetric,
+) string {
+	var opClass string
+	switch distMetric {
+	case vecpb.CosineDistance:
+		opClass = " vector_cosine_ops"
+	case vecpb.InnerProductDistance:
+		opClass = " vector_ip_ops"
+	case vecpb.L2SquaredDistance:
+		// L2 is the default operator class in CockroachDB, no suffix needed.
+	default:
+		panic(fmt.Sprintf("unsupported distance metric: %v", distMetric))
+	}
+	return fmt.Sprintf(
+		"CREATE VECTOR INDEX %s ON %s (embedding%s)",
+		indexName, tableName, opClass,
+	)
+}
+
+func (d *crdbDialect) checkIndexCreationStatus(
+	ctx context.Context, pool *pgxpool.Pool,
+) (float64, error) {
+	var status string
+	var fractionCompleted float64
+
+	rows, err := pool.Query(ctx, `
+		SELECT status, fraction_completed
+		FROM [SHOW JOBS]
+		WHERE description LIKE '%%vecbench%%'
+		AND job_type = 'NEW SCHEMA CHANGE'
+		ORDER BY created DESC
+		LIMIT 1`)
+	if err != nil {
+		return 0, errors.Wrap(err, "querying job progress")
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return 0, errors.Wrap(err, "querying job progress")
+		}
+		return 0.0, nil
+	}
+
+	if err := rows.Scan(&status, &fractionCompleted); err != nil {
+		return 0, errors.Wrap(err, "scanning job progress")
+	}
+
+	if status == "succeeded" {
+		return 1.0, nil
+	}
+	if status == "failed" || status == "canceled" {
+		return fractionCompleted, errors.Newf(
+			"index creation job failed with status: %s", status)
+	}
+
+	return fractionCompleted, nil
+}
+
+func (d *crdbDialect) formatVectorParam(vec vector.T) any {
+	return vec
+}
+
+func (d *crdbDialect) setSearchEffort(ctx context.Context, conn *pgxpool.Conn, beamSize int) error {
+	_, err := conn.Exec(ctx, fmt.Sprintf("SET vector_search_beam_size = %d", beamSize))
+	return errors.Wrap(err, "setting vector_search_beam_size")
+}
+
+// additionalMetrics fetches vector index metrics from the CockroachDB
+// Prometheus endpoint.
+func (d *crdbDialect) additionalMetrics() ([]IndexMetric, error) {
+	var metricsToTrack = map[string]float64{
+		"sql_vecindex_successful_splits":     -1,
+		"sql_vecindex_pending_splits_merges": -1,
+	}
+
+	// Parse connection string to extract host.
+	config, err := pgxpool.ParseConfig(*flagDBConnStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing connection string")
+	}
+
+	// Extract host and convert SQL port to CockroachDB HTTP port.
+	host := config.ConnConfig.Host
+	port := "8080"
+
+	url := fmt.Sprintf("http://%s:%s/_status/vars", host, port)
+
+	resp, err := httputil.Get(context.Background(), url)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching metrics")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Newf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		metricName := parts[0]
+
+		// Trim any labels.
+		labelOffset := strings.Index(metricName, "{")
+		if labelOffset > 0 {
+			metricName = line[:labelOffset]
+		}
+
+		if _, ok := metricsToTrack[metricName]; ok {
+			var value float64
+			if _, err := fmt.Sscanf(parts[1], "%f", &value); err == nil {
+				metricsToTrack[metricName] = value
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrap(err, "scanning metrics")
+	}
+
+	metrics := []IndexMetric{
+		{Name: "successful splits", Value: metricsToTrack["sql_vecindex_successful_splits"]},
+		{Name: "pending splits/merges", Value: metricsToTrack["sql_vecindex_pending_splits_merges"]},
+	}
+
+	return metrics, nil
+}
+
+// pgvectorDialect implements sqlDialect for PostgreSQL with the pgvector
+// extension.
+type pgvectorDialect struct{}
+
+func (d *pgvectorDialect) setup(ctx context.Context, pool *pgxpool.Pool) error {
+	_, err := pool.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS vector")
+	return errors.Wrap(err, "creating pgvector extension")
+}
+
+func (d *pgvectorDialect) createIndexQuery(
+	indexName, tableName string, distMetric vecpb.DistanceMetric,
+) string {
+	var opClass string
+	switch distMetric {
+	case vecpb.L2SquaredDistance:
+		opClass = "vector_l2_ops"
+	case vecpb.CosineDistance:
+		opClass = "vector_cosine_ops"
+	case vecpb.InnerProductDistance:
+		opClass = "vector_ip_ops"
+	default:
+		panic(fmt.Sprintf("unsupported distance metric: %v", distMetric))
+	}
+	return fmt.Sprintf(
+		"CREATE INDEX %s ON %s USING hnsw (embedding %s)",
+		indexName, tableName, opClass,
+	)
+}
+
+func (d *pgvectorDialect) checkIndexCreationStatus(
+	ctx context.Context, pool *pgxpool.Pool,
+) (float64, error) {
+	// pgvector index creation is synchronous — CREATE INDEX blocks until
+	// complete. Return -1 to indicate progress tracking is not available.
+	return -1, nil
+}
+
+func (d *pgvectorDialect) formatVectorParam(vec vector.T) any {
+	// pgvector needs the vector as a text string (e.g. "[1,2,3]") since pgx
+	// would otherwise send []float32 as a float4[] array, which PostgreSQL
+	// won't auto-cast to the vector type.
+	return vec.String()
+}
+
+func (d *pgvectorDialect) setSearchEffort(
+	ctx context.Context, conn *pgxpool.Conn, beamSize int,
+) error {
+	_, err := conn.Exec(ctx, fmt.Sprintf("SET hnsw.ef_search = %d", beamSize))
+	return errors.Wrap(err, "setting hnsw.ef_search")
+}
+
+func (d *pgvectorDialect) additionalMetrics() ([]IndexMetric, error) {
+	// PostgreSQL doesn't expose CRDB-specific Prometheus metrics.
+	return nil, nil
+}

--- a/pkg/cmd/vecbench/sql_provider.go
+++ b/pkg/cmd/vecbench/sql_provider.go
@@ -6,10 +6,8 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"net/http"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -17,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -40,26 +37,30 @@ func (s *SQLSearchState) Close() {
 }
 
 // SQLProvider implements VectorProvider using a SQL database connection to a
-// CockroachDB instance.
+// CockroachDB or PostgreSQL+pgvector instance. Database-specific behavior is
+// delegated to the sqlDialect interface.
 type SQLProvider struct {
-	datasetName string
-	dims        int
-	distMetric  vecpb.DistanceMetric
-	options     cspann.IndexOptions
-	pool        *pgxpool.Pool
-	tableName   string
-	indexName   string
-	retryCount  atomic.Uint64
+	datasetName  string
+	dims         int
+	distMetric   vecpb.DistanceMetric
+	options      cspann.IndexOptions
+	pool         *pgxpool.Pool
+	tableName    string
+	indexName    string
+	retryCount   atomic.Uint64
+	dialect      sqlDialect
+	followerRead bool
 }
 
-// NewSQLProvider creates a new SQLProvider that connects to a CockroachDB
-// instance.
+// NewSQLProvider creates a new SQLProvider that connects to a CockroachDB or
+// PostgreSQL instance.
 func NewSQLProvider(
 	ctx context.Context,
 	datasetName string,
 	dims int,
 	distMetric vecpb.DistanceMetric,
 	options cspann.IndexOptions,
+	followerRead bool,
 ) (*SQLProvider, error) {
 	// Create connection pool.
 	config, err := pgxpool.ParseConfig(*flagDBConnStr)
@@ -88,14 +89,24 @@ func NewSQLProvider(
 	tableName := fmt.Sprintf("vecbench_%s", sanitizeIdentifier(datasetName))
 	indexName := fmt.Sprintf("vecbench_%s_embedding_idx", sanitizeIdentifier(datasetName))
 
+	// Select the dialect based on the --pgvector flag.
+	var dialect sqlDialect
+	if *flagPgvector {
+		dialect = &pgvectorDialect{}
+	} else {
+		dialect = &crdbDialect{}
+	}
+
 	return &SQLProvider{
-		datasetName: datasetName,
-		distMetric:  distMetric,
-		dims:        dims,
-		options:     options,
-		pool:        pool,
-		tableName:   tableName,
-		indexName:   indexName,
+		datasetName:  datasetName,
+		distMetric:   distMetric,
+		dims:         dims,
+		options:      options,
+		pool:         pool,
+		tableName:    tableName,
+		indexName:    indexName,
+		dialect:      dialect,
+		followerRead: followerRead,
 	}, nil
 }
 
@@ -139,74 +150,29 @@ func (s *SQLProvider) New(ctx context.Context) error {
 		return errors.Wrap(err, "dropping table")
 	}
 
-	// Enable vector indexes if not already enabled.
-	_, err = s.pool.Exec(ctx, "SET CLUSTER SETTING feature.vector_index.enabled = true")
-	if err != nil {
-		return errors.Wrap(err, "enabling vector indexes")
+	if err := s.dialect.setup(ctx, s.pool); err != nil {
+		return errors.Wrap(err, "database setup")
 	}
 
 	// Create table without vector index. Index creation is handled separately.
+	// Use BYTEA for the id column, which is compatible with both CockroachDB
+	// (where it is an alias for BYTES) and PostgreSQL.
 	_, err = s.pool.Exec(ctx, fmt.Sprintf(`CREATE TABLE %s (
-		id BYTES PRIMARY KEY,
+		id BYTEA PRIMARY KEY,
 		embedding VECTOR(%d))`, s.tableName, s.dims))
 	return errors.Wrap(err, "creating table")
 }
 
+// CreateIndex implements the VectorProvider interface.
 func (s *SQLProvider) CreateIndex(ctx context.Context) error {
-	var opClass string
-	switch s.distMetric {
-	case vecpb.CosineDistance:
-		opClass = " vector_cosine_ops"
-	case vecpb.InnerProductDistance:
-		opClass = " vector_ip_ops"
-	}
-
-	_, err := s.pool.Exec(ctx, fmt.Sprintf(
-		"CREATE VECTOR INDEX %s ON %s (embedding%s)",
-		s.indexName,
-		s.tableName,
-		opClass,
-	))
+	query := s.dialect.createIndexQuery(s.indexName, s.tableName, s.distMetric)
+	_, err := s.pool.Exec(ctx, query)
 	return errors.Wrap(err, "creating index")
 }
 
 // CheckIndexCreationStatus implements the VectorProvider interface.
 func (s *SQLProvider) CheckIndexCreationStatus(ctx context.Context) (float64, error) {
-	var status string
-	var fractionCompleted float64
-
-	// Query for jobs related to our index creation.
-	rows, err := s.pool.Query(ctx, `
-		SELECT status, fraction_completed
-		FROM [SHOW JOBS]
-		WHERE description LIKE '%%vecbench%%'
-		AND job_type = 'NEW SCHEMA CHANGE'
-		ORDER BY created DESC
-		LIMIT 1`)
-	if err != nil {
-		return 0, errors.Wrap(err, "querying job progress")
-	}
-	defer rows.Close()
-
-	if !rows.Next() {
-		if err := rows.Err(); err != nil {
-			return 0, errors.Wrap(err, "querying job progress")
-		}
-		return 0.0, nil
-	}
-
-	if err := rows.Scan(&status, &fractionCompleted); err != nil {
-		return 0, errors.Wrap(err, "scanning job progress")
-	}
-
-	if status == "succeeded" {
-		return 1.0, nil
-	} else if status == "failed" || status == "canceled" {
-		return fractionCompleted, errors.Newf("index creation job failed with status: %s", status)
-	}
-
-	// Job is still running.
-	return fractionCompleted, nil
+	return s.dialect.checkIndexCreationStatus(ctx, s.pool)
 }
 
 // InsertVectors implements the VectorProvider interface.
@@ -227,7 +193,7 @@ func (s *SQLProvider) InsertVectors(
 		j := i * 2
 		fmt.Fprintf(&queryBuilder, " ($%d, $%d)", j+1, j+2)
 		args[j] = keys[i]
-		args[j+1] = vectors.At(i)
+		args[j+1] = s.dialect.formatVectorParam(vectors.At(i))
 	}
 	query := queryBuilder.String()
 
@@ -264,10 +230,8 @@ func (s *SQLProvider) SetupSearch(
 		}
 	}()
 
-	// Set the vector_search_beam_size session variable.
-	_, err = conn.Exec(ctx, fmt.Sprintf("SET vector_search_beam_size = %d", beamSize))
-	if err != nil {
-		return nil, errors.Wrap(err, "setting vector_search_beam_size")
+	if err := s.dialect.setSearchEffort(ctx, conn, beamSize); err != nil {
+		return nil, errors.Wrap(err, "configuring search effort")
 	}
 
 	var op string
@@ -281,12 +245,16 @@ func (s *SQLProvider) SetupSearch(
 	}
 
 	// Construct the query for vector search.
+	var aost string
+	if s.followerRead {
+		aost = " AS OF SYSTEM TIME follower_read_timestamp()"
+	}
 	query := fmt.Sprintf(`
 		SELECT id
-		FROM %s
+		FROM %s%s
 		ORDER BY embedding %s $1
 		LIMIT %d
-	`, s.tableName, op, maxResults)
+	`, s.tableName, aost, op, maxResults)
 
 	state := &SQLSearchState{
 		conn:  conn,
@@ -305,8 +273,8 @@ func (s *SQLProvider) Search(
 		return nil, errors.New("invalid search state type")
 	}
 
-	// Execute the prepared statement.
-	rows, err := sqlState.conn.Query(ctx, sqlState.query, vec)
+	rows, err := sqlState.conn.Query(
+		ctx, sqlState.query, s.dialect.formatVectorParam(vec))
 	if err != nil {
 		return nil, errors.Wrap(err, "executing search query")
 	}
@@ -331,20 +299,19 @@ func (s *SQLProvider) Search(
 
 // GetMetrics implements the VectorProvider interface.
 func (s *SQLProvider) GetMetrics() ([]IndexMetric, error) {
-	// Start with our existing metrics
+	// Start with the provider's own metrics.
 	metrics := []IndexMetric{
 		// retryCount is the number of times that InsertVectors encounters
 		// conflicts and needs to retry.
 		{Name: "insert retries", Value: float64(s.retryCount.Load())},
 	}
 
-	// Fetch Prometheus metrics.
-	promMetrics, err := s.fetchPrometheusMetrics()
+	additionalMetrics, err := s.dialect.additionalMetrics()
 	if err != nil {
 		return nil, err
 	}
 
-	return append(promMetrics, metrics...), nil
+	return append(additionalMetrics, metrics...), nil
 }
 
 // FormatStats implements the VectorProvider interface.
@@ -361,83 +328,4 @@ func sanitizeIdentifier(s string) string {
 		}
 		return '_'
 	}, s)
-}
-
-// Fetch metrics from the Prometheus endpoint.
-func (s *SQLProvider) fetchPrometheusMetrics() ([]IndexMetric, error) {
-	var metricsToTrack = map[string]float64{
-		"sql_vecindex_successful_splits":     -1,
-		"sql_vecindex_pending_splits_merges": -1,
-	}
-
-	// Parse connection string to extract host.
-	config, err := pgxpool.ParseConfig(*flagDBConnStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing connection string")
-	}
-
-	// Extract host and convert SQL port to CockroachDB HTTP port.
-	host := config.ConnConfig.Host
-	port := "8080"
-
-	url := fmt.Sprintf("http://%s:%s/_status/vars", host, port)
-
-	// Fetch metrics
-	resp, err := httputil.Get(context.Background(), url)
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching metrics")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Newf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	// Parse metrics.
-	scanner := bufio.NewScanner(resp.Body)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Skip comments and empty lines.
-		if strings.HasPrefix(line, "#") || line == "" {
-			continue
-		}
-
-		// Parse metric line (format: metric_name value).
-		parts := strings.Fields(line)
-		if len(parts) < 2 {
-			continue
-		}
-		metricName := parts[0]
-
-		// Trim any labels.
-		labelOffset := strings.Index(metricName, "{")
-		if labelOffset > 0 {
-			metricName = line[:labelOffset]
-		}
-
-		// Check if this is a metric we want to track and parse its value.
-		if _, ok := metricsToTrack[metricName]; ok {
-			var value float64
-			if _, err := fmt.Sscanf(parts[1], "%f", &value); err == nil {
-				metricsToTrack[metricName] = value
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, errors.Wrap(err, "scanning metrics")
-	}
-
-	// Construct vecbench metrics from the raw CRDB metrics.
-	var metrics []IndexMetric
-	if splits, ok := metricsToTrack["sql_vecindex_successful_splits"]; ok {
-		metrics = append(metrics, IndexMetric{Name: "successful splits", Value: splits})
-	}
-	if pending, ok := metricsToTrack["sql_vecindex_pending_splits_merges"]; ok {
-		metrics = append(metrics, IndexMetric{Name: "pending splits/merges", Value: pending})
-	}
-
-	return metrics, nil
 }

--- a/pkg/cmd/vecbench/vector_provider.go
+++ b/pkg/cmd/vecbench/vector_provider.go
@@ -58,9 +58,9 @@ type VectorProvider interface {
 	// table/store creation when the index should be created before data import.
 	CreateIndex(ctx context.Context) error
 
-	// CheckIndexCreationStatus returns the percentage complete (0.0-1.0) of index
-	// creation and any error. For providers that don't support async index creation,
-	// this should return 1.0, nil.
+	// CheckIndexCreationStatus returns the progress of index creation. A value
+	// in [0.0, 1.0] indicates the fraction complete. A negative value indicates
+	// that progress tracking is not available (e.g. synchronous index creation).
 	CheckIndexCreationStatus(ctx context.Context) (float64, error)
 
 	// SetupSearch allows the provider to perform expensive up-front steps in


### PR DESCRIPTION
Introduce a sqlDialect interface that abstracts database-specific behavior, letting vecbench benchmark both CockroachDB and PostgreSQL+pgvector. The --pgvector flag selects the PostgreSQL backend (CREATE EXTENSION, HNSW indexes, hnsw.ef_search tuning), while crdbDialect retains CRDB-specific behavior (cluster settings, SHOW JOBS progress, Prometheus metrics).

Add --export-csv to write build and search results to CSV files for comparison across runs.

Add --follower-read to append AS OF SYSTEM TIME follower_read_timestamp() to search queries, enabling follower-read benchmarking in geo-distributed clusters. Rejected with --memstore or --pgvector.

Epic: none
Release note: None