### PR TITLE
sql: wrap DistSQL gRPC errors with InternalConnectionFailure (58C01)

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -127,6 +127,7 @@ func (req runnerRequest) run() error {
 
 	client, err := execinfrapb.DialDistSQLClient(req.sqlInstanceDialer, req.ctx, roachpb.NodeID(req.sqlInstanceID), rpcbase.DefaultClass)
 	if err != nil {
+		err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "dial error")
 		// Mark this error as special runnerDialErr so that we could retry this
 		// distributed query as local.
 		err = &runnerDialErr{err: err}
@@ -136,7 +137,7 @@ func (req runnerRequest) run() error {
 	// TODO(radu): do we want a timeout here?
 	resp, err := client.SetupFlow(req.ctx, req.flowReq)
 	if err != nil {
-		res.err = err
+		res.err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "SetupFlow RPC error")
 	} else {
 		res.err = resp.Error.ErrorDetail(req.ctx)
 	}

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -201,6 +203,10 @@ func (m *Outbox) flush(ctx context.Context) error {
 	}
 	if sendErr != nil {
 		HandleStreamErr(ctx, "flushing", sendErr, m.flowCtxCancel, m.outboxCtxCancel)
+		// This error probably won't reach the client, but we wrap it with an
+		// internal connection failure error code anyway for consistency with
+		// other DistSQL connection failures.
+		sendErr = pgerror.Wrap(sendErr, pgcode.InternalConnectionFailure, "outbox communication error")
 		// Make sure the stream is not used any more.
 		m.stream = nil
 		log.Dev.VWarningf(ctx, 1, "Outbox flush error: %s", sendErr)
@@ -402,6 +408,10 @@ func (m *Outbox) startWatchdogGoroutine(
 				if err != io.EOF {
 					// io.EOF is considered a graceful termination of the gRPC
 					// stream, so it is ignored.
+					// This error probably won't reach the client, but we wrap it with an
+					// internal connection failure error code anyway for consistency with
+					// other DistSQL connection failures.
+					err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "outbox communication error")
 					m.setErr(err)
 				}
 				HandleStreamErr(ctx, "watchdog Recv", err, m.flowCtxCancel, m.outboxCtxCancel)


### PR DESCRIPTION
In #41451 we introduced error code 58C01 for connection failures between nodes. In #64312 we started using this error code for some DistSQL connection failures. But, the outbox and flow setup paths currently propagate raw gRPC errors without a pgcode. This makes it harder for clients and internal retry logic to classify these errors consistently.

This commit wraps gRPC errors in a few places:

- flowinfra outbox flush and watchdog paths: wrap non-EOF errors with pgcode.InternalConnectionFailure at the call sites. These won't ever reach the client, but I think we should wrap them for consistency.

- distsql_running.go runnerRequest.run(): wrap dial errors and SetupFlow RPC errors with pgcode.InternalConnectionFailure.

Fixes: #170356

Release note (bug fix): Fix a few node-to-node connection error paths in DistSQL execution to return error code 58C01 (InternalConnectionFailure) instead of XXUUU (Uncategorized).

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>