### PR TITLE
kvserver/reports: regression test for voter constraint misattribution

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -704,6 +704,115 @@ func TestSuperRegionConstraintConformanceZoneSurvival(t *testing.T) {
 	})
 }
 
+// TestRBRConstraintStatsAttribution verifies that the constraint stats reporter
+// attributes voter constraint entries to RBR partition subzones rather than the
+// database zone. This is a regression test for a bug where visitNewZone only
+// checked zone.Constraints (not zone.VoterConstraints) to decide whether a
+// subzone's config applies, causing it to skip partition subzones that define
+// voterConstraints but inherit constraints from the database, and misattribute
+// all violations to the database zone.
+func TestRBRConstraintStatsAttribution(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+	skip.UnderDuress(t)
+
+	regionNames := []string{
+		"us-west-1",  // primary
+		"us-east-1",  // secondary
+		"eu-west-1",
+	}
+	tc, sqlDB, cleanup :=
+		multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
+			t,
+			regionNames,
+			2, /* serversPerRegion */
+			base.TestingKnobs{},
+		)
+	defer cleanup()
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	tdb.Exec(t, "SET CLUSTER SETTING kv.replication_reports.interval = '1ms'")
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'")
+	tdb.Exec(t, "SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms'")
+
+	tdb.Exec(t, `CREATE DATABASE testdb PRIMARY REGION "us-west-1"
+		REGIONS "us-east-1", "eu-west-1"`)
+	tdb.Exec(t, `ALTER DATABASE testdb SET SECONDARY REGION "us-east-1"`)
+
+	tdb.Exec(t, `CREATE TABLE testdb.rbr(k INT PRIMARY KEY, v INT)
+		LOCALITY REGIONAL BY ROW`)
+	tdb.Exec(t, `INSERT INTO testdb.rbr(crdb_region, k, v) VALUES
+		('us-west-1', 1, 10), ('us-east-1', 2, 20), ('eu-west-1', 3, 30)`)
+
+	var dbZoneID int
+	tdb.QueryRow(t,
+		"SELECT zone_id FROM crdb_internal.zones WHERE database_name = 'testdb' AND table_name IS NULL",
+	).Scan(&dbZoneID)
+
+	var tblZoneID int
+	tdb.QueryRow(t,
+		"SELECT zone_id FROM crdb_internal.zones WHERE table_name = 'rbr'",
+	).Scan(&tblZoneID)
+
+	forceProcess := func() error {
+		for i := 0; i < tc.NumServers(); i++ {
+			if err := tc.Server(i).GetStores().(*kvserver.Stores).VisitStores(
+				func(s *kvserver.Store) error {
+					return s.ForceReplicationScanAndProcess()
+				},
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Wait for constraint stats to be generated for both the table's
+	// subzones and the database zone.
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceProcess(); err != nil {
+			return err
+		}
+		for _, zid := range []int{dbZoneID, tblZoneID} {
+			var count int
+			if err := sqlDB.QueryRow(
+				`SELECT count(*) FROM system.replication_constraint_stats
+				  WHERE zone_id = $1`, zid,
+			).Scan(&count); err != nil {
+				return err
+			}
+			if count == 0 {
+				return fmt.Errorf("constraint stats not yet generated for zone %d", zid)
+			}
+		}
+		return nil
+	})
+
+	// The key assertion: voter_constraint entries for the RBR partitions must
+	// appear under the table's zone_id (with partition subzone_ids), not under
+	// the database's zone_id. The bug caused the reporter to skip partition
+	// subzones (because zone.Constraints was nil, even though
+	// zone.VoterConstraints was set) and attribute everything to the DB zone.
+	//
+	// With 3 regions and 1 index, we expect 3 partition subzones, each with
+	// at least one voter_constraint entry.
+	var tblVoterConstraintCount int
+	tdb.QueryRow(t,
+		`SELECT count(DISTINCT subzone_id) FROM system.replication_constraint_stats
+		  WHERE zone_id = $1 AND subzone_id > 0 AND type = 'voter_constraint'`,
+		tblZoneID,
+	).Scan(&tblVoterConstraintCount)
+	require.Equal(t, 3, tblVoterConstraintCount,
+		"expected voter_constraint entries for all 3 partition subzones under "+
+			"table zone %d, but found %d — the reporter likely misattributed them "+
+			"to the database zone",
+		tblZoneID, tblVoterConstraintCount)
+}
+
 // TestSuperRegionWithNumReplicasExtension verifies that creating an RBR table
 // with super regions succeeds when the user has set num_replicas via a zone
 // config extension to a value lower than the default.

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -463,28 +463,45 @@ func (v *constraintConformanceVisitor) visitNewZone(
 		v.visitErr = retErr != nil
 	}()
 
-	// Find the applicable constraints, which may be inherited.
+	// Find the applicable constraints, which may be inherited independently.
+	// A subzone may define its own VoterConstraints while inheriting
+	// Constraints from a parent zone, so we walk the zone hierarchy and
+	// capture each field from the most specific zone that defines it.
 	var numVoters int
 	var constraints []zonepb.ConstraintsConjunction
 	var voterConstraints []zonepb.ConstraintsConjunction
 	var zKey ZoneKey
+	var foundConstraints, foundVoterConstraints, foundNumVoters bool
 	_, err := visitZones(ctx, r, v.cfg, ignoreSubzonePlaceholders,
 		func(_ context.Context, zone *zonepb.ZoneConfig, key ZoneKey) bool {
-			if zone.Constraints == nil {
-				return false
+			// Use the most specific zone that defines any constraint field
+			// as the zone key for reporting.
+			if !foundConstraints && !foundVoterConstraints {
+				if zone.Constraints != nil || zone.VoterConstraints != nil {
+					zKey = key
+				}
 			}
-			// Check num voters and only set it if it is different from num replicas.
-			var numReplicas int32
-			if zone.NumReplicas != nil {
-				numReplicas = *zone.NumReplicas
+			if !foundVoterConstraints && zone.VoterConstraints != nil {
+				voterConstraints = zone.VoterConstraints
+				foundVoterConstraints = true
 			}
-			if zone.NumVoters != nil && numReplicas != *zone.NumVoters {
-				numVoters = int(*zone.NumVoters)
+			if !foundConstraints && zone.Constraints != nil {
+				constraints = zone.Constraints
+				foundConstraints = true
 			}
-			constraints = zone.Constraints
-			voterConstraints = zone.VoterConstraints
-			zKey = key
-			return true
+			// NumVoters is inherited from the most specific zone that sets
+			// it, independently of which zone provides Constraints.
+			if !foundNumVoters && zone.NumVoters != nil {
+				var numReplicas int32
+				if zone.NumReplicas != nil {
+					numReplicas = *zone.NumReplicas
+				}
+				if numReplicas != *zone.NumVoters {
+					numVoters = int(*zone.NumVoters)
+				}
+				foundNumVoters = true
+			}
+			return foundConstraints && foundVoterConstraints
 		})
 	if err != nil {
 		return errors.Wrap(err, "unexpected error visiting zones")

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -504,6 +504,107 @@ func TestConformanceReportSubzoneVoterConstraints(t *testing.T) {
 	runConformanceReportTest(t, tc)
 }
 
+// TestConformanceReportSubzoneVoterConstraintsWorkaround verifies that
+// explicitly setting constraints on a partition (duplicating the DB-level
+// constraints) works around the visitNewZone bug where subzones with only
+// voterConstraints are skipped. This simulates the customer workaround of
+// using ALTER PARTITION ... CONFIGURE ZONE USING constraints = '...' to make
+// the subzone visible to the (unfixed) constraint conformance reporter.
+func TestConformanceReportSubzoneVoterConstraintsWorkaround(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tc := conformanceConstraintTestCase{
+		name: "partition with explicit constraints workaround",
+		baseReportTestCase: baseReportTestCase{
+			defaultZone: zone{voters: 3},
+			schema: []database{
+				{
+					name: "db1",
+					zone: &zone{
+						voters:           2,
+						nonVoters:        1,
+						constraints:      `{"+region=us":1,"+region=eu":1}`,
+						voterConstraints: `{"+region=us":1}`,
+					},
+					tables: []table{{
+						name: "t1",
+						// Workaround: partition p1 sets BOTH voterConstraints
+						// AND constraints explicitly. The constraints duplicate
+						// what would be inherited from the DB, but setting them
+						// makes zone.Constraints non-nil so the buggy visitor
+						// finds the subzone.
+						partitions: []partition{{
+							name:  "p1",
+							start: []int{100},
+							end:   []int{200},
+							zone: &zone{
+								voters:           2,
+								nonVoters:        1,
+								constraints:      `{"+region=us":1,"+region=eu":1}`,
+								voterConstraints: `{"+region=eu":1}`,
+							},
+						}},
+					}},
+				},
+			},
+			splits: []split{
+				{key: "/Table/t1", stores: "1 2 3"},
+				{key: "/Table/t1/pk/100", stores: "4 5 6"},
+			},
+			nodes: []node{
+				{id: 1, locality: "region=us", stores: []store{{id: 1}}},
+				{id: 2, locality: "region=us", stores: []store{{id: 2}}},
+				{id: 3, locality: "region=us", stores: []store{{id: 3}}},
+				{id: 4, locality: "region=eu", stores: []store{{id: 4}}},
+				{id: 5, locality: "region=eu", stores: []store{{id: 5}}},
+				{id: 6, locality: "region=eu", stores: []store{{id: 6}}},
+			},
+		},
+		exp: []constraintEntry{
+			// DB-level: only the non-partition range.
+			{
+				object:         "db1",
+				constraint:     "+region=eu:1",
+				constraintType: Constraint,
+				numRanges:      1,
+			},
+			{
+				object:         "db1",
+				constraint:     "+region=us:1",
+				constraintType: Constraint,
+				numRanges:      0,
+			},
+			{
+				object:         "db1",
+				constraint:     "+region=us:1",
+				constraintType: VoterConstraint,
+				numRanges:      0,
+			},
+			// Partition p1: now has explicit constraints, so visitor
+			// finds it even without the fix.
+			{
+				object:         "t1.p1",
+				constraint:     "+region=eu:1",
+				constraintType: Constraint,
+				numRanges:      0,
+			},
+			{
+				object:         "t1.p1",
+				constraint:     "+region=us:1",
+				constraintType: Constraint,
+				numRanges:      1,
+			},
+			{
+				object:         "t1.p1",
+				constraint:     "+region=eu:1",
+				constraintType: VoterConstraint,
+				numRanges:      0,
+			},
+		},
+	}
+	runConformanceReportTest(t, tc)
+}
+
 // runConformanceReportTest runs one test case. It processes the input schema,
 // runs the reports, and verifies that the report looks as expected.
 func runConformanceReportTest(t *testing.T, tc conformanceConstraintTestCase) {

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -404,6 +404,106 @@ func TestConformanceReport(t *testing.T) {
 	}
 }
 
+// TestConformanceReportSubzoneVoterConstraints verifies that the constraint
+// conformance report correctly attributes voter constraint violations to
+// partition subzones that define voterConstraints but inherit constraints from
+// the database. This is a regression test for the case where visitNewZone skips
+// a subzone because zone.Constraints is nil, even though VoterConstraints is
+// set, causing violations to be misattributed to the database zone.
+func TestConformanceReportSubzoneVoterConstraints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tc := conformanceConstraintTestCase{
+		name: "partition with voter constraints only",
+		baseReportTestCase: baseReportTestCase{
+			defaultZone: zone{voters: 3},
+			schema: []database{
+				{
+					name: "db1",
+					zone: &zone{
+						voters:           2,
+						nonVoters:        1,
+						constraints:      `{"+region=us":1,"+region=eu":1}`,
+						voterConstraints: `{"+region=us":1}`,
+					},
+					tables: []table{{
+						name: "t1",
+						// Partition p1 sets its own voterConstraints but
+						// inherits constraints from the database.
+						partitions: []partition{{
+							name:  "p1",
+							start: []int{100},
+							end:   []int{200},
+							zone: &zone{
+								voters:           2,
+								nonVoters:        1,
+								voterConstraints: `{"+region=eu":1}`,
+							},
+						}},
+					}},
+				},
+			},
+			splits: []split{
+				// Range outside the partition — governed by the database zone.
+				{key: "/Table/t1", stores: "1 2 3"},
+				// Range inside partition p1 — should use p1's voterConstraints.
+				{key: "/Table/t1/pk/100", stores: "4 5 6"},
+			},
+			nodes: []node{
+				// Stores 1-3: region=us — satisfies the DB voter constraint.
+				{id: 1, locality: "region=us", stores: []store{{id: 1}}},
+				{id: 2, locality: "region=us", stores: []store{{id: 2}}},
+				{id: 3, locality: "region=us", stores: []store{{id: 3}}},
+				// Stores 4-6: region=eu — satisfies partition p1's voter constraint,
+				// but violates the DB's voter constraint (+region=us:1).
+				{id: 4, locality: "region=eu", stores: []store{{id: 4}}},
+				{id: 5, locality: "region=eu", stores: []store{{id: 5}}},
+				{id: 6, locality: "region=eu", stores: []store{{id: 6}}},
+			},
+		},
+		exp: []constraintEntry{
+			// DB-level constraints — only the range outside the partition is
+			// checked against these under the DB key.
+			{
+				object:         "db1",
+				constraint:     "+region=eu:1",
+				constraintType: Constraint,
+				numRanges:      1,
+			},
+			{
+				object:         "db1",
+				constraint:     "+region=us:1",
+				constraintType: Constraint,
+				numRanges:      0,
+			},
+			{
+				object:         "db1",
+				constraint:     "+region=us:1",
+				constraintType: VoterConstraint,
+				numRanges:      0,
+			},
+			// Partition p1: the partition range inherits Constraints from the
+			// DB, so constraint violations are reported under the partition
+			// key. All replicas are in region=eu, so +region=us:1 is violated.
+			{
+				object:         "t1.p1",
+				constraint:     "+region=us:1",
+				constraintType: Constraint,
+				numRanges:      1,
+			},
+			// Partition p1 voter constraint — the partition range should be
+			// counted here, not at the DB level.
+			{
+				object:         "t1.p1",
+				constraint:     "+region=eu:1",
+				constraintType: VoterConstraint,
+				numRanges:      0,
+			},
+		},
+	}
+	runConformanceReportTest(t, tc)
+}
+
 // runConformanceReportTest runs one test case. It processes the input schema,
 // runs the reports, and verifies that the report looks as expected.
 func runConformanceReportTest(t *testing.T, tc conformanceConstraintTestCase) {


### PR DESCRIPTION
The constraint conformance report visitor in `visitNewZone` only checks `zone.Constraints == nil` to decide whether a subzone's config applies. For RBR partition subzones that define `VoterConstraints` but inherit `Constraints` from the database (i.e. `Constraints` is nil), the visitor skips the subzone and walks up to the database zone config, causing all voter constraint violations to be misattributed to the database zone instead of the partition subzone.

Add two regression tests that reproduce this bug:

1. A unit test (`TestConformanceReportSubzoneVoterConstraints`) that directly exercises the constraint conformance report with a partition subzone that has only `voterConstraints` set.

2. An integration test (`TestRBRConstraintStatsAttribution`) that sets up a multi-region cluster with a secondary region and an RBR table, then verifies that `system.replication_constraint_stats` attributes voter constraint entries to the table's partition subzones rather than the database zone.

Both tests currently fail, confirming the bug.

Epic: none
Release note: None