### PR TITLE
sql/sem/eval: fix data race on shared AST nodes in domain CHECK evaluation

### DIFF
--- a/pkg/sql/catalog/typedesc/BUILD.bazel
+++ b/pkg/sql/catalog/typedesc/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/enum",
-        "//pkg/sql/parserutils",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",

--- a/pkg/sql/catalog/typedesc/hydrate.go
+++ b/pkg/sql/catalog/typedesc/hydrate.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -159,17 +158,10 @@ func ensureTypeMetadataIsHydrated(
 		n := d.NumCheckConstraints()
 		checks := make([]types.DomainCheckConstraint, n)
 		for i := 0; i < n; i++ {
-			exprStr := d.GetCheckConstraintExpr(i)
 			checks[i] = types.DomainCheckConstraint{
 				Name:         d.GetCheckConstraintName(i),
-				Expr:         exprStr,
+				Expr:         d.GetCheckConstraintExpr(i),
 				ConstraintID: d.GetCheckConstraintID(i),
-			}
-			// Pre-parse the CHECK expression so that eval-time validation can
-			// skip the parse step. Errors are intentionally ignored; the
-			// eval-time fallback will surface them.
-			if parsed, err := parserutils.ParseExpr(exprStr); err == nil {
-				checks[i].ParsedExpr = parsed
 			}
 		}
 		tm.DomainData = &types.DomainMetadata{

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -122,6 +122,7 @@ go_test(
         "cast_rand_test.go",
         "cast_test.go",
         "compare_test.go",
+        "domain_test.go",
         "eval_internal_test.go",
         "eval_test.go",
         "like_test.go",
@@ -143,6 +144,7 @@ go_test(
         "//pkg/sql/opt/optbuilder",
         "//pkg/sql/opt/xform",
         "//pkg/sql/parser",
+        "//pkg/sql/parserutils",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/randgen",
@@ -168,6 +170,7 @@ go_test(
         "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/sql/sem/eval/domain.go
+++ b/pkg/sql/sem/eval/domain.go
@@ -47,8 +47,7 @@ func ValidateDomainConstraints(
 
 // evalDomainCheckConstraint evaluates a single CHECK constraint expression
 // against the given datum. VALUE references are substituted with the datum,
-// and the result is evaluated as a boolean. The parsed expression is cached
-// during type hydration to avoid re-parsing on every call.
+// and the result is evaluated as a boolean.
 func evalDomainCheckConstraint(
 	ctx context.Context,
 	evalCtx *Context,
@@ -56,21 +55,17 @@ func evalDomainCheckConstraint(
 	domainType *types.T,
 	chk *types.DomainCheckConstraint,
 ) error {
-	var expr tree.Expr
-	if cached, ok := chk.ParsedExpr.(tree.Expr); ok {
-		expr = cached
-	} else {
-		var err error
-		expr, err = parserutils.ParseExpr(chk.Expr)
-		if err != nil {
-			return err
-		}
+	// Parse a fresh expression tree per call. TypeCheck below mutates AST
+	// nodes in place, so a tree shared across concurrent callers would race.
+	expr, err := parserutils.ParseExpr(chk.Expr)
+	if err != nil {
+		return err
 	}
 
 	// Replace VALUE references with the actual datum. In the parsed expression,
 	// VALUE appears as an UnresolvedName with a single part named "value"
 	// (case-insensitive).
-	expr, err := tree.SimpleVisit(expr, func(e tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+	expr, err = tree.SimpleVisit(expr, func(e tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		if n, ok := e.(*tree.UnresolvedName); ok {
 			if n.NumParts == 1 && strings.EqualFold(n.Parts[0], "value") {
 				return false, d, nil

--- a/pkg/sql/sem/eval/domain_test.go
+++ b/pkg/sql/sem/eval/domain_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package eval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestDomainCheckConstraintDataRace verifies that concurrent evaluation of
+// domain CHECK constraints does not race. The CHECK expression uses a function
+// call (abs) that does not reference VALUE, exercising the code path where
+// re-parsing is necessary to avoid sharing AST nodes across goroutines.
+func TestDomainCheckConstraintDataRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Inject the parser so that parserutils.ParseExpr works (we can't import
+	// pkg/sql due to import cycles, so do the injection manually).
+	origParseExpr := parserutils.ParseExpr
+	parserutils.ParseExpr = parser.ParseExpr
+	t.Cleanup(func() { parserutils.ParseExpr = origParseExpr })
+
+	ctx := context.Background()
+
+	// Build a domain type with a CHECK constraint whose parsed expression
+	// contains a function call (abs) that does NOT reference VALUE. This
+	// means SimpleVisit will not copy that subtree, leaving it shared
+	// across all concurrent evaluations.
+	domainType := types.MakeDomain(types.Int, 100000 /* typeOID */, 100001 /* arrayTypeOID */)
+	domainType.TypeMeta = types.UserDefinedTypeMetadata{
+		Name: &types.UserDefinedTypeName{Name: "d_racetest"},
+		DomainData: &types.DomainMetadata{
+			BaseType: types.Int,
+			CheckConstraints: []types.DomainCheckConstraint{
+				{
+					Name: "d_racetest_check",
+					Expr: "VALUE > 0 AND abs(1) > 0",
+				},
+			},
+		},
+	}
+
+	const goroutines = 8
+	const iterations = 500
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for range goroutines {
+		g.Go(func() error {
+			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+			defer evalCtx.Stop(gCtx)
+			for i := range iterations {
+				d := tree.NewDInt(tree.DInt(i + 1))
+				if err := eval.ValidateDomainConstraints(gCtx, evalCtx, d, domainType); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -370,12 +370,6 @@ type DomainCheckConstraint struct {
 	Expr string
 	// ConstraintID uniquely identifies this constraint within the domain.
 	ConstraintID catid.ConstraintID
-	// ParsedExpr is the cached parsed expression tree from hydration.
-	// Typed as any to avoid an import cycle with tree. At runtime this
-	// holds a tree.Expr obtained via parserutils.ParseExpr. It may be nil
-	// if hydration has not occurred or if the expression failed to parse;
-	// callers must handle the nil case by re-parsing from Expr.
-	ParsedExpr any
 }
 
 func (e *EnumMetadata) debugString() string {


### PR DESCRIPTION
The cached ParsedExpr on DomainCheckConstraint is shared across all concurrent callers via the hydrated descriptor cache. When evalDomainCheckConstraint ran SimpleVisit to substitute VALUE references, subtrees not containing VALUE were not copied (copy-on-write only copies changed nodes). TypeCheck then mutated those shared nodes in-place (FuncExpr.fn, NumVal fields, etc.), causing data races under concurrent INSERT or CAST operations on domain-typed columns.

Fix by always re-parsing the expression from its string representation, giving each caller its own AST. This matches how table-level CHECK constraints, DEFAULT expressions, and computed columns all work — they parse fresh per-statement rather than reusing a cached tree.

Fixes: #170295

Release note: None
Epic: CRDB-62146
