### PR TITLE
rpc: add DRPC interceptor equivalents for tests using gRPC-only ContextTestingKnobs

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -121,6 +121,8 @@ go_test(
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_storj_drpc//:drpc",
+        "@io_storj_drpc//drpcclient",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
+	"storj.io/drpc/drpcclient"
 )
 
 // TestColdStartLatency attempts to capture the cold start latency for
@@ -72,6 +74,31 @@ func TestColdStartLatency(t *testing.T) {
 	var latencyEnabled atomic.Bool
 	var addrsToNodeIDs syncutil.Map[string, int]
 
+	resolveNodeID := func(target string) int {
+		if nodeIDPtr, ok := addrsToNodeIDs.Load(target); ok {
+			return *nodeIDPtr
+		}
+		return 0
+	}
+
+	hostUnaryLogic := func(
+		ctx context.Context, i int, target, method string,
+		req, reply interface{}, invoke func() error,
+	) error {
+		if !log.ExpensiveLogEnabled(ctx, 2) {
+			return invoke()
+		}
+		nodeID := resolveNodeID(target)
+		start := timeutil.Now()
+		defer func() {
+			log.VEventf(ctx, 2, "%d->%d (%v->%v) %s %v %v took %v",
+				i, nodeID, localities[i], localities[nodeID],
+				method, req, reply, timeutil.Since(start),
+			)
+		}()
+		return invoke()
+	}
+
 	// Set up the host cluster.
 	perServerArgs := make(map[int]base.TestServerArgs, numNodes)
 	for i := 0; i < numNodes; i++ {
@@ -94,21 +121,22 @@ func TestColdStartLatency(t *testing.T) {
 						cc *grpc.ClientConn, invoker grpc.UnaryInvoker,
 						opts ...grpc.CallOption,
 					) error {
-						if !log.ExpensiveLogEnabled(ctx, 2) {
+						return hostUnaryLogic(ctx, i, target, method, req, reply, func() error {
 							return invoker(ctx, method, req, reply, cc, opts...)
-						}
-						var nodeID int
-						if nodeIDPtr, ok := addrsToNodeIDs.Load(target); ok {
-							nodeID = *nodeIDPtr
-						}
-						start := timeutil.Now()
-						defer func() {
-							log.VEventf(ctx, 2, "%d->%d (%v->%v) %s %v %v took %v",
-								i, nodeID, localities[i], localities[nodeID],
-								method, req, reply, timeutil.Since(start),
-							)
-						}()
-						return invoker(ctx, method, req, reply, cc, opts...)
+						})
+					}
+				},
+				UnaryClientInterceptorDRPC: func(
+					target string, class rpcbase.ConnectionClass,
+				) drpcclient.UnaryClientInterceptor {
+					return func(
+						ctx context.Context, rpc string, enc drpc.Encoding,
+						in, out drpc.Message, cc *drpcclient.ClientConn,
+						invoker drpcclient.UnaryInvoker,
+					) error {
+						return hostUnaryLogic(ctx, i, target, rpc, in, out, func() error {
+							return invoker(ctx, rpc, enc, in, out, cc)
+						})
 					}
 				},
 			},
@@ -191,6 +219,44 @@ COMMIT;`}
 			<-ctx.Done()
 		}
 	}
+
+	tenantStreamSetup := func(
+		ctx context.Context, i int, target, method string,
+	) (int, time.Time) {
+		nodeID := resolveNodeID(target)
+		start := timeutil.Now()
+		maybeWait(ctx, i, nodeID)
+		return nodeID, start
+	}
+
+	tenantStreamLog := func(
+		ctx context.Context, i, nodeID int, method, target string,
+	) {
+		if !log.ExpensiveLogEnabled(ctx, 2) {
+			return
+		}
+		log.VEventf(
+			ctx, 2, "tenant%d->%d opening stream %v to %v (%v->%v)",
+			i, nodeID, method, target, localities[i], localities[nodeID],
+		)
+	}
+
+	tenantUnaryLogic := func(
+		ctx context.Context, i, nodeID int, method string,
+		req, reply interface{}, invoke func() error,
+	) error {
+		maybeWait(ctx, i, nodeID)
+		start := timeutil.Now()
+		defer func() {
+			log.VEventf(
+				ctx, 2, "tenant%d->%d %v->%v %s %v %v took %v",
+				i, nodeID, localities[i], localities[nodeID],
+				method, req, reply, timeutil.Since(start),
+			)
+		}()
+		return invoke()
+	}
+
 	tenantServerKnobs := func(i int) *server.TestingKnobs {
 		return &server.TestingKnobs{
 			ContextTestingKnobs: rpc.ContextTestingKnobs{
@@ -205,21 +271,8 @@ COMMIT;`}
 						ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
 						method string, streamer grpc.Streamer, opts ...grpc.CallOption,
 					) (grpc.ClientStream, error) {
-						var nodeID int
-						if nodeIDPtr, ok := addrsToNodeIDs.Load(target); ok {
-							nodeID = *nodeIDPtr
-						}
-						start := timeutil.Now()
-						maybeWait(ctx, i, nodeID)
-						defer func() {
-							if !log.ExpensiveLogEnabled(ctx, 2) {
-								return
-							}
-							log.VEventf(
-								ctx, 2, "tenant%d->%d opening stream %v to %v (%v->%v)",
-								i, nodeID, method, target, localities[i], localities[nodeID],
-							)
-						}()
+						nodeID, start := tenantStreamSetup(ctx, i, target, method)
+						defer tenantStreamLog(ctx, i, nodeID, method, target)
 						c, err := streamer(ctx, desc, cc, method, opts...)
 						if err != nil {
 							return nil, err
@@ -230,26 +283,51 @@ COMMIT;`}
 						}, nil
 					}
 				},
-				UnaryClientInterceptor: func(target string, class rpcbase.ConnectionClass) grpc.UnaryClientInterceptor {
-					var nodeID int
-					if nodeIDPtr, ok := addrsToNodeIDs.Load(target); ok {
-						nodeID = *nodeIDPtr
+				StreamClientInterceptorDRPC: func(
+					target string, class rpcbase.ConnectionClass,
+				) drpcclient.StreamClientInterceptor {
+					return func(
+						ctx context.Context, rpc string, enc drpc.Encoding,
+						cc *drpcclient.ClientConn, streamer drpcclient.Streamer,
+					) (drpc.Stream, error) {
+						nodeID, start := tenantStreamSetup(ctx, i, target, rpc)
+						defer tenantStreamLog(ctx, i, nodeID, rpc, target)
+						s, err := streamer(ctx, rpc, enc, cc)
+						if err != nil {
+							return nil, err
+						}
+						return wrappedDRPCStream{
+							start:  start,
+							Stream: s,
+						}, nil
 					}
+				},
+				UnaryClientInterceptor: func(
+					target string, class rpcbase.ConnectionClass,
+				) grpc.UnaryClientInterceptor {
+					nodeID := resolveNodeID(target)
 					return func(
 						ctx context.Context, method string, req, reply interface{},
 						cc *grpc.ClientConn, invoker grpc.UnaryInvoker,
 						opts ...grpc.CallOption,
 					) error {
-						maybeWait(ctx, i, nodeID)
-						start := timeutil.Now()
-						defer func() {
-							log.VEventf(
-								ctx, 2, "tenant%d->%d %v->%v %s %v %v took %v",
-								i, nodeID, localities[i], localities[nodeID],
-								method, req, reply, timeutil.Since(start),
-							)
-						}()
-						return invoker(ctx, method, req, reply, cc, opts...)
+						return tenantUnaryLogic(ctx, i, nodeID, method, req, reply, func() error {
+							return invoker(ctx, method, req, reply, cc, opts...)
+						})
+					}
+				},
+				UnaryClientInterceptorDRPC: func(
+					target string, class rpcbase.ConnectionClass,
+				) drpcclient.UnaryClientInterceptor {
+					nodeID := resolveNodeID(target)
+					return func(
+						ctx context.Context, rpc string, enc drpc.Encoding,
+						in, out drpc.Message, cc *drpcclient.ClientConn,
+						invoker drpcclient.UnaryInvoker,
+					) error {
+						return tenantUnaryLogic(ctx, i, nodeID, rpc, in, out, func() error {
+							return invoker(ctx, rpc, enc, in, out, cc)
+						})
 					}
 				},
 			},
@@ -399,5 +477,18 @@ func (w wrappedStream) RecvMsg(m interface{}) error {
 		return err
 	}
 	log.VEventf(w.ClientStream.Context(), 2, "stream received %T %v %v", m, timeutil.Since(w.start), m)
+	return nil
+}
+
+type wrappedDRPCStream struct {
+	start time.Time
+	drpc.Stream
+}
+
+func (w wrappedDRPCStream) MsgRecv(msg drpc.Message, enc drpc.Encoding) error {
+	if err := w.Stream.MsgRecv(msg, enc); err != nil {
+		return err
+	}
+	log.VEventf(w.Stream.Context(), 2, "stream received %T %v %v", msg, timeutil.Since(w.start), msg)
 	return nil
 }

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -256,6 +256,8 @@ go_test(
         "@com_github_sasha_s_go_deadlock//:go-deadlock",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_storj_drpc//:drpc",
+        "@io_storj_drpc//drpcclient",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -41,6 +41,8 @@ import (
 	"github.com/sasha-s/go-deadlock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
+	"storj.io/drpc/drpcclient"
 )
 
 type testRangefeedClient struct {
@@ -323,7 +325,8 @@ func TestMuxRangeFeedDoesNotStallOnError(t *testing.T) {
 	ctx := context.Background()
 
 	var (
-		rfMethod = "/cockroach.roachpb.Internal/MuxRangeFeed"
+		rfMethodGRPC = "/cockroach.roachpb.Internal/MuxRangeFeed"
+		rfMethodDRPC = "/cockroach.roachpb.RangeFeed/MuxRangeFeed"
 
 		maxErrors   = 10
 		shouldError atomic.Bool
@@ -335,7 +338,7 @@ func TestMuxRangeFeedDoesNotStallOnError(t *testing.T) {
 			ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
 			method string, streamer grpc.Streamer, opts ...grpc.CallOption,
 		) (grpc.ClientStream, error) {
-			if method == rfMethod {
+			if method == rfMethodGRPC {
 				if shouldError.Load() && errCount <= maxErrors {
 					errCount++
 					return nil, errors.Newf("test error %d", errCount)
@@ -344,6 +347,24 @@ func TestMuxRangeFeedDoesNotStallOnError(t *testing.T) {
 			return streamer(ctx, desc, cc, method, opts...)
 		}
 	}
+
+	streamInterceptorDRPC := func(
+		target string, class rpcbase.ConnectionClass,
+	) drpcclient.StreamClientInterceptor {
+		return func(
+			ctx context.Context, rpc string, enc drpc.Encoding,
+			cc *drpcclient.ClientConn, streamer drpcclient.Streamer,
+		) (drpc.Stream, error) {
+			if rpc == rfMethodDRPC {
+				if shouldError.Load() && errCount <= maxErrors {
+					errCount++
+					return nil, errors.Newf("test error %d", errCount)
+				}
+			}
+			return streamer(ctx, rpc, enc, cc)
+		}
+	}
+
 	const numServers int = 3
 	serverArgs := base.TestServerArgs{
 		RetryOptions: retry.Options{
@@ -353,7 +374,8 @@ func TestMuxRangeFeedDoesNotStallOnError(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				ContextTestingKnobs: rpc.ContextTestingKnobs{
-					StreamClientInterceptor: streamInterceptor,
+					StreamClientInterceptor:     streamInterceptor,
+					StreamClientInterceptorDRPC: streamInterceptorDRPC,
 				},
 			},
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -186,6 +186,7 @@ go_test(
         "@io_storj_drpc//:drpc",
         "@io_storj_drpc//drpcclient",
         "@io_storj_drpc//drpcctx",
+        "@io_storj_drpc//drpcmigrate",
         "@io_storj_drpc//drpcmux",
         "@io_storj_drpc//drpcserver",
         "@org_golang_google_grpc//:grpc",

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -52,6 +52,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"storj.io/drpc"
+	"storj.io/drpc/drpcclient"
+	"storj.io/drpc/drpcmigrate"
 	"storj.io/drpc/drpcmux"
 	"storj.io/drpc/drpcserver"
 )
@@ -1690,6 +1692,11 @@ func TestTestingKnobs(t *testing.T) {
 		class  rpcbase.ConnectionClass
 		method string
 	}
+	type drpcStreamCall struct {
+		target string
+		class  rpcbase.ConnectionClass
+		rpc    string
+	}
 	seen := make(map[interface{}]int)
 	var seenMu syncutil.Mutex
 	recordCall := func(call interface{}) {
@@ -1718,6 +1725,25 @@ func TestTestingKnobs(t *testing.T) {
 				return cs, nil
 			}
 		},
+		StreamClientInterceptorDRPC: func(
+			target string, class rpcbase.ConnectionClass,
+		) drpcclient.StreamClientInterceptor {
+			return func(
+				ctx context.Context, rpc string, enc drpc.Encoding,
+				cc *drpcclient.ClientConn, streamer drpcclient.Streamer,
+			) (drpc.Stream, error) {
+				s, err := streamer(ctx, rpc, enc, cc)
+				if err != nil {
+					return nil, err
+				}
+				recordCall(drpcStreamCall{
+					target: target,
+					class:  class,
+					rpc:    rpc,
+				})
+				return s, nil
+			}
+		},
 	})
 
 	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
@@ -1740,18 +1766,90 @@ func TestTestingKnobs(t *testing.T) {
 		require.Nil(t, cs.CloseSend())
 	}
 
+	// Set up a DRPC server and verify the DRPC stream interceptor is called.
+	drpcMux := drpcmux.New()
+	drpcSrv := drpcserver.NewWithOptions(drpcMux, drpcserver.Options{})
+	drpcS := &drpcServer{Server: drpcSrv, Mux: drpcMux}
+	require.NoError(t, DRPCRegisterHeartbeat(drpcS, &HeartbeatService{
+		clock:              clock,
+		remoteClockMonitor: serverCtx.RemoteClocks,
+		clusterID:          serverCtx.StorageClusterID,
+		nodeID:             serverCtx.NodeID,
+		version:            serverCtx.Settings.Version,
+	}))
+	drpcLn, err := net.Listen("tcp", util.TestAddr.String())
+	require.NoError(t, err)
+	tlsConfig, err := serverCtx.GetServerTLSConfig()
+	require.NoError(t, err)
+	// Strip the DRPC header first (sent in plaintext), then wrap with TLS.
+	drpcStrippedLn := &drpcHeaderStrippingListener{Listener: drpcLn, tlsConfig: tlsConfig}
+	require.NoError(t, stopper.RunAsyncTask(ctx, "drpc-serve", func(ctx context.Context) {
+		netutil.FatalIfUnexpected(drpcSrv.Serve(ctx, drpcStrippedLn))
+	}))
+	require.NoError(t, stopper.RunAsyncTask(ctx, "drpc-quiesce", func(ctx context.Context) {
+		<-stopper.ShouldQuiesce()
+		netutil.FatalIfUnexpected(drpcLn.Close())
+	}))
+	drpcAddr := drpcLn.Addr().String()
+	drpcConn, err := clientCtx.DRPCDialNode(
+		drpcAddr, serverNodeID, roachpb.Locality{}, rpcbase.DefaultClass,
+	).Connect(ctx)
+	require.NoError(t, err)
+	const drpcStreamMethod = "/cockroach.rpc.Heartbeat/Ping"
+	const numDefDRPCStream = 4
+	drpcEnc := drpcEncoding_File_rpc_heartbeat_proto{}
+	for i := 0; i < numDefDRPCStream; i++ {
+		stream, err := drpcConn.NewStream(ctx, drpcStreamMethod, drpcEnc)
+		require.NoError(t, err)
+		require.NoError(t, stream.MsgSend(&PingRequest{
+			ServerVersion: clientCtx.Settings.Version.LatestVersion(),
+		}, drpcEnc))
+		require.NoError(t, stream.MsgRecv(&PingResponse{}, drpcEnc))
+		require.NoError(t, stream.Close())
+	}
+
+	seenMu.Lock()
+	defer seenMu.Unlock()
 	exp := map[interface{}]int{
 		streamCall{
 			target: remoteAddr,
 			class:  rpcbase.DefaultClass,
 			method: streamMethod,
 		}: numDefStream,
+		drpcStreamCall{
+			target: drpcAddr,
+			class:  rpcbase.DefaultClass,
+			rpc:    drpcStreamMethod,
+		}: numDefDRPCStream,
 	}
-	seenMu.Lock()
-	defer seenMu.Unlock()
 	for call, num := range exp {
 		require.Equal(t, num, seen[call])
 	}
+}
+
+// drpcHeaderStrippingListener wraps a net.Listener, strips the DRPC
+// migration header from each accepted connection, then upgrades to TLS
+// if tlsConfig is non-nil. The DRPC client sends the header in plaintext
+// before the TLS handshake.
+type drpcHeaderStrippingListener struct {
+	net.Listener
+	tlsConfig *tls.Config
+}
+
+func (ln *drpcHeaderStrippingListener) Accept() (net.Conn, error) {
+	conn, err := ln.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, len(drpcmigrate.DRPCHeader))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if ln.tlsConfig != nil {
+		conn = tls.Server(conn, ln.tlsConfig)
+	}
+	return conn, nil
 }
 
 func BenchmarkGRPCDial(b *testing.B) {


### PR DESCRIPTION
Several tests set only the gRPC interceptors in ContextTestingKnobs. When DRPC is randomly enabled via TestDRPCEnabledRandomly, the interceptor-based test logic is silently bypassed — DRPC connections don't go through gRPC interceptors, so error injection, latency measurement, and interceptor validation don't fire.

Add corresponding DRPC interceptors for each affected test:

- dist_sender_rangefeed_test.go (TestMuxRangeFeedDoesNotStallOnError): Add StreamClientInterceptorDRPC that mirrors the gRPC stream interceptor's error injection on MuxRangeFeed calls.

- cold_start_latency_test.go (TestColdStartLatency): Add UnaryClientInterceptorDRPC and StreamClientInterceptorDRPC for both the host cluster and tenant server knobs, mirroring the timing/logging and cross-region blocking behavior. Add wrappedDRPCStream type that parallels the existing wrappedStream for gRPC.

- context_test.go (TestTestingKnobs): Add StreamClientInterceptorDRPC to verify DRPC interceptor knob wiring end-to-end. Set up a DRPC server with heartbeat service and a drpcHeaderStrippingListener that handles the DRPC migration header and TLS upgrade.

Fixes: #170096
Epic: None
Release note: None