### PR TITLE
release-25.2: logical: fix bug in tombstone updater

### DIFF
--- a/pkg/crosscluster/logical/tombstone_updater.go
+++ b/pkg/crosscluster/logical/tombstone_updater.go
@@ -168,9 +168,11 @@ func (tu *tombstoneUpdater) getDeleter(ctx context.Context, txn *kv.Txn) (row.De
 			return row.Deleter{}, err
 		}
 
-		cols, err := writeableColunms(ctx, tu.leased.descriptor.Underlying().(catalog.TableDescriptor))
-		if err != nil {
-			return row.Deleter{}, err
+		table := tu.leased.descriptor.Underlying().(catalog.TableDescriptor)
+		schema := getColumnSchema(table)
+		cols := make([]catalog.Column, len(schema))
+		for i, cs := range schema {
+			cols[i] = cs.column
 		}
 
 		tu.leased.deleter = row.MakeDeleter(tu.codec, tu.leased.descriptor.Underlying().(catalog.TableDescriptor), nil /* lockedIndexes */, cols, tu.sd, &tu.settings.SV, nil /* metrics */)

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -115,3 +115,44 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 		{"1", "42"},
 	})
 }
+
+// TestTombstoneUpdaterSecondaryIndex is a regression test for the panic
+// described in #159746. When a DELETE returns 0 rows (LWW loss or row already
+// deleted), the tombstone updater is called with only PK + 1 datums. Before the
+// fix, the Deleter would attempt to encode secondary index keys using ordinals
+// that exceed the length of the datums slice, causing an index-out-of-range
+// panic.
+func TestTombstoneUpdaterSecondaryIndex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	server, s, runners, dbNames := setupServerWithNumDBs(t, ctx, testClusterBaseClusterArgs, 1, 1)
+	defer server.Stopper().Stop(ctx)
+
+	runner := runners[0]
+	runner.Exec(t, `CREATE TABLE t (
+		pk INT PRIMARY KEY,
+		a INT,
+		b INT,
+		c INT,
+		INDEX idx_c (c)
+	)`)
+
+	desc := desctestutils.TestingGetMutableExistingTableDescriptor(
+		s.DB(), s.Codec(), dbNames[0], "t")
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	tu := newTombstoneUpdater(s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
+	defer tu.ReleaseLeases(ctx)
+
+	// Pass only PK + 1 datums, mimicking the real LWW delete path where the
+	// DELETE query only has PK columns in its WHERE clause plus an origin
+	// timestamp parameter.
+	datums := []any{
+		tree.NewDInt(tree.DInt(1)),
+		tree.NewDInt(tree.DInt(42)),
+	}
+
+	_, err := tu.updateTombstoneAny(ctx, nil, s.Clock().Now(), datums)
+	require.NoError(t, err)
+}

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -146,47 +146,14 @@ func (rd *Deleter) DeleteRow(
 ) error {
 	b := &KVBatchAdapter{Batch: batch}
 
-	// Delete the row from any secondary indices.
-	for i, index := range rd.Helper.Indexes {
-		// If the index ID exists in the set of indexes to ignore, do not
-		// attempt to delete from the index.
-		if pm.IgnoreForDel.Contains(int(index.GetID())) {
-			continue
-		}
-
-		// We want to include empty k/v pairs because we want to delete all k/v's for this row.
-		entries, err := rowenc.EncodeSecondaryIndex(
-			ctx,
-			rd.Helper.Codec,
-			rd.Helper.TableDesc,
-			index,
-			rd.FetchColIDtoRowIndex,
-			values,
-			vh.GetDel(),
-			true, /* includeEmpty */
-		)
-		if err != nil {
-			return err
-		}
-		alreadyLocked := rd.secondaryLocked != nil && rd.secondaryLocked.GetID() == index.GetID()
-		for _, e := range entries {
-			if err = rd.Helper.deleteIndexEntry(
-				ctx, b, index, &e.Key, alreadyLocked, rd.Helper.sd.BufferedWritesUseLockingOnNonUniqueIndexes,
-				traceKV, rd.Helper.secIndexValDirs[i],
-			); err != nil {
-				return err
-			}
-		}
-	}
-
 	primaryIndexKey, err := rd.Helper.encodePrimaryIndexKey(rd.FetchColIDtoRowIndex, values)
 	if err != nil {
 		return err
 	}
 
-	// Delete the row.
+	// Delete the row from the primary index.
 	var called bool
-	return rd.Helper.TableDesc.ForeachFamily(func(family *descpb.ColumnFamilyDescriptor) error {
+	err = rd.Helper.TableDesc.ForeachFamily(func(family *descpb.ColumnFamilyDescriptor) error {
 		if called {
 			// HACK: MakeFamilyKey appends to its argument, so on every loop iteration
 			// after the first, trim primaryIndexKey so nothing gets overwritten.
@@ -221,6 +188,50 @@ func (rd *Deleter) DeleteRow(
 		rd.key = nil
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	if oth.PreviousWasDeleted {
+		// If we are updating a tombstone, then there are no secondary index entries
+		// that need to be deleted.
+		return nil
+	}
+
+	// Delete the row from any secondary indices.
+	for i, index := range rd.Helper.Indexes {
+		// If the index ID exists in the set of indexes to ignore, do not
+		// attempt to delete from the index.
+		if pm.IgnoreForDel.Contains(int(index.GetID())) {
+			continue
+		}
+
+		// We want to include empty k/v pairs because we want to delete all k/v's for this row.
+		entries, err := rowenc.EncodeSecondaryIndex(
+			ctx,
+			rd.Helper.Codec,
+			rd.Helper.TableDesc,
+			index,
+			rd.FetchColIDtoRowIndex,
+			values,
+			vh.GetDel(),
+			true, /* includeEmpty */
+		)
+		if err != nil {
+			return err
+		}
+		alreadyLocked := rd.secondaryLocked != nil && rd.secondaryLocked.GetID() == index.GetID()
+		for _, e := range entries {
+			if err = rd.Helper.deleteIndexEntry(
+				ctx, b, index, &e.Key, alreadyLocked, rd.Helper.sd.BufferedWritesUseLockingOnNonUniqueIndexes,
+				traceKV, rd.Helper.secIndexValDirs[i],
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // encodeValueForPrimaryIndexFamily encodes the expected roachpb.Value


### PR DESCRIPTION
Backport 1/1 commits from #159746 (release-25.2), plus a regression test.

/cc @cockroachdb/replication

---

**Commit 1: logical: fix bug in tombstone updater**

This fixes a bug in the tombstone updater. The tombstone decoder was using the columns decoded by the kv writer when it needs to expect the columns decoded by the sql/crud writers. There is one difference between these two sets of columns that impacts computed columns:

1. The sql/crud writer only decode computed columns that are in the primary key.
2. The kv writer decodes virtual computed columns in the primary key and all stored computed columns in the row.

This mismatch can cause panics if the stored column is in an index (which is what the conflict workload noticed) and it can cause the tombstone updater to generate incorrect keys if there is a stored computed column with a lower column id than the primary key column.

A secondary discovery here is that the tombstone updater is formatting deletes for indexes other than the primary index. Now, the deleter will skip generating values for secondary indexes if the cput helper says its updating a deleted row.

**Commit 2: logical: add regression test for tombstone updater secondary index panic**

Prior to the fix in commit 1, the tombstone updater would panic with "index out of range" when updating a tombstone for any table with secondary indexes. The panic occurred because the LWW delete path passes only PK + 1 datums (primary key columns plus origin timestamp) to Deleter.DeleteRow, but the Deleter was built expecting all writable columns. When it attempted to encode secondary index keys, findColumnValue would access values[ordinal] where ordinal exceeded the datums slice length.

Add TestTombstoneUpdaterSecondaryIndex which creates a table with a secondary index and calls updateTombstoneAny with only PK + 1 datums, matching the real call path. Without the fix, this test panics with "index out of range [3] with length 2".

Fixes: #159306
Release note: None
Epic: none

Release justification: low risk change to fix an LDR crash loop