### PR TITLE
opt: bump DistinctCount instead of panicking on stat inconsistency

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -3170,14 +3171,40 @@ func (sb *statisticsBuilder) finalizeFromCardinality(relProps *props.Relational)
 	}
 }
 
+// distinctCountInvariantLogLimiter rate-limits the warning emitted when
+// the optimizer produces a column statistic that violates the
+// "distinct count > 0 if row count > 0" invariant. See the comment in
+// finalizeFromRowCountAndDistinctCounts.
+var distinctCountInvariantLogLimiter = log.Every(10 * time.Second)
+
 func (sb *statisticsBuilder) finalizeFromRowCountAndDistinctCounts(
 	colStat *props.ColumnStatistic, s *props.Statistics,
 ) {
 	rowCount := s.RowCount
 
-	// We should always have at least one distinct value if row count > 0.
+	// A column statistic with a non-zero row count must have a non-zero
+	// distinct count: every row contributes at least one observed value.
+	// Several optimizer paths enforce this directly (e.g., the outer-join
+	// guards in buildJoin and colStatJoin). When some other path produces
+	// inconsistent stats anyway (see #46230, #62289, #73106, #169804),
+	// fail loudly in test builds so the upstream bug surfaces, but recover
+	// in production so an internal estimation slip doesn't fail the user's
+	// query. Use the same heuristic colStatLeaf uses when no statistics
+	// are available; it's a more neutral guess than 1, which would assert
+	// that every row holds the same value and skew downstream selectivity
+	// estimates. Multi-column constraints below will tighten this if
+	// per-column statistics are present.
 	if rowCount > 0 && colStat.DistinctCount == 0 {
-		panic(errors.AssertionFailedf("estimated distinct count must be non-zero"))
+		if buildutil.CrdbTestBuild {
+			panic(errors.AssertionFailedf("estimated distinct count must be non-zero"))
+		}
+		if distinctCountInvariantLogLimiter.ShouldLog() {
+			log.Dev.Errorf(sb.ctx,
+				"estimated distinct count must be non-zero: cols=%s rowCount=%v nullCount=%v",
+				colStat.Cols, rowCount, colStat.NullCount,
+			)
+		}
+		colStat.DistinctCount = UnknownDistinctCountRatio * rowCount
 	}
 
 	// If this is a multi-column statistic, the distinct count should be no


### PR DESCRIPTION
## Summary

The optimizer's statistics builder asserts that a column statistic with a non-zero `RowCount` must have a non-zero `DistinctCount`. Several build paths (e.g. the outer-join cases in `buildJoin` and `colStatJoin`) already enforce this directly with `max(distinct, 1)`. History shows that other paths can still produce stats that violate the invariant: see #46230, #62289, #73106, and most recently #169804, where an INSPECT consistency check failed `TestWorkloadMultiRegion` because the optimizer panicked while planning the index-vs-PK CTE query.

These slip-ups are real bugs in the estimation path, but they don't produce incorrect results — only a planning failure. This PR treats the panic the same way as other test-only assertions in this file: keep it in test builds so the upstream cause surfaces, but recover in production using the same `UnknownDistinctCountRatio * rowCount` fallback `colStatLeaf` already uses when no statistics are available (per @michae2's suggestion in review). Violations are logged at `Error` level (rate-limited to once per 10s) so the upstream cause can still be tracked from production logs.

This PR addresses the symptom that's blocking the release; the upstream estimation bug for #169804 itself is still open and should be tracked separately by SQL Queries.

Informs: #169804
Epic: none