### PR TITLE
application_api: drop unsound reads/writes assertion in TestHotRanges2Response

### DIFF
--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -362,11 +362,6 @@ func TestHotRanges2Response(t *testing.T) {
 		}
 
 		if r.QPS > 0 {
-			if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 && r.ReadBytesPerSecond == 0 && r.WriteBytesPerSecond == 0 {
-				t.Errorf("qps %.2f > 0, expected either reads=%.2f, writes=%.2f, readBytes=%.2f or writeBytes=%.2f to be non-zero",
-					r.QPS, r.ReadsPerSecond, r.WritesPerSecond, r.ReadBytesPerSecond, r.WriteBytesPerSecond)
-			}
-
 			if cpuSupport && r.CPUTimePerSecond == 0 {
 				t.Errorf("qps %.2f > 0, expected cpu=%.2f to be non-zero", r.QPS, r.CPUTimePerSecond)
 			}


### PR DESCRIPTION
## Summary

`TestHotRanges2Response` asserted that `QPS > 0` implies at least one of
`ReadsPerSecond`, `WritesPerSecond`, `ReadBytesPerSecond`, or
`WriteBytesPerSecond` is also `> 0`. This invariant does not hold: QPS is
incremented for every batch that reaches a replica (lease renewals,
heartbeats, intent resolution, etc.), while the read/write counters are
only incremented when actual key data is read or mutated. A range
receiving only background batch traffic on system ranges legitimately has
`QPS > 0` with `reads = writes = 0`.

The assertion stayed latent because the test typically completes in under
`MinStatsDuration` (5s), during which all per-stat rates report 0 and the
gated assertion is skipped. Under `--race` the test runs long enough to
clear that floor, and ranges that only saw internal traffic trip the
check.

The CPU-time check is preserved: CPU is recorded for every batch
alongside QPS via `MeasureReqCPUNanos`, so `QPS > 0` should imply
`CPU > 0`.

Fixes: #169902
Epic: none