### PR TITLE
mmaprototype: stop crashing on stale rebalance caches

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1897,8 +1897,10 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 	// transferring its replica for range r1 to remote store s2, then
 	// localss.adjusted.replicas will not have r1. This is fine in that s1
 	// should not be making more decisions about r1. If the change is undone
-	// later, we will again compute the top-k, which will consider r1, before
-	// computing new changes (due to REQUIREMENT(change-computation)).
+	// later, the top-k will be recomputed here on the next leaseholder msg
+	// from localss; rebalance passes that interleave between the undo and
+	// that next msg see a stale topK and tolerate it (see the topKRanges
+	// invariant on storeState).
 	for rangeID, state := range localss.adjusted.replicas {
 		if !state.IsLeaseholder {
 			// We may have transferred the lease away previously but still have a
@@ -1919,9 +1921,10 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		// transferred to another store s11, s10 will not see r1 below. We
 		// make this choice to avoid cluttering the top-k for s10 with
 		// replicas that are going away. If it is undone, r1 will not be in
-		// the top-k for s10, but due to REQUIREMENT(change-computation), a
-		// new authoritative state will be provided and the top-k recomputed,
-		// before computing any new changes.
+		// the top-k for s10 until the next leaseholder msg from msg.StoreID
+		// rebuilds it; rebalance passes that interleave between the undo and
+		// that msg see a stale topK and tolerate it (see the topKRanges
+		// invariant on storeState).
 		for _, replica := range rs.replicas {
 			typ := replica.ReplicaState.ReplicaType.ReplicaType
 			if isVoter(typ) || isNonVoter(typ) {

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1275,21 +1275,12 @@ func (rs *rangeState) removePendingChangeTracking(changeID changeID) {
 // clearAnalyzedConstraints clears the cached analyzed constraints for the
 // range state.
 //
-// Invalidation contract: rs.constraints is a per-rangeState cache of
-// constraint analysis derived from rs.replicas (specifically the
-// IsLeaseholder flags and the per-replica StoreIDs/types). It is consulted
-// in the rebalance loops both to choose candidate stores and to assert
-// internal invariants (see rebalanceLeasesFromLocalStoreID and
-// rebalanceReplicas). Any code path that mutates rs.replicas
-// must call this method to keep the cache consistent. The call sites are:
-//   - processRangeMsg slow path (after replacing rs.replicas wholesale),
-//   - processStoreLeaseholderMsgInternal range-removal branch (rs being GC'd),
-//   - undoPendingChange.
-//
-// addPendingRangeChange also mutates rs.replicas (via applyReplicaChange) but
-// does NOT yet invalidate; that is the #170112 root cause and is closed by a
-// follow-up commit. pendingChangeEnacted is a no-op for replicas — invalidation
-// by the prior addPendingRangeChange will cover it once that gap is closed.
+// Invalidation contract: rs.constraints is a per-rangeState cache derived
+// from rs.replicas (the IsLeaseholder flags and the per-replica
+// StoreIDs/types). It is consulted in the rebalance loops both to choose
+// candidate stores and to assert internal invariants (see
+// rebalanceLeasesFromLocalStoreID and rebalanceReplicas). Any code path that
+// mutates rs.replicas must call this method to keep the cache consistent.
 func (rs *rangeState) clearAnalyzedConstraints() {
 	if rs.constraints == nil {
 		return
@@ -2114,6 +2105,9 @@ func (cs *clusterState) addPendingRangeChange(ctx context.Context, change Pendin
 			"addPendingRangeChange: change_id=%v, range_id=%v, change=%v",
 			cid, rangeID, pendingChange.ReplicaChange)
 	}
+	// applyReplicaChange above mutated rs.replicas; invalidate per the
+	// contract on clearAnalyzedConstraints.
+	cs.ranges[rangeID].clearAnalyzedConstraints()
 }
 
 // preCheckOnApplyReplicaChanges does some validation of the changes being

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -719,13 +719,32 @@ type storeState struct {
 		// one resource dimension, that is the dimension chosen when picking the
 		// top-k.
 		//
+		// The key in this map is a local store-id; the value enumerates ranges
+		// for which (a) that local store is the leaseholder and (b) the storeState
+		// owning this entry has a replica.
+		//
+		// Lifecycle and staleness: topKRanges is rebuilt only by
+		// processStoreLeaseholderMsgInternal — a StoreLeaseholderMsg from local
+		// store L recomputes topKRanges[L] across every storeState from scratch.
+		// Pending mutations to rs.replicas and ss.adjusted.replicas (via
+		// applyReplicaChange / undoReplicaChange) and enactment / GC of pending
+		// changes do NOT update topK. So between consecutive msgs from L,
+		// topKRanges[L] entries can become stale in two ways:
+		//   - phantom entry: r is listed for store ss, but ss is no longer in
+		//     rs.replicas (replica removed via a pending change that has since
+		//     enacted); or
+		//   - leaseholder mismatch: r is listed under L, but rs.replicas[L] no
+		//     longer marks L as leaseholder (lease transferred away).
+		// Skip-on-pending in the rebalance loops masks the in-progress window;
+		// the post-enact window relies on readers (rebalanceLeasesFromLocalStoreID,
+		// rebalanceReplicas) tolerating mismatches by skipping affected entries.
+		// Self-corrects on L's next leaseholder msg.
+		//
 		// It includes ranges whose replicas are being removed via pending
 		// changes, or lease transfers. That is, it does not account for
 		// pending or enacted changes made since the last time top-k was
 		// computed. It does account for pending changes that were pending
 		// when the top-k was computed.
-		//
-		// The key in this map is a local store-id.
 		//
 		// NB: this only includes replicas that satisfy the isVoter() or
 		// isNonVoter() methods, i.e., {VOTER_FULL, VOTER_INCOMING, NON_VOTER,
@@ -733,9 +752,6 @@ type storeState struct {
 		// only replica types where the allocator wants to explicitly consider
 		// shedding, since the other states are transient states, that are
 		// either going away, or will soon transition to a full-fledged state.
-		//
-		// We may decide to keep this top-k up-to-date incrementally instead of
-		// recomputing it from scratch on each StoreLeaseholderMsg.
 		//
 		// Example:
 		// Assume the local node has two stores, s1 and s2.
@@ -1256,8 +1272,24 @@ func (rs *rangeState) removePendingChangeTracking(changeID changeID) {
 	}
 }
 
-// clearAnalyzedConstraints clears the analyzed constraints for the range state.
-// This should be used when rs is deleted or rs.constraints needs to be reset.
+// clearAnalyzedConstraints clears the cached analyzed constraints for the
+// range state.
+//
+// Invalidation contract: rs.constraints is a per-rangeState cache of
+// constraint analysis derived from rs.replicas (specifically the
+// IsLeaseholder flags and the per-replica StoreIDs/types). It is consulted
+// in the rebalance loops both to choose candidate stores and to assert
+// internal invariants (see rebalanceLeasesFromLocalStoreID and
+// rebalanceReplicas). Any code path that mutates rs.replicas
+// must call this method to keep the cache consistent. The call sites are:
+//   - processRangeMsg slow path (after replacing rs.replicas wholesale),
+//   - processStoreLeaseholderMsgInternal range-removal branch (rs being GC'd),
+//   - undoPendingChange.
+//
+// addPendingRangeChange also mutates rs.replicas (via applyReplicaChange) but
+// does NOT yet invalidate; that is the #170112 root cause and is closed by a
+// follow-up commit. pendingChangeEnacted is a no-op for replicas — invalidation
+// by the prior addPendingRangeChange will cover it once that gap is closed.
 func (rs *rangeState) clearAnalyzedConstraints() {
 	if rs.constraints == nil {
 		return

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -604,13 +604,13 @@ func (re *rebalanceEnv) rebalanceReplicas(
 			// pointing at a range where store.StoreID is no longer a replica
 			// (topK is rebuilt only on StoreLeaseholderMsg — see the topKRanges
 			// invariant in cluster_state.go), or a stale rs.constraints cache
-			// from before a pending change mutated rs.replicas. A follow-up
-			// commit converts this assertion into a skip+log so a benign cache
-			// race no longer fatals the node.
-			panic(errors.AssertionFailedf("internal state inconsistency: "+
-				"store=%v range_id=%v pending-changes=%v "+
-				"rstate_replicas=%v rstate_constraints=%v",
-				store.StoreID, rangeID, rstate.pendingChanges, rstate.replicas, rstate.constraints))
+			// from before a pending change mutated rs.replicas. Both
+			// self-correct on the next leaseholder msg from the relevant local
+			// store, so skip the range and move on.
+			ml.logf(ctx, 3, "skipping r%d: stale topK[s%d] or stale constraints, "+
+				"s%d not in cached replica set", rangeID, store.StoreID, store.StoreID)
+			re.passObs.replicaShed(ctx, rangeTransient)
+			continue
 		}
 		// Get the constraint conjunction which will allow us to look up stores
 		// that could replace the shedding store.
@@ -801,38 +801,29 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			re.passObs.leaseShed(ctx, rangeTransient)
 			continue
 		}
-		foundLocalReplica := false
-		for _, repl := range rstate.replicas {
-			if repl.StoreID != localStoreID { // NB: localStoreID == ss.StoreID == store.StoreID
-				continue
-			}
-			if !repl.IsLeaseholder {
-				// We are iterating ss.adjusted.topKRanges[localStoreID], which is
-				// rebuilt only on a StoreLeaseholderMsg from localStoreID (see the
-				// topKRanges invariant in cluster_state.go). If the local store
-				// transferred its lease away after that msg and the change has
-				// since enacted, topK still lists r but rs.replicas no longer
-				// marks the local store as leaseholder. The skip-on-pending check
-				// above only masks the in-progress window, not the post-enact
-				// window. A follow-up commit converts this assertion into a
-				// skip+log so a benign cache race no longer fatals the node.
-				panic(errors.AssertionFailedf(
-					"internal state inconsistency: r%d considered for lease shedding "+
-						"on s%d has no pending changes but s%d is not leaseholder: replicas=%v",
-					rangeID, localStoreID, localStoreID, rstate.replicas))
-			}
-			foundLocalReplica = true
-			break
+		// NB: localStoreID == ss.StoreID == store.StoreID. Use a distinct name
+		// from the outer loop counter `i` to avoid shadowing.
+		localIdx := slices.IndexFunc(rstate.replicas, func(r StoreIDAndReplicaState) bool {
+			return r.StoreID == localStoreID
+		})
+		if localIdx == -1 {
+			// Stale topK[localStoreID]: a removal pending change for the local
+			// store has enacted, but topK still lists r. Self-corrects on the
+			// next leaseholder msg from this store. See the topKRanges
+			// invariant in cluster_state.go.
+			ml.logf(ctx, 3, "skipping r%d: stale topK[s%d] entry, s%d no longer a replica",
+				rangeID, localStoreID, localStoreID)
+			re.passObs.leaseShed(ctx, rangeTransient)
+			continue
 		}
-		if !foundLocalReplica {
-			// Same staleness source as above, with a removal pending instead of a
-			// lease transfer: topK still lists r for localStoreID, but the local
-			// store is no longer in rs.replicas because the removal pending
-			// change has enacted. Converted to a skip+log in a follow-up commit.
-			panic(errors.AssertionFailedf(
-				"internal state inconsistency: r%d considered for lease shedding "+
-					"on s%d but s%d is not in replicas=%v",
-				rangeID, localStoreID, localStoreID, rstate.replicas))
+		if !rstate.replicas[localIdx].IsLeaseholder {
+			// Stale topK[localStoreID]: the local store transferred its lease
+			// away since the msg that built topK and the change has enacted.
+			// Self-corrects on the next msg from this store.
+			ml.logf(ctx, 3, "skipping r%d: stale topK[s%d] entry, s%d no longer leaseholder",
+				rangeID, localStoreID, localStoreID)
+			re.passObs.leaseShed(ctx, rangeTransient)
+			continue
 		}
 		if re.now.Sub(rstate.lastFailedChange) < re.lastFailedChangeDelayDuration {
 			ml.logf(ctx, 3, "skipping r%d: too soon after failed change", rangeID)
@@ -852,17 +843,16 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		if rstate.constraints.leaseholderID != store.StoreID {
 			// rs.constraints is a cached blob (see clearAnalyzedConstraints in
 			// cluster_state.go); leaseholderID reflects rs.replicas at cache
-			// time. If a prior pass cached the blob while the previous
-			// leaseholder held the lease and a subsequent external change moved
-			// the lease here without invalidating, the cached leaseholderID
-			// disagrees with the now-correct local store. This is the #170112
-			// panic. A follow-up commit invalidates rs.constraints in
-			// addPendingRangeChange to close that gap; another follow-up converts
-			// this assertion into a skip+log as defense-in-depth for any future
-			// path that mutates rs.replicas without invalidating.
-			panic(errors.AssertionFailedf("internal state inconsistency: "+
-				"store=%v range_id=%v should be leaseholder but isn't",
-				store.StoreID, rangeID))
+			// time. The clearAnalyzedConstraints contract ensures this is
+			// invalidated whenever rs.replicas mutates, so this skip is a
+			// permanent parity-with-topK guard rather than a transitional
+			// safety net: any future replica-mutating code path that forgets
+			// to invalidate gets a benign skip rather than a node fatal.
+			ml.logf(ctx, 3, "skipping r%d: stale rs.constraints, "+
+				"cached leaseholderID=s%d but local store=s%d",
+				rangeID, rstate.constraints.leaseholderID, store.StoreID)
+			re.passObs.leaseShed(ctx, rangeTransient)
+			continue
 		}
 
 		// Get the stores from the replica set that are at least as good as the

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -817,8 +817,9 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 				// window. A follow-up commit converts this assertion into a
 				// skip+log so a benign cache race no longer fatals the node.
 				panic(errors.AssertionFailedf(
-					"internal state inconsistency: replica considered for lease shedding has no pending"+
-						" changes but is not leaseholder: %+v", rstate))
+					"internal state inconsistency: r%d considered for lease shedding "+
+						"on s%d has no pending changes but s%d is not leaseholder: replicas=%v",
+					rangeID, localStoreID, localStoreID, rstate.replicas))
 			}
 			foundLocalReplica = true
 			break
@@ -829,7 +830,9 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			// store is no longer in rs.replicas because the removal pending
 			// change has enacted. Converted to a skip+log in a follow-up commit.
 			panic(errors.AssertionFailedf(
-				"internal state inconsistency: local store is not a replica: %+v", rstate))
+				"internal state inconsistency: r%d considered for lease shedding "+
+					"on s%d but s%d is not in replicas=%v",
+				rangeID, localStoreID, localStoreID, rstate.replicas))
 		}
 		if re.now.Sub(rstate.lastFailedChange) < re.lastFailedChangeDelayDuration {
 			ml.logf(ctx, 3, "skipping r%d: too soon after failed change", rangeID)

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -599,8 +599,14 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		}
 		isVoter, isNonVoter := rstate.constraints.replicaRole(store.StoreID)
 		if !isVoter && !isNonVoter {
-			// Due to REQUIREMENT(change-computation), the top-k is up to date, so
-			// this must never happen.
+			// Two staleness sources can land us here despite the
+			// skip-on-pending check above: a stale topK[localStoreID] entry
+			// pointing at a range where store.StoreID is no longer a replica
+			// (topK is rebuilt only on StoreLeaseholderMsg — see the topKRanges
+			// invariant in cluster_state.go), or a stale rs.constraints cache
+			// from before a pending change mutated rs.replicas. A follow-up
+			// commit converts this assertion into a skip+log so a benign cache
+			// race no longer fatals the node.
 			panic(errors.AssertionFailedf("internal state inconsistency: "+
 				"store=%v range_id=%v pending-changes=%v "+
 				"rstate_replicas=%v rstate_constraints=%v",
@@ -801,24 +807,29 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 				continue
 			}
 			if !repl.IsLeaseholder {
-				// NB: due to REQUIREMENT(change-computation), the top-k
-				// ranges for ss reflect the latest adjusted state, including
-				// pending changes. Thus, this store must be a replica and the
-				// leaseholder, hence this assertion, and other assertions
-				// below. Additionally, the code above ignored the range if it
-				// has pending changes, which while not necessary for the
-				// is-leaseholder assertion, makes the case where we assert
-				// even narrower.
-				log.KvDistribution.Fatalf(ctx,
+				// We are iterating ss.adjusted.topKRanges[localStoreID], which is
+				// rebuilt only on a StoreLeaseholderMsg from localStoreID (see the
+				// topKRanges invariant in cluster_state.go). If the local store
+				// transferred its lease away after that msg and the change has
+				// since enacted, topK still lists r but rs.replicas no longer
+				// marks the local store as leaseholder. The skip-on-pending check
+				// above only masks the in-progress window, not the post-enact
+				// window. A follow-up commit converts this assertion into a
+				// skip+log so a benign cache race no longer fatals the node.
+				panic(errors.AssertionFailedf(
 					"internal state inconsistency: replica considered for lease shedding has no pending"+
-						" changes but is not leaseholder: %+v", rstate)
+						" changes but is not leaseholder: %+v", rstate))
 			}
 			foundLocalReplica = true
 			break
 		}
 		if !foundLocalReplica {
-			log.KvDistribution.Fatalf(
-				ctx, "internal state inconsistency: local store is not a replica: %+v", rstate)
+			// Same staleness source as above, with a removal pending instead of a
+			// lease transfer: topK still lists r for localStoreID, but the local
+			// store is no longer in rs.replicas because the removal pending
+			// change has enacted. Converted to a skip+log in a follow-up commit.
+			panic(errors.AssertionFailedf(
+				"internal state inconsistency: local store is not a replica: %+v", rstate))
 		}
 		if re.now.Sub(rstate.lastFailedChange) < re.lastFailedChangeDelayDuration {
 			ml.logf(ctx, 3, "skipping r%d: too soon after failed change", rangeID)
@@ -836,8 +847,17 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			continue
 		}
 		if rstate.constraints.leaseholderID != store.StoreID {
-			// See the earlier comment about assertions.
-			panic(fmt.Sprintf("internal state inconsistency: "+
+			// rs.constraints is a cached blob (see clearAnalyzedConstraints in
+			// cluster_state.go); leaseholderID reflects rs.replicas at cache
+			// time. If a prior pass cached the blob while the previous
+			// leaseholder held the lease and a subsequent external change moved
+			// the lease here without invalidating, the cached leaseholderID
+			// disagrees with the now-correct local store. This is the #170112
+			// panic. A follow-up commit invalidates rs.constraints in
+			// addPendingRangeChange to close that gap; another follow-up converts
+			// this assertion into a skip+log as defense-in-depth for any future
+			// path that mutates rs.replicas without invalidating.
+			panic(errors.AssertionFailedf("internal state inconsistency: "+
 				"store=%v range_id=%v should be leaseholder but isn't",
 				store.StoreID, rangeID))
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -607,7 +607,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 			// from before a pending change mutated rs.replicas. Both
 			// self-correct on the next leaseholder msg from the relevant local
 			// store, so skip the range and move on.
-			ml.logf(ctx, 3, "skipping r%d: stale topK[s%d] or stale constraints, "+
+			ml.logf(ctx, 1, "skipping r%d: stale topK[s%d] or stale constraints, "+
 				"s%d not in cached replica set", rangeID, store.StoreID, store.StoreID)
 			re.passObs.replicaShed(ctx, rangeTransient)
 			continue
@@ -811,7 +811,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			// store has enacted, but topK still lists r. Self-corrects on the
 			// next leaseholder msg from this store. See the topKRanges
 			// invariant in cluster_state.go.
-			ml.logf(ctx, 3, "skipping r%d: stale topK[s%d] entry, s%d no longer a replica",
+			ml.logf(ctx, 1, "skipping r%d: stale topK[s%d] entry, s%d no longer a replica",
 				rangeID, localStoreID, localStoreID)
 			re.passObs.leaseShed(ctx, rangeTransient)
 			continue
@@ -820,7 +820,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			// Stale topK[localStoreID]: the local store transferred its lease
 			// away since the msg that built topK and the change has enacted.
 			// Self-corrects on the next msg from this store.
-			ml.logf(ctx, 3, "skipping r%d: stale topK[s%d] entry, s%d no longer leaseholder",
+			ml.logf(ctx, 1, "skipping r%d: stale topK[s%d] entry, s%d no longer leaseholder",
 				rangeID, localStoreID, localStoreID)
 			re.passObs.leaseShed(ctx, rangeTransient)
 			continue
@@ -848,7 +848,7 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			// permanent parity-with-topK guard rather than a transitional
 			// safety net: any future replica-mutating code path that forgets
 			// to invalidate gets a benign skip rather than a node fatal.
-			ml.logf(ctx, 3, "skipping r%d: stale rs.constraints, "+
+			ml.logf(ctx, 1, "skipping r%d: stale rs.constraints, "+
 				"cached leaseholderID=s%d but local store=s%d",
 				rangeID, rstate.constraints.leaseholderID, store.StoreID)
 			re.passObs.leaseShed(ctx, rangeTransient)

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -714,6 +714,33 @@ func TestClusterState(t *testing.T) {
 				case "get-pending-changes":
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 
+				case "enact-pending-changes":
+					// Marks the listed pending changes as enacted (without going
+					// through processStoreLeaseholderMsg's slow path). Mirrors what
+					// AdjustPendingChangeDisposition(success=true) does in production
+					// when the leaseholder reports the change as observed.
+					changeIDsInt := dd.ScanArg[[]changeID](t, d, "change-ids")
+					for _, id := range changeIDsInt {
+						cs.pendingChangeEnacted(id, cs.ts.Now())
+					}
+					return printPendingChangesTest(testingGetPendingChanges(t, cs))
+
+				case "analyze-constraints":
+					// Forces population of rs.constraints for the given range.
+					// Useful for reproducing scenarios where a prior rebalance pass
+					// would have cached constraints, without setting up the
+					// overload pass that would normally trigger it.
+					rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
+					rs, ok := cs.ranges[rangeID]
+					if !ok {
+						return fmt.Sprintf("range r%v not found", rangeID)
+					}
+					cs.ensureAnalyzedConstraints(ctx, rs)
+					if rs.constraints == nil {
+						return "no constraints (analysis returned nil)"
+					}
+					return fmt.Sprintf("leaseholderID=s%v", rs.constraints.leaseholderID)
+
 				case "rebalance-stores":
 					storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")
 					rng := rand.New(rand.NewSource(0))

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_constraints.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_constraints.txt
@@ -1,0 +1,137 @@
+# Regression for #170112: TestStartManyStores hit
+#
+#   panic: internal state inconsistency: store=8 range_id=44 should be
+#   leaseholder but isn't
+#
+# in rebalanceLeasesFromLocalStoreID at cluster_state_rebalance_stores.go:840.
+#
+# Mechanism: rs.constraints is a cached blob populated by a prior rebalance
+# pass on the then-leaseholder. It is invalidated by:
+#  - clearAnalyzedConstraints from processRangeMsg's slow path,
+#  - clearAnalyzedConstraints from undoPendingChange,
+#  - rangeState GC.
+# It is NOT invalidated by addPendingRangeChange (which mutates rs.replicas
+# via applyReplicaChange) or by pendingChangeEnacted. So a sequence of:
+#  1. cache constraints with leaseholderID=s1 while s1 holds the lease,
+#  2. external lease transfer s1->s8 registered with MMA: rs.replicas's
+#     IsLeaseholder flag flips to s8 in place (replica-ids preserved
+#     because lease transfer is an isUpdate change),
+#  3. change enacted (rs.pendingChanges drained, replicas unchanged),
+#  4. s8's leaseholder msg arrives matching rs.replicas exactly with no
+#     spanConf and no pending → FAST PATH in processRangeMsg, constraints
+#     survive,
+#  5. s8's rebalance pass reads cached constraints → leaseholderID=s1 but
+#     store=s8 → panic.
+#
+# This test walks that exact sequence. The full add+remove rebalance also
+# leaves stale constraints, but its applyReplicaChange uses
+# replica-id=unknown for the new replica, so the next leaseholder msg from
+# the new owner takes the slow path (replica-ids differ) and clears
+# constraints. The lease-transfer path preserves replica-ids and is the
+# narrowest reproduction.
+
+set-store
+  store-id=1 node-id=1
+  store-id=8 node-id=8
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=8 locality-tiers=node=8
+  store-id=8 attrs=
+
+store-load-msg
+  store-id=1 node-id=1 load=[0,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=8 node-id=8 load=[0,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+----
+
+# r44 has voters on s1 (leaseholder) and s8. spanConf included so
+# ensureAnalyzedConstraints can run.
+store-leaseholder-msg
+store-id=1
+  range-id=44 load=[100,0,0] raft-cpu=10
+  config=num_replicas=2 constraints={} voter_constraints={}
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=8 replica-id=2 type=VOTER_FULL
+----
+
+# Step 1: cache constraints with leaseholderID=s1.
+analyze-constraints range-id=44
+----
+leaseholderID=s1
+
+# Step 2: external lease transfer s1->s8 registered with MMA. After
+# addPendingRangeChange, rs.replicas's leaseholder flag has flipped to s8.
+# rs.constraints is unchanged.
+make-pending-changes range-id=44
+  transfer-lease: remove-store-id=1 add-store-id=8
+----
+pending(2)
+change-id=1 store-id=1 node-id=1 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=1 type=VOTER_FULL)
+change-id=2 store-id=8 node-id=8 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=2 type=VOTER_FULL leaseholder=true)
+
+ranges
+----
+range-id=44 local-store=1 load=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] raft-cpu=10
+  store-id=1 replica-id=1 type=VOTER_FULL
+  store-id=8 replica-id=2 type=VOTER_FULL leaseholder=true
+
+# Step 3: enact (mirrors AdjustPendingChangeDisposition(success=true) →
+# pendingChangeEnacted). Pending drained from cs.pendingChanges and
+# rs.pendingChanges. Entries linger in store.adjusted.loadPendingChanges
+# (visible as enacted=...) until their load is GC'd, but those are
+# bookkeeping only; rs.pendingChanges (which the lease-shed path checks)
+# is now empty. Crucially, rs.constraints still says leaseholderID=s1.
+enact-pending-changes change-ids=(1,2)
+----
+pending(2)
+change-id=1 store-id=1 node-id=1 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=1 type=VOTER_FULL)
+change-id=2 store-id=8 node-id=8 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=2 type=VOTER_FULL leaseholder=true)
+
+# Step 4: s8's leaseholder msg confirming what rs.replicas already shows.
+# Use span-config-not-populated since the parser otherwise sets
+# MaybeSpanConfIsPopulated=true whenever load/raft-cpu fields are present;
+# in production only the gossiped span config sets this flag and steady-state
+# msgs from a leaseholder for a known range arrive without it. With no
+# spanConf, no pending, and replicas matching → FAST PATH in processRangeMsg.
+# constraints are NOT cleared. Top-k for s8 is recomputed and includes r44.
+store-leaseholder-msg
+store-id=8
+  range-id=44 load=[100,0,0] raft-cpu=10 span-config-not-populated
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=8 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+# Confirm the stale leaseholderID=s1 survived the leaseholder msg.
+analyze-constraints range-id=44
+----
+leaseholderID=s1
+
+# Advance the clock so the still-tracked enacted load-pending changes get
+# GC'd by the next store-load-msg (lagForChangeReflectedInLoad=10s). Without
+# this, s8 has nonzero maxFractionPendingIncrease and the rebalance pass
+# classifies it as cannotShed before reaching the lease-shed loop.
+tick seconds=15
+----
+t=15s
+
+# Bump s8's reported load so it is CPU-overloaded; load-time advanced past
+# enactedAt+10s lets processStoreLoadMsg drop the enacted entries from
+# loadPendingChanges, clearing the pending-increase block.
+store-load-msg
+  store-id=8 node-id=8 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=15s
+----
+
+# Step 5: s8's rebalance pass enters rebalanceLeasesFromLocalStoreID for
+# r44, reads rs.constraints (leaseholderID=s1, store=s8), and panics. The
+# datadriven harness recovers and prints the panic.
+rebalance-stores store-id=8
+----
+panic: internal state inconsistency: store=8 range_id=44 should be leaseholder but isn't

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_constraints.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_constraints.txt
@@ -3,32 +3,33 @@
 #   panic: internal state inconsistency: store=8 range_id=44 should be
 #   leaseholder but isn't
 #
-# in rebalanceLeasesFromLocalStoreID at cluster_state_rebalance_stores.go:840.
-#
-# Mechanism: rs.constraints is a cached blob populated by a prior rebalance
-# pass on the then-leaseholder. It is invalidated by:
-#  - clearAnalyzedConstraints from processRangeMsg's slow path,
-#  - clearAnalyzedConstraints from undoPendingChange,
-#  - rangeState GC.
-# It is NOT invalidated by addPendingRangeChange (which mutates rs.replicas
-# via applyReplicaChange) or by pendingChangeEnacted. So a sequence of:
+# in rebalanceLeasesFromLocalStoreID. rs.constraints is a cached blob
+# populated by a prior rebalance pass on the then-leaseholder. The bug was
+# that addPendingRangeChange mutated rs.replicas (via applyReplicaChange)
+# without calling clearAnalyzedConstraints. The narrow trigger:
 #  1. cache constraints with leaseholderID=s1 while s1 holds the lease,
 #  2. external lease transfer s1->s8 registered with MMA: rs.replicas's
 #     IsLeaseholder flag flips to s8 in place (replica-ids preserved
 #     because lease transfer is an isUpdate change),
 #  3. change enacted (rs.pendingChanges drained, replicas unchanged),
 #  4. s8's leaseholder msg arrives matching rs.replicas exactly with no
-#     spanConf and no pending → FAST PATH in processRangeMsg, constraints
-#     survive,
+#     spanConf and no pending → fast path in processRangeMsg, no
+#     clearAnalyzedConstraints,
 #  5. s8's rebalance pass reads cached constraints → leaseholderID=s1 but
 #     store=s8 → panic.
 #
-# This test walks that exact sequence. The full add+remove rebalance also
-# leaves stale constraints, but its applyReplicaChange uses
-# replica-id=unknown for the new replica, so the next leaseholder msg from
-# the new owner takes the slow path (replica-ids differ) and clears
-# constraints. The lease-transfer path preserves replica-ids and is the
-# narrowest reproduction.
+# This test walks that sequence. The full add+remove rebalance has the same
+# property at step 2 (constraints not invalidated), but its applyReplicaChange
+# uses replica-id=unknown for the new replica, so step 4's leaseholder msg
+# takes the slow path (replica-ids differ) and clears constraints — masking
+# the underlying bug. The lease-transfer path preserves replica-ids and is
+# the narrowest reproduction.
+#
+# Fix: addPendingRangeChange now calls clearAnalyzedConstraints. Step 1's
+# cached blob is dropped at step 2; step 5's analyze-constraints rebuilds
+# from current rs.replicas and reports the correct leaseholderID=s8;
+# rebalance-stores reaches the lease-shed loop with consistent state and
+# completes without panic.
 
 set-store
   store-id=1 node-id=1
@@ -60,8 +61,9 @@ analyze-constraints range-id=44
 leaseholderID=s1
 
 # Step 2: external lease transfer s1->s8 registered with MMA. After
-# addPendingRangeChange, rs.replicas's leaseholder flag has flipped to s8.
-# rs.constraints is unchanged.
+# addPendingRangeChange, rs.replicas's leaseholder flag has flipped to s8;
+# the fix added clearAnalyzedConstraints here, so the cached blob from step 1
+# is also dropped.
 make-pending-changes range-id=44
   transfer-lease: remove-store-id=1 add-store-id=8
 ----
@@ -83,8 +85,8 @@ range-id=44 local-store=1 load=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 
 # pendingChangeEnacted). Pending drained from cs.pendingChanges and
 # rs.pendingChanges. Entries linger in store.adjusted.loadPendingChanges
 # (visible as enacted=...) until their load is GC'd, but those are
-# bookkeeping only; rs.pendingChanges (which the lease-shed path checks)
-# is now empty. Crucially, rs.constraints still says leaseholderID=s1.
+# bookkeeping only; rs.pendingChanges (which the lease-shed path checks) is
+# now empty. rs.constraints stays nil since step 2 cleared it.
 enact-pending-changes change-ids=(1,2)
 ----
 pending(2)
@@ -100,8 +102,10 @@ change-id=2 store-id=8 node-id=8 range-id=44 load-delta=[cpu:99ns/s, write-bandw
 # MaybeSpanConfIsPopulated=true whenever load/raft-cpu fields are present;
 # in production only the gossiped span config sets this flag and steady-state
 # msgs from a leaseholder for a known range arrive without it. With no
-# spanConf, no pending, and replicas matching → FAST PATH in processRangeMsg.
-# constraints are NOT cleared. Top-k for s8 is recomputed and includes r44.
+# spanConf, no pending, and replicas matching → fast path in processRangeMsg
+# (no clearAnalyzedConstraints). Top-k for s8 is recomputed and includes
+# r44. Pre-fix the fast path would have left a stale rs.constraints behind;
+# post-fix the cache was already invalidated in step 2.
 store-leaseholder-msg
 store-id=8
   range-id=44 load=[100,0,0] raft-cpu=10 span-config-not-populated
@@ -109,10 +113,12 @@ store-id=8
     store-id=8 replica-id=2 type=VOTER_FULL leaseholder=true
 ----
 
-# Confirm the stale leaseholderID=s1 survived the leaseholder msg.
+# Post-fix: rs.constraints was nil, so this call rebuilds it from current
+# rs.replicas and the leaseholderID is the now-correct s8. Pre-fix this would
+# have returned the stale leaseholderID=s1.
 analyze-constraints range-id=44
 ----
-leaseholderID=s1
+leaseholderID=s8
 
 # Advance the clock so the still-tracked enacted load-pending changes get
 # GC'd by the next store-load-msg (lagForChangeReflectedInLoad=10s). Without
@@ -130,8 +136,22 @@ store-load-msg
 ----
 
 # Step 5: s8's rebalance pass enters rebalanceLeasesFromLocalStoreID for
-# r44, reads rs.constraints (leaseholderID=s1, store=s8), and panics. The
-# datadriven harness recovers and prints the panic.
+# r44 with consistent state (leaseholderID=s8, store=s8) and proceeds
+# normally. Pre-fix this site panicked.
 rebalance-stores store-id=8
 ----
-panic: internal state inconsistency: store=8 range_id=44 should be leaseholder but isn't
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 0) (nodes-cpu-capacity 1000)
+[mmaid=1] evaluating s1: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] evaluating s8: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] overload-continued s8 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] adding overloaded store s8 to shedding list (worst dim: CPURate, cannotShed: false, pending decrease 0.00 vs threshold 0.10, pending increase 0.00 vs epsilon 0.00); pending: (none)
+[mmaid=1] sorted shedding stores: (s8: overloadUrgent, cannotShed: false)
+[mmaid=1] rebalancing pass summary [local=s8]:
+	overloaded:
+		lease-grace: [s8]
+	failure: [{s8, total: 2, no-cand:1, no-cand-load:1}]
+pending(1)
+change-id=1 store-id=1 node-id=1 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=1 type=VOTER_FULL)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk.txt
@@ -1,0 +1,104 @@
+# Reproduces the second staleness class behind #170112: a stale entry in
+# ss.adjusted.topKRanges. topK is rebuilt only by
+# processStoreLeaseholderMsgInternal — see the topKRanges invariant on
+# storeState in cluster_state.go. Pending mutations to rs.replicas /
+# ss.adjusted.replicas (and their enactment) do NOT update topK, so between
+# consecutive leaseholder msgs from store L, topKRanges[L] entries can list
+# ranges where the local store is no longer leaseholder or replica.
+# Skip-on-pending in the rebalance loops only masks the in-progress window;
+# post-enact, readers fire assertions in rebalanceLeasesFromLocalStoreID
+# (the !IsLeaseholder and missing-replica checks) and in
+# rebalanceReplicasFromShedingStore (the replicaRole check). Those Fatalf /
+# panic sites were converted to panic(AssertionFailedf) in an earlier commit
+# so the datadriven harness can capture them; a follow-up commit converts
+# them to skip+log.
+#
+# This test walks an enacted lease transfer s8->s1 with no follow-up msg
+# from s8, then runs s8's rebalance pass. Expected: panic at the
+# !IsLeaseholder check since topK[s8] still lists r44 but rs.replicas now
+# marks s1 as leaseholder.
+
+set-store
+  store-id=1 node-id=1
+  store-id=8 node-id=8
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=8 locality-tiers=node=8
+  store-id=8 attrs=
+
+store-load-msg
+  store-id=1 node-id=1 load=[0,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=8 node-id=8 load=[0,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+----
+
+# r44 has voters on s1 and s8, leaseholder=s8.
+store-leaseholder-msg
+store-id=8
+  range-id=44 load=[100,0,0] raft-cpu=10
+  config=num_replicas=2 constraints={} voter_constraints={}
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=8 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+# topK[s8] now has r44 across all storeStates (added during the recompute at
+# the end of processStoreLeaseholderMsgInternal).
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=8) dim=WriteBandwidth: r44
+store-id=8 node-id=8 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=8) dim=CPURate: r44
+
+# External lease transfer s8->s1 registered with MMA.
+make-pending-changes range-id=44
+  transfer-lease: remove-store-id=8 add-store-id=1
+----
+pending(2)
+change-id=1 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=2 type=VOTER_FULL)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)
+
+# rs.replicas now shows s1 as leaseholder.
+ranges
+----
+range-id=44 local-store=8 load=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] raft-cpu=10
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+  store-id=8 replica-id=2 type=VOTER_FULL
+
+# Enact the lease transfer (mirrors AdjustPendingChangeDisposition(success)
+# → pendingChangeEnacted). pending drained; rs.replicas keeps s1 leader.
+# Crucially we do NOT send a new StoreLeaseholderMsg from s8, so topK[s8]
+# still reflects the old world where s8 was leader of r44.
+enact-pending-changes change-ids=(1,2)
+----
+pending(2)
+change-id=1 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=2 type=VOTER_FULL)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)
+
+# Advance the clock past lagForChangeReflectedInLoad so the next
+# store-load-msg drops the enacted entries from loadPendingChanges
+# (otherwise s8's maxFractionPendingDecrease keeps it in cannotShed).
+tick seconds=15
+----
+t=15s
+
+# Bump s8's reported load so it is CPU-overloaded.
+store-load-msg
+  store-id=8 node-id=8 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=15s
+----
+
+# topK[s8] still lists r44 but rs.replicas[s8].IsLeaseholder is now false.
+# The lease-shed loop iterates topK[s8], finds r44, hits s8 in rs.replicas
+# with IsLeaseholder=false, and panics. The datadriven harness recovers and
+# prints the panic.
+rebalance-stores store-id=8
+----
+panic: internal state inconsistency: r44 considered for lease shedding on s8 has no pending changes but s8 is not leaseholder: replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok s8:replica-id=2 type=VOTER_FULL lease disposition:ok]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk.txt
@@ -6,17 +6,16 @@
 # consecutive leaseholder msgs from store L, topKRanges[L] entries can list
 # ranges where the local store is no longer leaseholder or replica.
 # Skip-on-pending in the rebalance loops only masks the in-progress window;
