### PR TITLE
roachtest: add --details flag to list

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -15,6 +15,7 @@ import (
 	"os/user"
 	"regexp"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
@@ -130,6 +131,20 @@ Examples:
 			specs, hint := filter.FilterWithHint(r.AllTests())
 			if len(specs) == 0 {
 				return errors.Newf("%s", filter.NoMatchesHintString(hint))
+			}
+
+			if roachtestflags.ListDetails {
+				tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+				fmt.Fprintln(tw, "NAME\tOWNER\tTIMEOUT\tRANDOMIZED\tSKIP-POST-VALIDATIONS\tSKIP")
+				for _, s := range specs {
+					timeout := "-"
+					if s.Timeout != 0 {
+						timeout = s.Timeout.String()
+					}
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%t\t%s\t%s\n",
+						s.Name, s.Owner, timeout, s.Randomized, s.SkipPostValidations, s.Skip)
+				}
+				return tw.Flush()
 			}
 
 			for _, s := range specs {

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -257,6 +257,28 @@ const (
 	PostValidationAll = PostValidationReplicaDivergence | PostValidationInvalidDescriptors | PostValidationNoDeadNodes | PostValidationInspect
 )
 
+// String returns a human-readable representation of the set bits, e.g.
+// "ReplicaDivergence|InvalidDescriptors". Returns "none" if no bits are set.
+func (p PostValidation) String() string {
+	if p == 0 {
+		return "none"
+	}
+	var parts []string
+	if p&PostValidationReplicaDivergence != 0 {
+		parts = append(parts, "ReplicaDivergence")
+	}
+	if p&PostValidationInvalidDescriptors != 0 {
+		parts = append(parts, "InvalidDescriptors")
+	}
+	if p&PostValidationNoDeadNodes != 0 {
+		parts = append(parts, "NoDeadNodes")
+	}
+	if p&PostValidationInspect != 0 {
+		parts = append(parts, "Inspect")
+	}
+	return strings.Join(parts, "|")
+}
+
 // PromSub replaces all non prometheus friendly chars with "_". Note,
 // before creating a metric, read up on prom metric naming conventions:
 // https://prometheus.io/docs/practices/naming/

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -60,6 +60,12 @@ var (
 		Usage: `List only benchmarks`,
 	})
 
+	ListDetails bool
+	_           = registerListFlag(&ListDetails, FlagInfo{
+		Name:  "details",
+		Usage: `Include additional per-test fields (e.g. SkipPostValidations) in the listing`,
+	})
+
 	ForceCloudCompat bool
 	_                = registerRunFlag(&ForceCloudCompat, FlagInfo{
 		Name:  "force-cloud-compat",


### PR DESCRIPTION
This adds a --details flag to list that prints some other fields you might be interested in. Notably for my purposes, the SkipPostValidations field.

Epic: none
Release note: None