### PR TITLE
logical,txnmode: sort rawKVs as well as DecodedRows

### DIFF
--- a/pkg/crosscluster/logical/ldrdecoder/txn_decoder.go
+++ b/pkg/crosscluster/logical/ldrdecoder/txn_decoder.go
@@ -29,6 +29,13 @@ type Transaction struct {
 	WriteSet []DecodedRow
 }
 
+// TxnEnvelope pairs a decoded Transaction with the raw KV events it was
+// decoded from. RawKVs[i] is the source KV for Txn.WriteSet[i].
+type TxnEnvelope struct {
+	Txn    Transaction
+	RawKVs []streampb.StreamEvent_KV
+}
+
 type TxnDecoder struct {
 	decoder tableDecoder
 }

--- a/pkg/crosscluster/logical/txnlock/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnlock/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/crosscluster/logical/ldrdecoder",
         "//pkg/crosscluster/logical/sqlwriter",
+        "//pkg/repstream/streampb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis.go
@@ -26,7 +26,7 @@ type Lock struct {
 
 type LockSet struct {
 	Locks      []Lock
-	SortedRows []ldrdecoder.DecodedRow
+	SortedRows ldrdecoder.TxnEnvelope
 }
 
 type LockSynthesizer struct {
@@ -77,8 +77,14 @@ type rowsWithLock struct {
 }
 
 func (ls *LockSynthesizer) DeriveLocks(
-	ctx context.Context, rows []ldrdecoder.DecodedRow,
+	ctx context.Context, envelope ldrdecoder.TxnEnvelope,
 ) (LockSet, error) {
+	rows := envelope.Txn.WriteSet
+	if len(rows) != len(envelope.RawKVs) {
+		return LockSet{}, errors.AssertionFailedf(
+			"WriteSet and RawKVs must have the same length: %d vs %d", len(rows), len(envelope.RawKVs))
+	}
+
 	// We build a table of locks for two reasons:
 	// 1. We use it to eliminate duplicate locks for the same row.
 	// 2. We need to topologically sort the rows to get an apply order and
@@ -104,7 +110,7 @@ func (ls *LockSynthesizer) DeriveLocks(
 		}
 	}
 
-	sorted, err := ls.sort(ctx, rows, rowLocks, locks)
+	sorted, err := ls.sort(ctx, envelope, rowLocks, locks)
 	if err != nil {
 		return LockSet{}, err
 	}
@@ -113,7 +119,6 @@ func (ls *LockSynthesizer) DeriveLocks(
 		SortedRows: sorted,
 		Locks:      make([]Lock, 0, len(locks)),
 	}
-
 	for hash, lr := range locks {
 		lockSet.Locks = append(lockSet.Locks, Lock{
 			Hash: hash,

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_bench_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_bench_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -18,7 +19,7 @@ import (
 
 type benchSpec struct {
 	name                string
-	makeRows            func(n int) []ldrdecoder.DecodedRow
+	makeRows            func(n int) ([]ldrdecoder.DecodedRow, []streampb.StreamEvent_KV)
 	makeLockSynthesizer func(b *testing.B) *LockSynthesizer
 }
 
@@ -34,7 +35,7 @@ var benchSpecs = []benchSpec{
 // Each row is an update that forms a dependency chain via the unique constraint
 // on val: row i's new val equals row (i-1)'s old val. This produces n-1
 // dependency edges that the topological sort must resolve.
-func makeBasicBenchRows(n int) []ldrdecoder.DecodedRow {
+func makeBasicBenchRows(n int) ([]ldrdecoder.DecodedRow, []streampb.StreamEvent_KV) {
 	tableID := descpb.ID(100)
 	rows := make([]ldrdecoder.DecodedRow, n)
 	for i := range rows {
@@ -52,7 +53,9 @@ func makeBasicBenchRows(n int) []ldrdecoder.DecodedRow {
 			PrevRow: tree.Datums{id, oldVal},
 		}
 	}
-	return rows
+	// DeriveLocks doesn't read KV contents; pass zero-valued events of the
+	// right length to satisfy its parallel-slice contract.
+	return rows, make([]streampb.StreamEvent_KV, n)
 }
 
 func makeBasicLockSynthesizer(b *testing.B) *LockSynthesizer {
@@ -94,7 +97,7 @@ func makeBasicLockSynthesizer(b *testing.B) *LockSynthesizer {
 // update changes parent_id, producing outbound FK read locks on both old and
 // new values. The child's new parent_id references the corresponding parent's
 // new id, creating FK dependency edges for the topological sort.
-func makeFKBenchRows(n int) []ldrdecoder.DecodedRow {
+func makeFKBenchRows(n int) ([]ldrdecoder.DecodedRow, []streampb.StreamEvent_KV) {
 	parentTableID := descpb.ID(100)
 	childTableID := descpb.ID(200)
 	rows := make([]ldrdecoder.DecodedRow, 0, n)
@@ -111,7 +114,7 @@ func makeFKBenchRows(n int) []ldrdecoder.DecodedRow {
 			PrevRow: tree.Datums{tree.NewDInt(tree.DInt(n/2 + i + 1)), oldFK, tree.NewDInt(0)},
 		})
 	}
-	return rows
+	return rows, make([]streampb.StreamEvent_KV, len(rows))
 }
 
 func makeFKLockSynthesizer(b *testing.B) *LockSynthesizer {
@@ -164,11 +167,15 @@ func BenchmarkDeriveLocks(b *testing.B) {
 	for _, spec := range benchSpecs {
 		ls := spec.makeLockSynthesizer(b)
 		for _, n := range []int{2, 10, 50} {
-			rows := spec.makeRows(n)
+			rows, rawKVs := spec.makeRows(n)
+			txnEnv := ldrdecoder.TxnEnvelope{
+				Txn:    ldrdecoder.Transaction{WriteSet: rows},
+				RawKVs: rawKVs,
+			}
 			ctx := context.Background()
 			b.Run(fmt.Sprintf("rows=%d/%s", n, spec.name), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := ls.DeriveLocks(ctx, rows); err != nil {
+					if _, err := ls.DeriveLocks(ctx, txnEnv); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
@@ -1144,19 +1144,19 @@ func TestDeriveLocks(t *testing.T) {
 
 	decodeTxn := func(
 		t *testing.T, events []streampb.StreamEvent_KV,
-	) []ldrdecoder.DecodedRow {
+	) ldrdecoder.TxnEnvelope {
 		t.Helper()
 		txn, err := decoder.DecodeTxn(ctx, events)
 		require.NoError(t, err)
-		return txn.WriteSet
+		return ldrdecoder.TxnEnvelope{Txn: txn, RawKVs: events}
 	}
 
 	checkTxn := func(
 		t *testing.T, tc txnCase, label string,
 	) LockSet {
 		t.Helper()
-		rows := decodeTxn(t, tc.events)
-		result, err := ls.DeriveLocks(ctx, rows)
+		txnEnv := decodeTxn(t, tc.events)
+		result, err := ls.DeriveLocks(ctx, txnEnv)
 		if tc.err != nil {
 			require.ErrorIs(t, err, tc.err)
 			return LockSet{}
@@ -1173,7 +1173,7 @@ func TestDeriveLocks(t *testing.T) {
 		}
 		require.Equal(t, tc.writeLockCount, writeCount, "%s write lock count", label)
 		require.Equal(t, tc.readLockCount, readCount, "%s read lock count", label)
-		requireSortOrder(t, rows, result.SortedRows, tc.order, label)
+		requireSortOrder(t, txnEnv.Txn.WriteSet, result.SortedRows.Txn.WriteSet, tc.order, label)
 		return result
 	}
 

--- a/pkg/crosscluster/logical/txnlock/sort.go
+++ b/pkg/crosscluster/logical/txnlock/sort.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrdecoder"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -23,21 +24,27 @@ const (
 	statusVisited  sortStatus = 2
 )
 
-// sort topologically sorts the write set by the order writes should be
+// sort topologically sorts the txn envelope by the order writes should be
 // applied.
 func (ls *LockSynthesizer) sort(
 	ctx context.Context,
-	rows []ldrdecoder.DecodedRow,
+	envelope ldrdecoder.TxnEnvelope,
 	rowLocks [][]Lock,
 	locks map[LockHash]rowsWithLock,
-) ([]ldrdecoder.DecodedRow, error) {
-	status := make([]sortStatus, len(rows))
-	sorted := make([]ldrdecoder.DecodedRow, 0, len(rows))
+) (ldrdecoder.TxnEnvelope, error) {
+	n := len(envelope.Txn.WriteSet)
+	status := make([]sortStatus, n)
+	sorted := ldrdecoder.TxnEnvelope{
+		Txn: ldrdecoder.Transaction{
+			TxnID:    envelope.Txn.TxnID,
+			WriteSet: make([]ldrdecoder.DecodedRow, 0, n),
+		},
+		RawKVs: make([]streampb.StreamEvent_KV, 0, n),
+	}
 
-	for i := range rows {
-		err := ls.sortInner(ctx, i, rows, status, rowLocks, locks, &sorted)
-		if err != nil {
-			return nil, err
+	for i := range envelope.Txn.WriteSet {
+		if err := ls.sortInner(ctx, i, envelope, status, rowLocks, locks, &sorted); err != nil {
+			return ldrdecoder.TxnEnvelope{}, err
 		}
 	}
 
@@ -47,11 +54,11 @@ func (ls *LockSynthesizer) sort(
 func (ls *LockSynthesizer) sortInner(
 	ctx context.Context,
 	row int,
-	rows []ldrdecoder.DecodedRow,
+	envelope ldrdecoder.TxnEnvelope,
 	status []sortStatus,
 	rowLocks [][]Lock,
 	locks map[LockHash]rowsWithLock,
-	output *[]ldrdecoder.DecodedRow,
+	output *ldrdecoder.TxnEnvelope,
 ) error {
 	if status[row] == statusVisited {
 		return nil
@@ -77,20 +84,21 @@ func (ls *LockSynthesizer) sortInner(
 			if dependentRow == int32(row) {
 				continue
 			}
-			dep, err := ls.dependsOn(ctx, rows[row], rows[dependentRow])
+			dep, err := ls.dependsOn(ctx, envelope.Txn.WriteSet[row], envelope.Txn.WriteSet[dependentRow])
 			if err != nil {
 				return err
 			}
 			if !dep {
 				continue
 			}
-			if err := ls.sortInner(ctx, int(dependentRow), rows, status, rowLocks, locks, output); err != nil {
+			if err := ls.sortInner(ctx, int(dependentRow), envelope, status, rowLocks, locks, output); err != nil {
 				return err
 			}
 		}
 	}
 
 	status[row] = statusVisited
-	*output = append(*output, rows[row])
+	output.Txn.WriteSet = append(output.Txn.WriteSet, envelope.Txn.WriteSet[row])
+	output.RawKVs = append(output.RawKVs, envelope.RawKVs[row])
 	return nil
 }

--- a/pkg/crosscluster/logical/txnmode/ldr_coordinator_processor.go
+++ b/pkg/crosscluster/logical/txnmode/ldr_coordinator_processor.go
@@ -60,9 +60,8 @@ var coordinatorOutputTypes = []*types.T{
 // timestamp from the decode stage to the schedule stage. Exactly one of
 // transactions or checkpoint is set per batch.
 type decodedBatch struct {
-	transactions    []ldrdecoder.Transaction
-	rawTransactions [][]streampb.StreamEvent_KV
-	checkpoint      hlc.Timestamp
+	transactions []ldrdecoder.TxnEnvelope
+	checkpoint   hlc.Timestamp
 }
 
 type ldrCoordinatorProcessor struct {
@@ -238,8 +237,7 @@ func (p *ldrCoordinatorProcessor) runDecode(ctx context.Context) error {
 	ticker := time.NewTicker(maxInterval)
 	defer ticker.Stop()
 
-	var transactions []ldrdecoder.Transaction
-	var rawTransactions [][]streampb.StreamEvent_KV
+	var transactions []ldrdecoder.TxnEnvelope
 	rows := 0
 
 	flush := func() error {
@@ -249,12 +247,8 @@ func (p *ldrCoordinatorProcessor) runDecode(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case p.batches <- decodedBatch{
-			transactions:    transactions,
-			rawTransactions: rawTransactions,
-		}:
+		case p.batches <- decodedBatch{transactions: transactions}:
 			transactions = nil
-			rawTransactions = nil
 			rows = 0
 			ticker.Reset(maxInterval)
 			return nil
@@ -277,8 +271,10 @@ func (p *ldrCoordinatorProcessor) runDecode(ctx context.Context) error {
 					if err != nil {
 						return errors.Wrap(err, "decoding transaction")
 					}
-					transactions = append(transactions, decoded)
-					rawTransactions = append(rawTransactions, txnKVs)
+					transactions = append(transactions, ldrdecoder.TxnEnvelope{
+						Txn:    decoded,
+						RawKVs: txnKVs,
+					})
 					rows += len(decoded.WriteSet)
 				}
 				if batchRowCount <= rows {
@@ -344,19 +340,17 @@ func (p *ldrCoordinatorProcessor) runScheduleAndRoute(ctx context.Context) error
 			}
 
 			for i := range batch.transactions {
-				applierID := p.hydrateApplierID(ctx, batch.transactions[i])
-				batch.transactions[i].TxnID.ApplierID = applierID
+				envelope := batch.transactions[i]
+				applierID := p.hydrateApplierID(ctx, envelope.Txn)
+				envelope.Txn.TxnID.ApplierID = applierID
 
-				lockSet, err := p.lockSynthesizer.DeriveLocks(
-					ctx, batch.transactions[i].WriteSet,
-				)
+				lockSet, err := p.lockSynthesizer.DeriveLocks(ctx, envelope)
 				if err != nil {
 					return errors.Wrap(err, "deriving locks")
 				}
-				batch.transactions[i].WriteSet = lockSet.SortedRows
 
 				schedulerTxn := txnscheduler.Transaction{
-					TxnID: batch.transactions[i].TxnID,
+					TxnID: lockSet.SortedRows.Txn.TxnID,
 					Locks: lockSet.Locks,
 				}
 				dependencies, eventHorizon := p.scheduler.Schedule(
@@ -364,12 +358,12 @@ func (p *ldrCoordinatorProcessor) runScheduleAndRoute(ctx context.Context) error
 				)
 
 				scheduled := txnapply.ScheduledTransaction{
-					Transaction:  batch.transactions[i],
+					Transaction:  lockSet.SortedRows.Txn,
 					Dependencies: dependencies,
 					EventHorizon: eventHorizon,
 				}
 
-				row := p.encodeScheduledTxn(scheduled, applierID, batch.rawTransactions[i])
+				row := p.encodeScheduledTxn(scheduled, applierID, lockSet.SortedRows.RawKVs)
 				select {
 				case <-ctx.Done():
 					return ctx.Err()

--- a/pkg/crosscluster/logical/txnmode/txnmode_test.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_test.go
@@ -42,9 +42,7 @@ func setupParentChildReplication(
 
 	for _, db := range []*sqlutils.SQLRunner{sourceDB, destDB} {
 		db.Exec(t, "CREATE TABLE parent (id INT PRIMARY KEY)")
-		db.Exec(t, "CREATE TABLE child (id INT PRIMARY KEY, parent_id INT)")
-		// TODO(jeffswenson): add fk support to lock derivation then uncomment this.
-		// db.Exec(t, "CREATE TABLE child (id INT PRIMARY KEY, parent_id INT REFERENCES parent(id))")
+		db.Exec(t, "CREATE TABLE child (id INT PRIMARY KEY, parent_id INT REFERENCES parent(id))")
 	}
 
 	sourceURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("source_db"))
@@ -150,9 +148,9 @@ func TestTxnModeUniqueConstraintUpdate(t *testing.T) {
 
 	// Update the UUID (primary key) of the row with unique_value = 1337
 	// This tests that lock synthesis correctly orders the delete and insert operations
-	now := s.Clock().Now()
 	sourceDB.Exec(t, "UPDATE test_table SET uuid = gen_random_uuid() WHERE unique_value = 1337")
 
+	now := s.Clock().Now()
 	ldrtestutils.WaitUntilReplicatedTime(t, now, destDB, jobID)
 
 	// Verify the update was replicated (row with unique_value = 1337 still exists with new UUID)


### PR DESCRIPTION
We pair the rawKVs with their sorted DecodedRows when we send them over the wire to the applier, but we weren't sorting the rawKVs so they no longer matched with the respective DecodedRow.

Fixes: none
Epic: none
Release note: none