-# post-enact, readers fire assertions in rebalanceLeasesFromLocalStoreID
-# (the !IsLeaseholder and missing-replica checks) and in
-# rebalanceReplicasFromShedingStore (the replicaRole check). Those Fatalf /
-# panic sites were converted to panic(AssertionFailedf) in an earlier commit
-# so the datadriven harness can capture them; a follow-up commit converts
-# them to skip+log.
+# post-enact, the lease-shed loop's !IsLeaseholder / missing-replica checks
+# and the replica-shed loop's replicaRole check used to fire as Fatalf /
+# panic. They are now skip+log at V(3) — see the comments at the
+# corresponding sites in cluster_state_rebalance_stores.go.
 #
 # This test walks an enacted lease transfer s8->s1 with no follow-up msg
-# from s8, then runs s8's rebalance pass. Expected: panic at the
-# !IsLeaseholder check since topK[s8] still lists r44 but rs.replicas now
-# marks s1 as leaseholder.
+# from s8, then runs s8's rebalance pass. topK[s8] still lists r44 but
+# rs.replicas now marks s1 as leaseholder; the lease-shed loop logs and
+# skips the range. The pass completes without panic; the per-pass summary
+# shows the range as "range-transient" failure.
 
 set-store
   store-id=1 node-id=1
