### PR TITLE
build,release: forward IS_PRODUCTION_REPO into the release binary

### DIFF
--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -38,6 +38,10 @@ env:
   # Scheduled runs default to non-dry-run; manual runs honor the input.
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || '' }}
   TEST_ISSUE_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.test_issue_key || '' }}
+  # Forwarded into the container so the release binary's isProductionRepo()
+  # check sees the same value the workflow's `if:` gate uses. Without this,
+  # the binary defaults to non-prod and routes Slack to #db-release-test.
+  IS_PRODUCTION_REPO: ${{ vars.IS_PRODUCTION_REPO }}
   # Gated on USE_PROD_GCP so a staging-prod repo (IS_PRODUCTION_REPO=true,
   # USE_PROD_GCP unset) can rehearse the branch-cut flow against the dev
   # Secret Manager. There is no inputs.dry_run term — branch-cut's

--- a/.github/workflows/release-pick-sha.yml
+++ b/.github/workflows/release-pick-sha.yml
@@ -39,6 +39,10 @@ env:
   # Scheduled runs default to non-dry-run; manual runs honor the input.
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || '' }}
   TEST_ISSUE_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.test_issue_key || '' }}
+  # Forwarded into the container so the release binary's isProductionRepo()
+  # check sees the same value the workflow's `if:` gate uses. Without this,
+  # the binary defaults to non-prod and routes Slack to #db-release-test.
+  IS_PRODUCTION_REPO: ${{ vars.IS_PRODUCTION_REPO }}
   # Gated on USE_PROD_GCP so a staging-prod repo (IS_PRODUCTION_REPO=true,
   # USE_PROD_GCP unset) can rehearse the pick-SHA flow against the dev
   # Secret Manager. There is no inputs.dry_run term — pick-sha's --dry-run

--- a/build/github/release-cut-staging-branches.sh
+++ b/build/github/release-cut-staging-branches.sh
@@ -36,5 +36,5 @@ source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
 # helper to pick which GitHub repo holds the staging branches; without
 # it the binary falls back to cockroachdb/cockroach and looks for the
 # staging branch in the wrong place.
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e GITHUB_REPOSITORY" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e GITHUB_REPOSITORY -e IS_PRODUCTION_REPO" \
   run_bazel build/github/release-cut-staging-branches-impl.sh

--- a/build/github/release-pick-sha.sh
+++ b/build/github/release-pick-sha.sh
@@ -37,5 +37,5 @@ source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
 # helper to pick which GitHub repo holds the staging branches; without
 # it the binary falls back to cockroachdb/cockroach and looks for the
 # staging branch in the wrong place.
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e RELEASE_NOTES_API_KEY -e GITHUB_REPOSITORY" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e RELEASE_NOTES_API_KEY -e GITHUB_REPOSITORY -e IS_PRODUCTION_REPO" \
   run_bazel build/github/release-pick-sha-impl.sh


### PR DESCRIPTION
The release binary's isProductionRepo() check reads the IS_PRODUCTION_REPO env var to decide between the production Slack channel (#db-release-status) and the rehearsal channel (#db-release-test). The branch-cut and pick-sha workflows gate themselves on vars.IS_PRODUCTION_REPO via their job-level if:, but never exported the value to the run step or the bazel docker container. As a result, a non-dry-run on the production repo still routed Slack to #db-release-test.

Add IS_PRODUCTION_REPO to each workflow's env: block and to the docker -e passthrough list in the wrapper scripts, so the var reaches the binary on both layers.

Release note: None
Epic: none