### PR TITLE
loqrecovery: support separate engines

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -812,7 +812,7 @@ func applyRecoveryToLocalStore(
 	defer stopper.Stop(ctx)
 
 	var localNodeID roachpb.NodeID
-	batches := make(map[roachpb.StoreID]storage.Batch)
+	batches := make(map[roachpb.StoreID]loqrecovery.StoreBatches)
 	stores := make([]kvstorage.Engines, len(debugRecoverExecuteOpts.Stores.Specs))
 	for i, storeSpec := range debugRecoverExecuteOpts.Stores.Specs {
 		eng, err := OpenEngine(storeSpec.Path, stopper, fs.ReadWrite, storage.MustExist)
@@ -823,7 +823,7 @@ func applyRecoveryToLocalStore(
 		store := kvstorage.MakeEngines(eng)
 		stores[i] = store
 
-		batch := store.TODOBothEngines().NewBatch()
+		batch := loqrecovery.NewStoreBatches(store)
 		defer store.Close() //nolint:deferloop
 		defer batch.Close() //nolint:deferloop
 
@@ -846,7 +846,6 @@ func applyRecoveryToLocalStore(
 	}
 
 	updateTime := timeutil.Now()
-	// TODO(sep-raft-log): batches need to work with the split log/state engines.
 	prepReport, err := loqrecovery.PrepareUpdateReplicas(
 		ctx, nodeUpdates, uuid.DefaultGenerator, updateTime, localNodeID, batches)
 	if err != nil {

--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -324,6 +324,10 @@ func runDebugDeadReplicaCollect(cmd *cobra.Command, args []string) error {
 	} else {
 		var stores []kvstorage.Engines
 		for _, storeSpec := range debugRecoverCollectInfoOpts.Stores.Specs {
+			// TODO(sep-raft-log): handle stores bootstrapped with separated
+			// engines. Today we open a single engine at storeSpec.Path and wrap
+			// it via kvstorage.MakeEngines, which works only for the legacy
+			// single-engine layout. We probably need a function like OpenEngines().
 			eng, err := OpenEngine(storeSpec.Path, stopper, fs.ReadOnly, storage.MustExist)
 			if err != nil {
 				return errors.WithHint(errors.Wrapf(err,
@@ -815,6 +819,9 @@ func applyRecoveryToLocalStore(
 	batches := make(map[roachpb.StoreID]loqrecovery.StoreBatches)
 	stores := make([]kvstorage.Engines, len(debugRecoverExecuteOpts.Stores.Specs))
 	for i, storeSpec := range debugRecoverExecuteOpts.Stores.Specs {
+		// TODO(sep-raft-log): handle stores bootstrapped with separated
+		// engines. See the matching TODO in runDebugDeadReplicaCollect for
+		// details.
 		eng, err := OpenEngine(storeSpec.Path, stopper, fs.ReadWrite, storage.MustExist)
 		if err != nil {
 			return errors.Wrapf(err, "failed to open store at path %q. ensure that store path is "+

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
         "//pkg/kv/kvserver/raftlog",
+        "//pkg/kv/kvserver/spanset",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -370,6 +370,22 @@ func CommitReplicaChanges(batches map[roachpb.StoreID]storage.Batch) (ApplyUpdat
 func MaybeApplyPendingRecoveryPlan(
 	ctx context.Context, planStore PlanStore, engines []kvstorage.Engines, clock timeutil.TimeSource,
 ) (PrepareStoreReport, error) {
+	return maybeApplyPendingRecoveryPlan(ctx, planStore, engines, clock,
+		func(_ roachpb.StoreID, e kvstorage.Engines) storage.Batch {
+			return e.TODOBothEngines().NewBatch()
+		})
+}
+
+// maybeApplyPendingRecoveryPlan is the testable form of
+// MaybeApplyPendingRecoveryPlan. It accepts a per-store batch builder so tests
+// can inject Commit failures into the auto-apply path.
+func maybeApplyPendingRecoveryPlan(
+	ctx context.Context,
+	planStore PlanStore,
+	engines []kvstorage.Engines,
+	clock timeutil.TimeSource,
+	makeBatch func(roachpb.StoreID, kvstorage.Engines) storage.Batch,
+) (PrepareStoreReport, error) {
 	if len(engines) < 1 {
 		return PrepareStoreReport{}, nil
 	}
@@ -387,7 +403,7 @@ func MaybeApplyPendingRecoveryPlan(
 			if err != nil {
 				return errors.Wrap(err, "failed to read store ident when trying to apply loss of quorum recovery plan")
 			}
-			b := e.TODOBothEngines().NewBatch()
+			b := makeBatch(ident.StoreID, e)
 			defer b.Close() //nolint:deferloop
 			batches[ident.StoreID] = b
 		}

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -369,11 +369,12 @@ func CommitReplicaChanges(batches map[roachpb.StoreID]storage.Batch) (ApplyUpdat
 // Regardless of application success or failure, staged plan would be removed.
 func MaybeApplyPendingRecoveryPlan(
 	ctx context.Context, planStore PlanStore, engines []kvstorage.Engines, clock timeutil.TimeSource,
-) error {
+) (PrepareStoreReport, error) {
 	if len(engines) < 1 {
-		return nil
+		return PrepareStoreReport{}, nil
 	}
 
+	var report PrepareStoreReport
 	applyPlan := func(nodeID roachpb.NodeID, plan loqrecoverypb.ReplicaUpdatePlan) error {
 		if err := CheckEnginesVersion(ctx, engines, plan, false); err != nil {
 			return errors.Wrap(err, "failed to check cluster version against storage")
@@ -394,6 +395,7 @@ func MaybeApplyPendingRecoveryPlan(
 		if err != nil {
 			return err
 		}
+		report = prepRep
 		if len(prepRep.MissingStores) > 0 {
 			log.KvExec.Warningf(ctx, "loss of quorum recovery plan application expected stores on the node %s",
 				strutil.JoinIDs("s", prepRep.MissingStores))
@@ -412,10 +414,10 @@ func MaybeApplyPendingRecoveryPlan(
 	if err != nil {
 		// This is fatal error, we don't write application report since we didn't
 		// check the store yet.
-		return errors.Wrap(err, "failed to check if loss of quorum recovery plan is staged")
+		return PrepareStoreReport{}, errors.Wrap(err, "failed to check if loss of quorum recovery plan is staged")
 	}
 	if !exists {
-		return nil
+		return PrepareStoreReport{}, nil
 	}
 
 	// First read node parameters from the first store.
@@ -426,9 +428,9 @@ func MaybeApplyPendingRecoveryPlan(
 			// node. But we can't write an error here as store init might refuse to
 			// work if there are already some keys in store.
 			log.KvExec.Errorf(ctx, "node is not bootstrapped but it already has a recovery plan staged: %s", err)
-			return nil
+			return PrepareStoreReport{}, nil
 		}
-		return err
+		return PrepareStoreReport{}, err
 	}
 
 	if err := planStore.RemovePlan(); err != nil {
@@ -448,7 +450,7 @@ func MaybeApplyPendingRecoveryPlan(
 		loqrecoverypb.DeferredRecoveryActions{DecommissionedNodeIDs: plan.DecommissionedNodeIDs}); err != nil {
 		log.KvExec.Errorf(ctx, "failed to write loss of quorum recovery results to store: %s", err)
 	}
-	return nil
+	return report, nil
 }
 
 func CheckEnginesVersion(

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -76,6 +77,76 @@ func (r PrepareReplicaReport) StartKey() roachpb.RKey {
 	return r.Descriptor.StartKey
 }
 
+// StoreBatches is the per-store pair of batches that LoQ apply uses:
+// State holds writes to the state machine engine batch, Raft holds writes to
+// the log engine batch. When using a single engine, both batches are the same.
+// TODO(ibrahim): Refactor StoreBatches to consolidate with kvstorage.Batch.
+type StoreBatches struct {
+	State     storage.Batch
+	Raft      storage.Batch
+	separated bool
+}
+
+// NewStoreBatches creates a paired batch for the given store engines, it keeps
+// spanset assertions if they exist. If using a single engines, both batches
+// are the same (just with different spanset assertions if enabled).
+func NewStoreBatches(e kvstorage.Engines) StoreBatches {
+	if e.Separated() {
+		return StoreBatches{
+			State:     e.StateEngine().NewBatch(),
+			Raft:      e.LogEngine().NewBatch(),
+			separated: true,
+		}
+	}
+	// With a single engine, create one batch, and reference it by both pointers.
+	b := e.Engine().NewBatch()
+	if !spanset.EnableAssertions {
+		return StoreBatches{State: b, Raft: b}
+	}
+	// Additionally, if assertions are enabled, enclose the batch into the
+	// corresponding per-engine wrappers. With EnableAssertions, State/LogEngine
+	// are always wrapped, so we don't use conditional type assertions.
+	type batchWrapper interface {
+		WrapBatch(storage.Batch) storage.Batch
+	}
+	return StoreBatches{
+		State: e.StateEngine().(batchWrapper).WrapBatch(b),
+		Raft:  e.LogEngine().(batchWrapper).WrapBatch(b),
+	}
+}
+
+// Close closes the underlying batches.
+func (b StoreBatches) Close() {
+	b.State.Close()
+	if b.separated {
+		b.Raft.Close()
+	}
+}
+
+// empty reports whether neither batch contains pending writes.
+func (b StoreBatches) empty() bool {
+	if !b.separated {
+		return b.State.Empty()
+	}
+	return b.State.Empty() && b.Raft.Empty()
+}
+
+// commit flushes the batches to storage. With separated engines the log engine
+// batch is committed first (sync=true) so that on a crash mid-commit, the
+// partial state on disk (audit record, HardState) is recognized on the next
+// apply and the range is refixed via the idempotent retry path. With a single
+// underlying engine the State and Raft fields share one batch and only State
+// is committed.
+func (b StoreBatches) commit() error {
+	if !b.separated {
+		return b.State.Commit(true /* sync */)
+	}
+	if err := b.Raft.Commit(true /* sync */); err != nil {
+		return err
+	}
+	return b.State.Commit(true /* sync */)
+}
+
 // PrepareUpdateReplicas prepares all changes to be committed to provided stores
 // as a first step of apply stage. This function would write changes to stores
 // using provided batches and return a summary of changes that were done together
@@ -90,7 +161,7 @@ func PrepareUpdateReplicas(
 	uuidGen uuid.Generator,
 	updateTime time.Time,
 	nodeID roachpb.NodeID,
-	batches map[roachpb.StoreID]storage.Batch,
+	batches map[roachpb.StoreID]StoreBatches,
 ) (PrepareStoreReport, error) {
 	var report PrepareStoreReport
 
@@ -101,11 +172,11 @@ func PrepareUpdateReplicas(
 		if nodeID != update.NodeID() {
 			continue
 		}
-		if readWriter, ok := batches[update.StoreID()]; !ok {
+		if b, ok := batches[update.StoreID()]; !ok {
 			missing[update.StoreID()] = struct{}{}
 			continue
 		} else {
-			replicaReport, err := applyReplicaUpdate(ctx, readWriter, update)
+			replicaReport, err := applyReplicaUpdate(ctx, b, update)
 			if err != nil {
 				return PrepareStoreReport{}, errors.Wrapf(
 					err,
@@ -120,7 +191,7 @@ func PrepareUpdateReplicas(
 						"failed to generate uuid to write replica recovery evidence record")
 				}
 				if err := writeReplicaRecoveryStoreRecord(
-					uuid, updateTime.UnixNano(), update, replicaReport, readWriter); err != nil {
+					uuid, updateTime.UnixNano(), update, replicaReport, b.Raft); err != nil {
 					return PrepareStoreReport{}, errors.Wrap(err,
 						"failed writing replica recovery evidence record")
 				}
@@ -137,7 +208,7 @@ func PrepareUpdateReplicas(
 }
 
 func applyReplicaUpdate(
-	ctx context.Context, readWriter storage.ReadWriter, update loqrecoverypb.ReplicaUpdate,
+	ctx context.Context, b StoreBatches, update loqrecoverypb.ReplicaUpdate,
 ) (PrepareReplicaReport, error) {
 	clock := hlc.NewClockForTesting(nil)
 	report := PrepareReplicaReport{
@@ -177,7 +248,7 @@ func applyReplicaUpdate(
 	// versa).
 	key := keys.RangeDescriptorKey(update.StartKey.AsRKey())
 	res, err := storage.MVCCGet(
-		ctx, readWriter, key, clock.Now(), storage.MVCCGetOptions{Inconsistent: true})
+		ctx, b.State, key, clock.Now(), storage.MVCCGetOptions{Inconsistent: true})
 	if !res.Value.Exists() {
 		return PrepareReplicaReport{}, errors.Errorf(
 			"failed to find a range descriptor for range %v", key)
@@ -208,7 +279,7 @@ func applyReplicaUpdate(
 	}
 
 	sl := kvstorage.MakeStateLoader(localDesc.RangeID)
-	ms, err := sl.LoadMVCCStats(ctx, readWriter)
+	ms, err := sl.LoadMVCCStats(ctx, b.State)
 	if err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "loading MVCCStats")
 	}
@@ -260,7 +331,7 @@ func applyReplicaUpdate(
 		// A crude form of the intent resolution process: abort the
 		// transaction by deleting its record.
 		txnKey := keys.TransactionKey(res.Intent.Txn.Key, res.Intent.Txn.ID)
-		if _, _, err := storage.MVCCDelete(ctx, readWriter, txnKey, hlc.Timestamp{}, storage.MVCCWriteOptions{Stats: &ms}); err != nil {
+		if _, _, err := storage.MVCCDelete(ctx, b.State, txnKey, hlc.Timestamp{}, storage.MVCCWriteOptions{Stats: &ms}); err != nil {
 			return PrepareReplicaReport{}, err
 		}
 		update := roachpb.LockUpdate{
@@ -268,7 +339,7 @@ func applyReplicaUpdate(
 			Txn:    res.Intent.Txn,
 			Status: roachpb.ABORTED,
 		}
-		if _, _, _, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, &ms, update, storage.MVCCResolveWriteIntentOptions{}); err != nil {
+		if _, _, _, _, err := storage.MVCCResolveWriteIntent(ctx, b.State, &ms, update, storage.MVCCResolveWriteIntentOptions{}); err != nil {
 			return PrepareReplicaReport{}, err
 		}
 		report.AbortedTransaction = true
@@ -287,7 +358,7 @@ func applyReplicaUpdate(
 	newDesc.NextReplicaID = update.NextReplicaID
 
 	if err := storage.MVCCPutProto(
-		ctx, readWriter, key, clock.Now(),
+		ctx, b.State, key, clock.Now(),
 		&newDesc, storage.MVCCWriteOptions{Stats: &ms},
 	); err != nil {
 		return PrepareReplicaReport{}, err
@@ -298,27 +369,25 @@ func applyReplicaUpdate(
 		update.NewReplica.NodeID, update.NewReplica.StoreID)
 
 	// Persist the new replica ID.
-	if err := sl.SetRaftReplicaID(ctx, readWriter, update.NewReplica.ReplicaID); err != nil {
+	if err := sl.SetRaftReplicaID(ctx, b.State, update.NewReplica.ReplicaID); err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "setting new replica ID")
 	}
 
 	// Refresh stats
-	if err := sl.SetMVCCStats(ctx, readWriter, &ms); err != nil {
+	if err := sl.SetMVCCStats(ctx, b.State, &ms); err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "updating MVCCStats")
 	}
 
 	// Update the HardState to clear the LeadEpoch, as otherwise we may risk
 	// seeing an epoch regression in raft. See #136908 for more details.
-	hs, err := sl.LoadHardState(ctx, readWriter)
+	hs, err := sl.LoadHardState(ctx, b.Raft)
 	if err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "loading HardState")
 	}
 
 	hs.LeadEpoch = 0
 
-	// TODO(sep-raft-log): when raft and state machine engines are separated, this
-	// update must be written to the raft engine.
-	if err := sl.SetHardState(ctx, readWriter, hs); err != nil {
+	if err := sl.SetHardState(ctx, b.Raft, hs); err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "setting HardState")
 	}
 
@@ -333,18 +402,18 @@ type ApplyUpdateReport struct {
 
 // CommitReplicaChanges saves content storage batches into stores. This is the
 // second step of applying recovery plan.
-func CommitReplicaChanges(batches map[roachpb.StoreID]storage.Batch) (ApplyUpdateReport, error) {
+func CommitReplicaChanges(batches map[roachpb.StoreID]StoreBatches) (ApplyUpdateReport, error) {
 	var report ApplyUpdateReport
 	var updateErrors []string
 	// Commit changes to all stores. Stores could have pending changes if plan
 	// contains replicas belonging to them, or have no changes if no replicas
 	// belong to it or if changes has been applied earlier, and we try to reapply
 	// the same plan twice.
-	for id, batch := range batches {
-		if batch.Empty() {
+	for id, b := range batches {
+		if b.empty() {
 			continue
 		}
-		if err := batch.Commit(true); err != nil {
+		if err := b.commit(); err != nil {
 			// If we fail here, we can only try to run the whole process from scratch
 			// as this store is somehow broken.
 			updateErrors = append(updateErrors, fmt.Sprintf("failed to update store s%d: %v", id, err))
@@ -371,9 +440,7 @@ func MaybeApplyPendingRecoveryPlan(
 	ctx context.Context, planStore PlanStore, engines []kvstorage.Engines, clock timeutil.TimeSource,
 ) (PrepareStoreReport, error) {
 	return maybeApplyPendingRecoveryPlan(ctx, planStore, engines, clock,
-		func(_ roachpb.StoreID, e kvstorage.Engines) storage.Batch {
-			return e.TODOBothEngines().NewBatch()
-		})
+		func(_ roachpb.StoreID, e kvstorage.Engines) StoreBatches { return NewStoreBatches(e) })
 }
 
 // maybeApplyPendingRecoveryPlan is the testable form of
@@ -384,7 +451,7 @@ func maybeApplyPendingRecoveryPlan(
 	planStore PlanStore,
 	engines []kvstorage.Engines,
 	clock timeutil.TimeSource,
-	makeBatch func(roachpb.StoreID, kvstorage.Engines) storage.Batch,
+	makeBatches func(roachpb.StoreID, kvstorage.Engines) StoreBatches,
 ) (PrepareStoreReport, error) {
 	if len(engines) < 1 {
 		return PrepareStoreReport{}, nil
@@ -397,13 +464,13 @@ func maybeApplyPendingRecoveryPlan(
 		}
 
 		log.KvExec.Infof(ctx, "applying staged loss of quorum recovery plan %s", plan.PlanID)
-		batches := make(map[roachpb.StoreID]storage.Batch)
+		batches := make(map[roachpb.StoreID]StoreBatches)
 		for _, e := range engines {
 			ident, err := kvstorage.ReadStoreIdent(ctx, e.LogEngine())
 			if err != nil {
 				return errors.Wrap(err, "failed to read store ident when trying to apply loss of quorum recovery plan")
 			}
-			b := makeBatch(ident.StoreID, e)
+			b := makeBatches(ident.StoreID, e)
 			defer b.Close() //nolint:deferloop
 			batches[ident.StoreID] = b
 		}

--- a/pkg/kv/kvserver/loqrecovery/apply_test.go
+++ b/pkg/kv/kvserver/loqrecovery/apply_test.go
@@ -42,7 +42,7 @@ func TestApplyVerifiesVersion(t *testing.T) {
 
 	assertPlanError := func(t *testing.T, plan loqrecoverypb.ReplicaUpdatePlan, errMsg string) {
 		require.NoError(t, ps.SavePlan(plan), "failed to stage plan")
-		err := MaybeApplyPendingRecoveryPlan(ctx, ps, engines, clock)
+		_, err := MaybeApplyPendingRecoveryPlan(ctx, ps, engines, clock)
 		require.NoError(t, err, "fatal error applying recovery plan")
 		report, ok, err := readNodeRecoveryStatusInfo(ctx, engines[0].LogEngine())
 		require.NoError(t, err, "failed to read application outcome")

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -203,10 +203,6 @@ func visitStoreReplicas(
 		// at potentially uncommitted entries as we have no way to determine their
 		// outcome, and they will become committed as soon as the replica is
 		// designated as a survivor.
-		// TODO(sep-raft-log): decide which LogID to read from. If the raft and
-		// state machine readers are slightly out of sync, the LogIDs may mismatch.
-		// For the heuristics here, it would probably make sense to read from all
-		// LogIDs with unapplied entries.
 		rangeUpdates, err := GetDescriptorChangesFromRaftLog(
 			ctx, desc.RangeID, rstate.RaftAppliedIndex+1, math.MaxInt64, raftRO)
 		if err != nil {

--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -33,7 +33,7 @@ func writeReplicaRecoveryStoreRecord(
 	timestamp int64,
 	update loqrecoverypb.ReplicaUpdate,
 	report PrepareReplicaReport,
-	readWriter storage.ReadWriter,
+	raftRW kvstorage.RaftRW,
 ) error {
 	record := loqrecoverypb.ReplicaRecoveryRecord{
 		Timestamp:       timestamp,
@@ -49,7 +49,7 @@ func writeReplicaRecoveryStoreRecord(
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal update record entry")
 	}
-	if err := readWriter.PutUnversioned(
+	if err := raftRW.PutUnversioned(
 		keys.StoreUnsafeReplicaRecoveryKey(uuid), data); err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func UpdateRangeLogWithRecovery(
 
 func writeNodeRecoveryResults(
 	ctx context.Context,
-	writer storage.ReadWriter,
+	writer kvstorage.RaftRW,
 	result loqrecoverypb.PlanApplicationResult,
 	actions loqrecoverypb.DeferredRecoveryActions,
 ) error {
@@ -190,7 +190,7 @@ func writeNodeRecoveryResults(
 }
 
 func readNodeRecoveryStatusInfo(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader kvstorage.RaftRO,
 ) (loqrecoverypb.PlanApplicationResult, bool, error) {
 	var result loqrecoverypb.PlanApplicationResult
 	ok, err := storage.MVCCGetProto(ctx, reader, keys.StoreLossOfQuorumRecoveryStatusKey(),
@@ -205,7 +205,7 @@ func readNodeRecoveryStatusInfo(
 // ReadCleanupActionsInfo reads cleanup actions info if it is present in the
 // reader.
 func ReadCleanupActionsInfo(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader kvstorage.RaftRO,
 ) (loqrecoverypb.DeferredRecoveryActions, bool, error) {
 	var result loqrecoverypb.DeferredRecoveryActions
 	exists, err := storage.MVCCGetProto(ctx, reader, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
@@ -219,7 +219,7 @@ func ReadCleanupActionsInfo(
 
 // RemoveCleanupActionsInfo removes cleanup actions info if it is present in the
 // reader.
-func RemoveCleanupActionsInfo(ctx context.Context, writer storage.ReadWriter) error {
+func RemoveCleanupActionsInfo(ctx context.Context, writer kvstorage.RaftRW) error {
 	_, _, err := storage.MVCCDelete(ctx, writer, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
 		hlc.Timestamp{}, storage.MVCCWriteOptions{})
 	return err

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -761,6 +761,7 @@ func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData)
 	stores := e.parseStoresArg(t, d, true /* defaultToAll */)
 	restart := dd.ScanArgOr(t, &d, "restart", false)
 
+	var updated, skipped, missing int
 	if !restart {
 		nodes := e.groupStoresByNodeStore(t, stores)
 		defer func() {
@@ -772,16 +773,19 @@ func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData)
 		}()
 		updateTime := timeutil.Now()
 		for nodeID, stores := range nodes {
-			_, err := PrepareUpdateReplicas(ctx, e.plan, e.uuidGen, updateTime, nodeID,
+			rep, err := PrepareUpdateReplicas(ctx, e.plan, e.uuidGen, updateTime, nodeID,
 				stores)
 			if err != nil {
 				return "", err
 			}
+			updated += len(rep.UpdatedReplicas)
+			skipped += len(rep.SkippedReplicas)
+			missing += len(rep.MissingStores)
 			if _, err = CommitReplicaChanges(stores); err != nil {
 				return "", err
 			}
 		}
-		return "ok", nil
+		return fmt.Sprintf("updated=%d skipped=%d missing=%d", updated, skipped, missing), nil
 	}
 
 	nodes := e.groupStoresByNode(t, stores)
@@ -794,13 +798,16 @@ func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData)
 			t.Fatal("failed to save plan to plan store", err)
 		}
 
-		err := MaybeApplyPendingRecoveryPlan(ctx, ps, stores, e.clock)
+		rep, err := MaybeApplyPendingRecoveryPlan(ctx, ps, stores, e.clock)
 		if err != nil {
 			return "", err
 		}
+		updated += len(rep.UpdatedReplicas)
+		skipped += len(rep.SkippedReplicas)
+		missing += len(rep.MissingStores)
 	}
 
-	return "ok", nil
+	return fmt.Sprintf("updated=%d skipped=%d missing=%d", updated, skipped, missing), nil
 }
 
 func (e *quorumRecoveryEnv) cleanupStores() {

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -81,13 +81,14 @@ dump-store [stores=(1,2,3)]
   Prints content of the replica states in the store. If no stores are provided,
   uses all populated stores.
 
-apply-plan [stores=(1,2,3)] [restart=<bool>]
+apply-plan [stores=(1,2,3)] [restart=<bool>] [fail_commit=(s1,..)]
 
   Applies recovery plan on specified stores. If no stores are provided, uses all
   populated stores. If restart = false, simulates cli version of command where
   application could fail and roll back with an error. If restart = true,
   simulates half online approach where unattended operation succeeds but writes
   potential error into store.
+  fail_commit injects a Commit failure on the listed stores.
 
 dump-events [remove=<bool>] [status=<bool>]
 
@@ -756,14 +757,47 @@ func (e *quorumRecoveryEnv) handleDumpStore(t *testing.T, d datadriven.TestData)
 	return string(out)
 }
 
+// failingBatch wraps a storage.Batch and forces Commit to return an injected
+// error if commitErr is not nil.
+type failingBatch struct {
+	storage.Batch
+	commitErr error
+}
+
+func (b *failingBatch) Commit(sync bool) error {
+	if b.commitErr != nil {
+		return b.commitErr
+	}
+	return b.Batch.Commit(sync)
+}
+
 func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData) (string, error) {
 	ctx := context.Background()
 	stores := e.parseStoresArg(t, d, true /* defaultToAll */)
 	restart := dd.ScanArgOr(t, &d, "restart", false)
+	failCommit, _ := dd.ScanArgOpt[[]roachpb.StoreID](t, &d, "fail_commit")
+	failSet := make(map[roachpb.StoreID]struct{}, len(failCommit))
+	for _, id := range failCommit {
+		failSet[id] = struct{}{}
+	}
+	wrapBatch := func(storeID roachpb.StoreID, b storage.Batch) storage.Batch {
+		if _, fail := failSet[storeID]; !fail {
+			return b
+		}
+		return &failingBatch{
+			Batch:     b,
+			commitErr: errors.Newf("injected commit failure on s%d", storeID),
+		}
+	}
 
 	var updated, skipped, missing int
 	if !restart {
 		nodes := e.groupStoresByNodeStore(t, stores)
+		for _, perNode := range nodes {
+			for storeID, b := range perNode {
+				perNode[storeID] = wrapBatch(storeID, b)
+			}
+		}
 		defer func() {
 			for _, storeBatches := range nodes {
 				for _, b := range storeBatches {
@@ -798,7 +832,10 @@ func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData)
 			t.Fatal("failed to save plan to plan store", err)
 		}
 
-		rep, err := MaybeApplyPendingRecoveryPlan(ctx, ps, stores, e.clock)
+		rep, err := maybeApplyPendingRecoveryPlan(ctx, ps, stores, e.clock,
+			func(storeID roachpb.StoreID, eng kvstorage.Engines) storage.Batch {
+				return wrapBatch(storeID, eng.TODOBothEngines().NewBatch())
+			})
 		if err != nil {
 			return "", err
 		}

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -81,14 +81,16 @@ dump-store [stores=(1,2,3)]
   Prints content of the replica states in the store. If no stores are provided,
   uses all populated stores.
 
-apply-plan [stores=(1,2,3)] [restart=<bool>] [fail_commit=(s1,..)]
+apply-plan [stores=(1,2,3)] [restart=<bool>]
+          [fail_commit_state=(s1,..)] [fail_commit_raft=(s1,..)]
 
   Applies recovery plan on specified stores. If no stores are provided, uses all
   populated stores. If restart = false, simulates cli version of command where
   application could fail and roll back with an error. If restart = true,
   simulates half online approach where unattended operation succeeds but writes
   potential error into store.
-  fail_commit injects a Commit failure on the listed stores.
+  fail_commit_state / fail_commit_raft inject a Commit failure on the
+  State / Raft engine, respectively.
 
 dump-events [remove=<bool>] [status=<bool>]
 
@@ -96,6 +98,11 @@ dump-events [remove=<bool>] [status=<bool>]
   If remove=true then corresponding method is told to remove events after
   dumping in a way range log population does when consuming those events.
   If status=true, half-online approach recovery report is dumped for each store.
+
+require-separated
+
+  Skips the rest of the testdata file unless the runner is in the sep-eng
+  pass.
 */
 
 // Range info used for test data to avoid providing unnecessary fields that are
@@ -255,6 +262,9 @@ type quorumRecoveryEnv struct {
 	// Helper resources to make time and identifiers predictable.
 	uuidGen uuid.Generator
 	clock   timeutil.TimeSource
+
+	// separated indicates if engines should be separated or not.
+	separated bool
 }
 
 func (e *quorumRecoveryEnv) Handle(t *testing.T, d datadriven.TestData) string {
@@ -280,6 +290,15 @@ func (e *quorumRecoveryEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		out, err = e.handleApplyPlan(t, d)
 	case "dump-events":
 		out, err = e.dumpRecoveryEvents(t, d)
+	case "require-separated":
+		// Skip the rest of the testdata file unless the runner is in the
+		// sep-eng pass. Used by tests that assert behavior reachable only with
+		// distinct State and Raft batches (e.g., asymmetric per-engine commit
+		// failures where one engine commits and the other does not).
+		if !e.separated {
+			t.SkipNow()
+		}
+		out = "ok"
 	default:
 		t.Fatalf("%s: unknown command %s", d.Pos, d.Cmd)
 	}
@@ -606,7 +625,12 @@ func (e *quorumRecoveryEnv) getOrCreateStore(
 			storage.CacheSize(1<<20 /* 1 MiB */))
 		require.NoError(t, err)
 
-		engines := kvstorage.MakeEngines(eng)
+		var engines kvstorage.Engines
+		if e.separated {
+			engines = kvstorage.MakeSeparatedEnginesForTesting(eng, eng)
+		} else {
+			engines = kvstorage.MakeEngines(eng)
+		}
 		require.NoError(t, storage.MVCCPutProto(
 			context.Background(), engines.LogEngine(), keys.StoreIdentKey(), hlc.Timestamp{},
 			&roachpb.StoreIdent{
@@ -668,16 +692,16 @@ func (e *quorumRecoveryEnv) groupStoresByNode(
 
 func (e *quorumRecoveryEnv) groupStoresByNodeStore(
 	t *testing.T, storeIDs []roachpb.StoreID,
-) map[roachpb.NodeID]map[roachpb.StoreID]storage.Batch {
-	nodes := make(map[roachpb.NodeID]map[roachpb.StoreID]storage.Batch)
+) map[roachpb.NodeID]map[roachpb.StoreID]StoreBatches {
+	nodes := make(map[roachpb.NodeID]map[roachpb.StoreID]StoreBatches)
 	iterateSelectedStores(t, storeIDs, e.stores,
 		func(store kvstorage.Engines, nodeID roachpb.NodeID, storeID roachpb.StoreID) {
 			nodeStores, ok := nodes[nodeID]
 			if !ok {
-				nodeStores = make(map[roachpb.StoreID]storage.Batch)
+				nodeStores = make(map[roachpb.StoreID]StoreBatches)
 				nodes[nodeID] = nodeStores
 			}
-			nodeStores[storeID] = store.TODOBothEngines().NewBatch()
+			nodeStores[storeID] = NewStoreBatches(store)
 		})
 	return nodes
 }
@@ -771,31 +795,65 @@ func (b *failingBatch) Commit(sync bool) error {
 	return b.Batch.Commit(sync)
 }
 
-func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData) (string, error) {
-	ctx := context.Background()
-	stores := e.parseStoresArg(t, d, true /* defaultToAll */)
-	restart := dd.ScanArgOr(t, &d, "restart", false)
-	failCommit, _ := dd.ScanArgOpt[[]roachpb.StoreID](t, &d, "fail_commit")
-	failSet := make(map[roachpb.StoreID]struct{}, len(failCommit))
-	for _, id := range failCommit {
-		failSet[id] = struct{}{}
+// commitFailures collects the per-store, per-engine commit-failure injections
+// configured for an apply-plan command.
+type commitFailures struct {
+	state, raft map[roachpb.StoreID]struct{}
+}
+
+func (cf commitFailures) wrap(storeID roachpb.StoreID, sb StoreBatches) StoreBatches {
+	_, failState := cf.state[storeID]
+	_, failRaft := cf.raft[storeID]
+	if !failState && !failRaft {
+		return sb
 	}
-	wrapBatch := func(storeID roachpb.StoreID, b storage.Batch) storage.Batch {
-		if _, fail := failSet[storeID]; !fail {
-			return b
-		}
+	wrap := func(b storage.Batch) *failingBatch {
 		return &failingBatch{
 			Batch:     b,
 			commitErr: errors.Newf("injected commit failure on s%d", storeID),
 		}
 	}
+	if !sb.separated {
+		// One-eng stores share an underlying batch.
+		sb.State = wrap(sb.State)
+		return sb
+	}
+	if failState {
+		sb.State = wrap(sb.State)
+	}
+	if failRaft {
+		sb.Raft = wrap(sb.Raft)
+	}
+	return sb
+}
+
+func parseCommitFailures(t *testing.T, d *datadriven.TestData) commitFailures {
+	asSet := func(name string) map[roachpb.StoreID]struct{} {
+		ids, _ := dd.ScanArgOpt[[]roachpb.StoreID](t, d, name)
+		set := make(map[roachpb.StoreID]struct{}, len(ids))
+		for _, id := range ids {
+			set[id] = struct{}{}
+		}
+		return set
+	}
+	return commitFailures{
+		state: asSet("fail_commit_state"),
+		raft:  asSet("fail_commit_raft"),
+	}
+}
+
+func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData) (string, error) {
+	ctx := context.Background()
+	stores := e.parseStoresArg(t, d, true /* defaultToAll */)
+	restart := dd.ScanArgOr(t, &d, "restart", false)
+	failures := parseCommitFailures(t, &d)
 
 	var updated, skipped, missing int
 	if !restart {
 		nodes := e.groupStoresByNodeStore(t, stores)
 		for _, perNode := range nodes {
-			for storeID, b := range perNode {
-				perNode[storeID] = wrapBatch(storeID, b)
+			for storeID, sb := range perNode {
+				perNode[storeID] = failures.wrap(storeID, sb)
 			}
 		}
 		defer func() {
@@ -833,8 +891,8 @@ func (e *quorumRecoveryEnv) handleApplyPlan(t *testing.T, d datadriven.TestData)
 		}
 
 		rep, err := maybeApplyPendingRecoveryPlan(ctx, ps, stores, e.clock,
-			func(storeID roachpb.StoreID, eng kvstorage.Engines) storage.Batch {
-				return wrapBatch(storeID, eng.TODOBothEngines().NewBatch())
+			func(storeID roachpb.StoreID, eng kvstorage.Engines) StoreBatches {
+				return failures.wrap(storeID, NewStoreBatches(eng))
 			})
 		if err != nil {
 			return "", err

--- a/pkg/kv/kvserver/loqrecovery/recovery_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_test.go
@@ -21,17 +21,27 @@ import (
 func TestQuorumRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
-		testTime, _ := time.Parse(time.RFC3339, "2022-02-24T01:40:00Z")
-		env := quorumRecoveryEnv{
-			uuidGen: NewSeqGen(1),
-			clock:   timeutil.NewManualTime(testTime),
+	// Run every testdata file under both engine layouts.
+	for _, separated := range []bool{false, true} {
+		name := "one-eng"
+		if separated {
+			name = "sep-eng"
 		}
-		defer env.cleanupStores()
-		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
-			return env.Handle(t, *d)
+		t.Run(name, func(t *testing.T) {
+			datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
+				testTime, _ := time.Parse(time.RFC3339, "2022-02-24T01:40:00Z")
+				env := quorumRecoveryEnv{
+					uuidGen:   NewSeqGen(1),
+					clock:     timeutil.NewManualTime(testTime),
+					separated: separated,
+				}
+				defer env.cleanupStores()
+				datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+					return env.Handle(t, *d)
+				})
+			})
 		})
-	})
+	}
 }
 
 func TestValidatePlanReplicaSet(t *testing.T) {

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -134,13 +134,24 @@ func (s Server) ServeLocalReplicas(
 	for _, s := range stores {
 		s := s // copy for closure
 		g.Go(func() error {
-			// TODO(sep-raft-log): when raft and state machine engines are separate,
-			// we need two snapshots here. This path is online, so we should make sure
-			// these snapshots are consistent, or visitStoreReplicas handles the
-			// asynchronous snapshots well.
-			reader := s.TODOBothEngines().NewSnapshot()
-			defer reader.Close()
-			return visitStoreReplicas(ctx, reader, reader, s.StoreID(), s.NodeID(),
+			// If engines are separated, we can't snapshot both state and raft engines
+			// atomically. However, we take the state engine snapshot first.
+			// The reason is that the highest risk we worry about is to rollback a
+			// range change. If we take the log engine snapshot first, and then the
+			// state engine, we could apply some entries between these two events, and
+			// that means that RaftAppliedIndex could advance, and causes us to miss a
+			// descriptor change. But by taking the state engine first, the only thing
+			// that could change until we take the log engine snapshot is appending
+			// more raft log entries, which we will visit and report if they change
+			// a descriptor.
+			stateSnap := s.StateEngine().NewSnapshot()
+			defer stateSnap.Close()
+			raftSnap := stateSnap
+			if s.EnginesSeparated() {
+				raftSnap = s.LogEngine().NewSnapshot()
+				defer raftSnap.Close()
+			}
+			return visitStoreReplicas(ctx, stateSnap, raftSnap, s.StoreID(), s.NodeID(),
 				func(info loqrecoverypb.ReplicaInfo) error {
 					return syncStream.Send(&serverpb.RecoveryCollectLocalReplicaInfoResponse{ReplicaInfo: &info})
 				})

--- a/pkg/kv/kvserver/loqrecovery/testdata/apply_idempotent
+++ b/pkg/kv/kvserver/loqrecovery/testdata/apply_idempotent
@@ -1,0 +1,77 @@
+# Test verifying that re-applying the same recovery plan to a store that has
+# already been recovered is a no-op.
+
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # Designated replica in this store
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 11
+  RaftCommittedIndex: 13
+- StoreID: 2
+  RangeID: 2
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # Designated replica in this store
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+Replica updates:
+- RangeID: 1
+  StartKey: /Min
+  OldReplicaID: 1
+  NewReplica:
+    NodeID: 1
+    StoreID: 1
+    ReplicaID: 16
+  NextReplicaID: 17
+- RangeID: 2
+  StartKey: /Table/1
+  OldReplicaID: 2
+  NewReplica:
+    NodeID: 2
+    StoreID: 2
+    ReplicaID: 16
+  NextReplicaID: 17
+Decommissioned nodes:
+[n4, n5]
+
+# First apply: both replicas get rewritten.
+apply-plan stores=(1,2)
+----
+updated=2 skipped=0 missing=0
+
+# Audit records for both rewrites are present.
+dump-events stores=(1,2)
+----
+Events:
+updated range r1, Key:/Min, Store:s1 ReplicaID:16
+updated range r2, Key:/Table/1, Store:s2 ReplicaID:16
+
+# Second apply is a no-op.
+apply-plan stores=(1,2)
+----
+updated=0 skipped=2 missing=0
+
+# Audit records are unchanged to ensure that the second apply did not write new
+# ones.
+dump-events stores=(1,2)
+----
+Events:
+updated range r1, Key:/Min, Store:s1 ReplicaID:16
+updated range r2, Key:/Table/1, Store:s2 ReplicaID:16

--- a/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure
+++ b/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure
@@ -1,0 +1,133 @@
+# End-to-end test for the partial-commit failure path of CommitReplicaChanges.
+
+replication-data
+- NodeID: 1
+  StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # Designated replica in this store
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 11
+  RaftCommittedIndex: 13
+- NodeID: 1
+  StoreID: 2
+  RangeID: 2
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 2, ReplicaID: 2}  # Designated replica in this store
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+Replica updates:
+- RangeID: 1
+  StartKey: /Min
+  OldReplicaID: 1
+  NewReplica:
+    NodeID: 1
+    StoreID: 1
+    ReplicaID: 16
+  NextReplicaID: 17
+- RangeID: 2
+  StartKey: /Table/1
+  OldReplicaID: 2
+  NewReplica:
+    NodeID: 1
+    StoreID: 2
+    ReplicaID: 16
+  NextReplicaID: 17
+Decommissioned nodes:
+[n4, n5]
+
+# First apply: inject a Commit failure on store 2.
+apply-plan stores=(1,2) fail_commit=(2)
+----
+ERROR: failed to commit update to one or more stores: failed to update store s2: injected commit failure on s2
+
+# Since there was no error for s1 commit, it has the rewritten descriptor
+# (replica 16, single voter) while s2 still has the original three-replica
+# descriptor.
+dump-store stores=(1,2)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16
+- NodeID: 1
+  StoreID: 2
+  Descriptors:
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 2, ReplicaID: 2}
+    - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 4}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
+  LocalData:
+  - RangeID: 2
+    RaftReplicaID: 2
+
+# Audit records: only s1's write was committed.
+dump-events stores=(1,2)
+----
+Events:
+updated range r1, Key:/Min, Store:s1 ReplicaID:16
+
+# Rerunning apply-plan should skip s1, and commit s2.
+apply-plan stores=(1,2)
+----
+updated=1 skipped=1 missing=0
+
+# Final state: both stores recovered.
+dump-store stores=(1,2)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16
+- NodeID: 1
+  StoreID: 2
+  Descriptors:
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 2, ReplicaID: 16}
+  LocalData:
+  - RangeID: 2
+    RaftReplicaID: 16
+
+dump-events stores=(1,2)
+----
+Events:
+updated range r1, Key:/Min, Store:s1 ReplicaID:16
+updated range r2, Key:/Table/1, Store:s2 ReplicaID:16
+
+dump-events stores=(1,2)
+----
+Events:
+updated range r1, Key:/Min, Store:s1 ReplicaID:16
+updated range r2, Key:/Table/1, Store:s2 ReplicaID:16

--- a/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure_restart
+++ b/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure_restart
@@ -53,7 +53,7 @@ Decommissioned nodes:
 [n4, n5]
 
 # First apply: inject a Commit failure on store 2.
-apply-plan stores=(1,2) restart=true fail_commit=(2)
+apply-plan stores=(1,2) restart=true fail_commit_raft=(2)
 ----
 updated=2 skipped=0 missing=0
 

--- a/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure_restart
+++ b/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure_restart
@@ -1,0 +1,132 @@
+# End-to-end test for the partial-commit failure path under restart=true.
+
+replication-data
+- NodeID: 1
+  StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # Designated replica in this store
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 11
+  RaftCommittedIndex: 13
+- NodeID: 1
+  StoreID: 2
+  RangeID: 2
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 2, ReplicaID: 2}  # Designated replica in this store
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+Replica updates:
+- RangeID: 1
+  StartKey: /Min
+  OldReplicaID: 1
+  NewReplica:
+    NodeID: 1
+    StoreID: 1
+    ReplicaID: 16
+  NextReplicaID: 17
+- RangeID: 2
+  StartKey: /Table/1
+  OldReplicaID: 2
+  NewReplica:
+    NodeID: 1
+    StoreID: 2
+    ReplicaID: 16
+  NextReplicaID: 17
+Decommissioned nodes:
+[n4, n5]
+
+# First apply: inject a Commit failure on store 2.
+apply-plan stores=(1,2) restart=true fail_commit=(2)
+----
+updated=2 skipped=0 missing=0
+
+# On-disk state: s1 has the rewritten descriptor (replica 16, single voter)
+# while s2 still has the original three-replica descriptor.
+dump-store stores=(1,2)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16
+- NodeID: 1
+  StoreID: 2
+  Descriptors:
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 2, ReplicaID: 2}
+    - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 4}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
+  LocalData:
+  - RangeID: 2
+    RaftReplicaID: 2
+
+# Persisted recovery status records the per-node error so an operator
+# polling node status discovers the partial failure.
+# Remove the events so that next run only shows the new events it did.
+dump-events stores=(1,2) status=true remove=true
+----
+Events:
+updated range r1, Key:/Min, Store:s1 ReplicaID:16
+Statuses:
+node n1 applied plan 00000001-0000-4000-8000-000000000000 at 2022-02-24 01:40:00 +0000 UTC:failed to commit update to one or more stores: failed to update store s2: injected commit failure on s2
+
+# Rerunning apply-plan should skip s1, and commit s2.
+apply-plan stores=(1,2) restart=true
+----
+updated=1 skipped=1 missing=0
+
+# Final state: both stores recovered.
+dump-store stores=(1,2)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16
+- NodeID: 1
+  StoreID: 2
+  Descriptors:
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 2, ReplicaID: 16}
+  LocalData:
+  - RangeID: 2
+    RaftReplicaID: 16
+
+# The events show an update to store 2, and no status error.
+dump-events stores=(1,2) status=true
+----
+Events:
+updated range r2, Key:/Table/1, Store:s2 ReplicaID:16
+Statuses:
+node n1 applied plan 00000001-0000-4000-8000-000000000000 at 2022-02-24 01:40:00 +0000 UTC:

--- a/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure_sep_state
+++ b/pkg/kv/kvserver/loqrecovery/testdata/apply_partial_failure_sep_state
@@ -1,4 +1,9 @@
-# End-to-end test for the partial-commit failure path of CommitReplicaChanges.
+# End-to-end test for a partial-commit failure that exists only under separated
+# engines: the log engine commit succeeds but the state engine commit fails.
+
+require-separated
+----
+ok
 
 replication-data
 - NodeID: 1
@@ -52,14 +57,13 @@ Replica updates:
 Decommissioned nodes:
 [n4, n5]
 
-# First apply: inject a Commit failure on store 2.
-apply-plan stores=(1,2) fail_commit_raft=(2)
+# Inject a State-engine commit failure on s2.
+apply-plan stores=(1,2) fail_commit_state=(2)
 ----
 ERROR: failed to commit update to one or more stores: failed to update store s2: injected commit failure on s2
 
-# Since there was no error for s1 commit, it has the rewritten descriptor
-# (replica 16, single voter) while s2 still has the original three-replica
-# descriptor.
+# On-disk state: s1 has the rewritten descriptor; s2 still has the original
+# three-replica descriptor because its State-engine batch was discarded.
 dump-store stores=(1,2)
 ----
 - NodeID: 1
@@ -85,14 +89,18 @@ dump-store stores=(1,2)
   - RangeID: 2
     RaftReplicaID: 2
 
-# Audit records: only s1's write was committed.
+# Audit records: s1's record from its successful commit, AND s2's record
+# because s2's log-engine batch (which holds the audit-record write) was
+# committed even though the state-engine batch failed.
 dump-events stores=(1,2)
 ----
 Events:
 updated range r1, Key:/Min, Store:s1 ReplicaID:16
+updated range r2, Key:/Table/1, Store:s2 ReplicaID:16
 
-# Rerunning apply-plan should skip s1, and commit s2.
-apply-plan stores=(1,2)
+# Operator re-runs apply-plan. For s2, the state-engine descriptor is
+# still old, so the full sequence runs again.
+apply-plan stores=(1,2) counts=true
 ----
 updated=1 skipped=1 missing=0
 
@@ -120,14 +128,11 @@ dump-store stores=(1,2)
   - RangeID: 2
     RaftReplicaID: 16
 
+# s2 now has TWO audit records for r2: the witness from the failed first
+# attempt and the fresh one from the successful retry.
 dump-events stores=(1,2)
 ----
 Events:
 updated range r1, Key:/Min, Store:s1 ReplicaID:16
 updated range r2, Key:/Table/1, Store:s2 ReplicaID:16
-
-dump-events stores=(1,2)
-----
-Events:
-updated range r1, Key:/Min, Store:s1 ReplicaID:16
 updated range r2, Key:/Table/1, Store:s2 ReplicaID:16

--- a/pkg/kv/kvserver/loqrecovery/testdata/half_online_application_plan
+++ b/pkg/kv/kvserver/loqrecovery/testdata/half_online_application_plan
@@ -73,7 +73,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2) restart=true
 ----
-ok
+updated=3 skipped=0 missing=0
 
 dump-events stores=(1,2) remove=true status=true
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/half_online_apply_mismatching_plan
+++ b/pkg/kv/kvserver/loqrecovery/testdata/half_online_apply_mismatching_plan
@@ -53,7 +53,7 @@ ok
 
 apply-plan stores=(1) restart=true
 ----
-ok
+updated=0 skipped=0 missing=0
 
 dump-events stores=(1) status=true
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/learners_lose
+++ b/pkg/kv/kvserver/loqrecovery/testdata/learners_lose
@@ -53,7 +53,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_discarded
+++ b/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_discarded
@@ -56,7 +56,7 @@ Nodes to restart:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_wins
@@ -53,7 +53,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----
@@ -144,7 +144,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/max_applied_voter_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/max_applied_voter_wins
@@ -51,7 +51,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----
@@ -175,7 +175,7 @@ ok
 
 apply-plan stores=(1,2,5,6)
 ----
-ok
+updated=0 skipped=0 missing=0
 
 dump-store stores=(1,2,5,6)
 ----
@@ -314,7 +314,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/max_store_voter_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/max_store_voter_wins
@@ -52,7 +52,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----
@@ -143,7 +143,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=1 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_no_dead_peers
+++ b/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_no_dead_peers
@@ -45,7 +45,7 @@ ok
 
 apply-plan stores=(1,2,3)
 ----
-ok
+updated=0 skipped=0 missing=0
 
 dump-store stores=(1,2,3)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_quorum
+++ b/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_quorum
@@ -34,7 +34,7 @@ ok
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=0 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----
@@ -84,7 +84,7 @@ ok
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=0 skipped=0 missing=0
 
 dump-store stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/replica_changes_recorded
+++ b/pkg/kv/kvserver/loqrecovery/testdata/replica_changes_recorded
@@ -73,7 +73,7 @@ Decommissioned nodes:
 
 apply-plan stores=(1,2)
 ----
-ok
+updated=3 skipped=0 missing=0
 
 dump-events stores=(1,2) remove=true
 ----

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -326,7 +326,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create loss of quorum plan store")
 	}
-	if err := loqrecovery.MaybeApplyPendingRecoveryPlan(ctx, planStore, engines, timeutil.DefaultTimeSource{}); err != nil {
+	if _, err := loqrecovery.MaybeApplyPendingRecoveryPlan(ctx, planStore, engines, timeutil.DefaultTimeSource{}); err != nil {
 		return nil, errors.Wrap(err, "failed to apply loss of quorum recovery plan")
 	}
 


### PR DESCRIPTION
This PR makes LoQ tool support separate engines. See individual commits.

There is one TODO remaining for the offline restore case, which will be clearer once engines are physically separated, and we know the layout and the path.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>