### PR TITLE
release-26.2: roachtest: shorten index-backfill no-disk-limit snapshot prefix

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -38,8 +38,11 @@ type indexBackfillVariant struct {
 
 var indexBackfillVariants = []indexBackfillVariant{
 	{
-		nameSuffix:     "/no-disk-limit",
-		snapshotPrefix: "index-backfill-tpce-100k-nodisklimit",
+		nameSuffix: "/no-disk-limit",
+		// Keep the snapshot prefix short: GCE caps snapshot names at 63 chars,
+		// and snapshotName() appends a version+node infix that consumes ~22
+		// chars on top of the versionedSnapshotPrefix(t) prefix.
+		snapshotPrefix: "index-backfill-tpce-100k-nodl",
 	},
 	{
 		nameSuffix:         "/provisioned-bandwidth=false",


### PR DESCRIPTION
Backport 1/1 commits from #170276 on behalf of @tbg.

----

## Summary

The GCE snapshot name produced by `snapshotName()` for the
`admission-control/index-backfill/no-disk-limit` variant exceeded the
GCE 63-character limit, causing the test to fail at snapshot creation:

```
snapshot name "index-backfill-tpce-100k-nodisklimit-v26-3-v26-2-0-rc-1-n10-0004" exceeds 63 characters
```

The infix `-<crdbVersion>-n<nodeCount>-<NNNN>` appended by
`roachprod.snapshotName` consumes ~22 characters when the predecessor
binary version includes an `-rc.N` suffix. The prefix already reaches
42 characters once `versionedSnapshotPrefix(t)` appends `-v26-3`,
pushing the total to 64.

This shortens the prefix from `nodisklimit` to `nodl`. The other two
variants (`nobw`, `bw`) already fit within budget.

Existing snapshots under the old prefix become orphaned and will be
reaped via TTL; the next run repopulates from a fresh TPC-E setup
(~4h pre-work).

Fixes #170253

Epic: none

----

Release justification: