### PR TITLE
release-26.2.1-rc: spanconfig: skip test under race detector

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
@@ -49,6 +49,7 @@ import (
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "too slow under race")
 
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {


### PR DESCRIPTION
Backport 1/1 commits from #169977 on behalf of @bghal.

----

This test is flaking repeatedly under race due to timeouts.

Fixes: #169124

Release note: None


----

Release justification: Test-only change for flaky roachteset.