### PR TITLE
release-25.4: roachtest: reduce cluster creation noise in stdout

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -883,7 +883,7 @@ var create = roachprod.Create
 //
 // NOTE: setTest() needs to be called before a test can use this cluster.
 func (f *clusterFactory) newCluster(
-	ctx context.Context, cfg clusterConfig, setStatus func(string), teeOpt logger.TeeOptType,
+	ctx context.Context, cfg clusterConfig, setStatus func(string),
 ) (*clusterImpl, *vm.CreateOpts, error) {
 	if ctx.Err() != nil {
 		return nil, nil, errors.Wrap(ctx.Err(), "newCluster")
@@ -971,7 +971,7 @@ func (f *clusterFactory) newCluster(
 			retryStr = "-retry" + strconv.Itoa(i-1)
 		}
 		logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", genName+retryStr+".log")
-		l, err := logger.RootLogger(logPath, teeOpt)
+		clusterL, err := logger.RootLogger(logPath, logger.NoTee)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}
@@ -987,11 +987,11 @@ func (f *clusterFactory) newCluster(
 			destroyState: destroyState{
 				owned: true,
 			},
-			l: l,
+			l: clusterL,
 		}
 		c.status("creating cluster")
 
-		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
+		clusterL.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
 		createVMOpts.ClusterName = c.name
 		opts := []*cloud.ClusterCreateOpts{{Nodes: cfg.spec.NodeCount, CreateOpts: createVMOpts, ProviderOptsContainer: providerOptsContainer}}
 		// There can only be one local cluster so creating two sequentially overwrites the first.
@@ -1002,13 +1002,13 @@ func (f *clusterFactory) newCluster(
 				{Nodes: cfg.spec.WorkloadNodeCount, CreateOpts: createVMOpts, ProviderOptsContainer: workloadProviderOptsContainer},
 			}
 		}
-		err = create(ctx, l, cfg.username, opts...)
+		err = create(ctx, clusterL, cfg.username, opts...)
 		if err == nil {
 			if err := f.r.registerCluster(c); err != nil {
 				return nil, nil, err
 			}
 			c.status("idle")
-			l.Close()
+			clusterL.Close()
 			return c, &createVMOpts, nil
 		}
 
@@ -1022,8 +1022,8 @@ func (f *clusterFactory) newCluster(
 			return nil, nil, err
 		}
 
-		l.PrintfCtx(ctx, "cluster creation failed, cleaning up in case it was partially created: %s", err)
-		c.Destroy(ctx, closeLogger, l)
+		clusterL.PrintfCtx(ctx, "cluster creation failed, cleaning up in case it was partially created: %s", err)
+		c.Destroy(ctx, closeLogger, clusterL)
 		if i >= maxAttempts {
 			return nil, nil, err
 		}
