### PR TITLE
diagnosticsccl: stub SQL stats clock in TestUsageQuantization

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/isql",
+        "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
         "//pkg/testutils",
         "//pkg/testutils/diagutils",

--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/diagutils"
@@ -459,12 +460,21 @@ func TestUsageQuantization(t *testing.T) {
 	ctx := context.Background()
 
 	url := r.URL()
+	// Pin the SQL stats clock so that all executions land in the same
+	// aggregation window. In-memory stats are partitioned by aggregation
+	// timestamp, so a real clock that crosses an hour boundary mid-test
+	// would split a query's executions across multiple entries and break
+	// the per-entry count assertion below.
+	stubTime := timeutil.Now()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DiagnosticsTestingKnobs: diagnostics.TestingKnobs{
 					OverrideReportingURL: &url,
 				},
+			},
+			SQLStatsKnobs: &sqlstats.TestingKnobs{
+				StubTimeNow: func() time.Time { return stubTime },
 			},
 		},
 	})


### PR DESCRIPTION
In-memory SQL statement statistics are partitioned by aggregation window (see commit c09d6297b4a, which added `aggregatedTs` to `stmtKey`). `TestUsageQuantization` runs ~10010 executions of a single query and then asserts the per-entry quantized count. If the test happens to straddle an hour boundary, those executions are split across two `stmtKey` entries with different `aggregatedTs` values, and the assertion (which only inspects the first matching entry) fails because each entry sees a partial count.

Stub the SQL stats clock via `sqlstats.TestingKnobs.StubTimeNow` so all events land in the same aggregation window. This is more robust than summing counts across matching entries and re-bucketing, because per-entry counts are quantized upstream in `getScrubbedStmtStats` and a pathological split (e.g. 5005+5005) would still produce the wrong bucket after summing.

Resolves: #170329
Epic: none

Release note: None