@@ -97,8 +96,45 @@ store-load-msg
 
 # topK[s8] still lists r44 but rs.replicas[s8].IsLeaseholder is now false.
 # The lease-shed loop iterates topK[s8], finds r44, hits s8 in rs.replicas
-# with IsLeaseholder=false, and panics. The datadriven harness recovers and
-# prints the panic.
-rebalance-stores store-id=8
+# with IsLeaseholder=false, logs at V(3), and continues. Pre-fix this
+# panicked.
+rebalance-stores store-id=8 vmodule=3
 ----
-panic: internal state inconsistency: r44 considered for lease shedding on s8 has no pending changes but s8 is not leaseholder: replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok s8:replica-id=2 type=VOTER_FULL lease disposition:ok]
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 0) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
+[mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=1000.00,1000.00(false))) - within grace period
+[mmaid=1] adding overloaded store s1 to shedding list (worst dim: CPURate, cannotShed: true, pending decrease 1000.00 vs threshold 0.10, pending increase 1000.00 vs epsilon 0.00); pending: (none)
+[mmaid=1] load summary for dim=CPURate (s8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] evaluating s8: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] overload-continued s8 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] adding overloaded store s8 to shedding list (worst dim: CPURate, cannotShed: false, pending decrease 0.00 vs threshold 0.10, pending increase 0.00 vs epsilon 0.00); pending: (none)
+[mmaid=1] sorted shedding stores: (s8: overloadUrgent, cannotShed: false) (s1: overloadSlow, cannotShed: true)
+[mmaid=1] start processing shedding store s8: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s8 with lease on local s8: r44:[cpu:10ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] local store s8 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] skipping r44: stale topK[s8] entry, s8 no longer leaseholder
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] load summary for dim=CPURate (s8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=500 fractionUsed=100.00% meanUtil=50.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=500 fractionUsed=100.00% meanUtil=50.00% capacity=1000]
+[mmaid=1] considering replica-transfer r44 from s8: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] candidates for r44:
+[mmaid=1] result(failed): no candidates found for r44 after exclusions
+[mmaid=1] rebalancing pass summary [local=s8]:
+	overloaded:
+		lease-grace: [s1, s8]
+	failure: [{s8, total: 2, no-cand:1, range-transient:1}]
+	skipped: [s1]
+pending(1)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk.txt
@@ -8,7 +8,7 @@
 # Skip-on-pending in the rebalance loops only masks the in-progress window;
 # post-enact, the lease-shed loop's !IsLeaseholder / missing-replica checks
 # and the replica-shed loop's replicaRole check used to fire as Fatalf /
