### PR TITLE
txnfeed: add leaktest and log scope to unit tests

### DIFF
--- a/pkg/crosscluster/logical/txnfeed/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnfeed/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
 go_test(
     name = "txnfeed_test",
     srcs = [
+        "main_test.go",
         "merge_feed_bench_test.go",
         "merge_feed_test.go",
         "test_helpers_test.go",
@@ -40,6 +41,8 @@ go_test(
         "//pkg/testutils",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/crosscluster/logical/txnfeed/main_test.go
+++ b/pkg/crosscluster/logical/txnfeed/main_test.go
@@ -1,0 +1,10 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package txnfeed
+
+import _ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/crosscluster/logical/txnfeed/merge_feed_test.go
+++ b/pkg/crosscluster/logical/txnfeed/merge_feed_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
@@ -185,6 +187,9 @@ func generateMergeFeedInputs(
 }
 
 func TestMergeFeedRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	seed := time.Now().UnixNano()
 	t.Logf("seed: %d", seed)
 	rng := rand.New(rand.NewSource(seed))
@@ -270,6 +275,9 @@ func TestMergeFeedRandomized(t *testing.T) {
 }
 
 func TestMergeFeedEndTime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	coveringSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}
 
 	makeSubs := func() []streamclient.Subscription {

--- a/pkg/crosscluster/logical/txnfeed/transactions_test.go
+++ b/pkg/crosscluster/logical/txnfeed/transactions_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,6 +28,9 @@ func makeKV(key string, wallTime int64) streampb.StreamEvent_KV {
 }
 
 func TestTransactions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	// Build a batch with three transactions of different sizes: 1 KV at
 	// ts=10, 3 KVs at ts=20, and 5 KVs at ts=30.
 	batch := []streampb.StreamEvent_KV{


### PR DESCRIPTION
txnfeed: add leaktest and log scope to unit tests

Epic: none

Release note: none