### PR TITLE
release-25.4: logical: fix bug in tombstone updater

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -151,6 +151,7 @@ go_test(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/storageccl",
         "//pkg/clusterversion",
+        "//pkg/crosscluster/ldrrandgen",
         "//pkg/crosscluster/replicationtestutils",
         "//pkg/crosscluster/streamclient",
         "//pkg/crosscluster/streamclient/randclient",

--- a/pkg/crosscluster/logical/tombstone_updater.go
+++ b/pkg/crosscluster/logical/tombstone_updater.go
@@ -168,9 +168,11 @@ func (tu *tombstoneUpdater) getDeleter(ctx context.Context, txn *kv.Txn) (row.De
 			return row.Deleter{}, err
 		}
 
-		cols, err := writeableColunms(ctx, tu.leased.descriptor.Underlying().(catalog.TableDescriptor))
-		if err != nil {
-			return row.Deleter{}, err
+		table := tu.leased.descriptor.Underlying().(catalog.TableDescriptor)
+		schema := getColumnSchema(table)
+		cols := make([]catalog.Column, len(schema))
+		for i, cs := range schema {
+			cols[i] = cs.column
 		}
 
 		tu.leased.deleter = row.MakeDeleter(tu.codec, tu.leased.descriptor.Underlying().(catalog.TableDescriptor), nil /* lockedIndexes */, cols, tu.sd, &tu.settings.SV, nil /* metrics */)

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -7,18 +7,25 @@ package logical
 
 import (
 	"context"
+	"math/rand"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/ldrrandgen"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -114,4 +121,81 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 	destRunner.CheckQueryResults(t, "SELECT pk, payload FROM tab", [][]string{
 		{"1", "42"},
 	})
+}
+
+func TestTombstoneUpdaterRandomTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	server, s, runners, dbNames := setupServerWithNumDBs(t, ctx, testClusterBaseClusterArgs, 1, 1)
+	defer server.Stopper().Stop(ctx)
+
+	runner := runners[0]
+	dbName := dbNames[0]
+
+	rng, _ := randutil.NewPseudoRand()
+	tableName := "rand_table"
+
+	stmt := tree.SerializeForDisplay(ldrrandgen.GenerateLDRTable(ctx, rng, tableName, true))
+	t.Logf("Creating table with schema: %s", stmt)
+	runner.Exec(t, stmt)
+
+	desc := desctestutils.TestingGetMutableExistingTableDescriptor(
+		s.DB(), s.Codec(), dbName, tableName)
+
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	tu := newTombstoneUpdater(s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
+	defer tu.ReleaseLeases(ctx)
+
+	columnSchemas := getColumnSchema(desc)
+	cols := make([]catalog.Column, len(columnSchemas))
+	for i, cs := range columnSchemas {
+		cols[i] = cs.column
+	}
+
+	config := s.ExecutorConfig().(sql.ExecutorConfig)
+
+	writer, err := newSQLRowWriter(desc, sessiondata.InternalExecutorOverride{})
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		row := generateRandomRow(rng, cols)
+		before := s.Clock().Now()
+		after := s.Clock().Now()
+
+		err := sql.DescsTxn(ctx, &config, func(
+			ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
+		) error {
+			_, err := tu.updateTombstone(ctx, txn, after, row)
+			return err
+		})
+		require.NoError(t, err)
+
+		stats, err := tu.updateTombstone(ctx, nil, before, row)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), stats.kvWriteTooOld, "expected 1 kv put for tombstone update")
+
+		// Use the table writer to try and insert the previous row using the
+		// `before` timestamp. This should fail with LWW error because the
+		// tombstone was written at a later timestamp. It may fail with integer out
+		// of range error if the table has computed columns and the random datums
+		// add to produces something out of range.
+		err = s.InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return writer.InsertRow(ctx, txn, before, row)
+		})
+		require.Error(t, err)
+		if !(strings.Contains(err.Error(), "integer out of range") || isLwwLoser(err)) {
+			t.Fatalf("expected LWW or integer out of range error, got: %v", err)
+		}
+	}
+}
+
+func generateRandomRow(rng *rand.Rand, cols []catalog.Column) []tree.Datum {
+	row := make([]tree.Datum, 0, len(cols))
+	for _, col := range cols {
+		datum := randgen.RandDatum(rng, col.GetType(), col.IsNullable())
+		row = append(row, datum)
+	}
+	return row
 }

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -123,6 +123,47 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 	})
 }
 
+// TestTombstoneUpdaterSecondaryIndex is a regression test for the panic
+// described in #159746. When a DELETE returns 0 rows (LWW loss or row already
+// deleted), the tombstone updater is called with only PK + 1 datums. Before the
+// fix, the Deleter would attempt to encode secondary index keys using ordinals
+// that exceed the length of the datums slice, causing an index-out-of-range
+// panic.
+func TestTombstoneUpdaterSecondaryIndex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	server, s, runners, dbNames := setupServerWithNumDBs(t, ctx, testClusterBaseClusterArgs, 1, 1)
+	defer server.Stopper().Stop(ctx)
+
+	runner := runners[0]
+	runner.Exec(t, `CREATE TABLE t (
+		pk INT PRIMARY KEY,
+		a INT,
+		b INT,
+		c INT,
+		INDEX idx_c (c)
+	)`)
+
+	desc := desctestutils.TestingGetMutableExistingTableDescriptor(
+		s.DB(), s.Codec(), dbNames[0], "t")
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	tu := newTombstoneUpdater(s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
+	defer tu.ReleaseLeases(ctx)
+
+	// Pass only PK + 1 datums, mimicking the real LWW delete path where the
+	// DELETE query only has PK columns in its WHERE clause plus an origin
+	// timestamp parameter.
+	datums := []any{
+		tree.NewDInt(tree.DInt(1)),
+		tree.NewDInt(tree.DInt(42)),
+	}
+
+	_, err := tu.updateTombstoneAny(ctx, nil, s.Clock().Now(), datums)
+	require.NoError(t, err)
+}
+
 func TestTombstoneUpdaterRandomTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -212,6 +212,12 @@ func (rd *Deleter) DeleteRow(
 		return err
 	}
 
+	if oth.PreviousWasDeleted {
+		// If we are updating a tombstone, then there are no secondary index entries
+		// that need to be deleted.
+		return nil
+	}
+
 	// Delete the row from any secondary indices.
 	for i, index := range rd.Helper.Indexes {
 		// If the index ID exists in the set of indexes to ignore, do not


### PR DESCRIPTION
Backport 1/1 commits from #159746 (release-25.4), plus a regression test.

/cc @cockroachdb/replication

---

**Commit 1: logical: fix bug in tombstone updater**

This fixes a bug in the tombstone updater. The tombstone decoder was using the columns decoded by the kv writer when it needs to expect the columns decoded by the sql/crud writers. There is one difference between these two sets of columns that impacts computed columns:

1. The sql/crud writer only decode computed columns that are in the primary key.
2. The kv writer decodes virtual computed columns in the primary key and all stored computed columns in the row.

This mismatch can cause panics if the stored column is in an index (which is what the conflict workload noticed) and it can cause the tombstone updater to generate incorrect keys if there is a stored computed column with a lower column id than the primary key column.

A secondary discovery here is that the tombstone updater is formatting deletes for indexes other than the primary index. Now, the deleter will skip generating values for secondary indexes if the cput helper says its updating a deleted row.

**Commit 2: logical: add regression test for tombstone updater secondary index panic**

Prior to the fix in commit 1, the tombstone updater would panic with "index out of range" when updating a tombstone for any table with secondary indexes. The panic occurred because the LWW delete path passes only PK + 1 datums (primary key columns plus origin timestamp) to Deleter.DeleteRow, but the Deleter was built expecting all writable columns. When it attempted to encode secondary index keys, findColumnValue would access values[ordinal] where ordinal exceeded the datums slice length.

This bug did not require stored computed columns to trigger — any table with a single-column primary key and a secondary index on a column at ordinal position >= 2 would panic.

The existing TestTombstoneUpdaterRandomTables test did not catch this because it calls updateTombstone with a full row of datums (all columns), not the reduced PK+1 datums that the real LWW delete path uses.

Add TestTombstoneUpdaterSecondaryIndex which creates a table with a secondary index and calls updateTombstoneAny with only PK + 1 datums, matching the real call path. Without the fix, this test panics with "index out of range [3] with length 2".

Fixes: #159306
Release note: None
Epic: none

Release justification: low risk change to fix an LDR crash loop