### PR TITLE
obs: adjust clustermetrics for improved dx

### DIFF
--- a/pkg/obs/clustermetrics/cmmetrics/metric.go
+++ b/pkg/obs/clustermetrics/cmmetrics/metric.go
@@ -44,6 +44,7 @@ type Counter struct {
 // metadata is automatically registered so that the cmreader can
 // materialize this metric from the rangefeed.
 func NewCounter(metadata metric.Metadata) *Counter {
+	metadata.MetricType = prometheusgo.MetricType_COUNTER
 	ensureClusterMetricRegistered(metadata.Name, metadata)
 	return &Counter{
 		Counter: metric.NewCounter(metadata),
@@ -123,6 +124,7 @@ type Gauge struct {
 // metadata is automatically registered so that the cmreader can
 // materialize this metric from the rangefeed.
 func NewGauge(metadata metric.Metadata) *Gauge {
+	metadata.MetricType = prometheusgo.MetricType_GAUGE
 	ensureClusterMetricRegistered(metadata.Name, metadata)
 	return &Gauge{
 		Gauge: metric.NewGauge(metadata),
@@ -223,6 +225,7 @@ type WriteStopwatch struct {
 // metadata and time source. The metadata is automatically registered
 // so that the cmreader can materialize this metric from the rangefeed.
 func NewWriteStopwatch(metadata metric.Metadata, timeSource timeutil.TimeSource) *WriteStopwatch {
+	metadata.MetricType = prometheusgo.MetricType_GAUGE
 	ensureClusterMetricRegistered(metadata.Name, metadata)
 	return &WriteStopwatch{
 		Gauge:      metric.NewGauge(metadata),

--- a/pkg/obs/clustermetrics/cmmetrics/vector.go
+++ b/pkg/obs/clustermetrics/cmmetrics/vector.go
@@ -59,6 +59,7 @@ type GaugeVec struct {
 // names. The metadata is automatically registered so that the cmreader
 // can materialize this metric from the rangefeed.
 func NewGaugeVec(metadata metric.Metadata, labelNames ...string) *GaugeVec {
+	metadata.MetricType = prometheusgo.MetricType_GAUGE
 	ensureLabeledClusterMetricRegistered(metadata.Name, metadata, labelNames)
 	return &GaugeVec{
 		GaugeVec: metric.NewExportedGaugeVec(metadata, labelNames),
@@ -131,6 +132,7 @@ type CounterVec struct {
 // label names. The metadata is automatically registered so that the
 // cmreader can materialize this metric from the rangefeed.
 func NewCounterVec(metadata metric.Metadata, labelNames ...string) *CounterVec {
+	metadata.MetricType = prometheusgo.MetricType_COUNTER
 	ensureLabeledClusterMetricRegistered(metadata.Name, metadata, labelNames)
 	return &CounterVec{
 		CounterVec: metric.NewExportedCounterVec(metadata, labelNames),
@@ -209,6 +211,7 @@ type WriteStopwatchVec struct {
 func NewWriteStopwatchVec(
 	metadata metric.Metadata, timeSource timeutil.TimeSource, labelNames ...string,
 ) *WriteStopwatchVec {
+	metadata.MetricType = prometheusgo.MetricType_GAUGE
 	ensureLabeledClusterMetricRegistered(metadata.Name, metadata, labelNames)
 	return &WriteStopwatchVec{
 		GaugeVec:   metric.NewExportedGaugeVec(metadata, labelNames),

--- a/pkg/obs/clustermetrics/cmwriter/writer.go
+++ b/pkg/obs/clustermetrics/cmwriter/writer.go
@@ -87,7 +87,8 @@ func (w *Writer) AddMetric(m metric.Iterable) {
 }
 
 // AddMetricStruct registers all metric.Iterable fields in the given
-// struct with the Writer.
+// struct with the Writer. Walks nested structs, arrays, slices, and
+// maps to find Iterable values; nil pointer entries are skipped.
 func (w *Writer) AddMetricStruct(s interface{}) {
 	v := reflect.ValueOf(s)
 	if v.Kind() == reflect.Ptr {
@@ -98,11 +99,37 @@ func (w *Writer) AddMetricStruct(s interface{}) {
 		if !field.CanInterface() {
 			continue
 		}
-		if m, ok := field.Interface().(metric.Iterable); ok {
-			w.AddMetric(m)
-		} else if ms, ok := field.Interface().(metric.Struct); ok {
-			w.AddMetricStruct(ms)
+		switch field.Kind() {
+		case reflect.Array, reflect.Slice:
+			for j := 0; j < field.Len(); j++ {
+				w.addMetricValue(field.Index(j))
+			}
+		case reflect.Map:
+			iter := field.MapRange()
+			for iter.Next() {
+				w.addMetricValue(iter.Value())
+			}
+		default:
+			w.addMetricValue(field)
 		}
+	}
+}
+
+// addMetricValue inspects a single reflect.Value: it registers the
+// value if it is an Iterable, recurses if it is a metric.Struct, and
+// silently skips otherwise. Nil pointers are skipped.
+func (w *Writer) addMetricValue(val reflect.Value) {
+	if val.Kind() == reflect.Ptr && val.IsNil() {
+		return
+	}
+	if !val.CanInterface() {
+		return
+	}
+	switch typ := val.Interface().(type) {
+	case metric.Iterable:
+		w.AddMetric(typ)
+	case metric.Struct:
+		w.AddMetricStruct(typ)
 	}
 }
 

--- a/pkg/obs/clustermetrics/cmwriter/writer_test.go
+++ b/pkg/obs/clustermetrics/cmwriter/writer_test.go
@@ -391,6 +391,95 @@ func TestWriter_Flush(t *testing.T) {
 	})
 }
 
+type walkTestLeaf struct {
+	Count *cmmetrics.Counter
+}
+
+func (*walkTestLeaf) MetricStruct() {}
+
+// TestWriter_StructWalk verifies AddMetricStruct recurses into arrays,
+// slices, and maps and skips nil entries.
+func TestWriter_StructWalk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer cmmetrics.TestingAllowNonInitConstruction()()
+
+	newLeaf := func(name string) (*walkTestLeaf, *cmmetrics.Counter) {
+		c := cmmetrics.NewCounter(metric.Metadata{Name: name})
+		return &walkTestLeaf{Count: c}, c
+	}
+
+	t.Run("sparse array", func(t *testing.T) {
+		env := newTestEnv()
+		l1, c1 := newLeaf("arr.c1")
+		l2, c2 := newLeaf("arr.c2")
+		// Slots 0 and 2 are nil.
+		container := struct {
+			Specific [4]metric.Struct
+		}{}
+		container.Specific[1] = l1
+		container.Specific[3] = l2
+		env.writer.AddMetricStruct(&container)
+
+		c1.Inc(11)
+		c2.Inc(22)
+		env.writer.Flush(env.ctx)
+
+		stored, ok := env.store.get("arr.c1")
+		require.True(t, ok)
+		require.Equal(t, int64(11), stored.StoredValue)
+		stored, ok = env.store.get("arr.c2")
+		require.True(t, ok)
+		require.Equal(t, int64(22), stored.StoredValue)
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		env := newTestEnv()
+		l1, c1 := newLeaf("slc.c1")
+		l2, c2 := newLeaf("slc.c2")
+		container := struct {
+			Items []metric.Struct
+		}{
+			Items: []metric.Struct{l1, nil, l2},
+		}
+		env.writer.AddMetricStruct(&container)
+
+		c1.Inc(3)
+		c2.Inc(7)
+		env.writer.Flush(env.ctx)
+
+		stored, ok := env.store.get("slc.c1")
+		require.True(t, ok)
+		require.Equal(t, int64(3), stored.StoredValue)
+		stored, ok = env.store.get("slc.c2")
+		require.True(t, ok)
+		require.Equal(t, int64(7), stored.StoredValue)
+	})
+
+	t.Run("map", func(t *testing.T) {
+		env := newTestEnv()
+		l1, c1 := newLeaf("map.c1")
+		l2, c2 := newLeaf("map.c2")
+		container := struct {
+			ByName map[string]metric.Struct
+		}{
+			ByName: map[string]metric.Struct{"first": l1, "second": l2},
+		}
+		env.writer.AddMetricStruct(&container)
+
+		c1.Inc(5)
+		c2.Inc(8)
+		env.writer.Flush(env.ctx)
+
+		stored, ok := env.store.get("map.c1")
+		require.True(t, ok)
+		require.Equal(t, int64(5), stored.StoredValue)
+		stored, ok = env.store.get("map.c2")
+		require.True(t, ok)
+		require.Equal(t, int64(8), stored.StoredValue)
+	})
+}
+
 func TestWriter_OperationalMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
This patch makes a couple of small changes to the clustermetrics system to support a first adoption in PCR.

Namely:
- Some additional types are re-exported to mitigate dependency cycles.
- Metric constructors now set the `MetricType` on the metadata, without this change the generated yaml for the metrics all show the zero-value type: COUNTER.
- The writer's `AddMetricStruct` method is extended to support walking arrays as maps as well.

Informs: #169173

Release note: None