### PR TITLE
roachtest: re-apply cluster settings on reset in backup-restore tests

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -158,7 +158,8 @@ func backupRestoreRoundTrip(
 	m.Go(func(ctx context.Context) error {
 		testUtils, err := setupBackupRestoreTestUtils(
 			ctx, t, c, testRNG,
-			withMock(sp.mock), withOnlineRestore(sp.onlineRestore), withCompaction(!sp.onlineRestore),
+			withMock(sp.mock), withOnlineRestore(sp.onlineRestore),
+			withCompaction(!sp.onlineRestore), withClusterSettings(envOption),
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/tests/backup_restore_utils.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_utils.go
@@ -112,6 +112,12 @@ type CommonTestUtils struct {
 	onlineRestore     bool
 	compactionEnabled bool
 
+	// clusterSettings are the cluster setting options the test was started
+	// with. resetCluster re-applies them on every restart so the cluster comes
+	// back with the same configuration (notably env vars, which are read once
+	// at process start).
+	clusterSettings []install.ClusterSettingOption
+
 	connCache struct {
 		mu    syncutil.Mutex
 		cache []*gosql.DB
@@ -135,6 +141,12 @@ func withOnlineRestore(or bool) commonTestOption {
 func withCompaction(c bool) commonTestOption {
 	return func(cu *CommonTestUtils) {
 		cu.compactionEnabled = c
+	}
+}
+
+func withClusterSettings(s ...install.ClusterSettingOption) commonTestOption {
+	return func(cu *CommonTestUtils) {
+		cu.clusterSettings = append(cu.clusterSettings, s...)
 	}
 }
 
@@ -804,6 +816,9 @@ func (u *CommonTestUtils) resetCluster(
 	}
 
 	cockroachPath := clusterupgrade.CockroachPathForVersion(u.t, version)
+	// Prepend the test-wide cluster settings so caller-supplied settings
+	// override them on conflict.
+	settings = append(append([]install.ClusterSettingOption{}, u.clusterSettings...), settings...)
 	settings = append(settings, install.BinaryOption(cockroachPath), install.SimpleSecureOption(true))
 	return clusterupgrade.StartWithSettings(
 		ctx, l, u.cluster, u.roachNodes, option.NewStartOpts(opts...), settings...,


### PR DESCRIPTION
The backup-restore/small-ranges test starts the cluster with COCKROACH_MIN_RANGE_MAX_BYTES=1 so it can install range_max_bytes zone configs below the default 64 MiB floor. After every cluster backup,
resetCluster wipes and restarts the cluster, but the env var was not re-passed. RESTORE then brought the small-range zone configs back into a cluster with the default 64 MiB minimum, causing the schemachange workload's ALTER DATABASE ... PRIMARY REGION to fail inside validateExistingZoneCfg with an unexpected XXUUU error.

Hoist test-wide cluster settings into CommonTestUtils via a new withClusterSettings option, and have resetCluster always re-apply them.

Resolves: #170037
Epic: none

Release note: None