### PR TITLE
schemachanger: implement `OWNER TO` for domains

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_domain
+++ b/pkg/sql/logictest/testdata/logic_test/alter_domain
@@ -1,8 +1,7 @@
 # LogicTest: local
 
-# Test ALTER DOMAIN syntax. All operations currently return unimplemented
-# errors, but the grammar should parse correctly and dispatch through the
-# declarative schema changer.
+# Test ALTER DOMAIN syntax. Tests are added as operations are implemented
+# through the declarative schema changer.
 
 statement ok
 CREATE DOMAIN d AS INT DEFAULT 0 NOT NULL CHECK (VALUE > 0)
@@ -40,20 +39,26 @@ subtest end
 
 subtest add_constraint
 
-statement error pgcode 0A000 ALTER DOMAIN ADD CHECK CONSTRAINT is not supported
+statement error pgcode 0A000 ALTER DOMAIN ADD CONSTRAINT \.\.\. CHECK is not supported
 ALTER DOMAIN d ADD CHECK (VALUE < 100)
 
-statement error pgcode 0A000 ALTER DOMAIN ADD CHECK CONSTRAINT is not supported
+statement error pgcode 0A000 ALTER DOMAIN ADD CONSTRAINT \.\.\. CHECK is not supported
 ALTER DOMAIN d ADD CONSTRAINT positive CHECK (VALUE > 0)
 
-statement error pgcode 0A000 ALTER DOMAIN ADD CHECK CONSTRAINT is not supported
+statement error pgcode 0A000 ALTER DOMAIN ADD CONSTRAINT \.\.\. CHECK is not supported
 ALTER DOMAIN d ADD CONSTRAINT bounded CHECK (VALUE < 100) NOT VALID
 
-statement error pgcode 0A000 ALTER DOMAIN ADD NOT NULL CONSTRAINT is not supported
+statement error pgcode 0A000 ALTER DOMAIN ADD CONSTRAINT \.\.\. NOT NULL is not supported
 ALTER DOMAIN d ADD NOT NULL
 
-statement error pgcode 0A000 ALTER DOMAIN ADD NOT NULL CONSTRAINT is not supported
+statement error pgcode 0A000 ALTER DOMAIN ADD CONSTRAINT \.\.\. NOT NULL is not supported
 ALTER DOMAIN d ADD CONSTRAINT nn NOT NULL
+
+statement error pgcode 0A000 NOT NULL constraints cannot be marked NOT VALID
+ALTER DOMAIN d ADD NOT NULL NOT VALID
+
+statement error pgcode 0A000 NOT NULL constraints cannot be marked NOT VALID
+ALTER DOMAIN d ADD CONSTRAINT nn NOT NULL NOT VALID
 
 subtest end
 
@@ -83,8 +88,130 @@ subtest end
 
 subtest owner_to
 
-statement error pgcode 0A000 ALTER DOMAIN OWNER TO is not supported
-ALTER DOMAIN d OWNER TO testuser
+statement ok
+CREATE SCHEMA s_owner;
+CREATE DOMAIN s_owner.d_owner AS INT;
+CREATE USER IF NOT EXISTS testuser2
+
+# Ensure user must exist for set owner.
+statement error pq: role/user "fake_user" does not exist
+ALTER DOMAIN s_owner.d_owner OWNER TO fake_user
+
+# Superusers can alter owner to any user which has CREATE privileges on the
+# parent schema.
+statement error pq: user testuser does not have CREATE privilege on schema s_owner
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser
+
+statement ok
+GRANT CREATE, USAGE ON SCHEMA s_owner TO testuser, testuser2
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO root
+
+# Other users must be owner to alter the owner.
+user testuser
+
+statement error must be owner of type d_owner
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser
+
+# Other users must be owner to alter the owner to the current owner again.
+statement error must be owner of type d_owner
+ALTER DOMAIN s_owner.d_owner OWNER TO root
+
+# Non-superusers also must be a member of the new owning role.
+user root
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser
+
+# Setting the owner to the current owner is a no-op.
+statement ok
+REVOKE CREATE ON SCHEMA s_owner FROM testuser
+
+user testuser
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser
+
+user root
+
+statement ok
+GRANT CREATE ON SCHEMA s_owner TO testuser
+
+user testuser
+
+statement error must be member of role "testuser2"
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser2
+
+user root
+
+statement ok
+GRANT testuser2 TO testuser
+
+user testuser
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO testuser2
+
+# Ensure testuser2 is owner of both the domain and its array type.
+user root
+
+query TT
+SELECT typname, pg_get_userbyid(typowner) FROM pg_type WHERE typname IN ('d_owner', '_d_owner') ORDER BY typname;
+----
+_d_owner  testuser2
+d_owner   testuser2
+
+# Test CURRENT_USER and SESSION_USER forms.
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO root
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO CURRENT_USER
+
+query TT
+SELECT typname, pg_get_userbyid(typowner) FROM pg_type WHERE typname IN ('d_owner', '_d_owner') ORDER BY typname;
+----
+_d_owner  root
+d_owner   root
+
+statement ok
+ALTER DOMAIN s_owner.d_owner OWNER TO SESSION_USER
+
+query TT
+SELECT typname, pg_get_userbyid(typowner) FROM pg_type WHERE typname IN ('d_owner', '_d_owner') ORDER BY typname;
+----
+_d_owner  root
+d_owner   root
+
+# Ensure admins who don't have explicit CREATE privilege on a schema can
+# still become the owner.
+user root
+
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
+
+user testuser
+
+statement ok
+CREATE SCHEMA s_owner2
+
+statement ok
+CREATE DOMAIN s_owner2.d_owner2 AS TEXT
+
+user root
+
+statement ok
+GRANT root TO testuser
+
+user testuser
+
+# This should succeed despite root not having explicit CREATE privilege on s_owner2.
+statement ok
+ALTER DOMAIN s_owner2.d_owner2 OWNER TO root
 
 subtest end
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "statement_control.go",
         "table_zone_config.go",
         "truncate.go",
