### PR TITLE
schemachange: fix mixed-version trigger failures on multi-region tables

### DIFF
--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -551,7 +552,15 @@ func getFuncRefsDisallowingAlter(
 		}
 		switch t := desc.(type) {
 		case catalog.TableDescriptor:
-			if !t.IsView() && len(dep.TriggerIDs) == 0 && len(dep.PolicyIDs) == 0 {
+			// Trigger and policy back-references only block renames/schema
+			// changes once the cluster version reaches V26_3_Start. During
+			// a rolling upgrade from v26.2, some nodes may not enforce this
+			// check, so we skip it until all nodes are guaranteed to agree.
+			checkTriggerPolicyDeps := params.p.ExecCfg().Settings.Version.IsActive(
+				params.ctx, clusterversion.V26_3_Start,
+			)
+			hasTriggerPolicyDeps := len(dep.TriggerIDs) > 0 || len(dep.PolicyIDs) > 0
+			if !t.IsView() && !(checkTriggerPolicyDeps && hasTriggerPolicyDeps) {
 				continue
 			}
 			fullyResolvedName, err := params.p.GetQualifiedTableNameByID(

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -6432,6 +6432,9 @@ statement ok
 CREATE POLICY p_rls_dep ON t_rls_dep USING (public.rls_dep_fn(v));
 
 # Renaming the function referenced by the policy should be blocked.
+# In mixed-version clusters (before V26_3_Start), the policy dependency
+# check is skipped, so the rename succeeds.
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
 statement error cannot rename function "rls_dep_fn" because other objects \(\[policy "p_rls_dep" on .*t_rls_dep\]\) still depend on it
 ALTER FUNCTION rls_dep_fn(INT) RENAME TO rls_dep_fn_renamed;
 
@@ -6439,6 +6442,7 @@ ALTER FUNCTION rls_dep_fn(INT) RENAME TO rls_dep_fn_renamed;
 statement ok
 CREATE SCHEMA sc_rls_dep;
 
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
 statement error cannot set schema for function "rls_dep_fn" because other objects \(\[policy "p_rls_dep" on .*t_rls_dep\]\) still depend on it
 ALTER FUNCTION rls_dep_fn(INT) SET SCHEMA sc_rls_dep;
 

--- a/pkg/sql/logictest/testdata/logic_test/triggers
+++ b/pkg/sql/logictest/testdata/logic_test/triggers
@@ -1414,6 +1414,9 @@ statement ok
 ALTER TYPE typ RENAME TO typ2;
 
 # Routines are referenced by name, so renaming is not allowed.
+# In mixed-version clusters (before V26_3_Start), the trigger/policy dependency
+# check is skipped, so the rename succeeds.
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
 statement error cannot rename function "g" because other objects \(.*\) still depend on it
 ALTER FUNCTION g RENAME TO g2;
 
@@ -6499,6 +6502,9 @@ statement ok
 INSERT INTO t_tr_udf_dep VALUES (1, 1);
 
 # Renaming the UDF referenced by the trigger body should be blocked.
+# In mixed-version clusters (before V26_3_Start), the trigger dependency
+# check is skipped, so the rename succeeds.
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
 statement error cannot rename function "udf_dep_helper" because other objects \(\[trigger "tr_udf_dep" on .*t_tr_udf_dep\]\) still depend on it
 ALTER FUNCTION udf_dep_helper() RENAME TO udf_dep_helper_renamed;
 
@@ -6506,6 +6512,7 @@ ALTER FUNCTION udf_dep_helper() RENAME TO udf_dep_helper_renamed;
 statement ok
 CREATE SCHEMA sc_tr_dep;
 
+skipif config local-mixed-25.4 local-mixed-26.1 local-mixed-26.2
 statement error cannot set schema for function "udf_dep_helper" because other objects \(\[trigger "tr_udf_dep" on .*t_tr_udf_dep\]\) still depend on it
 ALTER FUNCTION udf_dep_helper() SET SCHEMA sc_tr_dep;
 

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1111,6 +1111,30 @@ FROM
 	return tree.Name(regionCol), nil
 }
 
+// sqlReferencesRegionColumn reports whether sql mentions any column
+// whose type is the crdb_internal_region enum.
+func (og *operationGenerator) sqlReferencesRegionColumn(
+	ctx context.Context, tx pgx.Tx, sql string,
+) (bool, error) {
+	regionCols, err := Collect(ctx, og, tx, pgx.RowTo[string], `
+SELECT DISTINCT a.attname
+  FROM pg_catalog.pg_attribute a
+  JOIN pg_catalog.pg_type t ON a.atttypid = t.oid
+ WHERE t.typname = 'crdb_internal_region'
+   AND a.attnum > 0
+   AND NOT a.attisdropped`,
+	)
+	if err != nil {
+		return false, err
+	}
+	for _, col := range regionCols {
+		if strings.Contains(sql, col) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // tableIsRegionalByRow checks whether the given table is a REGIONAL BY ROW table.
 func (og *operationGenerator) tableIsRegionalByRow(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4834,11 +4834,10 @@ func (og *operationGenerator) alterFunctionRename(ctx context.Context, tx pgx.Tx
 		return nil, err
 	}
 
-	// The server only blocks ALTER FUNCTION RENAME on trigger/policy back-refs
-	// starting in v26.3. In a mixed-version cluster the rename succeeds against
-	// older servers, so don't classify those functions as "with deps" or the
-	// workload will incorrectly expect a feature_not_supported error.
-	skipTriggerPolicyDeps, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3.Version())
+	// The server only blocks ALTER FUNCTION RENAME on trigger/policy
+	// back-refs when the cluster version reaches V26_3_Start. Mirror
+	// that gate here so the workload's error expectations match.
+	skipTriggerPolicyDeps, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3_Start.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -4956,11 +4955,9 @@ func (og *operationGenerator) alterFunctionSetSchema(
 	}
 
 	// The server only blocks ALTER FUNCTION SET SCHEMA on trigger/policy
-	// back-refs starting in v26.3. In a mixed-version cluster the statement
-	// succeeds against older servers, so don't classify those functions as
-	// "with deps" or the workload will incorrectly expect a
-	// feature_not_supported error.
-	skipTriggerPolicyDeps, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3.Version())
+	// back-refs when the cluster version reaches V26_3_Start. Mirror
+	// that gate here so the workload's error expectations match.
+	skipTriggerPolicyDeps, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3_Start.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -5653,6 +5650,24 @@ func (og *operationGenerator) createTriggerFunction(
 		return nil, err
 	}
 
+	// On clusters older than V26_3_Start, a trigger function that
+	// references a region column (of type crdb_internal_region) will
+	// cause a validation failure. Clear the SELECT if any of its
+	// tables have a region-typed column.
+	excludeRegion, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_3_Start.Version())
+	if err != nil {
+		return nil, err
+	}
+	if excludeRegion {
+		refsRegionCol, err := og.sqlReferencesRegionColumn(ctx, tx, selectStmt.sql)
+		if err != nil {
+			return nil, err
+		}
+		if refsRegionCol {
+			selectStmt.sql = "SELECT 1"
+		}
+	}
+
 	// Sometimes include a sequence reference to exercise trigger-sequence
 	// dependency tracking.
 	seqSelectStmt := ""
@@ -5675,6 +5690,21 @@ func (og *operationGenerator) createTriggerFunction(
 		enumMembers, err := og.collectEnumMembers(ctx, tx)
 		if err != nil {
 			return nil, err
+		}
+		// On clusters older than V26_3_Start, exclude the
+		// crdb_internal_region enum to avoid creating a type dependency
+		// that causes validation failures on v26.2 nodes (see #170091).
+		excludeRegion, err := isClusterVersionLessThan(
+			ctx, tx, clusterversion.V26_3_Start.Version(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if excludeRegion {
+			enumMembers = slices.DeleteFunc(enumMembers, func(m map[string]any) bool {
+				name, _ := m["name"].(string)
+				return strings.Contains(name, "crdb_internal_region")
+			})
 		}
 		var publicEnumExprs []string
 		for _, member := range enumMembers {


### PR DESCRIPTION
Previously, the schemachange workload could generate trigger functions that referenced the `crdb_internal_region` enum type, either through explicit enum cast expressions or by selecting columns of that type. When such a trigger was attached to a REGIONAL BY TABLE or GLOBAL table, v26.2 nodes would reject it with an internal error because their table descriptor validation did not recognize trigger-based type references as legitimate.

Additionally, the server-side check in `getFuncRefsDisallowingAlter` that blocks ALTER FUNCTION RENAME/SET SCHEMA when trigger or policy back-references exist had no cluster version gate. This caused inconsistent behavior during rolling upgrades: v26.3 nodes would block the operation while v26.2 nodes would allow it, making the outcome non-deterministic depending on which node served the request. The workload-side version checks also used `V26_3` (which equals `Latest` and requires all migrations to complete) instead of `V26_3_Start` (which only requires all nodes to run the v26.3 binary).

This commit:
1. Filters out the `crdb_internal_region` enum from trigger function enum cast expressions when the cluster version is below V26_3_Start.
2. Replaces the trigger function's SELECT with a trivial `SELECT 1` when it references any column of the `crdb_internal_region` type.
3. Gates the trigger/policy dependency check in `getFuncRefsDisallowingAlter` on V26_3_Start so all nodes agree during the mixed-version window.
4. Fixes the workload-side version gates in `alterFunctionRename` and `alterFunctionSetSchema` to use `V26_3_Start` instead of `V26_3`.

Resolves: #170091
Epic: none

Release note: None