@@ -1947,7 +1947,7 @@ func (c *clusterImpl) PutCockroach(ctx context.Context, l *logger.Logger, t *tes
 // PutLibraries inserts the specified libraries, by name, into all nodes on the cluster
 // at the specified location.
 func (c *clusterImpl) PutLibraries(
-	ctx context.Context, libraryDir string, libraries []string,
+	ctx context.Context, l *logger.Logger, libraryDir string, libraries []string,
 ) error {
 	if len(libraries) == 0 {
 		return nil
@@ -1957,6 +1957,12 @@ func (c *clusterImpl) PutLibraries(
 	}
 	c.status("uploading library files")
 	defer c.status("")
+
+	// Temporarily swap c.l so that RunE (which doesn't accept a logger
+	// parameter) writes to the caller-provided logger.
+	savedL := c.l
+	c.l = l
+	defer func() { c.l = savedL }()
 
 	if err := c.RunE(ctx, option.WithNodes(c.All()), "mkdir", "-p", libraryDir); err != nil {
 		return err
@@ -1974,7 +1980,7 @@ func (c *clusterImpl) PutLibraries(
 		putPath := filepath.Join(libraryDir, libName+ext)
 		if err := c.PutE(
 			ctx,
-			c.l,
+			l,
 			libraryFilePath,
 			putPath,
 		); err != nil {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -42,7 +42,7 @@ type Cluster interface {
 	Get(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error
 	Put(ctx context.Context, src, dest string, opts ...option.Option)
 	PutE(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error
-	PutLibraries(ctx context.Context, libraryDir string, libraries []string) error
+	PutLibraries(ctx context.Context, l *logger.Logger, libraryDir string, libraries []string) error
 	Stage(
 		ctx context.Context, l *logger.Logger, application, versionOrSHA, dir string, opts ...option.Option,
 	) error

--- a/pkg/cmd/roachtest/cluster/mock/mock_cluster_generated.go
+++ b/pkg/cmd/roachtest/cluster/mock/mock_cluster_generated.go
@@ -688,17 +688,17 @@ func (mr *MockClusterMockRecorder) PutE(arg0, arg1, arg2, arg3 interface{}, arg4
 }
 
 // PutLibraries mocks base method.
-func (m *MockCluster) PutLibraries(arg0 context.Context, arg1 string, arg2 []string) error {
+func (m *MockCluster) PutLibraries(arg0 context.Context, arg1 *logger.Logger, arg2 string, arg3 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutLibraries", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PutLibraries", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutLibraries indicates an expected call of PutLibraries.
-func (mr *MockClusterMockRecorder) PutLibraries(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterMockRecorder) PutLibraries(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLibraries", reflect.TypeOf((*MockCluster)(nil).PutLibraries), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLibraries", reflect.TypeOf((*MockCluster)(nil).PutLibraries), arg0, arg1, arg2, arg3)
 }
 
 // PutString mocks base method.

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -97,7 +97,7 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	runnerDir := filepath.Join(artifactsDir, runnerLogsDir)
 	runnerLogPath := filepath.Join(
 		runnerDir, fmt.Sprintf("test_runner-%d.log", timeutil.Now().Unix()))
-	l, tee := testRunnerLogger(context.Background(), parallelism, runnerLogPath)
+	runnerL, tee := testRunnerLogger(context.Background(), parallelism, runnerLogPath)
 	roachprod.ClearClusterCache = roachtestflags.ClearClusterCache
 
 	if runtime.GOOS == "darwin" {
@@ -132,7 +132,7 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	}
 
 	lopt := loggingOpt{
-		l:                   l,
+		runnerL:             runnerL,
 		tee:                 tee,
 		stdout:              os.Stdout,
 		stderr:              os.Stderr,
@@ -147,20 +147,20 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 		teamLoader:  team.DefaultLoadTeams,
 	}
 
-	l.Printf("global random seed: %d", roachtestflags.GlobalSeed)
+	runnerL.Printf("global random seed: %d", roachtestflags.GlobalSeed)
 	go func() {
 		if err := http.ListenAndServe(
 			fmt.Sprintf(":%d", roachtestflags.PromPort),
 			promhttp.HandlerFor(r.promRegistry, promhttp.HandlerOpts{}),
 		); err != nil {
-			l.Errorf("error serving prometheus: %v", err)
+			runnerL.Errorf("error serving prometheus: %v", err)
 		}
 	}()
 	// We're going to run all the workers (and thus all the tests) in a context
 	// that gets canceled when the Interrupt signal is received.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	CtrlC(ctx, l, cancel, cr)
+	CtrlC(ctx, runnerL, cancel, cr)
 	if false {
 		// Install goroutine leak checker and run it at the end of the entire test
 		// run. If a test is leaking a goroutine, then it will likely be still around.
@@ -173,7 +173,7 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 		// output pollutes stdout and makes roachtest annoying to use.
 		//
 		// Tracking issue: https://github.com/cockroachdb/cockroach/issues/148196
-		defer leaktest.AfterTest(l)()
+		defer leaktest.AfterTest(runnerL)()
 	}
 
 	// We allow roachprod users to set a default auth-mode through the
@@ -199,14 +199,14 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	// ctx above might be canceled in case a signal was received. If that's
 	// the case, we're running under a 5s timeout until the CtrlC() goroutine
 	// kills the process.
-	l.PrintfCtx(ctx, "runTests destroying all clusters")
-	cr.destroyAllClusters(context.Background(), l)
+	runnerL.PrintfCtx(ctx, "runTests destroying all unsaved clusters")
+	cr.destroyAllClusters(context.Background(), runnerL)
 
 	if roachtestflags.TeamCity {
 		// Collect the runner logs.
 		fmt.Printf("##teamcity[publishArtifacts '%s' => '%s']\n", filepath.Join(literalArtifactsDir, runnerLogsDir), runnerLogsDir)
 	}
-	runner.writeTestReports(ctx, l, artifactsDir)
+	runner.writeTestReports(ctx, runnerL, artifactsDir)
 
 	return err
 }

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -799,9 +799,9 @@ const (
 )
 
 type loggingOpt struct {
-	// l is the test runner logger.
+	// runnerL is the test runner logger.
 	// Note that individual test runs will use a different logger.
-	l *logger.Logger
+	runnerL *logger.Logger
 	// tee controls whether test logs (not test runner logs) also go to stdout or
 	// not.
 	tee            logger.TeeOptType

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -387,7 +387,7 @@ func (r *testRunner) Run(
 				!tests[i].Suites.Contains(registry.Weekly) &&
 				!tests[i].IsLastFailurePreempt() &&
 				rand.Float64() <= 0.75 {
-				lopt.l.PrintfCtx(ctx, "using spot VMs to run test %s", tests[i].Name)
+				lopt.runnerL.PrintfCtx(ctx, "using spot VMs to run test %s", tests[i].Name)
 				tests[i].Cluster.UseSpotVMs = true
 			}
 		}
@@ -402,9 +402,8 @@ func (r *testRunner) Run(
 	errs := &workerErrors{}
 
 	qp := quotapool.NewIntPool("cloud cpu", uint64(clustersOpt.cpuQuota))
-	l := lopt.l
 	runID = generateRunID(clustersOpt)
-	shout(ctx, l, lopt.stdout, "%s: %s", VmLabelTestRunID, runID)
+	shout(ctx, lopt.runnerL, lopt.stdout, "%s: %s", VmLabelTestRunID, runID)
 	var wg sync.WaitGroup
 
 	for i := 0; i < parallelism; i++ {
@@ -415,10 +414,10 @@ func (r *testRunner) Run(
 
 			name := fmt.Sprintf("w%d", i)
 			formattedPrefix := fmt.Sprintf("[%s] ", name)
-			childLogger, err := l.ChildLogger(name, logger.LogPrefix(formattedPrefix))
+			workerL, err := lopt.runnerL.ChildLogger(name, logger.LogPrefix(formattedPrefix))
 			if err != nil {
-				l.ErrorfCtx(ctx, "unable to create logger %s: %s", name, err)
-				childLogger = l
+				lopt.runnerL.ErrorfCtx(ctx, "unable to create logger %s: %s", name, err)
+				workerL = lopt.runnerL
 			}
 
 			err = r.runWorker(
@@ -428,7 +427,7 @@ func (r *testRunner) Run(
 				clustersOpt,
 				lopt,
 				topt,
-				childLogger,
+				workerL,
 				n*count,
 				github,
 			)
@@ -436,7 +435,7 @@ func (r *testRunner) Run(
 			if err != nil {
 				// A worker returned an error. Let's shut down.
 				msg := fmt.Sprintf("Worker %d returned with error. Quiescing. Error: %v", i, err)
-				shout(ctx, childLogger, lopt.stdout, msg)
+				shout(ctx, workerL, lopt.stdout, msg)
 				errs.AddErr(err)
 				// Stop the stopper. This will cause all workers to not pick up more
 				// tests after finishing the currently running one. We add one to the
@@ -459,32 +458,32 @@ func (r *testRunner) Run(
 	// Wait for all the workers to finish.
 	wg.Wait()
 	shutdownStart := timeutil.Now()
-	r.cr.destroyAllClusters(ctx, l)
+	r.cr.destroyAllClusters(ctx, lopt.runnerL)
 
 	if errs.Err() != nil {
-		shout(ctx, l, lopt.stdout, "FAIL (err: %s)", errs.Err())
+		shout(ctx, lopt.runnerL, lopt.stdout, "FAIL (err: %s)", errs.Err())
 		return errs.Err()
 	}
 	passFailLine := r.generateReport()
-	shout(ctx, l, lopt.stdout, passFailLine)
+	shout(ctx, lopt.runnerL, lopt.stdout, passFailLine)
 
 	// For the errors that don't short-circuit the pipeline run, return a joined
 	// error and leave case handling to the caller
 	var err error
 	if r.storageInvariantViolation.Load() {
-		shout(ctx, l, lopt.stdout, "potential data corruption: invariant violation detected")
+		shout(ctx, lopt.runnerL, lopt.stdout, "potential data corruption: invariant violation detected")
 		err = errors.Join(err, errStorageInvariantViolation)
 	}
 	if r.numGithubPostErrs > 0 {
-		shout(ctx, l, lopt.stdout, "%d errors occurred while posting to github", r.numGithubPostErrs)
+		shout(ctx, lopt.runnerL, lopt.stdout, "%d errors occurred while posting to github", r.numGithubPostErrs)
 		err = errors.Join(err, errGithubPostFailed)
 	}
 	if r.numClusterErrs > 0 {
-		shout(ctx, l, lopt.stdout, "%d clusters could not be created", r.numClusterErrs)
+		shout(ctx, lopt.runnerL, lopt.stdout, "%d clusters could not be created", r.numClusterErrs)
 		err = errors.Join(err, errSomeClusterProvisioningFailed)
 	}
 	if len(r.status.fail) > 0 {
-		shout(ctx, l, lopt.stdout, "%d tests failed", len(r.status.fail))
+		shout(ctx, lopt.runnerL, lopt.stdout, "%d tests failed", len(r.status.fail))
 		err = errors.Join(err, errTestsFailed)
 	}
 	if err != nil {
@@ -554,7 +553,7 @@ func (r *testRunner) allocateOrAttachToCluster(
 	if existingClusterName != "" {
 		// Logs for attaching to a cluster go to a dedicated log file.
 		logPath := filepath.Join(lopt.artifactsDir, runnerLogsDir, "cluster-create", existingClusterName+".log")
-		clusterL, err := logger.RootLogger(logPath, lopt.tee)
+		clusterL, err := logger.RootLogger(logPath, logger.NoTee)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -565,11 +564,13 @@ func (r *testRunner) allocateOrAttachToCluster(
 		// TODO(srosenberg): we need to think about validation here. Attaching to an incompatible cluster, e.g.,
 		// using arm64 AMI with amd64 binary, would result in obscure errors. The test runner ensures compatibility
 		// during cluster reuse, whereas attachment via CLI (e.g., via roachprod) does not.
-		lopt.l.PrintfCtx(ctx, "Attaching to existing cluster %s for test %s", existingClusterName, t.Name)
+		shout(ctx, lopt.runnerL, lopt.stdout, "Attaching to existing cluster %s for test %s (logs: %s)",
+			existingClusterName, t.Name,
+			filepath.Join(runnerLogsDir, "cluster-create", existingClusterName+".log"))
 		if c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr); err != nil {
 			// If the cluster is not found, we fall through to create a new cluster. Otherwise, we bail out.
 			if errors.Is(err, errClusterNotFound) {
-				lopt.l.PrintfCtx(ctx, "Error attaching to existing cluster %s: %s", existingClusterName, err)
+				lopt.runnerL.PrintfCtx(ctx, "Error attaching to existing cluster %s: %s", existingClusterName, err)
 			} else {
 				return nil, nil, err
 			}
@@ -579,12 +580,12 @@ func (r *testRunner) allocateOrAttachToCluster(
 			return c, nil, nil
 		}
 		// Fall through to create new cluster with name override.
-		lopt.l.PrintfCtx(
+		lopt.runnerL.PrintfCtx(
 			ctx, "Creating new cluster with custom name %q for test %s: %s (arch=%q)",
 			clustersOpt.clusterName, t.Name, t.Cluster, arch,
 		)
 	} else {
-		lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s (arch=%q)", t.Name, t.Cluster, arch)
+		lopt.runnerL.PrintfCtx(ctx, "Creating new cluster for test %s: %s (arch=%q)", t.Name, t.Cluster, arch)
 	}
 
 	cfg := clusterConfig{
@@ -595,7 +596,7 @@ func (r *testRunner) allocateOrAttachToCluster(
 		localCluster: clustersOpt.typ == localCluster,
 		arch:         arch,
 	}
-	return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus, lopt.tee)
+	return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus)
 }
 
 // runWorker runs tests in a loop until work is exhausted.
@@ -629,13 +630,13 @@ func (r *testRunner) runWorker(
 	clustersOpt clustersOpt,
 	lopt loggingOpt,
 	topt testOpts,
-	l *logger.Logger,
+	workerL *logger.Logger,
 	maxTotalFailures int,
 	github GithubPoster,
 ) error {
 	stdout := lopt.stdout
 
-	wStatus := r.addWorker(ctx, l, name)
+	wStatus := r.addWorker(ctx, workerL, name)
 	defer func() {
 		r.removeWorker(ctx, name)
 	}()
@@ -652,15 +653,15 @@ func (r *testRunner) runWorker(
 		wStatus.SetCluster(nil)
 
 		if c == nil {
-			l.PrintfCtx(ctx, "Worker exiting; no cluster to destroy.")
+			workerL.PrintfCtx(ctx, "Worker exiting; no cluster to destroy.")
 			return
 		}
 		doDestroy := ctx.Err() == nil
 		if doDestroy {
-			l.PrintfCtx(ctx, "Worker exiting; destroying cluster.")
-			c.Destroy(context.Background(), closeLogger, l)
+			workerL.PrintfCtx(ctx, "Worker exiting; destroying cluster.")
+			c.Destroy(context.Background(), closeLogger, workerL)
 		} else {
-			l.PrintfCtx(ctx, "Worker exiting with canceled ctx. Not destroying cluster.")
+			workerL.PrintfCtx(ctx, "Worker exiting with canceled ctx. Not destroying cluster.")
 		}
 	}()
 
@@ -669,7 +670,7 @@ func (r *testRunner) runWorker(
 		// Release any quota, in case we exit from the loop from an error path.
 		if alloc != nil {
 			if alloc.Acquired() > 0 {
-				l.PrintfCtx(ctx, "Releasing quota for %s CPUs", alloc.String())
+				workerL.PrintfCtx(ctx, "Releasing quota for %s CPUs", alloc.String())
 			}
 			qp.Release(alloc)
 		}
@@ -682,7 +683,7 @@ func (r *testRunner) runWorker(
 	for {
 		select {
 		case <-interrupt:
-			l.ErrorfCtx(ctx, "worker detected interruption")
+			workerL.ErrorfCtx(ctx, "worker detected interruption")
 			return errors.Errorf("interrupted")
 		default:
 			if ctx.Err() != nil {
@@ -704,20 +705,20 @@ func (r *testRunner) runWorker(
 		testToRun := testToRunRes{noWork: true}
 		if c != nil {
 			// Try to reuse cluster.
-			testToRun = work.selectTestForCluster(ctx, l, c.spec, r.cr, roachtestflags.Cloud)
+			testToRun = work.selectTestForCluster(ctx, workerL, c.spec, r.cr, roachtestflags.Cloud)
 			if !testToRun.noWork {
 				// We found a test to run on this cluster. Wipe the cluster.
-				if err := c.WipeForReuse(ctx, l, testToRun.spec.Cluster); err != nil {
+				if err := c.WipeForReuse(ctx, workerL, testToRun.spec.Cluster); err != nil {
 					// We do not count reuse attempt error toward clusterCreateErr. If
 					// either the Wipe or Extend failed, then destroy the cluster and attempt
 					// to create a fresh cluster for the selected test.
-					shout(ctx, l, stdout, "Unable to reuse cluster: %s due to: %s. Will attempt to create a fresh one",
+					shout(ctx, workerL, stdout, "Unable to reuse cluster: %s due to: %s. Will attempt to create a fresh one",
 						c.Name(), err)
 					// We don't release the quota allocation - the new cluster will be
 					// identical.
 					testToRun.canReuseCluster = false
 					// We use a context that can't be canceled for the Destroy().
-					c.Destroy(context.Background(), closeLogger, l)
+					c.Destroy(context.Background(), closeLogger, workerL)
 					wStatus.SetCluster(nil)
 					c = nil
 				}
@@ -731,8 +732,8 @@ func (r *testRunner) runWorker(
 				wStatus.SetStatus("destroying cluster")
 				// We failed to find a test that can take advantage of this cluster. So
 				// we're going to release it, which will deallocate its resources.
-				l.PrintfCtx(ctx, "No tests that can reuse cluster %s found. Destroying.", c)
-				r.destroyClusterAsync(clusterDestroyWg, c, l)
+				workerL.PrintfCtx(ctx, "No tests that can reuse cluster %s found. Destroying.", c)
+				r.destroyClusterAsync(clusterDestroyWg, c, workerL)
 				wStatus.SetCluster(nil)
 				c = nil
 			}
@@ -741,19 +742,19 @@ func (r *testRunner) runWorker(
 			// associated quota allocation.
 			if alloc != nil {
 				if alloc.Acquired() > 0 {
-					l.PrintfCtx(ctx, "Releasing quota for %s CPUs", alloc.String())
+					workerL.PrintfCtx(ctx, "Releasing quota for %s CPUs", alloc.String())
 				}
 				qp.Release(alloc)
 				alloc = nil
 			}
 
 			var err error
-			testToRun, alloc, err = work.selectTest(ctx, qp, l)
+			testToRun, alloc, err = work.selectTest(ctx, qp, workerL)
 			if err != nil {
 				return err
 			}
 			if testToRun.noWork {
-				shout(ctx, l, stdout, "No work remaining; runWorker is bailing out...")
+				shout(ctx, workerL, stdout, "No work remaining; runWorker is bailing out...")
 				return nil
 			}
 		}
@@ -772,7 +773,7 @@ func (r *testRunner) runWorker(
 			// somehow determine the capabilities at runtime.
 			arch = c.arch
 		} else {
-			arch = archForTest(ctx, l, testToRun.spec)
+			arch = archForTest(ctx, workerL, testToRun.spec)
 			if c != nil {
 				// Switch architecture of local cluster (see above).
 				c.arch = arch
@@ -785,7 +786,7 @@ func (r *testRunner) runWorker(
 		// (in RoachprodOpts). All the code below using arch is incorrect in this
 		// case.
 		if err := VerifyLibraries(testToRun.spec.NativeLibs, arch); err != nil {
-			shout(ctx, l, stdout, "Library verification failed: %s", err)
+			shout(ctx, workerL, stdout, "Library verification failed: %s", err)
 			return err
 		}
 
@@ -807,16 +808,21 @@ func (r *testRunner) runWorker(
 
 			if clusterCreateErr != nil {
 				atomic.AddInt32(&r.numClusterErrs, 1)
-				shout(ctx, l, stdout, "Unable to create (or reuse) cluster for test %s due to: %s.",
+				shout(ctx, workerL, stdout, "Unable to create (or reuse) cluster for test %s: %s",
 					testToRun.spec.Name, clusterCreateErr)
+				if c != nil {
+					shout(ctx, workerL, stdout, "Cluster logs: %s", filepath.Join(runnerLogsDir, "cluster-create", c.Name()+".log"))
+				}
 			} else {
 				if c.arch != arch {
 					// N.B. this can happen if requested machine type is not feasible/available.
-					l.PrintfCtx(ctx, "WARN: cluster arch for test differs %s: %s (cluster arch=%q, specified arch=%q)",
+					workerL.PrintfCtx(ctx, "WARN: cluster arch for test differs %s: %s (cluster arch=%q, specified arch=%q)",
 						testToRun.spec.Name, c.Name(), c.arch, arch)
 					arch = c.arch
 				}
-				l.PrintfCtx(ctx, "Created new cluster for test %s: %s (arch=%q)", testToRun.spec.Name, c.Name(), arch)
+				shout(ctx, workerL, stdout, "Cluster %s created for test %s (arch=%q, logs: %s)",
+					c.Name(), testToRun.spec.Name, arch,
+					filepath.Join(runnerLogsDir, "cluster-create", c.Name()+".log"))
 			}
 		}
 
@@ -824,7 +830,7 @@ func (r *testRunner) runWorker(
 		// cleaned up. Do it now instead of at the end as the test may be interrupted
 		// with ctrl c before we get there.
 		if c != nil && clustersOpt.debugMode == DebugKeepAlways {
-			c.Save(ctx, "cluster saved since --debug-always set", l)
+			c.Save(ctx, "cluster saved since --debug-always set", workerL)
 		}
 
 		wStatus.SetCluster(c)
@@ -889,10 +895,10 @@ func (r *testRunner) runWorker(
 			// but not in runTests() so keeping the invocation of getTestParameters()
 			// the same in both spots
 			params := getTestParameters(t, issueInfo.cluster, issueInfo.vmCreateOpts)
-			logTestParameters(l, params)
-			if _, githubErr := github.MaybePost(t, issueInfo, l, t.failureMsg(), params); githubErr != nil {
+			logTestParameters(workerL, params)
+			if _, githubErr := github.MaybePost(t, issueInfo, workerL, t.failureMsg(), params); githubErr != nil {
 				atomic.AddInt32(&r.numGithubPostErrs, 1)
-				shout(ctx, l, stdout, "failed to post issue: %s", githubErr)
+				shout(ctx, workerL, stdout, "failed to post issue: %s", githubErr)
 			}
 		}
 
@@ -902,19 +908,34 @@ func (r *testRunner) runWorker(
 			handleClusterCreationFailure(clusterCreateErr)
 		} else {
 			// Now run the test.
-			l.PrintfCtx(ctx, "Starting test: %s:%d on cluster=%s (arch=%q)", testToRun.spec.Name, testToRun.runNum, c.Name(), arch)
+			workerL.PrintfCtx(ctx, "Starting test: %s:%d on cluster=%s (arch=%q)", testToRun.spec.Name, testToRun.runNum, c.Name(), arch)
 
 			c.setTest(t)
 
+			// Create a test-level cluster setup logger with NoTee to pass
+			// into cluster setup methods to reduce noise in stdout when
+			// TeeToStdout is set (when parallelism is 1).
+			setupLogPath := filepath.Join(testArtifactsDir, "cluster_setup.log")
+			clusterSetupL, setupLogErr := logger.RootLogger(setupLogPath, logger.NoTee)
+			if setupLogErr != nil {
+				// Fall back to the worker logger if we can't create cluster_setup.log.
+				clusterSetupL = workerL
+			}
+
+			shout(ctx, workerL, stdout, "Setting up cluster %s for test %s", c.Name(), testToRun.spec.Name)
+
 			var setupErr error
 			if c.spec.NodeCount > 0 { // skip during tests
-				setupErr = c.PutCockroach(ctx, l, t)
+				setupErr = c.PutCockroach(ctx, clusterSetupL, t)
 			}
 			if setupErr == nil {
-				setupErr = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs)
+				setupErr = c.PutLibraries(ctx, clusterSetupL, "./lib", t.spec.NativeLibs)
 			}
 			if setupErr == nil {
-				setupErr = c.PutDeprecatedWorkload(ctx, l, t)
+				setupErr = c.PutDeprecatedWorkload(ctx, clusterSetupL, t)
+			}
+			if clusterSetupL != workerL {
+				clusterSetupL.Close()
 			}
 
 			if setupErr != nil {
@@ -922,8 +943,11 @@ func (r *testRunner) runWorker(
 				// initial files), we treat the error just like a cluster
 				// creation failure: the error is reported as an
 				// infrastructure flake, and we continue with the next test.
+				shout(ctx, workerL, stdout, "Cluster setup failed for test %s (setup logs: %s): %s",
+					testToRun.spec.Name, setupLogPath, setupErr)
 				handleClusterCreationFailure(setupErr)
 			} else {
+				shout(ctx, workerL, stdout, "Cluster %s ready for test %s.", c.Name(), testToRun.spec.Name)
 				// Tell the cluster that, from now on, it will be run "on behalf of this
 				// test".
 				c.status("running test")
@@ -1025,7 +1049,7 @@ func (r *testRunner) runWorker(
 			msg = "test failed: %s (run %d)"
 		}
 		msg = fmt.Sprintf(msg, t.Name(), testToRun.runNum)
-		l.PrintfCtx(ctx, msg)
+		workerL.PrintfCtx(ctx, msg)
 
 		testL.Close()
 		if t.Failed() {
@@ -1036,7 +1060,7 @@ func (r *testRunner) runWorker(
 					// Save the cluster for future debugging.
 					// We already marked the cluster as a saved cluster above in the case
 					// of DebugKeepAlways, but update it with the failureMsg.
-					c.Save(ctx, failureMsg, l)
+					c.Save(ctx, failureMsg, workerL)
 
 					// Continue with a fresh cluster.
 					c = nil
@@ -1044,8 +1068,8 @@ func (r *testRunner) runWorker(
 					if !c.saved() {
 						// On any test failure or error, we destroy the cluster. We could be
 						// more selective, but this sounds safer.
-						l.PrintfCtx(ctx, "destroying cluster %s because: %s", c, failureMsg)
-						c.Destroy(context.Background(), closeLogger, l)
+						workerL.PrintfCtx(ctx, "destroying cluster %s because: %s", c, failureMsg)
+						c.Destroy(context.Background(), closeLogger, workerL)
 					}
 					c = nil
 				}

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -93,7 +93,7 @@ func clusterOptWithProvisioningError() clustersOpt {
 
 func defaultLoggingOpt(buf *syncedBuffer) loggingOpt {
 	return loggingOpt{
-		l:            nilLogger(),
+		runnerL:      nilLogger(),
 		tee:          logger.NoTee,
 		stdout:       buf,
 		stderr:       buf,
@@ -341,7 +341,7 @@ func setupRunnerTest(t *testing.T, r testRegistryImpl, testFilters []string) *ru
 	var stdout syncedBuffer
 	var stderr syncedBuffer
 	lopt := loggingOpt{
-		l: func() *logger.Logger {
+		runnerL: func() *logger.Logger {
 			l, err := logger.RootLogger(filepath.Join(t.TempDir(), "test.log"), logger.NoTee)
 			if err != nil {
 				panic(err)
@@ -674,7 +674,7 @@ func TestNewCluster(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			createCallsCounter = 0
 			create = c.createMock
-			_, _, err := factory.newCluster(ctx, cfg, setStatus, true)
+			_, _, err := factory.newCluster(ctx, cfg, setStatus)
 			require.Error(t, err)
 			require.Equal(t, c.expectedCreateCalls, createCallsCounter)
 		})
@@ -724,7 +724,7 @@ func TestGCESameDefaultZone(t *testing.T) {
 		cfg.spec.Geo = c.geo
 		t.Run(c.name, func(t *testing.T) {
 			for i := 0; i < 100; i++ {
-				_, _, _ = factory.newCluster(ctx, cfg, setStatus, true)
+				_, _, _ = factory.newCluster(ctx, cfg, setStatus)
 			}
 		})
 	}


### PR DESCRIPTION
Backport 1/1 commits from #165251.

/cc @cockroachdb/release

---

Previously, if you ran a single roachtest with `count=1`, `teeOpt` would be set to `logger.TeeToStdout` in `lopt`, and all subsequent logs would be tee'd to stdout.  There was a lot of noise that often didn't relate to the test itself which mainly included cluster creation and downstream roachprod operations (e.g. AWS SSO errors, SSH key setup, and per-node binary staging status). See detailed annotated examples in the comments. After an ask to reduce noise to create a more focused stdout for LLM parsing, I have the following changes to reduce noise while keeping changes minimal.

Cluster Creation / Discovery & Attaching
* `_runner-logs/cluster-create/{existingClusterName}.log` will no longer Tee to stdout regardless of parallelism
* `_runner-logs/cluster-create/{generatedName}.log` will no longer Tee to stdout regardless of parallelism 

Worker Log: `_runner-logs/w{n}.log` still Tee if `parallelism==1`  but  the code paths that call `roachprod` methods to stage binaries and libs will use a **new** `cluster_setup.log` that is scoped to the test
* `{test_name}/run_{n}/cluster_setup.log` will not Tee regardless of parallelism

Test Runner Log: `_runner-logs/test_runner-%d.log` still Tee if `parallelism==1`

A different approach was considered that involved adding a flag to determine Tee'ing behavior, but the above approach was chosen due to mainly simplicity while achieving functional outcome. More details on that below in comments.

All detailed output is still written to existing log files (`_runner-logs/cluster-create/`) and a new `cluster_setup.log`
New brief breadcrumb messages inform the user what's happening and where to find detailed logs

The outcome for this is 30-50% reduction in noise to stdout depending on the cluster creation / discovering an existing cluster code path that is used.

Also `l` was overused and made figuring out the logger difficult. I replaced some usages with more descriptive names e.g. `l` --> `runnerL` and `workerL` where it made sense and to match with existing usage of `testL` and `clusterL`. Also sometimes even with the existing descriptive loggers, sometimes they would still be refered to as `l` at some points. Didn't make this change to util like functions, only the main functions / methods like `runTests`, `makeCluster`, `testRunner.Run`,` testRunner.runWorker`, etc.  Scoped this cleanup to logger usage outside of `testImpl` and it's various logs.

Release justification: test only change