### PR TITLE
sql: wrap gRPC stream errors with pgcode.InternalConnectionFailure

### DIFF
--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -340,7 +340,7 @@ func (o *Outbox) sendBatches(
 				err := stream.Send(o.scratch.msg)
 				sendCleanup()
 				if err != nil {
-					flowinfra.HandleStreamErr(ctx, "Send (streaming metadata)", err, flowCtxCancel, outboxCtxCancel)
+					_ = flowinfra.HandleStreamErr(ctx, "Send (streaming metadata)", err, flowCtxCancel, outboxCtxCancel)
 					return
 				}
 				continue
@@ -390,7 +390,7 @@ func (o *Outbox) sendBatches(
 			err = stream.Send(o.scratch.msg)
 			sendCleanup()
 			if err != nil {
-				flowinfra.HandleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
+				_ = flowinfra.HandleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
 				return
 			}
 		}
@@ -473,7 +473,7 @@ func (o *Outbox) runWithStream(
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
-				flowinfra.HandleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel)
+				_ = flowinfra.HandleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel)
 				break
 			}
 			switch {
@@ -497,14 +497,14 @@ func (o *Outbox) runWithStream(
 		}
 		o.moveToDraining(ctx, reason)
 		if err := o.sendDrainedMetadata(ctx, stream, errToSend); err != nil {
-			flowinfra.HandleStreamErr(ctx, "Send (draining metadata)", err, flowCtxCancel, outboxCtxCancel)
+			_ = flowinfra.HandleStreamErr(ctx, "Send (draining metadata)", err, flowCtxCancel, outboxCtxCancel)
 		} else {
 			// Close the stream. Note that if this block isn't reached, the stream
 			// is unusable.
 			// The receiver goroutine will read from the stream until any error
 			// is returned (most likely an io.EOF).
 			if err := stream.CloseSend(); err != nil {
-				flowinfra.HandleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
+				_ = flowinfra.HandleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
 			}
 		}
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -129,6 +129,7 @@ func (req runnerRequest) run() error {
 	if err != nil {
 		// Mark this error as special runnerDialErr so that we could retry this
 		// distributed query as local.
+		err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "dial error")
 		err = &runnerDialErr{err: err}
 		res.err = err
 		return err
@@ -136,7 +137,7 @@ func (req runnerRequest) run() error {
 	// TODO(radu): do we want a timeout here?
 	resp, err := client.SetupFlow(req.ctx, req.flowReq)
 	if err != nil {
-		res.err = err
+		res.err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "SetupFlow RPC error")
 	} else {
 		res.err = resp.Error.ErrorDetail(req.ctx)
 	}

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -200,7 +202,7 @@ func (m *Outbox) flush(ctx context.Context) error {
 		}
 	}
 	if sendErr != nil {
-		HandleStreamErr(ctx, "flushing", sendErr, m.flowCtxCancel, m.outboxCtxCancel)
+		sendErr = HandleStreamErr(ctx, "flushing", sendErr, m.flowCtxCancel, m.outboxCtxCancel)
 		// Make sure the stream is not used any more.
 		m.stream = nil
 		log.Dev.VWarningf(ctx, 1, "Outbox flush error: %s", sendErr)
@@ -399,12 +401,10 @@ func (m *Outbox) startWatchdogGoroutine(
 		for {
 			signal, err := stream.Recv()
 			if err != nil {
+				err = HandleStreamErr(ctx, "watchdog Recv", err, m.flowCtxCancel, m.outboxCtxCancel)
 				if err != io.EOF {
-					// io.EOF is considered a graceful termination of the gRPC
-					// stream, so it is ignored.
 					m.setErr(err)
 				}
-				HandleStreamErr(ctx, "watchdog Recv", err, m.flowCtxCancel, m.outboxCtxCancel)
 				break
 			}
 			switch {
@@ -457,21 +457,23 @@ func (m *Outbox) Err() error {
 	return m.mu.err
 }
 
-// HandleStreamErr is a utility method used to handle an error when calling
-// a method on a flowStreamClient. If err is an io.EOF, outboxCtxCancel is
-// called, for all other errors flowCtxCancel is. The given error is logged with
-// the associated opName.
+// HandleStreamErr is a utility method used to handle an error when calling a
+// method on a flowStreamClient. If err is an io.EOF, outboxCtxCancel is called
+// and io.EOF is returned as-is. For all other errors, flowCtxCancel is called
+// and the error is wrapped with pgcode.InternalConnectionFailure before being
+// returned. The given error is logged with the associated opName.
 func HandleStreamErr(
 	ctx context.Context,
 	opName redact.SafeString,
 	err error,
 	flowCtxCancel, outboxCtxCancel context.CancelFunc,
-) {
+) error {
 	if err == io.EOF {
 		log.VEventf(ctx, 2, "Outbox calling outboxCtxCancel after %s EOF", opName)
 		outboxCtxCancel()
-	} else {
-		log.VEventf(ctx, 1, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
-		flowCtxCancel()
+		return err
 	}
+	log.VEventf(ctx, 1, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
+	flowCtxCancel()
+	return pgerror.Wrap(err, pgcode.InternalConnectionFailure, "outbox communication error")
 }


### PR DESCRIPTION
When DistSQL flows encounter gRPC transport errors, the inbound stream path wraps them with pgcode.InternalConnectionFailure (58C01), but the outbox and flow setup paths propagate raw gRPC errors without a pgcode. This makes it harder for clients and internal retry logic (like IsSQLRetryableError) to classify these errors consistently.

Wrap gRPC errors in three places:

- flowinfra.HandleStreamErr: wrap non-EOF errors with pgcode.InternalConnectionFailure before returning. This is the single choke point for outbox stream errors across both row-based and columnar execution.

- distsql_running.go runnerRequest.run(): wrap dial errors and SetupFlow RPC errors with pgcode.InternalConnectionFailure.

Epic: none
Release note: None