+        "type_helpers.go",
         "zone_config_helpers.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
@@ -133,7 +133,7 @@ func alterDomainDropNotNull(
 func alterDomainAddCheckConstraint(
 	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainAddCheckConstraint,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN ADD CHECK CONSTRAINT is not supported"))
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN ADD CONSTRAINT ... CHECK is not supported"))
 }
 
 func alterDomainAddNotNullConstraint(
@@ -142,7 +142,11 @@ func alterDomainAddNotNullConstraint(
 	domainType *scpb.DomainType,
 	t *tree.AlterDomainAddNotNullConstraint,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN ADD NOT NULL CONSTRAINT is not supported"))
+	if t.ValidationBehavior == tree.ValidationSkip {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"NOT NULL constraints cannot be marked NOT VALID"))
+	}
+	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN ADD CONSTRAINT ... NOT NULL is not supported"))
 }
 
 func alterDomainDropConstraint(
@@ -166,7 +170,7 @@ func alterDomainValidateConstraint(
 func alterDomainOwner(
 	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainOwner,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN OWNER TO is not supported"))
+	setOwnerForTypeDesc(b, tn, domainType, domainType.TypeID, domainType.ArrayTypeID, t.Owner)
 }
 
 func alterDomainRename(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_schema.go
@@ -6,14 +6,9 @@
 package scbuildstmt
 
 import (
-	"strings"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
@@ -76,56 +71,4 @@ func AlterTableSetSchema(b BuildCtx, n *tree.AlterTableSetSchema) {
 		DescriptorType:    kind,
 	}
 	b.LogEventForExistingPayload(newNamespace, setSchemaEvent)
-}
-
-func resolveSchemaByName(b BuildCtx, schemaName tree.Name, databaseID catid.DescID) *scpb.Schema {
-	dbElts := b.QueryByID(databaseID)
-	dbNamespace := dbElts.FilterNamespace().MustGetOneElement()
-	// Resolve the new schema to get its elements
-	newSchemaPrefix := tree.ObjectNamePrefix{
-		CatalogName:     tree.Name(dbNamespace.Name),
-		SchemaName:      schemaName,
-		ExplicitCatalog: true,
-		ExplicitSchema:  true,
-	}
-	newSchema := b.ResolveSchema(newSchemaPrefix, ResolveParams{
-		RequiredPrivilege: privilege.CREATE,
-	}).FilterSchema().MustGetOneElement()
-	return newSchema
-}
-
-func panicIfSchemaIsTemporaryOrVirtual(schemaName tree.Name) {
-	name := string(schemaName)
-	if _, ok := catconstants.VirtualSchemaNames[name]; ok {
-		panic(pgerror.Newf(pgcode.FeatureNotSupported,
-			"cannot move objects into or out of virtual schemas"))
-	}
-	if strings.HasPrefix(name, catconstants.PgTempSchemaName) {
-		panic(pgerror.Newf(pgcode.FeatureNotSupported,
-			"cannot move objects into or out of temporary schemas"))
-	}
-}
-
-// moveDescriptorToSchema drops the old Namespace and SchemaChild elements for
-// the given descriptor and adds new ones with the updated schema ID.
-// It returns the new Namespace and SchemaChild elements.
-func moveDescriptorToSchema(
-	b BuildCtx, descID catid.DescID, currNamespace *scpb.Namespace, newSchemaID catid.DescID,
-) (*scpb.Namespace, *scpb.SchemaChild) {
-	// drop the old namespace and add a new one
-	newNamespace := *currNamespace
-	newNamespace.SchemaID = newSchemaID
-	b.Drop(currNamespace)
-	b.Add(&newNamespace)
-
-	// drop old schema child and add new one
-	currSchemaChild := b.QueryByID(descID).FilterSchemaChild().MustGetOneElement()
-	newSchemaChild := &scpb.SchemaChild{
-		ChildObjectID: descID,
-		SchemaID:      newSchemaID,
-	}
-	b.Drop(currSchemaChild)
-	b.Add(newSchemaChild)
-
-	return &newNamespace, newSchemaChild
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -12,13 +12,10 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/sql/decodeusername"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -319,68 +316,7 @@ func alterTypeSetSchema(
 func alterTypeOwner(
 	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeOwner,
 ) {
-	newOwner, err := decodeusername.FromRoleSpec(
-		b.SessionData(), username.PurposeValidation, t.Owner,
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	typeElts := b.QueryByID(enumType.TypeID)
-	oldOwner := typeElts.FilterOwner().MustGetOneElement()
-
-	if newOwner.Normalized() == oldOwner.Owner {
-		return
-	}
-
-	if !b.HasOwnership(enumType) {
-		panic(pgerror.Newf(pgcode.InsufficientPrivilege,
-			"must be owner of type %s", tn.Object()))
-	}
-
-	if err := b.CheckRoleExists(b, newOwner); err != nil {
-		panic(err)
-	}
-	if !b.CurrentUserHasAdminOrIsMemberOf(newOwner) {
-		panic(pgerror.Newf(pgcode.InsufficientPrivilege,
-			"must be member of role %q", newOwner))
-	}
-
-	schemaChild := typeElts.FilterSchemaChild().MustGetOneElement()
-	schemaElts := b.QueryByID(schemaChild.SchemaID)
-	schema := schemaElts.FilterSchema().MustGetOneElement()
-	if err := b.CheckPrivilegeForUser(schema, privilege.CREATE, newOwner); err != nil {
-		panic(err)
-	}
-
-	b.Replace(&scpb.Owner{
-		DescriptorID: enumType.TypeID,
-		Owner:        newOwner.Normalized(),
-	})
-
-	b.Replace(&scpb.Owner{
-		DescriptorID: enumType.ArrayTypeID,
-		Owner:        newOwner.Normalized(),
-	})
-
-	arrayElts := b.QueryByID(enumType.ArrayTypeID)
-	arrayNs := arrayElts.FilterNamespace().MustGetOneElement()
-	arrayTn := tree.MakeTypeNameWithPrefix(b.NamePrefix(enumType), arrayNs.Name)
-
-	b.LogEventForExistingPayload(&scpb.Owner{
-		DescriptorID: enumType.TypeID,
-		Owner:        newOwner.Normalized(),
-	}, &eventpb.AlterTypeOwner{
-		TypeName: tn.FQString(),
-		Owner:    newOwner.Normalized(),
-	})
-	b.LogEventForExistingPayload(&scpb.Owner{
-		DescriptorID: enumType.ArrayTypeID,
-		Owner:        newOwner.Normalized(),
-	}, &eventpb.AlterTypeOwner{
-		TypeName: arrayTn.FQString(),
-		Owner:    newOwner.Normalized(),
-	})
+	setOwnerForTypeDesc(b, tn, enumType, enumType.TypeID, enumType.ArrayTypeID, t.Owner)
 }
 
 func alterTypeDropValue(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/type_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/type_helpers.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/decodeusername"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+)
+
+func resolveSchemaByName(b BuildCtx, schemaName tree.Name, databaseID catid.DescID) *scpb.Schema {
+	dbElts := b.QueryByID(databaseID)
+	dbNamespace := dbElts.FilterNamespace().MustGetOneElement()
+	newSchemaPrefix := tree.ObjectNamePrefix{
+		CatalogName:     tree.Name(dbNamespace.Name),
+		SchemaName:      schemaName,
+		ExplicitCatalog: true,
+		ExplicitSchema:  true,
+	}
+	newSchema := b.ResolveSchema(newSchemaPrefix, ResolveParams{
+		RequiredPrivilege: privilege.CREATE,
+	}).FilterSchema().MustGetOneElement()
+	return newSchema
+}
+
+func panicIfSchemaIsTemporaryOrVirtual(schemaName tree.Name) {
+	name := string(schemaName)
+	if _, ok := catconstants.VirtualSchemaNames[name]; ok {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of virtual schemas"))
+	}
+	if strings.HasPrefix(name, catconstants.PgTempSchemaName) {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of temporary schemas"))
+	}
+}
+
+// setOwnerForTypeDesc implements OWNER TO for user-defined types that have an
+// associated array type (enums, composites, domains).
+func setOwnerForTypeDesc(
+	b BuildCtx,
+	tn *tree.TypeName,
+	typeElem scpb.Element,
+	typeID catid.DescID,
+	arrayTypeID catid.DescID,
+	owner tree.RoleSpec,
+) {
+	newOwner, err := decodeusername.FromRoleSpec(
+		b.SessionData(), username.PurposeValidation, owner,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	typeElts := b.QueryByID(typeID)
+	oldOwner := typeElts.FilterOwner().MustGetOneElement()
+
+	if newOwner.Normalized() == oldOwner.Owner {
+		return
+	}
+
+	if !b.HasOwnership(typeElem) {
+		panic(pgerror.Newf(pgcode.InsufficientPrivilege,
+			"must be owner of type %s", tn.Object()))
+	}
+
+	if err := b.CheckRoleExists(b, newOwner); err != nil {
+		panic(err)
+	}
+	if !b.CurrentUserHasAdminOrIsMemberOf(newOwner) {
+		panic(pgerror.Newf(pgcode.InsufficientPrivilege,
+			"must be member of role %q", newOwner))
+	}
+
+	schemaChild := typeElts.FilterSchemaChild().MustGetOneElement()
+	schemaElts := b.QueryByID(schemaChild.SchemaID)
+	schema := schemaElts.FilterSchema().MustGetOneElement()
+	if err := b.CheckPrivilegeForUser(schema, privilege.CREATE, newOwner); err != nil {
+		panic(err)
+	}
+
+	b.Replace(&scpb.Owner{
+		DescriptorID: typeID,
+		Owner:        newOwner.Normalized(),
+	})
+
+	b.Replace(&scpb.Owner{
+		DescriptorID: arrayTypeID,
+		Owner:        newOwner.Normalized(),
+	})
+
+	arrayElts := b.QueryByID(arrayTypeID)
+	arrayNs := arrayElts.FilterNamespace().MustGetOneElement()
+	arrayTn := tree.MakeTypeNameWithPrefix(b.NamePrefix(typeElem), arrayNs.Name)
+
+	b.LogEventForExistingPayload(&scpb.Owner{
+		DescriptorID: typeID,
+		Owner:        newOwner.Normalized(),
+	}, &eventpb.AlterTypeOwner{
+		TypeName: tn.FQString(),
+		Owner:    newOwner.Normalized(),
+	})
+	b.LogEventForExistingPayload(&scpb.Owner{
+		DescriptorID: arrayTypeID,
+		Owner:        newOwner.Normalized(),
+	}, &eventpb.AlterTypeOwner{
+		TypeName: arrayTn.FQString(),
+		Owner:    newOwner.Normalized(),
+	})
+}
+
+// moveDescriptorToSchema drops the old Namespace and SchemaChild elements for
+// the given descriptor and adds new ones with the updated schema ID. It returns
+// the new Namespace and SchemaChild elements.
+func moveDescriptorToSchema(
+	b BuildCtx, descID catid.DescID, currNamespace *scpb.Namespace, newSchemaID catid.DescID,
+) (*scpb.Namespace, *scpb.SchemaChild) {
+	newNamespace := *currNamespace
+	newNamespace.SchemaID = newSchemaID
+	b.Drop(currNamespace)
+	b.Add(&newNamespace)
+
+	currSchemaChild := b.QueryByID(descID).FilterSchemaChild().MustGetOneElement()
+	newSchemaChild := &scpb.SchemaChild{
+		ChildObjectID: descID,
+		SchemaID:      newSchemaID,
+	}
+	b.Drop(currSchemaChild)
+	b.Add(newSchemaChild)
+
+	return &newNamespace, newSchemaChild
+}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_domain
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_domain
@@ -1,3 +1,15 @@
 setup
 CREATE DOMAIN defaultdb.d AS INT DEFAULT 0 NOT NULL CHECK (VALUE > 0);
 ----
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d OWNER TO root
+----
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d OWNER TO testuser
+----
+- [[Owner:{DescID: 104}, PUBLIC], ABSENT]
+  {descriptorId: 104, owner: testuser}
+- [[Owner:{DescID: 105}, PUBLIC], ABSENT]
+  {descriptorId: 105, owner: testuser}


### PR DESCRIPTION
This change implements the `ALTER DOMAIN ... OWNER
TO` statement which was previously unsupported.
The legacy schemachanger did not support domain
types so logic tests are added to cover the
feature. 

Closes: #166941
Epic: CRDB-62146

Release note (sql change): The `ALTER DOMAIN ...
OWNER TO` statement is supported.