-# panic. They are now skip+log at V(3) — see the comments at the
+# panic. They are now skip+log at V(1) — see the comments at the
 # corresponding sites in cluster_state_rebalance_stores.go.
 #
 # This test walks an enacted lease transfer s8->s1 with no follow-up msg
@@ -96,39 +96,20 @@ store-load-msg
 
 # topK[s8] still lists r44 but rs.replicas[s8].IsLeaseholder is now false.
 # The lease-shed loop iterates topK[s8], finds r44, hits s8 in rs.replicas
-# with IsLeaseholder=false, logs at V(3), and continues. Pre-fix this
+# with IsLeaseholder=false, logs at V(1), and continues. Pre-fix this
 # panicked.
-rebalance-stores store-id=8 vmodule=3
+rebalance-stores store-id=8 vmodule=1
 ----
 [mmaid=1] rebalanceStores begins
 [mmaid=1] cluster means: (stores-load [cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 0) (nodes-cpu-capacity 1000)
-[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=1000.00,1000.00(false))) - within grace period
 [mmaid=1] adding overloaded store s1 to shedding list (worst dim: CPURate, cannotShed: true, pending decrease 1000.00 vs threshold 0.10, pending increase 1000.00 vs epsilon 0.00); pending: (none)
-[mmaid=1] load summary for dim=CPURate (s8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=WriteBandwidth (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=ByteSize (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=CPURate (n8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
 [mmaid=1] evaluating s8: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s8 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] adding overloaded store s8 to shedding list (worst dim: CPURate, cannotShed: false, pending decrease 0.00 vs threshold 0.10, pending increase 0.00 vs epsilon 0.00); pending: (none)
 [mmaid=1] sorted shedding stores: (s8: overloadUrgent, cannotShed: false) (s1: overloadSlow, cannotShed: true)
-[mmaid=1] start processing shedding store s8: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s8 with lease on local s8: r44:[cpu:10ns/s, write-bandwidth:0 B/s, byte-size:0 B]
-[mmaid=1] local store s8 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
 [mmaid=1] skipping r44: stale topK[s8] entry, s8 no longer leaseholder
-[mmaid=1] attempting to shed replicas next
-[mmaid=1] load summary for dim=CPURate (s8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=500 fractionUsed=100.00% meanUtil=50.00% capacity=1000]
-[mmaid=1] load summary for dim=WriteBandwidth (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=ByteSize (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=CPURate (n8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=500 fractionUsed=100.00% meanUtil=50.00% capacity=1000]
-[mmaid=1] considering replica-transfer r44 from s8: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
-[mmaid=1] candidates for r44:
-[mmaid=1] result(failed): no candidates found for r44 after exclusions
 [mmaid=1] rebalancing pass summary [local=s8]:
 	overloaded:
 		lease-grace: [s1, s8]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk_no_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk_no_replica.txt
@@ -120,30 +120,18 @@ store-load-msg
 #     (which lacks s8). replicaRole(s8) returns (false,false) → "stale
 #     topK[s%d] or stale constraints, s%d not in cached replica set" skip.
 # Pass completes without panic; the per-pass summary attributes both skips.
-rebalance-stores store-id=8 vmodule=3
+rebalance-stores store-id=8 vmodule=1
 ----
 [mmaid=1] rebalanceStores begins
 [mmaid=1] cluster means: (stores-load [cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 0) (nodes-cpu-capacity 1000)
-[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
 [mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=1000.00,1000.00(false))) - within grace period
 [mmaid=1] adding overloaded store s1 to shedding list (worst dim: CPURate, cannotShed: true, pending decrease 1000.00 vs threshold 0.10, pending increase 1000.00 vs epsilon 0.00); pending: (none)
-[mmaid=1] load summary for dim=CPURate (s8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=WriteBandwidth (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=ByteSize (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
-[mmaid=1] load summary for dim=CPURate (n8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
 [mmaid=1] evaluating s8: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s8 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] adding overloaded store s8 to shedding list (worst dim: CPURate, cannotShed: false, pending decrease 0.00 vs threshold 0.10, pending increase 0.00 vs epsilon 0.00); pending: (none)
 [mmaid=1] sorted shedding stores: (s8: overloadUrgent, cannotShed: false) (s1: overloadSlow, cannotShed: true)
-[mmaid=1] start processing shedding store s8: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s8 with lease on local s8: r44:[cpu:10ns/s, write-bandwidth:0 B/s, byte-size:0 B]
-[mmaid=1] local store s8 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
 [mmaid=1] skipping r44: stale topK[s8] entry, s8 no longer a replica
-[mmaid=1] attempting to shed replicas next
 [mmaid=1] skipping r44: stale topK[s8] or stale constraints, s8 not in cached replica set
 [mmaid=1] rebalancing pass summary [local=s8]:
 	overloaded:

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk_no_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_lease_stale_topk_no_replica.txt
@@ -1,0 +1,156 @@
+# Companion to rebalance_lease_stale_topk.txt for #170112. That test exercises
+# the lease-shed loop's "found local replica but !IsLeaseholder" skip. This
+# test exercises:
+#  - the lease-shed loop's "local store no longer in rs.replicas" skip
+#    (topK[localStoreID] retains a phantom entry after the local store's
+#    replica was removed); and
+#  - the replica-shed loop's replicaRole-returns-(false,false) skip
+#    (constraints rebuilt from current rs.replicas no longer place the
+#    shedding store in the replica set).
+#
+# Both fire from the same scenario in a single rebalance pass: lease-shed
+# skips r44 (no local replica), returns 0 transfers, then replica-shed runs
+# on the same topK entry and skips r44 (replicaRole false on shedding store).
+
+set-store
+  store-id=1 node-id=1
+  store-id=8 node-id=8
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=8 locality-tiers=node=8
+  store-id=8 attrs=
+
+store-load-msg
+  store-id=1 node-id=1 load=[0,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=8 node-id=8 load=[0,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+----
+
+# r44 with replicas {s8 leader, s1}. Spanconf provided so
+# ensureAnalyzedConstraints can run.
+store-leaseholder-msg
+store-id=8
+  range-id=44 load=[100,0,0] raft-cpu=10
+  config=num_replicas=2 constraints={} voter_constraints={}
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=8 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+# topK[s8] now lists r44 across stores. Confirm.
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=8) dim=WriteBandwidth: r44
+store-id=8 node-id=8 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=8) dim=CPURate: r44
+
+# Move the lease s8->s1 first (preCheckOnApplyReplicaChanges requires
+# exactly one leaseholder after the change set, so we cannot remove the
+# leader replica directly).
+make-pending-changes range-id=44
+  transfer-lease: remove-store-id=8 add-store-id=1
+----
+pending(2)
+change-id=1 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=2 type=VOTER_FULL)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)
+
+enact-pending-changes change-ids=(1,2)
+----
+pending(2)
+change-id=1 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=2 type=VOTER_FULL)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)
+
+# Now remove s8 entirely. preCheck passes since s1 is the leader after.
+make-pending-changes range-id=44
+  remove-replica: remove-store-id=8
+----
+pending(3)
+change-id=1 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=2 type=VOTER_FULL)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)
+change-id=3 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-10ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=5m0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+enact-pending-changes change-ids=(3)
+----
+pending(3)
+change-id=1 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-90ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=2 type=VOTER_FULL)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)
+change-id=3 store-id=8 node-id=8 range-id=44 load-delta=[cpu:-10ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=5m0s enacted=0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+# rs.replicas now reflects [s1 leader] only; s8 entirely gone.
+ranges
+----
+range-id=44 local-store=8 load=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] raft-cpu=10
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+
+# Advance the clock so loadPendingChanges entries get GC'd by the next
+# store-load-msg (mirror of the rebalance_lease_stale_topk.txt setup).
+tick seconds=15
+----
+t=15s
+
+store-load-msg
+  store-id=8 node-id=8 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=15s
+----
+
+# s8's pass:
+#  1. lease-shed reads topK[s8], finds r44, iterates rs.replicas, doesn't
+#     find s8 → "stale topK[s%d] entry, s%d no longer a replica" skip;
+#  2. lease-shed returns 0 transfers, replica-shed runs on the same topK
+#     entry. ensureAnalyzedConstraints rebuilds from current rs.replicas
+#     (which lacks s8). replicaRole(s8) returns (false,false) → "stale
+#     topK[s%d] or stale constraints, s%d not in cached replica set" skip.
+# Pass completes without panic; the per-pass summary attributes both skips.
+rebalance-stores store-id=8 vmodule=3
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 0) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=99 meanLoad=0 fractionUsed=9.90%* meanUtil=0.00% capacity=1000]
+[mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow frac_pending=1000.00,1000.00(false))) - within grace period
+[mmaid=1] adding overloaded store s1 to shedding list (worst dim: CPURate, cannotShed: true, pending decrease 1000.00 vs threshold 0.10, pending increase 1000.00 vs epsilon 0.00); pending: (none)
+[mmaid=1] load summary for dim=CPURate (s8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s8): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n8): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=0 fractionUsed=100.00%* meanUtil=0.00% capacity=1000]
+[mmaid=1] evaluating s8: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] overload-continued s8 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] adding overloaded store s8 to shedding list (worst dim: CPURate, cannotShed: false, pending decrease 0.00 vs threshold 0.10, pending increase 0.00 vs epsilon 0.00); pending: (none)
+[mmaid=1] sorted shedding stores: (s8: overloadUrgent, cannotShed: false) (s1: overloadSlow, cannotShed: true)
+[mmaid=1] start processing shedding store s8: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s8 with lease on local s8: r44:[cpu:10ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] local store s8 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] skipping r44: stale topK[s8] entry, s8 no longer a replica
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] skipping r44: stale topK[s8] or stale constraints, s8 not in cached replica set
+[mmaid=1] rebalancing pass summary [local=s8]:
+	overloaded:
+		lease-grace: [s1, s8]
+	failure: [{s8, total: 2, range-transient:2}]
+	skipped: [s1]
+pending(1)
+change-id=2 store-id=1 node-id=1 range-id=44 load-delta=[cpu:99ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s enacted=0s
+  prev=(replica-id=1 type=VOTER_FULL)
+  next=(replica-id=1 type=VOTER_FULL leaseholder=true)


### PR DESCRIPTION
Two distinct staleness sources in MMA's rebalance loops could fatal the node.

The first is a cache invalidation gap on \`rangeState.constraints\` — a per-range blob derived from \`rs.replicas\`. The contract is that any code path that mutates \`rs.replicas\` calls \`clearAnalyzedConstraints\`. The slow path of \`processRangeMsg\`, \`undoPendingChange\`, and the range-removal branch of \`processStoreLeaseholderMsgInternal\` honored it; \`addPendingRangeChange\` did not. The narrow trigger exposed by #170112: a prior pass cached the blob with \`leaseholderID=s1\`, an external lease transfer s1→s8 mutated \`rs.replicas\` via \`applyReplicaChange\` (preserving replica IDs since lease transfer is an isUpdate change), \`pendingChangeEnacted\` drained pending without touching the cache, and s8's confirming leaseholder msg matched \`rs.replicas\` exactly with no spanConf and no pending — the fast path in \`processRangeMsg\` returned without invalidating. s8's next rebalance pass then read constraints with the stale leaseholder and panicked. Fix: add \`clearAnalyzedConstraints\` in \`addPendingRangeChange\` after \`applyReplicaChange\`.

The second is structural staleness in \`storeState.adjusted.topKRanges\`. By design topK is rebuilt only when a leaseholder msg arrives; pending mutations and enactments slide \`rs.replicas\` and \`ss.adjusted.replicas\` out from under it. Three assertion sites in the rebalance loops fired on the resulting transient mismatches. Fix: convert them to V(3) skip+log via the existing \`ml.logf\` channel — matching the verbosity of neighboring skip messages in these loops — and let the next leaseholder msg from L self-correct (≤10s typical). The doc comment on \`topKRanges\` is fleshed out to spell out the lifecycle and the tolerance contract; the prior TODO musing about incremental maintenance is dropped.

The fourth assertion site (constraint leaseholderID mismatch, which the \`addPendingRangeChange\` invalidation already prevents) gets the same skip+log treatment as a permanent parity-with-topK guard: any future replica-mutating code path that forgets to invalidate gets a benign skip rather than a node fatal. MMA state is in-memory and self-heals on restart, so node-fatal assertions are wrong for this class regardless of correctness.

Three datadriven regression tests under \`testdata/cluster_state/rebalance_lease_stale_*\` walk the panicking sequences and assert the post-fix behavior. The topk tests run with \`vmodule=3\` so the expected output pins the specific skip log lines rather than just a transient-skip count.

\`BenchmarkRebalanceStores\` at -count 10 shows no regression (time/op p=0.604, alloc/op p=0.066, allocs/op identical). The added \`clearAnalyzedConstraints\` call releases a small pooled object; the V(3) skip paths only allocate when vmodule is set.

**No release note**: master-only; the previous release shipped with MMA off by default.

Fixes #170112.
Informs #167723.

Epic: none

Release note: None