### PR TITLE
release-26.2: mmaintegration: don't panic on stale removal target

### DIFF
--- a/pkg/kv/kvserver/mmaintegration/mma_conversion.go
+++ b/pkg/kv/kvserver/mmaintegration/mma_conversion.go
@@ -6,8 +6,6 @@
 package mmaintegration
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
@@ -93,9 +91,15 @@ func convertReplicaChangeToMMA(
 			})
 			replDescriptors := filteredSet.Descriptors()
 			if len(replDescriptors) != 1 {
-				panic(fmt.Sprintf(
+				// This is reachable when the replicate queue plans changes against
+				// one descriptor and applyChange then re-reads a fresher descriptor
+				// before passing both into NonMMAPreChangeReplicas: a concurrent
+				// replication change can remove the target store in between. The
+				// caller logs and skips MMA registration; the underlying
+				// changeReplicasImpl will detect the stale descriptor via its CPut.
+				return mmaprototype.PendingRangeChange{}, errors.Errorf(
 					"no replica found for removal target=%v post-filter=%v pre-filter=%v",
-					chg.Target.StoreID, replDescriptors, desc))
+					chg.Target.StoreID, replDescriptors, desc)
 			}
 			replDesc := replDescriptors[0]
 			isLeaseholder := replDesc.StoreID == leaseholderStoreID

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestConvertReplicaChangeToMMA
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestConvertReplicaChangeToMMA
@@ -92,13 +92,12 @@ panicked as expected
 # Regression for #170183: the replicate queue can pass a stale change set
 # (REMOVE_VOTER for a store that was concurrently removed by another
 # replication change) against a fresh range descriptor that no longer contains
-# that store. This currently panics, crashing the node. The next commit
-# converts the panic to an error so this benign descriptor race does not bring
-# down a node.
-convert-replica-changes expect-panic
+# that store. We return an error rather than panicking so this benign
+# descriptor race does not bring down the node.
+convert-replica-changes
 store-id=4 type=REMOVE_VOTER
 ----
-panicked as expected
+error: no replica found for removal target=4 post-filter=[] pre-filter=r1:{-} [(n1,s1):10, (n2,s2):20, next=0, gen=0]
 
 # Attempt to downgrade leaseholder voter to non-voter, without adding a voter,
 # returns an error.

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestConvertReplicaChangeToMMA
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestConvertReplicaChangeToMMA
@@ -89,7 +89,12 @@ store-id=3 type=ADD_NON_VOTER
 ----
 panicked as expected
 
-# Expect panic since removing non-existent replica.
+# Regression for #170183: the replicate queue can pass a stale change set
+# (REMOVE_VOTER for a store that was concurrently removed by another
+# replication change) against a fresh range descriptor that no longer contains
+# that store. This currently panics, crashing the node. The next commit
+# converts the panic to an error so this benign descriptor race does not bring
+# down a node.
 convert-replica-changes expect-panic
 store-id=4 type=REMOVE_VOTER
 ----


### PR DESCRIPTION
Backport 2/2 commits from #170270 on behalf of @tbg.

----

Fixes a node-fatal panic in `convertReplicaChangeToMMA` when the replicate queue passes a stale change set against a freshly-loaded range descriptor. The actual replication change goes through `changeReplicasImpl`, which detects the stale descriptor safely via its CPut; only the MMA bookkeeping panicked.

Two-commit red/green arc:
1. Reframes the existing "removing non-existent replica" datadriven case as the #170183 regression (comment-only).
2. Replaces `panic` with `errors.Errorf` and flips the test to expect the error. The function already returned `(_, error)` and the caller already logged + skipped MMA registration on error, so the diff is minimal.

`Errorf` (not `AssertionFailedf`) — this is a benign descriptor race, not a programming bug, so we don't want a sentry alert each time it fires.

**No release note**: master-only fix; the previous release shipped with MMA off by default, so no released-version users were exposed.

Fixes #170183.
Fixes #169923.
Fixes #169963.

Epic: none

Release note: None

----

Release justification: