### PR TITLE
crosscluster/logical: remove two deprecated job update calls

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -96,7 +96,7 @@ func (r *logicalReplicationResumer) Resume(ctx context.Context, execCtx interfac
 	jobExecCtx := execCtx.(sql.JobExecContext)
 
 	if r.jobUsesUDF() && !crosscluster.LogicalReplicationUDFWriterEnabled.Get(&jobExecCtx.ExecCfg().Settings.SV) {
-		r.updateStatusMessage(ctx, "job paused because UDF-based logical replication writer is disabled")
+		r.updateStatusMessage(ctx, jobExecCtx.ExecCfg().InternalDB, "job paused because UDF-based logical replication writer is disabled")
 		return jobs.MarkPauseRequestError(errors.Newf("UDF-based logical replication writer is disabled and will be deleted in a future CockroachDB release"))
 	}
 
@@ -119,27 +119,29 @@ func (r *logicalReplicationResumer) Resume(ctx context.Context, execCtx interfac
 func (r *logicalReplicationResumer) handleResumeError(
 	ctx context.Context, execCtx sql.JobExecContext, err error,
 ) error {
+	db := execCtx.ExecCfg().InternalDB
 	if err == nil {
-		r.updateStatusMessage(ctx, "")
+		r.updateStatusMessage(ctx, db, "")
 		return nil
 	}
 	if jobs.IsPermanentJobError(err) {
-		r.updateStatusMessage(ctx, redact.Sprintf("permanent error: %v", err))
+		r.updateStatusMessage(ctx, db, redact.Sprintf("permanent error: %v", err))
 		return err
 	}
-	r.updateStatusMessage(ctx, redact.Sprintf("pausing after error: %v", err))
+	r.updateStatusMessage(ctx, db, redact.Sprintf("pausing after error: %v", err))
 	return jobs.MarkPauseRequestError(err)
 }
 
 func (r *logicalReplicationResumer) updateStatusMessage(
-	ctx context.Context, status redact.RedactableString,
+	ctx context.Context, db isql.DB, status redact.RedactableString,
 ) {
 	log.Dev.Infof(ctx, "%s", status)
-	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
-	err := r.job.DeprecatedNoTxn().Update(ctx, func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
-		md.Progress.StatusMessage = string(status.Redact())
-		ju.UpdateProgress(md.Progress)
-		return nil
+	redactedStatus := string(status.Redact())
+	err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		if redactedStatus == "" {
+			return r.job.StatusStorage().Clear(ctx, txn)
+		}
+		return r.job.StatusStorage().Set(ctx, txn, redactedStatus)
 	})
 	if err != nil {
 		log.Dev.Warningf(ctx, "error when updating job running status: %s", err)

--- a/pkg/crosscluster/logical/txnmode/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnmode/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/isql",
         "//pkg/sql/physicalplan",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",

--- a/pkg/crosscluster/logical/txnmode/txnmode_dist.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_dist.go
@@ -291,6 +291,7 @@ func RunDistSQLFlow(
 
 	ch := newCheckpointHandler(
 		job,
+		execCtx.ExecCfg().InternalDB,
 		&execCtx.ExecCfg().Settings.SV,
 		frontierUpdates,
 		applierInstanceIDs,
@@ -338,6 +339,7 @@ func RunDistSQLFlow(
 // the flow down.
 type checkpointHandler struct {
 	job             *jobs.Job
+	db              isql.DB
 	sv              *settings.Values
 	frontierUpdates chan<- hlc.Timestamp
 	endTime         hlc.Timestamp
@@ -354,6 +356,7 @@ type checkpointHandler struct {
 // immediately return the checkpoint while waiting for fresher updates.
 func newCheckpointHandler(
 	job *jobs.Job,
+	db isql.DB,
 	sv *settings.Values,
 	frontierUpdates chan<- hlc.Timestamp,
 	applierInstanceIDs []base.SQLInstanceID,
@@ -369,6 +372,7 @@ func newCheckpointHandler(
 	}
 	return &checkpointHandler{
 		job:              job,
+		db:               db,
 		sv:               sv,
 		frontierUpdates:  frontierUpdates,
 		endTime:          endTime,
@@ -404,21 +408,9 @@ func (ch *checkpointHandler) handleMeta(
 		return nil
 	}
 
-	//lint:ignore SA1019 deprecated updater sets HighWater and ReplicatedTime on progress proto
-	if err := ch.job.DeprecatedNoTxn().Update(ctx,
-		func(txn isql.Txn, md jobs.DeprecatedJobMetadata, ju *jobs.DeprecatedJobUpdater) error {
-			if err := md.CheckRunningOrReverting(); err != nil {
-				return err
-			}
-			progress := md.Progress
-			prog := progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
-			prog.ReplicatedTime = replicatedTime
-			progress.Progress = &jobspb.Progress_HighWater{
-				HighWater: &replicatedTime,
-			}
-			ju.UpdateProgress(progress)
-			return nil
-		}); err != nil {
+	if err := ch.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return ch.job.ProgressStorage().SetResolved(ctx, txn, replicatedTime)
+	}); err != nil {
 		return err
 	}
 	ch.replicatedTime = replicatedTime

--- a/pkg/crosscluster/logical/txnmode/txnmode_dist_test.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_dist_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -330,6 +331,7 @@ func TestCheckpointHandler(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	registry := s.JobRegistry().(*jobs.Registry)
+	internalDB := s.InternalDB().(isql.DB)
 	db := sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
 
 	createJob := func(t *testing.T) *jobs.Job {
@@ -362,7 +364,7 @@ func TestCheckpointHandler(t *testing.T) {
 		applierIDs := []base.SQLInstanceID{1, 2}
 
 		ch := newCheckpointHandler(
-			job, nil, frontierCh, applierIDs, hlc.Timestamp{}, hlc.MaxTimestamp,
+			job, internalDB, nil, frontierCh, applierIDs, hlc.Timestamp{}, hlc.MaxTimestamp,
 			func() {},
 		)
 
@@ -393,7 +395,7 @@ func TestCheckpointHandler(t *testing.T) {
 		resumeTS := mkts(10)
 
 		ch := newCheckpointHandler(
-			job, nil, frontierCh, applierIDs, resumeTS, hlc.MaxTimestamp,
+			job, internalDB, nil, frontierCh, applierIDs, resumeTS, hlc.MaxTimestamp,
 			func() {},
 		)
 
@@ -435,7 +437,7 @@ func TestCheckpointHandler(t *testing.T) {
 		var flowCanceled bool
 
 		ch := newCheckpointHandler(
-			job, nil, frontierCh, applierIDs, hlc.Timestamp{}, endTime,
+			job, internalDB, nil, frontierCh, applierIDs, hlc.Timestamp{}, endTime,
 			func() { flowCanceled = true },
 		)
 


### PR DESCRIPTION
Replace deprecated `DeprecatedNoTxn().Update()` calls with the new
job storage APIs in two LDR code paths:

- Transactional LDR checkpoint persistence now uses
  `ProgressStorage().SetResolved()` instead of writing to the legacy
  progress proto. The read path already uses `ProgressStorage().Get()`.

- Status message updates on retry (all LDR flavors) now use
  `StatusStorage.Set()`/`Clear()`.

No data migration is needed since the product has not shipped and the
deprecated API already wrote to the new storage tables as a side effect.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>